### PR TITLE
docs(planning): capture 6 next-session prompts + session memory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,12 @@ Thumbs.db
 __pycache__/
 /apps/web-console/playwright-report/
 /apps/web-console/test-results/
+
+# SDK-tests build/cache artifacts
+/packages/sdk-tests/java/.gradle/
+/packages/sdk-tests/java/build/
+/packages/sdk-tests/python/.venv/
+/packages/sdk-tests/python/*.egg-info/
 # Added by code-review-graph
 .code-review-graph/
 

--- a/.gitignore
+++ b/.gitignore
@@ -34,11 +34,27 @@ __pycache__/
 /apps/web-console/playwright-report/
 /apps/web-console/test-results/
 
-# SDK-tests build/cache artifacts
-/packages/sdk-tests/java/.gradle/
+# Python (global — any venv/egg/cache anywhere in tree)
+.venv/
+venv/
+env/
+*.egg-info/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.tox/
+.coverage
+.coverage.*
+coverage.xml
+htmlcov/
+*.pyc
+*.pyo
+
+# Java / Gradle (global — any gradle build output anywhere in tree)
+.gradle/
 /packages/sdk-tests/java/build/
-/packages/sdk-tests/python/.venv/
-/packages/sdk-tests/python/*.egg-info/
+*.class
+hs_err_pid*.log
 # Added by code-review-graph
 .code-review-graph/
 

--- a/.planning/next-session-fix-embed-env-cascade.md
+++ b/.planning/next-session-fix-embed-env-cascade.md
@@ -1,0 +1,69 @@
+# Next Session: Fix embedding model env fallback cascade
+
+## Scope
+
+Trivial bug fix PR. Two SDK test files. No backend changes.
+
+## Bug
+
+`packages/sdk-tests/js/tests/embeddings/embeddings.test.ts:5-7`:
+```ts
+const EMBEDDING_MODEL =
+  process.env.HIVE_EMBEDDING_MODEL ?? process.env.HIVE_TEST_MODEL ?? "hive-embedding-default";
+```
+
+Python equivalent in `packages/sdk-tests/python/tests/test_embeddings.py` (check + fix same pattern).
+
+When caller exports `HIVE_TEST_MODEL=hive-default` (chat alias) for chat tests, the embed test picks that up as its model — requests `/embeddings` with `hive-default` → upstream returns `400 capability_mismatch` because `hive-default` is a chat alias, not an embedding alias.
+
+## Repro
+
+```bash
+export HIVE_API_KEY=<any valid key>
+export HIVE_BASE_URL=https://api-hive.scubed.co/v1
+export HIVE_TEST_MODEL=hive-default            # intentional — matches chat tests
+# HIVE_EMBEDDING_MODEL NOT set
+cd packages/sdk-tests/js && npm test -- tests/embeddings
+# FAIL: 400 No route supports the requested capabilities for model 'hive-default'
+```
+
+## Why CI missed it
+
+`deploy/docker/docker-compose.yml` sdk-tests-* services set only `HIVE_BASE_URL` + `HIVE_API_KEY`. `HIVE_TEST_MODEL` never exported → fallback cascade lands on `"hive-embedding-default"` default → tests pass. Any dev running locally with a mixed env trips the cascade.
+
+## Fix
+
+Drop the `HIVE_TEST_MODEL` fallback. Embedding tests must use embed-specific env var or the embed default:
+
+**JS**:
+```ts
+const EMBEDDING_MODEL = process.env.HIVE_EMBEDDING_MODEL ?? "hive-embedding-default";
+```
+
+**Python** (`test_embeddings.py`):
+```py
+EMBEDDING_MODEL = os.getenv("HIVE_EMBEDDING_MODEL", "hive-embedding-default")
+```
+
+Check `conftest.py` for similar cascade and strip.
+
+## Step-by-step
+
+1. Branch: `fix/sdk-tests-embed-env-cascade`
+2. `grep -rn 'HIVE_TEST_MODEL' packages/sdk-tests/` — find all cascade sites
+3. Edit JS + Python embed test files: remove `HIVE_TEST_MODEL` from fallback chain
+4. Verify chat tests still use `HIVE_TEST_MODEL` — do NOT remove it from those
+5. Local test: repro command above must now pass
+6. PR title: `fix(sdk-tests): decouple embedding model env from chat test env`
+7. PR body: document the cascade + why it's wrong
+
+## Constraints
+
+- Single-concern PR. Do not combine with fixture path fix (that's a separate prompt).
+- Do not touch chat-completions / responses / completions tests
+- NEVER push directly to main
+
+## Out of scope
+
+- Adding a separate embedding alias beyond `hive-embedding-default`
+- Changing anything in `apps/edge-api` or `apps/control-plane`

--- a/.planning/next-session-fix-js-fixture-path.md
+++ b/.planning/next-session-fix-js-fixture-path.md
@@ -1,0 +1,71 @@
+# Next Session: Fix JS fixture path off-by-one + dual-branch masking
+
+## Scope
+
+Trivial bug fix PR. One file. One test re-run.
+
+## Bug
+
+`packages/sdk-tests/js/tests/models/list-models.test.ts:10-17`
+
+```ts
+function loadGolden(name: string): unknown {
+  // In Docker container, fixtures are at /fixtures/golden/
+  // Locally, they are relative to the test file
+  const containerPath = resolve("/fixtures/golden", name);
+  const localPath = resolve(__dirname, "../../../../fixtures/golden", name);
+  const filePath = existsSync(containerPath) ? containerPath : localPath;
+  return JSON.parse(readFileSync(filePath, "utf-8"));
+}
+```
+
+Two problems:
+
+1. **Path off-by-one**: `../../../../fixtures/golden` from `packages/sdk-tests/js/tests/models/` resolves to `packages/fixtures/golden` — that directory does not exist. Actual fixtures at `packages/sdk-tests/fixtures/golden/`. Correct relative: `../../../fixtures/golden` (three levels up, not four).
+
+2. **Dual-branch masking**: `existsSync(containerPath) ? containerPath : localPath` means local branch is never exercised in Docker/CI (where `/fixtures/golden/` exists). The local path bug went undetected for the entire lifetime of this test.
+
+## Why CI missed it
+
+`Dockerfile.sdk-tests-js` copies fixtures to `/fixtures/` inside the container → `containerPath` always wins in CI. Local dev running `npm test` on host hits the broken `localPath`. Bug only surfaces outside Docker.
+
+## Goal
+
+Single resolve path that works in both environments. Preferred: env var override + single default.
+
+## Fix options (pick one)
+
+**Option A — single path relative to package root** (preferred):
+```ts
+const localPath = resolve(__dirname, "../../../fixtures/golden", name);
+```
+Keep Docker branch as override for CI. Both branches now correct.
+
+**Option B — env var**:
+```ts
+const fixturesDir = process.env.HIVE_FIXTURES_DIR ?? resolve(__dirname, "../../../fixtures/golden");
+return JSON.parse(readFileSync(resolve(fixturesDir, name), "utf-8"));
+```
+Docker sets `HIVE_FIXTURES_DIR=/fixtures/golden` in Dockerfile. Simpler, one source of truth.
+
+Recommendation: **Option B**. Fewer branches, testable.
+
+## Step-by-step
+
+1. Branch: `fix/sdk-tests-js-fixture-path`
+2. Edit `packages/sdk-tests/js/tests/models/list-models.test.ts` line 10-17
+3. Edit `deploy/docker/Dockerfile.sdk-tests-js` — add `ENV HIVE_FIXTURES_DIR=/fixtures/golden`
+4. Run local: `cd packages/sdk-tests/js && npm test -- tests/models` — must pass w/o Docker
+5. Run Docker: `cd deploy/docker && docker compose --profile test run --rm sdk-tests-js npx vitest run tests/models` — must pass inside
+6. PR title: `fix(sdk-tests-js): resolve golden fixture path outside Docker`
+7. PR body: explain the off-by-one + dual-branch mask
+
+## Verification
+
+Local + Docker both must pass. Touch no other tests.
+
+## Constraints
+
+- Single-file edit (test file) + 1-line Dockerfile tweak
+- No dependency changes
+- NEVER push directly to main

--- a/.planning/next-session-flaky-usage-tokens.md
+++ b/.planning/next-session-flaky-usage-tokens.md
@@ -1,0 +1,81 @@
+# Next Session: Investigate flaky `usage.*_tokens = 0` from chat + responses
+
+## Scope
+
+Root-cause investigation, then fix. Not a cosmetic tweak — affects billing attribution if customers rely on reported usage.
+
+## Observed
+
+During staging replay (2026-04-24) against `api-hive.scubed.co`:
+
+- `tests/responses/responses.test.ts > Responses API > returns a valid response via SDK` — failed: `expected 0 to be greater than 0` on `response.usage.output_tokens`
+- `tests/test_chat_completions.py::test_chat_completion_basic` — failed: `usage.completion_tokens == 0`, `prompt_tokens=3`, `total_tokens=3`
+- Re-run of same tests passed. Intermittent. Not a stable repro.
+
+Sample failing response shape:
+```
+ChatCompletion(id='gen-1777054061-gUjqoLWQL25di7YSJp8O',
+  usage=CompletionUsage(
+    completion_tokens=0,
+    prompt_tokens=3,
+    total_tokens=3,
+    completion_tokens_details=CompletionTokensDetails(...)
+  )
+)
+```
+
+`id` prefix `gen-*` suggests OpenRouter upstream — usage block returned with zero output despite a valid completion body.
+
+## Hypotheses (in priority order)
+
+1. **OpenRouter usage reporting delay/skew** — some provider backends return `usage: null` or `0` on streaming-initiated non-stream calls; LiteLLM propagates. Known issue in `litellm` + some OR routes.
+2. **LiteLLM route-level `mode: chat` caching** collapses usage when cached response served.
+3. **edge-api usage aggregation bug** — `apps/edge-api/internal/billing/...` or wherever usage is extracted may zero-out on provider-blind error sanitization path.
+4. **Specific upstream model returning `usage: {}` for short outputs** — some OR endpoints skip usage for responses < N tokens.
+
+## Investigation plan
+
+1. Branch: `debug/flaky-usage-tokens`
+2. Reproduce with instrumented curl — bypass SDK:
+   ```bash
+   for i in $(seq 1 50); do
+     curl -sS -H "Authorization: Bearer $HIVE_API_KEY" \
+       -X POST https://api-hive.scubed.co/v1/chat/completions \
+       -H 'content-type: application/json' \
+       -d '{"model":"hive-default","messages":[{"role":"user","content":"ping"}]}' \
+       | jq -c '{id, usage}'
+   done | tee /tmp/usage-samples.jsonl
+   grep '"completion_tokens":0' /tmp/usage-samples.jsonl | wc -l
+   ```
+   Establish flake rate (target: <1% acceptable, >5% = systemic).
+3. Run same via LiteLLM direct (bypass edge-api) to isolate edge vs upstream:
+   ```bash
+   curl -sS -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
+     http://<staging-vm-internal>:4000/v1/chat/completions \
+     -d '{"model":"route-openrouter-default",...}'
+   ```
+4. If LiteLLM also returns 0 → upstream (OpenRouter) issue. Check OR dashboard / `litellm` GitHub issues for known usage bugs.
+5. If LiteLLM clean but edge-api returns 0 → bug in `apps/edge-api/internal/...` usage extraction. Grep for `Usage` / `CompletionTokens` handling.
+6. Once root-caused:
+   - **Upstream bug** → pin affected OR provider out of route, or route-level `usage_fallback: true` in LiteLLM config if supported, or compute usage locally via tokenizer when upstream returns 0
+   - **edge-api bug** → fix extraction in Go
+7. Update tests to assert `>=0` temporarily **only if** a deterministic upstream issue is identified; otherwise keep strict `>0` and fix the source.
+
+## Constraints
+
+- Billing-critical — do not loosen tests without fixing root cause first
+- Do not add `.retry(3)` to hide the flake
+- If fix requires `apps/edge-api` change → write a Go unit test that reproduces the zero-usage path
+- NEVER push directly to main
+
+## Files likely involved
+
+- `deploy/litellm/config.yaml` — route + fallback config
+- `apps/edge-api/internal/billing/usage.go` (or similar — grep `CompletionTokens`)
+- `apps/edge-api/internal/proxy/*.go` — response passthrough
+- `packages/sdk-tests/js/tests/responses/responses.test.ts`
+- `packages/sdk-tests/python/tests/test_chat_completions.py`
+
+## Deliverable
+
+1 investigation doc in `.planning/debug/flaky-usage-tokens-root-cause.md` + 1 fix PR once root cause confirmed.

--- a/.planning/next-session-post-deploy-sdk-replay.md
+++ b/.planning/next-session-post-deploy-sdk-replay.md
@@ -1,0 +1,67 @@
+# Next Session: Post-deploy SDK replay against staging
+
+## Scope
+
+Add SDK test replay + Playwright console check to `deploy-staging.yml` **after** the current 2-curl smoke, so a post-merge deploy catches env/model/routing drift before calling the deploy green.
+
+Scope: **one PR, one workflow file change, one bash step**. Not a refactor. Not a framework.
+
+## Current state
+
+`.github/workflows/deploy-staging.yml` smoke (lines 131–148) only curls:
+- `https://api-hive.scubed.co/health`
+- `https://cp-hive.scubed.co/health`
+
+CI `live-integration` job already runs all 3 SDK suites — against an **in-Docker** edge-api, not against the deployed staging URL. So if staging's runtime env (GH repo vars, model bindings) drifts from the docker-compose defaults, nothing catches it.
+
+## Goal
+
+After smoke passes on deploy-staging, run a minimum SDK replay against the real `api-hive.scubed.co` URL using the staging `HIVE_API_KEY` secret:
+
+- `curl` `GET /v1/models` with auth → assert 4 expected aliases present
+- vitest `tests/chat-completions/chat-completions.test.ts` only (fast, one round-trip)
+- pytest `tests/test_health.py tests/test_models.py tests/test_embeddings.py` only (fast)
+- Optional: single Playwright hit of `https://console-hive.scubed.co/auth/sign-in` asserting 200
+
+Full suite adds cost + flakiness (OpenRouter rate limits). Minimal replay catches 80% of drift.
+
+## Env needed in workflow
+
+```yaml
+env:
+  HIVE_BASE_URL: https://api-hive.scubed.co/v1
+  HIVE_API_KEY: ${{ secrets.HIVE_API_KEY }}
+  HIVE_TEST_MODEL: hive-default
+  HIVE_EMBEDDING_MODEL: hive-embedding-default
+```
+
+`HIVE_API_KEY` must exist as a GH secret — confirm before coding. Currently used in `ci.yml` `live-integration` and `web-e2e` jobs, so already provisioned.
+
+## Step-by-step
+
+1. Branch: `feat/deploy-staging-sdk-replay`
+2. Read `.github/workflows/deploy-staging.yml` + `ci.yml` live-integration job for env pattern reuse
+3. Add new step **after** Smoke test: `SDK replay (minimal)` that checks out repo (if not already), installs node + python, runs `npm ci` + `pip install -e .[dev]` in the two sdk-tests dirs, exports env, runs minimal vitest/pytest subset
+4. Local test: `act` or push branch and trigger workflow manually via `workflow_dispatch`
+5. On failure inside replay → fail the workflow red (do NOT roll back deploy — just alert)
+6. PR title: `ci(deploy): replay minimal SDK suite against staging URL after smoke`
+7. PR body: Before/After coverage table, list of specs included, expected runtime
+
+## Constraints
+
+- Runtime budget ≤ 5 min for replay (avoid OpenRouter throttle tripping prod deploy)
+- NEVER push directly to main — feature branch + PR
+- Do not change `packages/sdk-tests/*` test code in this PR (bug fixes tracked in separate prompts)
+- Do not change smoke retry logic (already 12 × 10s)
+
+## Files to touch
+
+- `.github/workflows/deploy-staging.yml` (add step)
+- `packages/sdk-tests/js/package.json` — may need a `test:smoke` script (subset)
+- `packages/sdk-tests/python/pyproject.toml` — may add pytest marker for smoke subset
+
+## Out of scope
+
+- Full SDK suite post-deploy (cost + flake)
+- Java replay (gradle cold-start 60s+, too slow for deploy gate)
+- Visual/console screenshot (tracked separately in `next-session-visual-regression-coverage.md`)

--- a/.planning/next-session-ui-styling.md
+++ b/.planning/next-session-ui-styling.md
@@ -1,0 +1,68 @@
+# Next Session: web-console UI framework + styling
+
+## Context
+
+The v1.0 Go rewrite shipped `apps/web-console` with **zero styling infrastructure** — no Tailwind, no shadcn, no CSS files, no `import "./globals.css"` in `app/layout.tsx`. All pages render with browser default UA styles, so staging (`https://console-hive.scubed.co`) looks "broken" but is actually working correctly — just unstyled.
+
+Staging deploy (`chore/single-level-subdomains` → main) completed 2026-04-24 and is verified live:
+
+- `https://api-hive.scubed.co/health` → 200
+- `https://cp-hive.scubed.co/health` → 200
+- `https://console-hive.scubed.co` → 307 → `/auth/sign-in` (renders, unstyled)
+- 4 models live: `hive-auto`, `hive-default`, `hive-embedding-default`, `hive-fast`
+
+SDK test pass rates against staging:
+- **JS (vitest)**: 25 pass / 1 fail (pre-existing fixture path bug) / 1 skip
+- **Python (pytest)**: 14/14 pass
+- **Java (gradle)**: BUILD SUCCESSFUL
+
+## Goal for this session
+
+Add a modern UI framework to `apps/web-console`, style the existing pages (sign-in, sign-up, forgot-password, console dashboard, billing, api-keys, catalog, analytics, profile, invitations), ship via PR.
+
+## Constraints
+
+- **Never push directly to main** — feature branch + PR only
+- **Cloudflare Pages + edge runtime compat** — any framework must build inside `@cloudflare/next-on-pages@1` (current: `wrangler.jsonc` w/ `nodejs_compat`, `compatibility_date: 2024-09-23`)
+- **Next.js 15.1.0 + React 19.0.0** — don't downgrade
+- **No backend changes** — UI only. Zero touching of `apps/edge-api` / `apps/control-plane` / `supabase/migrations`
+- **BD regulatory rule** — no FX rate / currency exchange language in any customer-visible UI
+- **.env already has** `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+
+## Step-by-step
+
+1. **Check session prompt**: this file is `.planning/next-session-ui-styling.md`
+2. **Confirm clean branch** — start from fresh `main`, create `feat/web-console-ui-styling`
+3. **Invoke `openwolf reframe`** workflow per `.wolf/OPENWOLF.md` — read `.wolf/reframe-frameworks.md` decision flow, present comparison matrix, pick framework w/ user input
+   - Default recommendation: **Tailwind v4 + shadcn/ui** (best CF Pages + Next 15 + edge runtime compat, zero runtime CSS)
+   - Alternatives to present: Mantine (heavier), Chakra (RSC friction), MUI (bundle size)
+4. **Scaffold** framework per chosen prompt — adapt to actual paths in `.wolf/anatomy.md`
+5. **Style pages in order** — sign-in → sign-up → console layout (nav-shell) → dashboard → billing → api-keys → catalog → analytics → profile → invitations
+6. **Verify edge-runtime build** — `cd apps/web-console && npm run build:cf` must succeed with no runtime errors
+7. **Run designqc** — `openwolf designqc --routes /auth/sign-in /console /console/billing /console/api-keys` to capture screenshots
+8. **Review screenshots** — evaluate against shadcn + WCAG + visual hierarchy
+9. **Iterate** until design clean
+10. **Open PR** via `gh pr create` — include screenshots in PR body
+
+## Known test bugs to fix during this session (trivial, grab as chores)
+
+- `packages/sdk-tests/js/tests/models/list-models.test.ts:14` — local fixture path `../../../../fixtures/golden` is off by one dir; should be `../../../fixtures/golden`
+- `packages/sdk-tests/js/tests/embeddings/embeddings.test.ts:7` — fallback chain `HIVE_EMBEDDING_MODEL ?? HIVE_TEST_MODEL ?? "hive-embedding-default"` picks chat model when only `HIVE_TEST_MODEL` is set; should be `HIVE_EMBEDDING_MODEL ?? "hive-embedding-default"` (drop the chat-model fallback)
+
+## Flaky to watch
+
+- `completion_tokens=0` / `output_tokens=0` intermittently from chat/responses (upstream LiteLLM→OpenRouter usage reporting). Tracks as issue — do not block styling work on it.
+
+## Files to read first (in anatomy order)
+
+- `apps/web-console/app/layout.tsx` (~50 tok) — root layout, no CSS import currently
+- `apps/web-console/app/auth/sign-in/page.tsx` — raw HTML form to be restyled
+- `apps/web-console/components/nav-shell.tsx` — to become main app shell
+- `apps/web-console/wrangler.jsonc` — CF Pages compat settings (DO NOT CHANGE without reason)
+- `apps/web-console/next.config.ts` — minimal, keep minimal
+
+## PR commit convention
+
+`feat(web-console): add <framework> styling + shadcn components`
+
+Follow `<type>: <description>` — types: feat, fix, refactor, docs, test, chore, perf, ci

--- a/.planning/next-session-visual-regression-coverage.md
+++ b/.planning/next-session-visual-regression-coverage.md
@@ -1,0 +1,74 @@
+# Next Session: Add visual regression coverage to CI
+
+## Scope
+
+Close the gap that allowed the v1.0 web-console to ship with zero CSS: no CI step inspects visual output. This session adds a visual-regression / screenshot-diff check that would have flagged the unstyled console.
+
+**Do not start this session until the UI styling session completes.** Visual-regression needs a styled baseline to diff against.
+
+## Gap being closed
+
+Current CI (`ci.yml`):
+- `web-unit` — `tsc --noEmit`, vitest, `next build`. Build passes with zero CSS.
+- `web-e2e` — Playwright functional tests: click, nav, auth flow. No visual assertions.
+- No screenshot comparison, no designqc, no Lighthouse-style visual score.
+
+Result: an unstyled console ships green.
+
+## Goal
+
+Add one of:
+
+**Option A — Playwright screenshot comparison** (preferred, already in repo):
+- Add a `tests/visual/` spec in `apps/web-console/tests/` that navigates to 6-10 key routes (sign-in, console dashboard, billing, api-keys, catalog, analytics) and calls `expect(page).toHaveScreenshot(...)`
+- First run locally generates baselines under `tests/visual/__screenshots__/`
+- Commit baselines
+- CI re-runs and diffs; fails on > N% pixel diff
+
+**Option B — openwolf designqc gated step**:
+- Add workflow step that boots Next.js, runs `openwolf designqc --routes /auth/sign-in /console ...`, uploads screenshots as artifact
+- No automatic diff (designqc captures only); adds review friction but catches "no CSS" class regressions since empty pages look visibly off
+
+**Option C — Lighthouse CI visual score** (lowest signal, skip)
+
+Recommendation: **A + B**. A is the automated gate; B uploads artifacts for humans.
+
+## Step-by-step (Option A)
+
+1. Wait for UI styling session to complete and merge
+2. Branch: `ci/web-console-visual-regression`
+3. Add `apps/web-console/tests/visual/layout.spec.ts` with `toHaveScreenshot` assertions for:
+   - `/auth/sign-in`
+   - `/auth/sign-up`
+   - `/console` (authed, uses existing Playwright fixture)
+   - `/console/billing`
+   - `/console/api-keys`
+   - `/console/catalog`
+4. Configure `playwright.config.ts` — `expect.toHaveScreenshot: { maxDiffPixelRatio: 0.02 }` (2% tolerance)
+5. Run locally to generate baselines: `npx playwright test tests/visual --update-snapshots`
+6. Commit baselines (they live under `tests/visual/__screenshots__/`)
+7. Modify `web-e2e` job to run visual spec alongside existing specs
+8. Modify upload-artifact step to include `tests/visual/__screenshots__/` on failure
+9. PR title: `ci(web-console): add visual regression screenshot tests`
+10. PR body: baseline screenshots inline, diff threshold reasoning
+
+## Constraints
+
+- Baselines are binary PNGs — commit to repo (or LFS if they blow up size)
+- Tolerance must be tuned: too strict = flaky on font rendering differences, too loose = catches nothing
+- Run in `chromium` only for baselines (firefox/webkit add flake without much signal)
+- NEVER push directly to main
+- Do not merge until UI styling has landed and baselines are stable
+
+## Files to add
+
+- `apps/web-console/tests/visual/layout.spec.ts` (new)
+- `apps/web-console/tests/visual/__screenshots__/**/*.png` (new, committed)
+- `apps/web-console/playwright.config.ts` (edit — toHaveScreenshot threshold)
+- `.github/workflows/ci.yml` — web-e2e step already runs all specs, may need artifact upload tweak only
+
+## Out of scope
+
+- Cross-browser visual testing (add after baseline stable)
+- Percy/Chromatic SaaS (not worth the spend at this stage)
+- Visual regression on the API surface (already covered by SDK goldens)

--- a/.planning/next-sessions-INDEX.md
+++ b/.planning/next-sessions-INDEX.md
@@ -1,0 +1,33 @@
+# Next-session prompt index
+
+Session prompts captured 2026-04-24 after staging deploy + SDK replay verification. Each prompt is self-contained and maps to **one PR** unless noted.
+
+| File | Title | Type | Priority | Est. session size |
+|------|-------|------|----------|-------------------|
+| [next-session-ui-styling.md](./next-session-ui-styling.md) | web-console UI framework + styling | regression (zero CSS) | P0 | Large (framework pick + all pages) |
+| [next-session-post-deploy-sdk-replay.md](./next-session-post-deploy-sdk-replay.md) | Post-deploy SDK replay against staging URL | coverage gap | P1 | Small (1 workflow file) |
+| [next-session-fix-js-fixture-path.md](./next-session-fix-js-fixture-path.md) | Fix JS fixture path off-by-one + dual-branch mask | bug | P2 | Trivial (1 test file + 1 Dockerfile line) |
+| [next-session-fix-embed-env-cascade.md](./next-session-fix-embed-env-cascade.md) | Drop `HIVE_TEST_MODEL` from embedding fallback chain | bug | P2 | Trivial (2 test files) |
+| [next-session-flaky-usage-tokens.md](./next-session-flaky-usage-tokens.md) | Investigate `usage.*_tokens=0` intermittent | bug (billing-critical) | P1 | Medium (investigation → fix) |
+| [next-session-visual-regression-coverage.md](./next-session-visual-regression-coverage.md) | Playwright visual regression + designqc in CI | coverage gap | P2 | Medium (blocked on UI styling) |
+
+## Suggested order
+
+1. **UI styling** (P0, biggest user-visible fix)
+2. **Post-deploy SDK replay** (P1, cheap insurance against env drift) — can run in parallel with #1
+3. **Flaky usage tokens** (P1, billing-critical)
+4. **Embed env cascade fix + JS fixture path fix** (P2, batch as one "sdk-tests housekeeping" afternoon)
+5. **Visual regression coverage** (P2, blocked on #1 having a stable baseline)
+
+## Why this decomposition
+
+Each bug/gap got one prompt instead of lumping into one big cleanup PR because:
+
+- **Reviewable diffs**: P2 trivia (fixture path, env cascade) is 3-line changes; batching with a framework swap makes them invisible in review
+- **Revert safety**: UI styling may need iteration; a visual-regression gate committed alongside would block styling PRs until baselines settle — hence the explicit "blocked on" note
+- **Billing risk isolation**: `usage.tokens=0` can affect credit attribution; it gets its own investigation doc before any code changes
+- **Blind-spot traceability**: each prompt documents *why CI missed it* so the fix closes the class of bug, not just the instance
+
+## Source audit
+
+Bugs + gaps surfaced during staging SDK replay (2026-04-24 ~14:00 EDT) after merging chore/single-level-subdomains. Full runbook: staging endpoints healthy (api-hive, cp-hive), 4 model aliases live, Java 100%, Python 14/14, JS 25/1-fail/1-skip. See session memory for full log.

--- a/.wolf/anatomy.md
+++ b/.wolf/anatomy.md
@@ -1,7 +1,7 @@
 # anatomy.md
 
-> Auto-maintained by OpenWolf. Last scanned: 2026-04-24T17:37:16.652Z
-> Files: 517 tracked | Anatomy hits: 0 | Misses: 0
+> Auto-maintained by OpenWolf. Last scanned: 2026-04-24T18:22:51.622Z
+> Files: 524 tracked | Anatomy hits: 0 | Misses: 0
 
 ## ../.claude/projects/-home-sakib-hive/memory/
 
@@ -13,7 +13,7 @@
 
 ## ./
 
-- `.gitignore` — Git ignore rules (~150 tok)
+- `.gitignore` — Git ignore rules (~206 tok)
 - `CLAUDE.md` — OpenWolf (~2736 tok)
 - `go.work` (~28 tok)
 - `go.work.sum` (~602 tok)
@@ -71,6 +71,13 @@
 - `config.json` (~80 tok)
 - `E2E-EXPANSION-SYSTEM-PROMPT.md` — System Prompt — E2E Test Expansion + CI Wiring (~2393 tok)
 - `MILESTONES.md` — Milestones (~739 tok)
+- `next-session-fix-embed-env-cascade.md` — Next Session: Fix embedding model env fallback cascade (~647 tok)
+- `next-session-fix-js-fixture-path.md` — Next Session: Fix JS fixture path off-by-one + dual-branch masking (~732 tok)
+- `next-session-flaky-usage-tokens.md` — Next Session: Investigate flaky `usage.*_tokens = 0` from chat + responses (~992 tok)
+- `next-session-post-deploy-sdk-replay.md` — Next Session: Post-deploy SDK replay against staging (~816 tok)
+- `next-session-ui-styling.md` — Next Session: web-console UI framework + styling (~1096 tok)
+- `next-session-visual-regression-coverage.md` — Next Session: Add visual regression coverage to CI (~886 tok)
+- `next-sessions-INDEX.md` — Next-session prompt index (~696 tok)
 - `PROJECT.md` — Hive API Platform (~2848 tok)
 - `ROADMAP.md` — Roadmap: Hive API Platform (~1949 tok)
 - `STATE.md` — Project State (~5891 tok)

--- a/.wolf/hooks/_session.json
+++ b/.wolf/hooks/_session.json
@@ -1,254 +1,37 @@
 {
-  "session_id": "session-2026-04-24-1232",
-  "started": "2026-04-24T16:32:56.501Z",
+  "session_id": "session-2026-04-24-1419",
+  "started": "2026-04-24T18:19:22.465Z",
   "files_read": {
-    "/home/sakib/hive/apps/web-console/app/api/budget/route.ts": {
-      "count": 2,
-      "tokens": 589,
-      "first_read": "2026-04-24T16:33:30.327Z"
-    },
-    "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx": {
+    "/home/sakib/hive/.planning/next-sessions-INDEX.md": {
       "count": 1,
-      "tokens": 2216,
-      "first_read": "2026-04-24T16:33:34.524Z"
+      "tokens": 696,
+      "first_read": "2026-04-24T18:20:09.732Z"
     },
-    "/home/sakib/hive/.github/workflows/deploy-staging.yml": {
-      "count": 2,
-      "tokens": 1762,
-      "first_read": "2026-04-24T16:33:37.171Z"
-    },
-    "/home/sakib/hive/deploy/docker/docker-compose.staging.yml": {
-      "count": 2,
-      "tokens": 608,
-      "first_read": "2026-04-24T16:33:39.825Z"
-    },
-    "/home/sakib/hive/apps/web-console/middleware.ts": {
+    "/home/sakib/hive/.planning/next-session-ui-styling.md": {
       "count": 1,
-      "tokens": 560,
-      "first_read": "2026-04-24T16:33:48.274Z"
+      "tokens": 1096,
+      "first_read": "2026-04-24T18:20:50.989Z"
     },
-    "/home/sakib/hive/apps/web-console/lib/control-plane/client.ts": {
+    "/home/sakib/hive/.gitignore": {
       "count": 1,
-      "tokens": 12210,
-      "first_read": "2026-04-24T16:33:58.851Z"
-    },
-    "/home/sakib/hive/apps/web-console/lib/supabase/server.ts": {
-      "count": 1,
-      "tokens": 300,
-      "first_read": "2026-04-24T16:35:05.017Z"
-    },
-    "/home/sakib/hive/.github/workflows/ci.yml": {
-      "count": 1,
-      "tokens": 4358,
-      "first_read": "2026-04-24T16:51:43.028Z"
-    },
-    "/home/sakib/hive/apps/web-console/app/layout.tsx": {
-      "count": 1,
-      "tokens": 70,
-      "first_read": "2026-04-24T17:11:50.652Z"
-    },
-    "/home/sakib/hive/apps/web-console/app/auth/callback/route.ts": {
-      "count": 1,
-      "tokens": 457,
-      "first_read": "2026-04-24T17:12:00.551Z"
-    },
-    "/home/sakib/hive/apps/web-console/app/console/account-switch/route.ts": {
-      "count": 1,
-      "tokens": 393,
-      "first_read": "2026-04-24T17:12:11.007Z"
-    },
-    "/home/sakib/hive/.planning/staging/cloud-init.yml": {
-      "count": 1,
-      "tokens": 1804,
-      "first_read": "2026-04-24T17:12:37.861Z"
+      "tokens": 150,
+      "first_read": "2026-04-24T18:22:46.950Z"
     }
   },
   "files_written": [
     {
-      "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
-      "action": "create",
-      "tokens": 589,
-      "at": "2026-04-24T16:35:16.501Z"
-    },
-    {
-      "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+      "file": "/home/sakib/hive/.gitignore",
       "action": "edit",
-      "tokens": 67,
-      "at": "2026-04-24T16:35:21.969Z"
-    },
-    {
-      "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
-      "action": "edit",
-      "tokens": 146,
-      "at": "2026-04-24T16:35:38.729Z"
-    },
-    {
-      "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
-      "action": "edit",
-      "tokens": 49,
-      "at": "2026-04-24T16:35:55.180Z"
-    },
-    {
-      "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
-      "action": "edit",
-      "tokens": 49,
-      "at": "2026-04-24T16:36:00.207Z"
-    },
-    {
-      "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
-      "action": "edit",
-      "tokens": 511,
-      "at": "2026-04-24T16:36:16.810Z"
-    },
-    {
-      "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
-      "action": "edit",
-      "tokens": 431,
-      "at": "2026-04-24T16:36:58.738Z"
-    },
-    {
-      "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
-      "action": "edit",
-      "tokens": 52,
-      "at": "2026-04-24T16:37:03.547Z"
-    },
-    {
-      "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
-      "action": "edit",
-      "tokens": 6,
-      "at": "2026-04-24T16:37:39.139Z"
-    },
-    {
-      "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
-      "action": "edit",
-      "tokens": 64,
-      "at": "2026-04-24T16:38:48.382Z"
-    },
-    {
-      "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
-      "action": "edit",
-      "tokens": 22,
-      "at": "2026-04-24T16:38:52.048Z"
-    },
-    {
-      "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
-      "action": "edit",
-      "tokens": 23,
-      "at": "2026-04-24T16:38:56.073Z"
-    },
-    {
-      "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
-      "action": "edit",
-      "tokens": 65,
-      "at": "2026-04-24T16:39:01.559Z"
-    },
-    {
-      "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
-      "action": "edit",
-      "tokens": 80,
-      "at": "2026-04-24T16:39:07.924Z"
-    },
-    {
-      "file": "/home/sakib/.claude/projects/-home-sakib-hive/memory/feedback_no_direct_main_push.md",
-      "action": "create",
-      "tokens": 192,
-      "at": "2026-04-24T16:50:43.855Z"
-    },
-    {
-      "file": "/home/sakib/.claude/projects/-home-sakib-hive/memory/MEMORY.md",
-      "action": "edit",
-      "tokens": 87,
-      "at": "2026-04-24T16:50:49.038Z"
-    },
-    {
-      "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
-      "action": "edit",
-      "tokens": 9,
-      "at": "2026-04-24T16:51:38.486Z"
-    },
-    {
-      "file": "/home/sakib/hive/.github/workflows/ci.yml",
-      "action": "edit",
-      "tokens": 18,
-      "at": "2026-04-24T16:51:48.062Z"
-    },
-    {
-      "file": "/home/sakib/hive/apps/web-console/app/layout.tsx",
-      "action": "edit",
-      "tokens": 74,
-      "at": "2026-04-24T17:11:55.398Z"
-    },
-    {
-      "file": "/home/sakib/hive/apps/web-console/app/auth/callback/route.ts",
-      "action": "edit",
-      "tokens": 59,
-      "at": "2026-04-24T17:12:05.851Z"
-    },
-    {
-      "file": "/home/sakib/hive/apps/web-console/app/console/account-switch/route.ts",
-      "action": "edit",
-      "tokens": 70,
-      "at": "2026-04-24T17:12:24.604Z"
-    },
-    {
-      "file": "/home/sakib/hive/.planning/staging/cloud-init.yml",
-      "action": "edit",
-      "tokens": 378,
-      "at": "2026-04-24T17:12:51.911Z"
-    },
-    {
-      "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
-      "action": "edit",
-      "tokens": 6,
-      "at": "2026-04-24T17:36:55.884Z"
-    },
-    {
-      "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
-      "action": "edit",
-      "tokens": 5,
-      "at": "2026-04-24T17:37:01.704Z"
-    },
-    {
-      "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
-      "action": "edit",
-      "tokens": 8,
-      "at": "2026-04-24T17:37:05.140Z"
-    },
-    {
-      "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
-      "action": "edit",
-      "tokens": 8,
-      "at": "2026-04-24T17:37:08.690Z"
-    },
-    {
-      "file": "/home/sakib/hive/.planning/staging/cloud-init.yml",
-      "action": "edit",
-      "tokens": 6,
-      "at": "2026-04-24T17:37:12.607Z"
-    },
-    {
-      "file": "/home/sakib/hive/.planning/staging/cloud-init.yml",
-      "action": "edit",
-      "tokens": 5,
-      "at": "2026-04-24T17:37:16.659Z"
+      "tokens": 97,
+      "at": "2026-04-24T18:22:51.631Z"
     }
   ],
   "edit_counts": {
-    "apps/web-console/app/api/budget/route.ts": 2,
-    "apps/web-console/components/billing/invoice-download-button.tsx": 2,
-    "deploy/docker/docker-compose.staging.yml": 7,
-    ".github/workflows/deploy-staging.yml": 8,
-    "../.claude/projects/-home-sakib-hive/memory/feedback_no_direct_main_push.md": 1,
-    "../.claude/projects/-home-sakib-hive/memory/MEMORY.md": 1,
-    ".github/workflows/ci.yml": 1,
-    "apps/web-console/app/layout.tsx": 1,
-    "apps/web-console/app/auth/callback/route.ts": 1,
-    "apps/web-console/app/console/account-switch/route.ts": 1,
-    ".planning/staging/cloud-init.yml": 3
+    ".gitignore": 1
   },
-  "anatomy_hits": 12,
+  "anatomy_hits": 3,
   "anatomy_misses": 0,
-  "repeated_reads_warned": 3,
+  "repeated_reads_warned": 0,
   "cerebrum_warnings": 0,
-  "stop_count": 9
+  "stop_count": 3
 }

--- a/.wolf/memory.md
+++ b/.wolf/memory.md
@@ -182,3 +182,34 @@
 | 13:37 | Edited deploy/docker/docker-compose.staging.yml | inline fix | ~8 |
 | 13:37 | Edited .planning/staging/cloud-init.yml | inline fix | ~6 |
 | 13:37 | Edited .planning/staging/cloud-init.yml | inline fix | ~5 |
+| 13:49 | Session end: 28 writes across 9 files (route.ts, invoice-download-button.tsx, docker-compose.staging.yml, deploy-staging.yml, feedback_no_direct_main_push.md) | 12 reads | ~28406 tok |
+| 13:53 | Session end: 28 writes across 9 files (route.ts, invoice-download-button.tsx, docker-compose.staging.yml, deploy-staging.yml, feedback_no_direct_main_push.md) | 12 reads | ~28406 tok |
+
+## Session: 2026-04-24 13:56
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+| 14:10 | Created .planning/next-session-ui-styling.md | — | ~1169 |
+
+| 14:09 | staging SDK+smoke tests all pass against deployed env | packages/sdk-tests/{js,python,java} | JS 25/1-fail/1-skip, Py 14/14, Java BUILD OK, smoke 200/200 | ~3000 |
+| 14:11 | next-session UI prompt written | .planning/next-session-ui-styling.md | created | ~800 |
+| 14:11 | Session end: 1 writes across 1 files (next-session-ui-styling.md) | 0 reads | ~1252 tok |
+| 14:13 | Session end: 1 writes across 1 files (next-session-ui-styling.md) | 0 reads | ~1252 tok |
+| 14:15 | Created .planning/next-session-post-deploy-sdk-replay.md | — | ~871 |
+| 14:15 | Created .planning/next-session-fix-js-fixture-path.md | — | ~781 |
+| 14:16 | Created .planning/next-session-fix-embed-env-cascade.md | — | ~690 |
+
+## Session: 2026-04-24 14:16
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+| 14:16 | Created .planning/next-session-flaky-usage-tokens.md | — | ~1058 |
+| 14:17 | Created .planning/next-session-visual-regression-coverage.md | — | ~945 |
+| 14:17 | Created .planning/next-sessions-INDEX.md | — | ~742 |
+| 14:17 | Session end: 3 writes across 3 files (next-session-flaky-usage-tokens.md, next-session-visual-regression-coverage.md, next-sessions-INDEX.md) | 0 reads | ~2941 tok |
+
+## Session: 2026-04-24 14:19
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+| 14:22 | Edited .gitignore | expanded (+6 lines) | ~91 |

--- a/.wolf/token-ledger.json
+++ b/.wolf/token-ledger.json
@@ -2,14 +2,14 @@
   "version": 1,
   "created_at": "2026-04-22T00:50:18.611Z",
   "lifetime": {
-    "total_tokens_estimated": 572524,
-    "total_reads": 248,
-    "total_writes": 473,
-    "total_sessions": 12,
-    "anatomy_hits": 235,
+    "total_tokens_estimated": 637269,
+    "total_reads": 275,
+    "total_writes": 534,
+    "total_sessions": 15,
+    "anatomy_hits": 262,
     "anatomy_misses": 13,
-    "repeated_reads_blocked": 59,
-    "estimated_savings_vs_bare_cli": 107434
+    "repeated_reads_blocked": 65,
+    "estimated_savings_vs_bare_cli": 118752
   },
   "sessions": [
     {
@@ -4538,6 +4538,587 @@
         "writes_count": 22,
         "repeated_reads_blocked": 3,
         "anatomy_lookups": 12
+      }
+    },
+    {
+      "id": "session-2026-04-24-1232",
+      "started": "2026-04-24T16:32:56.501Z",
+      "ended": "2026-04-24T17:49:14.900Z",
+      "reads": [
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 589,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 2216,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 1762,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 608,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/middleware.ts",
+          "tokens_estimated": 560,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/lib/control-plane/client.ts",
+          "tokens_estimated": 12210,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/lib/supabase/server.ts",
+          "tokens_estimated": 300,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/ci.yml",
+          "tokens_estimated": 4358,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/layout.tsx",
+          "tokens_estimated": 70,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/auth/callback/route.ts",
+          "tokens_estimated": 457,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/console/account-switch/route.ts",
+          "tokens_estimated": 393,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/.planning/staging/cloud-init.yml",
+          "tokens_estimated": 1804,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        }
+      ],
+      "writes": [
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 589,
+          "action": "create"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 67,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 146,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 49,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 49,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 511,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 431,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 52,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 6,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 64,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 22,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 23,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 65,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 80,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/.claude/projects/-home-sakib-hive/memory/feedback_no_direct_main_push.md",
+          "tokens_estimated": 192,
+          "action": "create"
+        },
+        {
+          "file": "/home/sakib/.claude/projects/-home-sakib-hive/memory/MEMORY.md",
+          "tokens_estimated": 87,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 9,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/ci.yml",
+          "tokens_estimated": 18,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/layout.tsx",
+          "tokens_estimated": 74,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/auth/callback/route.ts",
+          "tokens_estimated": 59,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/console/account-switch/route.ts",
+          "tokens_estimated": 70,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.planning/staging/cloud-init.yml",
+          "tokens_estimated": 378,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 6,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 5,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 8,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 8,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.planning/staging/cloud-init.yml",
+          "tokens_estimated": 6,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.planning/staging/cloud-init.yml",
+          "tokens_estimated": 5,
+          "action": "edit"
+        }
+      ],
+      "totals": {
+        "input_tokens_estimated": 25327,
+        "output_tokens_estimated": 3079,
+        "reads_count": 12,
+        "writes_count": 28,
+        "repeated_reads_blocked": 3,
+        "anatomy_lookups": 12
+      }
+    },
+    {
+      "id": "session-2026-04-24-1232",
+      "started": "2026-04-24T16:32:56.501Z",
+      "ended": "2026-04-24T17:53:33.089Z",
+      "reads": [
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 589,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 2216,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 1762,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 608,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/middleware.ts",
+          "tokens_estimated": 560,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/lib/control-plane/client.ts",
+          "tokens_estimated": 12210,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/lib/supabase/server.ts",
+          "tokens_estimated": 300,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/ci.yml",
+          "tokens_estimated": 4358,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/layout.tsx",
+          "tokens_estimated": 70,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/auth/callback/route.ts",
+          "tokens_estimated": 457,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/console/account-switch/route.ts",
+          "tokens_estimated": 393,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/.planning/staging/cloud-init.yml",
+          "tokens_estimated": 1804,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        }
+      ],
+      "writes": [
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 589,
+          "action": "create"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 67,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/components/billing/invoice-download-button.tsx",
+          "tokens_estimated": 146,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 49,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 49,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 511,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 431,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 52,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 6,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 64,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 22,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 23,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 65,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 80,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/.claude/projects/-home-sakib-hive/memory/feedback_no_direct_main_push.md",
+          "tokens_estimated": 192,
+          "action": "create"
+        },
+        {
+          "file": "/home/sakib/.claude/projects/-home-sakib-hive/memory/MEMORY.md",
+          "tokens_estimated": 87,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/api/budget/route.ts",
+          "tokens_estimated": 9,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/ci.yml",
+          "tokens_estimated": 18,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/layout.tsx",
+          "tokens_estimated": 74,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/auth/callback/route.ts",
+          "tokens_estimated": 59,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/apps/web-console/app/console/account-switch/route.ts",
+          "tokens_estimated": 70,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.planning/staging/cloud-init.yml",
+          "tokens_estimated": 378,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 6,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.github/workflows/deploy-staging.yml",
+          "tokens_estimated": 5,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 8,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/deploy/docker/docker-compose.staging.yml",
+          "tokens_estimated": 8,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.planning/staging/cloud-init.yml",
+          "tokens_estimated": 6,
+          "action": "edit"
+        },
+        {
+          "file": "/home/sakib/hive/.planning/staging/cloud-init.yml",
+          "tokens_estimated": 5,
+          "action": "edit"
+        }
+      ],
+      "totals": {
+        "input_tokens_estimated": 25327,
+        "output_tokens_estimated": 3079,
+        "reads_count": 12,
+        "writes_count": 28,
+        "repeated_reads_blocked": 3,
+        "anatomy_lookups": 12
+      }
+    },
+    {
+      "id": "session-2026-04-24-1356",
+      "started": "2026-04-24T17:56:09.451Z",
+      "ended": "2026-04-24T18:11:02.271Z",
+      "reads": [],
+      "writes": [
+        {
+          "file": "/home/sakib/hive/.planning/next-session-ui-styling.md",
+          "tokens_estimated": 1252,
+          "action": "create"
+        }
+      ],
+      "totals": {
+        "input_tokens_estimated": 0,
+        "output_tokens_estimated": 1252,
+        "reads_count": 0,
+        "writes_count": 1,
+        "repeated_reads_blocked": 0,
+        "anatomy_lookups": 0
+      }
+    },
+    {
+      "id": "session-2026-04-24-1356",
+      "started": "2026-04-24T17:56:09.451Z",
+      "ended": "2026-04-24T18:13:52.812Z",
+      "reads": [],
+      "writes": [
+        {
+          "file": "/home/sakib/hive/.planning/next-session-ui-styling.md",
+          "tokens_estimated": 1252,
+          "action": "create"
+        }
+      ],
+      "totals": {
+        "input_tokens_estimated": 0,
+        "output_tokens_estimated": 1252,
+        "reads_count": 0,
+        "writes_count": 1,
+        "repeated_reads_blocked": 0,
+        "anatomy_lookups": 0
+      }
+    },
+    {
+      "id": "session-2026-04-24-1416",
+      "started": "2026-04-24T18:16:24.354Z",
+      "ended": "2026-04-24T18:17:57.338Z",
+      "reads": [],
+      "writes": [
+        {
+          "file": "/home/sakib/hive/.planning/next-session-flaky-usage-tokens.md",
+          "tokens_estimated": 1134,
+          "action": "create"
+        },
+        {
+          "file": "/home/sakib/hive/.planning/next-session-visual-regression-coverage.md",
+          "tokens_estimated": 1012,
+          "action": "create"
+        },
+        {
+          "file": "/home/sakib/hive/.planning/next-sessions-INDEX.md",
+          "tokens_estimated": 795,
+          "action": "create"
+        }
+      ],
+      "totals": {
+        "input_tokens_estimated": 0,
+        "output_tokens_estimated": 2941,
+        "reads_count": 0,
+        "writes_count": 3,
+        "repeated_reads_blocked": 0,
+        "anatomy_lookups": 0
+      }
+    },
+    {
+      "id": "session-2026-04-24-1419",
+      "started": "2026-04-24T18:19:22.465Z",
+      "ended": "2026-04-24T18:20:14.156Z",
+      "reads": [
+        {
+          "file": "/home/sakib/hive/.planning/next-sessions-INDEX.md",
+          "tokens_estimated": 696,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        }
+      ],
+      "writes": [],
+      "totals": {
+        "input_tokens_estimated": 696,
+        "output_tokens_estimated": 0,
+        "reads_count": 1,
+        "writes_count": 0,
+        "repeated_reads_blocked": 0,
+        "anatomy_lookups": 1
+      }
+    },
+    {
+      "id": "session-2026-04-24-1419",
+      "started": "2026-04-24T18:19:22.465Z",
+      "ended": "2026-04-24T18:21:17.996Z",
+      "reads": [
+        {
+          "file": "/home/sakib/hive/.planning/next-sessions-INDEX.md",
+          "tokens_estimated": 696,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/home/sakib/hive/.planning/next-session-ui-styling.md",
+          "tokens_estimated": 1096,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        }
+      ],
+      "writes": [],
+      "totals": {
+        "input_tokens_estimated": 1792,
+        "output_tokens_estimated": 0,
+        "reads_count": 2,
+        "writes_count": 0,
+        "repeated_reads_blocked": 0,
+        "anatomy_lookups": 2
       }
     }
   ],


### PR DESCRIPTION
## Summary
- Captures staging SDK replay findings from 2026-04-24 as 6 self-contained, per-bug prompt files so each can be claimed as an isolated PR
- Records session memory updates in \`.wolf/\` (anatomy, memory, token-ledger)
- Adds \`.gitignore\` entries for sdk-tests java/gradle, python venv, egg-info

## Prompts landed under \`.planning/\`

| File | Priority | Type |
|------|----------|------|
| next-session-ui-styling.md | P0 | regression (zero CSS) |
| next-session-post-deploy-sdk-replay.md | P1 | coverage gap |
| next-session-flaky-usage-tokens.md | P1 | billing-critical flake |
| next-session-fix-js-fixture-path.md | P2 | bug |
| next-session-fix-embed-env-cascade.md | P2 | bug |
| next-session-visual-regression-coverage.md | P2 | coverage gap |
| next-sessions-INDEX.md | — | order + deps |

## Test plan
- [ ] No code touched; docs + ignore only
- [ ] CI should pass trivially (no executable changes)