### PR TITLE
ci: pre-ship licence clearance gate -- SBOM, block AGPL/GPL (#242)

### DIFF
--- a/.github/workflows/license-gate.yml
+++ b/.github/workflows/license-gate.yml
@@ -1,0 +1,96 @@
+name: Licence Gate (SBOM + AGPL/GPL block)
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'apps/**'
+      - 'packages/**'
+      - 'go.work'
+      - 'go.work.sum'
+      - 'scripts/sbom-license-check.sh'
+      - 'scripts/license-allowlist.json'
+      - '.github/workflows/license-gate.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'apps/**'
+      - 'packages/**'
+      - 'go.work'
+      - 'go.work.sum'
+      - 'scripts/sbom-license-check.sh'
+      - 'scripts/license-allowlist.json'
+      - '.github/workflows/license-gate.yml'
+  workflow_dispatch:
+    inputs:
+      report_only:
+        description: 'Run in report-only mode (findings logged, build not failed)'
+        type: boolean
+        default: false
+
+# NOTE: This job is NOT yet wired into branch-protection required checks.
+# Enabling it as a required check is an owner decision tracked separately.
+# See .github/branch-protection-main.json for the current required-check list.
+
+concurrency:
+  group: license-gate-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  license-gate:
+    name: Licence gate (SBOM + AGPL/GPL block)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+          cache-dependency-path: |
+            apps/edge-api/go.sum
+            apps/control-plane/go.sum
+            packages/storage/go.sum
+
+      - name: Cache go-licenses binary
+        uses: actions/cache@v4
+        with:
+          path: ~/go/bin/go-licenses
+          key: go-licenses-v1.6.0-${{ runner.os }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: apps/web-console/package-lock.json
+
+      - name: Install web-console deps
+        working-directory: apps/web-console
+        run: npm ci --ignore-scripts
+
+      - name: Run licence gate
+        shell: bash
+        run: |
+          set -euo pipefail
+          flag=""
+          if [ "${{ github.event.inputs.report_only || 'false' }}" = "true" ]; then
+            flag="--report-only"
+          fi
+          chmod +x scripts/sbom-license-check.sh
+          ./scripts/sbom-license-check.sh $flag
+
+      - name: Upload SBOM artefacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom-${{ github.sha }}
+          path: |
+            SBOM.json
+            SBOM-go.json
+            SBOM-npm.json
+          if-no-files-found: ignore
+          retention-days: 90

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ Thumbs.db
 .docker/
 
 # Generated
+SBOM.json
+SBOM-go.json
+SBOM-npm.json
 /packages/openai-contract/generated/
 /apps/edge-api/internal/generated/
 __pycache__/

--- a/docs/license-allowlist.md
+++ b/docs/license-allowlist.md
@@ -1,0 +1,83 @@
+# Licence Exception Allowlist
+
+## Purpose
+
+The Hive sovereign edge is distributed as a proprietary, closed-integrated product to regulated buyers. AGPL and GPL dependencies are blocked by default because they impose source-disclosure obligations incompatible with that commercial model.
+
+This document describes the process for adding a justified exception when a blocked dependency cannot be replaced.
+
+## Blocked licences
+
+The following SPDX identifiers fail the licence gate unconditionally:
+
+| SPDX ID | Reason |
+|---------|--------|
+| GPL-1.0 | Source-disclosure obligation |
+| GPL-2.0, GPL-2.0-only, GPL-2.0-or-later | Source-disclosure obligation |
+| GPL-3.0, GPL-3.0-only, GPL-3.0-or-later | Source-disclosure obligation |
+| AGPL-2.0 | Network-use source-disclosure obligation |
+| AGPL-3.0, AGPL-3.0-only, AGPL-3.0-or-later | Network-use source-disclosure obligation |
+
+## Allowed licences (no action required)
+
+MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, MPL-2.0, LGPL-2.1, LGPL-3.0, CC0-1.0, Unlicense, and other permissive or weak-copyleft licences that do not require source disclosure of the combined work.
+
+## Adding an exception
+
+### When is an exception appropriate?
+
+An exception is appropriate only when all three conditions are met:
+
+1. No permissively licensed alternative exists that provides equivalent functionality.
+2. Legal counsel (or the responsible owner) has confirmed the specific usage does not trigger the licence's source-disclosure requirement (e.g. LGPL used only as a dynamically linked library with no modifications).
+3. The justification is documented and reviewable.
+
+### Process
+
+1. Open a PR that modifies `scripts/license-allowlist.json` only (keep the allowlist change isolated from feature work).
+
+2. Add an entry to the `packages` array:
+
+   ```json
+   {
+     "name": "<exact package name as it appears in the SBOM>",
+     "spdxId": "<blocked SPDX identifier>",
+     "ecosystem": "go | npm",
+     "justification": "One or two sentences explaining why replacement is not feasible and why the usage does not trigger source-disclosure obligations.",
+     "approvedBy": "<GitHub username of approving owner or counsel>",
+     "approvedAt": "<ISO 8601 date, e.g. 2026-07-01>"
+   }
+   ```
+
+3. Request review from the project owner (sakibsadmanshajib) and, for AGPL packages, from legal counsel before merging.
+
+4. The PR description must quote the relevant licence clause and explain why it does not apply to this usage.
+
+### Example entry
+
+```json
+{
+  "name": "some-library@2.1.0",
+  "spdxId": "LGPL-2.1",
+  "ecosystem": "npm",
+  "justification": "Used only as a dynamically linked runtime dependency with no source modifications. LGPL-2.1 Section 6 permits distribution without source disclosure under these conditions.",
+  "approvedBy": "sakibsadmanshajib",
+  "approvedAt": "2026-07-01"
+}
+```
+
+## Allowlist file location
+
+`scripts/license-allowlist.json`
+
+## Running the gate locally
+
+```bash
+# Full check (fails on violations):
+./scripts/sbom-license-check.sh
+
+# Audit mode (reports violations, exits 0):
+./scripts/sbom-license-check.sh --report-only
+```
+
+Generated SBOM files (`SBOM.json`, `SBOM-go.json`, `SBOM-npm.json`) are written to the repo root and should not be committed to version control (they are gitignored). CI uploads them as build artefacts on every run and attaches them to release tags.

--- a/scripts/license-allowlist.json
+++ b/scripts/license-allowlist.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "./license-allowlist.schema.json",
+  "comment": "Approved licence exceptions for the Hive sovereign edge. Each entry requires written justification and reviewer sign-off. See docs/license-allowlist.md.",
+  "packages": []
+}

--- a/scripts/sbom-license-check.sh
+++ b/scripts/sbom-license-check.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+# sbom-license-check.sh -- Generate a licence manifest for Go modules and npm
+# packages, then fail if any dependency is AGPL or GPL.
+#
+# Usage:
+#   ./scripts/sbom-license-check.sh [--report-only]
+#
+#   --report-only   Write the SBOM and report all findings without failing.
+#                   Use this flag to audit the current tree without blocking CI.
+#
+# Output files (written to repo root):
+#   SBOM-go.json      Go module licences as JSON array
+#   SBOM-npm.json     npm package licences as JSON array
+#   SBOM.json         Combined SPDX-2.3-compatible manifest
+#
+# Blocked licences (any SPDX variant):
+#   GPL-1.0, GPL-2.0, GPL-3.0 and all -only/-or-later suffixes
+#   AGPL-2.0, AGPL-3.0 and all -only/-or-later suffixes
+#
+# Adding a licence exception (allowlist):
+#   See docs/license-allowlist.md for the required process.
+#   Add the package to scripts/license-allowlist.json with written justification.
+#
+# Requirements:
+#   go >= 1.21
+#   github.com/google/go-licenses v1.6.0 (auto-installed if absent)
+#   node >= 18, npm, npx
+
+set -euo pipefail
+
+REPORT_ONLY=false
+for arg in "$@"; do
+  case "$arg" in
+    --report-only) REPORT_ONLY=true ;;
+    *) echo "Unknown argument: $arg" >&2; exit 1 ;;
+  esac
+done
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ALLOWLIST_FILE="${REPO_ROOT}/scripts/license-allowlist.json"
+GO_SBOM="${REPO_ROOT}/SBOM-go.json"
+NPM_SBOM="${REPO_ROOT}/SBOM-npm.json"
+NPM_RAW_TMP=$(mktemp)
+COMBINED_SBOM="${REPO_ROOT}/SBOM.json"
+GO_CSV_TMP=$(mktemp)
+trap 'rm -f "${GO_CSV_TMP}" "${NPM_RAW_TMP}"' EXIT
+
+# SPDX identifiers that are blocked unconditionally.
+BLOCKED_LICENSES=(
+  "GPL-1.0"
+  "GPL-2.0"
+  "GPL-2.0-only"
+  "GPL-2.0-or-later"
+  "GPL-3.0"
+  "GPL-3.0-only"
+  "GPL-3.0-or-later"
+  "AGPL-2.0"
+  "AGPL-3.0"
+  "AGPL-3.0-only"
+  "AGPL-3.0-or-later"
+)
+
+echo "==> Licence clearance gate"
+echo "    Repo root:   ${REPO_ROOT}"
+echo "    Allowlist:   ${ALLOWLIST_FILE}"
+echo "    Report-only: ${REPORT_ONLY}"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Helper: read allowlisted package names from scripts/license-allowlist.json
+# ---------------------------------------------------------------------------
+allowlisted_packages() {
+  if [ -f "${ALLOWLIST_FILE}" ]; then
+    node -e "
+      const data = JSON.parse(require('fs').readFileSync('${ALLOWLIST_FILE}', 'utf8'));
+      (data.packages || []).forEach(p => console.log(p.name));
+    " 2>/dev/null || true
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Step 1: Go licences
+# ---------------------------------------------------------------------------
+echo "==> Scanning Go modules..."
+
+GO_LICENSES_VERSION="v1.6.0"
+if ! command -v go-licenses &>/dev/null; then
+  echo "    Installing google/go-licenses@${GO_LICENSES_VERSION}..."
+  go install "github.com/google/go-licenses@${GO_LICENSES_VERSION}"
+fi
+
+GO_MODULES=(
+  "${REPO_ROOT}/apps/control-plane"
+  "${REPO_ROOT}/apps/edge-api"
+  "${REPO_ROOT}/packages/storage"
+  "${REPO_ROOT}/packages/audit-canonical"
+)
+
+for mod_path in "${GO_MODULES[@]}"; do
+  if [ ! -d "${mod_path}" ]; then
+    echo "    WARNING: module path not found, skipping: ${mod_path}"
+    continue
+  fi
+  mod_name=$(basename "${mod_path}")
+  echo "    Scanning module: ${mod_name}"
+  (
+    cd "${mod_path}"
+    # --ignore suppresses the first-party module itself so only third-party
+    # deps appear in the output.
+    go-licenses csv ./... \
+      --ignore "github.com/sakibsadmanshajib/hive" \
+      2>/dev/null
+  ) >> "${GO_CSV_TMP}" || {
+    echo "    WARNING: go-licenses returned non-zero for ${mod_name}."
+  }
+done
+
+sort -u "${GO_CSV_TMP}" -o "${GO_CSV_TMP}"
+
+# Convert CSV to JSON array. go-licenses CSV format: name,licenceURL,spdxId
+node - "${GO_CSV_TMP}" "${GO_SBOM}" <<'EOF'
+const fs = require('fs');
+const [,, csvPath, outPath] = process.argv;
+const lines = fs.readFileSync(csvPath, 'utf8').trim().split('\n').filter(Boolean);
+const entries = lines.map(line => {
+  const parts = line.split(',');
+  return {
+    name:      parts[0] || '',
+    url:       parts[1] || '',
+    spdxId:    (parts[2] || 'UNKNOWN').trim(),
+    ecosystem: 'go',
+  };
+});
+fs.writeFileSync(outPath, JSON.stringify(entries, null, 2));
+console.log('    Go entries: ' + entries.length);
+EOF
+
+# ---------------------------------------------------------------------------
+# Step 2: npm licences (web-console)
+# ---------------------------------------------------------------------------
+echo ""
+echo "==> Scanning npm packages (apps/web-console)..."
+
+WEB_CONSOLE="${REPO_ROOT}/apps/web-console"
+if [ ! -d "${WEB_CONSOLE}/node_modules" ]; then
+  echo "    node_modules not found -- running npm ci..."
+  (cd "${WEB_CONSOLE}" && npm ci --ignore-scripts)
+fi
+
+# Pinned version of license-checker (MIT licensed, well-maintained).
+# ponytail: npx --yes installs ephemerally; no persistent global install needed.
+npx --yes license-checker@25.0.1 \
+  --start "${WEB_CONSOLE}" \
+  --excludePrivatePackages \
+  --json > "${NPM_RAW_TMP}" 2>/dev/null
+
+node - "${NPM_RAW_TMP}" "${NPM_SBOM}" <<'EOF'
+const fs = require('fs');
+const [,, rawPath, outPath] = process.argv;
+const raw = JSON.parse(fs.readFileSync(rawPath, 'utf8'));
+const entries = Object.entries(raw).map(([pkg, info]) => ({
+  name:      pkg,
+  url:       info.repository || '',
+  spdxId:    (info.licenses || 'UNKNOWN').replace(/[()]/g, '').trim(),
+  ecosystem: 'npm',
+}));
+fs.writeFileSync(outPath, JSON.stringify(entries, null, 2));
+console.log('    npm entries: ' + entries.length);
+EOF
+
+# ---------------------------------------------------------------------------
+# Step 3: Combine into SBOM.json
+# ---------------------------------------------------------------------------
+echo ""
+echo "==> Writing combined SBOM..."
+
+node - "${GO_SBOM}" "${NPM_SBOM}" "${COMBINED_SBOM}" <<'EOF'
+const fs = require('fs');
+const [,, goPath, npmPath, outPath] = process.argv;
+const go  = JSON.parse(fs.readFileSync(goPath,  'utf8'));
+const npm = JSON.parse(fs.readFileSync(npmPath, 'utf8'));
+const combined = {
+  spdxVersion: 'SPDX-2.3',
+  dataLicence: 'CC0-1.0',
+  name:        'hive-sovereign-edge',
+  generatedAt: new Date().toISOString(),
+  packages:    [...go, ...npm],
+};
+fs.writeFileSync(outPath, JSON.stringify(combined, null, 2));
+console.log('    Total packages: ' + combined.packages.length);
+EOF
+
+# ---------------------------------------------------------------------------
+# Step 4: Licence gate -- detect blocked SPDX IDs
+# ---------------------------------------------------------------------------
+echo ""
+echo "==> Running licence gate..."
+
+ALLOWLIST_NAMES=$(allowlisted_packages)
+VIOLATION_COUNT=0
+VIOLATION_LOG=""
+
+# Stream each package from the combined SBOM through the checker.
+while IFS=$'\t' read -r pkg_name pkg_spdx; do
+  # Skip if explicitly allowlisted.
+  if [ -n "${ALLOWLIST_NAMES}" ] && echo "${ALLOWLIST_NAMES}" | grep -qxF "${pkg_name}"; then
+    echo "    ALLOWLISTED: ${pkg_name} (${pkg_spdx})"
+    continue
+  fi
+
+  for blocked in "${BLOCKED_LICENSES[@]}"; do
+    if echo "${pkg_spdx}" | grep -qiF "${blocked}"; then
+      VIOLATION_COUNT=$((VIOLATION_COUNT + 1))
+      VIOLATION_LOG="${VIOLATION_LOG}    * ${pkg_name}: ${pkg_spdx}\n"
+      echo "    BLOCKED: ${pkg_name} -- ${pkg_spdx}"
+      break
+    fi
+  done
+done < <(node - "${COMBINED_SBOM}" <<'EOF'
+const fs = require('fs');
+const d = JSON.parse(fs.readFileSync(process.argv[1], 'utf8'));
+d.packages.forEach(p => process.stdout.write((p.name || '') + '\t' + (p.spdxId || '') + '\n'));
+EOF
+)
+
+# ---------------------------------------------------------------------------
+# Step 5: Result
+# ---------------------------------------------------------------------------
+echo ""
+if [ "${VIOLATION_COUNT}" -eq 0 ]; then
+  echo "==> PASS -- No AGPL or GPL dependencies detected."
+  echo "    SBOM written to: ${COMBINED_SBOM}"
+  exit 0
+else
+  echo "==> FAIL -- ${VIOLATION_COUNT} blocked licence(s) found:"
+  printf "%b" "${VIOLATION_LOG}"
+  echo ""
+  echo "    To resolve:"
+  echo "    1. Replace the dependency with a permissively licensed alternative."
+  echo "    2. If an exception is legally justified, add it to scripts/license-allowlist.json"
+  echo "       following the process in docs/license-allowlist.md."
+  echo "    3. All exceptions require written justification and reviewer approval."
+  echo ""
+  echo "    SBOM written to: ${COMBINED_SBOM}"
+  if [ "${REPORT_ONLY}" = "true" ]; then
+    echo "    (--report-only mode: exiting 0)"
+    exit 0
+  fi
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/license-gate.yml`: scans Go modules (control-plane, edge-api, packages/storage, packages/audit-canonical) and web-console npm packages on every PR/push to main that touches app or package code.
- Adds `scripts/sbom-license-check.sh`: orchestrates `go-licenses v1.6.0` (Apache-2.0) and `license-checker v25.0.1` (BSD-3-Clause via npx), emits `SBOM-go.json`, `SBOM-npm.json`, and a combined `SBOM.json`.
- Adds `scripts/license-allowlist.json`: empty allowlist ships with this PR; exception entries require written justification and reviewer approval.
- Adds `docs/license-allowlist.md`: process doc for adding a justified exception.
- Gitignores generated SBOM files (CI uploads them as 90-day artefacts).

## Tools and versions

| Tool | Version | Licence |
|------|---------|---------|
| google/go-licenses | v1.6.0 (pinned) | Apache-2.0 |
| license-checker (npm) | 25.0.1 (pinned, via npx) | BSD-3-Clause |

## Blocked licences

GPL-1.0, GPL-2.0, GPL-2.0-only, GPL-2.0-or-later, GPL-3.0, GPL-3.0-only, GPL-3.0-or-later, AGPL-2.0, AGPL-3.0, AGPL-3.0-only, AGPL-3.0-or-later.

Allowed: MIT, Apache-2.0, BSD variants, ISC, MPL-2.0, LGPL (weak copyleft only), CC0-1.0.

## Current tree result

Scanner not run locally (Go build environment not available in this worktree). No known AGPL/GPL deps in the Go or npm dependency graphs based on dependency review. First CI run will surface any real violations as build failures.

## How to add a licence exception

1. Add an entry to `scripts/license-allowlist.json` with `name`, `spdxId`, `ecosystem`, `justification`, `approvedBy`, and `approvedAt`.
2. Open a dedicated PR for the allowlist change (isolated from feature work).
3. Obtain written approval from the project owner (sakibsadmanshajib) and, for AGPL entries, from legal counsel.
4. Full process in `docs/license-allowlist.md`.

## Not yet a required check

This workflow is intentionally NOT wired into branch-protection required checks. Enabling it as a required check is an owner decision tracked separately in `.github/branch-protection-main.json`. The job runs and reports on every qualifying PR so results are visible before the gate is enforced.

Closes #242

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces a licence-clearance CI gate that generates Go and npm SBOMs, then blocks any AGPL/GPL dependency from merging. Two bugs in `scripts/sbom-license-check.sh` make the gate non-functional as written and require fixes before the first CI run produces reliable results.

- **Gate always passes (process.argv off-by-one):** The final Node.js inline script at step 4 reads `process.argv[1]`, which is `'-'` (the stdin sentinel) when invoking `node -`. The SBOM path is at `process.argv[2]`. `fs.readFileSync('-')` throws `ENOENT` inside the process substitution; bash does not surface that exit status to `set -e`, so the `while` loop sees no input, `VIOLATION_COUNT` stays 0, and the script always exits 0 regardless of what licenses are in the SBOM.
- **LGPL false positive:** `grep -qiF \"${blocked}\"` is a substring match. The pattern `\"GPL-3.0\"` is a literal substring of `\"LGPL-3.0\"`, `\"LGPL-3.0-only\"`, and `\"LGPL-3.0-or-later\"`. LGPL-3.x is listed as allowed, but any package reporting that SPDX ID would be incorrectly blocked once the argv bug is fixed. Switching to `grep -qxF` (exact line match) fixes this.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Not safe to merge without fixing the two script bugs — the gate currently always reports PASS and would incorrectly block LGPL-3.x once the first bug is corrected.

The off-by-one `process.argv` error means the license gate produces no output from its process substitution and exits 0 unconditionally, making the entire gate ineffective from day one. The LGPL substring-match bug is a secondary correctness issue that would surface immediately after the first bug is fixed. Both issues are isolated to `sbom-license-check.sh` and have straightforward one-line fixes; the workflow structure, documentation, and gitignore changes are all solid.

scripts/sbom-license-check.sh needs two targeted fixes (process.argv index and grep match mode) before this gate provides any real protection.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/sbom-license-check.sh | Core license gate script with two correctness bugs: `process.argv[1]` should be `process.argv[2]` in the gate-checker step (renders the gate non-functional — always PASS), and `grep -qiF` substring matching causes LGPL-3.x to be falsely blocked by the GPL-3.x patterns. |
| .github/workflows/license-gate.yml | Workflow structure is sound (pinned actions, correct permissions, concurrency guard, artifact upload). Two minor issues: `packages/audit-canonical/go.sum` missing from `cache-dependency-path`, and `github.event.inputs.report_only` injected directly into shell rather than through an env var. |
| scripts/license-allowlist.json | Empty allowlist ships correctly; `$schema` reference points to a non-existent `license-allowlist.schema.json` file, causing broken schema validation in editors. |
| docs/license-allowlist.md | Process documentation is clear and complete: blocked/allowed license table, exception workflow, required JSON fields, and local usage instructions all look correct. |
| .gitignore | Adds the three generated SBOM files to gitignore; correct placement and no conflicts with existing entries. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%206%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%206%0Ascripts%2Fsbom-license-check.sh%3A220-221%0AGate%20checker%20reads%20%60process.argv%5B1%5D%60%2C%20which%20is%20%60'-'%60%20%28the%20stdin%20sentinel%29%20when%20a%20script%20is%20fed%20via%20%60node%20-%60%2C%20not%20the%20%60%24%7BCOMBINED_SBOM%7D%60%20path%20that%20is%20actually%20at%20%60process.argv%5B2%5D%60.%20%60fs.readFileSync%28'-'%2C%20'utf8'%29%60%20throws%20%60ENOENT%60%3B%20the%20error%20is%20inside%20a%20process-substitution%20%60%3C%20%3C%28...%29%60%20that%20bash%20does%20not%20surface%20to%20%60set%20-e%60%2C%20so%20the%20while%20loop%20receives%20no%20input%2C%20%60VIOLATION_COUNT%60%20stays%200%2C%20and%20the%20gate%20always%20reports%20PASS%20%E2%80%94%20regardless%20of%20what%20licenses%20are%20present%20in%20the%20SBOM.%20Every%20other%20inline%20script%20in%20this%20file%20correctly%20uses%20%60const%20%5B%2C%2C%20arg%5D%20%3D%20process.argv%60%20to%20skip%20indices%200%20and%201.%0A%0A%60%60%60suggestion%0Aconst%20fs%20%3D%20require%28'fs'%29%3B%0Aconst%20d%20%3D%20JSON.parse%28fs.readFileSync%28process.argv%5B2%5D%2C%20'utf8'%29%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%206%0Ascripts%2Fsbom-license-check.sh%3A212%0A%60grep%20-qiF%20%22%24%7Bblocked%7D%22%60%20is%20a%20substring%20check%2C%20not%20a%20full-string%20match.%20The%20pattern%20%60%22GPL-3.0%22%60%20is%20a%20literal%20substring%20of%20%60%22LGPL-3.0%22%60%2C%20%60%22LGPL-3.0-only%22%60%2C%20and%20%60%22LGPL-3.0-or-later%22%60%3B%20similarly%20%60%22GPL-2.0-or-later%22%60%20appears%20inside%20%60%22LGPL-2.0-or-later%22%60.%20%60docs%2Flicense-allowlist.md%60%20explicitly%20lists%20LGPL-2.1%20and%20LGPL-3.0%20as%20allowed%2C%20but%20this%20check%20would%20block%20any%20package%20reporting%20an%20LGPL-3.x%20SPDX%20identifier.%20Using%20%60grep%20-qxF%60%20%28exact%20whole-line%20match%29%20fixes%20the%20false-positive%20without%20changing%20the%20true-positive%20behaviour.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20echo%20%22%24%7Bpkg_spdx%7D%22%20%7C%20grep%20-qxF%20%22%24%7Bblocked%7D%22%3B%20then%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%206%0A.github%2Fworkflows%2Flicense-gate.yml%3A75-84%0AThe%20%60%24%7B%7B%20github.event.inputs.report_only%20%7D%7D%60%20expression%20is%20interpolated%20directly%20into%20the%20shell%20script%20body.%20For%20%60boolean%60%20inputs%20GitHub%20constrains%20the%20value%20to%20%60true%60%2F%60false%60%2C%20so%20the%20injection%20surface%20is%20narrow%20here%2C%20but%20the%20pattern%20is%20unsafe%20in%20general%20and%20the%20GitHub%20Actions%20hardening%20guide%20recommends%20routing%20context%20values%20through%20an%20%60env%3A%60%20key%20first%20to%20ensure%20they%20are%20never%20interpreted%20as%20shell%20code.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20-%20name%3A%20Run%20licence%20gate%0A%20%20%20%20%20%20%20%20shell%3A%20bash%0A%20%20%20%20%20%20%20%20env%3A%0A%20%20%20%20%20%20%20%20%20%20REPORT_ONLY%3A%20%24%7B%7B%20github.event.inputs.report_only%20%7C%7C%20'false'%20%7D%7D%0A%20%20%20%20%20%20%20%20run%3A%20%7C%0A%20%20%20%20%20%20%20%20%20%20set%20-euo%20pipefail%0A%20%20%20%20%20%20%20%20%20%20flag%3D%22%22%0A%20%20%20%20%20%20%20%20%20%20if%20%5B%20%22%24%7BREPORT_ONLY%7D%22%20%3D%20%22true%22%20%5D%3B%20then%0A%20%20%20%20%20%20%20%20%20%20%20%20flag%3D%22--report-only%22%0A%20%20%20%20%20%20%20%20%20%20fi%0A%20%20%20%20%20%20%20%20%20%20chmod%20%2Bx%20scripts%2Fsbom-license-check.sh%0A%20%20%20%20%20%20%20%20%20%20.%2Fscripts%2Fsbom-license-check.sh%20%24flag%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%206%0A.github%2Fworkflows%2Flicense-gate.yml%3A54-57%0A%60packages%2Faudit-canonical%60%20is%20scanned%20by%20%60sbom-license-check.sh%60%20%28line%2096%20of%20the%20shell%20script%29%20but%20its%20%60go.sum%60%20is%20not%20listed%20in%20%60cache-dependency-path%60.%20When%20that%20module's%20dependencies%20change%20the%20cache%20key%20will%20not%20invalidate%2C%20potentially%20serving%20a%20stale%20module%20cache%20for%20that%20scan%20target.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20cache-dependency-path%3A%20%7C%0A%20%20%20%20%20%20%20%20%20%20%20%20apps%2Fedge-api%2Fgo.sum%0A%20%20%20%20%20%20%20%20%20%20%20%20apps%2Fcontrol-plane%2Fgo.sum%0A%20%20%20%20%20%20%20%20%20%20%20%20packages%2Fstorage%2Fgo.sum%0A%20%20%20%20%20%20%20%20%20%20%20%20packages%2Faudit-canonical%2Fgo.sum%0A%60%60%60%0A%0A%282%20more%20issues%20omitted%20due%20to%20length%20limits.%20Use%20individual%20%22Fix%20in%20Claude%20Code%22%20links%20for%20remaining%20issues.%29%0A&repo=sakibsadmanshajib%2Fhive&pr=255&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%206%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%206%0Ascripts%2Fsbom-license-check.sh%3A220-221%0AGate%20checker%20reads%20%60process.argv%5B1%5D%60%2C%20which%20is%20%60'-'%60%20%28the%20stdin%20sentinel%29%20when%20a%20script%20is%20fed%20via%20%60node%20-%60%2C%20not%20the%20%60%24%7BCOMBINED_SBOM%7D%60%20path%20that%20is%20actually%20at%20%60process.argv%5B2%5D%60.%20%60fs.readFileSync%28'-'%2C%20'utf8'%29%60%20throws%20%60ENOENT%60%3B%20the%20error%20is%20inside%20a%20process-substitution%20%60%3C%20%3C%28...%29%60%20that%20bash%20does%20not%20surface%20to%20%60set%20-e%60%2C%20so%20the%20while%20loop%20receives%20no%20input%2C%20%60VIOLATION_COUNT%60%20stays%200%2C%20and%20the%20gate%20always%20reports%20PASS%20%E2%80%94%20regardless%20of%20what%20licenses%20are%20present%20in%20the%20SBOM.%20Every%20other%20inline%20script%20in%20this%20file%20correctly%20uses%20%60const%20%5B%2C%2C%20arg%5D%20%3D%20process.argv%60%20to%20skip%20indices%200%20and%201.%0A%0A%60%60%60suggestion%0Aconst%20fs%20%3D%20require%28'fs'%29%3B%0Aconst%20d%20%3D%20JSON.parse%28fs.readFileSync%28process.argv%5B2%5D%2C%20'utf8'%29%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%206%0Ascripts%2Fsbom-license-check.sh%3A212%0A%60grep%20-qiF%20%22%24%7Bblocked%7D%22%60%20is%20a%20substring%20check%2C%20not%20a%20full-string%20match.%20The%20pattern%20%60%22GPL-3.0%22%60%20is%20a%20literal%20substring%20of%20%60%22LGPL-3.0%22%60%2C%20%60%22LGPL-3.0-only%22%60%2C%20and%20%60%22LGPL-3.0-or-later%22%60%3B%20similarly%20%60%22GPL-2.0-or-later%22%60%20appears%20inside%20%60%22LGPL-2.0-or-later%22%60.%20%60docs%2Flicense-allowlist.md%60%20explicitly%20lists%20LGPL-2.1%20and%20LGPL-3.0%20as%20allowed%2C%20but%20this%20check%20would%20block%20any%20package%20reporting%20an%20LGPL-3.x%20SPDX%20identifier.%20Using%20%60grep%20-qxF%60%20%28exact%20whole-line%20match%29%20fixes%20the%20false-positive%20without%20changing%20the%20true-positive%20behaviour.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20echo%20%22%24%7Bpkg_spdx%7D%22%20%7C%20grep%20-qxF%20%22%24%7Bblocked%7D%22%3B%20then%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%206%0A.github%2Fworkflows%2Flicense-gate.yml%3A75-84%0AThe%20%60%24%7B%7B%20github.event.inputs.report_only%20%7D%7D%60%20expression%20is%20interpolated%20directly%20into%20the%20shell%20script%20body.%20For%20%60boolean%60%20inputs%20GitHub%20constrains%20the%20value%20to%20%60true%60%2F%60false%60%2C%20so%20the%20injection%20surface%20is%20narrow%20here%2C%20but%20the%20pattern%20is%20unsafe%20in%20general%20and%20the%20GitHub%20Actions%20hardening%20guide%20recommends%20routing%20context%20values%20through%20an%20%60env%3A%60%20key%20first%20to%20ensure%20they%20are%20never%20interpreted%20as%20shell%20code.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20-%20name%3A%20Run%20licence%20gate%0A%20%20%20%20%20%20%20%20shell%3A%20bash%0A%20%20%20%20%20%20%20%20env%3A%0A%20%20%20%20%20%20%20%20%20%20REPORT_ONLY%3A%20%24%7B%7B%20github.event.inputs.report_only%20%7C%7C%20'false'%20%7D%7D%0A%20%20%20%20%20%20%20%20run%3A%20%7C%0A%20%20%20%20%20%20%20%20%20%20set%20-euo%20pipefail%0A%20%20%20%20%20%20%20%20%20%20flag%3D%22%22%0A%20%20%20%20%20%20%20%20%20%20if%20%5B%20%22%24%7BREPORT_ONLY%7D%22%20%3D%20%22true%22%20%5D%3B%20then%0A%20%20%20%20%20%20%20%20%20%20%20%20flag%3D%22--report-only%22%0A%20%20%20%20%20%20%20%20%20%20fi%0A%20%20%20%20%20%20%20%20%20%20chmod%20%2Bx%20scripts%2Fsbom-license-check.sh%0A%20%20%20%20%20%20%20%20%20%20.%2Fscripts%2Fsbom-license-check.sh%20%24flag%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%206%0A.github%2Fworkflows%2Flicense-gate.yml%3A54-57%0A%60packages%2Faudit-canonical%60%20is%20scanned%20by%20%60sbom-license-check.sh%60%20%28line%2096%20of%20the%20shell%20script%29%20but%20its%20%60go.sum%60%20is%20not%20listed%20in%20%60cache-dependency-path%60.%20When%20that%20module's%20dependencies%20change%20the%20cache%20key%20will%20not%20invalidate%2C%20potentially%20serving%20a%20stale%20module%20cache%20for%20that%20scan%20target.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20cache-dependency-path%3A%20%7C%0A%20%20%20%20%20%20%20%20%20%20%20%20apps%2Fedge-api%2Fgo.sum%0A%20%20%20%20%20%20%20%20%20%20%20%20apps%2Fcontrol-plane%2Fgo.sum%0A%20%20%20%20%20%20%20%20%20%20%20%20packages%2Fstorage%2Fgo.sum%0A%20%20%20%20%20%20%20%20%20%20%20%20packages%2Faudit-canonical%2Fgo.sum%0A%60%60%60%0A%0A%23%23%23%20Issue%205%20of%206%0Ascripts%2Flicense-allowlist.json%3A1-2%0AThe%20%60%24schema%60%20key%20references%20%60.%2Flicense-allowlist.schema.json%60%2C%20but%20that%20file%20is%20not%20created%20in%20this%20PR%20and%20does%20not%20exist%20in%20the%20repository.%20Editors%20and%20JSON%20Schema%20validators%20will%20report%20a%20missing%20schema%20URI%20on%20every%20open%2C%20and%20contributors%20following%20the%20schema%20to%20add%20exception%20entries%20will%20get%20no%20validation%20feedback.%0A%0A%60%60%60suggestion%0A%7B%0A%60%60%60%0A%0A%23%23%23%20Issue%206%20of%206%0Ascripts%2Fsbom-license-check.sh%3A110-115%0A%60go-licenses%60%20stderr%20silenced%20across%20all%20modules%20%E2%80%94%20%602%3E%2Fdev%2Fnull%60%20swallows%20every%20diagnostic%20emitted%20by%20%60go-licenses%60%2C%20including%20%22cannot%20determine%20license%22%20notices%2C%20module-resolution%20errors%2C%20and%20dependency%20graph%20parse%20failures.%20When%20the%20tool%20returns%20non-zero%20the%20loop%20emits%20a%20WARNING%20to%20CI%20output%20but%20provides%20no%20indication%20of%20what%20actually%20failed.%0A%0A&pr=255&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22sakibsadmanshajib%2Fhive%22%20on%20the%20existing%20branch%20%22feat%2Fcarl-license-gate-242%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fcarl-license-gate-242%22.%0A%0AFix%20the%20following%206%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%206%0Ascripts%2Fsbom-license-check.sh%3A220-221%0AGate%20checker%20reads%20%60process.argv%5B1%5D%60%2C%20which%20is%20%60'-'%60%20%28the%20stdin%20sentinel%29%20when%20a%20script%20is%20fed%20via%20%60node%20-%60%2C%20not%20the%20%60%24%7BCOMBINED_SBOM%7D%60%20path%20that%20is%20actually%20at%20%60process.argv%5B2%5D%60.%20%60fs.readFileSync%28'-'%2C%20'utf8'%29%60%20throws%20%60ENOENT%60%3B%20the%20error%20is%20inside%20a%20process-substitution%20%60%3C%20%3C%28...%29%60%20that%20bash%20does%20not%20surface%20to%20%60set%20-e%60%2C%20so%20the%20while%20loop%20receives%20no%20input%2C%20%60VIOLATION_COUNT%60%20stays%200%2C%20and%20the%20gate%20always%20reports%20PASS%20%E2%80%94%20regardless%20of%20what%20licenses%20are%20present%20in%20the%20SBOM.%20Every%20other%20inline%20script%20in%20this%20file%20correctly%20uses%20%60const%20%5B%2C%2C%20arg%5D%20%3D%20process.argv%60%20to%20skip%20indices%200%20and%201.%0A%0A%60%60%60suggestion%0Aconst%20fs%20%3D%20require%28'fs'%29%3B%0Aconst%20d%20%3D%20JSON.parse%28fs.readFileSync%28process.argv%5B2%5D%2C%20'utf8'%29%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%206%0Ascripts%2Fsbom-license-check.sh%3A212%0A%60grep%20-qiF%20%22%24%7Bblocked%7D%22%60%20is%20a%20substring%20check%2C%20not%20a%20full-string%20match.%20The%20pattern%20%60%22GPL-3.0%22%60%20is%20a%20literal%20substring%20of%20%60%22LGPL-3.0%22%60%2C%20%60%22LGPL-3.0-only%22%60%2C%20and%20%60%22LGPL-3.0-or-later%22%60%3B%20similarly%20%60%22GPL-2.0-or-later%22%60%20appears%20inside%20%60%22LGPL-2.0-or-later%22%60.%20%60docs%2Flicense-allowlist.md%60%20explicitly%20lists%20LGPL-2.1%20and%20LGPL-3.0%20as%20allowed%2C%20but%20this%20check%20would%20block%20any%20package%20reporting%20an%20LGPL-3.x%20SPDX%20identifier.%20Using%20%60grep%20-qxF%60%20%28exact%20whole-line%20match%29%20fixes%20the%20false-positive%20without%20changing%20the%20true-positive%20behaviour.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20echo%20%22%24%7Bpkg_spdx%7D%22%20%7C%20grep%20-qxF%20%22%24%7Bblocked%7D%22%3B%20then%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%206%0A.github%2Fworkflows%2Flicense-gate.yml%3A75-84%0AThe%20%60%24%7B%7B%20github.event.inputs.report_only%20%7D%7D%60%20expression%20is%20interpolated%20directly%20into%20the%20shell%20script%20body.%20For%20%60boolean%60%20inputs%20GitHub%20constrains%20the%20value%20to%20%60true%60%2F%60false%60%2C%20so%20the%20injection%20surface%20is%20narrow%20here%2C%20but%20the%20pattern%20is%20unsafe%20in%20general%20and%20the%20GitHub%20Actions%20hardening%20guide%20recommends%20routing%20context%20values%20through%20an%20%60env%3A%60%20key%20first%20to%20ensure%20they%20are%20never%20interpreted%20as%20shell%20code.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20-%20name%3A%20Run%20licence%20gate%0A%20%20%20%20%20%20%20%20shell%3A%20bash%0A%20%20%20%20%20%20%20%20env%3A%0A%20%20%20%20%20%20%20%20%20%20REPORT_ONLY%3A%20%24%7B%7B%20github.event.inputs.report_only%20%7C%7C%20'false'%20%7D%7D%0A%20%20%20%20%20%20%20%20run%3A%20%7C%0A%20%20%20%20%20%20%20%20%20%20set%20-euo%20pipefail%0A%20%20%20%20%20%20%20%20%20%20flag%3D%22%22%0A%20%20%20%20%20%20%20%20%20%20if%20%5B%20%22%24%7BREPORT_ONLY%7D%22%20%3D%20%22true%22%20%5D%3B%20then%0A%20%20%20%20%20%20%20%20%20%20%20%20flag%3D%22--report-only%22%0A%20%20%20%20%20%20%20%20%20%20fi%0A%20%20%20%20%20%20%20%20%20%20chmod%20%2Bx%20scripts%2Fsbom-license-check.sh%0A%20%20%20%20%20%20%20%20%20%20.%2Fscripts%2Fsbom-license-check.sh%20%24flag%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%206%0A.github%2Fworkflows%2Flicense-gate.yml%3A54-57%0A%60packages%2Faudit-canonical%60%20is%20scanned%20by%20%60sbom-license-check.sh%60%20%28line%2096%20of%20the%20shell%20script%29%20but%20its%20%60go.sum%60%20is%20not%20listed%20in%20%60cache-dependency-path%60.%20When%20that%20module's%20dependencies%20change%20the%20cache%20key%20will%20not%20invalidate%2C%20potentially%20serving%20a%20stale%20module%20cache%20for%20that%20scan%20target.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20cache-dependency-path%3A%20%7C%0A%20%20%20%20%20%20%20%20%20%20%20%20apps%2Fedge-api%2Fgo.sum%0A%20%20%20%20%20%20%20%20%20%20%20%20apps%2Fcontrol-plane%2Fgo.sum%0A%20%20%20%20%20%20%20%20%20%20%20%20packages%2Fstorage%2Fgo.sum%0A%20%20%20%20%20%20%20%20%20%20%20%20packages%2Faudit-canonical%2Fgo.sum%0A%60%60%60%0A%0A%23%23%23%20Issue%205%20of%206%0Ascripts%2Flicense-allowlist.json%3A1-2%0AThe%20%60%24schema%60%20key%20references%20%60.%2Flicense-allowlist.schema.json%60%2C%20but%20that%20file%20is%20not%20created%20in%20this%20PR%20and%20does%20not%20exist%20in%20the%20repository.%20Editors%20and%20JSON%20Schema%20validators%20will%20report%20a%20missing%20schema%20URI%20on%20every%20open%2C%20and%20contributors%20following%20the%20schema%20to%20add%20exception%20entries%20will%20get%20no%20validation%20feedback.%0A%0A%60%60%60suggestion%0A%7B%0A%60%60%60%0A%0A%23%23%23%20Issue%206%20of%206%0Ascripts%2Fsbom-license-check.sh%3A110-115%0A%60go-licenses%60%20stderr%20silenced%20across%20all%20modules%20%E2%80%94%20%602%3E%2Fdev%2Fnull%60%20swallows%20every%20diagnostic%20emitted%20by%20%60go-licenses%60%2C%20including%20%22cannot%20determine%20license%22%20notices%2C%20module-resolution%20errors%2C%20and%20dependency%20graph%20parse%20failures.%20When%20the%20tool%20returns%20non-zero%20the%20loop%20emits%20a%20WARNING%20to%20CI%20output%20but%20provides%20no%20indication%20of%20what%20actually%20failed.%0A%0A&repo=sakibsadmanshajib%2Fhive&pr=255&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["ci: pre-ship licence clearance gate -- S..."](https://github.com/sakibsadmanshajib/hive/commit/966165137af65a8988fb0cd10541d2cceef2e103) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39983827)</sub>

> Greptile also left **6 inline comments** on this PR.

<!-- /greptile_comment -->