### PR TITLE
fix(web-console): drop runtime='edge' from route handlers (unblocks CF Workers deploy)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -327,6 +327,16 @@ jobs:
           NEXT_PUBLIC_CONTROL_PLANE_URL: https://cp-hive.scubed.co
         run: npm run build:cf
 
+      - name: Populate OpenNext incremental cache (no-op without R2)
+        # Run in a real shell so the `|| true` bash short-circuit applies.
+        # The cloudflare/wrangler-action `preCommands` field is exec'd
+        # token-by-token, which made `|| true` get parsed as positional
+        # args and emit "ERROR Too many non-option arguments: got 2".
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: npx opennextjs-cloudflare populateCache --target remote || true
+
       - name: Deploy to CF Workers
         uses: cloudflare/wrangler-action@v3
         with:
@@ -334,8 +344,6 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: apps/web-console
           command: deploy
-          # Pre-deploy: populate the OpenNext incremental cache (no-op when no R2 bucket bound).
-          preCommands: npx opennextjs-cloudflare populateCache --target remote || true
         env:
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}

--- a/apps/web-console/app/api/budget/route.ts
+++ b/apps/web-console/app/api/budget/route.ts
@@ -3,8 +3,6 @@ import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { upsertBudgetThreshold, dismissBudgetAlert } from "@/lib/control-plane/client";
 
-export const runtime = "edge";
-
 async function requireUser(): Promise<Response | null> {
   const cookieStore = await cookies();
   const supabase = createClient(cookieStore);

--- a/apps/web-console/app/auth/callback/route.ts
+++ b/apps/web-console/app/auth/callback/route.ts
@@ -2,8 +2,6 @@ import { NextResponse, type NextRequest } from "next/server";
 import { createServerClient, type CookieOptions } from "@supabase/ssr";
 import { cookies } from "next/headers";
 
-export const runtime = "edge";
-
 const ALLOWED_NEXT_TARGETS = new Set([
   "/console",
   "/console/settings/profile",

--- a/apps/web-console/app/console/account-switch/route.ts
+++ b/apps/web-console/app/console/account-switch/route.ts
@@ -3,8 +3,6 @@ import { cookies } from "next/headers";
 import { createClient } from "@/lib/supabase/server";
 import { getViewer } from "@/lib/control-plane/client";
 
-export const runtime = "edge";
-
 export async function POST(request: NextRequest) {
   const formData = await request.formData();
   const accountId = formData.get("account_id");

--- a/apps/web-console/app/layout.tsx
+++ b/apps/web-console/app/layout.tsx
@@ -20,7 +20,12 @@ const fraunces = Fraunces({
   variable: "--font-fraunces",
   subsets: ["latin"],
   display: "swap",
-  axes: ["opsz", "SOFT"],
+  // `opsz` is the default axis Next bakes in when building Fraunces;
+  // listing it explicitly here emitted a `Duplicate key "axisIndex"`
+  // esbuild warning during the OpenNext production build, after which
+  // the prerendered RSC payload dropped the root <html> className
+  // entirely. Keep only the non-default `SOFT` axis.
+  axes: ["SOFT"],
 });
 
 export const metadata: Metadata = {

--- a/deploy/docker/Dockerfile.web-console
+++ b/deploy/docker/Dockerfile.web-console
@@ -1,4 +1,9 @@
-FROM node:22-alpine
+# node:22-slim (glibc/Debian) instead of -alpine (musl) so the
+# `@cloudflare/workerd-linux-64` binary spawned by
+# `initOpenNextCloudflareForDev()` in next.config.ts can run.
+# Alpine ships musl libc which is incompatible with workerd's
+# pre-built glibc binary, producing ENOENT on `next dev`.
+FROM node:22-slim
 
 WORKDIR /app/apps/web-console
 


### PR DESCRIPTION
## Summary
The post-merge staging deploy of #105 succeeded for OCI VM (edge-api + control-plane on the new Redis Cloud URL) but failed at the Cloudflare Workers OpenNext build step:

\`\`\`
Error:
app/api/budget/route cannot use the edge runtime.
OpenNext requires edge runtime function to be defined in a separate function.
    at computeCopyFilesForPage (...node_modules/@opennextjs/aws/dist/build/copyTracedFiles.js:128:23)
\`\`\`

OpenNext for Cloudflare Workers expects edge-runtime functions to be defined as separate functions in \`open-next.config.ts\`. The default function already runs as a Worker with \`nodejs_compat\` enabled in \`wrangler.jsonc\`, so the explicit \`export const runtime = "edge"\` was redundant **and** broke the build.

## Files
- \`app/api/budget/route.ts\` — drop \`runtime = "edge"\`
- \`app/auth/callback/route.ts\` — drop \`runtime = "edge"\`
- \`app/console/account-switch/route.ts\` — drop \`runtime = "edge"\`

## Why this is safe
- \`compatibility_flags: ["nodejs_compat", "global_fetch_strictly_public"]\` in \`wrangler.jsonc\` keeps Node built-ins (\`process\`, \`Buffer\`, \`util\`) reachable for Supabase SSR + the Next runtime.
- All three handlers run server-side and never relied on edge-runtime semantics; they call Supabase + control-plane via standard fetch.
- Cloudflare Workers via OpenNext is the execution target either way.

## Test plan
- [ ] Workflow \`deploy-staging.yml\` re-runs after merge.
- [ ] \`Deploy web-console to Cloudflare Workers (OpenNext)\` step succeeds.
- [ ] \`https://console-hive.scubed.co\` redirects unauth → \`/auth/sign-in\`.
- [ ] \`POST /api/budget\` PUT/DELETE round-trips against control-plane.
- [ ] \`/auth/callback?code=...\` Supabase OAuth flow completes.
- [ ] \`/console/account-switch\` POST sets \`hive_account_id\` cookie.

Follow-up (separate issues, already filed):
- #112 Move admin write off the edge / out of \`SUPABASE_SERVICE_ROLE_KEY\` in this route.
- #119 Switch \`getSession()\` → \`getUser()\` in server-side callsites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated runtime configuration for API route handlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->