### PR TITLE
fix(e2e): match consent page by pathname, not URL substring (#269)

### DIFF
--- a/apps/web-console/e2e/phase-19/auth.setup.ts
+++ b/apps/web-console/e2e/phase-19/auth.setup.ts
@@ -21,10 +21,14 @@ setup("authenticate user A (tenant T1)", async ({ page }) => {
   await expect(hiveButton).toBeVisible({ timeout: 30_000 });
   await hiveButton.dispatchEvent("click");
   // Without this wait, the fills below race the redirect chain and land on
-  // OWUI's own native login form instead of the web-console one.
-  await page.waitForURL(/\/(auth\/sign-in|oauth\/consent)/, {
-    timeout: 30_000,
-  });
+  // OWUI's own native login form instead of the web-console one. The
+  // sign-in URL carries the consent path inside its `next` query param
+  // (run 28681138594), so regex/substring matching on the full URL
+  // false-positives on the sign-in page too -- match pathname only.
+  await page.waitForURL(
+    (u) => u.pathname === "/auth/sign-in" || u.pathname === "/oauth/consent",
+    { timeout: 30_000 },
+  );
 
   // getByLabel("Password") is a strict-mode violation here: the browser's
   // native password-reveal toggle button shares "Password" in its
@@ -102,10 +106,14 @@ setup("authenticate user B (tenant T2)", async ({ page }) => {
   await expect(hiveButton).toBeVisible({ timeout: 30_000 });
   await hiveButton.dispatchEvent("click");
   // Without this wait, the fills below race the redirect chain and land on
-  // OWUI's own native login form instead of the web-console one.
-  await page.waitForURL(/\/(auth\/sign-in|oauth\/consent)/, {
-    timeout: 30_000,
-  });
+  // OWUI's own native login form instead of the web-console one. The
+  // sign-in URL carries the consent path inside its `next` query param
+  // (run 28681138594), so regex/substring matching on the full URL
+  // false-positives on the sign-in page too -- match pathname only.
+  await page.waitForURL(
+    (u) => u.pathname === "/auth/sign-in" || u.pathname === "/oauth/consent",
+    { timeout: 30_000 },
+  );
 
   // getByLabel("Password") is a strict-mode violation here: the browser's
   // native password-reveal toggle button shares "Password" in its

--- a/apps/web-console/e2e/phase-19/owui/owui.setup.ts
+++ b/apps/web-console/e2e/phase-19/owui/owui.setup.ts
@@ -35,10 +35,14 @@ setup("OWUI OIDC sign-in via Hive consent", async ({ page }) => {
   // path past this point -- it only follows whatever the browser is
   // redirected to, which keeps it baseURL-agnostic.
   // Without this wait, the fills below race the redirect chain and land on
-  // OWUI's own native login form instead of the web-console one.
-  await page.waitForURL(/\/(auth\/sign-in|oauth\/consent)/, {
-    timeout: 30_000,
-  });
+  // OWUI's own native login form instead of the web-console one. The
+  // sign-in URL carries the consent path inside its `next` query param
+  // (run 28681138594), so regex/substring matching on the full URL
+  // false-positives on the sign-in page too -- match pathname only.
+  await page.waitForURL(
+    (u) => u.pathname === "/auth/sign-in" || u.pathname === "/oauth/consent",
+    { timeout: 30_000 },
+  );
 
   // getByLabel("Password") is a strict-mode violation here: the browser's
   // native password-reveal toggle button shares "Password" in its
@@ -51,8 +55,11 @@ setup("OWUI OIDC sign-in via Hive consent", async ({ page }) => {
   // "missing email or phone" alert, both textboxes empty). Fill and submit
   // can never be separated safely -- fuse them into one retry unit so every
   // submit attempt re-fills first.
+  // The sign-in URL carries the consent path inside its `next` query param
+  // (run 28681138594), so regex/substring matching on the full URL
+  // false-positives on the sign-in page too -- match pathname only.
   for (let i = 0; i < 6; i++) {
-    if (/\/oauth\/consent/.test(page.url())) break;
+    if (new URL(page.url()).pathname === "/oauth/consent") break;
     await emailBox.fill(email);
     await passwordBox.fill(password);
     if (
@@ -69,13 +76,15 @@ setup("OWUI OIDC sign-in via Hive consent", async ({ page }) => {
       // button may already be gone if a prior click's navigation landed late
     }
     try {
-      await page.waitForURL(/\/oauth\/consent/, { timeout: 5_000 });
+      await page.waitForURL((u) => u.pathname === "/oauth/consent", {
+        timeout: 5_000,
+      });
       break;
     } catch {
       // retry
     }
   }
-  expect(page.url()).toMatch(/\/oauth\/consent/);
+  expect(new URL(page.url()).pathname).toBe("/oauth/consent");
 
   // Lands back on /oauth/consent, now authenticated, showing the Hive Chat
   // client's requested scopes. Same hydration-race guard as above: check


### PR DESCRIPTION
## Summary

Run 28681138594 exposed a URL-matching bug in the OWUI journey specs. The sign-in URL is `/auth/sign-in?next=%2Foauth%2Fconsent%3Fauthorization_id%3D...`, and when the client router presents the `next` param decoded, every regex/substring check of the form `/\/oauth\/consent/.test(page.url())` or `waitForURL(/\/oauth\/consent/)` matches the sign-in page too, since the literal substring lives inside the query param.

Evidence from that run: trace shows consent returns 200, then bounces back to sign-in, then zero further requests (no password grant reaches the server). The failure snapshot is the sign-in page with empty fields and no alert -- the fused retry loop broke out immediately on the false-positive URL check, the loud `expect` passed for the same wrong reason, and the test then died later at the post-approve waits.

## Fix

Replaced every full-URL regex/substring match for the consent page with pathname equality, and audited both files for the same class of bug in sign-in detection:

- `apps/web-console/e2e/phase-19/owui/owui.setup.ts`: loop break, `waitForURL`, and the loud assert after the fused fill/submit loop now all compare `new URL(page.url()).pathname` (or a `waitForURL` predicate on `u.pathname`) against `"/oauth/consent"` instead of regex-testing the full URL.
- Both `owui.setup.ts` and `apps/web-console/e2e/phase-19/auth.setup.ts` (both tenant blocks): the initial post-click wait that accepts either the sign-in or consent page used a combined regex (`/\/(auth\/sign-in|oauth\/consent)/`) against the full URL, which has the same false-positive risk. Converted to a `waitForURL` predicate comparing `u.pathname` against `"/auth/sign-in"` or `"/oauth/consent"`.
- Origin-based checks for the OWUI return leg (the Approve retry loop and the two post-login OWUI-origin waits) were already correct and are unchanged.

## Test plan

- [ ] TypeScript transpile check passed locally on both edited files (zero diagnostics)
- [ ] CI Playwright OWUI e2e journey (phase-19) run is green
- [ ] Manual comparison against run 28681138594's trace and failure snapshot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end login and consent flow synchronization by matching browser redirects using the page path instead of the full URL.
  * Reduced false matches during authentication waits, making the setup flows more reliable on pages with similar URL patterns.
  * Tightened final redirect checks to ensure the expected consent page is reached consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->