### PR TITLE
fix: materialize .env.ci in phase-19 OWUI nightly workflow

### DIFF
--- a/.github/workflows/phase-19-owui-nightly.yml
+++ b/.github/workflows/phase-19-owui-nightly.yml
@@ -30,6 +30,57 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
+      - name: Materialize .env.ci
+        # local/test profiles boot control-plane + edge-api + open-webui +
+        # web-console, all of which fail fast without real Supabase/S3/LLM
+        # provider credentials (see CLAUDE.md fail-fast rule). Mirrors the
+        # secret set already proven working in ci.yml's live-integration job.
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          S3_ENDPOINT: ${{ secrets.S3_ENDPOINT }}
+          S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}
+          S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}
+          S3_REGION: ${{ secrets.S3_REGION }}
+          S3_BUCKET_FILES: ${{ secrets.S3_BUCKET_FILES }}
+          S3_BUCKET_IMAGES: ${{ secrets.S3_BUCKET_IMAGES }}
+          LITELLM_MASTER_KEY: ${{ secrets.LITELLM_MASTER_KEY }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+        run: |
+          set -euo pipefail
+          for v in SUPABASE_URL SUPABASE_ANON_KEY SUPABASE_SERVICE_ROLE_KEY HIVE_TEST_DB_URL \
+                   S3_ENDPOINT S3_ACCESS_KEY S3_SECRET_KEY S3_REGION \
+                   OPENROUTER_API_KEY GROQ_API_KEY; do
+            val="${!v:-}"
+            if [ -z "$val" ]; then
+              echo "::error::$v is empty; cannot materialize .env.ci"
+              exit 1
+            fi
+          done
+          cat > .env.ci <<EOF
+          SUPABASE_URL=${SUPABASE_URL}
+          SUPABASE_ANON_KEY=${SUPABASE_ANON_KEY}
+          SUPABASE_SERVICE_ROLE_KEY=${SUPABASE_SERVICE_ROLE_KEY}
+          SUPABASE_DB_URL=${HIVE_TEST_DB_URL}
+          REDIS_URL=redis://redis:6379/0
+          S3_ENDPOINT=${S3_ENDPOINT}
+          S3_ACCESS_KEY=${S3_ACCESS_KEY}
+          S3_SECRET_KEY=${S3_SECRET_KEY}
+          S3_REGION=${S3_REGION}
+          S3_BUCKET_FILES=${S3_BUCKET_FILES:-hive-files}
+          S3_BUCKET_IMAGES=${S3_BUCKET_IMAGES:-hive-images}
+          LITELLM_MASTER_KEY=${LITELLM_MASTER_KEY:-litellm-dev-key}
+          OPENROUTER_API_KEY=${OPENROUTER_API_KEY}
+          GROQ_API_KEY=${GROQ_API_KEY}
+          NEXT_PUBLIC_SUPABASE_URL=${NEXT_PUBLIC_SUPABASE_URL:-$SUPABASE_URL}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY=${NEXT_PUBLIC_SUPABASE_ANON_KEY:-$SUPABASE_ANON_KEY}
+          OWUI_SHIM_KEY=$(openssl rand -base64 32)
+          EOF
+          chmod 600 .env.ci
       - name: Boot stack with test-owui + observability-langfuse profiles
         run: |
           cd deploy/docker


### PR DESCRIPTION
## Root cause

`phase-19-owui-nightly` has failed every scheduled run since 2026-06-26 (7 consecutive failures, e.g. run 28572482796). The "Boot stack" step runs:

```
docker compose --env-file ../../.env.ci --profile local --profile test --profile test-owui --profile observability-langfuse up -d --build
```

`.env.ci` does not exist anywhere in the tree and no prior step creates it, so Docker Compose exits 1 with `couldn't find env file`. The OWUI health check and the Playwright suite are never reached.

## Fix

Added a "Materialize .env.ci" step before the compose boot that writes `.env.ci` at the repo root from GitHub secrets. This mirrors the secret set already proven working in `ci.yml`'s `live-integration` job, not `.env.example` placeholders, because the `local`/`test` profiles this job boots (`control-plane`, `edge-api`, `open-webui`, `web-console`) fail fast without real Supabase/S3/LLM-provider credentials (see repo `CLAUDE.md` fail-fast rule). Verified no other compose file defines the `test-owui`/`observability-langfuse` profile names referenced by this job (harmless no-ops, out of scope for this fix).

Details:
- `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`, S3 vars, `LITELLM_MASTER_KEY`, `OPENROUTER_API_KEY`, `GROQ_API_KEY`, `NEXT_PUBLIC_SUPABASE_*` sourced from existing repo secrets (same names `ci.yml` already consumes).
- The `HIVE_TEST_DB_URL` secret was already pulled into this job's env but never used anywhere — it is now wired in as `SUPABASE_DB_URL` for the compose stack.
- `OWUI_SHIM_KEY` (internal shared token between `edge-api` and `open-webui`, not an external credential) is generated fresh each run via `openssl rand -base64 32` rather than stored as a secret.
- Hard-fails with `::error::` if any of the required secrets are empty, so a missing/rotated secret surfaces as a clear message instead of a silent downstream compose failure.

## Test plan

- [ ] YAML validated locally (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/phase-19-owui-nightly.yml'))"`) — passes
- [ ] Manually trigger the workflow (`pull_request` + `run-owui-e2e` label, or wait for next scheduled run) and confirm the "Materialize .env.ci" step succeeds and the OWUI health check is reached
- [ ] Confirm Playwright suite (`pnpm e2e:owui`, `pnpm e2e:owui:perf`) runs to completion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved nightly CI setup by generating required runtime configuration automatically and validating that essential settings are present before the job starts.
  * Added safer handling for secrets and configuration values to reduce setup failures during automated runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes seven consecutive nightly failures of the `phase-19-owui-nightly` workflow by adding a "Materialize .env.ci" step that writes real Supabase, S3, and LLM-provider credentials from GitHub Secrets to `.env.ci` before Docker Compose boots the OWUI stack.

- **Root-cause fix**: The missing `.env.ci` caused `docker compose --env-file` to exit 1 before any container was started; the new step materializes the file with `chmod 600` and a fail-fast validation loop that surfaces missing secrets via `::error::`.
- **`OWUI_SHIM_KEY` handling**: Generated fresh per-run with `openssl rand -base64 32` inside the heredoc rather than stored as a static secret, which is appropriate for an internal shared token.
- **Inconsistency**: `LITELLM_MASTER_KEY` is pulled from secrets and described as required in the PR description, but is excluded from the fail-fast validation loop and falls back to the hardcoded string `litellm-dev-key` if the secret is absent or rotated.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the fix correctly addresses the root cause of 7 consecutive nightly failures with no behaviour changes to any application code.

The heredoc structure, validation loop, and secret wiring are all correct. The one gap is that LITELLM_MASTER_KEY is absent from the fail-fast loop and silently falls back to the hardcoded string `litellm-dev-key` if the secret is missing, rather than surfacing the problem the way every other required secret does.

.github/workflows/phase-19-owui-nightly.yml — specifically the validation loop around line 55 where LITELLM_MASTER_KEY is omitted.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/phase-19-owui-nightly.yml | Adds a "Materialize .env.ci" step that writes real credentials from GitHub Secrets to repo root before Docker Compose boots; correctly structured heredoc, validation loop, and chmod 600. One inconsistency: LITELLM_MASTER_KEY has a hardcoded fallback and is omitted from the fail-fast validation loop. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant GHA as GitHub Actions Runner
    participant Secrets as GitHub Secrets
    participant FS as Repo Filesystem
    participant DC as Docker Compose
    participant OWUI as Open WebUI :3003
    participant PW as Playwright

    GHA->>Secrets: "resolve SUPABASE_URL, S3_*, LITELLM_MASTER_KEY, etc."
    GHA->>GHA: validate required secrets (fail-fast loop)
    GHA->>FS: "cat > .env.ci (chmod 600)"
    Note over FS: OWUI_SHIM_KEY generated via openssl rand
    GHA->>DC: docker compose --env-file ../../.env.ci --profile local,test,test-owui,observability-langfuse up -d --build
    DC->>OWUI: boot open-webui + control-plane + edge-api + langfuse
    loop Health check (60x every 2s)
        GHA->>OWUI: curl http://localhost:3003/health
    end
    GHA->>PW: pnpm e2e:owui + pnpm e2e:owui:perf
    PW->>OWUI: run Playwright specs
    GHA->>GHA: SOC2 coverage report
    GHA->>GHA: upload playwright-report artifact
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant GHA as GitHub Actions Runner
    participant Secrets as GitHub Secrets
    participant FS as Repo Filesystem
    participant DC as Docker Compose
    participant OWUI as Open WebUI :3003
    participant PW as Playwright

    GHA->>Secrets: "resolve SUPABASE_URL, S3_*, LITELLM_MASTER_KEY, etc."
    GHA->>GHA: validate required secrets (fail-fast loop)
    GHA->>FS: "cat > .env.ci (chmod 600)"
    Note over FS: OWUI_SHIM_KEY generated via openssl rand
    GHA->>DC: docker compose --env-file ../../.env.ci --profile local,test,test-owui,observability-langfuse up -d --build
    DC->>OWUI: boot open-webui + control-plane + edge-api + langfuse
    loop Health check (60x every 2s)
        GHA->>OWUI: curl http://localhost:3003/health
    end
    GHA->>PW: pnpm e2e:owui + pnpm e2e:owui:perf
    PW->>OWUI: run Playwright specs
    GHA->>GHA: SOC2 coverage report
    GHA->>GHA: upload playwright-report artifact
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fphase-19-owui-nightly.yml%3A55-57%0A%60LITELLM_MASTER_KEY%60%20is%20listed%20in%20the%20step%20%60env%3A%60%20block%20and%20in%20the%20PR%20description%20as%20%22sourced%20from%20existing%20repo%20secrets%22%2C%20yet%20it%20is%20absent%20from%20the%20fail-fast%20validation%20loop%20and%20the%20heredoc%20silently%20falls%20back%20to%20the%20hardcoded%20string%20%60litellm-dev-key%60.%20If%20the%20secret%20is%20missing%20or%20rotated%2C%20the%20workflow%20continues%20with%20a%20known%2C%20predictable%20master%20key%20instead%20of%20surfacing%20the%20gap%20with%20%60%3A%3Aerror%3A%3A%60%20%E2%80%94%20contradicting%20the%20stated%20design%20goal%20of%20hard-failing%20on%20any%20empty%20required%20secret.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20for%20v%20in%20SUPABASE_URL%20SUPABASE_ANON_KEY%20SUPABASE_SERVICE_ROLE_KEY%20HIVE_TEST_DB_URL%20%5C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20S3_ENDPOINT%20S3_ACCESS_KEY%20S3_SECRET_KEY%20S3_REGION%20%5C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20LITELLM_MASTER_KEY%20OPENROUTER_API_KEY%20GROQ_API_KEY%3B%20do%0A%60%60%60%0A%0A&repo=sakibsadmanshajib%2Fhive&pr=262&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fphase-19-owui-nightly.yml%3A55-57%0A%60LITELLM_MASTER_KEY%60%20is%20listed%20in%20the%20step%20%60env%3A%60%20block%20and%20in%20the%20PR%20description%20as%20%22sourced%20from%20existing%20repo%20secrets%22%2C%20yet%20it%20is%20absent%20from%20the%20fail-fast%20validation%20loop%20and%20the%20heredoc%20silently%20falls%20back%20to%20the%20hardcoded%20string%20%60litellm-dev-key%60.%20If%20the%20secret%20is%20missing%20or%20rotated%2C%20the%20workflow%20continues%20with%20a%20known%2C%20predictable%20master%20key%20instead%20of%20surfacing%20the%20gap%20with%20%60%3A%3Aerror%3A%3A%60%20%E2%80%94%20contradicting%20the%20stated%20design%20goal%20of%20hard-failing%20on%20any%20empty%20required%20secret.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20for%20v%20in%20SUPABASE_URL%20SUPABASE_ANON_KEY%20SUPABASE_SERVICE_ROLE_KEY%20HIVE_TEST_DB_URL%20%5C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20S3_ENDPOINT%20S3_ACCESS_KEY%20S3_SECRET_KEY%20S3_REGION%20%5C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20LITELLM_MASTER_KEY%20OPENROUTER_API_KEY%20GROQ_API_KEY%3B%20do%0A%60%60%60%0A%0A&pr=262&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22sakibsadmanshajib%2Fhive%22%20on%20the%20existing%20branch%20%22fix%2Fnightly-env-ci%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fnightly-env-ci%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fphase-19-owui-nightly.yml%3A55-57%0A%60LITELLM_MASTER_KEY%60%20is%20listed%20in%20the%20step%20%60env%3A%60%20block%20and%20in%20the%20PR%20description%20as%20%22sourced%20from%20existing%20repo%20secrets%22%2C%20yet%20it%20is%20absent%20from%20the%20fail-fast%20validation%20loop%20and%20the%20heredoc%20silently%20falls%20back%20to%20the%20hardcoded%20string%20%60litellm-dev-key%60.%20If%20the%20secret%20is%20missing%20or%20rotated%2C%20the%20workflow%20continues%20with%20a%20known%2C%20predictable%20master%20key%20instead%20of%20surfacing%20the%20gap%20with%20%60%3A%3Aerror%3A%3A%60%20%E2%80%94%20contradicting%20the%20stated%20design%20goal%20of%20hard-failing%20on%20any%20empty%20required%20secret.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20for%20v%20in%20SUPABASE_URL%20SUPABASE_ANON_KEY%20SUPABASE_SERVICE_ROLE_KEY%20HIVE_TEST_DB_URL%20%5C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20S3_ENDPOINT%20S3_ACCESS_KEY%20S3_SECRET_KEY%20S3_REGION%20%5C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20LITELLM_MASTER_KEY%20OPENROUTER_API_KEY%20GROQ_API_KEY%3B%20do%0A%60%60%60%0A%0A&repo=sakibsadmanshajib%2Fhive&pr=262&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix: materialize .env.ci in phase-19 OWU..."](https://github.com/sakibsadmanshajib/hive/commit/4440b81f6314f4ec3dbf535381d6fbea400f8b7c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41576358)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->