### PR TITLE
fix: enable PKCE for OWUI OIDC against Supabase OAuth 2.1 (#269)

### DIFF
--- a/apps/web-console/e2e/phase-19/auth.setup.ts
+++ b/apps/web-console/e2e/phase-19/auth.setup.ts
@@ -20,6 +20,12 @@ setup("authenticate user A (tenant T1)", async ({ page }) => {
   const hiveButton = page.getByRole("button", { name: /continue with hive/i });
   await expect(hiveButton).toBeVisible({ timeout: 30_000 });
   await hiveButton.dispatchEvent("click");
+  // Without this wait, the fills below race the redirect chain and land on
+  // OWUI's own native login form instead of the web-console one.
+  await page.waitForURL(/\/(auth\/sign-in|oauth\/consent)/, {
+    timeout: 30_000,
+  });
+
   // getByLabel("Password") is a strict-mode violation here: the browser's
   // native password-reveal toggle button shares "Password" in its
   // accessible name. getByRole("textbox", ...) excludes it by role.
@@ -47,6 +53,12 @@ setup("authenticate user B (tenant T2)", async ({ page }) => {
   const hiveButton = page.getByRole("button", { name: /continue with hive/i });
   await expect(hiveButton).toBeVisible({ timeout: 30_000 });
   await hiveButton.dispatchEvent("click");
+  // Without this wait, the fills below race the redirect chain and land on
+  // OWUI's own native login form instead of the web-console one.
+  await page.waitForURL(/\/(auth\/sign-in|oauth\/consent)/, {
+    timeout: 30_000,
+  });
+
   // getByLabel("Password") is a strict-mode violation here: the browser's
   // native password-reveal toggle button shares "Password" in its
   // accessible name. getByRole("textbox", ...) excludes it by role.

--- a/apps/web-console/e2e/phase-19/owui/owui.setup.ts
+++ b/apps/web-console/e2e/phase-19/owui/owui.setup.ts
@@ -33,6 +33,12 @@ setup("OWUI OIDC sign-in via Hive consent", async ({ page }) => {
   // origin from OWUI_URL, so this spec never calls page.goto with a relative
   // path past this point -- it only follows whatever the browser is
   // redirected to, which keeps it baseURL-agnostic.
+  // Without this wait, the fills below race the redirect chain and land on
+  // OWUI's own native login form instead of the web-console one.
+  await page.waitForURL(/\/(auth\/sign-in|oauth\/consent)/, {
+    timeout: 30_000,
+  });
+
   // getByLabel("Password") is a strict-mode violation here: the browser's
   // native password-reveal toggle button shares "Password" in its
   // accessible name. getByRole("textbox", ...) excludes it by role.

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -316,6 +316,11 @@ services:
       OAUTH_CLIENT_ID: ${SUPABASE_OAUTH_CLIENT_ID:-}
       OAUTH_CLIENT_SECRET: ${SUPABASE_OAUTH_CLIENT_SECRET:-}
       OAUTH_SCOPES: "openid email profile"
+      # Supabase's OAuth 2.1 authorization server requires PKCE on every
+      # authorize request. authlib (OWUI's OAuth client) only sends
+      # code_challenge/code_challenge_method when this is set, so without it
+      # Supabase 302s straight back with error=invalid_request.
+      OAUTH_CODE_CHALLENGE_METHOD: "S256"
       ENABLE_OAUTH_ROLE_MANAGEMENT: "true"
       OAUTH_ROLES_CLAIM: "role"
       OAUTH_ALLOWED_ROLES: "ADMIN,MEMBER,VIEWER"


### PR DESCRIPTION
## Summary

Run 28673213729's network trace found the actual root cause behind every prior OWUI OAuth setup failure: the OAuth click works, OWUI hits `GET /oauth/oidc/login` (302), Supabase's `/auth/v1/oauth/authorize` runs, and Supabase 302s straight back to the OWUI callback with:

> error=invalid_request, error_description="PKCE flow requires both code_challenge and code_verifier"

Supabase's OAuth 2.1 authorization server mandates PKCE on every authorize request. OWUI's OAuth client (authlib) only sends `code_challenge`/`code_challenge_method` when `OAUTH_CODE_CHALLENGE_METHOD` is explicitly set. Without it, Supabase rejects the request and bounces the browser back to OWUI's own login page, which is what every previous locator/timing symptom in this chain was actually downstream of.

## Fix

1. `deploy/docker/docker-compose.yml`: added `OAUTH_CODE_CHALLENGE_METHOD: "S256"` to the `open-webui` service's OAuth env block, next to the other `OAUTH_*` vars. Checked `docker-compose.enterprise.yml` for a separate `open-webui` service override — it doesn't define one, so no second place needed updating.
2. `apps/web-console/e2e/phase-19/owui/owui.setup.ts` and `auth.setup.ts`: inserted `await page.waitForURL(/\/(auth\/sign-in|oauth\/consent)/, { timeout: 30_000 })` right after the `dispatchEvent("click")` on the Hive OAuth button, before the Email/Password fills. Without this wait, the fills raced the OWUI → Supabase → web-console redirect chain and could land on OWUI's own native login form instead of the web-console one.

## Local verification

Per the mandated lightweight check (standalone OWUI only, same rig as the prior PKCE-adjacent fixes in this chain): booted the pinned `ghcr.io/open-webui/open-webui:main@sha256:74093dadc9c6aabc23987a74fd8c2fb8d995b1a5b22e83b0036fb9d6af590e8c` image with dummy OAuth client creds, a real `OPENID_PROVIDER_URL` built from `SUPABASE_URL`, and `OAUTH_CODE_CHALLENGE_METHOD=S256`. A throwaway Playwright script (not committed) clicked the button and asserted the resulting Supabase authorize URL:

```
code_challenge present: true
code_challenge_method: S256
1 passed (7.6s)
```

This proves OWUI now sends PKCE params on the authorize request with this env var set. The full consent journey (sign-in, approve, redirect back) still needs the real CI stack with a registered OAuth client and still needs verification there. Container and throwaway script/config cleaned up after the check.

## Test plan

- [ ] Confirm the next nightly OWUI e2e run gets past the authorize step without `error=invalid_request` for PKCE.
- [ ] Confirm the sign-in/consent/redirect-back steps still complete once past that point.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sign-in reliability by waiting for the correct login/consent page before entering credentials.
  * Prevented occasional redirects to the wrong login screen during authentication.
  * Fixed OAuth login configuration so sign-in flows complete more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->