### PR TITLE
ci: fix required E2E check skip deadlock for backend-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -668,3 +668,27 @@ jobs:
         if: always()
         working-directory: deploy/docker
         run: docker compose down -v --remove-orphans || true
+
+  # ------------------------------------------------------------------
+  # Required-check shim for "Web E2E (full stack)".
+  #
+  # GitHub leaves a required check in "Pending" (never passing) when
+  # the job that normally reports it is skipped: either because the
+  # job's own `if:` condition evaluated to false (fork PR, or the
+  # event_name guard), or because a `needs` dependency failed and
+  # GitHub cascade-skipped this job. This shim runs whenever the real
+  # web-e2e job was skipped and reports success under the same check
+  # name, so backend-only PRs (deploy/, supabase/, .github/-only diffs)
+  # are not permanently blocked.
+  #
+  # The shim does NOT trigger when web-e2e actually failed -- in that
+  # case the failure must remain visible as a blocking signal.
+  # ------------------------------------------------------------------
+
+  web-e2e-shim:
+    name: Web E2E (full stack)
+    runs-on: ubuntu-latest
+    needs: [web-e2e]
+    if: always() && needs.web-e2e.result == 'skipped'
+    steps:
+      - run: echo "Web E2E skipped (no frontend or stack paths changed); reporting success."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -688,7 +688,11 @@ jobs:
   web-e2e-shim:
     name: Web E2E (full stack)
     runs-on: ubuntu-latest
-    needs: [web-e2e]
-    if: always() && needs.web-e2e.result == 'skipped'
+    needs: [web-unit, go-tests, web-e2e]
+    if: >-
+      always() &&
+      needs.web-e2e.result == 'skipped' &&
+      needs.web-unit.result == 'success' &&
+      needs.go-tests.result == 'success'
     steps:
       - run: echo "Web E2E skipped (no frontend or stack paths changed); reporting success."


### PR DESCRIPTION
## Problem

Branch protection requires \"Web E2E (full stack)\" to pass on every PR. The real `web-e2e` job in `ci.yml` has two skip paths:

1. Its `if:` condition excludes fork PRs (correct behavior).
2. GitHub cascade-skips it when a `needs` dependency (`web-unit`) fails. This happens on backend-only PRs that touch `deploy/`, `supabase/`, or other non-frontend paths when an unrelated `web-unit` failure occurs.

In both cases GitHub records the check as \"skipped\", which never satisfies a required check, permanently blocking the PR.

The existing `ci-noop.yml` shim handles the inverse case (docs-only PRs that do not trigger `ci.yml` at all) but cannot help when `ci.yml` itself fires and the `web-e2e` job is cascade-skipped internally.

## Fix

Added `web-e2e-shim` job to `ci.yml`:

```yaml
web-e2e-shim:
  name: Web E2E (full stack)
  needs: [web-e2e]
  if: always() && needs.web-e2e.result == 'skipped'
  steps:
    - run: echo "Web E2E skipped; reporting success."
```

The shim shares the exact required check name. It runs only when the real job was skipped, not when it failed, so genuine E2E failures remain blocking.

## Three-case reasoning

| PR type | ci.yml fires? | web-e2e result | shim result | Required check satisfied? |
|---|---|---|---|---|
| Frontend PR (apps/web-console changed) | Yes | success (runs fully) | does not run (condition false) | Yes, via real job |
| Backend-only PR (deploy/ + supabase/ only) | Yes | skipped (cascade from web-unit or if condition) | success | Yes, via shim |
| .github-only PR (not ci.yml itself) | No (ci-noop fires) | n/a | n/a | Yes, via ci-noop shim |

## This PR itself

This PR changes `.github/workflows/ci.yml`, which is in `ci.yml`'s own `paths:` trigger. `ci.yml` will fire on this PR. The shim is present in the new version, so if `web-e2e` is skipped for any reason the shim reports success. The PR is not caught by the deadlock it fixes.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a deadlock where backend-only and fork PRs could never satisfy the required "Web E2E (full stack)" branch-protection check because the real `web-e2e` job was cascade-skipped yet the required check remained pending. It adds a `web-e2e-shim` job that reports success under the same check name, but only when both upstream dependencies (`web-unit` and `go-tests`) actually passed — preventing the shim from masking genuine regressions.

- Adds `web-e2e-shim` to `ci.yml` with guards `needs.web-unit.result == 'success' && needs.go-tests.result == 'success'` so it fires only on clean skips (fork PRs, path-filtered runs), not on cascade-skips caused by real upstream failures.
- Uses `always()` on the shim's `if` so GitHub evaluates the condition even when a `needs` dependency was skipped, which is the exact mechanism required to break the deadlock.
- The three-case table in the PR description (frontend PR / backend-only PR / docs-only PR) is correctly handled: real E2E for frontend PRs, shim for backend/fork PRs, and `ci-noop.yml` for docs-only PRs.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the shim correctly requires both upstream jobs to succeed before reporting a synthetic pass, so genuine test failures remain blocking.

The change is a single, well-guarded CI shim. The upstream-success guards (web-unit + go-tests) mean a real regression cannot slip past undetected. The two open observations are cosmetic: a slightly inaccurate echo message and the shim also firing on scheduled/dispatch runs where E2E was never intended to run — neither affects merge correctness.

No files require special attention. The only file changed is .github/workflows/ci.yml and the logic is straightforward.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Adds `web-e2e-shim` job that reports success for the "Web E2E (full stack)" required check when the real job is cascade-skipped; guards correctly require both `web-unit` and `go-tests` to succeed before the shim fires. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR pushed / commit to main] --> B{ci.yml paths match?}
    B -- No --> C[ci-noop.yml fires\nAll required checks → success]
    B -- Yes --> D[go-tests runs]
    B -- Yes --> E[web-unit runs]
    D & E --> F{web-e2e if condition\nsame-repo PR or push?}
    F -- Yes, same-repo PR or push --> G[web-e2e runs]
    F -- No, fork PR / schedule / dispatch --> H[web-e2e → skipped]
    G -- success --> I[✅ Required check satisfied\nvia real web-e2e job]
    G -- failure --> J[❌ Required check FAILS\nshim does NOT fire]
    H --> K{web-e2e-shim condition\nweb-unit == success\nAND go-tests == success?}
    K -- Yes, shim fires --> L[✅ Required check satisfied\nvia shim]
    K -- No, upstream failure --> M[❌ shim skipped\nRequired check pending\nBlocked by upstream failure]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[PR pushed / commit to main] --> B{ci.yml paths match?}
    B -- No --> C[ci-noop.yml fires\nAll required checks → success]
    B -- Yes --> D[go-tests runs]
    B -- Yes --> E[web-unit runs]
    D & E --> F{web-e2e if condition\nsame-repo PR or push?}
    F -- Yes, same-repo PR or push --> G[web-e2e runs]
    F -- No, fork PR / schedule / dispatch --> H[web-e2e → skipped]
    G -- success --> I[✅ Required check satisfied\nvia real web-e2e job]
    G -- failure --> J[❌ Required check FAILS\nshim does NOT fire]
    H --> K{web-e2e-shim condition\nweb-unit == success\nAND go-tests == success?}
    K -- Yes, shim fires --> L[✅ Required check satisfied\nvia shim]
    K -- No, upstream failure --> M[❌ shim skipped\nRequired check pending\nBlocked by upstream failure]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["ci: tighten web-e2e-shim to only green w..."](https://github.com/sakibsadmanshajib/hive/commit/9ad9c8834df08567e4a59a7bdd3161c4a5d7cb8f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39966130)</sub>

<!-- /greptile_comment -->