### PR TITLE
fix: reconstruct SUPABASE_DB_URL in nightly from DB part secrets

### DIFF
--- a/.github/workflows/phase-19-owui-nightly.yml
+++ b/.github/workflows/phase-19-owui-nightly.yml
@@ -17,7 +17,6 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     env:
-      HIVE_TEST_DB_URL: ${{ secrets.HIVE_TEST_DB_URL }}
       OWUI_URL: http://localhost:3003
       OWUI_E2E_EMAIL: ${{ secrets.OWUI_E2E_EMAIL }}
       OWUI_E2E_PASSWORD: ${{ secrets.OWUI_E2E_PASSWORD }}
@@ -31,6 +30,33 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
+      - name: Reconstruct SUPABASE_DB_URL
+        # HIVE_TEST_DB_URL secret does not exist (phantom -- 2026-07-04 run
+        # 28643196239 failed on it). Reconstruct from the same DB part
+        # secrets ci.yml already uses successfully (see ci.yml
+        # "Reconstruct SUPABASE_DB_URL" step).
+        shell: bash
+        env:
+          SUPABASE_DB_HOST: ${{ secrets.SUPABASE_DB_HOST }}
+          SUPABASE_DB_PORT: ${{ secrets.SUPABASE_DB_PORT }}
+          SUPABASE_DB_USER: ${{ secrets.SUPABASE_DB_USER }}
+          SUPABASE_DB_NAME: ${{ secrets.SUPABASE_DB_NAME }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+        run: |
+          set -euo pipefail
+          for v in SUPABASE_DB_HOST SUPABASE_DB_PORT SUPABASE_DB_USER SUPABASE_DB_NAME SUPABASE_DB_PASSWORD; do
+            val="${!v:-}"
+            if [ -z "$val" ]; then
+              echo "::error::$v is empty; cannot reconstruct SUPABASE_DB_URL"
+              exit 1
+            fi
+          done
+          # Password is stored in its raw decoded form — URL-encode it here so the
+          # resulting URL round-trips through pgx/pgconn URL parsing correctly.
+          ENC_PW=$(python3 -c 'import os,urllib.parse as u; print(u.quote(os.environ["SUPABASE_DB_PASSWORD"], safe=""))')
+          url="postgresql://${SUPABASE_DB_USER}:${ENC_PW}@${SUPABASE_DB_HOST}:${SUPABASE_DB_PORT}/${SUPABASE_DB_NAME}"
+          echo "SUPABASE_DB_URL=$url" >> "$GITHUB_ENV"
+          echo "reconstructed DB URL (host=${SUPABASE_DB_HOST}, port=${SUPABASE_DB_PORT}, user=${SUPABASE_DB_USER}, db=${SUPABASE_DB_NAME})"
       - name: Materialize .env.ci
         # local/test profiles boot control-plane + edge-api + open-webui +
         # web-console, all of which fail fast without real Supabase/S3/LLM
@@ -53,7 +79,7 @@ jobs:
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
         run: |
           set -euo pipefail
-          for v in SUPABASE_URL SUPABASE_ANON_KEY SUPABASE_SERVICE_ROLE_KEY HIVE_TEST_DB_URL \
+          for v in SUPABASE_URL SUPABASE_ANON_KEY SUPABASE_SERVICE_ROLE_KEY SUPABASE_DB_URL \
                    S3_ENDPOINT S3_ACCESS_KEY S3_SECRET_KEY S3_REGION \
                    OPENROUTER_API_KEY GROQ_API_KEY; do
             val="${!v:-}"
@@ -66,7 +92,7 @@ jobs:
           SUPABASE_URL=${SUPABASE_URL}
           SUPABASE_ANON_KEY=${SUPABASE_ANON_KEY}
           SUPABASE_SERVICE_ROLE_KEY=${SUPABASE_SERVICE_ROLE_KEY}
-          SUPABASE_DB_URL=${HIVE_TEST_DB_URL}
+          SUPABASE_DB_URL=${SUPABASE_DB_URL}
           REDIS_URL=redis://redis:6379/0
           S3_ENDPOINT=${S3_ENDPOINT}
           S3_ACCESS_KEY=${S3_ACCESS_KEY}


### PR DESCRIPTION
## Root cause

PR #262 fixed the missing `.env.ci` file but wired the `HIVE_TEST_DB_URL` secret into `SUPABASE_DB_URL`. That secret does not exist in the repo secret store (confirmed against the repo secret list) so the newly dispatched run (28643196239) failed with `HIVE_TEST_DB_URL is empty; cannot materialize .env.ci`.

`ci.yml`'s `live-integration` job (green) never uses `HIVE_TEST_DB_URL` either. It reconstructs the Postgres DSN at runtime from five discrete secrets: `SUPABASE_DB_HOST`, `SUPABASE_DB_PORT`, `SUPABASE_DB_USER`, `SUPABASE_DB_NAME`, `SUPABASE_DB_PASSWORD`.

## Fix

Added a "Reconstruct SUPABASE_DB_URL" step to the nightly workflow, copied from ci.yml's proven pattern: build `postgresql://user:encoded_password@host:port/dbname`, URL-encoding the password with `urllib.parse.quote`, and export the result via `GITHUB_ENV` so later steps see it as `SUPABASE_DB_URL`.

- Removed the phantom `HIVE_TEST_DB_URL` secret reference from the job-level `env:` block.
- Replaced `HIVE_TEST_DB_URL` with `SUPABASE_DB_URL` in the `Materialize .env.ci` fail-fast validation list and in the `.env.ci` heredoc.
- The new step's own fail-fast loop validates the five DB part secrets are non-empty before building the URL.
- The log line after reconstruction prints only host/port/user/db name, never the password, matching the existing ci.yml precedent, so no credential leaks into the run log.

## Test plan

- [x] YAML validated locally (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/phase-19-owui-nightly.yml'))"`)
- [ ] Manually dispatch the workflow (`workflow_dispatch`, added in PR #263) and confirm the "Reconstruct SUPABASE_DB_URL" and "Materialize .env.ci" steps both succeed
- [ ] Confirm the OWUI health check and Playwright suite run to completion

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a broken nightly workflow by replacing a non-existent `HIVE_TEST_DB_URL` secret reference with the same DB-URL reconstruction pattern already proven in `ci.yml`'s `live-integration` job — building the connection string from five discrete secrets and exporting the result via `$GITHUB_ENV`.

- Removes `HIVE_TEST_DB_URL` from the job-level `env:` block and replaces its use in the `.env.ci` heredoc and validation loop with the correctly named `SUPABASE_DB_URL`.
- Adds a "Reconstruct SUPABASE_DB_URL" step that also includes an upfront fail-fast loop validating all five DB part secrets are non-empty (a slight improvement over the analogous step in `ci.yml`, which relies on a separate pre-verify step instead).
- The log line after reconstruction omits the password (logs only host, port, user, and db name), matching the established safe-logging precedent in `ci.yml`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The change is a clean swap of a confirmed-missing secret for a working reconstruction pattern already exercised in ci.yml; no new logic or risk surface is introduced.

The reconstruction step is a near-verbatim copy of the proven ci.yml pattern with an additional pre-validation loop — both well-understood bash constructs. GITHUB_ENV propagation from the Reconstruct step to the Materialize step is standard GitHub Actions behaviour. The password is URL-encoded before embedding and never logged. No conditional paths, no new secrets, no structural changes to the rest of the workflow.

No files require special attention; the single changed workflow file is straightforward and self-contained.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/phase-19-owui-nightly.yml | Removes phantom HIVE_TEST_DB_URL secret; adds proven Reconstruct SUPABASE_DB_URL step (with added fail-fast pre-validation) and updates Materialize step to consume the reconstructed variable via GITHUB_ENV. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: reconstruct SUPABASE\_DB\_URL in nigh..."](https://github.com/sakibsadmanshajib/hive/commit/9e7ff33110e6db256652da0a7ef0d60481d7b58a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41578343)</sub>

<!-- /greptile_comment -->