### PR TITLE
fix(control-plane): pre-create audit-WAL dir to unblock staging deploy

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -235,6 +235,28 @@ jobs:
           docker logout ghcr.io
           SH
 
+      - name: Dump container logs on failure
+        if: failure()
+        # When a container fails its healthcheck, `docker compose up` exits 1
+        # without surfacing any container output, leaving the workflow log
+        # showing only "is unhealthy". Pull the last 200 lines from each
+        # service and the compose ps state so the failure is diagnosable
+        # without manually SSHing into the VM.
+        run: |
+          ssh -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=accept-new \
+            deploy@${{ secrets.STAGING_HOST }} 'bash -s' <<'SH' || true
+          set +e
+          cd /opt/hive/deploy/docker
+          echo "::group::docker compose ps"
+          docker compose -f docker-compose.yml -f docker-compose.staging.yml ps
+          echo "::endgroup::"
+          for svc in control-plane edge-api litellm; do
+            echo "::group::logs ($svc)"
+            docker compose -f docker-compose.yml -f docker-compose.staging.yml logs --tail=200 --no-color "$svc" 2>&1 || true
+            echo "::endgroup::"
+          done
+          SH
+
       - name: Smoke test
         run: |
           for i in $(seq 1 12); do

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -242,17 +242,26 @@ jobs:
         # showing only "is unhealthy". Pull the last 200 lines from each
         # service and the compose ps state so the failure is diagnosable
         # without manually SSHing into the VM.
+        #
+        # NOTE: `--env-file /opt/hive/.env` is required even for read-only
+        # commands like `ps` / `logs` because docker-compose.staging.yml
+        # uses required interpolation (`${REDIS_URL:?...}`,
+        # `${LITELLM_MASTER_KEY:?...}`) which Compose evaluates on every
+        # invocation. Without it the diagnostic step would itself fail
+        # with an interpolation error and never reach the real container
+        # logs we're trying to capture.
         run: |
           ssh -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=accept-new \
             deploy@${{ secrets.STAGING_HOST }} 'bash -s' <<'SH' || true
           set +e
           cd /opt/hive/deploy/docker
+          COMPOSE=(docker compose -f docker-compose.yml -f docker-compose.staging.yml --env-file /opt/hive/.env)
           echo "::group::docker compose ps"
-          docker compose -f docker-compose.yml -f docker-compose.staging.yml ps
+          "${COMPOSE[@]}" ps
           echo "::endgroup::"
           for svc in control-plane edge-api litellm; do
             echo "::group::logs ($svc)"
-            docker compose -f docker-compose.yml -f docker-compose.staging.yml logs --tail=200 --no-color "$svc" 2>&1 || true
+            "${COMPOSE[@]}" logs --tail=200 --no-color "$svc" 2>&1 || true
             echo "::endgroup::"
           done
           SH

--- a/deploy/docker/Dockerfile.control-plane.prod
+++ b/deploy/docker/Dockerfile.control-plane.prod
@@ -15,7 +15,15 @@ RUN CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' -o /out/control-plane ./cm
 FROM alpine:3.20
 RUN apk add --no-cache ca-certificates wget && adduser -D -u 10001 app
 COPY --from=build /out/control-plane /usr/local/bin/control-plane
+# Pre-create the audit WAL directory under /var/lib/hive owned by the
+# non-root `app` user. The control-plane binary calls os.MkdirAll on
+# AUDIT_WAL_DIR (default /var/lib/hive/audit-wal) at startup and
+# log.Fatals if the mkdir fails — without this the unprivileged user
+# cannot create directories under /var/lib and the container exits
+# immediately, failing the healthcheck.
+RUN mkdir -p /var/lib/hive/audit-wal/events && chown -R app:app /var/lib/hive
 WORKDIR /app
 USER app
 EXPOSE 8081
+VOLUME ["/var/lib/hive/audit-wal"]
 ENTRYPOINT ["/usr/local/bin/control-plane"]

--- a/deploy/docker/docker-compose.staging.yml
+++ b/deploy/docker/docker-compose.staging.yml
@@ -40,7 +40,11 @@ services:
   control-plane:
     image: ${IMAGE_PREFIX:-ghcr.io/sakibsadmanshajib/hive}/control-plane:${IMAGE_TAG:-main}
     build: !reset null
-    volumes: !reset []
+    # Persist the audit-WAL across container recreates so any DLQ
+    # envelopes written while Postgres was unreachable survive a
+    # `docker compose up -d` and can be drained on the next boot.
+    volumes: !override
+      - audit-wal:/var/lib/hive/audit-wal
     depends_on: !reset []
     ports: !override
       - "127.0.0.1:8081:8081"
@@ -62,3 +66,5 @@ services:
 volumes:
   gomodcache: !reset null
   gobuildcache: !reset null
+  audit-wal:
+    driver: local


### PR DESCRIPTION
## Summary

- `control-plane` container has been crash-looping on the OCI staging VM since PR #143 merged (run [26044609257](https://github.com/sakibsadmanshajib/hive/actions/runs/26044609257/job/76565583611) fails at the `up -d` step with `container hive-control-plane-1 is unhealthy`).
- Phase 19 plan 03 wired an audit Write-Ahead-Log writer that unconditionally calls `os.MkdirAll(AUDIT_WAL_DIR/events, 0750)` at startup (`apps/control-plane/internal/audit/wal.go:37`) and `log.Fatal`s on error (`apps/control-plane/cmd/server/main.go:362`).
- The production image runs as a non-root `app` user (uid 10001) and never created `/var/lib/hive`, so the mkdir was rejected with `EACCES`, the process exited, and the healthcheck failed within seconds.

## Fixes

| File | Change |
|------|--------|
| `deploy/docker/Dockerfile.control-plane.prod` | Pre-create `/var/lib/hive/audit-wal/events` and `chown -R app:app /var/lib/hive` before `USER app`. Declare `VOLUME ["/var/lib/hive/audit-wal"]` so a host or named volume can persist the WAL. |
| `deploy/docker/docker-compose.staging.yml` | Mount a named `audit-wal` volume at `/var/lib/hive/audit-wal` on the `control-plane` service (replacing the previous `volumes: !reset []`) so DLQ envelopes survive container recreates. |
| `.github/workflows/deploy-staging.yml` | Add a `failure()` step that runs `docker compose ps` + tails the last 200 lines of each service log over SSH, so the next deploy-staging failure is diagnosable directly from the workflow log. |

## Verification

- YAML lint: both `deploy/docker/docker-compose.staging.yml` and `.github/workflows/deploy-staging.yml` parse cleanly (compose `!reset` / `!override` tags treated as pass-through).
- The Dockerfile change is a single additive `RUN mkdir … && chown …` plus a `VOLUME` declaration — no source-code changes, no behavior change for callers other than the previously-fatal mkdir now succeeding.
- The compose change only affects the staging overlay; dev / CI compositions remain untouched.

## Test plan

- [ ] Merge → next `deploy-staging` run pulls the new image and starts control-plane cleanly (no `is unhealthy`)
- [ ] `Smoke test` step reports `SMOKE OK` against `cp-hive.scubed.co/health`
- [ ] Named volume `audit-wal` exists on the VM after deploy (`docker volume ls | grep audit-wal`)
- [ ] If anything else regresses, the new `Dump container logs on failure` step prints the underlying `log.Fatal` line instead of just `is unhealthy`