### PR TITLE
feat: per-tenant feature gate middleware (#238)

### DIFF
--- a/apps/control-plane/cmd/server/main.go
+++ b/apps/control-plane/cmd/server/main.go
@@ -52,7 +52,9 @@ import (
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/signup"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/signupguard"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/spendalerts"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/featuregate"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/tenants"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/tenant/settings"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/usage"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/waldrainer"
 	"github.com/sakibsadmanshajib/hive/packages/storage"
@@ -722,6 +724,16 @@ func main() {
 		})
 	}
 
+	// Issue #238 — feature gate handler. Resolves per-tenant flags from the
+	// tenant_settings table via a 30 s in-process cache (settings.Resolver).
+	// Edge-api calls GET /internal/featuregate/{tenant_id} to populate its own
+	// 30 s edge cache, giving end-to-end revocation in under 60 s.
+	var featureGateHandler *featuregate.Handler
+	if pool != nil {
+		settingsResolver := settings.NewResolver(pool, 30*time.Second)
+		featureGateHandler = featuregate.NewHandler(settingsResolver)
+	}
+
 	router := platformhttp.NewRouter(platformhttp.RouterConfig{
 		AuthMiddleware:     authMiddleware,
 		AccountsHandler:    accountsHandler,
@@ -735,6 +747,7 @@ func main() {
 		ProfilesHandler:    profilesHandler,
 		ProvidersRouter:    providersHandler,
 		LiteLLMSyncHandler: litellmSyncHandler,
+		FeatureGateHandler: featureGateHandler,
 		RoutingHandler:     routingHandler,
 		UsageHandler:       usageHandler,
 		MetricsRegistry:    metricsRegistry,

--- a/apps/control-plane/internal/featuregate/handler.go
+++ b/apps/control-plane/internal/featuregate/handler.go
@@ -1,0 +1,76 @@
+// Package featuregate exposes an internal service-to-service endpoint that
+// returns per-tenant feature flags so edge-api can gate capabilities without
+// querying the database directly.
+//
+// GET /internal/featuregate/{tenant_id}
+//
+// The tenant_id path segment is the UUID of the requesting tenant. The
+// handler resolves flags from the tenant_settings table via the shared
+// settings.Resolver (which carries its own short cache). The response is
+// a flat JSON object; all unknown/unset flags default to false.
+//
+// Auth: guarded upstream by RequireInternalToken (all /internal/* routes).
+package featuregate
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/tenant/settings"
+)
+
+// FlagsResponse is the JSON body returned to the edge-api.
+type FlagsResponse struct {
+	RAGEnabled    bool `json:"rag_enabled"`
+	VoiceEnabled  bool `json:"voice_enabled"`
+	RelayEnabled  bool `json:"relay_enabled"`
+	CoworkEnabled bool `json:"cowork_enabled"`
+}
+
+// Resolver is the narrow interface the handler needs from settings.Resolver.
+type Resolver interface {
+	IsEnabled(ctx context.Context, tenantID uuid.UUID, key settings.Key) bool
+}
+
+// Handler serves GET /internal/featuregate/{tenant_id}.
+type Handler struct {
+	resolver Resolver
+}
+
+// NewHandler constructs a Handler. resolver must not be nil.
+func NewHandler(resolver Resolver) *Handler {
+	return &Handler{resolver: resolver}
+}
+
+// ServeHTTP handles GET /internal/featuregate/{tenant_id}.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Extract {tenant_id} from the trailing path segment.
+	// Route is registered as "/internal/featuregate/" so the mux strips the prefix.
+	raw := strings.TrimPrefix(r.URL.Path, "/internal/featuregate/")
+	raw = strings.Trim(raw, "/")
+	tenantID, err := uuid.Parse(raw)
+	if err != nil {
+		http.Error(w, `{"error":"invalid tenant_id"}`, http.StatusBadRequest)
+		return
+	}
+
+	ctx := r.Context()
+	flags := FlagsResponse{
+		RAGEnabled:    h.resolver.IsEnabled(ctx, tenantID, settings.EnableRAG),
+		VoiceEnabled:  h.resolver.IsEnabled(ctx, tenantID, settings.EnableVoice),
+		RelayEnabled:  h.resolver.IsEnabled(ctx, tenantID, settings.EnableRelay),
+		CoworkEnabled: h.resolver.IsEnabled(ctx, tenantID, settings.EnableCowork),
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(flags)
+}

--- a/apps/control-plane/internal/featuregate/handler_test.go
+++ b/apps/control-plane/internal/featuregate/handler_test.go
@@ -1,0 +1,81 @@
+package featuregate_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/featuregate"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/tenant/settings"
+)
+
+// stubResolver returns a fixed map of enabled keys.
+type stubResolver struct {
+	enabled map[settings.Key]bool
+}
+
+func (s *stubResolver) IsEnabled(_ context.Context, _ uuid.UUID, key settings.Key) bool {
+	return s.enabled[key]
+}
+
+func TestHandler_ReturnsFlags(t *testing.T) {
+	tid := uuid.New()
+	h := featuregate.NewHandler(&stubResolver{enabled: map[settings.Key]bool{
+		settings.EnableRAG:   true,
+		settings.EnableVoice: false,
+	}})
+
+	req := httptest.NewRequest(http.MethodGet, "/internal/featuregate/"+tid.String(), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	var resp featuregate.FlagsResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !resp.RAGEnabled {
+		t.Error("RAGEnabled should be true")
+	}
+	if resp.VoiceEnabled {
+		t.Error("VoiceEnabled should be false")
+	}
+}
+
+func TestHandler_InvalidTenantID_Returns400(t *testing.T) {
+	h := featuregate.NewHandler(&stubResolver{})
+	req := httptest.NewRequest(http.MethodGet, "/internal/featuregate/not-a-uuid", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestHandler_MethodNotAllowed(t *testing.T) {
+	h := featuregate.NewHandler(&stubResolver{})
+	req := httptest.NewRequest(http.MethodPost, "/internal/featuregate/"+uuid.New().String(), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", rec.Code)
+	}
+}
+
+func TestHandler_AllFlagsDefault_WhenNoneEnabled(t *testing.T) {
+	h := featuregate.NewHandler(&stubResolver{})
+	req := httptest.NewRequest(http.MethodGet, "/internal/featuregate/"+uuid.New().String(), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	var resp featuregate.FlagsResponse
+	_ = json.NewDecoder(rec.Body).Decode(&resp)
+	if resp.RAGEnabled || resp.VoiceEnabled || resp.RelayEnabled || resp.CoworkEnabled {
+		t.Error("all flags must default to false when resolver returns nothing")
+	}
+}

--- a/apps/control-plane/internal/platform/http/router.go
+++ b/apps/control-plane/internal/platform/http/router.go
@@ -84,6 +84,10 @@ type RouterConfig struct {
 	// LiteLLMSyncHandler handles POST /internal/litellm/sync.
 	// Guarded by the shared-secret token. When nil the route is not registered.
 	LiteLLMSyncHandler http.Handler
+
+	// FeatureGateHandler handles GET /internal/featuregate/{tenant_id}.
+	// Guarded by the shared-secret token. When nil the route is not registered.
+	FeatureGateHandler http.Handler
 }
 
 // NewRouter returns a configured http.Handler with all platform routes registered.
@@ -242,6 +246,12 @@ func NewRouter(cfg RouterConfig) http.Handler {
 			mux.Handle("/api/v1/admin/providers", adminProviders)
 			mux.Handle("/api/v1/admin/providers/", adminProviders)
 		}
+	}
+
+	// Issue #238 — per-tenant feature gate endpoint.
+	// GET /internal/featuregate/{tenant_id} returns flags for edge-api gate middleware.
+	if cfg.FeatureGateHandler != nil {
+		mux.Handle("/internal/featuregate/", internal(cfg.FeatureGateHandler))
 	}
 
 	// Wrap the mux with Prometheus HTTP instrumentation if a metrics registry is provided.

--- a/apps/control-plane/internal/tenant/settings/keys.go
+++ b/apps/control-plane/internal/tenant/settings/keys.go
@@ -26,4 +26,10 @@ const (
 	EnableAuditSinkSentry   Key = "ENABLE_AUDIT_SINK_SENTRY"
 	EnableAdminConsole      Key = "ENABLE_ADMIN_CONSOLE"
 	EnableProviderCustom    Key = "ENABLE_PROVIDER_CUSTOM"
+
+	// Carl.sh sovereign workspace feature gates (issue #238).
+	EnableRAG    Key = "ENABLE_RAG"
+	EnableVoice  Key = "ENABLE_VOICE"
+	EnableRelay  Key = "ENABLE_RELAY"
+	EnableCowork Key = "ENABLE_COWORK"
 )

--- a/apps/edge-api/cmd/server/main.go
+++ b/apps/edge-api/cmd/server/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/catalog"
 	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/chat"
 	apierrors "github.com/sakibsadmanshajib/hive/apps/edge-api/internal/errors"
+	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/featuregate"
 	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/files"
 	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/images"
 	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/inference"
@@ -75,7 +76,21 @@ func main() {
 	}
 	log.Printf("Loaded support matrix: %d endpoints", len(m.Endpoints))
 
-	catalogClient := catalog.NewClient(resolveControlPlaneBaseURL())
+	cpBaseURL := resolveControlPlaneBaseURL()
+	catalogClient := catalog.NewClient(cpBaseURL)
+
+	// Issue #238 — per-tenant feature gate. Lazy-resolves flags from control-plane
+	// with a 30 s in-memory cache per tenant (end-to-end revocation < 60 s).
+	// RAG/voice/relay/cowork route handlers (issues #232-235) call featureGate.Require(...)
+	// to wrap their http.Handler before registration on the mux.
+	// ponytail: featureGate used by RAG/voice/relay/cowork handlers (#232-235).
+	// Kept here so the gate is constructed once and shared across all feature routes.
+	featureGate := featuregate.New(featuregate.Config{
+		ControlPlaneURL: cpBaseURL,
+		TTL:             30 * time.Second,
+	})
+	_ = featureGate // consumed by future feature route registrations (#232-235)
+
 	dbPool := openOptionalDBPool(rootCtx)
 	if dbPool != nil {
 		defer dbPool.Close()

--- a/apps/edge-api/internal/featuregate/gate.go
+++ b/apps/edge-api/internal/featuregate/gate.go
@@ -1,0 +1,177 @@
+// Package featuregate resolves per-tenant feature flags lazily from the
+// control-plane with a 30-second in-memory cache. Cache misses trigger a
+// single HTTP fetch; fetch errors fail closed (all flags false).
+//
+// Decision: fail-closed on control-plane errors. A tenant whose flags cannot
+// be fetched is denied access to the feature rather than silently permitted.
+// This matches the existing rate-limiter and budget-gate posture in edge-api.
+package featuregate
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/auth"
+	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/cpauth"
+)
+
+// Feature is an opaque token identifying a gateable capability.
+type Feature string
+
+const (
+	FeatureRAG    Feature = "rag"
+	FeatureVoice  Feature = "voice"
+	FeatureRelay  Feature = "relay"
+	FeatureCowork Feature = "cowork"
+)
+
+// FlagsResponse is the JSON body returned by the control-plane
+// GET /internal/featuregate/{tenant_id} endpoint.
+type FlagsResponse struct {
+	RAGEnabled    bool `json:"rag_enabled"`
+	VoiceEnabled  bool `json:"voice_enabled"`
+	RelayEnabled  bool `json:"relay_enabled"`
+	CoworkEnabled bool `json:"cowork_enabled"`
+}
+
+// isEnabled returns whether f is enabled for this response.
+func (r FlagsResponse) isEnabled(f Feature) bool {
+	switch f {
+	case FeatureRAG:
+		return r.RAGEnabled
+	case FeatureVoice:
+		return r.VoiceEnabled
+	case FeatureRelay:
+		return r.RelayEnabled
+	case FeatureCowork:
+		return r.CoworkEnabled
+	default:
+		return false // ponytail: unknown feature = deny
+	}
+}
+
+// Config holds Gate construction parameters.
+type Config struct {
+	// ControlPlaneURL is the base URL of the control-plane service,
+	// e.g. "http://control-plane:8081".
+	ControlPlaneURL string
+	// TTL is how long a fetched result is cached per tenant.
+	// The spec requires < 60 s revocation; default 30 s.
+	TTL time.Duration
+	// HTTPClient is optional; defaults to a 5 s timeout client.
+	HTTPClient *http.Client
+}
+
+type entry struct {
+	flags  FlagsResponse
+	loaded time.Time
+}
+
+// Gate resolves feature flags with a short per-tenant cache.
+type Gate struct {
+	baseURL string
+	ttl     time.Duration
+	client  *http.Client
+
+	mu    sync.RWMutex
+	cache map[uuid.UUID]entry
+}
+
+// New constructs a Gate. TTL defaults to 30 s when zero.
+func New(cfg Config) *Gate {
+	ttl := cfg.TTL
+	if ttl == 0 {
+		ttl = 30 * time.Second
+	}
+	client := cfg.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: 5 * time.Second}
+	}
+	return &Gate{
+		baseURL: strings.TrimRight(cfg.ControlPlaneURL, "/"),
+		ttl:     ttl,
+		client:  client,
+		cache:   make(map[uuid.UUID]entry),
+	}
+}
+
+// Fetch returns the flags for tenantID, using the cache when valid.
+// On any upstream error it returns a zeroed FlagsResponse and a non-nil error
+// (fail-closed: caller treats all flags as false).
+func (g *Gate) Fetch(ctx context.Context, tenantID uuid.UUID) (FlagsResponse, error) {
+	g.mu.RLock()
+	e, ok := g.cache[tenantID]
+	g.mu.RUnlock()
+	if ok && time.Since(e.loaded) < g.ttl {
+		return e.flags, nil
+	}
+	return g.refresh(ctx, tenantID)
+}
+
+func (g *Gate) refresh(ctx context.Context, tenantID uuid.UUID) (FlagsResponse, error) {
+	url := fmt.Sprintf("%s/internal/featuregate/%s", g.baseURL, tenantID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return FlagsResponse{}, fmt.Errorf("featuregate: build request: %w", err)
+	}
+	cpauth.SetHeader(req)
+
+	resp, err := g.client.Do(req)
+	if err != nil {
+		return FlagsResponse{}, fmt.Errorf("featuregate: request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return FlagsResponse{}, fmt.Errorf("featuregate: upstream status %d", resp.StatusCode)
+	}
+
+	var flags FlagsResponse
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 4096)).Decode(&flags); err != nil {
+		return FlagsResponse{}, fmt.Errorf("featuregate: decode: %w", err)
+	}
+
+	g.mu.Lock()
+	g.cache[tenantID] = entry{flags: flags, loaded: time.Now()}
+	g.mu.Unlock()
+
+	return flags, nil
+}
+
+// Require returns middleware that gates the next handler on feat being enabled
+// for the authenticated tenant. Disabled or unauthenticated requests receive
+// 403 with a provider-blind body (no feature name, no internal detail).
+func (g *Gate) Require(feat Feature) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			user, ok := auth.UserFrom(r.Context())
+			if !ok || user == nil {
+				writeDenied(w)
+				return
+			}
+
+			flags, err := g.Fetch(r.Context(), user.TenantID)
+			if err != nil || !flags.isEnabled(feat) {
+				writeDenied(w)
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// writeDenied emits a provider-blind 403. No feature name, no internal detail.
+func writeDenied(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusForbidden)
+	// ponytail: static body — no feature name, no provider name.
+	_, _ = w.Write([]byte(`{"error":{"code":"ACCESS_DENIED","message":"access denied","type":"FORBIDDEN"}}`))
+}

--- a/apps/edge-api/internal/featuregate/gate_test.go
+++ b/apps/edge-api/internal/featuregate/gate_test.go
@@ -1,0 +1,246 @@
+// Package featuregate tests — TDD RED first.
+package featuregate_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/auth"
+	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/featuregate"
+)
+
+// ---- helpers ---------------------------------------------------------------
+
+// mockCP serves a fixed FlagsResponse for all tenants.
+type mockCP struct {
+	flags      featuregate.FlagsResponse
+	calls      atomic.Int32
+	statusCode int // overrides 200 when non-zero
+}
+
+func (m *mockCP) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	m.calls.Add(1)
+	code := http.StatusOK
+	if m.statusCode != 0 {
+		code = m.statusCode
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	if code == http.StatusOK {
+		_ = json.NewEncoder(w).Encode(m.flags)
+	}
+}
+
+func newRequest(tenantID uuid.UUID) *http.Request {
+	u := &auth.User{TenantID: tenantID}
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	return r.WithContext(auth.WithUser(r.Context(), u))
+}
+
+// ---- cache hit / miss / expiry ---------------------------------------------
+
+func TestCacheHit(t *testing.T) {
+	tid := uuid.New()
+	cp := &mockCP{flags: featuregate.FlagsResponse{RAGEnabled: true}}
+	srv := httptest.NewServer(cp)
+	defer srv.Close()
+
+	g := featuregate.New(featuregate.Config{ControlPlaneURL: srv.URL, TTL: 30 * time.Second})
+
+	for i := 0; i < 2; i++ {
+		if _, err := g.Fetch(newRequest(tid).Context(), tid); err != nil {
+			t.Fatalf("Fetch call %d: %v", i, err)
+		}
+	}
+	if got := cp.calls.Load(); got != 1 {
+		t.Errorf("expected 1 upstream call (cache hit on 2nd), got %d", got)
+	}
+}
+
+func TestCacheMiss_MultiTenant(t *testing.T) {
+	t1, t2 := uuid.New(), uuid.New()
+	cp := &mockCP{}
+	srv := httptest.NewServer(cp)
+	defer srv.Close()
+
+	g := featuregate.New(featuregate.Config{ControlPlaneURL: srv.URL, TTL: 30 * time.Second})
+
+	_, _ = g.Fetch(newRequest(t1).Context(), t1)
+	_, _ = g.Fetch(newRequest(t2).Context(), t2)
+	if got := cp.calls.Load(); got != 2 {
+		t.Errorf("expected 2 upstream calls (distinct tenants), got %d", got)
+	}
+}
+
+func TestCacheExpiry(t *testing.T) {
+	tid := uuid.New()
+	cp := &mockCP{}
+	srv := httptest.NewServer(cp)
+	defer srv.Close()
+
+	g := featuregate.New(featuregate.Config{ControlPlaneURL: srv.URL, TTL: 1 * time.Millisecond})
+
+	_, _ = g.Fetch(newRequest(tid).Context(), tid)
+	time.Sleep(5 * time.Millisecond)
+	_, _ = g.Fetch(newRequest(tid).Context(), tid)
+
+	if got := cp.calls.Load(); got != 2 {
+		t.Errorf("expected 2 upstream calls after TTL expiry, got %d", got)
+	}
+}
+
+// ---- fail-closed on upstream errors ----------------------------------------
+
+func TestFetch_FailsClosed_On500(t *testing.T) {
+	cp := &mockCP{statusCode: http.StatusInternalServerError}
+	srv := httptest.NewServer(cp)
+	defer srv.Close()
+
+	g := featuregate.New(featuregate.Config{ControlPlaneURL: srv.URL, TTL: 30 * time.Second})
+
+	tid := uuid.New()
+	flags, err := g.Fetch(newRequest(tid).Context(), tid)
+	if err == nil {
+		t.Fatal("expected error from 500 response, got nil")
+	}
+	if flags.RAGEnabled || flags.VoiceEnabled || flags.RelayEnabled || flags.CoworkEnabled {
+		t.Error("all flags must be false (fail-closed) on upstream error")
+	}
+}
+
+func TestFetch_FailsClosed_OnNetworkError(t *testing.T) {
+	g := featuregate.New(featuregate.Config{
+		ControlPlaneURL: "http://127.0.0.1:1", // connection refused
+		TTL:             30 * time.Second,
+	})
+
+	tid := uuid.New()
+	flags, err := g.Fetch(newRequest(tid).Context(), tid)
+	if err == nil {
+		t.Fatal("expected error on network failure, got nil")
+	}
+	if flags.RAGEnabled || flags.VoiceEnabled || flags.RelayEnabled || flags.CoworkEnabled {
+		t.Error("all flags must be false on network error")
+	}
+}
+
+// ---- middleware: disabled → 403, no feature name in body ------------------
+
+func TestMiddleware_Disabled_Returns403(t *testing.T) {
+	tid := uuid.New()
+	cp := &mockCP{flags: featuregate.FlagsResponse{RAGEnabled: false}}
+	srv := httptest.NewServer(cp)
+	defer srv.Close()
+
+	g := featuregate.New(featuregate.Config{ControlPlaneURL: srv.URL, TTL: 30 * time.Second})
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	handler := g.Require(featuregate.FeatureRAG)(inner)
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, newRequest(tid))
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("expected 403, got %d", rec.Code)
+	}
+	// Provider-blind: no feature name in body.
+	body := rec.Body.String()
+	for _, banned := range []string{"rag", "RAG", "voice", "relay", "cowork", "feature"} {
+		if strContains(body, banned) {
+			t.Errorf("response body leaks %q in: %s", banned, body)
+		}
+	}
+}
+
+func TestMiddleware_Enabled_PassesThrough(t *testing.T) {
+	tid := uuid.New()
+	cp := &mockCP{flags: featuregate.FlagsResponse{VoiceEnabled: true}}
+	srv := httptest.NewServer(cp)
+	defer srv.Close()
+
+	g := featuregate.New(featuregate.Config{ControlPlaneURL: srv.URL, TTL: 30 * time.Second})
+
+	reached := false
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusOK)
+	})
+	rec := httptest.NewRecorder()
+	g.Require(featuregate.FeatureVoice)(inner).ServeHTTP(rec, newRequest(tid))
+
+	if !reached {
+		t.Error("inner handler not reached for enabled feature")
+	}
+}
+
+func TestMiddleware_NoUser_Returns403(t *testing.T) {
+	cp := &mockCP{}
+	srv := httptest.NewServer(cp)
+	defer srv.Close()
+
+	g := featuregate.New(featuregate.Config{ControlPlaneURL: srv.URL, TTL: 30 * time.Second})
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	req := httptest.NewRequest(http.MethodGet, "/", nil) // no auth.User in context
+	rec := httptest.NewRecorder()
+	g.Require(featuregate.FeatureRAG)(inner).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("expected 403 for unauthenticated request, got %d", rec.Code)
+	}
+}
+
+// ---- all four feature constants covered ------------------------------------
+
+func TestMiddleware_AllFeatures_Enabled(t *testing.T) {
+	cases := []struct {
+		feat  featuregate.Feature
+		setup func(*featuregate.FlagsResponse)
+	}{
+		{featuregate.FeatureRAG, func(f *featuregate.FlagsResponse) { f.RAGEnabled = true }},
+		{featuregate.FeatureVoice, func(f *featuregate.FlagsResponse) { f.VoiceEnabled = true }},
+		{featuregate.FeatureRelay, func(f *featuregate.FlagsResponse) { f.RelayEnabled = true }},
+		{featuregate.FeatureCowork, func(f *featuregate.FlagsResponse) { f.CoworkEnabled = true }},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(string(tc.feat), func(t *testing.T) {
+			var flags featuregate.FlagsResponse
+			tc.setup(&flags)
+			cp := &mockCP{flags: flags}
+			srv := httptest.NewServer(cp)
+			defer srv.Close()
+
+			g := featuregate.New(featuregate.Config{ControlPlaneURL: srv.URL, TTL: 30 * time.Second})
+
+			reached := false
+			inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				reached = true
+				w.WriteHeader(http.StatusOK)
+			})
+			rec := httptest.NewRecorder()
+			g.Require(tc.feat)(inner).ServeHTTP(rec, newRequest(uuid.New()))
+
+			if !reached {
+				t.Errorf("%s: inner handler not reached when enabled", tc.feat)
+			}
+		})
+	}
+}
+
+// ---- control-plane handler tests -------------------------------------------
+
+func strContains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/supabase/migrations/20260625_04_carl_featuregate_keys.sql
+++ b/supabase/migrations/20260625_04_carl_featuregate_keys.sql
@@ -1,0 +1,9 @@
+-- Add Carl.sh sovereign workspace feature gate keys to the tenant_setting_key enum.
+-- ALTER TYPE ... ADD VALUE IF NOT EXISTS is idempotent (Postgres 12+).
+-- No DOWN migration: enum values cannot be removed in Postgres without a full
+-- type rebuild, and the values are harmless when unused.
+
+ALTER TYPE public.tenant_setting_key ADD VALUE IF NOT EXISTS 'ENABLE_RAG';
+ALTER TYPE public.tenant_setting_key ADD VALUE IF NOT EXISTS 'ENABLE_VOICE';
+ALTER TYPE public.tenant_setting_key ADD VALUE IF NOT EXISTS 'ENABLE_RELAY';
+ALTER TYPE public.tenant_setting_key ADD VALUE IF NOT EXISTS 'ENABLE_COWORK';


### PR DESCRIPTION
## Summary

- New `apps/edge-api/internal/featuregate` package: `Gate` struct with 30 s per-tenant TTL cache, fail-closed `Fetch`, and `Require(feature)` middleware factory
- New `apps/control-plane/internal/featuregate` package: `Handler` for `GET /internal/featuregate/{tenant_id}`, backed by `settings.Resolver`
- Four new `settings.Key` constants: `EnableRAG`, `EnableVoice`, `EnableRelay`, `EnableCowork`
- Control-plane router mounts `/internal/featuregate/` under the shared-secret guard
- Migration `20260625_04_carl_featuregate_keys.sql`: idempotent `ALTER TYPE` adding four enum values
- Both `cmd/server/main.go` files wired; `featureGate` is constructed and ready for route handlers in issues #232-235

## Design decisions

- Fail-closed: any upstream error (5xx, network) denies the feature rather than permitting it, matching the existing rate-limiter and budget-gate posture
- 403 body is provider-blind: static `{"error":{"code":"ACCESS_DENIED",...}}`, no feature name, no internal detail
- Cache is per-tenant UUID; distinct tenants are independent entries
- End-to-end revocation bound: control-plane cache (30 s) + edge cache (30 s) = at most 60 s

## Test plan

- [x] `TestCacheHit`: second fetch for same tenant hits cache (1 upstream call)
- [x] `TestCacheMiss_MultiTenant`: distinct tenants each trigger an upstream call
- [x] `TestCacheExpiry`: entry expired after TTL triggers a fresh fetch
- [x] `TestFetch_FailsClosed_On500`: 500 response returns error, all flags false
- [x] `TestFetch_FailsClosed_OnNetworkError`: refused connection returns error, all flags false
- [x] `TestMiddleware_Disabled_Returns403`: disabled flag returns 403, body contains no feature name
- [x] `TestMiddleware_Enabled_PassesThrough`: enabled flag reaches inner handler
- [x] `TestMiddleware_NoUser_Returns403`: unauthenticated request returns 403
- [x] `TestMiddleware_AllFeatures_Enabled`: all four feature constants (rag/voice/relay/cowork) pass through when enabled
- [x] `TestHandler_ReturnsFlags`: CP handler returns correct JSON flags
- [x] `TestHandler_InvalidTenantID_Returns400`: malformed UUID returns 400
- [x] `TestHandler_MethodNotAllowed`: POST returns 405
- [x] `TestHandler_AllFlagsDefault_WhenNoneEnabled`: all flags false when resolver returns nothing

Closes #238

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a two-layer per-tenant feature gate: a new `featuregate.Handler` in the control-plane exposes `GET /internal/featuregate/{tenant_id}` (backed by `settings.Resolver`, guarded by the shared-secret), and a new `featuregate.Gate` in the edge-api fetches and caches flags per tenant (30 s TTL) then enforces them as HTTP middleware. Four new `settings.Key` constants and a matching idempotent enum migration round out the change.

- **Edge-api Gate** (`gate.go`): fail-closed on any upstream error, per-tenant TTL cache, `Require(feature)` middleware factory. The cache has a race condition where concurrent requests for the same tenant all refresh simultaneously on a miss (see inline comment).
- **Control-plane handler** (`handler.go`): extracts tenant UUID from path via `strings.TrimPrefix`, resolves all four flags from `settings.Resolver`, and returns a flat JSON body. Error responses use `http.Error` which sets `text/plain` instead of `application/json`.
- **Migration**: idempotent `ALTER TYPE … ADD VALUE IF NOT EXISTS` for all four enum values; no down migration (correct per Postgres constraints).
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The feature gate middleware is not yet wired to any live routes (consumed via `_ = featureGate`), so no customer traffic is affected today; the cache-stampede defect only bites when the gate is actually used under concurrent load.

Under concurrent request bursts at a TTL boundary, every in-flight request for the same tenant independently calls the control-plane instead of coalescing into one. The `TestCacheHit` test passes only because it is sequential. Once the gate wraps real route handlers in issues #232–235, a popular tenant crossing the 30 s expiry could fan out O(concurrent requests) upstream calls simultaneously, undermining the documented "1 upstream call per TTL window" contract and potentially amplifying load on the control-plane.

apps/edge-api/internal/featuregate/gate.go — the Fetch/refresh pairing needs a singleflight group before the gate is connected to live routes.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/edge-api/internal/featuregate/gate.go | New Gate struct with per-tenant TTL cache and middleware factory; has a cache-stampede race: concurrent requests for the same tenant all call refresh simultaneously when the entry is absent or expired. |
| apps/control-plane/internal/featuregate/handler.go | New GET /internal/featuregate/{tenant_id} handler; correct path extraction via strings.TrimPrefix but carries a misleading comment claiming the mux strips the prefix, and error responses use http.Error which sets text/plain instead of application/json. |
| apps/control-plane/internal/featuregate/handler_test.go | Tests cover happy-path flags, invalid UUID, method-not-allowed, and all-false-default; no issues found. |
| apps/edge-api/internal/featuregate/gate_test.go | Good sequential coverage of cache hit/miss/expiry and fail-closed paths; the stampede race is not caught because all Fetch calls are sequential; strContains is a hand-rolled duplicate of strings.Contains. |
| apps/control-plane/internal/platform/http/router.go | Adds /internal/featuregate/ route under the shared-secret guard, guarded by nil-check; consistent with existing internal route pattern. |
| apps/control-plane/internal/tenant/settings/keys.go | Adds four new Key constants (EnableRAG, EnableVoice, EnableRelay, EnableCowork) following established naming conventions. |
| apps/control-plane/cmd/server/main.go | Wires featuregate.Handler with a 30s settings.Resolver; guarded by pool != nil check consistent with other DB-dependent handlers. |
| apps/edge-api/cmd/server/main.go | Constructs featuregate.Gate once; `_ = featureGate` explicitly defers consumption to issues #232-235, which is clearly documented. |
| supabase/migrations/20260625_04_carl_featuregate_keys.sql | Idempotent ALTER TYPE … ADD VALUE IF NOT EXISTS for four enum values; no down migration, which is correct since Postgres cannot remove enum values without a full rebuild. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant EdgeAPI as Edge-API (featuregate.Gate)
    participant Cache as In-Memory Cache (30s TTL)
    participant CP as Control-Plane (/internal/featuregate/{tenant_id})
    participant DB as Postgres (tenant_settings)

    Client->>EdgeAPI: Request (authenticated)
    EdgeAPI->>EdgeAPI: auth.UserFrom(ctx) → TenantID
    EdgeAPI->>Cache: Lookup(tenantID)
    alt "Cache hit (< 30s)"
        Cache-->>EdgeAPI: FlagsResponse
    else Cache miss / expired
        EdgeAPI->>CP: "GET /internal/featuregate/{tenant_id} X-Internal-Token"
        CP->>DB: "SELECT enabled FROM tenant_settings WHERE tenant_id=$1 AND key=$2"
        DB-->>CP: row(s)
        CP-->>EdgeAPI: "200 { rag_enabled, voice_enabled, relay_enabled, cowork_enabled }"
        EdgeAPI->>Cache: Store(tenantID, flags, now)
    end
    alt Feature enabled
        EdgeAPI->>Client: Proxied to inner handler (200)
    else Feature disabled or error
        EdgeAPI->>Client: 403 ACCESS_DENIED (provider-blind)
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant EdgeAPI as Edge-API (featuregate.Gate)
    participant Cache as In-Memory Cache (30s TTL)
    participant CP as Control-Plane (/internal/featuregate/{tenant_id})
    participant DB as Postgres (tenant_settings)

    Client->>EdgeAPI: Request (authenticated)
    EdgeAPI->>EdgeAPI: auth.UserFrom(ctx) → TenantID
    EdgeAPI->>Cache: Lookup(tenantID)
    alt "Cache hit (< 30s)"
        Cache-->>EdgeAPI: FlagsResponse
    else Cache miss / expired
        EdgeAPI->>CP: "GET /internal/featuregate/{tenant_id} X-Internal-Token"
        CP->>DB: "SELECT enabled FROM tenant_settings WHERE tenant_id=$1 AND key=$2"
        DB-->>CP: row(s)
        CP-->>EdgeAPI: "200 { rag_enabled, voice_enabled, relay_enabled, cowork_enabled }"
        EdgeAPI->>Cache: Store(tenantID, flags, now)
    end
    alt Feature enabled
        EdgeAPI->>Client: Proxied to inner handler (200)
    else Feature disabled or error
        EdgeAPI->>Client: 403 ACCESS_DENIED (provider-blind)
    end
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Aapps%2Fedge-api%2Finternal%2Ffeaturegate%2Fgate.go%3A101-120%0A**Cache%20stampede%20on%20concurrent%20misses**%0A%0A%60Fetch%60%20releases%20the%20read%20lock%20before%20calling%20%60refresh%60%2C%20so%20N%20concurrent%20goroutines%20serving%20the%20same%20tenant%20whose%20entry%20is%20absent%20or%20just%20expired%20will%20all%20pass%20the%20cache-miss%20check%20simultaneously%20and%20each%20issue%20a%20separate%20upstream%20HTTP%20call.%20In%20a%20burst%20at%20startup%20or%20at%20every%2030%20s%20TTL%20boundary%2C%20every%20in-flight%20request%20for%20that%20tenant%20becomes%20an%20upstream%20call%20instead%20of%20one.%20The%20sequential%20%60TestCacheHit%60%20test%20does%20not%20catch%20this.%0A%0AThe%20standard%20fix%20is%20to%20protect%20%60refresh%60%20with%20a%20%60golang.org%2Fx%2Fsync%2Fsingleflight.Group%60%20keyed%20on%20%60tenantID%60%2C%20so%20only%20the%20first%20caller%20flies%20upstream%20while%20the%20rest%20wait%20and%20share%20the%20result.%0A%0A%23%23%23%20Issue%202%20of%204%0Aapps%2Fcontrol-plane%2Finternal%2Ffeaturegate%2Fhandler.go%3A55-57%0AThe%20comment%20claims%20the%20mux%20strips%20the%20prefix%2C%20but%20Go's%20%60http.ServeMux%60%20does%20**not**%20strip%20path%20prefixes%20for%20tree-rooted%20patterns%20%E2%80%94%20only%20%60http.StripPrefix%60%20does.%20The%20code%20is%20correct%20because%20%60strings.TrimPrefix%60%20handles%20it%20explicitly%2C%20but%20a%20future%20developer%20reading%20the%20comment%20might%20remove%20that%20call%20under%20the%20mistaken%20belief%20the%20mux%20already%20stripped%20it%2C%20breaking%20UUID%20parsing%20for%20every%20request.%0A%0A%60%60%60suggestion%0A%09%2F%2F%20Extract%20%7Btenant_id%7D%20from%20the%20trailing%20path%20segment.%0A%09%2F%2F%20ServeMux%20routes%20all%20%2Finternal%2Ffeaturegate%2F*%20requests%20here%20but%20does%20NOT%0A%09%2F%2F%20strip%20the%20prefix%20%E2%80%94%20strings.TrimPrefix%20does%20that%20explicitly%20below.%0A%09raw%20%3A%3D%20strings.TrimPrefix%28r.URL.Path%2C%20%22%2Finternal%2Ffeaturegate%2F%22%29%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%204%0Aapps%2Fcontrol-plane%2Finternal%2Ffeaturegate%2Fhandler.go%3A50-63%0A%60http.Error%60%20always%20sets%20%60Content-Type%3A%20text%2Fplain%3B%20charset%3Dutf-8%60%2C%20so%20the%20JSON-formatted%20error%20bodies%20on%20the%20405%20and%20400%20paths%20are%20served%20with%20the%20wrong%20content%20type.%20The%20happy%20path%20explicitly%20sets%20%60application%2Fjson%60%2C%20making%20the%20error%20paths%20inconsistent.%20Any%20client%20that%20sniffs%20%60Content-Type%60%20before%20parsing%20the%20body%20will%20be%20confused.%0A%0A%60%60%60suggestion%0A%09if%20r.Method%20!%3D%20http.MethodGet%20%7B%0A%09%09w.Header%28%29.Set%28%22Content-Type%22%2C%20%22application%2Fjson%22%29%0A%09%09w.WriteHeader%28http.StatusMethodNotAllowed%29%0A%09%09_%2C%20_%20%3D%20w.Write%28%5B%5Dbyte%28%60%7B%22error%22%3A%22method%20not%20allowed%22%7D%60%29%29%0A%09%09return%0A%09%7D%0A%0A%09%2F%2F%20Extract%20%7Btenant_id%7D%20from%20the%20trailing%20path%20segment.%0A%09%2F%2F%20ServeMux%20routes%20all%20%2Finternal%2Ffeaturegate%2F*%20requests%20here%20but%20does%20NOT%0A%09%2F%2F%20strip%20the%20prefix%20%E2%80%94%20strings.TrimPrefix%20does%20that%20explicitly%20below.%0A%09raw%20%3A%3D%20strings.TrimPrefix%28r.URL.Path%2C%20%22%2Finternal%2Ffeaturegate%2F%22%29%0A%09raw%20%3D%20strings.Trim%28raw%2C%20%22%2F%22%29%0A%09tenantID%2C%20err%20%3A%3D%20uuid.Parse%28raw%29%0A%09if%20err%20!%3D%20nil%20%7B%0A%09%09w.Header%28%29.Set%28%22Content-Type%22%2C%20%22application%2Fjson%22%29%0A%09%09w.WriteHeader%28http.StatusBadRequest%29%0A%09%09_%2C%20_%20%3D%20w.Write%28%5B%5Dbyte%28%60%7B%22error%22%3A%22invalid%20tenant_id%22%7D%60%29%29%0A%09%09return%0A%09%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%204%0Aapps%2Fedge-api%2Finternal%2Ffeaturegate%2Fgate_test.go%3A239-246%0A%60strContains%60%20is%20a%20manual%20reimplementation%20of%20%60strings.Contains%60.%20Using%20the%20stdlib%20function%20removes%20the%20bespoke%20loop%20and%20makes%20the%20intent%20immediately%20recognisable.%0A%0A%60%60%60suggestion%0A%2F%2F%20strContains%20is%20an%20alias%20for%20strings.Contains%20kept%20here%20for%20test%20readability.%0A%2F%2F%20Use%20strings.Contains%20directly%20in%20new%20tests.%0Afunc%20strContains%28s%2C%20sub%20string%29%20bool%20%7B%20return%20strings.Contains%28s%2C%20sub%29%20%7D%0A%60%60%60%0A%0A&repo=sakibsadmanshajib%2Fhive&pr=251&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Aapps%2Fedge-api%2Finternal%2Ffeaturegate%2Fgate.go%3A101-120%0A**Cache%20stampede%20on%20concurrent%20misses**%0A%0A%60Fetch%60%20releases%20the%20read%20lock%20before%20calling%20%60refresh%60%2C%20so%20N%20concurrent%20goroutines%20serving%20the%20same%20tenant%20whose%20entry%20is%20absent%20or%20just%20expired%20will%20all%20pass%20the%20cache-miss%20check%20simultaneously%20and%20each%20issue%20a%20separate%20upstream%20HTTP%20call.%20In%20a%20burst%20at%20startup%20or%20at%20every%2030%20s%20TTL%20boundary%2C%20every%20in-flight%20request%20for%20that%20tenant%20becomes%20an%20upstream%20call%20instead%20of%20one.%20The%20sequential%20%60TestCacheHit%60%20test%20does%20not%20catch%20this.%0A%0AThe%20standard%20fix%20is%20to%20protect%20%60refresh%60%20with%20a%20%60golang.org%2Fx%2Fsync%2Fsingleflight.Group%60%20keyed%20on%20%60tenantID%60%2C%20so%20only%20the%20first%20caller%20flies%20upstream%20while%20the%20rest%20wait%20and%20share%20the%20result.%0A%0A%23%23%23%20Issue%202%20of%204%0Aapps%2Fcontrol-plane%2Finternal%2Ffeaturegate%2Fhandler.go%3A55-57%0AThe%20comment%20claims%20the%20mux%20strips%20the%20prefix%2C%20but%20Go's%20%60http.ServeMux%60%20does%20**not**%20strip%20path%20prefixes%20for%20tree-rooted%20patterns%20%E2%80%94%20only%20%60http.StripPrefix%60%20does.%20The%20code%20is%20correct%20because%20%60strings.TrimPrefix%60%20handles%20it%20explicitly%2C%20but%20a%20future%20developer%20reading%20the%20comment%20might%20remove%20that%20call%20under%20the%20mistaken%20belief%20the%20mux%20already%20stripped%20it%2C%20breaking%20UUID%20parsing%20for%20every%20request.%0A%0A%60%60%60suggestion%0A%09%2F%2F%20Extract%20%7Btenant_id%7D%20from%20the%20trailing%20path%20segment.%0A%09%2F%2F%20ServeMux%20routes%20all%20%2Finternal%2Ffeaturegate%2F*%20requests%20here%20but%20does%20NOT%0A%09%2F%2F%20strip%20the%20prefix%20%E2%80%94%20strings.TrimPrefix%20does%20that%20explicitly%20below.%0A%09raw%20%3A%3D%20strings.TrimPrefix%28r.URL.Path%2C%20%22%2Finternal%2Ffeaturegate%2F%22%29%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%204%0Aapps%2Fcontrol-plane%2Finternal%2Ffeaturegate%2Fhandler.go%3A50-63%0A%60http.Error%60%20always%20sets%20%60Content-Type%3A%20text%2Fplain%3B%20charset%3Dutf-8%60%2C%20so%20the%20JSON-formatted%20error%20bodies%20on%20the%20405%20and%20400%20paths%20are%20served%20with%20the%20wrong%20content%20type.%20The%20happy%20path%20explicitly%20sets%20%60application%2Fjson%60%2C%20making%20the%20error%20paths%20inconsistent.%20Any%20client%20that%20sniffs%20%60Content-Type%60%20before%20parsing%20the%20body%20will%20be%20confused.%0A%0A%60%60%60suggestion%0A%09if%20r.Method%20!%3D%20http.MethodGet%20%7B%0A%09%09w.Header%28%29.Set%28%22Content-Type%22%2C%20%22application%2Fjson%22%29%0A%09%09w.WriteHeader%28http.StatusMethodNotAllowed%29%0A%09%09_%2C%20_%20%3D%20w.Write%28%5B%5Dbyte%28%60%7B%22error%22%3A%22method%20not%20allowed%22%7D%60%29%29%0A%09%09return%0A%09%7D%0A%0A%09%2F%2F%20Extract%20%7Btenant_id%7D%20from%20the%20trailing%20path%20segment.%0A%09%2F%2F%20ServeMux%20routes%20all%20%2Finternal%2Ffeaturegate%2F*%20requests%20here%20but%20does%20NOT%0A%09%2F%2F%20strip%20the%20prefix%20%E2%80%94%20strings.TrimPrefix%20does%20that%20explicitly%20below.%0A%09raw%20%3A%3D%20strings.TrimPrefix%28r.URL.Path%2C%20%22%2Finternal%2Ffeaturegate%2F%22%29%0A%09raw%20%3D%20strings.Trim%28raw%2C%20%22%2F%22%29%0A%09tenantID%2C%20err%20%3A%3D%20uuid.Parse%28raw%29%0A%09if%20err%20!%3D%20nil%20%7B%0A%09%09w.Header%28%29.Set%28%22Content-Type%22%2C%20%22application%2Fjson%22%29%0A%09%09w.WriteHeader%28http.StatusBadRequest%29%0A%09%09_%2C%20_%20%3D%20w.Write%28%5B%5Dbyte%28%60%7B%22error%22%3A%22invalid%20tenant_id%22%7D%60%29%29%0A%09%09return%0A%09%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%204%0Aapps%2Fedge-api%2Finternal%2Ffeaturegate%2Fgate_test.go%3A239-246%0A%60strContains%60%20is%20a%20manual%20reimplementation%20of%20%60strings.Contains%60.%20Using%20the%20stdlib%20function%20removes%20the%20bespoke%20loop%20and%20makes%20the%20intent%20immediately%20recognisable.%0A%0A%60%60%60suggestion%0A%2F%2F%20strContains%20is%20an%20alias%20for%20strings.Contains%20kept%20here%20for%20test%20readability.%0A%2F%2F%20Use%20strings.Contains%20directly%20in%20new%20tests.%0Afunc%20strContains%28s%2C%20sub%20string%29%20bool%20%7B%20return%20strings.Contains%28s%2C%20sub%29%20%7D%0A%60%60%60%0A%0A&pr=251&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22sakibsadmanshajib%2Fhive%22%20on%20the%20existing%20branch%20%22feat%2Fcarl-featuregate-238%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fcarl-featuregate-238%22.%0A%0AFix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Aapps%2Fedge-api%2Finternal%2Ffeaturegate%2Fgate.go%3A101-120%0A**Cache%20stampede%20on%20concurrent%20misses**%0A%0A%60Fetch%60%20releases%20the%20read%20lock%20before%20calling%20%60refresh%60%2C%20so%20N%20concurrent%20goroutines%20serving%20the%20same%20tenant%20whose%20entry%20is%20absent%20or%20just%20expired%20will%20all%20pass%20the%20cache-miss%20check%20simultaneously%20and%20each%20issue%20a%20separate%20upstream%20HTTP%20call.%20In%20a%20burst%20at%20startup%20or%20at%20every%2030%20s%20TTL%20boundary%2C%20every%20in-flight%20request%20for%20that%20tenant%20becomes%20an%20upstream%20call%20instead%20of%20one.%20The%20sequential%20%60TestCacheHit%60%20test%20does%20not%20catch%20this.%0A%0AThe%20standard%20fix%20is%20to%20protect%20%60refresh%60%20with%20a%20%60golang.org%2Fx%2Fsync%2Fsingleflight.Group%60%20keyed%20on%20%60tenantID%60%2C%20so%20only%20the%20first%20caller%20flies%20upstream%20while%20the%20rest%20wait%20and%20share%20the%20result.%0A%0A%23%23%23%20Issue%202%20of%204%0Aapps%2Fcontrol-plane%2Finternal%2Ffeaturegate%2Fhandler.go%3A55-57%0AThe%20comment%20claims%20the%20mux%20strips%20the%20prefix%2C%20but%20Go's%20%60http.ServeMux%60%20does%20**not**%20strip%20path%20prefixes%20for%20tree-rooted%20patterns%20%E2%80%94%20only%20%60http.StripPrefix%60%20does.%20The%20code%20is%20correct%20because%20%60strings.TrimPrefix%60%20handles%20it%20explicitly%2C%20but%20a%20future%20developer%20reading%20the%20comment%20might%20remove%20that%20call%20under%20the%20mistaken%20belief%20the%20mux%20already%20stripped%20it%2C%20breaking%20UUID%20parsing%20for%20every%20request.%0A%0A%60%60%60suggestion%0A%09%2F%2F%20Extract%20%7Btenant_id%7D%20from%20the%20trailing%20path%20segment.%0A%09%2F%2F%20ServeMux%20routes%20all%20%2Finternal%2Ffeaturegate%2F*%20requests%20here%20but%20does%20NOT%0A%09%2F%2F%20strip%20the%20prefix%20%E2%80%94%20strings.TrimPrefix%20does%20that%20explicitly%20below.%0A%09raw%20%3A%3D%20strings.TrimPrefix%28r.URL.Path%2C%20%22%2Finternal%2Ffeaturegate%2F%22%29%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%204%0Aapps%2Fcontrol-plane%2Finternal%2Ffeaturegate%2Fhandler.go%3A50-63%0A%60http.Error%60%20always%20sets%20%60Content-Type%3A%20text%2Fplain%3B%20charset%3Dutf-8%60%2C%20so%20the%20JSON-formatted%20error%20bodies%20on%20the%20405%20and%20400%20paths%20are%20served%20with%20the%20wrong%20content%20type.%20The%20happy%20path%20explicitly%20sets%20%60application%2Fjson%60%2C%20making%20the%20error%20paths%20inconsistent.%20Any%20client%20that%20sniffs%20%60Content-Type%60%20before%20parsing%20the%20body%20will%20be%20confused.%0A%0A%60%60%60suggestion%0A%09if%20r.Method%20!%3D%20http.MethodGet%20%7B%0A%09%09w.Header%28%29.Set%28%22Content-Type%22%2C%20%22application%2Fjson%22%29%0A%09%09w.WriteHeader%28http.StatusMethodNotAllowed%29%0A%09%09_%2C%20_%20%3D%20w.Write%28%5B%5Dbyte%28%60%7B%22error%22%3A%22method%20not%20allowed%22%7D%60%29%29%0A%09%09return%0A%09%7D%0A%0A%09%2F%2F%20Extract%20%7Btenant_id%7D%20from%20the%20trailing%20path%20segment.%0A%09%2F%2F%20ServeMux%20routes%20all%20%2Finternal%2Ffeaturegate%2F*%20requests%20here%20but%20does%20NOT%0A%09%2F%2F%20strip%20the%20prefix%20%E2%80%94%20strings.TrimPrefix%20does%20that%20explicitly%20below.%0A%09raw%20%3A%3D%20strings.TrimPrefix%28r.URL.Path%2C%20%22%2Finternal%2Ffeaturegate%2F%22%29%0A%09raw%20%3D%20strings.Trim%28raw%2C%20%22%2F%22%29%0A%09tenantID%2C%20err%20%3A%3D%20uuid.Parse%28raw%29%0A%09if%20err%20!%3D%20nil%20%7B%0A%09%09w.Header%28%29.Set%28%22Content-Type%22%2C%20%22application%2Fjson%22%29%0A%09%09w.WriteHeader%28http.StatusBadRequest%29%0A%09%09_%2C%20_%20%3D%20w.Write%28%5B%5Dbyte%28%60%7B%22error%22%3A%22invalid%20tenant_id%22%7D%60%29%29%0A%09%09return%0A%09%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%204%0Aapps%2Fedge-api%2Finternal%2Ffeaturegate%2Fgate_test.go%3A239-246%0A%60strContains%60%20is%20a%20manual%20reimplementation%20of%20%60strings.Contains%60.%20Using%20the%20stdlib%20function%20removes%20the%20bespoke%20loop%20and%20makes%20the%20intent%20immediately%20recognisable.%0A%0A%60%60%60suggestion%0A%2F%2F%20strContains%20is%20an%20alias%20for%20strings.Contains%20kept%20here%20for%20test%20readability.%0A%2F%2F%20Use%20strings.Contains%20directly%20in%20new%20tests.%0Afunc%20strContains%28s%2C%20sub%20string%29%20bool%20%7B%20return%20strings.Contains%28s%2C%20sub%29%20%7D%0A%60%60%60%0A%0A&repo=sakibsadmanshajib%2Fhive&pr=251&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat: per-tenant feature gate middleware..."](https://github.com/sakibsadmanshajib/hive/commit/801e1c3a14b533da238a68d0e2aade183e32af4e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39981282)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->