### PR TITLE
fix: force-click OWUI OAuth login button in e2e setup (#269)

### DIFF
--- a/apps/web-console/e2e/phase-19/auth.setup.ts
+++ b/apps/web-console/e2e/phase-19/auth.setup.ts
@@ -12,7 +12,12 @@ setup("authenticate user A (tenant T1)", async ({ page }) => {
     return;
   }
   await page.goto(`${OWUI_URL}/`);
-  await page.getByRole("button", { name: /continue with hive/i }).click();
+  // ponytail: OWUI login page has a continuously animating element, so
+  // Playwright's click-stability check never settles; force-click after an
+  // explicit visibility wait instead.
+  const hiveButton = page.getByRole("button", { name: /continue with hive/i });
+  await expect(hiveButton).toBeVisible();
+  await hiveButton.click({ force: true });
   await page.getByLabel("Email").fill(email);
   await page.getByRole("button", { name: /next/i }).click();
   await page.getByLabel("Password").fill(password);
@@ -29,7 +34,12 @@ setup("authenticate user B (tenant T2)", async ({ page }) => {
     return;
   }
   await page.goto(`${OWUI_URL}/`);
-  await page.getByRole("button", { name: /continue with hive/i }).click();
+  // ponytail: OWUI login page has a continuously animating element, so
+  // Playwright's click-stability check never settles; force-click after an
+  // explicit visibility wait instead.
+  const hiveButton = page.getByRole("button", { name: /continue with hive/i });
+  await expect(hiveButton).toBeVisible();
+  await hiveButton.click({ force: true });
   await page.getByLabel("Email").fill(email);
   await page.getByRole("button", { name: /next/i }).click();
   await page.getByLabel("Password").fill(password);

--- a/apps/web-console/e2e/phase-19/auth.setup.ts
+++ b/apps/web-console/e2e/phase-19/auth.setup.ts
@@ -16,7 +16,7 @@ setup("authenticate user A (tenant T1)", async ({ page }) => {
   // Playwright's click-stability check never settles; force-click after an
   // explicit visibility wait instead.
   const hiveButton = page.getByRole("button", { name: /continue with hive/i });
-  await expect(hiveButton).toBeVisible();
+  await expect(hiveButton).toBeVisible({ timeout: 30_000 });
   await hiveButton.click({ force: true });
   await page.getByLabel("Email").fill(email);
   await page.getByRole("button", { name: /next/i }).click();
@@ -38,7 +38,7 @@ setup("authenticate user B (tenant T2)", async ({ page }) => {
   // Playwright's click-stability check never settles; force-click after an
   // explicit visibility wait instead.
   const hiveButton = page.getByRole("button", { name: /continue with hive/i });
-  await expect(hiveButton).toBeVisible();
+  await expect(hiveButton).toBeVisible({ timeout: 30_000 });
   await hiveButton.click({ force: true });
   await page.getByLabel("Email").fill(email);
   await page.getByRole("button", { name: /next/i }).click();

--- a/apps/web-console/e2e/phase-19/owui/owui.setup.ts
+++ b/apps/web-console/e2e/phase-19/owui/owui.setup.ts
@@ -21,7 +21,7 @@ setup("OWUI OIDC sign-in via Hive consent", async ({ page }) => {
   // Playwright's click-stability check never settles; force-click after an
   // explicit visibility wait instead.
   const hiveButton = page.getByRole("button", { name: /continue with hive/i });
-  await expect(hiveButton).toBeVisible();
+  await expect(hiveButton).toBeVisible({ timeout: 30_000 });
   await hiveButton.click({ force: true });
 
   // The OAuth click starts a real full-page redirect chain: OWUI -> Supabase

--- a/apps/web-console/e2e/phase-19/owui/owui.setup.ts
+++ b/apps/web-console/e2e/phase-19/owui/owui.setup.ts
@@ -17,7 +17,12 @@ setup("OWUI OIDC sign-in via Hive consent", async ({ page }) => {
   }
 
   await page.goto("/");
-  await page.getByRole("button", { name: /continue with hive/i }).click();
+  // ponytail: OWUI login page has a continuously animating element, so
+  // Playwright's click-stability check never settles; force-click after an
+  // explicit visibility wait instead.
+  const hiveButton = page.getByRole("button", { name: /continue with hive/i });
+  await expect(hiveButton).toBeVisible();
+  await hiveButton.click({ force: true });
 
   // The OAuth click starts a real full-page redirect chain: OWUI -> Supabase
   // authorize -> /oauth/consent (web-console origin, unauthenticated) ->


### PR DESCRIPTION
## Summary

Nightly run 28669196311 (both attempts) showed the `/continue with hive/i` locator now correctly resolves to the button, but the click itself never fires: the Playwright call log shows "element is not stable" retried 54+ times across the full 30s timeout. The OWUI login page has an element that animates continuously, so Playwright's actionability stability check (which requires the target's bounding box to stop moving between two consecutive animation frames) never settles.

## Changes

For the three "continue with hive" click sites (one in `owui.setup.ts`, two in `auth.setup.ts` for tenants A and B), replaced the plain `.click()` with an explicit `toBeVisible()` wait followed by `.click({ force: true })`, which skips the stability/receives-events checks that never pass on this page. A short comment at each site explains why the force click is needed.

No other logic changed.

## Test plan

- [ ] Confirm next nightly OWUI e2e run clicks through the OAuth button without the "element is not stable" retry loop.
- [ ] Confirm the rest of the OAuth redirect chain (consent, sign-in) still completes as before.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a flaky nightly e2e run by replacing plain `.click()` calls with an explicit `toBeVisible({ timeout: 30_000 })` guard followed by `.click({ force: true })` at all three "Continue with Hive" OAuth button sites, working around OWUI's continuously animating element that prevented Playwright's stability check from ever passing.

- **`auth.setup.ts`**: Both the user A and user B setup blocks now use the force-click pattern with an explicit 30 s visibility timeout, consistent with the `toHaveURL` timeout already present in the file.
- **`owui.setup.ts`**: The single click site in the OWUI OIDC setup receives the same treatment, with the 30 s visibility timeout matching the `toBeVisible` call at line 44.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Targeted, low-risk fix to e2e setup files only — no production code touched.

All three click sites are updated consistently with explicit visibility waits and matching 30 s timeouts. The force-click approach is well-understood for animation-heavy pages and is guarded by toBeVisible, so the change cannot silently click a missing button. No application logic is affected.

No files require special attention.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web-console/e2e/phase-19/auth.setup.ts | Replaces plain `.click()` with `toBeVisible({ timeout: 30_000 })` + `.click({ force: true })` in both the user A and user B setup blocks to work around OWUI's continuously animating element. |
| apps/web-console/e2e/phase-19/owui/owui.setup.ts | Applies the same force-click pattern (explicit `toBeVisible({ timeout: 30_000 })` + `.click({ force: true })`) to the single click site in the OWUI OIDC setup. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant PW as Playwright
    participant OWUI as OWUI Login Page
    participant Supabase as Supabase OAuth
    participant WC as Web Console /oauth/consent

    PW->>OWUI: page.goto("/")
    OWUI-->>PW: Page rendered (with animating element)
    PW->>OWUI: "expect(hiveButton).toBeVisible({ timeout: 30_000 })"
    Note over PW,OWUI: Waits for button visible in DOM
    PW->>OWUI: "hiveButton.click({ force: true })"
    Note over PW,OWUI: Skips stability/receives-events checks
    OWUI->>Supabase: Redirect to OAuth authorize
    Supabase->>WC: Redirect to /oauth/consent (unauthenticated)
    WC->>WC: "/auth/sign-in?next=..."
    PW->>WC: Fill email + password + click Continue
    WC->>WC: /oauth/consent (authenticated)
    PW->>WC: Click Approve
    WC->>OWUI: Redirect to OIDC callback
    OWUI-->>PW: Chat input visible → storageState saved
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant PW as Playwright
    participant OWUI as OWUI Login Page
    participant Supabase as Supabase OAuth
    participant WC as Web Console /oauth/consent

    PW->>OWUI: page.goto("/")
    OWUI-->>PW: Page rendered (with animating element)
    PW->>OWUI: "expect(hiveButton).toBeVisible({ timeout: 30_000 })"
    Note over PW,OWUI: Waits for button visible in DOM
    PW->>OWUI: "hiveButton.click({ force: true })"
    Note over PW,OWUI: Skips stability/receives-events checks
    OWUI->>Supabase: Redirect to OAuth authorize
    Supabase->>WC: Redirect to /oauth/consent (unauthenticated)
    WC->>WC: "/auth/sign-in?next=..."
    PW->>WC: Fill email + password + click Continue
    WC->>WC: /oauth/consent (authenticated)
    PW->>WC: Click Approve
    WC->>OWUI: Redirect to OIDC callback
    OWUI-->>PW: Chat input visible → storageState saved
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/web-console/e2e/phase-19/auth.setup.ts`, line 18-26 ([link](https://github.com/sakibsadmanshajib/hive/blob/d7db92932ed33ae94b16536652816758cbab26ee/apps/web-console/e2e/phase-19/auth.setup.ts#L18-L26)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The `toBeVisible()` calls here don't specify an explicit timeout, while the later `toHaveURL` assertion in the same file uses `{ timeout: 30_000 }`. If Playwright's configured `actionTimeout` or `timeout` is shorter than 30 s, the visibility wait could time out before the animated OWUI login page finishes rendering — defeating the purpose of the guard. Adding `{ timeout: 30_000 }` here keeps all the setup-phase waits consistent. The same pattern applies to the user B block below.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fweb-console%2Fe2e%2Fphase-19%2Fauth.setup.ts%0ALine%3A%2018-26%0A%0AComment%3A%0AThe%20%60toBeVisible%28%29%60%20calls%20here%20don't%20specify%20an%20explicit%20timeout%2C%20while%20the%20later%20%60toHaveURL%60%20assertion%20in%20the%20same%20file%20uses%20%60%7B%20timeout%3A%2030_000%20%7D%60.%20If%20Playwright's%20configured%20%60actionTimeout%60%20or%20%60timeout%60%20is%20shorter%20than%2030%20s%2C%20the%20visibility%20wait%20could%20time%20out%20before%20the%20animated%20OWUI%20login%20page%20finishes%20rendering%20%E2%80%94%20defeating%20the%20purpose%20of%20the%20guard.%20Adding%20%60%7B%20timeout%3A%2030_000%20%7D%60%20here%20keeps%20all%20the%20setup-phase%20waits%20consistent.%20The%20same%20pattern%20applies%20to%20the%20user%20B%20block%20below.%0A%0A%60%60%60suggestion%0A%20%20const%20hiveButton%20%3D%20page.getByRole%28%22button%22%2C%20%7B%20name%3A%20%2Fcontinue%20with%20hive%2Fi%20%7D%29%3B%0A%20%20await%20expect%28hiveButton%29.toBeVisible%28%7B%20timeout%3A%2030_000%20%7D%29%3B%0A%20%20await%20hiveButton.click%28%7B%20force%3A%20true%20%7D%29%3B%0A%20%20await%20page.getByLabel%28%22Email%22%29.fill%28email%29%3B%0A%20%20await%20page.getByRole%28%22button%22%2C%20%7B%20name%3A%20%2Fnext%2Fi%20%7D%29.click%28%29%3B%0A%20%20await%20page.getByLabel%28%22Password%22%29.fill%28password%29%3B%0A%20%20await%20page.getByRole%28%22button%22%2C%20%7B%20name%3A%20%2Fsign%20in%2Fi%20%7D%29.click%28%29%3B%0A%20%20await%20expect%28page%29.toHaveURL%28%2Flocalhost%3A3003%2F%2C%20%7B%20timeout%3A%2030_000%20%7D%29%3B%0A%20%20await%20page.context%28%29.storageState%28%7B%20path%3A%20STATE_A%20%7D%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=sakibsadmanshajib%2Fhive&pr=273&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fweb-console%2Fe2e%2Fphase-19%2Fauth.setup.ts%0ALine%3A%2018-26%0A%0AComment%3A%0AThe%20%60toBeVisible%28%29%60%20calls%20here%20don't%20specify%20an%20explicit%20timeout%2C%20while%20the%20later%20%60toHaveURL%60%20assertion%20in%20the%20same%20file%20uses%20%60%7B%20timeout%3A%2030_000%20%7D%60.%20If%20Playwright's%20configured%20%60actionTimeout%60%20or%20%60timeout%60%20is%20shorter%20than%2030%20s%2C%20the%20visibility%20wait%20could%20time%20out%20before%20the%20animated%20OWUI%20login%20page%20finishes%20rendering%20%E2%80%94%20defeating%20the%20purpose%20of%20the%20guard.%20Adding%20%60%7B%20timeout%3A%2030_000%20%7D%60%20here%20keeps%20all%20the%20setup-phase%20waits%20consistent.%20The%20same%20pattern%20applies%20to%20the%20user%20B%20block%20below.%0A%0A%60%60%60suggestion%0A%20%20const%20hiveButton%20%3D%20page.getByRole%28%22button%22%2C%20%7B%20name%3A%20%2Fcontinue%20with%20hive%2Fi%20%7D%29%3B%0A%20%20await%20expect%28hiveButton%29.toBeVisible%28%7B%20timeout%3A%2030_000%20%7D%29%3B%0A%20%20await%20hiveButton.click%28%7B%20force%3A%20true%20%7D%29%3B%0A%20%20await%20page.getByLabel%28%22Email%22%29.fill%28email%29%3B%0A%20%20await%20page.getByRole%28%22button%22%2C%20%7B%20name%3A%20%2Fnext%2Fi%20%7D%29.click%28%29%3B%0A%20%20await%20page.getByLabel%28%22Password%22%29.fill%28password%29%3B%0A%20%20await%20page.getByRole%28%22button%22%2C%20%7B%20name%3A%20%2Fsign%20in%2Fi%20%7D%29.click%28%29%3B%0A%20%20await%20expect%28page%29.toHaveURL%28%2Flocalhost%3A3003%2F%2C%20%7B%20timeout%3A%2030_000%20%7D%29%3B%0A%20%20await%20page.context%28%29.storageState%28%7B%20path%3A%20STATE_A%20%7D%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=273&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22sakibsadmanshajib%2Fhive%22%20on%20the%20existing%20branch%20%22fix%2Fowui-force-click-269%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fowui-force-click-269%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fweb-console%2Fe2e%2Fphase-19%2Fauth.setup.ts%0ALine%3A%2018-26%0A%0AComment%3A%0AThe%20%60toBeVisible%28%29%60%20calls%20here%20don't%20specify%20an%20explicit%20timeout%2C%20while%20the%20later%20%60toHaveURL%60%20assertion%20in%20the%20same%20file%20uses%20%60%7B%20timeout%3A%2030_000%20%7D%60.%20If%20Playwright's%20configured%20%60actionTimeout%60%20or%20%60timeout%60%20is%20shorter%20than%2030%20s%2C%20the%20visibility%20wait%20could%20time%20out%20before%20the%20animated%20OWUI%20login%20page%20finishes%20rendering%20%E2%80%94%20defeating%20the%20purpose%20of%20the%20guard.%20Adding%20%60%7B%20timeout%3A%2030_000%20%7D%60%20here%20keeps%20all%20the%20setup-phase%20waits%20consistent.%20The%20same%20pattern%20applies%20to%20the%20user%20B%20block%20below.%0A%0A%60%60%60suggestion%0A%20%20const%20hiveButton%20%3D%20page.getByRole%28%22button%22%2C%20%7B%20name%3A%20%2Fcontinue%20with%20hive%2Fi%20%7D%29%3B%0A%20%20await%20expect%28hiveButton%29.toBeVisible%28%7B%20timeout%3A%2030_000%20%7D%29%3B%0A%20%20await%20hiveButton.click%28%7B%20force%3A%20true%20%7D%29%3B%0A%20%20await%20page.getByLabel%28%22Email%22%29.fill%28email%29%3B%0A%20%20await%20page.getByRole%28%22button%22%2C%20%7B%20name%3A%20%2Fnext%2Fi%20%7D%29.click%28%29%3B%0A%20%20await%20page.getByLabel%28%22Password%22%29.fill%28password%29%3B%0A%20%20await%20page.getByRole%28%22button%22%2C%20%7B%20name%3A%20%2Fsign%20in%2Fi%20%7D%29.click%28%29%3B%0A%20%20await%20expect%28page%29.toHaveURL%28%2Flocalhost%3A3003%2F%2C%20%7B%20timeout%3A%2030_000%20%7D%29%3B%0A%20%20await%20page.context%28%29.storageState%28%7B%20path%3A%20STATE_A%20%7D%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=sakibsadmanshajib%2Fhive&pr=273&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(e2e): add explicit 30s timeout to OW..."](https://github.com/sakibsadmanshajib/hive/commit/6a93ebcdb5ee0b7a3de349aa45261d086490c35a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41658272)</sub>

<!-- /greptile_comment -->