### PR TITLE
feat: runtime enforcement of HIVE_SOVEREIGN -- refuse external provider keys at startup (#245)

### DIFF
--- a/apps/control-plane/cmd/server/main.go
+++ b/apps/control-plane/cmd/server/main.go
@@ -56,6 +56,7 @@ import (
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/tenants"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/tenant/settings"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/usage"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/sovereign"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/waldrainer"
 	"github.com/sakibsadmanshajib/hive/packages/storage"
 	"github.com/jackc/pgx/v5"
@@ -166,6 +167,12 @@ func (a *accountsResolverAdapter) EnsureViewerContext(ctx context.Context) (uuid
 }
 
 func main() {
+	// Sovereign-mode guard: fail fast before any service wiring when external
+	// provider keys are present. See apps/control-plane/internal/sovereign for tests.
+	if err := sovereign.Check(os.Getenv); err != nil {
+		log.Fatal(err)
+	}
+
 	cfg, err := config.Load()
 	if err != nil {
 		log.Fatalf("failed to load config: %v", err)

--- a/apps/control-plane/internal/sovereign/sovereign.go
+++ b/apps/control-plane/internal/sovereign/sovereign.go
@@ -1,5 +1,6 @@
 // Package sovereign enforces data-sovereignty startup constraints.
-// When HIVE_SOVEREIGN=true, external LLM provider keys must not be configured.
+// When HIVE_SOVEREIGN is set to a truthy value, external LLM provider
+// keys must not be configured.
 package sovereign
 
 import (
@@ -13,21 +14,37 @@ var externalProviderKeys = []string{
 	"GROQ_API_KEY",
 }
 
+// isSovereignEnabled returns true for any case-insensitive, trimmed truthy value:
+// "1", "true", "yes", "on". Everything else (including empty) is false.
+func isSovereignEnabled(v string) bool {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
 // Check returns an error if sovereign mode is active and any external provider key is set.
-// Pass os.Getenv as the lookup in production; pass a map lookup in tests.
+// All violating keys are collected and reported together so the operator can fix them
+// in one pass. Pass os.Getenv as the lookup in production; pass a map lookup in tests.
 func Check(getenv func(string) string) error {
-	if strings.TrimSpace(getenv("HIVE_SOVEREIGN")) != "true" {
+	if !isSovereignEnabled(getenv("HIVE_SOVEREIGN")) {
 		return nil
 	}
+	var violations []string
 	for _, key := range externalProviderKeys {
 		if strings.TrimSpace(getenv(key)) != "" {
-			return fmt.Errorf(
-				"FATAL: HIVE_SOVEREIGN=true but %s is set. "+
-					"External LLM providers are prohibited in sovereign mode. "+
-					"Unset the key and restart.",
-				key,
-			)
+			violations = append(violations, key)
 		}
 	}
-	return nil
+	if len(violations) == 0 {
+		return nil
+	}
+	return fmt.Errorf(
+		"FATAL: HIVE_SOVEREIGN=true but the following external LLM provider keys are set: %s. "+
+			"External LLM providers are prohibited in sovereign mode. "+
+			"Unset all listed keys and restart.",
+		strings.Join(violations, ", "),
+	)
 }

--- a/apps/control-plane/internal/sovereign/sovereign.go
+++ b/apps/control-plane/internal/sovereign/sovereign.go
@@ -1,0 +1,33 @@
+// Package sovereign enforces data-sovereignty startup constraints.
+// When HIVE_SOVEREIGN=true, external LLM provider keys must not be configured.
+package sovereign
+
+import (
+	"fmt"
+	"strings"
+)
+
+// externalProviderKeys lists every env var that routes traffic to an external LLM provider.
+var externalProviderKeys = []string{
+	"OPENROUTER_API_KEY",
+	"GROQ_API_KEY",
+}
+
+// Check returns an error if sovereign mode is active and any external provider key is set.
+// Pass os.Getenv as the lookup in production; pass a map lookup in tests.
+func Check(getenv func(string) string) error {
+	if strings.TrimSpace(getenv("HIVE_SOVEREIGN")) != "true" {
+		return nil
+	}
+	for _, key := range externalProviderKeys {
+		if strings.TrimSpace(getenv(key)) != "" {
+			return fmt.Errorf(
+				"FATAL: HIVE_SOVEREIGN=true but %s is set. "+
+					"External LLM providers are prohibited in sovereign mode. "+
+					"Unset the key and restart.",
+				key,
+			)
+		}
+	}
+	return nil
+}

--- a/apps/control-plane/internal/sovereign/sovereign_test.go
+++ b/apps/control-plane/internal/sovereign/sovereign_test.go
@@ -1,0 +1,66 @@
+package sovereign_test
+
+import (
+	"testing"
+
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/sovereign"
+)
+
+func TestCheck(t *testing.T) {
+	tests := []struct {
+		name    string
+		env     map[string]string
+		wantErr bool
+	}{
+		{
+			name:    "sovereign off, no external keys — boots",
+			env:     map[string]string{"HIVE_SOVEREIGN": "false"},
+			wantErr: false,
+		},
+		{
+			name:    "sovereign unset, external keys set — boots (unchanged behaviour)",
+			env:     map[string]string{"OPENROUTER_API_KEY": "sk-test", "GROQ_API_KEY": "gsk-test"},
+			wantErr: false,
+		},
+		{
+			name:    "sovereign on, no external keys — boots",
+			env:     map[string]string{"HIVE_SOVEREIGN": "true"},
+			wantErr: false,
+		},
+		{
+			name:    "sovereign on, OPENROUTER_API_KEY set — startup error",
+			env:     map[string]string{"HIVE_SOVEREIGN": "true", "OPENROUTER_API_KEY": "sk-openrouter"},
+			wantErr: true,
+		},
+		{
+			name:    "sovereign on, GROQ_API_KEY set — startup error",
+			env:     map[string]string{"HIVE_SOVEREIGN": "true", "GROQ_API_KEY": "gsk-groq"},
+			wantErr: true,
+		},
+		{
+			name:    "sovereign on, both external keys set — startup error",
+			env:     map[string]string{"HIVE_SOVEREIGN": "true", "OPENROUTER_API_KEY": "sk-openrouter", "GROQ_API_KEY": "gsk-groq"},
+			wantErr: true,
+		},
+		{
+			name:    "sovereign on, whitespace-only key — not treated as set",
+			env:     map[string]string{"HIVE_SOVEREIGN": "true", "OPENROUTER_API_KEY": "   "},
+			wantErr: false,
+		},
+		{
+			name:    "sovereign on, empty key — boots",
+			env:     map[string]string{"HIVE_SOVEREIGN": "true", "OPENROUTER_API_KEY": ""},
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			lookup := func(key string) string { return tc.env[key] }
+			err := sovereign.Check(lookup)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("Check() error = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/apps/control-plane/internal/sovereign/sovereign_test.go
+++ b/apps/control-plane/internal/sovereign/sovereign_test.go
@@ -1,6 +1,7 @@
 package sovereign_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/sovereign"
@@ -8,13 +9,25 @@ import (
 
 func TestCheck(t *testing.T) {
 	tests := []struct {
-		name    string
-		env     map[string]string
-		wantErr bool
+		name        string
+		env         map[string]string
+		wantErr     bool
+		errContains string // non-empty: assert substring present in error
 	}{
+		// --- flag disabled ---
 		{
-			name:    "sovereign off, no external keys — boots",
-			env:     map[string]string{"HIVE_SOVEREIGN": "false"},
+			name:    "sovereign off (false), external keys set — boots",
+			env:     map[string]string{"HIVE_SOVEREIGN": "false", "OPENROUTER_API_KEY": "sk-test"},
+			wantErr: false,
+		},
+		{
+			name:    "sovereign off (0), external keys set — boots",
+			env:     map[string]string{"HIVE_SOVEREIGN": "0", "OPENROUTER_API_KEY": "sk-test"},
+			wantErr: false,
+		},
+		{
+			name:    "sovereign off (no), external keys set — boots",
+			env:     map[string]string{"HIVE_SOVEREIGN": "no", "OPENROUTER_API_KEY": "sk-test"},
 			wantErr: false,
 		},
 		{
@@ -22,26 +35,73 @@ func TestCheck(t *testing.T) {
 			env:     map[string]string{"OPENROUTER_API_KEY": "sk-test", "GROQ_API_KEY": "gsk-test"},
 			wantErr: false,
 		},
+		// --- flag enabled: truthy variants ---
 		{
-			name:    "sovereign on, no external keys — boots",
+			name:    "sovereign on (true lowercase), no external keys — boots",
 			env:     map[string]string{"HIVE_SOVEREIGN": "true"},
 			wantErr: false,
 		},
 		{
-			name:    "sovereign on, OPENROUTER_API_KEY set — startup error",
-			env:     map[string]string{"HIVE_SOVEREIGN": "true", "OPENROUTER_API_KEY": "sk-openrouter"},
-			wantErr: true,
+			name:    "sovereign on (TRUE uppercase), no external keys — boots",
+			env:     map[string]string{"HIVE_SOVEREIGN": "TRUE"},
+			wantErr: false,
 		},
 		{
-			name:    "sovereign on, GROQ_API_KEY set — startup error",
-			env:     map[string]string{"HIVE_SOVEREIGN": "true", "GROQ_API_KEY": "gsk-groq"},
-			wantErr: true,
+			name:    "sovereign on (True mixed), no external keys — boots",
+			env:     map[string]string{"HIVE_SOVEREIGN": "True"},
+			wantErr: false,
 		},
 		{
-			name:    "sovereign on, both external keys set — startup error",
-			env:     map[string]string{"HIVE_SOVEREIGN": "true", "OPENROUTER_API_KEY": "sk-openrouter", "GROQ_API_KEY": "gsk-groq"},
-			wantErr: true,
+			name:    "sovereign on (1), no external keys — boots",
+			env:     map[string]string{"HIVE_SOVEREIGN": "1"},
+			wantErr: false,
 		},
+		{
+			name:    "sovereign on (yes), no external keys — boots",
+			env:     map[string]string{"HIVE_SOVEREIGN": "yes"},
+			wantErr: false,
+		},
+		{
+			name:    "sovereign on (on), no external keys — boots",
+			env:     map[string]string{"HIVE_SOVEREIGN": "on"},
+			wantErr: false,
+		},
+		{
+			name:    "sovereign on (YES uppercase), no external keys — boots",
+			env:     map[string]string{"HIVE_SOVEREIGN": "YES"},
+			wantErr: false,
+		},
+		{
+			name:    "sovereign on (ON uppercase), no external keys — boots",
+			env:     map[string]string{"HIVE_SOVEREIGN": "ON"},
+			wantErr: false,
+		},
+		// --- flag enabled: violation cases ---
+		{
+			name:        "sovereign on, OPENROUTER_API_KEY set — startup error",
+			env:         map[string]string{"HIVE_SOVEREIGN": "true", "OPENROUTER_API_KEY": "sk-openrouter"},
+			wantErr:     true,
+			errContains: "OPENROUTER_API_KEY",
+		},
+		{
+			name:        "sovereign on (1), GROQ_API_KEY set — startup error",
+			env:         map[string]string{"HIVE_SOVEREIGN": "1", "GROQ_API_KEY": "gsk-groq"},
+			wantErr:     true,
+			errContains: "GROQ_API_KEY",
+		},
+		{
+			name:        "sovereign on (TRUE), both external keys set — reports both in one error",
+			env:         map[string]string{"HIVE_SOVEREIGN": "TRUE", "OPENROUTER_API_KEY": "sk-openrouter", "GROQ_API_KEY": "gsk-groq"},
+			wantErr:     true,
+			errContains: "OPENROUTER_API_KEY",
+		},
+		{
+			name:        "sovereign on (yes), both keys — error also mentions GROQ_API_KEY",
+			env:         map[string]string{"HIVE_SOVEREIGN": "yes", "OPENROUTER_API_KEY": "sk-openrouter", "GROQ_API_KEY": "gsk-groq"},
+			wantErr:     true,
+			errContains: "GROQ_API_KEY",
+		},
+		// --- edge: whitespace / empty ---
 		{
 			name:    "sovereign on, whitespace-only key — not treated as set",
 			env:     map[string]string{"HIVE_SOVEREIGN": "true", "OPENROUTER_API_KEY": "   "},
@@ -60,6 +120,9 @@ func TestCheck(t *testing.T) {
 			err := sovereign.Check(lookup)
 			if (err != nil) != tc.wantErr {
 				t.Errorf("Check() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if tc.errContains != "" && err != nil && !strings.Contains(err.Error(), tc.errContains) {
+				t.Errorf("Check() error = %q, want substring %q", err.Error(), tc.errContains)
 			}
 		})
 	}

--- a/apps/edge-api/cmd/server/main.go
+++ b/apps/edge-api/cmd/server/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/matrix"
 	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/middleware"
 	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/proxy"
+	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/sovereign"
 	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/stt"
 	"github.com/sakibsadmanshajib/hive/packages/storage"
 	"github.com/google/uuid"
@@ -56,6 +57,12 @@ type storageConfig struct {
 }
 
 func main() {
+	// Sovereign-mode guard: fail fast before any service wiring when external
+	// provider keys are present. See apps/edge-api/internal/sovereign for tests.
+	if err := sovereign.Check(os.Getenv); err != nil {
+		log.Fatal(err)
+	}
+
 	// Root context cancels on SIGINT/SIGTERM so background goroutines
 	// rooted here (notably the jwx JWKS auto-refresher) exit cleanly
 	// instead of leaking through process shutdown — passing

--- a/apps/edge-api/internal/sovereign/sovereign.go
+++ b/apps/edge-api/internal/sovereign/sovereign.go
@@ -1,5 +1,6 @@
 // Package sovereign enforces data-sovereignty startup constraints.
-// When HIVE_SOVEREIGN=true, external LLM provider keys must not be configured.
+// When HIVE_SOVEREIGN is set to a truthy value, external LLM provider
+// keys must not be configured.
 package sovereign
 
 import (
@@ -13,21 +14,37 @@ var externalProviderKeys = []string{
 	"GROQ_API_KEY",
 }
 
+// isSovereignEnabled returns true for any case-insensitive, trimmed truthy value:
+// "1", "true", "yes", "on". Everything else (including empty) is false.
+func isSovereignEnabled(v string) bool {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
 // Check returns an error if sovereign mode is active and any external provider key is set.
-// Pass os.Getenv as the lookup in production; pass a map lookup in tests.
+// All violating keys are collected and reported together so the operator can fix them
+// in one pass. Pass os.Getenv as the lookup in production; pass a map lookup in tests.
 func Check(getenv func(string) string) error {
-	if strings.TrimSpace(getenv("HIVE_SOVEREIGN")) != "true" {
+	if !isSovereignEnabled(getenv("HIVE_SOVEREIGN")) {
 		return nil
 	}
+	var violations []string
 	for _, key := range externalProviderKeys {
 		if strings.TrimSpace(getenv(key)) != "" {
-			return fmt.Errorf(
-				"FATAL: HIVE_SOVEREIGN=true but %s is set. "+
-					"External LLM providers are prohibited in sovereign mode. "+
-					"Unset the key and restart.",
-				key,
-			)
+			violations = append(violations, key)
 		}
 	}
-	return nil
+	if len(violations) == 0 {
+		return nil
+	}
+	return fmt.Errorf(
+		"FATAL: HIVE_SOVEREIGN=true but the following external LLM provider keys are set: %s. "+
+			"External LLM providers are prohibited in sovereign mode. "+
+			"Unset all listed keys and restart.",
+		strings.Join(violations, ", "),
+	)
 }

--- a/apps/edge-api/internal/sovereign/sovereign.go
+++ b/apps/edge-api/internal/sovereign/sovereign.go
@@ -1,0 +1,33 @@
+// Package sovereign enforces data-sovereignty startup constraints.
+// When HIVE_SOVEREIGN=true, external LLM provider keys must not be configured.
+package sovereign
+
+import (
+	"fmt"
+	"strings"
+)
+
+// externalProviderKeys lists every env var that routes traffic to an external LLM provider.
+var externalProviderKeys = []string{
+	"OPENROUTER_API_KEY",
+	"GROQ_API_KEY",
+}
+
+// Check returns an error if sovereign mode is active and any external provider key is set.
+// Pass os.Getenv as the lookup in production; pass a map lookup in tests.
+func Check(getenv func(string) string) error {
+	if strings.TrimSpace(getenv("HIVE_SOVEREIGN")) != "true" {
+		return nil
+	}
+	for _, key := range externalProviderKeys {
+		if strings.TrimSpace(getenv(key)) != "" {
+			return fmt.Errorf(
+				"FATAL: HIVE_SOVEREIGN=true but %s is set. "+
+					"External LLM providers are prohibited in sovereign mode. "+
+					"Unset the key and restart.",
+				key,
+			)
+		}
+	}
+	return nil
+}

--- a/apps/edge-api/internal/sovereign/sovereign_test.go
+++ b/apps/edge-api/internal/sovereign/sovereign_test.go
@@ -1,0 +1,66 @@
+package sovereign_test
+
+import (
+	"testing"
+
+	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/sovereign"
+)
+
+func TestCheck(t *testing.T) {
+	tests := []struct {
+		name    string
+		env     map[string]string
+		wantErr bool
+	}{
+		{
+			name:    "sovereign off, no external keys — boots",
+			env:     map[string]string{"HIVE_SOVEREIGN": "false"},
+			wantErr: false,
+		},
+		{
+			name:    "sovereign unset, external keys set — boots (unchanged behaviour)",
+			env:     map[string]string{"OPENROUTER_API_KEY": "sk-test", "GROQ_API_KEY": "gsk-test"},
+			wantErr: false,
+		},
+		{
+			name:    "sovereign on, no external keys — boots",
+			env:     map[string]string{"HIVE_SOVEREIGN": "true"},
+			wantErr: false,
+		},
+		{
+			name:    "sovereign on, OPENROUTER_API_KEY set — startup error",
+			env:     map[string]string{"HIVE_SOVEREIGN": "true", "OPENROUTER_API_KEY": "sk-openrouter"},
+			wantErr: true,
+		},
+		{
+			name:    "sovereign on, GROQ_API_KEY set — startup error",
+			env:     map[string]string{"HIVE_SOVEREIGN": "true", "GROQ_API_KEY": "gsk-groq"},
+			wantErr: true,
+		},
+		{
+			name:    "sovereign on, both external keys set — startup error",
+			env:     map[string]string{"HIVE_SOVEREIGN": "true", "OPENROUTER_API_KEY": "sk-openrouter", "GROQ_API_KEY": "gsk-groq"},
+			wantErr: true,
+		},
+		{
+			name:    "sovereign on, whitespace-only key — not treated as set",
+			env:     map[string]string{"HIVE_SOVEREIGN": "true", "OPENROUTER_API_KEY": "   "},
+			wantErr: false,
+		},
+		{
+			name:    "sovereign on, empty key — boots",
+			env:     map[string]string{"HIVE_SOVEREIGN": "true", "OPENROUTER_API_KEY": ""},
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			lookup := func(key string) string { return tc.env[key] }
+			err := sovereign.Check(lookup)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("Check() error = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/apps/edge-api/internal/sovereign/sovereign_test.go
+++ b/apps/edge-api/internal/sovereign/sovereign_test.go
@@ -1,6 +1,7 @@
 package sovereign_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/sovereign"
@@ -8,13 +9,25 @@ import (
 
 func TestCheck(t *testing.T) {
 	tests := []struct {
-		name    string
-		env     map[string]string
-		wantErr bool
+		name         string
+		env          map[string]string
+		wantErr      bool
+		errContains  string // non-empty: assert substring present in error
 	}{
+		// --- flag disabled ---
 		{
-			name:    "sovereign off, no external keys — boots",
-			env:     map[string]string{"HIVE_SOVEREIGN": "false"},
+			name:    "sovereign off (false), external keys set — boots",
+			env:     map[string]string{"HIVE_SOVEREIGN": "false", "OPENROUTER_API_KEY": "sk-test"},
+			wantErr: false,
+		},
+		{
+			name:    "sovereign off (0), external keys set — boots",
+			env:     map[string]string{"HIVE_SOVEREIGN": "0", "OPENROUTER_API_KEY": "sk-test"},
+			wantErr: false,
+		},
+		{
+			name:    "sovereign off (no), external keys set — boots",
+			env:     map[string]string{"HIVE_SOVEREIGN": "no", "OPENROUTER_API_KEY": "sk-test"},
 			wantErr: false,
 		},
 		{
@@ -22,26 +35,73 @@ func TestCheck(t *testing.T) {
 			env:     map[string]string{"OPENROUTER_API_KEY": "sk-test", "GROQ_API_KEY": "gsk-test"},
 			wantErr: false,
 		},
+		// --- flag enabled: truthy variants ---
 		{
-			name:    "sovereign on, no external keys — boots",
+			name:    "sovereign on (true lowercase), no external keys — boots",
 			env:     map[string]string{"HIVE_SOVEREIGN": "true"},
 			wantErr: false,
 		},
 		{
-			name:    "sovereign on, OPENROUTER_API_KEY set — startup error",
-			env:     map[string]string{"HIVE_SOVEREIGN": "true", "OPENROUTER_API_KEY": "sk-openrouter"},
-			wantErr: true,
+			name:    "sovereign on (TRUE uppercase), no external keys — boots",
+			env:     map[string]string{"HIVE_SOVEREIGN": "TRUE"},
+			wantErr: false,
 		},
 		{
-			name:    "sovereign on, GROQ_API_KEY set — startup error",
-			env:     map[string]string{"HIVE_SOVEREIGN": "true", "GROQ_API_KEY": "gsk-groq"},
-			wantErr: true,
+			name:    "sovereign on (True mixed), no external keys — boots",
+			env:     map[string]string{"HIVE_SOVEREIGN": "True"},
+			wantErr: false,
 		},
 		{
-			name:    "sovereign on, both external keys set — startup error",
-			env:     map[string]string{"HIVE_SOVEREIGN": "true", "OPENROUTER_API_KEY": "sk-openrouter", "GROQ_API_KEY": "gsk-groq"},
-			wantErr: true,
+			name:    "sovereign on (1), no external keys — boots",
+			env:     map[string]string{"HIVE_SOVEREIGN": "1"},
+			wantErr: false,
 		},
+		{
+			name:    "sovereign on (yes), no external keys — boots",
+			env:     map[string]string{"HIVE_SOVEREIGN": "yes"},
+			wantErr: false,
+		},
+		{
+			name:    "sovereign on (on), no external keys — boots",
+			env:     map[string]string{"HIVE_SOVEREIGN": "on"},
+			wantErr: false,
+		},
+		{
+			name:    "sovereign on (YES uppercase), no external keys — boots",
+			env:     map[string]string{"HIVE_SOVEREIGN": "YES"},
+			wantErr: false,
+		},
+		{
+			name:    "sovereign on (ON uppercase), no external keys — boots",
+			env:     map[string]string{"HIVE_SOVEREIGN": "ON"},
+			wantErr: false,
+		},
+		// --- flag enabled: violation cases ---
+		{
+			name:        "sovereign on, OPENROUTER_API_KEY set — startup error",
+			env:         map[string]string{"HIVE_SOVEREIGN": "true", "OPENROUTER_API_KEY": "sk-openrouter"},
+			wantErr:     true,
+			errContains: "OPENROUTER_API_KEY",
+		},
+		{
+			name:        "sovereign on (1), GROQ_API_KEY set — startup error",
+			env:         map[string]string{"HIVE_SOVEREIGN": "1", "GROQ_API_KEY": "gsk-groq"},
+			wantErr:     true,
+			errContains: "GROQ_API_KEY",
+		},
+		{
+			name:        "sovereign on (TRUE), both external keys set — reports both in one error",
+			env:         map[string]string{"HIVE_SOVEREIGN": "TRUE", "OPENROUTER_API_KEY": "sk-openrouter", "GROQ_API_KEY": "gsk-groq"},
+			wantErr:     true,
+			errContains: "OPENROUTER_API_KEY",
+		},
+		{
+			name:        "sovereign on (yes), both keys — error also mentions GROQ_API_KEY",
+			env:         map[string]string{"HIVE_SOVEREIGN": "yes", "OPENROUTER_API_KEY": "sk-openrouter", "GROQ_API_KEY": "gsk-groq"},
+			wantErr:     true,
+			errContains: "GROQ_API_KEY",
+		},
+		// --- edge: whitespace / empty ---
 		{
 			name:    "sovereign on, whitespace-only key — not treated as set",
 			env:     map[string]string{"HIVE_SOVEREIGN": "true", "OPENROUTER_API_KEY": "   "},
@@ -60,6 +120,9 @@ func TestCheck(t *testing.T) {
 			err := sovereign.Check(lookup)
 			if (err != nil) != tc.wantErr {
 				t.Errorf("Check() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if tc.errContains != "" && err != nil && !strings.Contains(err.Error(), tc.errContains) {
+				t.Errorf("Check() error = %q, want substring %q", err.Error(), tc.errContains)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Adds `sovereign.Check(os.Getenv)` as the first call in `main()` for both `apps/edge-api` and `apps/control-plane`.
- When `HIVE_SOVEREIGN=true` and `OPENROUTER_API_KEY` or `GROQ_API_KEY` is set (non-empty after whitespace trim), the process calls `log.Fatal` with a clear actionable message and exits non-zero before any service wiring.
- When `HIVE_SOVEREIGN` is false/unset, behaviour is completely unchanged.

## New packages

- `apps/edge-api/internal/sovereign` — `Check(getenv func(string) string) error`
- `apps/control-plane/internal/sovereign` — identical API, separate module

The `getenv` parameter is injected so tests never touch `os.Setenv`.

## Test plan

- [x] Table-driven unit tests in each package: sovereign on + key set (error), sovereign on + no keys (ok), sovereign off + keys set (ok), whitespace-only key treated as unset (ok), empty key (ok)
- [x] Full suite `go test ./apps/edge-api/... ./apps/control-plane/... -count=1 -short` passes with zero regressions (60+ packages)
- [x] `go build ./apps/edge-api/cmd/server ./apps/control-plane/cmd/server` compiles clean

Closes #245. Refs #244.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces runtime enforcement of `HIVE_SOVEREIGN` mode by adding a `sovereign.Check(os.Getenv)` fail-fast guard at the top of `main()` in both `apps/edge-api` and `apps/control-plane`. When sovereign mode is active and `OPENROUTER_API_KEY` or `GROQ_API_KEY` is present (after whitespace trim), the process exits non-zero with an actionable error listing all violations before any service wiring occurs.

- New `internal/sovereign` packages (one per app) implement `isSovereignEnabled` with case-insensitive multi-value matching (`true`/`1`/`yes`/`on`) and accumulate all violating keys into a single error rather than returning on the first hit.
- Table-driven unit tests cover all truthy variants, both-keys violation, whitespace-only values, and the disabled flag path — no `os.Setenv` is touched in tests thanks to the injected `getenv` parameter.
- The `externalProviderKeys` list is duplicated between the two packages (acknowledged in the PR as a deliberate choice); future provider additions require keeping both lists in sync.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the guard only adds a fail-fast exit path that is dormant unless HIVE_SOVEREIGN is explicitly enabled, leaving all existing behaviour completely unchanged.

The previous feedback on case-insensitive flag detection and collecting all violations before returning has been addressed in this revision. The new code is fully covered by table-driven tests, the injection of getenv avoids any os.Setenv coupling, and the placement of the check before config.Load is the correct fail-fast position. The only remaining item is a cosmetic mismatch in the error message that hardcodes =true when the operator may have used =1 or =yes.

No files require special attention; the two sovereign packages are the only new logic and are well-tested.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/edge-api/internal/sovereign/sovereign.go | New sovereign check package: collects all violating keys before returning, handles multiple truthy values case-insensitively, trims whitespace on both flag and key values. Minor: error message hardcodes =true regardless of actual flag value. |
| apps/control-plane/internal/sovereign/sovereign.go | Byte-for-byte copy of the edge-api sovereign package; same minor cosmetic issue in the hardcoded =true in the error message. |
| apps/edge-api/cmd/server/main.go | Adds sovereign.Check(os.Getenv) as the very first call in main(), before config.Load and any service wiring — correct placement. |
| apps/control-plane/cmd/server/main.go | Same sovereign guard wired into control-plane main() at the correct fail-fast position. |
| apps/edge-api/internal/sovereign/sovereign_test.go | Comprehensive table-driven tests covering flag disabled, all truthy variants, both-keys violation, whitespace-only keys, and empty keys. |
| apps/control-plane/internal/sovereign/sovereign_test.go | Identical test suite to the edge-api package, referencing the control-plane import path. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[main called] --> B[sovereign.Check os.Getenv]
    B --> C{HIVE_SOVEREIGN truthy?}
    C -- no false/0/no/unset --> E[continue startup]
    C -- yes true/1/yes/on --> D{Any external provider key set?}
    D -- none found --> E
    D -- violations found --> F[collect all violating keys]
    F --> G[return error listing all keys]
    G --> H[log.Fatal exits non-zero]
    E --> I[config.Load]
    I --> J[service wiring]
    J --> K[serve]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[main called] --> B[sovereign.Check os.Getenv]
    B --> C{HIVE_SOVEREIGN truthy?}
    C -- no false/0/no/unset --> E[continue startup]
    C -- yes true/1/yes/on --> D{Any external provider key set?}
    D -- none found --> E
    D -- violations found --> F[collect all violating keys]
    F --> G[return error listing all keys]
    G --> H[log.Fatal exits non-zero]
    E --> I[config.Load]
    I --> J[service wiring]
    J --> K[serve]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: sovereign flag parse loose boolean ..."](https://github.com/sakibsadmanshajib/hive/commit/565ae5372eb212b5458db94fd0b943d971cd81c8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39990987)</sub>

<!-- /greptile_comment -->