### PR TITLE
fix(e2e): fuse credential fill and submit into one retry unit (#269)

### DIFF
--- a/apps/web-console/e2e/phase-19/auth.setup.ts
+++ b/apps/web-console/e2e/phase-19/auth.setup.ts
@@ -29,32 +29,42 @@ setup("authenticate user A (tenant T1)", async ({ page }) => {
   // getByLabel("Password") is a strict-mode violation here: the browser's
   // native password-reveal toggle button shares "Password" in its
   // accessible name. getByRole("textbox", ...) excludes it by role.
-  // web-console runs in dev mode in CI; a fill that lands before React
-  // hydration finishes gets wiped when the controlled input mounts. Retry
-  // each fill and verify the value actually stuck before moving on.
   const emailBox = page.getByRole("textbox", { name: /email/i });
-  for (let i = 0; i < 3; i++) {
-    await emailBox.fill(email);
-    if ((await emailBox.inputValue()) === email) break;
-  }
-  await expect(emailBox).toHaveValue(email);
-  await page.getByRole("button", { name: /next/i }).click();
-
   const passwordBox = page.getByRole("textbox", { name: /password/i });
-  for (let i = 0; i < 3; i++) {
-    await passwordBox.fill(password);
-    if ((await passwordBox.inputValue()) === password) break;
+  // web-console runs in dev mode in CI; React hydration can remount the
+  // controlled input *after* a fill already verified as stuck, wiping it, so
+  // a submit fired after that remount hits an empty field (run 28680373668:
+  // "missing email or phone" alert, both textboxes empty). Fill and submit
+  // can never be separated safely -- fuse them into one retry unit so every
+  // submit attempt re-fills first.
+  for (let i = 0; i < 6; i++) {
+    if (await passwordBox.isVisible().catch(() => false)) break;
+    await emailBox.fill(email);
+    if ((await emailBox.inputValue()) !== email) continue;
+    try {
+      await page
+        .getByRole("button", { name: /next/i })
+        .click({ timeout: 2_000 });
+    } catch {
+      // button may already be gone if a prior click's navigation landed late
+    }
+    try {
+      await expect(passwordBox).toBeVisible({ timeout: 5_000 });
+      break;
+    } catch {
+      // retry
+    }
   }
-  await expect(passwordBox).toHaveValue(password);
+  await expect(passwordBox).toBeVisible();
 
-  // Same hydration race as the fills: a click that lands before React
-  // attaches the handler is silently lost. Retry the click until the
-  // navigation actually happens. A successful click can still outlast the
-  // 5s wait below -- check the URL first and guard the click itself so a
-  // stale retry never re-clicks a button that already navigated away.
+  // Same fusion, same reason: the password field can be wiped after a
+  // verified fill, so refill it on every sign-in attempt too (run
+  // 28680373668: "missing email or phone" alert, both textboxes empty).
   const owuiOrigin = new URL(OWUI_URL).origin;
-  for (let i = 0; i < 5; i++) {
+  for (let i = 0; i < 6; i++) {
     if (new URL(page.url()).origin === owuiOrigin) break;
+    await passwordBox.fill(password);
+    if ((await passwordBox.inputValue()) !== password) continue;
     try {
       await page
         .getByRole("button", { name: /sign in/i })
@@ -100,32 +110,42 @@ setup("authenticate user B (tenant T2)", async ({ page }) => {
   // getByLabel("Password") is a strict-mode violation here: the browser's
   // native password-reveal toggle button shares "Password" in its
   // accessible name. getByRole("textbox", ...) excludes it by role.
-  // web-console runs in dev mode in CI; a fill that lands before React
-  // hydration finishes gets wiped when the controlled input mounts. Retry
-  // each fill and verify the value actually stuck before moving on.
   const emailBox = page.getByRole("textbox", { name: /email/i });
-  for (let i = 0; i < 3; i++) {
-    await emailBox.fill(email);
-    if ((await emailBox.inputValue()) === email) break;
-  }
-  await expect(emailBox).toHaveValue(email);
-  await page.getByRole("button", { name: /next/i }).click();
-
   const passwordBox = page.getByRole("textbox", { name: /password/i });
-  for (let i = 0; i < 3; i++) {
-    await passwordBox.fill(password);
-    if ((await passwordBox.inputValue()) === password) break;
+  // web-console runs in dev mode in CI; React hydration can remount the
+  // controlled input *after* a fill already verified as stuck, wiping it, so
+  // a submit fired after that remount hits an empty field (run 28680373668:
+  // "missing email or phone" alert, both textboxes empty). Fill and submit
+  // can never be separated safely -- fuse them into one retry unit so every
+  // submit attempt re-fills first.
+  for (let i = 0; i < 6; i++) {
+    if (await passwordBox.isVisible().catch(() => false)) break;
+    await emailBox.fill(email);
+    if ((await emailBox.inputValue()) !== email) continue;
+    try {
+      await page
+        .getByRole("button", { name: /next/i })
+        .click({ timeout: 2_000 });
+    } catch {
+      // button may already be gone if a prior click's navigation landed late
+    }
+    try {
+      await expect(passwordBox).toBeVisible({ timeout: 5_000 });
+      break;
+    } catch {
+      // retry
+    }
   }
-  await expect(passwordBox).toHaveValue(password);
+  await expect(passwordBox).toBeVisible();
 
-  // Same hydration race as the fills: a click that lands before React
-  // attaches the handler is silently lost. Retry the click until the
-  // navigation actually happens. A successful click can still outlast the
-  // 5s wait below -- check the URL first and guard the click itself so a
-  // stale retry never re-clicks a button that already navigated away.
+  // Same fusion, same reason: the password field can be wiped after a
+  // verified fill, so refill it on every sign-in attempt too (run
+  // 28680373668: "missing email or phone" alert, both textboxes empty).
   const owuiOrigin = new URL(OWUI_URL).origin;
-  for (let i = 0; i < 5; i++) {
+  for (let i = 0; i < 6; i++) {
     if (new URL(page.url()).origin === owuiOrigin) break;
+    await passwordBox.fill(password);
+    if ((await passwordBox.inputValue()) !== password) continue;
     try {
       await page
         .getByRole("button", { name: /sign in/i })

--- a/apps/web-console/e2e/phase-19/owui/owui.setup.ts
+++ b/apps/web-console/e2e/phase-19/owui/owui.setup.ts
@@ -45,31 +45,22 @@ setup("OWUI OIDC sign-in via Hive consent", async ({ page }) => {
   // accessible name. getByRole("textbox", ...) excludes it by role.
   const emailBox = page.getByRole("textbox", { name: /email/i });
   const passwordBox = page.getByRole("textbox", { name: /password/i });
-  // web-console runs in dev mode in CI; a fill that lands before React
-  // hydration finishes gets wiped when the controlled input mounts. Retry
-  // both fills together and verify the values actually stuck.
-  for (let i = 0; i < 3; i++) {
+  // web-console runs in dev mode in CI; React hydration can remount the
+  // controlled inputs *after* a fill already verified as stuck, wiping them,
+  // so a submit fired after that remount hits an empty form (run 28680373668:
+  // "missing email or phone" alert, both textboxes empty). Fill and submit
+  // can never be separated safely -- fuse them into one retry unit so every
+  // submit attempt re-fills first.
+  for (let i = 0; i < 6; i++) {
+    if (/\/oauth\/consent/.test(page.url())) break;
     await emailBox.fill(email);
     await passwordBox.fill(password);
     if (
-      (await emailBox.inputValue()) === email &&
-      (await passwordBox.inputValue()) === password
+      (await emailBox.inputValue()) !== email ||
+      (await passwordBox.inputValue()) !== password
     ) {
-      break;
+      continue;
     }
-  }
-  await expect(emailBox).toHaveValue(email);
-  await expect(passwordBox).toHaveValue(password);
-
-  // Same hydration race as the fills: a click that lands before React
-  // attaches the handler is silently lost (run 28676903599: zero
-  // /oauth/oidc/callback hits after this step, both attempts). Retry the
-  // click until the navigation actually happens. A successful click can
-  // still outlast the 5s wait below -- check the URL first and guard the
-  // click itself so a stale retry never re-clicks a button that already
-  // navigated away.
-  for (let i = 0; i < 5; i++) {
-    if (/\/oauth\/consent/.test(page.url())) break;
     try {
       await page
         .getByRole("button", { name: /continue/i })


### PR DESCRIPTION
## Summary

Run 28680373668 failed at owui.setup.ts:87. The failure snapshot shows the web-console sign-in page with a "missing email or phone" alert and both textboxes empty: the fills passed `toHaveValue` pre-hydration, React hydration then remounted the controlled inputs and wiped them, and the retry loop went on to submit the now-empty form.

Separate fill-then-submit phases can never be race-free against this hydration remount. This PR fuses fill and submit into a single retry unit in both e2e setup files, so every submit attempt re-fills its field(s) first and only submits once the fill is freshly verified.

## Changes

- `apps/web-console/e2e/phase-19/owui/owui.setup.ts`: the separate 3-attempt fill-verify loop and 5-attempt Continue-click retry loop are replaced by one fused loop (up to 6 attempts) that breaks early if already on `/oauth/consent`, fills both fields, verifies both values, guards the Continue click in its own try/catch, and waits up to 5s for the consent redirect before retrying.
- `apps/web-console/e2e/phase-19/auth.setup.ts`: same fusion applied per wizard step in both tenant blocks (user A, user B). The email+Next step fuses into one retry unit that waits for the password field to become visible; the password+Sign-in step fuses into one retry unit that waits for the OWUI-origin redirect.
- Approve retry loop and all post-conditions (30s OWUI-origin wait, 60s message-placeholder wait) are unchanged.

## Test plan

- [ ] TypeScript transpile check passed locally on both edited files (zero diagnostics)
- [ ] CI Playwright OWUI e2e journey (phase-19) run is green
- [ ] Manual review of the fused loops against run 28680373668's failure snapshot