### PR TITLE
chore(deploy): rename staging subdomains to single-level

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -132,8 +132,8 @@ jobs:
         run: |
           for i in $(seq 1 12); do
             api_ok=0; cp_ok=0
-            curl -fsS https://api.hive.scubed.co/health >/dev/null && api_ok=1 || true
-            curl -fsS https://cp.hive.scubed.co/health  >/dev/null && cp_ok=1 || true
+            curl -fsS https://api-hive.scubed.co/health >/dev/null && api_ok=1 || true
+            curl -fsS https://cp-hive.scubed.co/health  >/dev/null && cp_ok=1 || true
             if [ "$api_ok" = 1 ] && [ "$cp_ok" = 1 ]; then
               echo "SMOKE OK"
               exit 0
@@ -167,8 +167,8 @@ jobs:
         env:
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
-          NEXT_PUBLIC_API_URL: https://api.hive.scubed.co
-          NEXT_PUBLIC_CONTROL_PLANE_URL: https://cp.hive.scubed.co
+          NEXT_PUBLIC_API_URL: https://api-hive.scubed.co
+          NEXT_PUBLIC_CONTROL_PLANE_URL: https://cp-hive.scubed.co
         run: npm run build:cf
 
       - name: Deploy to CF Pages

--- a/.planning/staging/cloud-init.yml
+++ b/.planning/staging/cloud-init.yml
@@ -40,11 +40,11 @@ write_files:
         email sakibsadmanshajib@gmail.com
       }
 
-      api.hive.scubed.co {
+      api-hive.scubed.co {
         reverse_proxy 127.0.0.1:8080
       }
 
-      cp.hive.scubed.co {
+      cp-hive.scubed.co {
         reverse_proxy 127.0.0.1:8081
       }
 

--- a/.wolf/anatomy.md
+++ b/.wolf/anatomy.md
@@ -1,7 +1,7 @@
 # anatomy.md
 
-> Auto-maintained by OpenWolf. Last scanned: 2026-04-24T17:36:01.619Z
-> Files: 518 tracked | Anatomy hits: 0 | Misses: 0
+> Auto-maintained by OpenWolf. Last scanned: 2026-04-24T17:37:16.652Z
+> Files: 517 tracked | Anatomy hits: 0 | Misses: 0
 
 ## ../.claude/projects/-home-sakib-hive/memory/
 
@@ -595,7 +595,6 @@
 - `tsconfig.json` — TypeScript configuration (~164 tok)
 - `tsconfig.tsbuildinfo` (~43098 tok)
 - `vitest.config.ts` — Vitest test configuration (~129 tok)
-- `wrangler.jsonc` — Cloudflare Pages configuration — source of truth for compatibility settings. (~252 tok)
 
 ## apps/web-console/__tests__/
 

--- a/.wolf/hooks/_session.json
+++ b/.wolf/hooks/_session.json
@@ -197,29 +197,58 @@
       "at": "2026-04-24T17:12:51.911Z"
     },
     {
-      "file": "/home/sakib/hive/apps/web-console/wrangler.jsonc",
-      "action": "create",
-      "tokens": 270,
-      "at": "2026-04-24T17:36:01.625Z"
+      "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+      "action": "edit",
+      "tokens": 6,
+      "at": "2026-04-24T17:36:55.884Z"
+    },
+    {
+      "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+      "action": "edit",
+      "tokens": 5,
+      "at": "2026-04-24T17:37:01.704Z"
+    },
+    {
+      "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+      "action": "edit",
+      "tokens": 8,
+      "at": "2026-04-24T17:37:05.140Z"
+    },
+    {
+      "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+      "action": "edit",
+      "tokens": 8,
+      "at": "2026-04-24T17:37:08.690Z"
+    },
+    {
+      "file": "/home/sakib/hive/.planning/staging/cloud-init.yml",
+      "action": "edit",
+      "tokens": 6,
+      "at": "2026-04-24T17:37:12.607Z"
+    },
+    {
+      "file": "/home/sakib/hive/.planning/staging/cloud-init.yml",
+      "action": "edit",
+      "tokens": 5,
+      "at": "2026-04-24T17:37:16.659Z"
     }
   ],
   "edit_counts": {
     "apps/web-console/app/api/budget/route.ts": 2,
     "apps/web-console/components/billing/invoice-download-button.tsx": 2,
-    "deploy/docker/docker-compose.staging.yml": 5,
-    ".github/workflows/deploy-staging.yml": 6,
+    "deploy/docker/docker-compose.staging.yml": 7,
+    ".github/workflows/deploy-staging.yml": 8,
     "../.claude/projects/-home-sakib-hive/memory/feedback_no_direct_main_push.md": 1,
     "../.claude/projects/-home-sakib-hive/memory/MEMORY.md": 1,
     ".github/workflows/ci.yml": 1,
     "apps/web-console/app/layout.tsx": 1,
     "apps/web-console/app/auth/callback/route.ts": 1,
     "apps/web-console/app/console/account-switch/route.ts": 1,
-    ".planning/staging/cloud-init.yml": 1,
-    "apps/web-console/wrangler.jsonc": 1
+    ".planning/staging/cloud-init.yml": 3
   },
   "anatomy_hits": 12,
   "anatomy_misses": 0,
   "repeated_reads_warned": 3,
   "cerebrum_warnings": 0,
-  "stop_count": 18
+  "stop_count": 9
 }

--- a/.wolf/memory.md
+++ b/.wolf/memory.md
@@ -176,13 +176,9 @@
 | 13:12 | Edited apps/web-console/app/auth/callback/route.ts | 3→5 lines | ~59 |
 | 13:12 | Edited apps/web-console/app/console/account-switch/route.ts | 4→6 lines | ~70 |
 | 13:12 | Edited .planning/staging/cloud-init.yml | modified insert_before_reject() | ~378 |
-| 13:14 | Session end: 22 writes across 9 files (route.ts, invoice-download-button.tsx, docker-compose.staging.yml, deploy-staging.yml, feedback_no_direct_main_push.md) | 12 reads | ~28368 tok |
-| 13:14 | Session end: 22 writes across 9 files (route.ts, invoice-download-button.tsx, docker-compose.staging.yml, deploy-staging.yml, feedback_no_direct_main_push.md) | 12 reads | ~28368 tok |
-| 13:21 | Session end: 22 writes across 9 files (route.ts, invoice-download-button.tsx, docker-compose.staging.yml, deploy-staging.yml, feedback_no_direct_main_push.md) | 12 reads | ~28368 tok |
-| 13:21 | Session end: 22 writes across 9 files (route.ts, invoice-download-button.tsx, docker-compose.staging.yml, deploy-staging.yml, feedback_no_direct_main_push.md) | 12 reads | ~28368 tok |
-| 13:23 | Session end: 22 writes across 9 files (route.ts, invoice-download-button.tsx, docker-compose.staging.yml, deploy-staging.yml, feedback_no_direct_main_push.md) | 12 reads | ~28368 tok |
-| 13:26 | Session end: 22 writes across 9 files (route.ts, invoice-download-button.tsx, docker-compose.staging.yml, deploy-staging.yml, feedback_no_direct_main_push.md) | 12 reads | ~28368 tok |
-| 13:26 | Session end: 22 writes across 9 files (route.ts, invoice-download-button.tsx, docker-compose.staging.yml, deploy-staging.yml, feedback_no_direct_main_push.md) | 12 reads | ~28368 tok |
-| 13:31 | Session end: 22 writes across 9 files (route.ts, invoice-download-button.tsx, docker-compose.staging.yml, deploy-staging.yml, feedback_no_direct_main_push.md) | 12 reads | ~28368 tok |
-| 13:34 | Session end: 22 writes across 9 files (route.ts, invoice-download-button.tsx, docker-compose.staging.yml, deploy-staging.yml, feedback_no_direct_main_push.md) | 12 reads | ~28368 tok |
-| 13:36 | Created apps/web-console/wrangler.jsonc | — | ~252 |
+| 13:36 | Edited .github/workflows/deploy-staging.yml | inline fix | ~6 |
+| 13:37 | Edited .github/workflows/deploy-staging.yml | inline fix | ~5 |
+| 13:37 | Edited deploy/docker/docker-compose.staging.yml | inline fix | ~8 |
+| 13:37 | Edited deploy/docker/docker-compose.staging.yml | inline fix | ~8 |
+| 13:37 | Edited .planning/staging/cloud-init.yml | inline fix | ~6 |
+| 13:37 | Edited .planning/staging/cloud-init.yml | inline fix | ~5 |

--- a/deploy/docker/docker-compose.staging.yml
+++ b/deploy/docker/docker-compose.staging.yml
@@ -34,7 +34,7 @@ services:
       LITELLM_BASE_URL: http://litellm:4000
       LITELLM_MASTER_KEY: ${LITELLM_MASTER_KEY:?LITELLM_MASTER_KEY required (seed /opt/hive/.env)}
       REDIS_URL: ${REDIS_URL:?REDIS_URL required (seed /opt/hive/.env)}
-      EDGE_PUBLIC_URL: https://api.hive.scubed.co
+      EDGE_PUBLIC_URL: https://api-hive.scubed.co
       LOG_LEVEL: info
 
   control-plane:
@@ -49,7 +49,7 @@ services:
     mem_reservation: 120m
     environment:
       REDIS_URL: ${REDIS_URL:?REDIS_URL required (seed /opt/hive/.env)}
-      CONTROL_PLANE_PUBLIC_URL: https://cp.hive.scubed.co
+      CONTROL_PLANE_PUBLIC_URL: https://cp-hive.scubed.co
       LOG_LEVEL: info
 
   litellm:


### PR DESCRIPTION
## Summary

Staging subdomains rename so Cloudflare's free Universal SSL edge cert covers them when DNS proxy is enabled (orange cloud):
- `api.hive.scubed.co`     → `api-hive.scubed.co`
- `cp.hive.scubed.co`      → `cp-hive.scubed.co`
- `console.hive.scubed.co` → `console-hive.scubed.co`

CF free-tier Universal SSL covers `scubed.co` + `*.scubed.co` only — nested 2-level hostnames need ACM ($10/mo). Pages custom domains were a CF-side exception that auto-issued per-hostname certs; the rename removes that dependency too.

Intended as transitional — moving to a dedicated `hive` domain later.

## Changes

- `.github/workflows/deploy-staging.yml` — smoke URLs + web-console build env
- `deploy/docker/docker-compose.staging.yml` — EDGE_PUBLIC_URL / CONTROL_PLANE_PUBLIC_URL
- `.planning/staging/cloud-init.yml` — Caddyfile hostnames (future re-provisions)

## Pre-merge setup (done)

- New DNS records `api-hive.scubed.co` / `cp-hive.scubed.co` → VM IP (grey)
- VM Caddyfile updated to serve both old + new hostnames
- Caddy issued Let's Encrypt certs for new names
- Verified `curl https://api-hive.scubed.co/health` + `https://cp-hive.scubed.co/health` both 200

## Post-merge (out-of-band)

- Flip `api-hive` / `cp-hive` DNS to proxied (orange)
- Add `console-hive.scubed.co` CNAME + as Pages custom domain (proxied)
- Remove old 2-level DNS records + Pages custom domain

## Test plan

- [ ] CI green
- [ ] Merge triggers deploy-staging, new smoke URLs return 200
- [ ] Post-merge: all 3 `-hive` hostnames return 200 with CF-edge cert when proxied on
- [ ] Old 2-level hostnames removed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated staging environment domain configuration from `*.hive.scubed.co` to `*-hive.scubed.co` format for improved consistency across deployment and proxy configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->