### PR TITLE
fix(web-console): remove edge runtime from budget route to unblock OpenNext build

### DIFF
--- a/apps/web-console/app/api/budget/route.ts
+++ b/apps/web-console/app/api/budget/route.ts
@@ -3,8 +3,6 @@ import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { upsertBudgetThreshold, dismissBudgetAlert } from "@/lib/control-plane/client";
 
-export const runtime = "edge";
-
 async function requireUser(): Promise<Response | null> {
   const cookieStore = await cookies();
   const supabase = createClient(cookieStore);


### PR DESCRIPTION
## Summary

- **deploy-workers** (Cloudflare Workers via OpenNext) was failing at the OpenNext bundle step with: `app/api/budget/route cannot use the edge runtime. OpenNext requires edge runtime function to be defined in a separate function.`
- Root cause: `apps/web-console/app/api/budget/route.ts` declared `export const runtime = "edge"`, which `@opennextjs/cloudflare` forbids in the default server bundle. Cloudflare Workers executes everything on the edge already, so the declaration is both unnecessary and fatal to the build.
- Fix: remove the two-line `export const runtime = "edge"` declaration. No logic changes.

- **sdk-replay** was already passing (confirmed in run 27334186475, job 80754173550). No changes needed there.

## What was NOT changed

- No workflow file changes. The CI configuration is correct.
- No wrangler config changes. No owner action required.
- The `open-next.config.ts` is already minimal (`defineCloudflareConfig({})`) and correct.

## Test plan

- [ ] Merge triggers `deploy-staging` workflow on main
- [ ] "Build (OpenNext for Cloudflare Workers)" step passes (previously failing step)
- [ ] "Deploy to CF Workers" step executes (was skipped due to prior build failure)
- [ ] "SDK replay against staging URL" continues to pass
- [ ] Budget API endpoints (`PUT /api/budget`, `DELETE /api/budget`) remain functional on deployed worker

🤖 Generated with [Claude Code](https://claude.com/claude-code)