### PR TITLE
feat: audit taxonomy extension for inference, RAG, and data subject events (#239)

### DIFF
--- a/apps/control-plane/internal/audit/actions.go
+++ b/apps/control-plane/internal/audit/actions.go
@@ -1,5 +1,66 @@
 package audit
 
+// Action constants for security-tier events. These route synchronously
+// (fail-closed on Postgres write errors).
+const (
+	ActionAuthSigninSuccess         = "AUTH_SIGNIN_SUCCESS"
+	ActionAuthSigninFailure         = "AUTH_SIGNIN_FAILURE"
+	ActionAuthSignupSuccess         = "AUTH_SIGNUP_SUCCESS"
+	ActionAuthJWTInvalid            = "AUTH_JWT_INVALID"
+	ActionAuthJWTExpired            = "AUTH_JWT_EXPIRED"
+	ActionAuthSessionRevoked        = "AUTH_SESSION_REVOKED"
+	ActionAuthSigninFailureNoTenant = "AUTH_SIGNIN_FAILURE_NO_TENANT"
+	ActionAuthRoleChange            = "AUTH_ROLE_CHANGE"
+	ActionRBACGrant                 = "RBAC_GRANT"
+	ActionRBACRevoke                = "RBAC_REVOKE"
+	ActionRBACDeny                  = "RBAC_DENY"
+	ActionCrossTenantAttempt        = "CROSS_TENANT_ATTEMPT"
+	ActionTenantSettingUpdate       = "TENANT_SETTING_UPDATE"
+	ActionTenantSwitch              = "TENANT_SWITCH"
+	ActionTenantUserAdd             = "TENANT_USER_ADD"
+	ActionTenantUserRemove          = "TENANT_USER_REMOVE"
+	ActionOWUIGroupCreateSuccess    = "OWUI_GROUP_CREATE_SUCCESS"
+	ActionOWUIGroupCreateFailure    = "OWUI_GROUP_CREATE_FAILURE"
+	ActionOWUIGroupAddSuccess       = "OWUI_GROUP_ADD_SUCCESS"
+	ActionOWUIGroupAddFailure       = "OWUI_GROUP_ADD_FAILURE"
+	ActionAPIKeyIssue               = "API_KEY_ISSUE"
+	ActionAPIKeyRevoke              = "API_KEY_REVOKE"
+	ActionCryptoKeyRotate           = "CRYPTO_KEY_ROTATE"
+	ActionTLSCertRotate             = "TLS_CERT_ROTATE"
+	ActionJWKSFetchFailure          = "JWKS_FETCH_FAILURE"
+	ActionMigrationApply            = "MIGRATION_APPLY"
+	ActionDeployPush                = "DEPLOY_PUSH"
+	ActionBackupIntegrityFail       = "BACKUP_INTEGRITY_FAIL"
+	ActionAuditChainVerifyFail      = "AUDIT_CHAIN_VERIFY_FAIL"
+	ActionServerPanic               = "SERVER_PANIC"
+	ActionWebhookSignatureFail      = "WEBHOOK_SIGNATURE_FAIL"
+	ActionIncidentDeclare           = "INCIDENT_DECLARE"
+	ActionIncidentResolve           = "INCIDENT_RESOLVE"
+	// ActionDataSubjectRequest records Law 25 / PHIPA / OSFI B-10 data subject
+	// requests (access, erasure, portability). Security tier: fail-closed so
+	// the request is never silently lost.
+	ActionDataSubjectRequest = "DATA_SUBJECT_REQUEST"
+)
+
+// Action constants for WAL-tier events. These fall back to the local WAL
+// on Postgres write errors and are drained asynchronously.
+const (
+	// ActionLLMResponse records completion metadata only: completion_tokens,
+	// finish_reason, latency_ms. The completion text MUST NOT be included.
+	ActionLLMResponse = "LLM_RESPONSE"
+	// ActionRAGDocumentUpload records a document added to a retrieval corpus.
+	ActionRAGDocumentUpload = "RAG_DOCUMENT_UPLOAD"
+	// ActionRAGDocumentDelete records a document removed from a retrieval corpus.
+	ActionRAGDocumentDelete = "RAG_DOCUMENT_DELETE"
+	// ActionRAGSearch records a semantic search query against a retrieval corpus.
+	ActionRAGSearch = "RAG_SEARCH"
+	// ActionRAGChunkRetrieved records a single chunk returned by a retrieval query.
+	// resource_id = chunk_id; after_json = {"score": <float>, "document_id": <uuid>}.
+	ActionRAGChunkRetrieved = "RAG_CHUNK_RETRIEVED"
+	// ActionFileAccess records a read or download of a stored file.
+	ActionFileAccess = "FILE_ACCESS"
+)
+
 // Security-tier actions fail closed on Postgres write errors. LLM-tier
 // actions fall back to local WAL on Postgres failure. The classifier is
 // an immutable switch — there is no package-level map any test or
@@ -7,39 +68,40 @@ package audit
 func IsSecurityAction(action string) bool {
 	switch action {
 	case
-		"AUTH_SIGNIN_SUCCESS",
-		"AUTH_SIGNIN_FAILURE",
-		"AUTH_SIGNUP_SUCCESS",
-		"AUTH_JWT_INVALID",
-		"AUTH_JWT_EXPIRED",
-		"AUTH_SESSION_REVOKED",
-		"AUTH_SIGNIN_FAILURE_NO_TENANT",
-		"AUTH_ROLE_CHANGE",
-		"RBAC_GRANT",
-		"RBAC_REVOKE",
-		"RBAC_DENY",
-		"CROSS_TENANT_ATTEMPT",
-		"TENANT_SETTING_UPDATE",
-		"TENANT_SWITCH",
-		"TENANT_USER_ADD",
-		"TENANT_USER_REMOVE",
-		"OWUI_GROUP_CREATE_SUCCESS",
-		"OWUI_GROUP_CREATE_FAILURE",
-		"OWUI_GROUP_ADD_SUCCESS",
-		"OWUI_GROUP_ADD_FAILURE",
-		"API_KEY_ISSUE",
-		"API_KEY_REVOKE",
-		"CRYPTO_KEY_ROTATE",
-		"TLS_CERT_ROTATE",
-		"JWKS_FETCH_FAILURE",
-		"MIGRATION_APPLY",
-		"DEPLOY_PUSH",
-		"BACKUP_INTEGRITY_FAIL",
-		"AUDIT_CHAIN_VERIFY_FAIL",
-		"SERVER_PANIC",
-		"WEBHOOK_SIGNATURE_FAIL",
-		"INCIDENT_DECLARE",
-		"INCIDENT_RESOLVE":
+		ActionAuthSigninSuccess,
+		ActionAuthSigninFailure,
+		ActionAuthSignupSuccess,
+		ActionAuthJWTInvalid,
+		ActionAuthJWTExpired,
+		ActionAuthSessionRevoked,
+		ActionAuthSigninFailureNoTenant,
+		ActionAuthRoleChange,
+		ActionRBACGrant,
+		ActionRBACRevoke,
+		ActionRBACDeny,
+		ActionCrossTenantAttempt,
+		ActionTenantSettingUpdate,
+		ActionTenantSwitch,
+		ActionTenantUserAdd,
+		ActionTenantUserRemove,
+		ActionOWUIGroupCreateSuccess,
+		ActionOWUIGroupCreateFailure,
+		ActionOWUIGroupAddSuccess,
+		ActionOWUIGroupAddFailure,
+		ActionAPIKeyIssue,
+		ActionAPIKeyRevoke,
+		ActionCryptoKeyRotate,
+		ActionTLSCertRotate,
+		ActionJWKSFetchFailure,
+		ActionMigrationApply,
+		ActionDeployPush,
+		ActionBackupIntegrityFail,
+		ActionAuditChainVerifyFail,
+		ActionServerPanic,
+		ActionWebhookSignatureFail,
+		ActionIncidentDeclare,
+		ActionIncidentResolve,
+		ActionDataSubjectRequest:
 		return true
 	}
 	return false

--- a/apps/control-plane/internal/audit/actions_test.go
+++ b/apps/control-plane/internal/audit/actions_test.go
@@ -1,0 +1,219 @@
+package audit_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/audit"
+	canonical "github.com/sakibsadmanshajib/hive/packages/audit-canonical"
+)
+
+// TestNewActions_SecurityTierClassification verifies that DATA_SUBJECT_REQUEST
+// routes synchronously (security tier) and that all new WAL-tier actions
+// correctly return false from IsSecurityAction.
+func TestNewActions_SecurityTierClassification(t *testing.T) {
+	tests := []struct {
+		action     string
+		wantSec    bool
+		desc       string
+	}{
+		// Security tier — must be true.
+		{audit.ActionDataSubjectRequest, true, "Law 25/PHIPA/OSFI B-10 data subject request"},
+		// WAL tier — must be false.
+		{audit.ActionLLMResponse, false, "completion metadata, WAL tier"},
+		{audit.ActionRAGDocumentUpload, false, "RAG document upload, WAL tier"},
+		{audit.ActionRAGDocumentDelete, false, "RAG document delete, WAL tier"},
+		{audit.ActionRAGSearch, false, "RAG search query, WAL tier"},
+		{audit.ActionRAGChunkRetrieved, false, "RAG chunk retrieved, WAL tier"},
+		{audit.ActionFileAccess, false, "file access/download, WAL tier"},
+		// Regression: existing security actions must remain true.
+		{"AUTH_SIGNIN_SUCCESS", true, "existing auth action"},
+		{"CROSS_TENANT_ATTEMPT", true, "existing cross-tenant action"},
+		{"API_KEY_ISSUE", true, "existing key-issue action"},
+		// Regression: unknown action must be false.
+		{"UNKNOWN_ACTION", false, "unknown action defaults to WAL tier"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.action, func(t *testing.T) {
+			got := audit.IsSecurityAction(tc.action)
+			if got != tc.wantSec {
+				t.Errorf("IsSecurityAction(%q) = %v, want %v (%s)",
+					tc.action, got, tc.wantSec, tc.desc)
+			}
+		})
+	}
+}
+
+// TestNewActions_ConstantValues verifies the string values of each new constant
+// match the documented taxonomy so callers that hard-code these strings in SQL
+// queries or dashboards are not broken by a typo.
+func TestNewActions_ConstantValues(t *testing.T) {
+	tests := []struct {
+		constant string
+		want     string
+	}{
+		{audit.ActionDataSubjectRequest, "DATA_SUBJECT_REQUEST"},
+		{audit.ActionLLMResponse, "LLM_RESPONSE"},
+		{audit.ActionRAGDocumentUpload, "RAG_DOCUMENT_UPLOAD"},
+		{audit.ActionRAGDocumentDelete, "RAG_DOCUMENT_DELETE"},
+		{audit.ActionRAGSearch, "RAG_SEARCH"},
+		{audit.ActionRAGChunkRetrieved, "RAG_CHUNK_RETRIEVED"},
+		{audit.ActionFileAccess, "FILE_ACCESS"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.want, func(t *testing.T) {
+			if tc.constant != tc.want {
+				t.Errorf("constant value mismatch: got %q want %q", tc.constant, tc.want)
+			}
+		})
+	}
+}
+
+// TestNewActions_CanonicalSerialization verifies that each new action can be
+// round-tripped through the canonical.Row path without error and that the
+// resulting bytes contain the action string verbatim. This catches any
+// encoding regression before emission code is wired in.
+func TestNewActions_CanonicalSerialization(t *testing.T) {
+	newActions := []string{
+		audit.ActionDataSubjectRequest,
+		audit.ActionLLMResponse,
+		audit.ActionRAGDocumentUpload,
+		audit.ActionRAGDocumentDelete,
+		audit.ActionRAGSearch,
+		audit.ActionRAGChunkRetrieved,
+		audit.ActionFileAccess,
+	}
+
+	for _, action := range newActions {
+		t.Run(action, func(t *testing.T) {
+			row := canonical.Row{
+				ActorType: "SERVICE",
+				Action:    action,
+				Severity:  "INFO",
+				DeploySHA: "testsha",
+				Env:       "test",
+				TS:        "2026-06-25T00:00:00.000000Z",
+			}
+			got, err := row.Marshal()
+			if err != nil {
+				t.Fatalf("canonical.Row.Marshal() error: %v", err)
+			}
+			if len(got) == 0 {
+				t.Fatal("Marshal returned empty bytes")
+			}
+			// The canonical bytes must be valid JSON.
+			var parsed map[string]any
+			if err := json.Unmarshal(got, &parsed); err != nil {
+				t.Fatalf("Marshal produced invalid JSON: %v\nbytes: %s", err, got)
+			}
+			// The action field must appear verbatim.
+			if parsed["action"] != action {
+				t.Errorf("action field mismatch: got %q want %q", parsed["action"], action)
+			}
+		})
+	}
+}
+
+// TestNewActions_LLMResponseAfterJSON verifies the canonical serialization of
+// the LLM_RESPONSE after_json payload (completion_tokens, finish_reason,
+// latency_ms) using StableJSON so key order is deterministic and safe for
+// hash-chain inclusion.
+func TestNewActions_LLMResponseAfterJSON(t *testing.T) {
+	payload := map[string]any{
+		"finish_reason":     "stop",
+		"completion_tokens": 42,
+		"latency_ms":        137,
+	}
+	stable, err := canonical.StableJSON(payload)
+	if err != nil {
+		t.Fatalf("StableJSON error: %v", err)
+	}
+
+	row := canonical.Row{
+		ActorType: "SERVICE",
+		Action:    audit.ActionLLMResponse,
+		Severity:  "INFO",
+		DeploySHA: "testsha",
+		Env:       "test",
+		TS:        "2026-06-25T00:00:00.000000Z",
+		AfterJSON: stable,
+	}
+	got, err := row.Marshal()
+	if err != nil {
+		t.Fatalf("canonical.Row.Marshal() error: %v", err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal(got, &parsed); err != nil {
+		t.Fatalf("Marshal produced invalid JSON: %v", err)
+	}
+	if parsed["action"] != audit.ActionLLMResponse {
+		t.Errorf("action = %q, want %q", parsed["action"], audit.ActionLLMResponse)
+	}
+	// Verify after_json is present and contains expected keys.
+	afterRaw, ok := parsed["after_json"]
+	if !ok {
+		t.Fatal("after_json missing from canonical bytes")
+	}
+	after, ok := afterRaw.(map[string]any)
+	if !ok {
+		t.Fatalf("after_json not an object: %T", afterRaw)
+	}
+	for _, key := range []string{"completion_tokens", "finish_reason", "latency_ms"} {
+		if _, exists := after[key]; !exists {
+			t.Errorf("after_json missing key %q", key)
+		}
+	}
+}
+
+// TestNewActions_RAGChunkRetrievedAfterJSON verifies the canonical
+// serialization of the RAG_CHUNK_RETRIEVED after_json payload
+// (score, document_id) per the taxonomy contract.
+func TestNewActions_RAGChunkRetrievedAfterJSON(t *testing.T) {
+	payload := map[string]any{
+		"document_id": "11111111-1111-1111-1111-111111111111",
+		"score":       0.92,
+	}
+	stable, err := canonical.StableJSON(payload)
+	if err != nil {
+		t.Fatalf("StableJSON error: %v", err)
+	}
+
+	row := canonical.Row{
+		ActorType:  "SERVICE",
+		Action:     audit.ActionRAGChunkRetrieved,
+		ResourceID: "chunk-abc",
+		Severity:   "INFO",
+		DeploySHA:  "testsha",
+		Env:        "test",
+		TS:         "2026-06-25T00:00:00.000000Z",
+		AfterJSON:  stable,
+	}
+	got, err := row.Marshal()
+	if err != nil {
+		t.Fatalf("canonical.Row.Marshal() error: %v", err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal(got, &parsed); err != nil {
+		t.Fatalf("Marshal produced invalid JSON: %v", err)
+	}
+	if parsed["action"] != audit.ActionRAGChunkRetrieved {
+		t.Errorf("action = %q, want %q", parsed["action"], audit.ActionRAGChunkRetrieved)
+	}
+	if parsed["resource_id"] != "chunk-abc" {
+		t.Errorf("resource_id = %q, want %q", parsed["resource_id"], "chunk-abc")
+	}
+	afterRaw, ok := parsed["after_json"]
+	if !ok {
+		t.Fatal("after_json missing from canonical bytes")
+	}
+	after := afterRaw.(map[string]any)
+	if _, exists := after["document_id"]; !exists {
+		t.Error("after_json missing document_id")
+	}
+	if _, exists := after["score"]; !exists {
+		t.Error("after_json missing score")
+	}
+}

--- a/apps/control-plane/internal/audit/actions_test.go
+++ b/apps/control-plane/internal/audit/actions_test.go
@@ -27,9 +27,9 @@ func TestNewActions_SecurityTierClassification(t *testing.T) {
 		{audit.ActionRAGChunkRetrieved, false, "RAG chunk retrieved, WAL tier"},
 		{audit.ActionFileAccess, false, "file access/download, WAL tier"},
 		// Regression: existing security actions must remain true.
-		{"AUTH_SIGNIN_SUCCESS", true, "existing auth action"},
-		{"CROSS_TENANT_ATTEMPT", true, "existing cross-tenant action"},
-		{"API_KEY_ISSUE", true, "existing key-issue action"},
+		{audit.ActionAuthSigninSuccess, true, "existing auth action"},
+		{audit.ActionCrossTenantAttempt, true, "existing cross-tenant action"},
+		{audit.ActionAPIKeyIssue, true, "existing key-issue action"},
 		// Regression: unknown action must be false.
 		{"UNKNOWN_ACTION", false, "unknown action defaults to WAL tier"},
 	}
@@ -209,7 +209,10 @@ func TestNewActions_RAGChunkRetrievedAfterJSON(t *testing.T) {
 	if !ok {
 		t.Fatal("after_json missing from canonical bytes")
 	}
-	after := afterRaw.(map[string]any)
+	after, ok := afterRaw.(map[string]any)
+	if !ok {
+		t.Fatalf("after_json not an object: %T", afterRaw)
+	}
 	if _, exists := after["document_id"]; !exists {
 		t.Error("after_json missing document_id")
 	}

--- a/supabase/migrations/20260625_01_audit_taxonomy_extension.sql
+++ b/supabase/migrations/20260625_01_audit_taxonomy_extension.sql
@@ -1,0 +1,80 @@
+-- supabase/migrations/20260625_01_audit_taxonomy_extension.sql
+-- Extends the audit taxonomy with inference, RAG, file-access, and
+-- data-subject-request event types required for Quebec Law 25, PHIPA,
+-- and OSFI B-10 compliance.
+--
+-- The audit_log table uses a plain text action column (no enum), so
+-- this migration adds nothing structural to that table. It documents
+-- the new action strings as a Postgres comment on the table so the
+-- schema is self-describing, and it creates a lookup view that lists
+-- every known action together with its tier for operator reference.
+--
+-- Idempotent: safe to re-apply.
+
+BEGIN;
+
+-- Operator-visible reference view. Lists every documented action and
+-- whether it is security-tier (fail-closed) or wal-tier (async).
+-- Replace with CREATE OR REPLACE so re-applying is a no-op.
+CREATE OR REPLACE VIEW public.audit_action_taxonomy AS
+SELECT action, tier, description
+FROM (VALUES
+  -- Security tier (fail-closed on Postgres write error)
+  ('AUTH_SIGNIN_SUCCESS',          'security', 'Successful authentication'),
+  ('AUTH_SIGNIN_FAILURE',          'security', 'Failed authentication attempt'),
+  ('AUTH_SIGNUP_SUCCESS',          'security', 'New account created'),
+  ('AUTH_JWT_INVALID',             'security', 'JWT failed signature verification'),
+  ('AUTH_JWT_EXPIRED',             'security', 'JWT presented after expiry'),
+  ('AUTH_SESSION_REVOKED',         'security', 'Session explicitly revoked'),
+  ('AUTH_SIGNIN_FAILURE_NO_TENANT','security', 'Auth attempt with no matching tenant'),
+  ('AUTH_ROLE_CHANGE',             'security', 'User role modified'),
+  ('RBAC_GRANT',                   'security', 'Permission granted'),
+  ('RBAC_REVOKE',                  'security', 'Permission revoked'),
+  ('RBAC_DENY',                    'security', 'Access denied by policy'),
+  ('CROSS_TENANT_ATTEMPT',         'security', 'Request attempted cross-tenant access'),
+  ('TENANT_SETTING_UPDATE',        'security', 'Tenant configuration changed'),
+  ('TENANT_SWITCH',                'security', 'Actor switched active tenant'),
+  ('TENANT_USER_ADD',              'security', 'User added to tenant'),
+  ('TENANT_USER_REMOVE',           'security', 'User removed from tenant'),
+  ('OWUI_GROUP_CREATE_SUCCESS',    'security', 'Open WebUI group created'),
+  ('OWUI_GROUP_CREATE_FAILURE',    'security', 'Open WebUI group creation failed'),
+  ('OWUI_GROUP_ADD_SUCCESS',       'security', 'User added to Open WebUI group'),
+  ('OWUI_GROUP_ADD_FAILURE',       'security', 'Failed to add user to Open WebUI group'),
+  ('API_KEY_ISSUE',                'security', 'API key issued'),
+  ('API_KEY_REVOKE',               'security', 'API key revoked'),
+  ('CRYPTO_KEY_ROTATE',            'security', 'Cryptographic key rotated'),
+  ('TLS_CERT_ROTATE',              'security', 'TLS certificate rotated'),
+  ('JWKS_FETCH_FAILURE',           'security', 'JWKS endpoint returned error'),
+  ('MIGRATION_APPLY',              'security', 'Database migration applied'),
+  ('DEPLOY_PUSH',                  'security', 'New deployment pushed'),
+  ('BACKUP_INTEGRITY_FAIL',        'security', 'Backup integrity check failed'),
+  ('AUDIT_CHAIN_VERIFY_FAIL',      'security', 'Audit hash-chain verification failed'),
+  ('SERVER_PANIC',                 'security', 'Unhandled panic in server process'),
+  ('WEBHOOK_SIGNATURE_FAIL',       'security', 'Webhook HMAC signature invalid'),
+  ('INCIDENT_DECLARE',             'security', 'Security incident declared'),
+  ('INCIDENT_RESOLVE',             'security', 'Security incident resolved'),
+  -- DATA_SUBJECT_REQUEST: Law 25 (Quebec), PHIPA, OSFI B-10 data subject
+  -- access/erasure/portability requests. Security tier so the record is
+  -- never silently lost on Postgres write failure.
+  ('DATA_SUBJECT_REQUEST',         'security', 'Data subject access/erasure/portability request (Law 25 / PHIPA / OSFI B-10)'),
+  -- WAL tier (async, falls back to local WAL on Postgres write error)
+  -- LLM_RESPONSE: completion metadata only — completion_tokens, finish_reason,
+  -- latency_ms. The completion text MUST NOT appear in after_json.
+  ('LLM_RESPONSE',                 'wal', 'LLM completion metadata (tokens, finish_reason, latency_ms); no completion text'),
+  ('RAG_DOCUMENT_UPLOAD',          'wal', 'Document added to retrieval corpus'),
+  ('RAG_DOCUMENT_DELETE',          'wal', 'Document removed from retrieval corpus'),
+  ('RAG_SEARCH',                   'wal', 'Semantic search query issued against retrieval corpus'),
+  -- RAG_CHUNK_RETRIEVED: resource_id = chunk_id,
+  -- after_json = {"score": <float>, "document_id": <uuid>}
+  ('RAG_CHUNK_RETRIEVED',          'wal', 'Chunk returned by retrieval query; resource_id=chunk_id, after_json={score,document_id}'),
+  ('FILE_ACCESS',                  'wal', 'Stored file read or downloaded')
+) AS t(action, tier, description);
+
+COMMENT ON VIEW public.audit_action_taxonomy IS
+  'Reference listing of every documented audit action and its routing tier. '
+  'security = fail-closed synchronous write; wal = async with local WAL fallback.';
+
+GRANT SELECT ON public.audit_action_taxonomy TO auditor_ro;
+GRANT SELECT ON public.audit_action_taxonomy TO hive_app;
+
+COMMIT;

--- a/supabase/migrations/20260625_03_audit_taxonomy_extension.sql
+++ b/supabase/migrations/20260625_03_audit_taxonomy_extension.sql
@@ -1,4 +1,4 @@
--- supabase/migrations/20260625_01_audit_taxonomy_extension.sql
+-- supabase/migrations/20260625_03_audit_taxonomy_extension.sql
 -- Extends the audit taxonomy with inference, RAG, file-access, and
 -- data-subject-request event types required for Quebec Law 25, PHIPA,
 -- and OSFI B-10 compliance.


### PR DESCRIPTION
Closes #239.

## Summary

- Adds 7 new audit action constants in `apps/control-plane/internal/audit/actions.go` following the existing naming pattern.
- `DATA_SUBJECT_REQUEST` (security tier): added to `IsSecurityAction()` for Law 25 / PHIPA / OSFI B-10 compliance; fail-closed routing ensures the record is never silently lost.
- 6 WAL-tier constants: `LLM_RESPONSE`, `RAG_DOCUMENT_UPLOAD`, `RAG_DOCUMENT_DELETE`, `RAG_SEARCH`, `RAG_CHUNK_RETRIEVED`, `FILE_ACCESS`.
- Exports all pre-existing security-tier string literals as named constants (`ActionAuth*`, `ActionRBAC*`, etc.) so call sites avoid raw string duplication.
- Migration `20260625_01_audit_taxonomy_extension.sql`: idempotent `CREATE OR REPLACE VIEW public.audit_action_taxonomy` for operator reference. No schema changes to `audit_log` (plain text action column unchanged).
- No emission wiring added; handlers (RAG, inference) do not exist yet. This PR is taxonomy + classification only.

## Tests

5 new table-driven tests in `actions_test.go`:

- `TestNewActions_SecurityTierClassification`: verifies `DATA_SUBJECT_REQUEST` is security tier, all 6 WAL actions are not, existing actions unchanged, unknown action false.
- `TestNewActions_ConstantValues`: verifies each constant string matches the documented taxonomy name.
- `TestNewActions_CanonicalSerialization`: round-trips all 7 new actions through `canonical.Row.Marshal()` and verifies valid JSON + correct action field.
- `TestNewActions_LLMResponseAfterJSON`: verifies `completion_tokens`, `finish_reason`, `latency_ms` payload via `StableJSON` + canonical marshal.
- `TestNewActions_RAGChunkRetrievedAfterJSON`: verifies `resource_id=chunk_id` and `after_json={score, document_id}` contract.

Results: 14/14 pass (5 new + 9 existing), 3 DB-dependent skipped (no `HIVE_TEST_DB_URL`).

## Test plan

- [ ] `docker run ... go test ./apps/control-plane/internal/audit/... ./packages/audit-canonical/... -count=1 -short` passes.
- [ ] `IsSecurityAction("DATA_SUBJECT_REQUEST")` returns true.
- [ ] All 6 WAL-tier actions return false from `IsSecurityAction`.
- [ ] Migration applies cleanly via `supabase db push` or SQL editor.
- [ ] `SELECT * FROM public.audit_action_taxonomy` returns all 40 rows.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds 7 new audit action constants (`DATA_SUBJECT_REQUEST` at security tier; `LLM_RESPONSE`, `RAG_DOCUMENT_UPLOAD`, `RAG_DOCUMENT_DELETE`, `RAG_SEARCH`, `RAG_CHUNK_RETRIEVED`, `FILE_ACCESS` at WAL tier) and promotes 33 existing raw string literals in `IsSecurityAction` to exported named constants. A new idempotent view migration documents the full 40-action taxonomy for operator reference.

- **`actions.go`**: All pre-existing security-tier strings are exported as `Action*` constants; the `IsSecurityAction` switch is updated to reference them; `ActionDataSubjectRequest` is added and classified as security tier for Law 25 / PHIPA / OSFI B-10 compliance.
- **`actions_test.go`**: Five table-driven tests cover tier classification, constant string values, canonical serialization, and `after_json` payload contracts for `LLM_RESPONSE` and `RAG_CHUNK_RETRIEVED`; previously flagged raw-literal regression cases and single-value type assertion are both resolved in this revision.
- **`20260625_03_audit_taxonomy_extension.sql`**: `CREATE OR REPLACE VIEW public.audit_action_taxonomy` lists all 40 documented actions with tier and description; grants to `auditor_ro` and `hive_app` are idempotent; no structural changes to `audit_log`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — taxonomy-only change with no emission wiring; the migration is idempotent and adds no structural changes to audit_log.

No handlers are wired in this PR; the change is purely constant definitions, a switch update, and a reference view. The IsSecurityAction logic is straightforward, the new constants are correctly defined and tested, and the migration wraps cleanly in a transaction.

actions_test.go — TestNewActions_ConstantValues covers only the 7 new constants; the 33 existing-to-constant conversions have no string-value contract tests.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/control-plane/internal/audit/actions.go | Exports 33 existing security-tier raw strings as named constants and adds 7 new constants (1 security-tier, 6 WAL-tier); updates IsSecurityAction switch to reference constants; clean and consistent with existing pattern. |
| apps/control-plane/internal/audit/actions_test.go | Five new table-driven tests; previously flagged issues (raw literals in regression cases, single-value type assertion) are addressed; TestNewActions_ConstantValues covers only the 7 new constants, leaving the 33 newly-exported existing constants without string-value contract tests. |
| supabase/migrations/20260625_03_audit_taxonomy_extension.sql | Idempotent CREATE OR REPLACE VIEW with 40 rows matching the Go constants exactly; GRANT statements target roles created in earlier migrations; wrapped in explicit BEGIN/COMMIT. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Audit Event Emitted] --> B{IsSecurityAction?}
    B -->|true| C[Synchronous Postgres Write\nFail-Closed]
    B -->|false| D[Async WAL Write\nFalls back to local WAL]
    C --> E{Write Success?}
    E -->|yes| F[Event Recorded]
    E -->|no| G[Error Propagated\nEvent NOT silently dropped]
    D --> H{Write Success?}
    H -->|yes| F
    H -->|no| I[Local WAL Fallback\nDrained Asynchronously]

    subgraph "Security Tier (33 + 1 new)"
    J[AUTH_* / RBAC_* / TENANT_* / API_KEY_*\nCRYPTO_KEY_ROTATE / TLS_CERT_ROTATE\nMIGRATION_APPLY / DEPLOY_PUSH\nINCIDENT_* / DATA_SUBJECT_REQUEST]
    end

    subgraph "WAL Tier (6 new)"
    K[LLM_RESPONSE\nRAG_DOCUMENT_UPLOAD / RAG_DOCUMENT_DELETE\nRAG_SEARCH / RAG_CHUNK_RETRIEVED\nFILE_ACCESS]
    end

    J --> B
    K --> B
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Audit Event Emitted] --> B{IsSecurityAction?}
    B -->|true| C[Synchronous Postgres Write\nFail-Closed]
    B -->|false| D[Async WAL Write\nFalls back to local WAL]
    C --> E{Write Success?}
    E -->|yes| F[Event Recorded]
    E -->|no| G[Error Propagated\nEvent NOT silently dropped]
    D --> H{Write Success?}
    H -->|yes| F
    H -->|no| I[Local WAL Fallback\nDrained Asynchronously]

    subgraph "Security Tier (33 + 1 new)"
    J[AUTH_* / RBAC_* / TENANT_* / API_KEY_*\nCRYPTO_KEY_ROTATE / TLS_CERT_ROTATE\nMIGRATION_APPLY / DEPLOY_PUSH\nINCIDENT_* / DATA_SUBJECT_REQUEST]
    end

    subgraph "WAL Tier (6 new)"
    K[LLM_RESPONSE\nRAG_DOCUMENT_UPLOAD / RAG_DOCUMENT_DELETE\nRAG_SEARCH / RAG_CHUNK_RETRIEVED\nFILE_ACCESS]
    end

    J --> B
    K --> B
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["test: fix regression cases to use export..."](https://github.com/sakibsadmanshajib/hive/commit/2caf287fe6ffb59e2a30cf7e0190faa18c380058) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39960859)</sub>

<!-- /greptile_comment -->