### PR TITLE
feat: self-provision OWUI e2e test user in nightly workflow

### DIFF
--- a/.github/workflows/phase-19-owui-nightly.yml
+++ b/.github/workflows/phase-19-owui-nightly.yml
@@ -18,8 +18,6 @@ jobs:
     timeout-minutes: 30
     env:
       OWUI_URL: http://localhost:3003
-      OWUI_E2E_EMAIL: ${{ secrets.OWUI_E2E_EMAIL }}
-      OWUI_E2E_PASSWORD: ${{ secrets.OWUI_E2E_PASSWORD }}
       OWUI_E2E_MAX_USD_PER_RUN: '1'
       OWUI_E2E_MODE: 'true'
       LANGFUSE_HOST: ${{ secrets.LANGFUSE_HOST }}
@@ -108,6 +106,26 @@ jobs:
           OWUI_SHIM_KEY=$(openssl rand -base64 32)
           EOF
           chmod 600 .env.ci
+      - name: Seed OWUI e2e test user
+        # Self-provisions the owui-e2e tenant, GoTrue user, and membership
+        # directly against the Supabase project (idempotent, password
+        # rotated every run). Removes the need for hand-managed
+        # OWUI_E2E_EMAIL / OWUI_E2E_PASSWORD repo secrets.
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: |
+          set -euo pipefail
+          out=$(python3 scripts/seed-owui-e2e-user.py)
+          email=$(printf '%s\n' "$out" | grep '^EMAIL=' | cut -d= -f2-)
+          password=$(printf '%s\n' "$out" | grep '^PASSWORD=' | cut -d= -f2-)
+          if [ -z "$email" ] || [ -z "$password" ]; then
+            echo "::error::seed-owui-e2e-user.py did not print EMAIL/PASSWORD"
+            exit 1
+          fi
+          echo "::add-mask::$password"
+          echo "OWUI_E2E_EMAIL=$email" >> "$GITHUB_ENV"
+          echo "OWUI_E2E_PASSWORD=$password" >> "$GITHUB_ENV"
       - name: Boot stack with test-owui + observability-langfuse profiles
         run: |
           cd deploy/docker
@@ -128,10 +146,11 @@ jobs:
             exit 1
           fi
       - name: Run OWUI Playwright suite
+        # OWUI_E2E_EMAIL/PASSWORD are always provisioned by the "Seed OWUI
+        # e2e test user" step above (schedule, workflow_dispatch, and
+        # labeled pull_request runs all reach this step), so the suite no
+        # longer has a credential-missing skip path.
         run: |
-          if [ -z "${OWUI_E2E_EMAIL:-}" ] || [ -z "${OWUI_E2E_PASSWORD:-}" ]; then
-            echo "::warning::OWUI e2e skipped, OWUI_E2E_EMAIL/OWUI_E2E_PASSWORD secrets not provisioned"
-          fi
           npm i -g pnpm@9
           cd apps/web-console
           pnpm install

--- a/scripts/seed-owui-e2e-user.py
+++ b/scripts/seed-owui-e2e-user.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Idempotently provision the OWUI e2e test user, tenant, and membership.
+
+Run before the phase-19 OWUI nightly Playwright suite so OWUI_E2E_EMAIL /
+OWUI_E2E_PASSWORD never need to be hand-managed GitHub secrets. Safe to
+re-run: the tenant and membership rows are upserted, the GoTrue user is
+found-or-created, and its password is always rotated to a fresh random
+value so no run reuses a prior credential.
+
+Required env: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY
+
+Prints exactly two lines to stdout (and nothing else):
+  EMAIL=<email>
+  PASSWORD=<password>
+Everything else (progress, errors) goes to stderr.
+"""
+import json
+import os
+import secrets
+import string
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+TENANT_SLUG = "owui-e2e"
+TENANT_NAME = "OWUI E2E"
+# ponytail: no Go code branches on tenants.deployment today (grep confirmed
+# clean). ENTERPRISE_EDGE picked as the closer conceptual fit for a
+# self-hosted OWUI chat front-end; revisit if that ever becomes load-bearing.
+TENANT_DEPLOYMENT = "ENTERPRISE_EDGE"
+# .invalid is an IANA-reserved TLD (RFC 2606) meant for exactly this use;
+# verified live against this project's GoTrue instance that it accepts the
+# format (2026-07-03 probe, see PR description).
+USER_EMAIL = "owui-e2e@hive-e2e.invalid"
+MEMBER_ROLE = "MEMBER"
+MEMBER_STATUS = "ACTIVE"
+
+
+def env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        print(f"error: {name} is not set", file=sys.stderr)
+        sys.exit(1)
+    return value
+
+
+def request(base, headers, method, path, body=None, params=None, prefer=None):
+    url = base + path
+    if params:
+        url += "?" + urllib.parse.urlencode(params)
+    data = json.dumps(body).encode() if body is not None else None
+    req_headers = dict(headers)
+    if prefer:
+        req_headers["Prefer"] = prefer
+    req = urllib.request.Request(url, data=data, method=method, headers=req_headers)
+    try:
+        with urllib.request.urlopen(req) as resp:
+            raw = resp.read()
+            return resp.status, (json.loads(raw) if raw else None)
+    except urllib.error.HTTPError as e:
+        raw = e.read()
+        try:
+            return e.code, json.loads(raw)
+        except json.JSONDecodeError:
+            print(f"error: {method} {path} -> {e.code}: {raw[:300]!r}", file=sys.stderr)
+            sys.exit(1)
+
+
+def random_password() -> str:
+    # Prefix guarantees upper/lower/digit/symbol classes regardless of the
+    # random draw; total length (28) clears any realistic GoTrue min-length
+    # policy with room to spare, well under bcrypt's 72-byte limit.
+    alphabet = string.ascii_letters + string.digits + "!@#$%^&*-_"
+    return "Aa1!" + "".join(secrets.choice(alphabet) for _ in range(24))
+
+
+def main() -> None:
+    supabase_url = env("SUPABASE_URL").rstrip("/")
+    service_key = env("SUPABASE_SERVICE_ROLE_KEY")
+    headers = {
+        "Authorization": f"Bearer {service_key}",
+        "apikey": service_key,
+        "Content-Type": "application/json",
+    }
+    rest = supabase_url + "/rest/v1"
+    gotrue = supabase_url + "/auth/v1"
+
+    # 1. Upsert the tenant (service role bypasses RLS).
+    status, body = request(
+        rest, headers, "POST", "/tenants",
+        body={"slug": TENANT_SLUG, "name": TENANT_NAME, "deployment": TENANT_DEPLOYMENT},
+        params={"on_conflict": "slug"},
+        prefer="resolution=merge-duplicates,return=representation",
+    )
+    if status not in (200, 201) or not body:
+        print(f"error: tenant upsert failed: {status} {body}", file=sys.stderr)
+        sys.exit(1)
+    tenant_id = body[0]["id"]
+
+    # 2. Find-or-create the GoTrue user. `filter=<email>` does an exact
+    # server-side match (verified live; the `email=` param is NOT
+    # supported and 500s on this GoTrue version).
+    status, body = request(gotrue, headers, "GET", "/admin/users", params={"filter": USER_EMAIL})
+    if status != 200:
+        print(f"error: user lookup failed: {status} {body}", file=sys.stderr)
+        sys.exit(1)
+    existing = next(
+        (u for u in body.get("users", []) if u.get("email", "").lower() == USER_EMAIL.lower()),
+        None,
+    )
+
+    password = random_password()
+    user_metadata = {"selected_tenant_id": tenant_id}
+
+    if existing is None:
+        status, body = request(
+            gotrue, headers, "POST", "/admin/users",
+            body={
+                "email": USER_EMAIL,
+                "password": password,
+                "email_confirm": True,
+                "user_metadata": user_metadata,
+            },
+        )
+        if status not in (200, 201):
+            print(f"error: user create failed: {status} {body}", file=sys.stderr)
+            sys.exit(1)
+        user_id = body["id"]
+    else:
+        user_id = existing["id"]
+        # GoTrue's admin updateUserById MERGES user_metadata (verified
+        # live), so this only ever adds/refreshes selected_tenant_id.
+        # Password is rotated unconditionally on every run.
+        status, body = request(
+            gotrue, headers, "PUT", f"/admin/users/{user_id}",
+            body={"password": password, "user_metadata": user_metadata},
+        )
+        if status != 200:
+            print(f"error: user update failed: {status} {body}", file=sys.stderr)
+            sys.exit(1)
+
+    # 3. Upsert tenant membership.
+    status, body = request(
+        rest, headers, "POST", "/tenant_users",
+        body={
+            "tenant_id": tenant_id,
+            "user_id": user_id,
+            "role": MEMBER_ROLE,
+            "status": MEMBER_STATUS,
+        },
+        params={"on_conflict": "tenant_id,user_id"},
+        prefer="resolution=merge-duplicates",
+    )
+    if status not in (200, 201, 204):
+        print(f"error: membership upsert failed: {status} {body}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"EMAIL={USER_EMAIL}")
+    print(f"PASSWORD={password}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

The phase-19 OWUI nightly Playwright suite depended on hand-managed `OWUI_E2E_EMAIL` / `OWUI_E2E_PASSWORD` repo secrets, and silently skipped the suite when they were unset (PR #266). This removes that dependency by having the workflow provision its own test identity on every run.

- Adds `scripts/seed-owui-e2e-user.py`, an idempotent Python (stdlib only) script that, given `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY`:
  1. Upserts a `tenants` row (`slug=owui-e2e`) via PostgREST.
  2. Finds or creates the GoTrue user `owui-e2e@hive-e2e.invalid` via the Admin Users API.
  3. Always rotates the user's password to a fresh random value.
  4. Upserts a `MEMBER` / `ACTIVE` `tenant_users` membership row, which the custom access token hook (`20260516_07_phase19_custom_access_token_hook.sql`) reads to populate the `role` and `tenant_id` JWT claims OWUI's OIDC login checks against.
  5. Prints exactly `EMAIL=...` / `PASSWORD=...` to stdout; all diagnostics go to stderr.
- Wires a new "Seed OWUI e2e test user" step into `.github/workflows/phase-19-owui-nightly.yml`, placed after "Materialize .env.ci" and before booting the stack. It masks the password with `::add-mask::` before writing `OWUI_E2E_EMAIL` / `OWUI_E2E_PASSWORD` to `$GITHUB_ENV`.
- Removes the job-level `secrets.OWUI_E2E_EMAIL` / `secrets.OWUI_E2E_PASSWORD` env vars and the now-unreachable "credentials not provisioned" `::warning::` in the Playwright step, since every run that reaches this job (schedule, `workflow_dispatch`, and labeled pull requests) now always provisions credentials.

## Verification

Ran the script twice against the real Supabase project referenced by the local `.env` (same project the nightly workflow's secrets point at):

- Run 1: `EMAIL=owui-e2e@hive-e2e.invalid`, exit 0, no stderr output. Created tenant, user, and membership.
- Run 2: same email, different (rotated) password, exit 0, no stderr output.
- Confirmed via count queries after both runs: exactly one `tenants` row (`slug=owui-e2e`), exactly one `tenant_users` row (`role=MEMBER`, `status=ACTIVE`), and exactly one GoTrue user with an exact-match email — proving idempotency (no duplicate rows across two runs).
- Confirmed a real password-grant login with the run-2 credentials succeeds (`200`, valid access token issued).

**Known gap found during verification, out of scope for this PR:** decoding the issued JWT shows the `role` claim as `authenticated` and no `tenant_id` claim, meaning the custom access token hook is not currently invoked by this Supabase project. Per `docs/onboarding/phase-19-dev-setup.md`, enabling it is a manual Supabase Dashboard step (Auth → Hooks → Customize Access Token). That toggle is an operator/infra action outside this PR's scope (no Management API credential available to this change), but it will need to be confirmed/enabled for the nightly suite's OIDC sign-in step to actually succeed end-to-end.

## Test plan

- [x] `python3 -m py_compile scripts/seed-owui-e2e-user.py`
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/phase-19-owui-nightly.yml'))"`
- [x] Ran seed script twice locally against the real Supabase project; verified idempotency via count queries
- [x] Verified real password-grant login succeeds with rotated credentials
- [ ] Confirm the custom access token hook is enabled in the Supabase Dashboard (tracked as a follow-up, not part of this change)
- [ ] First scheduled/`workflow_dispatch` run of `phase-19-owui-nightly` on this branch/PR to confirm the seed step and Playwright suite pass in CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Nightly e2e runs now automatically generate and use test credentials, so the workflow no longer depends on preconfigured secret values.
  * A new provisioning step creates the required test user and tenant membership before Playwright tests run.

* **Bug Fixes**
  * Improved test setup reliability by ensuring credentials are always available, reducing skipped or failing e2e runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces hand-managed `OWUI_E2E_EMAIL`/`OWUI_E2E_PASSWORD` repo secrets with a self-provisioning seed script that idempotently creates the required Supabase tenant, GoTrue user, and membership row on every nightly run, rotating the password each time.

- Adds `scripts/seed-owui-e2e-user.py` (stdlib-only Python): upserts a `tenants` row, finds or creates the GoTrue user, always rotates the password, and upserts a `MEMBER`/`ACTIVE` `tenant_users` row; prints exactly `EMAIL=…` / `PASSWORD=…` to stdout with all diagnostics to stderr.
- Wires a new "Seed OWUI e2e test user" step into the nightly workflow: captures Python output without logging it, validates both values are present, masks the password with `::add-mask::` before writing to `$GITHUB_ENV`, and removes the now-obsolete credential-check warning from the Playwright step.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the workflow integration is correct and credential masking is handled properly.

The masking, capture, and env-writing order in the workflow step are all correct. The seed script has two robustness gaps — a missing null-guard before body.get() on the admin-users response, and a TOCTOU window if two concurrent runs on different refs both see no existing user and race to create it — but both are unlikely in the normal once-daily nightly pattern.

scripts/seed-owui-e2e-user.py: the user-lookup and user-creation paths (lines 104–129) have the null-body and TOCTOU edge cases.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/seed-owui-e2e-user.py | New stdlib-only Python script that idempotently provisions a tenant, GoTrue user, and membership row, then prints credentials to stdout. Logic is sound; two minor robustness gaps: no null-guard on the admin-users response body before .get(), and a TOCTOU window if two runs on different refs race to create the user. |
| .github/workflows/phase-19-owui-nightly.yml | Adds a seed step with correct set -euo pipefail, captures Python output into a variable (never logged), validates EMAIL/PASSWORD presence, masks the password with ::add-mask:: before writing to GITHUB_ENV, and removes the now-dead credential-check warning. Ordering of mask-then-write is correct. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant GHA as GitHub Actions Runner
    participant Py as seed-owui-e2e-user.py
    participant SB_REST as Supabase PostgREST
    participant GT as Supabase GoTrue

    GHA->>Py: python3 scripts/seed-owui-e2e-user.py
    Py->>SB_REST: "POST /rest/v1/tenants (on_conflict=slug)"
    SB_REST-->>Py: "200/201 [{id, slug, ...}]"
    Py->>GT: "GET /auth/v1/admin/users?filter=owui-e2e@hive-e2e.invalid"
    GT-->>Py: "200 {users: [...]}"
    alt User does not exist
        Py->>GT: POST /auth/v1/admin/users
        GT-->>Py: "201 {id, email, ...}"
    else User exists
        Py->>GT: "PUT /auth/v1/admin/users/{user_id}"
        GT-->>Py: "200 {id, email, ...}"
    end
    Py->>SB_REST: "POST /rest/v1/tenant_users (on_conflict=tenant_id,user_id)"
    SB_REST-->>Py: 200/201/204
    Py-->>GHA: stdout EMAIL and PASSWORD lines
    GHA->>GHA: add-mask password
    GHA->>GHA: write OWUI_E2E_EMAIL and OWUI_E2E_PASSWORD to GITHUB_ENV
    GHA->>GHA: Run Playwright suite with provisioned credentials
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant GHA as GitHub Actions Runner
    participant Py as seed-owui-e2e-user.py
    participant SB_REST as Supabase PostgREST
    participant GT as Supabase GoTrue

    GHA->>Py: python3 scripts/seed-owui-e2e-user.py
    Py->>SB_REST: "POST /rest/v1/tenants (on_conflict=slug)"
    SB_REST-->>Py: "200/201 [{id, slug, ...}]"
    Py->>GT: "GET /auth/v1/admin/users?filter=owui-e2e@hive-e2e.invalid"
    GT-->>Py: "200 {users: [...]}"
    alt User does not exist
        Py->>GT: POST /auth/v1/admin/users
        GT-->>Py: "201 {id, email, ...}"
    else User exists
        Py->>GT: "PUT /auth/v1/admin/users/{user_id}"
        GT-->>Py: "200 {id, email, ...}"
    end
    Py->>SB_REST: "POST /rest/v1/tenant_users (on_conflict=tenant_id,user_id)"
    SB_REST-->>Py: 200/201/204
    Py-->>GHA: stdout EMAIL and PASSWORD lines
    GHA->>GHA: add-mask password
    GHA->>GHA: write OWUI_E2E_EMAIL and OWUI_E2E_PASSWORD to GITHUB_ENV
    GHA->>GHA: Run Playwright suite with provisioned credentials
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ascripts%2Fseed-owui-e2e-user.py%3A104-111%0A**Unguarded%20%60body.get%28%29%60%20on%20potentially-%60None%60%20response**%0A%0A%60request%28%29%60%20returns%20%60None%60%20for%20the%20body%20when%20the%20HTTP%20response%20is%20empty%20%28%60raw%20%3D%20b%22%22%60%29.%20A%20degraded%20GoTrue%20instance%20returning%20a%20200%20with%20an%20empty%20body%20%28unlikely%20but%20possible%29%20would%20cause%20%60body.get%28%22users%22%2C%20%5B%5D%29%60%20to%20raise%20%60AttributeError%60%2C%20crashing%20the%20script%20with%20a%20Python%20traceback%20rather%20than%20the%20clean%20%60sys.exit%281%29%60%20error%20path%20used%20everywhere%20else.%20The%20fix%20is%20to%20treat%20a%20%60None%60%20body%20as%20an%20unexpected%20error%20before%20calling%20%60.get%28%29%60.%0A%0A%23%23%23%20Issue%202%20of%202%0Ascripts%2Fseed-owui-e2e-user.py%3A108-129%0A**TOCTOU%20race%20on%20concurrent%20runs%20for%20different%20refs**%0A%0ATwo%20simultaneous%20CI%20runs%20on%20different%20Git%20refs%20%28e.g.%2C%20a%20scheduled%20run%20on%20%60main%60%20and%20a%20%60workflow_dispatch%60%20on%20a%20feature%20branch%29%20can%20both%20execute%20the%20%60GET%20%2Fadmin%2Fusers%3Ffilter%3D...%60%20call%20and%20both%20see%20%60existing%20%3D%20None%60%2C%20then%20both%20attempt%20%60POST%20%2Fadmin%2Fusers%60.%20The%20second%20POST%20will%20receive%20a%20unique-constraint%20error.%20The%20concurrency%20group%20%28%60phase-19-owui-%24%7B%7B%20github.ref%20%7D%7D%60%29%20only%20serialises%20runs%20for%20the%20same%20ref%2C%20so%20cross-ref%20races%20are%20not%20prevented.%20The%20second%20run's%20seed%20step%20would%20fail%20with%20%60user%20create%20failed%3A%204xx%60%2C%20blocking%20that%20CI%20run%20until%20a%20re-trigger.%20Handling%20a%20409%2F422%20from%20the%20POST%20by%20re-fetching%20the%20user%20as%20a%20retry-as-update%20path%20would%20make%20the%20script%20robust%20across%20concurrent%20runs.%0A%0A&repo=sakibsadmanshajib%2Fhive&pr=268&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ascripts%2Fseed-owui-e2e-user.py%3A104-111%0A**Unguarded%20%60body.get%28%29%60%20on%20potentially-%60None%60%20response**%0A%0A%60request%28%29%60%20returns%20%60None%60%20for%20the%20body%20when%20the%20HTTP%20response%20is%20empty%20%28%60raw%20%3D%20b%22%22%60%29.%20A%20degraded%20GoTrue%20instance%20returning%20a%20200%20with%20an%20empty%20body%20%28unlikely%20but%20possible%29%20would%20cause%20%60body.get%28%22users%22%2C%20%5B%5D%29%60%20to%20raise%20%60AttributeError%60%2C%20crashing%20the%20script%20with%20a%20Python%20traceback%20rather%20than%20the%20clean%20%60sys.exit%281%29%60%20error%20path%20used%20everywhere%20else.%20The%20fix%20is%20to%20treat%20a%20%60None%60%20body%20as%20an%20unexpected%20error%20before%20calling%20%60.get%28%29%60.%0A%0A%23%23%23%20Issue%202%20of%202%0Ascripts%2Fseed-owui-e2e-user.py%3A108-129%0A**TOCTOU%20race%20on%20concurrent%20runs%20for%20different%20refs**%0A%0ATwo%20simultaneous%20CI%20runs%20on%20different%20Git%20refs%20%28e.g.%2C%20a%20scheduled%20run%20on%20%60main%60%20and%20a%20%60workflow_dispatch%60%20on%20a%20feature%20branch%29%20can%20both%20execute%20the%20%60GET%20%2Fadmin%2Fusers%3Ffilter%3D...%60%20call%20and%20both%20see%20%60existing%20%3D%20None%60%2C%20then%20both%20attempt%20%60POST%20%2Fadmin%2Fusers%60.%20The%20second%20POST%20will%20receive%20a%20unique-constraint%20error.%20The%20concurrency%20group%20%28%60phase-19-owui-%24%7B%7B%20github.ref%20%7D%7D%60%29%20only%20serialises%20runs%20for%20the%20same%20ref%2C%20so%20cross-ref%20races%20are%20not%20prevented.%20The%20second%20run's%20seed%20step%20would%20fail%20with%20%60user%20create%20failed%3A%204xx%60%2C%20blocking%20that%20CI%20run%20until%20a%20re-trigger.%20Handling%20a%20409%2F422%20from%20the%20POST%20by%20re-fetching%20the%20user%20as%20a%20retry-as-update%20path%20would%20make%20the%20script%20robust%20across%20concurrent%20runs.%0A%0A&pr=268&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22sakibsadmanshajib%2Fhive%22%20on%20the%20existing%20branch%20%22feat%2Fowui-e2e-seed-user%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fowui-e2e-seed-user%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ascripts%2Fseed-owui-e2e-user.py%3A104-111%0A**Unguarded%20%60body.get%28%29%60%20on%20potentially-%60None%60%20response**%0A%0A%60request%28%29%60%20returns%20%60None%60%20for%20the%20body%20when%20the%20HTTP%20response%20is%20empty%20%28%60raw%20%3D%20b%22%22%60%29.%20A%20degraded%20GoTrue%20instance%20returning%20a%20200%20with%20an%20empty%20body%20%28unlikely%20but%20possible%29%20would%20cause%20%60body.get%28%22users%22%2C%20%5B%5D%29%60%20to%20raise%20%60AttributeError%60%2C%20crashing%20the%20script%20with%20a%20Python%20traceback%20rather%20than%20the%20clean%20%60sys.exit%281%29%60%20error%20path%20used%20everywhere%20else.%20The%20fix%20is%20to%20treat%20a%20%60None%60%20body%20as%20an%20unexpected%20error%20before%20calling%20%60.get%28%29%60.%0A%0A%23%23%23%20Issue%202%20of%202%0Ascripts%2Fseed-owui-e2e-user.py%3A108-129%0A**TOCTOU%20race%20on%20concurrent%20runs%20for%20different%20refs**%0A%0ATwo%20simultaneous%20CI%20runs%20on%20different%20Git%20refs%20%28e.g.%2C%20a%20scheduled%20run%20on%20%60main%60%20and%20a%20%60workflow_dispatch%60%20on%20a%20feature%20branch%29%20can%20both%20execute%20the%20%60GET%20%2Fadmin%2Fusers%3Ffilter%3D...%60%20call%20and%20both%20see%20%60existing%20%3D%20None%60%2C%20then%20both%20attempt%20%60POST%20%2Fadmin%2Fusers%60.%20The%20second%20POST%20will%20receive%20a%20unique-constraint%20error.%20The%20concurrency%20group%20%28%60phase-19-owui-%24%7B%7B%20github.ref%20%7D%7D%60%29%20only%20serialises%20runs%20for%20the%20same%20ref%2C%20so%20cross-ref%20races%20are%20not%20prevented.%20The%20second%20run's%20seed%20step%20would%20fail%20with%20%60user%20create%20failed%3A%204xx%60%2C%20blocking%20that%20CI%20run%20until%20a%20re-trigger.%20Handling%20a%20409%2F422%20from%20the%20POST%20by%20re-fetching%20the%20user%20as%20a%20retry-as-update%20path%20would%20make%20the%20script%20robust%20across%20concurrent%20runs.%0A%0A&repo=sakibsadmanshajib%2Fhive&pr=268&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat: self-provision OWUI e2e test user ..."](https://github.com/sakibsadmanshajib/hive/commit/a8cc321f2158456d067258eeddbaf52c592004d5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41587179)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->