### PR TITLE
fix(ci,e2e): populate LiteLLM model vars and repair OWUI spec locators

### DIFF
--- a/.github/workflows/phase-19-owui-nightly.yml
+++ b/.github/workflows/phase-19-owui-nightly.yml
@@ -60,6 +60,13 @@ jobs:
         # web-console, all of which fail fast without real Supabase/S3/LLM
         # provider credentials (see CLAUDE.md fail-fast rule). Mirrors the
         # secret set already proven working in ci.yml's live-integration job.
+        #
+        # The model literals below (OPENROUTER_DEFAULT_MODEL, etc.) are model
+        # slugs, not secrets, and are hardcoded intentionally: without them
+        # LiteLLM boots with an empty model_list ("LLM Provider NOT provided.
+        # You passed model=") and OWUI's /api/models returns zero models, so
+        # no chat request can be sent (run 28684729556). Values mirror the
+        # free/cheap-tier defaults in .env.example and deploy/litellm/config.yaml.
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
@@ -103,6 +110,12 @@ jobs:
           LITELLM_MASTER_KEY=${LITELLM_MASTER_KEY:-litellm-dev-key}
           OPENROUTER_API_KEY=${OPENROUTER_API_KEY}
           GROQ_API_KEY=${GROQ_API_KEY}
+          OPENROUTER_DEFAULT_MODEL=openrouter/free
+          OPENROUTER_AUTO_MODEL=openrouter/free
+          OPENROUTER_EMBEDDING_MODEL=openrouter/nvidia/llama-nemotron-embed-vl-1b-v2:free
+          OPENROUTER_EMBEDDING_FALLBACK_MODEL=openrouter/qwen/qwen3-embedding-8b
+          GROQ_FAST_MODEL=groq/openai/gpt-oss-20b
+          GROQ_REASONING_MODEL=groq/openai/gpt-oss-120b
           NEXT_PUBLIC_SUPABASE_URL=${NEXT_PUBLIC_SUPABASE_URL:-$SUPABASE_URL}
           NEXT_PUBLIC_SUPABASE_ANON_KEY=${NEXT_PUBLIC_SUPABASE_ANON_KEY:-$SUPABASE_ANON_KEY}
           SUPABASE_OAUTH_CLIENT_ID=${SUPABASE_OAUTH_CLIENT_ID:-}

--- a/apps/web-console/e2e/phase-19/owui/03-chat-model-switch.spec.ts
+++ b/apps/web-console/e2e/phase-19/owui/03-chat-model-switch.spec.ts
@@ -6,8 +6,12 @@ test("switch model and confirm subsequent request goes to it", async ({
   page,
 }) => {
   await page.goto("/");
-  await page.getByTestId("model-selector").click();
-  await page.getByRole("option", { name: /claude-3-haiku/i }).click();
+  // OWUI 0.9.5 has no data-testid on the model trigger; the real control is
+  // the "Select a model" button (run 28684729556 failure snapshot).
+  await page.getByRole("button", { name: /select a model/i }).click();
+  // route-groq-fast is one of the routes configured in
+  // deploy/litellm/config.yaml / .env.ci for the nightly run.
+  await page.getByRole("option", { name: /route-groq-fast/i }).click();
   // OWUI 0.9.5 chat input is a contenteditable TipTap/ProseMirror div with
   // id="chat-input" (MessageInput.svelte + RichTextInput.svelte); no
   // "message" placeholder exists (run 28683831193).
@@ -20,5 +24,5 @@ test("switch model and confirm subsequent request goes to it", async ({
     page.keyboard.press("Enter"),
   ]);
   const body = req.postDataJSON() as { model?: string };
-  expect(body.model).toMatch(/claude/i);
+  expect(body.model).toMatch(/route-groq-fast/i);
 });

--- a/apps/web-console/e2e/phase-19/owui/06-tenant-model-visibility.spec.ts
+++ b/apps/web-console/e2e/phase-19/owui/06-tenant-model-visibility.spec.ts
@@ -4,7 +4,9 @@ test.use({ storageState: "e2e/phase-19/owui/.auth/owui-user.json" });
 
 test("user sees only models granted to tenant group", async ({ page }) => {
   await page.goto("/");
-  await page.getByTestId("model-selector").click();
+  // OWUI 0.9.5 has no data-testid on the model trigger; the real control is
+  // the "Select a model" button (run 28684729556 failure snapshot).
+  await page.getByRole("button", { name: /select a model/i }).click();
   const options = await page.getByRole("option").all();
   // Guard against an empty option list (e.g. catalog not seeded) — that
   // would vacuously pass the loop below and hide a real visibility bug.

--- a/apps/web-console/e2e/phase-19/owui/08-signout.spec.ts
+++ b/apps/web-console/e2e/phase-19/owui/08-signout.spec.ts
@@ -4,7 +4,11 @@ test.use({ storageState: "e2e/phase-19/owui/.auth/owui-user.json" });
 
 test("signout clears session and lands on signin page", async ({ page }) => {
   await page.goto("/");
-  await page.getByRole("button", { name: /account/i }).click();
+  // No accessible "account" button exists in OWUI 0.9.5. The profile menu
+  // trigger is an <img alt="Open User Profile Menu"> in Sidebar.svelte,
+  // visible in the header regardless of collapsed/expanded sidebar state
+  // (verified against the run 28684729556 failure snapshot).
+  await page.getByRole("img", { name: /open user profile menu/i }).click();
   await page.getByRole("menuitem", { name: /sign out/i }).click();
   await expect(
     page.getByRole("button", { name: /continue with hive/i }),


### PR DESCRIPTION
## Summary

Nightly run [28684729556](https://github.com/sakibsadmanshajib/hive/actions/runs/28684729556) showed OWUI OIDC setup passing but all six chat specs failing. Two independent root causes, both fixed here.

**1. LiteLLM booted with an empty model_list.** The "Materialize .env.ci" step in `phase-19-owui-nightly.yml` never set `OPENROUTER_DEFAULT_MODEL`, `OPENROUTER_AUTO_MODEL`, `GROQ_FAST_MODEL`, `GROQ_REASONING_MODEL`, or the embedding model vars, so LiteLLM logged `LLM Provider NOT provided. You passed model=` for every route and OWUI's `/api/models` returned zero models, meaning no chat request could ever be sent. Fixed by hardcoding these as literal model slugs (not secrets) in the `.env.ci` heredoc, matching the free/cheap-tier defaults already documented in `.env.example` and referenced by `deploy/litellm/config.yaml`.

**2. Two spec locator drifts against the real OWUI 0.9.5 DOM:**
- `03-chat-model-switch.spec.ts` and `06-tenant-model-visibility.spec.ts` used `getByTestId("model-selector")`, which does not exist. Replaced with `getByRole("button", { name: /select a model/i })`, confirmed from the failure snapshot. `03-chat-model-switch.spec.ts` also selected a fictitious `claude-3-haiku` option; updated to `route-groq-fast`, one of the routes now configured for the nightly run.
- `08-signout.spec.ts` clicked `getByRole("button", { name: /account/i })`, which has no accessible match (the sidebar was collapsed and no such control exists). The real profile menu trigger is an `<img alt="Open User Profile Menu">` from open-webui's `Sidebar.svelte`, visible in the header regardless of sidebar collapsed state. Confirmed against both the failure snapshot and the open-webui v0.9.5 source.

## Test plan

- [x] TS transpile check (`node --experimental-strip-types --check`) on all three edited spec files
- [x] YAML sanity check (`python3 yaml.safe_load`) on the modified workflow
- [ ] Nightly run (`workflow_dispatch` or next scheduled run) confirms LiteLLM boots with a non-empty model_list and all six OWUI chat specs pass

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>