### PR TITLE
fix(ci): inject CONTROL_PLANE_INTERNAL_TOKEN from dedicated staging secret

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -153,6 +153,7 @@ jobs:
         env:
           STAGING_ENV: ${{ secrets.STAGING_ENV }}
           STAGING_REDIS_URL: ${{ secrets.STAGING_REDIS_URL }}
+          STAGING_INTERNAL_TOKEN: ${{ secrets.STAGING_INTERNAL_TOKEN }}
         run: |
           printf '%s' "$STAGING_ENV" > /tmp/hive.env
           chmod 600 /tmp/hive.env
@@ -170,6 +171,20 @@ jobs:
           grep -vE '^REDIS_URL=' /tmp/hive.env > /tmp/hive.env.tmp || true
           mv /tmp/hive.env.tmp /tmp/hive.env
           printf 'REDIS_URL=%s\n' "$STAGING_REDIS_URL" >> /tmp/hive.env
+          chmod 600 /tmp/hive.env
+
+          # CONTROL_PLANE_INTERNAL_TOKEN is sourced from a dedicated secret so
+          # it can be rotated independently of the full STAGING_ENV blob.
+          # docker-compose.staging.yml uses :? (required) for this var since
+          # PR #156 added the /internal/* shared-secret guard.
+          if [ -z "${STAGING_INTERNAL_TOKEN:-}" ]; then
+            echo "FATAL: STAGING_INTERNAL_TOKEN secret is empty or unset." >&2
+            rm -f /tmp/hive.env
+            exit 1
+          fi
+          grep -vE '^CONTROL_PLANE_INTERNAL_TOKEN=' /tmp/hive.env > /tmp/hive.env.tmp || true
+          mv /tmp/hive.env.tmp /tmp/hive.env
+          printf 'CONTROL_PLANE_INTERNAL_TOKEN=%s\n' "$STAGING_INTERNAL_TOKEN" >> /tmp/hive.env
           chmod 600 /tmp/hive.env
 
           # Defensive: staging must use a managed Redis (Upstash, Redis


### PR DESCRIPTION
## Summary

- PR #156 added `/internal/*` shared-secret guard and changed `docker-compose.staging.yml` to use `:?` (required interpolation) for `CONTROL_PLANE_INTERNAL_TOKEN`
- The `STAGING_ENV` blob predates this change and does not contain the var, causing every staging deploy to fail at the compose pull step with: `required variable CONTROL_PLANE_INTERNAL_TOKEN is missing a value`
- Fix: add `STAGING_INTERNAL_TOKEN` dedicated secret (already set) and inject it in the Seed staging env step, matching the existing `STAGING_REDIS_URL` pattern

## Root cause

`deploy-staging` workflow run 27327346727 step "Pull & restart stack" failed immediately because `docker compose pull` does interpolation before pulling images and hit the `:?` guard.

## Test plan

- [x] `STAGING_INTERNAL_TOKEN` secret created with value matching running containers
- [ ] Deploy workflow run succeeds on merge
- [ ] `https://api-hive.scubed.co/health` returns 200
- [ ] `https://cp-hive.scubed.co/health` returns 200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated staging deployment workflow configuration to enhance security token management during environment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->