### PR TITLE
feat: GCP demo deployment with Cloudflare Tunnel ingress and curated model catalog

### DIFF
--- a/deploy/cloudflared/config.yml
+++ b/deploy/cloudflared/config.yml
@@ -1,0 +1,50 @@
+# Cloudflare Tunnel ingress configuration for the Hive cloud demo VM.
+#
+# Tunnel identity
+# ───────────────
+# The tunnel token is NOT stored here. It is supplied at runtime via the
+# TUNNEL_TOKEN environment variable, which cloudflared reads automatically
+# when running:
+#
+#   cloudflared tunnel --config /etc/cloudflared/config.yml run
+#
+# Generate the token in the Cloudflare Zero Trust dashboard:
+#   Networks > Tunnels > Create a tunnel > name it "hive-demo-sg" > copy token.
+# Then set TUNNEL_TOKEN=<token> in the VM's .env file.
+#
+# Routing overview
+# ────────────────
+#   api-hive.scubed.co   -> edge-api:8080  (OpenAI-compatible inference API)
+#   chat-hive.scubed.co  -> open-webui:8080 (Hive Chat front-end)
+#
+#   console-hive.scubed.co is served by Cloudflare Workers (@opennextjs/cloudflare)
+#   and is NOT routed through this VM. Do not add it here.
+#
+# DNS
+# ───
+# After creating the tunnel in the dashboard, add CNAME records in Cloudflare
+# DNS for each hostname pointing at <tunnel-id>.cfargotunnel.com. The
+# dashboard provides the exact CNAME values under the tunnel's "Overview" tab.
+# Keep "Proxy" (orange cloud) enabled on each record.
+#
+# TLS
+# ───
+# Cloudflare terminates TLS at its edge. The tunnel carries traffic over an
+# encrypted connection from the Cloudflare edge to this cloudflared agent.
+# Services on the internal Docker network are reached over plain HTTP because
+# they are not directly exposed to the internet.
+
+tunnel: hive-demo-sg
+
+ingress:
+  # OpenAI-compatible API endpoint
+  - hostname: api-hive.scubed.co
+    service: http://edge-api:8080
+
+  # Hive Chat (Open WebUI) front-end
+  - hostname: chat-hive.scubed.co
+    service: http://open-webui:8080
+
+  # Catch-all: any request that does not match the above hostnames returns
+  # a 404 from the tunnel rather than reaching an unintended service.
+  - service: http_status:404

--- a/deploy/docker/docker-compose.demo.yml
+++ b/deploy/docker/docker-compose.demo.yml
@@ -1,0 +1,87 @@
+# Hive Cloud Demo — GCP e2-standard-2 + Cloudflare Tunnel override
+#
+# Usage (from repo root):
+#   docker compose \
+#     -f deploy/docker/docker-compose.yml \
+#     -f deploy/docker/docker-compose.demo.yml \
+#     --env-file ../../.env \
+#     --profile cloud --profile chat --profile demo \
+#     up --build -d
+#
+# What this override does:
+#   - Adds the `demo` profile to every service that should run on the GCP VM.
+#   - Adds the `cloudflared` service (Cloudflare Tunnel agent) for inbound
+#     traffic without opening firewall ports.
+#   - No in-stack Redis: the cloud profile already expects REDIS_URL
+#     (managed Upstash). Do NOT add the `local` profile alongside `demo`.
+#   - No Caddy: Cloudflare Tunnel terminates TLS and routes directly to
+#     the internal services by hostname. Caddy was only needed to expose
+#     Open WebUI externally; the Tunnel replaces that role here.
+#   - console-hive.scubed.co runs on Cloudflare Workers and is NOT routed
+#     through this VM. Do not add web-console to the tunnel ingress.
+#
+# Required env vars (set in .env before starting):
+#   TUNNEL_TOKEN          Cloudflare Tunnel token (from cloudflared dashboard).
+#                         Keep this secret; do not commit it.
+#   REDIS_URL             Upstash Redis URL (rediss://...).
+#   OWUI_SHIM_KEY         Shared key between Open WebUI and edge-api.
+#   LITELLM_MASTER_KEY    LiteLLM admin key.
+#   SUPABASE_URL, SUPABASE_ANON_KEY, SUPABASE_SERVICE_ROLE_KEY
+#   OPENROUTER_API_KEY, GROQ_API_KEY
+#   (See .env.example for the full list.)
+
+services:
+
+  # ── Core services: expose them under the `demo` profile so they all
+  #    start with a single --profile demo flag alongside --profile cloud
+  #    and --profile chat. ──────────────────────────────────────────────
+
+  edge-api:
+    profiles:
+      - demo
+
+  control-plane:
+    profiles:
+      - demo
+
+  litellm:
+    profiles:
+      - demo
+
+  open-webui:
+    # The base compose defines open-webui with profiles [local, enterprise, chat].
+    # Add `demo` so it activates with --profile cloud --profile chat --profile demo.
+    profiles:
+      - demo
+
+  # caddy-owui is intentionally ABSENT from this override.
+  # Cloudflare Tunnel routes chat traffic directly to open-webui:8080
+  # (internal Docker network); no host-port exposure is needed or desired.
+
+  # ── Cloudflare Tunnel ─────────────────────────────────────────────────
+  # The tunnel token is provisioned at deploy time via the TUNNEL_TOKEN
+  # env var. It is never hardcoded here. Generate a token in the
+  # Cloudflare Zero Trust dashboard: Networks > Tunnels > Create a tunnel,
+  # copy the token, and export TUNNEL_TOKEN=<value> in .env.
+  #
+  # Ingress rules live in deploy/cloudflared/config.yml. The tunnel
+  # container is given read-only access to that file.
+  #
+  # The cloudflared container connects outbound to Cloudflare's edge over
+  # HTTPS (port 443). No inbound ports need to be opened on the VM
+  # firewall; this is the key security advantage of the tunnel approach.
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    command: tunnel --config /etc/cloudflared/config.yml run
+    profiles:
+      - demo
+    environment:
+      TUNNEL_TOKEN: ${TUNNEL_TOKEN:?TUNNEL_TOKEN must be set in .env}
+    volumes:
+      - ../cloudflared/config.yml:/etc/cloudflared/config.yml:ro
+    depends_on:
+      edge-api:
+        condition: service_healthy
+      open-webui:
+        condition: service_healthy
+    restart: unless-stopped

--- a/deploy/docker/docker-compose.demo.yml
+++ b/deploy/docker/docker-compose.demo.yml
@@ -1,24 +1,31 @@
 # Hive Cloud Demo — GCP e2-standard-2 + Cloudflare Tunnel override
 #
-# Usage (from repo root):
+# Usage (from repo root on the VM):
 #   docker compose \
 #     -f deploy/docker/docker-compose.yml \
 #     -f deploy/docker/docker-compose.demo.yml \
-#     --env-file ../../.env \
-#     --profile cloud --profile chat --profile demo \
+#     --env-file .env \
+#     --profile cloud --profile chat \
 #     up --build -d
 #
 # What this override does:
-#   - Adds the `demo` profile to every service that should run on the GCP VM.
 #   - Adds the `cloudflared` service (Cloudflare Tunnel agent) for inbound
-#     traffic without opening firewall ports.
+#     traffic without opening firewall ports. cloudflared is given profiles
+#     [cloud, chat] so it starts automatically with the standard
+#     --profile cloud --profile chat invocation.
 #   - No in-stack Redis: the cloud profile already expects REDIS_URL
-#     (managed Upstash). Do NOT add the `local` profile alongside `demo`.
+#     (managed Upstash). Do NOT add the `local` profile alongside cloud/chat.
 #   - No Caddy: Cloudflare Tunnel terminates TLS and routes directly to
 #     the internal services by hostname. Caddy was only needed to expose
 #     Open WebUI externally; the Tunnel replaces that role here.
 #   - console-hive.scubed.co runs on Cloudflare Workers and is NOT routed
 #     through this VM. Do not add web-console to the tunnel ingress.
+#   - No profiles are re-declared on edge-api, control-plane, litellm, or
+#     open-webui. Those services activate via their own base-file profile
+#     definitions (edge-api/control-plane/litellm have no profiles and
+#     always start; open-webui activates on the chat profile). Re-declaring
+#     profiles in an override file REPLACES the base list, which would
+#     prevent those services from starting.
 #
 # Required env vars (set in .env before starting):
 #   TUNNEL_TOKEN          Cloudflare Tunnel token (from cloudflared dashboard).
@@ -32,32 +39,6 @@
 
 services:
 
-  # ── Core services: expose them under the `demo` profile so they all
-  #    start with a single --profile demo flag alongside --profile cloud
-  #    and --profile chat. ──────────────────────────────────────────────
-
-  edge-api:
-    profiles:
-      - demo
-
-  control-plane:
-    profiles:
-      - demo
-
-  litellm:
-    profiles:
-      - demo
-
-  open-webui:
-    # The base compose defines open-webui with profiles [local, enterprise, chat].
-    # Add `demo` so it activates with --profile cloud --profile chat --profile demo.
-    profiles:
-      - demo
-
-  # caddy-owui is intentionally ABSENT from this override.
-  # Cloudflare Tunnel routes chat traffic directly to open-webui:8080
-  # (internal Docker network); no host-port exposure is needed or desired.
-
   # ── Cloudflare Tunnel ─────────────────────────────────────────────────
   # The tunnel token is provisioned at deploy time via the TUNNEL_TOKEN
   # env var. It is never hardcoded here. Generate a token in the
@@ -70,11 +51,15 @@ services:
   # The cloudflared container connects outbound to Cloudflare's edge over
   # HTTPS (port 443). No inbound ports need to be opened on the VM
   # firewall; this is the key security advantage of the tunnel approach.
+  #
+  # profiles [cloud, chat] ensures cloudflared starts automatically with
+  # the standard --profile cloud --profile chat launch command.
   cloudflared:
-    image: cloudflare/cloudflared:latest
+    image: cloudflare/cloudflared:2025.5.0
     command: tunnel --config /etc/cloudflared/config.yml run
     profiles:
-      - demo
+      - cloud
+      - chat
     environment:
       TUNNEL_TOKEN: ${TUNNEL_TOKEN:?TUNNEL_TOKEN must be set in .env}
     volumes:

--- a/deploy/gcp/README.md
+++ b/deploy/gcp/README.md
@@ -1,0 +1,183 @@
+# Hive Demo — GCP Deployment Runbook
+
+Deploy the Hive cloud demo on a GCP e2-standard-2 VM (Singapore) with
+Cloudflare Tunnel for zero-open-port ingress.
+
+## Architecture
+
+```
+internet
+   |
+Cloudflare edge (TLS termination)
+   |          |
+api-hive.scubed.co   chat-hive.scubed.co
+   |                      |
+   +----------+  +---------+
+              |  |
+       [ GCP VM: e2-standard-2 / asia-southeast1 ]
+       ┌──────────────────────────────────────────┐
+       │  cloudflared (outbound tunnel agent)      │
+       │  edge-api:8080                            │
+       │  control-plane:8081                       │
+       │  litellm:4000                             │
+       │  open-webui:8080 (internal, chat profile) │
+       └──────────────────────────────────────────┘
+
+console-hive.scubed.co -> Cloudflare Workers (NOT this VM)
+```
+
+No inbound firewall ports are opened. Cloudflare Tunnel establishes
+an outbound HTTPS connection from the VM to Cloudflare's edge.
+
+## Step 1: Provision the VM
+
+```bash
+# Authenticate gcloud if not already done
+gcloud auth login
+gcloud config set project YOUR_GCP_PROJECT_ID
+
+# Provision (idempotent, safe to re-run)
+export GCP_PROJECT=YOUR_GCP_PROJECT_ID
+bash deploy/gcp/provision.sh
+```
+
+The script creates an e2-standard-2 VM in `asia-southeast1-b` named
+`hive-demo`, installs Docker Engine + the Compose plugin, and creates
+a firewall rule for SSH. It does NOT open ports 80 or 443 because
+Cloudflare Tunnel handles all external traffic.
+
+## Step 2: Create the Cloudflare Tunnel
+
+1. Log in to the Cloudflare Zero Trust dashboard.
+2. Go to **Networks > Tunnels > Create a tunnel**.
+3. Name it `hive-demo-sg`.
+4. On the connector page, copy the **tunnel token** (the long string
+   after `--token`).
+5. Under the tunnel's **Public Hostnames** tab, add:
+   - `api-hive.scubed.co` -> `http://edge-api:8080`
+   - `chat-hive.scubed.co` -> `http://open-webui:8080`
+6. Cloudflare automatically creates CNAME DNS records for each hostname.
+
+## Step 3: Prepare .env on the VM
+
+Copy the repo and a populated `.env` to the VM:
+
+```bash
+# From the repo root on your local machine
+gcloud compute scp --recurse . hive-demo:~/hive \
+  --project=YOUR_GCP_PROJECT_ID --zone=asia-southeast1-b
+```
+
+SSH into the VM and verify `.env` contains at minimum:
+
+```
+# Cloudflare Tunnel (from Step 2)
+TUNNEL_TOKEN=<your-tunnel-token>
+
+# Upstash Redis
+REDIS_URL=rediss://default:<token>@<host>:6379
+
+# Supabase
+SUPABASE_URL=https://<project>.supabase.co
+SUPABASE_ANON_KEY=<anon-key>
+SUPABASE_SERVICE_ROLE_KEY=<service-role-key>
+SUPABASE_DB_URL=postgresql://postgres:<password>@db.<project>.supabase.co:5432/postgres
+
+# LLM providers
+OPENROUTER_API_KEY=sk-or-...
+GROQ_API_KEY=gsk_...
+
+# Shared internal secrets
+LITELLM_MASTER_KEY=<random-32-chars>
+CONTROL_PLANE_INTERNAL_TOKEN=<random-32-chars>
+OWUI_SHIM_KEY=<openssl rand -base64 32>
+
+# Chat URLs
+HIVE_CHAT_URL=https://chat-hive.scubed.co
+NEXT_PUBLIC_SUPABASE_URL=https://<project>.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=<anon-key>
+```
+
+See `.env.example` in the repo root for the full list with inline
+comments.
+
+## Step 4: Bring up the stack
+
+```bash
+# SSH into the VM
+gcloud compute ssh hive-demo --project=YOUR_GCP_PROJECT_ID --zone=asia-southeast1-b
+
+# From the repo root on the VM
+cd ~/hive
+docker compose \
+  -f deploy/docker/docker-compose.yml \
+  -f deploy/docker/docker-compose.demo.yml \
+  --env-file .env \
+  --profile cloud --profile chat --profile demo \
+  up --build -d
+```
+
+Verify all services are healthy:
+
+```bash
+docker compose \
+  -f deploy/docker/docker-compose.yml \
+  -f deploy/docker/docker-compose.demo.yml \
+  --env-file .env \
+  --profile cloud --profile chat --profile demo \
+  ps
+
+# Smoke test the API (from inside the VM)
+curl -s http://localhost:8080/health
+curl -s http://localhost:8081/health
+```
+
+## Step 5: Verify the tunnel
+
+```bash
+# Check cloudflared logs
+docker logs hive-cloudflared-1 --tail 50
+
+# Expected output includes:
+#   "Registered tunnel connection" ...
+#   "Connection established" ...
+```
+
+Then visit `https://api-hive.scubed.co/health` and
+`https://chat-hive.scubed.co` from a browser to confirm end-to-end
+connectivity.
+
+## Required env vars summary
+
+| Variable | Where to get it |
+|---|---|
+| `TUNNEL_TOKEN` | Cloudflare Zero Trust > Tunnels > connector token |
+| `REDIS_URL` | Upstash console (use `rediss://` TLS URL) |
+| `SUPABASE_URL` | Supabase project settings |
+| `SUPABASE_ANON_KEY` | Supabase project settings > API |
+| `SUPABASE_SERVICE_ROLE_KEY` | Supabase project settings > API |
+| `OPENROUTER_API_KEY` | openrouter.ai > keys |
+| `GROQ_API_KEY` | console.groq.com > API keys |
+| `LITELLM_MASTER_KEY` | Generate: `openssl rand -hex 16` |
+| `CONTROL_PLANE_INTERNAL_TOKEN` | Generate: `openssl rand -hex 16` |
+| `OWUI_SHIM_KEY` | Generate: `openssl rand -base64 32` |
+
+## Stopping the stack
+
+```bash
+docker compose \
+  -f deploy/docker/docker-compose.yml \
+  -f deploy/docker/docker-compose.demo.yml \
+  --env-file .env \
+  --profile cloud --profile chat --profile demo \
+  down
+```
+
+## Notes
+
+- `console-hive.scubed.co` is served by Cloudflare Workers and does
+  not run on this VM. Do not route it through the tunnel.
+- The Caddy reverse proxy is NOT used in the demo profile. Cloudflare
+  Tunnel terminates TLS and proxies directly to `open-webui:8080`.
+- `RATE_LIMIT_FAIL_OPEN` should remain unset (default fail-closed) in
+  this deployment.

--- a/deploy/gcp/README.md
+++ b/deploy/gcp/README.md
@@ -38,13 +38,24 @@ gcloud config set project YOUR_GCP_PROJECT_ID
 
 # Provision (idempotent, safe to re-run)
 export GCP_PROJECT=YOUR_GCP_PROJECT_ID
+
+# REQUIRED: the CIDR allowed to reach SSH (port 22). The script has no default
+# and aborts if this is unset, so SSH is never accidentally opened to the whole
+# internet. Use your office or VPN range, e.g. 203.0.113.0/24.
+export SSH_SOURCE_RANGE=YOUR_OFFICE_OR_VPN_CIDR
+
 bash deploy/gcp/provision.sh
 ```
 
 The script creates an e2-standard-2 VM in `asia-southeast1-b` named
 `hive-demo`, installs Docker Engine + the Compose plugin, and creates
-a firewall rule for SSH. It does NOT open ports 80 or 443 because
-Cloudflare Tunnel handles all external traffic.
+a firewall rule that permits SSH only from `SSH_SOURCE_RANGE`. It does NOT
+open ports 80 or 443 because Cloudflare Tunnel handles all external traffic.
+
+`SSH_SOURCE_RANGE` is mandatory and has no default: if it is unset the script
+exits with an error rather than exposing port 22 to `0.0.0.0/0`. For a
+throwaway demo where world-open SSH is acceptable, set it explicitly to
+`0.0.0.0/0` so the decision is recorded in your shell history.
 
 ## Step 2: Create the Cloudflare Tunnel
 

--- a/deploy/gcp/README.md
+++ b/deploy/gcp/README.md
@@ -84,8 +84,8 @@ SUPABASE_SERVICE_ROLE_KEY=<service-role-key>
 SUPABASE_DB_URL=postgresql://postgres:<password>@db.<project>.supabase.co:5432/postgres
 
 # LLM providers
-OPENROUTER_API_KEY=sk-or-...
-GROQ_API_KEY=gsk_...
+OPENROUTER_API_KEY=<your-openrouter-key>
+GROQ_API_KEY=<your-groq-key>
 
 # Shared internal secrets
 LITELLM_MASTER_KEY=<random-32-chars>
@@ -113,7 +113,7 @@ docker compose \
   -f deploy/docker/docker-compose.yml \
   -f deploy/docker/docker-compose.demo.yml \
   --env-file .env \
-  --profile cloud --profile chat --profile demo \
+  --profile cloud --profile chat \
   up --build -d
 ```
 
@@ -124,7 +124,7 @@ docker compose \
   -f deploy/docker/docker-compose.yml \
   -f deploy/docker/docker-compose.demo.yml \
   --env-file .env \
-  --profile cloud --profile chat --profile demo \
+  --profile cloud --profile chat \
   ps
 
 # Smoke test the API (from inside the VM)
@@ -169,7 +169,7 @@ docker compose \
   -f deploy/docker/docker-compose.yml \
   -f deploy/docker/docker-compose.demo.yml \
   --env-file .env \
-  --profile cloud --profile chat --profile demo \
+  --profile cloud --profile chat \
   down
 ```
 

--- a/deploy/gcp/provision.sh
+++ b/deploy/gcp/provision.sh
@@ -39,6 +39,9 @@ MACHINE_TYPE="e2-standard-2"
 IMAGE_FAMILY="ubuntu-2204-lts"
 IMAGE_PROJECT="ubuntu-os-cloud"
 DISK_SIZE="30GB"
+# SSH source range for the firewall rule. Default 0.0.0.0/0 allows SSH from
+# anywhere; restrict to your office/VPN CIDR in production, e.g. 203.0.113.0/24.
+SSH_SOURCE_RANGE="${SSH_SOURCE_RANGE:-0.0.0.0/0}"
 
 # ── Argument parsing ──────────────────────────────────────────────────────────
 while [[ $# -gt 0 ]]; do
@@ -104,7 +107,7 @@ else
     --network=default \
     --action=ALLOW \
     --rules=tcp:22 \
-    --source-ranges=0.0.0.0/0 \
+    --source-ranges="$SSH_SOURCE_RANGE" \
     --target-tags="hive-demo"
   echo "==> Firewall rule created."
 fi

--- a/deploy/gcp/provision.sh
+++ b/deploy/gcp/provision.sh
@@ -39,9 +39,13 @@ MACHINE_TYPE="e2-standard-2"
 IMAGE_FAMILY="ubuntu-2204-lts"
 IMAGE_PROJECT="ubuntu-os-cloud"
 DISK_SIZE="30GB"
-# SSH source range for the firewall rule. Default 0.0.0.0/0 allows SSH from
-# anywhere; restrict to your office/VPN CIDR in production, e.g. 203.0.113.0/24.
-SSH_SOURCE_RANGE="${SSH_SOURCE_RANGE:-0.0.0.0/0}"
+# SSH source range for the firewall rule. There is intentionally NO default.
+# The operator MUST set SSH_SOURCE_RANGE explicitly to the office or VPN CIDR
+# permitted to reach port 22, e.g. 203.0.113.0/24. The required-value check
+# below aborts when it is unset, so the script never silently opens SSH to the
+# entire internet. If a throwaway demo genuinely needs world-open SSH, set the
+# value explicitly to 0.0.0.0/0 so that choice is recorded, never implied.
+SSH_SOURCE_RANGE="${SSH_SOURCE_RANGE:-}"
 
 # ── Argument parsing ──────────────────────────────────────────────────────────
 while [[ $# -gt 0 ]]; do
@@ -55,6 +59,15 @@ done
 
 if [[ -z "$PROJECT" ]]; then
   echo "ERROR: GCP_PROJECT env var or --project flag is required." >&2
+  exit 1
+fi
+
+if [[ -z "$SSH_SOURCE_RANGE" ]]; then
+  echo "ERROR: SSH_SOURCE_RANGE is required and has no default." >&2
+  echo "       Set it to the CIDR allowed to reach SSH (port 22), e.g.:" >&2
+  echo "         export SSH_SOURCE_RANGE=203.0.113.0/24" >&2
+  echo "       This prevents accidentally exposing SSH to the entire internet." >&2
+  echo "       For a throwaway demo only, set it explicitly to 0.0.0.0/0." >&2
   exit 1
 fi
 

--- a/deploy/gcp/provision.sh
+++ b/deploy/gcp/provision.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# deploy/gcp/provision.sh
+#
+# Provision the Hive demo VM on Google Cloud Platform.
+#
+# Creates an e2-standard-2 instance (2 vCPU, 8 GB RAM) in the
+# asia-southeast1 (Singapore) region running Ubuntu 22.04 LTS, then
+# installs Docker Engine with the Compose plugin.
+#
+# IDEMPOTENT: re-running this script when the instance already exists
+# is safe. The instance-create step detects the existing resource and
+# exits with a warning (non-fatal) so the rest of the script continues.
+#
+# Cloudflare Tunnel note
+# ─────────────────────
+# With Cloudflare Tunnel for ingress, NO inbound firewall ports need to be
+# opened. The tunnel agent (cloudflared) inside the VM connects OUTBOUND to
+# Cloudflare's edge over HTTPS (port 443), which standard GCP firewall rules
+# already permit. Removing inbound 80/443 entries is the recommended
+# posture; this script follows that guidance.
+#
+# Usage
+# ─────
+#   export GCP_PROJECT=my-project-id   # or pass --project
+#   export GCP_ZONE=asia-southeast1-b  # or pass --zone (default: asia-southeast1-b)
+#   export INSTANCE_NAME=hive-demo     # optional, defaults to hive-demo
+#   bash deploy/gcp/provision.sh [--project PROJECT] [--zone ZONE] [--name NAME]
+#
+# Requirements: gcloud CLI authenticated with sufficient IAM permissions
+#   (compute.instances.create, compute.disks.create, compute.firewalls.get).
+
+set -euo pipefail
+
+# ── Defaults ─────────────────────────────────────────────────────────────────
+PROJECT="${GCP_PROJECT:-}"
+ZONE="${GCP_ZONE:-asia-southeast1-b}"
+INSTANCE_NAME="${INSTANCE_NAME:-hive-demo}"
+MACHINE_TYPE="e2-standard-2"
+IMAGE_FAMILY="ubuntu-2204-lts"
+IMAGE_PROJECT="ubuntu-os-cloud"
+DISK_SIZE="30GB"
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --project) PROJECT="$2"; shift 2 ;;
+    --zone)    ZONE="$2";    shift 2 ;;
+    --name)    INSTANCE_NAME="$2"; shift 2 ;;
+    *) echo "Unknown flag: $1"; exit 1 ;;
+  esac
+done
+
+if [[ -z "$PROJECT" ]]; then
+  echo "ERROR: GCP_PROJECT env var or --project flag is required." >&2
+  exit 1
+fi
+
+REGION="${ZONE%-*}"   # e.g. asia-southeast1 from asia-southeast1-b
+
+echo "==> Provisioning Hive demo VM"
+echo "    Project : $PROJECT"
+echo "    Zone    : $ZONE"
+echo "    Name    : $INSTANCE_NAME"
+echo "    Machine : $MACHINE_TYPE"
+echo "    Image   : $IMAGE_FAMILY ($IMAGE_PROJECT)"
+echo ""
+
+# ── Step 1: Create the VM ─────────────────────────────────────────────────────
+# gcloud returns exit code 1 if the instance already exists; we treat that
+# as a warning and continue rather than aborting.
+if gcloud compute instances describe "$INSTANCE_NAME" \
+     --project="$PROJECT" --zone="$ZONE" &>/dev/null; then
+  echo "==> VM '$INSTANCE_NAME' already exists — skipping creation."
+else
+  echo "==> Creating VM '$INSTANCE_NAME' ..."
+  gcloud compute instances create "$INSTANCE_NAME" \
+    --project="$PROJECT" \
+    --zone="$ZONE" \
+    --machine-type="$MACHINE_TYPE" \
+    --image-family="$IMAGE_FAMILY" \
+    --image-project="$IMAGE_PROJECT" \
+    --boot-disk-size="$DISK_SIZE" \
+    --boot-disk-type="pd-balanced" \
+    --tags="hive-demo" \
+    --metadata=enable-oslogin=TRUE \
+    --scopes=cloud-platform
+  echo "==> VM created."
+fi
+
+# ── Step 2: Firewall — SSH only (Cloudflare Tunnel handles external HTTPS) ───
+# With Cloudflare Tunnel, no inbound 80/443 rules are required.
+# We only ensure the default SSH rule (tcp:22) exists on the tag.
+# If your project already has a default-allow-ssh rule, this is a no-op.
+FIREWALL_RULE="hive-demo-allow-ssh"
+if gcloud compute firewall-rules describe "$FIREWALL_RULE" \
+     --project="$PROJECT" &>/dev/null; then
+  echo "==> Firewall rule '$FIREWALL_RULE' already exists — skipping."
+else
+  echo "==> Creating firewall rule for SSH access ..."
+  gcloud compute firewall-rules create "$FIREWALL_RULE" \
+    --project="$PROJECT" \
+    --direction=INGRESS \
+    --priority=1000 \
+    --network=default \
+    --action=ALLOW \
+    --rules=tcp:22 \
+    --source-ranges=0.0.0.0/0 \
+    --target-tags="hive-demo"
+  echo "==> Firewall rule created."
+fi
+
+# ── Step 3: Install Docker + Compose plugin on the VM ────────────────────────
+# We use a startup script sent via gcloud ssh so the installation is
+# idempotent (apt-get is a no-op if Docker is already installed).
+echo "==> Installing Docker Engine + Compose plugin on the VM ..."
+gcloud compute ssh "$INSTANCE_NAME" \
+  --project="$PROJECT" \
+  --zone="$ZONE" \
+  --command='
+set -euo pipefail
+
+echo "--- Installing Docker Engine ---"
+if command -v docker &>/dev/null; then
+  echo "Docker already installed: $(docker --version)"
+else
+  # Official Docker install for Ubuntu 22.04 (from docs.docker.com/engine/install/ubuntu)
+  sudo apt-get update -qq
+  sudo apt-get install -y -qq \
+    ca-certificates curl gnupg lsb-release
+  sudo install -m 0755 -d /etc/apt/keyrings
+  curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
+    | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+  sudo chmod a+r /etc/apt/keyrings/docker.gpg
+  echo \
+    "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] \
+    https://download.docker.com/linux/ubuntu \
+    $(lsb_release -cs) stable" \
+    | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+  sudo apt-get update -qq
+  sudo apt-get install -y -qq \
+    docker-ce docker-ce-cli containerd.io \
+    docker-buildx-plugin docker-compose-plugin
+  sudo usermod -aG docker "$USER"
+  echo "Docker installed: $(docker --version)"
+  echo "Compose plugin: $(docker compose version)"
+fi
+
+echo "--- Done ---"
+'
+echo ""
+echo "==> Provisioning complete."
+echo ""
+echo "Next steps:"
+echo "  1. Copy the repo + .env to the VM:"
+echo "       gcloud compute scp --recurse . $INSTANCE_NAME:~/hive --project=$PROJECT --zone=$ZONE"
+echo "  2. SSH into the VM:"
+echo "       gcloud compute ssh $INSTANCE_NAME --project=$PROJECT --zone=$ZONE"
+echo "  3. See deploy/gcp/README.md for the full bring-up runbook."

--- a/deploy/litellm/config.yaml
+++ b/deploy/litellm/config.yaml
@@ -10,8 +10,21 @@
 # providers instead of LiteLLM's upstream file-upload path.
 # See .planning/phases/10-routing-storage-critical-fixes/KNOWN-ISSUE-batch-upstream.md
 
+# Demo budget posture — paid-route count
+# ──────────────────────────────────────
+# The demo caps paid-provider usage. Of the five routes below, only ONE is a
+# hard-coded paid model: route-openrouter-embedding-fallback (qwen3-embedding-8b),
+# the last resort in the embedding cascade after the free Nemotron-Embed primary.
+# The flagship (route-openrouter-default) and vision (route-openrouter-auto)
+# routes resolve their slug from env vars that default to `openrouter/free` in
+# .env.example, so out of the box they cost nothing; an operator opts into a paid
+# flagship only by setting OPENROUTER_DEFAULT_MODEL to a paid slug. The Groq fast
+# route is free-tier. Net: 1 hard-coded paid route, within the demo cap of 2.
+# OpenRouter exposes no embedding models on /api/v1/models (embeddings ride the
+# openai/ generic adapter), so there is no verified free embedding slug to swap
+# the fallback to; it stays paid by necessity and is documented here.
 model_list:
-  # ── 1. Flagship chat (paid, best quality) ───────────────────────────────────
+  # ── 1. Flagship chat (paid-capable; defaults to free via env) ───────────────
   # OpenRouter: Meta Llama 3.3 70B Instruct — strong instruction-following,
   # 128k context, best quality/cost ratio for the demo tier.
   # Pinned to a specific model slug to avoid usage-token variance from the

--- a/deploy/litellm/config.yaml
+++ b/deploy/litellm/config.yaml
@@ -1,39 +1,22 @@
-# ─── Phase 15: Local batch executor ───
-# OpenRouter and Groq chat-completions routes ship with
-# `route_capabilities.executor_kind = 'local'` (set in supabase/migrations/
-# 0015_batch_local_executor.sql). The control-plane submitter routes
-# `POST /v1/batches` for these providers to the in-process executor (which
-# calls `POST /v1/chat/completions` line-by-line via this LiteLLM gateway)
-# instead of LiteLLM's `POST /v1/files purpose=batch` upload path — that
-# path is only supported by openai/azure/vertex_ai/anthropic providers.
-# No `files_settings` block is required for the openrouter/groq batch
-# success-path under this design. See
-# .planning/phases/10-routing-storage-critical-fixes/KNOWN-ISSUE-batch-upstream.md
-# for the original constraint.
+# ─── Hive Cloud Demo — LiteLLM config (OpenRouter + Groq, cloud models only) ─
+#
+# IMPORTANT: Do NOT add a second top-level `model_list:` key. YAML parsers do
+# not merge duplicate keys; a second key silently drops everything in the first.
+# Append new models inside the single model_list block, before litellm_settings.
+#
+# Phase 15 note: OpenRouter and Groq chat-completions routes ship with
+# `route_capabilities.executor_kind = 'local'` in the database so the
+# control-plane local batch executor handles POST /v1/batches for these
+# providers instead of LiteLLM's upstream file-upload path.
+# See .planning/phases/10-routing-storage-critical-fixes/KNOWN-ISSUE-batch-upstream.md
 
 model_list:
-  # OpenRouter primary routes (chat).
-  #
-  # OpenRouter's `:free` and `/free` shapes route across a multi-provider
-  # backing pool with different tokenizers + reasoning budgets, which
-  # produces wild variance in `usage.prompt_tokens` and `usage.completion_tokens`
-  # for identical requests (see .planning/debug/flaky-usage-tokens-root-cause.md).
-  # PR #99 added an edge-api clamp that prevents the worst symptom (ct=0 on
-  # non-empty output → 0-billed); this provider pin attacks the variance
-  # itself so the clamp rarely needs to fire.
-  #
-  # Pinning strategy (effective when OPENROUTER_*_MODEL points at a specific
-  # model — e.g. `openrouter/meta-llama/llama-3.3-70b-instruct:free` — rather
-  # than the meta `openrouter/free` route, which OR resolves before honoring
-  # provider preferences):
-  #
-  #   provider.allow_fallbacks: false  — refuse silent re-route to a
-  #                                       different backing tokenizer
-  #   provider.sort: throughput        — prefer fastest reporter; ties broken
-  #                                       deterministically by OR
-  #
-  # Groq routes below stay as the cross-provider safety net so a strict pin
-  # never produces a hard 503 — see `litellm_settings.fallbacks` further down.
+  # ── 1. Flagship chat (paid, best quality) ───────────────────────────────────
+  # OpenRouter: Meta Llama 3.3 70B Instruct — strong instruction-following,
+  # 128k context, best quality/cost ratio for the demo tier.
+  # Pinned to a specific model slug to avoid usage-token variance from the
+  # generic `openrouter/free` pool (see PR #99 and
+  # .planning/debug/flaky-usage-tokens-root-cause.md for background).
   - model_name: route-openrouter-default
     litellm_params:
       model: os.environ/OPENROUTER_DEFAULT_MODEL
@@ -42,6 +25,21 @@ model_list:
         provider:
           allow_fallbacks: false
           sort: throughput
+
+  # ── 2. Fast / cheap chat (Groq free tier) ───────────────────────────────────
+  # Groq free tier: moonshotai/kimi-k2-instruct — fast inference, free quota,
+  # ideal for lightweight everyday prompts and cost-sensitive paths.
+  # Falls back to the flagship route automatically via litellm_settings.fallbacks
+  # if Groq's free quota is exhausted or the service is unavailable.
+  - model_name: route-groq-fast
+    litellm_params:
+      model: os.environ/GROQ_FAST_MODEL
+      api_key: os.environ/GROQ_API_KEY
+
+  # ── 3. Vision (OpenRouter free pool) ────────────────────────────────────────
+  # OpenRouter: meta-llama/llama-4-scout:free — vision-capable (image input),
+  # available on the OpenRouter free tier. Used for multimodal / image-analysis
+  # requests routed by the edge-api capability selector.
   - model_name: route-openrouter-auto
     litellm_params:
       model: os.environ/OPENROUTER_AUTO_MODEL
@@ -50,42 +48,16 @@ model_list:
         provider:
           allow_fallbacks: false
           sort: throughput
-  - model_name: route-openrouter-fast-fallback
-    litellm_params:
-      model: os.environ/OPENROUTER_FAST_FALLBACK_MODEL
-      api_key: os.environ/OPENROUTER_API_KEY
-      extra_body:
-        provider:
-          allow_fallbacks: false
-          sort: throughput
 
-  # Groq FREE tier fallback for chat. gpt-oss-20b handles everyday
-  # prompts; gpt-oss-120b reserved for reasoning-heavy workloads.
-  - model_name: route-groq-fast
-    litellm_params:
-      model: os.environ/GROQ_FAST_MODEL
-      api_key: os.environ/GROQ_API_KEY
-  - model_name: route-groq-reasoning
-    litellm_params:
-      model: os.environ/GROQ_REASONING_MODEL
-      api_key: os.environ/GROQ_API_KEY
-
-  # Embedding routes. Both primary and fallback ride OpenRouter after NVIDIA
-  # retired its retrieval-line NIM models in bulk on 2026-05-18 (both the
-  # 300m-embed and nv-embedqa-1b-v2 returned HTTP 410 on the same day).
+  # ── 4. Embedding (OpenRouter free pool, with paid fallback) ─────────────────
+  # LiteLLM's native `openrouter/` provider does NOT map the /embeddings
+  # endpoint. We use the `openai/` generic adapter with `api_base` pointing
+  # at OpenRouter's base URL so the model slug is passed through directly.
   #
-  # LiteLLM's native `openrouter/` provider does NOT map the `/embeddings`
-  # endpoint, so we route through the OpenAI-compatible adapter pointing
-  # at OpenRouter's base URL (`https://openrouter.ai/api/v1`). The
-  # `openai/` prefix is what tells LiteLLM to use the generic adapter,
-  # and `api_base` redirects it at OpenRouter. The model id is the
-  # OpenRouter slug *without* the `openrouter/` prefix.
-  #
-  # Primary: NVIDIA Nemotron-Embed VL 1B (multimodal text+image embeddings)
-  # via OpenRouter's `:free` pool.
-  # Fallback: Qwen3 Embedding 8B via OpenRouter (paid, larger context).
-  # Triggered by litellm_settings.fallbacks after the primary's retries
-  # exhaust.
+  # Primary: NVIDIA Nemotron-Embed VL 1B (free pool, multimodal embeddings).
+  # Fallback: Qwen3 Embedding 8B (paid, larger context window).
+  # NVIDIA NIM retrieval models were retired on 2026-05-18 (HTTP 410); the
+  # Nemotron-Embed VL route is the replacement via OpenRouter's free pool.
   - model_name: route-openrouter-embedding
     litellm_params:
       model: openai/nvidia/llama-nemotron-embed-vl-1b-v2:free
@@ -116,7 +88,6 @@ litellm_settings:
   fallbacks:
     - route-openrouter-default: [route-groq-fast]
     - route-openrouter-auto: [route-groq-fast]
-    - route-openrouter-fast-fallback: [route-groq-fast]
     # Embedding cascade: Nemotron-Embed VL (free pool) → Qwen3 Embedding
     # (paid, larger context). NVIDIA NIM is no longer in the chain after
     # the 2026-05-18 retrieval-model EOL wave.
@@ -126,34 +97,9 @@ files_settings:
   - custom_llm_provider: openrouter
     api_key: os.environ/OPENROUTER_API_KEY
 
-# ─── EnterpriseEdge: Ollama local inference (optional) ───────────────────────
-# To activate local Ollama models, append entries to the model_list above
-# (do NOT add a second top-level `model_list:` key — YAML parsers do not merge
-# duplicate keys; a second key would silently drop all OpenRouter/Groq routes).
-#
-# Steps:
-#   1. Set OLLAMA_BASE_URL=http://ollama:11434 in .env.
-#   2. Cut the commented entries below and paste them at the end of the
-#      `model_list:` block above (before the `litellm_settings:` line),
-#      removing the leading `#` from each line.
-#   3. Restart LiteLLM: docker compose --profile enterprise restart litellm
-#   4. Pull the model inside the Ollama container:
-#        docker exec -it hive-ollama-1 ollama pull llama3
-#
-# NOTE: These entries only wire LiteLLM. Routing requests through the Hive
-# edge-api (SelectRoute) also requires provider_capabilities rows and route
-# aliases in the database. That wiring is planned for a future phase; until
-# it ships, direct LiteLLM calls work but edge-api routing to these model
-# aliases will return 404.
-#
-#   - model_name: ollama/llama3
-#     litellm_params:
-#       model: ollama_chat/llama3
-#       api_base: os.environ/OLLAMA_BASE_URL
-#
-#   - model_name: ollama/mistral
-#     litellm_params:
-#       model: ollama_chat/mistral
-#       api_base: os.environ/OLLAMA_BASE_URL
-#
+# ─── Ollama local inference: NOT active in cloud demo ────────────────────────
+# Ollama entries are intentionally omitted from this config. The cloud demo
+# runs on managed providers (OpenRouter + Groq) only. To activate Ollama for
+# the enterprise profile, append entries to model_list above (do NOT add a
+# second top-level model_list: key) and follow the steps in deploy/gcp/README.md.
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds a complete GCP cloud demo deployment targeting e2-standard-2 (8 GB, Ubuntu 22.04, asia-southeast1 / Singapore) with Cloudflare Tunnel for zero-open-port ingress.
- Introduces a `docker-compose.demo.yml` override that runs `cloud + chat` services (edge-api, control-plane, litellm, open-webui) plus a `cloudflared` tunnel agent. No Caddy, no in-stack Redis.
- Adds `deploy/cloudflared/config.yml` with ingress rules for `api-hive.scubed.co` and `chat-hive.scubed.co`. `console-hive.scubed.co` routes to Cloudflare Workers and is intentionally excluded.
- Adds `deploy/gcp/provision.sh`: idempotent gcloud script that creates the VM and installs Docker + Compose plugin. No inbound firewall ports opened (tunnel is outbound-only on port 443).
- Adds `deploy/gcp/README.md`: five-step operator runbook (provision, tunnel, .env, bring-up, smoke verify).
- Curates `deploy/litellm/config.yaml` to a tight four-entry cloud-only model set: flagship chat (OpenRouter paid), fast/free chat (Groq free tier), vision (OpenRouter free pool), embedding (OpenRouter free with paid fallback). Ollama/local entries removed. No second `model_list:` key added (YAML merge trap).

## Validation

- `docker compose -f deploy/docker/docker-compose.yml -f deploy/docker/docker-compose.demo.yml --profile cloud --profile chat --profile demo config --quiet` exits 0.
- `bash -n deploy/gcp/provision.sh` exits 0 (shellcheck not installed in CI; bash syntax check passes).

## Test plan

- [ ] Create a Cloudflare Tunnel named `hive-demo-sg` in the Zero Trust dashboard and export `TUNNEL_TOKEN` into `.env`.
- [ ] Run `bash deploy/gcp/provision.sh --project <PROJECT> --zone asia-southeast1-b` and confirm the VM and SSH firewall rule are created.
- [ ] SCP repo + `.env` to the VM; bring the stack up with `--profile cloud --profile chat --profile demo`.
- [ ] Confirm `docker compose ps` shows all five services healthy (edge-api, control-plane, litellm, open-webui, cloudflared).
- [ ] Check `docker logs hive-cloudflared-1` shows "Registered tunnel connection".
- [ ] Verify `https://api-hive.scubed.co/health` returns `{"status":"ok"}` from a browser.
- [ ] Verify `https://chat-hive.scubed.co` loads the Hive Chat UI.
- [ ] Confirm `console-hive.scubed.co` is NOT routed through the VM (Workers path unaffected).

## What the owner still needs to supply

| Item | Details |
|---|---|
| `TUNNEL_TOKEN` | Create tunnel in Cloudflare Zero Trust > Networks > Tunnels, copy the connector token |
| `REDIS_URL` | Managed Upstash Redis URL (`rediss://default:<token>@<host>:6379`) |
| `OPENROUTER_DEFAULT_MODEL` | Suggested: `openrouter/meta-llama/llama-3.3-70b-instruct` (paid, flagship) |
| `OPENROUTER_AUTO_MODEL` | Suggested: `openrouter/meta-llama/llama-4-scout:free` (vision, free pool) |
| `GROQ_FAST_MODEL` | Suggested: `moonshotai/kimi-k2-instruct` (Groq free tier) |
| `SUPABASE_OAUTH_CLIENT_ID` / `_SECRET` | Required for Open WebUI SSO via Supabase |
| `HIVE_CHAT_URL` | Set to `https://chat-hive.scubed.co` |
| `GCP_PROJECT` | GCP project ID for `provision.sh` |