### PR TITLE
fix(api): resolve OpenRouter test failures

### DIFF
--- a/apps/api/src/runtime/services.ts
+++ b/apps/api/src/runtime/services.ts
@@ -608,8 +608,8 @@ export type RuntimeServices = {
   };
 };
 
-export function createRuntimeServices(): RuntimeServices {
-  const env = getEnv();
+export function createRuntimeServices(providedEnv?: AppEnv): RuntimeServices {
+  const env = providedEnv ?? getEnv();
   const store = new PostgresStore(env.postgresUrl);
   const supabase =
     env.supabase.flags.authEnabled ||

--- a/apps/api/test/domain/credits-ledger.test.ts
+++ b/apps/api/test/domain/credits-ledger.test.ts
@@ -81,8 +81,10 @@ describe("CreditLedger", () => {
           },
         },
         providers: {
-          ollama: { baseUrl: "http://127.0.0.1:11434", model: "llama3.1:8b" },
-          groq: { baseUrl: "https://api.groq.com/openai/v1", model: "llama-3.1-8b-instant" },
+          circuitBreaker: { failureThreshold: 5, resetTimeoutMs: 30000 },
+          ollama: { baseUrl: "http://127.0.0.1:11434", model: "llama3.1:8b", timeoutMs: 4000, maxRetries: 1 },
+          groq: { baseUrl: "https://api.groq.com/openai/v1", model: "llama-3.1-8b-instant", timeoutMs: 4000, maxRetries: 1 },
+          openrouter: { baseUrl: "https://openrouter.ai/api/v1", model: "meta-llama/llama-3.1-8b-instruct", timeoutMs: 4000, maxRetries: 1 },
         },
         langfuse: {
           enabled: false,

--- a/apps/api/test/domain/payment-service.test.ts
+++ b/apps/api/test/domain/payment-service.test.ts
@@ -72,8 +72,10 @@ describe("PaymentService", () => {
           },
         },
         providers: {
-          ollama: { baseUrl: "http://127.0.0.1:11434", model: "llama3.1:8b" },
-          groq: { baseUrl: "https://api.groq.com/openai/v1", model: "llama-3.1-8b-instant" },
+          circuitBreaker: { failureThreshold: 5, resetTimeoutMs: 30000 },
+          ollama: { baseUrl: "http://127.0.0.1:11434", model: "llama3.1:8b", timeoutMs: 4000, maxRetries: 1 },
+          groq: { baseUrl: "https://api.groq.com/openai/v1", model: "llama-3.1-8b-instant", timeoutMs: 4000, maxRetries: 1 },
+          openrouter: { baseUrl: "https://openrouter.ai/api/v1", model: "meta-llama/llama-3.1-8b-instruct", timeoutMs: 4000, maxRetries: 1 },
         },
         langfuse: {
           enabled: false,

--- a/apps/api/test/routes/users-routes.test.ts
+++ b/apps/api/test/routes/users-routes.test.ts
@@ -92,8 +92,10 @@ describe("user routes", () => {
           },
         },
         providers: {
-          ollama: { baseUrl: "http://127.0.0.1:11434", model: "llama3.1:8b" },
-          groq: { baseUrl: "https://api.groq.com/openai/v1", model: "llama-3.1-8b-instant" },
+          circuitBreaker: { failureThreshold: 5, resetTimeoutMs: 30000 },
+          ollama: { baseUrl: "http://127.0.0.1:11434", model: "llama3.1:8b", timeoutMs: 4000, maxRetries: 1 },
+          groq: { baseUrl: "https://api.groq.com/openai/v1", model: "llama-3.1-8b-instant", timeoutMs: 4000, maxRetries: 1 },
+          openrouter: { baseUrl: "https://openrouter.ai/api/v1", model: "meta-llama/llama-3.1-8b-instruct", timeoutMs: 4000, maxRetries: 1 },
         },
         langfuse: {
           enabled: false,

--- a/apps/api/test/routes/users-settings-routes.test.ts
+++ b/apps/api/test/routes/users-settings-routes.test.ts
@@ -136,8 +136,10 @@ describe("user settings routes", () => {
           },
         },
         providers: {
-          ollama: { baseUrl: "http://127.0.0.1:11434", model: "llama3.1:8b" },
-          groq: { baseUrl: "https://api.groq.com/openai/v1", model: "llama-3.1-8b-instant" },
+          circuitBreaker: { failureThreshold: 5, resetTimeoutMs: 30000 },
+          ollama: { baseUrl: "http://127.0.0.1:11434", model: "llama3.1:8b", timeoutMs: 4000, maxRetries: 1 },
+          groq: { baseUrl: "https://api.groq.com/openai/v1", model: "llama-3.1-8b-instant", timeoutMs: 4000, maxRetries: 1 },
+          openrouter: { baseUrl: "https://openrouter.ai/api/v1", model: "meta-llama/llama-3.1-8b-instruct", timeoutMs: 4000, maxRetries: 1 },
         },
         langfuse: {
           enabled: false,

--- a/artifacts/superpowers/plan.md
+++ b/artifacts/superpowers/plan.md
@@ -1,38 +1,25 @@
 ## Goal
-Create a CHANGELOG.md file to track notable changes and update project documentation to reference it, ensuring compliance with AGENTS.md workflow.
+Fix OpenRouter-related test failures by allowing createRuntimeServices to accept an optional environment object and providing a safe default in tests.
 
 ## Assumptions
-- The analysis of git history and existing docs is accurate.
-- I have write access to the repository.
-- The 'CHANGELOG.md' content should reflect the 'Unreleased' and '0.1.0' states.
+- The test failures are due to createRuntimeServices calling getEnv() which throws when required OpenRouter env vars are missing.
+- Modifying createRuntimeServices to accept an optional env is a safe and common pattern for testing.
 
 ## Plan
-1.  **Create CHANGELOG.md**
-    -   **File:** 'CHANGELOG.md'
-    -   **Change:** Create file with 'Unreleased' and '0.1.0' sections.
-    -   **Verify:** 'cat CHANGELOG.md' checks for content.
+1.  **Update createRuntimeServices**
+    -   **File:** apps/api/src/runtime/services.ts
+    -   **Change:** Modify createRuntimeServices to accept an optional `env?: AppEnv` argument. If provided, use it; otherwise, call getEnv().
+    -   **Verify:** pnpm --filter @hive/api build
 
-2.  **Update AGENTS.md**
-    -   **File:** 'AGENTS.md'
-    -   **Change:** Add 'Update CHANGELOG.md for all notable changes' to 'Documentation Discipline' section.
-    -   **Verify:** 'grep CHANGELOG.md AGENTS.md' confirms addition.
-
-3.  **Update README.md**
-    -   **File:** 'README.md'
-    -   **Change:** Add link to 'CHANGELOG.md' in 'Start Here' section.
-    -   **Verify:** 'grep CHANGELOG.md README.md' confirms addition.
-
-4.  **Update docs/README.md**
-    -   **File:** 'docs/README.md'
-    -   **Change:** Add link to '../../CHANGELOG.md' in 'Start Here' section.
-    -   **Verify:** 'grep CHANGELOG.md docs/README.md' confirms addition.
+2.  **Fix failing tests by providing mock env**
+    -   **Files:** 
+        - apps/api/test/domain/credits-ledger.test.ts
+        - apps/api/test/domain/payment-service.test.ts
+        - apps/api/test/routes/users-routes.test.ts
+        - apps/api/test/routes/users-settings-routes.test.ts
+    -   **Change:** Update createRuntimeServices() calls to include a mock environment object that satisfies the AppEnv type, especially the new providers.openrouter configuration.
+    -   **Verify:** pnpm --filter @hive/api test
 
 ## Risks & mitigations
--   **Risk:** Incorrect file paths or broken links.
-    -   **Mitigation:** Verify file existence and relative paths.
--   **Risk:** Overwriting existing uncommitted changes (unlikely in fresh worktree).
-    -   **Mitigation:** 'git status' check before starting.
-
-## Rollback plan
--   'rm CHANGELOG.md'
--   'git checkout AGENTS.md README.md docs/README.md'
+-   **Risk:** Missing other required env vars in mock objects.
+    -   **Mitigation:** Use getEnv() as a base if possible, or ensure mock objects are comprehensive enough for the test case.


### PR DESCRIPTION
## Description

This PR fixes the test failures caused by the missing `openrouter` configuration in mock environments used during tests.

Key changes:
- Updated `createRuntimeServices` in `apps/api/src/runtime/services.ts` to accept an optional `AppEnv` argument, defaulting to `getEnv()` if not provided. This enables cleaner dependency injection in tests.
- Updated mock environment definitions in several test files to include the required `openrouter` configuration:
    - `apps/api/test/domain/credits-ledger.test.ts`
    - `apps/api/test/domain/payment-service.test.ts`
    - `apps/api/test/routes/users-routes.test.ts`
    - `apps/api/test/routes/users-settings-routes.test.ts`

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Verification

- Ran `pnpm --filter @hive/api build` - passed.
- Ran `pnpm --filter @hive/api test` - all 81 tests passed, including previously failing ones.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenRouter provider support with configurable base URL and model selection.
  * Introduced circuit breaker configuration with failure threshold and reset timeout for improved resilience.
  * Enhanced providers with per-request timeout and retry settings for better fault tolerance.

* **Refactor**
  * Improved runtime service initialization to support dependency injection, enabling flexible environment configuration for testing and customization.

* **Tests**
  * Updated test configurations to reflect new provider resilience capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->