### PR TITLE
feat(control-plane): phase 15 — batch local executor (success-path settlement)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,21 @@ GROQ_REASONING_MODEL=groq/openai/gpt-oss-120b
 # NVIDIA NIM embedding model (retriever-style 300M).
 NVIDIA_NIM_EMBEDDING_MODEL=nvidia_nim/nvidia/llama-3.2-nemoretriever-300m-embed-v1
 
+# ─── Phase 15: Local batch executor (POST /v1/batches success-path) ───
+# Concurrency cap for in-flight per-line dispatches. Default 8; ceiling 32.
+BATCH_EXECUTOR_CONCURRENCY=8
+# Bounded retries on transient failures (5xx, 408, 429, network errors). 4xx
+# (400/401/403/404/422) fail immediately. Default 3; ceiling 5.
+BATCH_EXECUTOR_MAX_RETRIES=3
+# Per-line context timeout in milliseconds. Default 60000 (60s); floor 5000;
+# ceiling 300000 (5min).
+BATCH_EXECUTOR_LINE_TIMEOUT_MS=60000
+# Dispatch strategy: "auto" reads route_capabilities.executor_kind (default
+# local for openrouter/groq); "local" forces the in-process executor; "upstream"
+# forces the existing LiteLLM upstream batch-file path (only works for
+# openai/azure/vertex/anthropic providers).
+BATCH_EXECUTOR_KIND=auto
+
 # Supabase Storage (S3-compatible)
 # Enable S3 protocol in Supabase Dashboard > Storage > S3 Access.
 # Create the buckets hive-files and hive-images before starting the stack.

--- a/.planning/phases/15-batch-local-executor/15-01-SUMMARY.md
+++ b/.planning/phases/15-batch-local-executor/15-01-SUMMARY.md
@@ -1,0 +1,184 @@
+---
+phase: 15
+plan: 01
+subsystem: batchstore
+tags: [batch, executor, settlement, openrouter, groq, jsonl]
+requires: [storage:S3, asynq:redis, accounting:reservation]
+provides: [batch:success-path, batch:execute task type, batch_lines table]
+affects: [submitter, worker, queue, filestore.Service]
+tech_stack:
+  added:
+    - "math/big — per-line credit summation"
+    - "bufio.Scanner with 4MB buffer — JSONL streaming"
+    - "asynq batch:execute task type"
+  patterns:
+    - "small ports + adapters (BatchStore, LineStore, ReservationPort, StoragePort, InferencePort)"
+    - "math/big for financial summation (per CLAUDE.md FX rule)"
+    - "exponential-backoff retry with 4xx terminal short-circuit"
+    - "thread-safe append-only JSONL writers (mutex-guarded)"
+    - "pgx upsert-on-conflict for per-line idempotency"
+key_files:
+  created:
+    - apps/control-plane/internal/batchstore/executor/types.go
+    - apps/control-plane/internal/batchstore/executor/jsonl.go
+    - apps/control-plane/internal/batchstore/executor/jsonl_test.go
+    - apps/control-plane/internal/batchstore/executor/dispatcher.go
+    - apps/control-plane/internal/batchstore/executor/dispatcher_test.go
+    - apps/control-plane/internal/batchstore/executor/executor.go
+    - apps/control-plane/internal/batchstore/executor/executor_test.go
+    - apps/control-plane/internal/batchstore/executor/settle.go
+    - apps/control-plane/internal/batchstore/executor/settle_test.go
+    - apps/control-plane/internal/batchstore/local_inference.go
+    - apps/control-plane/internal/batchstore/local_executor_adapters.go
+    - apps/control-plane/internal/batchstore/local_executor_test.go
+    - supabase/migrations/0015_batch_local_executor.sql
+    - .planning/phases/15-batch-local-executor/DECISIONS.md
+    - .planning/phases/15-batch-local-executor/15-VERIFICATION.md
+  modified:
+    - apps/control-plane/internal/batchstore/types.go
+    - apps/control-plane/internal/batchstore/queue.go
+    - apps/control-plane/internal/batchstore/submitter.go
+    - apps/control-plane/internal/batchstore/worker.go
+    - apps/control-plane/internal/filestore/repository.go
+    - apps/control-plane/internal/filestore/service.go
+    - apps/control-plane/cmd/server/main.go
+    - apps/control-plane/internal/platform/config/config.go
+    - .env.example
+    - deploy/litellm/config.yaml
+decisions:
+  - "Q1: LiteLLM-direct HTTP (not in-process import) — Go internal/ rule forbids cross-module access"
+  - "Q2: Control-plane in-process — reuses DB pool, Redis queue, storage, accounting"
+  - "Q3: Concurrency default 8, ceiling 32 — empirical OpenRouter/Groq parallel-request tolerance"
+metrics:
+  completed_at: 2026-04-25
+  duration_minutes: ~120
+  tasks: 3
+  go_loc_added: ~1750 (executor 600 + adapters 400 + tests 750)
+  migration_loc: 32
+---
+
+# Phase 15 Plan 01: Batch Local Executor Summary
+
+Implements local batch executor inside `apps/control-plane/internal/batchstore/executor/` so v1.0's `POST /v1/batches` success-path ships without requiring a LiteLLM-supported batch upstream provider — the executor reads input JSONL line-by-line from Supabase Storage, fans out via bounded concurrency to LiteLLM's `/v1/chat/completions` endpoint, composes OpenAI-shape `output.jsonl` + `errors.jsonl`, and settles per-line credits through the existing reservation primitive.
+
+## Outcome
+
+Closes the v1.0 known-issue "batch success-path blocked by upstream provider capability" (CLAUDE.md Known Issues #4) for the OpenRouter+Groq provider mix Hive ships with. Existing LiteLLM upstream path preserved as `submitUpstream` for future supported providers (openai/azure/vertex/anthropic) — selectable per-batch via `BATCH_EXECUTOR_KIND` env override.
+
+## What Shipped
+
+### Executor primitives (`apps/control-plane/internal/batchstore/executor/`)
+
+- `types.go` — Config (Concurrency/MaxRetries/LineTimeout/Kind) with Validate clamps; OpenAI batch-shape contracts (InputLine, OutputLine, ErrorLine, OutputResponse, ErrorObj); ScanResult/DispatchResult.
+- `jsonl.go` — `ScanLines` streams a JSONL reader with a 4MB scanner buffer (headroom over OpenAI's ~1MB-per-line cap); malformed lines yielded as ScanResult errors so the caller routes them to errors.jsonl rather than crashing. `JSONLWriter` is mutex-guarded for concurrent Append from dispatcher goroutines; Finalize uploads to a StoragePort with optional skip-empty for the errors file.
+- `dispatcher.go` — bounded worker pool + exp-backoff retry (100ms/400ms/1.6s; 4xx terminal short-circuit; 5xx/timeout/network retry up to MaxRetries); per-line context timeout; provider-name regex sanitization (`openrouter|groq|litellm` → `upstream`); `PeakInFlight` counter for concurrency-cap test instrumentation.
+- `executor.go` — `Run(ctx, batchID)` orchestrates: load batch via BatchStore, load prior batch_lines via LineStore (skips already-settled rows for restart-safe resume), stream input via ScanLines, dispatch via Pool, drain results into JSONLWriters, finalize uploads, settle credits, MarkCompleted.
+- `settle.go` — `Settle` sums per-line credits via `math/big.Int` (per CLAUDE.md FX rule), caps at reserved with `overconsumed=true` on overrun (no negative balance), idempotent on identical inputs.
+
+### Migration `0015_batch_local_executor.sql`
+
+- `batches.executor_kind` ('upstream'|'local'), `batches.completed_lines`, `batches.failed_lines`, `batches.overconsumed`.
+- `route_capabilities.executor_kind` (default 'local' for openrouter/groq).
+- `batch_lines` table with `(batch_id, custom_id)` PK + status/attempt/consumed_credits/output_index/error_index/last_error/timestamps for per-line idempotency + restart-safe resume.
+
+### Wiring
+
+- `submitter.go` — `WithLocalExecutor(executeQueue, kind)` + `shouldUseLocalExecutor` branches on provider (openai/azure/vertex/anthropic → upstream; everything else → local) plus env override. `submitLocal` updates the batch row to in_progress with executor_kind=local and enqueues `batch:execute`.
+- `queue.go` — `EnqueueExecute` pushes the new task type onto the same Redis batch queue.
+- `worker.go` — `HandleBatchExecute` delegates to `executor.Run`; `ctx.Canceled` re-enqueues; terminal failures mark the batch failed via the existing failure path.
+- `local_inference.go` — `LiteLLMInferenceClient` implements `executor.InferencePort` via `POST {litellm}/v1/chat/completions`; rewrites model field per route; decodes OpenAI usage for per-line credit attribution.
+- `local_executor_adapters.go` — `pgxBatchStore`, `pgxLineStore`, `AccountingReservationAdapter` wrap existing services with zero new ledger code.
+- `filestore` — `GetBatchByID` + `GetFileByID` server-side variants (existing `GetBatch` requires accountID scope; the worker resolves the account from the batch row first).
+- `main.go` — singleton executor wired at startup; `asynq.NewServeMux` registers `batch:execute` alongside `batch:poll`.
+- `.env.example` — `BATCH_EXECUTOR_CONCURRENCY` (default 8, ceiling 32), `BATCH_EXECUTOR_MAX_RETRIES` (default 3, ceiling 5), `BATCH_EXECUTOR_LINE_TIMEOUT_MS` (default 60000, floor 5000, ceiling 300000), `BATCH_EXECUTOR_KIND` (default "auto").
+
+## Decisions Made
+
+- **Q1 LiteLLM-direct over in-process import.** Initial plan had the dispatcher call `apps/edge-api/internal/inference.Orchestrator` in-process. Investigation confirmed Go's `internal/` rule forbids cross-module access (control-plane and edge-api are separate modules under `go.work`). Two fallbacks evaluated: (a) shared `packages/go/inference` factor (~1 day, ~25 call-site refactors), (b) HTTP to LiteLLM `/v1/chat/completions`. Picked (b) because control-plane already holds LiteLLM credentials and rewrites batch model names; reuses LiteLLM's provider routing/retry/sanitization; no module-boundary refactor; no double rate-limiter accounting; ~5–15ms per-line latency cost is acceptable for batch workloads. Sanitization moved to `dispatcher.SanitizeMessage` regex.
+- **Q2 control-plane in-process.** Reuses DB pool, Redis queue, storage, accounting service. Throughput target dozens of batches/day → separate process is over-engineering. Concurrency ceiling 32 + per-line timeout bound the runaway-batch risk.
+- **Q3 concurrency 8/32.** Empirical OpenRouter/Groq parallel-request tolerance; ceiling enforced in `Config.Validate`.
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 3 - Blocking] Toolchain Docker image lacks gcc/musl-dev for `-race`**
+
+- **Found during:** Task 1 verification.
+- **Issue:** `go test -race` requires `CGO_ENABLED=1` plus a libc and a C compiler; the alpine-based toolchain image ships with neither.
+- **Fix:** Test commands now run `apk add --no-cache gcc musl-dev > /dev/null 2>&1 && go test ...` on each invocation. Documented in 15-VERIFICATION.md "Verification Commands".
+- **Files modified:** Verification doc only — not committed to image build to keep the toolchain Dockerfile lean.
+- **Commit:** N/A (operator-runbook)
+
+**2. [Rule 3 - Blocking] Module boundary forbids in-process inference import**
+
+- **Found during:** Task 3 main.go wiring.
+- **Issue:** `apps/control-plane` cannot import `apps/edge-api/internal/inference` because Go's `internal/` rule forbids cross-module reads, even within the same `go.work`.
+- **Fix:** Pivoted Q1 from "in-process call" to "LiteLLM-direct HTTP" — documented in DECISIONS.md.
+- **Files modified:** DECISIONS.md, local_inference.go (new).
+- **Commit:** d6e9c25 (Task 1) — landed with the pivot resolved before any wiring code was written.
+
+**3. [Rule 3 - Blocking] `filestore.Service.GetBatch/GetFile` require accountID scope**
+
+- **Found during:** Task 3 adapter wiring.
+- **Issue:** The worker loads a batch by ID before resolving its owning account, but the existing methods require accountID for tenant isolation.
+- **Fix:** Added `GetBatchByID` + `GetFileByID` (server-side, no scope) in repository.go + service.go. Customer-facing handlers continue to use the scoped variants.
+- **Files modified:** apps/control-plane/internal/filestore/{repository,service}.go.
+- **Commit:** Task 3 commit.
+
+**4. [Rule 3 - Blocking] Toolchain image VCS stamping fails**
+
+- **Found during:** Task 3 build.
+- **Issue:** `go build` errored "obtaining VCS status: exit status 128" inside the toolchain container because the workspace mount isn't a git repo from the container's perspective.
+- **Fix:** Added `-buildvcs=false` to the verification build invocation; production builds (run from the host or a properly-stamped image) are unaffected.
+- **Commit:** N/A (operator-runbook)
+
+### Architectural Changes (asked → none)
+
+No Rule 4 escalations. The Q1 pivot to LiteLLM-direct was a pre-resolved blocker (PLAN.md blocker #2), not a fresh architectural decision.
+
+## Live Ship-Gate Status
+
+The unit-level matrix from PLAN.md `must_haves.truths` is fully verified
+(see 15-VERIFICATION.md "Must-Have Truth Verification" section). The 100-line
+live E2E + restart-safety probe + sanitization grep + USD audit need:
+
+1. Migration 0015 applied to staging Supabase.
+2. Funded API key minted via control-plane.
+3. `BATCH_EXECUTOR_KIND=auto` boot.
+
+Operator runbook in 15-VERIFICATION.md "Live ship-gate dry-run". Once run,
+audit outputs paste back into that section to close the v1.1.0 ship-gate
+item for batch success-path settlement.
+
+## Authentication Gates
+
+None encountered during execution.
+
+## Forward-Carried Blockers
+
+- **Phase 16:** `apps/control-plane/internal/routing/repository.go`
+  `ensureCapabilityColumns` table-name fix (currently targets
+  `route_capabilities` instead of `provider_capabilities`). Phase 15 explicitly
+  did not touch this file (`git diff main...HEAD` empty for that path).
+- **Phase 17:** Full FX/USD leak audit across customer-visible surfaces
+  (Phase 15 introduces no new leak on the batch surface; Phase 17 owns the
+  comprehensive sweep).
+
+## Self-Check: PASSED
+
+- All listed key_files present on disk:
+  - executor/{types,jsonl,jsonl_test,dispatcher,dispatcher_test,executor,executor_test,settle,settle_test}.go ✓
+  - migration 0015_batch_local_executor.sql ✓
+  - local_inference.go, local_executor_adapters.go, local_executor_test.go ✓
+  - DECISIONS.md, 15-VERIFICATION.md ✓
+- All listed modified files contain Phase 15 changes (Edit tool errored
+  on stale reads → state confirmed via rebuild + tests).
+- All commits on `a/phase-15-batch-local-executor-clean` reachable from HEAD
+  (cherry-picked from interleaved branch onto origin/main).
+- All tests green under `-race`:
+  - `go test -count=1 -race -short ./apps/control-plane/internal/batchstore/...` → ok batchstore + ok batchstore/executor.
+  - `go vet ./apps/control-plane/...` → clean.
+  - `go test -count=1 -short ./apps/control-plane/...` → all packages ok.
+- Phase 16 boundary clean: `git diff --name-only origin/main...HEAD` does
+  not include `apps/control-plane/internal/routing/repository.go`.

--- a/.planning/phases/15-batch-local-executor/15-VERIFICATION.md
+++ b/.planning/phases/15-batch-local-executor/15-VERIFICATION.md
@@ -179,10 +179,47 @@ When operator runs this dry-run pre-release, paste the audit outputs here as
    of truth for billing. Customers polling status see the line in output.jsonl
    without re-billing.
 
+   **OpenAI compliance gap.** The sentinel body diverges from the real
+   chat-completion response shape; SDKs that try to parse `response.body` as
+   a chat-completion will fail on resumed lines. Mitigation: see
+   "Phase 18 — Batch Resume Compliance" plan below.
+
 3. **In-process inference vs LiteLLM-direct** — DECISIONS.md Q1 documents the
    pivot from in-process call to LiteLLM HTTP. Trade-off accepted because Go
    `internal/` package rules forbid cross-module import (control-plane and
    edge-api are separate modules under go.work).
+
+## Codex Review Addressed (PR 134)
+
+Three findings from the Codex automated review on PR 134 fixed in commit
+`2dfb0ca`:
+
+1. **P0 — `MarkCompleted` wrote storage keys into `files(id)` FK columns.**
+   `batches.output_file_id` / `error_file_id` reference `public.files(id)`,
+   so writing raw storage paths broke `GET /v1/files/{id}` resolution after
+   batch completion. Fix: added `executor.FileRegistrar` port +
+   `pgxFileRegistrar` adapter wrapping `filestore.Service.CreateFile`.
+   Executor now creates `public.files` rows for the uploaded
+   `output.jsonl` / `errors.jsonl` artifacts and persists the returned IDs.
+   `JSONLWriter.Finalize` returns uploaded byte count so the registrar
+   records accurate `bytes`. Verified via updated `TestExecutor_*` tests.
+
+2. **P1 — `submitLocal` left credits reserved on enqueue failure.**
+   Pre-fix: `UpdateBatchStatus` to `in_progress` ran before `EnqueueExecute`;
+   if Asynq/Redis was unavailable the batch row stuck `in_progress` with
+   credits reserved indefinitely. Fix: both `UpdateBatchStatus` and
+   `EnqueueExecute` failure paths now route through `failSubmission`, which
+   marks the batch `failed` and releases the reservation. Mirrors the
+   upstream-path failure handling.
+
+3. **P2 — Dispatcher routed by per-line `body.model`, not batch alias.**
+   Pre-fix: dispatcher extracted the alias from each JSONL line's
+   `body.model`. That diverged from the upstream-path semantics
+   (`rewriteBatchJSONL` uses the batch's resolved `LiteLLMModelName`) and
+   could send lines to unintended routes. Fix: added `InputLine.Alias`
+   (json:"-"); executor injects `batch.ModelAlias` before dispatch;
+   dispatcher uses `Alias` for routing. Per-line `body.model` stays opaque
+   (the inference port still rewrites it to the LiteLLM model name).
 
 ## Out of Scope (separate phases)
 
@@ -192,3 +229,53 @@ When operator runs this dry-run pre-release, paste the audit outputs here as
 - **Phase 17:** Full FX/USD leak audit across all customer-visible
   surfaces (batch surface pre-checked here; `/v1/payments` surface owned
   by Phase 17).
+- **Phase 18 — Batch Resume Compliance (planned).** Closes Known Caveat #2
+  above. SDK-compatible resume of mid-run-killed batches without billing
+  divergence.
+
+  **Goal.** When the executor resumes a batch after a mid-run kill,
+  re-emitted output lines must carry the original chat-completion response
+  body verbatim so OpenAI SDK parsers don't fail. Billing semantics
+  (`consumed_credits` in `batch_lines` is source of truth, no re-dispatch,
+  no re-charge) are unchanged.
+
+  **Approach (recommended).** Persist the upstream response body to a new
+  `batch_lines.response_body bytea` column at the same transaction as
+  `MarkSucceeded`. On resume, re-emit prior succeeded lines using the
+  persisted body instead of the `{"resumed": true}` sentinel. Errors path
+  parallel: persist `last_error` (already present) plus `error_body bytea`
+  for the structured error envelope.
+
+  **Schema migration.** `0019_batch_resume_response.sql`:
+  ```sql
+  alter table public.batch_lines
+      add column response_body bytea,
+      add column error_body bytea;
+  ```
+
+  **Code touch points.**
+  - `executor.LineStore.MarkSucceeded`: add `responseBody []byte` parameter.
+  - `executor.LineStore.MarkFailed`: add `errorBody []byte` parameter.
+  - `executor.Executor.Run`: stop emitting the `{"resumed": true}` sentinel;
+    re-marshal prior `LineRow.ResponseBody` / `ErrorBody` instead.
+  - `pgxLineStore`: persist + scan the new columns.
+
+  **Trade-offs.**
+  - Storage cost: chat-completion bodies typically 1–20KB; 1M-line batch
+    ≈ 1–20GB on `batch_lines`. Acceptable at v1.1 scale; revisit at v1.2 if
+    batch volume grows. Mitigation: optionally compress with `pglz` or
+    column-level toast (Postgres handles automatically for >2KB).
+  - Migration ordering: column addition is non-blocking; backfill not
+    required (existing rows resume with sentinel until the next run).
+
+  **Acceptance criteria.**
+  - Resumed batch's `output.jsonl` parses end-to-end with the OpenAI Python
+    SDK (`openai.types.batch.Batch.output`).
+  - No duplicate `custom_id` rows; no double-charge.
+  - Existing `TestExecutor_RestartResume` extended to assert response body
+    contents match the original dispatch (not the sentinel shape).
+
+  **Out of scope for Phase 18.**
+  - Streaming-partial responses (chat-completion only; Phase 15 already
+    rejects non-`/v1/chat/completions` lines).
+  - Retroactive re-emission for batches completed before the migration.

--- a/.planning/phases/15-batch-local-executor/15-VERIFICATION.md
+++ b/.planning/phases/15-batch-local-executor/15-VERIFICATION.md
@@ -1,0 +1,194 @@
+# Phase 15 — Ship-Gate Verification
+
+**Date:** 2026-04-25
+**Branch:** `a/phase-15-batch-local-executor`
+**Scope:** Local batch executor for `POST /v1/batches` success-path settlement.
+**Out of scope:** `apps/control-plane/internal/routing/repository.go` `ensureCapabilityColumns` table-name fix (Phase 16); USD/FX leak audit beyond batch surface (Phase 17).
+
+## Must-Have Truth Verification
+
+The following truths from PLAN.md `must_haves.truths` are unit-verified by the
+batchstore tests. Live-stack verification is gated on a funded API key + the
+0015 migration applied to the staging Supabase project — captured under
+"Live ship-gate dry-run" below.
+
+### Truth 1 — Batch reaches `status='completed'` without an OPENAI_API_KEY
+
+- **Verified by:** `TestExecutor_MixedSuccessFailure` (executor_test.go).
+- **Outcome:** 100-line input, 95 success / 5 error → `MarkCompleted` invoked
+  with `completed_lines=95`, `failed_lines=5`. No LiteLLM-supported batch
+  provider (openai/azure/vertex/anthropic) involved — fake inference port
+  returns OpenAI-shape responses directly.
+
+### Truth 2 — output.jsonl line shape
+
+- **Verified by:** `TestExecutor_MixedSuccessFailure` asserts output.jsonl
+  uploaded to `hive-files/batches/b1/output.jsonl` with 95 newline-delimited
+  rows. Row shape is `OutputLine{ID, CustomID, Response{StatusCode,
+  RequestID, Body}, Error: nil}` per `executor/types.go`.
+
+### Truth 3 — errors.jsonl line shape
+
+- **Verified by:** `TestExecutor_MixedSuccessFailure` asserts errors.jsonl
+  uploaded with 5 rows; `TestExecutor_AllErrors` covers the 100% failure
+  case. Row shape is `ErrorLine{ID, CustomID, Response: nil,
+  Error{Code, Message}}`. `output_file_id` set to upload key only when
+  uploaded; `error_file_id` skipped on empty (TestExecutor_EmptyInput).
+
+### Truth 4 — actual_credits = sum of per-line consumed credits
+
+- **Verified by:** `TestExecutor_MixedSuccessFailure` asserts
+  `fakeReservationLE.lastActual = 950` (95 succeeded × 10 tokens),
+  `TestSettle_SumsExactlyAcrossManyLines` asserts exact-sum across 100
+  lines = 5650 with no rounding error using `math/big.Int`.
+  `TestSettle_Overconsumed` covers the cap-at-reserved safety net.
+
+### Truth 5 — concurrency bounded by env, ceiling 32
+
+- **Verified by:** `TestDispatcher_BoundedConcurrency` asserts peak in-flight
+  ≤ 4 with `Concurrency=4` over 100 lines. `TestConfig_Validate_ClampAndDefaults`
+  asserts Concurrency=999 clamps to ConcurrencyCeiling=32.
+
+### Truth 6 — retry policy 5xx + 4xx terminal
+
+- **Verified by:** `TestDispatcher_Retry503ThenSuccess` (503 ×2 → 200 succeeds
+  on attempt 3), `TestDispatcher_4xxNoRetry` (400 fails immediately,
+  attempts=1).
+
+### Truth 7 — provider-name sanitization
+
+- **Verified by:** `TestDispatcher_ProviderNameSanitized` asserts an
+  upstream error containing "openrouter upstream rejected the request via
+  litellm gateway" emerges as a sanitized message with no instance of
+  `openrouter`, `groq`, or `litellm`. `TestSanitizeMessage` covers the
+  rule directly across positive/negative cases.
+
+### Truth 8 — restart safety
+
+- **Verified by:** `TestExecutor_RestartResume` — pre-seeds 6 succeeded
+  batch_lines rows, runs executor with 10-line input, asserts dispatcher
+  was invoked exactly 4 times (skipping the 6 already-settled), final
+  output.jsonl contains 10 unique custom_ids with no duplicates, and
+  reservation actual_credits = 100 (no double-charge of the 6 prior).
+
+### Truth 9 — Phase 16 routing repo not touched
+
+- **Verified by:** `git diff --name-only origin/main...HEAD | grep -E
+  '^apps/control-plane/internal/routing/repository.go$'` returns empty.
+
+## Verification Commands
+
+```bash
+# Unit tests (run inside docker toolchain image with CGO for -race).
+cd /home/sakib/hive/deploy/docker && docker compose --env-file ../../.env \
+  --profile local --profile tools run --rm -T -e CGO_ENABLED=1 toolchain \
+  "apk add --no-cache gcc musl-dev > /dev/null 2>&1 && \
+   go test -count=1 -race -short ./apps/control-plane/internal/batchstore/..."
+# Expected: ok batchstore, ok batchstore/executor.
+
+# Vet + full short suite.
+cd /home/sakib/hive/deploy/docker && docker compose --env-file ../../.env \
+  --profile local --profile tools run --rm -T -e CGO_ENABLED=1 toolchain \
+  "apk add --no-cache gcc musl-dev > /dev/null 2>&1 && \
+   go vet ./apps/control-plane/... && \
+   go test -count=1 -short ./apps/control-plane/..."
+# Expected: vet clean; all packages ok.
+
+# Phase 16 boundary.
+git diff --name-only origin/main...HEAD | \
+  grep -E '^apps/control-plane/internal/routing/repository.go$'
+# Expected: empty stdout.
+```
+
+All commands above were executed during Phase 15 task execution and produced
+the expected outputs (see commit log on `a/phase-15-batch-local-executor`).
+
+## Live ship-gate dry-run (deferred)
+
+The 100-line live E2E + restart-safety probe + provider-name leak grep + USD
+audit listed in PLAN.md Task 3 Tests 4–7 require:
+
+1. Migration `supabase/migrations/0015_batch_local_executor.sql` applied to
+   staging Supabase.
+2. A funded API key minted via `POST /v1/keys`.
+3. Stack booted with `BATCH_EXECUTOR_KIND=auto` (default) so openrouter/groq
+   batches route through the local executor.
+
+Steps to run the live ship-gate (operator-only, blocked on staging migration
+window):
+
+```bash
+# 1. Apply migration.
+supabase db push  # or paste 0015_batch_local_executor.sql into SQL editor
+
+# 2. Boot stack.
+cd deploy/docker && docker compose --env-file ../../.env --profile local up --build
+
+# 3. Mint funded key (50000 credits).
+curl -X POST http://localhost:8081/v1/keys -H "Authorization: Bearer ..." -d '{"credits":50000}'
+
+# 4. Generate 100-line JSONL fixture (95 valid + 5 deliberately-broken bodies).
+python3 scripts/gen_batch_fixture.py 100 5 > /tmp/batch.jsonl
+
+# 5. Upload + submit.
+HIVE_API_KEY=<minted> python3 scripts/submit_batch.py /tmp/batch.jsonl
+
+# 6. Poll status until completed.
+while true; do
+  status=$(curl -s -H "Authorization: Bearer $HIVE_API_KEY" \
+    http://localhost:8080/v1/batches/<id> | jq -r .status)
+  [ "$status" = "completed" ] && break
+  sleep 5
+done
+
+# 7. Audits (tests 4–7 from PLAN.md).
+curl -s ... > /tmp/output.jsonl
+curl -s ... > /tmp/errors.jsonl
+
+# Sanitization: must return zero matches.
+grep -iE 'openrouter|groq|litellm' /tmp/output.jsonl /tmp/errors.jsonl
+
+# FX/USD leak: must return zero on /v1/batches GET response.
+curl -s -H "Authorization: Bearer $HIVE_API_KEY" \
+  http://localhost:8080/v1/batches/<id> | grep -iE 'amount_usd|usd_|fx_|exchange_rate'
+
+# Restart-safety: re-mint, post fresh batch, restart mid-run, verify completion.
+docker compose restart control-plane  # ~30 lines in
+# Confirm no duplicate custom_id in output.jsonl:
+jq -s 'group_by(.custom_id) | map(select(length > 1))' /tmp/output.jsonl
+# Expected: []
+```
+
+When operator runs this dry-run pre-release, paste the audit outputs here as
+`## Live audit results (date)` to close the v1.1.0 ship-gate.
+
+## Known Caveats
+
+1. **>4MB batch lines** — the JSONL scanner's buffer is sized to 4MB, headroom
+   over OpenAI's documented ~1MB-per-line cap. Lines exceeding 4MB yield a
+   `bufio.Scanner: token too long` error which the scanner emits via the
+   ScanResult error channel; the executor writes those to errors.jsonl with
+   code `invalid_json`. Documented per PLAN.md blocker #5.
+
+2. **Restart-safety re-emit semantics** — when the executor resumes a batch
+   after a mid-run kill, succeeded lines from the previous run are re-emitted
+   into the output.jsonl with a sentinel response body
+   `{"resumed": true, "request_id": "resumed"}` because the original upstream
+   response body is gone (transient memory). The line is NOT re-dispatched
+   and NOT re-charged — the consumed_credits in `batch_lines` is the source
+   of truth for billing. Customers polling status see the line in output.jsonl
+   without re-billing.
+
+3. **In-process inference vs LiteLLM-direct** — DECISIONS.md Q1 documents the
+   pivot from in-process call to LiteLLM HTTP. Trade-off accepted because Go
+   `internal/` package rules forbid cross-module import (control-plane and
+   edge-api are separate modules under go.work).
+
+## Out of Scope (separate phases)
+
+- **Phase 16:** `apps/control-plane/internal/routing/repository.go`
+  `ensureCapabilityColumns` table-name fix (currently targets
+  `route_capabilities` instead of `provider_capabilities`).
+- **Phase 17:** Full FX/USD leak audit across all customer-visible
+  surfaces (batch surface pre-checked here; `/v1/payments` surface owned
+  by Phase 17).

--- a/.planning/phases/15-batch-local-executor/DECISIONS.md
+++ b/.planning/phases/15-batch-local-executor/DECISIONS.md
@@ -1,0 +1,81 @@
+# Phase 15 — Open Decisions Resolved
+
+**Date:** 2026-04-25
+**Phase:** 15 — Batch Success-Path Settlement (Local Executor)
+**Branch:** `a/phase-15-batch-local-executor`
+
+## Q1. Loopback HTTP vs in-process call vs LiteLLM-direct
+
+**Decision: LiteLLM-direct (HTTP from control-plane to LiteLLM `POST /v1/chat/completions`).**
+
+**Rationale.** PLAN.md initially proposed an in-process call into
+`apps/edge-api/internal/inference.Orchestrator.ChatCompletion`. Investigation
+during Task 1 confirmed the architectural blocker noted in the plan's blockers
+section #2: control-plane and edge-api are independent Go modules
+(`apps/control-plane/go.mod` vs `apps/edge-api/go.mod`), and Go's `internal/`
+rule forbids cross-module imports of an `internal/` package. The PLAN's
+fallback was a shared `packages/go/inference` factor — a 1-day refactor that
+would touch ~25 edge-api call sites and require its own review cycle.
+
+A third option emerged from reading the existing `submitter.go`: control-plane
+already holds `litellmBaseURL` + `litellmMasterKey` for the batch-upload path
+and already rewrites JSONL bodies to the LiteLLM model name. Calling
+`POST {litellmBaseURL}/v1/chat/completions` directly from the dispatcher:
+
+- Uses the same provider routing, sanitization, retry, and capability path
+  that edge-api uses (LiteLLM is the unified gateway).
+- Reuses control-plane's existing LiteLLM credentials — no new infra.
+- Skips the module-boundary refactor entirely.
+- Skips loopback HTTP through edge-api (no double rate-limiter accounting,
+  no header re-signing).
+- Per-line usage comes back in the OpenAI response body's `usage` object
+  populated by LiteLLM, the same source edge-api consumes.
+
+**Trade-off accepted.** Sanitization for provider-name leaks now lives in
+the executor's response-shaping layer (`dispatcher.sanitizeError`) rather
+than reusing edge-api's `inference.errors` package. The sanitization rules
+are mechanical (strip provider tokens like `openrouter`, `groq`, `litellm`
+from error message strings) and tested in `dispatcher_test.go` Test 7.
+
+**Pre-resolution:** in-process import attempted and rejected by Go's
+`internal/` rule (separate modules). LiteLLM-direct adopted on 2026-04-25.
+
+## Q2. Executor in control-plane vs separate worker process
+
+**Decision: control-plane in-process, behind a config flag.** (Unchanged from
+PLAN.md.)
+
+**Rationale.** Reuses control-plane's DB pool, Redis queue (Asynq), storage
+client (S3-compatible Supabase), accounting service, and reservation
+primitive. v1.0 throughput target is dozens of batches/day, not thousands —
+a separate process is over-engineering. Horizontal scale path preserved by
+the existing Asynq queue (multiple control-plane replicas coordinate via
+Redis locks).
+
+**Trade-off accepted.** A runaway batch can compete with control-plane HTTP
+traffic for goroutines — mitigated by `BATCH_EXECUTOR_CONCURRENCY` ceiling
+(32) and per-line `BATCH_EXECUTOR_LINE_TIMEOUT_MS`. Promoting to a separate
+process is a v1.2 task if needed.
+
+## Q3. Concurrency default + ceiling
+
+**Decision: default 8, ceiling 32.** (Unchanged from PLAN.md.)
+
+**Rationale.** OpenRouter and Groq tolerate 8 parallel requests per key on
+free/paid tiers (no published hard cap, empirical). Ceiling 32 prevents
+accidental misconfiguration from saturating control-plane. Per-line timeout
+(60s default) bounds tail latency. Ceiling enforced server-side:
+`min(env, 32)` in `ExecutorConfig.Validate`. Per-route concurrency knob is a
+v1.2 task.
+
+## Phase 16 boundary
+
+This phase deliberately does NOT touch
+`apps/control-plane/internal/routing/repository.go`. The
+`ensureCapabilityColumns` table-name fix lands separately in Phase 16. Phase
+15 reads from the existing routing path via
+`routing.Service.SelectRoute(NeedBatch=true)` and trusts the route's
+provider field; the executor_kind decision is taken from the
+`BATCH_EXECUTOR_KIND` env var (defaulting to "local" for openrouter/groq
+providers) since the route_capabilities `executor_kind` column is added by
+this migration and read in Task 3.

--- a/.planning/v1.1-DEFERRED-SCOPE.md
+++ b/.planning/v1.1-DEFERRED-SCOPE.md
@@ -51,6 +51,10 @@ Fit for: chat applications, CLI coding agents, drop-in replacements of OpenAI SD
    - Files: `apps/control-plane/internal/accounts/types.go`, `apps/control-plane/internal/accounts/service.go`, `apps/web-console/lib/viewer-gates.ts`
    - Current: authorization is limited to workspace membership roles (`owner` / `member`) plus feature-specific booleans like `CanInviteMembers` and `CanManageAPIKeys`. That is not a reusable RBAC layer and it does not cover guest or unverified-user scopes consistently.
    - Recommended: design a shared permission matrix and enforce it in both control-plane handlers and web-console route gating so unverified or limited users cannot reach billing, API-key, analytics, or other sensitive surfaces by accident.
+9. **Phase 18 — Batch Resume Compliance**
+   - Source: `.planning/phases/15-batch-local-executor/15-VERIFICATION.md` Known Caveats #2 + "Phase 18 — Batch Resume Compliance (planned)" section.
+   - Current: when the local batch executor resumes a mid-run-killed batch, succeeded lines are re-emitted into `output.jsonl` with a `{"resumed": true}` sentinel because the original upstream response body is not persisted. Billing is unaffected (no re-dispatch, no re-charge), but the sentinel diverges from the chat-completion shape and breaks OpenAI SDK consumers parsing `response.body`.
+   - Recommended: persist `batch_lines.response_body` (and `error_body`) at the same transaction as `MarkSucceeded` / `MarkFailed`; re-emit verbatim on resume. Migration `0019_batch_resume_response.sql` + plumbing through `executor.LineStore`. Full plan in 15-VERIFICATION.md.
 
 ## Shipping Gate For v1.0
 

--- a/apps/control-plane/cmd/server/main.go
+++ b/apps/control-plane/cmd/server/main.go
@@ -321,7 +321,8 @@ func main() {
 							batchStore := batchstore.NewPgxBatchStore(filestoreSvc, filestoreSvc)
 							lineStore := batchstore.NewPgxLineStore(pool)
 							reservationPort := batchstore.NewAccountingReservationAdapter(accountingSvc)
-							ex, exErr := batchexecutor.NewExecutor(execCfg, batchStore, lineStore, storageClient, storageCfg.FilesBucket, dispatcher, reservationPort)
+							fileRegistrar := batchstore.NewPgxFileRegistrar(filestoreSvc)
+							ex, exErr := batchexecutor.NewExecutor(execCfg, batchStore, lineStore, storageClient, fileRegistrar, storageCfg.FilesBucket, dispatcher, reservationPort)
 							if exErr != nil {
 								log.Printf("WARNING: batch executor init failed: %v", exErr)
 							} else {

--- a/apps/control-plane/cmd/server/main.go
+++ b/apps/control-plane/cmd/server/main.go
@@ -313,12 +313,12 @@ func main() {
 							LineTimeout: time.Duration(cfg.BatchExecutorLineTimeoutMs) * time.Millisecond,
 							Kind:        batchexecutor.ExecutorKind(cfg.BatchExecutorKind),
 						}
-						inferenceClient := batchstore.NewLiteLLMInferenceClient(resolveLiteLLMBaseURL(), resolveLiteLLMMasterKey(), routingSvc)
+						inferenceClient := batchstore.NewLiteLLMInferenceClient(resolveLiteLLMBaseURL(), resolveLiteLLMMasterKey())
 						dispatcher, dispErr := batchexecutor.NewDispatcher(execCfg, inferenceClient, nil)
 						if dispErr != nil {
 							log.Printf("WARNING: batch executor dispatcher init failed: %v", dispErr)
 						} else {
-							batchStore := batchstore.NewPgxBatchStore(filestoreSvc, filestoreSvc)
+							batchStore := batchstore.NewPgxBatchStore(filestoreSvc, filestoreSvc, routingSvc)
 							lineStore := batchstore.NewPgxLineStore(pool)
 							reservationPort := batchstore.NewAccountingReservationAdapter(accountingSvc)
 							fileRegistrar := batchstore.NewPgxFileRegistrar(filestoreSvc)

--- a/apps/control-plane/cmd/server/main.go
+++ b/apps/control-plane/cmd/server/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hivegpt/hive/apps/control-plane/internal/apikeys"
 	"github.com/hivegpt/hive/apps/control-plane/internal/auth"
 	"github.com/hivegpt/hive/apps/control-plane/internal/batchstore"
+	batchexecutor "github.com/hivegpt/hive/apps/control-plane/internal/batchstore/executor"
 	"github.com/hivegpt/hive/apps/control-plane/internal/budgets"
 	"github.com/hivegpt/hive/apps/control-plane/internal/catalog"
 	"github.com/hivegpt/hive/apps/control-plane/internal/filestore"
@@ -281,17 +282,18 @@ func main() {
 					asynqClient := asynq.NewClient(redisOpt)
 					defer asynqClient.Close()
 
+					asynqQueue := batchstore.NewAsynqQueue(asynqClient)
 					if routingSvc != nil && accountingSvc != nil {
 						batchSubmitter = batchstore.NewSubmitter(
 							filestoreSvc,
 							routingSvc,
 							storageClient,
-							batchstore.NewAsynqQueue(asynqClient),
+							asynqQueue,
 							accountingSvc,
 							resolveLiteLLMBaseURL(),
 							resolveLiteLLMMasterKey(),
 							storageCfg.FilesBucket,
-						)
+						).WithLocalExecutor(asynqQueue, cfg.BatchExecutorKind)
 					}
 
 					batchWorker := batchstore.NewBatchWorker(
@@ -302,8 +304,36 @@ func main() {
 						storageCfg.FilesBucket,
 						accountingSvc,
 					)
+
+					// Phase 15: build local executor and wire into worker.
+					if routingSvc != nil && accountingSvc != nil {
+						execCfg := batchexecutor.Config{
+							Concurrency: cfg.BatchExecutorConcurrency,
+							MaxRetries:  cfg.BatchExecutorMaxRetries,
+							LineTimeout: time.Duration(cfg.BatchExecutorLineTimeoutMs) * time.Millisecond,
+							Kind:        batchexecutor.ExecutorKind(cfg.BatchExecutorKind),
+						}
+						inferenceClient := batchstore.NewLiteLLMInferenceClient(resolveLiteLLMBaseURL(), resolveLiteLLMMasterKey(), routingSvc)
+						dispatcher, dispErr := batchexecutor.NewDispatcher(execCfg, inferenceClient, nil)
+						if dispErr != nil {
+							log.Printf("WARNING: batch executor dispatcher init failed: %v", dispErr)
+						} else {
+							batchStore := batchstore.NewPgxBatchStore(filestoreSvc, filestoreSvc)
+							lineStore := batchstore.NewPgxLineStore(pool)
+							reservationPort := batchstore.NewAccountingReservationAdapter(accountingSvc)
+							ex, exErr := batchexecutor.NewExecutor(execCfg, batchStore, lineStore, storageClient, storageCfg.FilesBucket, dispatcher, reservationPort)
+							if exErr != nil {
+								log.Printf("WARNING: batch executor init failed: %v", exErr)
+							} else {
+								batchWorker.WithLocalExecutor(ex)
+								log.Printf("batch local executor ready (concurrency=%d kind=%s)", execCfg.Concurrency, execCfg.Kind)
+							}
+						}
+					}
+
 					asynqMux := asynq.NewServeMux()
 					asynqMux.HandleFunc(batchstore.TypeBatchPoll, batchWorker.HandleBatchPoll)
+					asynqMux.HandleFunc(batchstore.TypeBatchExecute, batchWorker.HandleBatchExecute)
 
 					asynqSrv := asynq.NewServer(
 						redisOpt,

--- a/apps/control-plane/internal/batchstore/executor/dispatcher.go
+++ b/apps/control-plane/internal/batchstore/executor/dispatcher.go
@@ -109,10 +109,14 @@ func (d *Dispatcher) Dispatch(ctx context.Context, line InputLine) DispatchResul
 		return d.errResult(line.CustomID, "invalid_request",
 			"request body missing or invalid model field", 1)
 	}
-	alias := strings.TrimSpace(line.Alias)
-	if alias == "" {
+	if strings.TrimSpace(line.Alias) == "" {
 		return d.errResult(line.CustomID, "invalid_request",
 			"missing batch model alias", 1)
+	}
+	model := strings.TrimSpace(line.LiteLLMModel)
+	if model == "" {
+		return d.errResult(line.CustomID, "invalid_request",
+			"missing resolved LiteLLM model for batch", 1)
 	}
 
 	backoff := []time.Duration{100 * time.Millisecond, 400 * time.Millisecond, 1600 * time.Millisecond}
@@ -121,7 +125,7 @@ func (d *Dispatcher) Dispatch(ctx context.Context, line InputLine) DispatchResul
 	for attempt := 1; attempt <= d.cfg.MaxRetries; attempt++ {
 		callCtx, cancel := context.WithTimeout(ctx, d.cfg.LineTimeout)
 		d.bumpInFlight(+1)
-		body, usage, status, callErr := d.inference.ChatCompletion(callCtx, alias, line.Body)
+		body, usage, status, callErr := d.inference.ChatCompletion(callCtx, model, line.Body)
 		d.bumpInFlight(-1)
 		cancel()
 
@@ -225,8 +229,11 @@ func (d *Dispatcher) errResult(customID, code, message string, attempts int) Dis
 }
 
 // providerNameRe matches provider tokens that must never appear in
-// customer-facing error messages. Case-insensitive.
-var providerNameRe = regexp.MustCompile(`(?i)\b(openrouter|groq|litellm)\b`)
+// customer-facing error messages. Case-insensitive. The list mirrors
+// apps/edge-api/internal/errors/provider_blind.go so the local-executor
+// surface enforces the same blocklist as edge-api's hot-path response
+// sanitization.
+var providerNameRe = regexp.MustCompile(`(?i)\b(anthropic|azure|bedrock|cerebras|cohere|deepseek|fireworks|gemini|google|groq|litellm|mistral|openai|openrouter|perplexity|together|vertex|xai)\b`)
 
 // SanitizeMessage strips provider tokens and any attached path/qualifier.
 // Replacement collapses adjacent whitespace.

--- a/apps/control-plane/internal/batchstore/executor/dispatcher.go
+++ b/apps/control-plane/internal/batchstore/executor/dispatcher.go
@@ -105,10 +105,14 @@ func (d *Dispatcher) Dispatch(ctx context.Context, line InputLine) DispatchResul
 		return d.errResult(line.CustomID, "invalid_request",
 			"method must be POST and url must be /v1/chat/completions", 1)
 	}
-	model, err := extractModel(line.Body)
-	if err != nil {
+	if _, err := extractModel(line.Body); err != nil {
 		return d.errResult(line.CustomID, "invalid_request",
 			"request body missing or invalid model field", 1)
+	}
+	alias := strings.TrimSpace(line.Alias)
+	if alias == "" {
+		return d.errResult(line.CustomID, "invalid_request",
+			"missing batch model alias", 1)
 	}
 
 	backoff := []time.Duration{100 * time.Millisecond, 400 * time.Millisecond, 1600 * time.Millisecond}
@@ -117,7 +121,7 @@ func (d *Dispatcher) Dispatch(ctx context.Context, line InputLine) DispatchResul
 	for attempt := 1; attempt <= d.cfg.MaxRetries; attempt++ {
 		callCtx, cancel := context.WithTimeout(ctx, d.cfg.LineTimeout)
 		d.bumpInFlight(+1)
-		body, usage, status, callErr := d.inference.ChatCompletion(callCtx, model, line.Body)
+		body, usage, status, callErr := d.inference.ChatCompletion(callCtx, alias, line.Body)
 		d.bumpInFlight(-1)
 		cancel()
 

--- a/apps/control-plane/internal/batchstore/executor/dispatcher.go
+++ b/apps/control-plane/internal/batchstore/executor/dispatcher.go
@@ -1,0 +1,295 @@
+package executor
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// InferencePort is a small interface that the dispatcher depends on.
+// In production the implementation is liteLLMInferenceClient (calls LiteLLM
+// /v1/chat/completions); in tests it is a fake. See DECISIONS.md Q1 for why
+// the dispatcher does not import edge-api/internal/inference.
+type InferencePort interface {
+	// ChatCompletion executes a single chat-completions request. The body is
+	// the raw JSON the customer supplied for that batch line; the model field
+	// inside is rewritten to the LiteLLM model name by the implementation.
+	// Returns the OpenAI response body, the OpenAI usage object (for
+	// per-line credit attribution), the upstream HTTP status code, and an
+	// error. A non-nil error with a non-2xx status indicates a customer- or
+	// upstream-attributable failure; a nil error means success.
+	ChatCompletion(ctx context.Context, model string, body json.RawMessage) (respBody json.RawMessage, usage *Usage, statusCode int, err error)
+}
+
+// Usage carries the per-line token counts the dispatcher attributes credits with.
+type Usage struct {
+	PromptTokens     int64
+	CompletionTokens int64
+	TotalTokens      int64
+}
+
+// CreditPolicy converts per-line usage to credits. Default is the same model
+// edge-api uses: 1 credit per 1k prompt tokens + 1 credit per 1k completion
+// tokens, rounded up. Tests can inject simpler policies.
+type CreditPolicy interface {
+	Credits(usage *Usage) int64
+}
+
+// DefaultCreditPolicy applies the per-line credit formula. Numbers chosen to
+// match the existing creditsPerRequest fallback in batchstore/worker.go
+// (1000 credits per chat-completions call) when usage is unavailable.
+type DefaultCreditPolicy struct{}
+
+// Credits returns prompt + completion tokens (1 credit per token) — matches
+// the granularity of the existing accounting service. Returns 1000 (the
+// fallback per-call cost in batchstore/worker.go) if usage is nil.
+func (DefaultCreditPolicy) Credits(usage *Usage) int64 {
+	if usage == nil {
+		return 1000
+	}
+	if usage.TotalTokens > 0 {
+		return usage.TotalTokens
+	}
+	return usage.PromptTokens + usage.CompletionTokens
+}
+
+// Dispatcher is a bounded worker pool that fans out per-line dispatches to
+// the inference port. It owns retry policy, per-line timeout, and provider-
+// name sanitization. Construct with NewDispatcher.
+type Dispatcher struct {
+	cfg       Config
+	inference InferencePort
+	credits   CreditPolicy
+	now       func() time.Time
+
+	// inflight is bumped before each in-flight call and decremented after; a
+	// test-visible peak counter records the maximum observed.
+	inflight   atomic.Int64
+	peakInFlt  atomic.Int64
+	peakUpdate sync.Mutex
+}
+
+// NewDispatcher constructs a Dispatcher. cfg.Validate is called.
+func NewDispatcher(cfg Config, inference InferencePort, credits CreditPolicy) (*Dispatcher, error) {
+	if inference == nil {
+		return nil, errors.New("dispatcher: inference port is required")
+	}
+	if credits == nil {
+		credits = DefaultCreditPolicy{}
+	}
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	return &Dispatcher{cfg: cfg, inference: inference, credits: credits, now: time.Now}, nil
+}
+
+// PeakInFlight returns the maximum number of in-flight dispatches observed
+// during the lifetime of this Dispatcher. Used by tests to assert the
+// concurrency cap is honored.
+func (d *Dispatcher) PeakInFlight() int64 { return d.peakInFlt.Load() }
+
+// Dispatch executes a single line and returns the result. The caller writes
+// the result into the appropriate output/error JSONL writer. Method/URL on
+// the input line are validated; non-POST or non-/v1/chat/completions lines
+// short-circuit to an error.
+func (d *Dispatcher) Dispatch(ctx context.Context, line InputLine) DispatchResult {
+	if !strings.EqualFold(line.Method, "POST") || line.URL != "/v1/chat/completions" {
+		return d.errResult(line.CustomID, "invalid_request",
+			"method must be POST and url must be /v1/chat/completions", 1)
+	}
+	model, err := extractModel(line.Body)
+	if err != nil {
+		return d.errResult(line.CustomID, "invalid_request",
+			"request body missing or invalid model field", 1)
+	}
+
+	backoff := []time.Duration{100 * time.Millisecond, 400 * time.Millisecond, 1600 * time.Millisecond}
+	var lastErr error
+	var lastStatus int
+	for attempt := 1; attempt <= d.cfg.MaxRetries; attempt++ {
+		callCtx, cancel := context.WithTimeout(ctx, d.cfg.LineTimeout)
+		d.bumpInFlight(+1)
+		body, usage, status, callErr := d.inference.ChatCompletion(callCtx, model, line.Body)
+		d.bumpInFlight(-1)
+		cancel()
+
+		if callErr == nil && status >= 200 && status < 300 {
+			out := &OutputLine{
+				ID:       "batch_req_" + uuid.New().String(),
+				CustomID: line.CustomID,
+				Response: &OutputResponse{StatusCode: status, RequestID: uuid.New().String(), Body: body},
+				Error:    nil,
+			}
+			res := DispatchResult{
+				CustomID:        line.CustomID,
+				Output:          out,
+				Attempts:        attempt,
+				ConsumedCredits: d.credits.Credits(usage),
+			}
+			if usage != nil {
+				res.UsedPromptTokens = usage.PromptTokens
+				res.UsedCompTokens = usage.CompletionTokens
+			}
+			return res
+		}
+
+		lastErr = callErr
+		lastStatus = status
+
+		// 4xx (except 408/429) — terminal, no retry.
+		if status >= 400 && status < 500 && status != 408 && status != 429 {
+			return d.errResult(line.CustomID, codeForStatus(status), errMessage(callErr, "request rejected"), attempt)
+		}
+		if errors.Is(callErr, context.DeadlineExceeded) || errors.Is(callCtx.Err(), context.DeadlineExceeded) {
+			// timeout — retry up to MaxRetries
+		}
+
+		// Backoff before next attempt unless we are past last.
+		if attempt < d.cfg.MaxRetries {
+			delay := backoff[min(attempt-1, len(backoff)-1)]
+			select {
+			case <-ctx.Done():
+				return d.errResult(line.CustomID, "cancelled", "execution cancelled", attempt)
+			case <-time.After(delay):
+			}
+		}
+	}
+	if lastStatus == 0 {
+		return d.errResult(line.CustomID, "upstream_error", errMessage(lastErr, "upstream request failed after retries"), d.cfg.MaxRetries)
+	}
+	return d.errResult(line.CustomID, codeForStatus(lastStatus), errMessage(lastErr, "upstream request failed after retries"), d.cfg.MaxRetries)
+}
+
+// Pool spawns d.cfg.Concurrency worker goroutines that read from in and write
+// per-line results to out. Pool returns when in is closed and all workers
+// have drained.
+func (d *Dispatcher) Pool(ctx context.Context, in <-chan InputLine, out chan<- DispatchResult) {
+	var wg sync.WaitGroup
+	for i := 0; i < d.cfg.Concurrency; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for line := range in {
+				select {
+				case <-ctx.Done():
+					return
+				default:
+				}
+				out <- d.Dispatch(ctx, line)
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func (d *Dispatcher) bumpInFlight(delta int64) {
+	cur := d.inflight.Add(delta)
+	if delta > 0 {
+		// Update peak if current exceeds it.
+		for {
+			peak := d.peakInFlt.Load()
+			if cur <= peak {
+				break
+			}
+			if d.peakInFlt.CompareAndSwap(peak, cur) {
+				break
+			}
+		}
+	}
+}
+
+func (d *Dispatcher) errResult(customID, code, message string, attempts int) DispatchResult {
+	return DispatchResult{
+		CustomID: customID,
+		Error: &ErrorLine{
+			ID:       "batch_req_" + uuid.New().String(),
+			CustomID: customID,
+			Response: nil,
+			Error:    &ErrorObj{Code: code, Message: SanitizeMessage(message)},
+		},
+		Attempts:        attempts,
+		ConsumedCredits: 0,
+	}
+}
+
+// providerNameRe matches provider tokens that must never appear in
+// customer-facing error messages. Case-insensitive.
+var providerNameRe = regexp.MustCompile(`(?i)\b(openrouter|groq|litellm)\b`)
+
+// SanitizeMessage strips provider tokens and any attached path/qualifier.
+// Replacement collapses adjacent whitespace.
+func SanitizeMessage(msg string) string {
+	if msg == "" {
+		return "upstream error"
+	}
+	cleaned := providerNameRe.ReplaceAllString(msg, "upstream")
+	cleaned = strings.Join(strings.Fields(cleaned), " ")
+	return cleaned
+}
+
+func errMessage(err error, fallback string) string {
+	if err == nil {
+		return fallback
+	}
+	return err.Error()
+}
+
+func codeForStatus(status int) string {
+	switch status {
+	case 0:
+		return "upstream_error"
+	case 400:
+		return "invalid_request"
+	case 401:
+		return "unauthorized"
+	case 403:
+		return "forbidden"
+	case 404:
+		return "not_found"
+	case 408:
+		return "timeout"
+	case 422:
+		return "invalid_request"
+	case 429:
+		return "rate_limited"
+	default:
+		if status >= 500 {
+			return "upstream_error"
+		}
+		return "request_rejected"
+	}
+}
+
+// extractModel reads the "model" field from the request body without fully
+// decoding it. Used so the body can be passed through unchanged to the
+// inference port (which itself rewrites the model field for LiteLLM).
+func extractModel(body json.RawMessage) (string, error) {
+	if len(body) == 0 {
+		return "", errors.New("empty body")
+	}
+	var head struct {
+		Model string `json:"model"`
+	}
+	if err := json.Unmarshal(body, &head); err != nil {
+		return "", fmt.Errorf("decode body: %w", err)
+	}
+	if strings.TrimSpace(head.Model) == "" {
+		return "", errors.New("missing model")
+	}
+	return head.Model, nil
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/apps/control-plane/internal/batchstore/executor/dispatcher_test.go
+++ b/apps/control-plane/internal/batchstore/executor/dispatcher_test.go
@@ -1,0 +1,351 @@
+package executor
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// fakeInference is a configurable test double for InferencePort.
+type fakeInference struct {
+	mu sync.Mutex
+
+	// handler returns (body, usage, statusCode, err) per call. May be nil; if
+	// nil, returns a successful empty response.
+	handler func(ctx context.Context, attempt int, model string, body json.RawMessage) (json.RawMessage, *Usage, int, error)
+
+	calls int
+
+	// concurrent tracks instantaneous in-flight count for concurrency tests.
+	concurrent     atomic.Int32
+	maxConcurrent  atomic.Int32
+	customIDCounts map[string]int
+}
+
+func (f *fakeInference) ChatCompletion(ctx context.Context, model string, body json.RawMessage) (json.RawMessage, *Usage, int, error) {
+	f.concurrent.Add(1)
+	defer f.concurrent.Add(-1)
+	for {
+		cur := f.concurrent.Load()
+		mx := f.maxConcurrent.Load()
+		if cur <= mx {
+			break
+		}
+		if f.maxConcurrent.CompareAndSwap(mx, cur) {
+			break
+		}
+	}
+
+	f.mu.Lock()
+	f.calls++
+	attempt := 0
+	// Track per-customID attempts via embedded JSON marker if present.
+	var probe struct {
+		ID string `json:"_test_id"`
+	}
+	_ = json.Unmarshal(body, &probe)
+	if f.customIDCounts == nil {
+		f.customIDCounts = map[string]int{}
+	}
+	if probe.ID != "" {
+		f.customIDCounts[probe.ID]++
+		attempt = f.customIDCounts[probe.ID]
+	} else {
+		attempt = f.calls
+	}
+	f.mu.Unlock()
+
+	if f.handler != nil {
+		return f.handler(ctx, attempt, model, body)
+	}
+	return json.RawMessage(`{"id":"chat_x","choices":[]}`), &Usage{PromptTokens: 10, CompletionTokens: 5, TotalTokens: 15}, 200, nil
+}
+
+func mustBody(t *testing.T, model string, extra string) json.RawMessage {
+	t.Helper()
+	b, err := json.Marshal(map[string]any{
+		"model":    model,
+		"messages": []map[string]string{{"role": "user", "content": "hi"}},
+		"_extra":   extra,
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return b
+}
+
+// Test 4: bounded concurrency — given Concurrency=4 and 100 lines,
+// instrumentation observes max 4 in-flight calls at any sample point.
+func TestDispatcher_BoundedConcurrency(t *testing.T) {
+	infer := &fakeInference{
+		handler: func(ctx context.Context, attempt int, model string, body json.RawMessage) (json.RawMessage, *Usage, int, error) {
+			// Hold each call long enough that all 4 workers race against the cap.
+			time.Sleep(10 * time.Millisecond)
+			return json.RawMessage(`{}`), &Usage{TotalTokens: 1}, 200, nil
+		},
+	}
+	disp, err := NewDispatcher(Config{Concurrency: 4, MaxRetries: 3, LineTimeout: 5 * time.Second}, infer, nil)
+	if err != nil {
+		t.Fatalf("new dispatcher: %v", err)
+	}
+
+	in := make(chan InputLine)
+	out := make(chan DispatchResult, 100)
+	go func() {
+		for i := 0; i < 100; i++ {
+			in <- InputLine{
+				CustomID: fmt.Sprintf("req-%d", i),
+				Method:   "POST",
+				URL:      "/v1/chat/completions",
+				Body:     mustBody(t, "alias-1", fmt.Sprintf("p%d", i)),
+			}
+		}
+		close(in)
+	}()
+
+	disp.Pool(context.Background(), in, out)
+	close(out)
+
+	count := 0
+	for range out {
+		count++
+	}
+	if count != 100 {
+		t.Fatalf("results=%d want 100", count)
+	}
+	if peak := disp.PeakInFlight(); peak > 4 {
+		t.Fatalf("peak inflight %d exceeded cap 4", peak)
+	}
+	if peak := infer.maxConcurrent.Load(); peak > 4 {
+		t.Fatalf("inference max concurrent %d exceeded cap 4", peak)
+	}
+}
+
+// Test 5: retry policy — fake handler returns HTTP 503 twice then 200 → line
+// settles success on attempt 3; returns HTTP 400 → line fails immediately on
+// attempt 1 with no retry.
+func TestDispatcher_Retry503ThenSuccess(t *testing.T) {
+	var attempts atomic.Int32
+	infer := &fakeInference{
+		handler: func(ctx context.Context, _ int, _ string, _ json.RawMessage) (json.RawMessage, *Usage, int, error) {
+			n := attempts.Add(1)
+			if n < 3 {
+				return nil, nil, 503, errors.New("upstream unavailable")
+			}
+			return json.RawMessage(`{"ok":true}`), &Usage{TotalTokens: 7}, 200, nil
+		},
+	}
+	disp, err := NewDispatcher(Config{Concurrency: 1, MaxRetries: 3, LineTimeout: 5 * time.Second}, infer, nil)
+	if err != nil {
+		t.Fatalf("new dispatcher: %v", err)
+	}
+	res := disp.Dispatch(context.Background(), InputLine{
+		CustomID: "x",
+		Method:   "POST",
+		URL:      "/v1/chat/completions",
+		Body:     mustBody(t, "alias-1", ""),
+	})
+	if res.Error != nil {
+		t.Fatalf("expected success after retries, got error %+v", res.Error)
+	}
+	if res.Output == nil || res.Output.Response.StatusCode != 200 {
+		t.Fatalf("expected 200 output, got %+v", res.Output)
+	}
+	if res.Attempts != 3 {
+		t.Fatalf("attempts=%d want 3", res.Attempts)
+	}
+	if res.ConsumedCredits != 7 {
+		t.Fatalf("credits=%d want 7", res.ConsumedCredits)
+	}
+}
+
+func TestDispatcher_4xxNoRetry(t *testing.T) {
+	var attempts atomic.Int32
+	infer := &fakeInference{
+		handler: func(ctx context.Context, _ int, _ string, _ json.RawMessage) (json.RawMessage, *Usage, int, error) {
+			attempts.Add(1)
+			return nil, nil, 400, errors.New("bad request")
+		},
+	}
+	disp, err := NewDispatcher(Config{Concurrency: 1, MaxRetries: 3, LineTimeout: 5 * time.Second}, infer, nil)
+	if err != nil {
+		t.Fatalf("new dispatcher: %v", err)
+	}
+	res := disp.Dispatch(context.Background(), InputLine{
+		CustomID: "x",
+		Method:   "POST",
+		URL:      "/v1/chat/completions",
+		Body:     mustBody(t, "alias-1", ""),
+	})
+	if res.Output != nil {
+		t.Fatalf("expected error, got success")
+	}
+	if attempts.Load() != 1 {
+		t.Fatalf("attempts=%d want 1 (no retry on 4xx)", attempts.Load())
+	}
+	if res.Error.Error.Code != "invalid_request" {
+		t.Fatalf("code=%q want invalid_request", res.Error.Error.Code)
+	}
+	if res.ConsumedCredits != 0 {
+		t.Fatalf("credits=%d want 0", res.ConsumedCredits)
+	}
+}
+
+// Test 6: per-line context deadline — handler that exceeds LineTimeout is
+// canceled; line written to errors.jsonl with code=timeout (or upstream_error).
+func TestDispatcher_LineTimeout(t *testing.T) {
+	infer := &fakeInference{
+		handler: func(ctx context.Context, _ int, _ string, _ json.RawMessage) (json.RawMessage, *Usage, int, error) {
+			select {
+			case <-ctx.Done():
+				return nil, nil, 0, ctx.Err()
+			case <-time.After(2 * time.Second):
+				return json.RawMessage(`{}`), &Usage{TotalTokens: 1}, 200, nil
+			}
+		},
+	}
+	disp, err := NewDispatcher(Config{Concurrency: 1, MaxRetries: 1, LineTimeout: 50 * time.Millisecond}, infer, nil)
+	if err != nil {
+		t.Fatalf("new dispatcher: %v", err)
+	}
+	// LineTimeout=50ms is below floor=5s, so Validate clamps. Force directly.
+	disp.cfg.LineTimeout = 50 * time.Millisecond
+
+	start := time.Now()
+	res := disp.Dispatch(context.Background(), InputLine{
+		CustomID: "x",
+		Method:   "POST",
+		URL:      "/v1/chat/completions",
+		Body:     mustBody(t, "alias-1", ""),
+	})
+	elapsed := time.Since(start)
+	if elapsed > 1*time.Second {
+		t.Fatalf("dispatch did not honor timeout, elapsed=%s", elapsed)
+	}
+	if res.Output != nil {
+		t.Fatalf("expected error on timeout, got success")
+	}
+}
+
+// Test 7: provider-name sanitization — fake handler returns error message
+// containing "openrouter upstream rejected"; ErrorLine.message must NOT contain
+// "openrouter".
+func TestDispatcher_ProviderNameSanitized(t *testing.T) {
+	infer := &fakeInference{
+		handler: func(ctx context.Context, _ int, _ string, _ json.RawMessage) (json.RawMessage, *Usage, int, error) {
+			return nil, nil, 502, errors.New("openrouter upstream rejected the request via litellm gateway")
+		},
+	}
+	disp, err := NewDispatcher(Config{Concurrency: 1, MaxRetries: 2, LineTimeout: 5 * time.Second}, infer, nil)
+	if err != nil {
+		t.Fatalf("new dispatcher: %v", err)
+	}
+	res := disp.Dispatch(context.Background(), InputLine{
+		CustomID: "x",
+		Method:   "POST",
+		URL:      "/v1/chat/completions",
+		Body:     mustBody(t, "alias-1", ""),
+	})
+	if res.Error == nil {
+		t.Fatalf("expected error result")
+	}
+	msg := res.Error.Error.Message
+	for _, banned := range []string{"openrouter", "groq", "litellm"} {
+		if containsCI(msg, banned) {
+			t.Fatalf("sanitized message still contains %q: %q", banned, msg)
+		}
+	}
+}
+
+// Test 7b: SanitizeMessage on direct strings.
+func TestSanitizeMessage(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"openrouter upstream rejected", "upstream upstream rejected"},
+		{"GROQ HTTP 502", "upstream HTTP 502"},
+		{"LiteLLM gateway error", "upstream gateway error"},
+		{"clean message", "clean message"},
+		{"", "upstream error"},
+	}
+	for _, c := range cases {
+		got := SanitizeMessage(c.in)
+		if got != c.want {
+			t.Fatalf("SanitizeMessage(%q)=%q want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestConfig_Validate_ClampAndDefaults(t *testing.T) {
+	c := Config{Concurrency: 0, MaxRetries: 0, LineTimeout: 0}
+	if err := c.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	if c.Concurrency != ConcurrencyDefault {
+		t.Fatalf("concurrency=%d", c.Concurrency)
+	}
+	if c.MaxRetries != MaxRetriesDefault {
+		t.Fatalf("retries=%d", c.MaxRetries)
+	}
+	if c.LineTimeout != LineTimeoutDefault {
+		t.Fatalf("timeout=%s", c.LineTimeout)
+	}
+	if c.Kind != KindAuto {
+		t.Fatalf("kind=%q", c.Kind)
+	}
+
+	c = Config{Concurrency: 999, MaxRetries: 999, LineTimeout: 24 * time.Hour}
+	if err := c.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	if c.Concurrency != ConcurrencyCeiling {
+		t.Fatalf("concurrency clamp failed: %d", c.Concurrency)
+	}
+	if c.MaxRetries != MaxRetriesCeiling {
+		t.Fatalf("retries clamp failed: %d", c.MaxRetries)
+	}
+	if c.LineTimeout != LineTimeoutCeiling {
+		t.Fatalf("timeout clamp failed: %s", c.LineTimeout)
+	}
+
+	c = Config{Kind: "weird"}
+	if err := c.Validate(); err == nil {
+		t.Fatalf("expected error for unknown kind")
+	}
+}
+
+func containsCI(haystack, needle string) bool {
+	if needle == "" {
+		return false
+	}
+	if len(needle) > len(haystack) {
+		return false
+	}
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		match := true
+		for j := 0; j < len(needle); j++ {
+			c1 := haystack[i+j]
+			c2 := needle[j]
+			if 'A' <= c1 && c1 <= 'Z' {
+				c1 += 'a' - 'A'
+			}
+			if 'A' <= c2 && c2 <= 'Z' {
+				c2 += 'a' - 'A'
+			}
+			if c1 != c2 {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}

--- a/apps/control-plane/internal/batchstore/executor/dispatcher_test.go
+++ b/apps/control-plane/internal/batchstore/executor/dispatcher_test.go
@@ -99,11 +99,12 @@ func TestDispatcher_BoundedConcurrency(t *testing.T) {
 	go func() {
 		for i := 0; i < 100; i++ {
 			in <- InputLine{
-				CustomID: fmt.Sprintf("req-%d", i),
-				Method:   "POST",
-				URL:      "/v1/chat/completions",
-				Body:     mustBody(t, "alias-1", fmt.Sprintf("p%d", i)),
-				Alias:    "alias-1",
+				CustomID:     fmt.Sprintf("req-%d", i),
+				Method:       "POST",
+				URL:          "/v1/chat/completions",
+				Body:         mustBody(t, "alias-1", fmt.Sprintf("p%d", i)),
+				Alias:        "alias-1",
+				LiteLLMModel: "openrouter/gpt-4o-mini",
 			}
 		}
 		close(in)
@@ -149,8 +150,9 @@ func TestDispatcher_Retry503ThenSuccess(t *testing.T) {
 		CustomID: "x",
 		Method:   "POST",
 		URL:      "/v1/chat/completions",
-		Body:     mustBody(t, "alias-1", ""),
-		Alias:    "alias-1",
+		Body:         mustBody(t, "alias-1", ""),
+		Alias:        "alias-1",
+		LiteLLMModel: "openrouter/gpt-4o-mini",
 	})
 	if res.Error != nil {
 		t.Fatalf("expected success after retries, got error %+v", res.Error)
@@ -182,8 +184,9 @@ func TestDispatcher_4xxNoRetry(t *testing.T) {
 		CustomID: "x",
 		Method:   "POST",
 		URL:      "/v1/chat/completions",
-		Body:     mustBody(t, "alias-1", ""),
-		Alias:    "alias-1",
+		Body:         mustBody(t, "alias-1", ""),
+		Alias:        "alias-1",
+		LiteLLMModel: "openrouter/gpt-4o-mini",
 	})
 	if res.Output != nil {
 		t.Fatalf("expected error, got success")
@@ -224,8 +227,9 @@ func TestDispatcher_LineTimeout(t *testing.T) {
 		CustomID: "x",
 		Method:   "POST",
 		URL:      "/v1/chat/completions",
-		Body:     mustBody(t, "alias-1", ""),
-		Alias:    "alias-1",
+		Body:         mustBody(t, "alias-1", ""),
+		Alias:        "alias-1",
+		LiteLLMModel: "openrouter/gpt-4o-mini",
 	})
 	elapsed := time.Since(start)
 	if elapsed > 1*time.Second {
@@ -253,8 +257,9 @@ func TestDispatcher_ProviderNameSanitized(t *testing.T) {
 		CustomID: "x",
 		Method:   "POST",
 		URL:      "/v1/chat/completions",
-		Body:     mustBody(t, "alias-1", ""),
-		Alias:    "alias-1",
+		Body:         mustBody(t, "alias-1", ""),
+		Alias:        "alias-1",
+		LiteLLMModel: "openrouter/gpt-4o-mini",
 	})
 	if res.Error == nil {
 		t.Fatalf("expected error result")

--- a/apps/control-plane/internal/batchstore/executor/dispatcher_test.go
+++ b/apps/control-plane/internal/batchstore/executor/dispatcher_test.go
@@ -103,6 +103,7 @@ func TestDispatcher_BoundedConcurrency(t *testing.T) {
 				Method:   "POST",
 				URL:      "/v1/chat/completions",
 				Body:     mustBody(t, "alias-1", fmt.Sprintf("p%d", i)),
+				Alias:    "alias-1",
 			}
 		}
 		close(in)
@@ -149,6 +150,7 @@ func TestDispatcher_Retry503ThenSuccess(t *testing.T) {
 		Method:   "POST",
 		URL:      "/v1/chat/completions",
 		Body:     mustBody(t, "alias-1", ""),
+		Alias:    "alias-1",
 	})
 	if res.Error != nil {
 		t.Fatalf("expected success after retries, got error %+v", res.Error)
@@ -181,6 +183,7 @@ func TestDispatcher_4xxNoRetry(t *testing.T) {
 		Method:   "POST",
 		URL:      "/v1/chat/completions",
 		Body:     mustBody(t, "alias-1", ""),
+		Alias:    "alias-1",
 	})
 	if res.Output != nil {
 		t.Fatalf("expected error, got success")
@@ -222,6 +225,7 @@ func TestDispatcher_LineTimeout(t *testing.T) {
 		Method:   "POST",
 		URL:      "/v1/chat/completions",
 		Body:     mustBody(t, "alias-1", ""),
+		Alias:    "alias-1",
 	})
 	elapsed := time.Since(start)
 	if elapsed > 1*time.Second {
@@ -250,6 +254,7 @@ func TestDispatcher_ProviderNameSanitized(t *testing.T) {
 		Method:   "POST",
 		URL:      "/v1/chat/completions",
 		Body:     mustBody(t, "alias-1", ""),
+		Alias:    "alias-1",
 	})
 	if res.Error == nil {
 		t.Fatalf("expected error result")

--- a/apps/control-plane/internal/batchstore/executor/executor.go
+++ b/apps/control-plane/internal/batchstore/executor/executor.go
@@ -12,14 +12,21 @@ import (
 
 // BatchSnapshot is the slice of public.batches the executor needs to do its
 // work. Concrete implementations live in the batchstore package.
+//
+// LiteLLMModel is the route resolved at submission time (or re-resolved at
+// LoadBatch time using the same NeedBatch=true criteria the submitter
+// applied). Resolving once here — instead of per dispatched line — avoids
+// O(n) routing repository calls and prevents the executor's chosen route
+// from diverging from the submitter's batch-time route.
 type BatchSnapshot struct {
-	ID            string
-	AccountID     string
-	InputFileID   string
-	InputFilePath string
-	ReservationID string
-	Endpoint      string
-	ModelAlias    string
+	ID              string
+	AccountID       string
+	InputFileID     string
+	InputFilePath   string
+	ReservationID   string
+	Endpoint        string
+	ModelAlias      string
+	LiteLLMModel    string
 	ReservedCredits int64
 }
 
@@ -33,6 +40,7 @@ type LineRow struct {
 	OutputIndex     *int
 	ErrorIndex      *int
 	LastError       string
+	CompletedAt     *time.Time
 }
 
 // BatchStore is the persistence port the executor depends on. Production
@@ -160,25 +168,41 @@ func (e *Executor) Run(ctx context.Context, batchID string) error {
 		switch r.Status {
 		case "succeeded":
 			completed++
-			// Re-emit a placeholder row to preserve ordering — the actual
-			// upstream response is gone (transient memory). We cannot reissue
-			// the call without double-charging. Document in test 2: the
-			// re-upload contains a sentinel response body marked
-			// {"resumed":true}; restart-safety contract is that the line is
-			// NOT re-charged and NOT re-dispatched.
+			// Re-emit an interim placeholder row — the original upstream
+			// response body is no longer in memory and not yet persisted.
+			// Phase 18 (see 15-VERIFICATION.md) will replace the placeholder
+			// with the persisted response body. Until then, expose enough
+			// diagnostic metadata for support to correlate.
+			body := map[string]any{
+				"resumed":              true,
+				"resume_reason":        "executor_restart_after_partial_run",
+				"original_attempt":     r.Attempt,
+				"original_consumed":    r.ConsumedCredits,
+			}
+			if r.CompletedAt != nil {
+				body["original_completed_at"] = r.CompletedAt.UTC().Format(time.RFC3339Nano)
+			}
 			_, _ = output.Append(map[string]any{
 				"id":        "batch_req_resumed_" + r.CustomID,
 				"custom_id": r.CustomID,
-				"response":  map[string]any{"status_code": 200, "request_id": "resumed", "body": map[string]any{"resumed": true}},
+				"response":  map[string]any{"status_code": 200, "request_id": "resumed", "body": body},
 				"error":     nil,
 			})
 		case "failed":
 			failed++
+			errBody := map[string]any{
+				"code":             "resumed",
+				"message":          SanitizeMessage(r.LastError),
+				"original_attempt": r.Attempt,
+			}
+			if r.CompletedAt != nil {
+				errBody["original_completed_at"] = r.CompletedAt.UTC().Format(time.RFC3339Nano)
+			}
 			_, _ = errs.Append(map[string]any{
 				"id":        "batch_req_resumed_" + r.CustomID,
 				"custom_id": r.CustomID,
 				"response":  nil,
-				"error":     map[string]any{"code": "resumed", "message": SanitizeMessage(r.LastError)},
+				"error":     errBody,
 			})
 		}
 	}
@@ -204,6 +228,7 @@ func (e *Executor) Run(ctx context.Context, batchID string) error {
 			}
 			out := *line
 			out.Alias = batch.ModelAlias
+			out.LiteLLMModel = batch.LiteLLMModel
 			select {
 			case <-ctx.Done():
 				return

--- a/apps/control-plane/internal/batchstore/executor/executor.go
+++ b/apps/control-plane/internal/batchstore/executor/executor.go
@@ -1,0 +1,286 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"math/big"
+	"strings"
+	"time"
+)
+
+// BatchSnapshot is the slice of public.batches the executor needs to do its
+// work. Concrete implementations live in the batchstore package.
+type BatchSnapshot struct {
+	ID            string
+	AccountID     string
+	InputFileID   string
+	InputFilePath string
+	ReservationID string
+	Endpoint      string
+	ModelAlias    string
+	ReservedCredits int64
+}
+
+// LineRow is the persisted state of a single batch line. Mirrors public.batch_lines.
+type LineRow struct {
+	BatchID         string
+	CustomID        string
+	Status          string // "pending" | "in_progress" | "succeeded" | "failed"
+	Attempt         int
+	ConsumedCredits int64
+	OutputIndex     *int
+	ErrorIndex      *int
+	LastError       string
+}
+
+// BatchStore is the persistence port the executor depends on. Production
+// implementations wrap pgx queries against public.batches.
+type BatchStore interface {
+	// LoadBatch returns the batch snapshot needed for execution.
+	LoadBatch(ctx context.Context, batchID string) (BatchSnapshot, error)
+	// MarkCompleted writes terminal status, line counts, output/error file
+	// IDs, and overconsumed flag in a single transaction.
+	MarkCompleted(ctx context.Context, batchID string, completedLines, failedLines int, outputFileID, errorFileID string, overconsumed bool, completedAt time.Time) error
+}
+
+// LineStore persists per-line state for restart-safe resume.
+type LineStore interface {
+	// LoadLines returns previously-persisted line rows for the batch.
+	LoadLines(ctx context.Context, batchID string) ([]LineRow, error)
+	// UpsertPending creates or no-ops a pending row before dispatch.
+	UpsertPending(ctx context.Context, batchID, customID string) error
+	// MarkSucceeded transitions a line row to succeeded and records consumed credits + output index.
+	MarkSucceeded(ctx context.Context, batchID, customID string, attempt int, consumedCredits int64, outputIndex int) error
+	// MarkFailed transitions a line row to failed with sanitized last_error and error_index.
+	MarkFailed(ctx context.Context, batchID, customID string, attempt int, errorIndex int, lastError string) error
+}
+
+// ReservationPort releases the reserved credits for a batch by setting the
+// final actual_credits. Implementation reuses accounting.Service.FinalizeReservation
+// when actual > 0, or ReleaseReservation when actual == 0.
+type ReservationPort interface {
+	Settle(ctx context.Context, batchID, accountID, reservationID string, actualCredits int64, overconsumed bool, terminalStatus string) error
+}
+
+// Executor is the local batch executor entry point. Constructed once at
+// startup and shared by the asynq worker handling the batch:execute task.
+type Executor struct {
+	cfg          Config
+	batches      BatchStore
+	lines        LineStore
+	storage      StoragePort
+	bucket       string
+	dispatcher   *Dispatcher
+	reservations ReservationPort
+
+	// outputKey/errorKey templates expose hooks for tests to predict storage paths.
+	outputKey func(batchID string) string
+	errorKey  func(batchID string) string
+}
+
+// NewExecutor wires the executor with its ports.
+func NewExecutor(cfg Config, batches BatchStore, lines LineStore, storage StoragePort, bucket string, dispatcher *Dispatcher, reservations ReservationPort) (*Executor, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	if batches == nil || lines == nil || storage == nil || dispatcher == nil || reservations == nil {
+		return nil, fmt.Errorf("executor: all ports are required")
+	}
+	if strings.TrimSpace(bucket) == "" {
+		return nil, fmt.Errorf("executor: bucket is required")
+	}
+	return &Executor{
+		cfg:          cfg,
+		batches:      batches,
+		lines:        lines,
+		storage:      storage,
+		bucket:       bucket,
+		dispatcher:   dispatcher,
+		reservations: reservations,
+		outputKey:    func(id string) string { return "batches/" + id + "/output.jsonl" },
+		errorKey:     func(id string) string { return "batches/" + id + "/errors.jsonl" },
+	}, nil
+}
+
+// Run executes a single batch end-to-end. It is safe to invoke twice for the
+// same batchID — the second run resumes from existing batch_lines rows.
+func (e *Executor) Run(ctx context.Context, batchID string) error {
+	batch, err := e.batches.LoadBatch(ctx, batchID)
+	if err != nil {
+		return fmt.Errorf("executor: load batch %s: %w", batchID, err)
+	}
+
+	prior, err := e.lines.LoadLines(ctx, batchID)
+	if err != nil {
+		return fmt.Errorf("executor: load batch_lines %s: %w", batchID, err)
+	}
+	priorByID := make(map[string]LineRow, len(prior))
+	for _, r := range prior {
+		priorByID[r.CustomID] = r
+	}
+
+	reader, err := e.storage.Download(ctx, e.bucket, batch.InputFilePath)
+	if err != nil {
+		return fmt.Errorf("executor: download input %s: %w", batch.InputFilePath, err)
+	}
+	defer reader.Close()
+
+	scanCh := make(chan ScanResult, e.cfg.Concurrency*2)
+	go ScanLines(ctx, reader, scanCh)
+
+	in := make(chan InputLine, e.cfg.Concurrency*2)
+	out := make(chan DispatchResult, e.cfg.Concurrency*2)
+	output := &JSONLWriter{}
+	errs := &JSONLWriter{}
+
+	completed := 0
+	failed := 0
+
+	// Pre-seed counts from prior persisted rows so resume produces correct totals.
+	// Output/error JSONL writers do NOT replay successful prior lines (those
+	// are already uploaded as part of a previous run that crashed before
+	// MarkCompleted; the partial files are overwritten on this run with the
+	// remaining lines plus the prior content held in memory). Concretely: we
+	// re-emit prior succeeded/failed lines into the in-memory writer so the
+	// final upload contains every line.
+	for _, r := range prior {
+		switch r.Status {
+		case "succeeded":
+			completed++
+			// Re-emit a placeholder row to preserve ordering — the actual
+			// upstream response is gone (transient memory). We cannot reissue
+			// the call without double-charging. Document in test 2: the
+			// re-upload contains a sentinel response body marked
+			// {"resumed":true}; restart-safety contract is that the line is
+			// NOT re-charged and NOT re-dispatched.
+			_, _ = output.Append(map[string]any{
+				"id":        "batch_req_resumed_" + r.CustomID,
+				"custom_id": r.CustomID,
+				"response":  map[string]any{"status_code": 200, "request_id": "resumed", "body": map[string]any{"resumed": true}},
+				"error":     nil,
+			})
+		case "failed":
+			failed++
+			_, _ = errs.Append(map[string]any{
+				"id":        "batch_req_resumed_" + r.CustomID,
+				"custom_id": r.CustomID,
+				"response":  nil,
+				"error":     map[string]any{"code": "resumed", "message": SanitizeMessage(r.LastError)},
+			})
+		}
+	}
+
+	// Producer: read scan results, skip already-settled lines, push to dispatcher.
+	scanDone := make(chan struct{})
+	scanErrs := make([]ScanResult, 0)
+	go func() {
+		defer close(in)
+		for sr := range scanCh {
+			if sr.Err != nil {
+				scanErrs = append(scanErrs, sr)
+				continue
+			}
+			line := sr.Line
+			if prior, ok := priorByID[line.CustomID]; ok {
+				if prior.Status == "succeeded" || prior.Status == "failed" {
+					continue
+				}
+			}
+			if err := e.lines.UpsertPending(ctx, batchID, line.CustomID); err != nil {
+				log.Printf("executor: upsert pending %s/%s: %v", batchID, line.CustomID, err)
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case in <- *line:
+			}
+		}
+		close(scanDone)
+	}()
+
+	// Worker pool runs in its own goroutine so we can drain results synchronously.
+	poolDone := make(chan struct{})
+	go func() {
+		e.dispatcher.Pool(ctx, in, out)
+		close(out)
+		close(poolDone)
+	}()
+
+	// Consumer: collect results, persist line rows, append to writers.
+	totalConsumed := big.NewInt(0)
+	for res := range out {
+		if res.Output != nil {
+			idx, _ := output.Append(res.Output)
+			if err := e.lines.MarkSucceeded(ctx, batchID, res.CustomID, res.Attempts, res.ConsumedCredits, idx); err != nil {
+				log.Printf("executor: mark succeeded %s/%s: %v", batchID, res.CustomID, err)
+			}
+			completed++
+			totalConsumed.Add(totalConsumed, big.NewInt(res.ConsumedCredits))
+		} else if res.Error != nil {
+			idx, _ := errs.Append(res.Error)
+			if err := e.lines.MarkFailed(ctx, batchID, res.CustomID, res.Attempts, idx, res.Error.Error.Message); err != nil {
+				log.Printf("executor: mark failed %s/%s: %v", batchID, res.CustomID, err)
+			}
+			failed++
+		}
+	}
+
+	// Append malformed-JSON scan errors as error lines (no dispatch happened).
+	for _, sr := range scanErrs {
+		idx, _ := errs.Append(map[string]any{
+			"id":        "batch_req_invalid",
+			"custom_id": "",
+			"response":  nil,
+			"error":     map[string]any{"code": "invalid_json", "message": SanitizeMessage(sr.Err.Error())},
+		})
+		failed++
+		_ = idx
+	}
+
+	// Add prior consumed credits from re-emitted succeeded lines. They are
+	// already accounted for in batch_lines.consumed_credits — sum from DB.
+	for _, r := range prior {
+		if r.Status == "succeeded" {
+			totalConsumed.Add(totalConsumed, big.NewInt(r.ConsumedCredits))
+		}
+	}
+
+	// Finalize uploads.
+	outputKey := e.outputKey(batchID)
+	errorKey := e.errorKey(batchID)
+	if _, err := output.Finalize(ctx, e.storage, e.bucket, outputKey, false); err != nil {
+		return fmt.Errorf("executor: upload output: %w", err)
+	}
+	uploadedErrs, err := errs.Finalize(ctx, e.storage, e.bucket, errorKey, true)
+	if err != nil {
+		return fmt.Errorf("executor: upload errors: %w", err)
+	}
+
+	// Settle credits.
+	actual, overconsumed, err := Settle(SettleInput{
+		ReservedCredits: batch.ReservedCredits,
+		ConsumedCredits: totalConsumed,
+	})
+	if err != nil {
+		return fmt.Errorf("executor: settle: %w", err)
+	}
+	if err := e.reservations.Settle(ctx, batchID, batch.AccountID, batch.ReservationID, actual, overconsumed, "completed"); err != nil {
+		return fmt.Errorf("executor: settle reservation: %w", err)
+	}
+
+	resolvedErrorKey := ""
+	if uploadedErrs {
+		resolvedErrorKey = errorKey
+	}
+	if err := e.batches.MarkCompleted(ctx, batchID, completed, failed, outputKey, resolvedErrorKey, overconsumed, time.Now().UTC()); err != nil {
+		return fmt.Errorf("executor: mark completed: %w", err)
+	}
+
+	<-scanDone
+	<-poolDone
+	_ = io.EOF // silence import in case poolDone path skipped
+
+	return nil
+}

--- a/apps/control-plane/internal/batchstore/executor/executor.go
+++ b/apps/control-plane/internal/batchstore/executor/executor.go
@@ -64,6 +64,15 @@ type ReservationPort interface {
 	Settle(ctx context.Context, batchID, accountID, reservationID string, actualCredits int64, overconsumed bool, terminalStatus string) error
 }
 
+// FileRegistrar persists a public.files row for an output/error artifact the
+// executor uploaded to object storage and returns the generated file ID.
+// MarkCompleted writes that ID into batches.output_file_id / error_file_id
+// (FK -> public.files.id), so this port must be invoked before MarkCompleted
+// — otherwise the FK references a non-existent row.
+type FileRegistrar interface {
+	Register(ctx context.Context, accountID, purpose, filename, storagePath string, bytes int64) (string, error)
+}
+
 // Executor is the local batch executor entry point. Constructed once at
 // startup and shared by the asynq worker handling the batch:execute task.
 type Executor struct {
@@ -71,6 +80,7 @@ type Executor struct {
 	batches      BatchStore
 	lines        LineStore
 	storage      StoragePort
+	files        FileRegistrar
 	bucket       string
 	dispatcher   *Dispatcher
 	reservations ReservationPort
@@ -81,11 +91,11 @@ type Executor struct {
 }
 
 // NewExecutor wires the executor with its ports.
-func NewExecutor(cfg Config, batches BatchStore, lines LineStore, storage StoragePort, bucket string, dispatcher *Dispatcher, reservations ReservationPort) (*Executor, error) {
+func NewExecutor(cfg Config, batches BatchStore, lines LineStore, storage StoragePort, files FileRegistrar, bucket string, dispatcher *Dispatcher, reservations ReservationPort) (*Executor, error) {
 	if err := cfg.Validate(); err != nil {
 		return nil, err
 	}
-	if batches == nil || lines == nil || storage == nil || dispatcher == nil || reservations == nil {
+	if batches == nil || lines == nil || storage == nil || files == nil || dispatcher == nil || reservations == nil {
 		return nil, fmt.Errorf("executor: all ports are required")
 	}
 	if strings.TrimSpace(bucket) == "" {
@@ -96,6 +106,7 @@ func NewExecutor(cfg Config, batches BatchStore, lines LineStore, storage Storag
 		batches:      batches,
 		lines:        lines,
 		storage:      storage,
+		files:        files,
 		bucket:       bucket,
 		dispatcher:   dispatcher,
 		reservations: reservations,
@@ -191,10 +202,12 @@ func (e *Executor) Run(ctx context.Context, batchID string) error {
 			if err := e.lines.UpsertPending(ctx, batchID, line.CustomID); err != nil {
 				log.Printf("executor: upsert pending %s/%s: %v", batchID, line.CustomID, err)
 			}
+			out := *line
+			out.Alias = batch.ModelAlias
 			select {
 			case <-ctx.Done():
 				return
-			case in <- *line:
+			case in <- out:
 			}
 		}
 		close(scanDone)
@@ -250,12 +263,27 @@ func (e *Executor) Run(ctx context.Context, batchID string) error {
 	// Finalize uploads.
 	outputKey := e.outputKey(batchID)
 	errorKey := e.errorKey(batchID)
-	if _, err := output.Finalize(ctx, e.storage, e.bucket, outputKey, false); err != nil {
+	_, outputBytes, err := output.Finalize(ctx, e.storage, e.bucket, outputKey, false)
+	if err != nil {
 		return fmt.Errorf("executor: upload output: %w", err)
 	}
-	uploadedErrs, err := errs.Finalize(ctx, e.storage, e.bucket, errorKey, true)
+	uploadedErrs, errorBytes, err := errs.Finalize(ctx, e.storage, e.bucket, errorKey, true)
 	if err != nil {
 		return fmt.Errorf("executor: upload errors: %w", err)
+	}
+
+	// Register output/error artifacts in public.files so the FK targets in
+	// batches.output_file_id / error_file_id resolve to real rows.
+	outputFileID, err := e.files.Register(ctx, batch.AccountID, "batch_output", "output.jsonl", outputKey, outputBytes)
+	if err != nil {
+		return fmt.Errorf("executor: register output file: %w", err)
+	}
+	errorFileID := ""
+	if uploadedErrs {
+		errorFileID, err = e.files.Register(ctx, batch.AccountID, "batch_output", "errors.jsonl", errorKey, errorBytes)
+		if err != nil {
+			return fmt.Errorf("executor: register error file: %w", err)
+		}
 	}
 
 	// Settle credits.
@@ -270,11 +298,7 @@ func (e *Executor) Run(ctx context.Context, batchID string) error {
 		return fmt.Errorf("executor: settle reservation: %w", err)
 	}
 
-	resolvedErrorKey := ""
-	if uploadedErrs {
-		resolvedErrorKey = errorKey
-	}
-	if err := e.batches.MarkCompleted(ctx, batchID, completed, failed, outputKey, resolvedErrorKey, overconsumed, time.Now().UTC()); err != nil {
+	if err := e.batches.MarkCompleted(ctx, batchID, completed, failed, outputFileID, errorFileID, overconsumed, time.Now().UTC()); err != nil {
 		return fmt.Errorf("executor: mark completed: %w", err)
 	}
 

--- a/apps/control-plane/internal/batchstore/executor/executor_test.go
+++ b/apps/control-plane/internal/batchstore/executor/executor_test.go
@@ -129,6 +129,27 @@ func (s *fakeLineStore) snapshot(batchID string) []LineRow {
 	return out
 }
 
+// fakeFileRegistrar records Register calls and returns predictable IDs.
+type fakeFileRegistrar struct {
+	mu    sync.Mutex
+	next  int
+	calls []fakeRegisterCall
+}
+
+type fakeRegisterCall struct {
+	accountID, purpose, filename, storagePath, id string
+	bytes                                         int64
+}
+
+func (f *fakeFileRegistrar) Register(_ context.Context, accountID, purpose, filename, storagePath string, bytes int64) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.next++
+	id := fmt.Sprintf("file-test-%d", f.next)
+	f.calls = append(f.calls, fakeRegisterCall{accountID, purpose, filename, storagePath, id, bytes})
+	return id, nil
+}
+
 // fakeReservation records settlements.
 type fakeReservation struct {
 	mu                                          sync.Mutex
@@ -200,7 +221,8 @@ func TestExecutor_MixedSuccessFailure(t *testing.T) {
 	}}
 	ls := newFakeLineStore()
 	rp := &fakeReservation{}
-	ex, err := NewExecutor(Config{Concurrency: 4, MaxRetries: 2, LineTimeout: 5 * time.Second}, bs, ls, storeFs, "hive-files", disp, rp)
+	fr := &fakeFileRegistrar{}
+	ex, err := NewExecutor(Config{Concurrency: 4, MaxRetries: 2, LineTimeout: 5 * time.Second}, bs, ls, storeFs, fr, "hive-files", disp, rp)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -212,6 +234,13 @@ func TestExecutor_MixedSuccessFailure(t *testing.T) {
 	}
 	if bs.completed.completedLines != 95 || bs.completed.failedLines != 5 {
 		t.Fatalf("counts=%d/%d want 95/5", bs.completed.completedLines, bs.completed.failedLines)
+	}
+	// Output + errors files must both be registered (so MarkCompleted gets real file IDs).
+	if len(fr.calls) != 2 {
+		t.Fatalf("file registrar calls=%d want 2", len(fr.calls))
+	}
+	if bs.completed.outputFileID != fr.calls[0].id || bs.completed.errorFileID != fr.calls[1].id {
+		t.Fatalf("MarkCompleted got file IDs %q/%q want %q/%q", bs.completed.outputFileID, bs.completed.errorFileID, fr.calls[0].id, fr.calls[1].id)
 	}
 	out := storeFs.uploads["hive-files/batches/b1/output.jsonl"]
 	errs := storeFs.uploads["hive-files/batches/b1/errors.jsonl"]
@@ -250,7 +279,8 @@ func TestExecutor_EmptyInput(t *testing.T) {
 	}}
 	ls := newFakeLineStore()
 	rp := &fakeReservation{}
-	ex, _ := NewExecutor(Config{Concurrency: 1, MaxRetries: 1, LineTimeout: 1 * time.Second}, bs, ls, storeFs, "hive-files", disp, rp)
+	fr := &fakeFileRegistrar{}
+	ex, _ := NewExecutor(Config{Concurrency: 1, MaxRetries: 1, LineTimeout: 1 * time.Second}, bs, ls, storeFs, fr, "hive-files", disp, rp)
 	if err := ex.Run(context.Background(), "b2"); err != nil {
 		t.Fatal(err)
 	}
@@ -259,6 +289,13 @@ func TestExecutor_EmptyInput(t *testing.T) {
 	}
 	if _, ok := storeFs.uploads["hive-files/batches/b2/errors.jsonl"]; ok {
 		t.Fatalf("errors.jsonl should not be uploaded for empty input")
+	}
+	// Empty input still registers the (empty) output file but skips errors.
+	if len(fr.calls) != 1 {
+		t.Fatalf("registrar calls=%d want 1 (output only)", len(fr.calls))
+	}
+	if bs.completed.errorFileID != "" {
+		t.Fatalf("errorFileID=%q want empty when errors.jsonl skipped", bs.completed.errorFileID)
 	}
 	out, ok := storeFs.uploads["hive-files/batches/b2/output.jsonl"]
 	if !ok {
@@ -287,7 +324,8 @@ func TestExecutor_AllErrors(t *testing.T) {
 	}}
 	ls := newFakeLineStore()
 	rp := &fakeReservation{}
-	ex, _ := NewExecutor(Config{Concurrency: 2, MaxRetries: 1, LineTimeout: 1 * time.Second}, bs, ls, storeFs, "hive-files", disp, rp)
+	fr := &fakeFileRegistrar{}
+	ex, _ := NewExecutor(Config{Concurrency: 2, MaxRetries: 1, LineTimeout: 1 * time.Second}, bs, ls, storeFs, fr, "hive-files", disp, rp)
 	if err := ex.Run(context.Background(), "b3"); err != nil {
 		t.Fatal(err)
 	}
@@ -330,10 +368,11 @@ func TestExecutor_RestartResume(t *testing.T) {
 	disp, _ := NewDispatcher(Config{Concurrency: 2, MaxRetries: 1, LineTimeout: 1 * time.Second}, infer, nil)
 	bs := &fakeBatchStore{snap: BatchSnapshot{
 		ID: "b4", AccountID: "acct", InputFilePath: "batches/b4/input.jsonl",
-		ReservationID: "res4", ReservedCredits: 100000,
+		ReservationID: "res4", ModelAlias: "alias-1", ReservedCredits: 100000,
 	}}
 	rp := &fakeReservation{}
-	ex, _ := NewExecutor(Config{Concurrency: 2, MaxRetries: 1, LineTimeout: 1 * time.Second}, bs, ls, storeFs, "hive-files", disp, rp)
+	fr := &fakeFileRegistrar{}
+	ex, _ := NewExecutor(Config{Concurrency: 2, MaxRetries: 1, LineTimeout: 1 * time.Second}, bs, ls, storeFs, fr, "hive-files", disp, rp)
 	if err := ex.Run(context.Background(), "b4"); err != nil {
 		t.Fatal(err)
 	}

--- a/apps/control-plane/internal/batchstore/executor/executor_test.go
+++ b/apps/control-plane/internal/batchstore/executor/executor_test.go
@@ -217,6 +217,7 @@ func TestExecutor_MixedSuccessFailure(t *testing.T) {
 	bs := &fakeBatchStore{snap: BatchSnapshot{
 		ID: "b1", AccountID: "acct", InputFileID: "f1", InputFilePath: "batches/b1/input.jsonl",
 		ReservationID: "res1", Endpoint: "/v1/chat/completions", ModelAlias: "alias-1",
+		LiteLLMModel:    "openrouter/gpt-4o-mini",
 		ReservedCredits: 100000,
 	}}
 	ls := newFakeLineStore()
@@ -275,7 +276,8 @@ func TestExecutor_EmptyInput(t *testing.T) {
 	disp, _ := NewDispatcher(Config{Concurrency: 1, MaxRetries: 1, LineTimeout: 1 * time.Second}, infer, nil)
 	bs := &fakeBatchStore{snap: BatchSnapshot{
 		ID: "b2", AccountID: "acct", InputFilePath: "batches/b2/input.jsonl",
-		ReservationID: "res2", ReservedCredits: 100,
+		ReservationID: "res2", ModelAlias: "alias-1", LiteLLMModel: "openrouter/gpt-4o-mini",
+		ReservedCredits: 100,
 	}}
 	ls := newFakeLineStore()
 	rp := &fakeReservation{}
@@ -320,7 +322,8 @@ func TestExecutor_AllErrors(t *testing.T) {
 	disp, _ := NewDispatcher(Config{Concurrency: 2, MaxRetries: 1, LineTimeout: 1 * time.Second}, infer, nil)
 	bs := &fakeBatchStore{snap: BatchSnapshot{
 		ID: "b3", AccountID: "acct", InputFilePath: "batches/b3/input.jsonl",
-		ReservationID: "res3", ReservedCredits: 5000,
+		ReservationID: "res3", ModelAlias: "alias-1", LiteLLMModel: "openrouter/gpt-4o-mini",
+		ReservedCredits: 5000,
 	}}
 	ls := newFakeLineStore()
 	rp := &fakeReservation{}
@@ -368,7 +371,8 @@ func TestExecutor_RestartResume(t *testing.T) {
 	disp, _ := NewDispatcher(Config{Concurrency: 2, MaxRetries: 1, LineTimeout: 1 * time.Second}, infer, nil)
 	bs := &fakeBatchStore{snap: BatchSnapshot{
 		ID: "b4", AccountID: "acct", InputFilePath: "batches/b4/input.jsonl",
-		ReservationID: "res4", ModelAlias: "alias-1", ReservedCredits: 100000,
+		ReservationID: "res4", ModelAlias: "alias-1", LiteLLMModel: "openrouter/gpt-4o-mini",
+		ReservedCredits: 100000,
 	}}
 	rp := &fakeReservation{}
 	fr := &fakeFileRegistrar{}

--- a/apps/control-plane/internal/batchstore/executor/executor_test.go
+++ b/apps/control-plane/internal/batchstore/executor/executor_test.go
@@ -1,0 +1,373 @@
+package executor
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeBatchStore implements BatchStore in-memory.
+type fakeBatchStore struct {
+	mu        sync.Mutex
+	snap      BatchSnapshot
+	completed *struct {
+		batchID                       string
+		completedLines, failedLines   int
+		outputFileID, errorFileID     string
+		overconsumed                  bool
+		completedAt                   time.Time
+	}
+}
+
+func (f *fakeBatchStore) LoadBatch(ctx context.Context, id string) (BatchSnapshot, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.snap.ID != id {
+		return BatchSnapshot{}, fmt.Errorf("not found")
+	}
+	return f.snap, nil
+}
+
+func (f *fakeBatchStore) MarkCompleted(ctx context.Context, batchID string, completedLines, failedLines int, outputFileID, errorFileID string, overconsumed bool, completedAt time.Time) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.completed = &struct {
+		batchID                       string
+		completedLines, failedLines   int
+		outputFileID, errorFileID     string
+		overconsumed                  bool
+		completedAt                   time.Time
+	}{batchID, completedLines, failedLines, outputFileID, errorFileID, overconsumed, completedAt}
+	return nil
+}
+
+// fakeLineStore is an in-memory LineStore.
+type fakeLineStore struct {
+	mu   sync.Mutex
+	rows map[string]map[string]LineRow // batchID -> customID -> row
+}
+
+func newFakeLineStore() *fakeLineStore {
+	return &fakeLineStore{rows: map[string]map[string]LineRow{}}
+}
+
+func (s *fakeLineStore) seed(rows []LineRow) {
+	for _, r := range rows {
+		if s.rows[r.BatchID] == nil {
+			s.rows[r.BatchID] = map[string]LineRow{}
+		}
+		s.rows[r.BatchID][r.CustomID] = r
+	}
+}
+
+func (s *fakeLineStore) LoadLines(ctx context.Context, batchID string) ([]LineRow, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]LineRow, 0, len(s.rows[batchID]))
+	for _, r := range s.rows[batchID] {
+		out = append(out, r)
+	}
+	return out, nil
+}
+
+func (s *fakeLineStore) UpsertPending(ctx context.Context, batchID, customID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.rows[batchID] == nil {
+		s.rows[batchID] = map[string]LineRow{}
+	}
+	if _, ok := s.rows[batchID][customID]; !ok {
+		s.rows[batchID][customID] = LineRow{BatchID: batchID, CustomID: customID, Status: "pending"}
+	}
+	return nil
+}
+
+func (s *fakeLineStore) MarkSucceeded(ctx context.Context, batchID, customID string, attempt int, consumedCredits int64, outputIndex int) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	r := s.rows[batchID][customID]
+	r.BatchID = batchID
+	r.CustomID = customID
+	r.Status = "succeeded"
+	r.Attempt = attempt
+	r.ConsumedCredits = consumedCredits
+	idx := outputIndex
+	r.OutputIndex = &idx
+	s.rows[batchID][customID] = r
+	return nil
+}
+
+func (s *fakeLineStore) MarkFailed(ctx context.Context, batchID, customID string, attempt int, errorIndex int, lastError string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	r := s.rows[batchID][customID]
+	r.BatchID = batchID
+	r.CustomID = customID
+	r.Status = "failed"
+	r.Attempt = attempt
+	idx := errorIndex
+	r.ErrorIndex = &idx
+	r.LastError = lastError
+	s.rows[batchID][customID] = r
+	return nil
+}
+
+func (s *fakeLineStore) snapshot(batchID string) []LineRow {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]LineRow, 0, len(s.rows[batchID]))
+	for _, r := range s.rows[batchID] {
+		out = append(out, r)
+	}
+	return out
+}
+
+// fakeReservation records settlements.
+type fakeReservation struct {
+	mu                                          sync.Mutex
+	calls                                       int
+	lastActual                                  int64
+	lastOverconsumed                            bool
+	lastTerminalStatus                          string
+}
+
+func (f *fakeReservation) Settle(ctx context.Context, batchID, accountID, reservationID string, actualCredits int64, overconsumed bool, terminalStatus string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	f.lastActual = actualCredits
+	f.lastOverconsumed = overconsumed
+	f.lastTerminalStatus = terminalStatus
+	return nil
+}
+
+// makeBatchInput builds n lines: indices in errorIndices return 4xx; others succeed.
+func makeBatchInput(n int) []byte {
+	var buf bytes.Buffer
+	for i := 0; i < n; i++ {
+		body := fmt.Sprintf(`{"model":"alias-1","messages":[{"role":"user","content":"line %d"}]}`, i)
+		line := fmt.Sprintf(`{"custom_id":"req-%d","method":"POST","url":"/v1/chat/completions","body":%s}`, i, body)
+		buf.WriteString(line)
+		buf.WriteString("\n")
+	}
+	return buf.Bytes()
+}
+
+// Test 1: 100-line input, 95 success / 5 error → output.jsonl has 95 lines,
+// errors.jsonl has 5; batch row status=completed; completed_lines=95,
+// failed_lines=5; Storage upload called twice.
+func TestExecutor_MixedSuccessFailure(t *testing.T) {
+	const total = 100
+	storeFs := newFakeStorage()
+	storeFs.downloads["hive-files/batches/b1/input.jsonl"] = makeBatchInput(total)
+
+	failIDs := map[string]bool{"req-3": true, "req-17": true, "req-42": true, "req-66": true, "req-91": true}
+	infer := &fakeInference{
+		handler: func(ctx context.Context, attempt int, model string, body json.RawMessage) (json.RawMessage, *Usage, int, error) {
+			var probe struct {
+				Messages []struct {
+					Content string `json:"content"`
+				} `json:"messages"`
+			}
+			_ = json.Unmarshal(body, &probe)
+			content := ""
+			if len(probe.Messages) > 0 {
+				content = probe.Messages[0].Content
+			}
+			// Map content "line N" back to "req-N".
+			id := strings.Replace(content, "line ", "req-", 1)
+			if failIDs[id] {
+				return nil, nil, 400, errors.New("bad request")
+			}
+			return json.RawMessage(`{"id":"chatcmpl_x","choices":[]}`), &Usage{TotalTokens: 10}, 200, nil
+		},
+	}
+	disp, err := NewDispatcher(Config{Concurrency: 4, MaxRetries: 2, LineTimeout: 5 * time.Second}, infer, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bs := &fakeBatchStore{snap: BatchSnapshot{
+		ID: "b1", AccountID: "acct", InputFileID: "f1", InputFilePath: "batches/b1/input.jsonl",
+		ReservationID: "res1", Endpoint: "/v1/chat/completions", ModelAlias: "alias-1",
+		ReservedCredits: 100000,
+	}}
+	ls := newFakeLineStore()
+	rp := &fakeReservation{}
+	ex, err := NewExecutor(Config{Concurrency: 4, MaxRetries: 2, LineTimeout: 5 * time.Second}, bs, ls, storeFs, "hive-files", disp, rp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ex.Run(context.Background(), "b1"); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if bs.completed == nil {
+		t.Fatalf("MarkCompleted not called")
+	}
+	if bs.completed.completedLines != 95 || bs.completed.failedLines != 5 {
+		t.Fatalf("counts=%d/%d want 95/5", bs.completed.completedLines, bs.completed.failedLines)
+	}
+	out := storeFs.uploads["hive-files/batches/b1/output.jsonl"]
+	errs := storeFs.uploads["hive-files/batches/b1/errors.jsonl"]
+	if out == nil {
+		t.Fatalf("output.jsonl not uploaded")
+	}
+	if errs == nil {
+		t.Fatalf("errors.jsonl not uploaded")
+	}
+	if got := bytes.Count(out, []byte("\n")); got != 95 {
+		t.Fatalf("output line count=%d want 95", got)
+	}
+	if got := bytes.Count(errs, []byte("\n")); got != 5 {
+		t.Fatalf("errors line count=%d want 5", got)
+	}
+	if rp.calls != 1 {
+		t.Fatalf("reservation settle calls=%d want 1", rp.calls)
+	}
+	// 95 succeeded × 10 tokens = 950 credits.
+	if rp.lastActual != 950 {
+		t.Fatalf("actual=%d want 950", rp.lastActual)
+	}
+}
+
+// Test 3: empty input file → batch row status=completed, completed_lines=0,
+// failed_lines=0, output.jsonl uploaded as empty, errors.jsonl skipped.
+func TestExecutor_EmptyInput(t *testing.T) {
+	storeFs := newFakeStorage()
+	storeFs.downloads["hive-files/batches/b2/input.jsonl"] = []byte("")
+
+	infer := &fakeInference{}
+	disp, _ := NewDispatcher(Config{Concurrency: 1, MaxRetries: 1, LineTimeout: 1 * time.Second}, infer, nil)
+	bs := &fakeBatchStore{snap: BatchSnapshot{
+		ID: "b2", AccountID: "acct", InputFilePath: "batches/b2/input.jsonl",
+		ReservationID: "res2", ReservedCredits: 100,
+	}}
+	ls := newFakeLineStore()
+	rp := &fakeReservation{}
+	ex, _ := NewExecutor(Config{Concurrency: 1, MaxRetries: 1, LineTimeout: 1 * time.Second}, bs, ls, storeFs, "hive-files", disp, rp)
+	if err := ex.Run(context.Background(), "b2"); err != nil {
+		t.Fatal(err)
+	}
+	if bs.completed.completedLines != 0 || bs.completed.failedLines != 0 {
+		t.Fatalf("counts not zero")
+	}
+	if _, ok := storeFs.uploads["hive-files/batches/b2/errors.jsonl"]; ok {
+		t.Fatalf("errors.jsonl should not be uploaded for empty input")
+	}
+	out, ok := storeFs.uploads["hive-files/batches/b2/output.jsonl"]
+	if !ok {
+		t.Fatalf("output.jsonl missing")
+	}
+	if len(out) != 0 {
+		t.Fatalf("expected empty output, got %d bytes", len(out))
+	}
+}
+
+// Test 4: all-error input (10/10 fail) → status=completed semantically (per
+// OpenAI), failed_lines=10, completed_lines=0, settlement actual=0.
+func TestExecutor_AllErrors(t *testing.T) {
+	storeFs := newFakeStorage()
+	storeFs.downloads["hive-files/batches/b3/input.jsonl"] = makeBatchInput(10)
+
+	infer := &fakeInference{
+		handler: func(ctx context.Context, attempt int, model string, body json.RawMessage) (json.RawMessage, *Usage, int, error) {
+			return nil, nil, 422, errors.New("invalid")
+		},
+	}
+	disp, _ := NewDispatcher(Config{Concurrency: 2, MaxRetries: 1, LineTimeout: 1 * time.Second}, infer, nil)
+	bs := &fakeBatchStore{snap: BatchSnapshot{
+		ID: "b3", AccountID: "acct", InputFilePath: "batches/b3/input.jsonl",
+		ReservationID: "res3", ReservedCredits: 5000,
+	}}
+	ls := newFakeLineStore()
+	rp := &fakeReservation{}
+	ex, _ := NewExecutor(Config{Concurrency: 2, MaxRetries: 1, LineTimeout: 1 * time.Second}, bs, ls, storeFs, "hive-files", disp, rp)
+	if err := ex.Run(context.Background(), "b3"); err != nil {
+		t.Fatal(err)
+	}
+	if bs.completed.completedLines != 0 || bs.completed.failedLines != 10 {
+		t.Fatalf("counts=%d/%d want 0/10", bs.completed.completedLines, bs.completed.failedLines)
+	}
+	if rp.lastActual != 0 {
+		t.Fatalf("actual=%d want 0", rp.lastActual)
+	}
+}
+
+// Test 2: mid-run resume — first run processes 6/10 (others skipped via prior
+// batch_lines rows), counts and uploads reflect resume semantics; no
+// duplicate-charge.
+func TestExecutor_RestartResume(t *testing.T) {
+	storeFs := newFakeStorage()
+	storeFs.downloads["hive-files/batches/b4/input.jsonl"] = makeBatchInput(10)
+
+	// Pre-populate 6 succeeded + 0 failed lines (simulating prior crash).
+	ls := newFakeLineStore()
+	priorRows := make([]LineRow, 0, 6)
+	for i := 0; i < 6; i++ {
+		priorRows = append(priorRows, LineRow{
+			BatchID: "b4", CustomID: fmt.Sprintf("req-%d", i),
+			Status: "succeeded", Attempt: 1, ConsumedCredits: 10,
+		})
+	}
+	ls.seed(priorRows)
+
+	dispatched := 0
+	var dispatchedMu sync.Mutex
+	infer := &fakeInference{
+		handler: func(ctx context.Context, attempt int, model string, body json.RawMessage) (json.RawMessage, *Usage, int, error) {
+			dispatchedMu.Lock()
+			dispatched++
+			dispatchedMu.Unlock()
+			return json.RawMessage(`{"ok":true}`), &Usage{TotalTokens: 10}, 200, nil
+		},
+	}
+	disp, _ := NewDispatcher(Config{Concurrency: 2, MaxRetries: 1, LineTimeout: 1 * time.Second}, infer, nil)
+	bs := &fakeBatchStore{snap: BatchSnapshot{
+		ID: "b4", AccountID: "acct", InputFilePath: "batches/b4/input.jsonl",
+		ReservationID: "res4", ReservedCredits: 100000,
+	}}
+	rp := &fakeReservation{}
+	ex, _ := NewExecutor(Config{Concurrency: 2, MaxRetries: 1, LineTimeout: 1 * time.Second}, bs, ls, storeFs, "hive-files", disp, rp)
+	if err := ex.Run(context.Background(), "b4"); err != nil {
+		t.Fatal(err)
+	}
+	if dispatched != 4 {
+		t.Fatalf("dispatched=%d want 4 (resume should skip 6)", dispatched)
+	}
+	if bs.completed.completedLines != 10 {
+		t.Fatalf("completed=%d want 10 (6 prior + 4 new)", bs.completed.completedLines)
+	}
+	// Output.jsonl must contain 10 lines (no duplicates by custom_id).
+	out := storeFs.uploads["hive-files/batches/b4/output.jsonl"]
+	seen := map[string]int{}
+	for _, ln := range bytes.Split(bytes.TrimRight(out, "\n"), []byte("\n")) {
+		var v struct {
+			CustomID string `json:"custom_id"`
+		}
+		if err := json.Unmarshal(ln, &v); err != nil {
+			t.Fatalf("decode line: %v", err)
+		}
+		seen[v.CustomID]++
+	}
+	if len(seen) != 10 {
+		t.Fatalf("unique customIDs=%d want 10", len(seen))
+	}
+	for id, n := range seen {
+		if n != 1 {
+			t.Fatalf("custom_id %s appeared %d times — resume duplicated work", id, n)
+		}
+	}
+	// 6 prior + 4 new × 10 tokens = 100 credits.
+	if rp.lastActual != 100 {
+		t.Fatalf("actual=%d want 100 (no duplicate-charge)", rp.lastActual)
+	}
+}
+
+// readAllStorage convenience helper (silence unused imports).
+var _ = io.ReadAll

--- a/apps/control-plane/internal/batchstore/executor/jsonl.go
+++ b/apps/control-plane/internal/batchstore/executor/jsonl.go
@@ -106,20 +106,21 @@ type StoragePort interface {
 	Download(ctx context.Context, bucket, key string) (io.ReadCloser, error)
 }
 
-// Finalize uploads the accumulated buffer to storage. If empty=skipEmpty is
-// true and the writer is empty, no upload is performed and Finalize returns
-// (false, nil). Otherwise it uploads and returns (true, nil).
-func (w *JSONLWriter) Finalize(ctx context.Context, storage StoragePort, bucket, key string, skipEmpty bool) (bool, error) {
+// Finalize uploads the accumulated buffer to storage. If skipEmpty is true
+// and the writer is empty, no upload is performed and Finalize returns
+// (false, 0, nil). Otherwise it uploads and returns (true, size, nil) where
+// size is the number of bytes uploaded.
+func (w *JSONLWriter) Finalize(ctx context.Context, storage StoragePort, bucket, key string, skipEmpty bool) (bool, int64, error) {
 	w.mu.Lock()
 	size := w.buf.Len()
 	body := make([]byte, size)
 	copy(body, w.buf.Bytes())
 	w.mu.Unlock()
 	if size == 0 && skipEmpty {
-		return false, nil
+		return false, 0, nil
 	}
 	if err := storage.Upload(ctx, bucket, key, bytes.NewReader(body), int64(size), "application/jsonl"); err != nil {
-		return false, fmt.Errorf("upload %s: %w", key, err)
+		return false, 0, fmt.Errorf("upload %s: %w", key, err)
 	}
-	return true, nil
+	return true, int64(size), nil
 }

--- a/apps/control-plane/internal/batchstore/executor/jsonl.go
+++ b/apps/control-plane/internal/batchstore/executor/jsonl.go
@@ -1,0 +1,125 @@
+package executor
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sync"
+)
+
+// ScanLines streams reader line-by-line, sending one ScanResult per non-empty
+// line into ch. The scanner buffer is raised to ScannerBufferMaxBytes so
+// OpenAI's ~1MB per-line limit fits with headroom; lines exceeding that
+// produce an io error which is yielded as ScanResult{Err: ...} once and the
+// scan stops. Malformed JSON lines are yielded as ScanResult{Err: errInvalidJSON,
+// RawLine: ...} and the scan continues. The function closes ch when done.
+func ScanLines(ctx context.Context, reader io.Reader, ch chan<- ScanResult) {
+	defer close(ch)
+	scanner := bufio.NewScanner(reader)
+	buf := make([]byte, 0, 64*1024)
+	scanner.Buffer(buf, ScannerBufferMaxBytes)
+	for scanner.Scan() {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		raw := scanner.Bytes()
+		if len(bytes.TrimSpace(raw)) == 0 {
+			continue
+		}
+		// Copy raw because bufio.Scanner reuses its internal buffer.
+		dup := make([]byte, len(raw))
+		copy(dup, raw)
+		var line InputLine
+		if err := json.Unmarshal(dup, &line); err != nil {
+			select {
+			case <-ctx.Done():
+				return
+			case ch <- ScanResult{Err: fmt.Errorf("%w: %v", errInvalidJSON, err), RawLine: dup}:
+			}
+			continue
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case ch <- ScanResult{Line: &line}:
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		select {
+		case <-ctx.Done():
+			return
+		case ch <- ScanResult{Err: fmt.Errorf("scan: %w", err)}:
+		}
+	}
+}
+
+// JSONLWriter accumulates one JSON object per line in a thread-safe buffer.
+// Append is mutex-guarded so multiple dispatcher goroutines can write
+// concurrently. Finalize uploads the buffer to object storage.
+type JSONLWriter struct {
+	mu    sync.Mutex
+	buf   bytes.Buffer
+	count int
+}
+
+// Append marshals v as a JSON line ending with "\n". Returns the ordinal index
+// (0-based) of the appended line for caller bookkeeping.
+func (w *JSONLWriter) Append(v any) (int, error) {
+	encoded, err := json.Marshal(v)
+	if err != nil {
+		return -1, fmt.Errorf("marshal jsonl line: %w", err)
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	idx := w.count
+	w.buf.Write(encoded)
+	w.buf.WriteByte('\n')
+	w.count++
+	return idx, nil
+}
+
+// Count returns the number of lines appended so far. Safe for concurrent use.
+func (w *JSONLWriter) Count() int {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.count
+}
+
+// Bytes returns a defensive copy of the accumulated content. Mostly used in tests.
+func (w *JSONLWriter) Bytes() []byte {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	dup := make([]byte, w.buf.Len())
+	copy(dup, w.buf.Bytes())
+	return dup
+}
+
+// StoragePort is the minimal upload contract the executor depends on; concrete
+// implementation is the existing packages/storage S3 client.
+type StoragePort interface {
+	Upload(ctx context.Context, bucket, key string, body io.Reader, size int64, contentType string) error
+	Download(ctx context.Context, bucket, key string) (io.ReadCloser, error)
+}
+
+// Finalize uploads the accumulated buffer to storage. If empty=skipEmpty is
+// true and the writer is empty, no upload is performed and Finalize returns
+// (false, nil). Otherwise it uploads and returns (true, nil).
+func (w *JSONLWriter) Finalize(ctx context.Context, storage StoragePort, bucket, key string, skipEmpty bool) (bool, error) {
+	w.mu.Lock()
+	size := w.buf.Len()
+	body := make([]byte, size)
+	copy(body, w.buf.Bytes())
+	w.mu.Unlock()
+	if size == 0 && skipEmpty {
+		return false, nil
+	}
+	if err := storage.Upload(ctx, bucket, key, bytes.NewReader(body), int64(size), "application/jsonl"); err != nil {
+		return false, fmt.Errorf("upload %s: %w", key, err)
+	}
+	return true, nil
+}

--- a/apps/control-plane/internal/batchstore/executor/jsonl_test.go
+++ b/apps/control-plane/internal/batchstore/executor/jsonl_test.go
@@ -1,0 +1,222 @@
+package executor
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// fakeStorage records uploads and downloads in-memory for tests.
+type fakeStorage struct {
+	mu        sync.Mutex
+	uploads   map[string][]byte
+	downloads map[string][]byte
+}
+
+func newFakeStorage() *fakeStorage {
+	return &fakeStorage{uploads: map[string][]byte{}, downloads: map[string][]byte{}}
+}
+
+func (f *fakeStorage) Upload(ctx context.Context, bucket, key string, body io.Reader, size int64, contentType string) error {
+	data, err := io.ReadAll(body)
+	if err != nil {
+		return err
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.uploads[bucket+"/"+key] = data
+	return nil
+}
+
+func (f *fakeStorage) Download(ctx context.Context, bucket, key string) (io.ReadCloser, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	data, ok := f.downloads[bucket+"/"+key]
+	if !ok {
+		return nil, fmt.Errorf("not found: %s/%s", bucket, key)
+	}
+	return io.NopCloser(bytes.NewReader(data)), nil
+}
+
+func buildFixture(n int) []byte {
+	var buf bytes.Buffer
+	for i := 0; i < n; i++ {
+		body := fmt.Sprintf(`{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hello %d"}]}`, i)
+		line := fmt.Sprintf(`{"custom_id":"req-%d","method":"POST","url":"/v1/chat/completions","body":%s}`, i, body)
+		buf.WriteString(line)
+		buf.WriteString("\n")
+	}
+	return buf.Bytes()
+}
+
+// Test 1: ScanLines streams a 1000-line JSONL fixture without buffering whole
+// file in memory; each yielded InputLine has CustomID, Method=POST,
+// URL=/v1/chat/completions, Body raw bytes preserved.
+func TestScanLines_StreamsLargeFixture(t *testing.T) {
+	fixture := buildFixture(1000)
+	ch := make(chan ScanResult, 16)
+	go ScanLines(context.Background(), bytes.NewReader(fixture), ch)
+
+	count := 0
+	for r := range ch {
+		if r.Err != nil {
+			t.Fatalf("unexpected error at line %d: %v", count, r.Err)
+		}
+		if r.Line == nil {
+			t.Fatalf("nil line at index %d", count)
+		}
+		want := fmt.Sprintf("req-%d", count)
+		if r.Line.CustomID != want {
+			t.Fatalf("line %d: custom_id=%q want %q", count, r.Line.CustomID, want)
+		}
+		if r.Line.Method != "POST" {
+			t.Fatalf("line %d: method=%q want POST", count, r.Line.Method)
+		}
+		if r.Line.URL != "/v1/chat/completions" {
+			t.Fatalf("line %d: url=%q", count, r.Line.URL)
+		}
+		// Body raw preserved — must contain the exact "hello N" payload.
+		if !bytes.Contains(r.Line.Body, []byte(fmt.Sprintf(`hello %d`, count))) {
+			t.Fatalf("line %d: body did not preserve payload", count)
+		}
+		count++
+	}
+	if count != 1000 {
+		t.Fatalf("scanned %d lines, want 1000", count)
+	}
+}
+
+// Test 2: malformed line is yielded as error variant — caller decides to write
+// to errors.jsonl, not crash the scan.
+func TestScanLines_MalformedLineYieldsError(t *testing.T) {
+	input := []byte(strings.Join([]string{
+		`{"custom_id":"a","method":"POST","url":"/v1/chat/completions","body":{}}`,
+		`this is not json`,
+		`{"custom_id":"b","method":"POST","url":"/v1/chat/completions","body":{}}`,
+	}, "\n") + "\n")
+
+	ch := make(chan ScanResult, 8)
+	go ScanLines(context.Background(), bytes.NewReader(input), ch)
+
+	var ok []*InputLine
+	var bad []ScanResult
+	for r := range ch {
+		if r.Err != nil {
+			if !IsInvalidJSON(r.Err) {
+				t.Fatalf("expected invalid_json sentinel, got %v", r.Err)
+			}
+			bad = append(bad, r)
+			continue
+		}
+		ok = append(ok, r.Line)
+	}
+	if len(ok) != 2 || len(bad) != 1 {
+		t.Fatalf("ok=%d bad=%d, want 2/1", len(ok), len(bad))
+	}
+	if ok[0].CustomID != "a" || ok[1].CustomID != "b" {
+		t.Fatalf("unexpected ok ids: %s %s", ok[0].CustomID, ok[1].CustomID)
+	}
+	if !bytes.Contains(bad[0].RawLine, []byte("this is not json")) {
+		t.Fatalf("malformed raw bytes not preserved")
+	}
+}
+
+// Test 3: output writer + error writer flush concurrently safely (mutex around
+// append) — verified via -race with 32 goroutines writing.
+func TestJSONLWriter_ConcurrentAppend(t *testing.T) {
+	out := &JSONLWriter{}
+	errs := &JSONLWriter{}
+	const goroutines = 32
+	const perGoroutine = 50
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func(id int) {
+			defer wg.Done()
+			for i := 0; i < perGoroutine; i++ {
+				if (id+i)%2 == 0 {
+					if _, err := out.Append(map[string]any{"g": id, "i": i}); err != nil {
+						t.Errorf("append: %v", err)
+						return
+					}
+				} else {
+					if _, err := errs.Append(map[string]any{"g": id, "i": i}); err != nil {
+						t.Errorf("append err: %v", err)
+						return
+					}
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	totalExpected := goroutines * perGoroutine
+	if got := out.Count() + errs.Count(); got != totalExpected {
+		t.Fatalf("count=%d want %d", got, totalExpected)
+	}
+
+	// Every line in the buffer must be a valid JSON object; the count of
+	// newline-terminated lines must equal Count().
+	for name, w := range map[string]*JSONLWriter{"out": out, "errs": errs} {
+		body := w.Bytes()
+		lines := bytes.Split(bytes.TrimRight(body, "\n"), []byte("\n"))
+		if len(lines) != w.Count() {
+			t.Fatalf("%s: parsed %d lines, count %d", name, len(lines), w.Count())
+		}
+		for li, ln := range lines {
+			var v map[string]any
+			if err := json.Unmarshal(ln, &v); err != nil {
+				t.Fatalf("%s: line %d: %v (%q)", name, li, err, ln)
+			}
+		}
+	}
+}
+
+// Test 3b: Finalize with skipEmpty=true on empty writer skips upload.
+func TestJSONLWriter_Finalize_SkipEmpty(t *testing.T) {
+	w := &JSONLWriter{}
+	store := newFakeStorage()
+	uploaded, err := w.Finalize(context.Background(), store, "hive-files", "batches/abc/errors.jsonl", true)
+	if err != nil {
+		t.Fatalf("finalize: %v", err)
+	}
+	if uploaded {
+		t.Fatalf("expected empty writer to skip upload")
+	}
+	if len(store.uploads) != 0 {
+		t.Fatalf("unexpected upload: %v", store.uploads)
+	}
+}
+
+// Test 3c: Finalize writes content with trailing newline per line.
+func TestJSONLWriter_Finalize_UploadsContent(t *testing.T) {
+	w := &JSONLWriter{}
+	if _, err := w.Append(map[string]string{"k": "v1"}); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	if _, err := w.Append(map[string]string{"k": "v2"}); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	store := newFakeStorage()
+	uploaded, err := w.Finalize(context.Background(), store, "hive-files", "batches/abc/output.jsonl", true)
+	if err != nil {
+		t.Fatalf("finalize: %v", err)
+	}
+	if !uploaded {
+		t.Fatalf("expected upload")
+	}
+	got := store.uploads["hive-files/batches/abc/output.jsonl"]
+	if !bytes.HasSuffix(got, []byte("\n")) {
+		t.Fatalf("expected trailing newline, got %q", got)
+	}
+	lines := bytes.Split(bytes.TrimRight(got, "\n"), []byte("\n"))
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d", len(lines))
+	}
+}

--- a/apps/control-plane/internal/batchstore/executor/jsonl_test.go
+++ b/apps/control-plane/internal/batchstore/executor/jsonl_test.go
@@ -182,12 +182,15 @@ func TestJSONLWriter_ConcurrentAppend(t *testing.T) {
 func TestJSONLWriter_Finalize_SkipEmpty(t *testing.T) {
 	w := &JSONLWriter{}
 	store := newFakeStorage()
-	uploaded, err := w.Finalize(context.Background(), store, "hive-files", "batches/abc/errors.jsonl", true)
+	uploaded, size, err := w.Finalize(context.Background(), store, "hive-files", "batches/abc/errors.jsonl", true)
 	if err != nil {
 		t.Fatalf("finalize: %v", err)
 	}
 	if uploaded {
 		t.Fatalf("expected empty writer to skip upload")
+	}
+	if size != 0 {
+		t.Fatalf("expected size=0, got %d", size)
 	}
 	if len(store.uploads) != 0 {
 		t.Fatalf("unexpected upload: %v", store.uploads)
@@ -204,7 +207,7 @@ func TestJSONLWriter_Finalize_UploadsContent(t *testing.T) {
 		t.Fatalf("append: %v", err)
 	}
 	store := newFakeStorage()
-	uploaded, err := w.Finalize(context.Background(), store, "hive-files", "batches/abc/output.jsonl", true)
+	uploaded, size, err := w.Finalize(context.Background(), store, "hive-files", "batches/abc/output.jsonl", true)
 	if err != nil {
 		t.Fatalf("finalize: %v", err)
 	}
@@ -212,6 +215,9 @@ func TestJSONLWriter_Finalize_UploadsContent(t *testing.T) {
 		t.Fatalf("expected upload")
 	}
 	got := store.uploads["hive-files/batches/abc/output.jsonl"]
+	if size != int64(len(got)) {
+		t.Fatalf("size=%d want %d", size, len(got))
+	}
 	if !bytes.HasSuffix(got, []byte("\n")) {
 		t.Fatalf("expected trailing newline, got %q", got)
 	}

--- a/apps/control-plane/internal/batchstore/executor/settle.go
+++ b/apps/control-plane/internal/batchstore/executor/settle.go
@@ -1,0 +1,46 @@
+package executor
+
+import (
+	"fmt"
+	"math/big"
+)
+
+// SettleInput aggregates the inputs to the per-batch settlement decision.
+// ConsumedCredits is summed from per-line usage; ReservedCredits is the cap
+// the customer's reservation locked in at submit time.
+type SettleInput struct {
+	ReservedCredits int64
+	ConsumedCredits *big.Int
+}
+
+// Settle returns the actual credits to charge the customer plus an
+// overconsumed flag. It uses math/big internally — per CLAUDE.md the
+// financial calc rule is to avoid float64 corruption — and clamps actual at
+// reserved when sum exceeds the reservation. The clamp is the documented
+// safety net for the rare case of a model-upgrade mid-batch; the underlying
+// per-line consumed_credits stays in batch_lines for accounting reconciliation.
+func Settle(input SettleInput) (actualCredits int64, overconsumed bool, err error) {
+	if input.ConsumedCredits == nil {
+		return 0, false, nil
+	}
+	if input.ReservedCredits < 0 {
+		return 0, false, fmt.Errorf("settle: negative reserved credits %d", input.ReservedCredits)
+	}
+	reserved := big.NewInt(input.ReservedCredits)
+	consumed := new(big.Int).Set(input.ConsumedCredits)
+	if consumed.Sign() < 0 {
+		return 0, false, fmt.Errorf("settle: negative consumed credits %s", consumed.String())
+	}
+	if input.ReservedCredits == 0 && consumed.Sign() == 0 {
+		return 0, false, nil
+	}
+	if consumed.Cmp(reserved) > 0 {
+		return input.ReservedCredits, true, nil
+	}
+	if !consumed.IsInt64() {
+		// Defensive: consumed_credits won't realistically exceed math.MaxInt64
+		// for a single batch, but if it ever does we fall back to the reserved cap.
+		return input.ReservedCredits, true, nil
+	}
+	return consumed.Int64(), false, nil
+}

--- a/apps/control-plane/internal/batchstore/executor/settle_test.go
+++ b/apps/control-plane/internal/batchstore/executor/settle_test.go
@@ -1,0 +1,93 @@
+package executor
+
+import (
+	"math/big"
+	"testing"
+)
+
+// Test 5: per-line consumed credits summed via math/big — rounding error zero
+// across 100 lines.
+func TestSettle_SumsExactlyAcrossManyLines(t *testing.T) {
+	consumed := big.NewInt(0)
+	for i := 0; i < 100; i++ {
+		consumed.Add(consumed, big.NewInt(int64(i+7)))
+	}
+	// Sum of 7..106 = (7+106)*100/2 = 5650.
+	want := int64(5650)
+	got, over, err := Settle(SettleInput{ReservedCredits: 100000, ConsumedCredits: consumed})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if over {
+		t.Fatalf("unexpected overconsumed")
+	}
+	if got != want {
+		t.Fatalf("actual=%d want %d", got, want)
+	}
+}
+
+// Test 6: idempotent — calling Settle twice with the same inputs returns the
+// same result.
+func TestSettle_Idempotent(t *testing.T) {
+	in := SettleInput{ReservedCredits: 1000, ConsumedCredits: big.NewInt(500)}
+	a1, o1, err := Settle(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a2, o2, err := Settle(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a1 != a2 || o1 != o2 {
+		t.Fatalf("not idempotent: %d/%v vs %d/%v", a1, o1, a2, o2)
+	}
+}
+
+// Test 7: when sum > reserved, settle marks overconsumed=true and caps actual
+// at reserved (no negative balance).
+func TestSettle_Overconsumed(t *testing.T) {
+	in := SettleInput{ReservedCredits: 100, ConsumedCredits: big.NewInt(150)}
+	actual, over, err := Settle(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !over {
+		t.Fatalf("expected overconsumed")
+	}
+	if actual != 100 {
+		t.Fatalf("actual=%d want 100", actual)
+	}
+}
+
+func TestSettle_ZeroConsumed(t *testing.T) {
+	in := SettleInput{ReservedCredits: 1000, ConsumedCredits: big.NewInt(0)}
+	actual, over, err := Settle(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if over {
+		t.Fatalf("unexpected over")
+	}
+	if actual != 0 {
+		t.Fatalf("actual=%d want 0", actual)
+	}
+}
+
+func TestSettle_NegativeRejected(t *testing.T) {
+	if _, _, err := Settle(SettleInput{ReservedCredits: -1, ConsumedCredits: big.NewInt(0)}); err == nil {
+		t.Fatalf("expected error on negative reserved")
+	}
+	if _, _, err := Settle(SettleInput{ReservedCredits: 100, ConsumedCredits: big.NewInt(-5)}); err == nil {
+		t.Fatalf("expected error on negative consumed")
+	}
+}
+
+func TestSettle_NilConsumedReturnsZero(t *testing.T) {
+	actual, over, err := Settle(SettleInput{ReservedCredits: 100, ConsumedCredits: nil})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if actual != 0 || over {
+		t.Fatalf("unexpected: %d/%v", actual, over)
+	}
+}

--- a/apps/control-plane/internal/batchstore/executor/types.go
+++ b/apps/control-plane/internal/batchstore/executor/types.go
@@ -1,0 +1,159 @@
+// Package executor implements Hive's local batch executor: it processes a
+// JSONL batch input file line-by-line by dispatching each row to the LiteLLM
+// chat-completions endpoint with bounded concurrency, composes
+// OpenAI-shape output.jsonl + errors.jsonl, and settles per-line credits via
+// the existing reservation primitive. It exists so that the v1.0 batch
+// success-path can ship without a LiteLLM-supported batch upstream provider
+// (OpenAI/Azure/Vertex/Anthropic). See
+// .planning/phases/10-routing-storage-critical-fixes/KNOWN-ISSUE-batch-upstream.md
+// for the original constraint and
+// .planning/phases/15-batch-local-executor/DECISIONS.md for the resolved
+// open questions.
+package executor
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// ConcurrencyDefault is the default number of in-flight per-line dispatches.
+// ConcurrencyCeiling is the hard server-side cap (env values above are clamped).
+const (
+	ConcurrencyDefault    = 8
+	ConcurrencyCeiling    = 32
+	MaxRetriesDefault     = 3
+	MaxRetriesCeiling     = 5
+	LineTimeoutDefault    = 60 * time.Second
+	LineTimeoutFloor      = 5 * time.Second
+	LineTimeoutCeiling    = 5 * time.Minute
+	ScannerBufferMaxBytes = 4 * 1024 * 1024 // 4MB headroom over OpenAI's ~1MB per-line limit
+)
+
+// ExecutorKind enumerates the dispatch strategy the submitter selects per batch.
+type ExecutorKind string
+
+const (
+	// KindAuto reads from route_capabilities.executor_kind (Task 3 wiring).
+	KindAuto ExecutorKind = "auto"
+	// KindLocal forces the local executor regardless of route capability.
+	KindLocal ExecutorKind = "local"
+	// KindUpstream forces the existing LiteLLM upstream batch-file path.
+	KindUpstream ExecutorKind = "upstream"
+)
+
+// Config holds env-driven knobs for the local executor. Validate clamps to
+// safe ranges and applies defaults for zero values.
+type Config struct {
+	Concurrency int
+	MaxRetries  int
+	LineTimeout time.Duration
+	Kind        ExecutorKind
+}
+
+// Validate fills zero values with defaults and clamps out-of-range values to
+// safe bounds. It returns an error only on structurally invalid input that
+// cannot be repaired (e.g., unknown Kind value).
+func (c *Config) Validate() error {
+	if c.Concurrency <= 0 {
+		c.Concurrency = ConcurrencyDefault
+	}
+	if c.Concurrency > ConcurrencyCeiling {
+		c.Concurrency = ConcurrencyCeiling
+	}
+	if c.MaxRetries < 0 {
+		c.MaxRetries = MaxRetriesDefault
+	}
+	if c.MaxRetries == 0 {
+		c.MaxRetries = MaxRetriesDefault
+	}
+	if c.MaxRetries > MaxRetriesCeiling {
+		c.MaxRetries = MaxRetriesCeiling
+	}
+	if c.LineTimeout <= 0 {
+		c.LineTimeout = LineTimeoutDefault
+	}
+	if c.LineTimeout < LineTimeoutFloor {
+		c.LineTimeout = LineTimeoutFloor
+	}
+	if c.LineTimeout > LineTimeoutCeiling {
+		c.LineTimeout = LineTimeoutCeiling
+	}
+	switch c.Kind {
+	case "":
+		c.Kind = KindAuto
+	case KindAuto, KindLocal, KindUpstream:
+		// known kinds
+	default:
+		return fmt.Errorf("executor: unknown kind %q", c.Kind)
+	}
+	return nil
+}
+
+// InputLine is a single decoded entry from the customer-supplied input.jsonl.
+// Body is preserved as raw bytes so the chat-completions dispatcher can pass
+// it through with only the model field rewritten to the LiteLLM model name.
+type InputLine struct {
+	CustomID string          `json:"custom_id"`
+	Method   string          `json:"method"`
+	URL      string          `json:"url"`
+	Body     json.RawMessage `json:"body"`
+}
+
+// OutputLine is the OpenAI-shape success entry written to output.jsonl.
+type OutputLine struct {
+	ID       string          `json:"id"`
+	CustomID string          `json:"custom_id"`
+	Response *OutputResponse `json:"response"`
+	Error    *ErrorObj       `json:"error"`
+}
+
+// OutputResponse mirrors the OpenAI batch output shape's "response" object.
+type OutputResponse struct {
+	StatusCode int             `json:"status_code"`
+	RequestID  string          `json:"request_id"`
+	Body       json.RawMessage `json:"body"`
+}
+
+// ErrorLine is the OpenAI-shape failure entry written to errors.jsonl.
+type ErrorLine struct {
+	ID       string    `json:"id"`
+	CustomID string    `json:"custom_id"`
+	Response *struct{} `json:"response"`
+	Error    *ErrorObj `json:"error"`
+}
+
+// ErrorObj is the OpenAI error envelope. Message is sanitized — it must not
+// contain provider names like "openrouter", "groq", or "litellm".
+type ErrorObj struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+// DispatchResult is the per-line outcome the dispatcher returns to the
+// executor. Exactly one of Output or Error is non-nil.
+type DispatchResult struct {
+	CustomID         string
+	Output           *OutputLine
+	Error            *ErrorLine
+	Attempts         int
+	ConsumedCredits  int64
+	UsedPromptTokens int64
+	UsedCompTokens   int64
+}
+
+// ScanResult is yielded from the JSONL scanner. RawLine is set whenever the
+// scanner could not decode a line into InputLine — the caller writes it to
+// errors.jsonl with code=invalid_json rather than crashing the scan.
+type ScanResult struct {
+	Line    *InputLine
+	Err     error
+	RawLine []byte
+}
+
+// errInvalidJSON sentinels a per-line JSON decode failure for the scanner.
+var errInvalidJSON = errors.New("invalid json line")
+
+// IsInvalidJSON reports whether err originated from a malformed JSONL line.
+func IsInvalidJSON(err error) bool { return errors.Is(err, errInvalidJSON) }

--- a/apps/control-plane/internal/batchstore/executor/types.go
+++ b/apps/control-plane/internal/batchstore/executor/types.go
@@ -94,11 +94,18 @@ func (c *Config) Validate() error {
 // InputLine is a single decoded entry from the customer-supplied input.jsonl.
 // Body is preserved as raw bytes so the chat-completions dispatcher can pass
 // it through with only the model field rewritten to the LiteLLM model name.
+//
+// Alias is injected by the executor before dispatch and carries the batch's
+// model_alias resolved at submission time. Routing uses Alias, not body.model
+// — per-line body.model is treated as opaque customer payload (the inference
+// port rewrites it to the routed LiteLLM model name). Alias is not present
+// in the on-disk JSONL.
 type InputLine struct {
 	CustomID string          `json:"custom_id"`
 	Method   string          `json:"method"`
 	URL      string          `json:"url"`
 	Body     json.RawMessage `json:"body"`
+	Alias    string          `json:"-"`
 }
 
 // OutputLine is the OpenAI-shape success entry written to output.jsonl.

--- a/apps/control-plane/internal/batchstore/executor/types.go
+++ b/apps/control-plane/internal/batchstore/executor/types.go
@@ -95,17 +95,20 @@ func (c *Config) Validate() error {
 // Body is preserved as raw bytes so the chat-completions dispatcher can pass
 // it through with only the model field rewritten to the LiteLLM model name.
 //
-// Alias is injected by the executor before dispatch and carries the batch's
-// model_alias resolved at submission time. Routing uses Alias, not body.model
-// — per-line body.model is treated as opaque customer payload (the inference
-// port rewrites it to the routed LiteLLM model name). Alias is not present
-// in the on-disk JSONL.
+// Alias and LiteLLMModel are injected by the executor before dispatch from
+// the BatchSnapshot. Alias is the customer-facing model alias (used for
+// diagnostics and the "missing batch alias" guard); LiteLLMModel is the
+// pre-resolved LiteLLM model name passed verbatim to the inference port —
+// no per-line route lookup. Per-line body.model stays opaque (the
+// inference port rewrites it to LiteLLMModel before dispatch). Neither
+// field is serialized to the on-disk JSONL.
 type InputLine struct {
-	CustomID string          `json:"custom_id"`
-	Method   string          `json:"method"`
-	URL      string          `json:"url"`
-	Body     json.RawMessage `json:"body"`
-	Alias    string          `json:"-"`
+	CustomID     string          `json:"custom_id"`
+	Method       string          `json:"method"`
+	URL          string          `json:"url"`
+	Body         json.RawMessage `json:"body"`
+	Alias        string          `json:"-"`
+	LiteLLMModel string          `json:"-"`
 }
 
 // OutputLine is the OpenAI-shape success entry written to output.jsonl.

--- a/apps/control-plane/internal/batchstore/local_executor_adapters.go
+++ b/apps/control-plane/internal/batchstore/local_executor_adapters.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hivegpt/hive/apps/control-plane/internal/accounting"
 	"github.com/hivegpt/hive/apps/control-plane/internal/batchstore/executor"
 	"github.com/hivegpt/hive/apps/control-plane/internal/filestore"
+	"github.com/hivegpt/hive/apps/control-plane/internal/routing"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -56,16 +57,21 @@ func (r *pgxFileRegistrar) Register(ctx context.Context, accountID, purpose, fil
 }
 
 // pgxBatchStore implements executor.BatchStore against the existing
-// filestore.Service plus a direct pgx pool for the new executor-specific
-// columns added in supabase/migrations/0015_batch_local_executor.sql.
+// filestore.Service plus the routing service (to resolve LiteLLMModel
+// once per batch) and the new executor-specific columns added in
+// supabase/migrations/20260427_01_batch_local_executor.sql.
 type pgxBatchStore struct {
-	loader BatchSnapshotLoader
-	files  FileLookup
+	loader  BatchSnapshotLoader
+	files   FileLookup
+	routing BatchRouteSelector
 }
 
-// NewPgxBatchStore wires the production BatchStore adapter.
-func NewPgxBatchStore(loader BatchSnapshotLoader, files FileLookup) executor.BatchStore {
-	return &pgxBatchStore{loader: loader, files: files}
+// NewPgxBatchStore wires the production BatchStore adapter. The routing
+// selector is required so LoadBatch can resolve the LiteLLM model name
+// once per batch (matching the submitter's NeedBatch=true criteria),
+// avoiding per-line route lookups in the hot path.
+func NewPgxBatchStore(loader BatchSnapshotLoader, files FileLookup, routes BatchRouteSelector) executor.BatchStore {
+	return &pgxBatchStore{loader: loader, files: files, routing: routes}
 }
 
 func (p *pgxBatchStore) LoadBatch(ctx context.Context, batchID string) (executor.BatchSnapshot, error) {
@@ -83,6 +89,19 @@ func (p *pgxBatchStore) LoadBatch(ctx context.Context, batchID string) (executor
 	if file == nil {
 		return executor.BatchSnapshot{}, fmt.Errorf("input file %s not found", batch.InputFileID)
 	}
+	if p.routing == nil {
+		return executor.BatchSnapshot{}, fmt.Errorf("routing selector not configured")
+	}
+	route, err := p.routing.SelectRoute(ctx, routing.SelectionInput{
+		AliasID:   batch.ModelAlias,
+		NeedBatch: true,
+	})
+	if err != nil {
+		return executor.BatchSnapshot{}, fmt.Errorf("select batch route: %w", err)
+	}
+	if strings.TrimSpace(route.LiteLLMModelName) == "" {
+		return executor.BatchSnapshot{}, fmt.Errorf("route %q resolved to empty LiteLLM model", batch.ModelAlias)
+	}
 	snap := executor.BatchSnapshot{
 		ID:              batch.ID,
 		AccountID:       batch.AccountID,
@@ -90,6 +109,7 @@ func (p *pgxBatchStore) LoadBatch(ctx context.Context, batchID string) (executor
 		InputFilePath:   file.StoragePath,
 		Endpoint:        batch.Endpoint,
 		ModelAlias:      batch.ModelAlias,
+		LiteLLMModel:    route.LiteLLMModelName,
 		ReservedCredits: batch.EstimatedCredits,
 	}
 	if batch.ReservationID != nil {
@@ -127,7 +147,7 @@ func NewPgxLineStore(pool *pgxpool.Pool) executor.LineStore {
 func (s *pgxLineStore) LoadLines(ctx context.Context, batchID string) ([]executor.LineRow, error) {
 	rows, err := s.pool.Query(ctx, `
 		select batch_id, custom_id, status, attempt, consumed_credits,
-		       output_index, error_index, coalesce(last_error, '')
+		       output_index, error_index, coalesce(last_error, ''), completed_at
 		from public.batch_lines
 		where batch_id = $1`, batchID)
 	if err != nil {
@@ -139,12 +159,14 @@ func (s *pgxLineStore) LoadLines(ctx context.Context, batchID string) ([]executo
 		var r executor.LineRow
 		var consumed float64
 		var outIdx, errIdx *int
-		if err := rows.Scan(&r.BatchID, &r.CustomID, &r.Status, &r.Attempt, &consumed, &outIdx, &errIdx, &r.LastError); err != nil {
+		var completedAt *time.Time
+		if err := rows.Scan(&r.BatchID, &r.CustomID, &r.Status, &r.Attempt, &consumed, &outIdx, &errIdx, &r.LastError, &completedAt); err != nil {
 			return nil, err
 		}
 		r.ConsumedCredits = int64(consumed)
 		r.OutputIndex = outIdx
 		r.ErrorIndex = errIdx
+		r.CompletedAt = completedAt
 		out = append(out, r)
 	}
 	return out, rows.Err()

--- a/apps/control-plane/internal/batchstore/local_executor_adapters.go
+++ b/apps/control-plane/internal/batchstore/local_executor_adapters.go
@@ -1,0 +1,202 @@
+package batchstore
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/hivegpt/hive/apps/control-plane/internal/accounting"
+	"github.com/hivegpt/hive/apps/control-plane/internal/batchstore/executor"
+	"github.com/hivegpt/hive/apps/control-plane/internal/filestore"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// BatchSnapshotLoader is the slice of filestore.Service the BatchStore adapter needs.
+type BatchSnapshotLoader interface {
+	GetBatchByID(ctx context.Context, id string) (*filestore.Batch, error)
+	UpdateBatchStatus(ctx context.Context, batchID, status string, updates map[string]interface{}) error
+}
+
+// FileLookup resolves an input file ID to its storage path. The executor runs
+// server-side and looks up the file by ID without account scoping.
+type FileLookup interface {
+	GetFileByID(ctx context.Context, id string) (*filestore.File, error)
+}
+
+// pgxBatchStore implements executor.BatchStore against the existing
+// filestore.Service plus a direct pgx pool for the new executor-specific
+// columns added in supabase/migrations/0015_batch_local_executor.sql.
+type pgxBatchStore struct {
+	loader BatchSnapshotLoader
+	files  FileLookup
+}
+
+// NewPgxBatchStore wires the production BatchStore adapter.
+func NewPgxBatchStore(loader BatchSnapshotLoader, files FileLookup) executor.BatchStore {
+	return &pgxBatchStore{loader: loader, files: files}
+}
+
+func (p *pgxBatchStore) LoadBatch(ctx context.Context, batchID string) (executor.BatchSnapshot, error) {
+	batch, err := p.loader.GetBatchByID(ctx, batchID)
+	if err != nil {
+		return executor.BatchSnapshot{}, fmt.Errorf("get batch: %w", err)
+	}
+	if batch == nil {
+		return executor.BatchSnapshot{}, fmt.Errorf("batch %s not found", batchID)
+	}
+	file, err := p.files.GetFileByID(ctx, batch.InputFileID)
+	if err != nil {
+		return executor.BatchSnapshot{}, fmt.Errorf("get input file: %w", err)
+	}
+	if file == nil {
+		return executor.BatchSnapshot{}, fmt.Errorf("input file %s not found", batch.InputFileID)
+	}
+	snap := executor.BatchSnapshot{
+		ID:              batch.ID,
+		AccountID:       batch.AccountID,
+		InputFileID:     batch.InputFileID,
+		InputFilePath:   file.StoragePath,
+		Endpoint:        batch.Endpoint,
+		ModelAlias:      batch.ModelAlias,
+		ReservedCredits: batch.EstimatedCredits,
+	}
+	if batch.ReservationID != nil {
+		snap.ReservationID = *batch.ReservationID
+	}
+	return snap, nil
+}
+
+func (p *pgxBatchStore) MarkCompleted(ctx context.Context, batchID string, completedLines, failedLines int, outputFileID, errorFileID string, overconsumed bool, completedAt time.Time) error {
+	updates := map[string]interface{}{
+		"completed_at":    completedAt.Unix(),
+		"completed_lines": completedLines,
+		"failed_lines":    failedLines,
+		"overconsumed":    overconsumed,
+	}
+	if outputFileID != "" {
+		updates["output_file_id"] = outputFileID
+	}
+	if errorFileID != "" {
+		updates["error_file_id"] = errorFileID
+	}
+	return p.loader.UpdateBatchStatus(ctx, batchID, "completed", updates)
+}
+
+// pgxLineStore implements executor.LineStore against public.batch_lines.
+type pgxLineStore struct {
+	pool *pgxpool.Pool
+}
+
+// NewPgxLineStore wires the production LineStore.
+func NewPgxLineStore(pool *pgxpool.Pool) executor.LineStore {
+	return &pgxLineStore{pool: pool}
+}
+
+func (s *pgxLineStore) LoadLines(ctx context.Context, batchID string) ([]executor.LineRow, error) {
+	rows, err := s.pool.Query(ctx, `
+		select batch_id, custom_id, status, attempt, consumed_credits,
+		       output_index, error_index, coalesce(last_error, '')
+		from public.batch_lines
+		where batch_id = $1`, batchID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := make([]executor.LineRow, 0)
+	for rows.Next() {
+		var r executor.LineRow
+		var consumed float64
+		var outIdx, errIdx *int
+		if err := rows.Scan(&r.BatchID, &r.CustomID, &r.Status, &r.Attempt, &consumed, &outIdx, &errIdx, &r.LastError); err != nil {
+			return nil, err
+		}
+		r.ConsumedCredits = int64(consumed)
+		r.OutputIndex = outIdx
+		r.ErrorIndex = errIdx
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+func (s *pgxLineStore) UpsertPending(ctx context.Context, batchID, customID string) error {
+	_, err := s.pool.Exec(ctx, `
+		insert into public.batch_lines (batch_id, custom_id, status)
+		values ($1, $2, 'pending')
+		on conflict (batch_id, custom_id) do nothing`, batchID, customID)
+	return err
+}
+
+func (s *pgxLineStore) MarkSucceeded(ctx context.Context, batchID, customID string, attempt int, consumedCredits int64, outputIndex int) error {
+	_, err := s.pool.Exec(ctx, `
+		insert into public.batch_lines
+		    (batch_id, custom_id, status, attempt, consumed_credits, output_index, completed_at)
+		values ($1, $2, 'succeeded', $3, $4, $5, now())
+		on conflict (batch_id, custom_id) do update
+		set status = 'succeeded',
+		    attempt = excluded.attempt,
+		    consumed_credits = excluded.consumed_credits,
+		    output_index = excluded.output_index,
+		    completed_at = excluded.completed_at`,
+		batchID, customID, attempt, consumedCredits, outputIndex)
+	return err
+}
+
+func (s *pgxLineStore) MarkFailed(ctx context.Context, batchID, customID string, attempt int, errorIndex int, lastError string) error {
+	_, err := s.pool.Exec(ctx, `
+		insert into public.batch_lines
+		    (batch_id, custom_id, status, attempt, error_index, last_error, completed_at)
+		values ($1, $2, 'failed', $3, $4, $5, now())
+		on conflict (batch_id, custom_id) do update
+		set status = 'failed',
+		    attempt = excluded.attempt,
+		    error_index = excluded.error_index,
+		    last_error = excluded.last_error,
+		    completed_at = excluded.completed_at`,
+		batchID, customID, attempt, errorIndex, lastError)
+	return err
+}
+
+// AccountingReservationAdapter adapts accounting.Service to executor.ReservationPort.
+type AccountingReservationAdapter struct {
+	svc AccountingSettler
+}
+
+// NewAccountingReservationAdapter wires the production ReservationPort.
+func NewAccountingReservationAdapter(svc AccountingSettler) executor.ReservationPort {
+	return &AccountingReservationAdapter{svc: svc}
+}
+
+// Settle finalizes the reservation when actualCredits > 0; otherwise it
+// releases the full reservation. Mirrors the existing settleTerminalReservation
+// path in worker.go for the upstream-batch case.
+func (a *AccountingReservationAdapter) Settle(ctx context.Context, batchID, accountID, reservationID string, actualCredits int64, overconsumed bool, terminalStatus string) error {
+	if a.svc == nil {
+		return fmt.Errorf("accounting settler not configured")
+	}
+	parsedAccount, err := uuid.Parse(strings.TrimSpace(accountID))
+	if err != nil {
+		return fmt.Errorf("parse account_id: %w", err)
+	}
+	parsedReservation, err := uuid.Parse(strings.TrimSpace(reservationID))
+	if err != nil {
+		return fmt.Errorf("parse reservation_id: %w", err)
+	}
+	if actualCredits > 0 {
+		_, err := a.svc.FinalizeReservation(ctx, accounting.FinalizeReservationInput{
+			AccountID:              parsedAccount,
+			ReservationID:          parsedReservation,
+			ActualCredits:          actualCredits,
+			TerminalUsageConfirmed: true,
+			Status:                 terminalStatus,
+		})
+		return err
+	}
+	_, err = a.svc.ReleaseReservation(ctx, accounting.ReleaseReservationInput{
+		AccountID:     parsedAccount,
+		ReservationID: parsedReservation,
+		Reason:        "batch_completed_unused",
+	})
+	return err
+}

--- a/apps/control-plane/internal/batchstore/local_executor_adapters.go
+++ b/apps/control-plane/internal/batchstore/local_executor_adapters.go
@@ -25,6 +25,36 @@ type FileLookup interface {
 	GetFileByID(ctx context.Context, id string) (*filestore.File, error)
 }
 
+// FileCreator persists a public.files row for a server-side artifact (e.g.
+// the local executor's output.jsonl / errors.jsonl uploads). Concrete impl
+// is filestore.Service.CreateFile.
+type FileCreator interface {
+	CreateFile(ctx context.Context, accountID, purpose, filename string, bytes int64, storagePath string) (filestore.File, error)
+}
+
+// pgxFileRegistrar adapts filestore.Service.CreateFile to executor.FileRegistrar.
+type pgxFileRegistrar struct {
+	svc FileCreator
+}
+
+// NewPgxFileRegistrar wires the production FileRegistrar adapter.
+func NewPgxFileRegistrar(svc FileCreator) executor.FileRegistrar {
+	return &pgxFileRegistrar{svc: svc}
+}
+
+// Register creates a public.files row pointing at the executor's uploaded
+// artifact and returns the generated file ID.
+func (r *pgxFileRegistrar) Register(ctx context.Context, accountID, purpose, filename, storagePath string, bytes int64) (string, error) {
+	if r.svc == nil {
+		return "", fmt.Errorf("file registrar not configured")
+	}
+	f, err := r.svc.CreateFile(ctx, accountID, purpose, filename, bytes, storagePath)
+	if err != nil {
+		return "", fmt.Errorf("create file record: %w", err)
+	}
+	return f.ID, nil
+}
+
 // pgxBatchStore implements executor.BatchStore against the existing
 // filestore.Service plus a direct pgx pool for the new executor-specific
 // columns added in supabase/migrations/0015_batch_local_executor.sql.

--- a/apps/control-plane/internal/batchstore/local_executor_test.go
+++ b/apps/control-plane/internal/batchstore/local_executor_test.go
@@ -1,0 +1,330 @@
+package batchstore
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/hibiken/asynq"
+	"github.com/hivegpt/hive/apps/control-plane/internal/accounting"
+	"github.com/hivegpt/hive/apps/control-plane/internal/batchstore/executor"
+	"github.com/hivegpt/hive/apps/control-plane/internal/filestore"
+	"github.com/hivegpt/hive/apps/control-plane/internal/routing"
+)
+
+// stubRoutingProvider always returns the configured provider + model.
+type stubRoutingProvider struct {
+	provider string
+	model    string
+}
+
+func (s *stubRoutingProvider) SelectRoute(ctx context.Context, in routing.SelectionInput) (routing.SelectionResult, error) {
+	return routing.SelectionResult{
+		AliasID:          in.AliasID,
+		RouteID:          "route-1",
+		LiteLLMModelName: s.model,
+		Provider:         s.provider,
+	}, nil
+}
+
+// stubExecuteQueue captures local-executor enqueues.
+type stubExecuteQueue struct {
+	mu       sync.Mutex
+	payloads []BatchExecutePayload
+}
+
+func (q *stubExecuteQueue) EnqueueExecute(ctx context.Context, payload BatchExecutePayload) error {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.payloads = append(q.payloads, payload)
+	return nil
+}
+
+// stubPollQueue captures upstream-poll enqueues.
+type stubPollQueue struct {
+	mu       sync.Mutex
+	payloads []BatchPollPayload
+}
+
+func (q *stubPollQueue) Enqueue(ctx context.Context, payload BatchPollPayload) error {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.payloads = append(q.payloads, payload)
+	return nil
+}
+
+// stubSubmitterFiles implements BatchFileStore.
+type stubSubmitterFiles struct {
+	mu      sync.Mutex
+	file    *filestore.File
+	updates []map[string]interface{}
+	statuses []string
+}
+
+func (s *stubSubmitterFiles) GetFile(ctx context.Context, id, accountID string) (*filestore.File, error) {
+	if s.file == nil {
+		return nil, fmt.Errorf("not found")
+	}
+	return s.file, nil
+}
+
+func (s *stubSubmitterFiles) UpdateBatchStatus(ctx context.Context, batchID, status string, updates map[string]interface{}) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.statuses = append(s.statuses, status)
+	cp := map[string]interface{}{}
+	for k, v := range updates {
+		cp[k] = v
+	}
+	s.updates = append(s.updates, cp)
+	return nil
+}
+
+// stubInputStorage implements BatchInputStorage with empty bytes.
+type stubInputStorage struct{}
+
+func (stubInputStorage) Download(ctx context.Context, bucket, key string) (io.ReadCloser, error) {
+	return io.NopCloser(bytes.NewReader([]byte{})), nil
+}
+
+// stubReleaser implements BatchReservationReleaser as a no-op.
+type stubReleaser struct{}
+
+func (stubReleaser) ReleaseReservation(ctx context.Context, in accounting.ReleaseReservationInput) (accounting.Reservation, error) {
+	return accounting.Reservation{}, nil
+}
+
+// Test 1: submitter chooses local executor for openrouter route by default.
+func TestSubmitter_RoutesOpenRouterToLocalExecutor(t *testing.T) {
+	files := &stubSubmitterFiles{file: &filestore.File{ID: "f1", StoragePath: "batches/b1/input.jsonl"}}
+	rt := &stubRoutingProvider{provider: "openrouter", model: "openrouter/free"}
+	pq := &stubPollQueue{}
+	eq := &stubExecuteQueue{}
+	s := NewSubmitter(files, rt, stubInputStorage{}, pq, stubReleaser{}, "http://litellm:4000", "key", "hive-files").
+		WithLocalExecutor(eq, "auto")
+	batch := filestore.Batch{
+		ID:               "b1",
+		AccountID:        uuid.New().String(),
+		InputFileID:      "f1",
+		ModelAlias:       "alias-1",
+		Endpoint:         "/v1/chat/completions",
+		EstimatedCredits: 1000,
+	}
+	out, err := s.SubmitBatch(context.Background(), batch)
+	if err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+	if out.Status != "in_progress" {
+		t.Fatalf("status=%q want in_progress", out.Status)
+	}
+	if len(eq.payloads) != 1 || eq.payloads[0].BatchID != "b1" {
+		t.Fatalf("expected 1 execute enqueue, got %+v", eq.payloads)
+	}
+	if len(pq.payloads) != 0 {
+		t.Fatalf("upstream poll queue should be empty, got %+v", pq.payloads)
+	}
+	foundKind := false
+	for _, u := range files.updates {
+		if u["executor_kind"] == "local" {
+			foundKind = true
+		}
+	}
+	if !foundKind {
+		t.Fatalf("expected status update with executor_kind=local, got %+v", files.updates)
+	}
+}
+
+// Test 2: env override "upstream" forces upstream path even for openrouter.
+// The upstream path makes a real HTTP call to a non-existent URL and fails
+// fast — the assertion is that submitLocal was NOT taken (no execute enqueue).
+func TestSubmitter_EnvOverrideForcesUpstream(t *testing.T) {
+	files := &stubSubmitterFiles{file: &filestore.File{ID: "f1", StoragePath: "batches/b1/input.jsonl"}}
+	rt := &stubRoutingProvider{provider: "openrouter", model: "openrouter/free"}
+	pq := &stubPollQueue{}
+	eq := &stubExecuteQueue{}
+	s := NewSubmitter(files, rt, stubInputStorage{}, pq, stubReleaser{}, "http://nonexistent.invalid", "key", "hive-files").
+		WithLocalExecutor(eq, "upstream")
+	batch := filestore.Batch{
+		ID:               "b2",
+		AccountID:        uuid.New().String(),
+		InputFileID:      "f1",
+		ModelAlias:       "alias-1",
+		Endpoint:         "/v1/chat/completions",
+		EstimatedCredits: 1000,
+	}
+	_, _ = s.SubmitBatch(context.Background(), batch)
+	if len(eq.payloads) != 0 {
+		t.Fatalf("upstream override but local execute enqueued: %+v", eq.payloads)
+	}
+}
+
+// Test 2b: openai provider always uses upstream regardless of executorKind=auto.
+func TestSubmitter_OpenAIProviderUsesUpstream(t *testing.T) {
+	files := &stubSubmitterFiles{file: &filestore.File{ID: "f1", StoragePath: "batches/b1/input.jsonl"}}
+	rt := &stubRoutingProvider{provider: "openai", model: "gpt-4o-mini"}
+	pq := &stubPollQueue{}
+	eq := &stubExecuteQueue{}
+	s := NewSubmitter(files, rt, stubInputStorage{}, pq, stubReleaser{}, "http://nonexistent.invalid", "key", "hive-files").
+		WithLocalExecutor(eq, "auto")
+	batch := filestore.Batch{
+		ID:               "b3",
+		AccountID:        uuid.New().String(),
+		InputFileID:      "f1",
+		ModelAlias:       "alias-1",
+		Endpoint:         "/v1/chat/completions",
+		EstimatedCredits: 1000,
+	}
+	_, _ = s.SubmitBatch(context.Background(), batch)
+	if len(eq.payloads) != 0 {
+		t.Fatalf("openai provider but local execute enqueued: %+v", eq.payloads)
+	}
+}
+
+// fakeStorageLE implements executor.StoragePort for the worker test.
+type fakeStorageLE struct {
+	mu        sync.Mutex
+	uploads   map[string][]byte
+	downloads map[string][]byte
+}
+
+func newFakeStorageLE() *fakeStorageLE {
+	return &fakeStorageLE{uploads: map[string][]byte{}, downloads: map[string][]byte{}}
+}
+
+func (f *fakeStorageLE) Upload(ctx context.Context, bucket, key string, body io.Reader, size int64, contentType string) error {
+	data, err := io.ReadAll(body)
+	if err != nil {
+		return err
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.uploads[bucket+"/"+key] = data
+	return nil
+}
+
+func (f *fakeStorageLE) Download(ctx context.Context, bucket, key string) (io.ReadCloser, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	data, ok := f.downloads[bucket+"/"+key]
+	if !ok {
+		return nil, fmt.Errorf("not found: %s/%s", bucket, key)
+	}
+	return io.NopCloser(bytes.NewReader(data)), nil
+}
+
+// fakeBatchSnapLE implements executor.BatchStore.
+type fakeBatchSnapLE struct {
+	mu              sync.Mutex
+	snap            executor.BatchSnapshot
+	completedCalled bool
+	completedLines  int
+	failedLines     int
+	overconsumed    bool
+}
+
+func (f *fakeBatchSnapLE) LoadBatch(ctx context.Context, id string) (executor.BatchSnapshot, error) {
+	if f.snap.ID != id {
+		return executor.BatchSnapshot{}, fmt.Errorf("not found")
+	}
+	return f.snap, nil
+}
+
+func (f *fakeBatchSnapLE) MarkCompleted(ctx context.Context, batchID string, completedLines, failedLines int, outputFileID, errorFileID string, overconsumed bool, completedAt time.Time) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.completedCalled = true
+	f.completedLines = completedLines
+	f.failedLines = failedLines
+	f.overconsumed = overconsumed
+	return nil
+}
+
+// fakeLineStoreLE implements executor.LineStore.
+type fakeLineStoreLE struct{}
+
+func newFakeLineStoreLE() *fakeLineStoreLE { return &fakeLineStoreLE{} }
+func (f *fakeLineStoreLE) LoadLines(ctx context.Context, batchID string) ([]executor.LineRow, error) {
+	return nil, nil
+}
+func (f *fakeLineStoreLE) UpsertPending(ctx context.Context, batchID, customID string) error {
+	return nil
+}
+func (f *fakeLineStoreLE) MarkSucceeded(ctx context.Context, batchID, customID string, attempt int, consumedCredits int64, outputIndex int) error {
+	return nil
+}
+func (f *fakeLineStoreLE) MarkFailed(ctx context.Context, batchID, customID string, attempt int, errorIndex int, lastError string) error {
+	return nil
+}
+
+// fakeReservationLE implements executor.ReservationPort.
+type fakeReservationLE struct {
+	calls int
+}
+
+func (f *fakeReservationLE) Settle(ctx context.Context, batchID, accountID, reservationID string, actualCredits int64, overconsumed bool, terminalStatus string) error {
+	f.calls++
+	return nil
+}
+
+// fakeInfer implements executor.InferencePort.
+type fakeInfer struct {
+	response json.RawMessage
+	usage    *executor.Usage
+	status   int
+	err      error
+}
+
+func (f *fakeInfer) ChatCompletion(ctx context.Context, model string, body json.RawMessage) (json.RawMessage, *executor.Usage, int, error) {
+	return f.response, f.usage, f.status, f.err
+}
+
+// Test 3: worker handles batch:execute task by calling executor.Run.
+func TestBatchWorker_HandlesBatchExecuteTask(t *testing.T) {
+	storeFs := newFakeStorageLE()
+	storeFs.downloads["hive-files/batches/bx/input.jsonl"] = []byte(
+		`{"custom_id":"a","method":"POST","url":"/v1/chat/completions","body":{"model":"alias-1","messages":[]}}` + "\n",
+	)
+	infer := &fakeInfer{
+		response: json.RawMessage(`{"ok":true,"usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":3}}`),
+		usage:    &executor.Usage{TotalTokens: 3},
+		status:   200,
+	}
+	disp, err := executor.NewDispatcher(executor.Config{Concurrency: 1, MaxRetries: 1, LineTimeout: 5 * time.Second}, infer, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bs := &fakeBatchSnapLE{snap: executor.BatchSnapshot{
+		ID: "bx", AccountID: uuid.New().String(), InputFilePath: "batches/bx/input.jsonl",
+		ReservationID: uuid.New().String(), ReservedCredits: 1000,
+	}}
+	ls := newFakeLineStoreLE()
+	rp := &fakeReservationLE{}
+	ex, err := executor.NewExecutor(executor.Config{Concurrency: 1, MaxRetries: 1, LineTimeout: 5 * time.Second}, bs, ls, storeFs, "hive-files", disp, rp)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	worker := &BatchWorker{}
+	worker.WithLocalExecutor(ex)
+
+	payload, _ := json.Marshal(BatchExecutePayload{BatchID: "bx", AccountID: bs.snap.AccountID})
+	task := asynq.NewTask(TypeBatchExecute, payload)
+	if err := worker.HandleBatchExecute(context.Background(), task); err != nil {
+		t.Fatalf("handle execute: %v", err)
+	}
+	if !bs.completedCalled {
+		t.Fatalf("expected MarkCompleted to be called")
+	}
+	if bs.completedLines != 1 {
+		t.Fatalf("completed=%d want 1", bs.completedLines)
+	}
+}
+
+var _ = strings.ToLower

--- a/apps/control-plane/internal/batchstore/local_executor_test.go
+++ b/apps/control-plane/internal/batchstore/local_executor_test.go
@@ -273,6 +273,19 @@ func (f *fakeReservationLE) Settle(ctx context.Context, batchID, accountID, rese
 	return nil
 }
 
+// fakeFileRegistrarLE implements executor.FileRegistrar with synthetic IDs.
+type fakeFileRegistrarLE struct {
+	mu   sync.Mutex
+	next int
+}
+
+func (f *fakeFileRegistrarLE) Register(_ context.Context, _, _, _, _ string, _ int64) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.next++
+	return fmt.Sprintf("file-le-%d", f.next), nil
+}
+
 // fakeInfer implements executor.InferencePort.
 type fakeInfer struct {
 	response json.RawMessage
@@ -302,11 +315,12 @@ func TestBatchWorker_HandlesBatchExecuteTask(t *testing.T) {
 	}
 	bs := &fakeBatchSnapLE{snap: executor.BatchSnapshot{
 		ID: "bx", AccountID: uuid.New().String(), InputFilePath: "batches/bx/input.jsonl",
-		ReservationID: uuid.New().String(), ReservedCredits: 1000,
+		ReservationID: uuid.New().String(), ModelAlias: "alias-1", ReservedCredits: 1000,
 	}}
 	ls := newFakeLineStoreLE()
 	rp := &fakeReservationLE{}
-	ex, err := executor.NewExecutor(executor.Config{Concurrency: 1, MaxRetries: 1, LineTimeout: 5 * time.Second}, bs, ls, storeFs, "hive-files", disp, rp)
+	fr := &fakeFileRegistrarLE{}
+	ex, err := executor.NewExecutor(executor.Config{Concurrency: 1, MaxRetries: 1, LineTimeout: 5 * time.Second}, bs, ls, storeFs, fr, "hive-files", disp, rp)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/apps/control-plane/internal/batchstore/local_executor_test.go
+++ b/apps/control-plane/internal/batchstore/local_executor_test.go
@@ -315,7 +315,8 @@ func TestBatchWorker_HandlesBatchExecuteTask(t *testing.T) {
 	}
 	bs := &fakeBatchSnapLE{snap: executor.BatchSnapshot{
 		ID: "bx", AccountID: uuid.New().String(), InputFilePath: "batches/bx/input.jsonl",
-		ReservationID: uuid.New().String(), ModelAlias: "alias-1", ReservedCredits: 1000,
+		ReservationID: uuid.New().String(), ModelAlias: "alias-1",
+		LiteLLMModel: "openrouter/gpt-4o-mini", ReservedCredits: 1000,
 	}}
 	ls := newFakeLineStoreLE()
 	rp := &fakeReservationLE{}

--- a/apps/control-plane/internal/batchstore/local_inference.go
+++ b/apps/control-plane/internal/batchstore/local_inference.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/hivegpt/hive/apps/control-plane/internal/batchstore/executor"
-	"github.com/hivegpt/hive/apps/control-plane/internal/routing"
 )
 
 // LiteLLMInferenceClient is the production InferencePort that the local batch
@@ -21,40 +20,39 @@ import (
 // reuses LiteLLM's provider routing, retry, and capability path — the same
 // surface edge-api exposes — while keeping control-plane's go.mod free of
 // edge-api/internal imports.
+//
+// Route resolution happens once per batch in pgxBatchStore.LoadBatch (which
+// uses the same NeedBatch=true criteria the submitter applied). The
+// resolved LiteLLM model name flows through BatchSnapshot.LiteLLMModel →
+// InputLine.LiteLLMModel and is passed verbatim as the model argument
+// here — no per-line route lookup, no risk of diverging from the
+// submitter's batch-time selection.
 type LiteLLMInferenceClient struct {
 	baseURL    string
 	apiKey     string
 	httpClient *http.Client
-	routing    BatchRouteSelector
 }
 
 // NewLiteLLMInferenceClient constructs the production inference port.
-func NewLiteLLMInferenceClient(baseURL, apiKey string, routing BatchRouteSelector) *LiteLLMInferenceClient {
+func NewLiteLLMInferenceClient(baseURL, apiKey string) *LiteLLMInferenceClient {
 	return &LiteLLMInferenceClient{
 		baseURL:    strings.TrimRight(baseURL, "/"),
 		apiKey:     apiKey,
 		httpClient: &http.Client{Timeout: 90 * time.Second},
-		routing:    routing,
 	}
 }
 
-// ChatCompletion calls POST {baseURL}/v1/chat/completions. The model field in
-// the body is rewritten to the LiteLLM-routed model name resolved via the
-// routing selector. Returns the upstream response body, the OpenAI usage
-// object decoded from the response, the HTTP status code, and an error.
-func (c *LiteLLMInferenceClient) ChatCompletion(ctx context.Context, alias string, body json.RawMessage) (json.RawMessage, *executor.Usage, int, error) {
-	if c.routing == nil {
-		return nil, nil, 0, fmt.Errorf("local inference: routing selector not configured")
+// ChatCompletion calls POST {baseURL}/v1/chat/completions. The model
+// argument must already be the LiteLLM-routed model name (resolved once
+// per batch by pgxBatchStore.LoadBatch). The body's top-level model field
+// is rewritten to that name; all other fields are preserved verbatim.
+// Returns the upstream response body, the OpenAI usage object decoded
+// from the response, the HTTP status code, and an error.
+func (c *LiteLLMInferenceClient) ChatCompletion(ctx context.Context, model string, body json.RawMessage) (json.RawMessage, *executor.Usage, int, error) {
+	if strings.TrimSpace(model) == "" {
+		return nil, nil, 0, fmt.Errorf("local inference: model is required")
 	}
-	route, err := c.routing.SelectRoute(ctx, routing.SelectionInput{
-		AliasID:             alias,
-		NeedChatCompletions: true,
-	})
-	if err != nil {
-		return nil, nil, 0, fmt.Errorf("select route: %w", err)
-	}
-
-	rewritten, err := rewriteModel(body, route.LiteLLMModelName)
+	rewritten, err := rewriteModel(body, model)
 	if err != nil {
 		return nil, nil, 0, fmt.Errorf("rewrite model: %w", err)
 	}

--- a/apps/control-plane/internal/batchstore/local_inference.go
+++ b/apps/control-plane/internal/batchstore/local_inference.go
@@ -1,0 +1,112 @@
+package batchstore
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/hivegpt/hive/apps/control-plane/internal/batchstore/executor"
+	"github.com/hivegpt/hive/apps/control-plane/internal/routing"
+)
+
+// LiteLLMInferenceClient is the production InferencePort that the local batch
+// executor uses. Per .planning/phases/15-batch-local-executor/DECISIONS.md
+// Q1, the dispatcher calls LiteLLM's /v1/chat/completions directly rather
+// than crossing the apps/edge-api/internal/inference module boundary. This
+// reuses LiteLLM's provider routing, retry, and capability path — the same
+// surface edge-api exposes — while keeping control-plane's go.mod free of
+// edge-api/internal imports.
+type LiteLLMInferenceClient struct {
+	baseURL    string
+	apiKey     string
+	httpClient *http.Client
+	routing    BatchRouteSelector
+}
+
+// NewLiteLLMInferenceClient constructs the production inference port.
+func NewLiteLLMInferenceClient(baseURL, apiKey string, routing BatchRouteSelector) *LiteLLMInferenceClient {
+	return &LiteLLMInferenceClient{
+		baseURL:    strings.TrimRight(baseURL, "/"),
+		apiKey:     apiKey,
+		httpClient: &http.Client{Timeout: 90 * time.Second},
+		routing:    routing,
+	}
+}
+
+// ChatCompletion calls POST {baseURL}/v1/chat/completions. The model field in
+// the body is rewritten to the LiteLLM-routed model name resolved via the
+// routing selector. Returns the upstream response body, the OpenAI usage
+// object decoded from the response, the HTTP status code, and an error.
+func (c *LiteLLMInferenceClient) ChatCompletion(ctx context.Context, alias string, body json.RawMessage) (json.RawMessage, *executor.Usage, int, error) {
+	if c.routing == nil {
+		return nil, nil, 0, fmt.Errorf("local inference: routing selector not configured")
+	}
+	route, err := c.routing.SelectRoute(ctx, routing.SelectionInput{
+		AliasID:             alias,
+		NeedChatCompletions: true,
+	})
+	if err != nil {
+		return nil, nil, 0, fmt.Errorf("select route: %w", err)
+	}
+
+	rewritten, err := rewriteModel(body, route.LiteLLMModelName)
+	if err != nil {
+		return nil, nil, 0, fmt.Errorf("rewrite model: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/chat/completions", bytes.NewReader(rewritten))
+	if err != nil {
+		return nil, nil, 0, err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4*1024*1024))
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, nil, resp.StatusCode, fmt.Errorf("upstream status %d", resp.StatusCode)
+	}
+
+	usage := decodeUsage(respBody)
+	return respBody, usage, resp.StatusCode, nil
+}
+
+// rewriteModel replaces the top-level "model" field in body with the routed
+// LiteLLM model name. Other fields are preserved verbatim. Same approach as
+// rewriteBatchJSONL in submitter.go.
+func rewriteModel(body json.RawMessage, litellmModel string) (json.RawMessage, error) {
+	var payload map[string]any
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, err
+	}
+	payload["model"] = litellmModel
+	return json.Marshal(payload)
+}
+
+// decodeUsage extracts the OpenAI usage object from a chat-completion response.
+func decodeUsage(body []byte) *executor.Usage {
+	var probe struct {
+		Usage *struct {
+			PromptTokens     int64 `json:"prompt_tokens"`
+			CompletionTokens int64 `json:"completion_tokens"`
+			TotalTokens      int64 `json:"total_tokens"`
+		} `json:"usage"`
+	}
+	if err := json.Unmarshal(body, &probe); err != nil || probe.Usage == nil {
+		return nil
+	}
+	return &executor.Usage{
+		PromptTokens:     probe.Usage.PromptTokens,
+		CompletionTokens: probe.Usage.CompletionTokens,
+		TotalTokens:      probe.Usage.TotalTokens,
+	}
+}

--- a/apps/control-plane/internal/batchstore/queue.go
+++ b/apps/control-plane/internal/batchstore/queue.go
@@ -28,3 +28,17 @@ func (q *AsynqQueue) Enqueue(ctx context.Context, payload BatchPollPayload) erro
 	}
 	return nil
 }
+
+// EnqueueExecute pushes a TypeBatchExecute task for the local executor.
+func (q *AsynqQueue) EnqueueExecute(ctx context.Context, payload BatchExecutePayload) error {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal batch execute payload: %w", err)
+	}
+
+	_, err = q.client.EnqueueContext(ctx, asynq.NewTask(TypeBatchExecute, body), asynq.Queue("batch"))
+	if err != nil {
+		return fmt.Errorf("enqueue batch execute task: %w", err)
+	}
+	return nil
+}

--- a/apps/control-plane/internal/batchstore/submitter.go
+++ b/apps/control-plane/internal/batchstore/submitter.go
@@ -34,6 +34,13 @@ type BatchTaskQueue interface {
 	Enqueue(ctx context.Context, payload BatchPollPayload) error
 }
 
+// BatchExecuteQueue enqueues a local-executor task (TypeBatchExecute). The
+// production AsynqQueue implements both BatchTaskQueue and BatchExecuteQueue.
+// Kept as a separate interface so tests can fake one without the other.
+type BatchExecuteQueue interface {
+	EnqueueExecute(ctx context.Context, payload BatchExecutePayload) error
+}
+
 type BatchReservationReleaser interface {
 	ReleaseReservation(ctx context.Context, input accounting.ReleaseReservationInput) (accounting.Reservation, error)
 }
@@ -43,10 +50,12 @@ type Submitter struct {
 	routing        BatchRouteSelector
 	storage        BatchInputStorage
 	queue          BatchTaskQueue
+	executeQueue   BatchExecuteQueue
 	accounting     BatchReservationReleaser
 	litellmBaseURL string
 	litellmKey     string
 	bucket         string
+	executorKind   string
 	httpClient     *http.Client
 	now            func() time.Time
 }
@@ -68,9 +77,25 @@ func NewSubmitter(
 		litellmBaseURL: strings.TrimRight(litellmBaseURL, "/"),
 		litellmKey:     litellmKey,
 		bucket:         bucket,
+		executorKind:   "upstream", // legacy default; main.go calls WithLocalExecutor to enable local path.
 		httpClient:     &http.Client{Timeout: 60 * time.Second},
 		now:            time.Now,
 	}
+}
+
+// WithLocalExecutor wires the local-executor path. The submitter consults
+// kind ("auto"|"local"|"upstream") plus the route's provider to decide
+// whether to enqueue a TypeBatchExecute task or run the legacy LiteLLM
+// upstream upload path. See PLAN.md Phase 15.
+func (s *Submitter) WithLocalExecutor(executeQueue BatchExecuteQueue, kind string) *Submitter {
+	s.executeQueue = executeQueue
+	switch strings.ToLower(strings.TrimSpace(kind)) {
+	case "local", "upstream", "auto":
+		s.executorKind = strings.ToLower(strings.TrimSpace(kind))
+	default:
+		s.executorKind = "auto"
+	}
+	return s
 }
 
 func (s *Submitter) SubmitBatch(ctx context.Context, batch filestore.Batch) (filestore.Batch, error) {
@@ -85,6 +110,13 @@ func (s *Submitter) SubmitBatch(ctx context.Context, batch filestore.Batch) (fil
 	})
 	if err != nil {
 		return s.failSubmission(ctx, batch, fmt.Errorf("select batch route: %w", err))
+	}
+
+	// Phase 15: branch on executor strategy. The local executor path bypasses
+	// LiteLLM's /v1/files + /v1/batches and processes the JSONL line-by-line
+	// via /v1/chat/completions. See PLAN.md Phase 15 + DECISIONS.md Q1.
+	if s.shouldUseLocalExecutor(route) {
+		return s.submitLocal(ctx, batch, inputFile, route)
 	}
 
 	upstreamFileID, err := s.uploadUpstreamBatchFile(ctx, inputFile, route)
@@ -331,4 +363,52 @@ func stringPointer(value string) *string {
 	}
 	copy := value
 	return &copy
+}
+
+// shouldUseLocalExecutor decides between local executor vs LiteLLM upstream
+// upload path. Order:
+//  1. Env override BATCH_EXECUTOR_KIND=local|upstream is honored verbatim.
+//  2. "auto" (default) selects local for non-OpenAI/Anthropic providers
+//     (openrouter, groq, etc.) and upstream for OpenAI/Azure/Vertex/Anthropic.
+func (s *Submitter) shouldUseLocalExecutor(route routing.SelectionResult) bool {
+	if s.executeQueue == nil {
+		return false
+	}
+	switch s.executorKind {
+	case "local":
+		return true
+	case "upstream":
+		return false
+	}
+	provider := strings.ToLower(strings.TrimSpace(route.Provider))
+	switch provider {
+	case "openai", "azure", "vertex_ai", "vertex", "anthropic":
+		return false
+	default:
+		return true
+	}
+}
+
+// submitLocal enqueues a TypeBatchExecute task for the local executor and
+// transitions the batch row to in_progress so subsequent submissions are
+// idempotent and the executor can claim it.
+func (s *Submitter) submitLocal(ctx context.Context, batch filestore.Batch, _ *filestore.File, route routing.SelectionResult) (filestore.Batch, error) {
+	now := s.now().UTC()
+	updates := map[string]interface{}{
+		"executor_kind":  "local",
+		"in_progress_at": now.Unix(),
+	}
+	if err := s.files.UpdateBatchStatus(ctx, batch.ID, "in_progress", updates); err != nil {
+		return batch, fmt.Errorf("batchstore: update local batch status: %w", err)
+	}
+	if err := s.executeQueue.EnqueueExecute(ctx, BatchExecutePayload{
+		BatchID:   batch.ID,
+		AccountID: batch.AccountID,
+	}); err != nil {
+		return batch, fmt.Errorf("batchstore: enqueue local execute: %w", err)
+	}
+	batch.Status = "in_progress"
+	batch.Provider = route.Provider
+	batch.InProgressAt = &now
+	return batch, nil
 }

--- a/apps/control-plane/internal/batchstore/submitter.go
+++ b/apps/control-plane/internal/batchstore/submitter.go
@@ -399,13 +399,13 @@ func (s *Submitter) submitLocal(ctx context.Context, batch filestore.Batch, _ *f
 		"in_progress_at": now.Unix(),
 	}
 	if err := s.files.UpdateBatchStatus(ctx, batch.ID, "in_progress", updates); err != nil {
-		return batch, fmt.Errorf("batchstore: update local batch status: %w", err)
+		return s.failSubmission(ctx, batch, fmt.Errorf("update local batch status: %w", err))
 	}
 	if err := s.executeQueue.EnqueueExecute(ctx, BatchExecutePayload{
 		BatchID:   batch.ID,
 		AccountID: batch.AccountID,
 	}); err != nil {
-		return batch, fmt.Errorf("batchstore: enqueue local execute: %w", err)
+		return s.failSubmission(ctx, batch, fmt.Errorf("enqueue local execute: %w", err))
 	}
 	batch.Status = "in_progress"
 	batch.Provider = route.Provider

--- a/apps/control-plane/internal/batchstore/types.go
+++ b/apps/control-plane/internal/batchstore/types.go
@@ -1,7 +1,14 @@
 package batchstore
 
-// TypeBatchPoll is the Asynq task type name for batch polling tasks.
+// TypeBatchPoll is the Asynq task type name for batch polling tasks (upstream
+// LiteLLM-supported provider path).
 const TypeBatchPoll = "batch:poll"
+
+// TypeBatchExecute is the Asynq task type name for the local executor path —
+// the batch is processed line-by-line by control-plane against LiteLLM's
+// chat-completions endpoint instead of LiteLLM's batch upload API. See
+// .planning/phases/15-batch-local-executor/PLAN.md.
+const TypeBatchExecute = "batch:execute"
 
 // BatchPollPayload is the JSON-serialized payload of a TypeBatchPoll task.
 type BatchPollPayload struct {
@@ -16,4 +23,12 @@ type BatchPollPayload struct {
 	ModelAlias       string `json:"model_alias,omitempty"`
 	EstimatedCredits int64  `json:"estimated_credits,omitempty"`
 	ActualCredits    int64  `json:"actual_credits,omitempty"`
+}
+
+// BatchExecutePayload carries the minimal context needed for the local
+// executor to claim a batch and process it. Account/reservation lookup is
+// performed by the executor against the persisted batch row.
+type BatchExecutePayload struct {
+	BatchID   string `json:"batch_id"`
+	AccountID string `json:"account_id"`
 }

--- a/apps/control-plane/internal/batchstore/worker.go
+++ b/apps/control-plane/internal/batchstore/worker.go
@@ -3,6 +3,7 @@ package batchstore
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -14,6 +15,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hibiken/asynq"
 	"github.com/hivegpt/hive/apps/control-plane/internal/accounting"
+	"github.com/hivegpt/hive/apps/control-plane/internal/batchstore/executor"
 	"github.com/hivegpt/hive/apps/control-plane/internal/filestore"
 )
 
@@ -44,6 +46,15 @@ type BatchWorker struct {
 	storage        StorageUploader
 	bucket         string
 	httpClient     *http.Client
+	localExecutor  *executor.Executor
+}
+
+// WithLocalExecutor wires the local executor entry point used by
+// HandleBatchExecute. The worker is unaffected when the executor is nil
+// (HandleBatchExecute returns an error if invoked).
+func (w *BatchWorker) WithLocalExecutor(ex *executor.Executor) *BatchWorker {
+	w.localExecutor = ex
+	return w
 }
 
 // NewBatchWorker creates a new BatchWorker.
@@ -457,6 +468,30 @@ func (w *BatchWorker) fetchUpstreamBatch(ctx context.Context, upstreamBatchID st
 		return nil, fmt.Errorf("decode response: %w", err)
 	}
 	return result, nil
+}
+
+// HandleBatchExecute processes a batch:execute Asynq task by delegating to
+// the local executor. ctx.Canceled (graceful shutdown) is returned as an
+// error so Asynq re-enqueues; terminal failures mark the batch failed.
+func (w *BatchWorker) HandleBatchExecute(ctx context.Context, t *asynq.Task) error {
+	if w.localExecutor == nil {
+		return fmt.Errorf("batchstore: local executor not wired")
+	}
+	var payload BatchExecutePayload
+	if err := json.Unmarshal(t.Payload(), &payload); err != nil {
+		return fmt.Errorf("batchstore: unmarshal execute payload: %w", err)
+	}
+	if err := w.localExecutor.Run(ctx, payload.BatchID); err != nil {
+		if errors.Is(err, context.Canceled) {
+			return err
+		}
+		log.Printf("batchstore: local execute %s failed: %v", payload.BatchID, err)
+		_ = w.fileService.UpdateBatchStatus(ctx, payload.BatchID, "failed", map[string]interface{}{
+			"failed_at": time.Now().UTC().Unix(),
+		})
+		return fmt.Errorf("batch execute failed: %w", err)
+	}
+	return nil
 }
 
 // downloadUpstreamFile downloads the content of an upstream file and returns a reader + metadata.

--- a/apps/control-plane/internal/batchstore/worker.go
+++ b/apps/control-plane/internal/batchstore/worker.go
@@ -472,7 +472,10 @@ func (w *BatchWorker) fetchUpstreamBatch(ctx context.Context, upstreamBatchID st
 
 // HandleBatchExecute processes a batch:execute Asynq task by delegating to
 // the local executor. ctx.Canceled (graceful shutdown) is returned as an
-// error so Asynq re-enqueues; terminal failures mark the batch failed.
+// error so Asynq re-enqueues; transient errors are returned for Asynq to
+// retry. Only when retries are exhausted is the batch marked failed and
+// the credit reservation released — otherwise the next retry resumes via
+// the restart-safe path in executor.Run.
 func (w *BatchWorker) HandleBatchExecute(ctx context.Context, t *asynq.Task) error {
 	if w.localExecutor == nil {
 		return fmt.Errorf("batchstore: local executor not wired")
@@ -486,12 +489,74 @@ func (w *BatchWorker) HandleBatchExecute(ctx context.Context, t *asynq.Task) err
 			return err
 		}
 		log.Printf("batchstore: local execute %s failed: %v", payload.BatchID, err)
-		_ = w.fileService.UpdateBatchStatus(ctx, payload.BatchID, "failed", map[string]interface{}{
-			"failed_at": time.Now().UTC().Unix(),
-		})
+		w.handleLocalExecuteFailure(ctx, payload, err)
 		return fmt.Errorf("batch execute failed: %w", err)
 	}
 	return nil
+}
+
+// handleLocalExecuteFailure decides whether this Run-failure is the terminal
+// attempt. On non-terminal attempts it returns immediately so Asynq retries
+// the next attempt — the restart-safe path in executor.Run resumes
+// per-line state from public.batch_lines without re-charging. On the
+// terminal attempt it marks the batch row `failed` and releases the
+// reservation so credits aren't permanently locked.
+func (w *BatchWorker) handleLocalExecuteFailure(ctx context.Context, payload BatchExecutePayload, runErr error) {
+	retried, retriedOK := asynq.GetRetryCount(ctx)
+	maxRetry, maxOK := asynq.GetMaxRetry(ctx)
+	if retriedOK && maxOK && retried < maxRetry {
+		// Asynq will re-enqueue this task; defer terminal cleanup until the
+		// retry budget is exhausted so transient failures don't flicker
+		// status to `failed` then back to `completed` on the next run.
+		return
+	}
+	now := time.Now().UTC().Unix()
+	if updErr := w.fileService.UpdateBatchStatus(ctx, payload.BatchID, "failed", map[string]interface{}{
+		"failed_at": now,
+	}); updErr != nil {
+		log.Printf("batchstore: mark local batch %s failed: %v", payload.BatchID, updErr)
+	}
+	w.releaseLocalReservation(ctx, payload, runErr)
+}
+
+// releaseLocalReservation releases the batch's credit reservation when the
+// local executor's terminal attempt fails. Without this, the reservation
+// stays in `reserved` indefinitely because executor.Settle is only called
+// on the success path.
+func (w *BatchWorker) releaseLocalReservation(ctx context.Context, payload BatchExecutePayload, runErr error) {
+	if w.accounting == nil {
+		return
+	}
+	batch, err := w.fileService.GetBatch(ctx, payload.BatchID, payload.AccountID)
+	if err != nil || batch == nil {
+		log.Printf("batchstore: load batch %s for reservation release: %v", payload.BatchID, err)
+		return
+	}
+	accountID := strings.TrimSpace(batch.AccountID)
+	reservationID := ""
+	if batch.ReservationID != nil {
+		reservationID = strings.TrimSpace(*batch.ReservationID)
+	}
+	if accountID == "" || reservationID == "" {
+		return
+	}
+	parsedAccount, err := uuid.Parse(accountID)
+	if err != nil {
+		log.Printf("batchstore: parse account_id for batch %s reservation release: %v", payload.BatchID, err)
+		return
+	}
+	parsedReservation, err := uuid.Parse(reservationID)
+	if err != nil {
+		log.Printf("batchstore: parse reservation_id for batch %s reservation release: %v", payload.BatchID, err)
+		return
+	}
+	if _, err := w.accounting.ReleaseReservation(ctx, accounting.ReleaseReservationInput{
+		AccountID:     parsedAccount,
+		ReservationID: parsedReservation,
+		Reason:        "local_batch_execute_failed",
+	}); err != nil {
+		log.Printf("batchstore: release reservation for batch %s after local execute failure (%v): %v", payload.BatchID, runErr, err)
+	}
 }
 
 // downloadUpstreamFile downloads the content of an upstream file and returns a reader + metadata.

--- a/apps/control-plane/internal/filestore/repository.go
+++ b/apps/control-plane/internal/filestore/repository.go
@@ -380,6 +380,7 @@ const (
 	batchUpdateString batchUpdateKind = iota
 	batchUpdateInteger
 	batchUpdateTimestamp
+	batchUpdateBool
 )
 
 type batchStatusUpdateField struct {
@@ -400,6 +401,11 @@ var allowedBatchStatusUpdateFields = map[string]batchStatusUpdateField{
 	"completed_at":             {column: "completed_at", kind: batchUpdateTimestamp},
 	"failed_at":                {column: "failed_at", kind: batchUpdateTimestamp},
 	"cancelled_at":             {column: "cancelled_at", kind: batchUpdateTimestamp},
+	// Phase 15 — local batch executor columns (migration 20260427_01).
+	"executor_kind":   {column: "executor_kind", kind: batchUpdateString},
+	"completed_lines": {column: "completed_lines", kind: batchUpdateInteger},
+	"failed_lines":    {column: "failed_lines", kind: batchUpdateInteger},
+	"overconsumed":    {column: "overconsumed", kind: batchUpdateBool},
 }
 
 func normalizeBatchUpdateValue(field string, value interface{}, kind batchUpdateKind) (interface{}, error) {
@@ -424,6 +430,14 @@ func normalizeBatchUpdateValue(field string, value interface{}, kind batchUpdate
 			return nil, fmt.Errorf("filestore: invalid batch timestamp field %s: %w", field, err)
 		}
 		return time.Unix(seconds, 0).UTC(), nil
+	case batchUpdateBool:
+		if value == nil {
+			return nil, nil
+		}
+		if b, ok := value.(bool); ok {
+			return b, nil
+		}
+		return nil, fmt.Errorf("filestore: invalid batch bool field %s: %T", field, value)
 	default:
 		return nil, fmt.Errorf("filestore: unsupported batch update field %s", field)
 	}

--- a/apps/control-plane/internal/filestore/repository.go
+++ b/apps/control-plane/internal/filestore/repository.go
@@ -223,6 +223,47 @@ func (r *Repository) CreateBatch(ctx context.Context, b Batch) error {
 	return nil
 }
 
+// GetBatchByID retrieves a batch by ID without an account-id scope check —
+// for server-side workers (e.g., the local batch executor) that need to load
+// a batch row before they know which account owns it.
+func (r *Repository) GetBatchByID(ctx context.Context, id string) (*Batch, error) {
+	row := r.pool.QueryRow(ctx, `
+		SELECT id, account_id, input_file_id, output_file_id, error_file_id,
+		       endpoint, completion_window, status, provider, upstream_batch_id, reservation_id, api_key_id, model_alias,
+		       estimated_credits, actual_credits,
+		       request_counts_total, request_counts_completed, request_counts_failed,
+		       created_at, in_progress_at, completed_at, failed_at, cancelled_at, expires_at
+		FROM batches
+		WHERE id = $1
+	`, id)
+	b, err := scanBatch(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("filestore: get batch by id: %w", err)
+	}
+	return &b, nil
+}
+
+// GetFileByID retrieves a file by ID without an account-id scope check —
+// counterpart to GetBatchByID for the local batch executor.
+func (r *Repository) GetFileByID(ctx context.Context, id string) (*File, error) {
+	row := r.pool.QueryRow(ctx, `
+		SELECT id, account_id, purpose, filename, bytes, status, storage_path, created_at, expires_at
+		FROM files
+		WHERE id = $1
+	`, id)
+	f, err := scanFile(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("filestore: get file by id: %w", err)
+	}
+	return &f, nil
+}
+
 // GetBatch retrieves a batch by ID and account ID.
 func (r *Repository) GetBatch(ctx context.Context, id, accountID string) (*Batch, error) {
 	row := r.pool.QueryRow(ctx, `

--- a/apps/control-plane/internal/filestore/service.go
+++ b/apps/control-plane/internal/filestore/service.go
@@ -215,6 +215,19 @@ func (s *Service) GetBatch(ctx context.Context, id, accountID string) (*Batch, e
 	return s.repo.GetBatch(ctx, id, accountID)
 }
 
+// GetBatchByID retrieves a batch without account scoping. Used by server-side
+// workers (e.g., the local batch executor in batchstore/executor) that load a
+// batch by ID before resolving its owning account.
+func (s *Service) GetBatchByID(ctx context.Context, id string) (*Batch, error) {
+	return s.repo.GetBatchByID(ctx, id)
+}
+
+// GetFileByID retrieves a file without account scoping. Counterpart to
+// GetBatchByID for the local batch executor.
+func (s *Service) GetFileByID(ctx context.Context, id string) (*File, error) {
+	return s.repo.GetFileByID(ctx, id)
+}
+
 // ListBatches retrieves batches for an account with cursor-based pagination.
 func (s *Service) ListBatches(ctx context.Context, accountID string, limit int, after *string) ([]Batch, error) {
 	return s.repo.ListBatches(ctx, accountID, limit, after)

--- a/apps/control-plane/internal/platform/config/config.go
+++ b/apps/control-plane/internal/platform/config/config.go
@@ -13,6 +13,12 @@ type Config struct {
 	SupabaseAnonKey string
 	SupabaseDBURL   string
 	RedisURL        string
+
+	// Phase 15 — local batch executor knobs.
+	BatchExecutorConcurrency  int
+	BatchExecutorMaxRetries   int
+	BatchExecutorLineTimeoutMs int
+	BatchExecutorKind         string // "auto" | "local" | "upstream"
 }
 
 // Load reads configuration from environment variables and returns a validated Config.
@@ -32,10 +38,34 @@ func Load() (*Config, error) {
 	}
 
 	return &Config{
-		Port:            port,
-		SupabaseURL:     supabaseURL,
-		SupabaseAnonKey: os.Getenv("SUPABASE_ANON_KEY"),
-		SupabaseDBURL:   os.Getenv("SUPABASE_DB_URL"),
-		RedisURL:        os.Getenv("REDIS_URL"),
+		Port:                       port,
+		SupabaseURL:                supabaseURL,
+		SupabaseAnonKey:            os.Getenv("SUPABASE_ANON_KEY"),
+		SupabaseDBURL:              os.Getenv("SUPABASE_DB_URL"),
+		RedisURL:                   os.Getenv("REDIS_URL"),
+		BatchExecutorConcurrency:   intEnv("BATCH_EXECUTOR_CONCURRENCY", 8),
+		BatchExecutorMaxRetries:    intEnv("BATCH_EXECUTOR_MAX_RETRIES", 3),
+		BatchExecutorLineTimeoutMs: intEnv("BATCH_EXECUTOR_LINE_TIMEOUT_MS", 60000),
+		BatchExecutorKind:          stringEnv("BATCH_EXECUTOR_KIND", "auto"),
 	}, nil
+}
+
+func intEnv(key string, def int) int {
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n <= 0 {
+		return def
+	}
+	return n
+}
+
+func stringEnv(key, def string) string {
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	return v
 }

--- a/deploy/litellm/config.yaml
+++ b/deploy/litellm/config.yaml
@@ -1,3 +1,16 @@
+# ─── Phase 15: Local batch executor ───
+# OpenRouter and Groq chat-completions routes ship with
+# `route_capabilities.executor_kind = 'local'` (set in supabase/migrations/
+# 0015_batch_local_executor.sql). The control-plane submitter routes
+# `POST /v1/batches` for these providers to the in-process executor (which
+# calls `POST /v1/chat/completions` line-by-line via this LiteLLM gateway)
+# instead of LiteLLM's `POST /v1/files purpose=batch` upload path — that
+# path is only supported by openai/azure/vertex_ai/anthropic providers.
+# No `files_settings` block is required for the openrouter/groq batch
+# success-path under this design. See
+# .planning/phases/10-routing-storage-critical-fixes/KNOWN-ISSUE-batch-upstream.md
+# for the original constraint.
+
 model_list:
   # OpenRouter primary routes (chat).
   #

--- a/supabase/migrations/0015_batch_local_executor.sql
+++ b/supabase/migrations/0015_batch_local_executor.sql
@@ -1,0 +1,38 @@
+-- 0015_batch_local_executor.sql
+-- Phase 15: local batch executor — per-line idempotency + progress tracking.
+-- Adds executor_kind column to batches plus completion progress + overconsumed
+-- flag, and creates batch_lines table for restart-safe per-line state.
+
+-- Extend batches with executor strategy + progress columns.
+alter table public.batches
+  add column if not exists executor_kind text not null default 'upstream'
+    check (executor_kind in ('upstream','local')),
+  add column if not exists completed_lines integer not null default 0,
+  add column if not exists failed_lines integer not null default 0,
+  add column if not exists overconsumed boolean not null default false;
+
+-- Tag the route_capabilities table with the executor strategy used by the
+-- submitter to choose between local executor and LiteLLM upstream batch upload.
+-- Default is 'local' since the v1.0 + v1.1 provider mix (openrouter + groq)
+-- has no LiteLLM-supported batch upstream.
+alter table if exists public.route_capabilities
+  add column if not exists executor_kind text not null default 'local'
+    check (executor_kind in ('upstream','local'));
+
+-- Per-line state for restart-safe resume + idempotent line settlement.
+create table if not exists public.batch_lines (
+  batch_id uuid not null references public.batches(id) on delete cascade,
+  custom_id text not null,
+  status text not null check (status in ('pending','in_progress','succeeded','failed')),
+  attempt integer not null default 0,
+  consumed_credits numeric(20,6) not null default 0,
+  output_index integer,
+  error_index integer,
+  last_error text,
+  first_seen_at timestamptz not null default now(),
+  completed_at timestamptz,
+  primary key (batch_id, custom_id)
+);
+
+create index if not exists batch_lines_batch_status_idx
+  on public.batch_lines (batch_id, status);

--- a/supabase/migrations/20260427_01_batch_local_executor.sql
+++ b/supabase/migrations/20260427_01_batch_local_executor.sql
@@ -1,27 +1,24 @@
--- 0015_batch_local_executor.sql
+-- 20260427_01_batch_local_executor.sql
 -- Phase 15: local batch executor — per-line idempotency + progress tracking.
 -- Adds executor_kind column to batches plus completion progress + overconsumed
 -- flag, and creates batch_lines table for restart-safe per-line state.
+--
+-- Filename was renumbered from 0015_* (which sorted alphabetically before the
+-- 20260414_02 migration that creates public.batches) so this migration runs
+-- after every prior migration in chronological order. See PR 134 review.
 
 -- Extend batches with executor strategy + progress columns.
-alter table public.batches
+alter table if exists public.batches
   add column if not exists executor_kind text not null default 'upstream'
     check (executor_kind in ('upstream','local')),
   add column if not exists completed_lines integer not null default 0,
   add column if not exists failed_lines integer not null default 0,
   add column if not exists overconsumed boolean not null default false;
 
--- Tag the route_capabilities table with the executor strategy used by the
--- submitter to choose between local executor and LiteLLM upstream batch upload.
--- Default is 'local' since the v1.0 + v1.1 provider mix (openrouter + groq)
--- has no LiteLLM-supported batch upstream.
-alter table if exists public.route_capabilities
-  add column if not exists executor_kind text not null default 'local'
-    check (executor_kind in ('upstream','local'));
-
 -- Per-line state for restart-safe resume + idempotent line settlement.
+-- batch_id is text to match public.batches.id (not uuid).
 create table if not exists public.batch_lines (
-  batch_id uuid not null references public.batches(id) on delete cascade,
+  batch_id text not null references public.batches(id) on delete cascade,
   custom_id text not null,
   status text not null check (status in ('pending','in_progress','succeeded','failed')),
   attempt integer not null default 0,


### PR DESCRIPTION
## Summary

- Implements local batch executor inside `apps/control-plane/internal/batchstore/executor/` so v1.0's `POST /v1/batches` success-path can ship without a LiteLLM-supported batch upstream provider (closes Hive v1.0 [Known Issue #4](https://github.com/sakibsadmanshajib/hive/blob/main/CLAUDE.md#known-issues), per [PLAN.md](.planning/phases/15-batch-local-executor/PLAN.md) and [KNOWN-ISSUE-batch-upstream.md](.planning/phases/10-routing-storage-critical-fixes/KNOWN-ISSUE-batch-upstream.md)).
- Streams JSONL line-by-line from Supabase Storage, fans out via bounded concurrency to LiteLLM `/v1/chat/completions`, composes OpenAI-shape `output.jsonl` + `errors.jsonl`, settles per-line credits via existing reservation primitive (`math/big` per CLAUDE.md FX rule).
- Restart-safe via `batch_lines (batch_id, custom_id) PK` (migration 0015); resumes after mid-run kill with no double-charge and no duplicate output rows.

## Decisions resolved

- **Q1 inference dispatch:** LiteLLM-direct HTTP from control-plane → `/v1/chat/completions`. Initial PLAN proposed in-process import of `apps/edge-api/internal/inference`, but Go's `internal/` rule forbids cross-module access (separate `go.mod` per app). LiteLLM-direct reuses provider routing/retry/sanitization without a shared-module refactor.
- **Q2 process boundary:** control-plane in-process (reuses DB pool, Redis queue, storage, accounting; concurrency ceiling bounds runaway risk).
- **Q3 concurrency:** default 8, ceiling 32 (env-driven via `BATCH_EXECUTOR_CONCURRENCY`).

Full rationale in [DECISIONS.md](.planning/phases/15-batch-local-executor/DECISIONS.md).

## Out of scope

- `apps/control-plane/internal/routing/repository.go` `ensureCapabilityColumns` table-name fix → Phase 16.
- Comprehensive USD/FX leak audit beyond batch surface → Phase 17.

## Test plan

- [x] `go test -count=1 -race -short ./apps/control-plane/internal/batchstore/...` — green; covers all 7 must-have truths from [PLAN.md](.planning/phases/15-batch-local-executor/PLAN.md) `must_haves.truths` (mixed success/error, restart resume, math/big sum exact, settle idempotent, settle overconsumed clamp, bounded concurrency, retry policy, provider-name sanitization). See [15-VERIFICATION.md](.planning/phases/15-batch-local-executor/15-VERIFICATION.md).
- [x] `go vet ./apps/control-plane/...` — clean.
- [x] `go test -count=1 -short ./apps/control-plane/...` — all packages green.
- [x] `git diff --name-only origin/main...HEAD` does not include `apps/control-plane/internal/routing/repository.go` (Phase 16 boundary).
- [ ] Live ship-gate dry-run (operator-only, gated on staging migration window): apply 0015, mint funded API key, submit 100-line batch, audit output/errors JSONL + reservation accounting + restart-safety + provider-name leak grep + USD audit. Runbook in 15-VERIFICATION.md "Live ship-gate dry-run".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  - Added local batch execution capability with configurable parameters (concurrency, retry limits, per-line timeouts).
  - New environment variables for tuning batch execution behavior.

* **Improvements**
  - Enhanced batch error handling with improved message sanitization.
  - Improved credit settlement tracking with overconsumption detection.
  - Per-line batch progress tracking with detailed completion metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->