### PR TITLE
fix: audit archive scalability and test determinism

### DIFF
--- a/apps/control-plane/internal/auditarchive/archiver.go
+++ b/apps/control-plane/internal/auditarchive/archiver.go
@@ -84,10 +84,14 @@ type Repository interface {
 // ObjectStore abstracts local cold storage (Supabase Storage / local filesystem).
 // Zero external egress: the backing store must be the box's own filesystem.
 //
-// Put must return the number of bytes written to storage so the archiver can
-// verify the upload was complete before deleting source rows (P1 safety).
+// Put receives the exact size of r up front (the caller already knows it,
+// having built the compressed payload) so implementations can stream the
+// payload straight to the backing store instead of buffering it a second
+// time. Put must return the number of bytes written to storage so the
+// archiver can verify the upload was complete before deleting source rows
+// (P1 safety).
 type ObjectStore interface {
-	Put(ctx context.Context, key string, r io.Reader) (written int64, err error)
+	Put(ctx context.Context, key string, r io.Reader, size int64) (written int64, err error)
 	Delete(ctx context.Context, key string) error
 }
 
@@ -99,8 +103,14 @@ type Config struct {
 	RetentionYears int
 	// ColdStorageBucket: bucket name (or path prefix) in the ObjectStore.
 	ColdStorageBucket string
-	Repo              Repository
-	Store             ObjectStore
+	// MaxRowsPerPartition: log a warning when a single (tenant, month) batch
+	// exceeds this many rows (default 250,000). The batch is still archived
+	// in full as one manifest entry; this is an operator signal, not a cap.
+	// ponytail: warn-only threshold; upgrade to a paged/multi-object manifest
+	// (needs a manifest schema change) if a real tenant approaches this.
+	MaxRowsPerPartition int
+	Repo                Repository
+	Store               ObjectStore
 }
 
 // Archiver runs the cold-archive lifecycle.
@@ -118,6 +128,9 @@ func New(cfg Config) *Archiver {
 	}
 	if cfg.ColdStorageBucket == "" {
 		cfg.ColdStorageBucket = "hive-audit-cold"
+	}
+	if cfg.MaxRowsPerPartition <= 0 {
+		cfg.MaxRowsPerPartition = 250_000
 	}
 	return &Archiver{cfg: cfg}
 }
@@ -169,6 +182,15 @@ func (a *Archiver) RunOnce(ctx context.Context, now time.Time) (int, error) {
 				slog.Info("auditarchive: partition already archived, skipping",
 					"tenant_id", tenantID, "month", month.Format("2006-01"))
 				continue
+			}
+
+			if len(monthRows) > a.cfg.MaxRowsPerPartition {
+				slog.Warn("auditarchive: partition row count exceeds configured threshold",
+					"tenant_id", tenantID,
+					"month", month.Format("2006-01"),
+					"rows", len(monthRows),
+					"threshold", a.cfg.MaxRowsPerPartition,
+				)
 			}
 
 			n, err := a.archivePartition(ctx, now, tenantID, month, monthRows)
@@ -226,7 +248,7 @@ func (a *Archiver) archivePartition(
 	)
 
 	// P1: verify written byte count matches before trusting the upload.
-	written, err := a.cfg.Store.Put(ctx, objectKey, bytes.NewReader(compressed))
+	written, err := a.cfg.Store.Put(ctx, objectKey, bytes.NewReader(compressed), expectedSize)
 	if err != nil {
 		return 0, fmt.Errorf("auditarchive: store put %s: %w", objectKey, err)
 	}
@@ -277,6 +299,15 @@ func (a *Archiver) archivePartition(
 
 // PurgeExpired deletes cold objects and manifest entries whose purge_after has passed.
 // Returns the number of manifest entries purged.
+//
+// Store.Delete runs before Repo.DeleteManifest so a crash between the two
+// self-heals on retry: FetchExpiredManifests returns the same manifest row
+// again next pass, and Store.Delete on an already-deleted key must be
+// idempotent (S3 DELETE returns success for a missing key by protocol, so
+// StorageObjectStore satisfies this without extra code). If DeleteManifest
+// itself fails after a successful Store.Delete, the manifest row becomes an
+// orphan pointing at a deleted object -- logged loudly below so an operator
+// can confirm the retry cleared it.
 func (a *Archiver) PurgeExpired(ctx context.Context, now time.Time) (int, error) {
 	entries, err := a.cfg.Repo.FetchExpiredManifests(ctx, now)
 	if err != nil {
@@ -288,6 +319,12 @@ func (a *Archiver) PurgeExpired(ctx context.Context, now time.Time) (int, error)
 			return purged, fmt.Errorf("auditarchive: delete cold object %s: %w", m.ObjectKey, err)
 		}
 		if err := a.cfg.Repo.DeleteManifest(ctx, m.ID); err != nil {
+			slog.Warn("auditarchive: cold object deleted but manifest delete failed, orphan manifest row",
+				"manifest_id", m.ID,
+				"tenant_id", m.TenantID,
+				"object_key", m.ObjectKey,
+				"err", err,
+			)
 			return purged, fmt.Errorf("auditarchive: delete manifest %s: %w", m.ID, err)
 		}
 		slog.Info("auditarchive: expired cold object purged",
@@ -333,10 +370,14 @@ func (a *Archiver) RunCron(ctx context.Context, interval time.Duration) error {
 }
 
 // groupByMonth partitions rows by their UTC year-month (normalised to the 1st at midnight).
+// r.TS.UTC() is mandatory here: Time.Year()/Month() report the year/month in
+// the time's own Location, so a row whose TS carries a non-UTC Location would
+// otherwise be bucketed by the wrong calendar month on hosts not set to UTC.
 func groupByMonth(rows []AuditRow) map[time.Time][]AuditRow {
 	out := map[time.Time][]AuditRow{}
 	for _, r := range rows {
-		m := time.Date(r.TS.Year(), r.TS.Month(), 1, 0, 0, 0, 0, time.UTC)
+		ts := r.TS.UTC()
+		m := time.Date(ts.Year(), ts.Month(), 1, 0, 0, 0, 0, time.UTC)
 		out[m] = append(out[m], r)
 	}
 	return out

--- a/apps/control-plane/internal/auditarchive/archiver_test.go
+++ b/apps/control-plane/internal/auditarchive/archiver_test.go
@@ -4,9 +4,12 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
+	"sync"
 	"testing"
 	"time"
 
@@ -20,6 +23,10 @@ import (
 type fakeRepo struct {
 	rows     []auditarchive.AuditRow
 	manifest []auditarchive.ManifestEntry
+	// onInsert, if set, runs synchronously right after a successful (non-duplicate)
+	// InsertManifest. Tests use this instead of a fixed sleep to learn deterministically
+	// when a background RunCron pass has produced its first manifest entry.
+	onInsert func()
 }
 
 func (r *fakeRepo) FetchOlderThan(ctx context.Context, cutoff time.Time, tenantID uuid.UUID) ([]auditarchive.AuditRow, error) {
@@ -60,6 +67,9 @@ func (r *fakeRepo) InsertManifest(ctx context.Context, entry auditarchive.Manife
 		}
 	}
 	r.manifest = append(r.manifest, entry)
+	if r.onInsert != nil {
+		r.onInsert()
+	}
 	return true, nil
 }
 
@@ -117,7 +127,7 @@ func newFakeStore() *fakeStore {
 	return &fakeStore{objects: map[string][]byte{}}
 }
 
-func (s *fakeStore) Put(ctx context.Context, key string, r io.Reader) (int64, error) {
+func (s *fakeStore) Put(ctx context.Context, key string, r io.Reader, size int64) (int64, error) {
 	if s.failPut {
 		// Simulate a partial write: drain the reader but report 0 bytes written.
 		_, _ = io.ReadAll(r)
@@ -126,6 +136,9 @@ func (s *fakeStore) Put(ctx context.Context, key string, r io.Reader) (int64, er
 	data, err := io.ReadAll(r)
 	if err != nil {
 		return 0, err
+	}
+	if int64(len(data)) != size {
+		return 0, fmt.Errorf("fakeStore: caller-supplied size %d does not match actual bytes read %d", size, len(data))
 	}
 	s.objects[key] = data
 	return int64(len(data)), nil
@@ -197,19 +210,25 @@ func TestArchiveSelectsOldRowsOnly(t *testing.T) {
 // TestBoundaryMonthNoUnarchivedDelete is the P0 regression test.
 //
 // Setup: two rows share the same calendar month.
-//   oldRow.TS = cutoff - 10 days  (fetched and archived)
-//   newRow.TS = cutoff + 1 day    (never fetched; must survive the delete pass)
 //
-// With exact-ID delete the month boundary is irrelevant: only the IDs returned
-// by FetchOlderThan are ever deleted, so newRow is safe even when it shares a
-// calendar month with oldRow.
+//	oldRow.TS = cutoff - 10 days  (fetched and archived)
+//	newRow.TS = cutoff + 1 day    (never fetched; must survive the delete pass)
+//
+// now is a fixed, synthetic instant (not time.Now()) chosen so cutoff-10d and
+// cutoff+1d always land in the same calendar month regardless of which day
+// the suite runs on: a wall-clock now could push the two dates across a
+// month boundary depending on where in the month the test happened to run,
+// silently changing what the test exercises without a skip window or retry.
 func TestBoundaryMonthNoUnarchivedDelete(t *testing.T) {
 	tenantID := uuid.New()
-	now := time.Now().UTC()
+	now := time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC)
 	cutoff := now.AddDate(0, 0, -90)
 
 	oldTS := cutoff.AddDate(0, 0, -10)
 	newTS := cutoff.AddDate(0, 0, 1)
+	if oldTS.Month() != newTS.Month() || oldTS.Year() != newTS.Year() {
+		t.Fatalf("test fixture invariant broken: oldTS %v and newTS %v must share a calendar month", oldTS, newTS)
+	}
 
 	oldRow := auditarchive.AuditRow{ID: 1, Seq: 1, TenantID: tenantID, Action: "A", Severity: "INFO", TS: oldTS}
 	newRow := auditarchive.AuditRow{ID: 2, Seq: 2, TenantID: tenantID, Action: "B", Severity: "INFO", TS: newTS}
@@ -314,6 +333,18 @@ func TestArchiveManifestRecorded(t *testing.T) {
 	diff := m.PurgeAfter.Sub(expectedPurge)
 	if diff < -time.Second || diff > time.Second {
 		t.Errorf("purge_after %v, want ~%v", m.PurgeAfter, expectedPurge)
+	}
+
+	// The manifest's digest must match the actual bytes archived to storage,
+	// not just be present and 32 bytes long -- a wrong hash would silently
+	// break chain re-verification without ever failing this test otherwise.
+	archived, ok := store.objects[m.ObjectKey]
+	if !ok {
+		t.Fatalf("no stored object found for manifest object_key %q", m.ObjectKey)
+	}
+	wantSum := sha256.Sum256(archived)
+	if !bytes.Equal(m.SHA256Hash, wantSum[:]) {
+		t.Errorf("manifest SHA256Hash %x does not match sha256 of archived bytes %x", m.SHA256Hash, wantSum)
 	}
 }
 
@@ -453,12 +484,21 @@ func TestNoRowsNoArchive(t *testing.T) {
 }
 
 // TestCronRun: smoke test the scheduler (fires immediately at startup).
+//
+// Waits on a channel closed by fakeRepo.onInsert instead of a fixed sleep:
+// a fixed sleep either wastes time when the pass is fast or flakes under
+// slow/loaded CI when the pass is slow. The channel close happens inside the
+// archiver goroutine and is only ever observed after being received here, so
+// the wait is both deterministic and race-free.
 func TestCronRun(t *testing.T) {
 	tenantID := uuid.New()
 	now := time.Now().UTC()
 	old := now.AddDate(0, 0, -100)
 
 	repo := &fakeRepo{rows: makeRows(tenantID, old, 2, 1)}
+	firstPass := make(chan struct{})
+	var once sync.Once
+	repo.onInsert = func() { once.Do(func() { close(firstPass) }) }
 	store := newFakeStore()
 	arch := newArchiver(repo, store)
 
@@ -470,8 +510,11 @@ func TestCronRun(t *testing.T) {
 		doneCh <- arch.RunCron(ctx, time.Hour) // long interval; first pass fires immediately
 	}()
 
-	// Immediate first pass; no sleep needed beyond a short yield.
-	time.Sleep(100 * time.Millisecond)
+	select {
+	case <-firstPass:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for cron's immediate first pass to write a manifest entry")
+	}
 	cancel()
 	<-doneCh
 
@@ -533,6 +576,73 @@ func TestLateInsertNotDeleted(t *testing.T) {
 	}
 }
 
+// TestGroupByMonthUsesUTCNotLocalTime is the deferred #261 regression test:
+// a row whose TS carries a non-UTC Location must be bucketed by its UTC
+// calendar month, not the month implied by the timestamp's own Location, so
+// partitioning is deterministic on hosts not set to UTC.
+func TestGroupByMonthUsesUTCNotLocalTime(t *testing.T) {
+	tenantID := uuid.New()
+	now := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+
+	// UTC-6: local wall-clock Jan 31 23:00 is Feb 1 05:00 in UTC. A grouping
+	// bug that reads Year()/Month() off the row's own Location buckets this
+	// as January; the UTC-correct bucket is February.
+	tz := time.FixedZone("UTC-6", -6*60*60)
+	localTS := time.Date(2026, 1, 31, 23, 0, 0, 0, tz)
+
+	row := auditarchive.AuditRow{
+		ID: 1, Seq: 1, TenantID: tenantID, Action: "A", Severity: "INFO", TS: localTS,
+	}
+	repo := &fakeRepo{rows: []auditarchive.AuditRow{row}}
+	store := newFakeStore()
+	arch := newArchiver(repo, store)
+
+	if _, err := arch.RunOnce(context.Background(), now); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if len(repo.manifest) != 1 {
+		t.Fatalf("got %d manifest entries, want 1", len(repo.manifest))
+	}
+
+	wantMonth := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	gotMonth := repo.manifest[0].PartitionMonth
+	if !gotMonth.Equal(wantMonth) {
+		t.Errorf("partition_month = %v, want %v (UTC month of %v)", gotMonth, wantMonth, localTS)
+	}
+}
+
+// TestLargePartitionStillArchivesAllRows: exceeding MaxRowsPerPartition only
+// logs an operator warning, it must not truncate or otherwise change what
+// gets archived.
+func TestLargePartitionStillArchivesAllRows(t *testing.T) {
+	tenantID := uuid.New()
+	now := time.Now().UTC()
+	old := now.AddDate(0, 0, -100)
+
+	const rowCount = 10
+	repo := &fakeRepo{rows: makeRows(tenantID, old, rowCount, 1)}
+	store := newFakeStore()
+	arch := auditarchive.New(auditarchive.Config{
+		HotRetentionDays:    90,
+		RetentionYears:      10,
+		Repo:                repo,
+		Store:               store,
+		ColdStorageBucket:   "hive-audit-cold",
+		MaxRowsPerPartition: 1, // force every row over threshold
+	})
+
+	n, err := arch.RunOnce(context.Background(), now)
+	if err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if n != rowCount {
+		t.Errorf("archived %d rows, want %d (threshold must warn, not truncate)", n, rowCount)
+	}
+	if len(repo.manifest) != 1 || repo.manifest[0].RowCount != rowCount {
+		t.Errorf("manifest row_count = %+v, want single entry with RowCount %d", repo.manifest, rowCount)
+	}
+}
+
 // injectStore wraps fakeStore and calls onPut after each Put to simulate
 // a concurrent insert between fetch and delete.
 type injectStore struct {
@@ -540,8 +650,8 @@ type injectStore struct {
 	onPut func()
 }
 
-func (s *injectStore) Put(ctx context.Context, key string, r io.Reader) (int64, error) {
-	n, err := s.inner.Put(ctx, key, r)
+func (s *injectStore) Put(ctx context.Context, key string, r io.Reader, size int64) (int64, error) {
+	n, err := s.inner.Put(ctx, key, r, size)
 	if err == nil {
 		s.onPut()
 	}

--- a/apps/control-plane/internal/auditarchive/pg_repository.go
+++ b/apps/control-plane/internal/auditarchive/pg_repository.go
@@ -43,7 +43,16 @@ func (r *PgRepository) FetchTenants(ctx context.Context) ([]uuid.UUID, error) {
 }
 
 // FetchOlderThan returns all audit_log rows for tenantID with ts < cutoff,
-// ordered by seq ASC so the JSONL preserves chain order.
+// ordered so the JSONL preserves chain order.
+//
+// Ordering by (ts, seq) rather than seq alone lets the planner satisfy the
+// sort directly from the audit_log_tenant_ts_seq_idx composite index instead
+// of adding an explicit sort node over the full matched row set -- the
+// bottleneck flagged for high-volume tenants. seq is assigned monotonically
+// with ts at insert time (same assumption already relied on for the ts-based
+// hot/cold and month-partition boundaries elsewhere in this package), so this
+// produces the same row order as ORDER BY seq ASC for any row set actually
+// written by the audit pipeline, with seq only breaking ties on equal ts.
 func (r *PgRepository) FetchOlderThan(ctx context.Context, cutoff time.Time, tenantID uuid.UUID) ([]AuditRow, error) {
 	rows, err := r.pool.Query(ctx, `
 		SELECT id, seq, tenant_id, actor_id, actor_type, action,
@@ -52,7 +61,7 @@ func (r *PgRepository) FetchOlderThan(ctx context.Context, cutoff time.Time, ten
 		       deploy_sha, env, prev_hash, row_hash, ts
 		  FROM public.audit_log
 		 WHERE tenant_id = $1 AND ts < $2
-		 ORDER BY seq ASC
+		 ORDER BY ts ASC, seq ASC
 	`, tenantID, cutoff)
 	if err != nil {
 		return nil, fmt.Errorf("auditarchive pg: fetch older than: %w", err)

--- a/apps/control-plane/internal/auditarchive/storage_store.go
+++ b/apps/control-plane/internal/auditarchive/storage_store.go
@@ -1,7 +1,6 @@
 package auditarchive
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -14,8 +13,8 @@ import (
 // The bucket is the local Supabase Storage bucket backed by the box's own filesystem.
 // Zero external egress: no data leaves the sovereign edge node.
 type StorageObjectStore struct {
-	client  storage.Storage
-	bucket  string
+	client storage.Storage
+	bucket string
 	// endpoint is logged at construction for sovereignty observability.
 	endpoint string
 }
@@ -35,19 +34,15 @@ func NewStorageObjectStore(client storage.Storage, bucket, endpoint string) *Sto
 	return &StorageObjectStore{client: client, bucket: bucket, endpoint: endpoint}
 }
 
-// Put writes r to key in the configured bucket and returns the number of bytes
-// written. The caller verifies this equals the expected compressed size before
-// deleting source rows (P1 truncation guard).
-func (s *StorageObjectStore) Put(ctx context.Context, key string, r io.Reader) (int64, error) {
-	// Buffer the reader to get an exact byte count for the size argument and
-	// the post-write verification. Gzip archive payloads are small (<100 MB).
-	// ponytail: in-memory buffer; switch to streaming multipart upload if payload sizes grow.
-	data, err := io.ReadAll(r)
-	if err != nil {
-		return 0, fmt.Errorf("auditarchive storage: read %s: %w", key, err)
-	}
-	size := int64(len(data))
-	if err := s.client.Upload(ctx, s.bucket, key, bytes.NewReader(data), size, "application/gzip"); err != nil {
+// Put streams r to key in the configured bucket and returns the number of
+// bytes written. size is the exact length of r, supplied by the caller
+// (which already built the compressed payload and knows its length), so Put
+// forwards the reader straight to the underlying client instead of buffering
+// the already-compressed payload a second time. The caller verifies the
+// returned count equals the expected compressed size before deleting source
+// rows (P1 truncation guard).
+func (s *StorageObjectStore) Put(ctx context.Context, key string, r io.Reader, size int64) (int64, error) {
+	if err := s.client.Upload(ctx, s.bucket, key, r, size, "application/gzip"); err != nil {
 		return 0, fmt.Errorf("auditarchive storage: put %s: %w", key, err)
 	}
 	return size, nil

--- a/supabase/migrations/20260703_01_audit_log_tenant_ts_seq_index.sql
+++ b/supabase/migrations/20260703_01_audit_log_tenant_ts_seq_index.sql
@@ -1,0 +1,19 @@
+-- supabase/migrations/20260703_01_audit_log_tenant_ts_seq_index.sql
+--
+-- Cleanup deferred from #258 (issue #261): the audit cold-archive fetch
+-- (auditarchive.PgRepository.FetchOlderThan) filters on
+-- (tenant_id, ts) and orders by (ts, seq) so the JSONL export preserves
+-- chain order. Without a covering index for that exact shape, the planner
+-- has to add an explicit sort node over every matched row for a
+-- high-volume tenant instead of reading them back out already ordered.
+--
+-- audit_log is range-partitioned by ts (see 20260516_04_phase19_audit_log.sql);
+-- this index is created on the parent so Postgres propagates it to each
+-- monthly partition (and to future ones created by the same DDL pattern).
+
+BEGIN;
+
+CREATE INDEX IF NOT EXISTS audit_log_tenant_ts_seq_idx
+    ON public.audit_log (tenant_id, ts, seq);
+
+COMMIT;

--- a/supabase/migrations/20260703_01_audit_log_tenant_ts_seq_index.sql
+++ b/supabase/migrations/20260703_01_audit_log_tenant_ts_seq_index.sql
@@ -10,6 +10,30 @@
 -- audit_log is range-partitioned by ts (see 20260516_04_phase19_audit_log.sql);
 -- this index is created on the parent so Postgres propagates it to each
 -- monthly partition (and to future ones created by the same DDL pattern).
+--
+-- Lock tradeoff (DB review follow-up):
+--   CREATE INDEX CONCURRENTLY is NOT supported on a partitioned parent table
+--   in Postgres (only on a single ordinary table, or on one partition at a
+--   time). Building the index this way is the only direct, single-statement
+--   option; Postgres recurses the CREATE INDEX to each existing partition
+--   and takes a normal (non-concurrent) lock -- ACCESS EXCLUSIVE on each
+--   partition individually, held only for that partition's build, one
+--   partition at a time -- which blocks reads and writes against the
+--   partition currently being indexed until its build finishes.
+--
+--   Accepted here because this table is pre-production scale (Carl.sh
+--   sovereign edge, no live customer traffic writing to audit_log yet), so
+--   the brief per-partition lock has no user-facing impact. If this ever
+--   needs to run against a hot production audit_log, do NOT repeat this
+--   pattern: build the index on each partition individually with
+--   CREATE INDEX CONCURRENTLY (supported for a single non-partitioned
+--   table), then ALTER INDEX ... ATTACH PARTITION into a parent index
+--   created with ONLY, so no partition is ever locked for the DDL.
+--
+--   audit_log_tenant_ts_idx (tenant_id, ts DESC) already exists and overlaps
+--   with the leading two columns of this index; left in place here per
+--   review, tracked as a follow-up candidate for consolidation, not dropped
+--   in this migration.
 
 BEGIN;
 


### PR DESCRIPTION
## Summary

Non-blocking cleanup deferred from #258 (audit retention cron review): performance, scalability, and test-quality follow-ups on the PHIPA/Law 25 audit cold-archive package. No behavior change to the correctness/write-once guarantees fixed in #258.

- `groupByMonth` now converts each row's `TS` to UTC before extracting the calendar month. `time.Time.Year()`/`Month()` report the value in the timestamp's own `Location`, so a row carrying a non-UTC location was previously bucketed by the wrong calendar month on hosts not set to UTC.
- `PgRepository.FetchOlderThan` now orders by `(ts, seq)` instead of `seq` alone, backed by a new `audit_log_tenant_ts_seq_idx` composite index (migration `20260703_01`), so Postgres can satisfy the ORDER BY directly from the index instead of sorting the full matched row set for a high-volume tenant. `seq` is assigned monotonically with `ts` at insert time, the same assumption the package already relies on for month-partition boundaries, so this preserves the existing JSONL chain order.
- `ObjectStore.Put` now takes the payload size from the caller, which already has it after building the compressed archive, instead of re-buffering the payload a second time via `io.ReadAll` before upload.
- `Archiver.RunOnce` logs a warning when a single (tenant, month) batch exceeds a configurable row threshold (`MaxRowsPerPartition`, default 250,000). This is an operator signal, not a cap: the batch is still archived in full as one manifest entry. Full manifest chunking (paged/multi-object manifests) needs a manifest schema change and is left for a follow-up if a real tenant approaches this threshold; marked with a `ponytail:` comment.
- `PurgeExpired` logs a warning when `Store.Delete` succeeds but `DeleteManifest` fails, since that leaves an orphan manifest row pointing at a deleted object. Documents why the existing delete-then-delete-manifest ordering self-heals on retry (S3 DELETE is idempotent on a missing key by protocol, confirmed against the `packages/storage` S3 client).

### Tests
- `TestBoundaryMonthNoUnarchivedDelete` now uses a fixed synthetic clock instead of `time.Now()`, so the two fixture timestamps always land in the same calendar month regardless of which day the suite runs.
- `TestArchiveManifestRecorded` now asserts the manifest's SHA-256 digest against the actual bytes written to the fake store.
- `TestCronRun` waits on a channel closed by the fake repository's first manifest insert instead of a fixed sleep.
- New `TestGroupByMonthUsesUTCNotLocalTime` and `TestLargePartitionStillArchivesAllRows`.

### Scope note
Full manifest chunking for very large months (splitting a single month into multiple manifest rows/objects) is intentionally not implemented here: it requires a manifest schema change (uniqueness key, `ManifestExists` semantics) that is disproportionate risk for a non-blocking, deferred item with no current production need. The warning threshold above gives operators visibility instead. Flagging so a follow-up issue can be opened if warranted.

Closes #261

## Test plan

- [x] `go test ./apps/control-plane/internal/auditarchive/... -count=1 -short -race` — 14/14 pass
- [x] `go build ./apps/control-plane/...` and `./apps/edge-api/...` — clean
- [x] `gofmt -l` / `go vet` — clean
- [ ] Live Postgres EXPLAIN verification of the new index (no live DB in this environment; index mirrors the existing proven `audit_log_tenant_ts_idx` pattern on the same partitioned table)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR applies five non-behavioral follow-ups to the PHIPA/Law 25 audit cold-archive package: a UTC normalization fix in `groupByMonth`, an `ORDER BY (ts, seq)` index optimization backed by a new migration, elimination of the double-buffer in `StorageObjectStore.Put`, an operator warning for over-threshold partition sizes, and orphan-manifest logging in `PurgeExpired`. Test determinism is improved by replacing `time.Now()` with fixed synthetic clocks and replacing a fixed sleep with channel-based synchronization.

- The `groupByMonth` UTC fix is correct and the new `TestGroupByMonthUsesUTCNotLocalTime` test exercises the exact boundary case (UTC-6 timestamp that crosses a month boundary at midnight UTC).
- The new `audit_log_tenant_ts_seq_idx` composite index matches the updated `ORDER BY ts ASC, seq ASC` query exactly; the migration's inline commentary on partitioned-table locking tradeoffs and the concurrent-index fallback path for production is thorough and accurate.
- `StorageObjectStore.Put` now returns the caller-supplied `size` hint on success rather than a count derived from the storage backend, leaving the `written != expectedSize` truncation guard in `archivePartition` effectively dead for the production store (only `Upload` errors are caught); `fakeStore.Put` validates real vs. expected bytes, creating a test/production asymmetry for this guard.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; changes are non-behavioral follow-ups with no writes to new tables and no protocol changes to the archive lifecycle.

All correctness fixes (UTC bucketing, test determinism, SHA-256 digest assertion) are well-implemented and the new tests cover the targeted edge cases. The only notable issue is in StorageObjectStore.Put: it returns the caller-supplied size on success, so the written != expectedSize guard in archivePartition always passes for the production store regardless of what the S3 client actually transferred — the guard is only meaningful in tests via fakeStore. The migration is accurate and the locking commentary is unusually thorough. The insertion-sort in sortBySeq could become slow if a tenant's monthly batch ever reaches the 250k warning threshold, but the PR intentionally defers that case to a future manifest-chunking change.

apps/control-plane/internal/auditarchive/storage_store.go — the Put return value and truncation guard semantics.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/control-plane/internal/auditarchive/archiver.go | UTC normalization fix in groupByMonth is correct; MaxRowsPerPartition warning-only threshold and PurgeExpired orphan-manifest logging are clean additions; Put signature change is propagated consistently. |
| apps/control-plane/internal/auditarchive/storage_store.go | Put now streams the reader directly instead of double-buffering, but returns the caller-supplied size hint unconditionally on success — the truncation guard in archivePartition is dead code for this implementation. |
| apps/control-plane/internal/auditarchive/pg_repository.go | ORDER BY changed from seq alone to (ts, seq) to enable index-only sort via the new composite index; relies on the documented monotonic seq/ts assumption already used elsewhere in the package. |
| apps/control-plane/internal/auditarchive/archiver_test.go | Fixed non-deterministic time.Now() usage with a fixed synthetic clock; replaced 100ms sleep in TestCronRun with a channel-based synchronization; added SHA-256 digest assertion; new UTC-timezone and large-partition tests are well-constructed. |
| supabase/migrations/20260703_01_audit_log_tenant_ts_seq_index.sql | New (tenant_id, ts, seq) index matches the updated query's ORDER BY exactly; migration correctly uses BEGIN/COMMIT and IF NOT EXISTS; locking tradeoffs and future concurrent-index path are well-documented inline. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Cron as RunCron
    participant Once as RunOnce
    participant Repo as PgRepository
    participant Arch as archivePartition
    participant Store as StorageObjectStore

    Cron->>Once: RunOnce(ctx, now)
    Once->>Repo: FetchTenants()
    loop per tenant
        Once->>Repo: FetchOlderThan(cutoff, tenantID) ORDER BY ts ASC, seq ASC
        Once->>Once: groupByMonth(rows) r.TS.UTC()
        Note over Once: warn if len(monthRows) > MaxRowsPerPartition
        loop per month
            Once->>Repo: ManifestExists(tenantID, month)
            Once->>Arch: archivePartition(tenant, month, rows)
            Arch->>Arch: sortBySeq(rows)
            Arch->>Arch: "JSONL -> gzip -> sha256"
            Arch->>Store: Put(key, reader, size) returns size hint
            Store->>Store: client.Upload(bucket, key, r, size, gzip)
            Arch->>Arch: "written != expectedSize? dead for StorageObjectStore"
            Arch->>Repo: InsertManifest(entry)
            Arch->>Repo: DeleteArchived(ids)
        end
    end
    Cron->>Once: PurgeExpired(ctx, now)
    loop per expired manifest
        Once->>Store: Delete(objectKey)
        Once->>Repo: DeleteManifest(id)
        Note over Once: Warn if DeleteManifest fails (orphan manifest)
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Cron as RunCron
    participant Once as RunOnce
    participant Repo as PgRepository
    participant Arch as archivePartition
    participant Store as StorageObjectStore

    Cron->>Once: RunOnce(ctx, now)
    Once->>Repo: FetchTenants()
    loop per tenant
        Once->>Repo: FetchOlderThan(cutoff, tenantID) ORDER BY ts ASC, seq ASC
        Once->>Once: groupByMonth(rows) r.TS.UTC()
        Note over Once: warn if len(monthRows) > MaxRowsPerPartition
        loop per month
            Once->>Repo: ManifestExists(tenantID, month)
            Once->>Arch: archivePartition(tenant, month, rows)
            Arch->>Arch: sortBySeq(rows)
            Arch->>Arch: "JSONL -> gzip -> sha256"
            Arch->>Store: Put(key, reader, size) returns size hint
            Store->>Store: client.Upload(bucket, key, r, size, gzip)
            Arch->>Arch: "written != expectedSize? dead for StorageObjectStore"
            Arch->>Repo: InsertManifest(entry)
            Arch->>Repo: DeleteArchived(ids)
        end
    end
    Cron->>Once: PurgeExpired(ctx, now)
    loop per expired manifest
        Once->>Store: Delete(objectKey)
        Once->>Repo: DeleteManifest(id)
        Note over Once: Warn if DeleteManifest fails (orphan manifest)
    end
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/control-plane/internal/auditarchive/storage_store.go`, line 44-49 ([link](https://github.com/sakibsadmanshajib/hive/blob/d172c28e9911ef62082bb2e0ea40f0a557d21e60/apps/control-plane/internal/auditarchive/storage_store.go#L44-L49)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> `StorageObjectStore.Put` always returns the caller-supplied `size` on success, never the bytes actually received by the storage backend. This means `archivePartition`'s `written != expectedSize` check (the "P1 truncation guard") compares `expectedSize` to itself — it is dead code for the production store. The only true protection against a failed upload is whether `s.client.Upload` returns a non-nil error. If the underlying client silently writes fewer bytes than requested, the guard would not fire, hot rows would be deleted, and the archive object would be silently corrupt.

   This pre-existed the PR (the old implementation also returned `int64(len(data))` — the pre-computed size — not a byte count from the remote). What makes it worth surfacing now is the asymmetry with `fakeStore.Put`, which validates `int64(len(data)) != size` and errors on mismatch: tests appear to exercise the guard end-to-end, but the production path cannot detect a storage-level truncation. Either update the interface contract to be explicit that `Put` returns the expected-size hint (not verified remote bytes), or add a byte-counting wrapper around `r` before passing it to `Upload`.

   

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fcontrol-plane%2Finternal%2Fauditarchive%2Fstorage_store.go%0ALine%3A%2044-49%0A%0AComment%3A%0A%60StorageObjectStore.Put%60%20always%20returns%20the%20caller-supplied%20%60size%60%20on%20success%2C%20never%20the%20bytes%20actually%20received%20by%20the%20storage%20backend.%20This%20means%20%60archivePartition%60's%20%60written%20!%3D%20expectedSize%60%20check%20%28the%20%22P1%20truncation%20guard%22%29%20compares%20%60expectedSize%60%20to%20itself%20%E2%80%94%20it%20is%20dead%20code%20for%20the%20production%20store.%20The%20only%20true%20protection%20against%20a%20failed%20upload%20is%20whether%20%60s.client.Upload%60%20returns%20a%20non-nil%20error.%20If%20the%20underlying%20client%20silently%20writes%20fewer%20bytes%20than%20requested%2C%20the%20guard%20would%20not%20fire%2C%20hot%20rows%20would%20be%20deleted%2C%20and%20the%20archive%20object%20would%20be%20silently%20corrupt.%0A%0AThis%20pre-existed%20the%20PR%20%28the%20old%20implementation%20also%20returned%20%60int64%28len%28data%29%29%60%20%E2%80%94%20the%20pre-computed%20size%20%E2%80%94%20not%20a%20byte%20count%20from%20the%20remote%29.%20What%20makes%20it%20worth%20surfacing%20now%20is%20the%20asymmetry%20with%20%60fakeStore.Put%60%2C%20which%20validates%20%60int64%28len%28data%29%29%20!%3D%20size%60%20and%20errors%20on%20mismatch%3A%20tests%20appear%20to%20exercise%20the%20guard%20end-to-end%2C%20but%20the%20production%20path%20cannot%20detect%20a%20storage-level%20truncation.%20Either%20update%20the%20interface%20contract%20to%20be%20explicit%20that%20%60Put%60%20returns%20the%20expected-size%20hint%20%28not%20verified%20remote%20bytes%29%2C%20or%20add%20a%20byte-counting%20wrapper%20around%20%60r%60%20before%20passing%20it%20to%20%60Upload%60.%0A%0A%60%60%60suggestion%0Afunc%20%28s%20*StorageObjectStore%29%20Put%28ctx%20context.Context%2C%20key%20string%2C%20r%20io.Reader%2C%20size%20int64%29%20%28int64%2C%20error%29%20%7B%0A%09%2F%2F%20Wrap%20r%20in%20a%20byte-counting%20reader%20so%20the%20returned%20value%20reflects%20what%20was%0A%09%2F%2F%20actually%20consumed%20by%20Upload%2C%20not%20just%20the%20caller-supplied%20hint.%20This%20makes%0A%09%2F%2F%20archivePartition's%20written%20!%3D%20expectedSize%20check%20meaningful%20for%20the%0A%09%2F%2F%20production%20store%2C%20not%20just%20for%20fakeStore.%0A%09cr%20%3A%3D%20%26countingReader%7Br%3A%20r%7D%0A%09if%20err%20%3A%3D%20s.client.Upload%28ctx%2C%20s.bucket%2C%20key%2C%20cr%2C%20size%2C%20%22application%2Fgzip%22%29%3B%20err%20!%3D%20nil%20%7B%0A%09%09return%200%2C%20fmt.Errorf%28%22auditarchive%20storage%3A%20put%20%25s%3A%20%25w%22%2C%20key%2C%20err%29%0A%09%7D%0A%09return%20cr.n%2C%20nil%0A%7D%0A%0Atype%20countingReader%20struct%20%7B%0A%09r%20io.Reader%0A%09n%20int64%0A%7D%0A%0Afunc%20%28c%20*countingReader%29%20Read%28p%20%5B%5Dbyte%29%20%28int%2C%20error%29%20%7B%0A%09n%2C%20err%20%3A%3D%20c.r.Read%28p%29%0A%09c.n%20%2B%3D%20int64%28n%29%0A%09return%20n%2C%20err%0A%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=sakibsadmanshajib%2Fhive&pr=267&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fcontrol-plane%2Finternal%2Fauditarchive%2Fstorage_store.go%0ALine%3A%2044-49%0A%0AComment%3A%0A%60StorageObjectStore.Put%60%20always%20returns%20the%20caller-supplied%20%60size%60%20on%20success%2C%20never%20the%20bytes%20actually%20received%20by%20the%20storage%20backend.%20This%20means%20%60archivePartition%60's%20%60written%20!%3D%20expectedSize%60%20check%20%28the%20%22P1%20truncation%20guard%22%29%20compares%20%60expectedSize%60%20to%20itself%20%E2%80%94%20it%20is%20dead%20code%20for%20the%20production%20store.%20The%20only%20true%20protection%20against%20a%20failed%20upload%20is%20whether%20%60s.client.Upload%60%20returns%20a%20non-nil%20error.%20If%20the%20underlying%20client%20silently%20writes%20fewer%20bytes%20than%20requested%2C%20the%20guard%20would%20not%20fire%2C%20hot%20rows%20would%20be%20deleted%2C%20and%20the%20archive%20object%20would%20be%20silently%20corrupt.%0A%0AThis%20pre-existed%20the%20PR%20%28the%20old%20implementation%20also%20returned%20%60int64%28len%28data%29%29%60%20%E2%80%94%20the%20pre-computed%20size%20%E2%80%94%20not%20a%20byte%20count%20from%20the%20remote%29.%20What%20makes%20it%20worth%20surfacing%20now%20is%20the%20asymmetry%20with%20%60fakeStore.Put%60%2C%20which%20validates%20%60int64%28len%28data%29%29%20!%3D%20size%60%20and%20errors%20on%20mismatch%3A%20tests%20appear%20to%20exercise%20the%20guard%20end-to-end%2C%20but%20the%20production%20path%20cannot%20detect%20a%20storage-level%20truncation.%20Either%20update%20the%20interface%20contract%20to%20be%20explicit%20that%20%60Put%60%20returns%20the%20expected-size%20hint%20%28not%20verified%20remote%20bytes%29%2C%20or%20add%20a%20byte-counting%20wrapper%20around%20%60r%60%20before%20passing%20it%20to%20%60Upload%60.%0A%0A%60%60%60suggestion%0Afunc%20%28s%20*StorageObjectStore%29%20Put%28ctx%20context.Context%2C%20key%20string%2C%20r%20io.Reader%2C%20size%20int64%29%20%28int64%2C%20error%29%20%7B%0A%09%2F%2F%20Wrap%20r%20in%20a%20byte-counting%20reader%20so%20the%20returned%20value%20reflects%20what%20was%0A%09%2F%2F%20actually%20consumed%20by%20Upload%2C%20not%20just%20the%20caller-supplied%20hint.%20This%20makes%0A%09%2F%2F%20archivePartition's%20written%20!%3D%20expectedSize%20check%20meaningful%20for%20the%0A%09%2F%2F%20production%20store%2C%20not%20just%20for%20fakeStore.%0A%09cr%20%3A%3D%20%26countingReader%7Br%3A%20r%7D%0A%09if%20err%20%3A%3D%20s.client.Upload%28ctx%2C%20s.bucket%2C%20key%2C%20cr%2C%20size%2C%20%22application%2Fgzip%22%29%3B%20err%20!%3D%20nil%20%7B%0A%09%09return%200%2C%20fmt.Errorf%28%22auditarchive%20storage%3A%20put%20%25s%3A%20%25w%22%2C%20key%2C%20err%29%0A%09%7D%0A%09return%20cr.n%2C%20nil%0A%7D%0A%0Atype%20countingReader%20struct%20%7B%0A%09r%20io.Reader%0A%09n%20int64%0A%7D%0A%0Afunc%20%28c%20*countingReader%29%20Read%28p%20%5B%5Dbyte%29%20%28int%2C%20error%29%20%7B%0A%09n%2C%20err%20%3A%3D%20c.r.Read%28p%29%0A%09c.n%20%2B%3D%20int64%28n%29%0A%09return%20n%2C%20err%0A%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=267&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22sakibsadmanshajib%2Fhive%22%20on%20the%20existing%20branch%20%22fix%2Faudit-archive-cleanup-261%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Faudit-archive-cleanup-261%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fcontrol-plane%2Finternal%2Fauditarchive%2Fstorage_store.go%0ALine%3A%2044-49%0A%0AComment%3A%0A%60StorageObjectStore.Put%60%20always%20returns%20the%20caller-supplied%20%60size%60%20on%20success%2C%20never%20the%20bytes%20actually%20received%20by%20the%20storage%20backend.%20This%20means%20%60archivePartition%60's%20%60written%20!%3D%20expectedSize%60%20check%20%28the%20%22P1%20truncation%20guard%22%29%20compares%20%60expectedSize%60%20to%20itself%20%E2%80%94%20it%20is%20dead%20code%20for%20the%20production%20store.%20The%20only%20true%20protection%20against%20a%20failed%20upload%20is%20whether%20%60s.client.Upload%60%20returns%20a%20non-nil%20error.%20If%20the%20underlying%20client%20silently%20writes%20fewer%20bytes%20than%20requested%2C%20the%20guard%20would%20not%20fire%2C%20hot%20rows%20would%20be%20deleted%2C%20and%20the%20archive%20object%20would%20be%20silently%20corrupt.%0A%0AThis%20pre-existed%20the%20PR%20%28the%20old%20implementation%20also%20returned%20%60int64%28len%28data%29%29%60%20%E2%80%94%20the%20pre-computed%20size%20%E2%80%94%20not%20a%20byte%20count%20from%20the%20remote%29.%20What%20makes%20it%20worth%20surfacing%20now%20is%20the%20asymmetry%20with%20%60fakeStore.Put%60%2C%20which%20validates%20%60int64%28len%28data%29%29%20!%3D%20size%60%20and%20errors%20on%20mismatch%3A%20tests%20appear%20to%20exercise%20the%20guard%20end-to-end%2C%20but%20the%20production%20path%20cannot%20detect%20a%20storage-level%20truncation.%20Either%20update%20the%20interface%20contract%20to%20be%20explicit%20that%20%60Put%60%20returns%20the%20expected-size%20hint%20%28not%20verified%20remote%20bytes%29%2C%20or%20add%20a%20byte-counting%20wrapper%20around%20%60r%60%20before%20passing%20it%20to%20%60Upload%60.%0A%0A%60%60%60suggestion%0Afunc%20%28s%20*StorageObjectStore%29%20Put%28ctx%20context.Context%2C%20key%20string%2C%20r%20io.Reader%2C%20size%20int64%29%20%28int64%2C%20error%29%20%7B%0A%09%2F%2F%20Wrap%20r%20in%20a%20byte-counting%20reader%20so%20the%20returned%20value%20reflects%20what%20was%0A%09%2F%2F%20actually%20consumed%20by%20Upload%2C%20not%20just%20the%20caller-supplied%20hint.%20This%20makes%0A%09%2F%2F%20archivePartition's%20written%20!%3D%20expectedSize%20check%20meaningful%20for%20the%0A%09%2F%2F%20production%20store%2C%20not%20just%20for%20fakeStore.%0A%09cr%20%3A%3D%20%26countingReader%7Br%3A%20r%7D%0A%09if%20err%20%3A%3D%20s.client.Upload%28ctx%2C%20s.bucket%2C%20key%2C%20cr%2C%20size%2C%20%22application%2Fgzip%22%29%3B%20err%20!%3D%20nil%20%7B%0A%09%09return%200%2C%20fmt.Errorf%28%22auditarchive%20storage%3A%20put%20%25s%3A%20%25w%22%2C%20key%2C%20err%29%0A%09%7D%0A%09return%20cr.n%2C%20nil%0A%7D%0A%0Atype%20countingReader%20struct%20%7B%0A%09r%20io.Reader%0A%09n%20int64%0A%7D%0A%0Afunc%20%28c%20*countingReader%29%20Read%28p%20%5B%5Dbyte%29%20%28int%2C%20error%29%20%7B%0A%09n%2C%20err%20%3A%3D%20c.r.Read%28p%29%0A%09c.n%20%2B%3D%20int64%28n%29%0A%09return%20n%2C%20err%0A%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=sakibsadmanshajib%2Fhive&pr=267&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fcontrol-plane%2Finternal%2Fauditarchive%2Fstorage_store.go%3A44-49%0A%60StorageObjectStore.Put%60%20always%20returns%20the%20caller-supplied%20%60size%60%20on%20success%2C%20never%20the%20bytes%20actually%20received%20by%20the%20storage%20backend.%20This%20means%20%60archivePartition%60's%20%60written%20!%3D%20expectedSize%60%20check%20%28the%20%22P1%20truncation%20guard%22%29%20compares%20%60expectedSize%60%20to%20itself%20%E2%80%94%20it%20is%20dead%20code%20for%20the%20production%20store.%20The%20only%20true%20protection%20against%20a%20failed%20upload%20is%20whether%20%60s.client.Upload%60%20returns%20a%20non-nil%20error.%20If%20the%20underlying%20client%20silently%20writes%20fewer%20bytes%20than%20requested%2C%20the%20guard%20would%20not%20fire%2C%20hot%20rows%20would%20be%20deleted%2C%20and%20the%20archive%20object%20would%20be%20silently%20corrupt.%0A%0AThis%20pre-existed%20the%20PR%20%28the%20old%20implementation%20also%20returned%20%60int64%28len%28data%29%29%60%20%E2%80%94%20the%20pre-computed%20size%20%E2%80%94%20not%20a%20byte%20count%20from%20the%20remote%29.%20What%20makes%20it%20worth%20surfacing%20now%20is%20the%20asymmetry%20with%20%60fakeStore.Put%60%2C%20which%20validates%20%60int64%28len%28data%29%29%20!%3D%20size%60%20and%20errors%20on%20mismatch%3A%20tests%20appear%20to%20exercise%20the%20guard%20end-to-end%2C%20but%20the%20production%20path%20cannot%20detect%20a%20storage-level%20truncation.%20Either%20update%20the%20interface%20contract%20to%20be%20explicit%20that%20%60Put%60%20returns%20the%20expected-size%20hint%20%28not%20verified%20remote%20bytes%29%2C%20or%20add%20a%20byte-counting%20wrapper%20around%20%60r%60%20before%20passing%20it%20to%20%60Upload%60.%0A%0A%60%60%60suggestion%0Afunc%20%28s%20*StorageObjectStore%29%20Put%28ctx%20context.Context%2C%20key%20string%2C%20r%20io.Reader%2C%20size%20int64%29%20%28int64%2C%20error%29%20%7B%0A%09%2F%2F%20Wrap%20r%20in%20a%20byte-counting%20reader%20so%20the%20returned%20value%20reflects%20what%20was%0A%09%2F%2F%20actually%20consumed%20by%20Upload%2C%20not%20just%20the%20caller-supplied%20hint.%20This%20makes%0A%09%2F%2F%20archivePartition's%20written%20!%3D%20expectedSize%20check%20meaningful%20for%20the%0A%09%2F%2F%20production%20store%2C%20not%20just%20for%20fakeStore.%0A%09cr%20%3A%3D%20%26countingReader%7Br%3A%20r%7D%0A%09if%20err%20%3A%3D%20s.client.Upload%28ctx%2C%20s.bucket%2C%20key%2C%20cr%2C%20size%2C%20%22application%2Fgzip%22%29%3B%20err%20!%3D%20nil%20%7B%0A%09%09return%200%2C%20fmt.Errorf%28%22auditarchive%20storage%3A%20put%20%25s%3A%20%25w%22%2C%20key%2C%20err%29%0A%09%7D%0A%09return%20cr.n%2C%20nil%0A%7D%0A%0Atype%20countingReader%20struct%20%7B%0A%09r%20io.Reader%0A%09n%20int64%0A%7D%0A%0Afunc%20%28c%20*countingReader%29%20Read%28p%20%5B%5Dbyte%29%20%28int%2C%20error%29%20%7B%0A%09n%2C%20err%20%3A%3D%20c.r.Read%28p%29%0A%09c.n%20%2B%3D%20int64%28n%29%0A%09return%20n%2C%20err%0A%7D%0A%60%60%60%0A%0A&repo=sakibsadmanshajib%2Fhive&pr=267&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fcontrol-plane%2Finternal%2Fauditarchive%2Fstorage_store.go%3A44-49%0A%60StorageObjectStore.Put%60%20always%20returns%20the%20caller-supplied%20%60size%60%20on%20success%2C%20never%20the%20bytes%20actually%20received%20by%20the%20storage%20backend.%20This%20means%20%60archivePartition%60's%20%60written%20!%3D%20expectedSize%60%20check%20%28the%20%22P1%20truncation%20guard%22%29%20compares%20%60expectedSize%60%20to%20itself%20%E2%80%94%20it%20is%20dead%20code%20for%20the%20production%20store.%20The%20only%20true%20protection%20against%20a%20failed%20upload%20is%20whether%20%60s.client.Upload%60%20returns%20a%20non-nil%20error.%20If%20the%20underlying%20client%20silently%20writes%20fewer%20bytes%20than%20requested%2C%20the%20guard%20would%20not%20fire%2C%20hot%20rows%20would%20be%20deleted%2C%20and%20the%20archive%20object%20would%20be%20silently%20corrupt.%0A%0AThis%20pre-existed%20the%20PR%20%28the%20old%20implementation%20also%20returned%20%60int64%28len%28data%29%29%60%20%E2%80%94%20the%20pre-computed%20size%20%E2%80%94%20not%20a%20byte%20count%20from%20the%20remote%29.%20What%20makes%20it%20worth%20surfacing%20now%20is%20the%20asymmetry%20with%20%60fakeStore.Put%60%2C%20which%20validates%20%60int64%28len%28data%29%29%20!%3D%20size%60%20and%20errors%20on%20mismatch%3A%20tests%20appear%20to%20exercise%20the%20guard%20end-to-end%2C%20but%20the%20production%20path%20cannot%20detect%20a%20storage-level%20truncation.%20Either%20update%20the%20interface%20contract%20to%20be%20explicit%20that%20%60Put%60%20returns%20the%20expected-size%20hint%20%28not%20verified%20remote%20bytes%29%2C%20or%20add%20a%20byte-counting%20wrapper%20around%20%60r%60%20before%20passing%20it%20to%20%60Upload%60.%0A%0A%60%60%60suggestion%0Afunc%20%28s%20*StorageObjectStore%29%20Put%28ctx%20context.Context%2C%20key%20string%2C%20r%20io.Reader%2C%20size%20int64%29%20%28int64%2C%20error%29%20%7B%0A%09%2F%2F%20Wrap%20r%20in%20a%20byte-counting%20reader%20so%20the%20returned%20value%20reflects%20what%20was%0A%09%2F%2F%20actually%20consumed%20by%20Upload%2C%20not%20just%20the%20caller-supplied%20hint.%20This%20makes%0A%09%2F%2F%20archivePartition's%20written%20!%3D%20expectedSize%20check%20meaningful%20for%20the%0A%09%2F%2F%20production%20store%2C%20not%20just%20for%20fakeStore.%0A%09cr%20%3A%3D%20%26countingReader%7Br%3A%20r%7D%0A%09if%20err%20%3A%3D%20s.client.Upload%28ctx%2C%20s.bucket%2C%20key%2C%20cr%2C%20size%2C%20%22application%2Fgzip%22%29%3B%20err%20!%3D%20nil%20%7B%0A%09%09return%200%2C%20fmt.Errorf%28%22auditarchive%20storage%3A%20put%20%25s%3A%20%25w%22%2C%20key%2C%20err%29%0A%09%7D%0A%09return%20cr.n%2C%20nil%0A%7D%0A%0Atype%20countingReader%20struct%20%7B%0A%09r%20io.Reader%0A%09n%20int64%0A%7D%0A%0Afunc%20%28c%20*countingReader%29%20Read%28p%20%5B%5Dbyte%29%20%28int%2C%20error%29%20%7B%0A%09n%2C%20err%20%3A%3D%20c.r.Read%28p%29%0A%09c.n%20%2B%3D%20int64%28n%29%0A%09return%20n%2C%20err%0A%7D%0A%60%60%60%0A%0A&pr=267&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22sakibsadmanshajib%2Fhive%22%20on%20the%20existing%20branch%20%22fix%2Faudit-archive-cleanup-261%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Faudit-archive-cleanup-261%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fcontrol-plane%2Finternal%2Fauditarchive%2Fstorage_store.go%3A44-49%0A%60StorageObjectStore.Put%60%20always%20returns%20the%20caller-supplied%20%60size%60%20on%20success%2C%20never%20the%20bytes%20actually%20received%20by%20the%20storage%20backend.%20This%20means%20%60archivePartition%60's%20%60written%20!%3D%20expectedSize%60%20check%20%28the%20%22P1%20truncation%20guard%22%29%20compares%20%60expectedSize%60%20to%20itself%20%E2%80%94%20it%20is%20dead%20code%20for%20the%20production%20store.%20The%20only%20true%20protection%20against%20a%20failed%20upload%20is%20whether%20%60s.client.Upload%60%20returns%20a%20non-nil%20error.%20If%20the%20underlying%20client%20silently%20writes%20fewer%20bytes%20than%20requested%2C%20the%20guard%20would%20not%20fire%2C%20hot%20rows%20would%20be%20deleted%2C%20and%20the%20archive%20object%20would%20be%20silently%20corrupt.%0A%0AThis%20pre-existed%20the%20PR%20%28the%20old%20implementation%20also%20returned%20%60int64%28len%28data%29%29%60%20%E2%80%94%20the%20pre-computed%20size%20%E2%80%94%20not%20a%20byte%20count%20from%20the%20remote%29.%20What%20makes%20it%20worth%20surfacing%20now%20is%20the%20asymmetry%20with%20%60fakeStore.Put%60%2C%20which%20validates%20%60int64%28len%28data%29%29%20!%3D%20size%60%20and%20errors%20on%20mismatch%3A%20tests%20appear%20to%20exercise%20the%20guard%20end-to-end%2C%20but%20the%20production%20path%20cannot%20detect%20a%20storage-level%20truncation.%20Either%20update%20the%20interface%20contract%20to%20be%20explicit%20that%20%60Put%60%20returns%20the%20expected-size%20hint%20%28not%20verified%20remote%20bytes%29%2C%20or%20add%20a%20byte-counting%20wrapper%20around%20%60r%60%20before%20passing%20it%20to%20%60Upload%60.%0A%0A%60%60%60suggestion%0Afunc%20%28s%20*StorageObjectStore%29%20Put%28ctx%20context.Context%2C%20key%20string%2C%20r%20io.Reader%2C%20size%20int64%29%20%28int64%2C%20error%29%20%7B%0A%09%2F%2F%20Wrap%20r%20in%20a%20byte-counting%20reader%20so%20the%20returned%20value%20reflects%20what%20was%0A%09%2F%2F%20actually%20consumed%20by%20Upload%2C%20not%20just%20the%20caller-supplied%20hint.%20This%20makes%0A%09%2F%2F%20archivePartition's%20written%20!%3D%20expectedSize%20check%20meaningful%20for%20the%0A%09%2F%2F%20production%20store%2C%20not%20just%20for%20fakeStore.%0A%09cr%20%3A%3D%20%26countingReader%7Br%3A%20r%7D%0A%09if%20err%20%3A%3D%20s.client.Upload%28ctx%2C%20s.bucket%2C%20key%2C%20cr%2C%20size%2C%20%22application%2Fgzip%22%29%3B%20err%20!%3D%20nil%20%7B%0A%09%09return%200%2C%20fmt.Errorf%28%22auditarchive%20storage%3A%20put%20%25s%3A%20%25w%22%2C%20key%2C%20err%29%0A%09%7D%0A%09return%20cr.n%2C%20nil%0A%7D%0A%0Atype%20countingReader%20struct%20%7B%0A%09r%20io.Reader%0A%09n%20int64%0A%7D%0A%0Afunc%20%28c%20*countingReader%29%20Read%28p%20%5B%5Dbyte%29%20%28int%2C%20error%29%20%7B%0A%09n%2C%20err%20%3A%3D%20c.r.Read%28p%29%0A%09c.n%20%2B%3D%20int64%28n%29%0A%09return%20n%2C%20err%0A%7D%0A%60%60%60%0A%0A&repo=sakibsadmanshajib%2Fhive&pr=267&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["docs: document index build lock tradeoff..."](https://github.com/sakibsadmanshajib/hive/commit/d172c28e9911ef62082bb2e0ea40f0a557d21e60) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41580880)</sub>

<!-- /greptile_comment -->