### PR TITLE
fix(sdk-tests): resolve fixture path + decouple embedding env cascade

### DIFF
--- a/deploy/docker/Dockerfile.sdk-tests-js
+++ b/deploy/docker/Dockerfile.sdk-tests-js
@@ -4,4 +4,5 @@ COPY packages/sdk-tests/js/package.json packages/sdk-tests/js/package-lock.json*
 RUN npm install
 COPY packages/sdk-tests/js/ ./
 COPY packages/sdk-tests/fixtures/ /fixtures/
+ENV HIVE_FIXTURES_DIR=/fixtures/golden
 CMD ["npx", "vitest", "run"]

--- a/packages/sdk-tests/js/tests/embeddings/embeddings.test.ts
+++ b/packages/sdk-tests/js/tests/embeddings/embeddings.test.ts
@@ -4,7 +4,7 @@ import OpenAI from "openai";
 const BASE_URL = process.env.HIVE_BASE_URL ?? "http://localhost:8080/v1";
 const API_KEY = process.env.HIVE_API_KEY ?? "test-key";
 const EMBEDDING_MODEL =
-  process.env.HIVE_EMBEDDING_MODEL ?? process.env.HIVE_TEST_MODEL ?? "hive-embedding-default";
+  process.env.HIVE_EMBEDDING_MODEL ?? "hive-embedding-default";
 
 describe("Embeddings", () => {
   const client = new OpenAI({ baseURL: BASE_URL, apiKey: API_KEY });

--- a/packages/sdk-tests/js/tests/models/list-models.test.ts
+++ b/packages/sdk-tests/js/tests/models/list-models.test.ts
@@ -1,19 +1,18 @@
 import { describe, it, expect } from "vitest";
 import OpenAI from "openai";
-import { readFileSync, existsSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 const BASE_URL = process.env.HIVE_BASE_URL ?? "http://localhost:8080/v1";
 const API_KEY = process.env.HIVE_API_KEY ?? "test-key";
 const authHeaders = { Authorization: `Bearer ${API_KEY}` };
 
+const FIXTURES_DIR =
+  process.env.HIVE_FIXTURES_DIR ??
+  resolve(__dirname, "../../../fixtures/golden");
+
 function loadGolden(name: string): unknown {
-  // In Docker container, fixtures are at /fixtures/golden/
-  // Locally, they are relative to the test file
-  const containerPath = resolve("/fixtures/golden", name);
-  const localPath = resolve(__dirname, "../../../../fixtures/golden", name);
-  const filePath = existsSync(containerPath) ? containerPath : localPath;
-  return JSON.parse(readFileSync(filePath, "utf-8"));
+  return JSON.parse(readFileSync(resolve(FIXTURES_DIR, name), "utf-8"));
 }
 
 describe("List Models", () => {

--- a/packages/sdk-tests/python/tests/test_embeddings.py
+++ b/packages/sdk-tests/python/tests/test_embeddings.py
@@ -5,10 +5,7 @@ from openai import OpenAI
 
 BASE_URL = os.getenv("HIVE_BASE_URL", "http://localhost:8080/v1")
 API_KEY = os.getenv("HIVE_API_KEY", "test-key")
-EMBEDDING_MODEL = os.getenv(
-    "HIVE_EMBEDDING_MODEL",
-    os.getenv("HIVE_TEST_MODEL", "hive-embedding-default"),
-)
+EMBEDDING_MODEL = os.getenv("HIVE_EMBEDDING_MODEL", "hive-embedding-default")
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

Two small, unrelated sdk-tests infrastructure bugs batched as housekeeping — both surfaced during staging SDK replay on 2026-04-24 (see \`.planning/next-session-fix-js-fixture-path.md\` and \`.planning/next-session-fix-embed-env-cascade.md\`, landing in #94).

### 1. JS fixture path off-by-one + dual-branch masking

\`packages/sdk-tests/js/tests/models/list-models.test.ts\` previously did:

\`\`\`ts
const containerPath = resolve(\"/fixtures/golden\", name);
const localPath    = resolve(__dirname, \"../../../../fixtures/golden\", name);
const filePath     = existsSync(containerPath) ? containerPath : localPath;
\`\`\`

- \`../../../../fixtures/golden\` from \`packages/sdk-tests/js/tests/models/\` resolves to \`packages/fixtures/golden\` — does not exist. Correct is \`../../../fixtures/golden\`.
- Inside Docker, \`/fixtures/golden\` always exists → container branch always won → local bug never exercised in CI.

**Fix**: env-var driven single source of truth.

\`\`\`ts
const FIXTURES_DIR =
  process.env.HIVE_FIXTURES_DIR ??
  resolve(__dirname, \"../../../fixtures/golden\");

function loadGolden(name) {
  return JSON.parse(readFileSync(resolve(FIXTURES_DIR, name), \"utf-8\"));
}
\`\`\`

\`Dockerfile.sdk-tests-js\` exports \`HIVE_FIXTURES_DIR=/fixtures/golden\` so the container contract is preserved without an \`existsSync\` branch.

### 2. Embedding env fallback picks chat model

JS + Python embed tests cascaded \`HIVE_EMBEDDING_MODEL → HIVE_TEST_MODEL\`. When a dev exported \`HIVE_TEST_MODEL=hive-default\` for chat tests, embed tests picked up the chat alias → upstream \`400 capability_mismatch\`.

CI missed it because \`docker-compose.yml\` sdk-tests-* services only set \`HIVE_BASE_URL\` + \`HIVE_API_KEY\`; \`HIVE_TEST_MODEL\` was never exported inside Docker, so the cascade fell through to the embed default.

**Fix**: drop \`HIVE_TEST_MODEL\` from the embed fallback chain. Chat tests keep \`HIVE_TEST_MODEL\` unchanged.

\`\`\`ts
// JS
const EMBEDDING_MODEL = process.env.HIVE_EMBEDDING_MODEL ?? \"hive-embedding-default\";
\`\`\`

\`\`\`py
# Python
EMBEDDING_MODEL = os.getenv(\"HIVE_EMBEDDING_MODEL\", \"hive-embedding-default\")
\`\`\`

## Test plan

- [x] Verified \`resolve(__dirname, \"../../../fixtures/golden\")\` resolves to \`packages/sdk-tests/fixtures/golden\` on host
- [x] Verified \`models-list.json\` exists at that path
- [ ] CI live-integration (runs inside Docker, both branches touched): fixture path fix should still pass via \`HIVE_FIXTURES_DIR\` env; embed tests should still pass with default
- [ ] Optional: re-run host \`cd packages/sdk-tests/js && npm test -- tests/models\` — must pass now against staging

## Files touched

- \`packages/sdk-tests/js/tests/models/list-models.test.ts\`
- \`packages/sdk-tests/js/tests/embeddings/embeddings.test.ts\`
- \`packages/sdk-tests/python/tests/test_embeddings.py\`
- \`deploy/docker/Dockerfile.sdk-tests-js\`

## Out of scope

- UI styling (P0, separate session)
- Post-deploy SDK replay workflow (P1, next PR)
- Flaky \`usage.tokens=0\` investigation (P1 billing-critical, separate)
- Visual regression coverage (P2, blocked on UI styling)