### PR TITLE
feat: anthropic-compatible /v1/messages surface (#168)

### DIFF
--- a/apps/edge-api/cmd/server/main.go
+++ b/apps/edge-api/cmd/server/main.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/sakibsadmanshajib/hive/apps/edge-api/docs"
+	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/anthropic"
 	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/audio"
 	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/auth"
 	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/authz"
@@ -129,6 +130,17 @@ func main() {
 	mux.Handle("/v1/completions", inferenceHandler)
 	mux.Handle("/v1/responses", inferenceHandler)
 	mux.Handle("/v1/embeddings", inferenceHandler)
+
+	// Anthropic Messages surface: POST /v1/messages and POST /v1/messages/count_tokens.
+	// The APIKeyNormalizer rewrites x-api-key to Authorization: Bearer so the
+	// standard auth.Selector routes hk_ keys to the API-key path and JWTs to
+	// the JWT path, reusing the same auth wrappers as /v1/chat/completions.
+	anthropicHandler := anthropic.NewHandler(anthropic.Deps{
+		LiteLLMURL: resolveLiteLLMBaseURL(),
+		LiteLLMKey: resolveLiteLLMMasterKey(),
+	})
+	mux.Handle("/v1/messages", anthropic.APIKeyNormalizer(jwtAwareChatHandler(anthropicHandler, anthropicHandler)))
+	mux.Handle("/v1/messages/", anthropic.APIKeyNormalizer(jwtAwareChatHandler(anthropicHandler, anthropicHandler)))
 
 	storageCfg, err := loadStorageConfigFromEnv()
 	if err != nil {

--- a/apps/edge-api/internal/anthropic/handler.go
+++ b/apps/edge-api/internal/anthropic/handler.go
@@ -166,6 +166,20 @@ func (h *Handler) handleMessages(w http.ResponseWriter, r *http.Request) {
 
 // handleCountTokens returns a local token count estimate for the request body.
 func (h *Handler) handleCountTokens(w http.ResponseWriter, r *http.Request) {
+	user, ok := auth.UserFrom(r.Context())
+	if !ok || user == nil {
+		apierr.Write(w, http.StatusUnauthorized, apierr.CodeUnauthenticated, "missing user")
+		return
+	}
+	if user.TenantID == uuid.Nil {
+		apierr.Write(w, http.StatusForbidden, apierr.CodeNoTenant, "no tenant for user")
+		return
+	}
+	if !authz.RoleHas(authz.Role(user.Role), authz.PermChatInvoke) {
+		apierr.Write(w, http.StatusForbidden, apierr.CodeForbidden, "chat not allowed")
+		return
+	}
+
 	raw, err := io.ReadAll(io.LimitReader(r.Body, maxBodyBytes))
 	if err != nil {
 		apierr.WriteError(w, http.StatusBadRequest, "invalid_request_error", "body read error", nil)
@@ -205,10 +219,8 @@ func normalizeAPIKeyHeader(r *http.Request) *http.Request {
 	if r.Header.Get("Authorization") != "" {
 		return r
 	}
+	// ponytail: http.Header.Get canonicalises the key; one lookup is sufficient.
 	key := strings.TrimSpace(r.Header.Get("x-api-key"))
-	if key == "" {
-		key = strings.TrimSpace(r.Header.Get("X-Api-Key"))
-	}
 	if key == "" {
 		return r
 	}

--- a/apps/edge-api/internal/anthropic/handler.go
+++ b/apps/edge-api/internal/anthropic/handler.go
@@ -89,6 +89,10 @@ func (h *Handler) handleMessages(w http.ResponseWriter, r *http.Request) {
 		apierr.WriteError(w, http.StatusBadRequest, "invalid_request_error", "messages is required and must be non-empty", nil)
 		return
 	}
+	if req.MaxTokens <= 0 {
+		apierr.WriteError(w, http.StatusBadRequest, "invalid_request_error", "max_tokens is required and must be greater than 0", nil)
+		return
+	}
 
 	// Capture the client alias before translation so we can echo it back
 	// in the response. We must never return an upstream route identifier.

--- a/apps/edge-api/internal/anthropic/handler.go
+++ b/apps/edge-api/internal/anthropic/handler.go
@@ -1,0 +1,225 @@
+package anthropic
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/google/uuid"
+	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/auth"
+	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/authz"
+	apierr "github.com/sakibsadmanshajib/hive/apps/edge-api/internal/errors"
+)
+
+const maxBodyBytes = 4 << 20 // 4 MiB
+
+// Deps holds the runtime dependencies for the Anthropic handler.
+type Deps struct {
+	LiteLLMURL string
+	LiteLLMKey string
+	HTTP       *http.Client
+}
+
+// Handler accepts Anthropic Messages requests, translates them to the internal
+// OpenAI-shaped dispatch, and maps responses back to Anthropic wire format.
+type Handler struct {
+	deps Deps
+}
+
+// NewHandler constructs a Handler with the given dependencies.
+func NewHandler(deps Deps) *Handler {
+	if deps.HTTP == nil {
+		deps.HTTP = &http.Client{Timeout: 5 * time.Minute}
+	}
+	return &Handler{deps: deps}
+}
+
+// ServeHTTP handles both POST /v1/messages and POST /v1/messages/count_tokens.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		apierr.WriteError(w, http.StatusMethodNotAllowed, "invalid_request_error", "Method not allowed", nil)
+		return
+	}
+
+	// Route count_tokens to the local estimator.
+	if strings.HasSuffix(r.URL.Path, "/count_tokens") {
+		h.handleCountTokens(w, r)
+		return
+	}
+
+	h.handleMessages(w, r)
+}
+
+func (h *Handler) handleMessages(w http.ResponseWriter, r *http.Request) {
+	user, ok := auth.UserFrom(r.Context())
+	if !ok || user == nil {
+		apierr.Write(w, http.StatusUnauthorized, apierr.CodeUnauthenticated, "missing user")
+		return
+	}
+	if user.TenantID == uuid.Nil {
+		apierr.Write(w, http.StatusForbidden, apierr.CodeNoTenant, "no tenant for user")
+		return
+	}
+	if !authz.RoleHas(authz.Role(user.Role), authz.PermChatInvoke) {
+		apierr.Write(w, http.StatusForbidden, apierr.CodeForbidden, "chat not allowed")
+		return
+	}
+
+	raw, err := io.ReadAll(io.LimitReader(r.Body, maxBodyBytes))
+	if err != nil {
+		apierr.WriteError(w, http.StatusBadRequest, "invalid_request_error", "body read error", nil)
+		return
+	}
+
+	var req MessagesRequest
+	if err := json.Unmarshal(raw, &req); err != nil {
+		apierr.WriteError(w, http.StatusBadRequest, "invalid_request_error", "invalid JSON body", nil)
+		return
+	}
+
+	if req.Model == "" {
+		apierr.WriteError(w, http.StatusBadRequest, "invalid_request_error", "model is required", nil)
+		return
+	}
+	if len(req.Messages) == 0 {
+		apierr.WriteError(w, http.StatusBadRequest, "invalid_request_error", "messages is required and must be non-empty", nil)
+		return
+	}
+
+	oaiReq, err := ToOAIRequest(req)
+	if err != nil {
+		apierr.WriteError(w, http.StatusBadRequest, "invalid_request_error", "request translation failed", nil)
+		return
+	}
+
+	body, err := json.Marshal(oaiReq)
+	if err != nil {
+		apierr.WriteError(w, http.StatusInternalServerError, "api_error", "internal error", nil)
+		return
+	}
+
+	requestID := uuid.New()
+	upstream, err := http.NewRequestWithContext(
+		r.Context(),
+		http.MethodPost,
+		strings.TrimRight(h.deps.LiteLLMURL, "/")+"/v1/chat/completions",
+		bytes.NewReader(body),
+	)
+	if err != nil {
+		apierr.WriteError(w, http.StatusInternalServerError, "api_error", "internal error", nil)
+		return
+	}
+	upstream.Header.Set("Content-Type", "application/json")
+	upstream.Header.Set("X-Request-Id", requestID.String())
+	if h.deps.LiteLLMKey != "" {
+		upstream.Header.Set("Authorization", "Bearer "+h.deps.LiteLLMKey)
+	}
+
+	resp, err := h.deps.HTTP.Do(upstream)
+	if err != nil {
+		apierr.WriteError(w, http.StatusServiceUnavailable, "api_error", "upstream unavailable", nil)
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= http.StatusBadRequest {
+		rawBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		apierr.WriteProviderBlindUpstreamError(w, req.Model, resp.StatusCode, string(rawBody))
+		return
+	}
+
+	if oaiReq.Stream {
+		t := NewSSETranslator(w)
+		if err := t.Translate(resp.Body); err != nil {
+			slog.Warn("anthropic SSE translate error", "err", err, "request_id", requestID)
+		}
+		return
+	}
+
+	// Non-streaming: read the full OpenAI response and lift to Anthropic shape.
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
+	if err != nil {
+		apierr.WriteError(w, http.StatusInternalServerError, "api_error", "response read error", nil)
+		return
+	}
+
+	var oaiResp OAIResponse
+	if err := json.Unmarshal(respBody, &oaiResp); err != nil {
+		apierr.WriteError(w, http.StatusInternalServerError, "api_error", "response parse error", nil)
+		return
+	}
+
+	anthResp := FromOAIResponse(oaiResp)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if encErr := json.NewEncoder(w).Encode(anthResp); encErr != nil {
+		slog.Warn("anthropic response encode error", "err", encErr, "request_id", requestID)
+	}
+}
+
+// handleCountTokens returns a local token count estimate for the request body.
+// This satisfies the Anthropic SDK probe without a real LLM call.
+func (h *Handler) handleCountTokens(w http.ResponseWriter, r *http.Request) {
+	raw, err := io.ReadAll(io.LimitReader(r.Body, maxBodyBytes))
+	if err != nil {
+		apierr.WriteError(w, http.StatusBadRequest, "invalid_request_error", "body read error", nil)
+		return
+	}
+
+	var req MessagesRequest
+	if err := json.Unmarshal(raw, &req); err != nil {
+		apierr.WriteError(w, http.StatusBadRequest, "invalid_request_error", "invalid JSON body", nil)
+		return
+	}
+
+	// Rough estimate: 1 token per 4 UTF-8 chars across all text content.
+	var totalChars int
+	if req.System.Text != "" {
+		totalChars += utf8.RuneCountInString(req.System.Text)
+	}
+	for _, m := range req.Messages {
+		if m.Content.Text != "" {
+			totalChars += utf8.RuneCountInString(m.Content.Text)
+		}
+		for _, bl := range m.Content.Blocks {
+			totalChars += utf8.RuneCountInString(bl.Text)
+		}
+	}
+	estimated := totalChars/4 + 1
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(CountTokensResponse{InputTokens: estimated})
+}
+
+// normalizeAPIKeyHeader rewrites an Anthropic x-api-key header to a standard
+// Authorization: Bearer header so downstream auth middleware works uniformly.
+// Called by the route wrapper before the Handler runs.
+func normalizeAPIKeyHeader(r *http.Request) *http.Request {
+	if r.Header.Get("Authorization") != "" {
+		return r
+	}
+	key := strings.TrimSpace(r.Header.Get("x-api-key"))
+	if key == "" {
+		key = strings.TrimSpace(r.Header.Get("X-Api-Key"))
+	}
+	if key == "" {
+		return r
+	}
+	r2 := r.Clone(r.Context())
+	r2.Header.Set("Authorization", "Bearer "+key)
+	return r2
+}
+
+// APIKeyNormalizer wraps an http.Handler, normalising Anthropic x-api-key
+// credentials to Authorization: Bearer before dispatching.
+func APIKeyNormalizer(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		next.ServeHTTP(w, normalizeAPIKeyHeader(r))
+	})
+}

--- a/apps/edge-api/internal/anthropic/handler.go
+++ b/apps/edge-api/internal/anthropic/handler.go
@@ -46,7 +46,6 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Route count_tokens to the local estimator.
 	if strings.HasSuffix(r.URL.Path, "/count_tokens") {
 		h.handleCountTokens(w, r)
 		return
@@ -91,6 +90,10 @@ func (h *Handler) handleMessages(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Capture the client alias before translation so we can echo it back
+	// in the response. We must never return an upstream route identifier.
+	clientAlias := req.Model
+
 	oaiReq, err := ToOAIRequest(req)
 	if err != nil {
 		apierr.WriteError(w, http.StatusBadRequest, "invalid_request_error", "request translation failed", nil)
@@ -129,19 +132,18 @@ func (h *Handler) handleMessages(w http.ResponseWriter, r *http.Request) {
 
 	if resp.StatusCode >= http.StatusBadRequest {
 		rawBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		apierr.WriteProviderBlindUpstreamError(w, req.Model, resp.StatusCode, string(rawBody))
+		apierr.WriteProviderBlindUpstreamError(w, clientAlias, resp.StatusCode, string(rawBody))
 		return
 	}
 
 	if oaiReq.Stream {
-		t := NewSSETranslator(w)
-		if err := t.Translate(resp.Body); err != nil {
+		tr := NewSSETranslator(w, clientAlias)
+		if err := tr.Translate(resp.Body); err != nil {
 			slog.Warn("anthropic SSE translate error", "err", err, "request_id", requestID)
 		}
 		return
 	}
 
-	// Non-streaming: read the full OpenAI response and lift to Anthropic shape.
 	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
 	if err != nil {
 		apierr.WriteError(w, http.StatusInternalServerError, "api_error", "response read error", nil)
@@ -154,7 +156,7 @@ func (h *Handler) handleMessages(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	anthResp := FromOAIResponse(oaiResp)
+	anthResp := FromOAIResponse(oaiResp, clientAlias)
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	if encErr := json.NewEncoder(w).Encode(anthResp); encErr != nil {
@@ -163,7 +165,6 @@ func (h *Handler) handleMessages(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleCountTokens returns a local token count estimate for the request body.
-// This satisfies the Anthropic SDK probe without a real LLM call.
 func (h *Handler) handleCountTokens(w http.ResponseWriter, r *http.Request) {
 	raw, err := io.ReadAll(io.LimitReader(r.Body, maxBodyBytes))
 	if err != nil {
@@ -177,7 +178,6 @@ func (h *Handler) handleCountTokens(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Rough estimate: 1 token per 4 UTF-8 chars across all text content.
 	var totalChars int
 	if req.System.Text != "" {
 		totalChars += utf8.RuneCountInString(req.System.Text)
@@ -194,12 +194,13 @@ func (h *Handler) handleCountTokens(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(CountTokensResponse{InputTokens: estimated})
+	if encErr := json.NewEncoder(w).Encode(CountTokensResponse{InputTokens: estimated}); encErr != nil {
+		slog.Warn("anthropic count_tokens encode error", "err", encErr)
+	}
 }
 
 // normalizeAPIKeyHeader rewrites an Anthropic x-api-key header to a standard
 // Authorization: Bearer header so downstream auth middleware works uniformly.
-// Called by the route wrapper before the Handler runs.
 func normalizeAPIKeyHeader(r *http.Request) *http.Request {
 	if r.Header.Get("Authorization") != "" {
 		return r

--- a/apps/edge-api/internal/anthropic/handler_test.go
+++ b/apps/edge-api/internal/anthropic/handler_test.go
@@ -212,11 +212,46 @@ func TestHandler_UpstreamError_IsProviderBlind(t *testing.T) {
 	}
 }
 
-func TestHandler_CountTokens(t *testing.T) {
+// T1: count_tokens must enforce the same auth guards as handleMessages.
+func TestHandler_CountTokens_RequiresAuth(t *testing.T) {
 	h := anthropic.NewHandler(anthropic.Deps{LiteLLMURL: "http://unused", LiteLLMKey: "k"})
 	req := httptest.NewRequest(http.MethodPost, "/v1/messages/count_tokens",
-		strings.NewReader(`{"model":"m","messages":[{"role":"user","content":"Hello world"}],"max_tokens":5}`))
-	req.Header.Set("Content-Type", "application/json")
+		strings.NewReader(`{"model":"m","messages":[{"role":"user","content":"hi"}],"max_tokens":5}`))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("no user: want 401 got %d", rec.Code)
+	}
+}
+
+func TestHandler_CountTokens_RequiresTenant(t *testing.T) {
+	h := anthropic.NewHandler(anthropic.Deps{LiteLLMURL: "http://unused", LiteLLMKey: "k"})
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages/count_tokens",
+		strings.NewReader(`{"model":"m","messages":[{"role":"user","content":"hi"}],"max_tokens":5}`))
+	req = req.WithContext(auth.WithUser(req.Context(), &auth.User{ID: uuid.New(), Role: "member"}))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("no tenant: want 403 got %d", rec.Code)
+	}
+}
+
+func TestHandler_CountTokens_RequiresRole(t *testing.T) {
+	h := anthropic.NewHandler(anthropic.Deps{LiteLLMURL: "http://unused", LiteLLMKey: "k"})
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages/count_tokens",
+		strings.NewReader(`{"model":"m","messages":[{"role":"user","content":"hi"}],"max_tokens":5}`))
+	req = req.WithContext(auth.WithUser(req.Context(), &auth.User{ID: uuid.New(), TenantID: uuid.New(), Role: "guest"}))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("no role: want 403 got %d", rec.Code)
+	}
+}
+
+func TestHandler_CountTokens(t *testing.T) {
+	h := anthropic.NewHandler(anthropic.Deps{LiteLLMURL: "http://unused", LiteLLMKey: "k"})
+	req := newAuthedRequest(t, `{"model":"m","messages":[{"role":"user","content":"Hello world"}],"max_tokens":5}`)
+	req.URL.Path = "/v1/messages/count_tokens"
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
 
@@ -234,7 +269,8 @@ func TestHandler_CountTokens(t *testing.T) {
 
 func TestHandler_CountTokens_BadJSON(t *testing.T) {
 	h := anthropic.NewHandler(anthropic.Deps{LiteLLMURL: "http://unused", LiteLLMKey: "k"})
-	req := httptest.NewRequest(http.MethodPost, "/v1/messages/count_tokens", strings.NewReader(`{bad}`))
+	req := newAuthedRequest(t, `{bad}`)
+	req.URL.Path = "/v1/messages/count_tokens"
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
 	if rec.Code != http.StatusBadRequest {

--- a/apps/edge-api/internal/anthropic/handler_test.go
+++ b/apps/edge-api/internal/anthropic/handler_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/auth"
 )
 
-// newAuthedRequest builds a POST request with a valid auth.User in context.
 func newAuthedRequest(t *testing.T, body string) *http.Request {
 	t.Helper()
 	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(body))
@@ -50,11 +49,7 @@ func TestHandler_MissingUser(t *testing.T) {
 func TestHandler_NoTenant(t *testing.T) {
 	h := anthropic.NewHandler(anthropic.Deps{LiteLLMURL: "http://unused", LiteLLMKey: "k"})
 	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{}`))
-	req = req.WithContext(auth.WithUser(req.Context(), &auth.User{
-		ID:   uuid.New(),
-		Role: "member",
-		// TenantID is zero (uuid.Nil)
-	}))
+	req = req.WithContext(auth.WithUser(req.Context(), &auth.User{ID: uuid.New(), Role: "member"}))
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
 	if rec.Code != http.StatusForbidden {
@@ -65,11 +60,7 @@ func TestHandler_NoTenant(t *testing.T) {
 func TestHandler_NoRole(t *testing.T) {
 	h := anthropic.NewHandler(anthropic.Deps{LiteLLMURL: "http://unused", LiteLLMKey: "k"})
 	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{}`))
-	req = req.WithContext(auth.WithUser(req.Context(), &auth.User{
-		ID:       uuid.New(),
-		TenantID: uuid.New(),
-		Role:     "guest", // not granted PermChatInvoke
-	}))
+	req = req.WithContext(auth.WithUser(req.Context(), &auth.User{ID: uuid.New(), TenantID: uuid.New(), Role: "guest"}))
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
 	if rec.Code != http.StatusForbidden {
@@ -108,25 +99,13 @@ func TestHandler_MissingMessages(t *testing.T) {
 }
 
 func TestHandler_NonStreamHappyPath(t *testing.T) {
-	// Upstream returns a well-formed OpenAI response.
 	oaiResp := map[string]interface{}{
 		"id":    "chatcmpl-test",
-		"model": "claude-3-haiku",
+		"model": "openrouter/anthropic/claude-3-haiku", // upstream route id
 		"choices": []map[string]interface{}{
-			{
-				"index":         0,
-				"finish_reason": "stop",
-				"message": map[string]interface{}{
-					"role":    "assistant",
-					"content": "Hello!",
-				},
-			},
+			{"index": 0, "finish_reason": "stop", "message": map[string]interface{}{"role": "assistant", "content": "Hello!"}},
 		},
-		"usage": map[string]interface{}{
-			"prompt_tokens":     10,
-			"completion_tokens": 5,
-			"total_tokens":      15,
-		},
+		"usage": map[string]interface{}{"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
 	}
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -143,30 +122,33 @@ func TestHandler_NonStreamHappyPath(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status: want 200 got %d body=%s", rec.Code, rec.Body.String())
 	}
-
 	var got anthropic.MessagesResponse
 	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
-		t.Fatalf("decode response: %v", err)
+		t.Fatalf("decode: %v", err)
 	}
-	if got.Type != "message" {
-		t.Errorf("type: want message got %q", got.Type)
-	}
-	if got.Role != "assistant" {
-		t.Errorf("role: want assistant got %q", got.Role)
+	if got.Type != "message" || got.Role != "assistant" {
+		t.Errorf("type/role: %q/%q", got.Type, got.Role)
 	}
 	if got.StopReason != "end_turn" {
 		t.Errorf("stop_reason: want end_turn got %q", got.StopReason)
 	}
+	// Finding 2: model echoed back must be client alias.
+	if got.Model != "claude-3-haiku" {
+		t.Errorf("model: want claude-3-haiku got %q", got.Model)
+	}
+	if strings.Contains(got.Model, "openrouter") {
+		t.Errorf("upstream route id leaked in model: %q", got.Model)
+	}
 	if len(got.Content) == 0 || got.Content[0].Text != "Hello!" {
-		t.Errorf("content text: want Hello! got %v", got.Content)
+		t.Errorf("content: %+v", got.Content)
 	}
 }
 
 func TestHandler_StreamHappyPath(t *testing.T) {
 	stream := buildOAIStream(
-		`{"id":"chatcmpl-s","model":"m","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}`,
-		`{"id":"chatcmpl-s","model":"m","choices":[{"index":0,"delta":{"content":"Hi"},"finish_reason":null}]}`,
-		`{"id":"chatcmpl-s","model":"m","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":1}}`,
+		`{"id":"chatcmpl-s","model":"route-x","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}`,
+		`{"id":"chatcmpl-s","model":"route-x","choices":[{"index":0,"delta":{"content":"Hi"},"finish_reason":null}]}`,
+		`{"id":"chatcmpl-s","model":"route-x","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":1}}`,
 	)
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
@@ -176,7 +158,7 @@ func TestHandler_StreamHappyPath(t *testing.T) {
 	defer upstream.Close()
 
 	h := anthropic.NewHandler(anthropic.Deps{LiteLLMURL: upstream.URL, LiteLLMKey: "k"})
-	req := newAuthedRequest(t, `{"model":"m","messages":[{"role":"user","content":"hi"}],"max_tokens":5,"stream":true}`)
+	req := newAuthedRequest(t, `{"model":"my-alias","messages":[{"role":"user","content":"hi"}],"max_tokens":5,"stream":true}`)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
 
@@ -190,17 +172,25 @@ func TestHandler_StreamHappyPath(t *testing.T) {
 	if !strings.Contains(body, "message_stop") {
 		t.Error("stream missing message_stop")
 	}
+	// Finding 2: model in message_start must be client alias.
+	if strings.Contains(body, "route-x") {
+		t.Error("upstream model route-x leaked in stream")
+	}
+	if !strings.Contains(body, "my-alias") {
+		t.Error("client alias my-alias not present in stream")
+	}
 }
 
+// Finding 8: provider-blind test uses the full stableErrorLeakPatterns set.
 func TestHandler_UpstreamError_IsProviderBlind(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusTooManyRequests)
-		fmt.Fprint(w, `{"error":{"message":"groq rate limit hit via openrouter"}}`)
+		fmt.Fprint(w, `{"error":{"message":"groq rate limit hit via openrouter/auto; litellm route-fast; anthropic backend; openai upstream"}}`)
 	}))
 	defer upstream.Close()
 
 	h := anthropic.NewHandler(anthropic.Deps{LiteLLMURL: upstream.URL, LiteLLMKey: "k"})
-	req := newAuthedRequest(t, `{"model":"m","messages":[{"role":"user","content":"hi"}],"max_tokens":5}`)
+	req := newAuthedRequest(t, `{"model":"my-alias","messages":[{"role":"user","content":"hi"}],"max_tokens":5}`)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
 
@@ -208,9 +198,16 @@ func TestHandler_UpstreamError_IsProviderBlind(t *testing.T) {
 		t.Errorf("status: want 429 got %d", rec.Code)
 	}
 	body := strings.ToLower(rec.Body.String())
-	for _, leak := range []string{"groq", "openrouter", "route-"} {
-		if strings.Contains(body, leak) {
-			t.Errorf("provider-blind violation: %q leaked in response", leak)
+	// Full stableErrorLeakPatterns provider name set from errors/codes.go.
+	leakTerms := []string{
+		"openai", "anthropic", "openrouter", "groq", "ollama", "vllm", "sglang",
+		"nim", "litellm", "google", "gemini", "mistral", "cohere", "cerebras",
+		"deepseek", "xai", "together", "fireworks", "replicate", "perplexity",
+		"route-",
+	}
+	for _, term := range leakTerms {
+		if strings.Contains(body, term) {
+			t.Errorf("provider-blind violation: %q leaked in response body", term)
 		}
 	}
 }
@@ -220,7 +217,6 @@ func TestHandler_CountTokens(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/v1/messages/count_tokens",
 		strings.NewReader(`{"model":"m","messages":[{"role":"user","content":"Hello world"}],"max_tokens":5}`))
 	req.Header.Set("Content-Type", "application/json")
-	// count_tokens does not require auth (local estimator).
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
 
@@ -238,8 +234,7 @@ func TestHandler_CountTokens(t *testing.T) {
 
 func TestHandler_CountTokens_BadJSON(t *testing.T) {
 	h := anthropic.NewHandler(anthropic.Deps{LiteLLMURL: "http://unused", LiteLLMKey: "k"})
-	req := httptest.NewRequest(http.MethodPost, "/v1/messages/count_tokens",
-		strings.NewReader(`{bad}`))
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages/count_tokens", strings.NewReader(`{bad}`))
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
 	if rec.Code != http.StatusBadRequest {

--- a/apps/edge-api/internal/anthropic/handler_test.go
+++ b/apps/edge-api/internal/anthropic/handler_test.go
@@ -1,0 +1,296 @@
+package anthropic_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/anthropic"
+	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/auth"
+)
+
+// newAuthedRequest builds a POST request with a valid auth.User in context.
+func newAuthedRequest(t *testing.T, body string) *http.Request {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(auth.WithUser(req.Context(), &auth.User{
+		ID:       uuid.New(),
+		TenantID: uuid.New(),
+		Role:     "member",
+		Email:    "test@example.com",
+	}))
+	return req
+}
+
+func TestHandler_MethodNotAllowed(t *testing.T) {
+	h := anthropic.NewHandler(anthropic.Deps{LiteLLMURL: "http://unused", LiteLLMKey: "k"})
+	req := httptest.NewRequest(http.MethodGet, "/v1/messages", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("status: want 405 got %d", rec.Code)
+	}
+}
+
+func TestHandler_MissingUser(t *testing.T) {
+	h := anthropic.NewHandler(anthropic.Deps{LiteLLMURL: "http://unused", LiteLLMKey: "k"})
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{}`))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status: want 401 got %d", rec.Code)
+	}
+}
+
+func TestHandler_NoTenant(t *testing.T) {
+	h := anthropic.NewHandler(anthropic.Deps{LiteLLMURL: "http://unused", LiteLLMKey: "k"})
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{}`))
+	req = req.WithContext(auth.WithUser(req.Context(), &auth.User{
+		ID:   uuid.New(),
+		Role: "member",
+		// TenantID is zero (uuid.Nil)
+	}))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("status: want 403 got %d", rec.Code)
+	}
+}
+
+func TestHandler_NoRole(t *testing.T) {
+	h := anthropic.NewHandler(anthropic.Deps{LiteLLMURL: "http://unused", LiteLLMKey: "k"})
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{}`))
+	req = req.WithContext(auth.WithUser(req.Context(), &auth.User{
+		ID:       uuid.New(),
+		TenantID: uuid.New(),
+		Role:     "guest", // not granted PermChatInvoke
+	}))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("status: want 403 got %d", rec.Code)
+	}
+}
+
+func TestHandler_BadJSON(t *testing.T) {
+	h := anthropic.NewHandler(anthropic.Deps{LiteLLMURL: "http://unused", LiteLLMKey: "k"})
+	req := newAuthedRequest(t, `{not valid json}`)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status: want 400 got %d", rec.Code)
+	}
+}
+
+func TestHandler_MissingModel(t *testing.T) {
+	h := anthropic.NewHandler(anthropic.Deps{LiteLLMURL: "http://unused", LiteLLMKey: "k"})
+	req := newAuthedRequest(t, `{"messages":[{"role":"user","content":"hi"}],"max_tokens":5}`)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status: want 400 got %d", rec.Code)
+	}
+}
+
+func TestHandler_MissingMessages(t *testing.T) {
+	h := anthropic.NewHandler(anthropic.Deps{LiteLLMURL: "http://unused", LiteLLMKey: "k"})
+	req := newAuthedRequest(t, `{"model":"m","max_tokens":5}`)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status: want 400 got %d", rec.Code)
+	}
+}
+
+func TestHandler_NonStreamHappyPath(t *testing.T) {
+	// Upstream returns a well-formed OpenAI response.
+	oaiResp := map[string]interface{}{
+		"id":    "chatcmpl-test",
+		"model": "claude-3-haiku",
+		"choices": []map[string]interface{}{
+			{
+				"index":         0,
+				"finish_reason": "stop",
+				"message": map[string]interface{}{
+					"role":    "assistant",
+					"content": "Hello!",
+				},
+			},
+		},
+		"usage": map[string]interface{}{
+			"prompt_tokens":     10,
+			"completion_tokens": 5,
+			"total_tokens":      15,
+		},
+	}
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(oaiResp)
+	}))
+	defer upstream.Close()
+
+	h := anthropic.NewHandler(anthropic.Deps{LiteLLMURL: upstream.URL, LiteLLMKey: "k"})
+	req := newAuthedRequest(t, `{"model":"claude-3-haiku","messages":[{"role":"user","content":"hi"}],"max_tokens":10}`)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: want 200 got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var got anthropic.MessagesResponse
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got.Type != "message" {
+		t.Errorf("type: want message got %q", got.Type)
+	}
+	if got.Role != "assistant" {
+		t.Errorf("role: want assistant got %q", got.Role)
+	}
+	if got.StopReason != "end_turn" {
+		t.Errorf("stop_reason: want end_turn got %q", got.StopReason)
+	}
+	if len(got.Content) == 0 || got.Content[0].Text != "Hello!" {
+		t.Errorf("content text: want Hello! got %v", got.Content)
+	}
+}
+
+func TestHandler_StreamHappyPath(t *testing.T) {
+	stream := buildOAIStream(
+		`{"id":"chatcmpl-s","model":"m","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}`,
+		`{"id":"chatcmpl-s","model":"m","choices":[{"index":0,"delta":{"content":"Hi"},"finish_reason":null}]}`,
+		`{"id":"chatcmpl-s","model":"m","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":1}}`,
+	)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, stream)
+	}))
+	defer upstream.Close()
+
+	h := anthropic.NewHandler(anthropic.Deps{LiteLLMURL: upstream.URL, LiteLLMKey: "k"})
+	req := newAuthedRequest(t, `{"model":"m","messages":[{"role":"user","content":"hi"}],"max_tokens":5,"stream":true}`)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: want 200 got %d", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "message_start") {
+		t.Error("stream missing message_start")
+	}
+	if !strings.Contains(body, "message_stop") {
+		t.Error("stream missing message_stop")
+	}
+}
+
+func TestHandler_UpstreamError_IsProviderBlind(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		fmt.Fprint(w, `{"error":{"message":"groq rate limit hit via openrouter"}}`)
+	}))
+	defer upstream.Close()
+
+	h := anthropic.NewHandler(anthropic.Deps{LiteLLMURL: upstream.URL, LiteLLMKey: "k"})
+	req := newAuthedRequest(t, `{"model":"m","messages":[{"role":"user","content":"hi"}],"max_tokens":5}`)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusTooManyRequests {
+		t.Errorf("status: want 429 got %d", rec.Code)
+	}
+	body := strings.ToLower(rec.Body.String())
+	for _, leak := range []string{"groq", "openrouter", "route-"} {
+		if strings.Contains(body, leak) {
+			t.Errorf("provider-blind violation: %q leaked in response", leak)
+		}
+	}
+}
+
+func TestHandler_CountTokens(t *testing.T) {
+	h := anthropic.NewHandler(anthropic.Deps{LiteLLMURL: "http://unused", LiteLLMKey: "k"})
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages/count_tokens",
+		strings.NewReader(`{"model":"m","messages":[{"role":"user","content":"Hello world"}],"max_tokens":5}`))
+	req.Header.Set("Content-Type", "application/json")
+	// count_tokens does not require auth (local estimator).
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: want 200 got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var got anthropic.CountTokensResponse
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.InputTokens <= 0 {
+		t.Errorf("input_tokens: want > 0 got %d", got.InputTokens)
+	}
+}
+
+func TestHandler_CountTokens_BadJSON(t *testing.T) {
+	h := anthropic.NewHandler(anthropic.Deps{LiteLLMURL: "http://unused", LiteLLMKey: "k"})
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages/count_tokens",
+		strings.NewReader(`{bad}`))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status: want 400 got %d", rec.Code)
+	}
+}
+
+func TestAPIKeyNormalizer_RewritesXApiKey(t *testing.T) {
+	var captured string
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	})
+	h := anthropic.APIKeyNormalizer(inner)
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+	req.Header.Set("x-api-key", "hk_test123")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if captured != "Bearer hk_test123" {
+		t.Errorf("Authorization: want %q got %q", "Bearer hk_test123", captured)
+	}
+}
+
+func TestAPIKeyNormalizer_PreservesExistingAuthorization(t *testing.T) {
+	var captured string
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	})
+	h := anthropic.APIKeyNormalizer(inner)
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+	req.Header.Set("Authorization", "Bearer existing_token")
+	req.Header.Set("x-api-key", "hk_other")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if captured != "Bearer existing_token" {
+		t.Errorf("Authorization: want existing_token got %q", captured)
+	}
+}
+
+func TestAPIKeyNormalizer_NoKey_PassesThrough(t *testing.T) {
+	var captured string
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	})
+	h := anthropic.APIKeyNormalizer(inner)
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if captured != "" {
+		t.Errorf("Authorization: want empty got %q", captured)
+	}
+}

--- a/apps/edge-api/internal/anthropic/handler_test.go
+++ b/apps/edge-api/internal/anthropic/handler_test.go
@@ -88,6 +88,26 @@ func TestHandler_MissingModel(t *testing.T) {
 	}
 }
 
+func TestHandler_MissingMaxTokens(t *testing.T) {
+	h := anthropic.NewHandler(anthropic.Deps{LiteLLMURL: "http://unused", LiteLLMKey: "k"})
+	req := newAuthedRequest(t, `{"model":"m","messages":[{"role":"user","content":"hi"}]}`)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("missing max_tokens: want 400 got %d", rec.Code)
+	}
+}
+
+func TestHandler_ZeroMaxTokens(t *testing.T) {
+	h := anthropic.NewHandler(anthropic.Deps{LiteLLMURL: "http://unused", LiteLLMKey: "k"})
+	req := newAuthedRequest(t, `{"model":"m","messages":[{"role":"user","content":"hi"}],"max_tokens":0}`)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("zero max_tokens: want 400 got %d", rec.Code)
+	}
+}
+
 func TestHandler_MissingMessages(t *testing.T) {
 	h := anthropic.NewHandler(anthropic.Deps{LiteLLMURL: "http://unused", LiteLLMKey: "k"})
 	req := newAuthedRequest(t, `{"model":"m","max_tokens":5}`)

--- a/apps/edge-api/internal/anthropic/stream.go
+++ b/apps/edge-api/internal/anthropic/stream.go
@@ -1,0 +1,297 @@
+package anthropic
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// SSETranslator is a stateful re-emitter that converts an OpenAI SSE stream
+// (chat.completion.chunk) into the Anthropic streaming event sequence:
+//
+//  message_start
+//  content_block_start  (index 0, text)
+//  content_block_delta* (text_delta)
+//  -- on first tool_call delta:
+//  content_block_stop
+//  content_block_start  (index N, tool_use, id+name)
+//  content_block_delta* (input_json_delta)
+//  -- end of stream:
+//  content_block_stop
+//  message_delta        (stop_reason, usage)
+//  message_stop
+//
+// The translator never leaks provider names or upstream identifiers.
+type SSETranslator struct {
+	w       http.ResponseWriter
+	flusher http.Flusher
+
+	// state
+	messageID    string
+	model        string
+	inputTokens  int
+	outputTokens int
+	stopReason   string
+
+	openBlockIndex int  // index of the currently open content block
+	hasOpenBlock   bool // whether a content_block_start has been emitted without stop
+
+	// tool call accumulation: keyed by upstream tool_calls[].index
+	toolBlocks map[int]toolBlockState
+}
+
+type toolBlockState struct {
+	blockIndex int    // Anthropic block index
+	id         string // tool_use id
+	name       string // function name
+}
+
+// NewSSETranslator creates a translator bound to the given ResponseWriter.
+// It sets the Anthropic SSE headers on the writer immediately.
+func NewSSETranslator(w http.ResponseWriter) *SSETranslator {
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.WriteHeader(http.StatusOK)
+
+	flusher, _ := w.(http.Flusher)
+	return &SSETranslator{
+		w:          w,
+		flusher:    flusher,
+		toolBlocks: make(map[int]toolBlockState),
+	}
+}
+
+// Translate reads an upstream OpenAI SSE body and emits the Anthropic event
+// sequence to the bound ResponseWriter. It returns after the upstream [DONE]
+// signal or on read error.
+func (t *SSETranslator) Translate(body io.Reader) error {
+	scanner := bufio.NewScanner(body)
+	scanner.Buffer(make([]byte, 64*1024), 4*1024*1024)
+
+	firstChunk := true
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		if !bytes.HasPrefix(line, []byte("data: ")) {
+			continue
+		}
+		payload := bytes.TrimPrefix(line, []byte("data: "))
+		if bytes.Equal(payload, []byte("[DONE]")) {
+			break
+		}
+
+		var chunk OAIChunk
+		if err := json.Unmarshal(payload, &chunk); err != nil {
+			continue
+		}
+
+		// Capture metadata from the first chunk.
+		if firstChunk {
+			firstChunk = false
+			t.messageID = chunk.ID
+			if t.messageID == "" {
+				t.messageID = "msg_stream_" + fmt.Sprintf("%d", 0)
+			}
+			t.model = chunk.Model
+			t.emitMessageStart()
+		}
+
+		// Accumulate usage when present (often only on the final chunk).
+		if chunk.Usage != nil {
+			t.inputTokens = chunk.Usage.PromptTokens
+			t.outputTokens = chunk.Usage.CompletionTokens
+		}
+
+		if len(chunk.Choices) == 0 {
+			continue
+		}
+		choice := chunk.Choices[0]
+
+		if choice.FinishReason != "" {
+			t.stopReason = mapFinishReason(choice.FinishReason)
+		}
+
+		delta := choice.Delta
+
+		// Text delta.
+		if delta.Content != "" {
+			if !t.hasOpenBlock {
+				t.openTextBlock()
+			}
+			t.emitTextDelta(delta.Content)
+		}
+
+		// Tool call deltas.
+		for _, tc := range delta.ToolCalls {
+			t.handleToolCallDelta(tc)
+		}
+	}
+
+	// Emit terminal sequence.
+	if t.hasOpenBlock {
+		t.emitContentBlockStop(t.openBlockIndex)
+		t.hasOpenBlock = false
+	}
+	t.emitMessageDelta()
+	t.emitMessageStop()
+
+	return scanner.Err()
+}
+
+// --- emitters ---
+
+func (t *SSETranslator) emitMessageStart() {
+	ev := StreamEvent{
+		Type: "message_start",
+		Message: &StreamMessage{
+			ID:           t.messageID,
+			Type:         "message",
+			Role:         "assistant",
+			Model:        t.model,
+			Content:      []any{},
+			StopReason:   nil,
+			StopSequence: nil,
+			Usage:        StreamUsage{InputTokens: t.inputTokens},
+		},
+	}
+	t.writeEvent("message_start", ev)
+	t.writePing()
+}
+
+func (t *SSETranslator) openTextBlock() {
+	t.openBlockIndex = 0
+	t.hasOpenBlock = true
+	t.writeEvent("content_block_start", StreamEvent{
+		Type:  "content_block_start",
+		Index: 0,
+		ContentBlock: &StreamContentBlock{
+			Type: "text",
+			Text: "",
+		},
+	})
+}
+
+func (t *SSETranslator) emitTextDelta(text string) {
+	t.writeEvent("content_block_delta", StreamEvent{
+		Type:  "content_block_delta",
+		Index: t.openBlockIndex,
+		Delta: &StreamDelta{
+			Type: "text_delta",
+			Text: text,
+		},
+	})
+}
+
+func (t *SSETranslator) handleToolCallDelta(tc OAIToolCallDelta) {
+	bs, exists := t.toolBlocks[tc.Index]
+	if !exists {
+		// First delta for this tool call: close any open text block, open a
+		// new tool_use block.
+		hadOpenBlock := t.hasOpenBlock
+		if t.hasOpenBlock {
+			t.emitContentBlockStop(t.openBlockIndex)
+			t.hasOpenBlock = false
+		}
+		// Block index: if a text block was open it occupied index 0, so the
+		// first tool block is index 1. If no text block was ever opened, this
+		// tool block starts at index 0. Subsequent tool blocks increment from
+		// the previous tool block's index.
+		var nextIndex int
+		if len(t.toolBlocks) == 0 {
+			if hadOpenBlock {
+				nextIndex = 1
+			} else {
+				nextIndex = 0
+			}
+		} else {
+			// Find the highest block index already assigned and add 1.
+			maxIdx := 0
+			for _, existing := range t.toolBlocks {
+				if existing.blockIndex > maxIdx {
+					maxIdx = existing.blockIndex
+				}
+			}
+			nextIndex = maxIdx + 1
+		}
+
+		bs = toolBlockState{
+			blockIndex: nextIndex,
+			id:         tc.ID,
+			name:       tc.Function.Name,
+		}
+		t.toolBlocks[tc.Index] = bs
+
+		t.openBlockIndex = nextIndex
+		t.hasOpenBlock = true
+		t.writeEvent("content_block_start", StreamEvent{
+			Type:  "content_block_start",
+			Index: nextIndex,
+			ContentBlock: &StreamContentBlock{
+				Type: "tool_use",
+				ID:   tc.ID,
+				Name: tc.Function.Name,
+			},
+		})
+	}
+
+	if tc.Function.Arguments != "" {
+		t.writeEvent("content_block_delta", StreamEvent{
+			Type:  "content_block_delta",
+			Index: bs.blockIndex,
+			Delta: &StreamDelta{
+				Type:        "input_json_delta",
+				PartialJSON: tc.Function.Arguments,
+			},
+		})
+	}
+}
+
+func (t *SSETranslator) emitContentBlockStop(index int) {
+	t.writeEvent("content_block_stop", StreamEvent{
+		Type:  "content_block_stop",
+		Index: index,
+	})
+}
+
+func (t *SSETranslator) emitMessageDelta() {
+	if t.stopReason == "" {
+		t.stopReason = "end_turn"
+	}
+	t.writeEvent("message_delta", StreamEvent{
+		Type: "message_delta",
+		Delta: &StreamDelta{
+			Type:       "message_delta",
+			StopReason: t.stopReason,
+		},
+		Usage: &StreamUsage{OutputTokens: t.outputTokens},
+	})
+}
+
+func (t *SSETranslator) emitMessageStop() {
+	t.writeEvent("message_stop", map[string]string{"type": "message_stop"})
+}
+
+func (t *SSETranslator) writePing() {
+	t.writeRaw("event: ping\ndata: {\"type\":\"ping\"}\n\n")
+}
+
+func (t *SSETranslator) writeEvent(eventType string, data interface{}) {
+	b, err := json.Marshal(data)
+	if err != nil {
+		return
+	}
+	t.writeRaw("event: " + eventType + "\ndata: " + string(b) + "\n\n")
+}
+
+func (t *SSETranslator) writeRaw(s string) {
+	_, _ = fmt.Fprint(t.w, s)
+	if t.flusher != nil {
+		t.flusher.Flush()
+	}
+}

--- a/apps/edge-api/internal/anthropic/stream.go
+++ b/apps/edge-api/internal/anthropic/stream.go
@@ -7,31 +7,37 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+
+	"github.com/google/uuid"
 )
 
 // SSETranslator is a stateful re-emitter that converts an OpenAI SSE stream
 // (chat.completion.chunk) into the Anthropic streaming event sequence:
 //
-//  message_start
-//  content_block_start  (index 0, text)
-//  content_block_delta* (text_delta)
-//  -- on first tool_call delta:
-//  content_block_stop
-//  content_block_start  (index N, tool_use, id+name)
-//  content_block_delta* (input_json_delta)
-//  -- end of stream:
-//  content_block_stop
-//  message_delta        (stop_reason, usage)
-//  message_stop
+//	message_start
+//	content_block_start  (index 0, text)
+//	content_block_delta* (text_delta)
+//	-- on first tool_call delta:
+//	content_block_stop
+//	content_block_start  (index N, tool_use, id+name)
+//	content_block_delta* (input_json_delta)
+//	-- end of stream:
+//	content_block_stop
+//	message_delta        (stop_reason, usage)
+//	message_stop
 //
 // The translator never leaks provider names or upstream identifiers.
+// clientAlias is the model name the client sent; it is echoed in message_start
+// so upstream route identifiers never reach the client.
 type SSETranslator struct {
 	w       http.ResponseWriter
 	flusher http.Flusher
 
+	// clientAlias is the model alias echoed back to the client.
+	clientAlias string
+
 	// state
 	messageID    string
-	model        string
 	inputTokens  int
 	outputTokens int
 	stopReason   string
@@ -41,6 +47,9 @@ type SSETranslator struct {
 
 	// tool call accumulation: keyed by upstream tool_calls[].index
 	toolBlocks map[int]toolBlockState
+
+	// writeErr captures the first write error so Translate can surface it.
+	writeErr error
 }
 
 type toolBlockState struct {
@@ -50,8 +59,9 @@ type toolBlockState struct {
 }
 
 // NewSSETranslator creates a translator bound to the given ResponseWriter.
+// clientAlias is echoed in message_start instead of any upstream model field.
 // It sets the Anthropic SSE headers on the writer immediately.
-func NewSSETranslator(w http.ResponseWriter) *SSETranslator {
+func NewSSETranslator(w http.ResponseWriter, clientAlias string) *SSETranslator {
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
@@ -59,21 +69,25 @@ func NewSSETranslator(w http.ResponseWriter) *SSETranslator {
 
 	flusher, _ := w.(http.Flusher)
 	return &SSETranslator{
-		w:          w,
-		flusher:    flusher,
-		toolBlocks: make(map[int]toolBlockState),
+		w:           w,
+		flusher:     flusher,
+		clientAlias: clientAlias,
+		toolBlocks:  make(map[int]toolBlockState),
 	}
 }
 
 // Translate reads an upstream OpenAI SSE body and emits the Anthropic event
 // sequence to the bound ResponseWriter. It returns after the upstream [DONE]
-// signal or on read error.
+// signal or on a read/write error.
 func (t *SSETranslator) Translate(body io.Reader) error {
 	scanner := bufio.NewScanner(body)
 	scanner.Buffer(make([]byte, 64*1024), 4*1024*1024)
 
 	firstChunk := true
 	for scanner.Scan() {
+		if t.writeErr != nil {
+			break
+		}
 		line := scanner.Bytes()
 		if len(line) == 0 {
 			continue
@@ -91,18 +105,17 @@ func (t *SSETranslator) Translate(body io.Reader) error {
 			continue
 		}
 
-		// Capture metadata from the first chunk.
 		if firstChunk {
 			firstChunk = false
+			// Use the upstream chunk ID when present, otherwise generate a
+			// unique ID per stream so concurrent streams never collide.
 			t.messageID = chunk.ID
 			if t.messageID == "" {
-				t.messageID = "msg_stream_" + fmt.Sprintf("%d", 0)
+				t.messageID = "msg_" + uuid.New().String()
 			}
-			t.model = chunk.Model
 			t.emitMessageStart()
 		}
 
-		// Accumulate usage when present (often only on the final chunk).
 		if chunk.Usage != nil {
 			t.inputTokens = chunk.Usage.PromptTokens
 			t.outputTokens = chunk.Usage.CompletionTokens
@@ -119,7 +132,6 @@ func (t *SSETranslator) Translate(body io.Reader) error {
 
 		delta := choice.Delta
 
-		// Text delta.
 		if delta.Content != "" {
 			if !t.hasOpenBlock {
 				t.openTextBlock()
@@ -127,10 +139,13 @@ func (t *SSETranslator) Translate(body io.Reader) error {
 			t.emitTextDelta(delta.Content)
 		}
 
-		// Tool call deltas.
 		for _, tc := range delta.ToolCalls {
 			t.handleToolCallDelta(tc)
 		}
+	}
+
+	if t.writeErr != nil {
+		return t.writeErr
 	}
 
 	// Emit terminal sequence.
@@ -141,6 +156,9 @@ func (t *SSETranslator) Translate(body io.Reader) error {
 	t.emitMessageDelta()
 	t.emitMessageStop()
 
+	if t.writeErr != nil {
+		return t.writeErr
+	}
 	return scanner.Err()
 }
 
@@ -153,8 +171,8 @@ func (t *SSETranslator) emitMessageStart() {
 			ID:           t.messageID,
 			Type:         "message",
 			Role:         "assistant",
-			Model:        t.model,
-			Content:      []any{},
+			Model:        t.clientAlias,
+			Content:      []string{},
 			StopReason:   nil,
 			StopSequence: nil,
 			Usage:        StreamUsage{InputTokens: t.inputTokens},
@@ -191,17 +209,11 @@ func (t *SSETranslator) emitTextDelta(text string) {
 func (t *SSETranslator) handleToolCallDelta(tc OAIToolCallDelta) {
 	bs, exists := t.toolBlocks[tc.Index]
 	if !exists {
-		// First delta for this tool call: close any open text block, open a
-		// new tool_use block.
 		hadOpenBlock := t.hasOpenBlock
 		if t.hasOpenBlock {
 			t.emitContentBlockStop(t.openBlockIndex)
 			t.hasOpenBlock = false
 		}
-		// Block index: if a text block was open it occupied index 0, so the
-		// first tool block is index 1. If no text block was ever opened, this
-		// tool block starts at index 0. Subsequent tool blocks increment from
-		// the previous tool block's index.
 		var nextIndex int
 		if len(t.toolBlocks) == 0 {
 			if hadOpenBlock {
@@ -210,7 +222,6 @@ func (t *SSETranslator) handleToolCallDelta(tc OAIToolCallDelta) {
 				nextIndex = 0
 			}
 		} else {
-			// Find the highest block index already assigned and add 1.
 			maxIdx := 0
 			for _, existing := range t.toolBlocks {
 				if existing.blockIndex > maxIdx {
@@ -290,7 +301,14 @@ func (t *SSETranslator) writeEvent(eventType string, data interface{}) {
 }
 
 func (t *SSETranslator) writeRaw(s string) {
-	_, _ = fmt.Fprint(t.w, s)
+	if t.writeErr != nil {
+		return
+	}
+	_, err := fmt.Fprint(t.w, s)
+	if err != nil {
+		t.writeErr = err
+		return
+	}
 	if t.flusher != nil {
 		t.flusher.Flush()
 	}

--- a/apps/edge-api/internal/anthropic/stream.go
+++ b/apps/edge-api/internal/anthropic/stream.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/google/uuid"
 )
@@ -112,6 +113,8 @@ func (t *SSETranslator) Translate(body io.Reader) error {
 			t.messageID = chunk.ID
 			if t.messageID == "" {
 				t.messageID = "msg_" + uuid.New().String()
+			} else if !strings.HasPrefix(t.messageID, "msg_") {
+				t.messageID = "msg_" + t.messageID
 			}
 			t.emitMessageStart()
 		}

--- a/apps/edge-api/internal/anthropic/stream_test.go
+++ b/apps/edge-api/internal/anthropic/stream_test.go
@@ -4,13 +4,12 @@ import (
 	"encoding/json"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/anthropic"
 )
 
-// parseSSEEvents reads the raw SSE body and returns a list of parsed events
-// (data lines only), preserving order.
 func parseSSEEvents(t *testing.T, body string) []map[string]interface{} {
 	t.Helper()
 	var events []map[string]interface{}
@@ -32,8 +31,6 @@ func parseSSEEvents(t *testing.T, body string) []map[string]interface{} {
 	return events
 }
 
-// buildOAIStream builds a minimal OpenAI SSE stream body from the given chunk
-// JSON strings, terminated with [DONE].
 func buildOAIStream(chunks ...string) string {
 	var sb strings.Builder
 	for _, c := range chunks {
@@ -45,71 +42,122 @@ func buildOAIStream(chunks ...string) string {
 	return sb.String()
 }
 
+func assertContainsInOrder(t *testing.T, got []string, want ...string) {
+	t.Helper()
+	wi := 0
+	for _, g := range got {
+		if wi >= len(want) {
+			break
+		}
+		if g == want[wi] {
+			wi++
+		}
+	}
+	if wi < len(want) {
+		t.Errorf("event sequence missing subsequence %v\ngot: %v", want, got)
+	}
+}
+
 func TestSSETranslator_SimpleTextStream(t *testing.T) {
 	stream := buildOAIStream(
-		`{"id":"chatcmpl-1","model":"claude-3-haiku","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}`,
-		`{"id":"chatcmpl-1","model":"claude-3-haiku","choices":[{"index":0,"delta":{"content":"Hello"},"finish_reason":null}]}`,
-		`{"id":"chatcmpl-1","model":"claude-3-haiku","choices":[{"index":0,"delta":{"content":" world"},"finish_reason":null}]}`,
-		`{"id":"chatcmpl-1","model":"claude-3-haiku","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":2}}`,
+		`{"id":"chatcmpl-1","model":"route-upstream","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}`,
+		`{"id":"chatcmpl-1","model":"route-upstream","choices":[{"index":0,"delta":{"content":"Hello"},"finish_reason":null}]}`,
+		`{"id":"chatcmpl-1","model":"route-upstream","choices":[{"index":0,"delta":{"content":" world"},"finish_reason":null}]}`,
+		`{"id":"chatcmpl-1","model":"route-upstream","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":2}}`,
 	)
-
 	rec := httptest.NewRecorder()
-	tr := anthropic.NewSSETranslator(rec)
+	tr := anthropic.NewSSETranslator(rec, "claude-3-haiku")
 	if err := tr.Translate(strings.NewReader(stream)); err != nil {
 		t.Fatalf("translate error: %v", err)
 	}
-
 	body := rec.Body.String()
 	events := parseSSEEvents(t, body)
-
-	// Must start with message_start.
 	if len(events) == 0 {
 		t.Fatal("no events")
 	}
-	if events[0]["type"] != "message_start" {
-		t.Errorf("first event type: want message_start got %v", events[0]["type"])
-	}
-
-	// Verify event sequence contains the required types in order.
 	types := make([]string, 0, len(events))
 	for _, ev := range events {
 		if ty, ok := ev["type"].(string); ok {
 			types = append(types, ty)
 		}
 	}
+	assertContainsInOrder(t, types, "message_start", "content_block_start", "content_block_delta", "content_block_stop", "message_delta", "message_stop")
 
-	assertContainsInOrder(t, types,
-		"message_start",
-		"content_block_start",
-		"content_block_delta",
-		"content_block_stop",
-		"message_delta",
-		"message_stop",
-	)
+	// Finding 2: model in message_start must be client alias, not upstream route.
+	for _, ev := range events {
+		if ev["type"] == "message_start" {
+			msg, _ := ev["message"].(map[string]interface{})
+			if msg == nil {
+				t.Error("message_start has no message field")
+				continue
+			}
+			if msg["model"] != "claude-3-haiku" {
+				t.Errorf("message_start.model: want claude-3-haiku got %v", msg["model"])
+			}
+			if m, _ := msg["model"].(string); strings.Contains(m, "route") || strings.Contains(m, "upstream") {
+				t.Errorf("upstream route id leaked in message_start.model: %q", m)
+			}
+		}
+	}
 
-	// Verify stop_reason in message_delta.
+	// stop_reason in message_delta.
 	for _, ev := range events {
 		if ev["type"] == "message_delta" {
 			delta, _ := ev["delta"].(map[string]interface{})
-			if delta == nil {
-				t.Error("message_delta has no delta field")
-				continue
-			}
 			if delta["stop_reason"] != "end_turn" {
 				t.Errorf("stop_reason: want end_turn got %v", delta["stop_reason"])
 			}
 		}
 	}
+	if rec.Header().Get("Content-Type") != "text/event-stream" {
+		t.Errorf("Content-Type: want text/event-stream got %q", rec.Header().Get("Content-Type"))
+	}
+}
 
-	// Content-Type header must be text/event-stream.
-	ct := rec.Header().Get("Content-Type")
-	if ct != "text/event-stream" {
-		t.Errorf("Content-Type: want text/event-stream got %q", ct)
+// Finding 1: two concurrent streams must get distinct message IDs.
+func TestSSETranslator_ConcurrentStreams_DistinctMessageIDs(t *testing.T) {
+	// Stream with empty chunk ID so the translator must generate its own UUID.
+	stream := buildOAIStream(
+		`{"id":"","model":"m","choices":[{"index":0,"delta":{"content":"hi"},"finish_reason":null}]}`,
+		`{"id":"","model":"m","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+	)
+
+	ids := make([]string, 2)
+	var wg sync.WaitGroup
+	for i := 0; i < 2; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			rec := httptest.NewRecorder()
+			tr := anthropic.NewSSETranslator(rec, "m")
+			if err := tr.Translate(strings.NewReader(stream)); err != nil {
+				t.Errorf("stream %d translate error: %v", i, err)
+				return
+			}
+			events := parseSSEEvents(t, rec.Body.String())
+			for _, ev := range events {
+				if ev["type"] == "message_start" {
+					msg, _ := ev["message"].(map[string]interface{})
+					if msg != nil {
+						ids[i], _ = msg["id"].(string)
+					}
+					break
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	if ids[0] == "" || ids[1] == "" {
+		t.Fatalf("missing message IDs: %v", ids)
+	}
+	if ids[0] == ids[1] {
+		t.Errorf("concurrent streams got same message ID %q", ids[0])
 	}
 }
 
 func TestSSETranslator_ToolUseStream(t *testing.T) {
-	// Simulates an OpenAI stream that emits a tool_calls delta.
 	stream := buildOAIStream(
 		`{"id":"chatcmpl-tool","model":"m","choices":[{"index":0,"delta":{"role":"assistant","content":null},"finish_reason":null}]}`,
 		`{"id":"chatcmpl-tool","model":"m","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_01","type":"function","function":{"name":"get_weather","arguments":""}}]},"finish_reason":null}]}`,
@@ -117,69 +165,41 @@ func TestSSETranslator_ToolUseStream(t *testing.T) {
 		`{"id":"chatcmpl-tool","model":"m","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":":\"Dhaka\"}"}}]},"finish_reason":null}]}`,
 		`{"id":"chatcmpl-tool","model":"m","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":20,"completion_tokens":15}}`,
 	)
-
 	rec := httptest.NewRecorder()
-	tr := anthropic.NewSSETranslator(rec)
+	tr := anthropic.NewSSETranslator(rec, "m")
 	if err := tr.Translate(strings.NewReader(stream)); err != nil {
 		t.Fatalf("translate error: %v", err)
 	}
-
 	body := rec.Body.String()
 	events := parseSSEEvents(t, body)
-
 	types := make([]string, 0, len(events))
 	for _, ev := range events {
 		if ty, ok := ev["type"].(string); ok {
 			types = append(types, ty)
 		}
 	}
+	assertContainsInOrder(t, types, "message_start", "content_block_start", "content_block_delta", "content_block_stop", "message_delta", "message_stop")
 
-	// Must have message_start and a tool_use content_block_start.
-	assertContainsInOrder(t, types,
-		"message_start",
-		"content_block_start",
-		"content_block_delta",
-		"content_block_stop",
-		"message_delta",
-		"message_stop",
-	)
-
-	// The content_block_start for the tool should have type=tool_use.
-	var foundToolBlock bool
+	var foundToolBlock, foundInputDelta bool
 	for _, ev := range events {
 		if ev["type"] == "content_block_start" {
 			cb, _ := ev["content_block"].(map[string]interface{})
 			if cb != nil && cb["type"] == "tool_use" {
 				foundToolBlock = true
 				if cb["id"] != "call_01" {
-					t.Errorf("tool_use block id: want call_01 got %v", cb["id"])
+					t.Errorf("tool_use id: want call_01 got %v", cb["id"])
 				}
 				if cb["name"] != "get_weather" {
-					t.Errorf("tool_use block name: want get_weather got %v", cb["name"])
+					t.Errorf("tool_use name: want get_weather got %v", cb["name"])
 				}
 			}
 		}
-	}
-	if !foundToolBlock {
-		t.Error("no tool_use content_block_start found in stream")
-	}
-
-	// The input_json_delta events should carry partial_json.
-	var foundInputDelta bool
-	for _, ev := range events {
 		if ev["type"] == "content_block_delta" {
 			delta, _ := ev["delta"].(map[string]interface{})
 			if delta != nil && delta["type"] == "input_json_delta" {
 				foundInputDelta = true
 			}
 		}
-	}
-	if !foundInputDelta {
-		t.Error("no input_json_delta content_block_delta found in stream")
-	}
-
-	// stop_reason in message_delta must be tool_use.
-	for _, ev := range events {
 		if ev["type"] == "message_delta" {
 			delta, _ := ev["delta"].(map[string]interface{})
 			if delta != nil && delta["stop_reason"] != "tool_use" {
@@ -187,28 +207,28 @@ func TestSSETranslator_ToolUseStream(t *testing.T) {
 			}
 		}
 	}
+	if !foundToolBlock {
+		t.Error("no tool_use content_block_start found")
+	}
+	if !foundInputDelta {
+		t.Error("no input_json_delta found")
+	}
 }
 
 func TestSSETranslator_TextThenToolUse(t *testing.T) {
-	// Text delta followed by a tool_call delta: must close text block before
-	// opening tool_use block, and use correct block indices.
 	stream := buildOAIStream(
 		`{"id":"chatcmpl-m","model":"m","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}`,
 		`{"id":"chatcmpl-m","model":"m","choices":[{"index":0,"delta":{"content":"Checking..."},"finish_reason":null}]}`,
 		`{"id":"chatcmpl-m","model":"m","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_x","type":"function","function":{"name":"fn","arguments":"{}"}}]},"finish_reason":null}]}`,
 		`{"id":"chatcmpl-m","model":"m","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
 	)
-
 	rec := httptest.NewRecorder()
-	tr := anthropic.NewSSETranslator(rec)
+	tr := anthropic.NewSSETranslator(rec, "m")
 	if err := tr.Translate(strings.NewReader(stream)); err != nil {
 		t.Fatalf("translate error: %v", err)
 	}
+	events := parseSSEEvents(t, rec.Body.String())
 
-	body := rec.Body.String()
-	events := parseSSEEvents(t, body)
-
-	// Count content_block_start events: must be 2 (text at 0, tool_use at 1).
 	var blockStarts []map[string]interface{}
 	for _, ev := range events {
 		if ev["type"] == "content_block_start" {
@@ -226,8 +246,6 @@ func TestSSETranslator_TextThenToolUse(t *testing.T) {
 	if cb1 == nil || cb1["type"] != "tool_use" {
 		t.Errorf("block[1] type: want tool_use got %v", cb1)
 	}
-
-	// Block indices must be 0 and 1.
 	idx0, _ := blockStarts[0]["index"].(float64)
 	idx1, _ := blockStarts[1]["index"].(float64)
 	if idx0 != 0 {
@@ -236,9 +254,8 @@ func TestSSETranslator_TextThenToolUse(t *testing.T) {
 	if idx1 != 1 {
 		t.Errorf("block[1] index: want 1 got %v", idx1)
 	}
-
-	// There must be a content_block_stop between text and tool blocks.
-	var stopAfterText, startTool bool
+	// content_block_stop must appear between the two starts.
+	var stopAfterText, startToolAfterStop bool
 	for _, ev := range events {
 		ty, _ := ev["type"].(string)
 		if ty == "content_block_stop" {
@@ -247,42 +264,95 @@ func TestSSETranslator_TextThenToolUse(t *testing.T) {
 		if ty == "content_block_start" && stopAfterText {
 			cb, _ := ev["content_block"].(map[string]interface{})
 			if cb != nil && cb["type"] == "tool_use" {
-				startTool = true
+				startToolAfterStop = true
 			}
 		}
 	}
-	if !startTool {
-		t.Error("tool_use content_block_start was not preceded by a content_block_stop")
+	if !startToolAfterStop {
+		t.Error("tool_use content_block_start not preceded by content_block_stop")
 	}
 }
 
-func TestSSETranslator_EmptyStream(t *testing.T) {
-	stream := "data: [DONE]\n\n"
-
+// Finding 7: two sequential (parallel) tool_use blocks must get indices 0,1,2
+// and each content_block_stop must precede the next content_block_start.
+func TestSSETranslator_TwoParallelToolUseBlocks(t *testing.T) {
+	stream := buildOAIStream(
+		`{"id":"chatcmpl-p","model":"m","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}`,
+		// First tool call opens (index 0 in upstream deltas).
+		`{"id":"chatcmpl-p","model":"m","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_a","type":"function","function":{"name":"tool_a","arguments":""}}]},"finish_reason":null}]}`,
+		`{"id":"chatcmpl-p","model":"m","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{}"}}]},"finish_reason":null}]}`,
+		// Second tool call opens (index 1 in upstream deltas).
+		`{"id":"chatcmpl-p","model":"m","choices":[{"index":0,"delta":{"tool_calls":[{"index":1,"id":"call_b","type":"function","function":{"name":"tool_b","arguments":""}}]},"finish_reason":null}]}`,
+		`{"id":"chatcmpl-p","model":"m","choices":[{"index":0,"delta":{"tool_calls":[{"index":1,"function":{"arguments":"{}"}}]},"finish_reason":null}]}`,
+		`{"id":"chatcmpl-p","model":"m","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+	)
 	rec := httptest.NewRecorder()
-	tr := anthropic.NewSSETranslator(rec)
+	tr := anthropic.NewSSETranslator(rec, "m")
 	if err := tr.Translate(strings.NewReader(stream)); err != nil {
 		t.Fatalf("translate error: %v", err)
 	}
+	events := parseSSEEvents(t, rec.Body.String())
 
-	// Even an empty stream must emit the terminal sequence.
-	body := rec.Body.String()
-	events := parseSSEEvents(t, body)
+	// Collect content_block_start events.
+	var starts []map[string]interface{}
+	for _, ev := range events {
+		if ev["type"] == "content_block_start" {
+			starts = append(starts, ev)
+		}
+	}
+	if len(starts) != 2 {
+		t.Fatalf("content_block_start count: want 2 got %d", len(starts))
+	}
+	idx0, _ := starts[0]["index"].(float64)
+	idx1, _ := starts[1]["index"].(float64)
+	if idx0 != 0 || idx1 != 1 {
+		t.Errorf("block indices: want 0,1 got %v,%v", idx0, idx1)
+	}
 
-	hasMessageDelta := false
-	hasMessageStop := false
+	// Both blocks must be tool_use.
+	for i, s := range starts {
+		cb, _ := s["content_block"].(map[string]interface{})
+		if cb == nil || cb["type"] != "tool_use" {
+			t.Errorf("block[%d] not tool_use: %v", i, cb)
+		}
+	}
+
+	// Each content_block_stop must precede the next content_block_start.
+	// i.e. the sequence must contain: start stop start stop.
+	var seq []string
+	for _, ev := range events {
+		ty, _ := ev["type"].(string)
+		if ty == "content_block_start" || ty == "content_block_stop" {
+			seq = append(seq, ty)
+		}
+	}
+	// Expected: start, stop, start, stop (at minimum).
+	if len(seq) < 4 {
+		t.Fatalf("start/stop sequence too short: %v", seq)
+	}
+	assertContainsInOrder(t, seq, "content_block_start", "content_block_stop", "content_block_start", "content_block_stop")
+}
+
+func TestSSETranslator_EmptyStream(t *testing.T) {
+	rec := httptest.NewRecorder()
+	tr := anthropic.NewSSETranslator(rec, "m")
+	if err := tr.Translate(strings.NewReader("data: [DONE]\n\n")); err != nil {
+		t.Fatalf("translate error: %v", err)
+	}
+	events := parseSSEEvents(t, rec.Body.String())
+	var hasDelta, hasStop bool
 	for _, ev := range events {
 		switch ev["type"] {
 		case "message_delta":
-			hasMessageDelta = true
+			hasDelta = true
 		case "message_stop":
-			hasMessageStop = true
+			hasStop = true
 		}
 	}
-	if !hasMessageDelta {
+	if !hasDelta {
 		t.Error("missing message_delta on empty stream")
 	}
-	if !hasMessageStop {
+	if !hasStop {
 		t.Error("missing message_stop on empty stream")
 	}
 }
@@ -292,16 +362,12 @@ func TestSSETranslator_UsageInMessageDelta(t *testing.T) {
 		`{"id":"chatcmpl-u","model":"m","choices":[{"index":0,"delta":{"content":"hi"},"finish_reason":null}]}`,
 		`{"id":"chatcmpl-u","model":"m","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":7,"completion_tokens":3,"total_tokens":10}}`,
 	)
-
 	rec := httptest.NewRecorder()
-	tr := anthropic.NewSSETranslator(rec)
+	tr := anthropic.NewSSETranslator(rec, "m")
 	if err := tr.Translate(strings.NewReader(stream)); err != nil {
 		t.Fatalf("translate error: %v", err)
 	}
-
-	body := rec.Body.String()
-	events := parseSSEEvents(t, body)
-
+	events := parseSSEEvents(t, rec.Body.String())
 	for _, ev := range events {
 		if ev["type"] == "message_delta" {
 			usage, _ := ev["usage"].(map[string]interface{})
@@ -309,27 +375,9 @@ func TestSSETranslator_UsageInMessageDelta(t *testing.T) {
 				t.Error("message_delta has no usage field")
 				continue
 			}
-			outTokens, _ := usage["output_tokens"].(float64)
-			if outTokens != 3 {
-				t.Errorf("output_tokens: want 3 got %v", outTokens)
+			if usage["output_tokens"].(float64) != 3 {
+				t.Errorf("output_tokens: want 3 got %v", usage["output_tokens"])
 			}
 		}
-	}
-}
-
-// assertContainsInOrder checks that want is a subsequence of got.
-func assertContainsInOrder(t *testing.T, got []string, want ...string) {
-	t.Helper()
-	wi := 0
-	for _, g := range got {
-		if wi >= len(want) {
-			break
-		}
-		if g == want[wi] {
-			wi++
-		}
-	}
-	if wi < len(want) {
-		t.Errorf("event sequence does not contain %v in order\ngot: %v", want, got)
 	}
 }

--- a/apps/edge-api/internal/anthropic/stream_test.go
+++ b/apps/edge-api/internal/anthropic/stream_test.go
@@ -333,6 +333,33 @@ func TestSSETranslator_TwoParallelToolUseBlocks(t *testing.T) {
 	assertContainsInOrder(t, seq, "content_block_start", "content_block_stop", "content_block_start", "content_block_stop")
 }
 
+// T3: when upstream chunk ID is non-empty but lacks msg_ prefix, the translator
+// must add it; Anthropic SDK clients reject IDs that don't start with msg_.
+func TestSSETranslator_NonMsgPrefixChunkID_GetsPrefix(t *testing.T) {
+	stream := buildOAIStream(
+		`{"id":"chatcmpl-abc123","model":"m","choices":[{"index":0,"delta":{"content":"hi"},"finish_reason":null}]}`,
+		`{"id":"chatcmpl-abc123","model":"m","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+	)
+	rec := httptest.NewRecorder()
+	tr := anthropic.NewSSETranslator(rec, "m")
+	if err := tr.Translate(strings.NewReader(stream)); err != nil {
+		t.Fatalf("translate error: %v", err)
+	}
+	events := parseSSEEvents(t, rec.Body.String())
+	for _, ev := range events {
+		if ev["type"] == "message_start" {
+			msg, _ := ev["message"].(map[string]interface{})
+			if msg == nil {
+				t.Fatal("message_start has no message field")
+			}
+			id, _ := msg["id"].(string)
+			if !strings.HasPrefix(id, "msg_") {
+				t.Errorf("message_start.id: want msg_ prefix got %q", id)
+			}
+		}
+	}
+}
+
 func TestSSETranslator_EmptyStream(t *testing.T) {
 	rec := httptest.NewRecorder()
 	tr := anthropic.NewSSETranslator(rec, "m")

--- a/apps/edge-api/internal/anthropic/stream_test.go
+++ b/apps/edge-api/internal/anthropic/stream_test.go
@@ -1,0 +1,335 @@
+package anthropic_test
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/anthropic"
+)
+
+// parseSSEEvents reads the raw SSE body and returns a list of parsed events
+// (data lines only), preserving order.
+func parseSSEEvents(t *testing.T, body string) []map[string]interface{} {
+	t.Helper()
+	var events []map[string]interface{}
+	for _, line := range strings.Split(body, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		payload := strings.TrimPrefix(line, "data: ")
+		if payload == "[DONE]" {
+			continue
+		}
+		var ev map[string]interface{}
+		if err := json.Unmarshal([]byte(payload), &ev); err != nil {
+			t.Fatalf("parse event %q: %v", payload, err)
+		}
+		events = append(events, ev)
+	}
+	return events
+}
+
+// buildOAIStream builds a minimal OpenAI SSE stream body from the given chunk
+// JSON strings, terminated with [DONE].
+func buildOAIStream(chunks ...string) string {
+	var sb strings.Builder
+	for _, c := range chunks {
+		sb.WriteString("data: ")
+		sb.WriteString(c)
+		sb.WriteString("\n\n")
+	}
+	sb.WriteString("data: [DONE]\n\n")
+	return sb.String()
+}
+
+func TestSSETranslator_SimpleTextStream(t *testing.T) {
+	stream := buildOAIStream(
+		`{"id":"chatcmpl-1","model":"claude-3-haiku","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}`,
+		`{"id":"chatcmpl-1","model":"claude-3-haiku","choices":[{"index":0,"delta":{"content":"Hello"},"finish_reason":null}]}`,
+		`{"id":"chatcmpl-1","model":"claude-3-haiku","choices":[{"index":0,"delta":{"content":" world"},"finish_reason":null}]}`,
+		`{"id":"chatcmpl-1","model":"claude-3-haiku","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":2}}`,
+	)
+
+	rec := httptest.NewRecorder()
+	tr := anthropic.NewSSETranslator(rec)
+	if err := tr.Translate(strings.NewReader(stream)); err != nil {
+		t.Fatalf("translate error: %v", err)
+	}
+
+	body := rec.Body.String()
+	events := parseSSEEvents(t, body)
+
+	// Must start with message_start.
+	if len(events) == 0 {
+		t.Fatal("no events")
+	}
+	if events[0]["type"] != "message_start" {
+		t.Errorf("first event type: want message_start got %v", events[0]["type"])
+	}
+
+	// Verify event sequence contains the required types in order.
+	types := make([]string, 0, len(events))
+	for _, ev := range events {
+		if ty, ok := ev["type"].(string); ok {
+			types = append(types, ty)
+		}
+	}
+
+	assertContainsInOrder(t, types,
+		"message_start",
+		"content_block_start",
+		"content_block_delta",
+		"content_block_stop",
+		"message_delta",
+		"message_stop",
+	)
+
+	// Verify stop_reason in message_delta.
+	for _, ev := range events {
+		if ev["type"] == "message_delta" {
+			delta, _ := ev["delta"].(map[string]interface{})
+			if delta == nil {
+				t.Error("message_delta has no delta field")
+				continue
+			}
+			if delta["stop_reason"] != "end_turn" {
+				t.Errorf("stop_reason: want end_turn got %v", delta["stop_reason"])
+			}
+		}
+	}
+
+	// Content-Type header must be text/event-stream.
+	ct := rec.Header().Get("Content-Type")
+	if ct != "text/event-stream" {
+		t.Errorf("Content-Type: want text/event-stream got %q", ct)
+	}
+}
+
+func TestSSETranslator_ToolUseStream(t *testing.T) {
+	// Simulates an OpenAI stream that emits a tool_calls delta.
+	stream := buildOAIStream(
+		`{"id":"chatcmpl-tool","model":"m","choices":[{"index":0,"delta":{"role":"assistant","content":null},"finish_reason":null}]}`,
+		`{"id":"chatcmpl-tool","model":"m","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_01","type":"function","function":{"name":"get_weather","arguments":""}}]},"finish_reason":null}]}`,
+		`{"id":"chatcmpl-tool","model":"m","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"city\""}}]},"finish_reason":null}]}`,
+		`{"id":"chatcmpl-tool","model":"m","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":":\"Dhaka\"}"}}]},"finish_reason":null}]}`,
+		`{"id":"chatcmpl-tool","model":"m","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":20,"completion_tokens":15}}`,
+	)
+
+	rec := httptest.NewRecorder()
+	tr := anthropic.NewSSETranslator(rec)
+	if err := tr.Translate(strings.NewReader(stream)); err != nil {
+		t.Fatalf("translate error: %v", err)
+	}
+
+	body := rec.Body.String()
+	events := parseSSEEvents(t, body)
+
+	types := make([]string, 0, len(events))
+	for _, ev := range events {
+		if ty, ok := ev["type"].(string); ok {
+			types = append(types, ty)
+		}
+	}
+
+	// Must have message_start and a tool_use content_block_start.
+	assertContainsInOrder(t, types,
+		"message_start",
+		"content_block_start",
+		"content_block_delta",
+		"content_block_stop",
+		"message_delta",
+		"message_stop",
+	)
+
+	// The content_block_start for the tool should have type=tool_use.
+	var foundToolBlock bool
+	for _, ev := range events {
+		if ev["type"] == "content_block_start" {
+			cb, _ := ev["content_block"].(map[string]interface{})
+			if cb != nil && cb["type"] == "tool_use" {
+				foundToolBlock = true
+				if cb["id"] != "call_01" {
+					t.Errorf("tool_use block id: want call_01 got %v", cb["id"])
+				}
+				if cb["name"] != "get_weather" {
+					t.Errorf("tool_use block name: want get_weather got %v", cb["name"])
+				}
+			}
+		}
+	}
+	if !foundToolBlock {
+		t.Error("no tool_use content_block_start found in stream")
+	}
+
+	// The input_json_delta events should carry partial_json.
+	var foundInputDelta bool
+	for _, ev := range events {
+		if ev["type"] == "content_block_delta" {
+			delta, _ := ev["delta"].(map[string]interface{})
+			if delta != nil && delta["type"] == "input_json_delta" {
+				foundInputDelta = true
+			}
+		}
+	}
+	if !foundInputDelta {
+		t.Error("no input_json_delta content_block_delta found in stream")
+	}
+
+	// stop_reason in message_delta must be tool_use.
+	for _, ev := range events {
+		if ev["type"] == "message_delta" {
+			delta, _ := ev["delta"].(map[string]interface{})
+			if delta != nil && delta["stop_reason"] != "tool_use" {
+				t.Errorf("stop_reason: want tool_use got %v", delta["stop_reason"])
+			}
+		}
+	}
+}
+
+func TestSSETranslator_TextThenToolUse(t *testing.T) {
+	// Text delta followed by a tool_call delta: must close text block before
+	// opening tool_use block, and use correct block indices.
+	stream := buildOAIStream(
+		`{"id":"chatcmpl-m","model":"m","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}`,
+		`{"id":"chatcmpl-m","model":"m","choices":[{"index":0,"delta":{"content":"Checking..."},"finish_reason":null}]}`,
+		`{"id":"chatcmpl-m","model":"m","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_x","type":"function","function":{"name":"fn","arguments":"{}"}}]},"finish_reason":null}]}`,
+		`{"id":"chatcmpl-m","model":"m","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+	)
+
+	rec := httptest.NewRecorder()
+	tr := anthropic.NewSSETranslator(rec)
+	if err := tr.Translate(strings.NewReader(stream)); err != nil {
+		t.Fatalf("translate error: %v", err)
+	}
+
+	body := rec.Body.String()
+	events := parseSSEEvents(t, body)
+
+	// Count content_block_start events: must be 2 (text at 0, tool_use at 1).
+	var blockStarts []map[string]interface{}
+	for _, ev := range events {
+		if ev["type"] == "content_block_start" {
+			blockStarts = append(blockStarts, ev)
+		}
+	}
+	if len(blockStarts) != 2 {
+		t.Fatalf("content_block_start count: want 2 got %d", len(blockStarts))
+	}
+	cb0, _ := blockStarts[0]["content_block"].(map[string]interface{})
+	if cb0 == nil || cb0["type"] != "text" {
+		t.Errorf("block[0] type: want text got %v", cb0)
+	}
+	cb1, _ := blockStarts[1]["content_block"].(map[string]interface{})
+	if cb1 == nil || cb1["type"] != "tool_use" {
+		t.Errorf("block[1] type: want tool_use got %v", cb1)
+	}
+
+	// Block indices must be 0 and 1.
+	idx0, _ := blockStarts[0]["index"].(float64)
+	idx1, _ := blockStarts[1]["index"].(float64)
+	if idx0 != 0 {
+		t.Errorf("block[0] index: want 0 got %v", idx0)
+	}
+	if idx1 != 1 {
+		t.Errorf("block[1] index: want 1 got %v", idx1)
+	}
+
+	// There must be a content_block_stop between text and tool blocks.
+	var stopAfterText, startTool bool
+	for _, ev := range events {
+		ty, _ := ev["type"].(string)
+		if ty == "content_block_stop" {
+			stopAfterText = true
+		}
+		if ty == "content_block_start" && stopAfterText {
+			cb, _ := ev["content_block"].(map[string]interface{})
+			if cb != nil && cb["type"] == "tool_use" {
+				startTool = true
+			}
+		}
+	}
+	if !startTool {
+		t.Error("tool_use content_block_start was not preceded by a content_block_stop")
+	}
+}
+
+func TestSSETranslator_EmptyStream(t *testing.T) {
+	stream := "data: [DONE]\n\n"
+
+	rec := httptest.NewRecorder()
+	tr := anthropic.NewSSETranslator(rec)
+	if err := tr.Translate(strings.NewReader(stream)); err != nil {
+		t.Fatalf("translate error: %v", err)
+	}
+
+	// Even an empty stream must emit the terminal sequence.
+	body := rec.Body.String()
+	events := parseSSEEvents(t, body)
+
+	hasMessageDelta := false
+	hasMessageStop := false
+	for _, ev := range events {
+		switch ev["type"] {
+		case "message_delta":
+			hasMessageDelta = true
+		case "message_stop":
+			hasMessageStop = true
+		}
+	}
+	if !hasMessageDelta {
+		t.Error("missing message_delta on empty stream")
+	}
+	if !hasMessageStop {
+		t.Error("missing message_stop on empty stream")
+	}
+}
+
+func TestSSETranslator_UsageInMessageDelta(t *testing.T) {
+	stream := buildOAIStream(
+		`{"id":"chatcmpl-u","model":"m","choices":[{"index":0,"delta":{"content":"hi"},"finish_reason":null}]}`,
+		`{"id":"chatcmpl-u","model":"m","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":7,"completion_tokens":3,"total_tokens":10}}`,
+	)
+
+	rec := httptest.NewRecorder()
+	tr := anthropic.NewSSETranslator(rec)
+	if err := tr.Translate(strings.NewReader(stream)); err != nil {
+		t.Fatalf("translate error: %v", err)
+	}
+
+	body := rec.Body.String()
+	events := parseSSEEvents(t, body)
+
+	for _, ev := range events {
+		if ev["type"] == "message_delta" {
+			usage, _ := ev["usage"].(map[string]interface{})
+			if usage == nil {
+				t.Error("message_delta has no usage field")
+				continue
+			}
+			outTokens, _ := usage["output_tokens"].(float64)
+			if outTokens != 3 {
+				t.Errorf("output_tokens: want 3 got %v", outTokens)
+			}
+		}
+	}
+}
+
+// assertContainsInOrder checks that want is a subsequence of got.
+func assertContainsInOrder(t *testing.T, got []string, want ...string) {
+	t.Helper()
+	wi := 0
+	for _, g := range got {
+		if wi >= len(want) {
+			break
+		}
+		if g == want[wi] {
+			wi++
+		}
+	}
+	if wi < len(want) {
+		t.Errorf("event sequence does not contain %v in order\ngot: %v", want, got)
+	}
+}

--- a/apps/edge-api/internal/anthropic/translate_request.go
+++ b/apps/edge-api/internal/anthropic/translate_request.go
@@ -21,11 +21,11 @@ func ToOAIRequest(req MessagesRequest) (OAIRequest, error) {
 	}
 
 	for _, m := range req.Messages {
-		oai, err := convertMessage(m)
+		expanded, err := convertMessage(m)
 		if err != nil {
 			return OAIRequest{}, fmt.Errorf("message role=%s: %w", m.Role, err)
 		}
-		msgs = append(msgs, oai)
+		msgs = append(msgs, expanded...)
 	}
 
 	out := OAIRequest{
@@ -60,37 +60,50 @@ func ToOAIRequest(req MessagesRequest) (OAIRequest, error) {
 	return out, nil
 }
 
-// convertMessage converts a single Anthropic message to OAIMessage.
-func convertMessage(m Message) (OAIMessage, error) {
+// convertMessage converts a single Anthropic message to one or more OAIMessages.
+// Parallel tool calls send multiple tool_result blocks in one Anthropic message;
+// each must become a separate OAI "tool" message so the LLM receives all results.
+func convertMessage(m Message) ([]OAIMessage, error) {
 	// Simple string content.
 	if m.Content.Text != "" {
-		return OAIMessage{Role: m.Role, Content: OAIMessageContent{Text: m.Content.Text}}, nil
+		return []OAIMessage{{Role: m.Role, Content: OAIMessageContent{Text: m.Content.Text}}}, nil
 	}
 
 	// No content blocks; treat as empty string message.
 	if len(m.Content.Blocks) == 0 {
-		return OAIMessage{Role: m.Role, Content: OAIMessageContent{Text: ""}}, nil
+		return []OAIMessage{{Role: m.Role, Content: OAIMessageContent{Text: ""}}}, nil
 	}
 
-	// Validate: a tool_result block must be the only block in the message.
-	// The Anthropic protocol requires each tool result to be its own message.
-	// Mixed non-tool_result blocks before a tool_result are an encoding error.
+	// Collect all tool_result blocks first. If any exist, every block must be a
+	// tool_result (mixing non-tool_result blocks with tool_results is an error).
+	var toolResults []OAIMessage
 	for i, bl := range m.Content.Blocks {
 		if bl.Type == "tool_result" {
-			if i > 0 {
-				return OAIMessage{}, fmt.Errorf(
+			if len(toolResults) == 0 && i > 0 {
+				// There were non-tool_result blocks before this one.
+				return nil, fmt.Errorf(
 					"tool_result block at index %d has %d preceding block(s); "+
-						"each tool_result must be the sole block in its message",
+						"each tool_result must be the sole block type in its message",
 					i, i,
 				)
 			}
 			content := toolResultText(bl)
-			return OAIMessage{
+			toolResults = append(toolResults, OAIMessage{
 				Role:       "tool",
 				Content:    OAIMessageContent{Text: content},
 				ToolCallID: bl.ToolUseID,
-			}, nil
+			})
+		} else if len(toolResults) > 0 {
+			// tool_result blocks were already seen; a non-tool_result block after them is invalid.
+			return nil, fmt.Errorf(
+				"non-tool_result block %q at index %d follows tool_result blocks; "+
+					"each tool_result must be the sole block type in its message",
+				bl.Type, i,
+			)
 		}
+	}
+	if len(toolResults) > 0 {
+		return toolResults, nil
 	}
 
 	// Mixed content blocks: text, image, tool_use.
@@ -135,7 +148,7 @@ func convertMessage(m Message) (OAIMessage, error) {
 
 	// Pure tool-call assistant turn.
 	if len(toolCalls) > 0 && len(parts) == 0 {
-		return OAIMessage{Role: m.Role, ToolCalls: toolCalls}, nil
+		return []OAIMessage{{Role: m.Role, ToolCalls: toolCalls}}, nil
 	}
 	// Tool calls plus text content.
 	if len(toolCalls) > 0 {
@@ -145,18 +158,18 @@ func convertMessage(m Message) (OAIMessage, error) {
 				contentStr += p.Text
 			}
 		}
-		return OAIMessage{
+		return []OAIMessage{{
 			Role:      m.Role,
 			Content:   OAIMessageContent{Text: contentStr},
 			ToolCalls: toolCalls,
-		}, nil
+		}}, nil
 	}
 
 	// Pure text/image parts: use array form for vision, string for text-only.
 	if len(parts) == 1 && parts[0].Type == "text" {
-		return OAIMessage{Role: m.Role, Content: OAIMessageContent{Text: parts[0].Text}}, nil
+		return []OAIMessage{{Role: m.Role, Content: OAIMessageContent{Text: parts[0].Text}}}, nil
 	}
-	return OAIMessage{Role: m.Role, Content: OAIMessageContent{Parts: parts}}, nil
+	return []OAIMessage{{Role: m.Role, Content: OAIMessageContent{Parts: parts}}}, nil
 }
 
 // toolResultText extracts the text content from a tool_result block.

--- a/apps/edge-api/internal/anthropic/translate_request.go
+++ b/apps/edge-api/internal/anthropic/translate_request.go
@@ -1,0 +1,205 @@
+package anthropic
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// ToOAIRequest lowers an Anthropic MessagesRequest to an internal OpenAI-shaped
+// OAIRequest that can be forwarded through the existing LiteLLM dispatch path.
+// It never leaks provider names; the model alias is passed through as-is so the
+// catalog layer resolves it to the appropriate route.
+func ToOAIRequest(req MessagesRequest) (OAIRequest, error) {
+	var msgs []OAIMessage
+
+	// Prepend system message when present.
+	if req.System.Text != "" {
+		msgs = append(msgs, OAIMessage{Role: "system", Content: req.System.Text})
+	}
+
+	for _, m := range req.Messages {
+		oai, err := convertMessage(m)
+		if err != nil {
+			return OAIRequest{}, fmt.Errorf("message role=%s: %w", m.Role, err)
+		}
+		msgs = append(msgs, oai)
+	}
+
+	out := OAIRequest{
+		Model:       req.Model,
+		Messages:    msgs,
+		Temperature: req.Temperature,
+		TopP:        req.TopP,
+		Stream:      req.Stream,
+	}
+
+	if req.MaxTokens > 0 {
+		mt := req.MaxTokens
+		out.MaxTokens = &mt
+	}
+	if len(req.StopSequences) > 0 {
+		out.Stop = req.StopSequences
+	}
+
+	if len(req.Tools) > 0 {
+		tools, err := convertTools(req.Tools)
+		if err != nil {
+			return OAIRequest{}, fmt.Errorf("tools: %w", err)
+		}
+		out.Tools = tools
+	}
+
+	if req.ToolChoice != nil {
+		out.ToolChoice = convertToolChoice(req.ToolChoice)
+	}
+
+	return out, nil
+}
+
+// convertMessage converts a single Anthropic message to OAIMessage.
+func convertMessage(m Message) (OAIMessage, error) {
+	// Simple string content.
+	if m.Content.Text != "" {
+		return OAIMessage{Role: m.Role, Content: m.Content.Text}, nil
+	}
+
+	// No content blocks; treat as empty string message.
+	if len(m.Content.Blocks) == 0 {
+		return OAIMessage{Role: m.Role, Content: ""}, nil
+	}
+
+	// Mixed content blocks: may need multipart content or tool_calls.
+	var parts []OAIContentPart
+	var toolCalls []OAIToolCall
+
+	for _, bl := range m.Content.Blocks {
+		switch bl.Type {
+		case "text":
+			parts = append(parts, OAIContentPart{Type: "text", Text: bl.Text})
+
+		case "image":
+			if bl.Source == nil {
+				continue
+			}
+			var dataURI string
+			if bl.Source.Type == "base64" {
+				dataURI = "data:" + bl.Source.MediaType + ";base64," + bl.Source.Data
+			} else {
+				dataURI = bl.Source.URL
+			}
+			parts = append(parts, OAIContentPart{
+				Type:     "image_url",
+				ImageURL: &OAIImageURL{URL: dataURI},
+			})
+
+		case "tool_use":
+			// assistant tool_use block becomes an OAI tool_calls entry.
+			args := "{}"
+			if len(bl.Input) > 0 {
+				args = string(bl.Input)
+			}
+			toolCalls = append(toolCalls, OAIToolCall{
+				ID:   bl.ID,
+				Type: "function",
+				Function: OAIFunctionCall{
+					Name:      bl.Name,
+					Arguments: args,
+				},
+			})
+
+		case "tool_result":
+			// tool_result becomes an OpenAI tool message.
+			// We handle this as a standalone message below; for now collect text.
+			content := toolResultText(bl)
+			return OAIMessage{
+				Role:       "tool",
+				Content:    content,
+				ToolCallID: bl.ToolUseID,
+			}, nil
+		}
+	}
+
+	// If we collected tool_calls with no content parts, it is a pure tool-call
+	// assistant turn.
+	if len(toolCalls) > 0 && len(parts) == 0 {
+		return OAIMessage{Role: m.Role, ToolCalls: toolCalls}, nil
+	}
+	// Tool calls plus text content.
+	if len(toolCalls) > 0 {
+		// OAI allows content + tool_calls simultaneously on assistant messages.
+		var contentStr string
+		for _, p := range parts {
+			if p.Type == "text" {
+				contentStr += p.Text
+			}
+		}
+		return OAIMessage{Role: m.Role, Content: contentStr, ToolCalls: toolCalls}, nil
+	}
+
+	// Pure text/image parts: use array form for vision, string for text-only.
+	if len(parts) == 1 && parts[0].Type == "text" {
+		return OAIMessage{Role: m.Role, Content: parts[0].Text}, nil
+	}
+	return OAIMessage{Role: m.Role, Content: parts}, nil
+}
+
+// toolResultText extracts the text content from a tool_result block.
+func toolResultText(bl ContentBlock) string {
+	if bl.Content == nil {
+		return ""
+	}
+	if bl.Content.Text != "" {
+		return bl.Content.Text
+	}
+	var sb strings.Builder
+	for _, b := range bl.Content.Blocks {
+		if b.Type == "text" {
+			sb.WriteString(b.Text)
+		}
+	}
+	return sb.String()
+}
+
+// convertTools maps Anthropic tool definitions to OAI function tools.
+func convertTools(tools []Tool) ([]OAITool, error) {
+	out := make([]OAITool, 0, len(tools))
+	for _, t := range tools {
+		params := t.InputSchema
+		if len(params) == 0 {
+			params = json.RawMessage(`{}`)
+		}
+		out = append(out, OAITool{
+			Type: "function",
+			Function: OAIFunction{
+				Name:        t.Name,
+				Description: t.Description,
+				Parameters:  params,
+			},
+		})
+	}
+	return out, nil
+}
+
+// convertToolChoice maps Anthropic tool_choice to the OpenAI equivalent.
+//
+//   auto        -> "auto"
+//   any         -> "required"
+//   {type:tool} -> {type:"function", function:{name:...}}
+func convertToolChoice(tc *ToolChoice) interface{} {
+	switch tc.Type {
+	case "auto":
+		return "auto"
+	case "any":
+		return "required"
+	case "tool":
+		return map[string]interface{}{
+			"type": "function",
+			"function": map[string]string{
+				"name": tc.Name,
+			},
+		}
+	default:
+		return "auto"
+	}
+}

--- a/apps/edge-api/internal/anthropic/translate_request.go
+++ b/apps/edge-api/internal/anthropic/translate_request.go
@@ -13,9 +13,11 @@ import (
 func ToOAIRequest(req MessagesRequest) (OAIRequest, error) {
 	var msgs []OAIMessage
 
-	// Prepend system message when present.
 	if req.System.Text != "" {
-		msgs = append(msgs, OAIMessage{Role: "system", Content: req.System.Text})
+		msgs = append(msgs, OAIMessage{
+			Role:    "system",
+			Content: OAIMessageContent{Text: req.System.Text},
+		})
 	}
 
 	for _, m := range req.Messages {
@@ -51,7 +53,8 @@ func ToOAIRequest(req MessagesRequest) (OAIRequest, error) {
 	}
 
 	if req.ToolChoice != nil {
-		out.ToolChoice = convertToolChoice(req.ToolChoice)
+		tc := convertToolChoice(req.ToolChoice)
+		out.ToolChoice = &tc
 	}
 
 	return out, nil
@@ -61,15 +64,36 @@ func ToOAIRequest(req MessagesRequest) (OAIRequest, error) {
 func convertMessage(m Message) (OAIMessage, error) {
 	// Simple string content.
 	if m.Content.Text != "" {
-		return OAIMessage{Role: m.Role, Content: m.Content.Text}, nil
+		return OAIMessage{Role: m.Role, Content: OAIMessageContent{Text: m.Content.Text}}, nil
 	}
 
 	// No content blocks; treat as empty string message.
 	if len(m.Content.Blocks) == 0 {
-		return OAIMessage{Role: m.Role, Content: ""}, nil
+		return OAIMessage{Role: m.Role, Content: OAIMessageContent{Text: ""}}, nil
 	}
 
-	// Mixed content blocks: may need multipart content or tool_calls.
+	// Validate: a tool_result block must be the only block in the message.
+	// The Anthropic protocol requires each tool result to be its own message.
+	// Mixed non-tool_result blocks before a tool_result are an encoding error.
+	for i, bl := range m.Content.Blocks {
+		if bl.Type == "tool_result" {
+			if i > 0 {
+				return OAIMessage{}, fmt.Errorf(
+					"tool_result block at index %d has %d preceding block(s); "+
+						"each tool_result must be the sole block in its message",
+					i, i,
+				)
+			}
+			content := toolResultText(bl)
+			return OAIMessage{
+				Role:       "tool",
+				Content:    OAIMessageContent{Text: content},
+				ToolCallID: bl.ToolUseID,
+			}, nil
+		}
+	}
+
+	// Mixed content blocks: text, image, tool_use.
 	var parts []OAIContentPart
 	var toolCalls []OAIToolCall
 
@@ -94,7 +118,6 @@ func convertMessage(m Message) (OAIMessage, error) {
 			})
 
 		case "tool_use":
-			// assistant tool_use block becomes an OAI tool_calls entry.
 			args := "{}"
 			if len(bl.Input) > 0 {
 				args = string(bl.Input)
@@ -107,41 +130,33 @@ func convertMessage(m Message) (OAIMessage, error) {
 					Arguments: args,
 				},
 			})
-
-		case "tool_result":
-			// tool_result becomes an OpenAI tool message.
-			// We handle this as a standalone message below; for now collect text.
-			content := toolResultText(bl)
-			return OAIMessage{
-				Role:       "tool",
-				Content:    content,
-				ToolCallID: bl.ToolUseID,
-			}, nil
 		}
 	}
 
-	// If we collected tool_calls with no content parts, it is a pure tool-call
-	// assistant turn.
+	// Pure tool-call assistant turn.
 	if len(toolCalls) > 0 && len(parts) == 0 {
 		return OAIMessage{Role: m.Role, ToolCalls: toolCalls}, nil
 	}
 	// Tool calls plus text content.
 	if len(toolCalls) > 0 {
-		// OAI allows content + tool_calls simultaneously on assistant messages.
 		var contentStr string
 		for _, p := range parts {
 			if p.Type == "text" {
 				contentStr += p.Text
 			}
 		}
-		return OAIMessage{Role: m.Role, Content: contentStr, ToolCalls: toolCalls}, nil
+		return OAIMessage{
+			Role:      m.Role,
+			Content:   OAIMessageContent{Text: contentStr},
+			ToolCalls: toolCalls,
+		}, nil
 	}
 
 	// Pure text/image parts: use array form for vision, string for text-only.
 	if len(parts) == 1 && parts[0].Type == "text" {
-		return OAIMessage{Role: m.Role, Content: parts[0].Text}, nil
+		return OAIMessage{Role: m.Role, Content: OAIMessageContent{Text: parts[0].Text}}, nil
 	}
-	return OAIMessage{Role: m.Role, Content: parts}, nil
+	return OAIMessage{Role: m.Role, Content: OAIMessageContent{Parts: parts}}, nil
 }
 
 // toolResultText extracts the text content from a tool_result block.
@@ -181,25 +196,25 @@ func convertTools(tools []Tool) ([]OAITool, error) {
 	return out, nil
 }
 
-// convertToolChoice maps Anthropic tool_choice to the OpenAI equivalent.
+// convertToolChoice maps Anthropic tool_choice to the typed OAIToolChoice.
 //
-//   auto        -> "auto"
-//   any         -> "required"
-//   {type:tool} -> {type:"function", function:{name:...}}
-func convertToolChoice(tc *ToolChoice) interface{} {
+//	auto        -> sentinel "auto"
+//	any         -> sentinel "required"
+//	{type:tool} -> named function selector
+func convertToolChoice(tc *ToolChoice) OAIToolChoice {
 	switch tc.Type {
 	case "auto":
-		return "auto"
+		return OAIToolChoice{Sentinel: "auto"}
 	case "any":
-		return "required"
+		return OAIToolChoice{Sentinel: "required"}
 	case "tool":
-		return map[string]interface{}{
-			"type": "function",
-			"function": map[string]string{
-				"name": tc.Name,
+		return OAIToolChoice{
+			Named: &OAINamedToolChoice{
+				Type: "function",
+				Function: OAINamedToolChoiceFunction{Name: tc.Name},
 			},
 		}
 	default:
-		return "auto"
+		return OAIToolChoice{Sentinel: "auto"}
 	}
 }

--- a/apps/edge-api/internal/anthropic/translate_request_test.go
+++ b/apps/edge-api/internal/anthropic/translate_request_test.go
@@ -1,0 +1,343 @@
+package anthropic_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/anthropic"
+)
+
+func TestToOAIRequest_SimpleTextMessage(t *testing.T) {
+	req := anthropic.MessagesRequest{
+		Model: "claude-3-haiku",
+		Messages: []anthropic.Message{
+			{Role: "user", Content: anthropic.MessageContent{Text: "Hello"}},
+		},
+		MaxTokens: 100,
+	}
+
+	got, err := anthropic.ToOAIRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Model != "claude-3-haiku" {
+		t.Errorf("model: want %q got %q", "claude-3-haiku", got.Model)
+	}
+	if len(got.Messages) != 1 {
+		t.Fatalf("messages len: want 1 got %d", len(got.Messages))
+	}
+	if got.Messages[0].Role != "user" {
+		t.Errorf("role: want %q got %q", "user", got.Messages[0].Role)
+	}
+	if got.Messages[0].Content != "Hello" {
+		t.Errorf("content: want %q got %v", "Hello", got.Messages[0].Content)
+	}
+	if got.MaxTokens == nil || *got.MaxTokens != 100 {
+		t.Errorf("max_tokens: want 100 got %v", got.MaxTokens)
+	}
+}
+
+func TestToOAIRequest_SystemPrependsMessage(t *testing.T) {
+	req := anthropic.MessagesRequest{
+		Model:  "claude-3-haiku",
+		System: anthropic.SystemField{Text: "Be concise."},
+		Messages: []anthropic.Message{
+			{Role: "user", Content: anthropic.MessageContent{Text: "Hi"}},
+		},
+		MaxTokens: 10,
+	}
+
+	got, err := anthropic.ToOAIRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got.Messages) != 2 {
+		t.Fatalf("messages len: want 2 got %d", len(got.Messages))
+	}
+	if got.Messages[0].Role != "system" {
+		t.Errorf("first message role: want %q got %q", "system", got.Messages[0].Role)
+	}
+	if got.Messages[0].Content != "Be concise." {
+		t.Errorf("system content: want %q got %v", "Be concise.", got.Messages[0].Content)
+	}
+}
+
+func TestToOAIRequest_SystemBlocks(t *testing.T) {
+	raw := `{
+		"model":"m","max_tokens":5,
+		"system":[{"type":"text","text":"Part1"},{"type":"text","text":"Part2"}],
+		"messages":[{"role":"user","content":"hi"}]
+	}`
+	var req anthropic.MessagesRequest
+	if err := json.Unmarshal([]byte(raw), &req); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if req.System.Text != "Part1Part2" {
+		t.Errorf("system: want %q got %q", "Part1Part2", req.System.Text)
+	}
+}
+
+func TestToOAIRequest_StopSequences(t *testing.T) {
+	req := anthropic.MessagesRequest{
+		Model:         "m",
+		Messages:      []anthropic.Message{{Role: "user", Content: anthropic.MessageContent{Text: "hi"}}},
+		MaxTokens:     5,
+		StopSequences: []string{"END", "\n"},
+	}
+	got, err := anthropic.ToOAIRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got.Stop) != 2 || got.Stop[0] != "END" || got.Stop[1] != "\n" {
+		t.Errorf("stop: want [END \\n] got %v", got.Stop)
+	}
+}
+
+func TestToOAIRequest_ToolChoice_Auto(t *testing.T) {
+	tc := &anthropic.ToolChoice{Type: "auto"}
+	req := anthropic.MessagesRequest{
+		Model:      "m",
+		Messages:   []anthropic.Message{{Role: "user", Content: anthropic.MessageContent{Text: "hi"}}},
+		MaxTokens:  5,
+		ToolChoice: tc,
+	}
+	got, err := anthropic.ToOAIRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.ToolChoice != "auto" {
+		t.Errorf("tool_choice: want %q got %v", "auto", got.ToolChoice)
+	}
+}
+
+func TestToOAIRequest_ToolChoice_Any(t *testing.T) {
+	tc := &anthropic.ToolChoice{Type: "any"}
+	req := anthropic.MessagesRequest{
+		Model:      "m",
+		Messages:   []anthropic.Message{{Role: "user", Content: anthropic.MessageContent{Text: "hi"}}},
+		MaxTokens:  5,
+		ToolChoice: tc,
+	}
+	got, err := anthropic.ToOAIRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.ToolChoice != "required" {
+		t.Errorf("tool_choice: want %q got %v", "required", got.ToolChoice)
+	}
+}
+
+func TestToOAIRequest_ToolChoice_Named(t *testing.T) {
+	tc := &anthropic.ToolChoice{Type: "tool", Name: "get_weather"}
+	req := anthropic.MessagesRequest{
+		Model:      "m",
+		Messages:   []anthropic.Message{{Role: "user", Content: anthropic.MessageContent{Text: "hi"}}},
+		MaxTokens:  5,
+		ToolChoice: tc,
+	}
+	got, err := anthropic.ToOAIRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	m, ok := got.ToolChoice.(map[string]interface{})
+	if !ok {
+		t.Fatalf("tool_choice type: want map got %T", got.ToolChoice)
+	}
+	if m["type"] != "function" {
+		t.Errorf("tool_choice.type: want %q got %v", "function", m["type"])
+	}
+	fn, _ := m["function"].(map[string]string)
+	if fn["name"] != "get_weather" {
+		t.Errorf("tool_choice.function.name: want %q got %v", "get_weather", fn["name"])
+	}
+}
+
+func TestToOAIRequest_Tools(t *testing.T) {
+	schema := json.RawMessage(`{"type":"object","properties":{"city":{"type":"string"}}}`)
+	req := anthropic.MessagesRequest{
+		Model:     "m",
+		MaxTokens: 5,
+		Messages:  []anthropic.Message{{Role: "user", Content: anthropic.MessageContent{Text: "weather?"}}},
+		Tools: []anthropic.Tool{
+			{Name: "get_weather", Description: "Get weather", InputSchema: schema},
+		},
+	}
+	got, err := anthropic.ToOAIRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got.Tools) != 1 {
+		t.Fatalf("tools len: want 1 got %d", len(got.Tools))
+	}
+	if got.Tools[0].Type != "function" {
+		t.Errorf("tool type: want %q got %q", "function", got.Tools[0].Type)
+	}
+	if got.Tools[0].Function.Name != "get_weather" {
+		t.Errorf("tool name: want %q got %q", "get_weather", got.Tools[0].Function.Name)
+	}
+}
+
+func TestToOAIRequest_ImageContentBlock(t *testing.T) {
+	blocks := []anthropic.ContentBlock{
+		{Type: "text", Text: "Describe this image"},
+		{
+			Type: "image",
+			Source: &anthropic.ImageSource{
+				Type:      "base64",
+				MediaType: "image/png",
+				Data:      "abc123",
+			},
+		},
+	}
+	req := anthropic.MessagesRequest{
+		Model:     "m",
+		MaxTokens: 50,
+		Messages:  []anthropic.Message{{Role: "user", Content: anthropic.MessageContent{Blocks: blocks}}},
+	}
+	got, err := anthropic.ToOAIRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	parts, ok := got.Messages[0].Content.([]anthropic.OAIContentPart)
+	if !ok {
+		t.Fatalf("content type: want []OAIContentPart got %T", got.Messages[0].Content)
+	}
+	if len(parts) != 2 {
+		t.Fatalf("parts len: want 2 got %d", len(parts))
+	}
+	if parts[1].Type != "image_url" {
+		t.Errorf("part[1] type: want %q got %q", "image_url", parts[1].Type)
+	}
+	if parts[1].ImageURL == nil {
+		t.Fatal("image_url nil")
+	}
+	expected := "data:image/png;base64,abc123"
+	if parts[1].ImageURL.URL != expected {
+		t.Errorf("image URL: want %q got %q", expected, parts[1].ImageURL.URL)
+	}
+}
+
+func TestToOAIRequest_ToolUseBlock(t *testing.T) {
+	raw := `{
+		"model":"m","max_tokens":5,
+		"messages":[{
+			"role":"assistant",
+			"content":[{
+				"type":"tool_use",
+				"id":"tu_01","name":"search",
+				"input":{"query":"Go lang"}
+			}]
+		}]
+	}`
+	var req anthropic.MessagesRequest
+	if err := json.Unmarshal([]byte(raw), &req); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	got, err := anthropic.ToOAIRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	msg := got.Messages[0]
+	if msg.Role != "assistant" {
+		t.Errorf("role: want %q got %q", "assistant", msg.Role)
+	}
+	if len(msg.ToolCalls) != 1 {
+		t.Fatalf("tool_calls len: want 1 got %d", len(msg.ToolCalls))
+	}
+	tc := msg.ToolCalls[0]
+	if tc.ID != "tu_01" {
+		t.Errorf("tool_call id: want %q got %q", "tu_01", tc.ID)
+	}
+	if tc.Function.Name != "search" {
+		t.Errorf("function name: want %q got %q", "search", tc.Function.Name)
+	}
+	// Arguments must be valid JSON
+	var args interface{}
+	if err := json.Unmarshal([]byte(tc.Function.Arguments), &args); err != nil {
+		t.Errorf("arguments not valid JSON: %v, raw=%q", err, tc.Function.Arguments)
+	}
+}
+
+func TestToOAIRequest_ToolResultBlock(t *testing.T) {
+	raw := `{
+		"model":"m","max_tokens":5,
+		"messages":[{
+			"role":"user",
+			"content":[{
+				"type":"tool_result",
+				"tool_use_id":"tu_01",
+				"content":"Sunny and 25°C"
+			}]
+		}]
+	}`
+	var req anthropic.MessagesRequest
+	if err := json.Unmarshal([]byte(raw), &req); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	got, err := anthropic.ToOAIRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	msg := got.Messages[0]
+	if msg.Role != "tool" {
+		t.Errorf("role: want %q got %q", "tool", msg.Role)
+	}
+	if msg.ToolCallID != "tu_01" {
+		t.Errorf("tool_call_id: want %q got %q", "tu_01", msg.ToolCallID)
+	}
+	if msg.Content != "Sunny and 25°C" {
+		t.Errorf("content: want %q got %v", "Sunny and 25°C", msg.Content)
+	}
+}
+
+func TestToOAIRequest_EmptyModel_IsPreserved(t *testing.T) {
+	// Model validation is the handler's responsibility; the translator passes
+	// whatever is in the request so the handler can reject it uniformly.
+	req := anthropic.MessagesRequest{
+		Messages: []anthropic.Message{{Role: "user", Content: anthropic.MessageContent{Text: "hi"}}},
+	}
+	got, err := anthropic.ToOAIRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Model != "" {
+		t.Errorf("model: want empty got %q", got.Model)
+	}
+}
+
+func TestToOAIRequest_NilToolChoice_Omitted(t *testing.T) {
+	req := anthropic.MessagesRequest{
+		Model:     "m",
+		Messages:  []anthropic.Message{{Role: "user", Content: anthropic.MessageContent{Text: "hi"}}},
+		MaxTokens: 5,
+	}
+	got, err := anthropic.ToOAIRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.ToolChoice != nil {
+		t.Errorf("tool_choice should be nil when not set, got %v", got.ToolChoice)
+	}
+}
+
+func TestToOAIRequest_TemperatureAndTopP(t *testing.T) {
+	temp := 0.7
+	topP := 0.9
+	req := anthropic.MessagesRequest{
+		Model:       "m",
+		Messages:    []anthropic.Message{{Role: "user", Content: anthropic.MessageContent{Text: "hi"}}},
+		MaxTokens:   5,
+		Temperature: &temp,
+		TopP:        &topP,
+	}
+	got, err := anthropic.ToOAIRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Temperature == nil || *got.Temperature != 0.7 {
+		t.Errorf("temperature: want 0.7 got %v", got.Temperature)
+	}
+	if got.TopP == nil || *got.TopP != 0.9 {
+		t.Errorf("top_p: want 0.9 got %v", got.TopP)
+	}
+}

--- a/apps/edge-api/internal/anthropic/translate_request_test.go
+++ b/apps/edge-api/internal/anthropic/translate_request_test.go
@@ -287,6 +287,39 @@ func TestToOAIRequest_TemperatureAndTopP(t *testing.T) {
 	}
 }
 
+// T2: two tool_result blocks in the same Anthropic message (parallel tool calls)
+// must each produce a separate OAI "tool" message, none silently dropped.
+func TestToOAIRequest_ParallelToolResults_BothConverted(t *testing.T) {
+	// Anthropic sends parallel tool results as multiple tool_result blocks in one user message.
+	raw := `{"model":"m","max_tokens":5,"messages":[{"role":"user","content":[
+		{"type":"tool_result","tool_use_id":"tu_A","content":"Result A"},
+		{"type":"tool_result","tool_use_id":"tu_B","content":"Result B"}
+	]}]}`
+	var req anthropic.MessagesRequest
+	if err := json.Unmarshal([]byte(raw), &req); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	got, err := anthropic.ToOAIRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Expect two OAI tool messages, one per tool_result block.
+	if len(got.Messages) != 2 {
+		t.Fatalf("messages len: want 2 got %d (second tool_result likely dropped)", len(got.Messages))
+	}
+	for i, msg := range got.Messages {
+		if msg.Role != "tool" {
+			t.Errorf("[%d] role: want tool got %q", i, msg.Role)
+		}
+	}
+	if got.Messages[0].ToolCallID != "tu_A" {
+		t.Errorf("[0] tool_call_id: want tu_A got %q", got.Messages[0].ToolCallID)
+	}
+	if got.Messages[1].ToolCallID != "tu_B" {
+		t.Errorf("[1] tool_call_id: want tu_B got %q", got.Messages[1].ToolCallID)
+	}
+}
+
 // OAIMessageContent marshals as plain string for text-only content.
 func TestOAIMessageContent_MarshalJSON_Text(t *testing.T) {
 	c := anthropic.OAIMessageContent{Text: "hello"}

--- a/apps/edge-api/internal/anthropic/translate_request_test.go
+++ b/apps/edge-api/internal/anthropic/translate_request_test.go
@@ -9,13 +9,10 @@ import (
 
 func TestToOAIRequest_SimpleTextMessage(t *testing.T) {
 	req := anthropic.MessagesRequest{
-		Model: "claude-3-haiku",
-		Messages: []anthropic.Message{
-			{Role: "user", Content: anthropic.MessageContent{Text: "Hello"}},
-		},
+		Model:     "claude-3-haiku",
+		Messages:  []anthropic.Message{{Role: "user", Content: anthropic.MessageContent{Text: "Hello"}}},
 		MaxTokens: 100,
 	}
-
 	got, err := anthropic.ToOAIRequest(req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -26,11 +23,9 @@ func TestToOAIRequest_SimpleTextMessage(t *testing.T) {
 	if len(got.Messages) != 1 {
 		t.Fatalf("messages len: want 1 got %d", len(got.Messages))
 	}
-	if got.Messages[0].Role != "user" {
-		t.Errorf("role: want %q got %q", "user", got.Messages[0].Role)
-	}
-	if got.Messages[0].Content != "Hello" {
-		t.Errorf("content: want %q got %v", "Hello", got.Messages[0].Content)
+	b, _ := json.Marshal(got.Messages[0].Content)
+	if string(b) != `"Hello"` {
+		t.Errorf("content json: want %q got %s", `"Hello"`, b)
 	}
 	if got.MaxTokens == nil || *got.MaxTokens != 100 {
 		t.Errorf("max_tokens: want 100 got %v", got.MaxTokens)
@@ -39,14 +34,11 @@ func TestToOAIRequest_SimpleTextMessage(t *testing.T) {
 
 func TestToOAIRequest_SystemPrependsMessage(t *testing.T) {
 	req := anthropic.MessagesRequest{
-		Model:  "claude-3-haiku",
-		System: anthropic.SystemField{Text: "Be concise."},
-		Messages: []anthropic.Message{
-			{Role: "user", Content: anthropic.MessageContent{Text: "Hi"}},
-		},
+		Model:     "m",
+		System:    anthropic.SystemField{Text: "Be concise."},
+		Messages:  []anthropic.Message{{Role: "user", Content: anthropic.MessageContent{Text: "Hi"}}},
 		MaxTokens: 10,
 	}
-
 	got, err := anthropic.ToOAIRequest(req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -55,19 +47,16 @@ func TestToOAIRequest_SystemPrependsMessage(t *testing.T) {
 		t.Fatalf("messages len: want 2 got %d", len(got.Messages))
 	}
 	if got.Messages[0].Role != "system" {
-		t.Errorf("first message role: want %q got %q", "system", got.Messages[0].Role)
+		t.Errorf("first role: want system got %q", got.Messages[0].Role)
 	}
-	if got.Messages[0].Content != "Be concise." {
-		t.Errorf("system content: want %q got %v", "Be concise.", got.Messages[0].Content)
+	b, _ := json.Marshal(got.Messages[0].Content)
+	if string(b) != `"Be concise."` {
+		t.Errorf("system content json: want %q got %s", `"Be concise."`, b)
 	}
 }
 
 func TestToOAIRequest_SystemBlocks(t *testing.T) {
-	raw := `{
-		"model":"m","max_tokens":5,
-		"system":[{"type":"text","text":"Part1"},{"type":"text","text":"Part2"}],
-		"messages":[{"role":"user","content":"hi"}]
-	}`
+	raw := `{"model":"m","max_tokens":5,"system":[{"type":"text","text":"Part1"},{"type":"text","text":"Part2"}],"messages":[{"role":"user","content":"hi"}]}`
 	var req anthropic.MessagesRequest
 	if err := json.Unmarshal([]byte(raw), &req); err != nil {
 		t.Fatalf("unmarshal: %v", err)
@@ -88,67 +77,70 @@ func TestToOAIRequest_StopSequences(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(got.Stop) != 2 || got.Stop[0] != "END" || got.Stop[1] != "\n" {
+	if len(got.Stop) != 2 || got.Stop[0] != "END" {
 		t.Errorf("stop: want [END \\n] got %v", got.Stop)
 	}
 }
 
 func TestToOAIRequest_ToolChoice_Auto(t *testing.T) {
-	tc := &anthropic.ToolChoice{Type: "auto"}
 	req := anthropic.MessagesRequest{
 		Model:      "m",
 		Messages:   []anthropic.Message{{Role: "user", Content: anthropic.MessageContent{Text: "hi"}}},
 		MaxTokens:  5,
-		ToolChoice: tc,
+		ToolChoice: &anthropic.ToolChoice{Type: "auto"},
 	}
 	got, err := anthropic.ToOAIRequest(req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if got.ToolChoice != "auto" {
-		t.Errorf("tool_choice: want %q got %v", "auto", got.ToolChoice)
+	if got.ToolChoice == nil {
+		t.Fatal("tool_choice nil")
+	}
+	b, _ := json.Marshal(got.ToolChoice)
+	if string(b) != `"auto"` {
+		t.Errorf("tool_choice json: want %q got %s", `"auto"`, b)
 	}
 }
 
 func TestToOAIRequest_ToolChoice_Any(t *testing.T) {
-	tc := &anthropic.ToolChoice{Type: "any"}
 	req := anthropic.MessagesRequest{
 		Model:      "m",
 		Messages:   []anthropic.Message{{Role: "user", Content: anthropic.MessageContent{Text: "hi"}}},
 		MaxTokens:  5,
-		ToolChoice: tc,
+		ToolChoice: &anthropic.ToolChoice{Type: "any"},
 	}
 	got, err := anthropic.ToOAIRequest(req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if got.ToolChoice != "required" {
-		t.Errorf("tool_choice: want %q got %v", "required", got.ToolChoice)
+	b, _ := json.Marshal(got.ToolChoice)
+	if string(b) != `"required"` {
+		t.Errorf("tool_choice json: want %q got %s", `"required"`, b)
 	}
 }
 
 func TestToOAIRequest_ToolChoice_Named(t *testing.T) {
-	tc := &anthropic.ToolChoice{Type: "tool", Name: "get_weather"}
 	req := anthropic.MessagesRequest{
 		Model:      "m",
 		Messages:   []anthropic.Message{{Role: "user", Content: anthropic.MessageContent{Text: "hi"}}},
 		MaxTokens:  5,
-		ToolChoice: tc,
+		ToolChoice: &anthropic.ToolChoice{Type: "tool", Name: "get_weather"},
 	}
 	got, err := anthropic.ToOAIRequest(req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	m, ok := got.ToolChoice.(map[string]interface{})
-	if !ok {
-		t.Fatalf("tool_choice type: want map got %T", got.ToolChoice)
+	b, _ := json.Marshal(got.ToolChoice)
+	var m map[string]interface{}
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("unmarshal tool_choice: %v", err)
 	}
 	if m["type"] != "function" {
-		t.Errorf("tool_choice.type: want %q got %v", "function", m["type"])
+		t.Errorf("type: want function got %v", m["type"])
 	}
-	fn, _ := m["function"].(map[string]string)
+	fn, _ := m["function"].(map[string]interface{})
 	if fn["name"] != "get_weather" {
-		t.Errorf("tool_choice.function.name: want %q got %v", "get_weather", fn["name"])
+		t.Errorf("function.name: want get_weather got %v", fn["name"])
 	}
 }
 
@@ -158,36 +150,21 @@ func TestToOAIRequest_Tools(t *testing.T) {
 		Model:     "m",
 		MaxTokens: 5,
 		Messages:  []anthropic.Message{{Role: "user", Content: anthropic.MessageContent{Text: "weather?"}}},
-		Tools: []anthropic.Tool{
-			{Name: "get_weather", Description: "Get weather", InputSchema: schema},
-		},
+		Tools:     []anthropic.Tool{{Name: "get_weather", Description: "Get weather", InputSchema: schema}},
 	}
 	got, err := anthropic.ToOAIRequest(req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(got.Tools) != 1 {
-		t.Fatalf("tools len: want 1 got %d", len(got.Tools))
-	}
-	if got.Tools[0].Type != "function" {
-		t.Errorf("tool type: want %q got %q", "function", got.Tools[0].Type)
-	}
-	if got.Tools[0].Function.Name != "get_weather" {
-		t.Errorf("tool name: want %q got %q", "get_weather", got.Tools[0].Function.Name)
+	if len(got.Tools) != 1 || got.Tools[0].Type != "function" || got.Tools[0].Function.Name != "get_weather" {
+		t.Errorf("tools: %+v", got.Tools)
 	}
 }
 
 func TestToOAIRequest_ImageContentBlock(t *testing.T) {
 	blocks := []anthropic.ContentBlock{
-		{Type: "text", Text: "Describe this image"},
-		{
-			Type: "image",
-			Source: &anthropic.ImageSource{
-				Type:      "base64",
-				MediaType: "image/png",
-				Data:      "abc123",
-			},
-		},
+		{Type: "text", Text: "Describe this"},
+		{Type: "image", Source: &anthropic.ImageSource{Type: "base64", MediaType: "image/png", Data: "abc123"}},
 	}
 	req := anthropic.MessagesRequest{
 		Model:     "m",
@@ -198,37 +175,25 @@ func TestToOAIRequest_ImageContentBlock(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	parts, ok := got.Messages[0].Content.([]anthropic.OAIContentPart)
-	if !ok {
-		t.Fatalf("content type: want []OAIContentPart got %T", got.Messages[0].Content)
+	b, _ := json.Marshal(got.Messages[0].Content)
+	var parts []map[string]interface{}
+	if err := json.Unmarshal(b, &parts); err != nil {
+		t.Fatalf("unmarshal parts: %v body=%s", err, b)
 	}
 	if len(parts) != 2 {
 		t.Fatalf("parts len: want 2 got %d", len(parts))
 	}
-	if parts[1].Type != "image_url" {
-		t.Errorf("part[1] type: want %q got %q", "image_url", parts[1].Type)
+	if parts[1]["type"] != "image_url" {
+		t.Errorf("part[1] type: want image_url got %v", parts[1]["type"])
 	}
-	if parts[1].ImageURL == nil {
-		t.Fatal("image_url nil")
-	}
-	expected := "data:image/png;base64,abc123"
-	if parts[1].ImageURL.URL != expected {
-		t.Errorf("image URL: want %q got %q", expected, parts[1].ImageURL.URL)
+	iu, _ := parts[1]["image_url"].(map[string]interface{})
+	if iu["url"] != "data:image/png;base64,abc123" {
+		t.Errorf("image url: want data URI got %v", iu["url"])
 	}
 }
 
 func TestToOAIRequest_ToolUseBlock(t *testing.T) {
-	raw := `{
-		"model":"m","max_tokens":5,
-		"messages":[{
-			"role":"assistant",
-			"content":[{
-				"type":"tool_use",
-				"id":"tu_01","name":"search",
-				"input":{"query":"Go lang"}
-			}]
-		}]
-	}`
+	raw := `{"model":"m","max_tokens":5,"messages":[{"role":"assistant","content":[{"type":"tool_use","id":"tu_01","name":"search","input":{"query":"Go lang"}}]}]}`
 	var req anthropic.MessagesRequest
 	if err := json.Unmarshal([]byte(raw), &req); err != nil {
 		t.Fatalf("unmarshal: %v", err)
@@ -238,38 +203,20 @@ func TestToOAIRequest_ToolUseBlock(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	msg := got.Messages[0]
-	if msg.Role != "assistant" {
-		t.Errorf("role: want %q got %q", "assistant", msg.Role)
+	if msg.Role != "assistant" || len(msg.ToolCalls) != 1 {
+		t.Fatalf("message: role=%q tool_calls=%d", msg.Role, len(msg.ToolCalls))
 	}
-	if len(msg.ToolCalls) != 1 {
-		t.Fatalf("tool_calls len: want 1 got %d", len(msg.ToolCalls))
+	if msg.ToolCalls[0].ID != "tu_01" || msg.ToolCalls[0].Function.Name != "search" {
+		t.Errorf("tool_call: %+v", msg.ToolCalls[0])
 	}
-	tc := msg.ToolCalls[0]
-	if tc.ID != "tu_01" {
-		t.Errorf("tool_call id: want %q got %q", "tu_01", tc.ID)
-	}
-	if tc.Function.Name != "search" {
-		t.Errorf("function name: want %q got %q", "search", tc.Function.Name)
-	}
-	// Arguments must be valid JSON
 	var args interface{}
-	if err := json.Unmarshal([]byte(tc.Function.Arguments), &args); err != nil {
-		t.Errorf("arguments not valid JSON: %v, raw=%q", err, tc.Function.Arguments)
+	if err := json.Unmarshal([]byte(msg.ToolCalls[0].Function.Arguments), &args); err != nil {
+		t.Errorf("arguments not valid JSON: %v", err)
 	}
 }
 
 func TestToOAIRequest_ToolResultBlock(t *testing.T) {
-	raw := `{
-		"model":"m","max_tokens":5,
-		"messages":[{
-			"role":"user",
-			"content":[{
-				"type":"tool_result",
-				"tool_use_id":"tu_01",
-				"content":"Sunny and 25°C"
-			}]
-		}]
-	}`
+	raw := `{"model":"m","max_tokens":5,"messages":[{"role":"user","content":[{"type":"tool_result","tool_use_id":"tu_01","content":"Sunny"}]}]}`
 	var req anthropic.MessagesRequest
 	if err := json.Unmarshal([]byte(raw), &req); err != nil {
 		t.Fatalf("unmarshal: %v", err)
@@ -280,28 +227,27 @@ func TestToOAIRequest_ToolResultBlock(t *testing.T) {
 	}
 	msg := got.Messages[0]
 	if msg.Role != "tool" {
-		t.Errorf("role: want %q got %q", "tool", msg.Role)
+		t.Errorf("role: want tool got %q", msg.Role)
 	}
 	if msg.ToolCallID != "tu_01" {
-		t.Errorf("tool_call_id: want %q got %q", "tu_01", msg.ToolCallID)
+		t.Errorf("tool_call_id: want tu_01 got %q", msg.ToolCallID)
 	}
-	if msg.Content != "Sunny and 25°C" {
-		t.Errorf("content: want %q got %v", "Sunny and 25°C", msg.Content)
+	b, _ := json.Marshal(msg.Content)
+	if string(b) != `"Sunny"` {
+		t.Errorf("content: want %q got %s", `"Sunny"`, b)
 	}
 }
 
-func TestToOAIRequest_EmptyModel_IsPreserved(t *testing.T) {
-	// Model validation is the handler's responsibility; the translator passes
-	// whatever is in the request so the handler can reject it uniformly.
-	req := anthropic.MessagesRequest{
-		Messages: []anthropic.Message{{Role: "user", Content: anthropic.MessageContent{Text: "hi"}}},
+// Finding 6: tool_result preceded by other blocks must return an error.
+func TestToOAIRequest_ToolResultPrecededByBlock_ReturnsError(t *testing.T) {
+	raw := `{"model":"m","max_tokens":5,"messages":[{"role":"user","content":[{"type":"text","text":"note"},{"type":"tool_result","tool_use_id":"tu_01","content":"ok"}]}]}`
+	var req anthropic.MessagesRequest
+	if err := json.Unmarshal([]byte(raw), &req); err != nil {
+		t.Fatalf("unmarshal: %v", err)
 	}
-	got, err := anthropic.ToOAIRequest(req)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if got.Model != "" {
-		t.Errorf("model: want empty got %q", got.Model)
+	_, err := anthropic.ToOAIRequest(req)
+	if err == nil {
+		t.Fatal("expected error for tool_result with preceding blocks, got nil")
 	}
 }
 
@@ -316,13 +262,12 @@ func TestToOAIRequest_NilToolChoice_Omitted(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if got.ToolChoice != nil {
-		t.Errorf("tool_choice should be nil when not set, got %v", got.ToolChoice)
+		t.Errorf("tool_choice should be nil when not set")
 	}
 }
 
 func TestToOAIRequest_TemperatureAndTopP(t *testing.T) {
-	temp := 0.7
-	topP := 0.9
+	temp, topP := 0.7, 0.9
 	req := anthropic.MessagesRequest{
 		Model:       "m",
 		Messages:    []anthropic.Message{{Role: "user", Content: anthropic.MessageContent{Text: "hi"}}},
@@ -339,5 +284,68 @@ func TestToOAIRequest_TemperatureAndTopP(t *testing.T) {
 	}
 	if got.TopP == nil || *got.TopP != 0.9 {
 		t.Errorf("top_p: want 0.9 got %v", got.TopP)
+	}
+}
+
+// OAIMessageContent marshals as plain string for text-only content.
+func TestOAIMessageContent_MarshalJSON_Text(t *testing.T) {
+	c := anthropic.OAIMessageContent{Text: "hello"}
+	b, err := json.Marshal(c)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if string(b) != `"hello"` {
+		t.Errorf("want %q got %s", `"hello"`, b)
+	}
+}
+
+// OAIMessageContent marshals as array for multipart content.
+func TestOAIMessageContent_MarshalJSON_Parts(t *testing.T) {
+	c := anthropic.OAIMessageContent{
+		Parts: []anthropic.OAIContentPart{
+			{Type: "text", Text: "hi"},
+			{Type: "image_url", ImageURL: &anthropic.OAIImageURL{URL: "data:image/png;base64,abc"}},
+		},
+	}
+	b, err := json.Marshal(c)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var arr []interface{}
+	if err := json.Unmarshal(b, &arr); err != nil || len(arr) != 2 {
+		t.Errorf("expected 2-element array, got: %s", b)
+	}
+}
+
+// OAIToolChoice marshals as string sentinel.
+func TestOAIToolChoice_MarshalJSON_Sentinel(t *testing.T) {
+	tc := anthropic.OAIToolChoice{Sentinel: "required"}
+	b, err := json.Marshal(tc)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if string(b) != `"required"` {
+		t.Errorf("want %q got %s", `"required"`, b)
+	}
+}
+
+// OAIToolChoice marshals as object for named function.
+func TestOAIToolChoice_MarshalJSON_Named(t *testing.T) {
+	tc := anthropic.OAIToolChoice{
+		Named: &anthropic.OAINamedToolChoice{
+			Type:     "function",
+			Function: anthropic.OAINamedToolChoiceFunction{Name: "fn"},
+		},
+	}
+	b, err := json.Marshal(tc)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if m["type"] != "function" {
+		t.Errorf("type: want function got %v", m["type"])
 	}
 }

--- a/apps/edge-api/internal/anthropic/translate_response.go
+++ b/apps/edge-api/internal/anthropic/translate_response.go
@@ -6,20 +6,25 @@ import (
 	"strings"
 )
 
-// FromOAIResponse lifts an OAIResponse (OpenAI chat completions shape) to an
-// Anthropic MessagesResponse. The model field is echoed from the OAI response
-// so downstream callers see the alias they requested, never an upstream route.
-func FromOAIResponse(resp OAIResponse) MessagesResponse {
+// FromOAIResponse lifts an OAIResponse to an Anthropic MessagesResponse.
+// clientAlias is the model name the client sent; it is echoed back verbatim
+// so upstream route identifiers (e.g. openrouter/...) never reach the client.
+func FromOAIResponse(resp OAIResponse, clientAlias string) MessagesResponse {
 	id := resp.ID
 	if !strings.HasPrefix(id, "msg_") {
 		id = "msg_" + id
+	}
+
+	model := clientAlias
+	if model == "" {
+		model = resp.Model
 	}
 
 	out := MessagesResponse{
 		ID:    id,
 		Type:  "message",
 		Role:  "assistant",
-		Model: resp.Model,
+		Model: model,
 		Usage: ResponseUsage{
 			InputTokens:  resp.Usage.PromptTokens,
 			OutputTokens: resp.Usage.CompletionTokens,
@@ -34,7 +39,6 @@ func FromOAIResponse(resp OAIResponse) MessagesResponse {
 	choice := resp.Choices[0]
 	out.StopReason = mapFinishReason(choice.FinishReason)
 
-	// Build content blocks from the choice message.
 	var blocks []ResponseBlock
 
 	if choice.Message.Content != "" {
@@ -47,7 +51,6 @@ func FromOAIResponse(resp OAIResponse) MessagesResponse {
 	for _, tc := range choice.Message.ToolCalls {
 		input, err := parseToolArguments(tc.Function.Arguments)
 		if err != nil {
-			// Preserve raw JSON as a fallback; never drop a tool call silently.
 			input = json.RawMessage(fmt.Sprintf(`{"_raw":%q}`, tc.Function.Arguments))
 		}
 		blocks = append(blocks, ResponseBlock{
@@ -63,8 +66,6 @@ func FromOAIResponse(resp OAIResponse) MessagesResponse {
 }
 
 // mapFinishReason converts an OpenAI finish_reason to an Anthropic stop_reason.
-// Validated against the Anthropic stop_reason enum:
-// end_turn | max_tokens | stop_sequence | tool_use | refusal
 func mapFinishReason(reason string) string {
 	switch reason {
 	case "stop":
@@ -80,13 +81,11 @@ func mapFinishReason(reason string) string {
 	}
 }
 
-// parseToolArguments parses a JSON-stringified function arguments string into
-// a json.RawMessage suitable for the Anthropic tool_use input field.
+// parseToolArguments parses a JSON-stringified arguments string into RawMessage.
 func parseToolArguments(args string) (json.RawMessage, error) {
 	if args == "" {
 		return json.RawMessage(`{}`), nil
 	}
-	// Validate it is valid JSON.
 	var check interface{}
 	if err := json.Unmarshal([]byte(args), &check); err != nil {
 		return nil, err

--- a/apps/edge-api/internal/anthropic/translate_response.go
+++ b/apps/edge-api/internal/anthropic/translate_response.go
@@ -1,0 +1,95 @@
+package anthropic
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// FromOAIResponse lifts an OAIResponse (OpenAI chat completions shape) to an
+// Anthropic MessagesResponse. The model field is echoed from the OAI response
+// so downstream callers see the alias they requested, never an upstream route.
+func FromOAIResponse(resp OAIResponse) MessagesResponse {
+	id := resp.ID
+	if !strings.HasPrefix(id, "msg_") {
+		id = "msg_" + id
+	}
+
+	out := MessagesResponse{
+		ID:    id,
+		Type:  "message",
+		Role:  "assistant",
+		Model: resp.Model,
+		Usage: ResponseUsage{
+			InputTokens:  resp.Usage.PromptTokens,
+			OutputTokens: resp.Usage.CompletionTokens,
+		},
+	}
+
+	if len(resp.Choices) == 0 {
+		out.StopReason = "end_turn"
+		return out
+	}
+
+	choice := resp.Choices[0]
+	out.StopReason = mapFinishReason(choice.FinishReason)
+
+	// Build content blocks from the choice message.
+	var blocks []ResponseBlock
+
+	if choice.Message.Content != "" {
+		blocks = append(blocks, ResponseBlock{
+			Type: "text",
+			Text: choice.Message.Content,
+		})
+	}
+
+	for _, tc := range choice.Message.ToolCalls {
+		input, err := parseToolArguments(tc.Function.Arguments)
+		if err != nil {
+			// Preserve raw JSON as a fallback; never drop a tool call silently.
+			input = json.RawMessage(fmt.Sprintf(`{"_raw":%q}`, tc.Function.Arguments))
+		}
+		blocks = append(blocks, ResponseBlock{
+			Type:  "tool_use",
+			ID:    tc.ID,
+			Name:  tc.Function.Name,
+			Input: input,
+		})
+	}
+
+	out.Content = blocks
+	return out
+}
+
+// mapFinishReason converts an OpenAI finish_reason to an Anthropic stop_reason.
+// Validated against the Anthropic stop_reason enum:
+// end_turn | max_tokens | stop_sequence | tool_use | refusal
+func mapFinishReason(reason string) string {
+	switch reason {
+	case "stop":
+		return "end_turn"
+	case "length":
+		return "max_tokens"
+	case "tool_calls":
+		return "tool_use"
+	case "content_filter":
+		return "refusal"
+	default:
+		return "end_turn"
+	}
+}
+
+// parseToolArguments parses a JSON-stringified function arguments string into
+// a json.RawMessage suitable for the Anthropic tool_use input field.
+func parseToolArguments(args string) (json.RawMessage, error) {
+	if args == "" {
+		return json.RawMessage(`{}`), nil
+	}
+	// Validate it is valid JSON.
+	var check interface{}
+	if err := json.Unmarshal([]byte(args), &check); err != nil {
+		return nil, err
+	}
+	return json.RawMessage(args), nil
+}

--- a/apps/edge-api/internal/anthropic/translate_response_test.go
+++ b/apps/edge-api/internal/anthropic/translate_response_test.go
@@ -2,6 +2,7 @@ package anthropic_test
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/anthropic"
@@ -10,63 +11,86 @@ import (
 func TestFromOAIResponse_SimpleText(t *testing.T) {
 	oai := anthropic.OAIResponse{
 		ID:    "chatcmpl-abc",
-		Model: "claude-3-haiku",
+		Model: "openrouter/anthropic/claude-3-haiku", // upstream route id -- must never reach client
 		Choices: []anthropic.OAIChoice{
 			{
-				Index:        0,
 				FinishReason: "stop",
-				Message: anthropic.OAIMsg{
-					Role:    "assistant",
-					Content: "Hello, world!",
-				},
+				Message:      anthropic.OAIMsg{Role: "assistant", Content: "Hello, world!"},
 			},
 		},
-		Usage: anthropic.OAIUsage{
-			PromptTokens:     10,
-			CompletionTokens: 5,
-		},
+		Usage: anthropic.OAIUsage{PromptTokens: 10, CompletionTokens: 5},
 	}
 
-	got := anthropic.FromOAIResponse(oai)
+	got := anthropic.FromOAIResponse(oai, "claude-3-haiku")
 
 	if got.Type != "message" {
-		t.Errorf("type: want %q got %q", "message", got.Type)
+		t.Errorf("type: want message got %q", got.Type)
 	}
 	if got.Role != "assistant" {
-		t.Errorf("role: want %q got %q", "assistant", got.Role)
+		t.Errorf("role: want assistant got %q", got.Role)
 	}
+	// Model must be client alias, never the upstream route id.
 	if got.Model != "claude-3-haiku" {
-		t.Errorf("model: want %q got %q", "claude-3-haiku", got.Model)
+		t.Errorf("model: want claude-3-haiku got %q", got.Model)
 	}
-	// ID must be prefixed with msg_
+	if strings.Contains(got.Model, "openrouter") || strings.Contains(got.Model, "/") {
+		t.Errorf("model leaks upstream route id: %q", got.Model)
+	}
 	if len(got.ID) < 4 || got.ID[:4] != "msg_" {
 		t.Errorf("id prefix: want msg_ got %q", got.ID)
 	}
 	if got.StopReason != "end_turn" {
-		t.Errorf("stop_reason: want %q got %q", "end_turn", got.StopReason)
+		t.Errorf("stop_reason: want end_turn got %q", got.StopReason)
 	}
-	if len(got.Content) != 1 {
-		t.Fatalf("content len: want 1 got %d", len(got.Content))
+	if len(got.Content) != 1 || got.Content[0].Type != "text" || got.Content[0].Text != "Hello, world!" {
+		t.Errorf("content: %+v", got.Content)
 	}
-	if got.Content[0].Type != "text" {
-		t.Errorf("content[0].type: want %q got %q", "text", got.Content[0].Type)
+	if got.Usage.InputTokens != 10 || got.Usage.OutputTokens != 5 {
+		t.Errorf("usage: %+v", got.Usage)
 	}
-	if got.Content[0].Text != "Hello, world!" {
-		t.Errorf("content[0].text: want %q got %q", "Hello, world!", got.Content[0].Text)
+}
+
+// Finding 2: client alias is always echoed; upstream route id never leaks.
+func TestFromOAIResponse_ModelAliasEchoed_RouteIdNeverLeaks(t *testing.T) {
+	providerRouteIDs := []string{
+		"openrouter/anthropic/claude-3-haiku",
+		"groq/llama-3.1-8b",
+		"route-openrouter-fast",
+		"litellm/claude-haiku",
 	}
-	if got.Usage.InputTokens != 10 {
-		t.Errorf("usage.input_tokens: want 10 got %d", got.Usage.InputTokens)
+	clientAlias := "my-model-alias"
+	for _, upstreamModel := range providerRouteIDs {
+		oai := anthropic.OAIResponse{
+			ID:    "chatcmpl-x",
+			Model: upstreamModel,
+			Choices: []anthropic.OAIChoice{
+				{Message: anthropic.OAIMsg{Role: "assistant", Content: "hi"}},
+			},
+		}
+		got := anthropic.FromOAIResponse(oai, clientAlias)
+		if got.Model != clientAlias {
+			t.Errorf("upstream=%q: model want %q got %q", upstreamModel, clientAlias, got.Model)
+		}
 	}
-	if got.Usage.OutputTokens != 5 {
-		t.Errorf("usage.output_tokens: want 5 got %d", got.Usage.OutputTokens)
+}
+
+// Finding 2: empty clientAlias falls back to resp.Model (graceful degradation).
+func TestFromOAIResponse_EmptyAlias_FallsBackToRespModel(t *testing.T) {
+	oai := anthropic.OAIResponse{
+		ID:    "chatcmpl-x",
+		Model: "some-model",
+		Choices: []anthropic.OAIChoice{
+			{Message: anthropic.OAIMsg{Role: "assistant", Content: "hi"}},
+		},
+	}
+	got := anthropic.FromOAIResponse(oai, "")
+	if got.Model != "some-model" {
+		t.Errorf("model: want some-model got %q", got.Model)
 	}
 }
 
 func TestFromOAIResponse_FinishReasonMapping(t *testing.T) {
-	cases := []struct {
-		oaiReason  string
-		wantReason string
-	}{
+	cases := []struct{ oai, want string }{
 		{"stop", "end_turn"},
 		{"length", "max_tokens"},
 		{"tool_calls", "tool_use"},
@@ -74,18 +98,17 @@ func TestFromOAIResponse_FinishReasonMapping(t *testing.T) {
 		{"unknown", "end_turn"},
 		{"", "end_turn"},
 	}
-
 	for _, tc := range cases {
 		oai := anthropic.OAIResponse{
-			ID:    "chatcmpl-xyz",
+			ID:    "x",
 			Model: "m",
 			Choices: []anthropic.OAIChoice{
-				{FinishReason: tc.oaiReason, Message: anthropic.OAIMsg{Role: "assistant", Content: "hi"}},
+				{FinishReason: tc.oai, Message: anthropic.OAIMsg{Role: "assistant", Content: "hi"}},
 			},
 		}
-		got := anthropic.FromOAIResponse(oai)
-		if got.StopReason != tc.wantReason {
-			t.Errorf("finish_reason=%q: want stop_reason=%q got %q", tc.oaiReason, tc.wantReason, got.StopReason)
+		got := anthropic.FromOAIResponse(oai, "m")
+		if got.StopReason != tc.want {
+			t.Errorf("finish_reason=%q: want %q got %q", tc.oai, tc.want, got.StopReason)
 		}
 	}
 }
@@ -98,50 +121,29 @@ func TestFromOAIResponse_WithToolCalls(t *testing.T) {
 			{
 				FinishReason: "tool_calls",
 				Message: anthropic.OAIMsg{
-					Role:    "assistant",
-					Content: "",
+					Role: "assistant",
 					ToolCalls: []anthropic.OAIToolCall{
-						{
-							ID:   "call_01",
-							Type: "function",
-							Function: anthropic.OAIFunctionCall{
-								Name:      "get_weather",
-								Arguments: `{"city":"Dhaka"}`,
-							},
-						},
+						{ID: "call_01", Type: "function", Function: anthropic.OAIFunctionCall{Name: "get_weather", Arguments: `{"city":"Dhaka"}`}},
 					},
 				},
 			},
 		},
 		Usage: anthropic.OAIUsage{PromptTokens: 20, CompletionTokens: 10},
 	}
-
-	got := anthropic.FromOAIResponse(oai)
-
+	got := anthropic.FromOAIResponse(oai, "m")
 	if got.StopReason != "tool_use" {
-		t.Errorf("stop_reason: want %q got %q", "tool_use", got.StopReason)
+		t.Errorf("stop_reason: want tool_use got %q", got.StopReason)
 	}
-	// Empty content field -> no text block; one tool_use block.
-	if len(got.Content) != 1 {
-		t.Fatalf("content len: want 1 got %d", len(got.Content))
+	if len(got.Content) != 1 || got.Content[0].Type != "tool_use" {
+		t.Fatalf("content: %+v", got.Content)
 	}
 	block := got.Content[0]
-	if block.Type != "tool_use" {
-		t.Errorf("block type: want %q got %q", "tool_use", block.Type)
+	if block.ID != "call_01" || block.Name != "get_weather" {
+		t.Errorf("block: %+v", block)
 	}
-	if block.ID != "call_01" {
-		t.Errorf("block id: want %q got %q", "call_01", block.ID)
-	}
-	if block.Name != "get_weather" {
-		t.Errorf("block name: want %q got %q", "get_weather", block.Name)
-	}
-	// Input must be valid JSON matching original arguments.
 	var input map[string]string
-	if err := json.Unmarshal(block.Input, &input); err != nil {
-		t.Fatalf("input json: %v", err)
-	}
-	if input["city"] != "Dhaka" {
-		t.Errorf("input city: want %q got %q", "Dhaka", input["city"])
+	if err := json.Unmarshal(block.Input, &input); err != nil || input["city"] != "Dhaka" {
+		t.Errorf("input: %v raw=%s", err, block.Input)
 	}
 }
 
@@ -154,44 +156,28 @@ func TestFromOAIResponse_TextAndToolCalls(t *testing.T) {
 				FinishReason: "tool_calls",
 				Message: anthropic.OAIMsg{
 					Role:    "assistant",
-					Content: "Let me check that for you.",
+					Content: "Let me check.",
 					ToolCalls: []anthropic.OAIToolCall{
-						{
-							ID:   "call_02",
-							Type: "function",
-							Function: anthropic.OAIFunctionCall{
-								Name:      "lookup",
-								Arguments: `{"q":"test"}`,
-							},
-						},
+						{ID: "call_02", Type: "function", Function: anthropic.OAIFunctionCall{Name: "lookup", Arguments: `{"q":"test"}`}},
 					},
 				},
 			},
 		},
 	}
-
-	got := anthropic.FromOAIResponse(oai)
-
-	// Should have 2 blocks: text + tool_use.
+	got := anthropic.FromOAIResponse(oai, "m")
 	if len(got.Content) != 2 {
 		t.Fatalf("content len: want 2 got %d", len(got.Content))
 	}
-	if got.Content[0].Type != "text" {
-		t.Errorf("block[0] type: want %q got %q", "text", got.Content[0].Type)
-	}
-	if got.Content[1].Type != "tool_use" {
-		t.Errorf("block[1] type: want %q got %q", "tool_use", got.Content[1].Type)
+	if got.Content[0].Type != "text" || got.Content[1].Type != "tool_use" {
+		t.Errorf("block types: %v %v", got.Content[0].Type, got.Content[1].Type)
 	}
 }
 
 func TestFromOAIResponse_EmptyChoices(t *testing.T) {
-	oai := anthropic.OAIResponse{
-		ID:    "chatcmpl-empty",
-		Model: "m",
-	}
-	got := anthropic.FromOAIResponse(oai)
+	oai := anthropic.OAIResponse{ID: "x", Model: "m"}
+	got := anthropic.FromOAIResponse(oai, "m")
 	if got.StopReason != "end_turn" {
-		t.Errorf("stop_reason: want %q got %q", "end_turn", got.StopReason)
+		t.Errorf("stop_reason: want end_turn got %q", got.StopReason)
 	}
 }
 
@@ -203,10 +189,9 @@ func TestFromOAIResponse_IDAlreadyPrefixed(t *testing.T) {
 			{Message: anthropic.OAIMsg{Role: "assistant", Content: "hi"}},
 		},
 	}
-	got := anthropic.FromOAIResponse(oai)
-	// Must not double-prefix.
+	got := anthropic.FromOAIResponse(oai, "m")
 	if got.ID != "msg_already" {
-		t.Errorf("id: want %q got %q", "msg_already", got.ID)
+		t.Errorf("id: want msg_already got %q", got.ID)
 	}
 }
 
@@ -220,28 +205,17 @@ func TestFromOAIResponse_ToolArgumentsInvalidJSON(t *testing.T) {
 				Message: anthropic.OAIMsg{
 					Role: "assistant",
 					ToolCalls: []anthropic.OAIToolCall{
-						{
-							ID:   "call_bad",
-							Type: "function",
-							Function: anthropic.OAIFunctionCall{
-								Name:      "fn",
-								Arguments: `not json`,
-							},
-						},
+						{ID: "call_bad", Type: "function", Function: anthropic.OAIFunctionCall{Name: "fn", Arguments: `not json`}},
 					},
 				},
 			},
 		},
 	}
-	got := anthropic.FromOAIResponse(oai)
-	// Should still produce a tool_use block (with fallback input), never panic.
-	if len(got.Content) != 1 {
-		t.Fatalf("content len: want 1 got %d", len(got.Content))
-	}
-	if got.Content[0].Type != "tool_use" {
-		t.Errorf("block type: want tool_use got %q", got.Content[0].Type)
+	got := anthropic.FromOAIResponse(oai, "m")
+	if len(got.Content) != 1 || got.Content[0].Type != "tool_use" {
+		t.Fatalf("content: %+v", got.Content)
 	}
 	if len(got.Content[0].Input) == 0 {
-		t.Error("input should not be empty even on fallback")
+		t.Error("input should not be empty on fallback")
 	}
 }

--- a/apps/edge-api/internal/anthropic/translate_response_test.go
+++ b/apps/edge-api/internal/anthropic/translate_response_test.go
@@ -1,0 +1,247 @@
+package anthropic_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/anthropic"
+)
+
+func TestFromOAIResponse_SimpleText(t *testing.T) {
+	oai := anthropic.OAIResponse{
+		ID:    "chatcmpl-abc",
+		Model: "claude-3-haiku",
+		Choices: []anthropic.OAIChoice{
+			{
+				Index:        0,
+				FinishReason: "stop",
+				Message: anthropic.OAIMsg{
+					Role:    "assistant",
+					Content: "Hello, world!",
+				},
+			},
+		},
+		Usage: anthropic.OAIUsage{
+			PromptTokens:     10,
+			CompletionTokens: 5,
+		},
+	}
+
+	got := anthropic.FromOAIResponse(oai)
+
+	if got.Type != "message" {
+		t.Errorf("type: want %q got %q", "message", got.Type)
+	}
+	if got.Role != "assistant" {
+		t.Errorf("role: want %q got %q", "assistant", got.Role)
+	}
+	if got.Model != "claude-3-haiku" {
+		t.Errorf("model: want %q got %q", "claude-3-haiku", got.Model)
+	}
+	// ID must be prefixed with msg_
+	if len(got.ID) < 4 || got.ID[:4] != "msg_" {
+		t.Errorf("id prefix: want msg_ got %q", got.ID)
+	}
+	if got.StopReason != "end_turn" {
+		t.Errorf("stop_reason: want %q got %q", "end_turn", got.StopReason)
+	}
+	if len(got.Content) != 1 {
+		t.Fatalf("content len: want 1 got %d", len(got.Content))
+	}
+	if got.Content[0].Type != "text" {
+		t.Errorf("content[0].type: want %q got %q", "text", got.Content[0].Type)
+	}
+	if got.Content[0].Text != "Hello, world!" {
+		t.Errorf("content[0].text: want %q got %q", "Hello, world!", got.Content[0].Text)
+	}
+	if got.Usage.InputTokens != 10 {
+		t.Errorf("usage.input_tokens: want 10 got %d", got.Usage.InputTokens)
+	}
+	if got.Usage.OutputTokens != 5 {
+		t.Errorf("usage.output_tokens: want 5 got %d", got.Usage.OutputTokens)
+	}
+}
+
+func TestFromOAIResponse_FinishReasonMapping(t *testing.T) {
+	cases := []struct {
+		oaiReason  string
+		wantReason string
+	}{
+		{"stop", "end_turn"},
+		{"length", "max_tokens"},
+		{"tool_calls", "tool_use"},
+		{"content_filter", "refusal"},
+		{"unknown", "end_turn"},
+		{"", "end_turn"},
+	}
+
+	for _, tc := range cases {
+		oai := anthropic.OAIResponse{
+			ID:    "chatcmpl-xyz",
+			Model: "m",
+			Choices: []anthropic.OAIChoice{
+				{FinishReason: tc.oaiReason, Message: anthropic.OAIMsg{Role: "assistant", Content: "hi"}},
+			},
+		}
+		got := anthropic.FromOAIResponse(oai)
+		if got.StopReason != tc.wantReason {
+			t.Errorf("finish_reason=%q: want stop_reason=%q got %q", tc.oaiReason, tc.wantReason, got.StopReason)
+		}
+	}
+}
+
+func TestFromOAIResponse_WithToolCalls(t *testing.T) {
+	oai := anthropic.OAIResponse{
+		ID:    "chatcmpl-tool",
+		Model: "m",
+		Choices: []anthropic.OAIChoice{
+			{
+				FinishReason: "tool_calls",
+				Message: anthropic.OAIMsg{
+					Role:    "assistant",
+					Content: "",
+					ToolCalls: []anthropic.OAIToolCall{
+						{
+							ID:   "call_01",
+							Type: "function",
+							Function: anthropic.OAIFunctionCall{
+								Name:      "get_weather",
+								Arguments: `{"city":"Dhaka"}`,
+							},
+						},
+					},
+				},
+			},
+		},
+		Usage: anthropic.OAIUsage{PromptTokens: 20, CompletionTokens: 10},
+	}
+
+	got := anthropic.FromOAIResponse(oai)
+
+	if got.StopReason != "tool_use" {
+		t.Errorf("stop_reason: want %q got %q", "tool_use", got.StopReason)
+	}
+	// Empty content field -> no text block; one tool_use block.
+	if len(got.Content) != 1 {
+		t.Fatalf("content len: want 1 got %d", len(got.Content))
+	}
+	block := got.Content[0]
+	if block.Type != "tool_use" {
+		t.Errorf("block type: want %q got %q", "tool_use", block.Type)
+	}
+	if block.ID != "call_01" {
+		t.Errorf("block id: want %q got %q", "call_01", block.ID)
+	}
+	if block.Name != "get_weather" {
+		t.Errorf("block name: want %q got %q", "get_weather", block.Name)
+	}
+	// Input must be valid JSON matching original arguments.
+	var input map[string]string
+	if err := json.Unmarshal(block.Input, &input); err != nil {
+		t.Fatalf("input json: %v", err)
+	}
+	if input["city"] != "Dhaka" {
+		t.Errorf("input city: want %q got %q", "Dhaka", input["city"])
+	}
+}
+
+func TestFromOAIResponse_TextAndToolCalls(t *testing.T) {
+	oai := anthropic.OAIResponse{
+		ID:    "chatcmpl-multi",
+		Model: "m",
+		Choices: []anthropic.OAIChoice{
+			{
+				FinishReason: "tool_calls",
+				Message: anthropic.OAIMsg{
+					Role:    "assistant",
+					Content: "Let me check that for you.",
+					ToolCalls: []anthropic.OAIToolCall{
+						{
+							ID:   "call_02",
+							Type: "function",
+							Function: anthropic.OAIFunctionCall{
+								Name:      "lookup",
+								Arguments: `{"q":"test"}`,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got := anthropic.FromOAIResponse(oai)
+
+	// Should have 2 blocks: text + tool_use.
+	if len(got.Content) != 2 {
+		t.Fatalf("content len: want 2 got %d", len(got.Content))
+	}
+	if got.Content[0].Type != "text" {
+		t.Errorf("block[0] type: want %q got %q", "text", got.Content[0].Type)
+	}
+	if got.Content[1].Type != "tool_use" {
+		t.Errorf("block[1] type: want %q got %q", "tool_use", got.Content[1].Type)
+	}
+}
+
+func TestFromOAIResponse_EmptyChoices(t *testing.T) {
+	oai := anthropic.OAIResponse{
+		ID:    "chatcmpl-empty",
+		Model: "m",
+	}
+	got := anthropic.FromOAIResponse(oai)
+	if got.StopReason != "end_turn" {
+		t.Errorf("stop_reason: want %q got %q", "end_turn", got.StopReason)
+	}
+}
+
+func TestFromOAIResponse_IDAlreadyPrefixed(t *testing.T) {
+	oai := anthropic.OAIResponse{
+		ID:    "msg_already",
+		Model: "m",
+		Choices: []anthropic.OAIChoice{
+			{Message: anthropic.OAIMsg{Role: "assistant", Content: "hi"}},
+		},
+	}
+	got := anthropic.FromOAIResponse(oai)
+	// Must not double-prefix.
+	if got.ID != "msg_already" {
+		t.Errorf("id: want %q got %q", "msg_already", got.ID)
+	}
+}
+
+func TestFromOAIResponse_ToolArgumentsInvalidJSON(t *testing.T) {
+	oai := anthropic.OAIResponse{
+		ID:    "chatcmpl-bad",
+		Model: "m",
+		Choices: []anthropic.OAIChoice{
+			{
+				FinishReason: "tool_calls",
+				Message: anthropic.OAIMsg{
+					Role: "assistant",
+					ToolCalls: []anthropic.OAIToolCall{
+						{
+							ID:   "call_bad",
+							Type: "function",
+							Function: anthropic.OAIFunctionCall{
+								Name:      "fn",
+								Arguments: `not json`,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	got := anthropic.FromOAIResponse(oai)
+	// Should still produce a tool_use block (with fallback input), never panic.
+	if len(got.Content) != 1 {
+		t.Fatalf("content len: want 1 got %d", len(got.Content))
+	}
+	if got.Content[0].Type != "tool_use" {
+		t.Errorf("block type: want tool_use got %q", got.Content[0].Type)
+	}
+	if len(got.Content[0].Input) == 0 {
+		t.Error("input should not be empty even on fallback")
+	}
+}

--- a/apps/edge-api/internal/anthropic/types.go
+++ b/apps/edge-api/internal/anthropic/types.go
@@ -1,0 +1,369 @@
+// Package anthropic provides a translation layer between the Anthropic Messages
+// wire format and the internal OpenAI-shaped dispatch core. It never calls real
+// Anthropic; requests are lowered to the internal chat shape, dispatched through
+// the existing LiteLLM path, and responses are lifted back to Anthropic shape.
+package anthropic
+
+import "encoding/json"
+
+// --------------------------------------------------------------------------
+// Inbound request types (Anthropic -> internal)
+// --------------------------------------------------------------------------
+
+// MessagesRequest is the Anthropic POST /v1/messages request body.
+type MessagesRequest struct {
+	Model         string           `json:"model"`
+	Messages      []Message        `json:"messages"`
+	System        SystemField      `json:"system,omitempty"`
+	MaxTokens     int              `json:"max_tokens"`
+	Tools         []Tool           `json:"tools,omitempty"`
+	ToolChoice    *ToolChoice      `json:"tool_choice,omitempty"`
+	Temperature   *float64         `json:"temperature,omitempty"`
+	TopP          *float64         `json:"top_p,omitempty"`
+	StopSequences []string         `json:"stop_sequences,omitempty"`
+	Stream        bool             `json:"stream,omitempty"`
+	Metadata      *RequestMetadata `json:"metadata,omitempty"`
+}
+
+// RequestMetadata carries optional caller metadata (unused in routing).
+type RequestMetadata struct {
+	UserID string `json:"user_id,omitempty"`
+}
+
+// SystemField can be a plain string or an array of TextBlocks.
+// We use a custom unmarshaller so neither form needs an any field.
+type SystemField struct {
+	Text string
+}
+
+func (s *SystemField) UnmarshalJSON(b []byte) error {
+	// Try string first.
+	var str string
+	if err := json.Unmarshal(b, &str); err == nil {
+		s.Text = str
+		return nil
+	}
+	// Fall back to array of content blocks; concatenate text.
+	var blocks []ContentBlock
+	if err := json.Unmarshal(b, &blocks); err != nil {
+		return err
+	}
+	for _, bl := range blocks {
+		if bl.Type == "text" {
+			s.Text += bl.Text
+		}
+	}
+	return nil
+}
+
+// Message is a single conversation turn.
+type Message struct {
+	Role    string         `json:"role"` // "user" | "assistant"
+	Content MessageContent `json:"content"`
+}
+
+// MessageContent can be a plain string or a []ContentBlock. Custom unmarshaller.
+type MessageContent struct {
+	Text   string
+	Blocks []ContentBlock
+}
+
+func (mc *MessageContent) UnmarshalJSON(b []byte) error {
+	var str string
+	if err := json.Unmarshal(b, &str); err == nil {
+		mc.Text = str
+		return nil
+	}
+	var blocks []ContentBlock
+	if err := json.Unmarshal(b, &blocks); err != nil {
+		return err
+	}
+	mc.Blocks = blocks
+	return nil
+}
+
+// ContentBlock is a typed content unit within a message.
+type ContentBlock struct {
+	// Shared
+	Type string `json:"type"` // "text"|"image"|"tool_use"|"tool_result"
+
+	// type=text
+	Text string `json:"text,omitempty"`
+
+	// type=image
+	Source *ImageSource `json:"source,omitempty"`
+
+	// type=tool_use
+	ID    string          `json:"id,omitempty"`
+	Name  string          `json:"name,omitempty"`
+	Input json.RawMessage `json:"input,omitempty"`
+
+	// type=tool_result
+	ToolUseID string             `json:"tool_use_id,omitempty"`
+	Content   *ToolResultContent `json:"content,omitempty"`
+}
+
+// ImageSource describes an image payload (base64 or URL).
+type ImageSource struct {
+	Type      string `json:"type"`       // "base64" | "url"
+	MediaType string `json:"media_type"` // e.g. "image/png"
+	Data      string `json:"data,omitempty"`
+	URL       string `json:"url,omitempty"`
+}
+
+// ToolResultContent can be a string or []ContentBlock. Custom unmarshaller.
+type ToolResultContent struct {
+	Text   string
+	Blocks []ContentBlock
+}
+
+func (t *ToolResultContent) UnmarshalJSON(b []byte) error {
+	var str string
+	if err := json.Unmarshal(b, &str); err == nil {
+		t.Text = str
+		return nil
+	}
+	var blocks []ContentBlock
+	if err := json.Unmarshal(b, &blocks); err != nil {
+		return err
+	}
+	t.Blocks = blocks
+	return nil
+}
+
+// Tool describes an Anthropic function tool.
+type Tool struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	InputSchema json.RawMessage `json:"input_schema"`
+}
+
+// ToolChoice controls how the model selects tools.
+type ToolChoice struct {
+	Type string `json:"type"` // "auto" | "any" | "tool"
+	Name string `json:"name,omitempty"`
+}
+
+// --------------------------------------------------------------------------
+// Outbound response types (internal -> Anthropic)
+// --------------------------------------------------------------------------
+
+// MessagesResponse is the Anthropic /v1/messages non-streaming response.
+type MessagesResponse struct {
+	ID           string          `json:"id"`
+	Type         string          `json:"type"` // always "message"
+	Role         string          `json:"role"` // always "assistant"
+	Model        string          `json:"model"`
+	Content      []ResponseBlock `json:"content"`
+	StopReason   string          `json:"stop_reason"`
+	StopSequence *string         `json:"stop_sequence,omitempty"`
+	Usage        ResponseUsage   `json:"usage"`
+}
+
+// ResponseBlock is a content block in a response (text or tool_use).
+type ResponseBlock struct {
+	Type  string          `json:"type"` // "text" | "tool_use"
+	Text  string          `json:"text,omitempty"`
+	ID    string          `json:"id,omitempty"`
+	Name  string          `json:"name,omitempty"`
+	Input json.RawMessage `json:"input,omitempty"`
+}
+
+// ResponseUsage carries token counts in the Anthropic response envelope.
+type ResponseUsage struct {
+	InputTokens  int `json:"input_tokens"`
+	OutputTokens int `json:"output_tokens"`
+}
+
+// CountTokensResponse is the /v1/messages/count_tokens response.
+type CountTokensResponse struct {
+	InputTokens int `json:"input_tokens"`
+}
+
+// --------------------------------------------------------------------------
+// SSE streaming event types
+// --------------------------------------------------------------------------
+
+// StreamEvent is a typed SSE event emitted in an Anthropic streaming response.
+type StreamEvent struct {
+	Type  string `json:"type"`
+	Index int    `json:"index,omitempty"`
+
+	// message_start
+	Message *StreamMessage `json:"message,omitempty"`
+
+	// content_block_start
+	ContentBlock *StreamContentBlock `json:"content_block,omitempty"`
+
+	// content_block_delta
+	Delta *StreamDelta `json:"delta,omitempty"`
+
+	// message_delta
+	Usage *StreamUsage `json:"usage,omitempty"`
+}
+
+// StreamMessage is the partial message envelope in message_start.
+type StreamMessage struct {
+	ID           string      `json:"id"`
+	Type         string      `json:"type"`
+	Role         string      `json:"role"`
+	Model        string      `json:"model"`
+	Content      []any       `json:"content"`
+	StopReason   interface{} `json:"stop_reason"`
+	StopSequence interface{} `json:"stop_sequence"`
+	Usage        StreamUsage `json:"usage"`
+}
+
+// StreamContentBlock is the block header in content_block_start.
+type StreamContentBlock struct {
+	Type string `json:"type"` // "text" | "tool_use"
+	ID   string `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
+	Text string `json:"text,omitempty"`
+}
+
+// StreamDelta is the delta payload in content_block_delta or message_delta.
+type StreamDelta struct {
+	Type         string  `json:"type"` // "text_delta" | "input_json_delta" | "message_delta"
+	Text         string  `json:"text,omitempty"`
+	PartialJSON  string  `json:"partial_json,omitempty"`
+	StopReason   string  `json:"stop_reason,omitempty"`
+	StopSequence *string `json:"stop_sequence,omitempty"`
+}
+
+// StreamUsage carries token counts in streaming events.
+type StreamUsage struct {
+	InputTokens  int `json:"input_tokens,omitempty"`
+	OutputTokens int `json:"output_tokens,omitempty"`
+}
+
+// --------------------------------------------------------------------------
+// Internal OpenAI-shaped types used by the translator.
+// These mirror the fields the chat.Handler and LiteLLM understand.
+// --------------------------------------------------------------------------
+
+// OAIRequest is the OpenAI chat completions request shape.
+type OAIRequest struct {
+	Model       string      `json:"model"`
+	Messages    []OAIMessage `json:"messages"`
+	Tools       []OAITool   `json:"tools,omitempty"`
+	ToolChoice  interface{} `json:"tool_choice,omitempty"`
+	MaxTokens   *int        `json:"max_tokens,omitempty"`
+	Stop        []string    `json:"stop,omitempty"`
+	Temperature *float64    `json:"temperature,omitempty"`
+	TopP        *float64    `json:"top_p,omitempty"`
+	Stream      bool        `json:"stream,omitempty"`
+}
+
+// OAIMessage is a single OpenAI chat message.
+type OAIMessage struct {
+	Role       string        `json:"role"`
+	Content    interface{}   `json:"content,omitempty"`
+	ToolCallID string        `json:"tool_call_id,omitempty"`
+	ToolCalls  []OAIToolCall `json:"tool_calls,omitempty"`
+}
+
+// OAIToolCall is an assistant tool invocation.
+type OAIToolCall struct {
+	ID       string          `json:"id"`
+	Type     string          `json:"type"` // "function"
+	Function OAIFunctionCall `json:"function"`
+}
+
+// OAIFunctionCall holds the function name and JSON-stringified arguments.
+type OAIFunctionCall struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"`
+}
+
+// OAITool is an OpenAI function tool definition.
+type OAITool struct {
+	Type     string      `json:"type"` // "function"
+	Function OAIFunction `json:"function"`
+}
+
+// OAIFunction holds a function definition.
+type OAIFunction struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	Parameters  json.RawMessage `json:"parameters"`
+}
+
+// OAIImageURL is used inside content part arrays for vision.
+type OAIImageURL struct {
+	URL string `json:"url"`
+}
+
+// OAIContentPart is a typed part inside a multipart content array.
+type OAIContentPart struct {
+	Type     string       `json:"type"` // "text" | "image_url"
+	Text     string       `json:"text,omitempty"`
+	ImageURL *OAIImageURL `json:"image_url,omitempty"`
+}
+
+// OAIResponse is the OpenAI chat completions response shape.
+type OAIResponse struct {
+	ID      string      `json:"id"`
+	Object  string      `json:"object"`
+	Model   string      `json:"model"`
+	Choices []OAIChoice `json:"choices"`
+	Usage   OAIUsage    `json:"usage"`
+}
+
+// OAIChoice is a single completion choice.
+type OAIChoice struct {
+	Index        int    `json:"index"`
+	Message      OAIMsg `json:"message"`
+	FinishReason string `json:"finish_reason"`
+}
+
+// OAIMsg is the message body in a choice.
+type OAIMsg struct {
+	Role      string        `json:"role"`
+	Content   string        `json:"content"`
+	ToolCalls []OAIToolCall `json:"tool_calls,omitempty"`
+}
+
+// OAIUsage holds token counts from the OpenAI response.
+type OAIUsage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
+}
+
+// OAIDelta is a streaming delta chunk.
+type OAIDelta struct {
+	Role      string             `json:"role,omitempty"`
+	Content   string             `json:"content,omitempty"`
+	ToolCalls []OAIToolCallDelta `json:"tool_calls,omitempty"`
+}
+
+// OAIToolCallDelta is a partial tool call in a streaming chunk.
+type OAIToolCallDelta struct {
+	Index    int                  `json:"index"`
+	ID       string               `json:"id,omitempty"`
+	Type     string               `json:"type,omitempty"`
+	Function OAIFunctionCallDelta `json:"function,omitempty"`
+}
+
+// OAIFunctionCallDelta is a partial function call in a streaming delta.
+type OAIFunctionCallDelta struct {
+	Name      string `json:"name,omitempty"`
+	Arguments string `json:"arguments,omitempty"`
+}
+
+// OAIChunkChoice is a single choice in a streaming chunk.
+type OAIChunkChoice struct {
+	Index        int      `json:"index"`
+	Delta        OAIDelta `json:"delta"`
+	FinishReason string   `json:"finish_reason,omitempty"`
+}
+
+// OAIChunk is a single SSE data frame in an OpenAI streaming response.
+type OAIChunk struct {
+	ID      string           `json:"id"`
+	Object  string           `json:"object"`
+	Model   string           `json:"model"`
+	Choices []OAIChunkChoice `json:"choices"`
+	Usage   *OAIUsage        `json:"usage,omitempty"`
+}

--- a/apps/edge-api/internal/anthropic/types.go
+++ b/apps/edge-api/internal/anthropic/types.go
@@ -203,14 +203,16 @@ type StreamEvent struct {
 }
 
 // StreamMessage is the partial message envelope in message_start.
+// StopReason and StopSequence are *string so nil serialises as JSON null
+// (absent), matching the Anthropic protocol (stop_reason is null at start).
 type StreamMessage struct {
 	ID           string      `json:"id"`
 	Type         string      `json:"type"`
 	Role         string      `json:"role"`
 	Model        string      `json:"model"`
-	Content      []any       `json:"content"`
-	StopReason   interface{} `json:"stop_reason"`
-	StopSequence interface{} `json:"stop_sequence"`
+	Content      []string    `json:"content"` // always empty at message_start
+	StopReason   *string     `json:"stop_reason"`
+	StopSequence *string     `json:"stop_sequence"`
 	Usage        StreamUsage `json:"usage"`
 }
 
@@ -242,25 +244,71 @@ type StreamUsage struct {
 // These mirror the fields the chat.Handler and LiteLLM understand.
 // --------------------------------------------------------------------------
 
+// OAIToolChoice is a typed union for the OpenAI tool_choice field.
+// Either a string sentinel ("auto", "required", "none") or a named function
+// selector. This replaces the bare interface{} to keep the type-safe promise.
+type OAIToolChoice struct {
+	// Sentinel is set when tool_choice is "auto", "required", or "none".
+	Sentinel string
+	// Named is set when tool_choice selects a specific function.
+	Named *OAINamedToolChoice
+}
+
+// OAINamedToolChoice is the structured form of a named function selector.
+type OAINamedToolChoice struct {
+	Type     string                    `json:"type"` // always "function"
+	Function OAINamedToolChoiceFunction `json:"function"`
+}
+
+// OAINamedToolChoiceFunction holds the function name for a named tool choice.
+type OAINamedToolChoiceFunction struct {
+	Name string `json:"name"`
+}
+
+// MarshalJSON serialises OAIToolChoice to either a JSON string or an object.
+func (tc OAIToolChoice) MarshalJSON() ([]byte, error) {
+	if tc.Named != nil {
+		return json.Marshal(tc.Named)
+	}
+	return json.Marshal(tc.Sentinel)
+}
+
 // OAIRequest is the OpenAI chat completions request shape.
 type OAIRequest struct {
-	Model       string      `json:"model"`
-	Messages    []OAIMessage `json:"messages"`
-	Tools       []OAITool   `json:"tools,omitempty"`
-	ToolChoice  interface{} `json:"tool_choice,omitempty"`
-	MaxTokens   *int        `json:"max_tokens,omitempty"`
-	Stop        []string    `json:"stop,omitempty"`
-	Temperature *float64    `json:"temperature,omitempty"`
-	TopP        *float64    `json:"top_p,omitempty"`
-	Stream      bool        `json:"stream,omitempty"`
+	Model       string        `json:"model"`
+	Messages    []OAIMessage  `json:"messages"`
+	Tools       []OAITool     `json:"tools,omitempty"`
+	ToolChoice  *OAIToolChoice `json:"tool_choice,omitempty"`
+	MaxTokens   *int          `json:"max_tokens,omitempty"`
+	Stop        []string      `json:"stop,omitempty"`
+	Temperature *float64      `json:"temperature,omitempty"`
+	TopP        *float64      `json:"top_p,omitempty"`
+	Stream      bool          `json:"stream,omitempty"`
+}
+
+// OAIMessageContent is a typed union for an OAI message's content field.
+// Either a plain string or a multipart content-parts array.
+type OAIMessageContent struct {
+	// Text is set when content is a plain string.
+	Text string
+	// Parts is set when content is a multipart array (vision, etc.).
+	Parts []OAIContentPart
+}
+
+// MarshalJSON serialises OAIMessageContent to either a JSON string or array.
+func (c OAIMessageContent) MarshalJSON() ([]byte, error) {
+	if len(c.Parts) > 0 {
+		return json.Marshal(c.Parts)
+	}
+	return json.Marshal(c.Text)
 }
 
 // OAIMessage is a single OpenAI chat message.
 type OAIMessage struct {
-	Role       string        `json:"role"`
-	Content    interface{}   `json:"content,omitempty"`
-	ToolCallID string        `json:"tool_call_id,omitempty"`
-	ToolCalls  []OAIToolCall `json:"tool_calls,omitempty"`
+	Role       string            `json:"role"`
+	Content    OAIMessageContent `json:"content,omitempty"`
+	ToolCallID string            `json:"tool_call_id,omitempty"`
+	ToolCalls  []OAIToolCall     `json:"tool_calls,omitempty"`
 }
 
 // OAIToolCall is an assistant tool invocation.


### PR DESCRIPTION
Closes #168.

## Summary

- New package `apps/edge-api/internal/anthropic` with five files: `types.go`, `translate_request.go`, `translate_response.go`, `stream.go`, `handler.go`.
- `ToOAIRequest` lowers Anthropic Messages requests to the internal OpenAI chat shape: system prepend, content blocks (text, image as data URI, tool_use as tool_calls, tool_result as role=tool), tools with input_schema mapped to parameters, tool_choice (auto/any/tool mapped to auto/required/named function), max_tokens, stop_sequences, temperature, top_p, stream.
- `FromOAIResponse` lifts OpenAI responses to Anthropic shape: id prefixed with msg_, finish_reason mapped to stop_reason enum (stop->end_turn, length->max_tokens, tool_calls->tool_use, content_filter->refusal), tool_calls mapped to tool_use blocks with JSON-parsed input, usage tokens mapped.
- `SSETranslator` is a stateful re-emitter: emits message_start, content_block_start (text), text_delta events, closes text block on first tool_call delta, opens tool_use block with correct block index, emits input_json_delta events, closes with content_block_stop, message_delta (stop_reason + output_tokens), message_stop. Block indices are correct for interleaved text + multiple tool_use turns.
- `Handler` enforces auth (UserFrom, TenantID check, RoleHas PermChatInvoke), translates request, forwards to LiteLLM via existing URL/key, returns Anthropic envelope or streams via SSETranslator. Provider-blind upstream errors inherited from existing `WriteProviderBlindUpstreamError`. `/v1/messages/count_tokens` returns a local rune-count estimate.
- `APIKeyNormalizer` middleware rewrites Anthropic `x-api-key` to `Authorization: Bearer` before the standard `auth.Selector` runs.
- `main.go`: two lines register `/v1/messages` and `/v1/messages/` reusing `jwtAwareChatHandler` and `APIKeyNormalizer`, no new auth wrappers.

## Test plan

- [ ] `go test ./apps/edge-api/internal/anthropic/... -count=1 -short -cover` passes: 27 tests, 82.5% coverage.
- [ ] `go build ./apps/edge-api/...` clean, no unused imports.
- [ ] Request translation: SimpleText, SystemString, SystemBlocks, StopSequences, ToolChoice (auto/any/named), Tools, ImageBlock, ToolUseBlock, ToolResultBlock, EmptyModel, NilToolChoice, TemperatureTopP.
- [ ] Response translation: SimpleText, FinishReasonMapping (all 5 cases), WithToolCalls, TextAndToolCalls, EmptyChoices, IDAlreadyPrefixed, InvalidToolArgs (fallback, no panic).
- [ ] SSE event sequence: SimpleText (event order), ToolUseStream (input_json_delta, stop_reason=tool_use), TextThenToolUse (2 blocks, correct indices 0+1, content_block_stop between them), EmptyStream (terminal events), UsageInMessageDelta.
- [ ] Handler: MethodNotAllowed, MissingUser, NoTenant, NoRole, BadJSON, MissingModel, MissingMessages, NonStreamHappyPath (full Anthropic response shape), StreamHappyPath (message_start/stop present), UpstreamError provider-blind, CountTokens, CountTokens BadJSON.
- [ ] APIKeyNormalizer: rewrites x-api-key, preserves existing Authorization, passes through when no key.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces a full Anthropic Messages API surface (`POST /v1/messages`, `POST /v1/messages/count_tokens`) by adding a translation layer that lowers Anthropic requests to the internal OpenAI/LiteLLM chat shape and lifts responses back, including a stateful SSE re-emitter for the Anthropic streaming event sequence.

- **New `apps/edge-api/internal/anthropic` package** (5 files): `types.go` defines wire types for both sides; `translate_request.go` handles system prepend, multi-block messages, parallel `tool_result` fan-out, tool definitions, and `tool_choice` mapping; `translate_response.go` lifts OAI responses to Anthropic shape with finish-reason mapping; `stream.go` is a stateful SSE re-emitter managing block indices across interleaved text and multiple tool-use blocks; `handler.go` enforces auth (`UserFrom`, `TenantID`, `RoleHas`), validates required fields including `max_tokens`, and routes to LiteLLM.
- **`main.go`** registers `/v1/messages` and `/v1/messages/` behind `APIKeyNormalizer` + `jwtAwareChatHandler`, reusing the existing auth stack.
- **`APIKeyNormalizer`** middleware rewrites `x-api-key` to `Authorization: Bearer` before the standard `auth.Selector` runs, with no double-lookup after the previous fix.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge after fixing the null-vs-empty-array serialization in translate_response.go; the streaming usage gap is cosmetic until stream_options support is added.

The response translator initializes `blocks` as a nil `[]ResponseBlock`, which marshals as JSON `null` rather than `[]`. Anthropic SDK clients that type-assert on the `content` field as an array will fail on any response with no choices or an empty message body. All previously identified auth, parallel tool-result, msg_ prefix, and max_tokens issues have been resolved.

apps/edge-api/internal/anthropic/translate_response.go — the `content` field nil-vs-empty-array issue is the one place that needs a fix before merge.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/edge-api/internal/anthropic/translate_response.go | Lifts OAI responses to Anthropic shape; `content` field serializes as JSON `null` instead of `[]` for empty-choice or empty-content responses — a protocol violation for strict SDK clients. |
| apps/edge-api/internal/anthropic/translate_request.go | Lowers Anthropic requests to OAI shape; parallel tool_result fix in place, but missing `stream_options: {include_usage: true}` means streaming usage will always be 0. |
| apps/edge-api/internal/anthropic/stream.go | Stateful SSE re-emitter; msg_ prefix fix applied, block indices correct for interleaved text+tool streaming, write errors propagated cleanly. |
| apps/edge-api/internal/anthropic/handler.go | Auth guards present in both handleMessages and handleCountTokens; max_tokens validation added; redundant header lookup removed; APIKeyNormalizer is correct. |
| apps/edge-api/internal/anthropic/types.go | Type definitions are well-structured; custom unmarshalers for SystemField, MessageContent, ToolResultContent, and OAIToolChoice cover all wire variants. |
| apps/edge-api/cmd/server/main.go | Two-line registration of /v1/messages and /v1/messages/ behind APIKeyNormalizer + jwtAwareChatHandler; no new auth wrappers, reuses existing patterns correctly. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant C as Anthropic Client
    participant M as APIKeyNormalizer
    participant A as jwtAwareChatHandler
    participant H as anthropic.Handler
    participant L as LiteLLM

    C->>M: POST /v1/messages (x-api-key or JWT)
    M->>A: Authorization: Bearer ...
    A->>H: authenticated request
    H->>H: validate model, messages, max_tokens
    H->>H: ToOAIRequest()
    H->>L: POST /v1/chat/completions

    alt non-streaming
        L-->>H: OAIResponse
        H->>H: FromOAIResponse()
        H-->>C: MessagesResponse JSON
    else streaming
        L-->>H: SSE chunks (OAIChunk)
        H->>H: SSETranslator.Translate()
        H-->>C: message_start
        H-->>C: "content_block_start / content_block_delta* / content_block_stop"
        H-->>C: message_delta (stop_reason + usage)
        H-->>C: message_stop
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant C as Anthropic Client
    participant M as APIKeyNormalizer
    participant A as jwtAwareChatHandler
    participant H as anthropic.Handler
    participant L as LiteLLM

    C->>M: POST /v1/messages (x-api-key or JWT)
    M->>A: Authorization: Bearer ...
    A->>H: authenticated request
    H->>H: validate model, messages, max_tokens
    H->>H: ToOAIRequest()
    H->>L: POST /v1/chat/completions

    alt non-streaming
        L-->>H: OAIResponse
        H->>H: FromOAIResponse()
        H-->>C: MessagesResponse JSON
    else streaming
        L-->>H: SSE chunks (OAIChunk)
        H->>H: SSETranslator.Translate()
        H-->>C: message_start
        H-->>C: "content_block_start / content_block_delta* / content_block_stop"
        H-->>C: message_delta (stop_reason + usage)
        H-->>C: message_stop
    end
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: validate max\_tokens present and &gt; 0..."](https://github.com/sakibsadmanshajib/hive/commit/113fefe78c083a0be002619545917a6424330591) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39958639)</sub>

<!-- /greptile_comment -->