### PR TITLE
fix(security): move email-verification finalize to control-plane, off the edge (#112)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,10 @@
 # `NEXT_PUBLIC_SUPABASE_ANON_KEY`
 # Leave `SUPABASE_SERVICE_ROLE_KEY` and `SUPABASE_DB_URL` blank unless you are
 # running the control-plane against your own Supabase project locally.
+# NOTE (#112): SUPABASE_SERVICE_ROLE_KEY is consumed ONLY by the control-plane
+# (server-side). The web-console no longer needs it — email verification is
+# finalized via the control-plane (edge forwards only the user session bearer).
+# Do not set SUPABASE_SERVICE_ROLE_KEY in the web-console / Cloudflare env.
 
 # Supabase
 SUPABASE_URL=https://yimgflllgdsbcibnaxqe.supabase.co

--- a/.planning/SECURITY-P0-BACKLOG.md
+++ b/.planning/SECURITY-P0-BACKLOG.md
@@ -19,7 +19,7 @@ these block any real launch of the metered-inference reselling product.
 | #107 | No RLS on tenant tables | ✅ merged | PR #155 — `20260529_01_rls_tenant_tables.sql`; live anon→0 verify at deploy |
 | #108 | /internal/* control-plane endpoints unauth | ✅ merged | PR #156 — X-Internal-Token shared-secret middleware (fails closed) |
 | #111 | CONTROL_PLANE_BASE_URL leaked into HTML | ✅ FIXED | PR open — server-side Route Handler proxy; form action now relative |
-| #112 | SUPABASE_SERVICE_ROLE_KEY silent failure on edge | ⏳ TODO | cross-service (move admin write to control-plane) |
+| #112 | SUPABASE_SERVICE_ROLE_KEY silent failure on edge | ✅ FIXED | PR open — authed control-plane `POST /api/v1/.../email-verification/finalize`; edge forwards session bearer only, service-role key off the edge |
 | #113 | Auth snapshot 1hr cache lets revoked keys work | ⏳ TODO | see below |
 | #116 | Free-tier abuse (CAPTCHA / IP limit / disposable email) | ⏳ TODO | needs Turnstile infra |
 
@@ -50,9 +50,11 @@ these block any real launch of the metered-inference reselling product.
 - Fix: versioned cache key `apikey:{hash}:v{gen}` bumped on revoke, OR control-plane Redis pub/sub invalidation consumed by edge, OR TTL ≤60s. Acceptance: revoked key → 401 within ≤60s across instances.
 - May touch edge auth path; check overlap with #150 before branching.
 
-### #112 service-role key on Cloudflare Worker edge route
-- `apps/web-console/app/auth/callback/route.ts:61-78` — guarded admin write silently skips on Workers when binding missing → users stuck unverified.
-- Fix: move admin write to control-plane `POST /internal/users/finalize-signup` (depends on #108 internal-auth being in place); edge only forwards session. Fail loud on control-plane if service-role key absent.
+### #112 service-role key on Cloudflare Worker edge route — ✅ FIXED (PR open)
+- Was: `apps/web-console/app/auth/callback/route.ts` guarded admin write (`if process.env.SUPABASE_SERVICE_ROLE_KEY` + `.catch(()=>undefined)`) silently skipped on Workers when the key was missing → users stuck unverified, plus a god-key in a public edge bundle.
+- Fixed by an **authenticated** control-plane endpoint `POST /api/v1/accounts/current/email-verification/finalize` (`internal/identity`). Edge forwards only the user session bearer (no service-role key, no internal token on the edge). The control-plane flips `hive_email_verified` via its service-role DB pool and **only when `email_confirmed_at IS NOT NULL`** (Supabase already confirmed) — a caller cannot self-verify an unconfirmed address. Write errors are loud 500 (never a silent no-op); 0 rows → 409.
+- Deviation from original plan (internal `finalize-signup` endpoint): chose an authed `/api/v1` endpoint instead, so the edge holds neither the service-role key nor the #108 internal token — strictly less privilege on the public edge. The session bearer is itself the proof of email ownership (issued post code-exchange).
+- Ops: remove `SUPABASE_SERVICE_ROLE_KEY` from the web-console/Cloudflare env; ensure `CONTROL_PLANE_BASE_URL` points at the public control-plane URL there.
 
 ### #111 CONTROL_PLANE_BASE_URL in HTML — ✅ FIXED (PR #157)
 - Was: `apps/web-console/app/console/members/page.tsx` invite `<form action="${CONTROL_PLANE_BASE_URL}/...">` inlined the internal URL into rendered HTML and POSTed cross-origin without the session bearer.
@@ -69,6 +71,6 @@ these block any real launch of the metered-inference reselling product.
 3. ✅ #107 (RLS) — PR #155 open (CI green, threads resolved).
 4. ✅ #108 (internal auth) — PR open (`fix/108-internal-endpoint-auth`).
 5. ✅ #111 (URL leak) — FIXED (server-side Route Handler proxy `app/api/console/members/route.ts`).
-6. #112 (service-role) — after #108 (now merged). **NEXT.**
-7. #113 (revoked cache), #116 (abuse).
+6. ✅ #112 (service-role) — FIXED (authed control-plane finalize endpoint; service-role off the edge).
+7. #113 (revoked cache) **NEXT**, then #116 (abuse), #51 (rate-limit fail-open).
 8. NEW: #51 (P0) — Redis rate-limit fail-open bypass — not in original #106–#120 sweep; triage with this batch.

--- a/apps/control-plane/cmd/server/main.go
+++ b/apps/control-plane/cmd/server/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/catalog"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/filestore"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/grants"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/identity"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/ledger"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/owui"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/payments"
@@ -559,9 +560,36 @@ func main() {
 		slog.Warn("CONTROL_PLANE_INTERNAL_TOKEN is not set; /internal/* service-to-service endpoints are UNAUTHENTICATED. Set it (and the matching value on edge-api) in any non-local deployment.")
 	}
 
+	// Identity: finalize email verification for the authenticated caller (#112).
+	// The privileged write lives here (the pool carries service-role DB
+	// privilege) instead of in the web-console edge route, and only flips the
+	// flag when Supabase has already confirmed the email. A nil pool leaves the
+	// handler unwired so the route returns a loud 500 rather than silently
+	// succeeding.
+	var identityHandler *identity.Handler
+	if pool != nil {
+		p := pool
+		identityHandler = identity.NewHandler(identity.Deps{
+			Audit: auditLogger,
+			FinalizeEmailVerified: func(ctx context.Context, userID uuid.UUID) (int64, error) {
+				tag, err := p.Exec(ctx,
+					`UPDATE auth.users
+					    SET raw_app_meta_data = COALESCE(raw_app_meta_data, '{}'::jsonb)
+					      || jsonb_build_object('hive_email_verified', true)
+					  WHERE id = $1
+					    AND email_confirmed_at IS NOT NULL`, userID)
+				if err != nil {
+					return 0, err
+				}
+				return tag.RowsAffected(), nil
+			},
+		})
+	}
+
 	router := platformhttp.NewRouter(platformhttp.RouterConfig{
 		AuthMiddleware:     authMiddleware,
 		AccountsHandler:    accountsHandler,
+		IdentityHandler:    identityHandler,
 		AccountingHandler:  accountingHandler,
 		APIKeysHandler:     apikeysHandler,
 		BudgetsHandler:     budgetsHandler,

--- a/apps/control-plane/cmd/server/main.go
+++ b/apps/control-plane/cmd/server/main.go
@@ -563,9 +563,12 @@ func main() {
 	// Identity: finalize email verification for the authenticated caller (#112).
 	// The privileged write lives here (the pool carries service-role DB
 	// privilege) instead of in the web-console edge route, and only flips the
-	// flag when Supabase has already confirmed the email. A nil pool leaves the
-	// handler unwired so the route returns a loud 500 rather than silently
-	// succeeding.
+	// flag when Supabase has already confirmed the email. When pool is nil the
+	// handler is left unwired and the route is not registered (the request 404s
+	// at the mux) — the control-plane does not run a real identity flow without
+	// a database anyway. The handler's own nil-dependency guard returns a loud
+	// 500 for the wired-but-misconfigured case (a future caller that constructs
+	// it without FinalizeEmailVerified).
 	var identityHandler *identity.Handler
 	if pool != nil {
 		p := pool

--- a/apps/control-plane/internal/identity/finalize.go
+++ b/apps/control-plane/internal/identity/finalize.go
@@ -1,0 +1,109 @@
+// Package identity exposes the authenticated "finalize email verification"
+// endpoint (issue #112).
+//
+// Background: the web-console /auth/callback edge route used to hold
+// SUPABASE_SERVICE_ROLE_KEY and PUT auth.users app_metadata directly. That put
+// a god-key in a public edge bundle and failed *silently* when the key was
+// absent (the write was guarded by `if (process.env.SUPABASE_SERVICE_ROLE_KEY)`
+// and `.catch(() => undefined)`), so email verification quietly never persisted.
+//
+// This handler moves the privileged write into the control-plane, which already
+// holds a service-role-privileged DB pool. The edge only forwards the user's
+// session bearer; the handler flips hive_email_verified for the *authenticated*
+// caller and only when Supabase has already confirmed the email
+// (email_confirmed_at IS NOT NULL — enforced by the injected write), so a caller
+// cannot self-verify an unconfirmed address. Any failure is loud (500), never a
+// silent no-op.
+package identity
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"net/http"
+
+	"github.com/google/uuid"
+
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/audit"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/auth"
+)
+
+// FinalizeFunc sets hive_email_verified=true for the user IFF Supabase has
+// already confirmed the email, returning the number of rows affected (0 means
+// the email is not confirmed or the user does not exist). It is the only path
+// that touches the service-role-privileged pool, so it is injected to keep the
+// handler unit-testable without a database.
+type FinalizeFunc func(ctx context.Context, userID uuid.UUID) (int64, error)
+
+// Deps wires the handler. Audit is optional (best-effort); FinalizeEmailVerified
+// is required and its absence is treated as a loud misconfiguration.
+type Deps struct {
+	Audit                 *audit.Logger
+	FinalizeEmailVerified FinalizeFunc
+}
+
+// Handler serves POST /api/v1/accounts/current/email-verification/finalize.
+type Handler struct{ deps Deps }
+
+// NewHandler constructs the finalize handler.
+func NewHandler(deps Deps) *Handler { return &Handler{deps: deps} }
+
+// ServeHTTP finalizes email verification for the authenticated viewer.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+	// Fail loud on misconfiguration rather than silently reporting success —
+	// the exact failure mode that #112 set out to eliminate.
+	if h == nil || h.deps.FinalizeEmailVerified == nil {
+		log.Print("identity: finalize handler invoked without FinalizeEmailVerified wired (misconfigured)")
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "service unavailable"})
+		return
+	}
+
+	viewer, ok := auth.ViewerFromContext(r.Context())
+	if !ok || viewer.UserID == uuid.Nil {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "missing user context"})
+		return
+	}
+
+	rows, err := h.deps.FinalizeEmailVerified(r.Context(), viewer.UserID)
+	if err != nil {
+		// Full error to the process log only; the client gets a generic message
+		// (it may embed SQL/DSN fragments). Audit carries a classification only.
+		log.Printf("identity: finalize email verification failed user=%s: %v", viewer.UserID, err)
+		h.audit(r.Context(), viewer.UserID, "EMAIL_VERIFY_FINALIZE_ERROR", audit.SeverityError,
+			map[string]string{"error": "finalize_write"})
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to finalize verification"})
+		return
+	}
+	if rows == 0 {
+		// Supabase has not confirmed the email (or the user is unknown). Never
+		// treat this as success — that would let a caller self-verify.
+		h.audit(r.Context(), viewer.UserID, "EMAIL_VERIFY_NOT_CONFIRMED", audit.SeverityWarning, nil)
+		writeJSON(w, http.StatusConflict, map[string]string{"error": "email is not confirmed"})
+		return
+	}
+
+	h.audit(r.Context(), viewer.UserID, "EMAIL_VERIFIED", audit.SeverityInfo, nil)
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+func (h *Handler) audit(ctx context.Context, userID uuid.UUID, action string, sev audit.Severity, before map[string]string) {
+	if h.deps.Audit == nil {
+		return
+	}
+	_ = h.deps.Audit.Log(ctx, audit.Event{
+		Actor:    audit.Actor{ID: userID, Type: audit.ActorUser},
+		Action:   action,
+		Severity: sev,
+		Before:   before,
+	})
+}
+
+func writeJSON(w http.ResponseWriter, status int, body map[string]string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}

--- a/apps/control-plane/internal/identity/finalize_test.go
+++ b/apps/control-plane/internal/identity/finalize_test.go
@@ -1,0 +1,106 @@
+package identity_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/auth"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/identity"
+)
+
+func newReq(ctx context.Context) *http.Request {
+	return httptest.NewRequest(http.MethodPost, "/api/v1/accounts/current/email-verification/finalize", nil).WithContext(ctx)
+}
+
+func TestFinalize_RejectsMissingViewer(t *testing.T) {
+	h := identity.NewHandler(identity.Deps{
+		FinalizeEmailVerified: func(context.Context, uuid.UUID) (int64, error) { return 1, nil },
+	})
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, newReq(context.Background()))
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 without an authenticated viewer, got %d", rr.Code)
+	}
+}
+
+func TestFinalize_FailsLoudWhenUnconfigured(t *testing.T) {
+	// No FinalizeEmailVerified wired → the service-role-backed write is absent.
+	// This MUST fail loud (500), never silently report success (the #112 bug).
+	h := identity.NewHandler(identity.Deps{})
+	ctx := auth.WithViewer(context.Background(), auth.Viewer{UserID: uuid.New()})
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, newReq(ctx))
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 (fail loud) when finalize dependency is unset, got %d", rr.Code)
+	}
+}
+
+func TestFinalize_PropagatesWriteErrorAsLoud500(t *testing.T) {
+	h := identity.NewHandler(identity.Deps{
+		FinalizeEmailVerified: func(context.Context, uuid.UUID) (int64, error) {
+			return 0, errors.New("boom: connection refused")
+		},
+	})
+	ctx := auth.WithViewer(context.Background(), auth.Viewer{UserID: uuid.New()})
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, newReq(ctx))
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 on write error, got %d", rr.Code)
+	}
+	// The raw upstream/DB error text must never reach the client body.
+	if body := rr.Body.String(); contains(body, "connection refused") || contains(body, "boom") {
+		t.Fatalf("internal error text leaked to client: %q", body)
+	}
+}
+
+func TestFinalize_NotConfirmedYieldsConflict(t *testing.T) {
+	// 0 rows affected → Supabase has not confirmed the email (email_confirmed_at
+	// IS NULL guard). We must NOT report success; surface 409 instead.
+	var gotUser uuid.UUID
+	want := uuid.New()
+	h := identity.NewHandler(identity.Deps{
+		FinalizeEmailVerified: func(_ context.Context, id uuid.UUID) (int64, error) {
+			gotUser = id
+			return 0, nil
+		},
+	})
+	ctx := auth.WithViewer(context.Background(), auth.Viewer{UserID: want})
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, newReq(ctx))
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("expected 409 when email not confirmed, got %d", rr.Code)
+	}
+	if gotUser != want {
+		t.Fatalf("handler must finalize the authenticated viewer's id; got %s want %s", gotUser, want)
+	}
+}
+
+func TestFinalize_SuccessReturnsOK(t *testing.T) {
+	h := identity.NewHandler(identity.Deps{
+		FinalizeEmailVerified: func(context.Context, uuid.UUID) (int64, error) { return 1, nil },
+	})
+	ctx := auth.WithViewer(context.Background(), auth.Viewer{UserID: uuid.New()})
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, newReq(ctx))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 on successful finalize, got %d", rr.Code)
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(sub) > 0 && len(s) >= len(sub) && (indexOf(s, sub) >= 0)
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}

--- a/apps/control-plane/internal/platform/http/router.go
+++ b/apps/control-plane/internal/platform/http/router.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/auth"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/budgets"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/catalog"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/identity"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/ledger"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/payments"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/platform/metrics"
@@ -38,6 +39,10 @@ type RouterConfig struct {
 	ProfilesHandler   *profiles.Handler
 	RoutingHandler    *routing.Handler
 	UsageHandler      *usage.Handler
+
+	// IdentityHandler finalizes email verification for the authenticated caller
+	// (issue #112). Registered under /api/v1 behind the auth middleware.
+	IdentityHandler *identity.Handler
 
 	// MetricsRegistry provides Prometheus counters/histograms for HTTP instrumentation.
 	// When non-nil, all requests are counted and timed via InstrumentHandler middleware.
@@ -151,6 +156,14 @@ func NewRouter(cfg RouterConfig) http.Handler {
 		mux.Handle("/api/v1/accounts/current/api-keys/", protectedAPIKeys)
 		// Internal service-to-service route — guarded by the shared-secret token.
 		mux.Handle("/internal/apikeys/resolve", internal(cfg.APIKeysHandler))
+	}
+
+	// Authenticated email-verification finalize (issue #112). Registered before
+	// the /api/v1/ catch-all; ServeMux longest-prefix match routes this exact
+	// path here. The edge forwards only the user's session bearer.
+	if cfg.IdentityHandler != nil && cfg.AuthMiddleware != nil {
+		mux.Handle("/api/v1/accounts/current/email-verification/finalize",
+			cfg.AuthMiddleware.Require(cfg.IdentityHandler))
 	}
 
 	if cfg.AccountsHandler != nil && cfg.AuthMiddleware != nil {

--- a/apps/web-console/__tests__/auth-routes.test.ts
+++ b/apps/web-console/__tests__/auth-routes.test.ts
@@ -164,6 +164,60 @@ describe("app/auth/callback/route.ts", () => {
       expect.objectContaining({ href: expect.stringContaining("/console") })
     );
   });
+
+  it("finalizes email verification via the control-plane with the session bearer (#112)", async () => {
+    const { NextRequest } = await import("next/server");
+    mockExchangeCodeForSession.mockResolvedValueOnce({
+      error: null,
+      data: { session: { access_token: "sess-token-xyz" } },
+    });
+    process.env.CONTROL_PLANE_BASE_URL = "http://control-plane:8081";
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const mod = await import("../app/auth/callback/route");
+    const req: Parameters<typeof mod.GET>[0] = new NextRequest(
+      "http://localhost:3000/auth/callback?code=abc&hive_verify=1"
+    );
+    await mod.GET(req);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [calledUrl, init] = fetchMock.mock.calls[0];
+    expect(String(calledUrl)).toContain(
+      "/api/v1/accounts/current/email-verification/finalize"
+    );
+    expect(init.method).toBe("POST");
+    expect(init.headers.Authorization).toBe("Bearer sess-token-xyz");
+    vi.unstubAllGlobals();
+  });
+
+  it("never calls the Supabase admin API or uses a service-role key (#112)", async () => {
+    const { NextRequest } = await import("next/server");
+    mockExchangeCodeForSession.mockResolvedValueOnce({
+      error: null,
+      data: { session: { access_token: "sess-token-xyz" } },
+    });
+    process.env.CONTROL_PLANE_BASE_URL = "http://control-plane:8081";
+    // If the route still reached for the service-role admin write, the URL
+    // would contain /auth/v1/admin/users — assert it never does.
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const mod = await import("../app/auth/callback/route");
+    const req: Parameters<typeof mod.GET>[0] = new NextRequest(
+      "http://localhost:3000/auth/callback?code=abc&hive_verify=1"
+    );
+    await mod.GET(req);
+
+    for (const [url, init] of fetchMock.mock.calls) {
+      expect(String(url)).not.toContain("/auth/v1/admin/users");
+      const auth = (init?.headers?.Authorization as string) ?? "";
+      // The forwarded credential is the short user session token, never the
+      // long service-role key.
+      expect(auth).toBe("Bearer sess-token-xyz");
+    }
+    vi.unstubAllGlobals();
+  });
 });
 
 describe("app/auth/sign-in/page.tsx", () => {

--- a/apps/web-console/__tests__/auth-routes.test.ts
+++ b/apps/web-console/__tests__/auth-routes.test.ts
@@ -209,6 +209,9 @@ describe("app/auth/callback/route.ts", () => {
     );
     await mod.GET(req);
 
+    // Non-vacuous: a regression that stops calling the control-plane entirely
+    // must fail this test, so assert at least one request was made.
+    expect(fetchMock).toHaveBeenCalled();
     for (const [url, init] of fetchMock.mock.calls) {
       expect(String(url)).not.toContain("/auth/v1/admin/users");
       const auth = (init?.headers?.Authorization as string) ?? "";

--- a/apps/web-console/app/auth/callback/route.ts
+++ b/apps/web-console/app/auth/callback/route.ts
@@ -50,30 +50,46 @@ export async function GET(request: NextRequest) {
 
     if (!error) {
       if (hiveVerify) {
-        const userId = data?.user?.id ?? data?.session?.user?.id;
-        const appMetadata =
-          data?.user?.app_metadata ??
-          data?.session?.user?.app_metadata ??
-          {};
-
-        if (userId && process.env.SUPABASE_SERVICE_ROLE_KEY) {
-          await fetch(
-            new URL(`/auth/v1/admin/users/${userId}`, process.env.NEXT_PUBLIC_SUPABASE_URL!),
-            {
-              method: "PUT",
-              headers: {
-                Authorization: `Bearer ${process.env.SUPABASE_SERVICE_ROLE_KEY}`,
-                apikey: process.env.SUPABASE_SERVICE_ROLE_KEY,
-                "Content-Type": "application/json",
-              },
-              body: JSON.stringify({
-                app_metadata: {
-                  ...appMetadata,
-                  hive_email_verified: true,
+        // Finalize email verification via the control-plane (#112). The
+        // privileged auth.users write used to happen here with
+        // SUPABASE_SERVICE_ROLE_KEY — a god-key in a public edge bundle that
+        // also failed *silently* when the key was unset. We now forward only
+        // the user's session bearer; the control-plane (which holds the
+        // service-role DB pool) flips hive_email_verified, and only when
+        // Supabase has already confirmed the email. No service-role key or
+        // internal token lives on the edge.
+        const accessToken = data?.session?.access_token;
+        const controlPlaneBaseUrl = process.env.CONTROL_PLANE_BASE_URL;
+        if (accessToken && controlPlaneBaseUrl) {
+          try {
+            const resp = await fetch(
+              new URL(
+                "/api/v1/accounts/current/email-verification/finalize",
+                controlPlaneBaseUrl,
+              ),
+              {
+                method: "POST",
+                headers: {
+                  Authorization: `Bearer ${accessToken}`,
+                  "Content-Type": "application/json",
                 },
-              }),
+                cache: "no-store",
+              },
+            );
+            if (!resp.ok) {
+              // Loud but non-fatal to the redirect: surface in server logs so a
+              // failure is observable rather than silently dropped.
+              console.error(
+                `auth/callback: email verification finalize failed (status ${resp.status})`,
+              );
             }
-          ).catch(() => undefined);
+          } catch (err) {
+            console.error("auth/callback: email verification finalize error", err);
+          }
+        } else {
+          console.error(
+            "auth/callback: cannot finalize email verification (missing session token or CONTROL_PLANE_BASE_URL)",
+          );
         }
       }
 

--- a/apps/web-console/app/auth/callback/route.ts
+++ b/apps/web-console/app/auth/callback/route.ts
@@ -74,6 +74,11 @@ export async function GET(request: NextRequest) {
                   "Content-Type": "application/json",
                 },
                 cache: "no-store",
+                // This step is best-effort and sits on the sign-in redirect
+                // path, so it must never make sign-in latency hostage to
+                // control-plane responsiveness. Hard-cap it; a timeout throws
+                // and is handled by the catch below (logged, redirect proceeds).
+                signal: AbortSignal.timeout(3000),
               },
             );
             if (!resp.ok) {


### PR DESCRIPTION
## Summary
Closes #112. The web-console `/auth/callback` edge route (Cloudflare Workers) held `SUPABASE_SERVICE_ROLE_KEY` and did the privileged `auth.users` app_metadata write itself — guarded by `if (process.env.SUPABASE_SERVICE_ROLE_KEY)` + `.catch(() => undefined)`. Two problems:
1. **Silent failure** — when the key is absent (it is *not* in the web-console env), the write is silently skipped, so users stay unverified with no error.
2. **God-key on a public edge bundle** — full-privilege service-role key in the Workers runtime.

## Fix
Move the privileged write into the control-plane (which already holds a service-role-privileged DB pool):

- **New authed endpoint** `POST /api/v1/accounts/current/email-verification/finalize` (`internal/identity`). Reads the authenticated viewer; flips `hive_email_verified` via the pool **only when `email_confirmed_at IS NOT NULL`** (Supabase already confirmed) — no self-verify. Write error → **loud 500** (never silent); 0 rows → **409**. The pool write is func-injected → unit-tested without a DB.
- **Edge callback** forwards only the user **session bearer** to that endpoint. No service-role key, no internal token on the edge.
- Removed `SUPABASE_SERVICE_ROLE_KEY` usage from web-console; `.env.example` notes it is control-plane-only.

### Deviation from the backlog sketch
The backlog suggested an `/internal/users/finalize-signup` endpoint (token-gated). I chose an **authenticated `/api/v1`** endpoint instead so the edge holds **neither** the service-role key **nor** the #108 internal token — strictly less privilege on the public edge. The session bearer issued at code-exchange is itself proof of email ownership.

## Test plan
- [x] control-plane `internal/identity`: 401 (no viewer), **fail-loud 500** (dep unwired), write-error 500 (no internal text leaked), not-confirmed 409, success 200
- [x] web-console callback: forwards bearer to CP finalize; **never** hits `/auth/v1/admin/users`; credential is the short session token, not a service-role key
- [x] `go build ./...` + `go vet` + control-plane/edge `-short` suite green
- [x] web-console 183 unit tests + `next build` green

## Ops (post-merge)
- Remove `SUPABASE_SERVICE_ROLE_KEY` from the web-console / Cloudflare env.
- Ensure `CONTROL_PLANE_BASE_URL` there points at the public control-plane URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated `.env.example` with clarifications on environment variable usage.
  * Updated security backlog documenting completed improvements.

* **New Features**
  * Added authenticated endpoint for email-verification finalization.

* **Tests**
  * Added test coverage for new email-verification endpoint and callback route.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sakibsadmanshajib/hive/pull/158?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->