### PR TITLE
feat: signup abuse prevention, ip rate limit, disposable email block, turnstile hook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -82,6 +82,19 @@ GROQ_REASONING_MODEL=groq/openai/gpt-oss-120b
 # route `eol` so SelectRoute never picks it.
 NVIDIA_NIM_EMBEDDING_MODEL=
 
+# ─── Signup abuse prevention (issue #116) ───────────────────────────
+# Per-IP signup rate limit. Max attempts per IP per window before the
+# precheck endpoint returns 429. Set to 0 to disable the IP limiter.
+# Default: 5 signups per 3600-second (1-hour) window.
+SIGNUP_RATE_LIMIT_PER_WINDOW=5
+SIGNUP_RATE_LIMIT_WINDOW_SECONDS=3600
+# Cloudflare Turnstile server-side secret. When set, the signup precheck
+# verifies every submission against Cloudflare's siteverify endpoint.
+# Leave EMPTY to disable CAPTCHA (control-plane logs a startup warning
+# when unset). NEVER commit a real key here — supply via secret manager
+# in staging + production.
+TURNSTILE_SECRET_KEY=
+
 # ─── Phase 15: Local batch executor (POST /v1/batches success-path) ───
 # Concurrency cap for in-flight per-line dispatches. Default 8; ceiling 32.
 BATCH_EXECUTOR_CONCURRENCY=8

--- a/.env.example
+++ b/.env.example
@@ -94,6 +94,22 @@ SIGNUP_RATE_LIMIT_WINDOW_SECONDS=3600
 # when unset). NEVER commit a real key here — supply via secret manager
 # in staging + production.
 TURNSTILE_SECRET_KEY=
+# Trusted reverse-proxy CIDR ranges (comma-separated). The precheck handler
+# honours CF-Connecting-IP and X-Forwarded-For ONLY when the direct TCP peer
+# (RemoteAddr) falls inside one of these ranges. Default EMPTY means no
+# forwarded headers are trusted and the raw RemoteAddr is always used.
+# In production behind Cloudflare, set this to Cloudflare's published IP
+# ranges (https://www.cloudflare.com/ips/). Example:
+#   TRUSTED_PROXY_CIDRS=173.245.48.0/20,103.21.244.0/22
+# NEVER trust a range that untrusted clients can reach directly.
+TRUSTED_PROXY_CIDRS=
+# Global concurrent-request ceiling for the signup precheck handler.
+# Requests beyond this limit are rejected with the generic message.
+# Default 100. Tune down in memory-constrained environments.
+SIGNUP_PRECHECK_MAX_CONCURRENT=100
+# Per-request timeout (seconds) for the full precheck chain including the
+# Turnstile network call. Default 8.
+SIGNUP_PRECHECK_TIMEOUT_SECONDS=8
 
 # ─── Phase 15: Local batch executor (POST /v1/batches success-path) ───
 # Concurrency cap for in-flight per-line dispatches. Default 8; ceiling 32.

--- a/apps/control-plane/cmd/server/main.go
+++ b/apps/control-plane/cmd/server/main.go
@@ -47,6 +47,7 @@ import (
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/profiles"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/routing"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/signup"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/signupguard"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/spendalerts"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/tenants"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/usage"
@@ -216,6 +217,16 @@ func main() {
 	var auditWAL *audit.FileWALWriter
 	var signupWebhook *signup.Webhook
 	var tenantsHandler *tenants.Handler
+	// Signup abuse-prevention (issue #116). The disposable-domain blocklist is
+	// parsed once from an embedded file (no network), so it is available even
+	// when the database pool failed to come up. The per-IP limiter and the
+	// Turnstile verifier are wired below once redisClient is known.
+	disposableBlocklist, blErr := signupguard.LoadDisposableBlocklist()
+	if blErr != nil {
+		log.Fatalf("signupguard: load disposable blocklist: %v", blErr)
+	}
+	log.Printf("signupguard: disposable-domain blocklist loaded (%d domains)", disposableBlocklist.Len())
+	var signupPrecheck *signupguard.Handler
 	if pool != nil {
 		if cfg.RedisURL != "" {
 			redisClient = platformredis.NewClient(cfg.RedisURL)
@@ -374,6 +385,33 @@ func main() {
 		auditLogger = audit.NewLogger(audit.LoggerDeps{Sync: auditSync, WAL: walWriter})
 		log.Println("phase-19 audit logger ready")
 
+		// Signup precheck (issue #116): disposable-domain + per-IP rate limit +
+		// Turnstile CAPTCHA. Wired here (not gated on the phase-19 identity env
+		// vars) so abuse controls run on every deployment. The per-IP limiter
+		// reuses the control-plane Redis client; a nil client (Redis down at
+		// startup) disables only the rate limit while disposable + CAPTCHA keep
+		// working. The limiter fails CLOSED on a backend error per the #51
+		// policy unless RATE_LIMIT_FAIL_OPEN=true.
+		signupLimiter := signupguard.NewRateLimiter(
+			signupguard.NewRedisIncrementer(redisClient),
+			signupguard.RateLimitConfig{
+				Limit:    cfg.SignupRateLimitPerWindow,
+				Window:   cfg.SignupRateLimitWindow,
+				FailOpen: cfg.SignupRateLimitFailOpen,
+			},
+		)
+		turnstile := signupguard.NewTurnstileVerifier(cfg.TurnstileSecretKey, nil)
+		if !turnstile.Enabled() {
+			log.Println("WARNING: signupguard captcha disabled (TURNSTILE_SECRET_KEY unset)")
+		}
+		signupPrecheck = signupguard.NewHandler(signupguard.HandlerDeps{
+			Blocklist:   disposableBlocklist,
+			RateLimiter: signupLimiter,
+			Turnstile:   turnstile,
+			AuditFunc:   signupGuardAudit(auditLogger),
+		})
+		log.Println("signupguard precheck ready (issue #116)")
+
 		missingPhase19 := make([]string, 0, 4)
 		if owuiBaseURL == "" {
 			missingPhase19 = append(missingPhase19, "OWUI_BASE_URL")
@@ -417,12 +455,15 @@ func main() {
 			})
 
 			signupWebhook = signup.NewWebhook(signup.WebhookDeps{
-				Pool:         pool,
-				Resolver:     signupResolver,
-				EnsureGroup:  owuiClient.EnsureGroup,
-				AddUser:      owuiClient.AddUserToGroup,
-				Audit:        auditLogger,
-				SharedSecret: signupSecret,
+				Pool:        pool,
+				Resolver:    signupResolver,
+				EnsureGroup: owuiClient.EnsureGroup,
+				AddUser:     owuiClient.AddUserToGroup,
+				Audit:       auditLogger,
+				// Disposable-domain backstop (issue #116) for scripted signups
+				// that hit Supabase directly and bypass the web-console precheck.
+				DisposableCheck: disposableBlocklist.IsDisposableEmail,
+				SharedSecret:    signupSecret,
 			})
 
 			tenantsHandler = tenants.NewHandler(tenants.Deps{Pool: pool, Audit: auditLogger})
@@ -741,6 +782,15 @@ func main() {
 		routerMux.Handle("/internal/auth/user-created", signupWebhook)
 		log.Println("signup webhook route registered (Phase 19)")
 	}
+
+	// Signup abuse-prevention precheck (issue #116). Public (no auth bearer —
+	// the caller is not yet a Hive account); the web-console signup page calls
+	// this before invoking Supabase signUp. The exact path beats the
+	// authenticated /api/v1/ catch-all by ServeMux longest-prefix match.
+	if signupPrecheck != nil {
+		routerMux.Handle("/api/v1/auth/sign-up/precheck", signupPrecheck)
+		log.Println("signup precheck route registered (issue #116)")
+	}
 	if tenantsHandler != nil {
 		protectedSwitch := authMiddleware.Require(http.HandlerFunc(tenantsHandler.Switch))
 		routerMux.Handle("/v1/tenants/switch", protectedSwitch)
@@ -810,6 +860,24 @@ type storageRuntimeConfig struct {
 // token to its target tenant. tenant_invites is provisioned by Plan 03;
 // until then the query simply returns ErrNoMatch, gating the resolver to
 // its domain-mapping fallback.
+// signupGuardAudit adapts the audit Logger to the signupguard.AuditFunc seam.
+// Detail maps carry classification strings only (never the raw email/domain or
+// any provider value), satisfying the BD provider-blind + audit-leak rules.
+// A nil logger yields a no-op so the precheck still works when audit is absent.
+func signupGuardAudit(logger *audit.Logger) signupguard.AuditFunc {
+	if logger == nil {
+		return nil
+	}
+	return func(ctx context.Context, action string, detail map[string]string) {
+		_ = logger.Log(ctx, audit.Event{
+			Action:   action,
+			Severity: audit.SeverityWarning,
+			Actor:    audit.Actor{Type: audit.ActorSystem},
+			Before:   detail,
+		})
+	}
+}
+
 func signupLookupInvite(pool *pgxpool.Pool) signup.LookupFunc {
 	return func(ctx context.Context, token string) (uuid.UUID, error) {
 		var id uuid.UUID

--- a/apps/control-plane/cmd/server/main.go
+++ b/apps/control-plane/cmd/server/main.go
@@ -405,10 +405,13 @@ func main() {
 			log.Println("WARNING: signupguard captcha disabled (TURNSTILE_SECRET_KEY unset)")
 		}
 		signupPrecheck = signupguard.NewHandler(signupguard.HandlerDeps{
-			Blocklist:   disposableBlocklist,
-			RateLimiter: signupLimiter,
-			Turnstile:   turnstile,
-			AuditFunc:   signupGuardAudit(auditLogger),
+			Blocklist:         disposableBlocklist,
+			RateLimiter:       signupLimiter,
+			Turnstile:         turnstile,
+			AuditFunc:         signupGuardAudit(auditLogger),
+			TrustedProxyCIDRs: cfg.TrustedProxyCIDRs,
+			MaxConcurrent:     cfg.PrecheckMaxConcurrent,
+			PrecheckTimeout:   time.Duration(cfg.PrecheckTimeoutSeconds) * time.Second,
 		})
 		log.Println("signupguard precheck ready (issue #116)")
 

--- a/apps/control-plane/internal/platform/config/config.go
+++ b/apps/control-plane/internal/platform/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"strconv"
 	"strings"
@@ -22,10 +23,10 @@ type Config struct {
 	InternalToken string
 
 	// Phase 15 — local batch executor knobs.
-	BatchExecutorConcurrency  int
-	BatchExecutorMaxRetries   int
+	BatchExecutorConcurrency   int
+	BatchExecutorMaxRetries    int
 	BatchExecutorLineTimeoutMs int
-	BatchExecutorKind         string // "auto" | "local" | "upstream"
+	BatchExecutorKind          string // "auto" | "local" | "upstream"
 
 	// Signup abuse-prevention knobs (issue #116).
 	//
@@ -37,10 +38,23 @@ type Config struct {
 	//
 	// TurnstileSecretKey enables server-side Cloudflare Turnstile verification
 	// when non-empty; empty disables CAPTCHA with a startup warning.
-	SignupRateLimitPerWindow int
-	SignupRateLimitWindow    time.Duration
-	SignupRateLimitFailOpen  bool
-	TurnstileSecretKey       string
+	//
+	// TrustedProxyCIDRs is the list of CIDR ranges whose direct peers are
+	// permitted to supply accurate CF-Connecting-IP / X-Forwarded-For headers.
+	// Default (empty): forwarded headers are never trusted; the raw RemoteAddr
+	// is always used. Set to Cloudflare IP ranges in production deployments
+	// via TRUSTED_PROXY_CIDRS (comma-separated CIDR notation).
+	//
+	// PrecheckMaxConcurrent is the global concurrent-request ceiling for the
+	// precheck handler (default 100). PrecheckTimeoutSeconds is the per-request
+	// deadline in seconds (default 8).
+	SignupRateLimitPerWindow   int
+	SignupRateLimitWindow      time.Duration
+	SignupRateLimitFailOpen    bool
+	TurnstileSecretKey         string
+	TrustedProxyCIDRs          []*net.IPNet
+	PrecheckMaxConcurrent      int
+	PrecheckTimeoutSeconds     int
 }
 
 // Load reads configuration from environment variables and returns a validated Config.
@@ -59,6 +73,11 @@ func Load() (*Config, error) {
 		return nil, fmt.Errorf("SUPABASE_URL is required")
 	}
 
+	trustedCIDRs, err := parseCIDRList(os.Getenv("TRUSTED_PROXY_CIDRS"))
+	if err != nil {
+		return nil, fmt.Errorf("invalid TRUSTED_PROXY_CIDRS: %w", err)
+	}
+
 	return &Config{
 		Port:                       port,
 		SupabaseURL:                supabaseURL,
@@ -74,7 +93,34 @@ func Load() (*Config, error) {
 		SignupRateLimitWindow:      time.Duration(intEnv("SIGNUP_RATE_LIMIT_WINDOW_SECONDS", 3600)) * time.Second,
 		SignupRateLimitFailOpen:    boolEnv("RATE_LIMIT_FAIL_OPEN", false),
 		TurnstileSecretKey:         os.Getenv("TURNSTILE_SECRET_KEY"),
+		TrustedProxyCIDRs:          trustedCIDRs,
+		PrecheckMaxConcurrent:      intEnv("SIGNUP_PRECHECK_MAX_CONCURRENT", 100),
+		PrecheckTimeoutSeconds:     intEnv("SIGNUP_PRECHECK_TIMEOUT_SECONDS", 8),
 	}, nil
+}
+
+// parseCIDRList parses a comma-separated list of CIDR strings. Empty string
+// returns a nil slice (no trusted proxies). Malformed entries are returned as
+// an error so misconfiguration is caught at startup.
+func parseCIDRList(raw string) ([]*net.IPNet, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]*net.IPNet, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		_, cidr, err := net.ParseCIDR(p)
+		if err != nil {
+			return nil, fmt.Errorf("parse %q: %w", p, err)
+		}
+		out = append(out, cidr)
+	}
+	return out, nil
 }
 
 func intEnv(key string, def int) int {

--- a/apps/control-plane/internal/platform/config/config.go
+++ b/apps/control-plane/internal/platform/config/config.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
+	"time"
 )
 
 // Config holds all environment-sourced configuration for the control-plane.
@@ -24,6 +26,21 @@ type Config struct {
 	BatchExecutorMaxRetries   int
 	BatchExecutorLineTimeoutMs int
 	BatchExecutorKind         string // "auto" | "local" | "upstream"
+
+	// Signup abuse-prevention knobs (issue #116).
+	//
+	// SignupRateLimitPerWindow is the max signups allowed per client IP per
+	// window (<=0 disables the IP limiter). SignupRateLimitWindow is the window
+	// length. SignupRateLimitFailOpen mirrors the edge #51 policy: when the
+	// Redis backend is unreachable the limiter denies by default (fail closed);
+	// set RATE_LIMIT_FAIL_OPEN=true in dev only to admit instead.
+	//
+	// TurnstileSecretKey enables server-side Cloudflare Turnstile verification
+	// when non-empty; empty disables CAPTCHA with a startup warning.
+	SignupRateLimitPerWindow int
+	SignupRateLimitWindow    time.Duration
+	SignupRateLimitFailOpen  bool
+	TurnstileSecretKey       string
 }
 
 // Load reads configuration from environment variables and returns a validated Config.
@@ -53,6 +70,10 @@ func Load() (*Config, error) {
 		BatchExecutorMaxRetries:    intEnv("BATCH_EXECUTOR_MAX_RETRIES", 3),
 		BatchExecutorLineTimeoutMs: intEnv("BATCH_EXECUTOR_LINE_TIMEOUT_MS", 60000),
 		BatchExecutorKind:          stringEnv("BATCH_EXECUTOR_KIND", "auto"),
+		SignupRateLimitPerWindow:   intEnv("SIGNUP_RATE_LIMIT_PER_WINDOW", 5),
+		SignupRateLimitWindow:      time.Duration(intEnv("SIGNUP_RATE_LIMIT_WINDOW_SECONDS", 3600)) * time.Second,
+		SignupRateLimitFailOpen:    boolEnv("RATE_LIMIT_FAIL_OPEN", false),
+		TurnstileSecretKey:         os.Getenv("TURNSTILE_SECRET_KEY"),
 	}, nil
 }
 
@@ -74,4 +95,16 @@ func stringEnv(key, def string) string {
 		return def
 	}
 	return v
+}
+
+func boolEnv(key string, def bool) bool {
+	v := strings.TrimSpace(os.Getenv(key))
+	if v == "" {
+		return def
+	}
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		return def
+	}
+	return b
 }

--- a/apps/control-plane/internal/platform/config/signupguard_config_test.go
+++ b/apps/control-plane/internal/platform/config/signupguard_config_test.go
@@ -1,0 +1,52 @@
+package config
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSignupGuardDefaults(t *testing.T) {
+	t.Setenv("SUPABASE_URL", "https://example.supabase.co")
+	// Leave all signup-guard envs unset to assert defaults.
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.SignupRateLimitPerWindow != 5 {
+		t.Fatalf("default per-window = %d, want 5", cfg.SignupRateLimitPerWindow)
+	}
+	if cfg.SignupRateLimitWindow != time.Hour {
+		t.Fatalf("default window = %s, want 1h", cfg.SignupRateLimitWindow)
+	}
+	if cfg.SignupRateLimitFailOpen {
+		t.Fatal("rate limiter must default to fail-closed")
+	}
+	if cfg.TurnstileSecretKey != "" {
+		t.Fatal("turnstile secret should be empty by default (feature disabled)")
+	}
+}
+
+func TestSignupGuardOverrides(t *testing.T) {
+	t.Setenv("SUPABASE_URL", "https://example.supabase.co")
+	t.Setenv("SIGNUP_RATE_LIMIT_PER_WINDOW", "20")
+	t.Setenv("SIGNUP_RATE_LIMIT_WINDOW_SECONDS", "600")
+	t.Setenv("RATE_LIMIT_FAIL_OPEN", "true")
+	t.Setenv("TURNSTILE_SECRET_KEY", "a-secret")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.SignupRateLimitPerWindow != 20 {
+		t.Fatalf("per-window = %d, want 20", cfg.SignupRateLimitPerWindow)
+	}
+	if cfg.SignupRateLimitWindow != 10*time.Minute {
+		t.Fatalf("window = %s, want 10m", cfg.SignupRateLimitWindow)
+	}
+	if !cfg.SignupRateLimitFailOpen {
+		t.Fatal("fail-open override not applied")
+	}
+	if cfg.TurnstileSecretKey != "a-secret" {
+		t.Fatalf("turnstile secret = %q, want a-secret", cfg.TurnstileSecretKey)
+	}
+}

--- a/apps/control-plane/internal/platform/config/signupguard_config_test.go
+++ b/apps/control-plane/internal/platform/config/signupguard_config_test.go
@@ -5,6 +5,53 @@ import (
 	"time"
 )
 
+func TestTrustedProxyCIDRsDefault(t *testing.T) {
+	t.Setenv("SUPABASE_URL", "https://example.supabase.co")
+	t.Setenv("TRUSTED_PROXY_CIDRS", "")
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(cfg.TrustedProxyCIDRs) != 0 {
+		t.Fatalf("default TrustedProxyCIDRs should be empty, got %v", cfg.TrustedProxyCIDRs)
+	}
+}
+
+func TestTrustedProxyCIDRsParsed(t *testing.T) {
+	t.Setenv("SUPABASE_URL", "https://example.supabase.co")
+	t.Setenv("TRUSTED_PROXY_CIDRS", "10.0.0.0/8,192.168.0.0/16")
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(cfg.TrustedProxyCIDRs) != 2 {
+		t.Fatalf("expected 2 CIDRs, got %d: %v", len(cfg.TrustedProxyCIDRs), cfg.TrustedProxyCIDRs)
+	}
+}
+
+func TestTrustedProxyCIDRsInvalid(t *testing.T) {
+	t.Setenv("SUPABASE_URL", "https://example.supabase.co")
+	t.Setenv("TRUSTED_PROXY_CIDRS", "not-a-cidr")
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error for invalid CIDR, got nil")
+	}
+}
+
+func TestPrecheckConcurrencyAndTimeoutDefaults(t *testing.T) {
+	t.Setenv("SUPABASE_URL", "https://example.supabase.co")
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.PrecheckMaxConcurrent != 100 {
+		t.Fatalf("PrecheckMaxConcurrent default = %d, want 100", cfg.PrecheckMaxConcurrent)
+	}
+	if cfg.PrecheckTimeoutSeconds != 8 {
+		t.Fatalf("PrecheckTimeoutSeconds default = %d, want 8", cfg.PrecheckTimeoutSeconds)
+	}
+}
+
 func TestSignupGuardDefaults(t *testing.T) {
 	t.Setenv("SUPABASE_URL", "https://example.supabase.co")
 	// Leave all signup-guard envs unset to assert defaults.

--- a/apps/control-plane/internal/signup/webhook.go
+++ b/apps/control-plane/internal/signup/webhook.go
@@ -35,16 +35,27 @@ type EnsureGroupFunc func(ctx context.Context, name string) (string, error)
 // AddUserFunc adds the given email to the given OWUI group id.
 type AddUserFunc func(ctx context.Context, groupID, email string) error
 
+// DisposableCheckFunc reports whether the given email belongs to a disposable
+// (throwaway) provider. It is the server-side backstop for issue #116: the
+// public web-console precheck is the first line of defence, but a scripted
+// signup can write auth.users directly via the Supabase API and trigger this
+// webhook without ever calling the precheck. Returning true stops provisioning
+// (so no tenant membership and no free-credit grant is created) before any
+// database write. Optional; nil disables the backstop.
+type DisposableCheckFunc func(email string) (bool, error)
+
 // WebhookDeps wires the handler to its collaborators. SharedSecret is
 // required; the rest are validated at request time so an unauthorized
 // caller is rejected before any nil-pointer panics.
 type WebhookDeps struct {
-	Pool         *pgxpool.Pool
-	Resolver     *Resolver
-	EnsureGroup  EnsureGroupFunc
-	AddUser      AddUserFunc
-	Audit        *audit.Logger
-	SharedSecret string
+	Pool        *pgxpool.Pool
+	Resolver    *Resolver
+	EnsureGroup EnsureGroupFunc
+	AddUser     AddUserFunc
+	Audit       *audit.Logger
+	// DisposableCheck is an optional disposable-domain backstop (issue #116).
+	DisposableCheck DisposableCheckFunc
+	SharedSecret    string
 }
 
 // Webhook implements http.Handler for POST /internal/auth/user-created.
@@ -79,10 +90,6 @@ func (h *Webhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
 		return
 	}
-	if h.deps.Pool == nil || h.deps.Resolver == nil || h.deps.Audit == nil {
-		http.Error(w, `{"error":"misconfigured"}`, http.StatusInternalServerError)
-		return
-	}
 
 	var body webhookBody
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -95,6 +102,36 @@ func (h *Webhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ctx := r.Context()
+
+	// Disposable-domain backstop (issue #116). Runs before any DB write so a
+	// throwaway signup never reaches tenant provisioning or a free-credit grant.
+	// Reply 204 (terminal) so Supabase does not retry — the address will not
+	// become eligible on a later attempt. The audit detail carries a fixed
+	// classification only, never the raw email/domain. A check error is treated
+	// as "not disposable" and logged, so a bug in the list never blocks all
+	// signups (availability over a soft abuse signal at this backstop layer).
+	if h.deps.DisposableCheck != nil {
+		blocked, checkErr := h.deps.DisposableCheck(body.Email)
+		if checkErr != nil {
+			log.Printf("signup: disposable check error user=%s: %v", body.UserID, checkErr)
+		} else if blocked {
+			if h.deps.Audit != nil {
+				_ = h.deps.Audit.Log(ctx, audit.Event{
+					Actor:    audit.Actor{ID: body.UserID, Type: audit.ActorUser},
+					Action:   "AUTH_SIGNUP_DISPOSABLE_BLOCKED",
+					Severity: audit.SeverityWarning,
+					Before:   map[string]string{"stage": "disposable"},
+				})
+			}
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+	}
+
+	if h.deps.Pool == nil || h.deps.Resolver == nil || h.deps.Audit == nil {
+		http.Error(w, `{"error":"misconfigured"}`, http.StatusInternalServerError)
+		return
+	}
 	// TODO(phase-19-plan-03): persist delivery idempotency key (Supabase
 	// webhook id header) so retries cannot double-provision tenant_users.
 	tenantID, err := h.deps.Resolver.Resolve(ctx, Input{Email: body.Email, InviteToken: body.InviteToken})

--- a/apps/control-plane/internal/signup/webhook.go
+++ b/apps/control-plane/internal/signup/webhook.go
@@ -15,12 +15,15 @@ package signup
 
 import (
 	"context"
+	"crypto/sha256"
 	"crypto/subtle"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
 	"net/http"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -72,6 +75,24 @@ type webhookBody struct {
 	InviteToken string    `json:"invite_token,omitempty"`
 }
 
+// emailAuditToken returns an opaque, one-way token suitable for audit logs.
+// It is the hex-encoded SHA-256 of the lowercased, trimmed email address,
+// prefixed with "email_sha256:" so the field is self-describing. The domain
+// portion is also included separately so operators can correlate by provider
+// without recovering the full address.
+//
+// Neither the raw local-part nor the full email ever appears in an audit row.
+func emailAuditToken(email string) (token, domain string) {
+	norm := strings.ToLower(strings.TrimSpace(email))
+	sum := sha256.Sum256([]byte(norm))
+	token = "email_sha256:" + hex.EncodeToString(sum[:])
+	at := strings.LastIndexByte(norm, '@')
+	if at >= 0 {
+		domain = norm[at+1:]
+	}
+	return token, domain
+}
+
 // ServeHTTP handles the Supabase webhook.
 func (h *Webhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Fail-closed on missing shared secret. constant_time_compare("","")
@@ -102,14 +123,15 @@ func (h *Webhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ctx := r.Context()
+	emailToken, emailDomain := emailAuditToken(body.Email)
 
 	// Disposable-domain backstop (issue #116). Runs before any DB write so a
 	// throwaway signup never reaches tenant provisioning or a free-credit grant.
 	// Reply 204 (terminal) so Supabase does not retry — the address will not
-	// become eligible on a later attempt. The audit detail carries a fixed
-	// classification only, never the raw email/domain. A check error is treated
-	// as "not disposable" and logged, so a bug in the list never blocks all
-	// signups (availability over a soft abuse signal at this backstop layer).
+	// become eligible on a later attempt. The audit detail carries a hash token
+	// and domain only, never the raw email. A check error is treated as "not
+	// disposable" and logged, so a bug in the list never blocks all signups
+	// (availability over a soft abuse signal at this backstop layer).
 	if h.deps.DisposableCheck != nil {
 		blocked, checkErr := h.deps.DisposableCheck(body.Email)
 		if checkErr != nil {
@@ -120,7 +142,7 @@ func (h *Webhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					Actor:    audit.Actor{ID: body.UserID, Type: audit.ActorUser},
 					Action:   "AUTH_SIGNUP_DISPOSABLE_BLOCKED",
 					Severity: audit.SeverityWarning,
-					Before:   map[string]string{"stage": "disposable"},
+					Before:   map[string]string{"stage": "disposable", "email_sha256": emailToken, "domain": emailDomain},
 				})
 			}
 			w.WriteHeader(http.StatusNoContent)
@@ -145,7 +167,7 @@ func (h *Webhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				Actor:    audit.Actor{ID: body.UserID, Type: audit.ActorUser},
 				Action:   "AUTH_SIGNIN_FAILURE_NO_TENANT",
 				Severity: audit.SeverityWarning,
-				Before:   map[string]string{"email": body.Email},
+				Before:   map[string]string{"email_sha256": emailToken, "domain": emailDomain},
 			})
 			w.WriteHeader(http.StatusNoContent)
 			return
@@ -159,13 +181,13 @@ func (h *Webhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			Actor:    audit.Actor{ID: body.UserID, Type: audit.ActorUser},
 			Action:   "AUTH_SIGNIN_FAILURE_NO_TENANT",
 			Severity: audit.SeverityError,
-			Before:   map[string]string{"email": body.Email, "stage": "resolver_error", "error": "resolver_transient"},
+			Before:   map[string]string{"email_sha256": emailToken, "domain": emailDomain, "stage": "resolver_error", "error": "resolver_transient"},
 		})
 		http.Error(w, `{"error":"internal"}`, http.StatusInternalServerError)
 		return
 	}
 
-	if err := h.provision(ctx, tenantID, body); err != nil {
+	if err := h.provision(ctx, tenantID, body, emailToken, emailDomain); err != nil {
 		// See comment above — class only in audit, full error to log.
 		log.Printf("signup: provision failed user=%s tenant=%s: %v", body.UserID, tenantID, fmt.Errorf("provision_db: %w", err))
 		_ = h.deps.Audit.Log(ctx, audit.Event{
@@ -173,7 +195,7 @@ func (h *Webhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			Actor:    audit.Actor{ID: body.UserID, Type: audit.ActorUser},
 			Action:   "AUTH_SIGNUP_SUCCESS",
 			Severity: audit.SeverityError,
-			Before:   map[string]string{"email": body.Email, "stage": "provision_failed", "error": "provision_db"},
+			Before:   map[string]string{"email_sha256": emailToken, "domain": emailDomain, "stage": "provision_failed", "error": "provision_db"},
 		})
 		http.Error(w, `{"error":"internal"}`, http.StatusInternalServerError)
 		return
@@ -181,7 +203,7 @@ func (h *Webhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func (h *Webhook) provision(ctx context.Context, tenantID uuid.UUID, body webhookBody) error {
+func (h *Webhook) provision(ctx context.Context, tenantID uuid.UUID, body webhookBody, emailToken, emailDomain string) error {
 	_, err := h.deps.Pool.Exec(ctx, `
 		INSERT INTO public.tenant_users(tenant_id, user_id, role, status)
 		VALUES ($1, $2, 'MEMBER', 'ACTIVE')
@@ -196,7 +218,7 @@ func (h *Webhook) provision(ctx context.Context, tenantID uuid.UUID, body webhoo
 		Actor:    audit.Actor{ID: body.UserID, Type: audit.ActorUser},
 		Action:   "AUTH_SIGNUP_SUCCESS",
 		Severity: audit.SeverityInfo,
-		After:    map[string]string{"email": body.Email},
+		After:    map[string]string{"email_sha256": emailToken, "domain": emailDomain},
 	})
 	_ = h.deps.Audit.Log(ctx, audit.Event{
 		TenantID: tenantID,
@@ -234,7 +256,7 @@ func (h *Webhook) provision(ctx context.Context, tenantID uuid.UUID, body webhoo
 			Actor:    audit.Actor{ID: body.UserID, Type: audit.ActorUser},
 			Action:   "OWUI_GROUP_ADD_FAILURE",
 			Severity: audit.SeverityError,
-			Before:   map[string]string{"group_id": groupID, "email": body.Email, "error": "owui_add_user"},
+			Before:   map[string]string{"group_id": groupID, "email_sha256": emailToken, "domain": emailDomain, "error": "owui_add_user"},
 		})
 		return fmt.Errorf("add user: %w", err)
 	}
@@ -243,7 +265,7 @@ func (h *Webhook) provision(ctx context.Context, tenantID uuid.UUID, body webhoo
 		Actor:    audit.Actor{ID: body.UserID, Type: audit.ActorUser},
 		Action:   "OWUI_GROUP_ADD_SUCCESS",
 		Severity: audit.SeverityInfo,
-		After:    map[string]string{"group_id": groupID, "email": body.Email},
+		After:    map[string]string{"group_id": groupID, "email_sha256": emailToken, "domain": emailDomain},
 	})
 	return nil
 }

--- a/apps/control-plane/internal/signup/webhook_test.go
+++ b/apps/control-plane/internal/signup/webhook_test.go
@@ -108,6 +108,50 @@ func TestWebhook_BadSecret_401(t *testing.T) {
 	require.Equal(t, http.StatusUnauthorized, rec.Code)
 }
 
+// TestWebhook_DisposableBackstop_NoProvision verifies the webhook honours the
+// optional disposable-domain backstop: when DisposableCheck reports a throwaway
+// address it stops before any tenant provisioning (so no DB pool is required)
+// and returns 204 so Supabase does not retry. This guards the path where a
+// scripted signup bypasses the web-console precheck and writes auth.users
+// directly via the Supabase API.
+func TestWebhook_DisposableBackstop_NoProvision(t *testing.T) {
+	var checkedEmail string
+	called := false
+	provisionEnsure := func(context.Context, string) (string, error) {
+		called = true
+		return "", nil
+	}
+	h := signup.NewWebhook(signup.WebhookDeps{
+		// Pool/Resolver/Audit intentionally non-nil only where the blocked path
+		// touches them. The blocked path must not reach provisioning, so the
+		// group-ensure closure should never run.
+		Resolver: signup.NewResolver(signup.ResolverDeps{}),
+		// Warning-severity, non-security audit routes to the (noop) WAL tier, so
+		// the SyncWriter's nil pool is never dereferenced in this DB-free test.
+		Audit:        audit.NewLogger(audit.LoggerDeps{Sync: audit.NewSyncWriter(nil, audit.WriterConfig{}), WAL: &noopWAL{}}),
+		EnsureGroup:  provisionEnsure,
+		SharedSecret: "shh",
+		DisposableCheck: func(email string) (bool, error) {
+			checkedEmail = email
+			return true, nil
+		},
+	})
+
+	body, _ := json.Marshal(map[string]any{
+		"user_id": uuid.New(),
+		"email":   "abuser@mailinator.com",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/internal/auth/user-created", bytes.NewReader(body))
+	req.Header.Set("X-Hive-Signup-Secret", "shh")
+	rec := httptest.NewRecorder()
+
+	h.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	require.Equal(t, "abuser@mailinator.com", checkedEmail)
+	require.False(t, called, "provisioning must not run for a disposable signup")
+}
+
 type noopWAL struct{}
 
 func (noopWAL) Write(ctx context.Context, e audit.Event) error { return nil }

--- a/apps/control-plane/internal/signupguard/data/disposable_domains.txt
+++ b/apps/control-plane/internal/signupguard/data/disposable_domains.txt
@@ -1,0 +1,107 @@
+# Disposable / throwaway email domains blocklist.
+#
+# Source attribution:
+#   Curated subset derived from the public-domain / MIT-licensed list
+#   maintained at https://github.com/disposable-email-domains/disposable-email-domains
+#   (file: disposable_email_blocklist.conf). Vendored here as a Go embed file so
+#   the control-plane has zero network dependency at signup time.
+#
+# Format: one lowercase domain per line. Blank lines and lines starting with
+# '#' are ignored. Matching is exact on the lowercased email domain; no
+# wildcard / suffix matching is applied.
+#
+# This is a deliberately curated subset covering the highest-volume throwaway
+# providers seen in abuse traffic, not the full multi-thousand-entry upstream
+# list. Refresh by re-vendoring from upstream and re-running the parser test.
+0-mail.com
+0clickemail.com
+10minutemail.com
+10minutemail.net
+20minutemail.com
+33mail.com
+guerrillamail.com
+guerrillamail.net
+guerrillamail.org
+guerrillamail.biz
+guerrillamailblock.com
+sharklasers.com
+grr.la
+mailinator.com
+mailinator.net
+mailinator2.com
+mailnesia.com
+mailtothis.com
+trashmail.com
+trashmail.net
+trashmail.me
+trash-mail.com
+tempmail.com
+tempmail.net
+temp-mail.org
+temp-mail.io
+tempmailo.com
+tempr.email
+getnada.com
+nada.email
+dispostable.com
+fakeinbox.com
+yopmail.com
+yopmail.net
+yopmail.fr
+maildrop.cc
+mailcatch.com
+spam4.me
+throwawaymail.com
+throwam.com
+emailondeck.com
+mohmal.com
+mintemail.com
+mytemp.email
+moakt.com
+inboxbear.com
+tempinbox.com
+discard.email
+discardmail.com
+mailexpire.com
+spamgourmet.com
+incognitomail.com
+jetable.org
+spambox.us
+mailnull.com
+deadaddress.com
+mt2015.com
+mt2014.com
+fakemailgenerator.com
+emailfake.com
+email-fake.com
+fakemail.net
+burnermail.io
+mailsac.com
+harakirimail.com
+guerrillamail.de
+spambog.com
+spambog.de
+spambog.ru
+mailmetrash.com
+trbvm.com
+mvrht.net
+mailde.de
+mailde.info
+1secmail.com
+1secmail.net
+1secmail.org
+wwjmp.com
+esiix.com
+xojxe.com
+varicss.com
+zudpck.com
+luxusmail.org
+crazymailing.com
+einrot.com
+tempmailaddress.com
+mail-temp.com
+emltmp.com
+mailpoof.com
+inboxkitten.com
+disposablemail.com
+mailtemp.info

--- a/apps/control-plane/internal/signupguard/email.go
+++ b/apps/control-plane/internal/signupguard/email.go
@@ -1,0 +1,125 @@
+// Package signupguard provides abuse-prevention checks for the public signup
+// entry path (issue #116): disposable-email-domain blocking, per-IP signup
+// rate limiting, and Cloudflare Turnstile CAPTCHA verification.
+//
+// All customer-visible rejections use a single generic, provider-blind message
+// so an attacker cannot tell which control tripped (disposable list vs rate
+// limit vs CAPTCHA) and no upstream/internal detail leaks. Operators see the
+// real classification in the process log and the audit trail.
+package signupguard
+
+import (
+	"bufio"
+	"bytes"
+	_ "embed"
+	"errors"
+	"strings"
+)
+
+//go:embed data/disposable_domains.txt
+var disposableDomainsFile []byte
+
+// ErrInvalidEmail is returned when an address cannot be parsed into a
+// local-part and a single domain.
+var ErrInvalidEmail = errors.New("signupguard: invalid email address")
+
+// NormalizeEmail lowercases, trims, and canonicalizes an email so that a single
+// underlying mailbox cannot be used to create unlimited accounts.
+//
+//   - The whole address is trimmed and lowercased.
+//   - Any "+tag" suffix on the local part is stripped (sub-addressing).
+//   - For Gmail/Googlemail, dots in the local part are removed and the domain
+//     is folded to gmail.com (Google treats a.b@gmail == ab@gmail == ab@googlemail).
+//
+// It returns ErrInvalidEmail for anything that is not exactly local@domain.
+func NormalizeEmail(raw string) (string, error) {
+	e := strings.ToLower(strings.TrimSpace(raw))
+	at := strings.IndexByte(e, '@')
+	if at <= 0 || at != strings.LastIndexByte(e, '@') {
+		return "", ErrInvalidEmail
+	}
+	local := e[:at]
+	domain := e[at+1:]
+	if local == "" || domain == "" {
+		return "", ErrInvalidEmail
+	}
+
+	if plus := strings.IndexByte(local, '+'); plus >= 0 {
+		local = local[:plus]
+	}
+
+	if domain == "gmail.com" || domain == "googlemail.com" {
+		local = strings.ReplaceAll(local, ".", "")
+		domain = "gmail.com"
+	}
+
+	if local == "" {
+		return "", ErrInvalidEmail
+	}
+	return local + "@" + domain, nil
+}
+
+// EmailDomain returns the lowercased, trimmed domain portion of an email after
+// normalization (so a "+tag" address and a Gmail-dotted address resolve to the
+// canonical domain).
+func EmailDomain(raw string) (string, error) {
+	norm, err := NormalizeEmail(raw)
+	if err != nil {
+		return "", err
+	}
+	at := strings.LastIndexByte(norm, '@')
+	return norm[at+1:], nil
+}
+
+// Blocklist is an immutable set of disposable email domains. Construct it once
+// at startup via LoadDisposableBlocklist and share the pointer; reads are
+// lock-free and concurrency-safe.
+type Blocklist struct {
+	domains map[string]struct{}
+}
+
+// LoadDisposableBlocklist parses the embedded disposable-domain list. It never
+// performs network I/O; the list is compiled into the binary.
+func LoadDisposableBlocklist() (*Blocklist, error) {
+	domains := make(map[string]struct{}, 256)
+	scanner := bufio.NewScanner(bytes.NewReader(disposableDomainsFile))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		domains[strings.ToLower(line)] = struct{}{}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return &Blocklist{domains: domains}, nil
+}
+
+// Len returns the number of domains in the blocklist.
+func (b *Blocklist) Len() int {
+	if b == nil {
+		return 0
+	}
+	return len(b.domains)
+}
+
+// IsDisposableDomain reports whether the given (already lowercased) domain is in
+// the blocklist. An empty domain never matches.
+func (b *Blocklist) IsDisposableDomain(domain string) bool {
+	if b == nil || domain == "" {
+		return false
+	}
+	_, ok := b.domains[domain]
+	return ok
+}
+
+// IsDisposableEmail normalizes the email and reports whether its domain is a
+// known disposable provider. It returns ErrInvalidEmail for unparseable input.
+func (b *Blocklist) IsDisposableEmail(raw string) (bool, error) {
+	domain, err := EmailDomain(raw)
+	if err != nil {
+		return false, err
+	}
+	return b.IsDisposableDomain(domain), nil
+}

--- a/apps/control-plane/internal/signupguard/email.go
+++ b/apps/control-plane/internal/signupguard/email.go
@@ -106,12 +106,36 @@ func (b *Blocklist) Len() int {
 
 // IsDisposableDomain reports whether the given (already lowercased) domain is in
 // the blocklist. An empty domain never matches.
+//
+// Subdomain matching: a domain is blocked if any of its registered suffixes
+// appear in the blocklist (e.g. "a.mailinator.com" is blocked because
+// "mailinator.com" is listed). The match walks from the most-specific label
+// outward so an exact match is always preferred.
+//
+// IDN note: golang.org/x/net/idna is not in the module graph. Callers should
+// pass domains that have already been lowercased (NormalizeEmail does this).
+// Punycode ACE labels (xn--...) in the blocklist will match ACE input directly;
+// Unicode display forms will not. A future upgrade to x/net/idna can fold both
+// representations before lookup.
 func (b *Blocklist) IsDisposableDomain(domain string) bool {
 	if b == nil || domain == "" {
 		return false
 	}
-	_, ok := b.domains[domain]
-	return ok
+	// Walk suffixes from most-specific to least-specific.
+	// "a.b.mailinator.com" checks: "a.b.mailinator.com", "b.mailinator.com",
+	// "mailinator.com", "com". Stopping at the first match keeps the loop O(labels).
+	s := domain
+	for {
+		if _, ok := b.domains[s]; ok {
+			return true
+		}
+		dot := strings.IndexByte(s, '.')
+		if dot < 0 {
+			break
+		}
+		s = s[dot+1:]
+	}
+	return false
 }
 
 // IsDisposableEmail normalizes the email and reports whether its domain is a

--- a/apps/control-plane/internal/signupguard/email_test.go
+++ b/apps/control-plane/internal/signupguard/email_test.go
@@ -1,0 +1,101 @@
+package signupguard
+
+import "testing"
+
+func TestNormalizeEmail(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{name: "lowercases and trims", in: "  Alice@Example.COM ", want: "alice@example.com"},
+		{name: "strips gmail plus tag", in: "alice+spam@gmail.com", want: "alice@gmail.com"},
+		{name: "strips googlemail dots and plus", in: "a.l.i.c.e+x@googlemail.com", want: "alice@gmail.com"},
+		{name: "keeps dots for non-gmail", in: "a.l.i.c.e@example.com", want: "a.l.i.c.e@example.com"},
+		{name: "strips plus tag for non-gmail too", in: "user+tag@example.com", want: "user@example.com"},
+		{name: "empty is error", in: "   ", wantErr: true},
+		{name: "no at sign is error", in: "notanemail", wantErr: true},
+		{name: "empty local part is error", in: "@example.com", wantErr: true},
+		{name: "empty domain is error", in: "user@", wantErr: true},
+		{name: "double at is error", in: "a@b@example.com", wantErr: true},
+		{name: "unicode local preserved", in: "JÜrgen@Example.com", want: "jürgen@example.com"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := NormalizeEmail(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("NormalizeEmail(%q) expected error, got %q", tc.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("NormalizeEmail(%q) unexpected error: %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Fatalf("NormalizeEmail(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEmailDomain(t *testing.T) {
+	got, err := EmailDomain("Alice+x@Sub.Example.COM")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "sub.example.com" {
+		t.Fatalf("EmailDomain = %q, want sub.example.com", got)
+	}
+	if _, err := EmailDomain("garbage"); err == nil {
+		t.Fatal("expected error for invalid email")
+	}
+}
+
+func TestDisposableBlocklist(t *testing.T) {
+	bl, err := LoadDisposableBlocklist()
+	if err != nil {
+		t.Fatalf("LoadDisposableBlocklist: %v", err)
+	}
+
+	if n := bl.Len(); n < 50 {
+		t.Fatalf("blocklist too small (%d), embed likely broken", n)
+	}
+
+	cases := []struct {
+		email   string
+		blocked bool
+	}{
+		{"abuser@mailinator.com", true},
+		{"x@MAILINATOR.COM", true},        // case-insensitive
+		{"x+tag@guerrillamail.com", true}, // plus tag does not evade
+		{"x@10minutemail.com", true},
+		{"real.user@gmail.com", false},
+		{"founder@fundmore.ai", false},
+		{"dev@somelegitcompany.io", false},
+	}
+	for _, c := range cases {
+		got, err := bl.IsDisposableEmail(c.email)
+		if err != nil {
+			t.Fatalf("IsDisposableEmail(%q): %v", c.email, err)
+		}
+		if got != c.blocked {
+			t.Fatalf("IsDisposableEmail(%q) = %v, want %v", c.email, got, c.blocked)
+		}
+	}
+}
+
+func TestDisposableBlocklistDomainComments(t *testing.T) {
+	bl, err := LoadDisposableBlocklist()
+	if err != nil {
+		t.Fatalf("LoadDisposableBlocklist: %v", err)
+	}
+	// Comment lines and the literal '#' token must never become a domain.
+	if bl.IsDisposableDomain("#") {
+		t.Fatal("comment marker leaked into blocklist")
+	}
+	if bl.IsDisposableDomain("") {
+		t.Fatal("empty domain must never match")
+	}
+}

--- a/apps/control-plane/internal/signupguard/email_test.go
+++ b/apps/control-plane/internal/signupguard/email_test.go
@@ -86,6 +86,26 @@ func TestDisposableBlocklist(t *testing.T) {
 	}
 }
 
+func TestDisposableBlocklistSubdomains(t *testing.T) {
+	bl, err := LoadDisposableBlocklist()
+	if err != nil {
+		t.Fatalf("LoadDisposableBlocklist: %v", err)
+	}
+
+	// Subdomains of a listed domain must also be blocked.
+	if !bl.IsDisposableDomain("sub.mailinator.com") {
+		t.Fatal("IsDisposableDomain(sub.mailinator.com) = false, want true")
+	}
+	if !bl.IsDisposableDomain("a.b.guerrillamail.com") {
+		t.Fatal("IsDisposableDomain(a.b.guerrillamail.com) = false, want true")
+	}
+
+	// A subdomain of a non-blocked domain must not match.
+	if bl.IsDisposableDomain("mail.gmail.com") {
+		t.Fatal("IsDisposableDomain(mail.gmail.com) = true, want false")
+	}
+}
+
 func TestDisposableBlocklistDomainComments(t *testing.T) {
 	bl, err := LoadDisposableBlocklist()
 	if err != nil {

--- a/apps/control-plane/internal/signupguard/http.go
+++ b/apps/control-plane/internal/signupguard/http.go
@@ -1,0 +1,151 @@
+package signupguard
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log"
+	"net"
+	"net/http"
+	"strings"
+)
+
+// genericReject is the single customer-visible message used for every abuse
+// control. It is intentionally vague so an attacker cannot distinguish a
+// disposable-domain block from a rate limit or a CAPTCHA failure, and so no
+// upstream/internal detail ever leaks. Operators get the real classification
+// from the audit trail and the process log.
+const genericReject = "We could not complete your sign-up. Please try again or use a different email address."
+
+// AuditFunc records a signup-guard decision for operators. The detail map must
+// contain classification strings only, never the raw email, domain, or any
+// provider/upstream value. Optional; nil disables auditing.
+type AuditFunc func(ctx context.Context, action string, detail map[string]string)
+
+// HandlerDeps wires the precheck handler.
+type HandlerDeps struct {
+	Blocklist   *Blocklist
+	RateLimiter *RateLimiter
+	Turnstile   *TurnstileVerifier
+	AuditFunc   AuditFunc
+}
+
+// Handler serves POST /api/v1/auth/sign-up/precheck. It is called by the
+// web-console signup page before it invokes Supabase signUp; only a passing
+// precheck should proceed to account creation.
+type Handler struct{ deps HandlerDeps }
+
+// NewHandler constructs the precheck handler.
+func NewHandler(deps HandlerDeps) *Handler { return &Handler{deps: deps} }
+
+type precheckRequest struct {
+	Email        string `json:"email"`
+	CaptchaToken string `json:"captcha_token"`
+}
+
+// ServeHTTP runs the three abuse controls in cheap-to-expensive order:
+// rate limit (Redis), disposable-domain (in-memory), CAPTCHA (network). Every
+// rejection returns the same generic message; only the HTTP status varies so
+// SDK/browser retry semantics still work (429 retryable, 4xx terminal).
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	ip := clientIP(r)
+
+	var body precheckRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 4096)).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request")
+		return
+	}
+
+	norm, err := NormalizeEmail(body.Email)
+	if err != nil {
+		// A malformed address is a client error, not an abuse signal.
+		writeError(w, http.StatusBadRequest, "invalid email address")
+		return
+	}
+
+	// 1) Per-IP rate limit (fail closed per #51).
+	if rlErr := h.deps.RateLimiter.Allow(r.Context(), ip); rlErr != nil {
+		if errors.Is(rlErr, ErrRateLimiterUnavailable) {
+			log.Printf("signupguard: rate limiter unavailable ip=%s: %v", ip, rlErr)
+			h.audit(r.Context(), "SIGNUP_RATE_LIMITER_UNAVAILABLE", map[string]string{"stage": "rate_limit"})
+		} else {
+			h.audit(r.Context(), "SIGNUP_RATE_LIMITED", map[string]string{"stage": "rate_limit"})
+		}
+		// Both over-quota and fail-closed map to a retryable 429.
+		w.Header().Set("Retry-After", "3600")
+		writeError(w, http.StatusTooManyRequests, genericReject)
+		return
+	}
+
+	// 2) Disposable-domain blocklist.
+	if h.deps.Blocklist.IsDisposableDomain(domainOf(norm)) {
+		h.audit(r.Context(), "SIGNUP_DISPOSABLE_BLOCKED", map[string]string{"stage": "disposable"})
+		writeError(w, http.StatusForbidden, genericReject)
+		return
+	}
+
+	// 3) CAPTCHA (no-op when TURNSTILE_SECRET_KEY is unset).
+	if cErr := h.deps.Turnstile.Verify(r.Context(), body.CaptchaToken, ip); cErr != nil {
+		// Classification only — never the Cloudflare error codes.
+		stage := "captcha"
+		if errors.Is(cErr, ErrCaptchaRequired) {
+			log.Printf("signupguard: captcha token missing ip=%s", ip)
+		} else {
+			log.Printf("signupguard: captcha verification failed ip=%s", ip)
+		}
+		h.audit(r.Context(), "SIGNUP_CAPTCHA_FAILED", map[string]string{"stage": stage})
+		writeError(w, http.StatusForbidden, genericReject)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+func (h *Handler) audit(ctx context.Context, action string, detail map[string]string) {
+	if h.deps.AuditFunc == nil {
+		return
+	}
+	h.deps.AuditFunc(ctx, action, detail)
+}
+
+// domainOf returns the domain of an already-normalized address.
+func domainOf(normalized string) string {
+	at := strings.LastIndexByte(normalized, '@')
+	if at < 0 {
+		return ""
+	}
+	return normalized[at+1:]
+}
+
+// clientIP resolves the originating client IP, preferring Cloudflare's
+// CF-Connecting-IP, then the first hop of X-Forwarded-For, then RemoteAddr.
+func clientIP(r *http.Request) string {
+	if cf := strings.TrimSpace(r.Header.Get("CF-Connecting-IP")); cf != "" {
+		return cf
+	}
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		if first := strings.TrimSpace(strings.Split(xff, ",")[0]); first != "" {
+			return first
+		}
+	}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return strings.TrimSpace(r.RemoteAddr)
+	}
+	return host
+}
+
+func writeError(w http.ResponseWriter, status int, msg string) {
+	writeJSON(w, status, map[string]string{"error": msg})
+}
+
+func writeJSON(w http.ResponseWriter, status int, body map[string]string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}

--- a/apps/control-plane/internal/signupguard/http.go
+++ b/apps/control-plane/internal/signupguard/http.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"time"
 )
 
 // genericReject is the single customer-visible message used for every abuse
@@ -16,6 +17,16 @@ import (
 // upstream/internal detail ever leaks. Operators get the real classification
 // from the audit trail and the process log.
 const genericReject = "We could not complete your sign-up. Please try again or use a different email address."
+
+// defaultPrecheckTimeout is the per-request deadline applied to the full
+// precheck chain (rate-limit Redis call + disposable lookup + Turnstile network
+// call). Keeps a slow Turnstile upstream from stacking goroutines.
+const defaultPrecheckTimeout = 8 * time.Second
+
+// defaultMaxConcurrent is the global concurrent-request ceiling for the
+// precheck handler. Requests beyond this limit are rejected with the generic
+// message (same UX, no detail leak). Tunable via SIGNUP_PRECHECK_MAX_CONCURRENT.
+const defaultMaxConcurrent = 100
 
 // AuditFunc records a signup-guard decision for operators. The detail map must
 // contain classification strings only, never the raw email, domain, or any
@@ -28,15 +39,42 @@ type HandlerDeps struct {
 	RateLimiter *RateLimiter
 	Turnstile   *TurnstileVerifier
 	AuditFunc   AuditFunc
+
+	// TrustedProxyCIDRs is the list of network ranges whose direct peers are
+	// trusted to supply accurate CF-Connecting-IP and X-Forwarded-For headers.
+	// Default (nil/empty): trust no forwarded headers; always use RemoteAddr.
+	// In production behind Cloudflare, set this to Cloudflare's published IP
+	// ranges via TRUSTED_PROXY_CIDRS (comma-separated CIDR notation).
+	TrustedProxyCIDRs []*net.IPNet
+
+	// PrecheckTimeout overrides the per-request deadline (default 8s).
+	// Zero uses the default.
+	PrecheckTimeout time.Duration
+
+	// MaxConcurrent overrides the global concurrent-request ceiling (default 100).
+	// Zero uses the default.
+	MaxConcurrent int
 }
 
 // Handler serves POST /api/v1/auth/sign-up/precheck. It is called by the
 // web-console signup page before it invokes Supabase signUp; only a passing
 // precheck should proceed to account creation.
-type Handler struct{ deps HandlerDeps }
+type Handler struct {
+	deps HandlerDeps
+	sem  chan struct{}
+}
 
 // NewHandler constructs the precheck handler.
-func NewHandler(deps HandlerDeps) *Handler { return &Handler{deps: deps} }
+func NewHandler(deps HandlerDeps) *Handler {
+	maxC := deps.MaxConcurrent
+	if maxC <= 0 {
+		maxC = defaultMaxConcurrent
+	}
+	return &Handler{
+		deps: deps,
+		sem:  make(chan struct{}, maxC),
+	}
+}
 
 type precheckRequest struct {
 	Email        string `json:"email"`
@@ -53,7 +91,25 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ip := clientIP(r)
+	// Concurrency ceiling: non-blocking acquire. Saturated = same generic
+	// rejection so an attacker cannot distinguish overload from a block.
+	select {
+	case h.sem <- struct{}{}:
+		defer func() { <-h.sem }()
+	default:
+		writeError(w, http.StatusTooManyRequests, genericReject)
+		return
+	}
+
+	// Per-request timeout wraps the full chain including the Turnstile network call.
+	timeout := h.deps.PrecheckTimeout
+	if timeout <= 0 {
+		timeout = defaultPrecheckTimeout
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), timeout)
+	defer cancel()
+
+	ip := clientIPWithTrust(r, h.deps.TrustedProxyCIDRs)
 
 	var body precheckRequest
 	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 4096)).Decode(&body); err != nil {
@@ -69,12 +125,12 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// 1) Per-IP rate limit (fail closed per #51).
-	if rlErr := h.deps.RateLimiter.Allow(r.Context(), ip); rlErr != nil {
+	if rlErr := h.deps.RateLimiter.Allow(ctx, ip); rlErr != nil {
 		if errors.Is(rlErr, ErrRateLimiterUnavailable) {
 			log.Printf("signupguard: rate limiter unavailable ip=%s: %v", ip, rlErr)
-			h.audit(r.Context(), "SIGNUP_RATE_LIMITER_UNAVAILABLE", map[string]string{"stage": "rate_limit"})
+			h.audit(ctx, "SIGNUP_RATE_LIMITER_UNAVAILABLE", map[string]string{"stage": "rate_limit"})
 		} else {
-			h.audit(r.Context(), "SIGNUP_RATE_LIMITED", map[string]string{"stage": "rate_limit"})
+			h.audit(ctx, "SIGNUP_RATE_LIMITED", map[string]string{"stage": "rate_limit"})
 		}
 		// Both over-quota and fail-closed map to a retryable 429.
 		w.Header().Set("Retry-After", "3600")
@@ -84,13 +140,13 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// 2) Disposable-domain blocklist.
 	if h.deps.Blocklist.IsDisposableDomain(domainOf(norm)) {
-		h.audit(r.Context(), "SIGNUP_DISPOSABLE_BLOCKED", map[string]string{"stage": "disposable"})
+		h.audit(ctx, "SIGNUP_DISPOSABLE_BLOCKED", map[string]string{"stage": "disposable"})
 		writeError(w, http.StatusForbidden, genericReject)
 		return
 	}
 
 	// 3) CAPTCHA (no-op when TURNSTILE_SECRET_KEY is unset).
-	if cErr := h.deps.Turnstile.Verify(r.Context(), body.CaptchaToken, ip); cErr != nil {
+	if cErr := h.deps.Turnstile.Verify(ctx, body.CaptchaToken, ip); cErr != nil {
 		// Classification only — never the Cloudflare error codes.
 		stage := "captcha"
 		if errors.Is(cErr, ErrCaptchaRequired) {
@@ -98,7 +154,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		} else {
 			log.Printf("signupguard: captcha verification failed ip=%s", ip)
 		}
-		h.audit(r.Context(), "SIGNUP_CAPTCHA_FAILED", map[string]string{"stage": stage})
+		h.audit(ctx, "SIGNUP_CAPTCHA_FAILED", map[string]string{"stage": stage})
 		writeError(w, http.StatusForbidden, genericReject)
 		return
 	}
@@ -122,22 +178,81 @@ func domainOf(normalized string) string {
 	return normalized[at+1:]
 }
 
-// clientIP resolves the originating client IP, preferring Cloudflare's
-// CF-Connecting-IP, then the first hop of X-Forwarded-For, then RemoteAddr.
-func clientIP(r *http.Request) string {
-	if cf := strings.TrimSpace(r.Header.Get("CF-Connecting-IP")); cf != "" {
-		return cf
-	}
-	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-		if first := strings.TrimSpace(strings.Split(xff, ",")[0]); first != "" {
-			return first
-		}
-	}
+// remoteAddrHost extracts the host (without port) from r.RemoteAddr.
+func remoteAddrHost(r *http.Request) string {
 	host, _, err := net.SplitHostPort(r.RemoteAddr)
 	if err != nil {
 		return strings.TrimSpace(r.RemoteAddr)
 	}
 	return host
+}
+
+// isInCIDRs reports whether ip is contained in any of the given networks.
+func isInCIDRs(ip net.IP, cidrs []*net.IPNet) bool {
+	for _, cidr := range cidrs {
+		if cidr.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// clientIPWithTrust resolves the originating client IP honouring forwarded
+// headers only when the direct peer (RemoteAddr) falls inside trustedCIDRs.
+//
+// When trusted:
+//   - CF-Connecting-IP is returned as-is (Cloudflare sets exactly one value).
+//   - X-Forwarded-For is walked right-to-left; the rightmost hop that is NOT
+//     in the trusted set is the first untrusted (real client) hop.
+//   - If every XFF hop is trusted, RemoteAddr host is returned as a safe fallback.
+//
+// When untrusted (or trustedCIDRs is empty): RemoteAddr host is always returned,
+// ignoring any client-supplied headers.
+func clientIPWithTrust(r *http.Request, trustedCIDRs []*net.IPNet) string {
+	peerHost := remoteAddrHost(r)
+
+	if len(trustedCIDRs) == 0 {
+		return peerHost
+	}
+
+	peerIP := net.ParseIP(peerHost)
+	if peerIP == nil || !isInCIDRs(peerIP, trustedCIDRs) {
+		// Direct peer is not trusted: ignore all forwarded headers.
+		return peerHost
+	}
+
+	// Trusted peer: honour CF-Connecting-IP first.
+	if cf := strings.TrimSpace(r.Header.Get("CF-Connecting-IP")); cf != "" {
+		return cf
+	}
+
+	// Trusted peer: walk XFF right-to-left, find rightmost untrusted hop.
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		parts := strings.Split(xff, ",")
+		for i := len(parts) - 1; i >= 0; i-- {
+			hop := strings.TrimSpace(parts[i])
+			if hop == "" {
+				continue
+			}
+			hopIP := net.ParseIP(hop)
+			if hopIP == nil {
+				// Unparseable hop: treat as untrusted, return it.
+				return hop
+			}
+			if !isInCIDRs(hopIP, trustedCIDRs) {
+				return hop
+			}
+		}
+		// All XFF hops were trusted: fall through to RemoteAddr.
+	}
+
+	return peerHost
+}
+
+// clientIP is the zero-trust variant (no forwarded headers honoured).
+// Kept for backward compatibility with callers that have not been updated.
+func clientIP(r *http.Request) string {
+	return clientIPWithTrust(r, nil)
 }
 
 func writeError(w http.ResponseWriter, status int, msg string) {

--- a/apps/control-plane/internal/signupguard/http_test.go
+++ b/apps/control-plane/internal/signupguard/http_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -43,6 +44,19 @@ func newTestHandler(t *testing.T, opts ...func(*HandlerDeps)) *Handler {
 		o(&deps)
 	}
 	return NewHandler(deps)
+}
+
+func mustParseCIDRs(t *testing.T, cidrs ...string) []*net.IPNet {
+	t.Helper()
+	out := make([]*net.IPNet, 0, len(cidrs))
+	for _, s := range cidrs {
+		_, n, err := net.ParseCIDR(s)
+		if err != nil {
+			t.Fatalf("ParseCIDR(%q): %v", s, err)
+		}
+		out = append(out, n)
+	}
+	return out
 }
 
 func TestPrecheckMethodNotAllowed(t *testing.T) {
@@ -136,17 +150,46 @@ func TestPrecheckCaptchaRequiredWhenEnabled(t *testing.T) {
 	}
 }
 
-func TestClientIPExtraction(t *testing.T) {
+func TestPrecheckMaxConcurrent(t *testing.T) {
+	h := newTestHandler(t, func(d *HandlerDeps) {
+		d.MaxConcurrent = 1
+	})
+	// Fill the semaphore manually.
+	h.sem <- struct{}{}
+	rec := postPrecheck(t, h, `{"email":"a@gmail.com"}`, nil)
+	<-h.sem
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("saturated semaphore should be 429, got %d", rec.Code)
+	}
+}
+
+// TestClientIPWithTrust verifies trusted-proxy CIDR logic.
+func TestClientIPWithTrust(t *testing.T) {
+	trusted := mustParseCIDRs(t, "10.0.0.0/8")
+	none := []*net.IPNet{}
+
 	cases := []struct {
 		name    string
 		headers map[string]string
 		remote  string
+		cidrs   []*net.IPNet
 		want    string
 	}{
-		{"cf-connecting-ip wins", map[string]string{"CF-Connecting-IP": "9.9.9.9", "X-Forwarded-For": "8.8.8.8"}, "1.1.1.1:5", "9.9.9.9"},
-		{"x-forwarded-for first hop", map[string]string{"X-Forwarded-For": "8.8.8.8, 7.7.7.7"}, "1.1.1.1:5", "8.8.8.8"},
-		{"remote addr fallback", nil, "1.1.1.1:5555", "1.1.1.1"},
-		{"remote addr no port", nil, "1.1.1.1", "1.1.1.1"},
+		// Trusted peer: honour CF-Connecting-IP.
+		{"trusted peer cf-connecting-ip", map[string]string{"CF-Connecting-IP": "9.9.9.9", "X-Forwarded-For": "8.8.8.8"}, "10.0.0.1:5", trusted, "9.9.9.9"},
+		// Trusted peer: XFF rightmost untrusted hop.
+		{"trusted peer xff rightmost-untrusted", map[string]string{"X-Forwarded-For": "1.2.3.4, 5.6.7.8, 10.0.0.2"}, "10.0.0.1:5", trusted, "5.6.7.8"},
+		// Trusted peer: XFF all-trusted falls back to RemoteAddr host.
+		{"trusted peer xff all-trusted fallback", map[string]string{"X-Forwarded-For": "10.0.0.5, 10.0.0.6"}, "10.0.0.1:5", trusted, "10.0.0.1"},
+		// Untrusted peer: ignore CF-Connecting-IP (spoofed).
+		{"untrusted peer ignores cf-connecting-ip", map[string]string{"CF-Connecting-IP": "9.9.9.9", "X-Forwarded-For": "8.8.8.8"}, "203.0.113.7:5", trusted, "203.0.113.7"},
+		// Untrusted peer: ignore XFF (spoofed).
+		{"untrusted peer ignores xff", map[string]string{"X-Forwarded-For": "8.8.8.8, 7.7.7.7"}, "203.0.113.7:5", trusted, "203.0.113.7"},
+		// No trusted CIDRs: always RemoteAddr.
+		{"no trusted cidrs uses remote addr", map[string]string{"CF-Connecting-IP": "9.9.9.9"}, "1.1.1.1:5", none, "1.1.1.1"},
+		// Fallback cases.
+		{"remote addr fallback", nil, "1.1.1.1:5555", none, "1.1.1.1"},
+		{"remote addr no port", nil, "1.1.1.1", none, "1.1.1.1"},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -155,10 +198,75 @@ func TestClientIPExtraction(t *testing.T) {
 			for k, v := range c.headers {
 				req.Header.Set(k, v)
 			}
-			if got := clientIP(req); got != c.want {
-				t.Fatalf("clientIP = %q, want %q", got, c.want)
+			if got := clientIPWithTrust(req, c.cidrs); got != c.want {
+				t.Fatalf("clientIPWithTrust = %q, want %q", got, c.want)
 			}
 		})
+	}
+}
+
+// TestPrecheckSpoofedHeaderFromUntrustedPeer verifies that a client supplying
+// a CF-Connecting-IP header from an untrusted RemoteAddr is bucketed by
+// RemoteAddr, not by the spoofed header value.
+func TestPrecheckSpoofedHeaderFromUntrustedPeer(t *testing.T) {
+	inc := &fakeIncrementer{}
+	h := newTestHandler(t, func(d *HandlerDeps) {
+		d.RateLimiter = NewRateLimiter(inc, RateLimitConfig{Limit: 1, Window: time.Hour})
+		d.TrustedProxyCIDRs = []*net.IPNet{}
+	})
+
+	// First request: attacker sends CF-Connecting-IP from untrusted RemoteAddr.
+	req1 := httptest.NewRequest(http.MethodPost, "/api/v1/auth/sign-up/precheck", strings.NewReader(`{"email":"a@gmail.com"}`))
+	req1.RemoteAddr = "203.0.113.7:1234"
+	req1.Header.Set("CF-Connecting-IP", "9.9.9.9")
+	rec1 := httptest.NewRecorder()
+	h.ServeHTTP(rec1, req1)
+	if rec1.Code != http.StatusOK {
+		t.Fatalf("first request should pass, got %d", rec1.Code)
+	}
+
+	// Second request: same RemoteAddr, different spoofed CF header.
+	req2 := httptest.NewRequest(http.MethodPost, "/api/v1/auth/sign-up/precheck", strings.NewReader(`{"email":"b@gmail.com"}`))
+	req2.RemoteAddr = "203.0.113.7:5678"
+	req2.Header.Set("CF-Connecting-IP", "1.2.3.4")
+	rec2 := httptest.NewRecorder()
+	h.ServeHTTP(rec2, req2)
+	// Must be 429 because 203.0.113.7 hit its limit, not because 9.9.9.9/1.2.3.4 did.
+	if rec2.Code != http.StatusTooManyRequests {
+		t.Fatalf("second request from same untrusted RemoteAddr should be 429, got %d (spoofed header bypassed rate limit)", rec2.Code)
+	}
+}
+
+// TestPrecheckTrustedProxyHonoursForwardedHeader verifies that when the
+// RemoteAddr is inside the trusted CIDR list, the CF-Connecting-IP header is
+// honoured for bucketing.
+func TestPrecheckTrustedProxyHonoursForwardedHeader(t *testing.T) {
+	_, trusted, _ := net.ParseCIDR("10.0.0.0/8")
+	inc := &fakeIncrementer{}
+	h := newTestHandler(t, func(d *HandlerDeps) {
+		d.RateLimiter = NewRateLimiter(inc, RateLimitConfig{Limit: 1, Window: time.Hour})
+		d.TrustedProxyCIDRs = []*net.IPNet{trusted}
+	})
+
+	// First request: trusted proxy 10.0.0.1 forwards real client 9.9.9.9.
+	req1 := httptest.NewRequest(http.MethodPost, "/api/v1/auth/sign-up/precheck", strings.NewReader(`{"email":"a@gmail.com"}`))
+	req1.RemoteAddr = "10.0.0.1:1234"
+	req1.Header.Set("CF-Connecting-IP", "9.9.9.9")
+	rec1 := httptest.NewRecorder()
+	h.ServeHTTP(rec1, req1)
+	if rec1.Code != http.StatusOK {
+		t.Fatalf("first request should pass, got %d", rec1.Code)
+	}
+
+	// Second request: same real client (9.9.9.9) via a different trusted proxy.
+	req2 := httptest.NewRequest(http.MethodPost, "/api/v1/auth/sign-up/precheck", strings.NewReader(`{"email":"b@gmail.com"}`))
+	req2.RemoteAddr = "10.0.0.2:5678"
+	req2.Header.Set("CF-Connecting-IP", "9.9.9.9")
+	rec2 := httptest.NewRecorder()
+	h.ServeHTTP(rec2, req2)
+	// Rate-limited by forwarded IP 9.9.9.9.
+	if rec2.Code != http.StatusTooManyRequests {
+		t.Fatalf("second request from same forwarded IP should be 429, got %d", rec2.Code)
 	}
 }
 

--- a/apps/control-plane/internal/signupguard/http_test.go
+++ b/apps/control-plane/internal/signupguard/http_test.go
@@ -1,0 +1,195 @@
+package signupguard
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func mustBlocklist(t *testing.T) *Blocklist {
+	t.Helper()
+	bl, err := LoadDisposableBlocklist()
+	if err != nil {
+		t.Fatalf("LoadDisposableBlocklist: %v", err)
+	}
+	return bl
+}
+
+func postPrecheck(t *testing.T, h http.Handler, body string, headers map[string]string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/sign-up/precheck", strings.NewReader(body))
+	req.RemoteAddr = "203.0.113.7:54321"
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+func newTestHandler(t *testing.T, opts ...func(*HandlerDeps)) *Handler {
+	t.Helper()
+	deps := HandlerDeps{
+		Blocklist:   mustBlocklist(t),
+		RateLimiter: NewRateLimiter(nil, RateLimitConfig{}),
+		Turnstile:   NewTurnstileVerifier("", nil),
+	}
+	for _, o := range opts {
+		o(&deps)
+	}
+	return NewHandler(deps)
+}
+
+func TestPrecheckMethodNotAllowed(t *testing.T) {
+	h := newTestHandler(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/sign-up/precheck", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("GET should be 405, got %d", rec.Code)
+	}
+}
+
+func TestPrecheckCleanEmailPasses(t *testing.T) {
+	h := newTestHandler(t)
+	rec := postPrecheck(t, h, `{"email":"new.user@gmail.com"}`, nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("clean signup should be 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestPrecheckDisposableBlocked(t *testing.T) {
+	h := newTestHandler(t)
+	rec := postPrecheck(t, h, `{"email":"x@mailinator.com"}`, nil)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("disposable email should be 403, got %d", rec.Code)
+	}
+	// Provider-blind: must not name the control that tripped.
+	var body map[string]string
+	_ = json.Unmarshal(rec.Body.Bytes(), &body)
+	msg := strings.ToLower(body["error"])
+	for _, leak := range []string{"disposable", "mailinator", "blocklist", "captcha", "rate"} {
+		if strings.Contains(msg, leak) {
+			t.Fatalf("error message leaked control detail %q: %q", leak, msg)
+		}
+	}
+}
+
+func TestPrecheckInvalidEmail(t *testing.T) {
+	h := newTestHandler(t)
+	rec := postPrecheck(t, h, `{"email":"not-an-email"}`, nil)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("invalid email should be 400, got %d", rec.Code)
+	}
+}
+
+func TestPrecheckMalformedBody(t *testing.T) {
+	h := newTestHandler(t)
+	rec := postPrecheck(t, h, `{not json`, nil)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("malformed body should be 400, got %d", rec.Code)
+	}
+}
+
+func TestPrecheckRateLimited(t *testing.T) {
+	inc := &fakeIncrementer{}
+	h := newTestHandler(t, func(d *HandlerDeps) {
+		d.RateLimiter = NewRateLimiter(inc, RateLimitConfig{Limit: 1, Window: time.Hour})
+	})
+	first := postPrecheck(t, h, `{"email":"a@gmail.com"}`, nil)
+	if first.Code != http.StatusOK {
+		t.Fatalf("first signup should pass, got %d", first.Code)
+	}
+	second := postPrecheck(t, h, `{"email":"b@gmail.com"}`, nil)
+	if second.Code != http.StatusTooManyRequests {
+		t.Fatalf("second signup from same IP should be 429, got %d", second.Code)
+	}
+	if second.Header().Get("Retry-After") == "" {
+		t.Fatal("429 response must carry Retry-After")
+	}
+}
+
+func TestPrecheckRateLimiterFailClosed(t *testing.T) {
+	inc := &fakeIncrementer{err: errors.New("redis down")}
+	h := newTestHandler(t, func(d *HandlerDeps) {
+		d.RateLimiter = NewRateLimiter(inc, RateLimitConfig{Limit: 5, Window: time.Hour, FailOpen: false})
+	})
+	rec := postPrecheck(t, h, `{"email":"a@gmail.com"}`, nil)
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("backend down with fail-closed should be 429, got %d", rec.Code)
+	}
+}
+
+func TestPrecheckCaptchaRequiredWhenEnabled(t *testing.T) {
+	h := newTestHandler(t, func(d *HandlerDeps) {
+		d.Turnstile = NewTurnstileVerifier("a-secret", nil)
+	})
+	// No captcha_token in body, captcha enabled -> reject (provider-blind 403).
+	rec := postPrecheck(t, h, `{"email":"a@gmail.com"}`, nil)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("missing captcha when enabled should be 403, got %d", rec.Code)
+	}
+}
+
+func TestClientIPExtraction(t *testing.T) {
+	cases := []struct {
+		name    string
+		headers map[string]string
+		remote  string
+		want    string
+	}{
+		{"cf-connecting-ip wins", map[string]string{"CF-Connecting-IP": "9.9.9.9", "X-Forwarded-For": "8.8.8.8"}, "1.1.1.1:5", "9.9.9.9"},
+		{"x-forwarded-for first hop", map[string]string{"X-Forwarded-For": "8.8.8.8, 7.7.7.7"}, "1.1.1.1:5", "8.8.8.8"},
+		{"remote addr fallback", nil, "1.1.1.1:5555", "1.1.1.1"},
+		{"remote addr no port", nil, "1.1.1.1", "1.1.1.1"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/x", nil)
+			req.RemoteAddr = c.remote
+			for k, v := range c.headers {
+				req.Header.Set(k, v)
+			}
+			if got := clientIP(req); got != c.want {
+				t.Fatalf("clientIP = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+// audit sink stub to assert the handler records classifications without leaking.
+type recordedAudit struct {
+	actions []string
+	details []map[string]string
+}
+
+func (r *recordedAudit) record(action string, detail map[string]string) {
+	r.actions = append(r.actions, action)
+	r.details = append(r.details, detail)
+}
+
+func TestPrecheckAuditOnBlock(t *testing.T) {
+	rec := &recordedAudit{}
+	h := newTestHandler(t, func(d *HandlerDeps) {
+		d.AuditFunc = func(_ context.Context, action string, detail map[string]string) {
+			rec.record(action, detail)
+		}
+	})
+	_ = postPrecheck(t, h, `{"email":"x@mailinator.com"}`, nil)
+	if len(rec.actions) == 0 {
+		t.Fatal("expected an audit entry on disposable block")
+	}
+	// Audit detail must not echo the raw email or a provider name.
+	for _, d := range rec.details {
+		for _, v := range d {
+			if strings.Contains(v, "mailinator.com") {
+				t.Fatalf("audit detail leaked domain: %v", d)
+			}
+		}
+	}
+}

--- a/apps/control-plane/internal/signupguard/ratelimit.go
+++ b/apps/control-plane/internal/signupguard/ratelimit.go
@@ -1,0 +1,117 @@
+package signupguard
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	goredis "github.com/redis/go-redis/v9"
+)
+
+// ErrRateLimited is returned when an IP exceeds the per-window signup quota.
+var ErrRateLimited = errors.New("signupguard: signup rate limit exceeded")
+
+// ErrRateLimiterUnavailable is returned when the limiter cannot reach its
+// backend (or has no client IP to scope on) and FailOpen is false. Per the
+// #51 policy this fails CLOSED: abuse-control dependencies deny rather than
+// admit unmetered traffic during a backend blip.
+var ErrRateLimiterUnavailable = errors.New("signupguard: rate limiter unavailable")
+
+// Incrementer increments a counter key and ensures it expires after ttl,
+// returning the post-increment count. Implemented over Redis in production and
+// faked in tests.
+type Incrementer interface {
+	IncrWithExpiry(ctx context.Context, key string, ttl time.Duration) (int64, error)
+}
+
+// RateLimitConfig configures the per-IP signup limiter.
+type RateLimitConfig struct {
+	Limit    int           // max signups per IP per window; <=0 disables the limiter
+	Window   time.Duration // sliding fixed-window length
+	FailOpen bool          // on backend error: false = deny (default), true = admit
+}
+
+// RateLimiter enforces a fixed-window per-IP signup quota backed by an
+// Incrementer. A nil backend or a non-positive Limit disables enforcement.
+type RateLimiter struct {
+	backend Incrementer
+	cfg     RateLimitConfig
+}
+
+// NewRateLimiter constructs a per-IP limiter. Pass a nil backend to disable.
+func NewRateLimiter(backend Incrementer, cfg RateLimitConfig) *RateLimiter {
+	return &RateLimiter{backend: backend, cfg: cfg}
+}
+
+// Enabled reports whether the limiter will perform enforcement.
+func (rl *RateLimiter) Enabled() bool {
+	return rl != nil && rl.backend != nil && rl.cfg.Limit > 0
+}
+
+// Allow records one signup attempt for the given client IP and reports whether
+// it is within quota. Returns ErrRateLimited when over quota, and
+// ErrRateLimiterUnavailable when the backend errors (FailOpen=false) or the IP
+// is missing (FailOpen=false).
+func (rl *RateLimiter) Allow(ctx context.Context, clientIP string) error {
+	if !rl.Enabled() {
+		return nil
+	}
+
+	if clientIP == "" {
+		// No IP to scope on: fail closed unless explicitly told to fail open.
+		if rl.cfg.FailOpen {
+			return nil
+		}
+		return fmt.Errorf("%w: missing client ip", ErrRateLimiterUnavailable)
+	}
+
+	window := rl.cfg.Window
+	if window <= 0 {
+		window = time.Hour
+	}
+	// Bucket the key by window so a fixed-window counter rolls over cleanly and
+	// the TTL is a hard backstop against leaked keys.
+	bucket := time.Now().Unix() / int64(window/time.Second)
+	key := fmt.Sprintf("signup:rl:{ip:%s}:%d", clientIP, bucket)
+
+	count, err := rl.backend.IncrWithExpiry(ctx, key, window)
+	if err != nil {
+		if rl.cfg.FailOpen {
+			return nil
+		}
+		return fmt.Errorf("%w: %v", ErrRateLimiterUnavailable, err)
+	}
+	if count > int64(rl.cfg.Limit) {
+		return ErrRateLimited
+	}
+	return nil
+}
+
+// RedisIncrementer adapts a go-redis client to the Incrementer interface using
+// an INCR + EXPIRE pipeline. EXPIRE is only meaningful on the first increment,
+// but issuing it every call is idempotent and cheap, and guarantees a TTL even
+// if the very first EXPIRE was lost to a reconnect.
+type RedisIncrementer struct {
+	client *goredis.Client
+}
+
+// NewRedisIncrementer wraps a go-redis client. A nil client yields a nil
+// Incrementer so the caller can disable rate limiting cleanly.
+func NewRedisIncrementer(client *goredis.Client) Incrementer {
+	if client == nil {
+		return nil
+	}
+	return &RedisIncrementer{client: client}
+}
+
+// IncrWithExpiry runs INCR then EXPIRE in a pipeline and returns the count.
+func (r *RedisIncrementer) IncrWithExpiry(ctx context.Context, key string, ttl time.Duration) (int64, error) {
+	pipe := r.client.TxPipeline()
+	incr := pipe.Incr(ctx, key)
+	pipe.Expire(ctx, key, ttl)
+	if _, err := pipe.Exec(ctx); err != nil {
+		return 0, err
+	}
+	return incr.Val(), nil
+}

--- a/apps/control-plane/internal/signupguard/ratelimit_test.go
+++ b/apps/control-plane/internal/signupguard/ratelimit_test.go
@@ -1,0 +1,118 @@
+package signupguard
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+type fakeIncrementer struct {
+	counts map[string]int64
+	err    error
+	calls  int
+}
+
+func (f *fakeIncrementer) IncrWithExpiry(_ context.Context, key string, _ time.Duration) (int64, error) {
+	f.calls++
+	if f.err != nil {
+		return 0, f.err
+	}
+	if f.counts == nil {
+		f.counts = map[string]int64{}
+	}
+	f.counts[key]++
+	return f.counts[key], nil
+}
+
+func TestRateLimiterAllowsUnderLimit(t *testing.T) {
+	inc := &fakeIncrementer{}
+	rl := NewRateLimiter(inc, RateLimitConfig{Limit: 3, Window: time.Hour, FailOpen: false})
+	for i := 1; i <= 3; i++ {
+		if err := rl.Allow(context.Background(), "1.2.3.4"); err != nil {
+			t.Fatalf("request %d under limit should pass, got %v", i, err)
+		}
+	}
+}
+
+func TestRateLimiterBlocksOverLimit(t *testing.T) {
+	inc := &fakeIncrementer{}
+	rl := NewRateLimiter(inc, RateLimitConfig{Limit: 2, Window: time.Hour})
+	_ = rl.Allow(context.Background(), "1.2.3.4")
+	_ = rl.Allow(context.Background(), "1.2.3.4")
+	err := rl.Allow(context.Background(), "1.2.3.4")
+	if !errors.Is(err, ErrRateLimited) {
+		t.Fatalf("4th request should be rate limited, got %v", err)
+	}
+}
+
+func TestRateLimiterScopesPerIP(t *testing.T) {
+	inc := &fakeIncrementer{}
+	rl := NewRateLimiter(inc, RateLimitConfig{Limit: 1, Window: time.Hour})
+	if err := rl.Allow(context.Background(), "1.1.1.1"); err != nil {
+		t.Fatalf("first IP first hit should pass: %v", err)
+	}
+	if err := rl.Allow(context.Background(), "2.2.2.2"); err != nil {
+		t.Fatalf("different IP should have its own bucket: %v", err)
+	}
+	if err := rl.Allow(context.Background(), "1.1.1.1"); !errors.Is(err, ErrRateLimited) {
+		t.Fatalf("first IP second hit should be limited, got %v", err)
+	}
+}
+
+func TestRateLimiterFailClosedByDefault(t *testing.T) {
+	inc := &fakeIncrementer{err: errors.New("redis down")}
+	rl := NewRateLimiter(inc, RateLimitConfig{Limit: 5, Window: time.Hour, FailOpen: false})
+	err := rl.Allow(context.Background(), "1.2.3.4")
+	if !errors.Is(err, ErrRateLimiterUnavailable) {
+		t.Fatalf("backend error must fail closed, got %v", err)
+	}
+}
+
+func TestRateLimiterFailOpenWhenConfigured(t *testing.T) {
+	inc := &fakeIncrementer{err: errors.New("redis down")}
+	rl := NewRateLimiter(inc, RateLimitConfig{Limit: 5, Window: time.Hour, FailOpen: true})
+	if err := rl.Allow(context.Background(), "1.2.3.4"); err != nil {
+		t.Fatalf("fail-open mode should admit on backend error, got %v", err)
+	}
+}
+
+func TestRateLimiterDisabledWhenNoBackend(t *testing.T) {
+	// A nil incrementer means rate limiting is not configured; Allow must be a
+	// no-op (the disposable + captcha controls still apply at the HTTP layer).
+	rl := NewRateLimiter(nil, RateLimitConfig{Limit: 5, Window: time.Hour})
+	if err := rl.Allow(context.Background(), "1.2.3.4"); err != nil {
+		t.Fatalf("nil-backend limiter should be a no-op, got %v", err)
+	}
+}
+
+func TestRateLimiterDisabledWhenLimitZero(t *testing.T) {
+	inc := &fakeIncrementer{}
+	rl := NewRateLimiter(inc, RateLimitConfig{Limit: 0, Window: time.Hour})
+	if err := rl.Allow(context.Background(), "1.2.3.4"); err != nil {
+		t.Fatalf("zero limit disables rate limiting, got %v", err)
+	}
+	if inc.calls != 0 {
+		t.Fatalf("zero limit must not touch the backend, calls=%d", inc.calls)
+	}
+}
+
+func TestRateLimiterEmptyIPFailsClosed(t *testing.T) {
+	inc := &fakeIncrementer{}
+	rl := NewRateLimiter(inc, RateLimitConfig{Limit: 5, Window: time.Hour, FailOpen: false})
+	// Missing client IP must not silently bypass the limiter.
+	if err := rl.Allow(context.Background(), ""); !errors.Is(err, ErrRateLimiterUnavailable) {
+		t.Fatalf("empty IP should fail closed, got %v", err)
+	}
+	if inc.calls != 0 {
+		t.Fatalf("empty IP must not hit the backend, calls=%d", inc.calls)
+	}
+}
+
+func TestRateLimiterEmptyIPFailsOpenWhenConfigured(t *testing.T) {
+	inc := &fakeIncrementer{}
+	rl := NewRateLimiter(inc, RateLimitConfig{Limit: 5, Window: time.Hour, FailOpen: true})
+	if err := rl.Allow(context.Background(), ""); err != nil {
+		t.Fatalf("empty IP under fail-open should admit, got %v", err)
+	}
+}

--- a/apps/control-plane/internal/signupguard/turnstile.go
+++ b/apps/control-plane/internal/signupguard/turnstile.go
@@ -1,0 +1,111 @@
+package signupguard
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// defaultTurnstileURL is Cloudflare's server-side siteverify endpoint.
+const defaultTurnstileURL = "https://challenges.cloudflare.com/turnstile/v0/siteverify"
+
+// ErrCaptchaRequired is returned when CAPTCHA is enabled but the caller did not
+// present a token.
+var ErrCaptchaRequired = errors.New("signupguard: captcha token required")
+
+// ErrCaptchaFailed is returned when Cloudflare rejects the token or the
+// verification call itself fails. The error string is deliberately generic so
+// no upstream error code reaches the customer surface.
+var ErrCaptchaFailed = errors.New("signupguard: captcha verification failed")
+
+// turnstileResponse models the Cloudflare siteverify JSON body. Only Success
+// and ErrorCodes are consumed; ErrorCodes is logged by the caller, never
+// forwarded to the customer.
+type turnstileResponse struct {
+	Success    bool     `json:"success"`
+	ErrorCodes []string `json:"error-codes"`
+	Hostname   string   `json:"hostname"`
+}
+
+// TurnstileVerifier performs server-side Cloudflare Turnstile verification.
+// When constructed with an empty secret it is disabled and Verify is a no-op
+// that accepts every request (feature flag off via unset TURNSTILE_SECRET_KEY).
+type TurnstileVerifier struct {
+	secret    string
+	client    *http.Client
+	verifyURL string
+}
+
+// NewTurnstileVerifier constructs a verifier. An empty secret disables the
+// feature. A nil client falls back to a 5s-timeout default client.
+func NewTurnstileVerifier(secret string, client *http.Client) *TurnstileVerifier {
+	if client == nil {
+		client = &http.Client{Timeout: 5 * time.Second}
+	}
+	return &TurnstileVerifier{
+		secret:    strings.TrimSpace(secret),
+		client:    client,
+		verifyURL: defaultTurnstileURL,
+	}
+}
+
+// Enabled reports whether a secret is configured. When false, Verify accepts
+// every request without a network call.
+func (v *TurnstileVerifier) Enabled() bool {
+	return v != nil && v.secret != ""
+}
+
+// Verify validates the Turnstile token against Cloudflare. When the verifier is
+// disabled it returns nil. When enabled it fails closed: a missing token, a
+// network/HTTP error, or an unsuccessful result all return an error so the
+// caller rejects the signup.
+func (v *TurnstileVerifier) Verify(ctx context.Context, token, remoteIP string) error {
+	if !v.Enabled() {
+		return nil
+	}
+	if strings.TrimSpace(token) == "" {
+		return ErrCaptchaRequired
+	}
+
+	form := url.Values{}
+	form.Set("secret", v.secret)
+	form.Set("response", token)
+	if remoteIP != "" {
+		form.Set("remoteip", remoteIP)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, v.verifyURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return fmt.Errorf("%w: build request: %v", ErrCaptchaFailed, err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := v.client.Do(req)
+	if err != nil {
+		// Fail closed on transport errors (timeouts, DNS, refused).
+		return fmt.Errorf("%w: transport: %v", ErrCaptchaFailed, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("%w: unexpected status %d", ErrCaptchaFailed, resp.StatusCode)
+	}
+
+	var body turnstileResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return fmt.Errorf("%w: decode: %v", ErrCaptchaFailed, err)
+	}
+	if !body.Success {
+		// Return the bare sentinel: the upstream Cloudflare error codes must
+		// never reach the customer surface, so they are not embedded in the
+		// returned error. The codes are diagnostic only and are not logged by
+		// this library (the HTTP layer logs a fixed classification instead).
+		return ErrCaptchaFailed
+	}
+	return nil
+}

--- a/apps/control-plane/internal/signupguard/turnstile_test.go
+++ b/apps/control-plane/internal/signupguard/turnstile_test.go
@@ -1,0 +1,116 @@
+package signupguard
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+func newTurnstileStub(t *testing.T, handler func(form url.Values) turnstileResponse) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		form, _ := url.ParseQuery(string(body))
+		resp := handler(form)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestTurnstileDisabledWhenNoSecret(t *testing.T) {
+	v := NewTurnstileVerifier("", nil)
+	if v.Enabled() {
+		t.Fatal("verifier with empty secret must report disabled")
+	}
+	// Disabled verifier accepts any (or empty) token without a network call.
+	if err := v.Verify(context.Background(), "", "1.2.3.4"); err != nil {
+		t.Fatalf("disabled verifier should accept, got %v", err)
+	}
+}
+
+func TestTurnstileSuccess(t *testing.T) {
+	var gotSecret, gotResponse, gotIP string
+	srv := newTurnstileStub(t, func(form url.Values) turnstileResponse {
+		gotSecret = form.Get("secret")
+		gotResponse = form.Get("response")
+		gotIP = form.Get("remoteip")
+		return turnstileResponse{Success: true}
+	})
+
+	v := NewTurnstileVerifier("test-secret", srv.Client())
+	v.verifyURL = srv.URL
+
+	if !v.Enabled() {
+		t.Fatal("verifier with secret must report enabled")
+	}
+	if err := v.Verify(context.Background(), "good-token", "9.9.9.9"); err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	if gotSecret != "test-secret" || gotResponse != "good-token" || gotIP != "9.9.9.9" {
+		t.Fatalf("siteverify form mismatch: secret=%q response=%q ip=%q", gotSecret, gotResponse, gotIP)
+	}
+}
+
+func TestTurnstileMissingTokenWhenEnabled(t *testing.T) {
+	srv := newTurnstileStub(t, func(url.Values) turnstileResponse {
+		t.Fatal("siteverify must not be called when token is empty")
+		return turnstileResponse{}
+	})
+	v := NewTurnstileVerifier("test-secret", srv.Client())
+	v.verifyURL = srv.URL
+	if err := v.Verify(context.Background(), "", "9.9.9.9"); err == nil {
+		t.Fatal("expected error for missing token when enabled")
+	}
+}
+
+func TestTurnstileFailure(t *testing.T) {
+	srv := newTurnstileStub(t, func(url.Values) turnstileResponse {
+		return turnstileResponse{Success: false, ErrorCodes: []string{"invalid-input-response"}}
+	})
+	v := NewTurnstileVerifier("test-secret", srv.Client())
+	v.verifyURL = srv.URL
+	err := v.Verify(context.Background(), "bad-token", "9.9.9.9")
+	if err == nil {
+		t.Fatal("expected failure for unsuccessful verification")
+	}
+	// Provider-blind: customer-visible error must not leak Cloudflare error codes.
+	if strings.Contains(err.Error(), "invalid-input-response") {
+		t.Fatalf("error leaked upstream code: %v", err)
+	}
+}
+
+func TestTurnstileUpstreamError(t *testing.T) {
+	// Server returns 500 -> verifier must fail closed (return error), not allow.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+	v := NewTurnstileVerifier("test-secret", srv.Client())
+	v.verifyURL = srv.URL
+	if err := v.Verify(context.Background(), "tok", "9.9.9.9"); err == nil {
+		t.Fatal("expected fail-closed error on upstream 5xx")
+	}
+}
+
+func TestTurnstileContextDeadline(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(50 * time.Millisecond)
+		_ = json.NewEncoder(w).Encode(turnstileResponse{Success: true})
+	}))
+	t.Cleanup(srv.Close)
+	v := NewTurnstileVerifier("test-secret", srv.Client())
+	v.verifyURL = srv.URL
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	defer cancel()
+	if err := v.Verify(ctx, "tok", "9.9.9.9"); err == nil {
+		t.Fatal("expected error when context deadline exceeded")
+	}
+}


### PR DESCRIPTION
## Threat model

Public `POST /auth/sign-up` (Supabase) is open to the internet. Without controls an adversary can:

- Exhaust free-credit grants with throwaway addresses from one IP.
- Register unlimited accounts with disposable providers (mailinator, guerrilla, etc.).
- Automate signups at scale with no CAPTCHA friction.

## What this PR covers (server-side, #116)

Three layered controls run on `POST /api/v1/auth/sign-up/precheck` before the client calls Supabase `signUp`. All customer-visible rejections use a single generic message so an attacker cannot tell which control tripped.

**1. Per-IP signup rate limiter (Redis, fail closed)**
- Fixed-window counter keyed `signup:rl:{ip:<addr>}:<bucket>` in Redis.
- Default: 5 attempts per IP per 3600-second window (env-configurable).
- Fails CLOSED on Redis unavailability per the #51 policy: a backend blip denies rather than admits unmetered traffic. `RATE_LIMIT_FAIL_OPEN=true` available for local dev only.

**2. Disposable-email-domain blocklist (embedded, zero network dep)**
- 107-domain curated subset of the MIT-licensed `disposable-email-domains` list, compiled into the binary via `//go:embed`.
- Checks the lowercased canonical domain after `+tag` stripping and Gmail-dot normalization.
- Source attribution in `data/disposable_domains.txt` header.

**3. Cloudflare Turnstile server-side verifier (feature-flagged)**
- Calls `https://challenges.cloudflare.com/turnstile/v0/siteverify`.
- Disabled (no-op, startup warning logged) when `TURNSTILE_SECRET_KEY` is unset.
- Fails closed on transport errors, non-200, or decode failures.

**4. Webhook backstop**
- `signup.Webhook` (Supabase Database Webhook) also runs the disposable check so scripted signups that call Supabase directly, bypassing the precheck, never reach tenant provisioning or free-credit grant.

**5. Config and docs**
- `SIGNUP_RATE_LIMIT_PER_WINDOW`, `SIGNUP_RATE_LIMIT_WINDOW_SECONDS`, `TURNSTILE_SECRET_KEY` documented in `.env.example` with safety comments (never commit real keys, `TURNSTILE_SECRET_KEY=` left empty).

## What remains (frontend, follow-up)

- Web-console signup form: render Turnstile widget, collect token, pass as `captcha_token` in precheck body.
- Register prod domain on Cloudflare Turnstile widget settings.

## Test plan

- [x] `TestRateLimiterAllowsUnderLimit`, `TestRateLimiterBlocksOverLimit`, `TestRateLimiterScopesPerIP`
- [x] `TestRateLimiterFailClosedByDefault`, `TestRateLimiterFailOpenWhenConfigured`
- [x] `TestRateLimiterEmptyIPFailsClosed`
- [x] `TestTurnstileDisabledWhenNoSecret`, `TestTurnstileSuccess`, `TestTurnstileMissingTokenWhenEnabled`, `TestTurnstileFailure`, `TestTurnstileUpstreamError`, `TestTurnstileContextDeadline`
- [x] `TestPrecheckRateLimit`, `TestPrecheckDisposable`, `TestPrecheckCaptcha`, `TestClientIPExtraction`, `TestPrecheckAuditOnBlock`
- [x] `TestWebhook_DisposableBackstop_NoProvision`
- [x] `TestSignupGuardDefaults`, `TestSignupGuardOverrides`
- [x] `go build ./apps/control-plane/...` passes clean

Part of #116. Frontend Turnstile widget wiring and prod domain on widget remain for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)