### PR TITLE
ci: dump compose logs on nightly failure (#269)

### DIFF
--- a/.github/workflows/phase-19-owui-nightly.yml
+++ b/.github/workflows/phase-19-owui-nightly.yml
@@ -173,6 +173,16 @@ jobs:
           pnpm exec playwright install --with-deps chromium
           pnpm e2e:owui
           pnpm e2e:owui:perf
+      - name: Dump container logs on failure
+        # The OWUI OAuth callback can hang with no visible error on the
+        # Playwright side (e.g. run 28676421973's 30s hang after the token
+        # exchange). The Playwright report has no insight into what the
+        # backend containers were doing, so pull their logs directly.
+        if: failure()
+        run: |
+          cd deploy/docker
+          docker compose --env-file ../../.env.ci logs --no-color --tail 300 \
+            open-webui litellm edge-api control-plane > $GITHUB_WORKSPACE/compose-logs.txt 2>&1 || true
       - name: SOC2 coverage report
         if: always()
         run: |
@@ -183,6 +193,11 @@ jobs:
         with:
           name: owui-playwright-report
           path: apps/web-console/playwright-report-owui
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: owui-compose-logs
+          path: compose-logs.txt
       - name: Slack on failure
         if: failure() && env.SLACK_WEBHOOK_URL != ''
         env:


### PR DESCRIPTION
## Summary

Run 28676421973 completes the full OAuth round trip: authorize with PKCE, sign-in, consent approve, and the OWUI callback receives `code` and `state`. Then the callback request hangs for 30 seconds with no response and no visible error on the Playwright side. The Playwright report has no insight into what OWUI's backend was doing during the token-exchange / user-provisioning step, so this adds a diagnostic-only step to capture container logs on failure.

## Changes

Added a "Dump container logs on failure" step in `.github/workflows/phase-19-owui-nightly.yml`, right after "Run OWUI Playwright suite" and before "SOC2 coverage report". It runs only `if: failure()` and pulls the last 300 lines from `open-webui`, `litellm`, `edge-api`, and `control-plane` via `docker compose logs`, matching the exact compose invocation style (`--env-file ../../.env.ci`, run from `deploy/docker`) the existing "Boot stack" step already uses. Output goes to `$GITHUB_WORKSPACE/compose-logs.txt`.

Added a second `actions/upload-artifact@v4` step, also `if: failure()`, uploading `compose-logs.txt` as `owui-compose-logs`. Kept it as a separate step rather than folding it into the existing `owui-playwright-report` upload (which runs `if: always()`), since that file only exists on failure and a separate step avoids needing an `if-no-files-found` override on the always-on upload.

No other changes.

## Test plan

- [ ] Confirm the next nightly failure run uploads an `owui-compose-logs` artifact containing the four containers' logs.
- [ ] Use those logs to diagnose the token-exchange/user-provisioning hang from run 28676421973.