### PR TITLE
fix(web-console): handle 404 from getAccountProfile as empty profile

### DIFF
--- a/apps/web-console/lib/control-plane/client.ts
+++ b/apps/web-console/lib/control-plane/client.ts
@@ -439,6 +439,22 @@ export async function getAccountProfile(): Promise<AccountProfile> {
     cache: "no-store",
   });
 
+  // Fresh accounts have no profile row yet — control-plane returns 404.
+  // Surface that as an empty, not-yet-set-up profile so dashboard, setup,
+  // and billing pages can render their needs-setup state instead of
+  // crashing the whole Server Components tree.
+  if (response.status === 404) {
+    return {
+      owner_name: "",
+      login_email: "",
+      display_name: "",
+      account_type: "",
+      country_code: "",
+      state_region: "",
+      profile_setup_complete: false,
+    };
+  }
+
   if (!response.ok) {
     throw new Error(await readResponseError(response, "Failed to fetch account profile"));
   }

--- a/apps/web-console/wrangler.jsonc
+++ b/apps/web-console/wrangler.jsonc
@@ -22,6 +22,13 @@
     "directory": ".open-next/assets",
     "binding": "ASSETS"
   },
+  "vars": {
+    // Server-only: Next.js Server Components and Route Handlers call
+    // the control-plane via this URL. Non-sensitive (public DNS), so
+    // checked in here. Sensitive secrets (e.g. SUPABASE_SERVICE_ROLE_KEY)
+    // must be set via `wrangler secret put`, never via `vars`.
+    "CONTROL_PLANE_BASE_URL": "https://cp-hive.scubed.co"
+  },
   "observability": {
     "enabled": true
   }


### PR DESCRIPTION
## Summary
Authenticated console pages still returned 500 after PR #122 because every page that calls `getAccountProfile()` throws on the 404 control-plane returns for accounts that haven't completed setup yet.

## Fix
`getAccountProfile()` now treats 404 as 'no profile yet' and returns defaults with `profile_setup_complete=false`. Callers already branch on that flag.

## Test plan
- [ ] Re-deploy via workflow_dispatch
- [ ] Sign in as qa-tester@hive.test on staging
- [ ] Land on /console with the 'Complete your workspace profile' banner (no 500)
- [ ] Walk through /console/setup
- [ ] /console/billing and /console/api-keys load

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling for new user accounts that don't yet have an existing profile. The app now gracefully initializes profile data instead of throwing an error, allowing new users to proceed smoothly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->