### PR TITLE
fix(e2e): post-login readiness via New Chat button (#269)

### DIFF
--- a/apps/web-console/e2e/phase-19/owui/owui.setup.ts
+++ b/apps/web-console/e2e/phase-19/owui/owui.setup.ts
@@ -135,8 +135,11 @@ setup("OWUI OIDC sign-in via Hive consent", async ({ page }) => {
   await page.waitForURL((u) => u.origin === owuiOrigin, {
     timeout: 30_000,
   });
-  await expect(page.getByPlaceholder(/message/i)).toBeVisible({
-    timeout: 60_000,
-  });
+  // Run 28683831193: the chat input carries no "message" placeholder in
+  // OWUI 0.9.5 -- the sidebar New Chat button is the post-login readiness
+  // signal instead (present in the failure snapshot alongside the greeting).
+  await expect(
+    page.getByRole("button", { name: /new chat/i }),
+  ).toBeVisible({ timeout: 60_000 });
   await page.context().storageState({ path: STATE });
 });


### PR DESCRIPTION
## Summary

Run 28683831193 confirms OIDC sign-in is fully working end to end. The failure snapshot is the logged-in OWUI chat home: greeting "Hello, owui-e2e@hive-e2e.invalid", the "How can I help you today?" paragraph, the sidebar with New Chat/Search/Notes/Workspace buttons, and the model selector. The only failure is the final readiness assertion: `getByPlaceholder(/message/i)` matches nothing in this OWUI version (`owui.setup.ts:138`), because the chat input carries no "message" placeholder in OWUI 0.9.5.

## Fix

- `apps/web-console/e2e/phase-19/owui/owui.setup.ts`: replaced the final `getByPlaceholder(/message/i)` readiness assert with `expect(page.getByRole("button", { name: /new chat/i })).toBeVisible({ timeout: 60_000 })`. The New Chat button is present in the failure snapshot's sidebar and is a version-stable readiness signal.
- `apps/web-console/e2e/phase-19/auth.setup.ts`: no equivalent placeholder assert exists in this file (its final step is an origin assert + `storageState`), so nothing to swap here.
- Grepped `apps/web-console/e2e/phase-19/owui/*.spec.ts` (all specs, including `performance/`) for the same pattern. Every remaining `getByPlaceholder(/message/i)` hit is a message-typing interaction (`.fill(...)` to send a chat message), not a readiness wait, so all six were left untouched per instruction. See the PR report for the full list.

## Test plan

- [ ] TypeScript transpile check passed locally on the edited file (zero diagnostics)
- [ ] CI Playwright OWUI e2e journey (phase-19) run gets past setup and into the actual spec suite
- [ ] Manual comparison against run 28683831193's failure snapshot (logged-in chat home, New Chat button visible)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the post-login readiness check to match the current chat interface.
  * The app now confirms the “New Chat” button is visible before continuing, improving stability when the chat input placeholder is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->