### PR TITLE
fix(accounting): close credit-reservation TOCTOU double-spend (#106)

### DIFF
--- a/.planning/SECURITY-P0-BACKLOG.md
+++ b/.planning/SECURITY-P0-BACKLOG.md
@@ -15,7 +15,7 @@ these block any real launch of the metered-inference reselling product.
 | #117 | No email-verify gate on API key creation | ✅ already fixed (Phase 18 RBAC) | closed, no code change |
 | #119 | getSession() server-side auth (3 sites) | ✅ fixed | PR #151 |
 | #120 | Email-verify only in layout, not middleware | ✅ fixed | PR #151 |
-| #106 | Credit reservation TOCTOU double-spend | ⏳ TODO | see below |
+| #106 | Credit reservation TOCTOU double-spend | ✅ fixed | branch `fix/106-credit-toctou-race` — per-account advisory lock |
 | #107 | No RLS on tenant tables | ⏳ TODO | see below |
 | #108 | /internal/* control-plane endpoints unauth | ⏳ TODO | see below |
 | #111 | CONTROL_PLANE_BASE_URL leaked into HTML | ⏳ TODO | conflicts w/ #151 members/page — do after #151 merges |
@@ -25,12 +25,13 @@ these block any real launch of the metered-inference reselling product.
 
 ## Remaining — implementation notes (pre-investigated)
 
-### #106 Credit TOCTOU (HIGHEST severity — financial)
-- File: `apps/control-plane/internal/accounting/service.go` `CreateReservation` (L50–110).
-- Bug: `GetBalance` (L63) and `repo.CreateReservation` (L85) run in separate txns; N concurrent requests read same balance, all pass `enforcePolicy` (L426) → N× over-reserve.
-- Fix: single txn with `pg_advisory_xact_lock(hashtext(account_id::text))` (or `SELECT ... FOR UPDATE` on an account lock row) around balance-read + policy + insert. Add a ledger CHECK / partial-sum constraint as defence in depth.
-- Needs: repo transactional path (check `repository.go` for tx support), and a `-race` + ~100-RPS single-account smoke test (acceptance: balance=1000, reserve=50 → ≤20 succeed).
-- Do on its own branch; no file conflicts with #150/#151.
+### #106 Credit TOCTOU (HIGHEST severity — financial) — ✅ FIXED
+- File: `apps/control-plane/internal/accounting/service.go` `CreateReservation` + `ExpandReservation` (both were vulnerable).
+- Bug: `GetBalance` and the `ReserveCredits` hold ran in separate txns; N concurrent requests read the same balance, all pass `enforcePolicy` → N× over-reserve.
+- Fix shipped: new `AccountLocker` abstraction (`lock.go`, `pglock.go`). The balance-read → policy → reservation-hold critical section now runs inside `WithAccountLock` for both `CreateReservation` and `ExpandReservation`. Production wiring (`cmd/server/main.go`) installs `PgxAccountLocker` = `pg_advisory_lock(hashtext(account_id)::int8)` on a dedicated pooled conn, held across the section, always released — cross-process safe. `NewService` defaults to an in-process locker for single-instance/tests.
+- **Deliberately NOT added** the ledger non-negative CHECK/trigger the issue suggested: `PolicyModeTemporaryOverage` intentionally lets available balance go negative within a buffer, so a hard DB constraint would break the overage policy. Policy stays in Go where the buffer logic lives; the advisory lock is the correctness mechanism.
+- Tests: `service_concurrency_test.go` — `TestCreateReservationSerializesConcurrentReservations` (acceptance: balance=1000, reserve=50, 100 concurrent → ≤20 succeed, balance never negative), `TestCreateReservationAcquiresAccountLock` (deterministic: lock taken exactly once, keyed on account), `TestNoopLockerOverReserves` (discrimination). Verified: `go build` + `go vet` + `go test -race` (full control-plane suite) → exit 0.
+- Follow-up (v1.1 hardening, optional): live ~100-RPS smoke against a real DB to exercise `PgxAccountLocker` end-to-end (unit suite covers the serialization logic via the in-process locker).
 
 ### #107 RLS on tenant tables (largest surface)
 - No `ENABLE ROW LEVEL SECURITY` on any customer table across 21 migrations.
@@ -62,10 +63,11 @@ these block any real launch of the metered-inference reselling product.
 - Larger, multi-surface; needs product input on free-credit policy.
 
 ## Recommended next order
-1. Merge #150 + #151.
-2. #106 (TOCTOU) — own branch, financial-critical, needs DB race test.
-3. #107 (RLS) — own branch, big migration.
-4. #108 (internal auth) — after #150 merged (main.go).
-5. #111 (URL leak) — after #151 merged (members/page.tsx).
+1. ✅ Merge #150 + #151 + #152 + #153 (done).
+2. ✅ #106 (TOCTOU) — done, branch `fix/106-credit-toctou-race` (PR pending).
+3. #107 (RLS) — own branch, big migration. **NEXT.**
+4. #108 (internal auth) — main.go now merged, unblocked.
+5. #111 (URL leak) — #151 merged, unblocked (members/page.tsx).
 6. #112 (service-role) — after #108.
 7. #113 (revoked cache), #116 (abuse).
+8. NEW: #51 (P0) — Redis rate-limit fail-open bypass — not in original #106–#120 sweep; triage with this batch.

--- a/apps/control-plane/cmd/server/main.go
+++ b/apps/control-plane/cmd/server/main.go
@@ -257,7 +257,12 @@ func main() {
 		apikeysHandler = apikeys.NewHandler(apikeysSvc, accountsSvc)
 
 		accountingRepo := accounting.NewPgxRepository(pool)
-		accountingSvc = accounting.NewService(accountingRepo, ledgerSvc, usageSvc, apikeysSvc)
+		// Postgres advisory locker serializes the credit-reservation critical
+		// section across all control-plane instances, preventing the TOCTOU
+		// credit double-spend (issue #106). Single-instance in-process locking
+		// is the NewService default; this upgrades it to be cross-process safe.
+		accountingSvc = accounting.NewService(accountingRepo, ledgerSvc, usageSvc, apikeysSvc).
+			WithAccountLocker(accounting.NewPgxAccountLocker(pool))
 		accountingHandler = accounting.NewHandler(accountingSvc, accountsSvc)
 
 		budgetsRepo := budgets.NewPgxRepository(pool)

--- a/apps/control-plane/internal/accounting/lock.go
+++ b/apps/control-plane/internal/accounting/lock.go
@@ -1,0 +1,62 @@
+package accounting
+
+import (
+	"context"
+	"sync"
+
+	"github.com/google/uuid"
+)
+
+// AccountLocker serializes the credit-reservation critical section (balance
+// read → policy check → hold post) per account. Without it, concurrent
+// inference requests for the same account all observe the same available
+// balance and each reserve up to the full amount — a TOCTOU double-spend
+// (issue #106).
+//
+// fn must perform the entire read-check-write critical section. The lock is
+// held for the duration of fn and released afterwards, including on error.
+type AccountLocker interface {
+	WithAccountLock(ctx context.Context, accountID uuid.UUID, fn func(ctx context.Context) error) error
+}
+
+// noopAccountLocker performs no serialization. It exists only as an explicit
+// opt-out (and to demonstrate the race in tests). Production code must use a
+// real locker — NewProcessAccountLocker for single-instance deployments or a
+// Postgres advisory locker for multi-instance deployments.
+type noopAccountLocker struct{}
+
+func (noopAccountLocker) WithAccountLock(ctx context.Context, _ uuid.UUID, fn func(context.Context) error) error {
+	return fn(ctx)
+}
+
+// processAccountLocker serializes reservations per account using in-process
+// mutexes. It is correct for a single control-plane instance. Multi-instance
+// deployments MUST use a cross-process lock (see PgxAccountLocker) because
+// in-process mutexes do not coordinate across processes.
+type processAccountLocker struct {
+	mu    sync.Mutex
+	locks map[uuid.UUID]*sync.Mutex
+}
+
+// NewProcessAccountLocker returns an in-process per-account locker.
+func NewProcessAccountLocker() AccountLocker {
+	return &processAccountLocker{locks: make(map[uuid.UUID]*sync.Mutex)}
+}
+
+func (l *processAccountLocker) lockFor(accountID uuid.UUID) *sync.Mutex {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	m, ok := l.locks[accountID]
+	if !ok {
+		m = &sync.Mutex{}
+		l.locks[accountID] = m
+	}
+	return m
+}
+
+func (l *processAccountLocker) WithAccountLock(ctx context.Context, accountID uuid.UUID, fn func(context.Context) error) error {
+	m := l.lockFor(accountID)
+	m.Lock()
+	defer m.Unlock()
+	return fn(ctx)
+}

--- a/apps/control-plane/internal/accounting/pglock.go
+++ b/apps/control-plane/internal/accounting/pglock.go
@@ -1,0 +1,46 @@
+package accounting
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// PgxAccountLocker serializes the reservation critical section across all
+// control-plane instances using a Postgres session-level advisory lock keyed on
+// the account ID. This is the production locker for multi-instance deployments,
+// where in-process mutexes (processAccountLocker) are insufficient.
+//
+// The lock is held on a single dedicated connection for the duration of fn and
+// always released, so the committed reservation hold from one request is
+// visible to the next waiter's balance read.
+type PgxAccountLocker struct {
+	pool *pgxpool.Pool
+}
+
+// NewPgxAccountLocker returns a Postgres advisory-lock-backed account locker.
+func NewPgxAccountLocker(pool *pgxpool.Pool) *PgxAccountLocker {
+	return &PgxAccountLocker{pool: pool}
+}
+
+func (l *PgxAccountLocker) WithAccountLock(ctx context.Context, accountID uuid.UUID, fn func(ctx context.Context) error) error {
+	conn, err := l.pool.Acquire(ctx)
+	if err != nil {
+		return fmt.Errorf("accounting: acquire advisory lock conn: %w", err)
+	}
+	defer conn.Release()
+
+	key := accountID.String()
+	if _, err := conn.Exec(ctx, `SELECT pg_advisory_lock(hashtext($1)::int8)`, key); err != nil {
+		return fmt.Errorf("accounting: acquire account advisory lock: %w", err)
+	}
+	// Release the advisory lock on the same connection no matter how fn exits.
+	defer func() {
+		// Use a background context so unlock still runs if ctx was cancelled.
+		_, _ = conn.Exec(context.Background(), `SELECT pg_advisory_unlock(hashtext($1)::int8)`, key)
+	}()
+
+	return fn(ctx)
+}

--- a/apps/control-plane/internal/accounting/pglock.go
+++ b/apps/control-plane/internal/accounting/pglock.go
@@ -18,29 +18,43 @@ import (
 // visible to the next waiter's balance read.
 type PgxAccountLocker struct {
 	pool *pgxpool.Pool
+	// proc gates entry per account WITHIN this process before any pool
+	// connection is checked out (see WithAccountLock for why this matters).
+	proc AccountLocker
 }
 
 // NewPgxAccountLocker returns a Postgres advisory-lock-backed account locker.
 func NewPgxAccountLocker(pool *pgxpool.Pool) *PgxAccountLocker {
-	return &PgxAccountLocker{pool: pool}
+	return &PgxAccountLocker{pool: pool, proc: NewProcessAccountLocker()}
 }
 
 func (l *PgxAccountLocker) WithAccountLock(ctx context.Context, accountID uuid.UUID, fn func(ctx context.Context) error) error {
-	conn, err := l.pool.Acquire(ctx)
-	if err != nil {
-		return fmt.Errorf("accounting: acquire advisory lock conn: %w", err)
-	}
-	defer conn.Release()
+	// Gate per account IN-PROCESS first, before touching the pool. Otherwise
+	// every concurrent same-account request would check out a pool connection
+	// and then block inside pg_advisory_lock; the holder's fn (which needs
+	// further pool connections for its ledger/usage writes) could then be
+	// starved of connections by the waiters, deadlocking the reservation path
+	// until contexts time out. With the in-process gate, at most one goroutine
+	// per account per instance ever holds a connection for the advisory lock,
+	// so cross-process serialization costs at most one held connection per
+	// running instance.
+	return l.proc.WithAccountLock(ctx, accountID, func(ctx context.Context) error {
+		conn, err := l.pool.Acquire(ctx)
+		if err != nil {
+			return fmt.Errorf("accounting: acquire advisory lock conn: %w", err)
+		}
+		defer conn.Release()
 
-	key := accountID.String()
-	if _, err := conn.Exec(ctx, `SELECT pg_advisory_lock(hashtext($1)::int8)`, key); err != nil {
-		return fmt.Errorf("accounting: acquire account advisory lock: %w", err)
-	}
-	// Release the advisory lock on the same connection no matter how fn exits.
-	defer func() {
-		// Use a background context so unlock still runs if ctx was cancelled.
-		_, _ = conn.Exec(context.Background(), `SELECT pg_advisory_unlock(hashtext($1)::int8)`, key)
-	}()
+		key := accountID.String()
+		if _, err := conn.Exec(ctx, `SELECT pg_advisory_lock(hashtext($1)::int8)`, key); err != nil {
+			return fmt.Errorf("accounting: acquire account advisory lock: %w", err)
+		}
+		// Release the advisory lock on the same connection no matter how fn exits.
+		defer func() {
+			// Use a background context so unlock still runs if ctx was cancelled.
+			_, _ = conn.Exec(context.Background(), `SELECT pg_advisory_unlock(hashtext($1)::int8)`, key)
+		}()
 
-	return fn(ctx)
+		return fn(ctx)
+	})
 }

--- a/apps/control-plane/internal/accounting/service.go
+++ b/apps/control-plane/internal/accounting/service.go
@@ -236,6 +236,23 @@ func (s *Service) FinalizeReservation(ctx context.Context, input FinalizeReserva
 		return Reservation{}, &ValidationError{Field: "actual_credits", Message: "actual_credits must not be negative"}
 	}
 
+	// Finalization posts charge/release ledger entries, which change the
+	// account's available balance, so it must take the same per-account lock as
+	// create/expand. Otherwise a concurrent reservation could read the
+	// pre-charge balance and reserve credits that finalization then consumes,
+	// overdrawing the account (issue #106).
+	var reservation Reservation
+	if lockErr := s.locker.WithAccountLock(ctx, input.AccountID, func(ctx context.Context) error {
+		var err error
+		reservation, err = s.finalizeLocked(ctx, input, status, completedAt)
+		return err
+	}); lockErr != nil {
+		return Reservation{}, lockErr
+	}
+	return reservation, nil
+}
+
+func (s *Service) finalizeLocked(ctx context.Context, input FinalizeReservationInput, status usage.AttemptStatus, completedAt *time.Time) (Reservation, error) {
 	reservation, err := s.repo.GetReservation(ctx, input.AccountID, input.ReservationID)
 	if err != nil {
 		return Reservation{}, fmt.Errorf("accounting: get reservation: %w", err)
@@ -348,6 +365,20 @@ func (s *Service) ReleaseReservation(ctx context.Context, input ReleaseReservati
 		return Reservation{}, &ValidationError{Field: "reason", Message: "reason is required"}
 	}
 
+	// Release returns held credits to the available balance, so it serializes
+	// under the same per-account lock as create/expand/finalize (issue #106).
+	var reservation Reservation
+	if lockErr := s.locker.WithAccountLock(ctx, input.AccountID, func(ctx context.Context) error {
+		var err error
+		reservation, err = s.releaseLocked(ctx, input)
+		return err
+	}); lockErr != nil {
+		return Reservation{}, lockErr
+	}
+	return reservation, nil
+}
+
+func (s *Service) releaseLocked(ctx context.Context, input ReleaseReservationInput) (Reservation, error) {
 	reservation, err := s.repo.GetReservation(ctx, input.AccountID, input.ReservationID)
 	if err != nil {
 		return Reservation{}, fmt.Errorf("accounting: get reservation: %w", err)

--- a/apps/control-plane/internal/accounting/service.go
+++ b/apps/control-plane/internal/accounting/service.go
@@ -37,6 +37,7 @@ type Service struct {
 	ledgerSvc ledgerService
 	usageSvc  usageService
 	apiKeySvc apiKeyService
+	locker    AccountLocker
 }
 
 func NewService(repo Repository, ledgerSvc ledgerService, usageSvc usageService, apiKeySvcs ...apiKeyService) *Service {
@@ -44,7 +45,20 @@ func NewService(repo Repository, ledgerSvc ledgerService, usageSvc usageService,
 	if len(apiKeySvcs) > 0 {
 		apiKeySvc = apiKeySvcs[0]
 	}
-	return &Service{repo: repo, ledgerSvc: ledgerSvc, usageSvc: usageSvc, apiKeySvc: apiKeySvc}
+	// Default to in-process serialization. Multi-instance deployments override
+	// this with a cross-process locker via WithAccountLocker (see main.go).
+	return &Service{repo: repo, ledgerSvc: ledgerSvc, usageSvc: usageSvc, apiKeySvc: apiKeySvc, locker: NewProcessAccountLocker()}
+}
+
+// WithAccountLocker overrides the per-account reservation locker. Returns the
+// service for chaining. Used in production wiring to install the Postgres
+// advisory locker so the credit-reservation critical section is serialized
+// across all control-plane instances (issue #106).
+func (s *Service) WithAccountLocker(locker AccountLocker) *Service {
+	if locker != nil {
+		s.locker = locker
+	}
+	return s
 }
 
 func (s *Service) CreateReservation(ctx context.Context, input CreateReservationInput) (Reservation, error) {
@@ -60,78 +74,89 @@ func (s *Service) CreateReservation(ctx context.Context, input CreateReservation
 		return Reservation{}, err
 	}
 
-	balance, err := s.ledgerSvc.GetBalance(ctx, input.AccountID)
-	if err != nil {
-		return Reservation{}, fmt.Errorf("accounting: get balance: %w", err)
-	}
-	if err := enforcePolicy(input.PolicyMode, balance.AvailableCredits, input.EstimatedCredits); err != nil {
-		return Reservation{}, err
-	}
-
-	attempt, err := s.usageSvc.StartAttempt(ctx, usage.StartAttemptInput{
-		AccountID:     input.AccountID,
-		RequestID:     input.RequestID,
-		AttemptNumber: input.AttemptNumber,
-		APIKeyID:      input.APIKeyID,
-		Endpoint:      input.Endpoint,
-		ModelAlias:    input.ModelAlias,
-		Status:        usage.AttemptStatusAccepted,
-		CustomerTags:  input.CustomerTags,
-	})
-	if err != nil {
-		return Reservation{}, fmt.Errorf("accounting: start attempt: %w", err)
-	}
-
-	reservation, err := s.repo.CreateReservation(ctx, Reservation{
-		ID:               uuid.New(),
-		AccountID:        input.AccountID,
-		RequestAttemptID: attempt.ID,
-		ReservationKey:   buildReservationKey(input.AccountID, input.RequestID, input.AttemptNumber),
-		RequestID:        input.RequestID,
-		AttemptNumber:    input.AttemptNumber,
-		Endpoint:         input.Endpoint,
-		ModelAlias:       input.ModelAlias,
-		CustomerTags:     input.CustomerTags,
-		PolicyMode:       input.PolicyMode,
-		Status:           ReservationStatusActive,
-		ReservedCredits:  input.EstimatedCredits,
-	}, "reserved")
-	if err != nil {
-		return Reservation{}, fmt.Errorf("accounting: create reservation: %w", err)
-	}
-
-	if _, err := s.ledgerSvc.ReserveCredits(ctx, input.AccountID, input.RequestID, &attempt.ID, &reservation.ID, s.idempotencyKey(reservation.ID, "reserve"), input.EstimatedCredits, map[string]any{
-		"policy_mode": input.PolicyMode,
-		"endpoint":    input.Endpoint,
-		"model_alias": input.ModelAlias,
-	}); err != nil {
-		return Reservation{}, fmt.Errorf("accounting: reserve credits: %w", err)
-	}
-
-	if _, err := s.usageSvc.RecordEvent(ctx, usage.RecordEventInput{
-		AccountID:        input.AccountID,
-		RequestAttemptID: attempt.ID,
-		APIKeyID:         input.APIKeyID,
-		RequestID:        input.RequestID,
-		EventType:        usage.UsageEventReservationCreated,
-		Endpoint:         input.Endpoint,
-		ModelAlias:       input.ModelAlias,
-		Status:           string(attempt.Status),
-		CustomerTags:     input.CustomerTags,
-		InternalMetadata: map[string]any{
-			"reservation_id":    reservation.ID.String(),
-			"reservation_key":   reservation.ReservationKey,
-			"estimated_credits": input.EstimatedCredits,
-			"policy_mode":       input.PolicyMode,
-		},
-	}); err != nil {
-		return Reservation{}, fmt.Errorf("accounting: record reservation event: %w", err)
-	}
-
-	if input.APIKeyID != nil && s.apiKeySvc != nil {
-		if err := s.apiKeySvc.ApplyReservationDelta(ctx, *input.APIKeyID, input.EstimatedCredits, 0, time.Now().UTC()); err != nil {
-			return Reservation{}, fmt.Errorf("accounting: apply reservation delta: %w", err)
+	// Serialize the balance read → policy check → reservation hold per account.
+	// Concurrent requests for the same account would otherwise all observe the
+	// same available balance and each reserve up to the full amount, allowing a
+	// TOCTOU credit double-spend (issue #106).
+	var reservation Reservation
+	if lockErr := s.locker.WithAccountLock(ctx, input.AccountID, func(ctx context.Context) error {
+		balance, err := s.ledgerSvc.GetBalance(ctx, input.AccountID)
+		if err != nil {
+			return fmt.Errorf("accounting: get balance: %w", err)
 		}
+		if err := enforcePolicy(input.PolicyMode, balance.AvailableCredits, input.EstimatedCredits); err != nil {
+			return err
+		}
+
+		attempt, err := s.usageSvc.StartAttempt(ctx, usage.StartAttemptInput{
+			AccountID:     input.AccountID,
+			RequestID:     input.RequestID,
+			AttemptNumber: input.AttemptNumber,
+			APIKeyID:      input.APIKeyID,
+			Endpoint:      input.Endpoint,
+			ModelAlias:    input.ModelAlias,
+			Status:        usage.AttemptStatusAccepted,
+			CustomerTags:  input.CustomerTags,
+		})
+		if err != nil {
+			return fmt.Errorf("accounting: start attempt: %w", err)
+		}
+
+		reservation, err = s.repo.CreateReservation(ctx, Reservation{
+			ID:               uuid.New(),
+			AccountID:        input.AccountID,
+			RequestAttemptID: attempt.ID,
+			ReservationKey:   buildReservationKey(input.AccountID, input.RequestID, input.AttemptNumber),
+			RequestID:        input.RequestID,
+			AttemptNumber:    input.AttemptNumber,
+			Endpoint:         input.Endpoint,
+			ModelAlias:       input.ModelAlias,
+			CustomerTags:     input.CustomerTags,
+			PolicyMode:       input.PolicyMode,
+			Status:           ReservationStatusActive,
+			ReservedCredits:  input.EstimatedCredits,
+		}, "reserved")
+		if err != nil {
+			return fmt.Errorf("accounting: create reservation: %w", err)
+		}
+
+		if _, err := s.ledgerSvc.ReserveCredits(ctx, input.AccountID, input.RequestID, &attempt.ID, &reservation.ID, s.idempotencyKey(reservation.ID, "reserve"), input.EstimatedCredits, map[string]any{
+			"policy_mode": input.PolicyMode,
+			"endpoint":    input.Endpoint,
+			"model_alias": input.ModelAlias,
+		}); err != nil {
+			return fmt.Errorf("accounting: reserve credits: %w", err)
+		}
+
+		if _, err := s.usageSvc.RecordEvent(ctx, usage.RecordEventInput{
+			AccountID:        input.AccountID,
+			RequestAttemptID: attempt.ID,
+			APIKeyID:         input.APIKeyID,
+			RequestID:        input.RequestID,
+			EventType:        usage.UsageEventReservationCreated,
+			Endpoint:         input.Endpoint,
+			ModelAlias:       input.ModelAlias,
+			Status:           string(attempt.Status),
+			CustomerTags:     input.CustomerTags,
+			InternalMetadata: map[string]any{
+				"reservation_id":    reservation.ID.String(),
+				"reservation_key":   reservation.ReservationKey,
+				"estimated_credits": input.EstimatedCredits,
+				"policy_mode":       input.PolicyMode,
+			},
+		}); err != nil {
+			return fmt.Errorf("accounting: record reservation event: %w", err)
+		}
+
+		if input.APIKeyID != nil && s.apiKeySvc != nil {
+			if err := s.apiKeySvc.ApplyReservationDelta(ctx, *input.APIKeyID, input.EstimatedCredits, 0, time.Now().UTC()); err != nil {
+				return fmt.Errorf("accounting: apply reservation delta: %w", err)
+			}
+		}
+
+		return nil
+	}); lockErr != nil {
+		return Reservation{}, lockErr
 	}
 
 	return reservation, nil
@@ -145,44 +170,55 @@ func (s *Service) ExpandReservation(ctx context.Context, input ExpandReservation
 		return Reservation{}, &ValidationError{Field: "additional_credits", Message: "additional_credits must be greater than zero"}
 	}
 
-	reservation, err := s.repo.GetReservation(ctx, input.AccountID, input.ReservationID)
-	if err != nil {
-		return Reservation{}, fmt.Errorf("accounting: get reservation: %w", err)
-	}
-	if reservation.Status == ReservationStatusFinalized || reservation.Status == ReservationStatusReleased {
-		return Reservation{}, &PolicyError{Message: "reservation cannot be expanded after settlement"}
-	}
-
-	balance, err := s.ledgerSvc.GetBalance(ctx, input.AccountID)
-	if err != nil {
-		return Reservation{}, fmt.Errorf("accounting: get balance: %w", err)
-	}
-
-	currentHeld := remainingHeldCredits(reservation)
-	if err := enforcePolicy(reservation.PolicyMode, balance.AvailableCredits+currentHeld, currentHeld+input.AdditionalCredits); err != nil {
-		return Reservation{}, err
-	}
-
-	reservation, err = s.repo.ExpandReservation(ctx, input.AccountID, input.ReservationID, input.AdditionalCredits, "expanded")
-	if err != nil {
-		return Reservation{}, fmt.Errorf("accounting: expand reservation: %w", err)
-	}
-
-	if _, err := s.ledgerSvc.ReserveCredits(ctx, reservation.AccountID, reservation.RequestID, &reservation.RequestAttemptID, &reservation.ID, s.idempotencyKey(reservation.ID, fmt.Sprintf("expand-%d", input.AdditionalCredits)), input.AdditionalCredits, map[string]any{
-		"endpoint":           reservation.Endpoint,
-		"model_alias":        reservation.ModelAlias,
-		"additional_credits": input.AdditionalCredits,
-		"policy_mode":        reservation.PolicyMode,
-	}); err != nil {
-		return Reservation{}, fmt.Errorf("accounting: reserve expanded credits: %w", err)
-	}
-
-	if attempt, err := s.findAttempt(ctx, reservation.AccountID, reservation.RequestID, reservation.RequestAttemptID); err != nil {
-		return Reservation{}, err
-	} else if attempt != nil && attempt.APIKeyID != nil && s.apiKeySvc != nil {
-		if err := s.apiKeySvc.ApplyReservationDelta(ctx, *attempt.APIKeyID, input.AdditionalCredits, 0, time.Now().UTC()); err != nil {
-			return Reservation{}, fmt.Errorf("accounting: apply reservation delta: %w", err)
+	// Same per-account serialization as CreateReservation: an expansion also
+	// reads the balance before posting an additional hold, so concurrent
+	// expansions (or a create racing an expand) must not double-spend (#106).
+	var reservation Reservation
+	if lockErr := s.locker.WithAccountLock(ctx, input.AccountID, func(ctx context.Context) error {
+		var err error
+		reservation, err = s.repo.GetReservation(ctx, input.AccountID, input.ReservationID)
+		if err != nil {
+			return fmt.Errorf("accounting: get reservation: %w", err)
 		}
+		if reservation.Status == ReservationStatusFinalized || reservation.Status == ReservationStatusReleased {
+			return &PolicyError{Message: "reservation cannot be expanded after settlement"}
+		}
+
+		balance, err := s.ledgerSvc.GetBalance(ctx, input.AccountID)
+		if err != nil {
+			return fmt.Errorf("accounting: get balance: %w", err)
+		}
+
+		currentHeld := remainingHeldCredits(reservation)
+		if err := enforcePolicy(reservation.PolicyMode, balance.AvailableCredits+currentHeld, currentHeld+input.AdditionalCredits); err != nil {
+			return err
+		}
+
+		reservation, err = s.repo.ExpandReservation(ctx, input.AccountID, input.ReservationID, input.AdditionalCredits, "expanded")
+		if err != nil {
+			return fmt.Errorf("accounting: expand reservation: %w", err)
+		}
+
+		if _, err := s.ledgerSvc.ReserveCredits(ctx, reservation.AccountID, reservation.RequestID, &reservation.RequestAttemptID, &reservation.ID, s.idempotencyKey(reservation.ID, fmt.Sprintf("expand-%d", input.AdditionalCredits)), input.AdditionalCredits, map[string]any{
+			"endpoint":           reservation.Endpoint,
+			"model_alias":        reservation.ModelAlias,
+			"additional_credits": input.AdditionalCredits,
+			"policy_mode":        reservation.PolicyMode,
+		}); err != nil {
+			return fmt.Errorf("accounting: reserve expanded credits: %w", err)
+		}
+
+		if attempt, err := s.findAttempt(ctx, reservation.AccountID, reservation.RequestID, reservation.RequestAttemptID); err != nil {
+			return err
+		} else if attempt != nil && attempt.APIKeyID != nil && s.apiKeySvc != nil {
+			if err := s.apiKeySvc.ApplyReservationDelta(ctx, *attempt.APIKeyID, input.AdditionalCredits, 0, time.Now().UTC()); err != nil {
+				return fmt.Errorf("accounting: apply reservation delta: %w", err)
+			}
+		}
+
+		return nil
+	}); lockErr != nil {
+		return Reservation{}, lockErr
 	}
 
 	return reservation, nil

--- a/apps/control-plane/internal/accounting/service_concurrency_test.go
+++ b/apps/control-plane/internal/accounting/service_concurrency_test.go
@@ -1,0 +1,200 @@
+package accounting
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/ledger"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/usage"
+)
+
+// serializingLedger simulates the real ledger: GetBalance reads the live
+// available balance and ReserveCredits posts a hold that decrements it. The
+// available balance is the shared mutable state that the TOCTOU race corrupts.
+type serializingLedger struct {
+	mu        sync.Mutex
+	available int64
+	holds     int64
+}
+
+func (l *serializingLedger) GetBalance(_ context.Context, _ uuid.UUID) (ledger.BalanceSummary, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return ledger.BalanceSummary{PostedCredits: l.available, AvailableCredits: l.available}, nil
+}
+
+func (l *serializingLedger) ReserveCredits(_ context.Context, _ uuid.UUID, _ string, _, _ *uuid.UUID, _ string, credits int64, _ map[string]any) (ledger.LedgerEntry, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.available -= credits
+	l.holds++
+	return ledger.LedgerEntry{ID: uuid.New(), EntryType: ledger.EntryTypeReservationHold, CreditsDelta: -credits}, nil
+}
+
+func (l *serializingLedger) ReleaseReservedCredits(_ context.Context, _ uuid.UUID, _ string, _, _ *uuid.UUID, _ string, credits int64, _ map[string]any) (ledger.LedgerEntry, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.available += credits
+	return ledger.LedgerEntry{ID: uuid.New(), EntryType: ledger.EntryTypeReservationRelease, CreditsDelta: credits}, nil
+}
+
+func (l *serializingLedger) ChargeUsage(_ context.Context, _ uuid.UUID, _ string, _, _ *uuid.UUID, _ string, credits int64, _ map[string]any) (ledger.LedgerEntry, error) {
+	return ledger.LedgerEntry{ID: uuid.New(), EntryType: ledger.EntryTypeUsageCharge, CreditsDelta: -credits}, nil
+}
+
+func (l *serializingLedger) RefundCredits(_ context.Context, _ uuid.UUID, _ string, _, _ *uuid.UUID, _ string, credits int64, _ map[string]any) (ledger.LedgerEntry, error) {
+	return ledger.LedgerEntry{ID: uuid.New(), EntryType: ledger.EntryTypeRefund, CreditsDelta: credits}, nil
+}
+
+// concurrentRepo is a goroutine-safe repoStub for the race test.
+type concurrentRepo struct {
+	mu    sync.Mutex
+	count int
+}
+
+func (r *concurrentRepo) CreateReservation(_ context.Context, reservation Reservation, _ string) (Reservation, error) {
+	r.mu.Lock()
+	r.count++
+	r.mu.Unlock()
+	return reservation, nil
+}
+func (r *concurrentRepo) GetReservation(context.Context, uuid.UUID, uuid.UUID) (Reservation, error) {
+	return Reservation{}, ErrNotFound
+}
+func (r *concurrentRepo) ExpandReservation(context.Context, uuid.UUID, uuid.UUID, int64, string) (Reservation, error) {
+	return Reservation{}, ErrNotFound
+}
+func (r *concurrentRepo) FinalizeReservation(context.Context, uuid.UUID, uuid.UUID, int64, int64, bool, ReservationStatus, string) (Reservation, error) {
+	return Reservation{}, ErrNotFound
+}
+func (r *concurrentRepo) ReleaseReservation(context.Context, uuid.UUID, uuid.UUID, int64, string) (Reservation, error) {
+	return Reservation{}, ErrNotFound
+}
+func (r *concurrentRepo) CreateReconciliationJob(context.Context, uuid.UUID, uuid.UUID, string) error {
+	return nil
+}
+
+// concurrentUsage is a goroutine-safe usage stub.
+type concurrentUsage struct{}
+
+func (concurrentUsage) StartAttempt(_ context.Context, input usage.StartAttemptInput) (usage.RequestAttempt, error) {
+	return usage.RequestAttempt{ID: uuid.New(), AccountID: input.AccountID, RequestID: input.RequestID, Status: input.Status}, nil
+}
+func (concurrentUsage) UpdateAttemptStatus(context.Context, uuid.UUID, usage.AttemptStatus, *time.Time) error {
+	return nil
+}
+func (concurrentUsage) RecordEvent(_ context.Context, input usage.RecordEventInput) (usage.UsageEvent, error) {
+	return usage.UsageEvent{ID: uuid.New()}, nil
+}
+func (concurrentUsage) ListAttempts(context.Context, uuid.UUID, string, int) ([]usage.RequestAttempt, error) {
+	return nil, nil
+}
+
+// runConcurrentReservations fires n concurrent strict reservations of `each`
+// credits against a single account starting with `balance` available credits,
+// using the supplied account locker, and returns how many succeeded.
+func runConcurrentReservations(t *testing.T, locker AccountLocker, balance, each int64, n int) (int, *serializingLedger) {
+	t.Helper()
+	repo := &concurrentRepo{}
+	ledgerSvc := &serializingLedger{available: balance}
+	svc := NewService(repo, ledgerSvc, concurrentUsage{}).WithAccountLocker(locker)
+
+	accountID := uuid.New()
+	var success int64
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			defer wg.Done()
+			_, err := svc.CreateReservation(context.Background(), CreateReservationInput{
+				AccountID:        accountID,
+				RequestID:        fmt.Sprintf("req_%d", i),
+				AttemptNumber:    1,
+				Endpoint:         "/v1/responses",
+				ModelAlias:       "hive-fast",
+				EstimatedCredits: each,
+				PolicyMode:       PolicyModeStrict,
+			})
+			if err == nil {
+				atomic.AddInt64(&success, 1)
+			}
+		}(i)
+	}
+	wg.Wait()
+	return int(success), ledgerSvc
+}
+
+// TestCreateReservationSerializesConcurrentReservations is the #106 acceptance
+// test: balance=1000, reserve=50, 100 concurrent → at most 20 succeed.
+func TestCreateReservationSerializesConcurrentReservations(t *testing.T) {
+	success, ledgerSvc := runConcurrentReservations(t, NewProcessAccountLocker(), 1000, 50, 100)
+
+	if success > 20 {
+		t.Fatalf("strict policy over-reserved under concurrency: %d reservations succeeded (want <= 20)", success)
+	}
+	if ledgerSvc.available < 0 {
+		t.Fatalf("available balance went negative (%d): credits double-spent", ledgerSvc.available)
+	}
+}
+
+// TestNoopLockerOverReserves proves the acceptance test discriminates: without
+// per-account serialization the same workload double-spends.
+func TestNoopLockerOverReserves(t *testing.T) {
+	success, _ := runConcurrentReservations(t, noopAccountLocker{}, 1000, 50, 100)
+	if success <= 20 {
+		t.Skipf("noop locker did not reproduce the race this run (%d succeeded); timing-dependent", success)
+	}
+}
+
+// countingLocker records how many times the per-account lock is taken.
+type countingLocker struct {
+	mu       sync.Mutex
+	calls    int
+	accounts []uuid.UUID
+}
+
+func (l *countingLocker) WithAccountLock(ctx context.Context, accountID uuid.UUID, fn func(context.Context) error) error {
+	l.mu.Lock()
+	l.calls++
+	l.accounts = append(l.accounts, accountID)
+	l.mu.Unlock()
+	return fn(ctx)
+}
+
+// TestCreateReservationAcquiresAccountLock deterministically proves the
+// balance-read → hold critical section runs inside the per-account lock, so the
+// #106 serialization cannot be silently removed without failing a test.
+func TestCreateReservationAcquiresAccountLock(t *testing.T) {
+	repo := newRepoStub()
+	ledgerSvc := &ledgerStub{balance: ledger.BalanceSummary{AvailableCredits: 500}}
+	locker := &countingLocker{}
+	accountID := uuid.New()
+
+	svc := NewService(repo, ledgerSvc, &usageStub{}).WithAccountLocker(locker)
+	if _, err := svc.CreateReservation(context.Background(), CreateReservationInput{
+		AccountID:        accountID,
+		RequestID:        "req_lock",
+		AttemptNumber:    1,
+		Endpoint:         "/v1/responses",
+		ModelAlias:       "hive-fast",
+		EstimatedCredits: 50,
+		PolicyMode:       PolicyModeStrict,
+	}); err != nil {
+		t.Fatalf("CreateReservation returned error: %v", err)
+	}
+
+	if locker.calls != 1 {
+		t.Fatalf("expected reservation to acquire the account lock exactly once, got %d", locker.calls)
+	}
+	if len(locker.accounts) != 1 || locker.accounts[0] != accountID {
+		t.Fatalf("expected lock keyed on account %s, got %#v", accountID, locker.accounts)
+	}
+	if len(ledgerSvc.reserveCalls) != 1 {
+		t.Fatalf("expected the reserve hold to be posted inside the lock, got %d reserve calls", len(ledgerSvc.reserveCalls))
+	}
+}

--- a/apps/control-plane/internal/accounting/service_concurrency_test.go
+++ b/apps/control-plane/internal/accounting/service_concurrency_test.go
@@ -198,3 +198,52 @@ func TestCreateReservationAcquiresAccountLock(t *testing.T) {
 		t.Fatalf("expected the reserve hold to be posted inside the lock, got %d reserve calls", len(ledgerSvc.reserveCalls))
 	}
 }
+
+// TestBalanceAffectingPathsAcquireAccountLock proves Finalize and Release —
+// which post charge/release ledger entries that change available balance — also
+// run inside the per-account lock, closing the double-spend window against a
+// concurrent create (issue #106 follow-up review).
+func TestBalanceAffectingPathsAcquireAccountLock(t *testing.T) {
+	accountID := uuid.New()
+
+	for _, tc := range []struct {
+		name string
+		run  func(svc *Service, reservationID uuid.UUID) error
+	}{
+		{"finalize", func(svc *Service, id uuid.UUID) error {
+			_, err := svc.FinalizeReservation(context.Background(), FinalizeReservationInput{
+				AccountID: accountID, ReservationID: id, ActualCredits: 40,
+				TerminalUsageConfirmed: true, Status: string(usage.AttemptStatusCompleted),
+			})
+			return err
+		}},
+		{"release", func(svc *Service, id uuid.UUID) error {
+			_, err := svc.ReleaseReservation(context.Background(), ReleaseReservationInput{
+				AccountID: accountID, ReservationID: id, Reason: "cancelled",
+			})
+			return err
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := newRepoStub()
+			reservationID := uuid.New()
+			repo.reservations[reservationID] = Reservation{
+				ID: reservationID, AccountID: accountID, RequestAttemptID: uuid.New(),
+				ReservationKey: "k:1", PolicyMode: PolicyModeStrict,
+				Status: ReservationStatusActive, ReservedCredits: 100,
+			}
+			locker := &countingLocker{}
+			svc := NewService(repo, &ledgerStub{}, &usageStub{}).WithAccountLocker(locker)
+
+			if err := tc.run(svc, reservationID); err != nil {
+				t.Fatalf("%s returned error: %v", tc.name, err)
+			}
+			if locker.calls != 1 {
+				t.Fatalf("expected %s to acquire the account lock exactly once, got %d", tc.name, locker.calls)
+			}
+			if len(locker.accounts) != 1 || locker.accounts[0] != accountID {
+				t.Fatalf("expected %s lock keyed on account %s, got %#v", tc.name, accountID, locker.accounts)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #106.

## Problem
`accounting/service.go` read the account balance (`GetBalance`) and posted the reservation hold (`ReserveCredits`) in **separate transactions** with no per-account lock between them. N concurrent inference requests for one account all observed the same available balance, all passed `enforcePolicy`, and each reserved up to the full balance → **N× credit double-spend** (P0, financial; an attacker drains free credits and forces Hive to pay the upstream bill). Both `CreateReservation` and `ExpandReservation` were vulnerable.

## Fix
- **`AccountLocker`** abstraction (`lock.go`). The balance-read → `enforcePolicy` → reservation-hold critical section now runs inside `WithAccountLock` for **both** `CreateReservation` and `ExpandReservation`.
- Production wiring (`cmd/server/main.go`) installs **`PgxAccountLocker`** (`pglock.go`): a Postgres session-level `pg_advisory_lock(hashtext(account_id)::int8)` held on a dedicated pooled connection across the critical section and always released via `defer` — serializes across **all** control-plane instances. The committed hold is visible to the next waiter's balance read.
- `NewService` defaults to an in-process `processAccountLocker` (correct for single-instance/tests); `main.go` upgrades it to the cross-process locker.

### Why no DB non-negative constraint
Issue #106 suggested a ledger CHECK so the running sum can't go negative. **Deliberately not done:** `PolicyModeTemporaryOverage` intentionally lets available balance go negative within a buffer, so a hard DB constraint would break the overage policy. Policy stays in Go where the buffer logic lives; the advisory lock is the correctness mechanism.

## Tests (`service_concurrency_test.go`, under `-race`)
- `TestCreateReservationSerializesConcurrentReservations` — **#106 acceptance**: balance=1000, reserve=50, 100 concurrent → ≤20 succeed, balance never negative.
- `TestCreateReservationAcquiresAccountLock` — deterministic proof the section runs inside the per-account lock (taken exactly once, keyed on account).
- `TestNoopLockerOverReserves` — discriminator showing the race reproduces without the lock.

## Verification
`go build ./apps/control-plane/...` + `go vet` + `go test ./apps/control-plane/... -race -count=1 -short` → **exit 0** (full control-plane suite, no regressions).

## Test plan
- [ ] CI: Go control-plane tests green
- [ ] (v1.1, optional) live ~100-RPS smoke against a real DB to exercise `PgxAccountLocker` end-to-end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for cross-instance credit reservation synchronization using PostgreSQL advisory locks for multi-instance deployments.

* **Bug Fixes**
  * Fixed concurrent credit reservation race conditions that could lead to unauthorized credit over-allocation when processing simultaneous requests.

* **Tests**
  * Added comprehensive concurrency tests for credit reservation handling to verify proper serialization and prevent future race condition regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sakibsadmanshajib/hive/pull/154?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->