### PR TITLE
fix(security): proxy member invites server-side, stop CONTROL_PLANE_BASE_URL HTML leak (#111)

### DIFF
--- a/.planning/SECURITY-P0-BACKLOG.md
+++ b/.planning/SECURITY-P0-BACKLOG.md
@@ -18,7 +18,7 @@ these block any real launch of the metered-inference reselling product.
 | #106 | Credit reservation TOCTOU double-spend | ✅ merged | PR #154 |
 | #107 | No RLS on tenant tables | ✅ PR open | PR #155 — `20260529_01_rls_tenant_tables.sql`; live anon→0 verify at deploy |
 | #108 | /internal/* control-plane endpoints unauth | ✅ PR open | branch `fix/108-internal-endpoint-auth` — X-Internal-Token shared-secret middleware |
-| #111 | CONTROL_PLANE_BASE_URL leaked into HTML | ⏳ TODO | conflicts w/ #151 members/page — do after #151 merges |
+| #111 | CONTROL_PLANE_BASE_URL leaked into HTML | ✅ FIXED | PR open — server-side Route Handler proxy; form action now relative |
 | #112 | SUPABASE_SERVICE_ROLE_KEY silent failure on edge | ⏳ TODO | cross-service (move admin write to control-plane) |
 | #113 | Auth snapshot 1hr cache lets revoked keys work | ⏳ TODO | see below |
 | #116 | Free-tier abuse (CAPTCHA / IP limit / disposable email) | ⏳ TODO | needs Turnstile infra |
@@ -67,7 +67,7 @@ these block any real launch of the metered-inference reselling product.
 2. ✅ #106 (TOCTOU) — MERGED (PR #154).
 3. ✅ #107 (RLS) — PR #155 open (CI green, threads resolved).
 4. ✅ #108 (internal auth) — PR open (`fix/108-internal-endpoint-auth`).
-5. #111 (URL leak) — #151 merged, unblocked (members/page.tsx). **NEXT.**
-6. #112 (service-role) — after #108.
+5. ✅ #111 (URL leak) — FIXED (server-side Route Handler proxy `app/api/console/members/route.ts`).
+6. #112 (service-role) — after #108 (now merged). **NEXT.**
 7. #113 (revoked cache), #116 (abuse).
 8. NEW: #51 (P0) — Redis rate-limit fail-open bypass — not in original #106–#120 sweep; triage with this batch.

--- a/.planning/SECURITY-P0-BACKLOG.md
+++ b/.planning/SECURITY-P0-BACKLOG.md
@@ -16,8 +16,8 @@ these block any real launch of the metered-inference reselling product.
 | #119 | getSession() server-side auth (3 sites) | ✅ fixed | PR #151 |
 | #120 | Email-verify only in layout, not middleware | ✅ fixed | PR #151 |
 | #106 | Credit reservation TOCTOU double-spend | ✅ merged | PR #154 |
-| #107 | No RLS on tenant tables | ✅ PR open | PR #155 — `20260529_01_rls_tenant_tables.sql`; live anon→0 verify at deploy |
-| #108 | /internal/* control-plane endpoints unauth | ✅ PR open | branch `fix/108-internal-endpoint-auth` — X-Internal-Token shared-secret middleware |
+| #107 | No RLS on tenant tables | ✅ merged | PR #155 — `20260529_01_rls_tenant_tables.sql`; live anon→0 verify at deploy |
+| #108 | /internal/* control-plane endpoints unauth | ✅ merged | PR #156 — X-Internal-Token shared-secret middleware (fails closed) |
 | #111 | CONTROL_PLANE_BASE_URL leaked into HTML | ✅ FIXED | PR open — server-side Route Handler proxy; form action now relative |
 | #112 | SUPABASE_SERVICE_ROLE_KEY silent failure on edge | ⏳ TODO | cross-service (move admin write to control-plane) |
 | #113 | Auth snapshot 1hr cache lets revoked keys work | ⏳ TODO | see below |
@@ -54,9 +54,10 @@ these block any real launch of the metered-inference reselling product.
 - `apps/web-console/app/auth/callback/route.ts:61-78` — guarded admin write silently skips on Workers when binding missing → users stuck unverified.
 - Fix: move admin write to control-plane `POST /internal/users/finalize-signup` (depends on #108 internal-auth being in place); edge only forwards session. Fail loud on control-plane if service-role key absent.
 
-### #111 CONTROL_PLANE_BASE_URL in HTML
-- `apps/web-console/app/console/members/page.tsx:126` — invite `<form action="${CONTROL_PLANE_BASE_URL}/...">` inlines internal URL.
-- Fix: Next.js Route Handler `app/api/console/members/route.ts` proxying server-side (mirrors other mutations). ⚠️ same file as PR #151 — do after #151 merges.
+### #111 CONTROL_PLANE_BASE_URL in HTML — ✅ FIXED (PR #157)
+- Was: `apps/web-console/app/console/members/page.tsx` invite `<form action="${CONTROL_PLANE_BASE_URL}/...">` inlined the internal URL into rendered HTML and POSTed cross-origin without the session bearer.
+- Fixed by server-side Route Handler `app/api/console/members/route.ts` (auth-check → `createInvitation()` helper attaches bearer + base URL server-only → 303 redirect). Form action is now relative `/api/console/members`. Errors map to generic status-class messages (no raw upstream text in URL); redirect resolves against canonical origin (`lib/http/origin.ts`).
+- Follow-up (separate): no invite mailer exists in repo — the acceptance token returned by the control-plane is not yet delivered to invitees. Tracked outside #111 (security scope).
 
 ### #116 free-tier abuse
 - Cloudflare Turnstile on sign-up/sign-in (CLOUDFLARE_API_TOKEN already present), Supabase per-IP signup limit, disposable-domain blocklist, gmail +tag normalization, cap free credits per verified identity.

--- a/apps/web-console/__tests__/members-invite-route.test.ts
+++ b/apps/web-console/__tests__/members-invite-route.test.ts
@@ -73,4 +73,34 @@ describe("app/api/console/members/route.ts POST", () => {
     expect(res.status).toBe(400);
     expect(mockCreateInvitation).not.toHaveBeenCalled();
   });
+
+  it("maps a ControlPlaneError to a generic status message and never leaks upstream text", async () => {
+    const { ControlPlaneError } = await import("../lib/control-plane/client");
+    mockCreateInvitation.mockRejectedValue(
+      new ControlPlaneError(403, "internal: provider acme rejected db row 42"),
+    );
+    const { POST } = await import("../app/api/console/members/route");
+    const res = await POST(formRequest("teammate@example.com"));
+
+    expect(res.status).toBe(303);
+    const location = res.headers.get("location") ?? "";
+    expect(location).toContain("/console/members");
+    expect(location).toContain("permission");
+    // Raw upstream/internal text must never reach the browser-visible URL.
+    expect(location).not.toContain("provider");
+    expect(location).not.toContain("db");
+  });
+
+  it("collapses a non-ControlPlaneError to the generic message (no internal config text)", async () => {
+    mockCreateInvitation.mockRejectedValue(
+      new Error("CONTROL_PLANE_BASE_URL is not configured"),
+    );
+    const { POST } = await import("../app/api/console/members/route");
+    const res = await POST(formRequest("teammate@example.com"));
+
+    expect(res.status).toBe(303);
+    const location = res.headers.get("location") ?? "";
+    expect(location).not.toContain("CONTROL_PLANE");
+    expect(location.toLowerCase()).toContain("could+not");
+  });
 });

--- a/apps/web-console/__tests__/members-invite-route.test.ts
+++ b/apps/web-console/__tests__/members-invite-route.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetUser = vi.fn();
+const mockCreateClient = vi.fn(() => ({
+  auth: { getUser: mockGetUser },
+}));
+const mockCreateInvitation = vi.fn();
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn(async () => ({ get: vi.fn(() => undefined), getAll: vi.fn(() => []) })),
+}));
+
+vi.mock("../lib/supabase/server", () => ({
+  createClient: mockCreateClient,
+}));
+
+vi.mock("../lib/control-plane/client", () => ({
+  createInvitation: mockCreateInvitation,
+  // ControlPlaneError is referenced by the route for status mapping.
+  ControlPlaneError: class ControlPlaneError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+      super(message);
+      this.name = "ControlPlaneError";
+      this.status = status;
+    }
+  },
+}));
+
+function formRequest(email: string): Request {
+  const body = new URLSearchParams({ email });
+  return new Request("http://localhost:3000/api/console/members", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: body.toString(),
+  });
+}
+
+describe("app/api/console/members/route.ts POST", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "u1", email: "owner@hive.com" } },
+      error: null,
+    });
+    mockCreateInvitation.mockResolvedValue(undefined);
+  });
+
+  it("proxies the invite server-side and redirects back to members on success", async () => {
+    const { POST } = await import("../app/api/console/members/route");
+    const res = await POST(formRequest("teammate@example.com"));
+
+    expect(mockCreateInvitation).toHaveBeenCalledWith("teammate@example.com");
+    expect(res.status).toBe(303);
+    const location = res.headers.get("location") ?? "";
+    expect(location).toContain("/console/members");
+    expect(location).toContain("invited=1");
+  });
+
+  it("rejects unauthenticated callers with 401 and never proxies", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+    const { POST } = await import("../app/api/console/members/route");
+    const res = await POST(formRequest("teammate@example.com"));
+
+    expect(res.status).toBe(401);
+    expect(mockCreateInvitation).not.toHaveBeenCalled();
+  });
+
+  it("rejects a missing or malformed email with 400 and never proxies", async () => {
+    const { POST } = await import("../app/api/console/members/route");
+    const res = await POST(formRequest("   "));
+
+    expect(res.status).toBe(400);
+    expect(mockCreateInvitation).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web-console/app/api/console/members/route.ts
+++ b/apps/web-console/app/api/console/members/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from "next/server";
 
 import { createClient } from "@/lib/supabase/server";
 import { ControlPlaneError, createInvitation } from "@/lib/control-plane/client";
+import { resolveCanonicalOrigin } from "@/lib/http/origin";
 
 // Server-side proxy for sending a workspace invite (issue #111).
 //
@@ -13,9 +14,9 @@ import { ControlPlaneError, createInvitation } from "@/lib/control-plane/client"
 // control-plane address server-only and attaches auth via the client helper.
 //
 // The form is a plain HTML <form method="POST"> (no client JS), so on success
-// we redirect (303) back to the members page; failures redirect back with an
-// `error` query param. Auth/validation failures short-circuit before any
-// upstream call.
+// we redirect (303) back to the members page; failures redirect back with a
+// generic, customer-safe `error` message. Auth/validation failures
+// short-circuit before any upstream call.
 export async function POST(request: Request): Promise<Response> {
   const cookieStore = await cookies();
   const supabase = createClient(cookieStore);
@@ -33,13 +34,11 @@ export async function POST(request: Request): Promise<Response> {
   }
 
   try {
+    // The 201 body carries the bearer-equivalent acceptance token; we keep it
+    // server-side only and never place it in the redirect URL.
     await createInvitation(email);
   } catch (err) {
-    const message =
-      err instanceof ControlPlaneError || err instanceof Error
-        ? err.message
-        : "Failed to send invitation";
-    return redirectToMembers(request, { error: message });
+    return redirectToMembers(request, { error: inviteErrorMessage(err) });
   }
 
   return redirectToMembers(request, { invited: "1" });
@@ -62,11 +61,37 @@ async function readEmail(request: Request): Promise<string | null> {
   return email;
 }
 
+// inviteErrorMessage maps a failure to a generic, status-class message. It never
+// forwards raw upstream/internal text (provider names, DB errors,
+// "CONTROL_PLANE_BASE_URL is not configured") into the browser-visible redirect
+// URL, history, or logs. Only the HTTP status of a ControlPlaneError informs the
+// wording; every other error collapses to the generic fallback.
+function inviteErrorMessage(err: unknown): string {
+  const generic = "Could not send the invitation. Please try again.";
+  if (!(err instanceof ControlPlaneError)) {
+    return generic;
+  }
+  switch (err.status) {
+    case 400:
+      return "Please check the email address and try again.";
+    case 403:
+      return "You do not have permission to invite members.";
+    case 404:
+      return "Workspace not found.";
+    case 409:
+      return "That person is already a member or has a pending invite.";
+    default:
+      return generic;
+  }
+}
+
 function redirectToMembers(
   request: Request,
   params: Record<string, string>,
 ): Response {
-  const url = new URL("/console/members", request.url);
+  // Resolve against the canonical app origin (not the spoofable request host)
+  // so this 303 cannot be steered to another origin via X-Forwarded-Host.
+  const url = new URL("/console/members", resolveCanonicalOrigin(request));
   for (const [key, value] of Object.entries(params)) {
     url.searchParams.set(key, value);
   }

--- a/apps/web-console/app/api/console/members/route.ts
+++ b/apps/web-console/app/api/console/members/route.ts
@@ -1,0 +1,74 @@
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+
+import { createClient } from "@/lib/supabase/server";
+import { ControlPlaneError, createInvitation } from "@/lib/control-plane/client";
+
+// Server-side proxy for sending a workspace invite (issue #111).
+//
+// The invite form used to POST cross-origin straight at the control-plane with
+// `action={process.env.CONTROL_PLANE_BASE_URL}/...`, which (a) leaked the
+// internal control-plane URL into the rendered HTML and (b) sent the request
+// from the browser without the user's session bearer. This handler keeps the
+// control-plane address server-only and attaches auth via the client helper.
+//
+// The form is a plain HTML <form method="POST"> (no client JS), so on success
+// we redirect (303) back to the members page; failures redirect back with an
+// `error` query param. Auth/validation failures short-circuit before any
+// upstream call.
+export async function POST(request: Request): Promise<Response> {
+  const cookieStore = await cookies();
+  const supabase = createClient(cookieStore);
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser();
+  if (error || !user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const email = await readEmail(request);
+  if (!email) {
+    return NextResponse.json({ error: "A valid email is required" }, { status: 400 });
+  }
+
+  try {
+    await createInvitation(email);
+  } catch (err) {
+    const message =
+      err instanceof ControlPlaneError || err instanceof Error
+        ? err.message
+        : "Failed to send invitation";
+    return redirectToMembers(request, { error: message });
+  }
+
+  return redirectToMembers(request, { invited: "1" });
+}
+
+async function readEmail(request: Request): Promise<string | null> {
+  const contentType = request.headers.get("content-type") ?? "";
+  let raw: unknown;
+  if (contentType.includes("application/json")) {
+    const body: unknown = await request.json().catch(() => null);
+    raw = body && typeof body === "object" ? (body as Record<string, unknown>).email : null;
+  } else {
+    const form = await request.formData().catch(() => null);
+    raw = form?.get("email");
+  }
+  if (typeof raw !== "string") return null;
+  const email = raw.trim();
+  // Minimal shape check; the control-plane is the authority on validity.
+  if (email.length === 0 || !email.includes("@")) return null;
+  return email;
+}
+
+function redirectToMembers(
+  request: Request,
+  params: Record<string, string>,
+): Response {
+  const url = new URL("/console/members", request.url);
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+  return NextResponse.redirect(url, 303);
+}

--- a/apps/web-console/app/auth/sign-out/route.ts
+++ b/apps/web-console/app/auth/sign-out/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { cookies } from "next/headers";
 import { createClient } from "@/lib/supabase/server";
+import { resolveCanonicalOrigin } from "@/lib/http/origin";
 
 // Sign-out is a state-changing action — only allow POST so the
 // SameSite=Lax auth cookies cannot be used to terminate a session via
@@ -11,29 +12,12 @@ export async function POST(request: NextRequest) {
 
   await supabase.auth.signOut();
 
-  // Resolve the redirect origin against the canonical app URL when one
-  // is configured (matches sign-up + forgot-password). This keeps the
-  // host trustworthy (no open-redirect via spoofed X-Forwarded-Host)
-  // and avoids the standalone-runtime trap where Next.js leaks
-  // `HOSTNAME=0.0.0.0` into `request.url` / `request.nextUrl.origin`.
-  // Fall back to the X-Forwarded-Host / Host headers for environments
-  // where NEXT_PUBLIC_APP_URL is not set (local dev, ad-hoc previews).
-  const appUrl = process.env.NEXT_PUBLIC_APP_URL;
-  let origin: string;
-  if (appUrl) {
-    origin = new URL(appUrl).origin;
-  } else {
-    const headers = request.headers;
-    const host =
-      headers.get("x-forwarded-host") ?? headers.get("host") ?? "localhost";
-    const isLoopback =
-      host.startsWith("localhost") ||
-      host.startsWith("127.0.0.1") ||
-      host.startsWith("[::1]");
-    const proto =
-      headers.get("x-forwarded-proto") ?? (isLoopback ? "http" : "https");
-    origin = `${proto}://${host}`;
-  }
+  // Resolve the redirect origin against the canonical app URL when one is
+  // configured (matches sign-up + forgot-password). This keeps the host
+  // trustworthy (no open-redirect via spoofed X-Forwarded-Host) and avoids the
+  // standalone-runtime trap where Next.js leaks `HOSTNAME=0.0.0.0` into
+  // `request.url` / `request.nextUrl.origin`.
+  const origin = resolveCanonicalOrigin(request);
   const redirectUrl = new URL("/auth/sign-in", origin);
 
   const response = NextResponse.redirect(redirectUrl, { status: 303 });

--- a/apps/web-console/app/console/members/page.tsx
+++ b/apps/web-console/app/console/members/page.tsx
@@ -132,7 +132,7 @@ export default async function MembersPage() {
             {canInvite ? (
               <form
                 method="POST"
-                action={`${process.env.CONTROL_PLANE_BASE_URL}/api/v1/accounts/current/invitations`}
+                action="/api/console/members"
                 className="grid gap-3 sm:grid-cols-[1fr_auto] sm:items-end"
               >
                 <Field label="Email" htmlFor="invite-email" required>

--- a/apps/web-console/lib/control-plane/client.ts
+++ b/apps/web-console/lib/control-plane/client.ts
@@ -535,6 +535,25 @@ export async function updateAccountProfile(
   return profile;
 }
 
+// createInvitation sends a workspace invite for the given email. It runs only
+// server-side (Route Handler) so the internal CONTROL_PLANE_BASE_URL is never
+// rendered into client HTML (issue #111). Throws ControlPlaneError so the route
+// can forward the upstream status (403 no-permission, 409 already-member, etc.)
+// instead of collapsing everything to 500.
+export async function createInvitation(email: string): Promise<void> {
+  const { baseUrl, headers } = await getRequestContext();
+  const response = await fetch(`${baseUrl}/api/v1/accounts/current/invitations`, {
+    method: "POST",
+    headers,
+    cache: "no-store",
+    body: JSON.stringify({ email }),
+  });
+
+  if (!response.ok) {
+    await throwControlPlaneError(response, "Failed to send invitation");
+  }
+}
+
 export async function getBillingProfile(): Promise<BillingProfile> {
   const { baseUrl, headers } = await getRequestContext();
   const response = await fetch(`${baseUrl}/api/v1/accounts/current/billing-profile`, {

--- a/apps/web-console/lib/control-plane/client.ts
+++ b/apps/web-console/lib/control-plane/client.ts
@@ -538,9 +538,14 @@ export async function updateAccountProfile(
 // createInvitation sends a workspace invite for the given email. It runs only
 // server-side (Route Handler) so the internal CONTROL_PLANE_BASE_URL is never
 // rendered into client HTML (issue #111). Throws ControlPlaneError so the route
-// can forward the upstream status (403 no-permission, 409 already-member, etc.)
-// instead of collapsing everything to 500.
-export async function createInvitation(email: string): Promise<void> {
+// can map the upstream status (403 no-permission, 409 already-member, etc.) to a
+// generic, customer-safe message instead of collapsing everything to 500.
+//
+// The control-plane returns the raw acceptance token in its 201 body. We return
+// it here so a server-side caller (e.g. an invite mailer) can use it, but it is
+// deliberately NOT surfaced in any client-facing redirect/URL — the token is
+// bearer-equivalent and must not leak into browser history or logs.
+export async function createInvitation(email: string): Promise<{ token: string | null }> {
   const { baseUrl, headers } = await getRequestContext();
   const response = await fetch(`${baseUrl}/api/v1/accounts/current/invitations`, {
     method: "POST",
@@ -552,6 +557,10 @@ export async function createInvitation(email: string): Promise<void> {
   if (!response.ok) {
     await throwControlPlaneError(response, "Failed to send invitation");
   }
+
+  const payload = parseJsonValue(await readResponseText(response));
+  const token = isJsonObject(payload) ? readStringField(payload, "token") : null;
+  return { token };
 }
 
 export async function getBillingProfile(): Promise<BillingProfile> {

--- a/apps/web-console/lib/http/origin.ts
+++ b/apps/web-console/lib/http/origin.ts
@@ -1,0 +1,27 @@
+// resolveCanonicalOrigin returns a trustworthy origin for server-side redirects.
+//
+// It prefers the canonical NEXT_PUBLIC_APP_URL so a spoofed X-Forwarded-Host
+// cannot drive an open redirect, and avoids the standalone-runtime trap where
+// Next.js leaks `HOSTNAME=0.0.0.0` into `request.url` / `request.nextUrl.origin`.
+// It falls back to the X-Forwarded-Host / Host headers for environments where
+// NEXT_PUBLIC_APP_URL is not set (local dev, ad-hoc previews).
+//
+// Shared by the auth sign-out route and the members invite proxy so every
+// host-header-dependent redirect resolves the same way.
+export function resolveCanonicalOrigin(request: { headers: Headers }): string {
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL;
+  if (appUrl) {
+    return new URL(appUrl).origin;
+  }
+
+  const headers = request.headers;
+  const host =
+    headers.get("x-forwarded-host") ?? headers.get("host") ?? "localhost";
+  const isLoopback =
+    host.startsWith("localhost") ||
+    host.startsWith("127.0.0.1") ||
+    host.startsWith("[::1]");
+  const proto =
+    headers.get("x-forwarded-proto") ?? (isLoopback ? "http" : "https");
+  return `${proto}://${host}`;
+}


### PR DESCRIPTION
## Summary
Closes #111. The members invite form posted directly to `${process.env.CONTROL_PLANE_BASE_URL}/api/v1/accounts/current/invitations`. Next.js inlines `process.env` into server-rendered HTML, so the **internal control-plane URL shipped to every browser**, and the POST went cross-origin from the client without the user's session bearer.

## Fix
- New server-side Route Handler `apps/web-console/app/api/console/members/route.ts`:
  - validates session via `supabase.auth.getUser` (**401** if absent),
  - validates email shape (**400** if missing/malformed),
  - calls new `createInvitation()` client helper (bearer + base URL attached server-only via `getRequestContext`; `ControlPlaneError` preserves upstream status),
  - **303**-redirects back to `/console/members` on success/error.
- `members/page.tsx` form `action` → relative `/api/console/members`. Internal URL never reaches client HTML.
- Mirrors the existing `app/api/budget` proxy pattern.

## Test plan
- [x] New route tests: success→303 redirect, unauth→401 (no proxy), bad email→400 (no proxy)
- [x] Full web-console unit suite — 179 passed
- [x] `next build` green (typecheck + 26 static pages)
- [x] Grep confirms no remaining `CONTROL_PLANE_BASE_URL` in client-rendered HTML (only server-side `fetch` in `invitations/accept` remains, which is not rendered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a security vulnerability where internal configuration was inadvertently exposed in the frontend.

* **Tests**
  * Added test coverage for member invitation functionality, including authentication validation and error handling scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sakibsadmanshajib/hive/pull/157?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->