### PR TITLE
feat: arm64 multi-arch prod images and OCI A1 catch script

### DIFF
--- a/deploy/docker/Dockerfile.control-plane.prod
+++ b/deploy/docker/Dockerfile.control-plane.prod
@@ -38,7 +38,6 @@ WORKDIR /src/apps/control-plane
 RUN CGO_ENABLED=0 GOARCH=${TARGETARCH} \
     go build -trimpath -ldflags='-s -w' -o /out/control-plane ./cmd/server
 
-
 # Runtime stage: no --platform needed here; buildx selects the correct
 # arch image automatically for the target platform.
 FROM alpine:3.20

--- a/deploy/docker/Dockerfile.control-plane.prod
+++ b/deploy/docker/Dockerfile.control-plane.prod
@@ -1,22 +1,52 @@
-# Production multi-stage build for control-plane
-FROM golang:1.24-alpine AS build
+# syntax=docker/dockerfile:1
+# Production multi-stage build for control-plane.
+# Supports linux/amd64 and linux/arm64 via docker buildx.
+# docker buildx injects BUILDPLATFORM and TARGETARCH automatically when
+# --platform is specified. A plain `docker build` (no buildx) still works
+# and builds for the host arch because TARGETARCH defaults to empty.
+
+# Build stage: pinned to the BUILD host's native arch so the Go toolchain
+# itself runs fast (no qemu overhead for the compiler).
+FROM --platform=$BUILDPLATFORM golang:1.24-alpine AS build
+
+# TARGETARCH is injected by buildx (value: amd64 or arm64).
+# When empty (plain docker build) Go uses the host GOARCH.
+ARG TARGETARCH
+
 RUN apk add --no-cache git ca-certificates
+
 WORKDIR /src
+
+# Cache dependencies: copy go.work and all module manifests first so the
+# workspace resolver downloads modules before source changes invalidate cache.
 COPY go.work go.work.sum* ./
 COPY apps/control-plane/go.mod apps/control-plane/go.sum* ./apps/control-plane/
 COPY apps/edge-api/go.mod apps/edge-api/go.sum* ./apps/edge-api/
 COPY packages/storage/go.mod packages/storage/go.sum* ./packages/storage/
 COPY packages/audit-canonical/go.mod packages/audit-canonical/go.sum* ./packages/audit-canonical/
 RUN cd apps/control-plane && go mod download
+
 COPY apps/control-plane/ ./apps/control-plane/
 COPY packages/storage/ ./packages/storage/
 COPY packages/audit-canonical/ ./packages/audit-canonical/
-WORKDIR /src/apps/control-plane
-RUN CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' -o /out/control-plane ./cmd/server
 
+WORKDIR /src/apps/control-plane
+
+# CGO_ENABLED=0 produces a fully static binary (no libc dependency),
+# which is required for cross-compilation and works on alpine.
+# GOARCH cross-compiles for the target platform (amd64 or arm64).
+RUN CGO_ENABLED=0 GOARCH=${TARGETARCH} \
+    go build -trimpath -ldflags='-s -w' -o /out/control-plane ./cmd/server
+
+
+# Runtime stage: no --platform needed here; buildx selects the correct
+# arch image automatically for the target platform.
 FROM alpine:3.20
+
 RUN apk add --no-cache ca-certificates wget && adduser -D -u 10001 app
+
 COPY --from=build /out/control-plane /usr/local/bin/control-plane
+
 # Pre-create the audit WAL directory under /var/lib/hive owned by the
 # non-root `app` user. The control-plane binary calls os.MkdirAll on
 # AUDIT_WAL_DIR (default /var/lib/hive/audit-wal) at startup and
@@ -24,6 +54,7 @@ COPY --from=build /out/control-plane /usr/local/bin/control-plane
 # cannot create directories under /var/lib and the container exits
 # immediately, failing the healthcheck.
 RUN mkdir -p /var/lib/hive/audit-wal/events && chown -R app:app /var/lib/hive
+
 WORKDIR /app
 USER app
 EXPOSE 8081

--- a/deploy/docker/Dockerfile.edge-api.prod
+++ b/deploy/docker/Dockerfile.edge-api.prod
@@ -42,7 +42,6 @@ WORKDIR /src/apps/edge-api
 RUN CGO_ENABLED=0 GOARCH=${TARGETARCH} \
     go build -trimpath -ldflags='-s -w' -o /out/edge-api ./cmd/server
 
-
 # Runtime stage: no --platform needed here; buildx selects the correct
 # arch image automatically for the target platform.
 FROM alpine:3.20

--- a/deploy/docker/Dockerfile.edge-api.prod
+++ b/deploy/docker/Dockerfile.edge-api.prod
@@ -1,26 +1,60 @@
-# Production multi-stage build for edge-api
-FROM golang:1.24-alpine AS build
+# syntax=docker/dockerfile:1
+# Production multi-stage build for edge-api.
+# Supports linux/amd64 and linux/arm64 via docker buildx.
+# docker buildx injects BUILDPLATFORM and TARGETARCH automatically when
+# --platform is specified. A plain `docker build` (no buildx) still works
+# and builds for the host arch because TARGETARCH defaults to empty.
+
+# Build stage: pinned to the BUILD host's native arch so the Go toolchain
+# itself runs fast (no qemu overhead for the compiler).
+FROM --platform=$BUILDPLATFORM golang:1.24-alpine AS build
+
+# TARGETARCH is injected by buildx (value: amd64 or arm64).
+# When empty (plain docker build) Go uses the host GOARCH.
+ARG TARGETARCH
+
 RUN apk add --no-cache git ca-certificates
+
 WORKDIR /src
+
+# Cache dependencies: copy go.work and all module manifests first so the
+# workspace resolver downloads modules before source changes invalidate cache.
 COPY go.work go.work.sum* ./
 COPY apps/edge-api/go.mod apps/edge-api/go.sum* ./apps/edge-api/
 COPY apps/control-plane/go.mod apps/control-plane/go.sum* ./apps/control-plane/
 COPY packages/storage/go.mod packages/storage/go.sum* ./packages/storage/
 COPY packages/audit-canonical/go.mod packages/audit-canonical/go.sum* ./packages/audit-canonical/
 RUN cd apps/edge-api && go mod download
+
 COPY apps/edge-api/ ./apps/edge-api/
 COPY packages/storage/ ./packages/storage/
 COPY packages/audit-canonical/ ./packages/audit-canonical/
-COPY packages/openai-contract/matrix/support-matrix.json ./packages/openai-contract/matrix/support-matrix.json
-COPY packages/openai-contract/generated/hive-openapi.yaml ./packages/openai-contract/generated/hive-openapi.yaml
-WORKDIR /src/apps/edge-api
-RUN CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' -o /out/edge-api ./cmd/server
+COPY packages/openai-contract/matrix/support-matrix.json \
+     ./packages/openai-contract/matrix/support-matrix.json
+COPY packages/openai-contract/generated/hive-openapi.yaml \
+     ./packages/openai-contract/generated/hive-openapi.yaml
 
+WORKDIR /src/apps/edge-api
+
+# CGO_ENABLED=0 produces a fully static binary (no libc dependency),
+# which is required for cross-compilation and works on alpine.
+# GOARCH cross-compiles for the target platform (amd64 or arm64).
+RUN CGO_ENABLED=0 GOARCH=${TARGETARCH} \
+    go build -trimpath -ldflags='-s -w' -o /out/edge-api ./cmd/server
+
+
+# Runtime stage: no --platform needed here; buildx selects the correct
+# arch image automatically for the target platform.
 FROM alpine:3.20
+
 RUN apk add --no-cache ca-certificates wget && adduser -D -u 10001 app
+
 COPY --from=build /out/edge-api /usr/local/bin/edge-api
-COPY --from=build /src/packages/openai-contract/matrix/support-matrix.json /app/packages/openai-contract/matrix/support-matrix.json
-COPY --from=build /src/packages/openai-contract/generated/hive-openapi.yaml /app/packages/openai-contract/generated/hive-openapi.yaml
+COPY --from=build /src/packages/openai-contract/matrix/support-matrix.json \
+     /app/packages/openai-contract/matrix/support-matrix.json
+COPY --from=build /src/packages/openai-contract/generated/hive-openapi.yaml \
+     /app/packages/openai-contract/generated/hive-openapi.yaml
+
 WORKDIR /app
 USER app
 EXPOSE 8080

--- a/deploy/docker/buildx.sh
+++ b/deploy/docker/buildx.sh
@@ -82,14 +82,22 @@ BUILD_FLAGS=(
 if [[ "${PUSH}" == "1" ]]; then
   BUILD_FLAGS+=(--push)
 else
-  # Without --push, load into local docker daemon. However, multi-platform
-  # images cannot be loaded simultaneously; load one platform at a time or
-  # omit --load and use --output type=oci,dest=<file> for artifact builds.
-  # Here we default to --load when push is disabled, which loads the image
-  # for the BUILD host's native arch only (buildx limitation).
-  echo "WARNING: --load with multi-platform only loads the host-native arch." \
-       "Use --push or export with --output to get a true multi-arch manifest." >&2
-  BUILD_FLAGS+=(--load)
+  # Count how many platforms were requested.
+  # docker buildx --load does not support multi-platform manifests; passing it
+  # with two or more platforms causes a hard error. When only one platform is
+  # specified, --load is safe and loads the image into the local daemon.
+  # When multiple platforms are specified without --push, omit any output flag
+  # so buildx builds and caches in the builder without exporting. Callers who
+  # need a portable artifact can set HIVE_PUSH=1 or use --output directly.
+  platform_count=$(echo "${PLATFORMS}" | tr ',' '\n' | grep -c .)
+  if [[ "${platform_count}" -eq 1 ]]; then
+    BUILD_FLAGS+=(--load)
+  else
+    echo "INFO: multiple platforms (${PLATFORMS}) without --push: building and caching" \
+         "in builder '${BUILDER}' only (no local daemon load)." \
+         "Re-run with --push or HIVE_PUSH=1 to export images." >&2
+    # No --load here; multi-platform load is not supported by docker buildx.
+  fi
 fi
 
 # ---- edge-api ---------------------------------------------------------------

--- a/deploy/docker/buildx.sh
+++ b/deploy/docker/buildx.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# deploy/docker/buildx.sh
+#
+# Build (and optionally push) the Hive Go service images for both
+# linux/amd64 and linux/arm64 using docker buildx.
+#
+# Usage:
+#   ./deploy/docker/buildx.sh [--push] [--tag TAG] [--registry REGISTRY]
+#
+# Environment variables (all have defaults):
+#   HIVE_REGISTRY   Container registry prefix  (default: ghcr.io/sakibsadmanshajib/hive)
+#   HIVE_TAG        Image tag                  (default: git short SHA, or "latest" if no git)
+#   HIVE_PUSH       Set to "1" to push after building (default: 0)
+#   HIVE_PLATFORMS  Comma-separated platforms  (default: linux/amd64,linux/arm64)
+#   HIVE_BUILDER    Buildx builder name        (default: hive-multiarch)
+#
+# Flag equivalents (flags override env vars):
+#   --push              Push to registry after build
+#   --tag TAG           Override HIVE_TAG
+#   --registry REGISTRY Override HIVE_REGISTRY
+#
+# The script must be run from the repo root (where go.work lives) because
+# Docker build context is "." and Dockerfiles use paths like apps/edge-api/.
+
+set -euo pipefail
+
+# ---- defaults ---------------------------------------------------------------
+REGISTRY="${HIVE_REGISTRY:-ghcr.io/sakibsadmanshajib/hive}"
+TAG="${HIVE_TAG:-$(git rev-parse --short HEAD 2>/dev/null || echo "latest")}"
+PUSH="${HIVE_PUSH:-0}"
+PLATFORMS="${HIVE_PLATFORMS:-linux/amd64,linux/arm64}"
+BUILDER="${HIVE_BUILDER:-hive-multiarch}"
+
+# ---- flag parsing -----------------------------------------------------------
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --push)
+      PUSH=1
+      shift
+      ;;
+    --tag)
+      TAG="$2"
+      shift 2
+      ;;
+    --registry)
+      REGISTRY="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown flag: $1" >&2
+      echo "Usage: $0 [--push] [--tag TAG] [--registry REGISTRY]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+EDGE_API_IMAGE="${REGISTRY}/edge-api:${TAG}"
+CONTROL_PLANE_IMAGE="${REGISTRY}/control-plane:${TAG}"
+
+echo "==> Hive multi-arch build"
+echo "    Platforms : ${PLATFORMS}"
+echo "    Registry  : ${REGISTRY}"
+echo "    Tag       : ${TAG}"
+echo "    Push      : ${PUSH}"
+echo "    Builder   : ${BUILDER}"
+echo
+
+# ---- ensure buildx builder exists -------------------------------------------
+if ! docker buildx inspect "${BUILDER}" &>/dev/null; then
+  echo "==> Creating buildx builder: ${BUILDER}"
+  docker buildx create --name "${BUILDER}" --driver docker-container --bootstrap
+fi
+
+docker buildx use "${BUILDER}"
+
+# ---- build flags ------------------------------------------------------------
+BUILD_FLAGS=(
+  --platform "${PLATFORMS}"
+  --provenance=false   # avoids extra index layers for registries that do not support them
+)
+
+if [[ "${PUSH}" == "1" ]]; then
+  BUILD_FLAGS+=(--push)
+else
+  # Without --push, load into local docker daemon. However, multi-platform
+  # images cannot be loaded simultaneously; load one platform at a time or
+  # omit --load and use --output type=oci,dest=<file> for artifact builds.
+  # Here we default to --load when push is disabled, which loads the image
+  # for the BUILD host's native arch only (buildx limitation).
+  echo "WARNING: --load with multi-platform only loads the host-native arch." \
+       "Use --push or export with --output to get a true multi-arch manifest." >&2
+  BUILD_FLAGS+=(--load)
+fi
+
+# ---- edge-api ---------------------------------------------------------------
+echo "==> Building edge-api -> ${EDGE_API_IMAGE}"
+docker buildx build \
+  "${BUILD_FLAGS[@]}" \
+  --file deploy/docker/Dockerfile.edge-api.prod \
+  --tag "${EDGE_API_IMAGE}" \
+  .
+
+echo "    Done: ${EDGE_API_IMAGE}"
+echo
+
+# ---- control-plane ----------------------------------------------------------
+echo "==> Building control-plane -> ${CONTROL_PLANE_IMAGE}"
+docker buildx build \
+  "${BUILD_FLAGS[@]}" \
+  --file deploy/docker/Dockerfile.control-plane.prod \
+  --tag "${CONTROL_PLANE_IMAGE}" \
+  .
+
+echo "    Done: ${CONTROL_PLANE_IMAGE}"
+echo
+
+echo "==> All builds complete."
+if [[ "${PUSH}" == "1" ]]; then
+  echo "    Images pushed to ${REGISTRY} with tag ${TAG}."
+else
+  echo "    Images NOT pushed. Re-run with --push or HIVE_PUSH=1 to publish."
+fi

--- a/deploy/oci/README.md
+++ b/deploy/oci/README.md
@@ -1,0 +1,98 @@
+# OCI A1 Flex Staging Runbook
+
+Hive's free-forever staging target is an Oracle OCI A1 Flex instance (arm64, 2 OCPU / 12 GB RAM). OCI free-tier A1 capacity is frequently sold out; `catch-a1.sh` polls until a slot becomes available.
+
+## Prerequisites
+
+1. **OCI CLI** installed and authenticated (`oci setup config` or `~/.oci/config`).
+2. An SSH key pair. The public key is injected into the instance at launch.
+3. The following OCIDs from your OCI tenancy:
+   - Compartment OCID
+   - Subnet OCID (in the target region, with public IP assignment enabled)
+   - Boot image OCID (arm64-compatible; Oracle Linux 8 or Ubuntu 22.04 for aarch64)
+
+## Running the catch script
+
+```bash
+# Export required variables
+export OCI_COMPARTMENT_ID="ocid1.compartment.oc1..aaaa..."
+export OCI_SUBNET_ID="ocid1.subnet.oc1.ap-mumbai-1.aaaa..."
+export OCI_IMAGE_ID="ocid1.image.oc1..aaaa..."
+export OCI_SSH_KEY_FILE="$HOME/.ssh/id_ed25519.pub"
+export OCI_REGION="ap-mumbai-1"          # optional if set in ~/.oci/config
+export OCI_DISPLAY_NAME="hive-a1-staging" # default if omitted
+
+# Start the catch loop (runs until an instance is provisioned or you Ctrl-C)
+chmod +x deploy/oci/catch-a1.sh
+./deploy/oci/catch-a1.sh
+```
+
+All variables can also be passed as flags:
+
+```bash
+./deploy/oci/catch-a1.sh \
+  --compartment ocid1.compartment.oc1..aaaa... \
+  --subnet      ocid1.subnet.oc1.ap-mumbai-1.aaaa... \
+  --image       ocid1.image.oc1..aaaa... \
+  --ssh-key     ~/.ssh/id_ed25519.pub \
+  --region      ap-mumbai-1
+```
+
+## What the script does
+
+1. Lists all availability domains (ADs) in the region.
+2. Checks whether an instance named `OCI_DISPLAY_NAME` already exists (idempotent).
+3. Cycles through ADs, trying 1 OCPU/6 GB first, then 2 OCPU/12 GB.
+4. On "Out of host capacity" (HTTP 500 / InternalError), sleeps and retries with exponential backoff (30 s default, doubles each cycle, capped at 300 s).
+5. On success, prints the instance OCID and connection instructions, then exits 0.
+
+## Backoff tuning
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `BACKOFF_MIN` | `30` | Initial sleep in seconds |
+| `BACKOFF_MAX` | `300` | Maximum sleep cap in seconds |
+| `BACKOFF_FACTOR` | `2` | Multiplier per cycle |
+
+## After provisioning
+
+```bash
+# 1. Find the public IP
+oci compute instance list-vnics \
+  --instance-id <INSTANCE_OCID> \
+  --query 'data[0]."public-ip"' --raw-output
+
+# 2. SSH into the instance
+ssh -i ~/.ssh/id_ed25519 opc@<PUBLIC_IP>
+
+# 3. Install Docker (Oracle Linux 8)
+sudo dnf install -y docker
+sudo systemctl enable --now docker
+sudo usermod -aG docker opc
+# Log out and back in so the group takes effect.
+
+# 4. Clone the repo and start the Hive enterprise stack
+git clone https://github.com/sakibsadmanshajib/hive.git
+cd hive
+cp .env.example .env   # fill in all required variables
+cd deploy/docker
+docker compose --env-file ../../.env --profile enterprise up -d
+```
+
+## Multi-arch image builds
+
+Before deploying to the A1 instance, build and push the arm64 images:
+
+```bash
+# From the repo root
+export HIVE_REGISTRY="ghcr.io/sakibsadmanshajib/hive"
+export HIVE_TAG="$(git rev-parse --short HEAD)"
+
+# Build for both amd64 and arm64, push to registry
+./deploy/docker/buildx.sh --push
+
+# On the A1 instance, pull and run the arm64 variant automatically
+# (Docker on arm64 pulls the arm64 manifest from the multi-arch image)
+```
+
+See `deploy/docker/buildx.sh --help` for all options.

--- a/deploy/oci/catch-a1.sh
+++ b/deploy/oci/catch-a1.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+# deploy/oci/catch-a1.sh
+#
+# Polls Oracle OCI until a VM.Standard.A1.Flex instance is provisioned.
+# OCI's free tier A1 capacity (arm64) is scarce; this script retries with
+# exponential backoff across all availability domains in the home region,
+# first attempting 1 OCPU/6 GB RAM and then 2 OCPU/12 GB RAM.
+#
+# Prerequisites:
+#   - OCI CLI installed and configured (~/.oci/config or env vars)
+#   - OCI_CLI_SUPPRESS_FILE_PERMISSIONS_WARNING=True if using instance principal
+#
+# Usage:
+#   ./deploy/oci/catch-a1.sh [--compartment OCID] [--subnet OCID] \
+#                             [--image OCID] [--ssh-key PATH] \
+#                             [--region REGION] [--display-name NAME]
+#
+# Environment variables (all required unless passed as flags):
+#   OCI_COMPARTMENT_ID   Compartment OCID
+#   OCI_SUBNET_ID        Subnet OCID (in the target region)
+#   OCI_IMAGE_ID         Boot image OCID (arm64-compatible, e.g. Oracle Linux 8)
+#   OCI_SSH_KEY_FILE     Path to public SSH key file (or set OCI_SSH_KEY directly)
+#   OCI_SSH_KEY          Public SSH key text (alternative to OCI_SSH_KEY_FILE)
+#   OCI_REGION           OCI region identifier (default: from CLI config)
+#   OCI_DISPLAY_NAME     Instance display name (default: hive-a1-staging)
+#
+# Shape sizing:
+#   The script tries 1 OCPU/6 GB first (fits within the Always Free 2 OCPU/12 GB
+#   ceiling and leaves headroom). On consecutive failure it escalates to 2 OCPU/12 GB.
+#   Both sizes stay within the Always Free limit.
+#
+# Backoff:
+#   Starts at BACKOFF_MIN seconds, doubles each cycle up to BACKOFF_MAX,
+#   then holds at BACKOFF_MAX. Each cycle tries all ADs before sleeping.
+#
+# Safety:
+#   - Idempotent: if an instance is already running with OCI_DISPLAY_NAME,
+#     the script detects it and exits 0 without launching a duplicate.
+#   - Safe to Ctrl-C at any time; no partial state is left because OCI
+#     launches are atomic (the instance either starts or returns an error).
+
+set -euo pipefail
+
+# ---- defaults ---------------------------------------------------------------
+COMPARTMENT_ID="${OCI_COMPARTMENT_ID:-}"
+SUBNET_ID="${OCI_SUBNET_ID:-}"
+IMAGE_ID="${OCI_IMAGE_ID:-}"
+SSH_KEY="${OCI_SSH_KEY:-}"
+SSH_KEY_FILE="${OCI_SSH_KEY_FILE:-}"
+REGION="${OCI_REGION:-}"
+DISPLAY_NAME="${OCI_DISPLAY_NAME:-hive-a1-staging}"
+
+BACKOFF_MIN="${BACKOFF_MIN:-30}"    # seconds between first retry
+BACKOFF_MAX="${BACKOFF_MAX:-300}"   # cap at 5 minutes
+BACKOFF_FACTOR="${BACKOFF_FACTOR:-2}"
+
+SHAPE="VM.Standard.A1.Flex"
+
+# ---- flag parsing -----------------------------------------------------------
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --compartment) COMPARTMENT_ID="$2"; shift 2 ;;
+    --subnet)      SUBNET_ID="$2"; shift 2 ;;
+    --image)       IMAGE_ID="$2"; shift 2 ;;
+    --ssh-key)     SSH_KEY_FILE="$2"; shift 2 ;;
+    --region)      REGION="$2"; shift 2 ;;
+    --display-name) DISPLAY_NAME="$2"; shift 2 ;;
+    *)
+      echo "Unknown flag: $1" >&2
+      echo "Usage: $0 [--compartment OCID] [--subnet OCID] [--image OCID]" \
+           "[--ssh-key PATH] [--region REGION] [--display-name NAME]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# ---- validate required inputs -----------------------------------------------
+missing=()
+[[ -z "${COMPARTMENT_ID}" ]] && missing+=("OCI_COMPARTMENT_ID / --compartment")
+[[ -z "${SUBNET_ID}" ]]      && missing+=("OCI_SUBNET_ID / --subnet")
+[[ -z "${IMAGE_ID}" ]]       && missing+=("OCI_IMAGE_ID / --image")
+
+# Resolve SSH key text
+if [[ -z "${SSH_KEY}" && -n "${SSH_KEY_FILE}" ]]; then
+  if [[ ! -f "${SSH_KEY_FILE}" ]]; then
+    echo "ERROR: SSH key file not found: ${SSH_KEY_FILE}" >&2
+    exit 1
+  fi
+  SSH_KEY="$(cat "${SSH_KEY_FILE}")"
+fi
+[[ -z "${SSH_KEY}" ]] && missing+=("OCI_SSH_KEY or OCI_SSH_KEY_FILE / --ssh-key")
+
+if [[ ${#missing[@]} -gt 0 ]]; then
+  echo "ERROR: Missing required configuration:" >&2
+  for m in "${missing[@]}"; do echo "  - ${m}" >&2; done
+  exit 1
+fi
+
+# ---- region flag for CLI calls ----------------------------------------------
+REGION_FLAG=()
+if [[ -n "${REGION}" ]]; then
+  REGION_FLAG=(--region "${REGION}")
+fi
+
+# ---- helpers ----------------------------------------------------------------
+log() { echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] $*"; }
+
+# Returns 0 and prints the instance OCID if an instance with OCI_DISPLAY_NAME
+# already exists in RUNNING or PROVISIONING state.
+check_existing() {
+  oci compute instance list \
+    "${REGION_FLAG[@]}" \
+    --compartment-id "${COMPARTMENT_ID}" \
+    --display-name   "${DISPLAY_NAME}" \
+    --lifecycle-state RUNNING \
+    --lifecycle-state PROVISIONING \
+    --query 'data[0].id' \
+    --raw-output \
+    2>/dev/null || true
+}
+
+# Attempt to launch a single instance.
+# Args: $1=ocpus $2=memory_gb $3=availability_domain
+# Returns 0 on success (prints instance OCID), non-zero on capacity error.
+try_launch() {
+  local ocpus="$1"
+  local memory_gb="$2"
+  local ad="$3"
+
+  log "Trying ${ocpus} OCPU / ${memory_gb} GB in AD: ${ad}"
+
+  # Capture both stdout (OCID on success) and stderr (error message).
+  local output
+  local rc=0
+  output=$(oci compute instance launch \
+    "${REGION_FLAG[@]}" \
+    --compartment-id                   "${COMPARTMENT_ID}" \
+    --availability-domain              "${ad}" \
+    --display-name                     "${DISPLAY_NAME}" \
+    --shape                            "${SHAPE}" \
+    --shape-config                     "{\"ocpus\": ${ocpus}, \"memoryInGBs\": ${memory_gb}}" \
+    --image-id                         "${IMAGE_ID}" \
+    --subnet-id                        "${SUBNET_ID}" \
+    --assign-public-ip                 true \
+    --metadata                         "{\"ssh_authorized_keys\": \"${SSH_KEY}\"}" \
+    --wait-for-state                   RUNNING \
+    --max-wait-seconds                 600 \
+    --query 'data.id' \
+    --raw-output \
+    2>&1) || rc=$?
+
+  if [[ ${rc} -eq 0 ]]; then
+    echo "${output}"
+    return 0
+  fi
+
+  # OCI returns HTTP 500 with code InternalError for out-of-capacity.
+  # Also covers LimitExceeded (429) if service limit is hit.
+  if echo "${output}" | grep -qiE "Out of host capacity|InternalError|LimitExceeded|ServiceError"; then
+    log "  Capacity unavailable in ${ad}: $(echo "${output}" | grep -oiE 'Out of host capacity|InternalError|LimitExceeded' | head -1)"
+    return 1
+  fi
+
+  # Unexpected error: log and propagate.
+  log "ERROR: unexpected OCI error:"
+  echo "${output}" >&2
+  return "${rc}"
+}
+
+# ---- list availability domains ----------------------------------------------
+log "Fetching availability domains for compartment ${COMPARTMENT_ID}..."
+ADS=$(oci iam availability-domain list \
+  "${REGION_FLAG[@]}" \
+  --compartment-id "${COMPARTMENT_ID}" \
+  --query 'data[*].name' \
+  --raw-output \
+  2>/dev/null | tr -d '[]"' | tr ',' ' ')
+
+if [[ -z "${ADS}" ]]; then
+  log "ERROR: Could not list availability domains. Check OCI CLI config and compartment OCID." >&2
+  exit 1
+fi
+
+log "Availability domains: ${ADS}"
+
+# ---- check for existing instance -------------------------------------------
+log "Checking for existing instance with display name '${DISPLAY_NAME}'..."
+EXISTING=$(check_existing)
+if [[ -n "${EXISTING}" ]]; then
+  log "Instance already exists: ${EXISTING}"
+  log "Nothing to do. Exiting 0."
+  exit 0
+fi
+
+# ---- sizing ladder ----------------------------------------------------------
+# Try 1 OCPU/6 GB first, then 2 OCPU/12 GB.
+declare -a SIZES=(
+  "1 6"
+  "2 12"
+)
+
+# ---- main retry loop --------------------------------------------------------
+backoff="${BACKOFF_MIN}"
+attempt=0
+
+log "Starting catch loop for ${SHAPE}. Ctrl-C to stop."
+
+while true; do
+  attempt=$(( attempt + 1 ))
+  log "=== Attempt ${attempt} ==="
+
+  for size_spec in "${SIZES[@]}"; do
+    read -r ocpus memory_gb <<< "${size_spec}"
+
+    for ad in ${ADS}; do
+      instance_id=$(try_launch "${ocpus}" "${memory_gb}" "${ad}") && {
+        log "SUCCESS! Instance provisioned."
+        log "  OCID        : ${instance_id}"
+        log "  Size        : ${ocpus} OCPU / ${memory_gb} GB"
+        log "  AD          : ${ad}"
+        log "  Display name: ${DISPLAY_NAME}"
+        log ""
+        log "Next steps:"
+        log "  1. Find the public IP: oci compute instance list-vnics --instance-id ${instance_id}"
+        log "  2. SSH: ssh -i <private_key> opc@<public_ip>"
+        log "  3. Run the Hive enterprise stack: docker compose --profile enterprise up -d"
+        exit 0
+      } || true  # non-zero means capacity error; continue to next AD/size
+    done
+  done
+
+  log "All ADs exhausted for this attempt. Sleeping ${backoff}s before retry..."
+  sleep "${backoff}"
+
+  # Exponential backoff with cap.
+  backoff=$(( backoff * BACKOFF_FACTOR ))
+  if [[ ${backoff} -gt ${BACKOFF_MAX} ]]; then
+    backoff="${BACKOFF_MAX}"
+  fi
+done

--- a/deploy/oci/catch-a1.sh
+++ b/deploy/oci/catch-a1.sh
@@ -229,7 +229,8 @@ while true; do
   for size_spec in "${SIZES[@]}"; do
     read -r ocpus memory_gb <<< "${size_spec}"
 
-    for ad in ${ADS}; do
+    read -ra ADS_ARRAY <<< "${ADS}"
+    for ad in "${ADS_ARRAY[@]}"; do
       instance_id=$(try_launch "${ocpus}" "${memory_gb}" "${ad}") && {
         log "SUCCESS! Instance provisioned."
         log "  OCID        : ${instance_id}"

--- a/deploy/oci/catch-a1.sh
+++ b/deploy/oci/catch-a1.sh
@@ -53,6 +53,11 @@ DISPLAY_NAME="${OCI_DISPLAY_NAME:-hive-a1-staging}"
 BACKOFF_MIN="${BACKOFF_MIN:-30}"    # seconds between first retry
 BACKOFF_MAX="${BACKOFF_MAX:-300}"   # cap at 5 minutes
 BACKOFF_FACTOR="${BACKOFF_FACTOR:-2}"
+# Ensure BACKOFF_FACTOR is a positive integer to prevent arithmetic errors.
+if ! [[ "${BACKOFF_FACTOR}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "ERROR: BACKOFF_FACTOR must be a positive integer, got: '${BACKOFF_FACTOR}'" >&2
+  exit 1
+fi
 
 SHAPE="VM.Standard.A1.Flex"
 
@@ -108,15 +113,27 @@ log() { echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] $*"; }
 # Returns 0 and prints the instance OCID if an instance with OCI_DISPLAY_NAME
 # already exists in RUNNING or PROVISIONING state.
 check_existing() {
-  oci compute instance list \
+  local running provisioning combined
+  running=$(oci compute instance list \
     "${REGION_FLAG[@]}" \
     --compartment-id "${COMPARTMENT_ID}" \
     --display-name   "${DISPLAY_NAME}" \
     --lifecycle-state RUNNING \
-    --lifecycle-state PROVISIONING \
-    --query 'data[0].id' \
+    --query 'data[*].id' \
     --raw-output \
-    2>/dev/null || true
+    2>/dev/null || echo "[]")
+  provisioning=$(oci compute instance list \
+    "${REGION_FLAG[@]}" \
+    --compartment-id "${COMPARTMENT_ID}" \
+    --display-name   "${DISPLAY_NAME}" \
+    --lifecycle-state PROVISIONING \
+    --query 'data[*].id' \
+    --raw-output \
+    2>/dev/null || echo "[]")
+  # Combine both arrays and return first hit, if any.
+  combined=$(printf '%s\n%s\n' "${running}" "${provisioning}" \
+    | grep -v '^\[\]$' | grep -v '^$' | head -1 || true)
+  echo "${combined}"
 }
 
 # Attempt to launch a single instance.
@@ -142,7 +159,7 @@ try_launch() {
     --image-id                         "${IMAGE_ID}" \
     --subnet-id                        "${SUBNET_ID}" \
     --assign-public-ip                 true \
-    --metadata                         "{\"ssh_authorized_keys\": \"${SSH_KEY}\"}" \
+    --metadata                         "$(jq -n --arg k "${SSH_KEY}" '{"ssh_authorized_keys":$k}')" \
     --wait-for-state                   RUNNING \
     --max-wait-seconds                 600 \
     --query 'data.id' \


### PR DESCRIPTION
## Summary

- **Dockerfile.edge-api.prod / Dockerfile.control-plane.prod**: both prod images now build for `linux/amd64` and `linux/arm64` via docker buildx. Build stage is pinned to `$BUILDPLATFORM` (runs native Go toolchain on the builder host); `GOARCH=${TARGETARCH}` in the `go build` step cross-compiles the static binary. `CGO_ENABLED=0` was already set so no libc dependency exists. The `alpine:3.20` runtime stage resolves the correct arch manifest automatically. Both files pass `docker build --check` with zero warnings.
- **deploy/docker/buildx.sh**: convenience script to build and optionally push both images for `linux/amd64,linux/arm64`. Reads `HIVE_REGISTRY`, `HIVE_TAG`, `HIVE_PUSH`, `HIVE_PLATFORMS`, `HIVE_BUILDER` from env or `--push`/`--tag`/`--registry` flags. Creates a `hive-multiarch` buildx builder if one does not already exist.
- **deploy/oci/catch-a1.sh**: polling script for the OCI A1 Flex free-tier capacity lottery. Cycles through all ADs in the region, tries 1 OCPU/6 GB first then 2 OCPU/12 GB, sleeps on `InternalError`/`Out of host capacity` with exponential backoff (30 s to 300 s). Idempotent: detects an existing instance by display name and exits 0 without launching a duplicate.
- **deploy/oci/README.md**: runbook covering prerequisites, catch script usage, post-provision Docker setup, and multi-arch image build/deploy workflow.

## What is NOT changed

- App logic (no Go source changes).
- Dev Dockerfiles (`Dockerfile.edge-api`, `Dockerfile.control-plane`) — these use `air` hot-reload and are unchanged.
- `docker-compose.yml` and profiles — unchanged.
- `docker-bake.hcl` — unchanged (bake targets still point to the dev Dockerfiles; CI can be updated separately to use the prod Dockerfiles with `--platform`).

## Test plan

- [ ] `docker build --check -f deploy/docker/Dockerfile.edge-api.prod .` passes (verified: no warnings).
- [ ] `docker build --check -f deploy/docker/Dockerfile.control-plane.prod .` passes (verified: no warnings).
- [ ] `bash -n deploy/docker/buildx.sh` passes (verified: syntax clean).
- [ ] `bash -n deploy/oci/catch-a1.sh` passes (verified: syntax clean).
- [ ] On a machine with `docker buildx` and a multi-arch builder: run `./deploy/docker/buildx.sh` (no `--push`) and confirm both images appear in `docker images` for host arch.
- [ ] On a machine with OCI CLI configured: export required env vars (real compartment/subnet/image OCIDs) and run `./deploy/oci/catch-a1.sh` to confirm it lists ADs and enters the retry loop without crashing.
- [ ] When an A1 instance is provisioned, pull the pushed images on the arm64 host and confirm `docker run --rm ghcr.io/sakibsadmanshajib/hive/edge-api:<TAG> --version` (or equivalent healthcheck) works on arm64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)