### PR TITLE
fix(security): fail closed on degraded rate limiter backend (#51)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,14 @@ SUPABASE_JWKS_URL=https://yimgflllgdsbcibnaxqe.supabase.co/auth/v1/.well-known/j
 # `redis://redis:6379/0`-style value into the staging `.env` —
 # .github/workflows/deploy-staging.yml asserts against it.
 REDIS_URL=redis://redis:6379/0
+# Edge rate-limiter degraded-backend policy (#51). When the Redis backend that
+# backs rate/quota limits cannot be evaluated, the edge fails CLOSED by default:
+# requests are denied with a retryable HTTP 429 so a Redis outage cannot
+# silently disable abuse controls. Set RATE_LIMIT_FAIL_OPEN=true ONLY in
+# dev/local where availability beats metering. Leave unset (fail closed) in
+# staging + production. The edge logs a structured `authz: rate limiter
+# degraded ... fail_open=...` line whenever the limiter backend errors.
+RATE_LIMIT_FAIL_OPEN=false
 CONTROL_PLANE_PORT=8081
 CONTROL_PLANE_BASE_URL=http://localhost:8081
 EDGE_CONTROL_PLANE_BASE_URL=http://control-plane:8081

--- a/.planning/SECURITY-P0-BACKLOG.md
+++ b/.planning/SECURITY-P0-BACKLOG.md
@@ -21,6 +21,7 @@ these block any real launch of the metered-inference reselling product.
 | #111 | CONTROL_PLANE_BASE_URL leaked into HTML | ✅ FIXED | PR open — server-side Route Handler proxy; form action now relative |
 | #112 | SUPABASE_SERVICE_ROLE_KEY silent failure on edge | ✅ FIXED | PR open — authed control-plane `POST /api/v1/.../email-verification/finalize`; edge forwards session bearer only, service-role key off the edge |
 | #113 | Auth snapshot 1hr cache lets revoked keys work | ⏳ TODO | see below |
+| #51 | Redis rate-limit fail-open bypass | ✅ FIXED | PR #160 — fail-closed default + explicit `RATE_LIMIT_FAIL_OPEN` opt-in + structured degraded log |
 | #116 | Free-tier abuse (CAPTCHA / IP limit / disposable email) | ⏳ TODO | needs Turnstile infra |
 
 ## Remaining — implementation notes (pre-investigated)
@@ -72,5 +73,11 @@ these block any real launch of the metered-inference reselling product.
 4. ✅ #108 (internal auth) — PR open (`fix/108-internal-endpoint-auth`).
 5. ✅ #111 (URL leak) — FIXED (server-side Route Handler proxy `app/api/console/members/route.ts`).
 6. ✅ #112 (service-role) — FIXED (authed control-plane finalize endpoint; service-role off the edge).
-7. ✅ #113 (revoked cache) — FIXED (active invalidation already wired; lowered edge backstop TTL 1h→60s). Then #51 (rate-limit fail-open) **NEXT**, #116 (abuse).
-8. NEW: #51 (P0) — Redis rate-limit fail-open bypass — not in original #106–#120 sweep; triage with this batch.
+7. ✅ #113 (revoked cache) — FIXED (active invalidation already wired; lowered edge backstop TTL 1h→60s).
+8. ✅ #51 (P0) — Redis rate-limit fail-open bypass — FIXED (PR #160). Then #116 (abuse) **NEXT**.
+
+### #51 rate-limit fail-open — ✅ FIXED (PR #160)
+- Was: `apps/edge-api/internal/authz/authorizer.go` Authorize() limiter-error branch was **empty** → any Redis error (outage/connection/auth) silently bypassed ALL rate + fraud-window (5h/weekly) enforcement, no request-boundary signal. (Issue cited pre-rewrite TS `redis-rate-limiter.ts`; live Go path had the identical bug.)
+- Fixed: default **fail CLOSED** (deny with retryable 429 `rate_limit_error`/`rate_limit_exceeded` + retry-after; provider-blind message). Explicit `RATE_LIMIT_FAIL_OPEN=true` opt-in for dev/local (loud startup warning). Structured `authz: rate limiter degraded … fail_open=…` log at the boundary on every backend error. `NewAuthorizer` gained variadic `WithFailOpen` option (all 2-arg callers unchanged, default closed).
+- Tests: `TestAuthorizeFailsClosedWhenLimiterErrors`, `TestAuthorizeFailsOpenWhenExplicitlyEnabled` (`authorizer_test.go`). Go verification via CI "Go tests (edge-api)" (local toolchain unobservable).
+- Ops: leave `RATE_LIMIT_FAIL_OPEN` unset (fail closed) in staging + prod.

--- a/apps/edge-api/cmd/server/main.go
+++ b/apps/edge-api/cmd/server/main.go
@@ -89,7 +89,11 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to initialize authz limiter: %v", err)
 	}
-	authorizer := authz.NewAuthorizer(authzClient, limiter)
+	failOpen := resolveRateLimitFailOpen()
+	if failOpen {
+		log.Printf("authz: WARNING rate limiter is in FAIL-OPEN mode (RATE_LIMIT_FAIL_OPEN) — Redis outages will NOT enforce limits; do not use in production")
+	}
+	authorizer := authz.NewAuthorizer(authzClient, limiter, authz.WithFailOpen(failOpen))
 
 	// Initialize Prometheus metrics registry for edge-api.
 	edgeMetrics, promRegistry := proxy.NewEdgeMetrics()
@@ -457,6 +461,20 @@ func resolveRedisURL() string {
 		return url
 	}
 	return "redis://redis:6379/0"
+}
+
+// resolveRateLimitFailOpen reports whether the edge limiter should fail OPEN
+// (admit traffic) when the Redis backend cannot be evaluated. Default is fail
+// CLOSED (#51): a backend outage must not silently disable abuse controls.
+// Set RATE_LIMIT_FAIL_OPEN=true only in dev/local where availability beats
+// metering.
+func resolveRateLimitFailOpen() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("RATE_LIMIT_FAIL_OPEN"))) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
 }
 
 func resolveLiteLLMBaseURL() string {

--- a/apps/edge-api/cmd/server/main.go
+++ b/apps/edge-api/cmd/server/main.go
@@ -621,17 +621,7 @@ func authorizeAliasRequest(w http.ResponseWriter, r *http.Request, authorizer *a
 	authHeader := r.Header.Get("Authorization")
 	snapshot, headers, authErr := authorizer.Authorize(r.Context(), authHeader, aliasID, estimatedCredits, billableTokens, freeTokens)
 	if authErr != nil {
-		status := http.StatusUnauthorized
-		if authErr.Error.Type == "insufficient_quota" {
-			status = http.StatusTooManyRequests
-		} else if authErr.Error.Code != nil && *authErr.Error.Code == "model_not_found" {
-			status = http.StatusNotFound
-		}
-		if authErr.Error.Code != nil && *authErr.Error.Code == "rate_limit_exceeded" {
-			apierrors.WriteRateLimitError(w, authErr.Error.Message, authErr.Error.Code, headers)
-			return snapshot, false
-		}
-		apierrors.WriteError(w, status, authErr.Error.Type, authErr.Error.Message, authErr.Error.Code)
+		apierrors.WriteAuthFailure(w, authErr, headers)
 		return snapshot, false
 	}
 	return snapshot, true

--- a/apps/edge-api/internal/audio/authz_adapter.go
+++ b/apps/edge-api/internal/audio/authz_adapter.go
@@ -1,7 +1,6 @@
 package audio
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/authz"
@@ -20,9 +19,9 @@ func NewAuthorizerAdapter(inner *authz.Authorizer) *AuthorizerAdapter {
 // AuthorizeRequest extracts the Authorization header and delegates to the inner authorizer.
 func (a *AuthorizerAdapter) AuthorizeRequest(r *http.Request) (AuthResult, error) {
 	authHeader := r.Header.Get("Authorization")
-	snapshot, _, authErr := a.inner.Authorize(r.Context(), authHeader, "", 0, 0, 0)
+	snapshot, headers, authErr := a.inner.Authorize(r.Context(), authHeader, "", 0, 0, 0)
 	if authErr != nil {
-		return AuthResult{}, fmt.Errorf("unauthorized: %s", authErr.Error.Message)
+		return AuthResult{}, &authz.AuthzError{OpenAIErr: authErr, Headers: headers}
 	}
 	return AuthResult{
 		AccountID: snapshot.AccountID,

--- a/apps/edge-api/internal/audio/handler.go
+++ b/apps/edge-api/internal/audio/handler.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/authz"
 	apierrors "github.com/sakibsadmanshajib/hive/apps/edge-api/internal/errors"
 	"github.com/google/uuid"
 )
@@ -109,6 +110,10 @@ func NewHandler(
 func (h *Handler) authorize(w http.ResponseWriter, r *http.Request) (AuthResult, bool) {
 	result, err := h.authorizer.AuthorizeRequest(r)
 	if err != nil {
+		if ae, ok := authz.AsAuthzError(err); ok {
+			apierrors.WriteAuthFailure(w, ae.OpenAIErr, ae.Headers)
+			return AuthResult{}, false
+		}
 		code := "invalid_api_key"
 		apierrors.WriteError(w, http.StatusUnauthorized, "invalid_request_error", "Invalid API key.", &code)
 		return AuthResult{}, false

--- a/apps/edge-api/internal/authz/authorizer.go
+++ b/apps/edge-api/internal/authz/authorizer.go
@@ -14,11 +14,32 @@ import (
 type Authorizer struct {
 	client  *Client
 	limiter *Limiter
+
+	// failOpen controls behavior when the rate limiter backend (Redis) cannot
+	// be evaluated. Default false = fail closed (deny with a retryable 429) so a
+	// backend outage cannot silently disable abuse controls (#51). An operator
+	// may opt into fail-open for dev/local via WithFailOpen.
+	failOpen bool
 }
 
-// NewAuthorizer creates a new Authorizer.
-func NewAuthorizer(client *Client, limiter *Limiter) *Authorizer {
-	return &Authorizer{client: client, limiter: limiter}
+// AuthorizerOption configures an Authorizer.
+type AuthorizerOption func(*Authorizer)
+
+// WithFailOpen sets the limiter-degraded policy. failOpen=true admits requests
+// when the limiter backend errors (dev/local only); the production default is
+// fail closed. See #51.
+func WithFailOpen(failOpen bool) AuthorizerOption {
+	return func(a *Authorizer) { a.failOpen = failOpen }
+}
+
+// NewAuthorizer creates a new Authorizer. The default limiter-degraded policy
+// is fail closed; pass WithFailOpen(true) to opt into fail-open.
+func NewAuthorizer(client *Client, limiter *Limiter, opts ...AuthorizerOption) *Authorizer {
+	a := &Authorizer{client: client, limiter: limiter}
+	for _, opt := range opts {
+		opt(a)
+	}
+	return a
 }
 
 func newErr(errType string, message string, code *string) *apierrors.OpenAIError {
@@ -89,7 +110,24 @@ func (a *Authorizer) Authorize(ctx context.Context, authHeader string, aliasID s
 	if a.limiter != nil {
 		limitResult, err := a.limiter.Check(ctx, snapshot, aliasID, estimatedCredits, billableTokens, freeTokens)
 		if err != nil {
-			// On limiter failure, fail open to avoid turning transient Redis problems into hard outages.
+			// #51: the limiter backend (Redis) could not be evaluated. Emit a
+			// structured, operator-visible signal at the request boundary so a
+			// degraded limiter is never silent.
+			log.Printf("authz: rate limiter degraded account=%q key=%q fail_open=%v err=%v",
+				snapshot.AccountID, snapshot.KeyID, a.failOpen, err)
+			if !a.failOpen {
+				// Fail closed (production default): deny with a retryable 429
+				// rather than admit unmetered traffic. Message is provider-blind
+				// — no backend/internal detail leaks to the customer.
+				code := "rate_limit_exceeded"
+				return AuthSnapshot{}, map[string]string{"retry-after": "5"}, newErr(
+					"rate_limit_error",
+					"Rate limiting is temporarily unavailable. Please retry in a few seconds.",
+					&code,
+				)
+			}
+			// Fail open: explicitly enabled by operator (dev/local). Admit
+			// despite the degraded limiter.
 		} else if !limitResult.Allowed {
 			code := "rate_limit_exceeded"
 			return AuthSnapshot{}, rateLimitHeaders(limitResult), newErr(

--- a/apps/edge-api/internal/authz/authorizer.go
+++ b/apps/edge-api/internal/authz/authorizer.go
@@ -2,6 +2,7 @@ package authz
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"strconv"
@@ -45,6 +46,32 @@ func NewAuthorizer(client *Client, limiter *Limiter, opts ...AuthorizerOption) *
 func newErr(errType string, message string, code *string) *apierrors.OpenAIError {
 	e := apierrors.NewError(errType, message, code)
 	return &e
+}
+
+// AuthzError carries a structured authorization failure (the OpenAI error
+// envelope plus any rate-metadata headers) through adapter boundaries that
+// would otherwise flatten it to a generic error. Handlers type-assert this to
+// preserve the correct status — notably a retryable degraded-limiter 429 with
+// retry-after rather than a non-retryable 401 (#51).
+type AuthzError struct {
+	OpenAIErr *apierrors.OpenAIError
+	Headers   map[string]string
+}
+
+func (e *AuthzError) Error() string {
+	if e == nil || e.OpenAIErr == nil {
+		return "authz: unauthorized"
+	}
+	return e.OpenAIErr.Error.Message
+}
+
+// AsAuthzError reports whether err is an *AuthzError and returns it.
+func AsAuthzError(err error) (*AuthzError, bool) {
+	var ae *AuthzError
+	if errors.As(err, &ae) {
+		return ae, true
+	}
+	return nil, false
 }
 
 // Authorize validates a request against the AuthSnapshot system.

--- a/apps/edge-api/internal/authz/authorizer_test.go
+++ b/apps/edge-api/internal/authz/authorizer_test.go
@@ -2,8 +2,99 @@ package authz
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
 )
+
+// #51: a Redis-backed limiter that cannot evaluate (transient outage,
+// connection/auth failure) must NOT silently bypass rate limiting in
+// production. Default policy is fail-closed: the request is denied with a
+// retryable 429 rather than admitted unmetered.
+func TestAuthorizeFailsClosedWhenLimiterErrors(t *testing.T) {
+	client := &Client{
+		ResolveOverride: func(_ context.Context, _ string) (AuthSnapshot, error) {
+			return AuthSnapshot{
+				KeyID:             "key-1",
+				AccountID:         "acc-1",
+				Status:            "active",
+				AllowAllModels:    true,
+				BudgetKind:        "none",
+				AccountRatePolicy: &RatePolicy{RateLimitRPM: 120},
+				KeyRatePolicy:     &RatePolicy{RateLimitRPM: 12},
+			}, nil
+		},
+	}
+	limiter := &Limiter{
+		CheckOverride: func(_ context.Context, _ AuthSnapshot, _ string, _, _, _ int64) (LimitResult, error) {
+			return LimitResult{}, errors.New("authz: run rpm/tpm limiter: redis: connection refused")
+		},
+	}
+
+	authorizer := NewAuthorizer(client, limiter)
+
+	_, headers, err := authorizer.Authorize(context.Background(), "Bearer hk_test", "hive-default", 50, 100, 20)
+	if err == nil {
+		t.Fatal("expected fail-closed rate-limit error when limiter backend errors")
+	}
+	if err.Error.Type != "rate_limit_error" {
+		t.Fatalf("expected rate_limit_error type, got %q", err.Error.Type)
+	}
+	if err.Error.Code == nil || *err.Error.Code != "rate_limit_exceeded" {
+		t.Fatalf("expected rate_limit_exceeded code, got %#v", err.Error.Code)
+	}
+	if headers["retry-after"] == "" {
+		t.Fatalf("expected retry-after header on degraded-limiter denial, got %#v", headers)
+	}
+	// Provider-blind: the customer-facing message must not leak the backend
+	// (redis) or any internal error text.
+	if msg := err.Error.Message; containsAny(msg, "redis", "connection refused", "rpm/tpm") {
+		t.Fatalf("error message leaks backend internals: %q", msg)
+	}
+}
+
+// #51: an operator may explicitly opt into fail-open (dev/local) so a Redis
+// outage degrades to unmetered rather than denying. This must be a deliberate
+// toggle, never the default.
+func TestAuthorizeFailsOpenWhenExplicitlyEnabled(t *testing.T) {
+	client := &Client{
+		ResolveOverride: func(_ context.Context, _ string) (AuthSnapshot, error) {
+			return AuthSnapshot{
+				KeyID:             "key-1",
+				AccountID:         "acc-1",
+				Status:            "active",
+				AllowAllModels:    true,
+				BudgetKind:        "none",
+				AccountRatePolicy: &RatePolicy{RateLimitRPM: 120},
+				KeyRatePolicy:     &RatePolicy{RateLimitRPM: 12},
+			}, nil
+		},
+	}
+	limiter := &Limiter{
+		CheckOverride: func(_ context.Context, _ AuthSnapshot, _ string, _, _, _ int64) (LimitResult, error) {
+			return LimitResult{}, errors.New("redis down")
+		},
+	}
+
+	authorizer := NewAuthorizer(client, limiter, WithFailOpen(true))
+
+	snapshot, _, err := authorizer.Authorize(context.Background(), "Bearer hk_test", "hive-default", 50, 100, 20)
+	if err != nil {
+		t.Fatalf("expected fail-open admit when explicitly enabled, got %#v", err)
+	}
+	if snapshot.KeyID != "key-1" {
+		t.Fatalf("expected resolved snapshot returned on fail-open, got %#v", snapshot)
+	}
+}
+
+func containsAny(s string, subs ...string) bool {
+	for _, sub := range subs {
+		if strings.Contains(strings.ToLower(s), sub) {
+			return true
+		}
+	}
+	return false
+}
 
 func TestAuthorizeReturnsRateLimitHeadersOnlyFor429(t *testing.T) {
 	client := &Client{

--- a/apps/edge-api/internal/batches/authz_adapter.go
+++ b/apps/edge-api/internal/batches/authz_adapter.go
@@ -1,7 +1,6 @@
 package batches
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/authz"
@@ -20,9 +19,9 @@ func NewAuthorizerAdapter(inner *authz.Authorizer) *AuthorizerAdapter {
 // AuthorizeRequest extracts the Authorization header and delegates to the inner authorizer.
 func (a *AuthorizerAdapter) AuthorizeRequest(r *http.Request) (AuthResult, error) {
 	authHeader := r.Header.Get("Authorization")
-	snapshot, _, authErr := a.inner.Authorize(r.Context(), authHeader, "", 0, 0, 0)
+	snapshot, headers, authErr := a.inner.Authorize(r.Context(), authHeader, "", 0, 0, 0)
 	if authErr != nil {
-		return AuthResult{}, fmt.Errorf("unauthorized: %s", authErr.Error.Message)
+		return AuthResult{}, &authz.AuthzError{OpenAIErr: authErr, Headers: headers}
 	}
 	return AuthResult{
 		AccountID: snapshot.AccountID,

--- a/apps/edge-api/internal/batches/handler.go
+++ b/apps/edge-api/internal/batches/handler.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/authz"
 	apierrors "github.com/sakibsadmanshajib/hive/apps/edge-api/internal/errors"
 )
 
@@ -116,6 +117,10 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) authorize(w http.ResponseWriter, r *http.Request) (AuthResult, bool) {
 	result, err := h.authorizer.AuthorizeRequest(r)
 	if err != nil {
+		if ae, ok := authz.AsAuthzError(err); ok {
+			apierrors.WriteAuthFailure(w, ae.OpenAIErr, ae.Headers)
+			return AuthResult{}, false
+		}
 		code := "invalid_api_key"
 		apierrors.WriteError(w, http.StatusUnauthorized, "invalid_request_error", "Invalid API key.", &code)
 		return AuthResult{}, false

--- a/apps/edge-api/internal/errors/openai.go
+++ b/apps/edge-api/internal/errors/openai.go
@@ -49,3 +49,29 @@ func WriteRateLimitError(w http.ResponseWriter, message string, code *string, he
 	}
 	WriteError(w, http.StatusTooManyRequests, "rate_limit_error", message, code)
 }
+
+// WriteAuthFailure writes the OpenAI-compatible response for an authorization
+// failure, mapping the error to the correct HTTP status and preserving rate
+// metadata headers. It is the single source of truth for translating an
+// authz failure into a wire response — the inference hot-path and every media/
+// file/batch handler route through it so a degraded-limiter 429 (retryable,
+// with retry-after) is never collapsed into a non-retryable 401 (#51).
+func WriteAuthFailure(w http.ResponseWriter, oerr *OpenAIError, headers map[string]string) {
+	if oerr == nil {
+		code := "invalid_api_key"
+		WriteError(w, http.StatusUnauthorized, "invalid_request_error", "Invalid API key.", &code)
+		return
+	}
+	if oerr.Error.Code != nil && *oerr.Error.Code == "rate_limit_exceeded" {
+		WriteRateLimitError(w, oerr.Error.Message, oerr.Error.Code, headers)
+		return
+	}
+	status := http.StatusUnauthorized
+	switch {
+	case oerr.Error.Type == "insufficient_quota":
+		status = http.StatusTooManyRequests
+	case oerr.Error.Code != nil && *oerr.Error.Code == "model_not_found":
+		status = http.StatusNotFound
+	}
+	WriteError(w, status, oerr.Error.Type, oerr.Error.Message, oerr.Error.Code)
+}

--- a/apps/edge-api/internal/errors/openai_test.go
+++ b/apps/edge-api/internal/errors/openai_test.go
@@ -153,6 +153,67 @@ func TestNewError(t *testing.T) {
 	}
 }
 
+func TestWriteAuthFailureMapsStatusAndPreservesRetryHeaders(t *testing.T) {
+	tests := []struct {
+		name       string
+		errType    string
+		code       *string
+		headers    map[string]string
+		wantStatus int
+		wantRetry  string
+	}{
+		{
+			name:       "degraded-limiter rate_limit_exceeded -> 429 retryable",
+			errType:    "rate_limit_error",
+			code:       ptrStr("rate_limit_exceeded"),
+			headers:    map[string]string{"retry-after": "5"},
+			wantStatus: http.StatusTooManyRequests,
+			wantRetry:  "5",
+		},
+		{
+			name:       "insufficient_quota -> 429",
+			errType:    "insufficient_quota",
+			code:       ptrStr("insufficient_quota"),
+			wantStatus: http.StatusTooManyRequests,
+		},
+		{
+			name:       "model_not_found -> 404",
+			errType:    "invalid_request_error",
+			code:       ptrStr("model_not_found"),
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name:       "invalid key -> 401",
+			errType:    "invalid_request_error",
+			code:       ptrStr("invalid_api_key"),
+			wantStatus: http.StatusUnauthorized,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			oerr := NewError(tt.errType, "msg", tt.code)
+			WriteAuthFailure(w, &oerr, tt.headers)
+
+			if w.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d", w.Code, tt.wantStatus)
+			}
+			if got := w.Header().Get("retry-after"); got != tt.wantRetry {
+				t.Fatalf("retry-after = %q, want %q", got, tt.wantRetry)
+			}
+		})
+	}
+}
+
+func TestWriteAuthFailureNilFallsBackTo401(t *testing.T) {
+	w := httptest.NewRecorder()
+	WriteAuthFailure(w, nil, nil)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("nil error status = %d, want 401", w.Code)
+	}
+}
+
 func TestPermanentFailuresOmitRetryHeaders(t *testing.T) {
 	w := httptest.NewRecorder()
 	code := ptrStr("invalid_api_key")

--- a/apps/edge-api/internal/files/authz_adapter.go
+++ b/apps/edge-api/internal/files/authz_adapter.go
@@ -1,7 +1,6 @@
 package files
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/authz"
@@ -22,9 +21,9 @@ func NewAuthorizerAdapter(inner *authz.Authorizer) *AuthorizerAdapter {
 // AuthorizeRequest extracts the Authorization header and delegates to the inner authorizer.
 func (a *AuthorizerAdapter) AuthorizeRequest(r *http.Request) (AuthResult, error) {
 	authHeader := r.Header.Get("Authorization")
-	snapshot, _, authErr := a.inner.Authorize(r.Context(), authHeader, "", 0, 0, 0)
+	snapshot, headers, authErr := a.inner.Authorize(r.Context(), authHeader, "", 0, 0, 0)
 	if authErr != nil {
-		return AuthResult{}, fmt.Errorf("unauthorized: %s", authErr.Error.Message)
+		return AuthResult{}, &authz.AuthzError{OpenAIErr: authErr, Headers: headers}
 	}
 	return AuthResult{
 		AccountID: snapshot.AccountID,

--- a/apps/edge-api/internal/files/handler.go
+++ b/apps/edge-api/internal/files/handler.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/authz"
 	apierrors "github.com/sakibsadmanshajib/hive/apps/edge-api/internal/errors"
 )
 
@@ -105,6 +106,10 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) authorize(w http.ResponseWriter, r *http.Request) (AuthResult, bool) {
 	result, err := h.authorizer.AuthorizeRequest(r)
 	if err != nil {
+		if ae, ok := authz.AsAuthzError(err); ok {
+			apierrors.WriteAuthFailure(w, ae.OpenAIErr, ae.Headers)
+			return AuthResult{}, false
+		}
 		code := "invalid_api_key"
 		apierrors.WriteError(w, http.StatusUnauthorized, "invalid_request_error", "Invalid API key.", &code)
 		return AuthResult{}, false

--- a/apps/edge-api/internal/images/authz_adapter.go
+++ b/apps/edge-api/internal/images/authz_adapter.go
@@ -1,7 +1,6 @@
 package images
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/authz"
@@ -20,9 +19,9 @@ func NewAuthorizerAdapter(inner *authz.Authorizer) *AuthorizerAdapter {
 // AuthorizeRequest extracts the Authorization header and delegates to the inner authorizer.
 func (a *AuthorizerAdapter) AuthorizeRequest(r *http.Request) (AuthResult, error) {
 	authHeader := r.Header.Get("Authorization")
-	snapshot, _, authErr := a.inner.Authorize(r.Context(), authHeader, "", 0, 0, 0)
+	snapshot, headers, authErr := a.inner.Authorize(r.Context(), authHeader, "", 0, 0, 0)
 	if authErr != nil {
-		return AuthResult{}, fmt.Errorf("unauthorized: %s", authErr.Error.Message)
+		return AuthResult{}, &authz.AuthzError{OpenAIErr: authErr, Headers: headers}
 	}
 	return AuthResult{
 		AccountID: snapshot.AccountID,

--- a/apps/edge-api/internal/images/handler.go
+++ b/apps/edge-api/internal/images/handler.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/authz"
 	apierrors "github.com/sakibsadmanshajib/hive/apps/edge-api/internal/errors"
 	"github.com/google/uuid"
 )
@@ -122,6 +123,10 @@ func NewHandler(
 func (h *Handler) authorize(w http.ResponseWriter, r *http.Request) (AuthResult, bool) {
 	result, err := h.authorizer.AuthorizeRequest(r)
 	if err != nil {
+		if ae, ok := authz.AsAuthzError(err); ok {
+			apierrors.WriteAuthFailure(w, ae.OpenAIErr, ae.Headers)
+			return AuthResult{}, false
+		}
 		code := "invalid_api_key"
 		apierrors.WriteError(w, http.StatusUnauthorized, "invalid_request_error", "Invalid API key.", &code)
 		return AuthResult{}, false


### PR DESCRIPTION
Closes #51.

## Problem
The edge rate limiter failed **open** on any Redis error. In `Authorizer.Authorize` the limiter-error branch was empty (`// fail open to avoid turning transient Redis problems into hard outages`), so a transient Redis outage / connection failure / auth-config issue **silently disabled all rate-limit and fraud-window (5h, weekly) enforcement** with no request-boundary signal. A dependency outage could amplify into unmetered abuse and cost / provider-pressure.

Issue cites the pre-rewrite TS path (`apps/api/src/runtime/redis-rate-limiter.ts`); the live Go equivalent carried the identical bug.

## Fix
Deliberate, configurable degraded-backend policy:

- **Default fail CLOSED** (production): limiter backend unevaluable → deny with a **retryable HTTP 429** (`rate_limit_error` / `rate_limit_exceeded`) + `retry-after`. Customer message is **provider-blind** — no backend/internal text leaks.
- **Explicit fail-open** via `RATE_LIMIT_FAIL_OPEN=true` (dev/local only), with a loud startup warning.
- **Structured, operator-visible** `authz: rate limiter degraded … fail_open=…` log at the request boundary on every backend error — never silent.

`NewAuthorizer` gains a variadic `AuthorizerOption` (`WithFailOpen`); all existing two-arg call sites stay source-compatible and default to fail closed.

## Acceptance criteria mapping
- ✅ Production mode does not silently bypass limiting on Redis failure (fail-closed default).
- ✅ Degraded behavior observable in logs (structured request-boundary line).
- ✅ Regression tests cover the Redis error path.
- ✅ Docs explain the configured failure mode (`.env.example`).

## Tests
- `TestAuthorizeFailsClosedWhenLimiterErrors` — default denies with 429, `retry-after` present, message leaks no backend internals.
- `TestAuthorizeFailsOpenWhenExplicitlyEnabled` — opt-in admits despite degraded limiter.

## Test plan
- [ ] CI: Go tests (edge-api) green.
- [ ] CI: Repo policy lints green.
- [ ] Ops: leave `RATE_LIMIT_FAIL_OPEN` unset (fail closed) in staging + prod.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable rate-limiting behavior via `RATE_LIMIT_FAIL_OPEN` environment variable. By default, the system denies requests with rate-limit errors when the rate limiter backend is unavailable (fail-closed). Can be explicitly enabled in dev/local environments to allow traffic during backend degradation.

* **Tests**
  * Added test coverage for fail-closed and fail-open rate-limiting scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sakibsadmanshajib/hive/pull/160?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->