### PR TITLE
docs: add v1.2 agentic surface roadmap (anthropic api, mcp, router llm)

### DIFF
--- a/.planning/v1.2-agentic-surface.md
+++ b/.planning/v1.2-agentic-surface.md
@@ -123,6 +123,10 @@ tool-capable provider (medium-term). Phase 27 assumes the medium-term passthroug
    served contract stays the single source of truth.
 7. **Provider-blind and BDT guarantees:** every error and metadata surface on `/v1/messages` reuses the
    edge provider-blind sanitisation (`internal/errors/provider_blind.go`) and emits no USD/FX.
+8. **Auth header normalization:** the edge auth path normalises `x-api-key` headers (sent by the official
+   Anthropic Python and TypeScript SDKs) to the internal `Authorization: Bearer hk_...` form before
+   inference authorization, so SDK requests reach the `/v1/messages` translator without failing at the
+   auth selector. This is a Phase 27 implementation requirement, not a non-goal.
 
 ### Non-Goals (Phase 27)
 
@@ -290,7 +294,7 @@ boot the v1.2 surface with the correct defaults.
 
 | Feature | Hive Cloud default | EnterpriseEdge default | Gating mechanism |
 |---------|--------------------|------------------------|------------------|
-| Anthropic `/v1/messages` | on | on | always-on edge route; no flag needed once #118 fixed |
+| Anthropic `/v1/messages` | on | on | env-gated, on by default; flag allows rollback or staged cutover |
 | MCP connectors | on, per-tenant via `tenant_settings` | on, single tenant | RBAC-gated config; `tenant_settings` row |
 | Router-LLM | shadow first, then per-tenant enforce | off by default | env flag plus `tenant_settings` policy |
 
@@ -341,5 +345,6 @@ no new product fork; it only adds env-gated capabilities to the existing one-mon
 
 This is a roadmap draft. Each phase requires its own GSD executable spec/plan with per-task evidence
 frames before implementation, the same approval gate used in v1.0 and v1.1. No v1.2 phase begins until
-the v1.1 ship gates `chat_app_reaudit` and `web_search_tool` both pass, and Phase 27 specifically waits on
+the v1.1 ship gate `chat_app_reaudit` passes (unconditional); `web_search_tool` is required only if kept
+in v1.1 launch scope (conditional per `.planning/STATE.md` Phase 26 note). Phase 27 specifically waits on
 issue #118 (tools passthrough) being fixed on the OpenAI surface first.

--- a/.planning/v1.2-agentic-surface.md
+++ b/.planning/v1.2-agentic-surface.md
@@ -1,0 +1,345 @@
+---
+milestone: v1.2
+milestone_name: agentic-surface
+status: roadmap-draft
+created: 2026-06-10
+previous_milestone: v1.1
+previous_milestone_name: deferred-scope-and-chat-app
+phases: 27-30
+tracks: C (agentic-api), D (connectors-routing), E (productization)
+exec_mode: dependency ordered; gated behind v1.1 ship gates
+---
+
+# v1.2 Master Plan — Agentic Surface
+
+> **Status:** roadmap draft. Each phase still requires its own executable GSD spec/plan
+> before implementation, following the same approval gate as v1.0 and v1.1.
+
+## Why This Milestone
+
+v1.0 shipped the developer API core (OpenAI-shaped surface, prepaid BDT billing, provider-blind
+routing). v1.1 adds the chat app (Open WebUI), provider catalog, credit/quota engine, shared RAG,
+admin console, and web search. v1.2 turns Hive from an OpenAI-shaped gateway into an **agentic AI
+workstation for Bangladesh**: a second client-facing API dialect (Anthropic Messages), first-class
+tool connectivity (MCP), and an intelligent routing layer that decides where each request runs by
+cost, latency, task type, and tenant policy.
+
+These three capabilities share one theme: agentic workloads. Coding agents and assistant frameworks
+increasingly speak Anthropic's Messages format, expect MCP connectors, and benefit from routing that
+is smarter than a static model map. Delivering them is what lets the same monorepo serve both
+products in the owner vision: Hive Cloud (hosted multi-tenant SaaS) and EnterpriseEdge (self-hosted
+single-tenant), with a future desktop app reusing the same edge surface.
+
+## Entry Gate (HARD)
+
+v1.2 work does **not** start until every v1.1 ship gate passes. From `.planning/STATE.md`:
+
+| v1.1 Gate | Source phase | Must be |
+|-----------|--------------|---------|
+| `fx_usd_zero_leak` | Phase 17 | true (already closed 2026-05-09) |
+| `rbac_matrix` | Phase 18 | true (already closed 2026-05-14) |
+| `chat_app_reaudit` | Phase 25 | **true** (currently false) |
+| `web_search_tool` | Phase 26 | **true if kept in v1.1 launch scope** (currently conditional) |
+
+The two open gates, `chat_app_reaudit` and `web_search_tool`, are the explicit blockers. Until both
+resolve, no v1.2 phase may begin planning execution. This protects the BD regulatory surface (zero
+customer-visible USD/FX) across every new API dialect introduced here, because each new surface must
+inherit the same provider-blind and BDT-only guarantees that v1.1 finished hardening.
+
+## Decisions Locked
+
+| Item | Choice |
+|------|--------|
+| API dialect strategy | Hive serves the OpenAI surface (v1.0) plus an **Anthropic Messages** surface (`/v1/messages`). Both translate down to one internal OpenAI-shaped dispatch path; we do not maintain two parallel inference engines. |
+| Translation home | The Anthropic-to-internal translation lives in `edge-api` (request and SSE response mapping). Internal dispatch (`apps/edge-api/internal/chat/dispatch.go`, `internal/inference/`) stays the single execution path. |
+| Tool prerequisite | Anthropic tool use cannot ship before issue #118 (tools/`tool_choice`/`response_format` passthrough) is fixed on `/v1/chat/completions`. The OpenAI surface must pass tool calls through first; the Anthropic surface reuses that plumbing. |
+| MCP trust boundary | MCP connector configuration is per-tenant and lives in `control-plane`. Edge runs tool calls through a proxy that never logs tenant secrets and never leaks provider or connector identity in customer-visible errors. |
+| Router-LLM scope | Router-LLM is an intelligent **pre-routing classifier** that sits above the existing static LiteLLM routing, not a replacement for it. LiteLLM keeps doing the mechanical fan-out to OpenRouter/Groq; Router-LLM decides the route handle. |
+| Money language | BDT-only across every new surface. No customer-facing FX or USD on the Anthropic surface, MCP errors, or routing metadata. Inherits v1.1 Phase 17 guarantees. |
+| Productization | Every v1.2 feature lands in both Hive Cloud and EnterpriseEdge from the same deploy script, env-gated. No product-specific code forks. |
+
+## Phase Order
+
+| # | Phase | Track | Depends On | Sizing | Execution note |
+|---|-------|-------|------------|--------|----------------|
+| 27 | Anthropic Messages API Surface | C | v1.1 gates, issue #118 | L | `/v1/messages` translation layer on edge-api. Reuses internal OpenAI dispatch. |
+| 28 | MCP Connector Support | D | 27 (tool plumbing), v1.1 Phase 20 catalog | L | Per-tenant MCP registry in control-plane, edge execution proxy, provider-blind error model. |
+| 29 | Router-LLM Intelligent Routing | D | v1.1 Phase 20 catalog, v1.1 Phase 21 credit/quota | M | Classifier-driven pre-routing above LiteLLM. Includes offline + shadow evaluation. |
+| 30 | Productization and Dual-Product Cutover | E | 27, 28, 29 | M | Env-gated landing of all v1.2 features in Hive Cloud and EnterpriseEdge via one deploy script. |
+
+Critical path: `(#118 fix) -> 27 -> 28 -> 30`, with `29` proceeding in parallel after v1.1 Phase 20/21
+prerequisites and joining at `30`. Phase 29 does not depend on Phase 27 or 28; it can run alongside
+either, and only the productization cutover (Phase 30) needs all three complete.
+
+---
+
+## Phase 27 — Anthropic Messages API Surface [C]
+
+**Sizing: L. Depends on: v1.1 ship gates, issue #118.**
+
+### Objective
+
+Add a `POST /v1/messages` endpoint to `edge-api` that accepts Anthropic Messages requests, translates
+them into the existing internal OpenAI-shaped dispatch, and translates the response (including
+streaming SSE events and tool use) back into Anthropic's wire format. Token accounting and BDT billing
+must work identically to the OpenAI surface.
+
+### Why
+
+Coding agents and assistant frameworks increasingly default to the Anthropic Messages format. Today a
+BD developer using such a tool cannot point it at Hive. Supporting `/v1/messages` removes that barrier
+with no second inference engine: the translation is a boundary adapter over the path Hive already runs.
+
+### Prerequisite (BLOCKING)
+
+Issue #118 (tools, `tool_choice`, `response_format` silently dropped at `/v1/chat/completions`) must be
+fixed first. Anthropic tool use maps onto the same internal tool-call plumbing. Shipping `/v1/messages`
+tool support while the OpenAI surface still drops tools would create two divergent tool behaviours over
+one dispatch path. Phase 27 therefore starts only after #118's acceptance criteria pass: an SDK call
+with `tools=[...]` either returns a provider-blind 400 (short-term) or completes a tool round-trip via a
+tool-capable provider (medium-term). Phase 27 assumes the medium-term passthrough is in place.
+
+### Scope
+
+1. **Request translation:** Anthropic Messages request (`model`, `system`, `messages[]` with text and
+   tool_use/tool_result blocks, `tools[]`, `tool_choice`, `max_tokens`, `stop_sequences`, `metadata`)
+   mapped onto the internal OpenAI-shaped request consumed by `internal/chat/dispatch.go`. The `system`
+   top-level field maps to a leading system message. Anthropic content blocks map to OpenAI message
+   content and `tool_calls`/`tool` roles.
+2. **Non-streaming response translation:** internal OpenAI-shaped completion mapped back to an Anthropic
+   `message` object (`content[]` blocks, `stop_reason`, `usage.input_tokens`/`output_tokens`).
+3. **Streaming SSE event mapping:** internal stream (`internal/inference/stream.go`) mapped to the
+   Anthropic event sequence (`message_start`, `content_block_start`, `content_block_delta`,
+   `content_block_stop`, `message_delta`, `message_stop`, `ping`). This is the highest-risk slice: the
+   two event models differ in granularity and ordering, and tool-use deltas must be reconstructed into
+   Anthropic `input_json_delta` events.
+4. **Tool use mapping:** OpenAI `tool_calls` reconstructed into Anthropic `tool_use` content blocks and
+   back, including streamed partial JSON arguments.
+5. **Token accounting for billing:** Anthropic `usage` fields populated from the same usage events that
+   feed prepaid BDT reservations and settlement (`internal/inference/accounting_client.go`). No new
+   billing path; the Anthropic surface is an additional reader of the existing accounting events.
+6. **Contract artifacts:** `packages/openai-contract` gains a Hive overlay describing the Anthropic
+   surface and its support classification, kept consistent with the existing support matrix so the
+   served contract stays the single source of truth.
+7. **Provider-blind and BDT guarantees:** every error and metadata surface on `/v1/messages` reuses the
+   edge provider-blind sanitisation (`internal/errors/provider_blind.go`) and emits no USD/FX.
+
+### Non-Goals (Phase 27)
+
+- Anthropic Admin, Workspaces, or Message Batches endpoints. Only `/v1/messages`.
+- Prompt caching semantics specific to Anthropic (`cache_control` blocks) beyond pass-through token
+  accounting if a provider supports it. Full cache-tier billing is deferred.
+- Anthropic-specific vision or document block ingestion beyond what the internal dispatch already
+  supports for the OpenAI surface.
+- A separate Anthropic-flavoured SDK test corpus beyond a minimal `/v1/messages` integration suite.
+
+### Acceptance
+
+- Anthropic Python/TypeScript SDK pointed at Hive base URL completes a non-streaming `messages.create`.
+- Streaming `messages.stream` yields a valid Anthropic event sequence reconstructed from the internal
+  stream.
+- A tool-use round trip (`tool_use` then `tool_result`) completes via a tool-capable provider.
+- Usage tokens recorded on `/v1/messages` reconcile against the same ledger reservations as the
+  equivalent `/v1/chat/completions` call.
+- No USD/FX or provider identity appears in any `/v1/messages` response, error, or metadata.
+
+---
+
+## Phase 28 — MCP Connector Support [D]
+
+**Sizing: L. Depends on: Phase 27 tool plumbing, v1.1 Phase 20 provider catalog.**
+
+### Objective
+
+Let tenants register MCP (Model Context Protocol) connectors and have agentic requests invoke MCP tools
+through Hive. A tool registry lives in `control-plane`, per-tenant connector configuration is stored and
+governed there, and `edge-api` runs an execution proxy that calls configured MCP servers on behalf of a
+request, with a strict security model.
+
+### Why
+
+MCP is becoming the standard way agents reach external tools and data. For the agentic workstation
+vision, tenants need to wire their own connectors (internal search, ticketing, databases) without Hive
+hardcoding integrations. Putting the registry in control-plane keeps configuration, RBAC, and audit in
+the same governance plane as the provider catalog (v1.1 Phase 20), and keeps the hot path on edge thin.
+
+### Scope
+
+1. **MCP tool registry (control-plane):** schema and CRUD for connector definitions (transport, endpoint,
+   declared tools, scopes). Mirrors the hybrid provider-catalog pattern from v1.1 Phase 20 (stock vs
+   tenant-managed) so operators get a familiar governance model.
+2. **Per-tenant connector config:** connectors scoped to `tenant_settings`, gated by the v1.1 Phase 18
+   RBAC matrix (admin-managed). Single-tenant EnterpriseEdge sees one tenant; Hive Cloud isolates per
+   tenant.
+3. **Edge execution proxy:** when a request's tool call targets an MCP-registered tool, edge resolves the
+   connector for the tenant, executes the MCP call, and folds the result back into the tool-result turn
+   of the dispatch. Reuses the Phase 27 / issue #118 tool plumbing rather than inventing a parallel path.
+4. **Security model (HARD):**
+   - **No tenant secrets in logs:** connector credentials are referenced, never logged; redaction reuses
+     the recursive metadata redaction already applied to usage events.
+   - **Provider-blind and connector-blind errors:** MCP failures sanitise to a customer-safe error that
+     names neither the upstream provider nor the connector implementation.
+   - **Egress control:** connector endpoints are validated against a tenant allowlist; no arbitrary
+     server-side request forgery surface from tenant-supplied URLs.
+   - **Credential storage:** secrets stored via the existing secret-handling path (env or secret manager),
+     never in plain columns or audit rows.
+5. **Billing:** MCP tool invocations that incur model spend settle through the existing prepaid BDT
+   reservation path. Pure connector calls without model spend are metered per tenant policy (count-based),
+   not FX-priced.
+
+### Non-Goals (Phase 28)
+
+- A public MCP marketplace or third-party connector store (the v1.1 master plan already lists MCP
+  marketplace exposure as out of scope; v1.2 ships private per-tenant connectors only).
+- Hive acting as an MCP **server** exposing Hive tools to external agents. v1.2 is MCP **client** only.
+- Long-running or stateful MCP sessions beyond a single request's tool turns.
+- Automatic connector discovery; all connectors are explicitly registered.
+
+### Acceptance
+
+- A tenant admin registers an MCP connector via control-plane, gated by the RBAC matrix.
+- An agentic request invokes a registered MCP tool; the result returns in the tool-result turn.
+- No connector secret or endpoint appears in logs, audit rows, or customer-visible errors.
+- A connector failure returns a provider-blind, connector-blind error with no USD/FX.
+- A request to a non-allowlisted endpoint is rejected before any outbound call.
+
+---
+
+## Phase 29 — Router-LLM Intelligent Routing [D]
+
+**Sizing: M. Depends on: v1.1 Phase 20 provider catalog, v1.1 Phase 21 credit/quota engine.**
+
+### Objective
+
+Add an intelligent routing layer above the existing static LiteLLM routing. A cheap classifier model
+inspects each request and selects a route handle by task type, cost, latency target, and tenant policy,
+choosing between self-hosted and cloud providers. LiteLLM still performs the mechanical dispatch to the
+chosen route.
+
+### Distinction From Existing Static Routing
+
+Today routing is static: control-plane resolves an alias to a private route handle, applies capability,
+allowlist, and fallback checks, then hands LiteLLM a model group keyed by that route handle (per the v1.0
+decisions in `.planning/STATE.md`). The mapping is fixed per alias. Router-LLM adds a **decision step
+before** that resolution: instead of one alias deterministically picking one route, a classifier can send
+a simple summarisation request to a cheap self-hosted model and a hard reasoning request to a premium
+cloud provider, under the same public alias, governed by tenant policy and live cost/latency signals.
+LiteLLM remains unchanged downstream; Router-LLM only changes which route handle LiteLLM receives.
+
+### Why
+
+For Bangladesh-market economics, routing cheap traffic to self-hosted or low-cost providers and reserving
+premium providers for hard tasks directly reduces cost per request, which feeds the prepaid BDT margin.
+The classifier must be cheap enough that its overhead does not erase the savings, which is the central
+evaluation question below.
+
+### Scope
+
+1. **Classifier:** a small, cheap model (self-hosted preferred) that labels a request by task type and
+   difficulty, emitting a routing decision (candidate route handle plus confidence).
+2. **Policy layer:** per-tenant routing policy (allowed providers, cost ceiling, latency target,
+   self-host preference) sourced from `tenant_settings`, consistent with the Phase 21 credit/quota model.
+3. **Decision integration:** Router-LLM output feeds the existing alias-to-route resolution as an input,
+   never bypassing capability, allowlist, or fallback checks. A disabled or low-confidence classifier
+   falls back to the current static route, so Router-LLM is strictly additive and safe to turn off.
+4. **Observability:** every routing decision recorded (anonymised, BDT-only, provider-blind in any
+   customer-visible projection) for the evaluation harness and operator dashboards.
+
+### Evaluation Plan
+
+Router-LLM ships only if it demonstrably helps, measured before any production traffic:
+
+- **Offline replay:** replay a labelled corpus of historical request shapes (no stored prompt bodies,
+  per the v1.0 no-prompt-at-rest decision; use shape and metadata only) through the classifier and
+  compare chosen routes against an oracle of cost and quality.
+- **Metrics:** routing accuracy versus oracle, mean and tail cost per request, mean and tail added
+  latency from the classifier step, and fallback rate. Target: net cost reduction after classifier
+  overhead, with added p95 latency under an agreed budget and no quality regression on hard tasks.
+- **Shadow mode:** run Router-LLM in shadow on live traffic (decision logged, not enforced) before
+  enabling enforcement, comparing shadow decisions to actual static routes.
+- **Gate:** enforcement enabled per tenant only after shadow metrics meet the cost/latency/quality
+  thresholds. EnterpriseEdge ships Router-LLM disabled by default.
+
+### Non-Goals (Phase 29)
+
+- Per-query LLM result ranking or re-ranking (already out of scope in the v1.1 master plan).
+- Replacing LiteLLM. Router-LLM never performs provider dispatch itself.
+- Training a bespoke classifier model in v1.2; use an existing cheap model. Custom training is deferred.
+- Cross-tenant route learning or shared routing intelligence; policy stays per tenant.
+
+### Acceptance
+
+- With Router-LLM disabled, routing behaviour is byte-identical to the current static path.
+- In shadow mode, decisions are logged with no production impact and no USD/FX in any projection.
+- Offline replay shows net cost reduction after classifier overhead within the latency budget.
+- A low-confidence or failed classification falls back to the static route without erroring the request.
+
+---
+
+## Phase 30 — Productization and Dual-Product Cutover [E]
+
+**Sizing: M. Depends on: Phases 27, 28, 29.**
+
+### Objective
+
+Land every v1.2 feature in both products from the same deploy script, env-gated, with no product-specific
+code fork. Confirm Hive Cloud (hosted multi-tenant) and EnterpriseEdge (self-hosted single-tenant) both
+boot the v1.2 surface with the correct defaults.
+
+### How Each Feature Lands In Both Products
+
+| Feature | Hive Cloud default | EnterpriseEdge default | Gating mechanism |
+|---------|--------------------|------------------------|------------------|
+| Anthropic `/v1/messages` | on | on | always-on edge route; no flag needed once #118 fixed |
+| MCP connectors | on, per-tenant via `tenant_settings` | on, single tenant | RBAC-gated config; `tenant_settings` row |
+| Router-LLM | shadow first, then per-tenant enforce | off by default | env flag plus `tenant_settings` policy |
+
+The same `deploy/docker` Compose stack and bootstrap script ship both products. EnterpriseEdge is the
+single-tenant default of the same image family (consistent with the v1.1 master-plan tenant model);
+multi-tenant behaviour is gated through `tenant_settings`. No second codebase, no second image. v1.2 adds
+no new product fork; it only adds env-gated capabilities to the existing one-monorepo, one-image model.
+
+### Scope
+
+1. **Env gating:** all three v1.2 features default-configured per product through environment plus
+   `tenant_settings`, documented in `.env.example` with inline comments and the EnterpriseEdge env template.
+2. **Deploy parity check:** the bootstrap/deploy script provisions the v1.2 surface for both products from
+   one path; a smoke check confirms `/v1/messages`, MCP registry, and Router-LLM shadow all respond under
+   each product's defaults.
+3. **Docs:** developer docs for the Anthropic surface and MCP connectors; operator docs for Router-LLM
+   policy and the shadow-to-enforce flow.
+4. **Final audit:** re-run the BD regulatory surface audit (zero customer-visible USD/FX, provider-blind
+   errors) across all new v1.2 surfaces before cutover, mirroring the v1.1 cutover discipline.
+
+### Non-Goals (Phase 30)
+
+- The future desktop app. v1.2 keeps the edge surface desktop-ready (stable `/v1/messages` and tool
+  plumbing) but ships no desktop client.
+- Region expansion beyond Bangladesh.
+- Pricing or packaging changes to the prepaid BDT model.
+
+### Acceptance
+
+- One deploy script boots Hive Cloud and EnterpriseEdge with the correct per-product v1.2 defaults.
+- Smoke check passes for `/v1/messages`, MCP registry, and Router-LLM shadow under both products.
+- Final BD regulatory audit shows zero customer-visible USD/FX and provider-blind errors on all v1.2
+  surfaces.
+
+---
+
+## Milestone-Level Non-Goals (v1.2)
+
+- **No public MCP marketplace** and no Hive-as-MCP-server. Private, per-tenant MCP client only.
+- **No bespoke classifier training.** Router-LLM uses an existing cheap model.
+- **No desktop app.** Edge stays desktop-ready; the client is a later milestone.
+- **No new payment rails or pricing changes.** Prepaid BDT only, inherited from v1.0/v1.1.
+- **No region expansion beyond Bangladesh.**
+- **No second codebase or product-specific fork.** One monorepo, one image family, env-gated.
+- **No new customer-visible money language.** BDT-only; zero FX/USD on every new surface.
+
+## Approval Gate
+
+This is a roadmap draft. Each phase requires its own GSD executable spec/plan with per-task evidence
+frames before implementation, the same approval gate used in v1.0 and v1.1. No v1.2 phase begins until
+the v1.1 ship gates `chat_app_reaudit` and `web_search_tool` both pass, and Phase 27 specifically waits on
+issue #118 (tools passthrough) being fixed on the OpenAI surface first.


### PR DESCRIPTION
## Summary

Adds the v1.2 milestone roadmap document (`.planning/v1.2-agentic-surface.md`). Documentation only, no code changes.

v1.2 turns Hive from an OpenAI-shaped gateway into an agentic AI workstation for Bangladesh, across four phases (27-30):

- **Phase 27 (L): Anthropic Messages API surface.** `POST /v1/messages` translation layer on edge-api over the existing internal OpenAI-shaped dispatch (request mapping, streaming SSE event mapping, tool use mapping, BDT token accounting). Blocking prerequisite: issue #118 (tools passthrough) fixed on the OpenAI surface first.
- **Phase 28 (L): MCP connector support.** Per-tenant MCP tool registry in control-plane, edge execution proxy, strict security model (no tenant secrets in logs, provider-blind and connector-blind errors, egress allowlist).
- **Phase 29 (M): Router-LLM intelligent routing.** Cheap classifier sitting above (not replacing) static LiteLLM routing, choosing route handle by task type, cost, latency, and tenant policy. Includes offline replay and shadow-mode evaluation plan with a per-tenant enforcement gate.
- **Phase 30 (M): Productization and dual-product cutover.** Env-gated landing of all v1.2 features in both Hive Cloud and EnterpriseEdge from one deploy script, no product fork.

## Gates

- Hard entry gate: v1.2 begins only after v1.1 ship gates `chat_app_reaudit` and `web_search_tool` both pass.
- BDT-only, provider-blind guarantees inherited on every new surface.
- Explicit milestone-level non-goals included (no MCP marketplace, no Hive-as-MCP-server, no bespoke classifier training, no desktop app, no new payment rails, no region expansion).

## Test plan

- [ ] Roadmap reviewed for phase ordering, dependencies, and sizing accuracy.
- [ ] Confirm gate references match `.planning/STATE.md` current values.

Document follows the existing `.planning` phase-doc style (front matter, decisions-locked table, phase-order table, per-phase objective/why/scope/non-goals/acceptance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)