### PR TITLE
feat: phase 20 schema, custom providers, tenant model visibility, tools capability flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,13 +21,25 @@ SUPABASE_JWKS_URL=https://<PROJECT_REF>.supabase.co/auth/v1/.well-known/jwks.jso
 
 # Control-plane / Redis
 #
+# Compose profile quick reference:
+#   --profile local       Developer laptop. In-stack docker Redis, no OWUI by default.
+#   --profile cloud       Hive Cloud (hosted SaaS). Expects managed Upstash REDIS_URL
+#                         and Supabase externals. No in-stack redis. Add --profile chat
+#                         to also start Open WebUI + Caddy on top.
+#   --profile enterprise  Hive EnterpriseEdge (self-hosted single box). In-stack Redis,
+#                         Open WebUI, Caddy, and optional Ollama local inference.
+#                         Set OLLAMA_BASE_URL=http://ollama:11434 to activate Ollama.
+#   --profile monitoring  Adds Prometheus, Grafana, Alertmanager (any profile).
+#   --profile test        SDK integration tests (activates in-stack redis for test deps).
+#   --profile tools       Go toolchain container for running tests without local Go.
+#
 # Local dev (default below): the in-stack docker redis lives in the `local`
 # profile of deploy/docker/docker-compose.yml. Run with
 # `docker compose --profile local --env-file ../../.env up --build`.
 #
-# Staging + production: REDIS_URL must point at a managed Upstash Redis
-# instance over TLS, e.g. `rediss://default:<token>@<host>:6379`. The Go
-# clients (edge-api + control-plane) use go-redis/v9's ParseURL and
+# Staging + production (cloud profile): REDIS_URL must point at a managed
+# Upstash Redis instance over TLS, e.g. `rediss://default:<token>@<host>:6379`.
+# The Go clients (edge-api + control-plane) use go-redis/v9's ParseURL and
 # asynq.ParseRedisURI — both accept rediss:// natively, so no code change
 # is required between local docker redis and Upstash. Never seed a
 # `redis://redis:6379/0`-style value into the staging `.env` —
@@ -202,3 +214,11 @@ GRAFANA_ADMIN_USER=admin
 # in place; rotate before any non-local deploy. Generate with:
 # openssl rand -base64 24
 GRAFANA_ADMIN_PASSWORD=
+
+# ─── EnterpriseEdge: Ollama local inference (--profile enterprise) ───
+# Set to http://ollama:11434 when using the enterprise profile so LiteLLM
+# can reach the in-stack Ollama service. Leave empty for cloud/local
+# profiles where Ollama is not active.
+# After setting this value, uncomment the ollama model entries in
+# deploy/litellm/config.yaml and restart LiteLLM.
+OLLAMA_BASE_URL=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,12 +62,22 @@ Supabase Storage only object storage backend. Enable S3 protocol in Supabase Sto
 ```bash
 cd deploy/docker
 
-# Core stack (edge-api + control-plane + redis + litellm + web-console).
-# `--profile local` activates the in-stack docker redis. Staging + prod
-# do not carry that profile — they use managed Upstash Redis via REDIS_URL.
+# Local dev: core stack with in-stack Redis.
 docker compose --env-file ../../.env --profile local up --build
 
-# With monitoring (adds Prometheus, Grafana, Alertmanager)
+# Hive Cloud (hosted SaaS): core services expecting managed Upstash Redis.
+# Set REDIS_URL=rediss://... in .env before running.
+docker compose --env-file ../../.env --profile cloud up --build
+
+# Hive Cloud with chat front-end (Open WebUI + Caddy on top of cloud):
+docker compose --env-file ../../.env --profile cloud --profile chat up --build
+
+# Hive EnterpriseEdge (self-hosted single box): core + in-stack Redis + OWUI + Caddy.
+# Optional Ollama: set OLLAMA_BASE_URL=http://ollama:11434 in .env and
+# uncomment the ollama model entries in deploy/litellm/config.yaml.
+docker compose --env-file ../../.env --profile enterprise up --build
+
+# Add monitoring to any profile (Prometheus, Grafana, Alertmanager):
 docker compose --env-file ../../.env --profile local --profile monitoring up --build
 ```
 

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -123,11 +123,17 @@ services:
       dockerfile: deploy/docker/Dockerfile.control-plane
     ports:
       - "8081:8081"
-    # Note: no depends_on redis here. The `local` and `enterprise` profiles
-    # include in-stack redis which starts independently; the `cloud` profile
-    # uses managed Upstash Redis via REDIS_URL and has no in-stack redis
-    # service. The application itself connects via REDIS_URL and fails fast
-    # on misconfiguration — no compose-level ordering needed.
+    # `required: false` makes the redis dependency optional at the Compose
+    # level. When the `local` or `enterprise` profile is active the in-stack
+    # redis service exists and control-plane waits for it to be healthy before
+    # starting, preventing a race where control-plane pings Redis once at boot
+    # and permanently marks redisClient=nil on a miss. When the `cloud` profile
+    # is active there is no in-stack redis service, so Compose skips the
+    # dependency entirely and control-plane connects via the managed REDIS_URL.
+    depends_on:
+      redis:
+        condition: service_healthy
+        required: false
     volumes:
       - gomodcache:/go/pkg/mod
       - gobuildcache:/root/.cache/go-build
@@ -181,8 +187,12 @@ services:
       - local
       - test
       - enterprise
+    # Bind to loopback only. Local devs can still reach redis on 127.0.0.1:6379
+    # for debugging. Enterprise deployments do not expose Redis on all host
+    # interfaces; no TLS or password is configured on this service, so a
+    # network-reachable port would be an unauthenticated attack surface.
     ports:
-      - "6379:6379"
+      - "127.0.0.1:6379:6379"
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 5s
@@ -215,8 +225,10 @@ services:
       - local
       - enterprise
       - chat
-    ports:
-      - "3002:8080"
+    # No direct host-port binding. All external access goes through caddy-owui
+    # on port 3003, which enforces admin/signup/mutation guards defined in
+    # Caddyfile.owui. Exposing port 3002 directly would bypass those defences
+    # on enterprise and cloud deployments.
     depends_on:
       edge-api:
         condition: service_healthy
@@ -317,14 +329,18 @@ services:
     image: ollama/ollama:latest
     profiles:
       - enterprise
-    ports:
-      - "11434:11434"
+    # No host-port binding. LiteLLM reaches Ollama over the internal Compose
+    # network at http://ollama:11434. Exposing 11434 on the host would allow
+    # unauthenticated inference calls that bypass Edge and LiteLLM auth.
     volumes:
       - ollama-models:/root/.ollama
     environment:
       OLLAMA_HOST: "0.0.0.0"
     healthcheck:
-      test: ["CMD-SHELL", "curl -fsSL http://localhost:11434/api/tags || exit 1"]
+      # ollama/ollama image ships with the ollama binary but not curl.
+      # `ollama list` exits 0 when the daemon is ready and returns the
+      # loaded model catalogue; it is the canonical in-image liveness probe.
+      test: ["CMD", "ollama", "list"]
       interval: 15s
       timeout: 5s
       retries: 5

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -66,6 +66,10 @@ services:
       GROQ_REASONING_MODEL: ${GROQ_REASONING_MODEL}
       NVIDIA_NIM_API_KEY: ${NVIDIA_NIM_API_KEY}
       NVIDIA_NIM_EMBEDDING_MODEL: ${NVIDIA_NIM_EMBEDDING_MODEL}
+      # EnterpriseEdge: set to http://ollama:11434 when using the enterprise
+      # profile with the in-stack Ollama service. Consumed by the commented
+      # ollama_chat/ model entries in deploy/litellm/config.yaml.
+      OLLAMA_BASE_URL: ${OLLAMA_BASE_URL:-}
     volumes:
       - ../../deploy/litellm/config.yaml:/app/config.yaml
     command: ["--config=/app/config.yaml"]
@@ -119,9 +123,11 @@ services:
       dockerfile: deploy/docker/Dockerfile.control-plane
     ports:
       - "8081:8081"
-    depends_on:
-      redis:
-        condition: service_healthy
+    # Note: no depends_on redis here. The `local` and `enterprise` profiles
+    # include in-stack redis which starts independently; the `cloud` profile
+    # uses managed Upstash Redis via REDIS_URL and has no in-stack redis
+    # service. The application itself connects via REDIS_URL and fails fast
+    # on misconfiguration — no compose-level ordering needed.
     volumes:
       - gomodcache:/go/pkg/mod
       - gobuildcache:/root/.cache/go-build
@@ -162,17 +168,19 @@ services:
       retries: 5
       start_period: 120s
 
-  # Local-dev Redis only. Staging + production use Upstash via REDIS_URL.
-  # Gated to `local` and `test` profiles so a bare `docker compose up`
-  # (or any deploy that doesn't opt in) never starts a docker redis. Local
-  # dev: `docker compose --profile local up`. SDK tests: also activate
-  # `--profile test` so the redis dependency resolves for sdk-tests-*
-  # services.
+  # In-stack Redis. Active for local dev, SDK tests, and self-hosted
+  # enterprise deployments. Cloud deployments use managed Upstash via
+  # REDIS_URL and do NOT activate this service.
+  # Profiles:
+  #   local      - in-stack dev redis. Run: docker compose --profile local up
+  #   test       - SDK integration tests need the redis dependency resolved.
+  #   enterprise - Hive EnterpriseEdge self-hosted box includes in-stack redis.
   redis:
     image: redis:8.4-alpine
     profiles:
       - local
       - test
+      - enterprise
     ports:
       - "6379:6379"
     healthcheck:
@@ -196,11 +204,17 @@ services:
       NEXT_PUBLIC_APP_URL: ${NEXT_PUBLIC_APP_URL:-http://localhost:3000}
       CONTROL_PLANE_BASE_URL: http://control-plane:8081
 
-  # Hive Phase 19 — Open WebUI front-end for EnterpriseEdge users.
+  # Hive Phase 19 — Open WebUI front-end for EnterpriseEdge and cloud chat users.
+  # Profiles:
+  #   local      - developer laptop with in-stack redis.
+  #   enterprise - Hive EnterpriseEdge self-hosted box (includes in-stack redis + Ollama).
+  #   chat       - compose on top of cloud profile for a hosted chat front-end.
   open-webui:
     image: ghcr.io/open-webui/open-webui:main@sha256:74093dadc9c6aabc23987a74fd8c2fb8d995b1a5b22e83b0036fb9d6af590e8c
     profiles:
       - local
+      - enterprise
+      - chat
     ports:
       - "3002:8080"
     depends_on:
@@ -275,6 +289,8 @@ services:
     image: caddy:2-alpine@sha256:86deaf5e3d3408a6ccec08fbb79989783dd26e206ae10bcf78a801dc8c9ab794
     profiles:
       - local
+      - enterprise
+      - chat
     ports:
       - "3003:80"
     depends_on:
@@ -284,6 +300,35 @@ services:
       - ./Caddyfile.owui:/etc/caddy/Caddyfile:ro
       - caddy-data:/data
       - caddy-config:/config
+    restart: unless-stopped
+
+  # Hive EnterpriseEdge — optional local Ollama inference backend.
+  # Active only under the `enterprise` profile. Serves keyless local models
+  # (e.g. llama3, mistral) via the Ollama HTTP API on port 11434.
+  # OLLAMA_BASE_URL is passed to LiteLLM via the environment so the
+  # ollama_chat/ model entries in deploy/litellm/config.yaml resolve
+  # correctly. See the commented example block in config.yaml for how to
+  # wire a local model into the LiteLLM model_list.
+  # GPU passthrough: add a `deploy.resources.reservations.devices` block
+  # to this service definition for NVIDIA GPU access (see Docker Compose
+  # GPU docs). Not enabled here because the investor-demo box may be
+  # CPU-only; add it after hardware is confirmed.
+  ollama:
+    image: ollama/ollama:latest
+    profiles:
+      - enterprise
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama-models:/root/.ollama
+    environment:
+      OLLAMA_HOST: "0.0.0.0"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsSL http://localhost:11434/api/tags || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
     restart: unless-stopped
 
   prometheus:
@@ -342,3 +387,6 @@ volumes:
   owui-data:
   caddy-data:
   caddy-config:
+  # ollama-models persists pulled model weights across container recreates.
+  # Active only when the `enterprise` profile is used.
+  ollama-models:

--- a/deploy/litellm/config.yaml
+++ b/deploy/litellm/config.yaml
@@ -127,17 +127,25 @@ files_settings:
     api_key: os.environ/OPENROUTER_API_KEY
 
 # ─── EnterpriseEdge: Ollama local inference (optional) ───────────────────────
-# Uncomment the block below when running the `enterprise` compose profile with
-# the in-stack Ollama service. Set OLLAMA_BASE_URL=http://ollama:11434 in your
-# .env (the litellm service receives it via the OLLAMA_BASE_URL env passthrough
-# in docker-compose.yml).
+# To activate local Ollama models, append entries to the model_list above
+# (do NOT add a second top-level `model_list:` key — YAML parsers do not merge
+# duplicate keys; a second key would silently drop all OpenRouter/Groq routes).
 #
-# Add one entry per model you want to expose. The model_name is the slug
-# clients send in the `model` field; the litellm_params.model value must match
-# a model already pulled into Ollama (run `docker exec -it hive-ollama-1
-# ollama pull llama3` after the stack is up).
+# Steps:
+#   1. Set OLLAMA_BASE_URL=http://ollama:11434 in .env.
+#   2. Cut the commented entries below and paste them at the end of the
+#      `model_list:` block above (before the `litellm_settings:` line),
+#      removing the leading `#` from each line.
+#   3. Restart LiteLLM: docker compose --profile enterprise restart litellm
+#   4. Pull the model inside the Ollama container:
+#        docker exec -it hive-ollama-1 ollama pull llama3
 #
-# model_list:
+# NOTE: These entries only wire LiteLLM. Routing requests through the Hive
+# edge-api (SelectRoute) also requires provider_capabilities rows and route
+# aliases in the database. That wiring is planned for a future phase; until
+# it ships, direct LiteLLM calls work but edge-api routing to these model
+# aliases will return 404.
+#
 #   - model_name: ollama/llama3
 #     litellm_params:
 #       model: ollama_chat/llama3
@@ -148,6 +156,4 @@ files_settings:
 #       model: ollama_chat/mistral
 #       api_base: os.environ/OLLAMA_BASE_URL
 #
-# After adding entries here, restart LiteLLM:
-#   docker compose --profile enterprise restart litellm
 # ─────────────────────────────────────────────────────────────────────────────

--- a/deploy/litellm/config.yaml
+++ b/deploy/litellm/config.yaml
@@ -125,3 +125,29 @@ litellm_settings:
 files_settings:
   - custom_llm_provider: openrouter
     api_key: os.environ/OPENROUTER_API_KEY
+
+# ─── EnterpriseEdge: Ollama local inference (optional) ───────────────────────
+# Uncomment the block below when running the `enterprise` compose profile with
+# the in-stack Ollama service. Set OLLAMA_BASE_URL=http://ollama:11434 in your
+# .env (the litellm service receives it via the OLLAMA_BASE_URL env passthrough
+# in docker-compose.yml).
+#
+# Add one entry per model you want to expose. The model_name is the slug
+# clients send in the `model` field; the litellm_params.model value must match
+# a model already pulled into Ollama (run `docker exec -it hive-ollama-1
+# ollama pull llama3` after the stack is up).
+#
+# model_list:
+#   - model_name: ollama/llama3
+#     litellm_params:
+#       model: ollama_chat/llama3
+#       api_base: os.environ/OLLAMA_BASE_URL
+#
+#   - model_name: ollama/mistral
+#     litellm_params:
+#       model: ollama_chat/mistral
+#       api_base: os.environ/OLLAMA_BASE_URL
+#
+# After adding entries here, restart LiteLLM:
+#   docker compose --profile enterprise restart litellm
+# ─────────────────────────────────────────────────────────────────────────────

--- a/supabase/migrations/20260611_01_provider_catalog_schema.sql
+++ b/supabase/migrations/20260611_01_provider_catalog_schema.sql
@@ -1,0 +1,157 @@
+-- =============================================================================
+-- Phase 20-01: Provider Catalog schema
+--   * Relax provider_routes CHECK constraint (openrouter/groq only -> non-empty)
+--   * Create custom_providers table with seed rows for openrouter + groq
+--   * Create tenant_model_visibility table
+--   * ADD COLUMN tools_supported to provider_capabilities
+--   * Extend model_aliases.visibility CHECK to include 'restricted'
+--   * RLS: enable + force, FOR ALL TO hive_app policies (idempotent DO $$)
+--   * GRANTs for hive_app on both new tables
+--   * updated_at triggers (reuse public.set_updated_at())
+-- =============================================================================
+
+begin;
+
+-- ---------------------------------------------------------------------------
+-- Task 1: Relax provider_routes CHECK constraint
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE public.provider_routes
+  DROP CONSTRAINT IF EXISTS provider_routes_provider_check;
+
+ALTER TABLE public.provider_routes
+  ADD CONSTRAINT provider_routes_provider_nonempty
+    CHECK (provider <> '');
+
+-- ---------------------------------------------------------------------------
+-- Task 2: custom_providers table
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS public.custom_providers (
+  id             UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  slug           TEXT        NOT NULL UNIQUE,
+  display_name   TEXT        NOT NULL,
+  base_url       TEXT        NOT NULL,
+  api_key_env    TEXT        NOT NULL,
+  litellm_prefix TEXT        NOT NULL,
+  enabled        BOOLEAN     NOT NULL DEFAULT true,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS custom_providers_slug_idx    ON public.custom_providers (slug);
+CREATE INDEX IF NOT EXISTS custom_providers_enabled_idx ON public.custom_providers (enabled);
+
+INSERT INTO public.custom_providers
+  (slug, display_name, base_url, api_key_env, litellm_prefix, enabled)
+VALUES
+  ('openrouter', 'OpenRouter', 'https://openrouter.ai/api/v1',   'OPENROUTER_API_KEY', 'openrouter/', true),
+  ('groq',       'Groq',       'https://api.groq.com/openai/v1', 'GROQ_API_KEY',       'groq/',       true)
+ON CONFLICT (slug) DO NOTHING;
+
+-- ---------------------------------------------------------------------------
+-- Task 3: tenant_model_visibility table
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS public.tenant_model_visibility (
+  id         UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id  UUID        NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  alias_id   TEXT        NOT NULL REFERENCES public.model_aliases(alias_id) ON DELETE CASCADE,
+  visible    BOOLEAN     NOT NULL DEFAULT true,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (tenant_id, alias_id)
+);
+
+CREATE INDEX IF NOT EXISTS tmv_tenant_idx ON public.tenant_model_visibility (tenant_id);
+CREATE INDEX IF NOT EXISTS tmv_alias_idx  ON public.tenant_model_visibility (alias_id);
+
+-- ---------------------------------------------------------------------------
+-- Task 4: provider_capabilities — ADD COLUMN tools_supported
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE public.provider_capabilities
+  ADD COLUMN IF NOT EXISTS tools_supported BOOLEAN NOT NULL DEFAULT false;
+
+-- ---------------------------------------------------------------------------
+-- Task 5: model_aliases.visibility CHECK extended to include 'restricted'
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE public.model_aliases
+  DROP CONSTRAINT IF EXISTS model_aliases_visibility_check;
+
+ALTER TABLE public.model_aliases
+  ADD CONSTRAINT model_aliases_visibility_check
+    CHECK (visibility IN ('public', 'preview', 'internal', 'restricted'));
+
+-- ---------------------------------------------------------------------------
+-- Task 6: RLS — custom_providers
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE public.custom_providers ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.custom_providers FORCE ROW LEVEL SECURITY;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename  = 'custom_providers'
+      AND policyname = 'custom_providers_service_role_all'
+  ) THEN
+    CREATE POLICY custom_providers_service_role_all
+      ON public.custom_providers
+      FOR ALL TO hive_app
+      USING (true)
+      WITH CHECK (true);
+  END IF;
+END $$;
+
+-- ---------------------------------------------------------------------------
+-- Task 6: RLS — tenant_model_visibility
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE public.tenant_model_visibility ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.tenant_model_visibility FORCE ROW LEVEL SECURITY;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename  = 'tenant_model_visibility'
+      AND policyname = 'tenant_model_visibility_service_role_all'
+  ) THEN
+    CREATE POLICY tenant_model_visibility_service_role_all
+      ON public.tenant_model_visibility
+      FOR ALL TO hive_app
+      USING (true)
+      WITH CHECK (true);
+  END IF;
+END $$;
+
+-- GRANTs (RLS policies do not imply DML privileges)
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.custom_providers         TO hive_app;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.tenant_model_visibility  TO hive_app;
+
+-- ---------------------------------------------------------------------------
+-- Task 7: updated_at triggers
+-- ---------------------------------------------------------------------------
+
+-- Ensure the function exists (idempotent; all prior migrations already create it,
+-- but guard here for standalone replay safety).
+CREATE OR REPLACE FUNCTION public.set_updated_at()
+  RETURNS TRIGGER
+  LANGUAGE plpgsql
+AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE TRIGGER set_custom_providers_updated_at
+  BEFORE UPDATE ON public.custom_providers
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+CREATE OR REPLACE TRIGGER set_tenant_model_visibility_updated_at
+  BEFORE UPDATE ON public.tenant_model_visibility
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+commit;

--- a/supabase/migrations/20260611_01_provider_catalog_schema.sql
+++ b/supabase/migrations/20260611_01_provider_catalog_schema.sql
@@ -1,12 +1,13 @@
 -- =============================================================================
 -- Phase 20-01: Provider Catalog schema
 --   * Relax provider_routes CHECK constraint (openrouter/groq only -> non-empty)
---   * Create custom_providers table with seed rows for openrouter + groq
+--   * Create custom_providers table with seed rows for openrouter, groq, nvidia_nim
 --   * Create tenant_model_visibility table
 --   * ADD COLUMN tools_supported to provider_capabilities
 --   * Extend model_aliases.visibility CHECK to include 'restricted'
 --   * RLS: enable + force, FOR ALL TO hive_app policies (idempotent DO $$)
 --   * GRANTs for hive_app on both new tables
+--   * FK: provider_routes.provider -> custom_providers(slug)
 --   * updated_at triggers (reuse public.set_updated_at())
 -- =============================================================================
 
@@ -42,12 +43,28 @@ CREATE TABLE IF NOT EXISTS public.custom_providers (
 CREATE INDEX IF NOT EXISTS custom_providers_slug_idx    ON public.custom_providers (slug);
 CREATE INDEX IF NOT EXISTS custom_providers_enabled_idx ON public.custom_providers (enabled);
 
+-- Seed known providers. nvidia_nim seeded (enabled=false) so the FK below
+-- validates the existing route-nvidia-embedding row from
+-- 20260424_02_embedding_fallback_route.sql.
 INSERT INTO public.custom_providers
   (slug, display_name, base_url, api_key_env, litellm_prefix, enabled)
 VALUES
-  ('openrouter', 'OpenRouter', 'https://openrouter.ai/api/v1',   'OPENROUTER_API_KEY', 'openrouter/', true),
-  ('groq',       'Groq',       'https://api.groq.com/openai/v1', 'GROQ_API_KEY',       'groq/',       true)
+  ('openrouter', 'OpenRouter', 'https://openrouter.ai/api/v1',        'OPENROUTER_API_KEY', 'openrouter/', true),
+  ('groq',       'Groq',       'https://api.groq.com/openai/v1',      'GROQ_API_KEY',       'groq/',       true),
+  ('nvidia_nim', 'NVIDIA NIM', 'https://integrate.api.nvidia.com/v1', 'NVIDIA_API_KEY',     'nvidia_nim/', false)
 ON CONFLICT (slug) DO NOTHING;
+
+-- ---------------------------------------------------------------------------
+-- Task 2b: FK provider_routes.provider -> custom_providers(slug)
+-- Placed after seed inserts so all existing rows validate immediately.
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE public.provider_routes
+  DROP CONSTRAINT IF EXISTS provider_routes_provider_fk;
+
+ALTER TABLE public.provider_routes
+  ADD CONSTRAINT provider_routes_provider_fk
+    FOREIGN KEY (provider) REFERENCES public.custom_providers(slug) ON DELETE RESTRICT;
 
 -- ---------------------------------------------------------------------------
 -- Task 3: tenant_model_visibility table
@@ -63,8 +80,9 @@ CREATE TABLE IF NOT EXISTS public.tenant_model_visibility (
   UNIQUE (tenant_id, alias_id)
 );
 
-CREATE INDEX IF NOT EXISTS tmv_tenant_idx ON public.tenant_model_visibility (tenant_id);
-CREATE INDEX IF NOT EXISTS tmv_alias_idx  ON public.tenant_model_visibility (alias_id);
+-- tmv_tenant_idx omitted: UNIQUE(tenant_id, alias_id) already creates a
+-- tenant_id-leading index, making a standalone tenant_id index redundant.
+CREATE INDEX IF NOT EXISTS tmv_alias_idx ON public.tenant_model_visibility (alias_id);
 
 -- ---------------------------------------------------------------------------
 -- Task 4: provider_capabilities — ADD COLUMN tools_supported


### PR DESCRIPTION
## Summary

- Adds `supabase/migrations/20260611_01_provider_catalog_schema.sql` implementing all Phase 20-01 schema changes per `.planning/phases/20-provider-catalog/20-01-schema.md`
- Relaxes `provider_routes` CHECK constraint from `IN ('openrouter', 'groq')` to non-empty free-text, unblocking arbitrary provider slugs
- Creates `custom_providers` (slug UNIQUE, litellm_prefix, enabled, updated_at) with seed rows for openrouter + groq (idempotent ON CONFLICT DO NOTHING)
- Creates `tenant_model_visibility` with `UNIQUE(tenant_id, alias_id)`; `tenant_id` references `public.tenants(id)` (not accounts)
- Adds `tools_supported BOOLEAN NOT NULL DEFAULT false` to `provider_capabilities`
- Extends `model_aliases.visibility` CHECK to include `'restricted'`
- RLS enabled + forced on both new tables; idempotent `DO $$ BEGIN IF NOT EXISTS` policies `FOR ALL TO hive_app`
- `GRANT SELECT, INSERT, UPDATE, DELETE` on both tables to `hive_app`
- `updated_at` triggers on both tables; `set_updated_at()` guarded with `CREATE OR REPLACE`

## Acceptance criteria verified (static)

- [x] `provider_routes_provider_check` dropped; `provider_routes_provider_nonempty` replaces it
- [x] `custom_providers` slug UNIQUE, enabled, litellm_prefix columns present
- [x] Seed rows for openrouter + groq, idempotent
- [x] `tenant_model_visibility` UNIQUE(tenant_id, alias_id); FK to `public.tenants(id)`
- [x] RLS enable + force + idempotent DO $$ policy on both tables
- [x] GRANTs on both tables to hive_app
- [x] `tools_supported` column on `provider_capabilities`
- [x] `restricted` added to `model_aliases.visibility` CHECK
- [x] `updated_at` triggers on both new tables
- [x] Migration filename follows `YYYYMMDD_NN_...sql` convention

## Test plan

- [ ] Apply migration against a fresh Supabase local instance: `supabase db push` returns no errors
- [ ] Confirm `\d provider_routes` no longer shows `IN ('openrouter', 'groq')`
- [ ] Insert `custom_providers` row with slug `together`; confirm accepted
- [ ] Insert `provider_routes` row with `provider = 'together'`; confirm accepted
- [ ] Insert duplicate `(tenant_id, alias_id)` into `tenant_model_visibility`; confirm unique violation
- [ ] Confirm `hive_app` can SELECT/INSERT/UPDATE/DELETE both new tables
- [ ] Confirm anon/authenticated roles read 0 rows (RLS blocks them)

## Plan reference

`.planning/phases/20-provider-catalog/20-01-schema.md` (Wave 1, Phase 20)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup instructions with four deployment profile options: local, cloud, cloud with chat, and enterprise modes.
  * Clarified Redis requirements for staging/production environments and documented optional Ollama configuration.

* **New Features**
  * Added enterprise deployment profile supporting local, self-hosted AI model inference.
  * Extended database schema for custom provider management and tenant-level model visibility controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->