### PR TITLE
ci(deploy-staging): inject REDIS_URL from dedicated secret

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -151,24 +151,40 @@ jobs:
       - name: Seed staging env
         env:
           STAGING_ENV: ${{ secrets.STAGING_ENV }}
+          STAGING_REDIS_URL: ${{ secrets.STAGING_REDIS_URL }}
         run: |
           printf '%s' "$STAGING_ENV" > /tmp/hive.env
+          chmod 600 /tmp/hive.env
+
+          # REDIS_URL is sourced from a dedicated secret (STAGING_REDIS_URL)
+          # so staging-only Upstash credentials can be rotated without
+          # rewriting the full STAGING_ENV blob. Any REDIS_URL line baked
+          # into STAGING_ENV is overridden here.
+          if [ -z "${STAGING_REDIS_URL:-}" ]; then
+            echo "FATAL: STAGING_REDIS_URL secret is empty or unset." >&2
+            rm -f /tmp/hive.env
+            exit 1
+          fi
+          # Strip any existing REDIS_URL= lines, then append the canonical one.
+          grep -vE '^REDIS_URL=' /tmp/hive.env > /tmp/hive.env.tmp || true
+          mv /tmp/hive.env.tmp /tmp/hive.env
+          printf 'REDIS_URL=%s\n' "$STAGING_REDIS_URL" >> /tmp/hive.env
           chmod 600 /tmp/hive.env
 
           # Defensive: staging must use managed Upstash Redis, never the
           # local docker container. The base compose `redis` service is
           # gated to `--profile local` and the staging override drops the
           # depends_on, but we assert here too so a copy-paste mistake in
-          # the STAGING_ENV secret can't silently route writes to a
+          # the STAGING_REDIS_URL secret can't silently route writes to a
           # non-existent localhost redis.
           if grep -E '^REDIS_URL=redis://(redis|localhost|127\.0\.0\.1)' /tmp/hive.env; then
-            echo "FATAL: STAGING_ENV REDIS_URL points at a docker/local redis." >&2
+            echo "FATAL: STAGING_REDIS_URL points at a docker/local redis." >&2
             echo "Staging must use rediss://default:<token>@<host>:6379 (Upstash)." >&2
             rm -f /tmp/hive.env
             exit 1
           fi
           if ! grep -qE '^REDIS_URL=' /tmp/hive.env; then
-            echo "FATAL: STAGING_ENV missing REDIS_URL." >&2
+            echo "FATAL: REDIS_URL injection failed (no REDIS_URL line in /tmp/hive.env)." >&2
             rm -f /tmp/hive.env
             exit 1
           fi

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -157,7 +157,7 @@ jobs:
           chmod 600 /tmp/hive.env
 
           # REDIS_URL is sourced from a dedicated secret (STAGING_REDIS_URL)
-          # so staging-only Upstash credentials can be rotated without
+          # so staging-only managed-Redis credentials can be rotated without
           # rewriting the full STAGING_ENV blob. Any REDIS_URL line baked
           # into STAGING_ENV is overridden here.
           if [ -z "${STAGING_REDIS_URL:-}" ]; then
@@ -171,15 +171,18 @@ jobs:
           printf 'REDIS_URL=%s\n' "$STAGING_REDIS_URL" >> /tmp/hive.env
           chmod 600 /tmp/hive.env
 
-          # Defensive: staging must use managed Upstash Redis, never the
-          # local docker container. The base compose `redis` service is
-          # gated to `--profile local` and the staging override drops the
-          # depends_on, but we assert here too so a copy-paste mistake in
-          # the STAGING_REDIS_URL secret can't silently route writes to a
-          # non-existent localhost redis.
-          if grep -E '^REDIS_URL=redis://(redis|localhost|127\.0\.0\.1)' /tmp/hive.env; then
+          # Defensive: staging must use a managed Redis (Upstash, Redis
+          # Cloud, etc.), never the local docker container. The base
+          # compose `redis` service is gated to `--profile local` and the
+          # staging override drops the depends_on, but we assert here too
+          # so a copy-paste mistake in the STAGING_REDIS_URL secret can't
+          # silently route writes to a non-existent localhost redis.
+          # Hostname token must be bounded by `:` `/` or end-of-line so
+          # legitimate managed hostnames like `redis-19287.foo.cloud` are
+          # not falsely flagged as the docker `redis` service name.
+          if grep -E '^REDIS_URL=rediss?://([^@]*@)?(redis|localhost|127\.0\.0\.1)(:|/|$)' /tmp/hive.env; then
             echo "FATAL: STAGING_REDIS_URL points at a docker/local redis." >&2
-            echo "Staging must use rediss://default:<token>@<host>:6379 (Upstash)." >&2
+            echo "Staging must use a managed Redis (e.g. redis://default:<token>@<host>:<port>)." >&2
             rm -f /tmp/hive.env
             exit 1
           fi


### PR DESCRIPTION
## Summary
- Move staging Redis URL out of the monolithic `STAGING_ENV` blob into a dedicated `STAGING_REDIS_URL` secret.
- Strip any baked-in `REDIS_URL=` line from `STAGING_ENV` and append the canonical value from `STAGING_REDIS_URL` before the existing docker/local guard runs.
- Existing safety check (must be `rediss://...` Upstash, never `redis://redis|localhost|127.0.0.1`) is preserved and now validates the injected value.

## Why
Recent staging deploys failed because `STAGING_ENV` shipped with a `REDIS_URL=redis://redis:6379/0` line copied from the local dev template. The defensive guard correctly aborted the deploy. Splitting `REDIS_URL` into its own secret lets us rotate the Upstash token without re-uploading the entire env blob and removes the copy-paste failure mode.

## Test plan
- [x] `STAGING_REDIS_URL` secret set with `rediss://default:<token>@<host>.upstash.io:6379`
- [ ] Trigger `deploy-staging.yml` via `workflow_dispatch` on this branch
- [ ] Confirm "Seed staging env" step passes
- [ ] Confirm `/opt/hive/.env` on the VM has only one `REDIS_URL=` line and it points at Upstash
- [ ] Confirm edge-api + control-plane come up healthy on staging