### PR TITLE
fix(e2e): treat consent approval as optional repeat-grant leg (#269)

### DIFF
--- a/apps/web-console/e2e/phase-19/auth.setup.ts
+++ b/apps/web-console/e2e/phase-19/auth.setup.ts
@@ -43,9 +43,13 @@ setup("authenticate user A (tenant T1)", async ({ page }) => {
   // "missing email or phone" alert, both textboxes empty). Fill and submit
   // can never be separated safely -- fuse them into one retry unit so every
   // submit attempt re-fills first.
+  // Run 28682845959: a successful submit can move the page past this step
+  // before the next-field wait below resolves. An unguarded refill on the
+  // next attempt then fills a detached email box and hangs until the test
+  // timeout -- check the email box is still there before touching it.
   for (let i = 0; i < 6; i++) {
-    if (await passwordBox.isVisible().catch(() => false)) break;
-    await emailBox.fill(email);
+    if (!(await emailBox.isVisible().catch(() => false))) break;
+    await emailBox.fill(email, { timeout: 2_000 });
     if ((await emailBox.inputValue()) !== email) continue;
     try {
       await page
@@ -66,10 +70,13 @@ setup("authenticate user A (tenant T1)", async ({ page }) => {
   // Same fusion, same reason: the password field can be wiped after a
   // verified fill, so refill it on every sign-in attempt too (run
   // 28680373668: "missing email or phone" alert, both textboxes empty).
+  // Run 28682845959: same hang risk as the step above -- a successful
+  // submit can move the page on before the origin wait below resolves, so
+  // check the password box is still there before refilling it.
   const owuiOrigin = new URL(OWUI_URL).origin;
   for (let i = 0; i < 6; i++) {
-    if (new URL(page.url()).origin === owuiOrigin) break;
-    await passwordBox.fill(password);
+    if (!(await passwordBox.isVisible().catch(() => false))) break;
+    await passwordBox.fill(password, { timeout: 2_000 });
     if ((await passwordBox.inputValue()) !== password) continue;
     try {
       await page
@@ -130,9 +137,13 @@ setup("authenticate user B (tenant T2)", async ({ page }) => {
   // "missing email or phone" alert, both textboxes empty). Fill and submit
   // can never be separated safely -- fuse them into one retry unit so every
   // submit attempt re-fills first.
+  // Run 28682845959: a successful submit can move the page past this step
+  // before the next-field wait below resolves. An unguarded refill on the
+  // next attempt then fills a detached email box and hangs until the test
+  // timeout -- check the email box is still there before touching it.
   for (let i = 0; i < 6; i++) {
-    if (await passwordBox.isVisible().catch(() => false)) break;
-    await emailBox.fill(email);
+    if (!(await emailBox.isVisible().catch(() => false))) break;
+    await emailBox.fill(email, { timeout: 2_000 });
     if ((await emailBox.inputValue()) !== email) continue;
     try {
       await page
@@ -153,10 +164,13 @@ setup("authenticate user B (tenant T2)", async ({ page }) => {
   // Same fusion, same reason: the password field can be wiped after a
   // verified fill, so refill it on every sign-in attempt too (run
   // 28680373668: "missing email or phone" alert, both textboxes empty).
+  // Run 28682845959: same hang risk as the step above -- a successful
+  // submit can move the page on before the origin wait below resolves, so
+  // check the password box is still there before refilling it.
   const owuiOrigin = new URL(OWUI_URL).origin;
   for (let i = 0; i < 6; i++) {
-    if (new URL(page.url()).origin === owuiOrigin) break;
-    await passwordBox.fill(password);
+    if (!(await passwordBox.isVisible().catch(() => false))) break;
+    await passwordBox.fill(password, { timeout: 2_000 });
     if ((await passwordBox.inputValue()) !== password) continue;
     try {
       await page

--- a/apps/web-console/e2e/phase-19/owui/owui.setup.ts
+++ b/apps/web-console/e2e/phase-19/owui/owui.setup.ts
@@ -52,64 +52,80 @@ setup("OWUI OIDC sign-in via Hive consent", async ({ page }) => {
   // visible) or we're already on consent (Approve visible).
   await expect(emailBox.or(approveButton)).toBeVisible({ timeout: 30_000 });
 
-  // Run 28681926134: same race means a URL check can't safely decide
-  // whether login is still needed -- ask the DOM (Approve visible) instead.
-  if (!(await approveButton.isVisible().catch(() => false))) {
-    // web-console runs in dev mode in CI; React hydration can remount the
-    // controlled inputs *after* a fill already verified as stuck, wiping
-    // them, so a submit fired after that remount hits an empty form (run
-    // 28680373668: "missing email or phone" alert, both textboxes empty).
-    // Fill and submit can never be separated safely -- fuse them into one
-    // retry unit so every submit attempt re-fills first. Exit condition is
-    // now Approve visible, not a URL/pathname check (run 28681926134).
-    for (let i = 0; i < 6; i++) {
-      await emailBox.fill(email);
-      await passwordBox.fill(password);
-      if (
-        (await emailBox.inputValue()) !== email ||
-        (await passwordBox.inputValue()) !== password
-      ) {
-        continue;
-      }
-      try {
-        await page
-          .getByRole("button", { name: /continue/i })
-          .click({ timeout: 2_000 });
-      } catch {
-        // button may already be gone if a prior click's navigation landed late
-      }
-      try {
-        await expect(approveButton).toBeVisible({ timeout: 5_000 });
-        break;
-      } catch {
-        // retry
-      }
+  // web-console runs in dev mode in CI; React hydration can remount the
+  // controlled inputs *after* a fill already verified as stuck, wiping
+  // them, so a submit fired after that remount hits an empty form (run
+  // 28680373668: "missing email or phone" alert, both textboxes empty).
+  // Fill and submit can never be separated safely -- fuse them into one
+  // retry unit so every submit attempt re-fills first.
+  for (let i = 0; i < 6; i++) {
+    // Run 28682845959: a successful submit can move the page past sign-in
+    // -- straight to consent, or straight past consent too if this
+    // user+client already has a grant -- before the Approve-visible wait
+    // below resolves. An unguarded refill on the next attempt then fills a
+    // detached email box and hangs until the test timeout.
+    if (!(await emailBox.isVisible().catch(() => false))) break;
+    await emailBox.fill(email, { timeout: 2_000 });
+    await passwordBox.fill(password, { timeout: 2_000 });
+    if (
+      (await emailBox.inputValue()) !== email ||
+      (await passwordBox.inputValue()) !== password
+    ) {
+      continue;
     }
-  }
-  await expect(approveButton).toBeVisible({ timeout: 15_000 });
-
-  // Lands back on /oauth/consent, now authenticated, showing the Hive Chat
-  // client's requested scopes. Same hydration-race guard as above: check
-  // first, click inside a try so a stale retry never re-clicks a button
-  // that already navigated away, then wait in short windows.
-  const owuiOrigin = new URL(OWUI_URL).origin;
-  for (let i = 0; i < 5; i++) {
-    if (new URL(page.url()).origin === owuiOrigin) break;
     try {
       await page
-        .getByRole("button", { name: /approve/i })
+        .getByRole("button", { name: /continue/i })
         .click({ timeout: 2_000 });
     } catch {
       // button may already be gone if a prior click's navigation landed late
     }
     try {
-      await page.waitForURL((u) => u.origin === owuiOrigin, {
-        timeout: 5_000,
-      });
+      await expect(approveButton).toBeVisible({ timeout: 5_000 });
       break;
     } catch {
       // retry
     }
+  }
+
+  // Run 28682845959: trace shows password grant 200, consent 200, straight
+  // to the OWUI callback with no Approve click -- Supabase auto-approves a
+  // previously-granted client+user pair, so the consent screen appears at
+  // most once per user+client (first-ever run). Poll for either outcome
+  // instead of asserting Approve will always show.
+  const owuiOrigin = new URL(OWUI_URL).origin;
+  const approvePollDeadline = Date.now() + 30_000;
+  while (
+    new URL(page.url()).origin !== owuiOrigin &&
+    Date.now() < approvePollDeadline
+  ) {
+    if (await approveButton.isVisible().catch(() => false)) {
+      // Lands back on /oauth/consent, now authenticated, showing the Hive
+      // Chat client's requested scopes. Same hydration-race guard as
+      // above: check first, click inside a try so a stale retry never
+      // re-clicks a button that already navigated away, then wait in
+      // short windows.
+      for (let i = 0; i < 5; i++) {
+        if (new URL(page.url()).origin === owuiOrigin) break;
+        try {
+          await page
+            .getByRole("button", { name: /approve/i })
+            .click({ timeout: 2_000 });
+        } catch {
+          // button may already be gone if a prior click's navigation landed late
+        }
+        try {
+          await page.waitForURL((u) => u.origin === owuiOrigin, {
+            timeout: 5_000,
+          });
+          break;
+        } catch {
+          // retry
+        }
+      }
+      break;
+    }
+    await page.waitForTimeout(500);
   }
 
   // Run 28676421973: OAuth exchange itself verified fast and correct in


### PR DESCRIPTION
## Summary

Run 28682845959's trace proves the full OIDC flow now succeeds end-to-end: password grant 200, consent 200, authorizations GET 200, a 307 to the OWUI callback with a code, OWUI's `/auth` 200, and the SPA loading models/changelog/banners (user logged in). No Approve click ever occurred: Supabase auto-approves a previously-granted client+user pair (this e2e user approved the client in an earlier run), so the consent screen never rendered at all.

The spec failed anyway. Its login loop's second attempt called `emailBox.fill()` after the page had already navigated on past sign-in, and `fill()` with no explicit timeout hung for the full 180s test budget (`owui.setup.ts:66`).

## Fix

- `apps/web-console/e2e/phase-19/owui/owui.setup.ts`: the login loop's exit check is now "is the email box still visible" (not "is Approve visible", which may never become true) -- if the page has moved on for any reason, the loop stops immediately instead of blindly refilling a detached field. Every fill and click inside the loop now carries an explicit `{ timeout: 2_000 }` so no single action can stall past a few seconds. After the loop, since consent is optional, the spec polls for up to 30s for either arrival at the OWUI origin (done) or the Approve button becoming visible (run the existing guarded approve retry, then proceed) -- it no longer asserts Approve must appear.
- `apps/web-console/e2e/phase-19/auth.setup.ts` (both tenant blocks): mirrors the applicable part of the same fix. Both wizard-step retry loops (email+Next, password+Sign-in) now check that their own input box is still visible at the top of each attempt (rather than checking the next step's success signal), and every fill call now carries the same explicit `{ timeout: 2_000 }`, closing the identical hang risk. These loops have no consent/approve concept, so the optional-consent polling logic doesn't apply here.
- Kept unchanged, as instructed: the guarded approve retry loop's own internal logic, the final origin `waitForURL`, the 60s message-placeholder `expect`, and `storageState`.

## Test plan

- [ ] TypeScript transpile check passed locally on both edited files (zero diagnostics)
- [ ] CI Playwright OWUI e2e journey (phase-19) run is green, including a repeat-grant run where consent is skipped
- [ ] Manual comparison against run 28682845959's trace (password grant 200, consent 200, no Approve click, SPA loaded)