### PR TITLE
docs(ci): document + persist main branch-protection merge policy

### DIFF
--- a/.github/MERGE-POLICY.md
+++ b/.github/MERGE-POLICY.md
@@ -1,0 +1,60 @@
+# Merge Policy (enforced on `main`)
+
+A pull request **cannot** be merged into `main` unless **both** hold:
+
+1. **No failed/missing tests** — every required status check is green.
+2. **No unresolved review comments** — all PR review conversations are resolved.
+
+This is enforced server-side by GitHub branch protection on `main`, including
+for repository admins (`enforce_admins: true`). It is not advisory and cannot be
+bypassed from the CLI or UI.
+
+## What is enforced
+
+| Setting | Value | Effect |
+|---------|-------|--------|
+| `required_conversation_resolution` | `true` | Any unresolved review thread blocks merge |
+| `required_status_checks.contexts` | see below | Any failed/missing required check blocks merge |
+| `enforce_admins` | `true` | Admins are subject to the same rules |
+| `allow_force_pushes` | `false` | No force-push to `main` |
+| `allow_deletions` | `false` | `main` cannot be deleted |
+
+### Required status checks
+- `Go tests (control-plane)`
+- `Go tests (edge-api)`
+- `Go tests (storage)`
+- `Repo policy lints (tenant + audit)`
+- `Web console (type + unit + build)`
+- `Live integration (SDK tests + smoke)`
+- `Web E2E (full stack)`
+
+These are the jobs in `.github/workflows/ci.yml`, which runs on every
+same-repo pull request with no path filter (so it never deadlocks a PR).
+`chat-app-ci.yml` jobs are path-filtered and therefore **not** required.
+`strict` is `false`: checks must pass, but a PR is not forced to be rebased
+onto the latest `main` first.
+
+> Note: `required_pull_request_reviews` is not set — this repo currently has no
+> mandatory human approver (solo/small team). Add it later by setting
+> `required_approving_review_count` in the config below.
+
+## Re-applying / updating
+
+The canonical config lives in `.github/branch-protection-main.json`. Re-apply with:
+
+```bash
+gh api -X PUT repos/sakibsadmanshajib/hive/branches/main/protection \
+  -H "Accept: application/vnd.github+json" \
+  --input .github/branch-protection-main.json
+```
+
+Verify:
+
+```bash
+gh api repos/sakibsadmanshajib/hive/branches/main/protection \
+  --jq '{conversation_resolution_required:.required_conversation_resolution.enabled, enforce_admins:.enforce_admins.enabled, required_checks:.required_status_checks.contexts}'
+```
+
+If a required check name changes in `ci.yml`, update both the workflow and the
+`contexts` array here in the same PR, otherwise merges will block on a check
+that never reports.

--- a/.github/branch-protection-main.json
+++ b/.github/branch-protection-main.json
@@ -1,0 +1,21 @@
+{
+  "required_status_checks": {
+    "strict": false,
+    "contexts": [
+      "Go tests (control-plane)",
+      "Go tests (edge-api)",
+      "Go tests (storage)",
+      "Repo policy lints (tenant + audit)",
+      "Web console (type + unit + build)",
+      "Live integration (SDK tests + smoke)",
+      "Web E2E (full stack)"
+    ]
+  },
+  "enforce_admins": true,
+  "required_pull_request_reviews": null,
+  "restrictions": null,
+  "required_conversation_resolution": true,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "required_linear_history": false
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,7 @@ With `go.work`, Docker test commands must use full module-relative paths (`./app
 - **Immutability**: New objects, never mutate existing. Ledger append-only.
 - **Commits**: `<type>: <description>` — types: feat, fix, refactor, docs, test, chore, perf, ci
 - **No hardcoded secrets**: Env vars only. Never commit `.env`.
+- **Merge policy** (`main`, enforced by GitHub branch protection incl. admins): a PR is **not mergeable** while it has any failed/missing required test or any unresolved review comment. See `.github/MERGE-POLICY.md`; config in `.github/branch-protection-main.json`. Always resolve every review thread before merging.
 - **Provider-blind errors**: Sanitize at both control-plane + edge boundaries. Provider names never leak to customers.
 - **math/big for FX**: All financial calcs use `math/big` to prevent float64 corruption.
 - **Storage backend**: Supabase Storage only object storage backend. `edge-api` + `control-plane` fail fast unless required S3 env vars present, and `hive-files` + `hive-images` must exist before startup.


### PR DESCRIPTION
Persists the merge policy now enforced on `main` via GitHub branch protection (set 2026-05-29):

- **No unresolved review comments** → `required_conversation_resolution: true`
- **No failed/missing tests** → 7 required `ci.yml` status checks
- Applies to admins (`enforce_admins: true`); no force-push / deletion of `main`

Adds `.github/branch-protection-main.json` (canonical config + re-apply command), `.github/MERGE-POLICY.md` (runbook), and a CLAUDE.md pointer so the rule is discoverable and reproducible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)