### PR TITLE
ci(deploy): replay minimal SDK suite against staging URL after smoke

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -213,6 +213,55 @@ jobs:
           echo "SMOKE FAIL"
           exit 1
 
+  sdk-replay:
+    name: SDK replay against staging URL
+    needs: [detect-changes, deploy-vm]
+    if: needs.detect-changes.outputs.should_deploy == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      HIVE_BASE_URL: https://api-hive.scubed.co/v1
+      HIVE_API_KEY: ${{ secrets.HIVE_API_KEY }}
+      HIVE_TEST_MODEL: hive-default
+      HIVE_EMBEDDING_MODEL: hive-embedding-default
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Assert model catalog
+        run: |
+          set -euo pipefail
+          body="$(curl -fsS -H "Authorization: Bearer $HIVE_API_KEY" "$HIVE_BASE_URL/models")"
+          echo "$body" | jq -e '.data | length >= 4' >/dev/null
+          for alias in hive-auto hive-default hive-embedding-default hive-fast; do
+            echo "$body" | jq -e --arg id "$alias" '.data | map(.id) | index($id) != null' >/dev/null \
+              || { echo "missing alias: $alias"; exit 1; }
+          done
+          echo "catalog OK"
+
+      - name: Install JS sdk-tests deps
+        working-directory: packages/sdk-tests/js
+        run: npm install --no-audit --no-fund
+
+      - name: Run JS chat-completions replay
+        working-directory: packages/sdk-tests/js
+        run: npx vitest run tests/chat-completions
+
+      - name: Install Python sdk-tests deps
+        working-directory: packages/sdk-tests/python
+        run: pip install -e '.[dev]'
+
+      - name: Run Python health/models/embeddings replay
+        working-directory: packages/sdk-tests/python
+        run: pytest tests/test_health.py tests/test_models.py tests/test_embeddings.py -q
+
   deploy-pages:
     name: Deploy web-console to Cloudflare Pages
     needs: deploy-vm


### PR DESCRIPTION
## Summary

Adds a new \`sdk-replay\` job to \`.github/workflows/deploy-staging.yml\` that runs after \`deploy-vm\` (parallel with \`deploy-pages\`). Closes the CI coverage gap documented in \`.planning/next-session-post-deploy-sdk-replay.md\` (landing in #94): \`ci.yml live-integration\` exercises only an in-Docker edge-api and never the deployed URL, so staging env/model drift slips past the 2-curl smoke.

## Replay surface (budget ≤ 5 min)

| Check | Purpose |
|-------|---------|
| \`GET /v1/models\` w/ auth | Assert all four aliases present: \`hive-auto\`, \`hive-default\`, \`hive-embedding-default\`, \`hive-fast\` |
| vitest \`tests/chat-completions\` | One round-trip via OpenAI SDK — catches auth/routing/usage regressions |
| pytest \`test_health test_models test_embeddings\` | Fast Python parity |

## Env

\`\`\`yaml
HIVE_BASE_URL: https://api-hive.scubed.co/v1
HIVE_API_KEY: \${{ secrets.HIVE_API_KEY }}   # already provisioned (ci.yml)
HIVE_TEST_MODEL: hive-default
HIVE_EMBEDDING_MODEL: hive-embedding-default
\`\`\`

## Why minimal

Full SDK suite post-deploy would:

1. Burn OpenRouter rate budget on every push/cron
2. Amplify known flakes (\`usage.*_tokens=0\` — see separate P1 investigation prompt)
3. Add >5 min to deploy path

Minimal replay catches 80% of drift; failure fails the workflow red but does NOT roll back the VM — \`deploy-vm\` has already landed by the time replay runs.

## Out of scope

- Java replay (gradle cold-start >60s)
- Visual/console screenshot (tracked in \`next-session-visual-regression-coverage.md\`, blocked on UI styling PR)
- Full suite (cost + flake)

## Test plan

- [x] YAML syntax validated locally
- [ ] Trigger via \`workflow_dispatch\` after merge to smoke the new job end-to-end
- [ ] Confirm failure path (tamper model alias) fails workflow as expected on a follow-up test