### PR TITLE
fix(edge-api): extend usage clamp to responses + streaming paths

### DIFF
--- a/apps/edge-api/internal/inference/responses.go
+++ b/apps/edge-api/internal/inference/responses.go
@@ -260,9 +260,12 @@ func normalizeResponsesSync(respBody []byte, aliasID string, req ResponsesReques
 	// Build output items from choices.
 	outputItems := buildOutputItemsFromChoices(chatResp.Choices)
 
-	// Translate usage.
+	// Translate usage. Clamp upstream-zero completion_tokens against the
+	// actual output text so we never bill 0 on a non-empty response (see
+	// .planning/debug/flaky-usage-tokens-root-cause.md).
 	var respUsage *ResponsesUsage
 	if chatResp.Usage != nil {
+		clampZeroCompletionUsage(chatResp.Usage, responsesOutputTexts(outputItems), chatResp.ID, aliasID, EndpointResponses)
 		respUsage = chatToResponsesUsage(chatResp.Usage)
 	}
 

--- a/apps/edge-api/internal/inference/stream.go
+++ b/apps/edge-api/internal/inference/stream.go
@@ -16,14 +16,17 @@ import (
 	apierrors "github.com/hivegpt/hive/apps/edge-api/internal/errors"
 )
 
-// UsageAccumulator tracks token usage across SSE streaming chunks.
+// UsageAccumulator tracks token usage and output text across SSE streaming chunks.
+// Content is recorded so the usage clamp can recompute completion_tokens when
+// the upstream terminal usage chunk reports 0 on a non-empty response.
 type UsageAccumulator struct {
-	InputTokens      int64
-	OutputTokens     int64
-	ReasoningTokens  int64
-	CachedTokens     int64
-	TotalTokens      int64
-	HasUsage         bool
+	InputTokens     int64
+	OutputTokens    int64
+	ReasoningTokens int64
+	CachedTokens    int64
+	TotalTokens     int64
+	HasUsage        bool
+	Content         strings.Builder
 }
 
 // Accumulate copies usage fields from a chunk if present.
@@ -41,6 +44,29 @@ func (a *UsageAccumulator) Accumulate(chunk ChatCompletionChunk) {
 	if chunk.Usage.PromptTokensDetails != nil {
 		a.CachedTokens = chunk.Usage.PromptTokensDetails.CachedTokens
 	}
+}
+
+// AccumulateContent appends all delta content + refusal text carried by a
+// streaming chunk. Tool-call deltas are ignored — they do not consume
+// completion tokens in the same way as visible output text.
+func (a *UsageAccumulator) AccumulateContent(chunk ChatCompletionChunk) {
+	for _, choice := range chunk.Choices {
+		if choice.Delta.Content != nil {
+			a.Content.WriteString(*choice.Delta.Content)
+		}
+		if choice.Delta.Refusal != nil {
+			a.Content.WriteString(*choice.Delta.Refusal)
+		}
+	}
+}
+
+// ClampUsage applies the zero-completion-tokens clamp against the accumulated
+// output text. Safe to call with nil chunk.Usage — it's a no-op.
+func (a *UsageAccumulator) ClampUsage(u *UsageResponse, upstreamID, aliasID, endpoint string) {
+	if u == nil {
+		return
+	}
+	clampZeroCompletionUsage(u, []string{a.Content.String()}, upstreamID, aliasID, endpoint)
 }
 
 // ToUsageResponse constructs a UsageResponse from accumulated values.
@@ -255,6 +281,14 @@ func (o *Orchestrator) executeStreaming(
 			if err := json.Unmarshal([]byte(jsonData), &chunk); err == nil {
 				// Rewrite model to alias ID
 				chunk.Model = aliasID
+				// Track output content so the usage clamp has ground truth.
+				accumulator.AccumulateContent(chunk)
+				// Clamp upstream-zero completion_tokens against the
+				// content streamed so far. Usage typically arrives in
+				// the terminal chunk once all deltas are flushed.
+				if chunk.Usage != nil {
+					accumulator.ClampUsage(chunk.Usage, chunk.ID, aliasID, endpoint)
+				}
 				// Accumulate usage if present
 				accumulator.Accumulate(chunk)
 				// Re-marshal sanitized chunk

--- a/apps/edge-api/internal/inference/stream_responses.go
+++ b/apps/edge-api/internal/inference/stream_responses.go
@@ -241,6 +241,13 @@ func (o *Orchestrator) executeResponsesStreaming(
 			continue
 		}
 
+		// Clamp upstream-zero completion_tokens against the content streamed
+		// so far. Usage chunks typically arrive last with empty choices, so
+		// translator.currentContent already holds the full response body.
+		if chunk.Usage != nil {
+			clampZeroCompletionUsage(chunk.Usage, []string{translator.currentContent.String()}, chunk.ID, model, EndpointResponses)
+		}
+
 		// Accumulate usage if present.
 		acc.Accumulate(chunk)
 

--- a/apps/edge-api/internal/inference/usage_clamp.go
+++ b/apps/edge-api/internal/inference/usage_clamp.go
@@ -79,3 +79,22 @@ func completionChoiceTexts(choices []CompletionChoice) []string {
 	}
 	return out
 }
+
+// responsesOutputTexts returns the visible output_text content of every
+// Responses API message item. Tool-call and reasoning items have no billable
+// completion-text contribution (reasoning tokens are tracked separately via
+// usage.completion_tokens_details.reasoning_tokens) and are skipped.
+func responsesOutputTexts(items []ResponseOutputItem) []string {
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		if item.Type != "message" {
+			continue
+		}
+		for _, part := range item.Content {
+			if part.Type == "output_text" && part.Text != "" {
+				out = append(out, part.Text)
+			}
+		}
+	}
+	return out
+}

--- a/apps/edge-api/internal/inference/usage_clamp_test.go
+++ b/apps/edge-api/internal/inference/usage_clamp_test.go
@@ -130,3 +130,112 @@ func TestNormalizeChatCompletion_PreservesNonZeroCt(t *testing.T) {
 		t.Fatalf("clamp wrongly mutated nonzero usage: %+v", usage)
 	}
 }
+
+func TestNormalizeResponsesSync_ClampsZeroCt(t *testing.T) {
+	// Upstream chat body with nonempty content and completion_tokens=0.
+	body := []byte(`{"id":"gen-zct-responses","object":"chat.completion","created":0,"model":"hive-default","choices":[{"index":0,"message":{"role":"assistant","content":"ok\n"},"finish_reason":"stop"}],"usage":{"prompt_tokens":4,"completion_tokens":0,"total_tokens":4}}`)
+	req := ResponsesRequest{Model: "hive-default"}
+	_, usage, err := normalizeResponsesSync(body, "hive-default", req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if usage == nil {
+		t.Fatal("usage nil")
+	}
+	if usage.CompletionTokens == 0 {
+		t.Fatalf("clamp did not engage: %+v", usage)
+	}
+	if usage.TotalTokens != usage.PromptTokens+usage.CompletionTokens {
+		t.Fatalf("total_tokens not recomputed: %+v", usage)
+	}
+}
+
+func TestNormalizeResponsesSync_PreservesNonZeroCt(t *testing.T) {
+	body := []byte(`{"id":"r","object":"chat.completion","created":0,"model":"hive-default","choices":[{"index":0,"message":{"role":"assistant","content":"hi"},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":7,"total_tokens":12}}`)
+	req := ResponsesRequest{Model: "hive-default"}
+	_, usage, err := normalizeResponsesSync(body, "hive-default", req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if usage.CompletionTokens != 7 || usage.TotalTokens != 12 {
+		t.Fatalf("clamp wrongly mutated nonzero usage: %+v", usage)
+	}
+}
+
+func TestResponsesOutputTexts_IgnoresNonOutputText(t *testing.T) {
+	items := []ResponseOutputItem{
+		{
+			Type: "message",
+			Content: []ResponseContentPart{
+				{Type: "output_text", Text: "hello"},
+				{Type: "output_text", Text: ""},      // empty — skipped
+				{Type: "reasoning", Text: "hidden"},  // non-output_text part — skipped
+			},
+		},
+		{
+			Type:    "reasoning", // reasoning item — whole item skipped (reasoning_tokens tracked separately)
+			Content: []ResponseContentPart{{Type: "output_text", Text: "deep thoughts"}},
+		},
+	}
+	got := responsesOutputTexts(items)
+	if len(got) != 1 {
+		t.Fatalf("unexpected output texts: %+v", got)
+	}
+	if got[0] != "hello" {
+		t.Fatalf("first text wrong: %q", got[0])
+	}
+}
+
+func TestUsageAccumulator_AccumulateContentAndClamp(t *testing.T) {
+	acc := &UsageAccumulator{}
+	// Deltas.
+	acc.AccumulateContent(ChatCompletionChunk{
+		Choices: []ChunkChoice{{Delta: ChunkDelta{Content: ptrStr("hello ")}}},
+	})
+	acc.AccumulateContent(ChatCompletionChunk{
+		Choices: []ChunkChoice{{Delta: ChunkDelta{Content: ptrStr("world")}}},
+	})
+	// Terminal usage chunk with ct=0 — should be clamped.
+	usage := &UsageResponse{PromptTokens: 3, CompletionTokens: 0, TotalTokens: 3}
+	acc.ClampUsage(usage, "chatcmpl-stream", "hive-default", EndpointChatCompletions)
+	if usage.CompletionTokens == 0 {
+		t.Fatalf("expected clamp to engage on streamed content, got 0")
+	}
+	if usage.TotalTokens != usage.PromptTokens+usage.CompletionTokens {
+		t.Fatalf("total_tokens not recomputed: %+v", usage)
+	}
+}
+
+func TestUsageAccumulator_ClampNoopWithEmptyContent(t *testing.T) {
+	acc := &UsageAccumulator{}
+	// No deltas accumulated — legit empty stream (e.g. tool-call only).
+	usage := &UsageResponse{PromptTokens: 5, CompletionTokens: 0, TotalTokens: 5}
+	acc.ClampUsage(usage, "id", "alias", EndpointChatCompletions)
+	if usage.CompletionTokens != 0 || usage.TotalTokens != 5 {
+		t.Fatalf("clamp engaged on empty content: %+v", usage)
+	}
+}
+
+func TestUsageAccumulator_ClampPreservesNonZero(t *testing.T) {
+	acc := &UsageAccumulator{}
+	acc.AccumulateContent(ChatCompletionChunk{
+		Choices: []ChunkChoice{{Delta: ChunkDelta{Content: ptrStr("hi")}}},
+	})
+	usage := &UsageResponse{PromptTokens: 3, CompletionTokens: 4, TotalTokens: 7}
+	acc.ClampUsage(usage, "id", "alias", EndpointChatCompletions)
+	if usage.CompletionTokens != 4 || usage.TotalTokens != 7 {
+		t.Fatalf("clamp wrongly mutated nonzero usage: %+v", usage)
+	}
+}
+
+func TestUsageAccumulator_AccumulateContentRefusal(t *testing.T) {
+	acc := &UsageAccumulator{}
+	acc.AccumulateContent(ChatCompletionChunk{
+		Choices: []ChunkChoice{{Delta: ChunkDelta{Refusal: ptrStr("I cannot help with that")}}},
+	})
+	usage := &UsageResponse{PromptTokens: 5, CompletionTokens: 0, TotalTokens: 5}
+	acc.ClampUsage(usage, "id", "alias", EndpointChatCompletions)
+	if usage.CompletionTokens == 0 {
+		t.Fatalf("refusal content should clamp ct, got 0")
+	}
+}


### PR DESCRIPTION
## Summary

Extends the `clampZeroCompletionUsage` helper (#99) to the three remaining
code paths that feed the billing ledger:

- Responses API sync (`normalizeResponsesSync`)
- Chat completions streaming (`executeStreaming`)
- Responses streaming (`executeResponsesStreaming`)

Same symptom as #99: OpenRouter backing providers intermittently return
`usage.completion_tokens=0` while the response text is non-empty. Since
`OutputTokens = usage.CompletionTokens` is the only signal the
orchestrator records, any zero propagates to the ledger as a 100%
under-billing event. #99 closed this for chat completions + legacy
completions; this PR closes the Responses + streaming gap.

### Approach

- **Responses sync**: clamp `chatResp.Usage` before translating to
  `ResponsesUsage`, using a new `responsesOutputTexts` helper that walks
  `output_text` parts inside `message` items only. Reasoning items are
  excluded — reasoning tokens are tracked separately via
  `CompletionTokensDetails.ReasoningTokens` and counting their text
  again would double-bill.
- **Chat streaming**: `UsageAccumulator` now also tracks streamed
  assistant content (`delta.content` + `delta.refusal`) via
  `AccumulateContent`, and exposes a `ClampUsage` method. The scan loop
  clamps the upstream usage chunk in-flight **before re-marshaling**, so
  the wire and the ledger both see the corrected ct.
- **Responses streaming**: the existing `translator.currentContent`
  builder is ground truth by the time the terminal usage chunk arrives
  (usage chunks have empty `choices`). Clamp is applied on
  `chunk.Usage` before `acc.Accumulate(chunk)`.

### Constraints honoured

- Reasoning tokens untouched (`CompletionTokensDetails` preserved).
- Streaming clamp fires only on the terminal usage chunk — never on
  incremental deltas, which would inflate ct via double-counting.
- `stream_options.include_usage=false` callers receive no usage block;
  clamp is a no-op there (nothing to clamp).
- Refusal text counted (same as chat sync path) — refusal consumes real
  completion tokens upstream.

### Tests added

- `TestNormalizeResponsesSync_ClampsZeroCt` — responses sync with
  `completion_tokens=0` and non-empty content clamps correctly.
- `TestNormalizeResponsesSync_PreservesNonZeroCt` — non-zero upstream ct
  is not mutated.
- `TestResponsesOutputTexts_IgnoresNonOutputText` — reasoning items +
  empty text skipped.
- `TestUsageAccumulator_AccumulateContentAndClamp` — streaming content
  accumulates across deltas, clamp engages on terminal zero ct.
- `TestUsageAccumulator_ClampNoopWithEmptyContent` — tool-call-only
  streams (no visible text) leave ct=0 alone.
- `TestUsageAccumulator_ClampPreservesNonZero` — streaming non-zero ct
  is not mutated.
- `TestUsageAccumulator_AccumulateContentRefusal` — refusal deltas count
  toward clamp.

### Regression coverage

PR #96 added a post-deploy SDK replay that exercises `/v1/responses` and
streaming chat completions through the official OpenAI SDK on every
staging deploy. Any future clamp regression becomes a billing test
failure before it reaches users.

## Test plan

- [x] `go test ./apps/edge-api/internal/inference/... -count=1 -short`
- [x] `go test ./apps/edge-api/... -count=1 -short` (no regressions)
- [x] `go vet ./apps/edge-api/...`
- [ ] Post-merge: 30-curl burst against
      `POST /v1/responses` with `{"model":"hive-default","input":"ping"}`
      — expect zero `ct=0` on non-empty output items.
- [ ] Post-merge: 30-curl burst against
      `POST /v1/chat/completions` with `stream:true, stream_options:{include_usage:true}`
      — expect zero `ct=0` on non-empty streamed content.

## Out of scope

- Tokenizer accuracy upgrade (current heuristic: `ceil(byte_len/4)` —
  conservative cl100k approximation). Switch to `tiktoken-go` only if a
  later audit shows >20% under-billing on long replies.
- LiteLLM backing-provider pinning to reduce upstream variance — tracked
  in `.planning/next-session-litellm-route-pinning.md`.
- Cross-request retroactive ledger reprice — business decision, not
  code.