### PR TITLE
ci: allow manual dispatch of phase-19 OWUI nightly

### DIFF
--- a/.github/workflows/phase-19-owui-nightly.yml
+++ b/.github/workflows/phase-19-owui-nightly.yml
@@ -5,6 +5,7 @@ on:
     - cron: '0 6 * * *'
   pull_request:
     types: [labeled]
+  workflow_dispatch:
 
 concurrency:
   group: phase-19-owui-${{ github.ref }}
@@ -12,7 +13,7 @@ concurrency:
 
 jobs:
   owui-e2e:
-    if: ${{ github.event_name == 'schedule' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-owui-e2e')) }}
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-owui-e2e')) }}
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     env:


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` trigger to `phase-19-owui-nightly.yml` so the nightly OWUI E2E suite can be run manually.
- Extends the `owui-e2e` job's `if` condition to also run on `workflow_dispatch` events (previously it only fired for `schedule` or a labeled `pull_request`, which would have silently skipped manual runs).

This enables manual verification of nightly fixes without waiting for the next scheduled run.

## Test plan
- [ ] Trigger the workflow manually via `gh workflow run phase-19-owui-nightly.yml` or the Actions UI and confirm the `owui-e2e` job executes (not skipped).

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds `workflow_dispatch` as a trigger to the `phase-19-owui-nightly.yml` workflow and correspondingly extends the `owui-e2e` job's `if` condition to permit execution on manual runs, in addition to the existing `schedule` and labeled `pull_request` events.

- **Trigger added**: `workflow_dispatch:` appended to the `on:` block, enabling the workflow to be started from the Actions UI or `gh workflow run`.
- **Guard updated**: The job-level `if` now checks `github.event_name == 'workflow_dispatch'` alongside the existing schedule and label conditions — without this, manual dispatch would trigger the workflow file but silently skip every job inside it.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — two-line change correctly wires manual dispatch through both the trigger block and the job guard.

The only code touched is the `on:` trigger block and the `if` condition on the single job. Both changes are consistent with each other and with the existing pattern used for `schedule` and `pull_request`. The `concurrency` group already uses `github.ref`, which resolves correctly for `workflow_dispatch` runs. No secrets access, no logic in steps, and no other files changed.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/phase-19-owui-nightly.yml | Adds workflow_dispatch trigger and updates job-level if condition to include it — change is correct and minimal with no logic regressions. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Trigger] --> B{github.event_name?}
    B -- schedule --> C[owui-e2e job runs]
    B -- workflow_dispatch\n✅ NEW --> C
    B -- pull_request --> D{has label\nrun-owui-e2e?}
    D -- yes --> C
    D -- no --> E[job skipped]
    C --> F[Boot stack]
    F --> G[Run Playwright suite]
    G --> H[SOC2 coverage report]
    H --> I{failure?}
    I -- yes --> J[Slack notification]
    I -- no --> K[Upload playwright artifact]
    J --> K
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Trigger] --> B{github.event_name?}
    B -- schedule --> C[owui-e2e job runs]
    B -- workflow_dispatch\n✅ NEW --> C
    B -- pull_request --> D{has label\nrun-owui-e2e?}
    D -- yes --> C
    D -- no --> E[job skipped]
    C --> F[Boot stack]
    F --> G[Run Playwright suite]
    G --> H[SOC2 coverage report]
    H --> I{failure?}
    I -- yes --> J[Slack notification]
    I -- no --> K[Upload playwright artifact]
    J --> K
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["ci: allow manual dispatch of phase-19 OW..."](https://github.com/sakibsadmanshajib/hive/commit/5b8fecf1b311572d02d20ca0bbbb1c7fd99f78e7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41577652)</sub>

<!-- /greptile_comment -->