### PR TITLE
fix(security): server-side auth validation in web-console (#119, #120)

### DIFF
--- a/apps/web-console/__tests__/invitation-accept.test.tsx
+++ b/apps/web-console/__tests__/invitation-accept.test.tsx
@@ -5,8 +5,10 @@ const mockRedirect = vi.fn(() => {
   throw redirectError;
 });
 const mockGetSession = vi.fn();
+const mockGetUser = vi.fn();
 const mockCreateClient = vi.fn(() => ({
   auth: {
+    getUser: mockGetUser,
     getSession: mockGetSession,
   },
 }));
@@ -29,6 +31,12 @@ describe("app/invitations/accept/page.tsx", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     process.env.CONTROL_PLANE_BASE_URL = "http://localhost:8081";
+    mockGetUser.mockResolvedValue({
+      data: {
+        user: { id: "test-user", email: "test@hive.com" },
+      },
+      error: null,
+    });
     mockGetSession.mockResolvedValue({
       data: {
         session: {

--- a/apps/web-console/app/console/members/page.tsx
+++ b/apps/web-console/app/console/members/page.tsx
@@ -50,6 +50,15 @@ function statusTone(status: string): { label: string; tone: ToneName } {
 export default async function MembersPage() {
   const cookieStore = await cookies();
   const supabase = createClient(cookieStore);
+  // Validate the JWT server-side (getUser round-trips to Supabase and
+  // rejects revoked tokens); getSession alone only reads the cookie.
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    redirect("/auth/sign-in");
+  }
+
   const {
     data: { session },
   } = await supabase.auth.getSession();

--- a/apps/web-console/app/invitations/accept/page.tsx
+++ b/apps/web-console/app/invitations/accept/page.tsx
@@ -33,6 +33,16 @@ export default async function AcceptInvitationPage({
   const cookieStore = await cookies();
   const supabase = createClient(cookieStore);
 
+  // Validate the JWT against Supabase (getUser round-trips and rejects
+  // revoked tokens) before trusting the session for the bearer token.
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/auth/sign-in?next=/invitations/accept");
+  }
+
   const {
     data: { session },
   } = await supabase.auth.getSession();

--- a/apps/web-console/lib/control-plane/client.ts
+++ b/apps/web-console/lib/control-plane/client.ts
@@ -115,6 +115,17 @@ async function getRequestContext(): Promise<RequestContext> {
   const cookieStore = await cookies();
   const supabase = createClient(cookieStore);
 
+  // Validate the JWT against Supabase (getUser does a server round-trip
+  // and rejects revoked tokens) before trusting the session. getSession
+  // only reads the cookie and would accept a revoked token.
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+  if (userError || !user) {
+    throw new Error("No active session");
+  }
+
   const {
     data: { session },
   } = await supabase.auth.getSession();

--- a/apps/web-console/middleware.ts
+++ b/apps/web-console/middleware.ts
@@ -38,10 +38,33 @@ export async function middleware(request: NextRequest) {
 
   const { pathname } = request.nextUrl;
 
+  // Redirect while preserving any auth cookies getUser() refreshed onto
+  // supabaseResponse. A bare NextResponse.redirect would drop the rotated
+  // session cookies, so the next request would carry a stale token.
+  const redirectTo = (path: string) => {
+    const res = NextResponse.redirect(new URL(path, request.url));
+    supabaseResponse.cookies.getAll().forEach((cookie) => {
+      res.cookies.set(cookie);
+    });
+    return res;
+  };
+
+  // Mirror the control-plane's email-verified rule (auth/client.go): the
+  // app_metadata.hive_email_verified override wins when present, otherwise
+  // fall back to Supabase's email_confirmed_at. Gating on email_confirmed_at
+  // alone would wrongly admit a user whose Supabase email is confirmed but
+  // whose hive_email_verified override is false.
+  const appMetadata = user?.app_metadata as
+    | { hive_email_verified?: boolean }
+    | undefined;
+  const emailVerified =
+    typeof appMetadata?.hive_email_verified === "boolean"
+      ? appMetadata.hive_email_verified
+      : Boolean(user?.email_confirmed_at);
+
   // Protect /console: redirect unauthenticated users to sign-in
   if (pathname.startsWith("/console") && !user) {
-    const signInUrl = new URL("/auth/sign-in", request.url);
-    return NextResponse.redirect(signInUrl);
+    return redirectTo("/auth/sign-in");
   }
 
   // Email-verification gate, enforced server-side on every console route.
@@ -53,17 +76,15 @@ export async function middleware(request: NextRequest) {
   if (
     pathname.startsWith("/console") &&
     user &&
-    !user.email_confirmed_at &&
+    !emailVerified &&
     pathname !== "/console/settings/profile"
   ) {
-    const verifyUrl = new URL("/console/settings/profile", request.url);
-    return NextResponse.redirect(verifyUrl);
+    return redirectTo("/console/settings/profile");
   }
 
   // Redirect authenticated users from root to /console
   if (pathname === "/" && user) {
-    const consoleUrl = new URL("/console", request.url);
-    return NextResponse.redirect(consoleUrl);
+    return redirectTo("/console");
   }
 
   return supabaseResponse;

--- a/apps/web-console/middleware.ts
+++ b/apps/web-console/middleware.ts
@@ -44,6 +44,22 @@ export async function middleware(request: NextRequest) {
     return NextResponse.redirect(signInUrl);
   }
 
+  // Email-verification gate, enforced server-side on every console route.
+  // Previously only the console layout component checked verification, so
+  // a direct fetch / curl with a valid session cookie could still reach
+  // gated pages (e.g. /console/api-keys). Unverified users are redirected
+  // to the profile page — the app's verification surface — which is
+  // exempted here to avoid a redirect loop.
+  if (
+    pathname.startsWith("/console") &&
+    user &&
+    !user.email_confirmed_at &&
+    pathname !== "/console/settings/profile"
+  ) {
+    const verifyUrl = new URL("/console/settings/profile", request.url);
+    return NextResponse.redirect(verifyUrl);
+  }
+
   // Redirect authenticated users from root to /console
   if (pathname === "/" && user) {
     const consoleUrl = new URL("/console", request.url);


### PR DESCRIPTION
Second batch of the P0/P1 security backlog (#106–#120).

## Fixes
- **#119** — Three server-side callsites trusted \`supabase.auth.getSession()\`, which only reads the cookie and accepts revoked tokens. Each now validates via \`getUser()\` (a Supabase round-trip) before acting; where the access token is still needed to call the control-plane, \`getSession()\` is kept for the token *after* \`getUser()\` authenticates.
  - \`lib/control-plane/client.ts\`
  - \`app/console/members/page.tsx\`
  - \`app/invitations/accept/page.tsx\`
- **#120** — Email verification was enforced only by the console layout component, so direct fetches / curl with a valid session cookie reached gated pages (e.g. \`/console/api-keys\`). The check now lives in \`middleware.ts\` and runs server-side on every \`/console\` route.

## Note on redirect target
The issue text suggested \`/auth/verify-email\`, but that route does not exist in this app — the actual verification surface is \`/console/settings/profile\` (the existing unverified-redirect target used by \`members/page.tsx\`). The middleware redirects there and exempts that path to avoid a loop, matching established app behaviour. Verification status uses the Supabase-native \`user.email_confirmed_at\` already fetched by \`getUser()\` (no extra control-plane round-trip in edge middleware).

## Test plan
- [x] \`tsc --noEmit\` clean
- [ ] CI: web console type+unit+build, web-e2e (unverified redirect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced authentication security with stricter user validation across console and invitation flows.
  * Added email verification requirement for console access; unverified users are prompted to verify their email address.
  * Improved session persistence during redirects for better authentication reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sakibsadmanshajib/hive/pull/151?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->