### PR TITLE
fix: wire signup precheck before supabase.auth.signUp (issue #116)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -106,6 +106,11 @@ SIGNUP_RATE_LIMIT_WINDOW_SECONDS=3600
 # when unset). NEVER commit a real key here — supply via secret manager
 # in staging + production.
 TURNSTILE_SECRET_KEY=
+# Cloudflare Turnstile site key (public, safe for browser). Rendered in the
+# web-console signup form. Leave EMPTY to disable the CAPTCHA widget in the
+# browser (widget is skipped gracefully when unset). Must match the site key
+# for the same Cloudflare Turnstile widget configured above.
+NEXT_PUBLIC_TURNSTILE_SITE_KEY=
 # Trusted reverse-proxy CIDR ranges (comma-separated). The precheck handler
 # honours CF-Connecting-IP and X-Forwarded-For ONLY when the direct TCP peer
 # (RemoteAddr) falls inside one of these ranges. Default EMPTY means no

--- a/apps/web-console/__tests__/signup-precheck-route.test.ts
+++ b/apps/web-console/__tests__/signup-precheck-route.test.ts
@@ -1,0 +1,142 @@
+/**
+ * TDD: signup-precheck proxy route (issue #116).
+ *
+ * Verifies that the Route Handler at /api/auth/signup-precheck:
+ * 1. Forwards { email, captcha_token } to the control-plane precheck endpoint.
+ * 2. Returns the upstream status and body verbatim on success (200).
+ * 3. Returns the upstream status and body verbatim on rejection (403/429).
+ * 4. Returns 503 when CONTROL_PLANE_BASE_URL is not set.
+ * 5. Returns 400 on malformed request body.
+ * 6. Returns 503 on network failure (fetch throws).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+describe("app/api/auth/signup-precheck/route.ts", () => {
+  const originalEnv = process.env.CONTROL_PLANE_BASE_URL;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllGlobals();
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.CONTROL_PLANE_BASE_URL;
+    } else {
+      process.env.CONTROL_PLANE_BASE_URL = originalEnv;
+    }
+    vi.unstubAllGlobals();
+  });
+
+  it("forwards the request to the control-plane precheck endpoint and returns 200", async () => {
+    process.env.CONTROL_PLANE_BASE_URL = "http://localhost:8081";
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ status: "ok" }), { status: 200 })
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { POST } = await import(
+      "../app/api/auth/signup-precheck/route"
+    );
+    const req = new Request("http://localhost:3000/api/auth/signup-precheck", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "user@example.com", captcha_token: "tok123" }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const [calledUrl, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(calledUrl).toBe(
+      "http://localhost:8081/api/v1/auth/sign-up/precheck"
+    );
+    expect(init.method).toBe("POST");
+    const sentBody = JSON.parse(init.body as string) as {
+      email: string;
+      captcha_token: string;
+    };
+    expect(sentBody.email).toBe("user@example.com");
+    expect(sentBody.captcha_token).toBe("tok123");
+  });
+
+  it("returns 403 when the control-plane rejects the request", async () => {
+    process.env.CONTROL_PLANE_BASE_URL = "http://localhost:8081";
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            error:
+              "We could not complete your sign-up. Please try again or use a different email address.",
+          }),
+          { status: 403 }
+        )
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { POST } = await import(
+      "../app/api/auth/signup-precheck/route"
+    );
+    const req = new Request("http://localhost:3000/api/auth/signup-precheck", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "throwaway@mailnull.com", captcha_token: "" }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 503 when CONTROL_PLANE_BASE_URL is not configured", async () => {
+    delete process.env.CONTROL_PLANE_BASE_URL;
+
+    const { POST } = await import(
+      "../app/api/auth/signup-precheck/route"
+    );
+    const req = new Request("http://localhost:3000/api/auth/signup-precheck", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "user@example.com", captcha_token: "" }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(503);
+  });
+
+  it("returns 400 on malformed request body", async () => {
+    process.env.CONTROL_PLANE_BASE_URL = "http://localhost:8081";
+
+    const { POST } = await import(
+      "../app/api/auth/signup-precheck/route"
+    );
+    const req = new Request("http://localhost:3000/api/auth/signup-precheck", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not-json",
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 503 when fetch throws (network failure)", async () => {
+    process.env.CONTROL_PLANE_BASE_URL = "http://localhost:8081";
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("ECONNREFUSED")));
+
+    const { POST } = await import(
+      "../app/api/auth/signup-precheck/route"
+    );
+    const req = new Request("http://localhost:3000/api/auth/signup-precheck", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "user@example.com", captcha_token: "" }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(503);
+  });
+});

--- a/apps/web-console/app/api/auth/signup-precheck/route.ts
+++ b/apps/web-console/app/api/auth/signup-precheck/route.ts
@@ -43,24 +43,30 @@ export async function POST(request: Request): Promise<Response> {
 
   const upstreamUrl = `${baseUrl}/api/v1/auth/sign-up/precheck`;
 
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 5000);
+
   let upstream: Response;
   try {
     upstream = await fetch(upstreamUrl, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ email: body.email, captcha_token: body.captcha_token }),
+      signal: controller.signal,
     });
   } catch {
-    // Network-level failure: do not expose internal URL or error detail.
+    // Network-level failure or timeout: do not expose internal URL or error detail.
     return NextResponse.json(
       { error: "Service temporarily unavailable. Please try again." },
       { status: 503 }
     );
+  } finally {
+    clearTimeout(timeoutId);
   }
 
-  let upstreamBody: Record<string, string>;
+  let upstreamBody: Record<string, unknown>;
   try {
-    upstreamBody = (await upstream.json()) as Record<string, string>;
+    upstreamBody = (await upstream.json()) as Record<string, unknown>;
   } catch {
     upstreamBody = {};
   }

--- a/apps/web-console/app/api/auth/signup-precheck/route.ts
+++ b/apps/web-console/app/api/auth/signup-precheck/route.ts
@@ -1,0 +1,69 @@
+// Proxy route for the signup abuse-prevention precheck (issue #116).
+//
+// The control-plane precheck endpoint (POST /api/v1/auth/sign-up/precheck)
+// requires a server-side call because CONTROL_PLANE_BASE_URL is never exposed
+// to the browser. This Route Handler receives { email, captcha_token } from
+// the signup page, forwards the request to the control-plane, and returns the
+// upstream status and body verbatim. It never proxies upstream error detail
+// that could leak internal information; only the generic message from the
+// control-plane travels to the client.
+
+import { NextResponse } from "next/server";
+
+interface PrecheckBody {
+  email: string;
+  captcha_token: string;
+}
+
+function isPrecheckBody(value: unknown): value is PrecheckBody {
+  if (value === null || typeof value !== "object") return false;
+  const record = value as Record<string, unknown>;
+  return typeof record.email === "string" && typeof record.captcha_token === "string";
+}
+
+export async function POST(request: Request): Promise<Response> {
+  const baseUrl = process.env.CONTROL_PLANE_BASE_URL;
+  if (!baseUrl) {
+    return NextResponse.json(
+      { error: "Service temporarily unavailable. Please try again." },
+      { status: 503 }
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid request body." }, { status: 400 });
+  }
+
+  if (!isPrecheckBody(body)) {
+    return NextResponse.json({ error: "Invalid request body." }, { status: 400 });
+  }
+
+  const upstreamUrl = `${baseUrl}/api/v1/auth/sign-up/precheck`;
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(upstreamUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: body.email, captcha_token: body.captcha_token }),
+    });
+  } catch {
+    // Network-level failure: do not expose internal URL or error detail.
+    return NextResponse.json(
+      { error: "Service temporarily unavailable. Please try again." },
+      { status: 503 }
+    );
+  }
+
+  let upstreamBody: Record<string, string>;
+  try {
+    upstreamBody = (await upstream.json()) as Record<string, string>;
+  } catch {
+    upstreamBody = {};
+  }
+
+  return NextResponse.json(upstreamBody, { status: upstream.status });
+}

--- a/apps/web-console/app/auth/sign-up/page.tsx
+++ b/apps/web-console/app/auth/sign-up/page.tsx
@@ -1,12 +1,37 @@
 "use client";
 
 import { createClient } from "@/lib/supabase/browser";
-import { useState, type FormEvent } from "react";
+import { useState, useRef, useEffect, type FormEvent } from "react";
 import { Mail } from "lucide-react";
 
 import { AuthShell } from "@/components/app-shell/auth-shell";
 import { Button } from "@/components/ui/button";
 import { Field, Input } from "@/components/ui/input";
+
+// Minimal ambient type for the Cloudflare Turnstile widget. The full SDK type
+// is not installed as a dev dependency; we only need the render/remove surface.
+declare global {
+  interface Window {
+    turnstile?: {
+      render: (
+        container: string | HTMLElement,
+        options: {
+          sitekey: string;
+          callback: (token: string) => void;
+          "expired-callback": () => void;
+          "error-callback": () => void;
+          theme?: "light" | "dark" | "auto";
+        }
+      ) => string;
+      remove: (widgetId: string) => void;
+    };
+  }
+}
+
+const TURNSTILE_SITE_KEY =
+  typeof process !== "undefined"
+    ? process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY ?? ""
+    : "";
 
 export default function SignUpPage() {
   const supabase = createClient();
@@ -15,11 +40,84 @@ export default function SignUpPage() {
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [captchaToken, setCaptchaToken] = useState<string | null>(null);
+
+  const turnstileContainerRef = useRef<HTMLDivElement | null>(null);
+  const widgetIdRef = useRef<string | null>(null);
+
+  // Load the Turnstile script and render the widget when a site key is
+  // configured. When NEXT_PUBLIC_TURNSTILE_SITE_KEY is unset (local dev),
+  // the widget is skipped and captchaToken stays null, which the precheck
+  // endpoint accepts (server-side key also absent in dev).
+  useEffect(() => {
+    if (!TURNSTILE_SITE_KEY || !turnstileContainerRef.current) return;
+
+    const scriptId = "cf-turnstile-script";
+    const alreadyLoaded = document.getElementById(scriptId) !== null;
+
+    function renderWidget() {
+      if (!window.turnstile || !turnstileContainerRef.current) return;
+      widgetIdRef.current = window.turnstile.render(
+        turnstileContainerRef.current,
+        {
+          sitekey: TURNSTILE_SITE_KEY,
+          callback: (token) => setCaptchaToken(token),
+          "expired-callback": () => setCaptchaToken(null),
+          "error-callback": () => setCaptchaToken(null),
+          theme: "light",
+        }
+      );
+    }
+
+    if (alreadyLoaded) {
+      renderWidget();
+      return;
+    }
+
+    const script = document.createElement("script");
+    script.id = scriptId;
+    script.src = "https://challenges.cloudflare.com/turnstile/v0/api.js";
+    script.async = true;
+    script.defer = true;
+    script.onload = renderWidget;
+    document.head.appendChild(script);
+
+    return () => {
+      if (widgetIdRef.current && window.turnstile) {
+        window.turnstile.remove(widgetIdRef.current);
+      }
+    };
+  }, []);
 
   async function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
     setError(null);
     setLoading(true);
+
+    // Abuse-prevention precheck (issue #116): rate limit, disposable-domain
+    // blocklist, and Turnstile CAPTCHA. The call goes through a Next.js Route
+    // Handler so CONTROL_PLANE_BASE_URL stays server-side only.
+    const precheckRes = await fetch("/api/auth/signup-precheck", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, captcha_token: captchaToken ?? "" }),
+    });
+
+    if (!precheckRes.ok) {
+      let msg =
+        "We could not complete your sign-up. Please try again or use a different email address.";
+      try {
+        const body = (await precheckRes.json()) as { error?: string };
+        if (typeof body.error === "string" && body.error.length > 0) {
+          msg = body.error;
+        }
+      } catch {
+        // Ignore parse errors; generic message is already set.
+      }
+      setError(msg);
+      setLoading(false);
+      return;
+    }
 
     const appUrl =
       process.env.NEXT_PUBLIC_APP_URL ??
@@ -27,7 +125,7 @@ export default function SignUpPage() {
         ? window.location.origin
         : "http://localhost:3000");
 
-    const { error } = await supabase.auth.signUp({
+    const { error: signUpError } = await supabase.auth.signUp({
       email,
       password,
       options: {
@@ -35,8 +133,8 @@ export default function SignUpPage() {
       },
     });
 
-    if (error) {
-      setError(error.message);
+    if (signUpError) {
+      setError(signUpError.message);
       setLoading(false);
       return;
     }
@@ -111,6 +209,9 @@ export default function SignUpPage() {
             minLength={8}
           />
         </Field>
+        {TURNSTILE_SITE_KEY ? (
+          <div ref={turnstileContainerRef} className="flex justify-center" />
+        ) : null}
         {error ? (
           <p
             role="alert"

--- a/apps/web-console/app/auth/sign-up/page.tsx
+++ b/apps/web-console/app/auth/sign-up/page.tsx
@@ -94,53 +94,64 @@ export default function SignUpPage() {
     setError(null);
     setLoading(true);
 
-    // Abuse-prevention precheck (issue #116): rate limit, disposable-domain
-    // blocklist, and Turnstile CAPTCHA. The call goes through a Next.js Route
-    // Handler so CONTROL_PLANE_BASE_URL stays server-side only.
-    const precheckRes = await fetch("/api/auth/signup-precheck", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ email, captcha_token: captchaToken ?? "" }),
-    });
+    try {
+      // Abuse-prevention precheck (issue #116): rate limit, disposable-domain
+      // blocklist, and Turnstile CAPTCHA. The call goes through a Next.js Route
+      // Handler so CONTROL_PLANE_BASE_URL stays server-side only.
+      const precheckRes = await fetch("/api/auth/signup-precheck", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, captcha_token: captchaToken ?? "" }),
+      });
 
-    if (!precheckRes.ok) {
-      let msg =
-        "We could not complete your sign-up. Please try again or use a different email address.";
-      try {
-        const body = (await precheckRes.json()) as { error?: string };
-        if (typeof body.error === "string" && body.error.length > 0) {
-          msg = body.error;
+      if (!precheckRes.ok) {
+        let msg =
+          "We could not complete your sign-up. Please try again or use a different email address.";
+        try {
+          const body: unknown = await precheckRes.json();
+          if (
+            body !== null &&
+            typeof body === "object" &&
+            "error" in body &&
+            typeof (body as Record<string, unknown>).error === "string" &&
+            ((body as Record<string, unknown>).error as string).length > 0
+          ) {
+            msg = (body as Record<string, unknown>).error as string;
+          }
+        } catch {
+          // Ignore parse errors; generic message is already set.
         }
-      } catch {
-        // Ignore parse errors; generic message is already set.
+        setError(msg);
+        return;
       }
-      setError(msg);
+
+      const appUrl =
+        process.env.NEXT_PUBLIC_APP_URL ??
+        (typeof window !== "undefined"
+          ? window.location.origin
+          : "http://localhost:3000");
+
+      const { error: signUpError } = await supabase.auth.signUp({
+        email,
+        password,
+        options: {
+          emailRedirectTo: `${appUrl}/auth/callback`,
+        },
+      });
+
+      if (signUpError) {
+        setError(signUpError.message);
+        return;
+      }
+
+      setSuccess(true);
+    } catch {
+      setError(
+        "An unexpected error occurred. Please check your connection and try again."
+      );
+    } finally {
       setLoading(false);
-      return;
     }
-
-    const appUrl =
-      process.env.NEXT_PUBLIC_APP_URL ??
-      (typeof window !== "undefined"
-        ? window.location.origin
-        : "http://localhost:3000");
-
-    const { error: signUpError } = await supabase.auth.signUp({
-      email,
-      password,
-      options: {
-        emailRedirectTo: `${appUrl}/auth/callback`,
-      },
-    });
-
-    if (signUpError) {
-      setError(signUpError.message);
-      setLoading(false);
-      return;
-    }
-
-    setSuccess(true);
-    setLoading(false);
   }
 
   if (success) {


### PR DESCRIPTION
## Summary

- The staging audit (PR #212) confirmed the signup page called `supabase.auth.signUp` directly at `apps/web-console/app/auth/sign-up/page.tsx:30`, bypassing the entire `signupguard` package built for issue #116. The PR #166 review thread claim that precheck was wired was incorrect; no call to the precheck endpoint existed anywhere in the file.
- The control-plane webhook backstop (`DisposableCheckFunc` in `apps/control-plane/internal/signup/webhook.go:135`) is intact and continues to block disposable-domain signups that arrive via direct Supabase API writes, but it does not cover the rate limit or Turnstile CAPTCHA, so the frontend precheck is still required.

## Changes

**`apps/web-console/app/auth/sign-up/page.tsx`**
Before calling `supabase.auth.signUp`, the form handler now POSTs to `/api/auth/signup-precheck`. A non-200 response blocks signup and surfaces the generic message from the control-plane. A Cloudflare Turnstile widget is rendered when `NEXT_PUBLIC_TURNSTILE_SITE_KEY` is set; when the env var is absent (local dev), the widget is skipped and the captcha token is sent as an empty string, which the control-plane accepts when `TURNSTILE_SECRET_KEY` is also unset.

**`apps/web-console/app/api/auth/signup-precheck/route.ts`** (new)
Next.js Route Handler that proxies `{ email, captcha_token }` to `POST /api/v1/auth/sign-up/precheck` on the control-plane. Reading `CONTROL_PLANE_BASE_URL` server-side keeps the internal URL out of the browser. Returns 503 when unconfigured or on network failure; never forwards internal error detail to the client.

**`apps/web-console/__tests__/signup-precheck-route.test.ts`** (new)
Unit tests for the Route Handler: success path, upstream rejection (403), missing `CONTROL_PLANE_BASE_URL` (503), malformed body (400), network failure (503).

**`.env.example`**
Added `NEXT_PUBLIC_TURNSTILE_SITE_KEY` alongside `TURNSTILE_SECRET_KEY` with instructions.

## Test plan

- [ ] Run `npm run test:unit` (requires local node_modules install) or `cd deploy/docker && docker compose run web-console npm run test:unit` to execute the Route Handler unit tests.
- [ ] Run `cd deploy/docker && docker compose run web-console npm run build` to type-check.
- [ ] With the full stack running locally, attempt signup with a disposable email address and verify a 403 is returned before `supabase.auth.signUp` is reached.
- [ ] With `NEXT_PUBLIC_TURNSTILE_SITE_KEY` set, verify the Turnstile widget renders on the signup form.
- [ ] With `NEXT_PUBLIC_TURNSTILE_SITE_KEY` unset (dev), verify signup still proceeds without the widget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)