### PR TITLE
chore(web-console): wrangler.jsonc repo source-of-truth for CF Pages

### DIFF
--- a/.wolf/anatomy.md
+++ b/.wolf/anatomy.md
@@ -1,7 +1,7 @@
 # anatomy.md
 
-> Auto-maintained by OpenWolf. Last scanned: 2026-04-24T17:12:51.903Z
-> Files: 517 tracked | Anatomy hits: 0 | Misses: 0
+> Auto-maintained by OpenWolf. Last scanned: 2026-04-24T17:36:01.619Z
+> Files: 518 tracked | Anatomy hits: 0 | Misses: 0
 
 ## ../.claude/projects/-home-sakib-hive/memory/
 
@@ -595,6 +595,7 @@
 - `tsconfig.json` — TypeScript configuration (~164 tok)
 - `tsconfig.tsbuildinfo` (~43098 tok)
 - `vitest.config.ts` — Vitest test configuration (~129 tok)
+- `wrangler.jsonc` — Cloudflare Pages configuration — source of truth for compatibility settings. (~252 tok)
 
 ## apps/web-console/__tests__/
 

--- a/.wolf/hooks/_session.json
+++ b/.wolf/hooks/_session.json
@@ -195,6 +195,12 @@
       "action": "edit",
       "tokens": 378,
       "at": "2026-04-24T17:12:51.911Z"
+    },
+    {
+      "file": "/home/sakib/hive/apps/web-console/wrangler.jsonc",
+      "action": "create",
+      "tokens": 270,
+      "at": "2026-04-24T17:36:01.625Z"
     }
   ],
   "edit_counts": {
@@ -208,11 +214,12 @@
     "apps/web-console/app/layout.tsx": 1,
     "apps/web-console/app/auth/callback/route.ts": 1,
     "apps/web-console/app/console/account-switch/route.ts": 1,
-    ".planning/staging/cloud-init.yml": 1
+    ".planning/staging/cloud-init.yml": 1,
+    "apps/web-console/wrangler.jsonc": 1
   },
   "anatomy_hits": 12,
   "anatomy_misses": 0,
   "repeated_reads_warned": 3,
   "cerebrum_warnings": 0,
-  "stop_count": 9
+  "stop_count": 18
 }

--- a/.wolf/memory.md
+++ b/.wolf/memory.md
@@ -176,3 +176,13 @@
 | 13:12 | Edited apps/web-console/app/auth/callback/route.ts | 3→5 lines | ~59 |
 | 13:12 | Edited apps/web-console/app/console/account-switch/route.ts | 4→6 lines | ~70 |
 | 13:12 | Edited .planning/staging/cloud-init.yml | modified insert_before_reject() | ~378 |
+| 13:14 | Session end: 22 writes across 9 files (route.ts, invoice-download-button.tsx, docker-compose.staging.yml, deploy-staging.yml, feedback_no_direct_main_push.md) | 12 reads | ~28368 tok |
+| 13:14 | Session end: 22 writes across 9 files (route.ts, invoice-download-button.tsx, docker-compose.staging.yml, deploy-staging.yml, feedback_no_direct_main_push.md) | 12 reads | ~28368 tok |
+| 13:21 | Session end: 22 writes across 9 files (route.ts, invoice-download-button.tsx, docker-compose.staging.yml, deploy-staging.yml, feedback_no_direct_main_push.md) | 12 reads | ~28368 tok |
+| 13:21 | Session end: 22 writes across 9 files (route.ts, invoice-download-button.tsx, docker-compose.staging.yml, deploy-staging.yml, feedback_no_direct_main_push.md) | 12 reads | ~28368 tok |
+| 13:23 | Session end: 22 writes across 9 files (route.ts, invoice-download-button.tsx, docker-compose.staging.yml, deploy-staging.yml, feedback_no_direct_main_push.md) | 12 reads | ~28368 tok |
+| 13:26 | Session end: 22 writes across 9 files (route.ts, invoice-download-button.tsx, docker-compose.staging.yml, deploy-staging.yml, feedback_no_direct_main_push.md) | 12 reads | ~28368 tok |
+| 13:26 | Session end: 22 writes across 9 files (route.ts, invoice-download-button.tsx, docker-compose.staging.yml, deploy-staging.yml, feedback_no_direct_main_push.md) | 12 reads | ~28368 tok |
+| 13:31 | Session end: 22 writes across 9 files (route.ts, invoice-download-button.tsx, docker-compose.staging.yml, deploy-staging.yml, feedback_no_direct_main_push.md) | 12 reads | ~28368 tok |
+| 13:34 | Session end: 22 writes across 9 files (route.ts, invoice-download-button.tsx, docker-compose.staging.yml, deploy-staging.yml, feedback_no_direct_main_push.md) | 12 reads | ~28368 tok |
+| 13:36 | Created apps/web-console/wrangler.jsonc | — | ~252 |

--- a/.wolf/token-ledger.json
+++ b/.wolf/token-ledger.json
@@ -2,14 +2,14 @@
   "version": 1,
   "created_at": "2026-04-22T00:50:18.611Z",
   "lifetime": {
-    "total_tokens_estimated": 317212,
-    "total_reads": 140,
-    "total_writes": 275,
+    "total_tokens_estimated": 572524,
+    "total_reads": 248,
+    "total_writes": 473,
     "total_sessions": 12,
-    "anatomy_hits": 127,
+    "anatomy_hits": 235,
     "anatomy_misses": 13,
-    "repeated_reads_blocked": 32,
-    "estimated_savings_vs_bare_cli": 59203
+    "repeated_reads_blocked": 59,
+    "estimated_savings_vs_bare_cli": 107434
   },
   "sessions": [
     {
@@ -2747,6 +2747,1797 @@
         "writes_count": 18,
         "repeated_reads_blocked": 3,
         "anatomy_lookups": 8
+      }
+    },
+    {
+      "id": "session-2026-04-24-1232",
+      "started": "2026-04-24T16:32:56.501Z",
+      "ended": "2026-04-24T17:14:09.108Z",
+      "reads": [
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 589,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 2216,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 1762,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 608,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/middleware.ts",
+          "tokens_estimated": 560,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/lib/control-plane/client.ts",
+          "tokens_estimated": 12210,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/lib/supabase/server.ts",
+          "tokens_estimated": 300,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/ci.yml",
+          "tokens_estimated": 4358,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/layout.tsx",
+          "tokens_estimated": 70,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/auth/callback/route.ts",
+          "tokens_estimated": 457,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/console/account-switch/route.ts",
+          "tokens_estimated": 393,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/.planning/staging/cloud-init.yml",
+          "tokens_estimated": 1804,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        }
+      ],
+      "writes": [
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 589,
+          "action": "create"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 67,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 146,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 49,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 49,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 511,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 431,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 52,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 6,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 64,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 22,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 23,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 65,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 80,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/.claude/projects/-home-sakib-hive/memory/feedback_no_direct_main_push.md",
+          "tokens_estimated": 192,
+          "action": "create"
+        },
+        {
+          "file": "/home/sakib/.claude/projects/-home-sakib-hive/memory/MEMORY.md",
+          "tokens_estimated": 87,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 9,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/ci.yml",
+          "tokens_estimated": 18,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/layout.tsx",
+          "tokens_estimated": 74,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/auth/callback/route.ts",
+          "tokens_estimated": 59,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/console/account-switch/route.ts",
+          "tokens_estimated": 70,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.planning/staging/cloud-init.yml",
+          "tokens_estimated": 378,
+          "action": "edit"
+        }
+      ],
+      "totals": {
+        "input_tokens_estimated": 25327,
+        "output_tokens_estimated": 3041,
+        "reads_count": 12,
+        "writes_count": 22,
+        "repeated_reads_blocked": 3,
+        "anatomy_lookups": 12
+      }
+    },
+    {
+      "id": "session-2026-04-24-1232",
+      "started": "2026-04-24T16:32:56.501Z",
+      "ended": "2026-04-24T17:14:22.556Z",
+      "reads": [
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 589,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 2216,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 1762,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 608,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/middleware.ts",
+          "tokens_estimated": 560,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/lib/control-plane/client.ts",
+          "tokens_estimated": 12210,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/lib/supabase/server.ts",
+          "tokens_estimated": 300,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/ci.yml",
+          "tokens_estimated": 4358,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/layout.tsx",
+          "tokens_estimated": 70,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/auth/callback/route.ts",
+          "tokens_estimated": 457,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/console/account-switch/route.ts",
+          "tokens_estimated": 393,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/.planning/staging/cloud-init.yml",
+          "tokens_estimated": 1804,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        }
+      ],
+      "writes": [
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 589,
+          "action": "create"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 67,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 146,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 49,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 49,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 511,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 431,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 52,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 6,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 64,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 22,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 23,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 65,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 80,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/.claude/projects/-home-sakib-hive/memory/feedback_no_direct_main_push.md",
+          "tokens_estimated": 192,
+          "action": "create"
+        },
+        {
+          "file": "/home/sakib/.claude/projects/-home-sakib-hive/memory/MEMORY.md",
+          "tokens_estimated": 87,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 9,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/ci.yml",
+          "tokens_estimated": 18,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/layout.tsx",
+          "tokens_estimated": 74,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/auth/callback/route.ts",
+          "tokens_estimated": 59,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/console/account-switch/route.ts",
+          "tokens_estimated": 70,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.planning/staging/cloud-init.yml",
+          "tokens_estimated": 378,
+          "action": "edit"
+        }
+      ],
+      "totals": {
+        "input_tokens_estimated": 25327,
+        "output_tokens_estimated": 3041,
+        "reads_count": 12,
+        "writes_count": 22,
+        "repeated_reads_blocked": 3,
+        "anatomy_lookups": 12
+      }
+    },
+    {
+      "id": "session-2026-04-24-1232",
+      "started": "2026-04-24T16:32:56.501Z",
+      "ended": "2026-04-24T17:21:27.401Z",
+      "reads": [
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 589,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 2216,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 1762,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 608,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/middleware.ts",
+          "tokens_estimated": 560,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/lib/control-plane/client.ts",
+          "tokens_estimated": 12210,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/lib/supabase/server.ts",
+          "tokens_estimated": 300,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/ci.yml",
+          "tokens_estimated": 4358,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/layout.tsx",
+          "tokens_estimated": 70,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/auth/callback/route.ts",
+          "tokens_estimated": 457,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/console/account-switch/route.ts",
+          "tokens_estimated": 393,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/.planning/staging/cloud-init.yml",
+          "tokens_estimated": 1804,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        }
+      ],
+      "writes": [
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 589,
+          "action": "create"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 67,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 146,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 49,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 49,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 511,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 431,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 52,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 6,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 64,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 22,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 23,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 65,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 80,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/.claude/projects/-home-sakib-hive/memory/feedback_no_direct_main_push.md",
+          "tokens_estimated": 192,
+          "action": "create"
+        },
+        {
+          "file": "/home/sakib/.claude/projects/-home-sakib-hive/memory/MEMORY.md",
+          "tokens_estimated": 87,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 9,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/ci.yml",
+          "tokens_estimated": 18,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/layout.tsx",
+          "tokens_estimated": 74,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/auth/callback/route.ts",
+          "tokens_estimated": 59,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/console/account-switch/route.ts",
+          "tokens_estimated": 70,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.planning/staging/cloud-init.yml",
+          "tokens_estimated": 378,
+          "action": "edit"
+        }
+      ],
+      "totals": {
+        "input_tokens_estimated": 25327,
+        "output_tokens_estimated": 3041,
+        "reads_count": 12,
+        "writes_count": 22,
+        "repeated_reads_blocked": 3,
+        "anatomy_lookups": 12
+      }
+    },
+    {
+      "id": "session-2026-04-24-1232",
+      "started": "2026-04-24T16:32:56.501Z",
+      "ended": "2026-04-24T17:21:45.899Z",
+      "reads": [
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 589,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 2216,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 1762,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 608,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/middleware.ts",
+          "tokens_estimated": 560,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/lib/control-plane/client.ts",
+          "tokens_estimated": 12210,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/lib/supabase/server.ts",
+          "tokens_estimated": 300,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/ci.yml",
+          "tokens_estimated": 4358,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/layout.tsx",
+          "tokens_estimated": 70,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/auth/callback/route.ts",
+          "tokens_estimated": 457,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/console/account-switch/route.ts",
+          "tokens_estimated": 393,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/.planning/staging/cloud-init.yml",
+          "tokens_estimated": 1804,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        }
+      ],
+      "writes": [
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 589,
+          "action": "create"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 67,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 146,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 49,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 49,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 511,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 431,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 52,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 6,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 64,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 22,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 23,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 65,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 80,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/.claude/projects/-home-sakib-hive/memory/feedback_no_direct_main_push.md",
+          "tokens_estimated": 192,
+          "action": "create"
+        },
+        {
+          "file": "/home/sakib/.claude/projects/-home-sakib-hive/memory/MEMORY.md",
+          "tokens_estimated": 87,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 9,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/ci.yml",
+          "tokens_estimated": 18,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/layout.tsx",
+          "tokens_estimated": 74,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/auth/callback/route.ts",
+          "tokens_estimated": 59,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/console/account-switch/route.ts",
+          "tokens_estimated": 70,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.planning/staging/cloud-init.yml",
+          "tokens_estimated": 378,
+          "action": "edit"
+        }
+      ],
+      "totals": {
+        "input_tokens_estimated": 25327,
+        "output_tokens_estimated": 3041,
+        "reads_count": 12,
+        "writes_count": 22,
+        "repeated_reads_blocked": 3,
+        "anatomy_lookups": 12
+      }
+    },
+    {
+      "id": "session-2026-04-24-1232",
+      "started": "2026-04-24T16:32:56.501Z",
+      "ended": "2026-04-24T17:23:17.318Z",
+      "reads": [
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 589,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 2216,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 1762,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 608,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/middleware.ts",
+          "tokens_estimated": 560,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/lib/control-plane/client.ts",
+          "tokens_estimated": 12210,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/lib/supabase/server.ts",
+          "tokens_estimated": 300,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/ci.yml",
+          "tokens_estimated": 4358,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/layout.tsx",
+          "tokens_estimated": 70,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/auth/callback/route.ts",
+          "tokens_estimated": 457,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/console/account-switch/route.ts",
+          "tokens_estimated": 393,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/.planning/staging/cloud-init.yml",
+          "tokens_estimated": 1804,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        }
+      ],
+      "writes": [
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 589,
+          "action": "create"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 67,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 146,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 49,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 49,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 511,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 431,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 52,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 6,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 64,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 22,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 23,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 65,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 80,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/.claude/projects/-home-sakib-hive/memory/feedback_no_direct_main_push.md",
+          "tokens_estimated": 192,
+          "action": "create"
+        },
+        {
+          "file": "/home/sakib/.claude/projects/-home-sakib-hive/memory/MEMORY.md",
+          "tokens_estimated": 87,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 9,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/ci.yml",
+          "tokens_estimated": 18,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/layout.tsx",
+          "tokens_estimated": 74,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/auth/callback/route.ts",
+          "tokens_estimated": 59,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/console/account-switch/route.ts",
+          "tokens_estimated": 70,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.planning/staging/cloud-init.yml",
+          "tokens_estimated": 378,
+          "action": "edit"
+        }
+      ],
+      "totals": {
+        "input_tokens_estimated": 25327,
+        "output_tokens_estimated": 3041,
+        "reads_count": 12,
+        "writes_count": 22,
+        "repeated_reads_blocked": 3,
+        "anatomy_lookups": 12
+      }
+    },
+    {
+      "id": "session-2026-04-24-1232",
+      "started": "2026-04-24T16:32:56.501Z",
+      "ended": "2026-04-24T17:26:01.314Z",
+      "reads": [
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 589,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 2216,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 1762,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 608,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/middleware.ts",
+          "tokens_estimated": 560,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/lib/control-plane/client.ts",
+          "tokens_estimated": 12210,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/lib/supabase/server.ts",
+          "tokens_estimated": 300,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/ci.yml",
+          "tokens_estimated": 4358,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/layout.tsx",
+          "tokens_estimated": 70,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/auth/callback/route.ts",
+          "tokens_estimated": 457,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/console/account-switch/route.ts",
+          "tokens_estimated": 393,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/.planning/staging/cloud-init.yml",
+          "tokens_estimated": 1804,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        }
+      ],
+      "writes": [
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 589,
+          "action": "create"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 67,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 146,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 49,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 49,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 511,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 431,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 52,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 6,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 64,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 22,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 23,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 65,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 80,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/.claude/projects/-home-sakib-hive/memory/feedback_no_direct_main_push.md",
+          "tokens_estimated": 192,
+          "action": "create"
+        },
+        {
+          "file": "/home/sakib/.claude/projects/-home-sakib-hive/memory/MEMORY.md",
+          "tokens_estimated": 87,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 9,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/ci.yml",
+          "tokens_estimated": 18,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/layout.tsx",
+          "tokens_estimated": 74,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/auth/callback/route.ts",
+          "tokens_estimated": 59,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/console/account-switch/route.ts",
+          "tokens_estimated": 70,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.planning/staging/cloud-init.yml",
+          "tokens_estimated": 378,
+          "action": "edit"
+        }
+      ],
+      "totals": {
+        "input_tokens_estimated": 25327,
+        "output_tokens_estimated": 3041,
+        "reads_count": 12,
+        "writes_count": 22,
+        "repeated_reads_blocked": 3,
+        "anatomy_lookups": 12
+      }
+    },
+    {
+      "id": "session-2026-04-24-1232",
+      "started": "2026-04-24T16:32:56.501Z",
+      "ended": "2026-04-24T17:26:17.735Z",
+      "reads": [
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 589,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 2216,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 1762,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 608,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/middleware.ts",
+          "tokens_estimated": 560,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/lib/control-plane/client.ts",
+          "tokens_estimated": 12210,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/lib/supabase/server.ts",
+          "tokens_estimated": 300,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/ci.yml",
+          "tokens_estimated": 4358,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/layout.tsx",
+          "tokens_estimated": 70,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/auth/callback/route.ts",
+          "tokens_estimated": 457,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/console/account-switch/route.ts",
+          "tokens_estimated": 393,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/.planning/staging/cloud-init.yml",
+          "tokens_estimated": 1804,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        }
+      ],
+      "writes": [
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 589,
+          "action": "create"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 67,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 146,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 49,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 49,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 511,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 431,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 52,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 6,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 64,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 22,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 23,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 65,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 80,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/.claude/projects/-home-sakib-hive/memory/feedback_no_direct_main_push.md",
+          "tokens_estimated": 192,
+          "action": "create"
+        },
+        {
+          "file": "/home/sakib/.claude/projects/-home-sakib-hive/memory/MEMORY.md",
+          "tokens_estimated": 87,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 9,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/ci.yml",
+          "tokens_estimated": 18,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/layout.tsx",
+          "tokens_estimated": 74,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/auth/callback/route.ts",
+          "tokens_estimated": 59,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/console/account-switch/route.ts",
+          "tokens_estimated": 70,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.planning/staging/cloud-init.yml",
+          "tokens_estimated": 378,
+          "action": "edit"
+        }
+      ],
+      "totals": {
+        "input_tokens_estimated": 25327,
+        "output_tokens_estimated": 3041,
+        "reads_count": 12,
+        "writes_count": 22,
+        "repeated_reads_blocked": 3,
+        "anatomy_lookups": 12
+      }
+    },
+    {
+      "id": "session-2026-04-24-1232",
+      "started": "2026-04-24T16:32:56.501Z",
+      "ended": "2026-04-24T17:31:43.448Z",
+      "reads": [
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 589,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 2216,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 1762,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 608,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/middleware.ts",
+          "tokens_estimated": 560,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/lib/control-plane/client.ts",
+          "tokens_estimated": 12210,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/lib/supabase/server.ts",
+          "tokens_estimated": 300,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/ci.yml",
+          "tokens_estimated": 4358,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/layout.tsx",
+          "tokens_estimated": 70,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/auth/callback/route.ts",
+          "tokens_estimated": 457,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/console/account-switch/route.ts",
+          "tokens_estimated": 393,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/.planning/staging/cloud-init.yml",
+          "tokens_estimated": 1804,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        }
+      ],
+      "writes": [
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 589,
+          "action": "create"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 67,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 146,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 49,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 49,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 511,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 431,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 52,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 6,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 64,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 22,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 23,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 65,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 80,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/.claude/projects/-home-sakib-hive/memory/feedback_no_direct_main_push.md",
+          "tokens_estimated": 192,
+          "action": "create"
+        },
+        {
+          "file": "/home/sakib/.claude/projects/-home-sakib-hive/memory/MEMORY.md",
+          "tokens_estimated": 87,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 9,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/ci.yml",
+          "tokens_estimated": 18,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/layout.tsx",
+          "tokens_estimated": 74,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/auth/callback/route.ts",
+          "tokens_estimated": 59,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/console/account-switch/route.ts",
+          "tokens_estimated": 70,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.planning/staging/cloud-init.yml",
+          "tokens_estimated": 378,
+          "action": "edit"
+        }
+      ],
+      "totals": {
+        "input_tokens_estimated": 25327,
+        "output_tokens_estimated": 3041,
+        "reads_count": 12,
+        "writes_count": 22,
+        "repeated_reads_blocked": 3,
+        "anatomy_lookups": 12
+      }
+    },
+    {
+      "id": "session-2026-04-24-1232",
+      "started": "2026-04-24T16:32:56.501Z",
+      "ended": "2026-04-24T17:34:06.664Z",
+      "reads": [
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 589,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 2216,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 1762,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 608,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/middleware.ts",
+          "tokens_estimated": 560,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/lib/control-plane/client.ts",
+          "tokens_estimated": 12210,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/lib/supabase/server.ts",
+          "tokens_estimated": 300,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/ci.yml",
+          "tokens_estimated": 4358,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/layout.tsx",
+          "tokens_estimated": 70,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/auth/callback/route.ts",
+          "tokens_estimated": 457,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/console/account-switch/route.ts",
+          "tokens_estimated": 393,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/.planning/staging/cloud-init.yml",
+          "tokens_estimated": 1804,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        }
+      ],
+      "writes": [
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 589,
+          "action": "create"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 67,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 146,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 49,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 49,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 511,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 431,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 52,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 6,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 64,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 22,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 23,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 65,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 80,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/.claude/projects/-home-sakib-hive/memory/feedback_no_direct_main_push.md",
+          "tokens_estimated": 192,
+          "action": "create"
+        },
+        {
+          "file": "/home/sakib/.claude/projects/-home-sakib-hive/memory/MEMORY.md",
+          "tokens_estimated": 87,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 9,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/ci.yml",
+          "tokens_estimated": 18,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/layout.tsx",
+          "tokens_estimated": 74,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/auth/callback/route.ts",
+          "tokens_estimated": 59,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/console/account-switch/route.ts",
+          "tokens_estimated": 70,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.planning/staging/cloud-init.yml",
+          "tokens_estimated": 378,
+          "action": "edit"
+        }
+      ],
+      "totals": {
+        "input_tokens_estimated": 25327,
+        "output_tokens_estimated": 3041,
+        "reads_count": 12,
+        "writes_count": 22,
+        "repeated_reads_blocked": 3,
+        "anatomy_lookups": 12
       }
     }
   ],

--- a/apps/web-console/wrangler.jsonc
+++ b/apps/web-console/wrangler.jsonc
@@ -1,0 +1,22 @@
+// Cloudflare Pages configuration — source of truth for compatibility settings.
+//
+// Applied at project-scope via CF API during initial setup and also via
+// `wrangler pages deploy`. See docs:
+//   https://developers.cloudflare.com/pages/functions/wrangler-configuration/
+//   https://developers.cloudflare.com/workers/configuration/compatibility-flags/
+//
+// Why nodejs_compat:
+//   Next 15 + @cloudflare/next-on-pages pulls in Node built-ins (process,
+//   Buffer, util) through Supabase SSR + Next runtime helpers. Without this
+//   flag the Worker runtime throws:
+//     "Error - no nodejs_compat compatibility flag"
+//
+// compatibility_date 2024-09-23 is the earliest date that enables
+// nodejs_compat v2 semantics.
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "hive-console",
+  "compatibility_date": "2024-09-23",
+  "compatibility_flags": ["nodejs_compat"],
+  "pages_build_output_dir": ".vercel/output/static"
+}


### PR DESCRIPTION
## Summary

Adds `apps/web-console/wrangler.jsonc` so the Cloudflare Pages deploy configuration (`compatibility_date` + `compatibility_flags`) lives in the repo rather than only in the CF dashboard.

Without `nodejs_compat` the Pages Worker throws `"Error - no nodejs_compat compatibility flag"` at request time because Next 15 + `@cloudflare/next-on-pages` pulls Node built-ins (Buffer, process, util) through Supabase SSR + Next runtime helpers. The same values were set via CF API during initial deploy; this commit makes them re-applicable from code.

## Test plan

- [ ] CI green
- [ ] Merge triggers deploy-staging, wrangler picks up the file at build time
- [ ] `curl https://console.hive.scubed.co/` still returns 200 Next.js (unchanged behavior)