### PR TITLE
fix(e2e): scope probe skip + credits-card assertion (addresses #125 reviews)

### DIFF
--- a/apps/web-console/tests/e2e/_probe/staging-flows.spec.ts
+++ b/apps/web-console/tests/e2e/_probe/staging-flows.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 
 // All endpoints + credentials are environment-specific. Pull them from env
 // (typically populated from .env via `set -a; source .env; set +a` or the
@@ -13,34 +13,58 @@ const CONTROL_PLANE =
 const QA_TESTER_EMAIL = process.env.HIVE_QA_TESTER_EMAIL ?? "";
 const QA_TESTER_PASSWORD = process.env.HIVE_QA_TESTER_PASSWORD ?? "";
 const QA_UNVERIFIED_EMAIL = process.env.HIVE_QA_UNVERIFIED_EMAIL ?? "";
-const QA_UNVERIFIED_PASSWORD =
-  process.env.HIVE_QA_UNVERIFIED_PASSWORD ?? "";
+const QA_UNVERIFIED_PASSWORD = process.env.HIVE_QA_UNVERIFIED_PASSWORD ?? "";
 
-test.skip(
-  !QA_TESTER_EMAIL || !QA_TESTER_PASSWORD,
-  "HIVE_QA_TESTER_EMAIL / HIVE_QA_TESTER_PASSWORD not set",
-);
+const HAS_TESTER_CREDS = !!(QA_TESTER_EMAIL && QA_TESTER_PASSWORD);
+const HAS_UNVERIFIED_CREDS = !!(QA_UNVERIFIED_EMAIL && QA_UNVERIFIED_PASSWORD);
 
-test("sign-in lands on /console with credit balance + workspace banner", async ({ page }) => {
+async function signIn(page: Page, email: string, password: string) {
   await page.goto(`${BASE}/auth/sign-in`);
-  await page.locator("#email").fill(QA_TESTER_EMAIL);
-  await page.locator("#password").fill(QA_TESTER_PASSWORD);
+  await page.locator("#email").fill(email);
+  await page.locator("#password").fill(password);
   await page.click('button[type="submit"]');
   // baseURL hostname contains "console" (console-hive.scubed.co), so a glob
   // like "**/console**" would resolve while still on /auth/sign-in. Match by
-  // pathname instead so this only succeeds after a real redirect into /console.
+  // pathname instead so this only succeeds after a real /console redirect.
   await page.waitForURL((url) => url.pathname.startsWith("/console"), {
     timeout: 25000,
   });
+}
+
+test("sign-in lands on /console with credit balance + workspace banner", async ({
+  page,
+}) => {
+  test.skip(
+    !HAS_TESTER_CREDS,
+    "HIVE_QA_TESTER_EMAIL / HIVE_QA_TESTER_PASSWORD not set",
+  );
+  await signIn(page, QA_TESTER_EMAIL, QA_TESTER_PASSWORD);
+
+  // Scope the numeric assertion to the "Available credits" card. Other cards
+  // on /console (e.g. "Today's activity") also render `p[data-numeric=true]`
+  // placeholders showing "—", so a global `.first()` could pass even when
+  // the actual credit balance is missing.
+  const creditsHeading = page.getByRole("heading", {
+    name: "Available credits",
+  });
+  await expect(creditsHeading).toBeVisible();
+  const creditsCard = page
+    .locator('[class*="card"], section, article')
+    .filter({ has: creditsHeading })
+    .first();
   await expect(
-    page.getByRole("heading", { name: "Available credits" }),
+    creditsCard.locator('p[data-numeric="true"]').first(),
   ).toBeVisible();
-  // Don't assert an exact credit amount — usage charges accrue between runs.
-  // Just verify a non-zero balance renders in the dashboard's numeric slot.
-  await expect(page.locator('p[data-numeric="true"]').first()).toBeVisible();
+  // Usage accrues between runs so we don't pin to a fixed amount, but the
+  // credit slot should always render a digit, never just an em-dash.
+  await expect(
+    creditsCard.locator('p[data-numeric="true"]').first(),
+  ).toHaveText(/\d/);
 });
 
-test("sign-up form blocks malformed submissions client-side", async ({ page }) => {
+test("sign-up form blocks malformed submissions client-side", async ({
+  page,
+}) => {
   await page.goto(`${BASE}/auth/sign-up`);
   await page.locator("#email").fill("not-an-email");
   await page.locator("#password").fill("short");
@@ -50,7 +74,7 @@ test("sign-up form blocks malformed submissions client-side", async ({ page }) =
 
 test("unverified user sign-in shows error", async ({ page }) => {
   test.skip(
-    !QA_UNVERIFIED_EMAIL || !QA_UNVERIFIED_PASSWORD,
+    !HAS_UNVERIFIED_CREDS,
     "HIVE_QA_UNVERIFIED_EMAIL / HIVE_QA_UNVERIFIED_PASSWORD not set",
   );
   await page.goto(`${BASE}/auth/sign-in`);
@@ -64,20 +88,18 @@ test("unverified user sign-in shows error", async ({ page }) => {
 });
 
 test("account setup page renders the profile form", async ({ page }) => {
-  await page.goto(`${BASE}/auth/sign-in`);
-  await page.locator("#email").fill(QA_TESTER_EMAIL);
-  await page.locator("#password").fill(QA_TESTER_PASSWORD);
-  await page.click('button[type="submit"]');
-  await page.waitForURL((url) => url.pathname.startsWith("/console"), {
-    timeout: 25000,
-  });
+  test.skip(
+    !HAS_TESTER_CREDS,
+    "HIVE_QA_TESTER_EMAIL / HIVE_QA_TESTER_PASSWORD not set",
+  );
+  await signIn(page, QA_TESTER_EMAIL, QA_TESTER_PASSWORD);
 
   const response = await page.goto(`${BASE}/console/setup`);
   expect(response?.status()).toBe(200);
   await page.waitForLoadState("networkidle", { timeout: 20000 });
   // ownerName + accountName + accountType selectors render only when the form
   // is shown. If profile already complete server may redirect to /console; in
-  // either case we should land on a page whose body contains "workspace".
+  // either case we should land on a /console path.
   const url = page.url();
   if (url.includes("/console/setup")) {
     await expect(page.locator("#ownerName")).toBeVisible();
@@ -89,13 +111,11 @@ test("account setup page renders the profile form", async ({ page }) => {
 });
 
 test("api keys page renders", async ({ page }) => {
-  await page.goto(`${BASE}/auth/sign-in`);
-  await page.locator("#email").fill(QA_TESTER_EMAIL);
-  await page.locator("#password").fill(QA_TESTER_PASSWORD);
-  await page.click('button[type="submit"]');
-  await page.waitForURL((url) => url.pathname.startsWith("/console"), {
-    timeout: 25000,
-  });
+  test.skip(
+    !HAS_TESTER_CREDS,
+    "HIVE_QA_TESTER_EMAIL / HIVE_QA_TESTER_PASSWORD not set",
+  );
+  await signIn(page, QA_TESTER_EMAIL, QA_TESTER_PASSWORD);
 
   const response = await page.goto(`${BASE}/console/api-keys`);
   expect(response?.status()).toBe(200);


### PR DESCRIPTION
## Summary
Follow-up to #125. Resolves three pieces of automated review feedback.

- **Codex P2 / CodeRabbit Major** — the file-level `test.skip` disabled every test in the spec when tester credentials were unset, including the malformed sign-up + public health checks. Scope the skip to the three auth-dependent tests (`sign-in lands…`, `account setup page…`, `api keys page renders`) so the credential-free probes always run.
- **Codex P1** — `page.locator('p[data-numeric="true"]').first()` could match the *"Today's activity"* placeholder rendering "—" instead of the actual credit balance, so the assertion was passing while credits were missing. Now scoped to the card containing the *"Available credits"* heading, and asserts the value contains a digit (never just em-dash).
- **CodeRabbit nitpick** — extracted the `goto → fill → submit → waitForURL` block into a single `signIn(page, email, password)` helper.

## Test plan
- [x] Local probe vs staging: 6/6 pass
- [ ] CI green