### PR TITLE
chore(litellm): pin OpenRouter backing providers

### DIFF
--- a/deploy/litellm/config.yaml
+++ b/deploy/litellm/config.yaml
@@ -1,18 +1,50 @@
 model_list:
-  # OpenRouter primary routes (chat). `openrouter/free` disperses load across
-  # OR's free-model pool — fragile under burst, hence the Groq fallbacks below.
+  # OpenRouter primary routes (chat).
+  #
+  # OpenRouter's `:free` and `/free` shapes route across a multi-provider
+  # backing pool with different tokenizers + reasoning budgets, which
+  # produces wild variance in `usage.prompt_tokens` and `usage.completion_tokens`
+  # for identical requests (see .planning/debug/flaky-usage-tokens-root-cause.md).
+  # PR #99 added an edge-api clamp that prevents the worst symptom (ct=0 on
+  # non-empty output → 0-billed); this provider pin attacks the variance
+  # itself so the clamp rarely needs to fire.
+  #
+  # Pinning strategy (effective when OPENROUTER_*_MODEL points at a specific
+  # model — e.g. `openrouter/meta-llama/llama-3.3-70b-instruct:free` — rather
+  # than the meta `openrouter/free` route, which OR resolves before honoring
+  # provider preferences):
+  #
+  #   provider.allow_fallbacks: false  — refuse silent re-route to a
+  #                                       different backing tokenizer
+  #   provider.sort: throughput        — prefer fastest reporter; ties broken
+  #                                       deterministically by OR
+  #
+  # Groq routes below stay as the cross-provider safety net so a strict pin
+  # never produces a hard 503 — see `litellm_settings.fallbacks` further down.
   - model_name: route-openrouter-default
     litellm_params:
       model: os.environ/OPENROUTER_DEFAULT_MODEL
       api_key: os.environ/OPENROUTER_API_KEY
+      extra_body:
+        provider:
+          allow_fallbacks: false
+          sort: throughput
   - model_name: route-openrouter-auto
     litellm_params:
       model: os.environ/OPENROUTER_AUTO_MODEL
       api_key: os.environ/OPENROUTER_API_KEY
+      extra_body:
+        provider:
+          allow_fallbacks: false
+          sort: throughput
   - model_name: route-openrouter-fast-fallback
     litellm_params:
       model: os.environ/OPENROUTER_FAST_FALLBACK_MODEL
       api_key: os.environ/OPENROUTER_API_KEY
+      extra_body:
+        provider:
+          allow_fallbacks: false
+          sort: throughput
 
   # Groq FREE tier fallback for chat. gpt-oss-20b handles everyday
   # prompts; gpt-oss-120b reserved for reasoning-heavy workloads.


### PR DESCRIPTION
## Summary

Adds OpenRouter backing-provider pinning to all three chat routes in
`deploy/litellm/config.yaml`:

```yaml
extra_body:
  provider:
    allow_fallbacks: false
    sort: throughput
```

Attacks the upstream-variance root cause documented in
`.planning/debug/flaky-usage-tokens-root-cause.md`:

| metric             | min | max | observation                       |
|--------------------|----:|----:|-----------------------------------|
| `prompt_tokens`     | 4   | 70  | identical 3-word user message     |
| `completion_tokens` | 0   | 442 | identical reply `ok`              |

PR #99 already plugs the worst billing symptom (`ct=0` clamp on the
chat-completions + legacy completions paths). PR #101 extends that clamp
to responses + streaming. This PR is the third leg — preventive instead
of defensive: stop landing on bad providers in the first place so the
clamp rarely needs to fire.

## How the pin works

- `provider.allow_fallbacks: false` — refuse OR's silent re-route to a
  different backing tokenizer mid-pool. Prevents the `pt=4 → pt=70` jump
  for identical inputs.
- `provider.sort: throughput` — deterministic preference order. OR
  picks the throughput-leading reporter first; ties broken
  deterministically by OR's internal scoring.

## Effective scope

Pinning at the OR `provider` body field is honored only when the
`OPENROUTER_*_MODEL` env var points at a **specific** OR model — for
example `openrouter/meta-llama/llama-3.3-70b-instruct:free`. The meta
`openrouter/free` shape (current default in checked-in `.env.example`)
resolves before OR honors provider preferences, so ops should follow up
with a `.env` change to a pinned model when ready.

The pin is a **no-op** (harmless) on the `openrouter/free` shape and
**effective** on explicit models — so this PR is safe to land before the
`.env` change.

## What's untouched

- Groq fallback routes — cross-provider safety net so a strict pin never
  produces a hard 503 if the chosen OR backend is down. The
  `litellm_settings.fallbacks` block already cascades chat from OR to
  Groq.
- NVIDIA NIM embedding route — sole embedding provider, no variance
  observed in the burst. Pinning here would add fragility with no
  benefit.
- OPENROUTER_*_MODEL env vars themselves — kept env-driven so deploys
  can flip to a specific model without a config redeploy.

## Test plan

- [x] `python3 -c 'import yaml; yaml.safe_load(open(...))'` — config
      parses cleanly.
- [ ] After merge + ops `.env` flip to a specific OR model, run a
      30-curl burst against
      `POST /v1/chat/completions {"model":"hive-default","messages":[{"role":"user","content":"ping"}]}`
      and confirm `prompt_tokens` collapses into a narrow band (target:
      ±10% across the burst).
- [ ] Same burst, confirm `usage.completion_tokens` distribution narrows
      and post-clamp `ct=0` events trend to zero.
- [ ] Verify Groq fallback still engages on OR 5xx by killing OR auth
      transiently in a staging soak.

## Out of scope

- Switching `OPENROUTER_DEFAULT_MODEL` from `openrouter/free` to a
  pinned model — `.env` is per-deployment and lives outside this repo.
- Embedding pin (no variance observed).
- Pricing changes in `apps/control-plane` catalog.

## Why this is separate from #99 / #101

- #99 is **defensive** (clamp `ct=0` to a tokenizer estimate so the
  ledger never records 0 on real output).
- #101 extends the clamp to responses + streaming.
- This PR is **preventive** — stop landing on bad providers in the
  first place. The three are independent and can land in any order.