### PR TITLE
fix: stabilize OWUI OIDC journey locators (#269)

### DIFF
--- a/apps/web-console/e2e/phase-19/auth.setup.ts
+++ b/apps/web-console/e2e/phase-19/auth.setup.ts
@@ -20,9 +20,12 @@ setup("authenticate user A (tenant T1)", async ({ page }) => {
   const hiveButton = page.getByRole("button", { name: /continue with hive/i });
   await expect(hiveButton).toBeVisible({ timeout: 30_000 });
   await hiveButton.dispatchEvent("click");
-  await page.getByLabel("Email").fill(email);
+  // getByLabel("Password") is a strict-mode violation here: the browser's
+  // native password-reveal toggle button shares "Password" in its
+  // accessible name. getByRole("textbox", ...) excludes it by role.
+  await page.getByRole("textbox", { name: /email/i }).fill(email);
   await page.getByRole("button", { name: /next/i }).click();
-  await page.getByLabel("Password").fill(password);
+  await page.getByRole("textbox", { name: /password/i }).fill(password);
   await page.getByRole("button", { name: /sign in/i }).click();
   await expect(page).toHaveURL(/localhost:3003/, { timeout: 30_000 });
   await page.context().storageState({ path: STATE_A });
@@ -44,9 +47,12 @@ setup("authenticate user B (tenant T2)", async ({ page }) => {
   const hiveButton = page.getByRole("button", { name: /continue with hive/i });
   await expect(hiveButton).toBeVisible({ timeout: 30_000 });
   await hiveButton.dispatchEvent("click");
-  await page.getByLabel("Email").fill(email);
+  // getByLabel("Password") is a strict-mode violation here: the browser's
+  // native password-reveal toggle button shares "Password" in its
+  // accessible name. getByRole("textbox", ...) excludes it by role.
+  await page.getByRole("textbox", { name: /email/i }).fill(email);
   await page.getByRole("button", { name: /next/i }).click();
-  await page.getByLabel("Password").fill(password);
+  await page.getByRole("textbox", { name: /password/i }).fill(password);
   await page.getByRole("button", { name: /sign in/i }).click();
   await expect(page).toHaveURL(/localhost:3003/, { timeout: 30_000 });
   await page.context().storageState({ path: STATE_B });

--- a/apps/web-console/e2e/phase-19/owui/owui.setup.ts
+++ b/apps/web-console/e2e/phase-19/owui/owui.setup.ts
@@ -33,8 +33,11 @@ setup("OWUI OIDC sign-in via Hive consent", async ({ page }) => {
   // origin from OWUI_URL, so this spec never calls page.goto with a relative
   // path past this point -- it only follows whatever the browser is
   // redirected to, which keeps it baseURL-agnostic.
-  await page.getByLabel("Email").fill(email);
-  await page.getByLabel("Password").fill(password);
+  // getByLabel("Password") is a strict-mode violation here: the browser's
+  // native password-reveal toggle button shares "Password" in its
+  // accessible name. getByRole("textbox", ...) excludes it by role.
+  await page.getByRole("textbox", { name: /email/i }).fill(email);
+  await page.getByRole("textbox", { name: /password/i }).fill(password);
   await page.getByRole("button", { name: /continue/i }).click();
 
   // Lands back on /oauth/consent, now authenticated, showing the Hive Chat


### PR DESCRIPTION
## Summary

Nightly run 28672241828 got past the OAuth redirect and email fill, then hit a strict-mode violation at `owui.setup.ts:37`: `getByLabel("Password")` resolved to two elements, the actual password `<input>` and the browser's native password-reveal toggle button (both expose "Password" in their accessible name).

## Fix

Replaced `getByLabel("Email")` / `getByLabel("Password")` with `getByRole("textbox", { name: /email/i })` / `getByRole("textbox", { name: /password/i })` at all four affected sites: the one email/password pair in `owui.setup.ts`, and both tenant blocks (`user A`, `user B`) in `auth.setup.ts`. Filtering by role excludes the toggle button (role `button`, not `textbox`) regardless of its accessible name, so this is structurally immune to the same clash. Applied the same defensive change to the Email locators too, since they sit right next to the affected Password ones and share the same risk profile.

## Verification performed

Read the actual web-console sign-in page source (`apps/web-console/app/auth/sign-in/page.tsx` and its shared `Input`/`Field` components in `apps/web-console/components/ui/input.tsx`) to confirm there is exactly one `<input type="email">` and one `<input type="password">` element on that page, with no custom visibility-toggle markup of our own, no hidden duplicate inputs, and no other role=`textbox` element with "email" or "password" in its name. That confirms the role-based locator cannot introduce a new ambiguity on the web-console side. The toggle button causing the reported strict-mode violation is browser-native (Chromium's built-in password-reveal affordance), not something this repo renders, which is also why `getByLabel` could not distinguish it. `auth.setup.ts`'s password field lives on OWUI's own third-party login UI, so its markup isn't in this repo to read directly, but it renders through the same Chromium engine and the same class of native toggle risk applies, so the same fix was applied there proactively per the task's request.

## Scope note: full local OIDC-journey verification not performed in this PR

The task also asked for a full local run of the nightly's stack (`docker compose` with `local`/`test`/`test-owui` profiles) plus registering a new, separate confidential OAuth client via GoTrue's admin API (`POST {SUPABASE_URL}/auth/v1/admin/oauth/clients`) using the `SUPABASE_SERVICE_ROLE_KEY` from `.env`, to exercise the full journey (sign-in, consent, redirect back) end to end before opening this PR.

I did not perform that step. Minting a new OAuth client via the service-role key is a live, persistent mutation against the same shared Supabase project the real nightly CI depends on, and I don't have a standing, previously-reviewed script in this repo for it (`scripts/` only has `seed-owui-e2e-user.py`, no OAuth-client-registration tooling), so it would have been an ad hoc admin-API call against production-adjacent auth infrastructure using a high-privilege secret. That is a materially different risk class from everything else in this chain (git branches, local ephemeral Docker containers, throwaway scratch scripts), and I don't think a relayed task instruction is sufficient authorization for it on its own. Recommend the repo owner either provisions this OAuth client themselves (or explicitly signs off on a subagent doing it) before the full local OIDC journey is exercised end to end.

Everything else in this PR (the locator fix itself and the source-level verification of it) is safe, scoped, and complete.

## Test plan

- [ ] Owner or an authorized process registers/confirms a local-dev OAuth client and re-runs `pnpm exec playwright test --project=owui-setup` locally end to end.
- [ ] Confirm the next nightly OWUI e2e run gets past the `owui.setup.ts:37` line without a strict-mode violation.
- [ ] Confirm the consent-approve and redirect-back steps still complete as before.