### PR TITLE
docs: add v1.3 device deployment and model advisor design

### DIFF
--- a/.planning/v1.3-device-deployment-and-model-advisor.md
+++ b/.planning/v1.3-device-deployment-and-model-advisor.md
@@ -37,7 +37,7 @@ surface BDT-only and provider-blind, inheriting the v1.1 Phase 17 guarantees.
 
 v1.3 work does **not** start until v1.2 ships. The Model Advisor is the one exception: it folds into
 v1.2 Phase 30 and ships with v1.2, because the EnterpriseEdge installer wizard cannot pick a default
-model without it. All device-app phases (Phase 31 onward) wait for the v1.2 approval gate to clear.
+model without it. All device-app phases (Phase 32 onward) wait for the v1.2 approval gate to clear.
 
 | Prerequisite | Source | Must be |
 |--------------|--------|---------|
@@ -58,7 +58,7 @@ classifier output schema and per-tenant policy shape are locked.
 | Detection scope | Read-only host probing per platform. No telemetry leaves the host except the fingerprint the operator submits to the local control-plane. No prompt or workload data is involved. |
 | Router-agent reuse | Device apps do **not** invent new routing logic. The on-device small model is a thin local expression of the v1.2 Phase 29 Router-LLM policy: classify local-vs-escalate, then either run locally or call Hive Cloud over the existing edge surface. |
 | Money language | BDT-only across every new surface, including any device-app billing view of escalated (cloud-billed) requests. Local-only requests are not billed. No FX or USD anywhere customer-visible. Inherits v1.1 Phase 17. |
-| Build order | Model Advisor first (rides v1.2 Phase 30). Mobile app next (Phase 31). Desktop app after (Phase 32). No device client is built before v1.2 ships. |
+| Build order | Model Advisor first (rides v1.2 Phase 30). Mobile app next (Phase 32). Desktop app after (Phase 33). No device client is built before v1.2 ships. |
 
 ## Deployment Target Matrix
 
@@ -68,14 +68,124 @@ refined by the advisor's evaluation, not hard guarantees.
 | # | Host class | Status | Memory / accelerator | Local model posture | Routing posture |
 |---|-----------|--------|----------------------|---------------------|-----------------|
 | a | **Hive Cloud** | exists | managed cloud accelerators | provider-side, via LiteLLM fan-out | full Router-LLM (v1.2 Phase 29), billed BDT |
-| b | **EnterpriseEdge — datacentre / workstation** | near-term | unified-memory accelerator class, e.g. NVIDIA DGX Spark with GB10 Grace Blackwell, 128 GB unified-memory class | large local model: 70B+ dense or MoE at Q4, served by in-bundle Ollama/LiteLLM | Router-LLM available, off by default per v1.2 Phase 30 |
-| c | **Consumer self-host — desktop / laptop** | near-term | RTX desktop GPU 8 to 24 GB VRAM tiers; powerful laptops: Apple silicon unified memory, mobile RTX | mid local model sized to VRAM tier (see advisor tiers) | static routing or Router-LLM optional |
-| d | **Mobile app — on-device router-agent** | future (v1.3 Phase 31) | phone NPU, small unified RAM | 1 to 3B router-classifier model on NPU | router-agent: handle locally vs escalate to Hive Cloud |
-| e | **Desktop app — on-device router-agent** | future (v1.3 Phase 32) | desktop CPU/GPU/NPU, more headroom than mobile | larger local capability than mobile, same router pattern | router-agent with more local execution before escalation |
+| b | **EnterpriseEdge — datacentre / workstation** | near-term | unified-memory accelerator class (see hardware notes below) | large local model: 70B+ dense or MoE at Q4, served by in-bundle Ollama/LiteLLM | Router-LLM available, off by default per v1.2 Phase 30 |
+| c | **Consumer self-host — desktop / laptop** | near-term | RTX desktop GPU (see VRAM tiers below); Apple silicon unified memory | mid local model sized to VRAM tier (see advisor tiers) | static routing or Router-LLM optional |
+| d | **Mobile app — on-device router-agent** | future (v1.3 Phase 32) | phone NPU, small unified RAM | 1 to 3B router-classifier model on NPU | router-agent: handle locally vs escalate to Hive Cloud |
+| e | **Desktop app — on-device router-agent** | future (v1.3 Phase 33) | desktop CPU/GPU/NPU, more headroom than mobile | larger local capability than mobile, same router pattern | router-agent with more local execution before escalation |
 
 Host classes (a), (b), (c) all run the same Hive image family. Classes (d) and (e) are new clients that
 speak to that image family (or to Hive Cloud) over the existing edge surface; they add a local
 router-agent but introduce no new server fork.
+
+---
+
+## Hardware Reference (June 2026 validated facts)
+
+> Sources: NVIDIA newsroom, Tom's Hardware, PCWorld, Micro Center (all accessed June 2026); Apple WWDC
+> keynote and developer session recordings June 8 2026; Microsoft Windows ML release notes May 2026.
+
+### NVIDIA DGX Spark and RTX Spark Superchip (Computex 2026)
+
+**DGX Spark desktop** (GB10 Grace Blackwell Superchip): available at retail, $4,699 (Micro Center,
+June 2026). 128 GB unified LPDDR5x, 500 TFLOPS FP4. Memory bandwidth is 273 GB/s, which caps
+throughput on models above approximately 120B parameters to roughly 38 tokens/s at Q4 (Tom's Hardware,
+June 2026). Practical capacity ceiling is approximately 200B parameters in FP4 quantization. Fits
+advisor tier (b) for dense 70B at Q4 or a mid MoE.
+
+**RTX Spark Superchip** (same GB10 silicon, OEM program): announced Computex June 1 2026 (NVIDIA
+newsroom). Partners include ASUS, Dell, HP, Lenovo, Surface, and MSI in laptops and mini PC form
+factors. Availability: fall 2026. Microsoft positioned Windows as the "agentic AI OS" in a joint
+NVIDIA and Microsoft partnership announcement at Computex (PCWorld, June 2026). The advisor should
+treat RTX Spark Superchip hosts identically to DGX Spark on the hardware fingerprint (same GB10,
+128 GB unified LPDDR5x) while flagging the OEM form factor for installer context.
+
+### RTX 50 Series VRAM Tiers (Blackwell, June 2026)
+
+| GPU | VRAM | Street price (approx) | Advisor tier |
+|-----|------|-----------------------|-------------|
+| RTX 5090 | 32 GB | $3,500+ | 32B at Q4; 70B Q4 with partial offload |
+| RTX 5080 | 16 GB | mid-high | 13 to 14B at Q4 |
+| RTX 5070 Ti | 16 GB | mid | 13 to 14B at Q4 |
+| RTX 5070 | 12 GB | mid | 13 to 14B at Q4 or 7B at higher precision |
+| RTX 5060 Ti | 8 or 16 GB | entry | 7B at Q4 (8 GB SKU); 13B at Q4 (16 GB SKU) |
+
+Blackwell FP4 native quantization reduces effective VRAM requirements compared with prior generations,
+so the advisor should prefer FP4-quantized GGUF where the runtime supports it (Tom's Hardware, June
+2026). No RTX 50 Super refresh exists as of June 2026.
+
+### Apple Silicon (WWDC June 8 2026)
+
+Apple announced the **AFM 3 family** at WWDC June 8 2026:
+
+- **AFM 3 Core**: ships on all devices (iPhones, iPads, Macs). Runs fully on-device.
+- **AFM 3 Core Advanced**: approximately 20B sparse parameters with 1 to 4B active parameters via
+  instruction-following pruning. Flash-resident, loaded to DRAM per prompt. Requires A19 Pro or M3+
+  with more than 8 GB RAM.
+- **FoundationModels framework** is now open to third-party models (Anthropic, Google, and
+  open-source weights). Private Cloud Compute (PCC) access is also exposed to third-party apps.
+- **M5 and M5 Pro** chips were announced. ANE TOPS figures were not independently verified as of June
+  2026; the advisor must not quote them until confirmed.
+
+**Runtime guidance for Apple silicon LLMs:** prefer **MLX** over ONNX Runtime with CoreML EP for
+Apple silicon LLM inference. MLX achieves materially better throughput on Apple unified memory and is
+the community-standard approach as of June 2026. ONNX Runtime with CoreML EP remains viable for small
+classification models that are already in ONNX format.
+
+Scale the advisor recommendation by `hw.memsize` (unified memory) as the VRAM-equivalent ceiling.
+
+### Windows ML and NPU Execution Providers (May 2026)
+
+Windows ML now delivers NPU Execution Providers automatically via Windows Update (Microsoft release
+notes, May 2026):
+
+- **Qualcomm QNN EP v2.2605.2.0** via KB5096135 (May 2026)
+- **OpenVINO EP** for Intel NPUs
+- **VitisAI EP** for AMD XDNA
+- **NvTensorRtRtx EP** for NVIDIA RTX (Blackwell optimised path)
+
+The detection layer on Windows **must query the Windows ML `ExecutionProviderCatalog`** rather than
+performing manual EP installs. This is the authoritative runtime source on Windows as of May 2026.
+Manual EP management is no longer the correct default path.
+
+**ONNX Runtime** remains the correct cross-NPU inference bet for always-on small models (router
+classifier, ASR cleanup, embeddings) because all four Windows ML EPs target it.
+
+---
+
+## ASR and Bangla Language Support (Product-Critical)
+
+> **This section is product-critical for the Bangladesh market.** Read before specifying any
+> voice or dictation feature.
+
+### English ASR
+
+**NVIDIA Parakeet V3** is the fastest English ASR model available locally (open NeMo, June 2026).
+However, **Parakeet has no Bangla support** (open NeMo issue, tracked, unresolved as of June 2026).
+It is not a viable primary ASR choice for the BD market.
+
+### Bangla and Multilingual ASR
+
+**Whisper Large v3 Turbo** (OpenAI, open weights) supports 99 languages including Bengali and is the
+recommended primary ASR model for any Hive feature requiring Bangla voice input. **Distil-Whisper**
+(Hugging Face) is the recommended compressed alternative when latency or memory is constrained.
+
+These are currently the **only viable local Bangla ASR paths**. Any device capability that includes
+voice dictation or ASR must default to Whisper Large v3 Turbo for Bangla support. An optional
+Parakeet fast path for English-only contexts is acceptable as a secondary accelerated path, but the
+primary model must handle Bangla.
+
+### Local Chat Models (June 2026 recommendations)
+
+| Model | Size | Notes |
+|-------|------|-------|
+| Llama 3.3 | 8B / 70B | Meta, strong general capability |
+| Qwen 3 | 7B / 72B | Best multilingual performance; recommended for Bangla-adjacent tasks |
+| Mistral Small 3 | mid | Strong instruction following |
+| Phi-4-mini | 3.8B | Lightweight, good for cleanup and routing classifier |
+| Gemma 3 | 1B | Router/classifier candidate, very low footprint |
+
+For Bangla-heavy workloads, **Qwen 3** is the preferred local chat model family due to its multilingual
+training coverage.
 
 ---
 
@@ -94,6 +204,10 @@ quantization tier. Expose the recommendation as a `control-plane` API and consum
 EnterpriseEdge installer wizard, driven by the **same deploy script** that boots Hive Cloud and
 EnterpriseEdge per the owner requirement.
 
+The Model Advisor gains a **second recommendation dimension** from v1.3: in addition to recommending a
+chat model per detected VRAM/memory, it also recommends a capability pack configuration per detected
+NPU class (see On-Device Capability Suite, below).
+
 ### Why
 
 EnterpriseEdge ships as a compose bundle (gateway plus Open WebUI plus LiteLLM plus optional Ollama),
@@ -108,25 +222,29 @@ pitch: your AI, your server, your data.
    - NVIDIA: `nvidia-smi` and NVML for VRAM, compute capability, driver version.
    - Linux generic: `/proc/meminfo` for RAM, `lspci` for accelerator presence.
    - Apple silicon: `sysctl` (`hw.memsize`, chip identifiers) for unified memory.
-   - Windows: WMI (`Win32_VideoController`, `Win32_PhysicalMemory`).
-   - Emit a normalised hardware fingerprint: total RAM, per-GPU VRAM, accelerator family, NPU class.
-2. **Advisor engine (S) in control-plane:** map the fingerprint to a ranked recommendation of model
-   family plus quantization tier (below), with a fallback recommendation and a clear "host too small"
-   path. Expose as a recommendation API the installer calls.
+   - Windows: query `Windows ML ExecutionProviderCatalog` for available NPU EPs (QNN, OpenVINO,
+     VitisAI, NvTensorRtRtx), plus WMI (`Win32_VideoController`, `Win32_PhysicalMemory`) for VRAM
+     and RAM. Do **not** attempt manual EP detection or installation; the catalog is authoritative.
+   - Emit a normalised hardware fingerprint: total RAM, per-GPU VRAM, accelerator family, NPU class,
+     available EPs on Windows.
+2. **Advisor engine (S) in control-plane:** map the fingerprint to (a) a ranked recommendation of
+   model family plus quantization tier and (b) a capability pack recommendation per NPU class (see
+   On-Device Capability Suite). Expose both as a recommendation API the installer calls.
 3. **Installer wizard step (S/M):** the EnterpriseEdge deploy/bootstrap script adds a detect-then-recommend
    step, presents the top recommendation, lets the operator accept or override, and writes the choice into
    the bundle's model config (Ollama/LiteLLM) before first boot. Same script path serves cloud and enterprise.
 
 ### Recommended Tiers (advisor defaults)
 
-| Detected host | Recommendation | Notes |
-|---------------|----------------|-------|
-| 8 GB VRAM (RTX entry / mobile RTX) | 7B at Q4 | fits with headroom; the safe consumer default |
-| 12 to 16 GB VRAM | 13 to 14B at Q4, or 7B at higher precision | mid desktop tier |
-| 24 GB VRAM (RTX high-end) | 32B at Q4 | upper consumer / prosumer tier |
-| 128 GB unified-memory class (e.g. DGX Spark GB10) | 70B+ dense at Q4, or a larger MoE | datacentre/workstation tier (host class b) |
-| Apple silicon unified memory | scale by `hw.memsize`, treat unified RAM as the VRAM-equivalent ceiling | laptop tier (host class c) |
-| Mobile NPU, small unified RAM | 1 to 3B router-classifier model | router-agent tier, host class d, feeds Phase 31 |
+| Detected host | Chat model recommendation | Notes |
+|---------------|--------------------------|-------|
+| 8 GB VRAM (RTX 5060 Ti 8 GB or equivalent entry) | 7B at Q4 | fits with headroom; safe consumer default |
+| 12 to 16 GB VRAM (RTX 5070, 5070 Ti, 5080, 5060 Ti 16 GB) | 13 to 14B at Q4, or 7B at higher precision | mid desktop tier |
+| 32 GB VRAM (RTX 5090) | 32B at Q4; 70B Q4 with partial offload | upper consumer / prosumer tier |
+| 128 GB unified-memory class (DGX Spark GB10, RTX Spark Superchip) | 70B+ dense at Q4, or a larger MoE; bandwidth cap (273 GB/s) limits throughput above ~120B to ~38 tok/s | datacentre/workstation tier (host class b) |
+| Apple silicon unified memory | scale by `hw.memsize`; use MLX runtime for LLMs; CoreML/ONNX for small classifiers | laptop tier (host class c) |
+| Mobile NPU, small unified RAM | 1 to 3B router-classifier model | router-agent tier, host class d, feeds Phase 32 |
+| Windows with QNN EP (Snapdragon X) | capability pack NPU path via QNN EP; chat model sized to available DRAM | Copilot+ PC tier |
 
 ### Prior Art (OSS to study, adopt patterns, not vendor)
 
@@ -148,15 +266,102 @@ pitch: your AI, your server, your data.
 ### Acceptance
 
 - Detection produces a correct fingerprint on each target platform (NVIDIA, generic Linux, Apple silicon,
-  Windows) without writing to the host.
+  Windows) without writing to the host. On Windows, EP detection uses the Windows ML
+  `ExecutionProviderCatalog` exclusively.
 - The advisor API returns a sane ranked recommendation for each tier above, including a "host too small"
-  fallback.
+  fallback, plus a capability pack recommendation per NPU class.
 - The EnterpriseEdge installer wizard, driven by the one shared deploy script, presents and persists the
   recommended model config before first boot, with operator override.
 
 ---
 
-## Phase 31 — Mobile App with On-Device Router-Agent [F]
+## On-Device Capability Suite
+
+> Owner directive: device apps ship **local capability packs** alongside the router-agent. The Model
+> Advisor gains a second recommendation dimension for these packs (per NPU class, not just chat model
+> per VRAM). This section defines the capability pack scope that flows into Phase 32 (mobile) and
+> Phase 33 (desktop).
+
+### Motivation
+
+The router-agent alone routes requests. The capability packs make those local requests actually useful:
+voice dictation without cloud privacy exposure, text rewriting without network latency, offline OCR for
+Bangla documents, private file search, and a classifier that does not need a cloud round-trip. Together
+they form the "device-local Hive" value proposition that differentiates from cloud-only assistants.
+
+### Capability Pack Definitions
+
+#### Pack 1: Voice Dictation (Wispr Flow pattern, fully on-device)
+
+Wispr Flow is the reference pattern for system-wide AI dictation. As of June 2026 Wispr Flow is
+independent, $15/month, and **cloud-only** (no on-device processing). That privacy gap is the product
+opening for Hive's on-device dictation.
+
+Implementation:
+
+- **Primary ASR:** Whisper Large v3 Turbo. Mandatory for Bangla support (99 languages, Bengali
+  included). Parakeet V3 is an optional English-only accelerated path but must never replace Whisper
+  as the primary model for this market.
+- **LLM cleanup pass:** Phi-4-mini class (3.8B) for punctuation normalisation, disfluency removal,
+  and sentence boundary cleanup after transcription.
+- Runtime: ONNX Runtime via the Windows ML EP catalog on Windows (QNN EP for Snapdragon X,
+  NvTensorRtRtx for RTX); llama.cpp/GGUF for the cleanup LLM on RTX and unified-memory boxes;
+  MLX on Apple silicon.
+
+#### Pack 2: System-Wide Text Rewrite / Fix / Translate
+
+A system extension (share sheet on iOS/iPadOS, system extension or context menu on desktop) that
+passes selected text to a local small LLM (Phi-4-mini or Gemma 3 1B class depending on memory tier)
+for rewrite, grammar fix, or translate operations. No network call for the operation; local only.
+
+#### Pack 3: OCR for Bangla and English Documents
+
+On-device OCR using an ONNX-format model (e.g. TrOCR or PaddleOCR adapted for Bengali script),
+running via ONNX Runtime NPU EP on Windows or CoreML on Apple. Enables offline document extraction
+for the BD government and finance customer segments.
+
+#### Pack 4: Local Embeddings for Private File RAG
+
+A local embedding model (e.g. nomic-embed-text or a quantized multilingual-e5 variant) generating
+vectors for private files. Stored in a local vector index (LanceDB or similar embedded store). No
+data leaves the device. Feeds the router-agent's "handle locally" path for document Q&A.
+
+#### Pack 5: Router Classifier
+
+The existing router-agent model (1 to 3B, Gemma 3 1B or Phi-4-mini class) also serves as the Pack 5
+classifier. Defined here for completeness; it is the core of Phase 32 and Phase 33.
+
+### Runtime Split
+
+| Pack | Windows NPU path | Apple path | RTX / unified-memory path |
+|------|-----------------|------------|--------------------------|
+| Voice ASR (Whisper) | ONNX Runtime + QNN EP (via Windows ML catalog) | MLX | llama.cpp GGUF / CUDA |
+| LLM cleanup (Phi-4-mini) | ONNX Runtime + NvTensorRtRtx or QNN | MLX | llama.cpp GGUF |
+| Text rewrite (small LLM) | ONNX Runtime + available EP | MLX | llama.cpp GGUF |
+| OCR | ONNX Runtime + NPU EP | CoreML | ONNX Runtime + CUDA |
+| Embeddings | ONNX Runtime + NPU EP | MLX / CoreML | ONNX Runtime + CUDA |
+| Router classifier | ONNX Runtime + QNN EP | MLX | llama.cpp GGUF |
+
+**Guiding principle:** ONNX Runtime (via Windows ML EP catalog) for always-on small models on Windows
+NPUs. llama.cpp/GGUF for larger chat models on RTX and unified-memory boxes. MLX on Apple silicon
+for all LLM workloads. Never manually install EPs on Windows; the catalog is the delivery mechanism.
+
+### Model Advisor: Capability Pack Dimension
+
+When the advisor engine processes a hardware fingerprint it now returns **two outputs**:
+
+1. Chat model recommendation (per VRAM/memory tier, as before).
+2. Capability pack configuration per detected NPU class:
+   - Which packs are feasible given detected memory and NPU EP availability.
+   - Which ASR model path (Whisper primary, Parakeet optional English fast path if RTX present).
+   - Which cleanup LLM tier (Phi-4-mini vs Gemma 3 1B based on available DRAM above the ASR model).
+   - Whether local embeddings are feasible (requires spare memory after ASR + router models).
+
+This means the installer wizard can pre-configure the full capability stack, not just the chat model.
+
+---
+
+## Phase 32 — Mobile App with On-Device Router-Agent [F]
 
 **Sizing: L. Depends on: v1.2 Phase 29 Router-LLM, v1.2 Phase 30, Model Advisor add-on.**
 
@@ -164,7 +369,8 @@ pitch: your AI, your server, your data.
 
 Ship a mobile app that runs a small (1 to 3B) router-classifier LLM on the device NPU. The router-agent
 classifies each request as **handle locally** (cheap, private, offline-capable) or **escalate to Hive
-Cloud** (billed, premium capability), and routes accordingly over the existing edge surface.
+Cloud** (billed, premium capability), and routes accordingly over the existing edge surface. The app also
+ships with the on-device capability packs (Packs 1 to 5) sized to the mobile NPU tier.
 
 ### Why
 
@@ -173,21 +379,30 @@ while still reaching premium cloud capability when a task warrants it. For the B
 means usable offline behaviour, lower data cost, and a clear BDT bill that only reflects escalated cloud
 requests. The local-vs-escalate split is the same economic lever as Phase 29, expressed at the device.
 
+On-device voice dictation (Pack 1) is a specific product differentiator: Wispr Flow is cloud-only at
+$15/month; Hive's Pack 1 is fully private and offline-capable, a meaningful advantage for BD users
+concerned about voice data leaving the device.
+
 ### Scope
 
-1. **On-device router model:** a 1 to 3B classifier running on the NPU, sized by the advisor's mobile
-   tier. Emits the same local-vs-escalate decision shape as the Phase 29 classifier.
-2. **Routing policy reuse:** the device router consumes the v1.2 Phase 29 routing policy (task type, cost
-   ceiling, latency target, escalate threshold) rather than defining a parallel policy. Escalation calls
-   Hive Cloud over the edge surface and is billed BDT; local execution is not billed.
-3. **Offline path:** local-only requests work without connectivity; escalation degrades gracefully when
+1. **On-device router model:** a 1 to 3B classifier (Gemma 3 1B or Phi-4-mini class) running on the
+   device NPU, sized by the advisor's mobile tier. Emits the same local-vs-escalate decision shape as
+   the Phase 29 classifier.
+2. **Routing policy reuse:** the device router consumes the v1.2 Phase 29 routing policy (task type,
+   cost ceiling, latency target, escalate threshold) rather than defining a parallel policy. Escalation
+   calls Hive Cloud over the edge surface and is billed BDT; local execution is not billed.
+3. **Capability packs (mobile tier):** Pack 1 (Whisper Large v3 Turbo for Bangla and English ASR,
+   Phi-4-mini cleanup), Pack 2 (text rewrite), Pack 5 (router classifier). Pack 3 (OCR) and Pack 4
+   (embeddings) included if device memory permits, as determined by the advisor's mobile-tier capability
+   config.
+4. **Offline path:** local-only requests work without connectivity; escalation degrades gracefully when
    offline (queue or decline, never silent failure).
-4. **Money surface:** the app shows BDT-only billing for escalated requests, zero FX or USD, provider-blind.
+5. **Money surface:** the app shows BDT-only billing for escalated requests, zero FX or USD, provider-blind.
 
-### Non-Goals (Phase 31)
+### Non-Goals (Phase 32)
 
 - No on-device training or fine-tuning of the router model.
-- No desktop client in this phase (that is Phase 32).
+- No desktop client in this phase (that is Phase 33).
 - No new server-side routing logic; the device reuses Phase 29's policy contract.
 - No new payment rail; prepaid BDT only.
 
@@ -197,38 +412,50 @@ requests. The local-vs-escalate split is the same economic lever as Phase 29, ex
 - Local-only requests run offline and are not billed.
 - Escalated requests reach Hive Cloud over the edge surface and are billed BDT, provider-blind.
 - The device decision contract matches the Phase 29 classifier output schema (no divergent policy).
+- Pack 1 transcribes Bangla speech locally using Whisper Large v3 Turbo without any cloud call.
 
 ---
 
-## Phase 32 — Desktop App with On-Device Router-Agent [F]
+## Phase 33 — Desktop App with On-Device Router-Agent [F]
 
-**Sizing: M. Depends on: Phase 31.**
+**Sizing: M. Depends on: Phase 32.**
 
 ### Objective
 
-Ship a desktop app using the same router-agent pattern as Phase 31, with more local execution headroom
-before escalation, sized by the advisor's desktop/laptop tiers.
+Ship a desktop app using the same router-agent pattern as Phase 32, with more local execution headroom
+before escalation, sized by the advisor's desktop/laptop tiers, and the full capability pack suite
+enabled at the higher memory tier.
 
 ### Why
 
 A desktop has more memory and accelerator headroom than a phone, so the local-vs-escalate threshold
 shifts: more work runs locally before the router escalates to Hive Cloud. The pattern, policy, and
 billing surface are identical to mobile; only the local capability ceiling differs. Building it after
-the mobile app lets the desktop reuse the proven Phase 31 router-agent and routing-policy integration.
+the mobile app lets the desktop reuse the proven Phase 32 router-agent and routing-policy integration.
+
+The desktop tier also enables Pack 4 (local embeddings for private file RAG) and higher-quality Pack 3
+(OCR) that are memory-constrained on mobile.
 
 ### Scope
 
-1. **Larger local model:** sized by the advisor's desktop/laptop tiers (RTX 8 to 24 GB, Apple silicon
-   unified memory), so more requests resolve locally.
-2. **Same router-agent and policy:** reuse the Phase 31 device router and the Phase 29 routing policy
+1. **Larger local model:** sized by the advisor's desktop/laptop tiers (RTX 12 to 32 GB VRAM, Apple
+   silicon unified memory, Snapdragon X QNN EP), so more requests resolve locally. Model selection
+   follows the June 2026 advisor tiers above (Llama 3.3 70B or Qwen 3 72B on 128 GB class; 13 to 14B
+   on 16 GB VRAM; 7B on 8 GB VRAM).
+2. **Same router-agent and policy:** reuse the Phase 32 device router and the Phase 29 routing policy
    contract; only the escalation threshold and local model size change.
-3. **Edge-surface reuse:** escalation uses the same edge surface that v1.2 Phase 30 kept desktop-ready;
+3. **Full capability pack suite (desktop tier):** Packs 1 to 5, all enabled at the advisor's desktop
+   memory tier. Pack 1 uses Whisper Large v3 Turbo as primary (Bangla and English); Parakeet V3
+   available as an optional English fast path on RTX-equipped desktops. Runtime: llama.cpp/GGUF on
+   RTX and unified-memory boxes; ONNX Runtime via Windows ML EP catalog on Windows NPU path (QNN,
+   NvTensorRtRtx); MLX on Apple silicon.
+4. **Edge-surface reuse:** escalation uses the same edge surface that v1.2 Phase 30 kept desktop-ready;
    no new server route.
-4. **Money surface:** BDT-only for escalated requests, identical to Phase 31.
+5. **Money surface:** BDT-only for escalated requests, identical to Phase 32.
 
-### Non-Goals (Phase 32)
+### Non-Goals (Phase 33)
 
-- No new routing engine; identical policy contract to Phases 29 and 31.
+- No new routing engine; identical policy contract to Phases 29 and 32.
 - No on-device training.
 - No region expansion beyond Bangladesh.
 - No new payment rail or pricing change.
@@ -238,7 +465,10 @@ the mobile app lets the desktop reuse the proven Phase 31 router-agent and routi
 - The desktop router-agent runs the advisor-recommended desktop-tier model and escalates only above the
   configured threshold.
 - Escalated requests bill BDT, provider-blind, over the existing edge surface.
-- The desktop decision contract matches the Phase 29 and Phase 31 policy schema.
+- The desktop decision contract matches the Phase 29 and Phase 32 policy schema.
+- Pack 1 transcribes Bangla speech locally (Whisper Large v3 Turbo) on all desktop platforms;
+  Parakeet fast path active only as secondary on RTX-equipped hosts.
+- On Windows, all NPU inference uses the Windows ML EP catalog path (no manual EP installs).
 
 ---
 
@@ -246,12 +476,12 @@ the mobile app lets the desktop reuse the proven Phase 31 router-agent and routi
 
 | # | Phase | Track | Depends On | Sizing | Execution note |
 |---|-------|-------|------------|--------|----------------|
-| 30 (add-on) | Hardware Detection and Model Advisor | E | v1.2 Phase 30, prior-art detection | S detection, S advisor, S/M wizard | Rides v1.2 Phase 30; ships with v1.2 because the EnterpriseEdge installer needs it. One shared deploy script. |
-| 31 | Mobile App with On-Device Router-Agent | F | v1.2 Phase 29, v1.2 Phase 30, Advisor | L | 1 to 3B router model on NPU, reuses Phase 29 routing policy. |
-| 32 | Desktop App with On-Device Router-Agent | F | Phase 31 | M | Same router pattern, more local headroom, advisor desktop tier. |
+| 30 (add-on) | Hardware Detection and Model Advisor | E | v1.2 Phase 30, prior-art detection | S detection, S advisor, S/M wizard | Rides v1.2 Phase 30; ships with v1.2 because the EnterpriseEdge installer needs it. One shared deploy script. Advisor returns two outputs: chat model rec + capability pack rec per NPU. |
+| 32 | Mobile App with On-Device Router-Agent | F | v1.2 Phase 29, v1.2 Phase 30, Advisor | L | 1 to 3B router model on NPU, reuses Phase 29 routing policy. Ships capability packs 1 to 5 at mobile tier. |
+| 33 | Desktop App with On-Device Router-Agent | F | Phase 32 | M | Same router pattern, more local headroom, advisor desktop tier. Full capability pack suite. |
 
-Critical path: `v1.2 Phase 29 + Phase 30 (with Advisor add-on) -> 31 -> 32`. The Advisor ships inside
-v1.2; the device apps are the new v1.3 work and run strictly after v1.2 ships.
+Critical path: `v1.2 Phase 29 + Phase 30 (with Advisor add-on) -> Phase 32 -> Phase 33`. The Advisor
+ships inside v1.2; the device apps are the new v1.3 work and run strictly after v1.2 ships.
 
 ## Milestone-Level Non-Goals (v1.3)
 
@@ -273,6 +503,6 @@ v1.2; the device apps are the new v1.3 work and run strictly after v1.2 ships.
 
 This is a roadmap draft. Each phase requires its own GSD executable spec/plan with per-task evidence
 frames before implementation, the same approval gate used in v1.0, v1.1, and v1.2. The Model Advisor
-add-on ships under the v1.2 Phase 30 approval gate. No v1.3 device-app phase (31 onward) begins until
-v1.2 ships and its approval gate clears, and Phase 31 specifically waits on the v1.2 Phase 29 Router-LLM
-routing policy contract being locked.
+add-on ships under the v1.2 Phase 30 approval gate. No v1.3 device-app phase (Phase 32 onward) begins
+until v1.2 ships and its approval gate clears, and Phase 32 specifically waits on the v1.2 Phase 29
+Router-LLM routing policy contract being locked.


### PR DESCRIPTION
## Summary

Adds the v1.3 roadmap design doc covering Hive's device deployment strategy and the near-term Hardware Detection plus Model Advisor feature, in the existing `.planning` phase-doc style.

`.planning/v1.3-device-deployment-and-model-advisor.md`

## What it covers

- **Deployment target matrix** across five host classes: Hive Cloud (exists), EnterpriseEdge on datacentre/workstation hardware (DGX Spark GB10, 128 GB unified-memory class), consumer self-host (RTX 8 to 24 GB tiers, Apple silicon laptops), future mobile app, future desktop app.
- **Hardware Detection plus Model Advisor** (near-term build): per-platform detection (nvidia-smi/NVML, /proc + lspci, Apple silicon sysctl, Windows WMI), advisor engine mapping RAM/VRAM/NPU to model plus quantization tiers, control-plane recommendation API plus EnterpriseEdge installer wizard step from the one shared deploy script. Prior art cited: llm-checker, Ollama VRAM estimation, LM Studio, GPUStack.
- **Router-agent pattern** for device apps: small local LLM classifies handle-locally vs escalate-to-Hive-Cloud, reusing the v1.2 Phase 29 Router-LLM routing policy.
- **Phasing**: Model Advisor rides v1.2 Phase 30 (productization), because the EnterpriseEdge installer needs it. New v1.3 phases are Phase 31 (mobile router-agent app) and Phase 32 (desktop router-agent app), numbered after v1.2's last phase (30).

## Phase numbers

- Model Advisor: Phase 30 add-on (ships with v1.2)
- Phase 31: Mobile app with on-device router-agent
- Phase 32: Desktop app with on-device router-agent

## Sizing calls

- Detection layer S, advisor engine S, installer wizard step S/M
- Phase 31 (mobile) L, Phase 32 (desktop) M

## Explicit non-goal

No mobile or desktop client is built before v1.2 ships.

## Test plan

- [ ] Doc review for phase-doc style consistency with `.planning/v1.2-agentic-surface.md`
- [ ] Confirm phase numbering does not collide with v1.2 (last phase 30)

This is a planning/design doc; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated v1.3 roadmap with revised device deployment phases and dependency alignment
  * Enhanced Model Advisor documentation to include capability pack configuration recommendations
  * Added hardware reference guidance and on-device capability suite definitions for Voice Dictation, Text Rewrite, OCR, Embeddings, and Router Classifier

<!-- end of auto-generated comment: release notes by coderabbit.ai -->