### PR TITLE
fix: featuregate cache singleflight and review nits

### DIFF
--- a/apps/control-plane/internal/featuregate/handler.go
+++ b/apps/control-plane/internal/featuregate/handler.go
@@ -53,17 +53,20 @@ func NewHandler(resolver Resolver) *Handler {
 // ServeHTTP handles GET /internal/featuregate/{tenant_id}.
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
-		http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
 		return
 	}
 
-	// Extract {tenant_id} from the trailing path segment.
-	// Route is registered as "/internal/featuregate/" so the mux strips the prefix.
+	// Extract {tenant_id} from the trailing path segment. The mux is
+	// registered with the prefix pattern "/internal/featuregate/" (see
+	// router.go), but net/http's ServeMux does not strip that prefix from
+	// r.URL.Path for a plain (non-StripPrefix) handler registration; this
+	// handler strips it itself.
 	raw := strings.TrimPrefix(r.URL.Path, "/internal/featuregate/")
 	raw = strings.Trim(raw, "/")
 	tenantID, err := uuid.Parse(raw)
 	if err != nil {
-		http.Error(w, `{"error":"invalid tenant_id"}`, http.StatusBadRequest)
+		writeError(w, http.StatusBadRequest, "invalid tenant_id")
 		return
 	}
 
@@ -83,4 +86,16 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	_ = json.NewEncoder(w).Encode(flags)
+}
+
+// writeError emits a JSON error body with a matching Content-Type header.
+// http.Error always forces "text/plain", which mismatches the JSON body this
+// handler otherwise returns; kept in sync with the provider-blind JSON error
+// pattern used elsewhere in control-plane (e.g. internal/providers/http.go).
+func writeError(w http.ResponseWriter, status int, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(struct {
+		Error string `json:"error"`
+	}{Error: message})
 }

--- a/apps/control-plane/internal/featuregate/handler_test.go
+++ b/apps/control-plane/internal/featuregate/handler_test.go
@@ -55,6 +55,11 @@ func TestHandler_InvalidTenantID_Returns400(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("expected 400, got %d", rec.Code)
 	}
+	// The body is a JSON object; Content-Type must say so (issue #253 P2:
+	// http.Error forces text/plain, which mismatches a JSON body).
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("expected Content-Type application/json, got %q", ct)
+	}
 }
 
 func TestHandler_MethodNotAllowed(t *testing.T) {
@@ -64,6 +69,9 @@ func TestHandler_MethodNotAllowed(t *testing.T) {
 	h.ServeHTTP(rec, req)
 	if rec.Code != http.StatusMethodNotAllowed {
 		t.Errorf("expected 405, got %d", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("expected Content-Type application/json, got %q", ct)
 	}
 }
 

--- a/apps/edge-api/go.mod
+++ b/apps/edge-api/go.mod
@@ -5,11 +5,14 @@ go 1.24.0
 toolchain go1.24.13
 
 require (
+	github.com/jackc/pgerrcode v0.0.0-20250907135507-afb5586c32a6
 	github.com/jackc/pgx/v5 v5.7.2
 	github.com/lestrrat-go/jwx/v2 v2.1.6
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	github.com/sakibsadmanshajib/hive/packages/audit-canonical v0.0.0
 	github.com/stretchr/testify v1.11.1
+	golang.org/x/sync v0.16.0
 )
 
 require (
@@ -19,7 +22,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 // indirect
 	github.com/goccy/go-json v0.10.3 // indirect
-	github.com/jackc/pgerrcode v0.0.0-20250907135507-afb5586c32a6 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
@@ -31,13 +33,11 @@ require (
 	github.com/lestrrat-go/option v1.0.1 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/segmentio/asm v1.2.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	golang.org/x/crypto v0.41.0 // indirect
-	golang.org/x/sync v0.16.0 // indirect
 	golang.org/x/text v0.28.0 // indirect
 	google.golang.org/protobuf v1.36.10 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/apps/edge-api/internal/featuregate/gate.go
+++ b/apps/edge-api/internal/featuregate/gate.go
@@ -20,6 +20,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/auth"
 	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/cpauth"
+	"golang.org/x/sync/singleflight"
 )
 
 // Feature is an opaque token identifying a gateable capability.
@@ -91,6 +92,10 @@ type Gate struct {
 
 	mu    sync.RWMutex
 	cache map[uuid.UUID]entry
+
+	// group collapses concurrent cache misses for the same tenant into a
+	// single upstream fetch (issue #253: cold-cache stampede).
+	group singleflight.Group
 }
 
 // New constructs a Gate. TTL defaults to 30 s when zero.
@@ -121,7 +126,14 @@ func (g *Gate) Fetch(ctx context.Context, tenantID uuid.UUID) (FlagsResponse, er
 	if ok && time.Since(e.loaded) < g.ttl {
 		return e.flags, nil
 	}
-	return g.refresh(ctx, tenantID)
+
+	v, err, _ := g.group.Do(tenantID.String(), func() (any, error) {
+		return g.refresh(ctx, tenantID)
+	})
+	if err != nil {
+		return FlagsResponse{}, err
+	}
+	return v.(FlagsResponse), nil
 }
 
 func (g *Gate) refresh(ctx context.Context, tenantID uuid.UUID) (FlagsResponse, error) {

--- a/apps/edge-api/internal/featuregate/gate.go
+++ b/apps/edge-api/internal/featuregate/gate.go
@@ -128,7 +128,13 @@ func (g *Gate) Fetch(ctx context.Context, tenantID uuid.UUID) (FlagsResponse, er
 	}
 
 	v, err, _ := g.group.Do(tenantID.String(), func() (any, error) {
-		return g.refresh(ctx, tenantID)
+		// Detach from the winning caller's context. singleflight runs this
+		// closure once and shares its result with every waiter on the key; if
+		// the winner's request is cancelled mid-flight (client disconnect), a
+		// captured ctx would fail the shared refresh and hand the same error to
+		// every waiter, causing a burst of spurious fail-closed 403s. The HTTP
+		// client's own 5s timeout still bounds the fetch (issue #253 review).
+		return g.refresh(context.WithoutCancel(ctx), tenantID)
 	})
 	if err != nil {
 		return FlagsResponse{}, err

--- a/apps/edge-api/internal/featuregate/gate_test.go
+++ b/apps/edge-api/internal/featuregate/gate_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -20,11 +22,15 @@ import (
 type mockCP struct {
 	flags      featuregate.FlagsResponse
 	calls      atomic.Int32
-	statusCode int // overrides 200 when non-zero
+	statusCode int           // overrides 200 when non-zero
+	delay      time.Duration // artificial upstream latency, for stampede tests
 }
 
 func (m *mockCP) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	m.calls.Add(1)
+	if m.delay > 0 {
+		time.Sleep(m.delay)
+	}
 	code := http.StatusOK
 	if m.statusCode != 0 {
 		code = m.statusCode
@@ -94,6 +100,44 @@ func TestCacheExpiry(t *testing.T) {
 	}
 }
 
+// ---- cache stampede: concurrent miss dedup (issue #253) --------------------
+
+// TestFetch_ConcurrentMiss_SingleUpstreamCall reproduces the cold-cache
+// stampede: N goroutines call Fetch for the same tenant before the first
+// upstream response returns. Only one upstream request should fire; the rest
+// must wait for and share that result (singleflight).
+func TestFetch_ConcurrentMiss_SingleUpstreamCall(t *testing.T) {
+	tid := uuid.New()
+	cp := &mockCP{flags: featuregate.FlagsResponse{RAGEnabled: true}}
+	cp.delay = 50 * time.Millisecond
+	srv := httptest.NewServer(cp)
+	defer srv.Close()
+
+	g := featuregate.New(featuregate.Config{ControlPlaneURL: srv.URL, TTL: 30 * time.Second})
+
+	const n = 20
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			flags, err := g.Fetch(newRequest(tid).Context(), tid)
+			if err != nil {
+				t.Errorf("Fetch: %v", err)
+				return
+			}
+			if !flags.RAGEnabled {
+				t.Error("expected shared result to have RAGEnabled=true")
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := cp.calls.Load(); got != 1 {
+		t.Errorf("expected 1 upstream call under concurrent cold-cache miss, got %d", got)
+	}
+}
+
 // ---- fail-closed on upstream errors ----------------------------------------
 
 func TestFetch_FailsClosed_On500(t *testing.T) {
@@ -151,7 +195,7 @@ func TestMiddleware_Disabled_Returns403(t *testing.T) {
 	// Provider-blind: no feature name in body.
 	body := rec.Body.String()
 	for _, banned := range []string{"rag", "RAG", "voice", "relay", "cowork", "feature"} {
-		if strContains(body, banned) {
+		if strings.Contains(body, banned) {
 			t.Errorf("response body leaks %q in: %s", banned, body)
 		}
 	}
@@ -275,7 +319,7 @@ func TestMiddleware_SSO_Disabled_Returns403(t *testing.T) {
 	// Provider-blind: body must not leak "sso" or "saml" or "oidc".
 	body := rec.Body.String()
 	for _, banned := range []string{"sso", "SSO", "saml", "SAML", "oidc", "OIDC", "feature"} {
-		if strContains(body, banned) {
+		if strings.Contains(body, banned) {
 			t.Errorf("response body leaks %q: %s", banned, body)
 		}
 	}
@@ -311,15 +355,4 @@ func TestFetch_SSOFlag_False_OnZeroResponse(t *testing.T) {
 	if flags.SSOEnabled {
 		t.Error("SSOEnabled must default to false")
 	}
-}
-
-// ---- control-plane handler tests -------------------------------------------
-
-func strContains(s, sub string) bool {
-	for i := 0; i+len(sub) <= len(s); i++ {
-		if s[i:i+len(sub)] == sub {
-			return true
-		}
-	}
-	return false
 }


### PR DESCRIPTION
## Summary

Non-blocking polish items deferred from the PR #251 (feature gate middleware) review, batched in issue #253.

- **Cache stampede fix (greptile P1 / reviewer P2):** on a cold or expired per-tenant cache entry, concurrent edge-api requests all missed and each called control-plane, producing duplicate upstream RPCs under burst. `Gate.Fetch` now collapses concurrent misses for the same tenant into a single upstream fetch using `golang.org/x/sync/singleflight`, keyed by tenant ID. `golang.org/x/sync` was already an indirect dependency of edge-api; `go mod tidy` promoted it (and two unrelated already-direct-use packages, `jackc/pgerrcode` and `prometheus/client_model`) to direct requires. No new checksums were needed.
- **control-plane `handler.go` comment (P2):** corrected a comment that claimed the mux strips the `/internal/featuregate/` path prefix. It does not; the handler strips it itself via `strings.TrimPrefix`.
- **control-plane `handler.go` Content-Type (P2):** `http.Error` always forces `Content-Type: text/plain`, which mismatched the JSON error bodies this handler returns. Replaced both call sites with a small `writeError` helper that sets `application/json`, matching the provider-blind JSON error pattern used elsewhere in control-plane (e.g. `internal/providers/http.go`).
- **`gate_test.go` nit:** removed the hand-rolled `strContains` helper in favor of `strings.Contains`.

Out of scope: later comments added to issue #253 reference unrelated items from PR #257 (sovereign guard NVIDIA key, sovereign package dedup) and PR #258 (auditarchive test skip, purge warning log). Those are different subsystems from this featuregate-scoped cleanup and are not addressed here.

## Test plan

- [x] `go test ./apps/edge-api/internal/featuregate/... -race -count=5` — new `TestFetch_ConcurrentMiss_SingleUpstreamCall` reproduces the stampede (20 calls) before the fix, passes (1 call) after, clean under `-race` across 5 runs.
- [x] `go test ./apps/control-plane/internal/featuregate/... -race` — new Content-Type assertions on the 400 and 405 paths, all handler tests pass.
- [x] `go test ./apps/edge-api/... -count=1 -short` — full module regression, no failures.
- [x] `go test ./apps/control-plane/... -count=1 -short` — full module regression, no failures.
- [x] `go build ./apps/edge-api/... && go build ./apps/control-plane/...` — clean.
- [x] `go vet` on both touched packages — clean.
- [x] `gofmt -l` on both touched packages — clean.

Closes #253

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR delivers three focused fixes from the feature gate middleware review (issue #253): a singleflight dedup for cold/expired per-tenant cache misses in edge-api's `Gate.Fetch`, a corrected comment in the control-plane handler explaining that the handler (not the mux) strips the path prefix, and a `writeError` helper that sets `Content-Type: application/json` instead of the `text/plain` that `http.Error` would force.

- **Cache stampede fix (`gate.go`):** `Gate.Fetch` now wraps the upstream refresh in `singleflight.Group.Do`, keyed by tenant UUID string, collapsing concurrent cold-cache misses into a single upstream RPC. `context.WithoutCancel` is applied to decouple the in-flight fetch from any individual caller's context lifetime, preventing a cancelled winner from handing the same error to all waiters.
- **`writeError` helper (`handler.go`):** Replaces both `http.Error` call sites on the error paths with a `writeError` function that sets `Content-Type: application/json` before writing the status code, keeping the error format consistent with the 200 OK response body.
- **Test additions:** New `TestFetch_ConcurrentMiss_SingleUpstreamCall` with 20 concurrent goroutines and 50 ms mock latency verifies exactly one upstream call; handler tests add `Content-Type` assertions on the 400 and 405 error paths.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all three changes are small, well-scoped, and covered by new or updated tests that pass under -race.

The singleflight implementation is correct: the key is the tenant UUID string, the shared result is a value type so there are no aliasing hazards, and context.WithoutCancel correctly prevents a cancelled winner from propagating its error to waiting goroutines. The writeError helper preserves the existing JSON body format while fixing the Content-Type mismatch. go.mod changes are mechanical promotions from indirect to direct with no version bumps.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/edge-api/internal/featuregate/gate.go | Adds singleflight.Group to Gate; Fetch wraps refresh in group.Do with context.WithoutCancel — correct deduplication of concurrent cold-cache misses with proper context isolation. |
| apps/edge-api/internal/featuregate/gate_test.go | Adds TestFetch_ConcurrentMiss_SingleUpstreamCall (20 goroutines, 50 ms mock delay, asserts calls==1); removes hand-rolled strContains in favour of strings.Contains. Tests are sound. |
| apps/control-plane/internal/featuregate/handler.go | Introduces writeError helper setting Content-Type: application/json; fixes misleading comment about mux vs handler prefix stripping. Both changes are correct. |
| apps/control-plane/internal/featuregate/handler_test.go | Extends 400 and 405 test cases with Content-Type assertions. Tests are correctly anchored to the new writeError behaviour. |
| apps/edge-api/go.mod | Promotes golang.org/x/sync, jackc/pgerrcode, and prometheus/client_model from indirect to direct requires; no new checksums needed. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant G1 as Goroutine 1 (winner)
    participant G2 as Goroutine 2..N (waiters)
    participant SF as singleflight.Group
    participant Cache as Gate.cache (RWMutex)
    participant CP as Control-Plane

    G1->>Cache: RLock read entry
    Cache-->>G1: miss (cold or expired)
    G2->>Cache: RLock read entry
    Cache-->>G2: miss

    G1->>SF: group.Do(tenantID)
    note over SF: in-flight key registered
    G2->>SF: group.Do(tenantID)
    note over SF: joins in-flight no new call

    SF->>CP: refresh(context.WithoutCancel(ctx))
    note over SF: context detached from winner lifetime
    CP-->>SF: FlagsResponse

    SF->>Cache: Lock write entry
    SF-->>G1: v.(FlagsResponse), nil
    SF-->>G2: shared result (same value), nil
    note over SF: in-flight key removed

    note over G1,G2: Next caller after Do completes sees cache HIT
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant G1 as Goroutine 1 (winner)
    participant G2 as Goroutine 2..N (waiters)
    participant SF as singleflight.Group
    participant Cache as Gate.cache (RWMutex)
    participant CP as Control-Plane

    G1->>Cache: RLock read entry
    Cache-->>G1: miss (cold or expired)
    G2->>Cache: RLock read entry
    Cache-->>G2: miss

    G1->>SF: group.Do(tenantID)
    note over SF: in-flight key registered
    G2->>SF: group.Do(tenantID)
    note over SF: joins in-flight no new call

    SF->>CP: refresh(context.WithoutCancel(ctx))
    note over SF: context detached from winner lifetime
    CP-->>SF: FlagsResponse

    SF->>Cache: Lock write entry
    SF-->>G1: v.(FlagsResponse), nil
    SF-->>G2: shared result (same value), nil
    note over SF: in-flight key removed

    note over G1,G2: Next caller after Do completes sees cache HIT
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: address review feedback (#253)"](https://github.com/sakibsadmanshajib/hive/commit/caf7ec2a6ae0a7edeb68702b5310720e60182be3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41579967)</sub>

<!-- /greptile_comment -->