### PR TITLE
docs: add phase 20 provider catalog plans including capability based tool routing

### DIFF
--- a/.planning/phases/20-provider-catalog/20-01-schema.md
+++ b/.planning/phases/20-provider-catalog/20-01-schema.md
@@ -87,7 +87,7 @@ ON CONFLICT (slug) DO NOTHING;
 ```sql
 CREATE TABLE IF NOT EXISTS public.tenant_model_visibility (
   id           UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
-  tenant_id    UUID        NOT NULL REFERENCES public.accounts(id) ON DELETE CASCADE,
+  tenant_id    UUID        NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
   alias_id     TEXT        NOT NULL REFERENCES public.model_aliases(alias_id) ON DELETE CASCADE,
   visible      BOOLEAN     NOT NULL DEFAULT true,
   created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
@@ -184,7 +184,7 @@ Write a SQL migration test (same pattern as existing `*_test.sql` files in `/tmp
 - [ ] `provider_routes` CHECK constraint no longer enumerates `openrouter`/`groq`; any non-empty string is accepted.
 - [ ] `custom_providers` table exists with `slug UNIQUE`, `enabled`, `litellm_prefix` columns.
 - [ ] Seed rows for `openrouter` and `groq` present (idempotent).
-- [ ] `tenant_model_visibility` table exists with `UNIQUE(tenant_id, alias_id)`.
+- [ ] `tenant_model_visibility` table exists with `UNIQUE(tenant_id, alias_id)`; `tenant_id` references `public.tenants(id)` (not `accounts`).
 - [ ] Both tables have RLS enabled + forced; `hive_app` service-role policy (idempotent DO $$) present.
 - [ ] `GRANT SELECT, INSERT, UPDATE, DELETE ON ... TO hive_app` present for both tables.
 - [ ] `updated_at` triggers fire on both tables.

--- a/.planning/phases/20-provider-catalog/20-01-schema.md
+++ b/.planning/phases/20-provider-catalog/20-01-schema.md
@@ -1,0 +1,186 @@
+---
+phase: 20-provider-catalog
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+size: M
+branch: b/phase-20-provider-catalog
+milestone: v1.1
+track: A
+files_modified:
+  - supabase/migrations/YYYYMMDD_01_phase20_provider_catalog_schema.sql
+autonomous: true
+---
+
+# Plan 20-01 — Schema: custom_providers, tenant_model_visibility, provider_routes relaxation
+
+## Objective
+
+Create the two new tables that underpin the provider catalog feature and relax the existing `provider_routes` CHECK constraint so operators can register providers beyond the hardcoded `(openrouter, groq)` pair. All DDL follows the RLS pattern established in `supabase/migrations/20260529_01_*.sql`.
+
+---
+
+## Tasks
+
+### Task 1: Relax provider_routes CHECK constraint
+
+**File:** `supabase/migrations/YYYYMMDD_01_phase20_provider_catalog_schema.sql`
+
+The current `provider_routes` table carries:
+
+```sql
+CONSTRAINT provider_routes_provider_check
+  CHECK (provider IN ('openrouter', 'groq'))
+```
+
+defined in `supabase/migrations/20260331_02_routing_policy.sql`.
+
+Drop and replace with a free-text non-empty constraint so any provider slug registered in `custom_providers` is valid:
+
+```sql
+ALTER TABLE public.provider_routes
+  DROP CONSTRAINT IF EXISTS provider_routes_provider_check;
+
+ALTER TABLE public.provider_routes
+  ADD CONSTRAINT provider_routes_provider_nonempty
+    CHECK (provider <> '');
+```
+
+**Acceptance:** `\d provider_routes` no longer shows `IN ('openrouter', 'groq')`.
+
+---
+
+### Task 2: Create custom_providers table
+
+```sql
+CREATE TABLE IF NOT EXISTS public.custom_providers (
+  id            UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  slug          TEXT        NOT NULL UNIQUE,          -- e.g. "openrouter", "groq", "together"
+  display_name  TEXT        NOT NULL,
+  base_url      TEXT        NOT NULL,
+  api_key_env   TEXT        NOT NULL,                 -- name of env var holding the key, e.g. "OPENROUTER_API_KEY"
+  litellm_prefix TEXT       NOT NULL,                 -- LiteLLM provider prefix, e.g. "openrouter/"
+  enabled       BOOLEAN     NOT NULL DEFAULT true,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS custom_providers_slug_idx ON public.custom_providers (slug);
+CREATE INDEX IF NOT EXISTS custom_providers_enabled_idx ON public.custom_providers (enabled);
+```
+
+Seed the two known providers so existing `provider_routes` rows remain referentially consistent:
+
+```sql
+INSERT INTO public.custom_providers (slug, display_name, base_url, api_key_env, litellm_prefix, enabled)
+VALUES
+  ('openrouter', 'OpenRouter', 'https://openrouter.ai/api/v1', 'OPENROUTER_API_KEY', 'openrouter/', true),
+  ('groq',       'Groq',       'https://api.groq.com/openai/v1', 'GROQ_API_KEY',     'groq/',       true)
+ON CONFLICT (slug) DO NOTHING;
+```
+
+---
+
+### Task 3: Create tenant_model_visibility table
+
+```sql
+CREATE TABLE IF NOT EXISTS public.tenant_model_visibility (
+  id           UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id    UUID        NOT NULL REFERENCES public.accounts(id) ON DELETE CASCADE,
+  alias_id     UUID        NOT NULL REFERENCES public.model_aliases(id) ON DELETE CASCADE,
+  visible      BOOLEAN     NOT NULL DEFAULT true,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (tenant_id, alias_id)
+);
+
+CREATE INDEX IF NOT EXISTS tmv_tenant_idx ON public.tenant_model_visibility (tenant_id);
+CREATE INDEX IF NOT EXISTS tmv_alias_idx  ON public.tenant_model_visibility (alias_id);
+```
+
+---
+
+### Task 4: RLS policies
+
+Follow the pattern from `supabase/migrations/20260529_01_*.sql` exactly (enable + force, then idempotent service-role policy):
+
+```sql
+-- custom_providers
+ALTER TABLE public.custom_providers ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.custom_providers FORCE ROW LEVEL SECURITY;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'custom_providers'
+      AND policyname = 'custom_providers_service_role_all'
+  ) THEN
+    CREATE POLICY custom_providers_service_role_all
+      ON public.custom_providers
+      FOR ALL TO hive_app
+      USING (true)
+      WITH CHECK (true);
+  END IF;
+END $$;
+
+-- tenant_model_visibility
+ALTER TABLE public.tenant_model_visibility ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.tenant_model_visibility FORCE ROW LEVEL SECURITY;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'tenant_model_visibility'
+      AND policyname = 'tenant_model_visibility_service_role_all'
+  ) THEN
+    CREATE POLICY tenant_model_visibility_service_role_all
+      ON public.tenant_model_visibility
+      FOR ALL TO hive_app
+      USING (true)
+      WITH CHECK (true);
+  END IF;
+END $$;
+```
+
+---
+
+### Task 5: updated_at trigger (reuse or create)
+
+Apply the standard `set_updated_at()` trigger (already present in the migration history) to both new tables:
+
+```sql
+CREATE TRIGGER set_custom_providers_updated_at
+  BEFORE UPDATE ON public.custom_providers
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+CREATE TRIGGER set_tenant_model_visibility_updated_at
+  BEFORE UPDATE ON public.tenant_model_visibility
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+```
+
+If `public.set_updated_at()` does not exist at time of execution, define it once in this migration (idempotent `CREATE OR REPLACE`).
+
+---
+
+### TDD Notes
+
+Write a SQL migration test (same pattern as existing `*_test.sql` files in `/tmp/`):
+
+1. Verify `custom_providers_provider_check` constraint is gone from `provider_routes`.
+2. Insert a row into `custom_providers` with slug `"together"` and verify it saves.
+3. Insert a row into `provider_routes` with `provider = 'together'` and verify it no longer rejects.
+4. Insert a row into `tenant_model_visibility` referencing a known account and alias, verify uniqueness constraint on duplicate.
+
+---
+
+## Acceptance Criteria
+
+- [ ] `provider_routes` CHECK constraint no longer enumerates `openrouter`/`groq`; any non-empty string is accepted.
+- [ ] `custom_providers` table exists with `slug UNIQUE`, `enabled`, `litellm_prefix` columns.
+- [ ] Seed rows for `openrouter` and `groq` present (idempotent).
+- [ ] `tenant_model_visibility` table exists with `UNIQUE(tenant_id, alias_id)`.
+- [ ] Both tables have RLS enabled + forced; `hive_app` service-role policy (idempotent DO $$) present.
+- [ ] `updated_at` triggers fire on both tables.
+- [ ] Migration file named `YYYYMMDD_01_phase20_provider_catalog_schema.sql` following project convention.
+- [ ] `supabase db push` (or `apply_migration`) applies cleanly with no errors.

--- a/.planning/phases/20-provider-catalog/20-01-schema.md
+++ b/.planning/phases/20-provider-catalog/20-01-schema.md
@@ -88,7 +88,7 @@ ON CONFLICT (slug) DO NOTHING;
 CREATE TABLE IF NOT EXISTS public.tenant_model_visibility (
   id           UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
   tenant_id    UUID        NOT NULL REFERENCES public.accounts(id) ON DELETE CASCADE,
-  alias_id     UUID        NOT NULL REFERENCES public.model_aliases(id) ON DELETE CASCADE,
+  alias_id     TEXT        NOT NULL REFERENCES public.model_aliases(alias_id) ON DELETE CASCADE,
   visible      BOOLEAN     NOT NULL DEFAULT true,
   created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
   updated_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
@@ -141,6 +141,11 @@ DO $$ BEGIN
       WITH CHECK (true);
   END IF;
 END $$;
+
+-- Grant table privileges so hive_app can actually read/write the rows.
+-- RLS policies do not imply DML privileges; both are required.
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.custom_providers TO hive_app;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.tenant_model_visibility TO hive_app;
 ```
 
 ---
@@ -181,6 +186,7 @@ Write a SQL migration test (same pattern as existing `*_test.sql` files in `/tmp
 - [ ] Seed rows for `openrouter` and `groq` present (idempotent).
 - [ ] `tenant_model_visibility` table exists with `UNIQUE(tenant_id, alias_id)`.
 - [ ] Both tables have RLS enabled + forced; `hive_app` service-role policy (idempotent DO $$) present.
+- [ ] `GRANT SELECT, INSERT, UPDATE, DELETE ON ... TO hive_app` present for both tables.
 - [ ] `updated_at` triggers fire on both tables.
 - [ ] Migration file named `YYYYMMDD_01_phase20_provider_catalog_schema.sql` following project convention.
 - [ ] `supabase db push` (or `apply_migration`) applies cleanly with no errors.

--- a/.planning/phases/20-provider-catalog/20-02-provider-crud.md
+++ b/.planning/phases/20-provider-catalog/20-02-provider-crud.md
@@ -35,7 +35,7 @@ PUT    /internal/providers/{id}     update provider
 DELETE /internal/providers/{id}     delete provider (soft: sets enabled=false)
 ```
 
-Auth: shared-secret header `X-Internal-Secret: <INTERNAL_SECRET>` (same mechanism as `platform/http/internalauth.go`). Platform admins (`platform.RequirePlatformAdmin`) may also access these routes via the standard JWT path.
+Auth: shared-secret header `X-Internal-Token: <INTERNAL_SECRET>` via `internalauth.RequireInternalToken` middleware (the actual middleware name in `apps/control-plane/internal/internalauth/internalauth.go`; the header is `X-Internal-Token`, not `X-Internal-Secret`). Platform admins (`platform.RequirePlatformAdmin`) may also access these routes via the standard JWT path.
 
 ---
 

--- a/.planning/phases/20-provider-catalog/20-02-provider-crud.md
+++ b/.planning/phases/20-provider-catalog/20-02-provider-crud.md
@@ -1,0 +1,164 @@
+---
+phase: 20-provider-catalog
+plan: 02
+type: execute
+wave: 2
+depends_on: [20-01]
+size: M
+branch: b/phase-20-provider-catalog
+milestone: v1.1
+track: A
+files_modified:
+  - apps/control-plane/internal/providers/repository.go
+  - apps/control-plane/internal/providers/service.go
+  - apps/control-plane/internal/providers/http.go
+  - apps/control-plane/internal/providers/http_test.go
+  - apps/control-plane/cmd/server/main.go
+autonomous: true
+---
+
+# Plan 20-02 — Provider CRUD Package + Internal Endpoints
+
+## Objective
+
+Implement a new `internal/providers` Go package in `apps/control-plane` that provides full CRUD for `custom_providers` rows, exposed via internal HTTP endpoints protected by shared-secret auth. Platform admins can also reach these endpoints using `platform.RequirePlatformAdmin`.
+
+---
+
+## Architecture
+
+```
+POST   /internal/providers          create provider
+GET    /internal/providers          list providers
+GET    /internal/providers/{id}     get provider
+PUT    /internal/providers/{id}     update provider
+DELETE /internal/providers/{id}     delete provider (soft: sets enabled=false)
+```
+
+Auth: shared-secret header `X-Internal-Secret: <INTERNAL_SECRET>` (same mechanism as `platform/http/internalauth.go`). Platform admins (`platform.RequirePlatformAdmin`) may also access these routes via the standard JWT path.
+
+---
+
+## Tasks
+
+### Task 1: Repository layer
+
+**File:** `apps/control-plane/internal/providers/repository.go`
+
+```go
+package providers
+
+import (
+    "context"
+    "time"
+
+    "github.com/google/uuid"
+    "github.com/jmoiern/sqlx"  // match existing DB driver in control-plane
+)
+
+type Provider struct {
+    ID            uuid.UUID `db:"id"`
+    Slug          string    `db:"slug"`
+    DisplayName   string    `db:"display_name"`
+    BaseURL       string    `db:"base_url"`
+    APIKeyEnv     string    `db:"api_key_env"`
+    LiteLLMPrefix string    `db:"litellm_prefix"`
+    Enabled       bool      `db:"enabled"`
+    CreatedAt     time.Time `db:"created_at"`
+    UpdatedAt     time.Time `db:"updated_at"`
+}
+
+type Repository interface {
+    Create(ctx context.Context, p Provider) (Provider, error)
+    List(ctx context.Context) ([]Provider, error)
+    Get(ctx context.Context, id uuid.UUID) (Provider, error)
+    Update(ctx context.Context, id uuid.UUID, p Provider) (Provider, error)
+    Delete(ctx context.Context, id uuid.UUID) error   // soft: enabled=false
+}
+```
+
+Implement `pgRepository` backed by the existing `*sqlx.DB` connection (match how `apps/control-plane/internal/routing/repository.go` receives its DB handle via constructor injection). Use parameterized queries only (no `fmt.Sprintf` with user data).
+
+---
+
+### Task 2: Service layer
+
+**File:** `apps/control-plane/internal/providers/service.go`
+
+Thin service wrapping the repository. Responsibilities:
+
+- Validate input (slug non-empty, base_url valid URL scheme, api_key_env non-empty).
+- Return typed errors (`ErrNotFound`, `ErrSlugConflict`) that the HTTP handler maps to 404/409.
+- No business logic beyond validation and delegation to Repository.
+
+---
+
+### Task 3: HTTP handler
+
+**File:** `apps/control-plane/internal/providers/http.go`
+
+- Use the same `chi` router pattern as existing control-plane handlers.
+- Request/response structs use `encoding/json`; no external serialization library unless already present.
+- All handler methods return structured JSON errors: `{"error": "...", "code": "..."}`.
+- `DELETE` is a soft delete (sets `enabled = false`); return 200 with the updated record.
+
+Request body for create/update:
+
+```json
+{
+  "slug":           "together",
+  "display_name":   "Together AI",
+  "base_url":       "https://api.together.xyz/v1",
+  "api_key_env":    "TOGETHER_API_KEY",
+  "litellm_prefix": "together_ai/",
+  "enabled":        true
+}
+```
+
+---
+
+### Task 4: Auth middleware wiring
+
+Reuse `platform/http/internalauth.go` `InternalAuthMiddleware` (shared-secret). Mount the providers router under `/internal/providers` inside the internal-only sub-router already guarded by that middleware. Do NOT expose these endpoints on the public-facing router.
+
+Also accept `platform.RequirePlatformAdmin` as a second auth path: mount a parallel route group under `/api/v1/admin/providers` protected by `platform.RequirePlatformAdmin`. Both groups call the same handler functions.
+
+**File:** `apps/control-plane/cmd/server/main.go` (or wherever routes are registered).
+
+---
+
+### Task 5: Unit tests
+
+**File:** `apps/control-plane/internal/providers/http_test.go`
+
+TDD: write tests before handler implementation.
+
+Required cases:
+
+1. `POST /internal/providers` with valid body returns 201 + provider JSON.
+2. `POST /internal/providers` with duplicate slug returns 409.
+3. `POST /internal/providers` with empty slug returns 400.
+4. `GET /internal/providers` returns array including seeded openrouter + groq rows.
+5. `PUT /internal/providers/{id}` updates `display_name`; returns 200 with updated record.
+6. `DELETE /internal/providers/{id}` sets `enabled=false`; subsequent GET shows `enabled: false`.
+7. Request without shared-secret header returns 401.
+
+Use a test DB or mock repository that satisfies the `Repository` interface (prefer interface mock over real DB in unit tests; integration test in 20-06 hits real DB).
+
+---
+
+## TDD Notes
+
+RED first: write `http_test.go` stubs that fail compilation. GREEN: implement handler. IMPROVE: ensure no `fmt.Sprintf` with user input, no unhandled errors, all paths return structured JSON.
+
+---
+
+## Acceptance Criteria
+
+- [ ] `apps/control-plane/internal/providers/` package compiles with `go build ./apps/control-plane/...`.
+- [ ] `Repository` interface satisfied by `pgRepository` with parameterized queries.
+- [ ] Internal endpoints mounted under `/internal/providers` behind shared-secret middleware.
+- [ ] Admin endpoints mounted under `/api/v1/admin/providers` behind `platform.RequirePlatformAdmin`.
+- [ ] All 7 unit test cases pass.
+- [ ] `go vet ./apps/control-plane/...` clean.
+- [ ] No hardcoded provider slugs anywhere in the new package.

--- a/.planning/phases/20-provider-catalog/20-03-litellm-config.md
+++ b/.planning/phases/20-provider-catalog/20-03-litellm-config.md
@@ -1,0 +1,200 @@
+---
+phase: 20-provider-catalog
+plan: 03
+type: execute
+wave: 2
+depends_on: [20-01]
+size: M
+branch: b/phase-20-provider-catalog
+milestone: v1.1
+track: A
+files_modified:
+  - apps/control-plane/internal/litellmconfig/generator.go
+  - apps/control-plane/internal/litellmconfig/generator_test.go
+  - apps/control-plane/internal/litellmconfig/restart.go
+  - apps/control-plane/internal/litellmconfig/restart_test.go
+  - deploy/docker/docker-compose.yml
+  - deploy/litellm/config.yaml
+  - .env.example
+autonomous: true
+---
+
+# Plan 20-03 — LiteLLM Config Generation + Controlled Restart
+
+## Objective
+
+Implement a control-plane subsystem that generates `deploy/litellm/config.yaml` from the current state of `provider_routes` and `custom_providers` tables, then triggers a controlled LiteLLM proxy restart so new providers become live without manual intervention.
+
+**Verified mechanism (do not re-research):** LiteLLM has NO `POST /reload` endpoint. The file-based config path (`deploy/litellm/config.yaml`) requires a proxy restart on change. The zero-downtime alternative is DB-backed config (`DATABASE_URL` + `general_settings.store_model_in_db: true`) enabling live mutation via admin API (`POST /model/new`, `/model/update`, `/model/delete`, master key auth). This plan implements file-based restart as the primary path and documents the DB-backed alternative for executor decision at build time.
+
+---
+
+## Tasks
+
+### Task 1: Config generator
+
+**File:** `apps/control-plane/internal/litellmconfig/generator.go`
+
+Package `litellmconfig` exposes:
+
+```go
+type ModelEntry struct {
+    ModelName   string
+    LiteLLMName string   // e.g. "openrouter/openai/gpt-4o"
+    APIBase     string
+    APIKeyEnv   string
+}
+
+type Config struct {
+    Models         []ModelEntry
+    GeneralSettings GeneralSettings
+}
+
+type GeneralSettings struct {
+    MasterKey string
+}
+
+// Generate builds a LiteLLM config.yaml byte slice from the provided model entries.
+// It does NOT read from DB itself; the caller supplies the entries.
+func Generate(cfg Config) ([]byte, error)
+
+// WriteAndRestart writes the generated config to the given path and signals a restart.
+func WriteAndRestart(ctx context.Context, configPath string, cfg Config, restarter Restarter) error
+```
+
+The YAML output must match the structure LiteLLM expects:
+
+```yaml
+model_list:
+  - model_name: <ModelEntry.ModelName>
+    litellm_params:
+      model: <ModelEntry.LiteLLMName>
+      api_base: <ModelEntry.APIBase>
+      api_key: "os.environ/<ModelEntry.APIKeyEnv>"
+
+general_settings:
+  master_key: <cfg.GeneralSettings.MasterKey>
+```
+
+Use `gopkg.in/yaml.v3` (already present in the module or add it — check `go.mod`).
+
+---
+
+### Task 2: Restart mechanism
+
+**File:** `apps/control-plane/internal/litellmconfig/restart.go`
+
+```go
+type Restarter interface {
+    Restart(ctx context.Context) error
+}
+
+// DockerRestarter signals a LiteLLM container restart via the Docker socket.
+// It calls `docker restart <containerName>` using exec.CommandContext.
+// containerName read from env var LITELLM_CONTAINER_NAME (default: "litellm").
+type DockerRestarter struct { ContainerName string }
+
+func (r DockerRestarter) Restart(ctx context.Context) error
+```
+
+The control-plane container must have access to the Docker socket. This is wired via compose volume mount (Task 5 below).
+
+**Timeout:** wrap the `docker restart` call in a 30-second context deadline. Log outcome at INFO level (success) or ERROR level (failure). On failure, return the error to the caller; the caller is responsible for alerting.
+
+**Alternative path (document, do not implement unless executor decides):** If the operator sets `LITELLM_CONFIG_MODE=db` in the environment, the subsystem should instead call `POST /model/new` (and `/update`, `/delete`) on the LiteLLM admin API using the `LITELLM_MASTER_KEY`. Document this path in a `// TODO(litellm-db-mode)` comment block in `restart.go` with the required env vars and API contract. The executor must re-confirm the exact `/model/*` API shape via Context7 at build time before implementing.
+
+---
+
+### Task 3: Service integration
+
+**File:** `apps/control-plane/internal/litellmconfig/generator.go` (or a new `service.go`)
+
+Expose a `SyncService` that:
+
+1. Queries `custom_providers` (enabled only) and `provider_routes` from the DB.
+2. Builds `[]ModelEntry` by joining routes with their provider's `base_url`, `api_key_env`, `litellm_prefix`.
+3. Calls `Generate` to produce YAML bytes.
+4. Calls `WriteAndRestart`.
+
+Wire `SyncService` into the control-plane HTTP surface as:
+
+```
+POST /internal/litellm/sync
+```
+
+Protected by shared-secret middleware. Returns 200 on success, 500 with error JSON on failure. This endpoint is called by the provider CRUD handlers (Plan 20-02) after any create/update/delete.
+
+---
+
+### Task 4: Unit tests
+
+**File:** `apps/control-plane/internal/litellmconfig/generator_test.go`
+
+TDD:
+
+1. `Generate` with two model entries produces valid YAML with correct `model_list` length.
+2. `Generate` with empty entries produces an empty `model_list` (not nil YAML).
+3. `Generate` output parses back without error via `yaml.Unmarshal`.
+4. `WriteAndRestart` calls `Restarter.Restart` exactly once on success.
+5. `WriteAndRestart` does NOT call `Restarter.Restart` if `Generate` fails.
+
+**File:** `apps/control-plane/internal/litellmconfig/restart_test.go`
+
+Use a `MockRestarter` implementing `Restarter` to verify call count and error propagation. Do NOT call real `docker restart` in unit tests.
+
+---
+
+### Task 5: Docker Compose volume wiring
+
+**File:** `deploy/docker/docker-compose.yml`
+
+The control-plane service must:
+
+- Mount the Docker socket: `- /var/run/docker.sock:/var/run/docker.sock:ro`
+- Mount the LiteLLM config directory as a shared volume so the generated file is visible to the LiteLLM container:
+  ```yaml
+  volumes:
+    - litellm-config:/etc/litellm
+  ```
+  The LiteLLM container must already mount the same volume at the path it reads from (`--config /etc/litellm/config.yaml`).
+- Add env var: `LITELLM_CONTAINER_NAME: ${LITELLM_CONTAINER_NAME:-litellm}`
+- Add env var: `LITELLM_CONFIG_PATH: ${LITELLM_CONFIG_PATH:-/etc/litellm/config.yaml}`
+
+Add `litellm-config` to the top-level `volumes:` block.
+
+Read the existing compose file before editing to ensure the additions integrate consistently with current service definitions.
+
+---
+
+### Task 6: .env.example additions
+
+**File:** `.env.example`
+
+Add a `# === LiteLLM config generation ===` block:
+
+```
+LITELLM_CONTAINER_NAME=litellm
+LITELLM_CONFIG_PATH=/etc/litellm/config.yaml
+LITELLM_MASTER_KEY=                   # required — set before deploying
+# LITELLM_CONFIG_MODE=db              # uncomment to use DB-backed live-reload instead of file+restart
+```
+
+---
+
+## TDD Notes
+
+Generator is pure (no I/O) and trivially unit-testable. Restarter interface decouples from Docker in tests. Write tests before implementing `Generate` and `WriteAndRestart`.
+
+---
+
+## Acceptance Criteria
+
+- [ ] `Generate` produces valid LiteLLM YAML for any non-empty `[]ModelEntry`.
+- [ ] `WriteAndRestart` calls `Restarter.Restart` after successful write; skips on generate failure.
+- [ ] `DockerRestarter.Restart` calls `docker restart <name>` with 30-second timeout.
+- [ ] `POST /internal/litellm/sync` returns 200 and the LiteLLM container restarts within 35 seconds.
+- [ ] Docker socket mounted read-only into control-plane container in compose.
+- [ ] Shared `litellm-config` volume wired between control-plane and litellm containers.
+- [ ] `.env.example` documents all new env vars including the `LITELLM_CONFIG_MODE=db` alternative.
+- [ ] All 5 generator unit tests + 2 restart unit tests pass.
+- [ ] Executor note: confirm DB-backed `/model/*` API shape via Context7 before deciding on `LITELLM_CONFIG_MODE=db` implementation.

--- a/.planning/phases/20-provider-catalog/20-03-litellm-config.md
+++ b/.planning/phases/20-provider-catalog/20-03-litellm-config.md
@@ -138,7 +138,7 @@ The control-plane container must have access to the Docker socket. This is wired
 
 Expose a `SyncService` that:
 
-1. Queries `custom_providers` (enabled only) and `provider_routes` from the DB.
+1. Queries `custom_providers` (enabled only) and `provider_routes` from the DB, filtering to active routes only (`health_state NOT IN ('eol', 'disabled')` or whatever the current active-state predicate is — verify the exact column and values in `supabase/migrations/20260331_02_routing_policy.sql` before implementing). Routes retained for history with `health_state='eol'` or disabled must not appear in the generated `model_list`.
 2. Builds `[]ModelEntry` by joining routes with their provider's `base_url`, `api_key_env`, `litellm_prefix`.
 3. Calls `Generate` to produce YAML bytes.
 4. Calls `WriteAndRestart`.
@@ -217,6 +217,7 @@ Generator is pure (no I/O) and trivially unit-testable. Restarter interface deco
 ## Acceptance Criteria
 
 - [ ] `Generate` produces valid LiteLLM YAML for any non-empty `[]ModelEntry`.
+- [ ] `SyncService` excludes inactive/EOL routes from the generated `model_list`; only active routes are emitted.
 - [ ] `WriteAndRestart` calls `Restarter.Restart` after successful write; skips on generate failure.
 - [ ] `WriteAndRestart` merges new `model_list` into existing config YAML, preserving `litellm_settings` and all non-generated keys.
 - [ ] `DockerRestarter.Restart` uses Docker socket HTTP API (no `docker` binary dependency); socket mount is read-write.

--- a/.planning/phases/20-provider-catalog/20-03-litellm-config.md
+++ b/.planning/phases/20-provider-catalog/20-03-litellm-config.md
@@ -76,6 +76,14 @@ general_settings:
   master_key: <cfg.GeneralSettings.MasterKey>
 ```
 
+> **Config preservation (critical):** `WriteAndRestart` must NOT blindly overwrite `deploy/litellm/config.yaml`. The existing file contains `litellm_settings` (fallbacks, retry, drop_params), per-model `model_info`, provider `extra_body`, and `files_settings` blocks that are not captured in `[]ModelEntry`. The write strategy must:
+> 1. Parse the existing YAML file (if present) into a `map[string]interface{}`.
+> 2. Replace only the `model_list` key with the newly generated entries.
+> 3. Merge `general_settings` (update `master_key`; preserve all other keys).
+> 4. Marshal the merged map back to YAML and write atomically (write to a temp file, then `os.Rename`).
+>
+> The `Config` struct must carry an `ExistingConfigPath string` field so `WriteAndRestart` can locate the file to merge from. If the file does not exist, write from scratch (first-run case).
+
 Use `gopkg.in/yaml.v3` (already present in the module or add it — check `go.mod`).
 
 ---
@@ -89,17 +97,36 @@ type Restarter interface {
     Restart(ctx context.Context) error
 }
 
-// DockerRestarter signals a LiteLLM container restart via the Docker socket.
-// It calls `docker restart <containerName>` using exec.CommandContext.
-// containerName read from env var LITELLM_CONTAINER_NAME (default: "litellm").
+// DockerRestarter signals a LiteLLM container restart via the Docker socket HTTP API.
+// It sends POST /containers/<containerName>/restart to the Unix socket at
+// /var/run/docker.sock using a net/http transport — no `docker` CLI binary required.
+// containerName is read from env var LITELLM_CONTAINER_NAME (default: "litellm").
+//
+// Implementation sketch:
+//   transport := &http.Transport{
+//       DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+//           return (&net.Dialer{}).DialContext(ctx, "unix", "/var/run/docker.sock")
+//       },
+//   }
+//   client := &http.Client{Transport: transport}
+//   req, _ := http.NewRequestWithContext(ctx,
+//       http.MethodPost,
+//       "http://localhost/containers/"+r.ContainerName+"/restart?t=10",
+//       nil)
+//   resp, err := client.Do(req)
+//
+// This avoids needing the `docker` CLI binary installed in the control-plane image.
+// Only /var/run/docker.sock must be mounted (read-write).
 type DockerRestarter struct { ContainerName string }
 
 func (r DockerRestarter) Restart(ctx context.Context) error
 ```
 
-The control-plane container must have access to the Docker socket. This is wired via compose volume mount (Task 5 below).
+The control-plane container must have access to the Docker socket. This is wired via compose volume mount (Task 5 below). Mount must be **read-write** (not `:ro`) because the restart API requires write access to the socket.
 
-**Timeout:** wrap the `docker restart` call in a 30-second context deadline. Log outcome at INFO level (success) or ERROR level (failure). On failure, return the error to the caller; the caller is responsible for alerting.
+> **No docker binary needed:** the implementation calls the Docker Engine HTTP API directly over the Unix socket via `net/http`. Do NOT install the `docker` CLI in `deploy/docker/Dockerfile.control-plane`; the socket mount alone is sufficient.
+
+**Timeout:** wrap the restart HTTP call in a 30-second context deadline. Log outcome at INFO level (success) or ERROR level (failure). On failure, return the error to the caller; the caller is responsible for alerting.
 
 **Alternative path (document, do not implement unless executor decides):** If the operator sets `LITELLM_CONFIG_MODE=db` in the environment, the subsystem should instead call `POST /model/new` (and `/update`, `/delete`) on the LiteLLM admin API using the `LITELLM_MASTER_KEY`. Document this path in a `// TODO(litellm-db-mode)` comment block in `restart.go` with the required env vars and API contract. The executor must re-confirm the exact `/model/*` API shape via Context7 at build time before implementing.
 
@@ -191,9 +218,11 @@ Generator is pure (no I/O) and trivially unit-testable. Restarter interface deco
 
 - [ ] `Generate` produces valid LiteLLM YAML for any non-empty `[]ModelEntry`.
 - [ ] `WriteAndRestart` calls `Restarter.Restart` after successful write; skips on generate failure.
-- [ ] `DockerRestarter.Restart` calls `docker restart <name>` with 30-second timeout.
+- [ ] `WriteAndRestart` merges new `model_list` into existing config YAML, preserving `litellm_settings` and all non-generated keys.
+- [ ] `DockerRestarter.Restart` uses Docker socket HTTP API (no `docker` binary dependency); socket mount is read-write.
+- [ ] `DockerRestarter.Restart` calls Docker Engine API `POST /containers/<name>/restart` over Unix socket with 30-second timeout.
 - [ ] `POST /internal/litellm/sync` returns 200 and the LiteLLM container restarts within 35 seconds.
-- [ ] Docker socket mounted read-only into control-plane container in compose.
+- [ ] Docker socket mounted read-write (not `:ro`) into control-plane container in compose.
 - [ ] Shared `litellm-config` volume wired between control-plane and litellm containers.
 - [ ] `.env.example` documents all new env vars including the `LITELLM_CONFIG_MODE=db` alternative.
 - [ ] All 5 generator unit tests + 2 restart unit tests pass.

--- a/.planning/phases/20-provider-catalog/20-04-tenant-visibility.md
+++ b/.planning/phases/20-provider-catalog/20-04-tenant-visibility.md
@@ -82,6 +82,8 @@ Read the existing file before editing. Update the `GET /api/v1/catalog/models` h
 
 Unauthenticated requests (public API key context with no tenant) fall back to returning only `visibility = 'public'` aliases with no tenant-specific overrides.
 
+> **Auth middleware prerequisite:** `GET /api/v1/catalog/models` is currently mounted without authentication middleware in the router. Before this handler change can safely read tenant claims, the route must be wrapped with the JWT auth middleware (the same middleware used on `/v1/...` inference routes). Read `apps/control-plane/platform/http/router.go` to find the exact mount point and apply the middleware there. If the route is intentionally unauthenticated for public catalog browsing, add an explicit claim-presence check: when no tenant claim is present, use the unauthenticated fallback path; when a claim is present but invalid, return 401.
+
 ---
 
 ### Task 3: Tenant visibility admin endpoint
@@ -107,29 +109,34 @@ After any PUT/DELETE, trigger an OWUI sync for the affected alias (Task 4).
 Read the existing file before editing. Extend the client with:
 
 ```go
-// UpsertModelAccessControl creates or updates the model entry in OWUI and sets
-// access_control so only members of groupID can read it.
-// Passing groupID = "" sets access_control to null (public).
-func (c *Client) UpsertModelAccessControl(ctx context.Context, modelID string, groupID string) error
+// SyncModelAccessControl fetches the current access_control for modelID from OWUI,
+// merges the provided allowedGroupIDs into the read.group_ids list, and writes it back.
+// Passing an empty allowedGroupIDs slice sets access_control to null (public).
+// This function replaces the original single-groupID design to support multi-tenant grants:
+// granting alias X to tenant B must not revoke tenant A's existing grant.
+func (c *Client) SyncModelAccessControl(ctx context.Context, modelID string, allowedGroupIDs []string) error
 ```
 
 Implementation:
 
-1. `POST /api/v1/models/` with body:
+1. `GET /api/v1/models/<modelID>` to fetch current `access_control` (if the model does not exist in OWUI, treat current `read.group_ids` as empty).
+2. Build the new `read.group_ids` as the caller-supplied `allowedGroupIDs` (the caller is responsible for computing the full desired set from `tenant_model_visibility`; this function does not query the DB).
+3. `POST /api/v1/models/` with body:
    ```json
    {
      "id": "<modelID>",
      "access_control": {
-       "read":  {"group_ids": ["<groupID>"], "user_ids": []},
-       "write": {"group_ids": [],            "user_ids": []}
+       "read":  {"group_ids": <allowedGroupIDs>, "user_ids": []},
+       "write": {"group_ids": [],                "user_ids": []}
      }
    }
    ```
-   If `groupID` is empty, send `"access_control": null`.
-2. Auth header: `Authorization: Bearer <OWUI_ADMIN_TOKEN>` (existing pattern in the client).
-3. On 404 (model not yet in OWUI), attempt `POST` to create; on 200/existing, use `POST` (OWUI upserts on model ID).
+   If `allowedGroupIDs` is empty or nil, send `"access_control": null`.
+4. Auth header: `Authorization: Bearer <OWUI_ADMIN_TOKEN>` (existing pattern in the client).
 
-Wire `UpsertModelAccessControl` into the visibility admin endpoint: after writing to `tenant_model_visibility`, call `UpsertModelAccessControl(ctx, alias.ExternalModelID, tenantGroupID)`. The tenant's OWUI group ID is resolved via `EnsureGroup(ctx, tenantID.String())` (already exists).
+> **Caller responsibility:** the visibility admin endpoint (Task 3) must compute the full current allowlist before calling `SyncModelAccessControl`. After any PUT/DELETE on `tenant_model_visibility`, query all `visible=true` rows for the affected alias, resolve each tenant's OWUI group ID (`"tenant_"+tenantID.String()`), and pass the complete resulting `[]string` to `SyncModelAccessControl`. This ensures grants are additive and revocations are precise.
+
+Wire `UpsertModelAccessControl` into the visibility admin endpoint: after writing to `tenant_model_visibility`, call `UpsertModelAccessControl(ctx, alias.ExternalModelID, tenantGroupID)`. The tenant's OWUI group ID is resolved via `EnsureGroup(ctx, "tenant_"+tenantID.String())` — note the `tenant_` prefix, which matches the naming convention used by the signup provisioning code when creating OWUI groups. Using bare `tenantID.String()` targets a different (empty) group and would silently grant access to nobody.
 
 ---
 
@@ -147,9 +154,10 @@ TDD cases:
 
 **File:** `apps/control-plane/internal/owui/client_test.go`
 
-1. `UpsertModelAccessControl` with a non-empty groupID sends `access_control` JSON with that group ID.
-2. `UpsertModelAccessControl` with empty groupID sends `access_control: null`.
-3. HTTP 401 from OWUI returns a typed error.
+1. `SyncModelAccessControl` with a non-empty `allowedGroupIDs` slice sends correct `access_control` JSON.
+2. `SyncModelAccessControl` with empty/nil `allowedGroupIDs` sends `access_control: null`.
+3. `SyncModelAccessControl` performs a GET before the POST to confirm merge semantics (mock returns existing groups; verify new call includes all groups).
+4. HTTP 401 from OWUI returns a typed error.
 
 Use `httptest.NewServer` to mock the OWUI API in tests.
 
@@ -168,6 +176,9 @@ Write service tests against a mock repository (interface). Write OWUI client tes
 - [ ] `visibility=public` aliases visible by default unless explicitly blocked by `visible=false` row.
 - [ ] `visibility=restricted` aliases hidden unless `visible=true` row exists for tenant.
 - [ ] Visibility admin endpoints (`/internal/catalog/visibility/...`) write to `tenant_model_visibility` and trigger OWUI sync.
-- [ ] `UpsertModelAccessControl` sets `access_control.read.group_ids` to the tenant's OWUI group ID; empty groupID sends null (public).
-- [ ] All 5 catalog service tests + 3 OWUI client tests pass.
+- [ ] `SyncModelAccessControl` sets `access_control.read.group_ids` to the full computed allowlist; nil/empty sends null (public).
+- [ ] Multi-tenant grant does not revoke prior tenant's access (second PUT extends the allowlist).
+- [ ] OWUI group resolved as `"tenant_"+tenantID.String()` matching signup provisioning convention.
+- [ ] `GET /api/v1/catalog/models` route wrapped in JWT auth middleware before handler extracts claims.
+- [ ] All 5 catalog service tests + 4 OWUI client tests pass.
 - [ ] `go vet ./apps/control-plane/...` clean.

--- a/.planning/phases/20-provider-catalog/20-04-tenant-visibility.md
+++ b/.planning/phases/20-provider-catalog/20-04-tenant-visibility.md
@@ -1,0 +1,160 @@
+---
+phase: 20-provider-catalog
+plan: 04
+type: execute
+wave: 3
+depends_on: [20-01, 20-02, 20-03]
+size: M
+branch: b/phase-20-provider-catalog
+milestone: v1.1
+track: A
+files_modified:
+  - apps/control-plane/internal/catalog/service.go
+  - apps/control-plane/internal/catalog/service_test.go
+  - apps/control-plane/internal/catalog/http.go
+  - apps/control-plane/internal/owui/client.go
+  - apps/control-plane/internal/owui/client_test.go
+autonomous: true
+---
+
+# Plan 20-04 — Tenant Model Visibility + Open WebUI Access Control Sync
+
+## Objective
+
+Filter the public catalog endpoint so each tenant sees only the model aliases they are permitted to use, and synchronize those visibility rules to Open WebUI's per-model `access_control` objects so the chat surface enforces the same constraint.
+
+---
+
+## Context (Verified Facts)
+
+- `GET /api/v1/catalog/models` currently has no tenant filter; `ModelAlias.Visibility` field exists but is unused in filtering.
+- Open WebUI: `ENABLE_MODEL_FILTER` + `MODEL_FILTER_LIST` are deprecated/removed. Current mechanism: per-model `access_control` objects via admin API `POST/GET /api/v1/models/` with `{read: {group_ids: [...], user_ids: [...]}, write: {...}}`. `null` means public.
+- `apps/control-plane/internal/owui/client.go` already has `EnsureGroup` and `AddUserToGroup`. This plan adds model upsert with `access_control` keyed by tenant group ID.
+
+---
+
+## Tasks
+
+### Task 1: Catalog service tenant filtering
+
+**File:** `apps/control-plane/internal/catalog/service.go`
+
+Read the existing file before editing. Current `ListModels` (or equivalent) returns all aliases with `visibility = 'public'` or all aliases with no filter. Update the signature to accept a `tenantID uuid.UUID` parameter:
+
+```go
+// ListModelsForTenant returns aliases the tenant is permitted to use.
+// Rules (in order):
+//   1. If ModelAlias.Visibility == "public" and no tenant_model_visibility row exists for
+//      (tenantID, aliasID), the alias is included (public default).
+//   2. If ModelAlias.Visibility == "restricted" and a tenant_model_visibility row with
+//      visible=true exists for (tenantID, aliasID), the alias is included.
+//   3. If ModelAlias.Visibility == "restricted" and no such row exists, the alias is excluded.
+//   4. If a tenant_model_visibility row with visible=false exists for any alias, that alias
+//      is always excluded regardless of Visibility field.
+func (s *Service) ListModelsForTenant(ctx context.Context, tenantID uuid.UUID) ([]ModelAlias, error)
+```
+
+The query joins `model_aliases` with `tenant_model_visibility` using a LEFT JOIN and applies the rules above in SQL (not Go-side filtering) to avoid loading all rows.
+
+---
+
+### Task 2: Catalog HTTP handler update
+
+**File:** `apps/control-plane/internal/catalog/http.go`
+
+Read the existing file before editing. Update the `GET /api/v1/catalog/models` handler to:
+
+1. Extract `tenantID` from the authenticated JWT claims (the field already exists in the claims struct per Phase 10 conventions; verify the exact field name before editing).
+2. Call `ListModelsForTenant(ctx, tenantID)` instead of the current unfiltered call.
+3. Return the filtered list; response shape unchanged.
+
+Unauthenticated requests (public API key context with no tenant) fall back to returning only `visibility = 'public'` aliases with no tenant-specific overrides.
+
+---
+
+### Task 3: Tenant visibility admin endpoint
+
+Add to the providers/admin area (or a new `catalog/admin` sub-router):
+
+```
+PUT  /internal/catalog/visibility/{tenantID}/{aliasID}   upsert tenant_model_visibility row
+DELETE /internal/catalog/visibility/{tenantID}/{aliasID} set visible=false
+GET  /internal/catalog/visibility/{tenantID}             list visibility rows for tenant
+```
+
+Protected by shared-secret middleware. Calls into a new `VisibilityRepository` (same pattern as Plan 20-02's `Repository`).
+
+After any PUT/DELETE, trigger an OWUI sync for the affected alias (Task 4).
+
+---
+
+### Task 4: Open WebUI access_control sync
+
+**File:** `apps/control-plane/internal/owui/client.go`
+
+Read the existing file before editing. Extend the client with:
+
+```go
+// UpsertModelAccessControl creates or updates the model entry in OWUI and sets
+// access_control so only members of groupID can read it.
+// Passing groupID = "" sets access_control to null (public).
+func (c *Client) UpsertModelAccessControl(ctx context.Context, modelID string, groupID string) error
+```
+
+Implementation:
+
+1. `POST /api/v1/models/` with body:
+   ```json
+   {
+     "id": "<modelID>",
+     "access_control": {
+       "read":  {"group_ids": ["<groupID>"], "user_ids": []},
+       "write": {"group_ids": [],            "user_ids": []}
+     }
+   }
+   ```
+   If `groupID` is empty, send `"access_control": null`.
+2. Auth header: `Authorization: Bearer <OWUI_ADMIN_TOKEN>` (existing pattern in the client).
+3. On 404 (model not yet in OWUI), attempt `POST` to create; on 200/existing, use `POST` (OWUI upserts on model ID).
+
+Wire `UpsertModelAccessControl` into the visibility admin endpoint: after writing to `tenant_model_visibility`, call `UpsertModelAccessControl(ctx, alias.ExternalModelID, tenantGroupID)`. The tenant's OWUI group ID is resolved via `EnsureGroup(ctx, tenantID.String())` (already exists).
+
+---
+
+### Task 5: Unit tests
+
+**File:** `apps/control-plane/internal/catalog/service_test.go`
+
+TDD cases:
+
+1. Tenant with no `tenant_model_visibility` rows sees all `visibility=public` aliases.
+2. Tenant with `visible=false` row for a public alias does NOT see that alias.
+3. Tenant with `visible=true` row for a `restricted` alias DOES see it.
+4. Tenant with no row for a `restricted` alias does NOT see it.
+5. Unauthenticated (no tenantID) returns only `public` aliases.
+
+**File:** `apps/control-plane/internal/owui/client_test.go`
+
+1. `UpsertModelAccessControl` with a non-empty groupID sends `access_control` JSON with that group ID.
+2. `UpsertModelAccessControl` with empty groupID sends `access_control: null`.
+3. HTTP 401 from OWUI returns a typed error.
+
+Use `httptest.NewServer` to mock the OWUI API in tests.
+
+---
+
+## TDD Notes
+
+Write service tests against a mock repository (interface). Write OWUI client tests against `httptest.Server`. Do not hit a real OWUI instance in unit tests.
+
+---
+
+## Acceptance Criteria
+
+- [ ] `GET /api/v1/catalog/models` returns only visibility-permitted aliases for the authenticated tenant.
+- [ ] `visibility=public` aliases visible by default unless explicitly blocked by `visible=false` row.
+- [ ] `visibility=restricted` aliases hidden unless `visible=true` row exists for tenant.
+- [ ] Visibility admin endpoints (`/internal/catalog/visibility/...`) write to `tenant_model_visibility` and trigger OWUI sync.
+- [ ] `UpsertModelAccessControl` sets `access_control.read.group_ids` to the tenant's OWUI group ID; empty groupID sends null (public).
+- [ ] All 5 catalog service tests + 3 OWUI client tests pass.
+- [ ] `go vet ./apps/control-plane/...` clean.

--- a/.planning/phases/20-provider-catalog/20-04-tenant-visibility.md
+++ b/.planning/phases/20-provider-catalog/20-04-tenant-visibility.md
@@ -31,6 +31,18 @@ Filter the public catalog endpoint so each tenant sees only the model aliases th
 - Open WebUI: `ENABLE_MODEL_FILTER` + `MODEL_FILTER_LIST` are deprecated/removed. Current mechanism: per-model `access_control` objects via admin API `POST/GET /api/v1/models/` with `{read: {group_ids: [...], user_ids: [...]}, write: {...}}`. `null` means public.
 - `apps/control-plane/internal/owui/client.go` already has `EnsureGroup` and `AddUserToGroup`. This plan adds model upsert with `access_control` keyed by tenant group ID.
 
+> **Schema prerequisite:** The `model_aliases.visibility` CHECK currently allows only `public`, `preview`, and `internal` (see `supabase/migrations/20260331_01_model_catalog.sql`). The `"restricted"` value used in the filtering rules below does not yet exist. The phase-20 migration (Plan 20-01 or a dedicated migration step) **must** add `'restricted'` to that CHECK before this service code is deployed:
+>
+> ```sql
+> ALTER TABLE public.model_aliases
+>   DROP CONSTRAINT IF EXISTS model_aliases_visibility_check;
+> ALTER TABLE public.model_aliases
+>   ADD CONSTRAINT model_aliases_visibility_check
+>     CHECK (visibility IN ('public', 'preview', 'internal', 'restricted'));
+> ```
+>
+> Add this DDL to `YYYYMMDD_01_phase20_provider_catalog_schema.sql` (Plan 20-01 Task 1.5) and add the acceptance criterion: `model_aliases.visibility` CHECK accepts `'restricted'`.
+
 ---
 
 ## Tasks
@@ -151,6 +163,7 @@ Write service tests against a mock repository (interface). Write OWUI client tes
 
 ## Acceptance Criteria
 
+- [ ] `model_aliases.visibility` CHECK constraint extended to include `'restricted'` (prerequisite migration).
 - [ ] `GET /api/v1/catalog/models` returns only visibility-permitted aliases for the authenticated tenant.
 - [ ] `visibility=public` aliases visible by default unless explicitly blocked by `visible=false` row.
 - [ ] `visibility=restricted` aliases hidden unless `visible=true` row exists for tenant.

--- a/.planning/phases/20-provider-catalog/20-05-tool-call-passthrough.md
+++ b/.planning/phases/20-provider-catalog/20-05-tool-call-passthrough.md
@@ -11,7 +11,8 @@ track: A
 files_modified:
   - apps/edge-api/internal/inference/chat_completions.go
   - apps/edge-api/internal/inference/errors.go
-  - apps/edge-api/internal/routing/selector.go
+  - apps/control-plane/internal/routing/service.go
+  - apps/control-plane/internal/routing/types.go
   - packages/openai-contract/support-matrix.md
   - packages/sdk-tests/tool_call_test.js        (new or existing test file)
 autonomous: true
@@ -28,7 +29,7 @@ Allow `tools`, `tool_choice`, and `response_format` to pass through the edge-api
 ## Context (Verified Facts)
 
 - **Rejection point:** `apps/edge-api/internal/inference/errors.go` `writeUnsupportedParamError`, called from the guard in `chat_completions.go`.
-- **Capability columns:** `provider_capabilities` table with tool/vision flags added in Phase 16. These columns are already available.
+- **Capability columns:** `provider_capabilities` table exists from Phase 16, but repo-wide search confirms it does NOT yet include a `tools_supported` column (Phase 16 added `responses`, `chat_completions`, `embeddings`, `streaming`, `reasoning`, `cache`, `media`, `batch` only). This plan must add `tools_supported` via a migration step before any code can gate on it.
 - **Routing selection:** `routing.SelectionInput` carries `AllowedProviders` and `AllowedAliases` plus capability flags (Phase 10 baseline). The selector must be told to restrict to tool-capable routes.
 - **Current behaviour:** Any request carrying `tools` or `tool_choice` hits `writeUnsupportedParamError` unconditionally.
 - **Target behaviour (MVP gate):** Gate 400 on alias capability. If at least one route for the alias has `tools_supported = true` in `provider_capabilities`, pass through the parameter and constrain routing to capable routes only.
@@ -37,11 +38,34 @@ Allow `tools`, `tool_choice`, and `response_format` to pass through the edge-api
 
 ## Tasks
 
+### Task 0: Add tools_supported column to provider_capabilities
+
+**File:** `supabase/migrations/YYYYMMDD_01_phase20_provider_catalog_schema.sql` (append to the phase-20 migration)
+
+```sql
+ALTER TABLE public.provider_capabilities
+  ADD COLUMN IF NOT EXISTS tools_supported BOOLEAN NOT NULL DEFAULT false;
+```
+
+Seed known capable providers (update after verifying actual provider capability):
+
+```sql
+UPDATE public.provider_capabilities
+SET tools_supported = true
+WHERE provider IN ('openrouter', 'groq');
+```
+
+**Acceptance:** `\d provider_capabilities` shows `tools_supported boolean not null default false`.
+
+---
+
 ### Task 1: Extend SelectionInput with capability constraint
 
-**File:** `apps/edge-api/internal/routing/selector.go`
+**File:** `apps/control-plane/internal/routing/service.go` (or `types.go` — verify the exact struct location before editing; route selection lives in the control-plane, not the edge-api)
 
-Read the existing file before editing. Add to `SelectionInput`:
+> **Correction:** There is no `apps/edge-api/internal/routing/selector.go`. Route selection lives in `apps/control-plane/internal/routing/{types,service}.go`. The edge-api only holds the HTTP mirror in `apps/edge-api/internal/inference/routing_client.go`. All selector changes go to the control-plane package.
+
+Read `apps/control-plane/internal/routing/types.go` and `service.go` before editing. Add to `SelectionInput` (or the equivalent capability-filter struct):
 
 ```go
 // RequireToolCapable, when true, restricts route selection to routes where
@@ -49,7 +73,7 @@ Read the existing file before editing. Add to `SelectionInput`:
 RequireToolCapable bool
 ```
 
-Update the route selection logic: when `RequireToolCapable` is true, filter `AllowedProviders` to those with `tools_supported = true` in `provider_capabilities`. If filtering produces an empty set, return a typed error `ErrNoCapableRoute` (new sentinel).
+Update the route selection logic: when `RequireToolCapable` is true, filter `AllowedProviders` to those with `tools_supported = true` in `provider_capabilities`. If filtering produces an empty set, return a typed error `ErrNoCapableRoute` (new sentinel, declared in the control-plane routing package).
 
 ---
 
@@ -122,7 +146,7 @@ Test case 3: Send `response_format: {type: "json_object"}` to a tool-capable ali
 
 ### Task 6: Routing unit tests
 
-**File:** `apps/edge-api/internal/routing/selector_test.go` (existing file — extend)
+**File:** `apps/control-plane/internal/routing/service_test.go` (or `selector_test.go` — verify existing test file name before editing)
 
 Read the existing file before editing. Add:
 
@@ -142,7 +166,8 @@ The `ErrNoCapableRoute` sentinel should be declared in `selector.go` and tested 
 
 ## Acceptance Criteria
 
-- [ ] `SelectionInput.RequireToolCapable = true` restricts to `tools_supported = true` routes; returns `ErrNoCapableRoute` on empty result.
+- [ ] `tools_supported` column added to `provider_capabilities` via migration.
+- [ ] `SelectionInput.RequireToolCapable = true` in control-plane routing restricts to `tools_supported = true` routes; returns `ErrNoCapableRoute` on empty result.
 - [ ] Request with `tools` to a tool-capable alias returns 200; tools + tool_choice + response_format passed downstream unchanged.
 - [ ] Request with `tools` to an incapable alias returns 400 with `code: "unsupported_parameter"` and `param: "tools"`.
 - [ ] `writeUnsupportedParamError` includes `param` field in JSON body.
@@ -151,4 +176,5 @@ The `ErrNoCapableRoute` sentinel should be declared in `selector.go` and tested 
 - [ ] SDK test case 2 (negative) passes unconditionally.
 - [ ] Selector unit tests (3 cases) pass.
 - [ ] `go vet ./apps/edge-api/...` clean.
+- [ ] `go vet ./apps/control-plane/...` clean.
 - [ ] Existing `chat_completions.go` tests (no tools params) still pass — zero regressions.

--- a/.planning/phases/20-provider-catalog/20-05-tool-call-passthrough.md
+++ b/.planning/phases/20-provider-catalog/20-05-tool-call-passthrough.md
@@ -1,0 +1,154 @@
+---
+phase: 20-provider-catalog
+plan: 05
+type: execute
+wave: 3
+depends_on: [20-01, 20-02]
+size: L
+branch: b/phase-20-provider-catalog
+milestone: v1.1
+track: A
+files_modified:
+  - apps/edge-api/internal/inference/chat_completions.go
+  - apps/edge-api/internal/inference/errors.go
+  - apps/edge-api/internal/routing/selector.go
+  - packages/openai-contract/support-matrix.md
+  - packages/sdk-tests/tool_call_test.js        (new or existing test file)
+autonomous: true
+---
+
+# Plan 20-05 — Capability-Based Tool-Call Passthrough (Issue #118)
+
+## Objective
+
+Allow `tools`, `tool_choice`, and `response_format` to pass through the edge-api to any model alias that has at least one tool-capable backing route (as indicated by `provider_capabilities`). Return 400 (`unsupported_parameter`) only when the alias has zero capable routes. This unblocks function-calling SDK use cases currently 400-rejected at the inference layer.
+
+---
+
+## Context (Verified Facts)
+
+- **Rejection point:** `apps/edge-api/internal/inference/errors.go` `writeUnsupportedParamError`, called from the guard in `chat_completions.go`.
+- **Capability columns:** `provider_capabilities` table with tool/vision flags added in Phase 16. These columns are already available.
+- **Routing selection:** `routing.SelectionInput` carries `AllowedProviders` and `AllowedAliases` plus capability flags (Phase 10 baseline). The selector must be told to restrict to tool-capable routes.
+- **Current behaviour:** Any request carrying `tools` or `tool_choice` hits `writeUnsupportedParamError` unconditionally.
+- **Target behaviour (MVP gate):** Gate 400 on alias capability. If at least one route for the alias has `tools_supported = true` in `provider_capabilities`, pass through the parameter and constrain routing to capable routes only.
+
+---
+
+## Tasks
+
+### Task 1: Extend SelectionInput with capability constraint
+
+**File:** `apps/edge-api/internal/routing/selector.go`
+
+Read the existing file before editing. Add to `SelectionInput`:
+
+```go
+// RequireToolCapable, when true, restricts route selection to routes where
+// provider_capabilities.tools_supported = true.
+RequireToolCapable bool
+```
+
+Update the route selection logic: when `RequireToolCapable` is true, filter `AllowedProviders` to those with `tools_supported = true` in `provider_capabilities`. If filtering produces an empty set, return a typed error `ErrNoCapableRoute` (new sentinel).
+
+---
+
+### Task 2: Capability check in chat_completions.go
+
+**File:** `apps/edge-api/internal/inference/chat_completions.go`
+
+Read the existing file before editing. Locate the guard that calls `writeUnsupportedParamError` for `tools`/`tool_choice`/`response_format`. Replace the unconditional rejection with:
+
+```
+1. Check whether the request carries tools/tool_choice/response_format.
+2. If yes: query whether the alias has >= 1 tool-capable route.
+   a. Build SelectionInput with RequireToolCapable=true.
+   b. Call selector.Select(...).
+   c. If selector returns ErrNoCapableRoute: call writeUnsupportedParamError (400) — same as today.
+   d. If selector succeeds: proceed with the capable-route selection; pass tools/tool_choice/response_format downstream unchanged.
+3. If no tools params: existing flow unchanged.
+```
+
+The capability query should reuse the existing DB/cache access pattern already present in `chat_completions.go` for routing. Do not add a new DB round-trip if the capability data is already loaded as part of route selection.
+
+---
+
+### Task 3: Update errors.go error message
+
+**File:** `apps/edge-api/internal/inference/errors.go`
+
+Read the existing file before editing. Update `writeUnsupportedParamError` to include the specific unsupported parameter name in the error response body so SDK callers know which field caused the rejection:
+
+```json
+{
+  "error": {
+    "message": "Model does not support parameter: tools. Choose an alias with tool-calling capability.",
+    "type": "invalid_request_error",
+    "code": "unsupported_parameter",
+    "param": "tools"
+  }
+}
+```
+
+The `param` field is already part of the OpenAI error schema. Pass the parameter name from the call site.
+
+---
+
+### Task 4: Update openai-contract support matrix
+
+**File:** `packages/openai-contract/support-matrix.md`
+
+Add a row or update the existing `tools`/`tool_choice` row to document:
+
+- Status: `conditional` (supported when alias has tool-capable route).
+- Edge behaviour: passes through to LiteLLM; 400 returned only on incapable alias.
+- Related: `provider_capabilities.tools_supported` column (Phase 16).
+
+---
+
+### Task 5: SDK integration tests
+
+**File:** `packages/sdk-tests/tool_call_test.js` (create if absent)
+
+Using the OpenAI JS SDK (already present in `packages/sdk-tests` per Phase 10 baseline):
+
+Test case 1 (positive): Send a chat completion request with `tools` array to an alias known to have a tool-capable route. Assert HTTP 200 and a response with `finish_reason: "tool_calls"` or `"stop"` (provider-dependent). Mark as `skip` if no tool-capable provider key is configured in env (`SKIP_TOOL_TESTS=1`).
+
+Test case 2 (negative): Send the same request to an alias explicitly configured with zero tool-capable routes. Assert HTTP 400 with `code: "unsupported_parameter"` and `param: "tools"`.
+
+Test case 3: Send `response_format: {type: "json_object"}` to a tool-capable alias. Assert 200.
+
+---
+
+### Task 6: Routing unit tests
+
+**File:** `apps/edge-api/internal/routing/selector_test.go` (existing file — extend)
+
+Read the existing file before editing. Add:
+
+1. `RequireToolCapable=true` with a provider that has `tools_supported=true` returns that provider.
+2. `RequireToolCapable=true` with all providers having `tools_supported=false` returns `ErrNoCapableRoute`.
+3. `RequireToolCapable=false` (default) with mixed capability returns any provider (existing behaviour preserved).
+
+---
+
+## TDD Notes
+
+Start with the selector unit tests (pure logic, no I/O). Then write the `chat_completions.go` integration test using an in-process handler. SDK tests run last and require a live stack.
+
+The `ErrNoCapableRoute` sentinel should be declared in `selector.go` and tested in isolation before wiring into `chat_completions.go`.
+
+---
+
+## Acceptance Criteria
+
+- [ ] `SelectionInput.RequireToolCapable = true` restricts to `tools_supported = true` routes; returns `ErrNoCapableRoute` on empty result.
+- [ ] Request with `tools` to a tool-capable alias returns 200; tools + tool_choice + response_format passed downstream unchanged.
+- [ ] Request with `tools` to an incapable alias returns 400 with `code: "unsupported_parameter"` and `param: "tools"`.
+- [ ] `writeUnsupportedParamError` includes `param` field in JSON body.
+- [ ] `packages/openai-contract/support-matrix.md` updated with `conditional` status for tools/tool_choice/response_format.
+- [ ] SDK test case 1 passes on a tool-capable alias (or marked skip if no provider key configured).
+- [ ] SDK test case 2 (negative) passes unconditionally.
+- [ ] Selector unit tests (3 cases) pass.
+- [ ] `go vet ./apps/edge-api/...` clean.
+- [ ] Existing `chat_completions.go` tests (no tools params) still pass — zero regressions.

--- a/.planning/phases/20-provider-catalog/20-05-tool-call-passthrough.md
+++ b/.planning/phases/20-provider-catalog/20-05-tool-call-passthrough.md
@@ -30,7 +30,7 @@ Allow `tools`, `tool_choice`, and `response_format` to pass through the edge-api
 
 - **Rejection point:** `apps/edge-api/internal/inference/errors.go` `writeUnsupportedParamError`, called from the guard in `chat_completions.go`.
 - **Capability columns:** `provider_capabilities` table exists from Phase 16, but repo-wide search confirms it does NOT yet include a `tools_supported` column (Phase 16 added `responses`, `chat_completions`, `embeddings`, `streaming`, `reasoning`, `cache`, `media`, `batch` only). This plan must add `tools_supported` via a migration step before any code can gate on it.
-- **Routing selection:** `routing.SelectionInput` carries `AllowedProviders` and `AllowedAliases` plus capability flags (Phase 10 baseline). The selector must be told to restrict to tool-capable routes.
+- **Routing selection:** `routing.SelectionInput` carries `AllowedProviders` and `AllowedAliases` plus capability flags (Phase 10 baseline). The selector must be told to restrict to tool-capable routes. Filtering must operate at individual route granularity, not provider-slug granularity, because one provider can have mixed-capability routes for the same alias.
 - **Current behaviour:** Any request carrying `tools` or `tool_choice` hits `writeUnsupportedParamError` unconditionally.
 - **Target behaviour (MVP gate):** Gate 400 on alias capability. If at least one route for the alias has `tools_supported = true` in `provider_capabilities`, pass through the parameter and constrain routing to capable routes only.
 
@@ -73,7 +73,7 @@ Read `apps/control-plane/internal/routing/types.go` and `service.go` before edit
 RequireToolCapable bool
 ```
 
-Update the route selection logic: when `RequireToolCapable` is true, filter `AllowedProviders` to those with `tools_supported = true` in `provider_capabilities`. If filtering produces an empty set, return a typed error `ErrNoCapableRoute` (new sentinel, declared in the control-plane routing package).
+Update the route selection logic: when `RequireToolCapable` is true, filter the candidate **routes** (not just provider slugs) to those where the route's provider has `tools_supported = true` in `provider_capabilities`. Filtering at the provider-slug level is insufficient because the same provider may have both tool-capable and non-tool-capable routes for a given alias (e.g. a vision-only route and a chat+tools route registered under the same provider slug). The filter must operate on individual route entries so that a non-capable route for a capable provider is still excluded. If filtering produces an empty route set, return a typed error `ErrNoCapableRoute` (new sentinel, declared in the control-plane routing package).
 
 ---
 
@@ -152,7 +152,8 @@ Read the existing file before editing. Add:
 
 1. `RequireToolCapable=true` with a provider that has `tools_supported=true` returns that provider.
 2. `RequireToolCapable=true` with all providers having `tools_supported=false` returns `ErrNoCapableRoute`.
-3. `RequireToolCapable=false` (default) with mixed capability returns any provider (existing behaviour preserved).
+3. `RequireToolCapable=false` (default) with mixed capability returns any route (existing behaviour preserved).
+4. `RequireToolCapable=true` with a provider that has one capable and one non-capable route returns only the capable route (not the whole provider).
 
 ---
 
@@ -167,7 +168,8 @@ The `ErrNoCapableRoute` sentinel should be declared in `selector.go` and tested 
 ## Acceptance Criteria
 
 - [ ] `tools_supported` column added to `provider_capabilities` via migration.
-- [ ] `SelectionInput.RequireToolCapable = true` in control-plane routing restricts to `tools_supported = true` routes; returns `ErrNoCapableRoute` on empty result.
+- [ ] `SelectionInput.RequireToolCapable = true` in control-plane routing restricts to individual routes where the provider has `tools_supported = true`; returns `ErrNoCapableRoute` when no such route exists.
+- [ ] A provider with mixed-capability routes (some capable, some not) does not pass a non-capable route through when `RequireToolCapable=true`.
 - [ ] Request with `tools` to a tool-capable alias returns 200; tools + tool_choice + response_format passed downstream unchanged.
 - [ ] Request with `tools` to an incapable alias returns 400 with `code: "unsupported_parameter"` and `param: "tools"`.
 - [ ] `writeUnsupportedParamError` includes `param` field in JSON body.

--- a/.planning/phases/20-provider-catalog/20-06-tests-verification.md
+++ b/.planning/phases/20-provider-catalog/20-06-tests-verification.md
@@ -1,0 +1,148 @@
+---
+phase: 20-provider-catalog
+plan: 06
+type: execute
+wave: 4
+depends_on: [20-01, 20-02, 20-03, 20-04, 20-05]
+size: M
+branch: b/phase-20-provider-catalog
+milestone: v1.1
+track: A
+files_modified:
+  - apps/control-plane/internal/providers/integration_test.go
+  - apps/edge-api/internal/inference/chat_completions_integration_test.go
+  - packages/sdk-tests/tool_call_test.js
+  - .planning/phases/20-provider-catalog/20-VERIFICATION.md
+autonomous: true
+---
+
+# Plan 20-06 — Integration Tests + VERIFICATION.md
+
+## Objective
+
+Write integration tests that exercise the full Phase 20 feature stack against a real DB and live containers, then produce `20-VERIFICATION.md` recording pass/fail evidence for every must-have truth.
+
+---
+
+## Tasks
+
+### Task 1: Provider CRUD integration test
+
+**File:** `apps/control-plane/internal/providers/integration_test.go`
+
+Build tag: `//go:build integration`
+
+Prerequisites: real Postgres DB with Phase 20 migration applied. Uses the same test-DB wiring as existing integration tests in the project (check `apps/control-plane/internal/` for the pattern).
+
+Test flow:
+
+1. `POST /internal/providers` creates a provider with slug `"test-provider-XXXXXX"` (random suffix).
+2. `GET /internal/providers/{id}` returns the created row.
+3. `PUT /internal/providers/{id}` updates `display_name`; verify updated value in response and DB.
+4. `DELETE /internal/providers/{id}` sets `enabled=false`; verify `GET` returns `enabled: false`.
+5. Attempt `POST /internal/providers` with the same slug; assert 409.
+6. `INSERT INTO provider_routes (provider=<slug>)` succeeds (no CHECK constraint violation).
+7. Cleanup: delete test rows.
+
+---
+
+### Task 2: Tenant visibility integration test
+
+**File:** `apps/control-plane/internal/catalog/catalog_integration_test.go`
+
+Build tag: `//go:build integration`
+
+Test flow:
+
+1. Seed two aliases: one `visibility=public`, one `visibility=restricted`.
+2. `GET /api/v1/catalog/models` as tenant A (no visibility rows): assert public alias present, restricted absent.
+3. Insert `tenant_model_visibility` row `(tenantA, restrictedAlias, visible=true)`.
+4. Repeat GET: assert restricted alias now present for tenant A.
+5. Insert `tenant_model_visibility` row `(tenantA, publicAlias, visible=false)`.
+6. Repeat GET: assert public alias now absent for tenant A.
+7. `GET /api/v1/catalog/models` as tenant B (no rows): still sees original public set.
+8. Cleanup test rows.
+
+---
+
+### Task 3: LiteLLM sync integration test
+
+**File:** `apps/control-plane/internal/litellmconfig/sync_integration_test.go`
+
+Build tag: `//go:build integration`
+
+Requires Docker socket accessible from test host (CI must bind-mount it). Use a `MockRestarter` that records the call rather than calling real `docker restart` in this test.
+
+Test flow:
+
+1. Seed a `custom_providers` row and two `provider_routes` rows referencing it.
+2. Call `SyncService.Sync(ctx)`.
+3. Read the written config file; parse YAML; assert `model_list` length matches seeded routes.
+4. Assert `MockRestarter.Restart` was called exactly once.
+5. Assert YAML `api_key` field is `os.environ/PROVIDER_KEY_ENV` format (not a literal key).
+
+---
+
+### Task 4: Tool-call passthrough integration test
+
+**File:** `apps/edge-api/internal/inference/chat_completions_integration_test.go`
+
+Build tag: `//go:build integration`
+
+Uses the in-process handler test helper (or `httptest.NewServer` wrapping the edge-api handler).
+
+Test flow:
+
+1. Configure a route with `tools_supported=true` in `provider_capabilities`.
+2. Send `POST /v1/chat/completions` with `tools: [...]`. Assert 200 and upstream request (captured via a mock LiteLLM) contains the `tools` field.
+3. Configure a route with `tools_supported=false`.
+4. Same request to that route. Assert 400, `code: "unsupported_parameter"`, `param: "tools"`.
+5. Request with no `tools` field to the incapable route. Assert 200 (existing flow unbroken).
+
+---
+
+### Task 5: VERIFICATION.md
+
+**File:** `.planning/phases/20-provider-catalog/20-VERIFICATION.md`
+
+Shape: same as `phases/11-verification-cleanup/11-VERIFICATION.md` (Must-Have Truth Verification table + Requirement Coverage + Blockers + Ship-Gate Mapping).
+
+Must-Have Truth Verification table rows:
+
+| # | Truth | Verify Command | Status |
+|---|-------|---------------|--------|
+| 1 | `provider_routes` CHECK constraint no longer enumerates `openrouter`/`groq` | `psql -c "\d provider_routes" | grep -v "IN ('openrouter"` | PENDING |
+| 2 | `custom_providers` table with slug/litellm_prefix/enabled columns exists | `psql -c "\d custom_providers"` | PENDING |
+| 3 | `tenant_model_visibility` with `UNIQUE(tenant_id, alias_id)` exists | `psql -c "\d tenant_model_visibility"` | PENDING |
+| 4 | Provider CRUD endpoints return 201/200/409/401 as specified | `go test -tags integration ./apps/control-plane/internal/providers/...` | PENDING |
+| 5 | Catalog tenant filtering hides restricted aliases without visibility rows | `go test -tags integration ./apps/control-plane/internal/catalog/...` | PENDING |
+| 6 | OWUI `access_control` set to tenant group on visibility grant | unit test `owui/client_test.go` | PENDING |
+| 7 | LiteLLM config YAML generated from DB rows; restart triggered | `go test -tags integration ./apps/control-plane/internal/litellmconfig/...` | PENDING |
+| 8 | Tool-capable alias accepts `tools` (200); incapable alias rejects (400) | `go test -tags integration ./apps/edge-api/internal/inference/...` | PENDING |
+| 9 | SDK tool-call test passes or is skipped with `SKIP_TOOL_TESTS=1` | `cd packages/sdk-tests && node tool_call_test.js` | PENDING |
+| 10 | `go vet ./apps/...` clean across both services | `go vet ./apps/control-plane/... && go vet ./apps/edge-api/...` | PENDING |
+
+The executor fills in Status (PASS/FAIL) and captures command output snippets.
+
+Blockers section: must address any of the following if they arise:
+
+- LiteLLM DB-backed `/model/*` API shape not re-confirmed via Context7 at build time.
+- Docker socket not available in CI environment (sync integration test deferred).
+- Tool-capable provider key absent in test environment (`SKIP_TOOL_TESTS=1` deferral).
+
+Ship-Gate Mapping:
+
+- Phase 20 closes v1.1 ship-gate items: "Provider catalog admin API", "Tenant model access control", "Tool-call capability gating (issue #118 medium-term fix)".
+- Does NOT close: Phase 21 tier limits, Phase 22 RAG, Phase 23 Bengali translations.
+
+---
+
+## Acceptance Criteria
+
+- [ ] All 5 integration test files compile with `-tags integration`.
+- [ ] Provider CRUD integration (Task 1): 7 steps pass against real DB.
+- [ ] Catalog visibility integration (Task 2): 8-step flow passes.
+- [ ] LiteLLM sync integration (Task 3): YAML output + restart call verified.
+- [ ] Tool-call integration (Task 4): positive (200) + negative (400) + no-regression (200) cases pass.
+- [ ] `20-VERIFICATION.md` exists with Must-Have table, Requirement Coverage, Blockers (explicit empty list acceptable), and Ship-Gate Mapping sections.
+- [ ] Executor has updated Status column from PENDING to PASS/FAIL with captured evidence.

--- a/.planning/phases/20-provider-catalog/PLAN.md
+++ b/.planning/phases/20-provider-catalog/PLAN.md
@@ -1,0 +1,93 @@
+---
+phase: 20-provider-catalog
+type: plan
+milestone: v1.1
+branch: b/phase-20-provider-catalog
+track: A
+depends_on:
+  - 10-routing-storage-critical-fixes   # provider_routes table, routing.SelectionInput baseline
+  - 16-capability-columns-fix           # provider_capabilities table with tool/vision flags
+autonomous: true
+---
+
+# Phase 20 — Provider Catalog
+
+**Goal:** Give platform administrators the ability to register arbitrary LLM providers and models at runtime, control which models each tenant may use, and propagate that visibility to LiteLLM (inference layer) and Open WebUI (chat surface) without manual file edits or container rebuilds.
+
+**Scope:**
+
+1. Schema: `custom_providers` + `tenant_model_visibility` tables; relax `provider_routes` CHECK constraint.
+2. Provider CRUD: internal Go package + internal HTTP endpoints (shared-secret + platform admin auth).
+3. LiteLLM config generation + controlled proxy restart (file-based primary path; DB-backed noted as zero-downtime alternative).
+4. Tenant model visibility: catalog filtering by `ModelAlias.Visibility` + `tenant_model_visibility`; Open WebUI per-model `access_control` sync.
+5. Capability-based tool-call passthrough: edge-api forwards `tools`/`tool_choice`/`response_format` when the alias has at least one tool-capable route; 400 only when no capable route exists.
+6. Tests + VERIFICATION.md.
+
+---
+
+## Wave Structure
+
+```
+Wave 1 (sequential first):
+  20-01   Schema changes
+
+Wave 2 (parallel):
+  20-02   Provider CRUD package + endpoints
+  20-03   LiteLLM config generation + restart
+
+Wave 3 (parallel):
+  20-04   Tenant model visibility + OWUI sync
+  20-05   Capability-based tool-call passthrough
+
+Wave 4 (sequential last):
+  20-06   Tests + VERIFICATION.md
+```
+
+---
+
+## Dependencies Between Plans
+
+```
+20-01
+  └── 20-02 (needs custom_providers table)
+  └── 20-03 (needs relaxed provider_routes, config gen reads from tables)
+       └── 20-04 (needs tenant_model_visibility table from 20-01, OWUI client from 20-03 wiring)
+       └── 20-05 (needs provider_capabilities columns from Phase 16, SelectionInput from Phase 10)
+            └── 20-06 (tests all of the above)
+```
+
+---
+
+## Files Expected to Change (Phase-Level Summary)
+
+| Area | Key Paths |
+|------|-----------|
+| Schema | `supabase/migrations/YYYYMMDD_NN_phase20_provider_catalog.sql` |
+| Go: providers | `apps/control-plane/internal/providers/` (new package) |
+| Go: catalog | `apps/control-plane/internal/catalog/service.go` |
+| Go: routing | `apps/edge-api/internal/routing/selector.go`, `apps/edge-api/internal/inference/chat_completions.go`, `apps/edge-api/internal/inference/errors.go` |
+| Go: OWUI | `apps/control-plane/internal/owui/client.go` |
+| LiteLLM | `deploy/litellm/config.yaml`, `deploy/docker/docker-compose.yml` |
+| Contract | `packages/openai-contract/support-matrix.md` |
+| SDK tests | `packages/sdk-tests/` |
+| Env | `.env.example` |
+| Planning | `.planning/phases/20-provider-catalog/20-VERIFICATION.md` |
+
+---
+
+## Acceptance Criteria (Phase-Level)
+
+- [ ] A new provider row inserted into `custom_providers` flows through to a fresh `config.yaml` and restarts LiteLLM within the documented window.
+- [ ] A tenant with `tenant_model_visibility` rows sees only permitted aliases from `GET /api/v1/catalog/models`.
+- [ ] OWUI per-model `access_control` reflects the same tenant group constraint as `tenant_model_visibility`.
+- [ ] An alias backed by a tool-capable route accepts `tools` + `tool_choice` without a 400; an alias with no capable route returns 400 as before.
+- [ ] All Go unit tests pass; SDK integration tests green on tool-capable alias.
+- [ ] 20-VERIFICATION.md records pass/fail for every must-have truth.
+
+---
+
+## Related Plans
+
+- `.planning/phases/10-routing-storage-critical-fixes/PLAN.md` — `provider_routes`, `SelectionInput`, `ModelAlias`
+- `.planning/phases/16-capability-columns-fix/PLAN.md` — `provider_capabilities` tool/vision columns
+- `.planning/phases/19-chat-app-fork-strip/PLAN.md` — OWUI client foundation (`EnsureGroup`, `AddUserToGroup`)


### PR DESCRIPTION
## Summary

- Adds `.planning/phases/20-provider-catalog/PLAN.md` with wave structure, phase-level dependencies, and acceptance criteria for the full provider catalog feature.
- Adds six execution plans (20-01 through 20-06) covering: schema changes, provider CRUD, LiteLLM config generation with controlled restart, tenant model visibility with Open WebUI access_control sync, capability-based tool-call passthrough (issue #118), and integration tests plus VERIFICATION.md.
- Bakes in verified facts: `provider_routes` CHECK constraint relaxation, LiteLLM file-based restart as primary path with DB-backed `/model/*` alternative documented, Open WebUI deprecated filter flags replaced by per-model `access_control` objects, and edge-api tool-call gating keyed on `provider_capabilities.tools_supported`.

## Test plan

- [ ] Review each plan file for correctness against the verified facts in the brief.
- [ ] Confirm wave ordering matches declared `depends_on` fields.
- [ ] Confirm migration naming convention (`YYYYMMDD_NN_desc.sql`) and RLS pattern match `supabase/migrations/20260529_01_*.sql`.
- [ ] Confirm OWUI `access_control` shape matches live API (no `ENABLE_MODEL_FILTER` references).
- [ ] Confirm executor note in 20-03 to re-verify LiteLLM DB-backed `/model/*` shape via Context7 before implementing that alternative path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)