### PR TITLE
test(sdk): update tool and response_format replay tests for phase 20 passthrough

### DIFF
--- a/packages/sdk-tests/js/tests/chat-completions/chat-completions.test.ts
+++ b/packages/sdk-tests/js/tests/chat-completions/chat-completions.test.ts
@@ -48,64 +48,70 @@ describe("Chat Completions", () => {
     ).rejects.toMatchObject({ status: 404 });
   });
 
-  it("rejects tools with 400 unsupported_parameter", async () => {
-    // The edge explicitly rejects tool calling until full support ships (#118).
-    await expect(
-      client.chat.completions.create({
-        model: MODEL,
-        messages: [
-          { role: "user", content: "What is the weather like in London?" },
-        ],
-        max_tokens: 256,
-        tools: [
-          {
-            type: "function",
-            function: {
-              name: "get_weather",
-              description: "Get the current weather for a location",
-              parameters: {
-                type: "object",
-                properties: {
-                  location: {
-                    type: "string",
-                    description: "The city to get weather for",
-                  },
+  it("passes tools through and returns a tool_calls completion", async () => {
+    // Phase 20 (#118): capability-based passthrough ships. Capable routes
+    // (openrouter, groq) have tools_supported=true seeded, so tool calls are
+    // forwarded rather than rejected. The edge must NOT 400 on tools.
+    const response = await client.chat.completions.create({
+      model: MODEL,
+      messages: [
+        { role: "user", content: "What is the weather like in London?" },
+      ],
+      max_tokens: 256,
+      tools: [
+        {
+          type: "function",
+          function: {
+            name: "get_weather",
+            description: "Get the current weather for a location",
+            parameters: {
+              type: "object",
+              properties: {
+                location: {
+                  type: "string",
+                  description: "The city to get weather for",
                 },
-                required: ["location"],
               },
+              required: ["location"],
             },
           },
-        ],
-      }),
-    ).rejects.toMatchObject({
-      status: 400,
-      error: {
-        type: "invalid_request_error",
-        code: "unsupported_parameter",
-      },
+        },
+      ],
     });
+
+    expect(response.object).toBe("chat.completion");
+    expect(response.choices.length).toBeGreaterThanOrEqual(1);
+    // Model should invoke the tool.
+    expect(response.choices[0].finish_reason).toBe("tool_calls");
+    expect(response.choices[0].message.tool_calls).toBeDefined();
+    expect(response.choices[0].message.tool_calls!.length).toBeGreaterThan(0);
+    expect(response.choices[0].message.tool_calls![0].function.name).toBe(
+      "get_weather",
+    );
   });
 
-  it("rejects response_format with 400 unsupported_parameter", async () => {
-    // The edge explicitly rejects response_format until full support ships (#118).
-    await expect(
-      client.chat.completions.create({
-        model: MODEL,
-        messages: [
-          {
-            role: "user",
-            content: 'Return a JSON object with a single key "status" set to "ok".',
-          },
-        ],
-        max_tokens: 256,
-        response_format: { type: "json_object" },
-      }),
-    ).rejects.toMatchObject({
-      status: 400,
-      error: {
-        type: "invalid_request_error",
-        code: "unsupported_parameter",
-      },
+  it("passes response_format through and returns valid JSON", async () => {
+    // Phase 20 (#118): response_format forwarded to capable routes.
+    // The edge must NOT 400 on response_format; content must be parseable JSON.
+    const response = await client.chat.completions.create({
+      model: MODEL,
+      messages: [
+        {
+          role: "user",
+          content: 'Return a JSON object with a single key "status" set to "ok".',
+        },
+      ],
+      max_tokens: 256,
+      response_format: { type: "json_object" },
     });
+
+    expect(response.object).toBe("chat.completion");
+    expect(response.choices.length).toBeGreaterThanOrEqual(1);
+    const content = response.choices[0].message.content;
+    expect(typeof content).toBe("string");
+    // Content must be parseable JSON containing at least one key.
+    const parsed = JSON.parse(content!);
+    expect(typeof parsed).toBe("object");
+    expect(parsed).not.toBeNull();
   });
 });

--- a/packages/sdk-tests/js/tests/chat-completions/chat-completions.test.ts
+++ b/packages/sdk-tests/js/tests/chat-completions/chat-completions.test.ts
@@ -77,6 +77,9 @@ describe("Chat Completions", () => {
           },
         },
       ],
+      // Force the model to invoke get_weather so the tool_calls assertions are
+      // deterministic and do not depend on the model's auto-routing decision.
+      tool_choice: { type: "function", function: { name: "get_weather" } },
     });
 
     expect(response.object).toBe("chat.completion");


### PR DESCRIPTION
## Summary

- Phase 20 (#118) ships capability-based tool-call routing: `tools` and `response_format` are now forwarded to capable routes (openrouter and groq seeded with `tools_supported=true`) instead of being unconditionally rejected with 400.
- The two SDK replay tests still asserted the old behaviour, causing the post-deploy healthcheck job in run #27392766395 to fail with `promise resolved instead of rejecting`.
- Both tests updated to assert the new correct behaviour: `tools` yields `finish_reason: tool_calls` with a `get_weather` tool call; `response_format: json_object` yields parseable JSON output.

## Root cause of deploy failure

Run #27392766395 (triggered by merge of #206) succeeded at build and deploy. Both health URLs returned 200. Failure was only in the post-deploy SDK replay step because the test expectations were written for the pre-phase-20 unconditional-400 guard that PR #206 intentionally replaced.

## Test plan

- [ ] CI passes (deploy-staging SDK replay: both tool tests green)
- [ ] `api-hive.scubed.co/health` returns 200
- [ ] `cp-hive.scubed.co/health` returns 200
- [ ] Tool smoke: POST /v1/chat/completions with tools array using hive-default returns finish_reason tool_calls, NOT 400

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat Completions now supports `tools` parameter for function tool invocations and `response_format` parameter for JSON-formatted responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->