### PR TITLE
fix: skip OWUI e2e suite cleanly when e2e credentials are not provisioned

### DIFF
--- a/.github/workflows/phase-19-owui-nightly.yml
+++ b/.github/workflows/phase-19-owui-nightly.yml
@@ -129,6 +129,9 @@ jobs:
           fi
       - name: Run OWUI Playwright suite
         run: |
+          if [ -z "${OWUI_E2E_EMAIL:-}" ] || [ -z "${OWUI_E2E_PASSWORD:-}" ]; then
+            echo "::warning::OWUI e2e skipped, OWUI_E2E_EMAIL/OWUI_E2E_PASSWORD secrets not provisioned"
+          fi
           npm i -g pnpm@9
           cd apps/web-console
           pnpm install

--- a/apps/web-console/e2e/phase-19/owui/playwright.owui.config.ts
+++ b/apps/web-console/e2e/phase-19/owui/playwright.owui.config.ts
@@ -1,5 +1,13 @@
 import { defineConfig, devices } from "@playwright/test";
 
+// ponytail: without creds, owui.setup.ts skips and never writes storageState.
+// Match zero spec files for the dependent projects in that case so the run
+// exits clean (0 failed) instead of every spec ENOENT-ing on the missing
+// storageState file.
+const hasCreds = Boolean(
+  process.env.OWUI_E2E_EMAIL && process.env.OWUI_E2E_PASSWORD,
+);
+
 export default defineConfig({
   testDir: "./",
   timeout: 30_000,
@@ -20,13 +28,13 @@ export default defineConfig({
     { name: "owui-setup", testMatch: /owui\.setup\.ts$/ },
     {
       name: "owui",
-      testMatch: /\d{2}-.*\.spec\.ts$/,
+      testMatch: hasCreds ? /\d{2}-.*\.spec\.ts$/ : [],
       dependencies: ["owui-setup"],
       use: { ...devices["Desktop Chrome"] },
     },
     {
       name: "owui-perf",
-      testMatch: /performance\/.*\.spec\.ts$/,
+      testMatch: hasCreds ? /performance\/.*\.spec\.ts$/ : [],
       dependencies: ["owui-setup"],
       use: { ...devices["Desktop Chrome"] },
     },


### PR DESCRIPTION
## Summary

- `owui.setup.ts` calls `setup.skip()` when `OWUI_E2E_EMAIL`/`OWUI_E2E_PASSWORD` are unset, but it never writes `.auth/owui-user.json`. Playwright does not stop a project's dependents when its dependency setup skips, so the `owui` and `owui-perf` projects (14 specs) hard-failed with ENOENT reading the missing storageState file. See nightly run 28643449477.
- `playwright.owui.config.ts` now computes `hasCreds` from the same env vars and matches zero spec files for the `owui`/`owui-perf` projects when credentials are absent, so the run exits clean (0 failed) instead of erroring per spec. With credentials present, project definitions are unchanged.
- `phase-19-owui-nightly.yml` emits a `::warning::` annotation before the Playwright run when credentials are absent, so a credentials-absent skip is visible in the Actions UI instead of silently passing.

## Verification

Local `--list` runs against the edited config (playwright installed in the sibling checkout, `NODE_PATH` pointed at its `node_modules` since this worktree has none):

Without `OWUI_E2E_EMAIL`/`OWUI_E2E_PASSWORD` set:
```
Listing tests:
  [owui-setup] › owui.setup.ts:5:6 › OWUI OIDC sign-in
Total: 1 test in 1 file
```
(exit 0 — `owui`/`owui-perf` match no spec files)

With both env vars set (dummy values):
```
Listing tests:
  [owui-setup] › owui.setup.ts:5:6 › OWUI OIDC sign-in
  [owui] › 01-chat-send-stream.spec.ts:5:5 › chat message streams a response
  [owui] › 02-chat-multi-turn.spec.ts:5:5 › second turn references first turn context
  [owui] › 03-chat-model-switch.spec.ts:5:5 › switch model and confirm subsequent request goes to it
  [owui] › 04-rag-personal-pdf-upload.spec.ts:9:5 › upload personal PDF and confirm embeddings land in pgvector
  [owui] › 05-rag-personal-citation.spec.ts:8:5 › ask grounded question and receive citation
  [owui] › 06-tenant-model-visibility.spec.ts:5:5 › user sees only models granted to tenant group
  [owui] › 07-image-upload-vision.spec.ts:8:5 › upload image and vision model returns content-aware answer
  [owui] › 08-signout.spec.ts:5:5 › signout clears session and lands on signin page
  [owui-perf] › performance/embed-latency.spec.ts:18:5 › personal-doc ingestion under budget
  [owui-perf] › performance/ttfb.spec.ts:15:5 › first-token latency under budget
Total: 11 tests in 11 files
```
(matches pre-fix project matching exactly — unchanged with credentials present)

- [x] Local `--list` verification without creds: 1 test (setup only), exit 0
- [x] Local `--list` verification with creds: all 11 specs listed, unchanged
- [x] Workflow YAML validated with `yaml.safe_load`
- [ ] Full nightly run (owner/CI to confirm on next scheduled run or `workflow_dispatch`)

Scope limited to `playwright.owui.config.ts` and `phase-19-owui-nightly.yml`. Did not touch `featuregate` or `auditarchive` packages.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a nightly-run breakage where `owui.setup.ts` calling `test.skip()` would skip writing `.auth/owui-user.json`, but Playwright still ran the 14 dependent specs which then hard-failed with ENOENT on the missing `storageState` file. The fix computes `hasCreds` from the same env vars in the Playwright config and sets `testMatch: []` for `owui`/`owui-perf` projects when credentials are absent, so the run exits cleanly with 0 failures.

- **`playwright.owui.config.ts`**: `hasCreds` is evaluated at config-load time; `owui` and `owui-perf` projects receive an empty `testMatch` array when credentials are absent, preventing any spec from being collected or failing.
- **`phase-19-owui-nightly.yml`**: A `::warning::` GitHub Actions annotation is emitted when credentials are absent, making the skip visible in the Actions UI; the annotation is placed inside the "Run OWUI Playwright suite" step after the Docker stack has already booted.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the Playwright config change is minimal and correctly prevents spec collection when credentials are absent; the only rough edge is that the Docker stack boots unnecessarily on credential-absent runs.

The `testMatch: []` approach is correct and verified by the author's local `--list` output showing 0 owui/owui-perf tests without credentials, and an unchanged listing with credentials present. The one imperfection is in the workflow: the 'Boot stack' step spins up Open WebUI and waits up to 120 s for a health check before the credential check is ever reached, wasting CI time on every credential-absent nightly run.

`phase-19-owui-nightly.yml` — the credential guard should ideally be moved before the Docker stack boot so the 120 s health-check wait is not incurred on no-op runs.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web-console/e2e/phase-19/owui/playwright.owui.config.ts | Adds `hasCreds` flag computed from env vars; sets `testMatch: []` for `owui`/`owui-perf` projects when credentials are absent, preventing ENOENT failures on the missing storageState file. |
| .github/workflows/phase-19-owui-nightly.yml | Adds a `::warning::` annotation when OWUI e2e credentials are absent; the Docker stack (including Open WebUI) still fully boots before the credential check is reached, wasting ~2–3 min of CI time on credential-absent runs. |

</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Nightly trigger / workflow_dispatch] --> B[Reconstruct SUPABASE_DB_URL]
    B --> C[Materialize .env.ci\nfails fast if core secrets absent]
    C --> D[Boot Docker stack\nOpen WebUI health-check up to 120s]
    D --> E{OWUI_E2E_EMAIL\nOWUI_E2E_PASSWORD set?}
    E -- No --> F[emit ::warning:: annotation]
    F --> G[pnpm e2e:owui\n--project=owui\ntestMatch: empty array\n0 tests exit 0]
    G --> H[pnpm e2e:owui:perf\n--project=owui-perf\ntestMatch: empty array\n0 tests exit 0]
    H --> I[Clean exit 0]
    E -- Yes --> J[pnpm e2e:owui\nowui-setup writes storageState\n8 specs run]
    J --> K[pnpm e2e:owui:perf\n2 perf specs run]
    K --> L[Exit 0 if all pass]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Nightly trigger / workflow_dispatch] --> B[Reconstruct SUPABASE_DB_URL]
    B --> C[Materialize .env.ci\nfails fast if core secrets absent]
    C --> D[Boot Docker stack\nOpen WebUI health-check up to 120s]
    D --> E{OWUI_E2E_EMAIL\nOWUI_E2E_PASSWORD set?}
    E -- No --> F[emit ::warning:: annotation]
    F --> G[pnpm e2e:owui\n--project=owui\ntestMatch: empty array\n0 tests exit 0]
    G --> H[pnpm e2e:owui:perf\n--project=owui-perf\ntestMatch: empty array\n0 tests exit 0]
    H --> I[Clean exit 0]
    E -- Yes --> J[pnpm e2e:owui\nowui-setup writes storageState\n8 specs run]
    J --> K[pnpm e2e:owui:perf\n2 perf specs run]
    K --> L[Exit 0 if all pass]
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/phase-19-owui-nightly.yml`, line 111-141 ([link](https://github.com/sakibsadmanshajib/hive/blob/678ba4d6d513df601b078d5d62a1a63a6834948d/.github/workflows/phase-19-owui-nightly.yml#L111-L141)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Full stack boots even when OWUI credentials are absent**

   The "Boot stack" step (lines 111–129) always runs before the credential check, so Open WebUI is spun up and the 120 s health-check polling loop runs regardless of whether `OWUI_E2E_EMAIL`/`OWUI_E2E_PASSWORD` are provisioned. On a credential-absent nightly run the workflow correctly exits 0, but it still consumes the full stack-boot time (~2–3 min) before running zero tests.

   A lightweight fix is to add a pre-boot step that writes a step output (`has_creds=true/false`) and guard the boot and Playwright steps with `if: steps.check-creds.outputs.has_creds == 'true'`. The `::warning::` annotation can also be moved into that check step so visibility is preserved without the wasted boot.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Fphase-19-owui-nightly.yml%0ALine%3A%20111-141%0A%0AComment%3A%0A**Full%20stack%20boots%20even%20when%20OWUI%20credentials%20are%20absent**%0A%0AThe%20%22Boot%20stack%22%20step%20%28lines%20111%E2%80%93129%29%20always%20runs%20before%20the%20credential%20check%2C%20so%20Open%20WebUI%20is%20spun%20up%20and%20the%20120%20s%20health-check%20polling%20loop%20runs%20regardless%20of%20whether%20%60OWUI_E2E_EMAIL%60%2F%60OWUI_E2E_PASSWORD%60%20are%20provisioned.%20On%20a%20credential-absent%20nightly%20run%20the%20workflow%20correctly%20exits%200%2C%20but%20it%20still%20consumes%20the%20full%20stack-boot%20time%20%28~2%E2%80%933%20min%29%20before%20running%20zero%20tests.%0A%0AA%20lightweight%20fix%20is%20to%20add%20a%20pre-boot%20step%20that%20writes%20a%20step%20output%20%28%60has_creds%3Dtrue%2Ffalse%60%29%20and%20guard%20the%20boot%20and%20Playwright%20steps%20with%20%60if%3A%20steps.check-creds.outputs.has_creds%20%3D%3D%20'true'%60.%20The%20%60%3A%3Awarning%3A%3A%60%20annotation%20can%20also%20be%20moved%20into%20that%20check%20step%20so%20visibility%20is%20preserved%20without%20the%20wasted%20boot.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=sakibsadmanshajib%2Fhive&pr=266&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Fphase-19-owui-nightly.yml%0ALine%3A%20111-141%0A%0AComment%3A%0A**Full%20stack%20boots%20even%20when%20OWUI%20credentials%20are%20absent**%0A%0AThe%20%22Boot%20stack%22%20step%20%28lines%20111%E2%80%93129%29%20always%20runs%20before%20the%20credential%20check%2C%20so%20Open%20WebUI%20is%20spun%20up%20and%20the%20120%20s%20health-check%20polling%20loop%20runs%20regardless%20of%20whether%20%60OWUI_E2E_EMAIL%60%2F%60OWUI_E2E_PASSWORD%60%20are%20provisioned.%20On%20a%20credential-absent%20nightly%20run%20the%20workflow%20correctly%20exits%200%2C%20but%20it%20still%20consumes%20the%20full%20stack-boot%20time%20%28~2%E2%80%933%20min%29%20before%20running%20zero%20tests.%0A%0AA%20lightweight%20fix%20is%20to%20add%20a%20pre-boot%20step%20that%20writes%20a%20step%20output%20%28%60has_creds%3Dtrue%2Ffalse%60%29%20and%20guard%20the%20boot%20and%20Playwright%20steps%20with%20%60if%3A%20steps.check-creds.outputs.has_creds%20%3D%3D%20'true'%60.%20The%20%60%3A%3Awarning%3A%3A%60%20annotation%20can%20also%20be%20moved%20into%20that%20check%20step%20so%20visibility%20is%20preserved%20without%20the%20wasted%20boot.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=266&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22sakibsadmanshajib%2Fhive%22%20on%20the%20existing%20branch%20%22fix%2Fowui-e2e-skip-without-creds%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fowui-e2e-skip-without-creds%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Fphase-19-owui-nightly.yml%0ALine%3A%20111-141%0A%0AComment%3A%0A**Full%20stack%20boots%20even%20when%20OWUI%20credentials%20are%20absent**%0A%0AThe%20%22Boot%20stack%22%20step%20%28lines%20111%E2%80%93129%29%20always%20runs%20before%20the%20credential%20check%2C%20so%20Open%20WebUI%20is%20spun%20up%20and%20the%20120%20s%20health-check%20polling%20loop%20runs%20regardless%20of%20whether%20%60OWUI_E2E_EMAIL%60%2F%60OWUI_E2E_PASSWORD%60%20are%20provisioned.%20On%20a%20credential-absent%20nightly%20run%20the%20workflow%20correctly%20exits%200%2C%20but%20it%20still%20consumes%20the%20full%20stack-boot%20time%20%28~2%E2%80%933%20min%29%20before%20running%20zero%20tests.%0A%0AA%20lightweight%20fix%20is%20to%20add%20a%20pre-boot%20step%20that%20writes%20a%20step%20output%20%28%60has_creds%3Dtrue%2Ffalse%60%29%20and%20guard%20the%20boot%20and%20Playwright%20steps%20with%20%60if%3A%20steps.check-creds.outputs.has_creds%20%3D%3D%20'true'%60.%20The%20%60%3A%3Awarning%3A%3A%60%20annotation%20can%20also%20be%20moved%20into%20that%20check%20step%20so%20visibility%20is%20preserved%20without%20the%20wasted%20boot.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=sakibsadmanshajib%2Fhive&pr=266&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fphase-19-owui-nightly.yml%3A111-141%0A**Full%20stack%20boots%20even%20when%20OWUI%20credentials%20are%20absent**%0A%0AThe%20%22Boot%20stack%22%20step%20%28lines%20111%E2%80%93129%29%20always%20runs%20before%20the%20credential%20check%2C%20so%20Open%20WebUI%20is%20spun%20up%20and%20the%20120%20s%20health-check%20polling%20loop%20runs%20regardless%20of%20whether%20%60OWUI_E2E_EMAIL%60%2F%60OWUI_E2E_PASSWORD%60%20are%20provisioned.%20On%20a%20credential-absent%20nightly%20run%20the%20workflow%20correctly%20exits%200%2C%20but%20it%20still%20consumes%20the%20full%20stack-boot%20time%20%28~2%E2%80%933%20min%29%20before%20running%20zero%20tests.%0A%0AA%20lightweight%20fix%20is%20to%20add%20a%20pre-boot%20step%20that%20writes%20a%20step%20output%20%28%60has_creds%3Dtrue%2Ffalse%60%29%20and%20guard%20the%20boot%20and%20Playwright%20steps%20with%20%60if%3A%20steps.check-creds.outputs.has_creds%20%3D%3D%20'true'%60.%20The%20%60%3A%3Awarning%3A%3A%60%20annotation%20can%20also%20be%20moved%20into%20that%20check%20step%20so%20visibility%20is%20preserved%20without%20the%20wasted%20boot.%0A%0A&repo=sakibsadmanshajib%2Fhive&pr=266&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fphase-19-owui-nightly.yml%3A111-141%0A**Full%20stack%20boots%20even%20when%20OWUI%20credentials%20are%20absent**%0A%0AThe%20%22Boot%20stack%22%20step%20%28lines%20111%E2%80%93129%29%20always%20runs%20before%20the%20credential%20check%2C%20so%20Open%20WebUI%20is%20spun%20up%20and%20the%20120%20s%20health-check%20polling%20loop%20runs%20regardless%20of%20whether%20%60OWUI_E2E_EMAIL%60%2F%60OWUI_E2E_PASSWORD%60%20are%20provisioned.%20On%20a%20credential-absent%20nightly%20run%20the%20workflow%20correctly%20exits%200%2C%20but%20it%20still%20consumes%20the%20full%20stack-boot%20time%20%28~2%E2%80%933%20min%29%20before%20running%20zero%20tests.%0A%0AA%20lightweight%20fix%20is%20to%20add%20a%20pre-boot%20step%20that%20writes%20a%20step%20output%20%28%60has_creds%3Dtrue%2Ffalse%60%29%20and%20guard%20the%20boot%20and%20Playwright%20steps%20with%20%60if%3A%20steps.check-creds.outputs.has_creds%20%3D%3D%20'true'%60.%20The%20%60%3A%3Awarning%3A%3A%60%20annotation%20can%20also%20be%20moved%20into%20that%20check%20step%20so%20visibility%20is%20preserved%20without%20the%20wasted%20boot.%0A%0A&pr=266&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22sakibsadmanshajib%2Fhive%22%20on%20the%20existing%20branch%20%22fix%2Fowui-e2e-skip-without-creds%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fowui-e2e-skip-without-creds%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fphase-19-owui-nightly.yml%3A111-141%0A**Full%20stack%20boots%20even%20when%20OWUI%20credentials%20are%20absent**%0A%0AThe%20%22Boot%20stack%22%20step%20%28lines%20111%E2%80%93129%29%20always%20runs%20before%20the%20credential%20check%2C%20so%20Open%20WebUI%20is%20spun%20up%20and%20the%20120%20s%20health-check%20polling%20loop%20runs%20regardless%20of%20whether%20%60OWUI_E2E_EMAIL%60%2F%60OWUI_E2E_PASSWORD%60%20are%20provisioned.%20On%20a%20credential-absent%20nightly%20run%20the%20workflow%20correctly%20exits%200%2C%20but%20it%20still%20consumes%20the%20full%20stack-boot%20time%20%28~2%E2%80%933%20min%29%20before%20running%20zero%20tests.%0A%0AA%20lightweight%20fix%20is%20to%20add%20a%20pre-boot%20step%20that%20writes%20a%20step%20output%20%28%60has_creds%3Dtrue%2Ffalse%60%29%20and%20guard%20the%20boot%20and%20Playwright%20steps%20with%20%60if%3A%20steps.check-creds.outputs.has_creds%20%3D%3D%20'true'%60.%20The%20%60%3A%3Awarning%3A%3A%60%20annotation%20can%20also%20be%20moved%20into%20that%20check%20step%20so%20visibility%20is%20preserved%20without%20the%20wasted%20boot.%0A%0A&repo=sakibsadmanshajib%2Fhive&pr=266&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix: skip OWUI e2e suite cleanly when e2..."](https://github.com/sakibsadmanshajib/hive/commit/678ba4d6d513df601b078d5d62a1a63a6834948d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41580302)</sub>

<!-- /greptile_comment -->