### PR TITLE
fix(web-console): expose CONTROL_PLANE_BASE_URL to Worker runtime

### DIFF
--- a/apps/web-console/wrangler.jsonc
+++ b/apps/web-console/wrangler.jsonc
@@ -22,6 +22,13 @@
     "directory": ".open-next/assets",
     "binding": "ASSETS"
   },
+  "vars": {
+    // Server-only: Next.js Server Components and Route Handlers call
+    // the control-plane via this URL. Non-sensitive (public DNS), so
+    // checked in here. Sensitive secrets (e.g. SUPABASE_SERVICE_ROLE_KEY)
+    // must be set via `wrangler secret put`, never via `vars`.
+    "CONTROL_PLANE_BASE_URL": "https://cp-hive.scubed.co"
+  },
   "observability": {
     "enabled": true
   }


### PR DESCRIPTION
## Summary
Authenticated routes (/console/**) returned 500 with a digest-only Server Components error after sign-in on staging. `getViewer()` / `getBalance()` / `getBudgetThreshold()` all throw because `process.env.CONTROL_PLANE_BASE_URL` is undefined in the Worker runtime — the deploy workflow only set NEXT_PUBLIC_* env at build time.

## Fix
Add `CONTROL_PLANE_BASE_URL` to `wrangler.jsonc` `vars` (non-sensitive). Cloudflare Workers exposes `vars` as runtime `process.env.X`, satisfying the existing `lib/control-plane/client.ts:131` check.

## Test plan
- [ ] Re-deploy via `workflow_dispatch`.
- [ ] Sign in as `qa-tester@hive.test`.
- [ ] Land on /console without 500.
- [ ] /console/api-keys, /console/billing, /console/settings/profile load.