### PR TITLE
fix: hydration-safe credential fill in OIDC setup journey (#269)

### DIFF
--- a/apps/web-console/e2e/phase-19/auth.setup.ts
+++ b/apps/web-console/e2e/phase-19/auth.setup.ts
@@ -29,9 +29,23 @@ setup("authenticate user A (tenant T1)", async ({ page }) => {
   // getByLabel("Password") is a strict-mode violation here: the browser's
   // native password-reveal toggle button shares "Password" in its
   // accessible name. getByRole("textbox", ...) excludes it by role.
-  await page.getByRole("textbox", { name: /email/i }).fill(email);
+  // web-console runs in dev mode in CI; a fill that lands before React
+  // hydration finishes gets wiped when the controlled input mounts. Retry
+  // each fill and verify the value actually stuck before moving on.
+  const emailBox = page.getByRole("textbox", { name: /email/i });
+  for (let i = 0; i < 3; i++) {
+    await emailBox.fill(email);
+    if ((await emailBox.inputValue()) === email) break;
+  }
+  await expect(emailBox).toHaveValue(email);
   await page.getByRole("button", { name: /next/i }).click();
-  await page.getByRole("textbox", { name: /password/i }).fill(password);
+
+  const passwordBox = page.getByRole("textbox", { name: /password/i });
+  for (let i = 0; i < 3; i++) {
+    await passwordBox.fill(password);
+    if ((await passwordBox.inputValue()) === password) break;
+  }
+  await expect(passwordBox).toHaveValue(password);
   await page.getByRole("button", { name: /sign in/i }).click();
   await expect(page).toHaveURL(/localhost:3003/, { timeout: 30_000 });
   await page.context().storageState({ path: STATE_A });
@@ -62,9 +76,23 @@ setup("authenticate user B (tenant T2)", async ({ page }) => {
   // getByLabel("Password") is a strict-mode violation here: the browser's
   // native password-reveal toggle button shares "Password" in its
   // accessible name. getByRole("textbox", ...) excludes it by role.
-  await page.getByRole("textbox", { name: /email/i }).fill(email);
+  // web-console runs in dev mode in CI; a fill that lands before React
+  // hydration finishes gets wiped when the controlled input mounts. Retry
+  // each fill and verify the value actually stuck before moving on.
+  const emailBox = page.getByRole("textbox", { name: /email/i });
+  for (let i = 0; i < 3; i++) {
+    await emailBox.fill(email);
+    if ((await emailBox.inputValue()) === email) break;
+  }
+  await expect(emailBox).toHaveValue(email);
   await page.getByRole("button", { name: /next/i }).click();
-  await page.getByRole("textbox", { name: /password/i }).fill(password);
+
+  const passwordBox = page.getByRole("textbox", { name: /password/i });
+  for (let i = 0; i < 3; i++) {
+    await passwordBox.fill(password);
+    if ((await passwordBox.inputValue()) === password) break;
+  }
+  await expect(passwordBox).toHaveValue(password);
   await page.getByRole("button", { name: /sign in/i }).click();
   await expect(page).toHaveURL(/localhost:3003/, { timeout: 30_000 });
   await page.context().storageState({ path: STATE_B });

--- a/apps/web-console/e2e/phase-19/owui/owui.setup.ts
+++ b/apps/web-console/e2e/phase-19/owui/owui.setup.ts
@@ -42,9 +42,28 @@ setup("OWUI OIDC sign-in via Hive consent", async ({ page }) => {
   // getByLabel("Password") is a strict-mode violation here: the browser's
   // native password-reveal toggle button shares "Password" in its
   // accessible name. getByRole("textbox", ...) excludes it by role.
-  await page.getByRole("textbox", { name: /email/i }).fill(email);
-  await page.getByRole("textbox", { name: /password/i }).fill(password);
+  const emailBox = page.getByRole("textbox", { name: /email/i });
+  const passwordBox = page.getByRole("textbox", { name: /password/i });
+  // web-console runs in dev mode in CI; a fill that lands before React
+  // hydration finishes gets wiped when the controlled input mounts. Retry
+  // both fills together and verify the values actually stuck.
+  for (let i = 0; i < 3; i++) {
+    await emailBox.fill(email);
+    await passwordBox.fill(password);
+    if (
+      (await emailBox.inputValue()) === email &&
+      (await passwordBox.inputValue()) === password
+    ) {
+      break;
+    }
+  }
+  await expect(emailBox).toHaveValue(email);
+  await expect(passwordBox).toHaveValue(password);
   await page.getByRole("button", { name: /continue/i }).click();
+
+  // A failed submit (e.g. a field silently wiped again) should surface here
+  // as a clear URL-wait timeout instead of a dangling Approve-button wait.
+  await page.waitForURL(/\/oauth\/consent/, { timeout: 30_000 });
 
   // Lands back on /oauth/consent, now authenticated, showing the Hive Chat
   // client's requested scopes.


### PR DESCRIPTION
## Summary

Run 28675307333 got further than any prior attempt: the OAuth authorize step succeeds with PKCE (302), the consent page loads (200), and the browser bounces to `/auth/sign-in?next=%2Foauth%2Fconsent%3Fauthorization_id%3D...` (200). The spec then times out waiting for the Approve button. The failure page snapshot shows why: the password textbox contains the filled value, but the email textbox is empty and focused, so the required `email` field blocks submission and Continue never actually navigates anywhere.

This is a hydration race: web-console runs in dev mode in CI. The email fill landed before React hydration finished on the sign-in page and got wiped when the controlled input mounted and reset its value to the initial (empty) state; the password fill happened slightly later and survived.

## Fix

`owui.setup.ts`: replaced the single email+password fill pair with a combined retry loop (both fields are on the same page simultaneously here) that fills both, checks `inputValue()` on each, and retries up to 3 times until both actually stuck, followed by explicit `toHaveValue` assertions before clicking Continue. Also added `await page.waitForURL(/\/oauth\/consent/, { timeout: 30_000 })` right after the Continue click and before waiting for the Approve button, so a failed submit (e.g. a field silently wiped again) now surfaces as a clear URL-wait timeout instead of a dangling Approve-button wait with no diagnostic value.

`auth.setup.ts` (both tenant blocks, user A and user B): OWUI's own native login here is a two-step wizard (email, Next, then password, Sign in), so the two fields are never on the page at the same time. Applied the same retry-and-verify pattern per field instead of a combined loop: fill email, verify with `inputValue()`, retry up to 3 times, assert with `toHaveValue`, click Next; then the same for password before Sign in. The existing `expect(page).toHaveURL(/localhost:3003/, ...)` assertion after Sign in already plays the same "surface failures clearly" role that the `waitForURL` addition plays in `owui.setup.ts`, so no further change was needed there.

## Verification

Local verification of the actual journey isn't feasible for this leg without the full stack (already noted as infeasible in the prior PKCE PR for the same reason). Verified statically instead: ran both edited files through TypeScript's `transpileModule` for a syntax check (0 errors on both) since a full `tsc --noEmit` against the repo's real tsconfig needs the full monorepo `node_modules` install, which wasn't warranted for a syntax-level check. The retry-and-verify pattern itself is deterministic (fill, read back, compare, retry on mismatch) and doesn't depend on timing assumptions beyond Playwright's own auto-waiting.

## Test plan

- [ ] Confirm the next nightly OWUI e2e run gets past the sign-in submit with both fields populated.
- [ ] Confirm the Approve button appears and the journey completes to OWUI callback / `localhost:3003` as expected.