### PR TITLE
feat: phase 20 provider CRUD endpoints and repository

### DIFF
--- a/apps/control-plane/cmd/server/main.go
+++ b/apps/control-plane/cmd/server/main.go
@@ -45,6 +45,7 @@ import (
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/platform/metrics"
 	platformredis "github.com/sakibsadmanshajib/hive/apps/control-plane/internal/platform/redis"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/profiles"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/providers"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/routing"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/signup"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/signupguard"
@@ -198,6 +199,7 @@ func main() {
 	var roleSvc *platform.RoleService
 	var authzMW authz.Middleware // Phase 18: set after roleSvc+accountsSvc are ready
 	var catalogHandler *catalog.Handler
+	var providersHandler *providers.Handler
 	var ledgerHandler *ledger.Handler
 	var profilesHandler *profiles.Handler
 	var routingHandler *routing.Handler
@@ -247,6 +249,11 @@ func main() {
 		catalogRepo := catalog.NewPgxRepository(pool)
 		catalogSvc := catalog.NewService(catalogRepo)
 		catalogHandler = catalog.NewHandler(catalogSvc)
+
+		providersRepo := providers.NewPgxRepository(pool)
+		providersSvc := providers.NewService(providersRepo)
+		providersHandler = providers.NewHandler(providersSvc)
+		log.Println("providers module ready (Phase 20 Plan 02)")
 
 		routingRepo := routing.NewPgxRepository(pool)
 		routingSvc = routing.NewService(routingRepo)
@@ -644,12 +651,14 @@ func main() {
 		LedgerHandler:      ledgerHandler,
 		PaymentsHandler:    paymentsHandler,
 		ProfilesHandler:    profilesHandler,
+		ProvidersRouter:    providersHandler,
 		RoutingHandler:     routingHandler,
 		UsageHandler:       usageHandler,
 		MetricsRegistry:    metricsRegistry,
 		PrometheusRegistry: promRegistry,
 		Mux:                routerMux,
 		InternalToken:      cfg.InternalToken,
+		RoleSvc:            roleSvc,
 	})
 
 	// Wire filestore internal endpoints if the database pool is available.

--- a/apps/control-plane/internal/platform/http/router.go
+++ b/apps/control-plane/internal/platform/http/router.go
@@ -65,6 +65,20 @@ type RouterConfig struct {
 	// control-plane logs a startup warning; when set, callers must present a matching
 	// X-Internal-Token header.
 	InternalToken string
+
+	// ProvidersRouter exposes an InternalMux() for CRUD over custom_providers.
+	// Mounted under /internal/providers (shared-secret) and
+	// /api/v1/admin/providers (platform admin JWT).
+	// Using a narrow interface avoids an import cycle between platform/http and providers.
+	ProvidersRouter interface {
+		InternalMux() http.Handler
+	}
+
+	// RoleSvc is required to gate the /api/v1/admin/providers routes
+	// with RequirePlatformAdmin. When nil those admin routes are skipped.
+	RoleSvc interface {
+		RequirePlatformAdmin(http.Handler) http.Handler
+	}
 }
 
 // NewRouter returns a configured http.Handler with all platform routes registered.
@@ -187,6 +201,23 @@ func NewRouter(cfg RouterConfig) http.Handler {
 		mux.Handle("/webhooks/sslcommerz/success", cfg.PaymentsHandler)
 		mux.Handle("/webhooks/sslcommerz/fail", cfg.PaymentsHandler)
 		mux.Handle("/webhooks/sslcommerz/cancel", cfg.PaymentsHandler)
+	}
+
+	// Phase 20 Plan 02 — provider CRUD routes.
+	// /internal/providers/* is guarded by the shared-secret token.
+	// /api/v1/admin/providers/* is guarded by RequirePlatformAdmin (JWT path).
+	if cfg.ProvidersRouter != nil {
+		internalProviders := internal(cfg.ProvidersRouter.InternalMux())
+		mux.Handle("/internal/providers", internalProviders)
+		mux.Handle("/internal/providers/", internalProviders)
+
+		if cfg.RoleSvc != nil && cfg.AuthMiddleware != nil {
+			adminProviders := cfg.AuthMiddleware.Require(
+				cfg.RoleSvc.RequirePlatformAdmin(cfg.ProvidersRouter.InternalMux()),
+			)
+			mux.Handle("/api/v1/admin/providers", adminProviders)
+			mux.Handle("/api/v1/admin/providers/", adminProviders)
+		}
 	}
 
 	// Wrap the mux with Prometheus HTTP instrumentation if a metrics registry is provided.

--- a/apps/control-plane/internal/providers/http.go
+++ b/apps/control-plane/internal/providers/http.go
@@ -1,0 +1,203 @@
+package providers
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// Handler exposes CRUD endpoints for custom_providers.
+type Handler struct {
+	svc *Service
+}
+
+// NewHandler returns a Handler backed by the given service.
+func NewHandler(svc *Service) *Handler {
+	return &Handler{svc: svc}
+}
+
+// InternalMux returns an http.Handler that routes the five CRUD endpoints.
+// Callers should wrap this with RequireInternalToken before mounting.
+//
+//	POST   /internal/providers
+//	GET    /internal/providers
+//	GET    /internal/providers/{id}
+//	PUT    /internal/providers/{id}
+//	DELETE /internal/providers/{id}
+func (h *Handler) InternalMux() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/internal/providers", h.handleCollection)
+	mux.HandleFunc("/internal/providers/", h.handleItem)
+	return mux
+}
+
+// handleCollection routes POST (create) and GET (list).
+func (h *Handler) handleCollection(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost:
+		h.handleCreate(w, r)
+	case http.MethodGet:
+		h.handleList(w, r)
+	default:
+		writeJSONError(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
+	}
+}
+
+// handleItem routes GET/PUT/DELETE for /internal/providers/{id}.
+func (h *Handler) handleItem(w http.ResponseWriter, r *http.Request) {
+	id, ok := extractID(w, r.URL.Path)
+	if !ok {
+		return
+	}
+	switch r.Method {
+	case http.MethodGet:
+		h.handleGet(w, r, id)
+	case http.MethodPut:
+		h.handleUpdate(w, r, id)
+	case http.MethodDelete:
+		h.handleDelete(w, r, id)
+	default:
+		writeJSONError(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
+	}
+}
+
+// providerRequest is the JSON body for create and update operations.
+type providerRequest struct {
+	Slug          string `json:"slug"`
+	DisplayName   string `json:"display_name"`
+	BaseURL       string `json:"base_url"`
+	APIKeyEnv     string `json:"api_key_env"`
+	LiteLLMPrefix string `json:"litellm_prefix"`
+	Enabled       bool   `json:"enabled"`
+}
+
+func (h *Handler) handleCreate(w http.ResponseWriter, r *http.Request) {
+	var req providerRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid_body", "request body must be valid JSON")
+		return
+	}
+
+	p := Provider{
+		Slug:          req.Slug,
+		DisplayName:   req.DisplayName,
+		BaseURL:       req.BaseURL,
+		APIKeyEnv:     req.APIKeyEnv,
+		LiteLLMPrefix: req.LiteLLMPrefix,
+		Enabled:       req.Enabled,
+	}
+
+	created, err := h.svc.Create(r.Context(), p)
+	if err != nil {
+		mapServiceError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, created)
+}
+
+func (h *Handler) handleList(w http.ResponseWriter, r *http.Request) {
+	providers, err := h.svc.List(r.Context())
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "internal_error", "failed to list providers")
+		return
+	}
+	writeJSON(w, http.StatusOK, providers)
+}
+
+func (h *Handler) handleGet(w http.ResponseWriter, r *http.Request, id uuid.UUID) {
+	p, err := h.svc.Get(r.Context(), id)
+	if err != nil {
+		mapServiceError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, p)
+}
+
+func (h *Handler) handleUpdate(w http.ResponseWriter, r *http.Request, id uuid.UUID) {
+	var req providerRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid_body", "request body must be valid JSON")
+		return
+	}
+
+	p := Provider{
+		Slug:          req.Slug,
+		DisplayName:   req.DisplayName,
+		BaseURL:       req.BaseURL,
+		APIKeyEnv:     req.APIKeyEnv,
+		LiteLLMPrefix: req.LiteLLMPrefix,
+		Enabled:       req.Enabled,
+	}
+
+	updated, err := h.svc.Update(r.Context(), id, p)
+	if err != nil {
+		mapServiceError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, updated)
+}
+
+func (h *Handler) handleDelete(w http.ResponseWriter, r *http.Request, id uuid.UUID) {
+	if err := h.svc.Delete(r.Context(), id); err != nil {
+		mapServiceError(w, err)
+		return
+	}
+	// Return the updated (disabled) record so callers can confirm enabled=false.
+	p, err := h.svc.Get(r.Context(), id)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "internal_error", "soft delete succeeded but get failed")
+		return
+	}
+	writeJSON(w, http.StatusOK, p)
+}
+
+// mapServiceError translates sentinel errors to HTTP status codes.
+func mapServiceError(w http.ResponseWriter, err error) {
+	var valErr *ErrValidation
+	switch {
+	case errors.As(err, &valErr):
+		writeJSONError(w, http.StatusBadRequest, "validation_error", valErr.Error())
+	case errors.Is(err, ErrNotFound):
+		writeJSONError(w, http.StatusNotFound, "not_found", "provider not found")
+	case errors.Is(err, ErrSlugConflict):
+		writeJSONError(w, http.StatusConflict, "slug_conflict", "a provider with that slug already exists")
+	default:
+		writeJSONError(w, http.StatusInternalServerError, "internal_error", "an internal error occurred")
+	}
+}
+
+// extractID parses the UUID segment from a path like /internal/providers/{id}.
+func extractID(w http.ResponseWriter, path string) (uuid.UUID, bool) {
+	// Trim trailing slash then get the last segment.
+	path = strings.TrimSuffix(path, "/")
+	idx := strings.LastIndex(path, "/")
+	if idx < 0 {
+		writeJSONError(w, http.StatusBadRequest, "invalid_path", "missing provider id")
+		return uuid.Nil, false
+	}
+	seg := path[idx+1:]
+	id, err := uuid.Parse(seg)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid_id", "provider id must be a valid UUID")
+		return uuid.Nil, false
+	}
+	return id, true
+}
+
+type errorResponse struct {
+	Error string `json:"error"`
+	Code  string `json:"code"`
+}
+
+func writeJSONError(w http.ResponseWriter, status int, code, message string) {
+	writeJSON(w, status, errorResponse{Error: message, Code: code})
+}
+
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}

--- a/apps/control-plane/internal/providers/http_test.go
+++ b/apps/control-plane/internal/providers/http_test.go
@@ -1,0 +1,369 @@
+package providers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	platformhttp "github.com/sakibsadmanshajib/hive/apps/control-plane/internal/platform/http"
+)
+
+// =============================================================================
+// Stub repository — satisfies Repository interface without a real DB.
+// =============================================================================
+
+type stubRepo struct {
+	providers   []Provider
+	createErr   error
+	listErr     error
+	getErr      error
+	updateErr   error
+	deleteErr   error
+}
+
+func (s *stubRepo) Create(_ context.Context, p Provider) (Provider, error) {
+	if s.createErr != nil {
+		return Provider{}, s.createErr
+	}
+	p.ID = uuid.New()
+	p.CreatedAt = time.Now().UTC()
+	p.UpdatedAt = time.Now().UTC()
+	s.providers = append(s.providers, p)
+	return p, nil
+}
+
+func (s *stubRepo) List(_ context.Context) ([]Provider, error) {
+	if s.listErr != nil {
+		return nil, s.listErr
+	}
+	return s.providers, nil
+}
+
+func (s *stubRepo) Get(_ context.Context, id uuid.UUID) (Provider, error) {
+	if s.getErr != nil {
+		return Provider{}, s.getErr
+	}
+	for _, p := range s.providers {
+		if p.ID == id {
+			return p, nil
+		}
+	}
+	return Provider{}, ErrNotFound
+}
+
+func (s *stubRepo) Update(_ context.Context, id uuid.UUID, updated Provider) (Provider, error) {
+	if s.updateErr != nil {
+		return Provider{}, s.updateErr
+	}
+	for i, p := range s.providers {
+		if p.ID == id {
+			updated.ID = id
+			updated.CreatedAt = p.CreatedAt
+			updated.UpdatedAt = time.Now().UTC()
+			s.providers[i] = updated
+			return updated, nil
+		}
+	}
+	return Provider{}, ErrNotFound
+}
+
+func (s *stubRepo) Delete(_ context.Context, id uuid.UUID) error {
+	if s.deleteErr != nil {
+		return s.deleteErr
+	}
+	for i, p := range s.providers {
+		if p.ID == id {
+			s.providers[i].Enabled = false
+			return nil
+		}
+	}
+	return ErrNotFound
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+const testToken = "test-internal-secret"
+
+func newTestHandler(repo Repository) http.Handler {
+	svc := NewService(repo)
+	h := NewHandler(svc)
+	// Wrap with internal token middleware matching catalog/routing pattern.
+	return platformhttp.RequireInternalToken(testToken, h.InternalMux())
+}
+
+func bodyJSON(t *testing.T, v any) *bytes.Buffer {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("bodyJSON: %v", err)
+	}
+	return bytes.NewBuffer(b)
+}
+
+func decodeProvider(t *testing.T, body *bytes.Buffer) Provider {
+	t.Helper()
+	var p Provider
+	if err := json.NewDecoder(body).Decode(&p); err != nil {
+		t.Fatalf("decodeProvider: %v, body: %s", err, body.String())
+	}
+	return p
+}
+
+func decodeProviders(t *testing.T, body *bytes.Buffer) []Provider {
+	t.Helper()
+	var ps []Provider
+	if err := json.NewDecoder(body).Decode(&ps); err != nil {
+		t.Fatalf("decodeProviders: %v, body: %s", err, body.String())
+	}
+	return ps
+}
+
+// =============================================================================
+// Test cases — all 7 required by plan 20-02.
+// =============================================================================
+
+// Case 1: POST with valid body returns 201 + provider JSON.
+func TestCreateProviderValidBodyReturns201(t *testing.T) {
+	repo := &stubRepo{}
+	handler := newTestHandler(repo)
+
+	body := map[string]any{
+		"slug":           "together",
+		"display_name":   "Together AI",
+		"base_url":       "https://api.together.xyz/v1",
+		"api_key_env":    "TOGETHER_API_KEY",
+		"litellm_prefix": "together_ai/",
+		"enabled":        true,
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/internal/providers", bodyJSON(t, body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(platformhttp.InternalTokenHeader, testToken)
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	p := decodeProvider(t, rr.Body)
+	if p.Slug != "together" {
+		t.Errorf("expected slug 'together', got %q", p.Slug)
+	}
+	if p.ID == uuid.Nil {
+		t.Error("expected non-nil ID")
+	}
+}
+
+// Case 2: POST with duplicate slug returns 409.
+func TestCreateProviderDuplicateSlugReturns409(t *testing.T) {
+	repo := &stubRepo{createErr: ErrSlugConflict}
+	handler := newTestHandler(repo)
+
+	body := map[string]any{
+		"slug":         "openrouter",
+		"display_name": "OpenRouter",
+		"base_url":     "https://openrouter.ai/api/v1",
+		"api_key_env":  "OPENROUTER_API_KEY",
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/internal/providers", bodyJSON(t, body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(platformhttp.InternalTokenHeader, testToken)
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// Case 3: POST with empty slug returns 400.
+func TestCreateProviderEmptySlugReturns400(t *testing.T) {
+	repo := &stubRepo{}
+	handler := newTestHandler(repo)
+
+	body := map[string]any{
+		"slug":         "",
+		"display_name": "Missing Slug",
+		"base_url":     "https://example.com",
+		"api_key_env":  "KEY",
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/internal/providers", bodyJSON(t, body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(platformhttp.InternalTokenHeader, testToken)
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// Case 4: GET /internal/providers returns array including seeded rows.
+func TestListProvidersReturnsSeedRows(t *testing.T) {
+	openrouterID := uuid.New()
+	groqID := uuid.New()
+
+	repo := &stubRepo{
+		providers: []Provider{
+			{
+				ID:            openrouterID,
+				Slug:          "openrouter",
+				DisplayName:   "OpenRouter",
+				BaseURL:       "https://openrouter.ai/api/v1",
+				APIKeyEnv:     "OPENROUTER_API_KEY",
+				LiteLLMPrefix: "openrouter/",
+				Enabled:       true,
+			},
+			{
+				ID:            groqID,
+				Slug:          "groq",
+				DisplayName:   "Groq",
+				BaseURL:       "https://api.groq.com/openai/v1",
+				APIKeyEnv:     "GROQ_API_KEY",
+				LiteLLMPrefix: "groq/",
+				Enabled:       true,
+			},
+		},
+	}
+	handler := newTestHandler(repo)
+
+	req := httptest.NewRequest(http.MethodGet, "/internal/providers", nil)
+	req.Header.Set(platformhttp.InternalTokenHeader, testToken)
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	providers := decodeProviders(t, rr.Body)
+	if len(providers) != 2 {
+		t.Fatalf("expected 2 providers, got %d", len(providers))
+	}
+
+	slugs := map[string]bool{}
+	for _, p := range providers {
+		slugs[p.Slug] = true
+	}
+	if !slugs["openrouter"] || !slugs["groq"] {
+		t.Errorf("expected openrouter + groq slugs, got %v", slugs)
+	}
+}
+
+// Case 5: PUT updates display_name; returns 200 with updated record.
+func TestUpdateProviderDisplayNameReturns200(t *testing.T) {
+	id := uuid.New()
+	repo := &stubRepo{
+		providers: []Provider{
+			{
+				ID:            id,
+				Slug:          "together",
+				DisplayName:   "Together AI",
+				BaseURL:       "https://api.together.xyz/v1",
+				APIKeyEnv:     "TOGETHER_API_KEY",
+				LiteLLMPrefix: "together_ai/",
+				Enabled:       true,
+			},
+		},
+	}
+	handler := newTestHandler(repo)
+
+	updateBody := map[string]any{
+		"slug":           "together",
+		"display_name":   "Together AI (updated)",
+		"base_url":       "https://api.together.xyz/v1",
+		"api_key_env":    "TOGETHER_API_KEY",
+		"litellm_prefix": "together_ai/",
+		"enabled":        true,
+	}
+
+	req := httptest.NewRequest(http.MethodPut, "/internal/providers/"+id.String(), bodyJSON(t, updateBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(platformhttp.InternalTokenHeader, testToken)
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	p := decodeProvider(t, rr.Body)
+	if p.DisplayName != "Together AI (updated)" {
+		t.Errorf("expected updated display_name, got %q", p.DisplayName)
+	}
+}
+
+// Case 6: DELETE sets enabled=false; subsequent GET shows enabled: false.
+func TestDeleteProviderSetsEnabledFalse(t *testing.T) {
+	id := uuid.New()
+	repo := &stubRepo{
+		providers: []Provider{
+			{
+				ID:          id,
+				Slug:        "together",
+				DisplayName: "Together AI",
+				BaseURL:     "https://api.together.xyz/v1",
+				APIKeyEnv:   "TOGETHER_API_KEY",
+				Enabled:     true,
+			},
+		},
+	}
+	handler := newTestHandler(repo)
+
+	// Soft delete.
+	delReq := httptest.NewRequest(http.MethodDelete, "/internal/providers/"+id.String(), nil)
+	delReq.Header.Set(platformhttp.InternalTokenHeader, testToken)
+	delRR := httptest.NewRecorder()
+	handler.ServeHTTP(delRR, delReq)
+
+	if delRR.Code != http.StatusOK {
+		t.Fatalf("expected 200 on delete, got %d: %s", delRR.Code, delRR.Body.String())
+	}
+
+	// Subsequent GET shows enabled: false.
+	getReq := httptest.NewRequest(http.MethodGet, "/internal/providers/"+id.String(), nil)
+	getReq.Header.Set(platformhttp.InternalTokenHeader, testToken)
+	getRR := httptest.NewRecorder()
+	handler.ServeHTTP(getRR, getReq)
+
+	if getRR.Code != http.StatusOK {
+		t.Fatalf("expected 200 on get, got %d: %s", getRR.Code, getRR.Body.String())
+	}
+
+	p := decodeProvider(t, getRR.Body)
+	if p.Enabled {
+		t.Error("expected enabled=false after soft delete")
+	}
+}
+
+// Case 7: Request without shared-secret header returns 401.
+func TestMissingInternalTokenReturns401(t *testing.T) {
+	repo := &stubRepo{}
+	handler := newTestHandler(repo)
+
+	req := httptest.NewRequest(http.MethodGet, "/internal/providers", nil)
+	// Intentionally omit the X-Internal-Token header.
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d: %s", rr.Code, rr.Body.String())
+	}
+}

--- a/apps/control-plane/internal/providers/http_test.go
+++ b/apps/control-plane/internal/providers/http_test.go
@@ -367,3 +367,125 @@ func TestMissingInternalTokenReturns401(t *testing.T) {
 		t.Fatalf("expected 401, got %d: %s", rr.Code, rr.Body.String())
 	}
 }
+
+// =============================================================================
+// Charset validation tests (reviewer finding 1 — YAML injection guard).
+// =============================================================================
+
+func TestCreateProviderInvalidSlugCharsReturns400(t *testing.T) {
+	cases := []struct {
+		name string
+		slug string
+	}{
+		{"uppercase", "OpenRouter"},
+		{"leading hyphen", "-openrouter"},
+		{"newline", "open\nrouter"},
+		{"colon", "open:router"},
+		{"space", "open router"},
+		{"too long", "a123456789012345678901234567890123456789012345678901234567890abcde"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			repo := &stubRepo{}
+			handler := newTestHandler(repo)
+
+			body := map[string]any{
+				"slug":        tc.slug,
+				"display_name": "Test",
+				"base_url":    "https://example.com",
+				"api_key_env": "VALID_KEY",
+			}
+
+			req := httptest.NewRequest(http.MethodPost, "/internal/providers", bodyJSON(t, body))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set(platformhttp.InternalTokenHeader, testToken)
+			rr := httptest.NewRecorder()
+
+			handler.ServeHTTP(rr, req)
+
+			if rr.Code != http.StatusBadRequest {
+				t.Errorf("slug %q: expected 400, got %d: %s", tc.slug, rr.Code, rr.Body.String())
+			}
+		})
+	}
+}
+
+func TestCreateProviderInvalidAPIKeyEnvReturns400(t *testing.T) {
+	cases := []struct {
+		name      string
+		apiKeyEnv string
+	}{
+		{"lowercase", "openrouter_api_key"},
+		{"leading digit", "1OPENROUTER_KEY"},
+		{"shell injection", "KEY=$(whoami)"},
+		{"space", "OPEN ROUTER"},
+		{"newline", "KEY\nINJECT"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			repo := &stubRepo{}
+			handler := newTestHandler(repo)
+
+			body := map[string]any{
+				"slug":        "valid-slug",
+				"display_name": "Test",
+				"base_url":    "https://example.com",
+				"api_key_env": tc.apiKeyEnv,
+			}
+
+			req := httptest.NewRequest(http.MethodPost, "/internal/providers", bodyJSON(t, body))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set(platformhttp.InternalTokenHeader, testToken)
+			rr := httptest.NewRecorder()
+
+			handler.ServeHTTP(rr, req)
+
+			if rr.Code != http.StatusBadRequest {
+				t.Errorf("api_key_env %q: expected 400, got %d: %s", tc.apiKeyEnv, rr.Code, rr.Body.String())
+			}
+		})
+	}
+}
+
+func TestCreateProviderInvalidLiteLLMPrefixReturns400(t *testing.T) {
+	cases := []struct {
+		name   string
+		prefix string
+	}{
+		{"newline", "openrouter/\n"},
+		{"semicolon", "openrouter;rm"},
+		{"backtick", "openrouter`cmd`"},
+		{"dollar brace", "openrouter${KEY}"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			repo := &stubRepo{}
+			handler := newTestHandler(repo)
+
+			body := map[string]any{
+				"slug":           "valid-slug",
+				"display_name":   "Test",
+				"base_url":       "https://example.com",
+				"api_key_env":    "VALID_KEY",
+				"litellm_prefix": tc.prefix,
+			}
+
+			req := httptest.NewRequest(http.MethodPost, "/internal/providers", bodyJSON(t, body))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set(platformhttp.InternalTokenHeader, testToken)
+			rr := httptest.NewRecorder()
+
+			handler.ServeHTTP(rr, req)
+
+			if rr.Code != http.StatusBadRequest {
+				t.Errorf("litellm_prefix %q: expected 400, got %d: %s", tc.prefix, rr.Code, rr.Body.String())
+			}
+		})
+	}
+}

--- a/apps/control-plane/internal/providers/repository.go
+++ b/apps/control-plane/internal/providers/repository.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -169,13 +169,10 @@ func (r *pgxRepository) Delete(ctx context.Context, id uuid.UUID) error {
 	return nil
 }
 
-// isUniqueViolation returns true when err is a Postgres unique-constraint violation (SQLSTATE 23505).
+// isUniqueViolation returns true when err is a Postgres unique-constraint
+// violation (SQLSTATE 23505). Uses pgconn.PgError type assertion so the check
+// is exact and cannot false-positive on wrapped error messages.
 func isUniqueViolation(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := err.Error()
-	return strings.Contains(msg, "23505") ||
-		strings.Contains(msg, "unique constraint") ||
-		strings.Contains(msg, "duplicate key")
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "23505"
 }

--- a/apps/control-plane/internal/providers/repository.go
+++ b/apps/control-plane/internal/providers/repository.go
@@ -1,0 +1,181 @@
+package providers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// ErrNotFound is returned when a provider row does not exist.
+var ErrNotFound = errors.New("provider not found")
+
+// ErrSlugConflict is returned when a create or update violates the slug unique constraint.
+var ErrSlugConflict = errors.New("provider slug already exists")
+
+// Provider represents a row in public.custom_providers.
+type Provider struct {
+	ID            uuid.UUID `json:"id"             db:"id"`
+	Slug          string    `json:"slug"           db:"slug"`
+	DisplayName   string    `json:"display_name"   db:"display_name"`
+	BaseURL       string    `json:"base_url"       db:"base_url"`
+	APIKeyEnv     string    `json:"api_key_env"    db:"api_key_env"`
+	LiteLLMPrefix string    `json:"litellm_prefix" db:"litellm_prefix"`
+	Enabled       bool      `json:"enabled"        db:"enabled"`
+	CreatedAt     time.Time `json:"created_at"     db:"created_at"`
+	UpdatedAt     time.Time `json:"updated_at"     db:"updated_at"`
+}
+
+// Repository defines the data-access contract for custom_providers.
+type Repository interface {
+	Create(ctx context.Context, p Provider) (Provider, error)
+	List(ctx context.Context) ([]Provider, error)
+	Get(ctx context.Context, id uuid.UUID) (Provider, error)
+	Update(ctx context.Context, id uuid.UUID, p Provider) (Provider, error)
+	Delete(ctx context.Context, id uuid.UUID) error // soft: sets enabled=false
+}
+
+type pgxRepository struct {
+	pool *pgxpool.Pool
+}
+
+// NewPgxRepository returns a Repository backed by the given connection pool.
+func NewPgxRepository(pool *pgxpool.Pool) Repository {
+	return &pgxRepository{pool: pool}
+}
+
+func (r *pgxRepository) Create(ctx context.Context, p Provider) (Provider, error) {
+	p.ID = uuid.New()
+	now := time.Now().UTC()
+	p.CreatedAt = now
+	p.UpdatedAt = now
+
+	row := r.pool.QueryRow(ctx, `
+		INSERT INTO public.custom_providers
+			(id, slug, display_name, base_url, api_key_env, litellm_prefix, enabled, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		RETURNING id, slug, display_name, base_url, api_key_env, litellm_prefix, enabled, created_at, updated_at`,
+		p.ID, p.Slug, p.DisplayName, p.BaseURL, p.APIKeyEnv, p.LiteLLMPrefix, p.Enabled, p.CreatedAt, p.UpdatedAt,
+	)
+
+	var out Provider
+	if err := row.Scan(
+		&out.ID, &out.Slug, &out.DisplayName, &out.BaseURL,
+		&out.APIKeyEnv, &out.LiteLLMPrefix, &out.Enabled,
+		&out.CreatedAt, &out.UpdatedAt,
+	); err != nil {
+		if isUniqueViolation(err) {
+			return Provider{}, ErrSlugConflict
+		}
+		return Provider{}, fmt.Errorf("providers: create: %w", err)
+	}
+	return out, nil
+}
+
+func (r *pgxRepository) List(ctx context.Context) ([]Provider, error) {
+	rows, err := r.pool.Query(ctx, `
+		SELECT id, slug, display_name, base_url, api_key_env, litellm_prefix, enabled, created_at, updated_at
+		FROM public.custom_providers
+		ORDER BY created_at ASC`)
+	if err != nil {
+		return nil, fmt.Errorf("providers: list: %w", err)
+	}
+	defer rows.Close()
+
+	var out []Provider
+	for rows.Next() {
+		var p Provider
+		if err := rows.Scan(
+			&p.ID, &p.Slug, &p.DisplayName, &p.BaseURL,
+			&p.APIKeyEnv, &p.LiteLLMPrefix, &p.Enabled,
+			&p.CreatedAt, &p.UpdatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("providers: list scan: %w", err)
+		}
+		out = append(out, p)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("providers: list rows: %w", err)
+	}
+	if out == nil {
+		out = []Provider{}
+	}
+	return out, nil
+}
+
+func (r *pgxRepository) Get(ctx context.Context, id uuid.UUID) (Provider, error) {
+	row := r.pool.QueryRow(ctx, `
+		SELECT id, slug, display_name, base_url, api_key_env, litellm_prefix, enabled, created_at, updated_at
+		FROM public.custom_providers
+		WHERE id = $1`, id)
+
+	var p Provider
+	if err := row.Scan(
+		&p.ID, &p.Slug, &p.DisplayName, &p.BaseURL,
+		&p.APIKeyEnv, &p.LiteLLMPrefix, &p.Enabled,
+		&p.CreatedAt, &p.UpdatedAt,
+	); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return Provider{}, ErrNotFound
+		}
+		return Provider{}, fmt.Errorf("providers: get: %w", err)
+	}
+	return p, nil
+}
+
+func (r *pgxRepository) Update(ctx context.Context, id uuid.UUID, p Provider) (Provider, error) {
+	now := time.Now().UTC()
+	row := r.pool.QueryRow(ctx, `
+		UPDATE public.custom_providers
+		SET slug=$2, display_name=$3, base_url=$4, api_key_env=$5, litellm_prefix=$6, enabled=$7, updated_at=$8
+		WHERE id=$1
+		RETURNING id, slug, display_name, base_url, api_key_env, litellm_prefix, enabled, created_at, updated_at`,
+		id, p.Slug, p.DisplayName, p.BaseURL, p.APIKeyEnv, p.LiteLLMPrefix, p.Enabled, now,
+	)
+
+	var out Provider
+	if err := row.Scan(
+		&out.ID, &out.Slug, &out.DisplayName, &out.BaseURL,
+		&out.APIKeyEnv, &out.LiteLLMPrefix, &out.Enabled,
+		&out.CreatedAt, &out.UpdatedAt,
+	); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return Provider{}, ErrNotFound
+		}
+		if isUniqueViolation(err) {
+			return Provider{}, ErrSlugConflict
+		}
+		return Provider{}, fmt.Errorf("providers: update: %w", err)
+	}
+	return out, nil
+}
+
+func (r *pgxRepository) Delete(ctx context.Context, id uuid.UUID) error {
+	tag, err := r.pool.Exec(ctx, `
+		UPDATE public.custom_providers SET enabled=false, updated_at=$2 WHERE id=$1`,
+		id, time.Now().UTC(),
+	)
+	if err != nil {
+		return fmt.Errorf("providers: delete: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// isUniqueViolation returns true when err is a Postgres unique-constraint violation (SQLSTATE 23505).
+func isUniqueViolation(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "23505") ||
+		strings.Contains(msg, "unique constraint") ||
+		strings.Contains(msg, "duplicate key")
+}

--- a/apps/control-plane/internal/providers/service.go
+++ b/apps/control-plane/internal/providers/service.go
@@ -5,9 +5,24 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"regexp"
 
 	"github.com/google/uuid"
 )
+
+// slugRe allows lowercase alphanumeric, hyphens, and underscores; must start
+// with a letter or digit; max 64 chars. Values flow into LiteLLM YAML config
+// (plan 20-03), so the charset is intentionally tight.
+var slugRe = regexp.MustCompile(`^[a-z0-9][a-z0-9_-]{0,63}$`)
+
+// apiKeyEnvRe matches conventional POSIX env-var names: uppercase letters,
+// digits, underscores; must start with a letter or underscore; max 128 chars.
+var apiKeyEnvRe = regexp.MustCompile(`^[A-Z_][A-Z0-9_]{0,127}$`)
+
+// litellmPrefixRe allows the characters that appear in valid LiteLLM model
+// prefixes (e.g. "openrouter/", "together_ai/", "groq/"): alphanumeric,
+// hyphens, underscores, forward-slashes, and dots; max 128 chars.
+var litellmPrefixRe = regexp.MustCompile(`^[a-zA-Z0-9_./-]{0,128}$`)
 
 // Service wraps the Repository with input validation.
 type Service struct {
@@ -61,12 +76,23 @@ func (e *ErrValidation) Error() string {
 }
 
 // validate checks the required fields on a Provider before persistence.
+// Charset rules are strict because slug, api_key_env, and litellm_prefix
+// flow verbatim into generated LiteLLM YAML config (plan 20-03).
 func validate(p Provider) error {
 	if p.Slug == "" {
 		return &ErrValidation{Field: "slug", Message: "must not be empty"}
 	}
+	if !slugRe.MatchString(p.Slug) {
+		return &ErrValidation{Field: "slug", Message: "must match ^[a-z0-9][a-z0-9_-]{0,63}$ (lowercase, digits, hyphens, underscores; max 64 chars)"}
+	}
 	if p.APIKeyEnv == "" {
 		return &ErrValidation{Field: "api_key_env", Message: "must not be empty"}
+	}
+	if !apiKeyEnvRe.MatchString(p.APIKeyEnv) {
+		return &ErrValidation{Field: "api_key_env", Message: "must be a valid env var name: uppercase letters, digits, underscores; max 128 chars"}
+	}
+	if p.LiteLLMPrefix != "" && !litellmPrefixRe.MatchString(p.LiteLLMPrefix) {
+		return &ErrValidation{Field: "litellm_prefix", Message: "contains disallowed characters; allowed: alphanumeric, _, -, /, ."}
 	}
 	if p.BaseURL != "" {
 		u, err := url.Parse(p.BaseURL)

--- a/apps/control-plane/internal/providers/service.go
+++ b/apps/control-plane/internal/providers/service.go
@@ -1,0 +1,88 @@
+package providers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+
+	"github.com/google/uuid"
+)
+
+// Service wraps the Repository with input validation.
+type Service struct {
+	repo Repository
+}
+
+// NewService returns a Service backed by the given repository.
+func NewService(repo Repository) *Service {
+	return &Service{repo: repo}
+}
+
+// Create validates input then delegates to the repository.
+func (s *Service) Create(ctx context.Context, p Provider) (Provider, error) {
+	if err := validate(p); err != nil {
+		return Provider{}, err
+	}
+	return s.repo.Create(ctx, p)
+}
+
+// List returns all providers.
+func (s *Service) List(ctx context.Context) ([]Provider, error) {
+	return s.repo.List(ctx)
+}
+
+// Get returns a single provider by ID.
+func (s *Service) Get(ctx context.Context, id uuid.UUID) (Provider, error) {
+	return s.repo.Get(ctx, id)
+}
+
+// Update validates input then delegates to the repository.
+func (s *Service) Update(ctx context.Context, id uuid.UUID, p Provider) (Provider, error) {
+	if err := validate(p); err != nil {
+		return Provider{}, err
+	}
+	return s.repo.Update(ctx, id, p)
+}
+
+// Delete soft-deletes a provider (sets enabled=false).
+func (s *Service) Delete(ctx context.Context, id uuid.UUID) error {
+	return s.repo.Delete(ctx, id)
+}
+
+// ErrValidation wraps a field-level validation message.
+type ErrValidation struct {
+	Field   string
+	Message string
+}
+
+func (e *ErrValidation) Error() string {
+	return fmt.Sprintf("validation: %s: %s", e.Field, e.Message)
+}
+
+// validate checks the required fields on a Provider before persistence.
+func validate(p Provider) error {
+	if p.Slug == "" {
+		return &ErrValidation{Field: "slug", Message: "must not be empty"}
+	}
+	if p.APIKeyEnv == "" {
+		return &ErrValidation{Field: "api_key_env", Message: "must not be empty"}
+	}
+	if p.BaseURL != "" {
+		u, err := url.Parse(p.BaseURL)
+		if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
+			return &ErrValidation{Field: "base_url", Message: "must be a valid http or https URL"}
+		}
+	}
+	return nil
+}
+
+// IsNotFound reports whether the error is a not-found sentinel.
+func IsNotFound(err error) bool {
+	return errors.Is(err, ErrNotFound)
+}
+
+// IsSlugConflict reports whether the error is a slug-conflict sentinel.
+func IsSlugConflict(err error) bool {
+	return errors.Is(err, ErrSlugConflict)
+}


### PR DESCRIPTION
## Summary

- Adds `apps/control-plane/internal/providers` package with `Repository`, `Service`, and `Handler` for full CRUD over `custom_providers` table (phase 20 schema, merged in #197)
- Mounts `/internal/providers` routes behind `RequireInternalToken` (shared-secret) and `/api/v1/admin/providers` behind `RequirePlatformAdmin` (JWT path)
- Resolves import cycle by exposing a narrow `ProvidersRouter` interface in `platform/http` router config instead of importing the concrete package

## Test plan

- [ ] All 7 unit test cases pass with stub repository (no real DB): POST valid returns 201, POST duplicate slug returns 409, POST empty slug returns 400, GET list returns seeded rows, PUT updates display_name returns 200, DELETE sets enabled=false and subsequent GET confirms, missing token returns 401
- [ ] `go build ./apps/control-plane/...` clean
- [ ] `go test ./apps/control-plane/internal/providers/... -count=1 -v` all PASS
- [ ] Integration tests against real DB covered in phase 20 plan 20-06

🤖 Generated with [Claude Code](https://claude.com/claude-code)