### PR TITLE
ci(deploy-staging): hourly cron with diff-gate vs last successful run

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -13,8 +13,8 @@ on:
       - 'deploy/litellm/**'
       - '.github/workflows/deploy-staging.yml'
   schedule:
-    # Every 6 hours
-    - cron: '0 */6 * * *'
+    # Hourly — `detect-changes` job skips deploy if no diff vs last successful run
+    - cron: '0 * * * *'
   workflow_dispatch:
 
 concurrency:
@@ -26,8 +26,77 @@ env:
   IMAGE_PREFIX: ghcr.io/${{ github.repository }}
 
 jobs:
+  detect-changes:
+    name: Detect changes vs last successful deploy
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    outputs:
+      should_deploy: ${{ steps.check.outputs.should_deploy }}
+      reason: ${{ steps.check.outputs.reason }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT: ${{ github.event_name }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          # push + workflow_dispatch: always deploy (paths filter already applies to push)
+          if [ "$EVENT" != "schedule" ]; then
+            echo "should_deploy=true"  >> "$GITHUB_OUTPUT"
+            echo "reason=non-cron ($EVENT)" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Cron: only deploy if watched paths changed vs the SHA of the last
+          # successful deploy-staging run. If no prior run recorded, deploy once.
+          last_sha=$(gh run list \
+              --workflow=deploy-staging.yml \
+              --branch=main \
+              --status=success \
+              --limit=1 \
+              --json headSha \
+              --jq '.[0].headSha // ""')
+
+          if [ -z "$last_sha" ]; then
+            echo "should_deploy=true"  >> "$GITHUB_OUTPUT"
+            echo "reason=no prior successful deploy"  >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$last_sha" = "$HEAD_SHA" ]; then
+            echo "should_deploy=false" >> "$GITHUB_OUTPUT"
+            echo "reason=HEAD == last_deploy_sha ($last_sha)" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Make sure we have the last-deploy SHA locally so git diff can resolve it.
+          git fetch --quiet origin "$last_sha" || true
+
+          if git diff --quiet "$last_sha" "$HEAD_SHA" -- \
+              apps packages deploy/docker deploy/litellm \
+              .github/workflows/deploy-staging.yml; then
+            echo "should_deploy=false" >> "$GITHUB_OUTPUT"
+            echo "reason=no diff in watched paths since $last_sha" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_deploy=true"  >> "$GITHUB_OUTPUT"
+            echo "reason=diff detected since $last_sha"  >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Log decision
+        run: echo "should_deploy=${{ steps.check.outputs.should_deploy }} reason='${{ steps.check.outputs.reason }}'"
+
   build-images:
     name: Build & push Go images
+    needs: detect-changes
+    if: needs.detect-changes.outputs.should_deploy == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

Changes the staging cron from every 6h to **hourly**, but adds a \`detect-changes\` gate so the hourly tick only triggers a real deploy when watched paths have changed since the last successful \`deploy-staging\` run. Conflicts with #96 in the same workflow file (rebase the merged-second one).

## Why

Old \`0 */6 * * *\` cron rebuilt + redeployed the stack 4×/day even when nothing was different — GHCR image churn, CF Pages rebuild, OCI restart cycles, all for zero code change. Now: hourly when there is a diff, no work when there isn't.

## How

\`detect-changes\` job runs first on every trigger:

| Trigger | Decision |
|---------|----------|
| \`push\` | always deploy (push already path-filtered) |
| \`workflow_dispatch\` | always deploy |
| \`schedule\` (cron) | gh-api lookup of last successful run's SHA → \`git diff --quiet\` against HEAD over watched paths → deploy only on diff |

Downstream jobs (\`build-images\` → \`deploy-vm\` → \`deploy-pages\`) gate on \`needs.detect-changes.outputs.should_deploy == 'true'\`. When skipped, the dependents skip via default \`success()\` semantics.

First-run case (no prior successful run) deploys once so fresh branches still bootstrap.

## Watched paths (same set as the existing \`push.paths\` filter)

- \`apps\`
- \`packages\`
- \`deploy/docker\`
- \`deploy/litellm\`
- \`.github/workflows/deploy-staging.yml\`

## Test plan

- [x] YAML syntax valid (yaml.safe_load OK)
- [ ] Merge → wait for first scheduled cron tick — \`detect-changes\` should output \`should_deploy=false reason='HEAD == last_deploy_sha'\` (or 'no diff in watched paths since ...')
- [ ] Push a no-op doc-only commit on main → cron tick should still skip (paths filter handles it on push, diff-gate handles it on cron)
- [ ] Push a real \`apps/edge-api/...\` change → cron should deploy

## Conflicts

This PR + #96 both edit \`.github/workflows/deploy-staging.yml\`. Whichever lands second needs a rebase — trivial (additive non-overlapping changes: this PR adds a \`detect-changes\` job at the top + cron schedule line; #96 adds a \`sdk-replay\` job between \`deploy-vm\` and \`deploy-pages\`). #96 should also gain \`needs: detect-changes, if: needs.detect-changes.outputs.should_deploy == 'true'\` so the replay also skips on quiet ticks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized staging deployment workflow with automated change detection. The system now verifies whether monitored files have been modified before proceeding with builds and deployments, significantly reducing unnecessary deployment cycles and improving resource efficiency.
  * Updated deployment automation schedule to perform checks at hourly intervals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->