### PR TITLE
feat: phase 20 LiteLLM config generation and controlled restart

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -222,3 +222,20 @@ GRAFANA_ADMIN_PASSWORD=
 # After setting this value, uncomment the ollama model entries in
 # deploy/litellm/config.yaml and restart LiteLLM.
 OLLAMA_BASE_URL=
+
+# === LiteLLM config generation (Phase 20 Plan 03) ===
+# LITELLM_CONTAINER_NAME: Docker container name to restart after config write.
+#   Default: litellm (matches the service name in docker-compose.yml).
+LITELLM_CONTAINER_NAME=litellm
+# LITELLM_CONFIG_PATH: Path inside the control-plane container where the
+#   generated config.yaml is written. Must match the litellm-config volume
+#   mount on both control-plane and litellm services.
+LITELLM_CONFIG_PATH=/etc/litellm/config.yaml
+# LITELLM_MASTER_KEY: LiteLLM proxy admin key. Required before deploying.
+#   Must match the value passed to the litellm service. Already set above;
+#   repeated here for documentation of the config-generation subsystem.
+# LITELLM_CONFIG_MODE: Uncomment to use LiteLLM DB-backed live-reload
+#   (POST /model/new|update|delete) instead of file-based restart.
+#   Requires LiteLLM configured with DATABASE_URL and
+#   general_settings.store_model_in_db: true. See restart.go TODO comment.
+# LITELLM_CONFIG_MODE=db

--- a/apps/control-plane/cmd/server/main.go
+++ b/apps/control-plane/cmd/server/main.go
@@ -261,14 +261,22 @@ func main() {
 		// LITELLM_CONFIG_PATH defaults to /etc/litellm/config.yaml (shared volume mount).
 		// LITELLM_MASTER_KEY is the LiteLLM proxy admin key.
 		// LITELLM_CONTAINER_NAME is read inside NewDefaultDockerRestarter (default: litellm).
+		litellmConfigMode := strings.TrimSpace(os.Getenv("LITELLM_CONFIG_MODE"))
 		litellmConfigPath := os.Getenv("LITELLM_CONFIG_PATH")
 		if litellmConfigPath == "" {
 			litellmConfigPath = "/etc/litellm/config.yaml"
 		}
-		litellmMasterKey := os.Getenv("LITELLM_MASTER_KEY")
-		litellmRestarter := litellmconfig.NewDefaultDockerRestarter("")
-		litellmSyncSvc := litellmconfig.NewSyncService(pool, litellmConfigPath, litellmMasterKey, litellmRestarter)
-		litellmSyncHandler = litellmconfig.NewSyncHandler(litellmSyncSvc)
+		litellmMasterKey := resolveLiteLLMMasterKey()
+		switch litellmConfigMode {
+		case "", "file":
+			litellmRestarter := litellmconfig.NewDefaultDockerRestarter("")
+			litellmSyncSvc := litellmconfig.NewSyncService(pool, litellmConfigPath, litellmMasterKey, litellmRestarter)
+			litellmSyncHandler = litellmconfig.NewSyncHandler(litellmSyncSvc)
+		case "db":
+			log.Fatalf("LITELLM_CONFIG_MODE=db is documented but not yet implemented in control-plane startup")
+		default:
+			log.Fatalf("invalid LITELLM_CONFIG_MODE %q: supported values are file (default) and db (not yet implemented)", litellmConfigMode)
+		}
 		log.Println("litellm sync handler ready (Phase 20 Plan 03)")
 
 		routingRepo := routing.NewPgxRepository(pool)

--- a/apps/control-plane/cmd/server/main.go
+++ b/apps/control-plane/cmd/server/main.go
@@ -45,6 +45,7 @@ import (
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/platform/metrics"
 	platformredis "github.com/sakibsadmanshajib/hive/apps/control-plane/internal/platform/redis"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/profiles"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/litellmconfig"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/providers"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/routing"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/signup"
@@ -200,6 +201,7 @@ func main() {
 	var authzMW authz.Middleware // Phase 18: set after roleSvc+accountsSvc are ready
 	var catalogHandler *catalog.Handler
 	var providersHandler *providers.Handler
+	var litellmSyncHandler http.Handler
 	var ledgerHandler *ledger.Handler
 	var profilesHandler *profiles.Handler
 	var routingHandler *routing.Handler
@@ -254,6 +256,20 @@ func main() {
 		providersSvc := providers.NewService(providersRepo)
 		providersHandler = providers.NewHandler(providersSvc)
 		log.Println("providers module ready (Phase 20 Plan 02)")
+
+		// Phase 20 Plan 03 — LiteLLM config sync handler.
+		// LITELLM_CONFIG_PATH defaults to /etc/litellm/config.yaml (shared volume mount).
+		// LITELLM_MASTER_KEY is the LiteLLM proxy admin key.
+		// LITELLM_CONTAINER_NAME is read inside NewDefaultDockerRestarter (default: litellm).
+		litellmConfigPath := os.Getenv("LITELLM_CONFIG_PATH")
+		if litellmConfigPath == "" {
+			litellmConfigPath = "/etc/litellm/config.yaml"
+		}
+		litellmMasterKey := os.Getenv("LITELLM_MASTER_KEY")
+		litellmRestarter := litellmconfig.NewDefaultDockerRestarter("")
+		litellmSyncSvc := litellmconfig.NewSyncService(pool, litellmConfigPath, litellmMasterKey, litellmRestarter)
+		litellmSyncHandler = litellmconfig.NewSyncHandler(litellmSyncSvc)
+		log.Println("litellm sync handler ready (Phase 20 Plan 03)")
 
 		routingRepo := routing.NewPgxRepository(pool)
 		routingSvc = routing.NewService(routingRepo)
@@ -652,6 +668,7 @@ func main() {
 		PaymentsHandler:    paymentsHandler,
 		ProfilesHandler:    profilesHandler,
 		ProvidersRouter:    providersHandler,
+		LiteLLMSyncHandler: litellmSyncHandler,
 		RoutingHandler:     routingHandler,
 		UsageHandler:       usageHandler,
 		MetricsRegistry:    metricsRegistry,

--- a/apps/control-plane/internal/litellmconfig/generator.go
+++ b/apps/control-plane/internal/litellmconfig/generator.go
@@ -6,6 +6,7 @@ package litellmconfig
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -104,11 +105,16 @@ func WriteAndRestart(ctx context.Context, configPath string, cfg Config, restart
 
 	if existingRaw, readErr := os.ReadFile(existingPath); readErr == nil {
 		var existingMap map[string]interface{}
-		if parseErr := yaml.Unmarshal(existingRaw, &existingMap); parseErr == nil && existingMap != nil {
+		if parseErr := yaml.Unmarshal(existingRaw, &existingMap); parseErr != nil {
+			return fmt.Errorf("litellmconfig: parse existing config: %w", parseErr)
+		}
+		if existingMap != nil {
 			merged = mergeConfig(existingMap, newMap)
 		}
+	} else if !errors.Is(readErr, os.ErrNotExist) {
+		return fmt.Errorf("litellmconfig: read existing config: %w", readErr)
 	}
-	// If the file doesn't exist or can't be parsed, merged stays as newMap (first-run).
+	// If the file does not exist, merged stays as newMap (first-run).
 
 	finalData, err := yaml.Marshal(merged)
 	if err != nil {

--- a/apps/control-plane/internal/litellmconfig/generator.go
+++ b/apps/control-plane/internal/litellmconfig/generator.go
@@ -162,8 +162,41 @@ func mergeConfig(existing, generated map[string]interface{}) map[string]interfac
 		result[k] = v
 	}
 
-	// Replace model_list entirely.
-	result["model_list"] = generated["model_list"]
+	// Replace model_list with newly generated entries, but preserve per-model
+	// model_info from the existing config (e.g. mode: embedding set by the
+	// seed config on embedding routes).
+	newList, _ := generated["model_list"].([]interface{})
+	if newList != nil {
+		// Build a lookup of existing model_info keyed by model_name.
+		existingInfo := map[string]interface{}{}
+		if oldList, ok := existing["model_list"].([]interface{}); ok {
+			for _, item := range oldList {
+				if entry, ok := item.(map[string]interface{}); ok {
+					if name, ok := entry["model_name"].(string); ok {
+						if info, exists := entry["model_info"]; exists {
+							existingInfo[name] = info
+						}
+					}
+				}
+			}
+		}
+		// Restore model_info on each new entry where it existed before.
+		for i, item := range newList {
+			if entry, ok := item.(map[string]interface{}); ok {
+				if name, ok := entry["model_name"].(string); ok {
+					if info, exists := existingInfo[name]; exists {
+						updated := make(map[string]interface{}, len(entry)+1)
+						for k, v := range entry {
+							updated[k] = v
+						}
+						updated["model_info"] = info
+						newList[i] = updated
+					}
+				}
+			}
+		}
+	}
+	result["model_list"] = newList
 
 	// Merge general_settings: start from existing, overlay new master_key.
 	if newGS, ok := generated["general_settings"].(map[string]interface{}); ok {

--- a/apps/control-plane/internal/litellmconfig/generator.go
+++ b/apps/control-plane/internal/litellmconfig/generator.go
@@ -1,0 +1,182 @@
+// Package litellmconfig generates LiteLLM proxy configuration YAML from the
+// current state of provider_routes and custom_providers tables, and triggers
+// a controlled LiteLLM container restart so new providers become live without
+// manual intervention.
+package litellmconfig
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ModelEntry represents a single LiteLLM model_list entry.
+type ModelEntry struct {
+	ModelName   string
+	LiteLLMName string // e.g. "openrouter/openai/gpt-4o"
+	APIBase     string
+	APIKeyEnv   string
+}
+
+// GeneralSettings holds the LiteLLM general_settings block.
+type GeneralSettings struct {
+	MasterKey string
+}
+
+// Config is the input to Generate and WriteAndRestart.
+type Config struct {
+	Models          []ModelEntry
+	GeneralSettings GeneralSettings
+	// ExistingConfigPath is the path of the on-disk config to merge from.
+	// WriteAndRestart reads this file to preserve non-generated keys.
+	// If the file does not exist, the config is written from scratch.
+	ExistingConfigPath string
+}
+
+// Restarter signals the LiteLLM process to reload its config.
+type Restarter interface {
+	Restart(ctx context.Context) error
+}
+
+// Generate builds a LiteLLM config.yaml byte slice from the provided model
+// entries. It does NOT read from DB itself; the caller supplies the entries.
+func Generate(cfg Config) ([]byte, error) {
+	// Build model_list as a sequence of maps to preserve key order.
+	modelList := make([]map[string]interface{}, 0, len(cfg.Models))
+	for _, m := range cfg.Models {
+		entry := map[string]interface{}{
+			"model_name": m.ModelName,
+			"litellm_params": map[string]interface{}{
+				"model":    m.LiteLLMName,
+				"api_base": m.APIBase,
+				"api_key":  "os.environ/" + m.APIKeyEnv,
+			},
+		}
+		modelList = append(modelList, entry)
+	}
+
+	out := map[string]interface{}{
+		"model_list": modelList,
+		"general_settings": map[string]interface{}{
+			"master_key": cfg.GeneralSettings.MasterKey,
+		},
+	}
+
+	data, err := yaml.Marshal(out)
+	if err != nil {
+		return nil, fmt.Errorf("litellmconfig: marshal: %w", err)
+	}
+	return data, nil
+}
+
+// WriteAndRestart writes the generated config to configPath using an atomic
+// merge strategy, then calls restarter.Restart.
+//
+// Merge strategy (critical — preserves operator-managed keys):
+//  1. Parse the existing YAML file (if present) into map[string]interface{}.
+//  2. Replace only the model_list key with the newly generated entries.
+//  3. Merge general_settings: update master_key, preserve all other keys.
+//  4. Marshal the merged map to YAML and write atomically via temp file + rename.
+//
+// If the existing file does not exist, the config is written from scratch.
+func WriteAndRestart(ctx context.Context, configPath string, cfg Config, restarter Restarter) error {
+	// Generate the new content.
+	newData, err := Generate(cfg)
+	if err != nil {
+		return fmt.Errorf("litellmconfig: generate: %w", err)
+	}
+
+	// Parse the new YAML into a map for merging.
+	var newMap map[string]interface{}
+	if err := yaml.Unmarshal(newData, &newMap); err != nil {
+		return fmt.Errorf("litellmconfig: unmarshal generated: %w", err)
+	}
+
+	// Attempt to read and parse the existing config for merge.
+	merged := newMap
+	existingPath := cfg.ExistingConfigPath
+	if existingPath == "" {
+		existingPath = configPath
+	}
+
+	if existingRaw, readErr := os.ReadFile(existingPath); readErr == nil {
+		var existingMap map[string]interface{}
+		if parseErr := yaml.Unmarshal(existingRaw, &existingMap); parseErr == nil && existingMap != nil {
+			merged = mergeConfig(existingMap, newMap)
+		}
+	}
+	// If the file doesn't exist or can't be parsed, merged stays as newMap (first-run).
+
+	finalData, err := yaml.Marshal(merged)
+	if err != nil {
+		return fmt.Errorf("litellmconfig: marshal merged: %w", err)
+	}
+
+	// Ensure the target directory exists.
+	dir := filepath.Dir(configPath)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("litellmconfig: mkdir: %w", err)
+	}
+
+	// Atomic write: temp file in same directory, then rename.
+	tmp, err := os.CreateTemp(dir, "litellm-config-*.yaml.tmp")
+	if err != nil {
+		return fmt.Errorf("litellmconfig: create temp: %w", err)
+	}
+	tmpName := tmp.Name()
+
+	_, writeErr := tmp.Write(finalData)
+	closeErr := tmp.Close()
+	if writeErr != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("litellmconfig: write temp: %w", writeErr)
+	}
+	if closeErr != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("litellmconfig: close temp: %w", closeErr)
+	}
+
+	if err := os.Rename(tmpName, configPath); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("litellmconfig: rename: %w", err)
+	}
+
+	// Signal restart after successful write.
+	if err := restarter.Restart(ctx); err != nil {
+		return fmt.Errorf("litellmconfig: restart: %w", err)
+	}
+	return nil
+}
+
+// mergeConfig merges the newly generated config map into the existing config map.
+// Rules:
+//   - model_list is replaced entirely with the new value.
+//   - general_settings is merged: master_key updated, all other keys preserved.
+//   - All other top-level keys from existing are preserved unchanged.
+func mergeConfig(existing, generated map[string]interface{}) map[string]interface{} {
+	result := make(map[string]interface{}, len(existing))
+	for k, v := range existing {
+		result[k] = v
+	}
+
+	// Replace model_list entirely.
+	result["model_list"] = generated["model_list"]
+
+	// Merge general_settings: start from existing, overlay new master_key.
+	if newGS, ok := generated["general_settings"].(map[string]interface{}); ok {
+		existingGS, _ := existing["general_settings"].(map[string]interface{})
+		mergedGS := make(map[string]interface{})
+		for k, v := range existingGS {
+			mergedGS[k] = v
+		}
+		if mk, ok := newGS["master_key"]; ok {
+			mergedGS["master_key"] = mk
+		}
+		result["general_settings"] = mergedGS
+	}
+
+	return result
+}

--- a/apps/control-plane/internal/litellmconfig/generator_test.go
+++ b/apps/control-plane/internal/litellmconfig/generator_test.go
@@ -1,0 +1,252 @@
+package litellmconfig_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/litellmconfig"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// --- helpers ---
+
+func twoModels() []litellmconfig.ModelEntry {
+	return []litellmconfig.ModelEntry{
+		{
+			ModelName:   "gpt-4o",
+			LiteLLMName: "openrouter/openai/gpt-4o",
+			APIBase:     "https://openrouter.ai/api/v1",
+			APIKeyEnv:   "OPENROUTER_API_KEY",
+		},
+		{
+			ModelName:   "llama-3",
+			LiteLLMName: "groq/llama-3-70b-8192",
+			APIBase:     "https://api.groq.com/openai/v1",
+			APIKeyEnv:   "GROQ_API_KEY",
+		},
+	}
+}
+
+// --- Generate tests ---
+
+func TestGenerateTwoModelsProducesCorrectModelList(t *testing.T) {
+	cfg := litellmconfig.Config{
+		Models: twoModels(),
+		GeneralSettings: litellmconfig.GeneralSettings{
+			MasterKey: "test-master-key",
+		},
+	}
+
+	out, err := litellmconfig.Generate(cfg)
+	require.NoError(t, err)
+	require.NotEmpty(t, out)
+
+	// Parse back to verify structure.
+	var parsed map[string]interface{}
+	require.NoError(t, yaml.Unmarshal(out, &parsed))
+
+	modelList, ok := parsed["model_list"].([]interface{})
+	require.True(t, ok, "model_list must be a sequence")
+	assert.Len(t, modelList, 2)
+
+	// Verify first entry.
+	first := modelList[0].(map[string]interface{})
+	assert.Equal(t, "gpt-4o", first["model_name"])
+	params := first["litellm_params"].(map[string]interface{})
+	assert.Equal(t, "openrouter/openai/gpt-4o", params["model"])
+	assert.Equal(t, "https://openrouter.ai/api/v1", params["api_base"])
+	assert.Equal(t, "os.environ/OPENROUTER_API_KEY", params["api_key"])
+}
+
+func TestGenerateEmptyModelsProducesEmptyModelList(t *testing.T) {
+	cfg := litellmconfig.Config{
+		Models: []litellmconfig.ModelEntry{},
+		GeneralSettings: litellmconfig.GeneralSettings{
+			MasterKey: "k",
+		},
+	}
+
+	out, err := litellmconfig.Generate(cfg)
+	require.NoError(t, err)
+
+	var parsed map[string]interface{}
+	require.NoError(t, yaml.Unmarshal(out, &parsed))
+
+	// model_list must be present and empty (not nil/absent).
+	raw, exists := parsed["model_list"]
+	require.True(t, exists, "model_list key must be present even when empty")
+	// YAML unmarshals an empty sequence as nil or []interface{} — both acceptable.
+	if raw != nil {
+		list, ok := raw.([]interface{})
+		require.True(t, ok)
+		assert.Empty(t, list)
+	}
+}
+
+func TestGenerateOutputParsesWithoutError(t *testing.T) {
+	cfg := litellmconfig.Config{
+		Models: twoModels(),
+		GeneralSettings: litellmconfig.GeneralSettings{
+			MasterKey: "round-trip-key",
+		},
+	}
+
+	out, err := litellmconfig.Generate(cfg)
+	require.NoError(t, err)
+
+	var parsed map[string]interface{}
+	err = yaml.Unmarshal(out, &parsed)
+	assert.NoError(t, err, "generated YAML must round-trip without error")
+}
+
+func TestGenerateSetsGeneralSettingsMasterKey(t *testing.T) {
+	cfg := litellmconfig.Config{
+		Models: twoModels(),
+		GeneralSettings: litellmconfig.GeneralSettings{
+			MasterKey: "my-secret-master-key",
+		},
+	}
+
+	out, err := litellmconfig.Generate(cfg)
+	require.NoError(t, err)
+
+	var parsed map[string]interface{}
+	require.NoError(t, yaml.Unmarshal(out, &parsed))
+
+	gs, ok := parsed["general_settings"].(map[string]interface{})
+	require.True(t, ok, "general_settings must be a mapping")
+	assert.Equal(t, "my-secret-master-key", gs["master_key"])
+}
+
+// --- WriteAndRestart tests ---
+
+// mockRestarter records calls to Restart and can be configured to return an error.
+type mockRestarter struct {
+	calls    int
+	returnErr error
+}
+
+func (m *mockRestarter) Restart(_ context.Context) error {
+	m.calls++
+	return m.returnErr
+}
+
+func TestWriteAndRestartCallsRestarterOnSuccess(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+
+	cfg := litellmconfig.Config{
+		Models: twoModels(),
+		GeneralSettings: litellmconfig.GeneralSettings{
+			MasterKey: "test-key",
+		},
+		ExistingConfigPath: configPath,
+	}
+
+	r := &mockRestarter{}
+	err := litellmconfig.WriteAndRestart(context.Background(), configPath, cfg, r)
+	require.NoError(t, err)
+	assert.Equal(t, 1, r.calls, "Restart must be called exactly once on success")
+
+	// Verify file was written.
+	data, readErr := os.ReadFile(configPath)
+	require.NoError(t, readErr)
+	assert.True(t, strings.Contains(string(data), "model_list"), "written file must contain model_list")
+}
+
+func TestWriteAndRestartPreservesExistingKeys(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+
+	// Write a pre-existing config with litellm_settings.
+	existing := `
+litellm_settings:
+  drop_params: true
+  num_retries: 3
+general_settings:
+  master_key: old-key
+  some_other_key: preserve-me
+model_list:
+  - model_name: old-model
+    litellm_params:
+      model: openrouter/old
+`
+	require.NoError(t, os.WriteFile(configPath, []byte(existing), 0o600))
+
+	cfg := litellmconfig.Config{
+		Models: twoModels(),
+		GeneralSettings: litellmconfig.GeneralSettings{
+			MasterKey: "new-key",
+		},
+		ExistingConfigPath: configPath,
+	}
+
+	r := &mockRestarter{}
+	err := litellmconfig.WriteAndRestart(context.Background(), configPath, cfg, r)
+	require.NoError(t, err)
+
+	data, readErr := os.ReadFile(configPath)
+	require.NoError(t, readErr)
+	content := string(data)
+
+	// litellm_settings must be preserved.
+	assert.Contains(t, content, "litellm_settings")
+	assert.Contains(t, content, "drop_params")
+	// general_settings.some_other_key must survive.
+	assert.Contains(t, content, "preserve-me")
+	// master_key must be updated.
+	assert.Contains(t, content, "new-key")
+	// old-model must be replaced by new models.
+	assert.NotContains(t, content, "old-model")
+	assert.Contains(t, content, "gpt-4o")
+}
+
+func TestWriteAndRestartSkipsRestarterOnGenerateFailure(t *testing.T) {
+	// To trigger a Generate failure we rely on the fact that nil Models slice
+	// with a bad config path combination never happens in normal flow.
+	// Instead we verify behavior when the restarter would return an error:
+	// the file write happens, but we confirm the restarter IS called (the write
+	// succeeded) and we propagate the error.
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+
+	cfg := litellmconfig.Config{
+		Models: twoModels(),
+		GeneralSettings: litellmconfig.GeneralSettings{
+			MasterKey: "k",
+		},
+		ExistingConfigPath: configPath,
+	}
+
+	restartErr := errors.New("docker unavailable")
+	r := &mockRestarter{returnErr: restartErr}
+	err := litellmconfig.WriteAndRestart(context.Background(), configPath, cfg, r)
+	assert.ErrorIs(t, err, restartErr, "restart error must be propagated")
+	assert.Equal(t, 1, r.calls, "Restart must still be called once (write succeeded)")
+}
+
+func TestWriteAndRestartFirstRunNoExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	// Point to a path that does NOT yet exist.
+	configPath := filepath.Join(dir, "nonexistent", "config.yaml")
+
+	cfg := litellmconfig.Config{
+		Models: twoModels(),
+		GeneralSettings: litellmconfig.GeneralSettings{
+			MasterKey: "first-run",
+		},
+		ExistingConfigPath: configPath,
+	}
+
+	r := &mockRestarter{}
+	// Should write from scratch without error.
+	err := litellmconfig.WriteAndRestart(context.Background(), configPath, cfg, r)
+	require.NoError(t, err)
+	assert.Equal(t, 1, r.calls)
+}

--- a/apps/control-plane/internal/litellmconfig/generator_test.go
+++ b/apps/control-plane/internal/litellmconfig/generator_test.go
@@ -250,3 +250,50 @@ func TestWriteAndRestartFirstRunNoExistingFile(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, r.calls)
 }
+
+func TestWriteAndRestartPreservesModelInfo(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+
+	// Write a pre-existing config that has model_info on an embedding route.
+	existing := `
+model_list:
+  - model_name: route-embedding
+    litellm_params:
+      model: openai/text-embedding-3-small
+      api_key: os.environ/OPENAI_API_KEY
+    model_info:
+      mode: embedding
+general_settings:
+  master_key: old-key
+`
+	require.NoError(t, os.WriteFile(configPath, []byte(existing), 0o600))
+
+	// New sync includes the same model_name but WITHOUT model_info.
+	cfg := litellmconfig.Config{
+		Models: []litellmconfig.ModelEntry{
+			{
+				ModelName:   "route-embedding",
+				LiteLLMName: "openai/text-embedding-3-small",
+				APIBase:     "https://api.openai.com/v1",
+				APIKeyEnv:   "OPENAI_API_KEY",
+			},
+		},
+		GeneralSettings: litellmconfig.GeneralSettings{
+			MasterKey: "new-key",
+		},
+		ExistingConfigPath: configPath,
+	}
+
+	r := &mockRestarter{}
+	err := litellmconfig.WriteAndRestart(context.Background(), configPath, cfg, r)
+	require.NoError(t, err)
+
+	data, readErr := os.ReadFile(configPath)
+	require.NoError(t, readErr)
+	content := string(data)
+
+	// model_info with mode: embedding must survive the merge.
+	assert.Contains(t, content, "model_info", "model_info must be preserved across sync")
+	assert.Contains(t, content, "embedding", "mode: embedding must be preserved across sync")
+}

--- a/apps/control-plane/internal/litellmconfig/http.go
+++ b/apps/control-plane/internal/litellmconfig/http.go
@@ -1,0 +1,50 @@
+package litellmconfig
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+)
+
+// SyncHandler exposes POST /internal/litellm/sync.
+// It must be wrapped with RequireInternalToken by the router.
+type SyncHandler struct {
+	svc SyncRunner
+}
+
+// NewSyncHandler returns an http.Handler backed by the given SyncRunner.
+func NewSyncHandler(svc SyncRunner) http.Handler {
+	return &SyncHandler{svc: svc}
+}
+
+func (h *SyncHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeJSON(w, http.StatusMethodNotAllowed, errorBody{
+			Code:    "method_not_allowed",
+			Message: "only POST is accepted",
+		})
+		return
+	}
+
+	if err := h.svc.Sync(r.Context()); err != nil {
+		slog.Error("litellmconfig: sync handler: sync failed", "error", err)
+		writeJSON(w, http.StatusInternalServerError, errorBody{
+			Code:    "sync_failed",
+			Message: "litellm config sync failed",
+		})
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+type errorBody struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+func writeJSON(w http.ResponseWriter, status int, body interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}

--- a/apps/control-plane/internal/litellmconfig/http_test.go
+++ b/apps/control-plane/internal/litellmconfig/http_test.go
@@ -1,0 +1,58 @@
+package litellmconfig_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/litellmconfig"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeSyncService satisfies litellmconfig.SyncRunner for HTTP handler tests.
+type fakeSyncService struct {
+	calls int
+	err   error
+}
+
+func (f *fakeSyncService) Sync(ctx context.Context) error {
+	f.calls++
+	return f.err
+}
+
+func TestSyncHandlerReturns200OnSuccess(t *testing.T) {
+	svc := &fakeSyncService{}
+	h := litellmconfig.NewSyncHandler(svc)
+
+	req := httptest.NewRequest(http.MethodPost, "/internal/litellm/sync", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, 1, svc.calls)
+}
+
+func TestSyncHandlerReturns500OnSyncFailure(t *testing.T) {
+	svc := &fakeSyncService{err: context.DeadlineExceeded}
+	h := litellmconfig.NewSyncHandler(svc)
+
+	req := httptest.NewRequest(http.MethodPost, "/internal/litellm/sync", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+}
+
+func TestSyncHandlerReturns405OnGet(t *testing.T) {
+	svc := &fakeSyncService{}
+	h := litellmconfig.NewSyncHandler(svc)
+
+	req := httptest.NewRequest(http.MethodGet, "/internal/litellm/sync", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusMethodNotAllowed, rr.Code)
+	require.Equal(t, 0, svc.calls)
+}

--- a/apps/control-plane/internal/litellmconfig/restart.go
+++ b/apps/control-plane/internal/litellmconfig/restart.go
@@ -6,7 +6,9 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
+	"regexp"
 	"time"
 )
 
@@ -16,9 +18,23 @@ const (
 	restartTimeout       = 30 * time.Second
 )
 
+// containerNameRe is the strict allowlist for Docker container names.
+// Docker itself allows [a-zA-Z0-9][a-zA-Z0-9_.-]+ so we match that exactly.
+// Validated at construction time to prevent path injection into the Docker
+// Engine API URL (e.g. a value like "../images/prune" would target an
+// unintended endpoint).
+var containerNameRe = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_./-]*$`)
+
 // DockerRestarter signals a LiteLLM container restart via the Docker Engine
 // HTTP API over a Unix socket. No `docker` CLI binary is required; only the
 // socket mount is needed.
+//
+// Security note: mounting /var/run/docker.sock grants host-root-equivalent
+// capability to this process. All calls are intentionally restricted to a
+// single restart endpoint (POST /containers/<name>/restart). No exec, create,
+// image, or other container operations are performed. The sync endpoint that
+// triggers this restarter is guarded by RequireInternalToken so it is
+// unreachable from the public internet.
 //
 // The restart API call uses:
 //
@@ -39,23 +55,28 @@ const (
 //
 // Confirm exact /model/* API shape via Context7 (LiteLLM docs) before implementing.
 type DockerRestarter struct {
-	ContainerName string
+	containerName string
 	socketPath    string
 }
 
 // NewDockerRestarter returns a DockerRestarter targeting the given container
-// name and Unix socket path.
-func NewDockerRestarter(containerName, socketPath string) *DockerRestarter {
-	return &DockerRestarter{
-		ContainerName: containerName,
-		socketPath:    socketPath,
+// name and Unix socket path. Returns an error if containerName fails the
+// Docker name allowlist (prevents path injection into the Docker Engine API).
+func NewDockerRestarter(containerName, socketPath string) (*DockerRestarter, error) {
+	if !containerNameRe.MatchString(containerName) {
+		return nil, fmt.Errorf("litellmconfig: invalid container name %q: must match %s", containerName, containerNameRe)
 	}
+	return &DockerRestarter{
+		containerName: containerName,
+		socketPath:    socketPath,
+	}, nil
 }
 
 // NewDefaultDockerRestarter returns a DockerRestarter whose container name is
 // read from LITELLM_CONTAINER_NAME (default: "litellm"). The socketPath
 // parameter allows tests to inject a fake socket; pass "" to use the
 // production default /var/run/docker.sock.
+// Panics if the resolved container name fails validation (startup misconfiguration).
 func NewDefaultDockerRestarter(socketPath string) *DockerRestarter {
 	if socketPath == "" {
 		socketPath = defaultSocketPath
@@ -64,10 +85,11 @@ func NewDefaultDockerRestarter(socketPath string) *DockerRestarter {
 	if name == "" {
 		name = defaultContainerName
 	}
-	return &DockerRestarter{
-		ContainerName: name,
-		socketPath:    socketPath,
+	r, err := NewDockerRestarter(name, socketPath)
+	if err != nil {
+		panic(fmt.Sprintf("litellmconfig: LITELLM_CONTAINER_NAME is invalid: %v", err))
 	}
+	return r
 }
 
 // Restart sends POST /containers/<name>/restart to the Docker Engine over the
@@ -85,15 +107,17 @@ func (r *DockerRestarter) Restart(ctx context.Context) error {
 	}
 	client := &http.Client{Transport: transport}
 
-	url := fmt.Sprintf("http://localhost/containers/%s/restart?t=10", r.ContainerName)
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
+	// url.PathEscape ensures the container name is safe even if validation is
+	// somehow bypassed; the allowlist regex is the primary defence.
+	endpoint := "http://localhost/containers/" + url.PathEscape(r.containerName) + "/restart?t=10"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, nil)
 	if err != nil {
 		return fmt.Errorf("litellmconfig: docker restart: build request: %w", err)
 	}
 
 	resp, err := client.Do(req)
 	if err != nil {
-		slog.Error("litellmconfig: docker restart: request failed", "container", r.ContainerName, "error", err)
+		slog.Error("litellmconfig: docker restart: request failed", "container", r.containerName, "error", err)
 		return fmt.Errorf("litellmconfig: docker restart: %w", err)
 	}
 	defer resp.Body.Close()
@@ -101,12 +125,12 @@ func (r *DockerRestarter) Restart(ctx context.Context) error {
 	// Docker returns 204 No Content on success.
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		slog.Error("litellmconfig: docker restart: unexpected status",
-			"container", r.ContainerName,
+			"container", r.containerName,
 			"status", resp.StatusCode,
 		)
-		return fmt.Errorf("litellmconfig: docker restart: unexpected status %d for container %q", resp.StatusCode, r.ContainerName)
+		return fmt.Errorf("litellmconfig: docker restart: unexpected status %d for container %q", resp.StatusCode, r.containerName)
 	}
 
-	slog.Info("litellmconfig: docker restart: success", "container", r.ContainerName)
+	slog.Info("litellmconfig: docker restart: success", "container", r.containerName)
 	return nil
 }

--- a/apps/control-plane/internal/litellmconfig/restart.go
+++ b/apps/control-plane/internal/litellmconfig/restart.go
@@ -1,0 +1,112 @@
+package litellmconfig
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"time"
+)
+
+const (
+	defaultContainerName = "litellm"
+	defaultSocketPath    = "/var/run/docker.sock"
+	restartTimeout       = 30 * time.Second
+)
+
+// DockerRestarter signals a LiteLLM container restart via the Docker Engine
+// HTTP API over a Unix socket. No `docker` CLI binary is required; only the
+// socket mount is needed.
+//
+// The restart API call uses:
+//
+//	POST /containers/<containerName>/restart?t=10
+//
+// over the Unix socket at socketPath (default /var/run/docker.sock).
+// The socket must be mounted read-write (not :ro) in the container.
+//
+// TODO(litellm-db-mode): When LITELLM_CONFIG_MODE=db, call the LiteLLM admin
+// API instead of restarting the container:
+//   - POST /model/new        (with Authorization: Bearer <LITELLM_MASTER_KEY>)
+//   - POST /model/update
+//   - DELETE /model/delete
+//
+// Required env vars for DB mode:
+//   - LITELLM_MASTER_KEY    — admin API key
+//   - LITELLM_BASE_URL      — base URL of the LiteLLM proxy (e.g. http://litellm:4000)
+//
+// Confirm exact /model/* API shape via Context7 (LiteLLM docs) before implementing.
+type DockerRestarter struct {
+	ContainerName string
+	socketPath    string
+}
+
+// NewDockerRestarter returns a DockerRestarter targeting the given container
+// name and Unix socket path.
+func NewDockerRestarter(containerName, socketPath string) *DockerRestarter {
+	return &DockerRestarter{
+		ContainerName: containerName,
+		socketPath:    socketPath,
+	}
+}
+
+// NewDefaultDockerRestarter returns a DockerRestarter whose container name is
+// read from LITELLM_CONTAINER_NAME (default: "litellm"). The socketPath
+// parameter allows tests to inject a fake socket; pass "" to use the
+// production default /var/run/docker.sock.
+func NewDefaultDockerRestarter(socketPath string) *DockerRestarter {
+	if socketPath == "" {
+		socketPath = defaultSocketPath
+	}
+	name := os.Getenv("LITELLM_CONTAINER_NAME")
+	if name == "" {
+		name = defaultContainerName
+	}
+	return &DockerRestarter{
+		ContainerName: name,
+		socketPath:    socketPath,
+	}
+}
+
+// Restart sends POST /containers/<name>/restart to the Docker Engine over the
+// Unix socket. The call is bounded by a 30-second context deadline.
+// Returns a non-nil error when the Docker Engine responds with a non-2xx status
+// or the connection fails.
+func (r *DockerRestarter) Restart(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, restartTimeout)
+	defer cancel()
+
+	transport := &http.Transport{
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			return (&net.Dialer{}).DialContext(ctx, "unix", r.socketPath)
+		},
+	}
+	client := &http.Client{Transport: transport}
+
+	url := fmt.Sprintf("http://localhost/containers/%s/restart?t=10", r.ContainerName)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
+	if err != nil {
+		return fmt.Errorf("litellmconfig: docker restart: build request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		slog.Error("litellmconfig: docker restart: request failed", "container", r.ContainerName, "error", err)
+		return fmt.Errorf("litellmconfig: docker restart: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Docker returns 204 No Content on success.
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		slog.Error("litellmconfig: docker restart: unexpected status",
+			"container", r.ContainerName,
+			"status", resp.StatusCode,
+		)
+		return fmt.Errorf("litellmconfig: docker restart: unexpected status %d for container %q", resp.StatusCode, r.ContainerName)
+	}
+
+	slog.Info("litellmconfig: docker restart: success", "container", r.ContainerName)
+	return nil
+}

--- a/apps/control-plane/internal/litellmconfig/restart.go
+++ b/apps/control-plane/internal/litellmconfig/restart.go
@@ -23,7 +23,7 @@ const (
 // Validated at construction time to prevent path injection into the Docker
 // Engine API URL (e.g. a value like "../images/prune" would target an
 // unintended endpoint).
-var containerNameRe = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_./-]*$`)
+var containerNameRe = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_.-]*$`)
 
 // DockerRestarter signals a LiteLLM container restart via the Docker Engine
 // HTTP API over a Unix socket. No `docker` CLI binary is required; only the

--- a/apps/control-plane/internal/litellmconfig/restart_test.go
+++ b/apps/control-plane/internal/litellmconfig/restart_test.go
@@ -26,7 +26,7 @@ func startFakeDockerEngine(t *testing.T, socketPath string, statusCode int, rece
 	srv := &http.Server{
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			select {
-			case received <- r.URL.Path + "?" + r.URL.RawQuery:
+			case received <- r.URL.Path:
 			default:
 			}
 			if statusCode == http.StatusNotFound {

--- a/apps/control-plane/internal/litellmconfig/restart_test.go
+++ b/apps/control-plane/internal/litellmconfig/restart_test.go
@@ -1,0 +1,148 @@
+package litellmconfig_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/litellmconfig"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDockerRestarterCallsDockerEngineAPI verifies that DockerRestarter sends
+// POST /containers/<name>/restart to a fake Docker Engine over a Unix socket.
+func TestDockerRestarterCallsDockerEngineAPI(t *testing.T) {
+	// Create a temp Unix socket.
+	dir := t.TempDir()
+	socketPath := filepath.Join(dir, "docker.sock")
+
+	requestReceived := make(chan string, 1)
+
+	listener, err := net.Listen("unix", socketPath)
+	require.NoError(t, err)
+	defer listener.Close()
+
+	// Fake Docker Engine HTTP server over the Unix socket.
+	fakeSrv := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestReceived <- r.URL.Path + "?" + r.URL.RawQuery
+			w.WriteHeader(http.StatusNoContent) // Docker returns 204 on success.
+		}),
+	}
+	go func() { _ = fakeSrv.Serve(listener) }()
+	defer fakeSrv.Close()
+
+	r := litellmconfig.NewDockerRestarter("test-litellm", socketPath)
+	err = r.Restart(context.Background())
+	require.NoError(t, err)
+
+	select {
+	case req := <-requestReceived:
+		assert.Contains(t, req, "/containers/test-litellm/restart")
+	default:
+		t.Fatal("no request received by fake Docker Engine")
+	}
+}
+
+// TestDockerRestarterPropagatesHTTPError verifies that a non-204 response is
+// treated as an error.
+func TestDockerRestarterPropagatesHTTPError(t *testing.T) {
+	dir := t.TempDir()
+	socketPath := filepath.Join(dir, "docker.sock")
+
+	listener, err := net.Listen("unix", socketPath)
+	require.NoError(t, err)
+	defer listener.Close()
+
+	fakeSrv := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			body, _ := json.Marshal(map[string]string{"message": "No such container"})
+			_, _ = w.Write(body)
+		}),
+	}
+	go func() { _ = fakeSrv.Serve(listener) }()
+	defer fakeSrv.Close()
+
+	r := litellmconfig.NewDockerRestarter("no-such-container", socketPath)
+	err = r.Restart(context.Background())
+	assert.Error(t, err, "non-204 response must be returned as error")
+	assert.Contains(t, err.Error(), "404")
+}
+
+// TestDockerRestarterUsesEnvVarContainerName verifies DefaultDockerRestarter
+// picks up LITELLM_CONTAINER_NAME when set.
+func TestDockerRestarterUsesEnvVarContainerName(t *testing.T) {
+	t.Setenv("LITELLM_CONTAINER_NAME", "custom-litellm")
+
+	dir := t.TempDir()
+	socketPath := filepath.Join(dir, "docker.sock")
+
+	requestReceived := make(chan string, 1)
+
+	listener, err := net.Listen("unix", socketPath)
+	require.NoError(t, err)
+	defer listener.Close()
+
+	fakeSrv := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestReceived <- r.URL.Path
+			w.WriteHeader(http.StatusNoContent)
+		}),
+	}
+	go func() { _ = fakeSrv.Serve(listener) }()
+	defer fakeSrv.Close()
+
+	r := litellmconfig.NewDefaultDockerRestarter(socketPath)
+	err = r.Restart(context.Background())
+	require.NoError(t, err)
+
+	select {
+	case path := <-requestReceived:
+		assert.Contains(t, path, "custom-litellm")
+	default:
+		t.Fatal("no request received")
+	}
+}
+
+// TestDockerRestarterDefaultContainerName verifies the default container name
+// is "litellm" when env var is not set.
+func TestDockerRestarterDefaultContainerName(t *testing.T) {
+	os.Unsetenv("LITELLM_CONTAINER_NAME")
+
+	dir := t.TempDir()
+	socketPath := filepath.Join(dir, "docker.sock")
+
+	requestReceived := make(chan string, 1)
+
+	listener, err := net.Listen("unix", socketPath)
+	require.NoError(t, err)
+	defer listener.Close()
+
+	fakeSrv := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestReceived <- r.URL.Path
+			w.WriteHeader(http.StatusNoContent)
+		}),
+	}
+	go func() { _ = fakeSrv.Serve(listener) }()
+	defer fakeSrv.Close()
+
+	r := litellmconfig.NewDefaultDockerRestarter(socketPath)
+	err = r.Restart(context.Background())
+	require.NoError(t, err)
+
+	select {
+	case path := <-requestReceived:
+		assert.Equal(t, fmt.Sprintf("/containers/%s/restart", "litellm"), path)
+	default:
+		t.Fatal("no request received")
+	}
+}

--- a/apps/control-plane/internal/litellmconfig/restart_test.go
+++ b/apps/control-plane/internal/litellmconfig/restart_test.go
@@ -26,7 +26,7 @@ func startFakeDockerEngine(t *testing.T, socketPath string, statusCode int, rece
 	srv := &http.Server{
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			select {
-			case received <- r.URL.Path:
+			case received <- r.Method + " " + r.URL.Path:
 			default:
 			}
 			if statusCode == http.StatusNotFound {
@@ -61,7 +61,7 @@ func TestDockerRestarterCallsDockerEngineAPI(t *testing.T) {
 
 	select {
 	case req := <-received:
-		assert.Contains(t, req, "/containers/test-litellm/restart")
+		assert.Equal(t, http.MethodPost+" /containers/test-litellm/restart", req)
 	default:
 		t.Fatal("no request received by fake Docker Engine")
 	}
@@ -95,6 +95,7 @@ func TestDockerRestarterRejectsInvalidContainerName(t *testing.T) {
 		"litellm\x00null",
 		"name with spaces",
 		"name;rm -rf",
+		"litellm/foo",
 	}
 	for _, name := range cases {
 		_, err := litellmconfig.NewDockerRestarter(name, "/var/run/docker.sock")
@@ -120,7 +121,7 @@ func TestDockerRestarterUsesEnvVarContainerName(t *testing.T) {
 
 	select {
 	case path := <-received:
-		assert.Contains(t, path, "custom-litellm")
+		assert.Equal(t, http.MethodPost+" /containers/custom-litellm/restart", path)
 	default:
 		t.Fatal("no request received")
 	}
@@ -144,7 +145,7 @@ func TestDockerRestarterDefaultContainerName(t *testing.T) {
 
 	select {
 	case path := <-received:
-		assert.Equal(t, fmt.Sprintf("/containers/%s/restart", "litellm"), path)
+		assert.Equal(t, http.MethodPost+" "+fmt.Sprintf("/containers/%s/restart", "litellm"), path)
 	default:
 		t.Fatal("no request received")
 	}

--- a/apps/control-plane/internal/litellmconfig/restart_test.go
+++ b/apps/control-plane/internal/litellmconfig/restart_test.go
@@ -15,35 +15,52 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// startFakeDockerEngine starts an HTTP server over a Unix socket that records
+// request paths and returns the given statusCode. Caller must close the
+// returned server and listener.
+func startFakeDockerEngine(t *testing.T, socketPath string, statusCode int, received chan<- string) (*http.Server, net.Listener) {
+	t.Helper()
+	listener, err := net.Listen("unix", socketPath)
+	require.NoError(t, err)
+
+	srv := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			select {
+			case received <- r.URL.Path + "?" + r.URL.RawQuery:
+			default:
+			}
+			if statusCode == http.StatusNotFound {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(statusCode)
+				body, _ := json.Marshal(map[string]string{"message": "No such container"})
+				_, _ = w.Write(body)
+			} else {
+				w.WriteHeader(statusCode)
+			}
+		}),
+	}
+	go func() { _ = srv.Serve(listener) }()
+	return srv, listener
+}
+
 // TestDockerRestarterCallsDockerEngineAPI verifies that DockerRestarter sends
 // POST /containers/<name>/restart to a fake Docker Engine over a Unix socket.
 func TestDockerRestarterCallsDockerEngineAPI(t *testing.T) {
-	// Create a temp Unix socket.
 	dir := t.TempDir()
 	socketPath := filepath.Join(dir, "docker.sock")
+	received := make(chan string, 1)
 
-	requestReceived := make(chan string, 1)
+	srv, ln := startFakeDockerEngine(t, socketPath, http.StatusNoContent, received)
+	defer srv.Close()
+	defer ln.Close()
 
-	listener, err := net.Listen("unix", socketPath)
+	r, err := litellmconfig.NewDockerRestarter("test-litellm", socketPath)
 	require.NoError(t, err)
-	defer listener.Close()
 
-	// Fake Docker Engine HTTP server over the Unix socket.
-	fakeSrv := &http.Server{
-		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			requestReceived <- r.URL.Path + "?" + r.URL.RawQuery
-			w.WriteHeader(http.StatusNoContent) // Docker returns 204 on success.
-		}),
-	}
-	go func() { _ = fakeSrv.Serve(listener) }()
-	defer fakeSrv.Close()
-
-	r := litellmconfig.NewDockerRestarter("test-litellm", socketPath)
-	err = r.Restart(context.Background())
-	require.NoError(t, err)
+	require.NoError(t, r.Restart(context.Background()))
 
 	select {
-	case req := <-requestReceived:
+	case req := <-received:
 		assert.Contains(t, req, "/containers/test-litellm/restart")
 	default:
 		t.Fatal("no request received by fake Docker Engine")
@@ -55,26 +72,34 @@ func TestDockerRestarterCallsDockerEngineAPI(t *testing.T) {
 func TestDockerRestarterPropagatesHTTPError(t *testing.T) {
 	dir := t.TempDir()
 	socketPath := filepath.Join(dir, "docker.sock")
+	received := make(chan string, 1)
 
-	listener, err := net.Listen("unix", socketPath)
+	srv, ln := startFakeDockerEngine(t, socketPath, http.StatusNotFound, received)
+	defer srv.Close()
+	defer ln.Close()
+
+	r, err := litellmconfig.NewDockerRestarter("no-such-container", socketPath)
 	require.NoError(t, err)
-	defer listener.Close()
 
-	fakeSrv := &http.Server{
-		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusNotFound)
-			body, _ := json.Marshal(map[string]string{"message": "No such container"})
-			_, _ = w.Write(body)
-		}),
+	restartErr := r.Restart(context.Background())
+	assert.Error(t, restartErr, "non-204 response must be returned as error")
+	assert.Contains(t, restartErr.Error(), "404")
+}
+
+// TestDockerRestarterRejectsInvalidContainerName verifies that path-injection
+// values are rejected at construction time.
+func TestDockerRestarterRejectsInvalidContainerName(t *testing.T) {
+	cases := []string{
+		"",
+		"../images/prune",
+		"litellm\x00null",
+		"name with spaces",
+		"name;rm -rf",
 	}
-	go func() { _ = fakeSrv.Serve(listener) }()
-	defer fakeSrv.Close()
-
-	r := litellmconfig.NewDockerRestarter("no-such-container", socketPath)
-	err = r.Restart(context.Background())
-	assert.Error(t, err, "non-204 response must be returned as error")
-	assert.Contains(t, err.Error(), "404")
+	for _, name := range cases {
+		_, err := litellmconfig.NewDockerRestarter(name, "/var/run/docker.sock")
+		assert.Error(t, err, "expected error for container name %q", name)
+	}
 }
 
 // TestDockerRestarterUsesEnvVarContainerName verifies DefaultDockerRestarter
@@ -84,28 +109,17 @@ func TestDockerRestarterUsesEnvVarContainerName(t *testing.T) {
 
 	dir := t.TempDir()
 	socketPath := filepath.Join(dir, "docker.sock")
+	received := make(chan string, 1)
 
-	requestReceived := make(chan string, 1)
-
-	listener, err := net.Listen("unix", socketPath)
-	require.NoError(t, err)
-	defer listener.Close()
-
-	fakeSrv := &http.Server{
-		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			requestReceived <- r.URL.Path
-			w.WriteHeader(http.StatusNoContent)
-		}),
-	}
-	go func() { _ = fakeSrv.Serve(listener) }()
-	defer fakeSrv.Close()
+	srv, ln := startFakeDockerEngine(t, socketPath, http.StatusNoContent, received)
+	defer srv.Close()
+	defer ln.Close()
 
 	r := litellmconfig.NewDefaultDockerRestarter(socketPath)
-	err = r.Restart(context.Background())
-	require.NoError(t, err)
+	require.NoError(t, r.Restart(context.Background()))
 
 	select {
-	case path := <-requestReceived:
+	case path := <-received:
 		assert.Contains(t, path, "custom-litellm")
 	default:
 		t.Fatal("no request received")
@@ -119,28 +133,17 @@ func TestDockerRestarterDefaultContainerName(t *testing.T) {
 
 	dir := t.TempDir()
 	socketPath := filepath.Join(dir, "docker.sock")
+	received := make(chan string, 1)
 
-	requestReceived := make(chan string, 1)
-
-	listener, err := net.Listen("unix", socketPath)
-	require.NoError(t, err)
-	defer listener.Close()
-
-	fakeSrv := &http.Server{
-		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			requestReceived <- r.URL.Path
-			w.WriteHeader(http.StatusNoContent)
-		}),
-	}
-	go func() { _ = fakeSrv.Serve(listener) }()
-	defer fakeSrv.Close()
+	srv, ln := startFakeDockerEngine(t, socketPath, http.StatusNoContent, received)
+	defer srv.Close()
+	defer ln.Close()
 
 	r := litellmconfig.NewDefaultDockerRestarter(socketPath)
-	err = r.Restart(context.Background())
-	require.NoError(t, err)
+	require.NoError(t, r.Restart(context.Background()))
 
 	select {
-	case path := <-requestReceived:
+	case path := <-received:
 		assert.Equal(t, fmt.Sprintf("/containers/%s/restart", "litellm"), path)
 	default:
 		t.Fatal("no request received")

--- a/apps/control-plane/internal/litellmconfig/service.go
+++ b/apps/control-plane/internal/litellmconfig/service.go
@@ -1,0 +1,100 @@
+package litellmconfig
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// SyncRunner is the interface consumed by the HTTP handler.
+type SyncRunner interface {
+	Sync(ctx context.Context) error
+}
+
+// routeRow is a join of provider_routes and custom_providers for active routes.
+type routeRow struct {
+	ModelName     string
+	LiteLLMPrefix string
+	LiteLLMName   string // provider_routes.model_id — the upstream model identifier
+	BaseURL       string
+	APIKeyEnv     string
+}
+
+// SyncService queries the DB for active provider routes, generates LiteLLM
+// YAML, writes it atomically, and triggers a container restart.
+type SyncService struct {
+	pool       *pgxpool.Pool
+	configPath string
+	masterKey  string
+	restarter  Restarter
+}
+
+// NewSyncService returns a SyncService wired with the given dependencies.
+func NewSyncService(pool *pgxpool.Pool, configPath, masterKey string, restarter Restarter) *SyncService {
+	return &SyncService{
+		pool:       pool,
+		configPath: configPath,
+		masterKey:  masterKey,
+		restarter:  restarter,
+	}
+}
+
+// Sync queries active provider routes, builds model entries, and calls
+// WriteAndRestart. Active routes are those with health_state NOT equal to
+// 'disabled'. Routes with 'healthy' or 'degraded' health_state are included.
+func (s *SyncService) Sync(ctx context.Context) error {
+	rows, err := s.pool.Query(ctx, `
+		SELECT
+			pr.route_id        AS model_name,
+			cp.litellm_prefix  AS litellm_prefix,
+			pr.model_id        AS litellm_name,
+			cp.base_url        AS base_url,
+			cp.api_key_env     AS api_key_env
+		FROM public.provider_routes pr
+		JOIN public.custom_providers cp ON cp.id = pr.provider_id
+		WHERE pr.health_state != 'disabled'
+		  AND cp.enabled = true
+		ORDER BY pr.route_id ASC
+	`)
+	if err != nil {
+		return fmt.Errorf("litellmconfig: sync: query routes: %w", err)
+	}
+	defer rows.Close()
+
+	var entries []ModelEntry
+	for rows.Next() {
+		var r routeRow
+		if err := rows.Scan(&r.ModelName, &r.LiteLLMPrefix, &r.LiteLLMName, &r.BaseURL, &r.APIKeyEnv); err != nil {
+			return fmt.Errorf("litellmconfig: sync: scan route: %w", err)
+		}
+
+		litellmModel := r.LiteLLMName
+		if r.LiteLLMPrefix != "" {
+			litellmModel = r.LiteLLMPrefix + r.LiteLLMName
+		}
+
+		entries = append(entries, ModelEntry{
+			ModelName:   r.ModelName,
+			LiteLLMName: litellmModel,
+			APIBase:     r.BaseURL,
+			APIKeyEnv:   r.APIKeyEnv,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("litellmconfig: sync: rows error: %w", err)
+	}
+
+	slog.Info("litellmconfig: sync: active routes loaded", "count", len(entries))
+
+	cfg := Config{
+		Models: entries,
+		GeneralSettings: GeneralSettings{
+			MasterKey: s.masterKey,
+		},
+		ExistingConfigPath: s.configPath,
+	}
+
+	return WriteAndRestart(ctx, s.configPath, cfg, s.restarter)
+}

--- a/apps/control-plane/internal/litellmconfig/service.go
+++ b/apps/control-plane/internal/litellmconfig/service.go
@@ -42,8 +42,9 @@ func NewSyncService(pool *pgxpool.Pool, configPath, masterKey string, restarter 
 }
 
 // Sync queries active provider routes, builds model entries, and calls
-// WriteAndRestart. Active routes are those with health_state NOT equal to
-// 'disabled'. Routes with 'healthy' or 'degraded' health_state are included.
+// WriteAndRestart. Active routes are those with health_state in ('healthy',
+// 'degraded'). Rows with health_state 'disabled' or 'eol' are excluded so
+// retired routes never receive live LiteLLM traffic.
 func (s *SyncService) Sync(ctx context.Context) error {
 	rows, err := s.pool.Query(ctx, `
 		SELECT
@@ -54,7 +55,7 @@ func (s *SyncService) Sync(ctx context.Context) error {
 			cp.api_key_env     AS api_key_env
 		FROM public.provider_routes pr
 		JOIN public.custom_providers cp ON cp.id = pr.provider_id
-		WHERE pr.health_state != 'disabled'
+		WHERE pr.health_state NOT IN ('disabled', 'eol')
 		  AND cp.enabled = true
 		ORDER BY pr.route_id ASC
 	`)

--- a/apps/control-plane/internal/litellmconfig/service.go
+++ b/apps/control-plane/internal/litellmconfig/service.go
@@ -54,7 +54,7 @@ func (s *SyncService) Sync(ctx context.Context) error {
 			cp.base_url        AS base_url,
 			cp.api_key_env     AS api_key_env
 		FROM public.provider_routes pr
-		JOIN public.custom_providers cp ON cp.id = pr.provider_id
+		JOIN public.custom_providers cp ON cp.slug = pr.provider
 		WHERE pr.health_state NOT IN ('disabled', 'eol')
 		  AND cp.enabled = true
 		ORDER BY pr.route_id ASC

--- a/apps/control-plane/internal/platform/http/router.go
+++ b/apps/control-plane/internal/platform/http/router.go
@@ -79,6 +79,10 @@ type RouterConfig struct {
 	RoleSvc interface {
 		RequirePlatformAdmin(http.Handler) http.Handler
 	}
+
+	// LiteLLMSyncHandler handles POST /internal/litellm/sync.
+	// Guarded by the shared-secret token. When nil the route is not registered.
+	LiteLLMSyncHandler http.Handler
 }
 
 // NewRouter returns a configured http.Handler with all platform routes registered.
@@ -201,6 +205,12 @@ func NewRouter(cfg RouterConfig) http.Handler {
 		mux.Handle("/webhooks/sslcommerz/success", cfg.PaymentsHandler)
 		mux.Handle("/webhooks/sslcommerz/fail", cfg.PaymentsHandler)
 		mux.Handle("/webhooks/sslcommerz/cancel", cfg.PaymentsHandler)
+	}
+
+	// Phase 20 Plan 03 — LiteLLM config sync endpoint.
+	// POST /internal/litellm/sync triggers config regeneration and container restart.
+	if cfg.LiteLLMSyncHandler != nil {
+		mux.Handle("/internal/litellm/sync", internal(cfg.LiteLLMSyncHandler))
 	}
 
 	// Phase 20 Plan 02 — provider CRUD routes.

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -71,8 +71,11 @@ services:
       # ollama_chat/ model entries in deploy/litellm/config.yaml.
       OLLAMA_BASE_URL: ${OLLAMA_BASE_URL:-}
     volumes:
-      - ../../deploy/litellm/config.yaml:/app/config.yaml
-    command: ["--config=/app/config.yaml"]
+      # Phase 20 Plan 03 — shared config volume: control-plane writes here,
+      # LiteLLM reads from it. The volume persists generated config across
+      # container recreates; the seed file is copied in on first start.
+      - litellm-config:/etc/litellm
+    command: ["--config=/etc/litellm/config.yaml"]
 
   sdk-tests-js:
     image: hive-sdk-tests-js:ci
@@ -137,6 +140,13 @@ services:
     volumes:
       - gomodcache:/go/pkg/mod
       - gobuildcache:/root/.cache/go-build
+      # Phase 20 Plan 03 — shared LiteLLM config volume (control-plane writes,
+      # LiteLLM reads). Mount read-write so control-plane can write atomically.
+      - litellm-config:/etc/litellm
+      # Docker socket mount (read-write required — the restart API needs write
+      # access). control-plane calls POST /containers/<name>/restart over the
+      # Unix socket directly via net/http; no docker CLI binary is needed.
+      - /var/run/docker.sock:/var/run/docker.sock
     environment:
       SUPABASE_URL: ${SUPABASE_URL}
       SUPABASE_ANON_KEY: ${SUPABASE_ANON_KEY}
@@ -167,6 +177,10 @@ services:
       OWUI_ADMIN_TOKEN: ${OWUI_ADMIN_TOKEN:-}
       SUPABASE_WEBHOOK_SECRET: ${SUPABASE_WEBHOOK_SECRET:-}
       AUDIT_WAL_DIR: ${AUDIT_WAL_DIR:-/var/lib/hive/audit-wal}
+      # Phase 20 Plan 03 — LiteLLM config generation and controlled restart.
+      LITELLM_CONTAINER_NAME: ${LITELLM_CONTAINER_NAME:-litellm}
+      LITELLM_CONFIG_PATH: ${LITELLM_CONFIG_PATH:-/etc/litellm/config.yaml}
+      LITELLM_MASTER_KEY: ${LITELLM_MASTER_KEY:-litellm-dev-key}
     healthcheck:
       test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8081/health"]
       interval: 5s
@@ -406,3 +420,8 @@ volumes:
   # ollama-models persists pulled model weights across container recreates.
   # Active only when the `enterprise` profile is used.
   ollama-models:
+  # litellm-config is a shared volume between control-plane (writer) and litellm
+  # (reader). control-plane generates config.yaml via POST /internal/litellm/sync
+  # and writes it atomically; litellm reads it at startup and on restart.
+  # Phase 20 Plan 03.
+  litellm-config:

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -51,6 +51,9 @@ services:
 
   litellm:
     image: ${LITELLM_IMAGE:-ghcr.io/berriai/litellm:v1.77.7-stable}
+    # Fixed container name so the control-plane Docker restart API can locate
+    # this container by name regardless of the Compose project name.
+    container_name: litellm
     ports:
       - "4000:4000"
     environment:
@@ -75,7 +78,20 @@ services:
       # LiteLLM reads from it. The volume persists generated config across
       # container recreates; the seed file is copied in on first start.
       - litellm-config:/etc/litellm
-    command: ["--config=/etc/litellm/config.yaml"]
+      # Mount the repo seed config read-only so the entrypoint can copy it
+      # into the shared volume when the volume is empty (first boot).
+      - ../../deploy/litellm/config.yaml:/seed/config.yaml:ro
+    # On first boot the shared volume is empty; copy the seed config so LiteLLM
+    # has a valid config.yaml before control-plane pushes its first sync.
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        if [ ! -f /etc/litellm/config.yaml ]; then
+          cp /seed/config.yaml /etc/litellm/config.yaml
+        fi
+        exec litellm --config=/etc/litellm/config.yaml
+    command: []
 
   sdk-tests-js:
     image: hive-sdk-tests-js:ci


### PR DESCRIPTION
## Summary

- Adds `apps/control-plane/internal/litellmconfig` package with pure `Generate` function, atomic `WriteAndRestart` (merges existing YAML, preserves `litellm_settings` and all non-generated keys), `DockerRestarter` (Docker Engine HTTP API over Unix socket, 30s timeout, no docker CLI), `SyncService` (queries active routes from DB), and `POST /internal/litellm/sync` HTTP handler guarded by `RequireInternalToken`
- Wires `litellm-config` shared named volume between `control-plane` (writer) and `litellm` (reader), plus Docker socket mount (read-write) in `docker-compose.yml`
- Documents `LITELLM_CONTAINER_NAME`, `LITELLM_CONFIG_PATH`, and `LITELLM_CONFIG_MODE=db` alternative in `.env.example`

## Test plan

- [x] 15 unit tests: 8 generator (golden YAML, empty list, round-trip, master key, WriteAndRestart success/preserve/error/first-run), 4 restart (fake Unix socket server validates API path, 404 propagation, env var container name, default name), 3 HTTP handler (200, 500, 405)
- [x] All 40 control-plane packages pass (`go test ./apps/control-plane/... -count=1 -short`)
- [x] `go build ./apps/control-plane/...` clean
- [x] `docker compose --profile local config -q` validates without errors
- [ ] Live smoke: `POST /internal/litellm/sync` with X-Internal-Token triggers LiteLLM restart (requires running stack)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added LiteLLM configuration synchronization from the database with automatic service restart capability
  * Added internal API endpoint to trigger configuration updates
  * Introduced persistent configuration storage via Docker volume for improved data durability
  * Added environment variables to configure container and configuration path settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->