### PR TITLE
feat(web-console): add sign-out route + UI

### DIFF
--- a/apps/web-console/app/auth/sign-out/route.ts
+++ b/apps/web-console/app/auth/sign-out/route.ts
@@ -11,9 +11,16 @@ export async function POST(request: NextRequest) {
 
   await supabase.auth.signOut();
 
-  const response = NextResponse.redirect(new URL("/auth/sign-in", request.url), {
-    status: 303,
-  });
+  // Build the redirect URL from `request.nextUrl` (which honors the
+  // X-Forwarded-Host / X-Forwarded-Proto headers Next.js sets on the
+  // edge) instead of `request.url`. The latter falls back to the
+  // socket bind address — `0.0.0.0:3000` inside a container — which
+  // browsers cannot resolve.
+  const redirectUrl = request.nextUrl.clone();
+  redirectUrl.pathname = "/auth/sign-in";
+  redirectUrl.search = "";
+
+  const response = NextResponse.redirect(redirectUrl, { status: 303 });
 
   // Clear any account-scoping cookie set by /console/account-switch.
   response.cookies.set("hive_account_id", "", {

--- a/apps/web-console/app/auth/sign-out/route.ts
+++ b/apps/web-console/app/auth/sign-out/route.ts
@@ -11,14 +11,21 @@ export async function POST(request: NextRequest) {
 
   await supabase.auth.signOut();
 
-  // Build the redirect URL from `request.nextUrl` (which honors the
-  // X-Forwarded-Host / X-Forwarded-Proto headers Next.js sets on the
-  // edge) instead of `request.url`. The latter falls back to the
-  // socket bind address — `0.0.0.0:3000` inside a container — which
-  // browsers cannot resolve.
-  const redirectUrl = request.nextUrl.clone();
-  redirectUrl.pathname = "/auth/sign-in";
-  redirectUrl.search = "";
+  // Build the redirect URL from explicit Host / X-Forwarded-* headers.
+  // Inside the docker image Next.js runs in standalone mode with
+  // `HOSTNAME=0.0.0.0`, which leaks into both `request.url` and
+  // `request.nextUrl.origin`. Resolving the host from headers gives a
+  // browser-resolvable origin in dev (localhost) and behind any
+  // upstream proxy (forwarded host) in staging/prod.
+  const headers = request.headers;
+  const host =
+    headers.get("x-forwarded-host") ?? headers.get("host") ?? "localhost";
+  const proto =
+    headers.get("x-forwarded-proto") ??
+    (host.startsWith("localhost") || host.startsWith("127.0.0.1")
+      ? "http"
+      : "https");
+  const redirectUrl = new URL("/auth/sign-in", `${proto}://${host}`);
 
   const response = NextResponse.redirect(redirectUrl, { status: 303 });
 

--- a/apps/web-console/app/auth/sign-out/route.ts
+++ b/apps/web-console/app/auth/sign-out/route.ts
@@ -2,7 +2,10 @@ import { NextResponse, type NextRequest } from "next/server";
 import { cookies } from "next/headers";
 import { createClient } from "@/lib/supabase/server";
 
-async function signOutAndRedirect(request: NextRequest) {
+// Sign-out is a state-changing action — only allow POST so the
+// SameSite=Lax auth cookies cannot be used to terminate a session via
+// cross-site top-level navigation (CSRF-style logout).
+export async function POST(request: NextRequest) {
   const cookieStore = await cookies();
   const supabase = createClient(cookieStore);
 
@@ -21,12 +24,4 @@ async function signOutAndRedirect(request: NextRequest) {
   });
 
   return response;
-}
-
-export async function POST(request: NextRequest) {
-  return signOutAndRedirect(request);
-}
-
-export async function GET(request: NextRequest) {
-  return signOutAndRedirect(request);
 }

--- a/apps/web-console/app/auth/sign-out/route.ts
+++ b/apps/web-console/app/auth/sign-out/route.ts
@@ -11,21 +11,30 @@ export async function POST(request: NextRequest) {
 
   await supabase.auth.signOut();
 
-  // Build the redirect URL from explicit Host / X-Forwarded-* headers.
-  // Inside the docker image Next.js runs in standalone mode with
-  // `HOSTNAME=0.0.0.0`, which leaks into both `request.url` and
-  // `request.nextUrl.origin`. Resolving the host from headers gives a
-  // browser-resolvable origin in dev (localhost) and behind any
-  // upstream proxy (forwarded host) in staging/prod.
-  const headers = request.headers;
-  const host =
-    headers.get("x-forwarded-host") ?? headers.get("host") ?? "localhost";
-  const proto =
-    headers.get("x-forwarded-proto") ??
-    (host.startsWith("localhost") || host.startsWith("127.0.0.1")
-      ? "http"
-      : "https");
-  const redirectUrl = new URL("/auth/sign-in", `${proto}://${host}`);
+  // Resolve the redirect origin against the canonical app URL when one
+  // is configured (matches sign-up + forgot-password). This keeps the
+  // host trustworthy (no open-redirect via spoofed X-Forwarded-Host)
+  // and avoids the standalone-runtime trap where Next.js leaks
+  // `HOSTNAME=0.0.0.0` into `request.url` / `request.nextUrl.origin`.
+  // Fall back to the X-Forwarded-Host / Host headers for environments
+  // where NEXT_PUBLIC_APP_URL is not set (local dev, ad-hoc previews).
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL;
+  let origin: string;
+  if (appUrl) {
+    origin = new URL(appUrl).origin;
+  } else {
+    const headers = request.headers;
+    const host =
+      headers.get("x-forwarded-host") ?? headers.get("host") ?? "localhost";
+    const isLoopback =
+      host.startsWith("localhost") ||
+      host.startsWith("127.0.0.1") ||
+      host.startsWith("[::1]");
+    const proto =
+      headers.get("x-forwarded-proto") ?? (isLoopback ? "http" : "https");
+    origin = `${proto}://${host}`;
+  }
+  const redirectUrl = new URL("/auth/sign-in", origin);
 
   const response = NextResponse.redirect(redirectUrl, { status: 303 });
 

--- a/apps/web-console/app/auth/sign-out/route.ts
+++ b/apps/web-console/app/auth/sign-out/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { cookies } from "next/headers";
+import { createClient } from "@/lib/supabase/server";
+
+async function signOutAndRedirect(request: NextRequest) {
+  const cookieStore = await cookies();
+  const supabase = createClient(cookieStore);
+
+  await supabase.auth.signOut();
+
+  const response = NextResponse.redirect(new URL("/auth/sign-in", request.url), {
+    status: 303,
+  });
+
+  // Clear any account-scoping cookie set by /console/account-switch.
+  response.cookies.set("hive_account_id", "", {
+    httpOnly: true,
+    sameSite: "lax",
+    path: "/",
+    maxAge: 0,
+  });
+
+  return response;
+}
+
+export async function POST(request: NextRequest) {
+  return signOutAndRedirect(request);
+}
+
+export async function GET(request: NextRequest) {
+  return signOutAndRedirect(request);
+}

--- a/apps/web-console/app/layout.tsx
+++ b/apps/web-console/app/layout.tsx
@@ -45,7 +45,17 @@ export default function RootLayout({ children }: RootLayoutProps) {
       lang="en"
       className={`${geistSans.variable} ${geistMono.variable} ${fraunces.variable}`}
     >
-      <body className="min-h-screen bg-canvas text-ink antialiased">
+      {/*
+        Browser extensions (Grammarly, etc.) mutate <body> attributes
+        before React hydrates, which produces a hydration mismatch
+        warning on every page load. Suppressing the warning on this
+        single boundary node is the React-recommended workaround and
+        does not silence mismatches inside the tree.
+      */}
+      <body
+        className="min-h-screen bg-canvas text-ink antialiased"
+        suppressHydrationWarning
+      >
         {children}
       </body>
     </html>

--- a/apps/web-console/components/app-shell/console-shell.tsx
+++ b/apps/web-console/components/app-shell/console-shell.tsx
@@ -161,22 +161,7 @@ export function ConsoleShell({
                 {user.email}
               </span>
             </div>
-            <form action="/auth/sign-out" method="post" className="shrink-0">
-              <button
-                type="submit"
-                aria-label="Sign out"
-                title="Sign out"
-                className={cn(
-                  "h-7 w-7 grid place-items-center rounded-md",
-                  "text-[var(--color-ink-3)]",
-                  "transition-colors duration-[var(--duration-fast)]",
-                  "hover:text-[var(--color-ink)] hover:bg-[var(--color-surface-inset)]",
-                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]",
-                )}
-              >
-                <LogOut size={14} />
-              </button>
-            </form>
+            <SignOutButton className="shrink-0" />
           </div>
         </div>
       </aside>
@@ -199,22 +184,7 @@ export function ConsoleShell({
             >
               Docs
             </Link>
-            <form action="/auth/sign-out" method="post" className="lg:hidden">
-              <button
-                type="submit"
-                aria-label="Sign out"
-                title="Sign out"
-                className={cn(
-                  "h-7 w-7 grid place-items-center rounded-md",
-                  "text-[var(--color-ink-3)]",
-                  "transition-colors duration-[var(--duration-fast)]",
-                  "hover:text-[var(--color-ink)] hover:bg-[var(--color-surface-inset)]",
-                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]",
-                )}
-              >
-                <LogOut size={14} />
-              </button>
-            </form>
+            <SignOutButton className="lg:hidden" />
           </div>
         </header>
         <main className="flex-1 overflow-y-auto">
@@ -222,6 +192,27 @@ export function ConsoleShell({
         </main>
       </div>
     </div>
+  );
+}
+
+function SignOutButton({ className }: { className?: string }) {
+  return (
+    <form action="/auth/sign-out" method="post" className={className}>
+      <button
+        type="submit"
+        aria-label="Sign out"
+        title="Sign out"
+        className={cn(
+          "h-7 w-7 grid place-items-center rounded-md",
+          "text-[var(--color-ink-3)]",
+          "transition-colors duration-[var(--duration-fast)]",
+          "hover:text-[var(--color-ink)] hover:bg-[var(--color-surface-inset)]",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]",
+        )}
+      >
+        <LogOut size={14} />
+      </button>
+    </form>
   );
 }
 

--- a/apps/web-console/components/app-shell/console-shell.tsx
+++ b/apps/web-console/components/app-shell/console-shell.tsx
@@ -9,6 +9,7 @@ import {
   Users,
   Settings,
   Wallet,
+  LogOut,
 } from "lucide-react";
 
 import { cn } from "@/lib/cn";
@@ -152,7 +153,7 @@ export function ConsoleShell({
             <div className="h-7 w-7 rounded-full bg-[var(--color-accent-soft)] grid place-items-center text-2xs text-[var(--color-accent-ink)] font-semibold">
               {(user.name?.[0] ?? user.email[0] ?? "?").toUpperCase()}
             </div>
-            <div className="flex flex-col gap-0.5 min-w-0">
+            <div className="flex flex-col gap-0.5 min-w-0 flex-1">
               <span className="text-xs text-[var(--color-ink)] truncate">
                 {user.name ?? user.email}
               </span>
@@ -160,6 +161,22 @@ export function ConsoleShell({
                 {user.email}
               </span>
             </div>
+            <form action="/auth/sign-out" method="post" className="shrink-0">
+              <button
+                type="submit"
+                aria-label="Sign out"
+                title="Sign out"
+                className={cn(
+                  "h-7 w-7 grid place-items-center rounded-md",
+                  "text-[var(--color-ink-3)]",
+                  "transition-colors duration-[var(--duration-fast)]",
+                  "hover:text-[var(--color-ink)] hover:bg-[var(--color-surface-inset)]",
+                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]",
+                )}
+              >
+                <LogOut size={14} />
+              </button>
+            </form>
           </div>
         </div>
       </aside>
@@ -175,13 +192,29 @@ export function ConsoleShell({
           <div className="flex items-center gap-3 text-sm text-[var(--color-ink-2)]">
             {topbar}
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-3">
             <Link
               href="https://hivegpt.io"
               className="text-xs text-[var(--color-ink-3)] hover:text-[var(--color-ink)] transition-colors"
             >
               Docs
             </Link>
+            <form action="/auth/sign-out" method="post" className="lg:hidden">
+              <button
+                type="submit"
+                aria-label="Sign out"
+                title="Sign out"
+                className={cn(
+                  "h-7 w-7 grid place-items-center rounded-md",
+                  "text-[var(--color-ink-3)]",
+                  "transition-colors duration-[var(--duration-fast)]",
+                  "hover:text-[var(--color-ink)] hover:bg-[var(--color-surface-inset)]",
+                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]",
+                )}
+              >
+                <LogOut size={14} />
+              </button>
+            </form>
           </div>
         </header>
         <main className="flex-1 overflow-y-auto">

--- a/apps/web-console/tests/e2e/profile-completion.spec.ts
+++ b/apps/web-console/tests/e2e/profile-completion.spec.ts
@@ -57,7 +57,7 @@ test.describe("profile completion", () => {
       await page.selectOption('select[name="accountType"]', "business");
       await page.fill('input[name="countryCode"]', "US");
       await page.fill('input[name="stateRegion"]', "CA");
-      await page.click('button[type="submit"]');
+      await page.getByRole("button", { name: "Save and continue" }).click();
 
       await page.waitForURL("**/console");
       await expect(page.getByText("Workspace:")).toBeVisible();
@@ -82,7 +82,7 @@ test.describe("profile completion", () => {
       await page.selectOption('select[name="accountType"]', "business");
       await page.fill('input[name="countryCode"]', "US");
       await page.fill('input[name="stateRegion"]', "CA");
-      await page.click('button[type="submit"]');
+      await page.getByRole("button", { name: "Save and continue" }).click();
 
       await page.waitForURL("**/console");
       // The redesigned dashboard's H1 is the workspace display name. Use a
@@ -118,7 +118,7 @@ test.describe("profile completion", () => {
       await page.goto("/console/settings/billing");
 
       await page.fill('input[name="legalEntityName"]', "Acme Labs LLC");
-      await page.click('button[type="submit"]');
+      await page.getByRole("button", { name: "Save billing details" }).click();
 
       await page.waitForURL("**/console/settings/billing");
       await expect(


### PR DESCRIPTION
## Summary
- Add `POST/GET /auth/sign-out` route handler — calls `supabase.auth.signOut()`, clears `hive_account_id` cookie, 303 → `/auth/sign-in`.
- Add LogOut icon button to `console-shell` user footer (desktop) and topbar (`lg:hidden` for mobile parity).
- Plain HTML `<form method="post">` — no client JS needed.

Closes the gap reported by the user: "no way to logout in web-console."

## Test plan
- [ ] Sign in to web-console, click LogOut icon next to avatar (desktop) — confirm redirect to `/auth/sign-in`
- [ ] Visit `/console` after sign-out — middleware should redirect back to `/auth/sign-in`
- [ ] Verify on mobile viewport — header LogOut icon visible, sidebar hidden
- [ ] Confirm `hive_account_id` cookie cleared after sign-out
- [ ] CI: web build, typecheck, E2E suite all green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added sign-out functionality allowing users to securely terminate their session. Sign-out controls are now available in both desktop and mobile interfaces for easy access.

* **Bug Fixes**
  * Fixed React hydration warnings that occurred due to pre-hydration DOM modifications from browser extensions.

* **Tests**
  * Enhanced end-to-end tests with improved accessibility-based element selectors for better reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->