### PR TITLE
fix(deploy): CF Pages edge runtime + iptables position

### DIFF
--- a/.planning/staging/cloud-init.yml
+++ b/.planning/staging/cloud-init.yml
@@ -88,16 +88,31 @@ runcmd:
   - echo '/swapfile none swap sw 0 0' >> /etc/fstab
   - sysctl --system
 
-  # iptables — OCI Ubuntu ships restrictive INPUT; open 80/443 robustly.
-  # Ensure RELATED,ESTABLISHED accept is present first, then append NEW accepts
-  # for 80/443 so rules cannot end up below a REJECT.
-  - iptables -C INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT 2>/dev/null || iptables -I INPUT 1 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-  - iptables -C INPUT -p tcp --dport 80  -m conntrack --ctstate NEW -j ACCEPT 2>/dev/null || iptables -A INPUT -p tcp --dport 80  -m conntrack --ctstate NEW -j ACCEPT
-  - iptables -C INPUT -p tcp --dport 443 -m conntrack --ctstate NEW -j ACCEPT 2>/dev/null || iptables -A INPUT -p tcp --dport 443 -m conntrack --ctstate NEW -j ACCEPT
-  - ip6tables -C INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT 2>/dev/null || ip6tables -I INPUT 1 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-  - ip6tables -C INPUT -p tcp --dport 80  -m conntrack --ctstate NEW -j ACCEPT 2>/dev/null || ip6tables -A INPUT -p tcp --dport 80  -m conntrack --ctstate NEW -j ACCEPT
-  - ip6tables -C INPUT -p tcp --dport 443 -m conntrack --ctstate NEW -j ACCEPT 2>/dev/null || ip6tables -A INPUT -p tcp --dport 443 -m conntrack --ctstate NEW -j ACCEPT
-  - netfilter-persistent save
+  # iptables — OCI Ubuntu ships a restrictive INPUT chain with a catch-all
+  # REJECT at the bottom. `iptables -A INPUT ... ACCEPT` appends BELOW the
+  # REJECT, so the ACCEPT is never reached (symptom: 443 refused).
+  # Fix: insert ACCEPTs at the REJECT rule's position so they land above it.
+  - |
+    insert_before_reject() {
+      local ipt=$1 dport=$2
+      "$ipt" -C INPUT -p tcp --dport "$dport" -m conntrack --ctstate NEW -j ACCEPT 2>/dev/null && return 0
+      local line
+      line=$("$ipt" -L INPUT --line-numbers -n | awk '/REJECT/{print $1; exit}')
+      if [ -n "$line" ]; then
+        "$ipt" -I INPUT "$line" -p tcp --dport "$dport" -m conntrack --ctstate NEW -j ACCEPT
+      else
+        "$ipt" -A INPUT -p tcp --dport "$dport" -m conntrack --ctstate NEW -j ACCEPT
+      fi
+    }
+    iptables -C INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT 2>/dev/null \
+      || iptables -I INPUT 1 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+    insert_before_reject iptables 80
+    insert_before_reject iptables 443
+    ip6tables -C INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT 2>/dev/null \
+      || ip6tables -I INPUT 1 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+    insert_before_reject ip6tables 80
+    insert_before_reject ip6tables 443
+    netfilter-persistent save
 
   # Docker install (amd64) — pin docker-compose-plugin >= 2.24 (for !reset/!override tag support)
   - install -m 0755 -d /etc/apt/keyrings

--- a/.wolf/anatomy.md
+++ b/.wolf/anatomy.md
@@ -1,6 +1,6 @@
 # anatomy.md
 
-> Auto-maintained by OpenWolf. Last scanned: 2026-04-24T16:51:48.054Z
+> Auto-maintained by OpenWolf. Last scanned: 2026-04-24T17:12:51.903Z
 > Files: 517 tracked | Anatomy hits: 0 | Misses: 0
 
 ## ../.claude/projects/-home-sakib-hive/memory/
@@ -287,7 +287,7 @@
 
 ## .planning/staging/
 
-- `cloud-init.yml` — cloud-config (~1804 tok)
+- `cloud-init.yml` — cloud-config (~1828 tok)
 
 ## apps/control-plane/
 
@@ -604,7 +604,7 @@
 
 ## apps/web-console/app/
 
-- `layout.tsx` — RootLayout (~70 tok)
+- `layout.tsx` — All dynamic routes run on the Cloudflare Pages Edge runtime. (~117 tok)
 - `page.tsx` — RootPage (~122 tok)
 
 ## apps/web-console/app/api/budget/
@@ -613,7 +613,7 @@
 
 ## apps/web-console/app/auth/callback/
 
-- `route.ts` — Next.js API route: GET (~457 tok)
+- `route.ts` — Next.js API route: GET (~763 tok)
 
 ## apps/web-console/app/auth/forgot-password/
 
@@ -638,7 +638,7 @@
 
 ## apps/web-console/app/console/account-switch/
 
-- `route.ts` — Next.js API route: POST (~393 tok)
+- `route.ts` — Next.js API route: POST (~402 tok)
 
 ## apps/web-console/app/console/analytics/
 

--- a/.wolf/buglog.json
+++ b/.wolf/buglog.json
@@ -194,6 +194,22 @@
       "related_bugs": [],
       "occurrences": 1,
       "last_seen": "2026-04-24T16:51:38.487Z"
+    },
+    {
+      "id": "bug-013",
+      "timestamp": "2026-04-24T17:12:51.912Z",
+      "error_message": "Missing error handling in unknown",
+      "file": ".planning/staging/cloud-init.yml",
+      "root_cause": "Code path had no error handling — exceptions would propagate uncaught",
+      "fix": "Added try/catch block",
+      "tags": [
+        "auto-detected",
+        "error-handling",
+        "yml"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-04-24T17:12:51.912Z"
     }
   ]
 }

--- a/.wolf/hooks/_session.json
+++ b/.wolf/hooks/_session.json
@@ -41,6 +41,26 @@
       "count": 1,
       "tokens": 4358,
       "first_read": "2026-04-24T16:51:43.028Z"
+    },
+    "/home/sakib/hive/apps/web-console/app/layout.tsx": {
+      "count": 1,
+      "tokens": 70,
+      "first_read": "2026-04-24T17:11:50.652Z"
+    },
+    "/home/sakib/hive/apps/web-console/app/auth/callback/route.ts": {
+      "count": 1,
+      "tokens": 457,
+      "first_read": "2026-04-24T17:12:00.551Z"
+    },
+    "/home/sakib/hive/apps/web-console/app/console/account-switch/route.ts": {
+      "count": 1,
+      "tokens": 393,
+      "first_read": "2026-04-24T17:12:11.007Z"
+    },
+    "/home/sakib/hive/.planning/staging/cloud-init.yml": {
+      "count": 1,
+      "tokens": 1804,
+      "first_read": "2026-04-24T17:12:37.861Z"
     }
   },
   "files_written": [
@@ -151,6 +171,30 @@
       "action": "edit",
       "tokens": 18,
       "at": "2026-04-24T16:51:48.062Z"
+    },
+    {
+      "file": "/home/sakib/hive/apps/web-console/app/layout.tsx",
+      "action": "edit",
+      "tokens": 74,
+      "at": "2026-04-24T17:11:55.398Z"
+    },
+    {
+      "file": "/home/sakib/hive/apps/web-console/app/auth/callback/route.ts",
+      "action": "edit",
+      "tokens": 59,
+      "at": "2026-04-24T17:12:05.851Z"
+    },
+    {
+      "file": "/home/sakib/hive/apps/web-console/app/console/account-switch/route.ts",
+      "action": "edit",
+      "tokens": 70,
+      "at": "2026-04-24T17:12:24.604Z"
+    },
+    {
+      "file": "/home/sakib/hive/.planning/staging/cloud-init.yml",
+      "action": "edit",
+      "tokens": 378,
+      "at": "2026-04-24T17:12:51.911Z"
     }
   ],
   "edit_counts": {
@@ -160,11 +204,15 @@
     ".github/workflows/deploy-staging.yml": 6,
     "../.claude/projects/-home-sakib-hive/memory/feedback_no_direct_main_push.md": 1,
     "../.claude/projects/-home-sakib-hive/memory/MEMORY.md": 1,
-    ".github/workflows/ci.yml": 1
+    ".github/workflows/ci.yml": 1,
+    "apps/web-console/app/layout.tsx": 1,
+    "apps/web-console/app/auth/callback/route.ts": 1,
+    "apps/web-console/app/console/account-switch/route.ts": 1,
+    ".planning/staging/cloud-init.yml": 1
   },
-  "anatomy_hits": 8,
+  "anatomy_hits": 12,
   "anatomy_misses": 0,
   "repeated_reads_warned": 3,
   "cerebrum_warnings": 0,
-  "stop_count": 1
+  "stop_count": 9
 }

--- a/.wolf/memory.md
+++ b/.wolf/memory.md
@@ -164,3 +164,15 @@
 | 12:50 | Edited ../.claude/projects/-home-sakib-hive/memory/MEMORY.md | 1→2 lines | ~81 |
 | 12:51 | Edited apps/web-console/app/api/budget/route.ts | "nodejs" → "edge" | ~9 |
 | 12:51 | Edited .github/workflows/ci.yml | 5→4 lines | ~18 |
+| 12:53 | Session end: 18 writes across 7 files (route.ts, invoice-download-button.tsx, docker-compose.staging.yml, deploy-staging.yml, feedback_no_direct_main_push.md) | 8 reads | ~25063 tok |
+| 12:58 | Session end: 18 writes across 7 files (route.ts, invoice-download-button.tsx, docker-compose.staging.yml, deploy-staging.yml, feedback_no_direct_main_push.md) | 8 reads | ~25063 tok |
+| 13:00 | Session end: 18 writes across 7 files (route.ts, invoice-download-button.tsx, docker-compose.staging.yml, deploy-staging.yml, feedback_no_direct_main_push.md) | 8 reads | ~25063 tok |
+| 13:03 | Session end: 18 writes across 7 files (route.ts, invoice-download-button.tsx, docker-compose.staging.yml, deploy-staging.yml, feedback_no_direct_main_push.md) | 8 reads | ~25063 tok |
+| 13:04 | Session end: 18 writes across 7 files (route.ts, invoice-download-button.tsx, docker-compose.staging.yml, deploy-staging.yml, feedback_no_direct_main_push.md) | 8 reads | ~25063 tok |
+| 13:07 | Session end: 18 writes across 7 files (route.ts, invoice-download-button.tsx, docker-compose.staging.yml, deploy-staging.yml, feedback_no_direct_main_push.md) | 8 reads | ~25063 tok |
+| 13:10 | Session end: 18 writes across 7 files (route.ts, invoice-download-button.tsx, docker-compose.staging.yml, deploy-staging.yml, feedback_no_direct_main_push.md) | 8 reads | ~25063 tok |
+| 13:10 | Session end: 18 writes across 7 files (route.ts, invoice-download-button.tsx, docker-compose.staging.yml, deploy-staging.yml, feedback_no_direct_main_push.md) | 8 reads | ~25063 tok |
+| 13:11 | Edited apps/web-console/app/layout.tsx | 5→9 lines | ~74 |
+| 13:12 | Edited apps/web-console/app/auth/callback/route.ts | 3→5 lines | ~59 |
+| 13:12 | Edited apps/web-console/app/console/account-switch/route.ts | 4→6 lines | ~70 |
+| 13:12 | Edited .planning/staging/cloud-init.yml | modified insert_before_reject() | ~378 |

--- a/.wolf/token-ledger.json
+++ b/.wolf/token-ledger.json
@@ -2,14 +2,14 @@
   "version": 1,
   "created_at": "2026-04-22T00:50:18.611Z",
   "lifetime": {
-    "total_tokens_estimated": 116708,
-    "total_reads": 76,
-    "total_writes": 131,
+    "total_tokens_estimated": 317212,
+    "total_reads": 140,
+    "total_writes": 275,
     "total_sessions": 12,
-    "anatomy_hits": 63,
+    "anatomy_hits": 127,
     "anatomy_misses": 13,
-    "repeated_reads_blocked": 8,
-    "estimated_savings_vs_bare_cli": 22731
+    "repeated_reads_blocked": 32,
+    "estimated_savings_vs_bare_cli": 59203
   },
   "sessions": [
     {
@@ -1507,6 +1507,1246 @@
         "writes_count": 14,
         "repeated_reads_blocked": 2,
         "anatomy_lookups": 7
+      }
+    },
+    {
+      "id": "session-2026-04-24-1232",
+      "started": "2026-04-24T16:32:56.501Z",
+      "ended": "2026-04-24T16:53:28.159Z",
+      "reads": [
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 589,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 2216,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 1762,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 608,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/middleware.ts",
+          "tokens_estimated": 560,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/lib/control-plane/client.ts",
+          "tokens_estimated": 12210,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/lib/supabase/server.ts",
+          "tokens_estimated": 300,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/ci.yml",
+          "tokens_estimated": 4358,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        }
+      ],
+      "writes": [
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 589,
+          "action": "create"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 67,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 146,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 49,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 49,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 511,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 431,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 52,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 6,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 64,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 22,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 23,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 65,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 80,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/.claude/projects/-home-sakib-hive/memory/feedback_no_direct_main_push.md",
+          "tokens_estimated": 192,
+          "action": "create"
+        },
+        {
+          "file": "/home/sakib/.claude/projects/-home-sakib-hive/memory/MEMORY.md",
+          "tokens_estimated": 87,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 9,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/ci.yml",
+          "tokens_estimated": 18,
+          "action": "edit"
+        }
+      ],
+      "totals": {
+        "input_tokens_estimated": 22603,
+        "output_tokens_estimated": 2460,
+        "reads_count": 8,
+        "writes_count": 18,
+        "repeated_reads_blocked": 3,
+        "anatomy_lookups": 8
+      }
+    },
+    {
+      "id": "session-2026-04-24-1232",
+      "started": "2026-04-24T16:32:56.501Z",
+      "ended": "2026-04-24T16:58:22.385Z",
+      "reads": [
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 589,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 2216,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 1762,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 608,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/middleware.ts",
+          "tokens_estimated": 560,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/lib/control-plane/client.ts",
+          "tokens_estimated": 12210,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/lib/supabase/server.ts",
+          "tokens_estimated": 300,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/ci.yml",
+          "tokens_estimated": 4358,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        }
+      ],
+      "writes": [
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 589,
+          "action": "create"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 67,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 146,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 49,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 49,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 511,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 431,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 52,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 6,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 64,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 22,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 23,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 65,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 80,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/.claude/projects/-home-sakib-hive/memory/feedback_no_direct_main_push.md",
+          "tokens_estimated": 192,
+          "action": "create"
+        },
+        {
+          "file": "/home/sakib/.claude/projects/-home-sakib-hive/memory/MEMORY.md",
+          "tokens_estimated": 87,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 9,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/ci.yml",
+          "tokens_estimated": 18,
+          "action": "edit"
+        }
+      ],
+      "totals": {
+        "input_tokens_estimated": 22603,
+        "output_tokens_estimated": 2460,
+        "reads_count": 8,
+        "writes_count": 18,
+        "repeated_reads_blocked": 3,
+        "anatomy_lookups": 8
+      }
+    },
+    {
+      "id": "session-2026-04-24-1232",
+      "started": "2026-04-24T16:32:56.501Z",
+      "ended": "2026-04-24T17:00:14.585Z",
+      "reads": [
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 589,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 2216,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 1762,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 608,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/middleware.ts",
+          "tokens_estimated": 560,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/lib/control-plane/client.ts",
+          "tokens_estimated": 12210,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/lib/supabase/server.ts",
+          "tokens_estimated": 300,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/ci.yml",
+          "tokens_estimated": 4358,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        }
+      ],
+      "writes": [
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 589,
+          "action": "create"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 67,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 146,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 49,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 49,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 511,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 431,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 52,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 6,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 64,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 22,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 23,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 65,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 80,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/.claude/projects/-home-sakib-hive/memory/feedback_no_direct_main_push.md",
+          "tokens_estimated": 192,
+          "action": "create"
+        },
+        {
+          "file": "/home/sakib/.claude/projects/-home-sakib-hive/memory/MEMORY.md",
+          "tokens_estimated": 87,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 9,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/ci.yml",
+          "tokens_estimated": 18,
+          "action": "edit"
+        }
+      ],
+      "totals": {
+        "input_tokens_estimated": 22603,
+        "output_tokens_estimated": 2460,
+        "reads_count": 8,
+        "writes_count": 18,
+        "repeated_reads_blocked": 3,
+        "anatomy_lookups": 8
+      }
+    },
+    {
+      "id": "session-2026-04-24-1232",
+      "started": "2026-04-24T16:32:56.501Z",
+      "ended": "2026-04-24T17:03:22.573Z",
+      "reads": [
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 589,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 2216,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 1762,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 608,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/middleware.ts",
+          "tokens_estimated": 560,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/lib/control-plane/client.ts",
+          "tokens_estimated": 12210,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/lib/supabase/server.ts",
+          "tokens_estimated": 300,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/ci.yml",
+          "tokens_estimated": 4358,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        }
+      ],
+      "writes": [
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 589,
+          "action": "create"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 67,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 146,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 49,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 49,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 511,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 431,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 52,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 6,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 64,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 22,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 23,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 65,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 80,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/.claude/projects/-home-sakib-hive/memory/feedback_no_direct_main_push.md",
+          "tokens_estimated": 192,
+          "action": "create"
+        },
+        {
+          "file": "/home/sakib/.claude/projects/-home-sakib-hive/memory/MEMORY.md",
+          "tokens_estimated": 87,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 9,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/ci.yml",
+          "tokens_estimated": 18,
+          "action": "edit"
+        }
+      ],
+      "totals": {
+        "input_tokens_estimated": 22603,
+        "output_tokens_estimated": 2460,
+        "reads_count": 8,
+        "writes_count": 18,
+        "repeated_reads_blocked": 3,
+        "anatomy_lookups": 8
+      }
+    },
+    {
+      "id": "session-2026-04-24-1232",
+      "started": "2026-04-24T16:32:56.501Z",
+      "ended": "2026-04-24T17:04:27.248Z",
+      "reads": [
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 589,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 2216,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 1762,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 608,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/middleware.ts",
+          "tokens_estimated": 560,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/lib/control-plane/client.ts",
+          "tokens_estimated": 12210,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/lib/supabase/server.ts",
+          "tokens_estimated": 300,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/ci.yml",
+          "tokens_estimated": 4358,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        }
+      ],
+      "writes": [
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 589,
+          "action": "create"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 67,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 146,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 49,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 49,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 511,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 431,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 52,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 6,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 64,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 22,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 23,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 65,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 80,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/.claude/projects/-home-sakib-hive/memory/feedback_no_direct_main_push.md",
+          "tokens_estimated": 192,
+          "action": "create"
+        },
+        {
+          "file": "/home/sakib/.claude/projects/-home-sakib-hive/memory/MEMORY.md",
+          "tokens_estimated": 87,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 9,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/ci.yml",
+          "tokens_estimated": 18,
+          "action": "edit"
+        }
+      ],
+      "totals": {
+        "input_tokens_estimated": 22603,
+        "output_tokens_estimated": 2460,
+        "reads_count": 8,
+        "writes_count": 18,
+        "repeated_reads_blocked": 3,
+        "anatomy_lookups": 8
+      }
+    },
+    {
+      "id": "session-2026-04-24-1232",
+      "started": "2026-04-24T16:32:56.501Z",
+      "ended": "2026-04-24T17:07:18.378Z",
+      "reads": [
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 589,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 2216,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 1762,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 608,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/middleware.ts",
+          "tokens_estimated": 560,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/lib/control-plane/client.ts",
+          "tokens_estimated": 12210,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/lib/supabase/server.ts",
+          "tokens_estimated": 300,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/ci.yml",
+          "tokens_estimated": 4358,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        }
+      ],
+      "writes": [
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 589,
+          "action": "create"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 67,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 146,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 49,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 49,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 511,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 431,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 52,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 6,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 64,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 22,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 23,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 65,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 80,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/.claude/projects/-home-sakib-hive/memory/feedback_no_direct_main_push.md",
+          "tokens_estimated": 192,
+          "action": "create"
+        },
+        {
+          "file": "/home/sakib/.claude/projects/-home-sakib-hive/memory/MEMORY.md",
+          "tokens_estimated": 87,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 9,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/ci.yml",
+          "tokens_estimated": 18,
+          "action": "edit"
+        }
+      ],
+      "totals": {
+        "input_tokens_estimated": 22603,
+        "output_tokens_estimated": 2460,
+        "reads_count": 8,
+        "writes_count": 18,
+        "repeated_reads_blocked": 3,
+        "anatomy_lookups": 8
+      }
+    },
+    {
+      "id": "session-2026-04-24-1232",
+      "started": "2026-04-24T16:32:56.501Z",
+      "ended": "2026-04-24T17:10:01.409Z",
+      "reads": [
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 589,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 2216,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 1762,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 608,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/middleware.ts",
+          "tokens_estimated": 560,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/lib/control-plane/client.ts",
+          "tokens_estimated": 12210,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/lib/supabase/server.ts",
+          "tokens_estimated": 300,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/ci.yml",
+          "tokens_estimated": 4358,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        }
+      ],
+      "writes": [
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 589,
+          "action": "create"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 67,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 146,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 49,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 49,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 511,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 431,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 52,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 6,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 64,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 22,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 23,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 65,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 80,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/.claude/projects/-home-sakib-hive/memory/feedback_no_direct_main_push.md",
+          "tokens_estimated": 192,
+          "action": "create"
+        },
+        {
+          "file": "/home/sakib/.claude/projects/-home-sakib-hive/memory/MEMORY.md",
+          "tokens_estimated": 87,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 9,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/ci.yml",
+          "tokens_estimated": 18,
+          "action": "edit"
+        }
+      ],
+      "totals": {
+        "input_tokens_estimated": 22603,
+        "output_tokens_estimated": 2460,
+        "reads_count": 8,
+        "writes_count": 18,
+        "repeated_reads_blocked": 3,
+        "anatomy_lookups": 8
+      }
+    },
+    {
+      "id": "session-2026-04-24-1232",
+      "started": "2026-04-24T16:32:56.501Z",
+      "ended": "2026-04-24T17:10:25.513Z",
+      "reads": [
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 589,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 2216,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 1762,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 608,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/middleware.ts",
+          "tokens_estimated": 560,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/lib/control-plane/client.ts",
+          "tokens_estimated": 12210,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/lib/supabase/server.ts",
+          "tokens_estimated": 300,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/ci.yml",
+          "tokens_estimated": 4358,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        }
+      ],
+      "writes": [
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 589,
+          "action": "create"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 67,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 146,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 49,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 49,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 511,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 431,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 52,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 6,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 64,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 22,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 23,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 65,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 80,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/.claude/projects/-home-sakib-hive/memory/feedback_no_direct_main_push.md",
+          "tokens_estimated": 192,
+          "action": "create"
+        },
+        {
+          "file": "/home/sakib/.claude/projects/-home-sakib-hive/memory/MEMORY.md",
+          "tokens_estimated": 87,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 9,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/ci.yml",
+          "tokens_estimated": 18,
+          "action": "edit"
+        }
+      ],
+      "totals": {
+        "input_tokens_estimated": 22603,
+        "output_tokens_estimated": 2460,
+        "reads_count": 8,
+        "writes_count": 18,
+        "repeated_reads_blocked": 3,
+        "anatomy_lookups": 8
       }
     }
   ],

--- a/apps/web-console/app/auth/callback/route.ts
+++ b/apps/web-console/app/auth/callback/route.ts
@@ -2,6 +2,8 @@ import { NextResponse, type NextRequest } from "next/server";
 import { createServerClient, type CookieOptions } from "@supabase/ssr";
 import { cookies } from "next/headers";
 
+export const runtime = "edge";
+
 const ALLOWED_NEXT_TARGETS = new Set([
   "/console",
   "/console/settings/profile",

--- a/apps/web-console/app/console/account-switch/route.ts
+++ b/apps/web-console/app/console/account-switch/route.ts
@@ -3,6 +3,8 @@ import { cookies } from "next/headers";
 import { createClient } from "@/lib/supabase/server";
 import { getViewer } from "@/lib/control-plane/client";
 
+export const runtime = "edge";
+
 export async function POST(request: NextRequest) {
   const formData = await request.formData();
   const accountId = formData.get("account_id");

--- a/apps/web-console/app/layout.tsx
+++ b/apps/web-console/app/layout.tsx
@@ -1,5 +1,9 @@
 import type { ReactNode } from "react";
 
+// All dynamic routes run on the Cloudflare Pages Edge runtime.
+// Inherited by nested segments (console, auth, invitations, etc.).
+export const runtime = "edge";
+
 interface RootLayoutProps {
   children: ReactNode;
 }


### PR DESCRIPTION
## Summary

Two post-merge fixes from first staging deploy:

### 1. CF Pages build failed (edge runtime)

`@cloudflare/next-on-pages` requires all non-static routes to export `runtime = 'edge'`. First deploy errored:
```
ERROR: Failed to produce a Cloudflare Pages build from the project.
The following routes were not configured to run with the Edge Runtime: /auth/callback, /console, /console/*, /invitations/accept, /index
```

Fix:
- `app/layout.tsx`: export `runtime = 'edge'` — cascades to every nested segment (console, auth, invitations)
- `app/auth/callback/route.ts`, `app/console/account-switch/route.ts`: explicit edge (route handlers don't inherit segment runtime config)

`/api/budget/route.ts` already has it (CodeRabbit review on PR #90).

### 2. iptables ACCEPT below REJECT (staging VM was unreachable)

OCI Ubuntu `INPUT` chain has a trailing `REJECT --reject-with icmp-host-prohibited`. Cloud-init used `iptables -A` which appended below the REJECT, so 443 was silently refused. First deploy's smoke test failed at curl stage.

Fix: new `insert_before_reject` helper in `runcmd` locates the REJECT rule's line number and uses `-I INPUT <N>` so the ACCEPT lands above it. Applied to both `iptables` (v4) and `ip6tables` (v6).

The running VM was patched manually; this commit makes the fix sticky for future re-provisions.

## Test plan

- [ ] CI green (build images, vm deploy, pages deploy all succeed)
- [ ] `curl https://console.hive.scubed.co` → 200 with CF Pages content
- [ ] `curl https://api.hive.scubed.co/health` still 200 (unchanged)
- [ ] `curl https://cp.hive.scubed.co/health` still 200 (unchanged)