### PR TITLE
fix: retry sign-in submit and harden post-login wait (#269)

### DIFF
--- a/.github/workflows/phase-19-owui-nightly.yml
+++ b/.github/workflows/phase-19-owui-nightly.yml
@@ -149,6 +149,37 @@ jobs:
             docker compose ps
             exit 1
           fi
+      - name: Probe Supabase token endpoint from OWUI container
+        # Diagnostic only, non-fatal (|| true). Leading hypothesis for the
+        # run 28676421973 callback hang: runner egress stall (IPv6/DNS
+        # connect) reaching Supabase from inside the container -- local
+        # repro with the identical image and endpoints completes in under
+        # 3s (~1.3s per call). Credentials are read from env and never
+        # printed; only status code and elapsed time are logged.
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_OAUTH_CLIENT_ID: ${{ secrets.SUPABASE_OAUTH_CLIENT_ID }}
+          SUPABASE_OAUTH_CLIENT_SECRET: ${{ secrets.SUPABASE_OAUTH_CLIENT_SECRET }}
+        run: |
+          cd deploy/docker
+          docker compose --env-file ../../.env.ci exec -T \
+            -e SUPABASE_URL -e SUPABASE_OAUTH_CLIENT_ID -e SUPABASE_OAUTH_CLIENT_SECRET \
+            open-webui python3 -c "
+          import os, time, httpx
+          t = time.time()
+          r = httpx.post(
+              os.environ['SUPABASE_URL'] + '/auth/v1/oauth/token',
+              data={
+                  'grant_type': 'authorization_code',
+                  'code': 'bogus',
+                  'redirect_uri': 'http://localhost:3003/oauth/oidc/callback',
+                  'code_verifier': 'bogus',
+              },
+              auth=(os.environ['SUPABASE_OAUTH_CLIENT_ID'], os.environ['SUPABASE_OAUTH_CLIENT_SECRET']),
+              timeout=20,
+          )
+          print('token-endpoint', r.status_code, round(time.time() - t, 2), 's')
+          " || true
       - name: Run OWUI Playwright suite
         # OWUI_E2E_EMAIL/PASSWORD are always provisioned by the "Seed OWUI
         # e2e test user" step above (schedule, workflow_dispatch, and

--- a/apps/web-console/e2e/phase-19/auth.setup.ts
+++ b/apps/web-console/e2e/phase-19/auth.setup.ts
@@ -46,8 +46,22 @@ setup("authenticate user A (tenant T1)", async ({ page }) => {
     if ((await passwordBox.inputValue()) === password) break;
   }
   await expect(passwordBox).toHaveValue(password);
-  await page.getByRole("button", { name: /sign in/i }).click();
-  await expect(page).toHaveURL(/localhost:3003/, { timeout: 30_000 });
+
+  // Same hydration race as the fills: a click that lands before React
+  // attaches the handler is silently lost. Retry the click until the
+  // navigation actually happens.
+  for (let i = 0; i < 5; i++) {
+    await page.getByRole("button", { name: /sign in/i }).click();
+    try {
+      await page.waitForURL((u) => u.origin === new URL(OWUI_URL).origin, {
+        timeout: 5_000,
+      });
+      break;
+    } catch {
+      // retry
+    }
+  }
+  expect(new URL(page.url()).origin).toBe(new URL(OWUI_URL).origin);
   await page.context().storageState({ path: STATE_A });
 });
 
@@ -93,7 +107,21 @@ setup("authenticate user B (tenant T2)", async ({ page }) => {
     if ((await passwordBox.inputValue()) === password) break;
   }
   await expect(passwordBox).toHaveValue(password);
-  await page.getByRole("button", { name: /sign in/i }).click();
-  await expect(page).toHaveURL(/localhost:3003/, { timeout: 30_000 });
+
+  // Same hydration race as the fills: a click that lands before React
+  // attaches the handler is silently lost. Retry the click until the
+  // navigation actually happens.
+  for (let i = 0; i < 5; i++) {
+    await page.getByRole("button", { name: /sign in/i }).click();
+    try {
+      await page.waitForURL((u) => u.origin === new URL(OWUI_URL).origin, {
+        timeout: 5_000,
+      });
+      break;
+    } catch {
+      // retry
+    }
+  }
+  expect(new URL(page.url()).origin).toBe(new URL(OWUI_URL).origin);
   await page.context().storageState({ path: STATE_B });
 });

--- a/apps/web-console/e2e/phase-19/auth.setup.ts
+++ b/apps/web-console/e2e/phase-19/auth.setup.ts
@@ -49,11 +49,21 @@ setup("authenticate user A (tenant T1)", async ({ page }) => {
 
   // Same hydration race as the fills: a click that lands before React
   // attaches the handler is silently lost. Retry the click until the
-  // navigation actually happens.
+  // navigation actually happens. A successful click can still outlast the
+  // 5s wait below -- check the URL first and guard the click itself so a
+  // stale retry never re-clicks a button that already navigated away.
+  const owuiOrigin = new URL(OWUI_URL).origin;
   for (let i = 0; i < 5; i++) {
-    await page.getByRole("button", { name: /sign in/i }).click();
+    if (new URL(page.url()).origin === owuiOrigin) break;
     try {
-      await page.waitForURL((u) => u.origin === new URL(OWUI_URL).origin, {
+      await page
+        .getByRole("button", { name: /sign in/i })
+        .click({ timeout: 2_000 });
+    } catch {
+      // button may already be gone if a prior click's navigation landed late
+    }
+    try {
+      await page.waitForURL((u) => u.origin === owuiOrigin, {
         timeout: 5_000,
       });
       break;
@@ -61,7 +71,7 @@ setup("authenticate user A (tenant T1)", async ({ page }) => {
       // retry
     }
   }
-  expect(new URL(page.url()).origin).toBe(new URL(OWUI_URL).origin);
+  expect(new URL(page.url()).origin).toBe(owuiOrigin);
   await page.context().storageState({ path: STATE_A });
 });
 
@@ -110,11 +120,21 @@ setup("authenticate user B (tenant T2)", async ({ page }) => {
 
   // Same hydration race as the fills: a click that lands before React
   // attaches the handler is silently lost. Retry the click until the
-  // navigation actually happens.
+  // navigation actually happens. A successful click can still outlast the
+  // 5s wait below -- check the URL first and guard the click itself so a
+  // stale retry never re-clicks a button that already navigated away.
+  const owuiOrigin = new URL(OWUI_URL).origin;
   for (let i = 0; i < 5; i++) {
-    await page.getByRole("button", { name: /sign in/i }).click();
+    if (new URL(page.url()).origin === owuiOrigin) break;
     try {
-      await page.waitForURL((u) => u.origin === new URL(OWUI_URL).origin, {
+      await page
+        .getByRole("button", { name: /sign in/i })
+        .click({ timeout: 2_000 });
+    } catch {
+      // button may already be gone if a prior click's navigation landed late
+    }
+    try {
+      await page.waitForURL((u) => u.origin === owuiOrigin, {
         timeout: 5_000,
       });
       break;
@@ -122,6 +142,6 @@ setup("authenticate user B (tenant T2)", async ({ page }) => {
       // retry
     }
   }
-  expect(new URL(page.url()).origin).toBe(new URL(OWUI_URL).origin);
+  expect(new URL(page.url()).origin).toBe(owuiOrigin);
   await page.context().storageState({ path: STATE_B });
 });

--- a/apps/web-console/e2e/phase-19/owui/owui.setup.ts
+++ b/apps/web-console/e2e/phase-19/owui/owui.setup.ts
@@ -1,6 +1,7 @@
 import { test as setup, expect } from "@playwright/test";
 
 const STATE = "e2e/phase-19/owui/.auth/owui-user.json";
+const OWUI_URL = process.env.OWUI_URL ?? "http://localhost:3002";
 
 setup("OWUI OIDC sign-in via Hive consent", async ({ page }) => {
   const email = process.env.OWUI_E2E_EMAIL;
@@ -59,20 +60,35 @@ setup("OWUI OIDC sign-in via Hive consent", async ({ page }) => {
   }
   await expect(emailBox).toHaveValue(email);
   await expect(passwordBox).toHaveValue(password);
-  await page.getByRole("button", { name: /continue/i }).click();
 
-  // A failed submit (e.g. a field silently wiped again) should surface here
-  // as a clear URL-wait timeout instead of a dangling Approve-button wait.
-  await page.waitForURL(/\/oauth\/consent/, { timeout: 30_000 });
+  // Same hydration race as the fills: a click that lands before React
+  // attaches the handler is silently lost (run 28676903599: zero
+  // /oauth/oidc/callback hits after this step, both attempts). Retry the
+  // click until the navigation actually happens.
+  for (let i = 0; i < 5; i++) {
+    await page.getByRole("button", { name: /continue/i }).click();
+    try {
+      await page.waitForURL(/\/oauth\/consent/, { timeout: 5_000 });
+      break;
+    } catch {
+      // retry
+    }
+  }
+  expect(page.url()).toMatch(/\/oauth\/consent/);
 
   // Lands back on /oauth/consent, now authenticated, showing the Hive Chat
   // client's requested scopes.
   await page.getByRole("button", { name: /approve/i }).click();
 
-  // approveAuthorization()'s redirect_url sends the browser back to OWUI's
-  // OIDC callback, completing sign-in.
-  await expect(page.getByPlaceholder(/message/i)).toBeVisible({
+  // Run 28676421973: OAuth exchange itself verified fast and correct in
+  // local repro, but OWUI's post-login SPA load (model-list fetch) can
+  // outlast a short wait. Accept any OWUI-origin URL first, then give the
+  // chat UI real time to finish loading.
+  await page.waitForURL((u) => u.origin === new URL(OWUI_URL).origin, {
     timeout: 30_000,
+  });
+  await expect(page.getByPlaceholder(/message/i)).toBeVisible({
+    timeout: 60_000,
   });
   await page.context().storageState({ path: STATE });
 });

--- a/apps/web-console/e2e/phase-19/owui/owui.setup.ts
+++ b/apps/web-console/e2e/phase-19/owui/owui.setup.ts
@@ -64,9 +64,19 @@ setup("OWUI OIDC sign-in via Hive consent", async ({ page }) => {
   // Same hydration race as the fills: a click that lands before React
   // attaches the handler is silently lost (run 28676903599: zero
   // /oauth/oidc/callback hits after this step, both attempts). Retry the
-  // click until the navigation actually happens.
+  // click until the navigation actually happens. A successful click can
+  // still outlast the 5s wait below -- check the URL first and guard the
+  // click itself so a stale retry never re-clicks a button that already
+  // navigated away.
   for (let i = 0; i < 5; i++) {
-    await page.getByRole("button", { name: /continue/i }).click();
+    if (/\/oauth\/consent/.test(page.url())) break;
+    try {
+      await page
+        .getByRole("button", { name: /continue/i })
+        .click({ timeout: 2_000 });
+    } catch {
+      // button may already be gone if a prior click's navigation landed late
+    }
     try {
       await page.waitForURL(/\/oauth\/consent/, { timeout: 5_000 });
       break;
@@ -77,14 +87,34 @@ setup("OWUI OIDC sign-in via Hive consent", async ({ page }) => {
   expect(page.url()).toMatch(/\/oauth\/consent/);
 
   // Lands back on /oauth/consent, now authenticated, showing the Hive Chat
-  // client's requested scopes.
-  await page.getByRole("button", { name: /approve/i }).click();
+  // client's requested scopes. Same hydration-race guard as above: check
+  // first, click inside a try so a stale retry never re-clicks a button
+  // that already navigated away, then wait in short windows.
+  const owuiOrigin = new URL(OWUI_URL).origin;
+  for (let i = 0; i < 5; i++) {
+    if (new URL(page.url()).origin === owuiOrigin) break;
+    try {
+      await page
+        .getByRole("button", { name: /approve/i })
+        .click({ timeout: 2_000 });
+    } catch {
+      // button may already be gone if a prior click's navigation landed late
+    }
+    try {
+      await page.waitForURL((u) => u.origin === owuiOrigin, {
+        timeout: 5_000,
+      });
+      break;
+    } catch {
+      // retry
+    }
+  }
 
   // Run 28676421973: OAuth exchange itself verified fast and correct in
   // local repro, but OWUI's post-login SPA load (model-list fetch) can
   // outlast a short wait. Accept any OWUI-origin URL first, then give the
   // chat UI real time to finish loading.
-  await page.waitForURL((u) => u.origin === new URL(OWUI_URL).origin, {
+  await page.waitForURL((u) => u.origin === owuiOrigin, {
     timeout: 30_000,
   });
   await expect(page.getByPlaceholder(/message/i)).toBeVisible({


### PR DESCRIPTION
## Summary

Two distinct flake points confirmed across runs 28676421973 and 28676903599.

Run 28676903599: both attempts stalled at `owui.setup.ts:66`'s `waitForURL(/\/oauth\/consent/)` right after clicking Continue on the console sign-in. Compose logs showed zero `/oauth/oidc/callback` hits, meaning the submit click itself was lost, the same dev-mode hydration race already fixed for the field fills, but on the click handler this time (click landed before React attached it).

Run 28676421973: sign-in and consent passed, the callback received `code`+`state`, then the final chat-input wait timed out. This is the post-login OWUI SPA load (model-list fetch dependency); the OAuth token exchange itself was verified fast and correct in local repro.

## Fix

`owui.setup.ts`: replaced the single Continue click + `waitForURL` with a retry loop (up to 5 iterations: click, try `waitForURL(/\/oauth\/consent/, { timeout: 5_000 })`, catch and retry). After the loop, asserts `page.url()` matches `/oauth/consent` so a genuine failure is loud instead of a silent last-iteration timeout. After the Approve click, replaced the single chat-placeholder wait with two steps: first `waitForURL((u) => u.origin === new URL(OWUI_URL).origin, { timeout: 30_000 })` (accepts any path on the OWUI origin), then `expect(page.getByPlaceholder(/message/i)).toBeVisible({ timeout: 60_000 })`, giving the SPA real time for its model-list fetch after the origin change is confirmed.

`auth.setup.ts` (both tenant blocks): applied the same retry-loop pattern to the "Sign in" click before the final URL assertion, and swapped the exact-string `toHaveURL(/localhost:3003/, ...)` assertion for the same origin-based `waitForURL` used in `owui.setup.ts`, for consistency. Note: `auth.setup.ts` has no consent/Approve step and no chat-input placeholder in its flow (it only needs to confirm the redirect landed back on the OWUI origin for `storageState` capture), so I did not add a chat-placeholder wait there. Also did not add retry protection to the "Next" click, since no flake evidence was reported against it. Flagging this adaptation for visibility, happy to extend if a similar flake surfaces there.

## Addendum: nightly diagnostic

Added a new step "Probe Supabase token endpoint from OWUI container" in `.github/workflows/phase-19-owui-nightly.yml`, between "Boot stack" and "Run OWUI Playwright suite". It execs into the `open-webui` container and times an `httpx` POST to `/auth/v1/oauth/token` with a bogus code (expected response: `400` in well under 2 seconds). Credentials (`SUPABASE_URL`, `SUPABASE_OAUTH_CLIENT_ID`, `SUPABASE_OAUTH_CLIENT_SECRET`, all already available as repo secrets used elsewhere in this workflow) are passed through as container env vars and never printed; only the status code and elapsed time are logged. The step is non-fatal (`|| true`). This targets the leading hypothesis for the run 28676421973 callback hang: a runner egress stall (IPv6/DNS connect) reaching Supabase from inside the container, since local repro with the identical image and endpoints completes in under 3 seconds (~1.3s per call).

## Verification

Static TypeScript syntax check (`ts.transpileModule`) on both edited spec files: 0 errors. The new workflow step's YAML was validated with `yaml.safe_load` to confirm it parses and sits in the intended step order (Boot stack -> Probe token endpoint -> Run OWUI Playwright suite -> Dump container logs on failure -> ...).

## Test plan

- [ ] Confirm the next nightly run's Continue/Sign-in clicks no longer silently drop under CI's dev-mode hydration timing.
- [ ] Confirm the post-login chat UI wait tolerates the SPA's model-list fetch time.
- [ ] Read the new token-endpoint probe's output on the next run to confirm or rule out the egress-stall hypothesis.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sign-in and authorization test flows to better handle hydration timing issues and navigation delays.
  * Increased wait/retry behavior so end-to-end authentication checks are less flaky.
  * Added a non-blocking diagnostic check for the OAuth token endpoint to help surface connectivity issues during nightly runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->