### PR TITLE
chore(gitignore): ignore local developer tooling caches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,15 @@ hs_err_pid*.log
 
 # Admin-only local scripts — never deployed, never shared.
 /scripts/admin/
+
+# Local developer tooling caches and artefacts (graphify, gh CLI cache,
+# node compile cache, root-level Go build binary, agent worktrees, skill lock).
+.claude/worktrees/
+.graphifyignore
+graphify-out/
+.graphify_*
+.graphify_python
+gh-cli-cache/
+node-compile-cache/
+/server
+skills-lock.json


### PR DESCRIPTION
## Summary

Adds nine ignore patterns covering per-developer tooling state that was leaking into worktree status:

- `.claude/worktrees/` — agent worktree dirs
- `.graphifyignore`, `graphify-out/`, `.graphify_*`, `.graphify_python` — graphify CLI artefacts
- `gh-cli-cache/`, `node-compile-cache/` — local caches
- `/server` — root-level Go build binary
- `skills-lock.json` — Caveman skill lock (per-developer)

All entries are local developer state — none should ever be tracked.

## Test plan

- [x] `git status` is clean after applying the new ignore patterns
- [x] No file removals or relocations