### PR TITLE
fix(e2e): target real OWUI chat input element (#269)

### DIFF
--- a/apps/web-console/e2e/phase-19/owui/01-chat-send-stream.spec.ts
+++ b/apps/web-console/e2e/phase-19/owui/01-chat-send-stream.spec.ts
@@ -4,7 +4,10 @@ test.use({ storageState: "e2e/phase-19/owui/.auth/owui-user.json" });
 
 test("chat message streams a response", async ({ page }) => {
   await page.goto("/");
-  await page.getByPlaceholder(/message/i).fill("Say hello.");
+  // OWUI 0.9.5 chat input is a contenteditable TipTap/ProseMirror div with
+  // id="chat-input" (MessageInput.svelte + RichTextInput.svelte); no
+  // "message" placeholder exists (run 28683831193).
+  await page.locator("#chat-input").fill("Say hello.");
   await page.keyboard.press("Enter");
   const reply = page.locator('[data-role="assistant"]').last();
   await expect(reply).toContainText(/.+/, { timeout: 20_000 });

--- a/apps/web-console/e2e/phase-19/owui/02-chat-multi-turn.spec.ts
+++ b/apps/web-console/e2e/phase-19/owui/02-chat-multi-turn.spec.ts
@@ -4,14 +4,17 @@ test.use({ storageState: "e2e/phase-19/owui/.auth/owui-user.json" });
 
 test("second turn references first turn context", async ({ page }) => {
   await page.goto("/");
-  await page.getByPlaceholder(/message/i).fill("My favourite colour is purple.");
+  // OWUI 0.9.5 chat input is a contenteditable TipTap/ProseMirror div with
+  // id="chat-input" (MessageInput.svelte + RichTextInput.svelte); no
+  // "message" placeholder exists (run 28683831193).
+  await page.locator("#chat-input").fill("My favourite colour is purple.");
   await page.keyboard.press("Enter");
   await page.waitForResponse(
     (r) => r.url().includes("/v1/chat/completions") && r.ok(),
     { timeout: 20_000 },
   );
 
-  await page.getByPlaceholder(/message/i).fill("What is my favourite colour?");
+  await page.locator("#chat-input").fill("What is my favourite colour?");
   await page.keyboard.press("Enter");
   await expect(page.locator('[data-role="assistant"]').last()).toContainText(
     /purple/i,

--- a/apps/web-console/e2e/phase-19/owui/03-chat-model-switch.spec.ts
+++ b/apps/web-console/e2e/phase-19/owui/03-chat-model-switch.spec.ts
@@ -8,7 +8,10 @@ test("switch model and confirm subsequent request goes to it", async ({
   await page.goto("/");
   await page.getByTestId("model-selector").click();
   await page.getByRole("option", { name: /claude-3-haiku/i }).click();
-  await page.getByPlaceholder(/message/i).fill("hi");
+  // OWUI 0.9.5 chat input is a contenteditable TipTap/ProseMirror div with
+  // id="chat-input" (MessageInput.svelte + RichTextInput.svelte); no
+  // "message" placeholder exists (run 28683831193).
+  await page.locator("#chat-input").fill("hi");
   const [req] = await Promise.all([
     page.waitForRequest(
       (r) =>

--- a/apps/web-console/e2e/phase-19/owui/05-rag-personal-citation.spec.ts
+++ b/apps/web-console/e2e/phase-19/owui/05-rag-personal-citation.spec.ts
@@ -15,7 +15,10 @@ test("ask grounded question and receive citation", async ({ page }) => {
   };
 
   await page.goto("/");
-  await page.getByPlaceholder(/message/i).fill(expected.prompt);
+  // OWUI 0.9.5 chat input is a contenteditable TipTap/ProseMirror div with
+  // id="chat-input" (MessageInput.svelte + RichTextInput.svelte); no
+  // "message" placeholder exists (run 28683831193).
+  await page.locator("#chat-input").fill(expected.prompt);
   await page.keyboard.press("Enter");
   const reply = page.locator('[data-role="assistant"]').last();
   await expect(reply).toContainText(new RegExp(expected.anchor, "i"), {

--- a/apps/web-console/e2e/phase-19/owui/07-image-upload-vision.spec.ts
+++ b/apps/web-console/e2e/phase-19/owui/07-image-upload-vision.spec.ts
@@ -28,7 +28,10 @@ test("upload image and vision model returns content-aware answer", async ({
     page.locator('[data-attachment-name*="cat"], img[alt*="cat" i], [data-role="attachment"]').first(),
   ).toBeVisible({ timeout: 15_000 });
 
-  await page.getByPlaceholder(/message/i).fill("What animal is in this image?");
+  // OWUI 0.9.5 chat input is a contenteditable TipTap/ProseMirror div with
+  // id="chat-input" (MessageInput.svelte + RichTextInput.svelte); no
+  // "message" placeholder exists (run 28683831193).
+  await page.locator("#chat-input").fill("What animal is in this image?");
   await page.keyboard.press("Enter");
   await expect(page.locator('[data-role="assistant"]').last()).toContainText(
     /cat/i,

--- a/apps/web-console/e2e/phase-19/owui/performance/ttfb.spec.ts
+++ b/apps/web-console/e2e/phase-19/owui/performance/ttfb.spec.ts
@@ -15,7 +15,10 @@ function budgetMs(envName: string, fallback: number): number {
 test("first-token latency under budget", async ({ page }) => {
   const budget = budgetMs("OWUI_TTFB_BUDGET_MS", 8000);
   await page.goto("/");
-  await page.getByPlaceholder(/message/i).fill("one word.");
+  // OWUI 0.9.5 chat input is a contenteditable TipTap/ProseMirror div with
+  // id="chat-input" (MessageInput.svelte + RichTextInput.svelte); no
+  // "message" placeholder exists (run 28683831193).
+  await page.locator("#chat-input").fill("one word.");
 
   // Bind the response wait to the specific request triggered by this
   // Enter keystroke. The previous URL+ok() predicate could latch onto


### PR DESCRIPTION
## Summary

The six message-typing sites reported in a prior PR all use `getByPlaceholder(/message/i).fill(...)`, which cannot match anything in OWUI 0.9.5: there is no HTML `placeholder` attribute on the chat input in this version.

## Source verification

Checked `open-webui/open-webui` at tag `v0.9.5` (commit `3660bc00fd807deced3400a63bfa6db47811a3bb`) via `gh api`:

- `src/lib/components/chat/MessageInput.svelte` line 1445: the chat input is a `<RichTextInput ... id="chat-input" ... placeholder={placeholder ? placeholder : $i18n.t('Send a Message')} ...>` component instance, not a raw `<textarea>`.
- `src/lib/components/common/RichTextInput.svelte` line 940: `editorProps: { attributes: { id } }` wires that `id` prop directly onto the TipTap/ProseMirror-rendered DOM node, which ProseMirror mounts as a `contenteditable` div. Line 761 confirms the placeholder is rendered via TipTap's `Placeholder.configure(...)` extension (a CSS `::before` overlay on the empty node), not a real HTML `placeholder` attribute -- which is exactly why `getByPlaceholder()` cannot see it.
- `MessageInput.svelte` also calls `document.getElementById('chat-input')` in several places (focus handling, drag-drop, etc.), confirming `#chat-input` is the live, stable selector for this element at runtime.

Playwright's `.fill()` works on `contenteditable` elements, so `page.locator("#chat-input").fill(...)` is a direct, minimal swap.

## Changes

Replaced `page.getByPlaceholder(/message/i)` with `page.locator("#chat-input")` at all six sites, each with a one-line comment (added once per file) citing the verified source and run 28683831193:

- `apps/web-console/e2e/phase-19/owui/01-chat-send-stream.spec.ts:7`
- `apps/web-console/e2e/phase-19/owui/02-chat-multi-turn.spec.ts:7,14`
- `apps/web-console/e2e/phase-19/owui/03-chat-model-switch.spec.ts:11`
- `apps/web-console/e2e/phase-19/owui/05-rag-personal-citation.spec.ts:18`
- `apps/web-console/e2e/phase-19/owui/07-image-upload-vision.spec.ts:31`
- `apps/web-console/e2e/phase-19/owui/performance/ttfb.spec.ts:18`

All Enter-press/send-button logic and every other locator in these specs are unchanged -- the source didn't indicate the send affordance differs, so those are left for CI to exercise for real.

## Test plan

- [ ] TypeScript transpile check passed locally on all six edited files (zero diagnostics)
- [ ] CI Playwright OWUI e2e suite (phase-19) gets past the chat-input fill step in each spec
- [ ] Manual spot-check of `#chat-input` against a live OWUI 0.9.5 instance