### PR TITLE
fix: OWUI setup spec waits for the actual OAuth button text (#269)

### DIFF
--- a/apps/web-console/e2e/phase-19/auth.setup.ts
+++ b/apps/web-console/e2e/phase-19/auth.setup.ts
@@ -12,7 +12,7 @@ setup("authenticate user A (tenant T1)", async ({ page }) => {
     return;
   }
   await page.goto(`${OWUI_URL}/`);
-  await page.getByRole("button", { name: /sign in with hive/i }).click();
+  await page.getByRole("button", { name: /continue with hive/i }).click();
   await page.getByLabel("Email").fill(email);
   await page.getByRole("button", { name: /next/i }).click();
   await page.getByLabel("Password").fill(password);
@@ -29,7 +29,7 @@ setup("authenticate user B (tenant T2)", async ({ page }) => {
     return;
   }
   await page.goto(`${OWUI_URL}/`);
-  await page.getByRole("button", { name: /sign in with hive/i }).click();
+  await page.getByRole("button", { name: /continue with hive/i }).click();
   await page.getByLabel("Email").fill(email);
   await page.getByRole("button", { name: /next/i }).click();
   await page.getByLabel("Password").fill(password);

--- a/apps/web-console/e2e/phase-19/owui/08-signout.spec.ts
+++ b/apps/web-console/e2e/phase-19/owui/08-signout.spec.ts
@@ -7,6 +7,6 @@ test("signout clears session and lands on signin page", async ({ page }) => {
   await page.getByRole("button", { name: /account/i }).click();
   await page.getByRole("menuitem", { name: /sign out/i }).click();
   await expect(
-    page.getByRole("button", { name: /sign in with hive/i }),
+    page.getByRole("button", { name: /continue with hive/i }),
   ).toBeVisible();
 });

--- a/apps/web-console/e2e/phase-19/owui/owui.setup.ts
+++ b/apps/web-console/e2e/phase-19/owui/owui.setup.ts
@@ -6,7 +6,7 @@ setup("OWUI OIDC sign-in via Hive consent", async ({ page }) => {
   const email = process.env.OWUI_E2E_EMAIL;
   const password = process.env.OWUI_E2E_PASSWORD;
   // SUPABASE_OAUTH_CLIENT_ID/SECRET are a separate, ops-provisioned pair
-  // (Supabase OAuth App registration) -- without them the "Sign in with
+  // (Supabase OAuth App registration) -- without them the "Continue with
   // Hive" button on OWUI has no functional OAuth client behind it, so this
   // whole journey cannot run yet. Skip cleanly rather than hard-fail.
   const oauthClientId = process.env.SUPABASE_OAUTH_CLIENT_ID;
@@ -17,7 +17,7 @@ setup("OWUI OIDC sign-in via Hive consent", async ({ page }) => {
   }
 
   await page.goto("/");
-  await page.getByRole("button", { name: /sign in with hive/i }).click();
+  await page.getByRole("button", { name: /continue with hive/i }).click();
 
   // The OAuth click starts a real full-page redirect chain: OWUI -> Supabase
   // authorize -> /oauth/consent (web-console origin, unauthenticated) ->

--- a/apps/web-console/e2e/phase-19/owui/playwright.owui.config.ts
+++ b/apps/web-console/e2e/phase-19/owui/playwright.owui.config.ts
@@ -4,7 +4,7 @@ import { defineConfig, devices } from "@playwright/test";
 // Match zero spec files for the dependent projects in that case so the run
 // exits clean (0 failed) instead of every spec ENOENT-ing on the missing
 // storageState file. SUPABASE_OAUTH_CLIENT_ID/SECRET gate the OAuth-backed
-// "Sign in with Hive" journey the same way OWUI_E2E_EMAIL/PASSWORD gate the
+// "Continue with Hive" journey the same way OWUI_E2E_EMAIL/PASSWORD gate the
 // seeded test user -- both must mirror owui.setup.ts's own skip condition.
 const hasCreds = Boolean(
   process.env.OWUI_E2E_EMAIL &&


### PR DESCRIPTION
## Summary

The OWUI OAuth e2e setup spec waited on `page.getByRole("button", { name: /sign in with hive/i })`, which never matches, causing the setup step to time out whenever `SUPABASE_OAUTH_CLIENT_ID`/`SUPABASE_OAUTH_CLIENT_SECRET` are provisioned and the journey actually runs.

Root cause: OWUI's `/api/config` confirms the OAuth provider is registered, but the button OWUI renders comes from its i18n template `"Continue with {{provider}}"` with `OAUTH_PROVIDER_NAME=Hive`, so the rendered text is "Continue with Hive", not "Sign in with Hive". The old regex never matched.

## Changes

- `owui.setup.ts`: locator regex updated to `/continue with hive/i`, comment wording corrected to match.
- `08-signout.spec.ts`: post-signout locator updated to the same corrected regex (it re-asserts the same button reappears after signout).
- `playwright.owui.config.ts`: comment wording corrected for consistency.

No other logic changed. This file only runs in CI.

## Test plan

- [ ] Confirm nightly OWUI e2e workflow run (with OAuth creds provisioned) passes the setup step and reaches the chat UI.
- [ ] Confirm the signout spec still finds the OAuth button post-signout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end checks to match the current sign-in and sign-out experience.
  * Adjusted validation for the authentication button shown after signing out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes an e2e test timeout caused by all OAuth button locators using the wrong text (`"Sign in with Hive"`) instead of what OWUI actually renders via its i18n template (`"Continue with Hive"`). Four files are updated to use `/continue with hive/i`.

- **`owui.setup.ts` / `auth.setup.ts`**: Locator regex corrected on every OAuth button click, unblocking the OIDC setup flow and the two auth-setup flows for users A and B.
- **`08-signout.spec.ts`**: Post-signout assertion updated to the same corrected regex so the signout spec can find the button after the session is cleared.
- **`playwright.owui.config.ts`**: Comment-only wording fix for consistency; no functional change.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all changes are narrow, targeted test locator fixes with no production code touched.

Every changed line is a test locator or a code comment. The old regex was provably wrong (OWUI's i18n template renders 'Continue with {{provider}}', not 'Sign in with {{provider}}'), and all occurrences across the four test files are updated consistently. There is no production logic, no new dependencies, and no conditional branching introduced.

No files require special attention; all four changed files are test-only and the fixes are consistent.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web-console/e2e/phase-19/auth.setup.ts | Two OAuth button locators corrected from `/sign in with hive/i` to `/continue with hive/i` for user A and user B setup flows — consistent with the actual OWUI i18n template output. |
| apps/web-console/e2e/phase-19/owui/owui.setup.ts | Locator regex and inline comment both corrected to 'Continue with Hive' — the root cause of the setup timeout is fixed here. |
| apps/web-console/e2e/phase-19/owui/08-signout.spec.ts | Post-signout assertion updated to match the corrected button text; no other logic changed. |
| apps/web-console/e2e/phase-19/owui/playwright.owui.config.ts | Comment-only change to align wording with the corrected button text; no functional impact. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Test as Playwright Test
    participant OWUI as OWUI UI
    participant Supabase as Supabase OAuth
    participant Consent as /oauth/consent

    Test->>OWUI: page.goto("/")
    OWUI-->>Test: Renders "Continue with Hive" button
    Test->>OWUI: click(/continue with hive/i) ✅ (was /sign in with hive/i ❌)
    OWUI->>Supabase: OAuth redirect chain begins
    Supabase->>Consent: Redirect to /oauth/consent
    Consent-->>Test: Email + Password form
    Test->>Consent: fill(email, password) → click(/continue/i)
    Consent-->>Test: Scopes page
    Test->>Consent: click(/approve/i)
    Consent->>OWUI: Redirect back via OIDC callback
    OWUI-->>Test: Chat UI visible (placeholder message input)
    Test->>Test: storageState saved
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Test as Playwright Test
    participant OWUI as OWUI UI
    participant Supabase as Supabase OAuth
    participant Consent as /oauth/consent

    Test->>OWUI: page.goto("/")
    OWUI-->>Test: Renders "Continue with Hive" button
    Test->>OWUI: click(/continue with hive/i) ✅ (was /sign in with hive/i ❌)
    OWUI->>Supabase: OAuth redirect chain begins
    Supabase->>Consent: Redirect to /oauth/consent
    Consent-->>Test: Email + Password form
    Test->>Consent: fill(email, password) → click(/continue/i)
    Consent-->>Test: Scopes page
    Test->>Consent: click(/approve/i)
    Consent->>OWUI: Redirect back via OIDC callback
    OWUI-->>Test: Chat UI visible (placeholder message input)
    Test->>Test: storageState saved
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(e2e): update auth.setup.ts to match ..."](https://github.com/sakibsadmanshajib/hive/commit/434b11d0ea33dbc8a76ee59708329ac7a35af133) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41653038)</sub>

<!-- /greptile_comment -->