### PR TITLE
fix: dispatch DOM click for OWUI OAuth login button in e2e setup (#269)

### DIFF
--- a/apps/web-console/e2e/phase-19/auth.setup.ts
+++ b/apps/web-console/e2e/phase-19/auth.setup.ts
@@ -13,11 +13,13 @@ setup("authenticate user A (tenant T1)", async ({ page }) => {
   }
   await page.goto(`${OWUI_URL}/`);
   // ponytail: OWUI login page has a continuously animating element, so
-  // Playwright's click-stability check never settles; force-click after an
-  // explicit visibility wait instead.
+  // Playwright's click-stability check never settles, and its force-click still
+  // requires the element in the viewport, which fails during the same
+  // animation. dispatchEvent fires the DOM click handler directly, regardless of
+  // geometry, stability, or overlays.
   const hiveButton = page.getByRole("button", { name: /continue with hive/i });
   await expect(hiveButton).toBeVisible({ timeout: 30_000 });
-  await hiveButton.click({ force: true });
+  await hiveButton.dispatchEvent("click");
   await page.getByLabel("Email").fill(email);
   await page.getByRole("button", { name: /next/i }).click();
   await page.getByLabel("Password").fill(password);
@@ -35,11 +37,13 @@ setup("authenticate user B (tenant T2)", async ({ page }) => {
   }
   await page.goto(`${OWUI_URL}/`);
   // ponytail: OWUI login page has a continuously animating element, so
-  // Playwright's click-stability check never settles; force-click after an
-  // explicit visibility wait instead.
+  // Playwright's click-stability check never settles, and its force-click still
+  // requires the element in the viewport, which fails during the same
+  // animation. dispatchEvent fires the DOM click handler directly, regardless of
+  // geometry, stability, or overlays.
   const hiveButton = page.getByRole("button", { name: /continue with hive/i });
   await expect(hiveButton).toBeVisible({ timeout: 30_000 });
-  await hiveButton.click({ force: true });
+  await hiveButton.dispatchEvent("click");
   await page.getByLabel("Email").fill(email);
   await page.getByRole("button", { name: /next/i }).click();
   await page.getByLabel("Password").fill(password);

--- a/apps/web-console/e2e/phase-19/owui/owui.setup.ts
+++ b/apps/web-console/e2e/phase-19/owui/owui.setup.ts
@@ -18,11 +18,13 @@ setup("OWUI OIDC sign-in via Hive consent", async ({ page }) => {
 
   await page.goto("/");
   // ponytail: OWUI login page has a continuously animating element, so
-  // Playwright's click-stability check never settles; force-click after an
-  // explicit visibility wait instead.
+  // Playwright's click-stability check never settles, and its force-click still
+  // requires the element in the viewport, which fails during the same
+  // animation. dispatchEvent fires the DOM click handler directly, regardless of
+  // geometry, stability, or overlays.
   const hiveButton = page.getByRole("button", { name: /continue with hive/i });
   await expect(hiveButton).toBeVisible({ timeout: 30_000 });
-  await hiveButton.click({ force: true });
+  await hiveButton.dispatchEvent("click");
 
   // The OAuth click starts a real full-page redirect chain: OWUI -> Supabase
   // authorize -> /oauth/consent (web-console origin, unauthenticated) ->


### PR DESCRIPTION
## Summary

Nightly run 28670467626 failed differently from the prior two attempts: the `toBeVisible({ timeout: 30_000 })` assertion now passes, but the follow-up `click({ force: true })` immediately throws "Element is outside of the viewport" (both retries, under 2s each). `force: true` skips Playwright's stability wait but still requires the target's bounding box to intersect the viewport; OWUI's login page has an entry animation that translates the form off-screen at some points in its cycle, and the force click lands on one of those frames.

## Fix

At the three "continue with hive" click sites (`owui.setup.ts` and both tenant blocks in `auth.setup.ts`), kept the `toBeVisible({ timeout: 30_000 })` wait and replaced `click({ force: true })` with `hiveButton.dispatchEvent("click")`. `dispatchEvent` fires a real DOM `click` event straight at the element regardless of geometry, stability, or overlays, so OWUI's Svelte `on:click` handler (which starts the OAuth redirect) still receives it even mid-animation. Comments at each site updated to explain why.

## Local verification (before opening this PR)

Per the iteration-cost concern, this was verified against a real Open WebUI container before pushing, not just reasoned about:

1. Read `deploy/docker/docker-compose.yml`'s `open-webui` service for the exact pinned image: `ghcr.io/open-webui/open-webui:main@sha256:74093dadc9c6aabc23987a74fd8c2fb8d995b1a5b22e83b0036fb9d6af590e8c`.
2. Booted that image standalone on an ephemeral host port, with `ENABLE_OAUTH_SIGNUP=true`, `OAUTH_PROVIDER_NAME=Hive`, a dummy `OAUTH_CLIENT_ID`/`OAUTH_CLIENT_SECRET`, and `OPENID_PROVIDER_URL` built from the real `SUPABASE_URL` (the OIDC discovery document is public and doesn't require a valid client to fetch). `RAG_EMBEDDING_ENGINE=openai` was set to skip a local embedding-model download that isn't relevant to this test and was blocking startup. `/api/config` confirmed the `oidc` provider registered with label "Hive".
3. Wrote a throwaway Playwright script (not committed) that performed exactly the fixed setup sequence: `goto /`, wait for `/continue with hive/i` to be visible with a 30s timeout, `dispatchEvent("click")`, then `waitForURL(/supabase\.co\/auth\/v1\/oauth\/authorize/, { timeout: 15_000 })`. Ran it with the web-console's own `@playwright/test` via `npx`.
4. Result: passed on the first try, no iteration needed. The click navigated to the Supabase OAuth authorize endpoint with the correct `client_id`, `redirect_uri`, and `scope` query params, confirming OWUI's click handler received the dispatched event and started the real OAuth redirect.
5. Cleaned up the throwaway script/config and the verification container afterward.

No other logic changed.

## Test plan

- [ ] Confirm the next nightly OWUI e2e run gets past the click step without a viewport or stability error.
- [ ] Confirm the rest of the OAuth redirect chain (consent, sign-in) still completes as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end login flows to use a more direct click action for the “Continue with Hive” button.
  * This should make authentication-related test runs more reliable and less prone to interaction timing issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->