### PR TITLE
fix: reject tools, tool_choice, response_format on /v1/chat/completions

### DIFF
--- a/apps/edge-api/internal/inference/chat_completions.go
+++ b/apps/edge-api/internal/inference/chat_completions.go
@@ -2,6 +2,7 @@ package inference
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 )
@@ -26,6 +27,16 @@ func handleChatCompletions(o *Orchestrator, w http.ResponseWriter, r *http.Reque
 	}
 	if len(req.Messages) == 0 {
 		writeMissingFieldError(w, "messages")
+		return
+	}
+
+	// Reject requests that carry tool-calling or structured-output fields that
+	// are not yet supported end-to-end (issue #118). Silently forwarding them
+	// causes the provider to ignore the fields and return a plain content
+	// response, which misleads SDK consumers into thinking the model did not
+	// use the tool. Return an explicit 400 until provider-routing support for
+	// these parameters is wired in a future phase.
+	if err := rejectUnsupportedChatParams(w, &req); err != nil {
 		return
 	}
 
@@ -63,6 +74,41 @@ func normalizeChatCompletion(respBody []byte, aliasID string) ([]byte, *UsageRes
 	}
 
 	return normalized, resp.Usage, nil
+}
+
+// rejectUnsupportedChatParams checks for fields that are parsed and present in
+// ChatCompletionRequest but not yet supported end-to-end. It writes a 400
+// response and returns a non-nil sentinel error when any unsupported parameter
+// is present, so the caller can return immediately.
+func rejectUnsupportedChatParams(w http.ResponseWriter, req *ChatCompletionRequest) error {
+	var param string
+	switch {
+	case len(req.Tools) > 0:
+		param = "tools"
+	case len(req.ToolChoice) > 0:
+		param = "tool_choice"
+	case len(req.ResponseFormat) > 0:
+		param = "response_format"
+	case len(req.Functions) > 0:
+		param = "functions"
+	case len(req.FunctionCall) > 0:
+		param = "function_call"
+	}
+
+	if param == "" && req.ParallelToolCalls != nil {
+		param = "parallel_tool_calls"
+	}
+
+	if param == "" {
+		return nil
+	}
+
+	code := "unsupported_parameter"
+	writeError(w, http.StatusBadRequest, "invalid_request_error",
+		"The '"+param+"' parameter is not yet supported. Tool calling and structured output will be available in a future release.",
+		&code,
+	)
+	return errors.New("unsupported parameter: " + param)
 }
 
 // writeError is a local helper to write OpenAI-style errors.

--- a/apps/edge-api/internal/inference/chat_completions.go
+++ b/apps/edge-api/internal/inference/chat_completions.go
@@ -81,17 +81,25 @@ func normalizeChatCompletion(respBody []byte, aliasID string) ([]byte, *UsageRes
 // response and returns a non-nil sentinel error when any unsupported parameter
 // is present, so the caller can return immediately.
 func rejectUnsupportedChatParams(w http.ResponseWriter, req *ChatCompletionRequest) error {
+	// isPresent returns true when a json.RawMessage field was explicitly set by
+	// the caller (non-empty and not the JSON literal "null"). Using len > 0 alone
+	// misses the case where the client sends `"tools": []` — Go unmarshals that
+	// as an empty non-nil slice whose JSON encoding is "[]", not "null".
+	isPresent := func(f json.RawMessage) bool {
+		return len(f) > 0 && string(f) != "null"
+	}
+
 	var param string
 	switch {
-	case len(req.Tools) > 0:
+	case isPresent(req.Tools):
 		param = "tools"
-	case len(req.ToolChoice) > 0:
+	case isPresent(req.ToolChoice):
 		param = "tool_choice"
-	case len(req.ResponseFormat) > 0:
+	case isPresent(req.ResponseFormat):
 		param = "response_format"
-	case len(req.Functions) > 0:
+	case isPresent(req.Functions):
 		param = "functions"
-	case len(req.FunctionCall) > 0:
+	case isPresent(req.FunctionCall):
 		param = "function_call"
 	}
 

--- a/apps/edge-api/internal/inference/chat_completions_tools_test.go
+++ b/apps/edge-api/internal/inference/chat_completions_tools_test.go
@@ -1,0 +1,134 @@
+package inference
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestChatCompletions_ToolsRejected verifies that requests carrying tools,
+// tool_choice, response_format, parallel_tool_calls, functions, or
+// function_call fields receive a 400 with an "unsupported_parameter" error
+// code (issue #118 short-term fix).
+//
+// The handler must NOT silently drop these fields and forward to LiteLLM,
+// because the backing provider may ignore them and return a plain content
+// response, causing silent behavioural divergence for SDK consumers.
+func TestChatCompletions_ToolsRejected(t *testing.T) {
+	h := NewHandler(&Orchestrator{})
+
+	cases := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "tools field rejected",
+			body: `{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}],"tools":[{"type":"function","function":{"name":"get_weather","description":"Get weather","parameters":{"type":"object","properties":{}}}}]}`,
+		},
+		{
+			name: "tool_choice field rejected",
+			body: `{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}],"tools":[{"type":"function","function":{"name":"f","description":"d","parameters":{"type":"object","properties":{}}}}],"tool_choice":"auto"}`,
+		},
+		{
+			name: "response_format field rejected",
+			body: `{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}],"response_format":{"type":"json_object"}}`,
+		},
+		{
+			name: "parallel_tool_calls field rejected",
+			body: `{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}],"tools":[{"type":"function","function":{"name":"f","description":"d","parameters":{"type":"object","properties":{}}}}],"parallel_tool_calls":true}`,
+		},
+		{
+			name: "functions (legacy) field rejected",
+			body: `{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}],"functions":[{"name":"get_weather","description":"Get weather","parameters":{"type":"object","properties":{}}}]}`,
+		},
+		{
+			name: "function_call (legacy) field rejected",
+			body: `{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}],"functions":[{"name":"f","description":"d","parameters":{"type":"object","properties":{}}}],"function_call":"auto"}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(tc.body))
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, req)
+
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400, got %d (body: %s)", w.Code, w.Body.String())
+			}
+
+			var resp map[string]any
+			if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+				t.Fatalf("response is not valid JSON: %v", err)
+			}
+
+			errObj, ok := resp["error"].(map[string]any)
+			if !ok {
+				t.Fatalf("expected top-level 'error' object, got: %v", resp)
+			}
+
+			code, _ := errObj["code"].(string)
+			if code != "unsupported_parameter" {
+				t.Errorf("expected code 'unsupported_parameter', got %q", code)
+			}
+
+			errType, _ := errObj["type"].(string)
+			if errType != "invalid_request_error" {
+				t.Errorf("expected type 'invalid_request_error', got %q", errType)
+			}
+
+			// Error message must not leak provider names (provider-blind rule).
+			msg, _ := errObj["message"].(string)
+			for _, forbidden := range []string{"OpenAI", "openai", "LiteLLM", "litellm", "openrouter", "OpenRouter", "groq", "Groq"} {
+				if strings.Contains(msg, forbidden) {
+					t.Errorf("error message leaks provider name %q: %s", forbidden, msg)
+				}
+			}
+		})
+	}
+}
+
+// TestChatCompletions_NoToolsPassesThrough verifies that a plain chat
+// completion request (no tools/tool_choice/response_format) is NOT rejected
+// by the tools guard and reaches the auth layer (returns 401 with no auth).
+func TestChatCompletions_NoToolsPassesThrough(t *testing.T) {
+	h := NewHandler(&Orchestrator{})
+	body := `{"model":"gpt-4o","messages":[{"role":"user","content":"hello"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	// 401 = reached auth layer, i.e. tools guard did NOT block it.
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 (plain request passes tools guard), got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestChatCompletions_StreamWithToolsRejected verifies that streaming requests
+// with tools are also rejected before they reach the streaming path.
+func TestChatCompletions_StreamWithToolsRejected(t *testing.T) {
+	h := NewHandler(&Orchestrator{})
+	body := `{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}],"stream":true,"tools":[{"type":"function","function":{"name":"f","description":"d","parameters":{"type":"object","properties":{}}}}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for streaming+tools, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("response is not valid JSON: %v", err)
+	}
+	errObj, ok := resp["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected error object")
+	}
+	code, _ := errObj["code"].(string)
+	if code != "unsupported_parameter" {
+		t.Errorf("expected code 'unsupported_parameter', got %q", code)
+	}
+}

--- a/apps/edge-api/internal/inference/chat_completions_tools_test.go
+++ b/apps/edge-api/internal/inference/chat_completions_tools_test.go
@@ -47,6 +47,13 @@ func TestChatCompletions_ToolsRejected(t *testing.T) {
 			name: "function_call (legacy) field rejected",
 			body: `{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}],"functions":[{"name":"f","description":"d","parameters":{"type":"object","properties":{}}}],"function_call":"auto"}`,
 		},
+		{
+			// Empty array must be treated as present (non-null), not silently ignored.
+			// A client sending `"tools": []` has explicitly opted in to the tools
+			// parameter and must receive the same 400 as a non-empty tools array.
+			name: "tools empty array rejected",
+			body: `{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}],"tools":[]}`,
+		},
 	}
 
 	for _, tc := range cases {

--- a/apps/edge-api/internal/inference/responses.go
+++ b/apps/edge-api/internal/inference/responses.go
@@ -131,6 +131,9 @@ func translateResponsesToChatCompletions(req ResponsesRequest) ([]byte, error) {
 	}
 
 	// tools: translate from Responses API format to chat/completions format.
+	// NOTE: tool forwarding here is intentional — the Responses API supports tools
+	// natively. The chat/completions guard in rejectUnsupportedChatParams does NOT
+	// apply to this path.
 	if len(req.Tools) > 0 && string(req.Tools) != "null" {
 		translated, err := translateToolsToChat(req.Tools)
 		if err == nil {

--- a/apps/edge-api/internal/inference/types.go
+++ b/apps/edge-api/internal/inference/types.go
@@ -53,6 +53,7 @@ type ChatCompletionRequest struct {
 	TopLogprobs         *int            `json:"top_logprobs,omitempty"`
 	Seed                *int            `json:"seed,omitempty"`
 	User                *string         `json:"user,omitempty"`
+	ParallelToolCalls   *bool           `json:"parallel_tool_calls,omitempty"`
 	Functions           json.RawMessage `json:"functions,omitempty"`
 	FunctionCall        json.RawMessage `json:"function_call,omitempty"`
 }

--- a/packages/openai-contract/matrix/support-matrix.json
+++ b/packages/openai-contract/matrix/support-matrix.json
@@ -98,7 +98,7 @@
       "path": "/v1/chat/completions",
       "status": "supported_now",
       "phase": 6,
-      "notes": "Chat completion inference"
+      "notes": "Chat completion inference. The following parameters are rejected with 400 unsupported_parameter until capability-based provider routing ships (planned Phase 20+): tools, tool_choice, response_format, parallel_tool_calls, functions, function_call."
     },
     {
       "method": "GET",

--- a/packages/sdk-tests/js/tests/chat-completions/chat-completions.test.ts
+++ b/packages/sdk-tests/js/tests/chat-completions/chat-completions.test.ts
@@ -48,61 +48,64 @@ describe("Chat Completions", () => {
     ).rejects.toMatchObject({ status: 404 });
   });
 
-  it("supports tool calling", async () => {
-    const response = await client.chat.completions.create({
-      model: MODEL,
-      messages: [
-        { role: "user", content: "What is the weather like in London?" },
-      ],
-      max_tokens: 256,
-      tools: [
-        {
-          type: "function",
-          function: {
-            name: "get_weather",
-            description: "Get the current weather for a location",
-            parameters: {
-              type: "object",
-              properties: {
-                location: {
-                  type: "string",
-                  description: "The city to get weather for",
+  it("rejects tools with 400 unsupported_parameter", async () => {
+    // The edge explicitly rejects tool calling until full support ships (#118).
+    await expect(
+      client.chat.completions.create({
+        model: MODEL,
+        messages: [
+          { role: "user", content: "What is the weather like in London?" },
+        ],
+        max_tokens: 256,
+        tools: [
+          {
+            type: "function",
+            function: {
+              name: "get_weather",
+              description: "Get the current weather for a location",
+              parameters: {
+                type: "object",
+                properties: {
+                  location: {
+                    type: "string",
+                    description: "The city to get weather for",
+                  },
                 },
+                required: ["location"],
               },
-              required: ["location"],
             },
           },
-        },
-      ],
+        ],
+      }),
+    ).rejects.toMatchObject({
+      status: 400,
+      error: {
+        type: "invalid_request_error",
+        code: "unsupported_parameter",
+      },
     });
-
-    // Response should complete without error — tool may or may not be called.
-    expect(response.choices.length).toBeGreaterThanOrEqual(1);
   });
 
-  it("supports response_format json_object", async () => {
-    const response = await client.chat.completions.create({
-      model: MODEL,
-      messages: [
-        {
-          role: "user",
-          content: 'Return a JSON object with a single key "status" set to "ok".',
-        },
-      ],
-      max_tokens: 256,
-      response_format: { type: "json_object" },
+  it("rejects response_format with 400 unsupported_parameter", async () => {
+    // The edge explicitly rejects response_format until full support ships (#118).
+    await expect(
+      client.chat.completions.create({
+        model: MODEL,
+        messages: [
+          {
+            role: "user",
+            content: 'Return a JSON object with a single key "status" set to "ok".',
+          },
+        ],
+        max_tokens: 256,
+        response_format: { type: "json_object" },
+      }),
+    ).rejects.toMatchObject({
+      status: 400,
+      error: {
+        type: "invalid_request_error",
+        code: "unsupported_parameter",
+      },
     });
-
-    expect(response.choices.length).toBeGreaterThanOrEqual(1);
-    // response_format json_object is a best-effort provider hint. Upstream
-    // providers may return null content with completion_tokens=0 (finish
-    // reason "stop") when the schema constraint can't be satisfied. Verify
-    // the request reached the provider (prompt billed) and, when content is
-    // present, parses as valid JSON.
-    expect(response.usage?.prompt_tokens ?? 0).toBeGreaterThan(0);
-    const content = response.choices[0].message.content;
-    if (content) {
-      expect(() => JSON.parse(content)).not.toThrow();
-    }
   });
 });


### PR DESCRIPTION
## Summary

- `tools`, `tool_choice`, `response_format`, `parallel_tool_calls`, `functions`, and `function_call` were silently forwarded to LiteLLM on `/v1/chat/completions`
- Providers that lack tool-call support ignore these fields and return a plain content response, so SDK consumers saw no `tool_calls` in the reply and assumed the model did not invoke the tool
- Short-term fix: return `400 invalid_request_error` with code `unsupported_parameter` for any of these fields, covering both streaming and non-streaming paths

## Root cause

`chat_completions.go:handleChatCompletions` reads the raw request body and passes it directly to `executeSync`/`executeStreaming`, which in turn forwards it to LiteLLM via `litellm_client.go:rewriteModel`. The `rewriteModel` function only rewrites the `model` field and preserves all other fields, so tools-bearing requests reached the provider. When the provider has no tool-call capability it silently drops the tools and returns a normal text completion, causing silent behavioural divergence.

Relevant files:
- Root cause: `apps/edge-api/internal/inference/chat_completions.go` (no parameter guard)
- Fix: `rejectUnsupportedChatParams` added before the streaming/sync branch
- Supporting: `ParallelToolCalls *bool` field added to `ChatCompletionRequest` in `types.go`

## Test plan

- [x] `TestChatCompletions_ToolsRejected`: each unsupported field (tools, tool_choice, response_format, parallel_tool_calls, functions, function_call) returns 400 with code `unsupported_parameter` and type `invalid_request_error`
- [x] Provider-blind check: error messages contain no provider names (OpenAI, LiteLLM, OpenRouter, Groq)
- [x] `TestChatCompletions_NoToolsPassesThrough`: plain request without tools is not blocked; reaches auth layer (401)
- [x] `TestChatCompletions_StreamWithToolsRejected`: streaming requests with tools are rejected with same 400 before reaching the streaming path
- [ ] Verify CI Go tests pass on this PR

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)