### PR TITLE
docs(planning): add 2 follow-up prompts + update index

### DIFF
--- a/.planning/next-session-clamp-responses-streaming.md
+++ b/.planning/next-session-clamp-responses-streaming.md
@@ -1,0 +1,129 @@
+# Next Session: Extend usage clamp to responses-API + streaming paths
+
+## Context
+
+PR #99 (merged 2026-04-24) shipped a `clampZeroCompletionUsage` helper that
+fixes the billing leak observed during the staging burst (5.9% of chat
+completions returned `usage.completion_tokens=0` while carrying real
+output text). The clamp is **currently wired only into**:
+
+- `normalizeChatCompletion` — `apps/edge-api/internal/inference/chat_completions.go`
+- `normalizeCompletion` — `apps/edge-api/internal/inference/completions.go`
+
+Two more code paths can hit the same upstream-zero-usage bug and are still
+unprotected:
+
+1. **Responses API** — `normalizeResponsesSync` in `apps/edge-api/internal/inference/responses.go:247`
+2. **Streaming accumulator** — `apps/edge-api/internal/inference/stream.go`,
+   especially the path around line 286 (`if includeUsage && !accumulator.HasUsage`)
+   and line 308 (`if accumulator.HasUsage`). Streaming usage events are
+   accumulated chunk-by-chunk and flushed at the end; the same upstream
+   provider that returns `ct=0` non-stream will return `usage` events with
+   `completion_tokens=0` on stream too.
+
+Both leaks have the same revenue impact as the chat-completions leak — the
+orchestrator records `OutputTokens = usage.CompletionTokens` for any path,
+so any zero propagates to the ledger.
+
+## Scope
+
+Single PR, single concern: extend the clamp to the two unprotected paths.
+
+Out of scope:
+
+- Embeddings (`normalizeEmbeddings`) — embedding usage shape is different
+  and `completion_tokens` is intentionally 0 there.
+- LiteLLM provider pinning to reduce variance (separate prompt:
+  `next-session-litellm-route-pinning.md`).
+- Cross-request retroactive ledger reprice (business decision, not code).
+
+## Goal
+
+After this session merges, a re-run of the same 50-curl burst against
+`api-hive.scubed.co/v1/responses` and `…/v1/chat/completions?stream=true`
+must show **zero `ct=0` events on non-empty output** — same guarantee that
+non-stream chat completions now have.
+
+## Step-by-step
+
+1. Branch: `fix/edge-api-usage-clamp-responses-streaming`
+2. Read `apps/edge-api/internal/inference/responses.go:247` —
+   `normalizeResponsesSync(respBody, aliasID, req)`. Note that responses
+   output is structured as `output[]` array of items
+   (`{type: "message", role, content[]}`, `{type: "reasoning", ...}`,
+   tool_call items, etc.) — not a flat `choices[].message.content`. You
+   need a helper `responsesOutputTexts(items []ResponsesOutputItem)` that
+   walks `output_text` items and returns the user-visible string slice.
+3. Wire `clampZeroCompletionUsage(usage, responsesOutputTexts(out), id, alias, EndpointResponses)`
+   into `normalizeResponsesSync` after the Unmarshal.
+4. Read `apps/edge-api/internal/inference/stream.go` — find the place
+   where the `accumulator` produces the final `UsageResponse`. Likely
+   around line 308–337. Walk the accumulator's recorded text content
+   (the assistant message accumulated across chunks) and pass that into
+   `clampZeroCompletionUsage` before the final flush to the orchestrator.
+   - For chat-completions streaming: text comes from
+     `delta.content` chunks → already accumulated as `accumulator.Content`
+     (or similar — verify field name).
+   - For responses streaming (`stream_responses.go`): text accumulates in
+     `output_text.delta` events.
+   - Both eventually call into the orchestrator's `recordCompletedEvent`
+     — clamp must fire BEFORE that call.
+5. Add unit tests in `usage_clamp_test.go`:
+   - `TestNormalizeResponsesSync_ClampsZeroCt` — synthetic body with
+     output_text and `usage.output_tokens=0`.
+   - `TestStreamAccumulator_ClampsZeroCt` (or co-locate with
+     `stream_test.go`) — feed synthetic chunks ending in a
+     `usage` chunk with `completion_tokens=0` plus a real assistant
+     message in earlier chunks; assert the final usage handed off has
+     non-zero ct.
+6. Run full edge-api test suite via Docker:
+   ```
+   cd deploy/docker && docker run --rm -v $(pwd)/../../:/workspace \
+     -v hive_gomodcache:/go/pkg/mod -w /workspace hive-toolchain \
+     'go test ./apps/edge-api/internal/inference/... -count=1 -short'
+   ```
+7. Manual verify post-deploy with 30-curl bursts:
+   - `POST /v1/responses` with `{"model":"hive-default","input":"ping"}` ×30
+   - `POST /v1/chat/completions` with `stream:true` ×30 — collect the
+     final `usage` chunk from each stream (or use `stream_options.include_usage:true`
+     to ensure usage is emitted)
+   - Compare to baseline: zero ct=0 on non-empty content events expected.
+
+## Files likely to touch
+
+- `apps/edge-api/internal/inference/responses.go`
+- `apps/edge-api/internal/inference/stream.go`
+- `apps/edge-api/internal/inference/stream_responses.go` (if responses
+  streaming has its own accumulator)
+- `apps/edge-api/internal/inference/usage_clamp.go` (add a
+  `responsesOutputTexts` helper next to `chatChoiceTexts` /
+  `completionChoiceTexts`)
+- `apps/edge-api/internal/inference/usage_clamp_test.go`
+
+## Constraints
+
+- Reasoning tokens (`completion_tokens_details.reasoning_tokens`) must
+  remain untouched — clamp only the headline counter.
+- Streaming path must NOT clamp on incremental chunks — clamp only at the
+  flush, when the full accumulator is known. A premature clamp would
+  produce inflated ct (counting the same chunk N times across deltas).
+- `stream_options.include_usage = false` callers do not get a usage block
+  at all — clamp is a no-op (nothing to clamp).
+- NEVER push directly to main — feature branch + PR.
+
+## Why CI will catch regressions
+
+PR #96 added a post-deploy SDK replay step against staging. Once this PR
+merges, the next deploy's replay will exercise the responses + streaming
+paths through the OpenAI SDK and reveal any clamp bug as a billing test
+failure.
+
+## PR title
+
+`fix(edge-api): extend usage clamp to responses + streaming paths`
+
+## Out of scope (future)
+
+- Tokenizer accuracy upgrade — current heuristic is `ceil(byte_len/4)`,
+  conservative cl100k approximation. Switch to `tiktoken-go` only if a
+  later audit shows >20% under-billing on long replies.

--- a/.planning/next-session-litellm-route-pinning.md
+++ b/.planning/next-session-litellm-route-pinning.md
@@ -1,0 +1,99 @@
+# Next Session: Pin LiteLLM backing providers for `hive-default` to reduce variance
+
+## Context
+
+Staging burst on 2026-04-24 (`.planning/debug/flaky-usage-tokens-root-cause.md`)
+captured wild variance for identical requests against
+`api-hive.scubed.co/v1/chat/completions`, model `hive-default`:
+
+| metric | min | max | observation |
+|--------|----:|----:|-------------|
+| `prompt_tokens`     | 4   | 70  | identical 3-word user message |
+| `completion_tokens` | 0   | 442 | identical reply `ok` |
+
+Cause: LiteLLM routes `hive-default` to multiple OpenRouter backing
+providers with different tokenizers and different reasoning budgets. The
+zero-ct billing leak (now fixed by #99 clamp) was the worst symptom but
+the variance itself is still a customer-visible inconsistency:
+
+- Unstable cost per request → unstable customer credit burn
+- Reasoning-capable providers silently consume hidden tokens (the ct=442
+  case has reasoning_tokens >> visible content)
+- Latency variance — some upstreams are 10× slower than others
+
+PR #99 fixes the *zero-ct billing leak*; this session attacks the
+*upstream-variance root cause* so the clamp rarely needs to fire.
+
+## Scope
+
+`deploy/litellm/config.yaml` only. No edge-api change. No SDK change.
+
+## Goal
+
+For `hive-default`, define a deterministic, narrow provider preference
+order so identical requests land on the same backing provider unless that
+provider is unavailable. Acceptable outcomes:
+
+- Same prompt → `prompt_tokens` within ±10% across 30 sequential requests
+- Same prompt → `completion_tokens` distribution narrows; outliers bounded
+- ct=0 events (post-clamp) become rare to none
+
+## Step-by-step
+
+1. Branch: `chore/litellm-pin-hive-default-providers`
+2. Read `deploy/litellm/config.yaml`. Find the `hive-default` model entry.
+   Note the current `model` field, fallback list, and any provider
+   constraints.
+3. Pull LiteLLM docs via Context7 (`resolve-library-id` → `query-docs`)
+   for the OpenRouter `provider_order` / `provider.preferences` syntax.
+   Confirm supported syntax in the version pinned in
+   `deploy/docker/docker-compose.yml` (search `image: ghcr.io/berriai/litellm`
+   or similar to get version).
+4. Pick 1–2 backing providers that:
+   - Report usage reliably (no zero-ct flakes in our 17-sample burst —
+     identify by the `gen-*` IDs that DID return non-zero ct)
+   - Have low pt variance (consistent system-prompt overhead)
+   - Are not reasoning-only models (avoid the ct=442 path unless that
+     reasoning is intentional for `hive-default`)
+5. Add `provider_order: [<picked>]` (or equivalent) under the model entry.
+   Optionally `allow_fallbacks: false` if we want strict pinning, OR
+   `fallbacks: [<safer set>]` if we want graceful degrade.
+6. Apply the same treatment for the `hive-fast` and `hive-auto` aliases
+   if their behavior shows the same variance — verify with a separate
+   small burst before changing.
+7. Validate locally:
+   ```
+   cd deploy/docker && docker compose --env-file ../../.env up litellm
+   curl -sS -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
+     -d '{"model":"hive-default","messages":[{"role":"user","content":"ping"}]}' \
+     -H 'content-type: application/json' \
+     http://localhost:4000/v1/chat/completions | jq '.usage, .id'
+   ```
+   Repeat 10×, confirm pt collapses to a narrow band.
+8. PR title: `chore(litellm): pin hive-default backing providers`
+9. PR body: include before/after pt+ct distribution from a 30-curl burst.
+
+## Constraints
+
+- Do NOT remove the model alias entirely — `hive-default` must continue to
+  resolve.
+- Do NOT touch `hive-embedding-default` — embed routes are separate, no
+  variance issue observed.
+- NEVER push directly to main — feature branch + PR.
+
+## Why this is separate from PR #99
+
+#99 is defensive (clamp ct=0 to a tokenizer estimate so the ledger never
+records 0 on real output). This session is preventive (stop landing on
+bad providers in the first place). The two are independent and can land
+in either order.
+
+## Files
+
+- `deploy/litellm/config.yaml`
+
+## Out of scope
+
+- Adding new model aliases
+- Changing pricing in `apps/control-plane` catalog
+- Switching off OpenRouter to a direct provider key (separate negotiation)

--- a/.planning/next-sessions-INDEX.md
+++ b/.planning/next-sessions-INDEX.md
@@ -1,33 +1,64 @@
 # Next-session prompt index
 
-Session prompts captured 2026-04-24 after staging deploy + SDK replay verification. Each prompt is self-contained and maps to **one PR** unless noted.
+Originally captured 2026-04-24 after staging deploy + SDK replay
+verification. Updated after the 2026-04-24 follow-up session shipped
+PRs #94 / #95 / #96 / #97 / #98 / #99 (six PRs merged).
 
-| File | Title | Type | Priority | Est. session size |
-|------|-------|------|----------|-------------------|
-| [next-session-ui-styling.md](./next-session-ui-styling.md) | web-console UI framework + styling | regression (zero CSS) | P0 | Large (framework pick + all pages) |
-| [next-session-post-deploy-sdk-replay.md](./next-session-post-deploy-sdk-replay.md) | Post-deploy SDK replay against staging URL | coverage gap | P1 | Small (1 workflow file) |
-| [next-session-fix-js-fixture-path.md](./next-session-fix-js-fixture-path.md) | Fix JS fixture path off-by-one + dual-branch mask | bug | P2 | Trivial (1 test file + 1 Dockerfile line) |
-| [next-session-fix-embed-env-cascade.md](./next-session-fix-embed-env-cascade.md) | Drop `HIVE_TEST_MODEL` from embedding fallback chain | bug | P2 | Trivial (2 test files) |
-| [next-session-flaky-usage-tokens.md](./next-session-flaky-usage-tokens.md) | Investigate `usage.*_tokens=0` intermittent | bug (billing-critical) | P1 | Medium (investigation → fix) |
-| [next-session-visual-regression-coverage.md](./next-session-visual-regression-coverage.md) | Playwright visual regression + designqc in CI | coverage gap | P2 | Medium (blocked on UI styling) |
+## Status
 
-## Suggested order
+| File | Title | Priority | Status |
+|------|-------|----------|--------|
+| [next-session-ui-styling.md](./next-session-ui-styling.md) | web-console UI framework + styling | P0 | **Pending** — needs framework pick + designqc loop |
+| [next-session-post-deploy-sdk-replay.md](./next-session-post-deploy-sdk-replay.md) | Post-deploy SDK replay against staging URL | P1 | **Done** — PR #96 merged |
+| [next-session-fix-js-fixture-path.md](./next-session-fix-js-fixture-path.md) | Fix JS fixture path + dual-branch mask | P2 | **Done** — PR #95 merged |
+| [next-session-fix-embed-env-cascade.md](./next-session-fix-embed-env-cascade.md) | Drop `HIVE_TEST_MODEL` from embed fallback | P2 | **Done** — PR #95 merged |
+| [next-session-flaky-usage-tokens.md](./next-session-flaky-usage-tokens.md) | Investigate `usage.*_tokens=0` | P1 | **Done** — investigation PR #97 + clamp fix PR #99 (chat + legacy completions only) |
+| [next-session-visual-regression-coverage.md](./next-session-visual-regression-coverage.md) | Playwright visual regression in CI | P2 | **Pending** — blocked on UI styling |
+| [next-session-clamp-responses-streaming.md](./next-session-clamp-responses-streaming.md) | Extend usage clamp to responses + streaming | P1 | **New** — follow-up to #99, billing-critical |
+| [next-session-litellm-route-pinning.md](./next-session-litellm-route-pinning.md) | Pin LiteLLM backing providers for `hive-default` | P2 | **New** — follow-up to #97 variance findings |
 
-1. **UI styling** (P0, biggest user-visible fix)
-2. **Post-deploy SDK replay** (P1, cheap insurance against env drift) — can run in parallel with #1
-3. **Flaky usage tokens** (P1, billing-critical)
-4. **Embed env cascade fix + JS fixture path fix** (P2, batch as one "sdk-tests housekeeping" afternoon)
-5. **Visual regression coverage** (P2, blocked on #1 having a stable baseline)
+## Suggested order (next 3 sessions)
+
+1. **Extend clamp to responses + streaming** (P1) — closes the remaining
+   billing-leak surface left after #99. Small, isolated PR.
+2. **Pin LiteLLM `hive-default` providers** (P2) — preventive fix that
+   makes the clamp rarely fire. Independent of #1.
+3. **UI styling** (P0) — large, iterative; user-input gate on framework
+   choice (default recommendation: Tailwind v4 + shadcn/ui).
+4. **Visual regression coverage** (P2) — only after UI styling has a
+   stable baseline.
+
+## What landed in the 2026-04-24 follow-up session
+
+- PR #94 — docs(planning): captured the original 6 prompts + session memory
+  (this index)
+- PR #95 — fix(sdk-tests): fixture path + embed env cascade (P2 batch)
+- PR #96 — ci(deploy): post-deploy SDK replay (P1)
+- PR #97 — docs(debug): root-cause flaky `usage.completion_tokens=0`
+  (P1, with measured 5.9% flake rate from a 17-sample staging burst)
+- PR #98 — ci(deploy-staging): hourly cron with diff-gate (replaces 6h
+  cron; only deploys when watched paths changed since last successful run)
+- PR #99 — fix(edge-api): clamp upstream `completion_tokens=0` on
+  non-empty output (chat + legacy completions; reasoning tokens preserved;
+  12-test suite)
 
 ## Why this decomposition
 
-Each bug/gap got one prompt instead of lumping into one big cleanup PR because:
-
-- **Reviewable diffs**: P2 trivia (fixture path, env cascade) is 3-line changes; batching with a framework swap makes them invisible in review
-- **Revert safety**: UI styling may need iteration; a visual-regression gate committed alongside would block styling PRs until baselines settle — hence the explicit "blocked on" note
-- **Billing risk isolation**: `usage.tokens=0` can affect credit attribution; it gets its own investigation doc before any code changes
-- **Blind-spot traceability**: each prompt documents *why CI missed it* so the fix closes the class of bug, not just the instance
+- **Reviewable diffs** — P2 trivia (fixture path, env cascade) is 3-line
+  changes; batching with a framework swap would make them invisible in
+  review.
+- **Revert safety** — UI styling may need iteration; visual-regression
+  gate committed alongside would block styling PRs until baselines settle.
+- **Billing risk isolation** — `usage.tokens=0` got its own investigation
+  doc (#97) before any code change (#99); next clamp extension keeps the
+  pattern (responses + streaming as a single follow-up PR).
+- **Blind-spot traceability** — each prompt documents *why CI missed it*
+  so the fix closes the class of bug, not just the instance.
 
 ## Source audit
 
-Bugs + gaps surfaced during staging SDK replay (2026-04-24 ~14:00 EDT) after merging chore/single-level-subdomains. Full runbook: staging endpoints healthy (api-hive, cp-hive), 4 model aliases live, Java 100%, Python 14/14, JS 25/1-fail/1-skip. See session memory for full log.
+Original bugs + gaps surfaced during staging SDK replay 2026-04-24
+~14:00 EDT after merging `chore/single-level-subdomains`. Follow-up
+prompts (`clamp-responses-streaming`, `litellm-route-pinning`) added
+2026-04-24 after the burst captured 5.9% flake rate against
+`api-hive.scubed.co/v1/chat/completions`.


### PR DESCRIPTION
## Summary

Capture the new work that surfaced during the 2026-04-24 follow-up session and update the index with merged-PR refs.

## New prompts

### \`.planning/next-session-clamp-responses-streaming.md\` (P1)

Extends the zero-completion-tokens clamp shipped in #99 to the two remaining unprotected code paths:

- \`normalizeResponsesSync\` — \`apps/edge-api/internal/inference/responses.go:247\`
- streaming accumulator — \`apps/edge-api/internal/inference/stream.go\` (chat + responses streaming)

Same billing-leak class as #99; just two more entry points. Includes step-by-step, file scope, test plan, and the constraint that streaming must clamp only at the final flush, never on incremental chunks.

### \`.planning/next-session-litellm-route-pinning.md\` (P2)

Attacks the upstream-variance root cause documented in #97 — \`hive-default\` produced pt=4..70 and ct=0..442 for identical prompts because OpenRouter routes across multiple backing providers. Pin the provider order in \`deploy/litellm/config.yaml\` so the clamp rarely needs to fire. Independent of the clamp-extension PR; can land in either order.

## Index update

Marks each original prompt with status + PR ref:

| Prompt | Status |
|--------|--------|
| ui-styling | Pending |
| post-deploy-sdk-replay | Done — #96 |
| fix-js-fixture-path | Done — #95 |
| fix-embed-env-cascade | Done — #95 |
| flaky-usage-tokens | Done — #97 (investigation) + #99 (clamp fix, chat + legacy only) |
| visual-regression-coverage | Pending — blocked on UI styling |
| **clamp-responses-streaming** | **New** |
| **litellm-route-pinning** | **New** |

Suggested next-3-sessions order documented inline.

## Test plan

- [x] Markdown lints (table rendering, link targets)
- [ ] Reviewer: confirm the clamp-extension scope matches the streaming + responses surface area you expect