### PR TITLE
fix(ci): mint a real Hive API key for the OWUI model-listing shim

### DIFF
--- a/.github/workflows/phase-19-owui-nightly.yml
+++ b/.github/workflows/phase-19-owui-nightly.yml
@@ -55,6 +55,31 @@ jobs:
           url="postgresql://${SUPABASE_DB_USER}:${ENC_PW}@${SUPABASE_DB_HOST}:${SUPABASE_DB_PORT}/${SUPABASE_DB_NAME}"
           echo "SUPABASE_DB_URL=$url" >> "$GITHUB_ENV"
           echo "reconstructed DB URL (host=${SUPABASE_DB_HOST}, port=${SUPABASE_DB_PORT}, user=${SUPABASE_DB_USER}, db=${SUPABASE_DB_NAME})"
+      - name: Seed OWUI e2e test user
+        # Self-provisions the owui-e2e tenant, GoTrue user, membership, and a
+        # real "hk_" Hive API key used as OWUI_SHIM_KEY (idempotent, password
+        # and key rotated every run). Runs BEFORE "Materialize .env.ci" now
+        # (moved from after it) because that step consumes the minted
+        # OWUI_SHIM_KEY. Removes the need for hand-managed OWUI_E2E_EMAIL /
+        # OWUI_E2E_PASSWORD repo secrets.
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: |
+          set -euo pipefail
+          out=$(python3 scripts/seed-owui-e2e-user.py)
+          email=$(printf '%s\n' "$out" | grep '^EMAIL=' | cut -d= -f2-)
+          password=$(printf '%s\n' "$out" | grep '^PASSWORD=' | cut -d= -f2-)
+          shim_key=$(printf '%s\n' "$out" | grep '^SHIM_KEY=' | cut -d= -f2-)
+          if [ -z "$email" ] || [ -z "$password" ] || [ -z "$shim_key" ]; then
+            echo "::error::seed-owui-e2e-user.py did not print EMAIL/PASSWORD/SHIM_KEY"
+            exit 1
+          fi
+          echo "::add-mask::$password"
+          echo "::add-mask::$shim_key"
+          echo "OWUI_E2E_EMAIL=$email" >> "$GITHUB_ENV"
+          echo "OWUI_E2E_PASSWORD=$password" >> "$GITHUB_ENV"
+          echo "OWUI_SHIM_KEY=$shim_key" >> "$GITHUB_ENV"
       - name: Materialize .env.ci
         # local/test profiles boot control-plane + edge-api + open-webui +
         # web-console, all of which fail fast without real Supabase/S3/LLM
@@ -67,6 +92,18 @@ jobs:
         # You passed model=") and OWUI's /api/models returns zero models, so
         # no chat request can be sent (run 28684729556). Values mirror the
         # free/cheap-tier defaults in .env.example and deploy/litellm/config.yaml.
+        #
+        # SUPABASE_JWT_ISSUER/AUDIENCE/JWKS_URL were previously omitted here,
+        # which silently disabled edge-api's whole phase-19 JWT + OWUI-unwrap
+        # wiring ("WARNING: phase-19 JWT auth wiring skipped", run
+        # 28685935882) -- every /v1/* call fell back to the raw API-key path
+        # instead of per-user JWT auth. Derived from SUPABASE_URL per the
+        # documented convention in .env.example; no new secret needed.
+        # OWUI_SHIM_KEY now comes from the "Seed OWUI e2e test user" step
+        # (a real hk_ Hive API key) instead of a random, unregistered value --
+        # see that step and scripts/seed-owui-e2e-user.py for why a random
+        # shim value can never authenticate OWUI's bodyless GET /v1/models
+        # connection probe.
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
@@ -88,7 +125,7 @@ jobs:
           set -euo pipefail
           for v in SUPABASE_URL SUPABASE_ANON_KEY SUPABASE_SERVICE_ROLE_KEY SUPABASE_DB_URL \
                    S3_ENDPOINT S3_ACCESS_KEY S3_SECRET_KEY S3_REGION \
-                   OPENROUTER_API_KEY GROQ_API_KEY; do
+                   OPENROUTER_API_KEY GROQ_API_KEY OWUI_SHIM_KEY; do
             val="${!v:-}"
             if [ -z "$val" ]; then
               echo "::error::$v is empty; cannot materialize .env.ci"
@@ -100,6 +137,9 @@ jobs:
           SUPABASE_ANON_KEY=${SUPABASE_ANON_KEY}
           SUPABASE_SERVICE_ROLE_KEY=${SUPABASE_SERVICE_ROLE_KEY}
           SUPABASE_DB_URL=${SUPABASE_DB_URL}
+          SUPABASE_JWT_ISSUER=${SUPABASE_URL}/auth/v1
+          SUPABASE_JWT_AUDIENCE=authenticated
+          SUPABASE_JWKS_URL=${SUPABASE_URL}/auth/v1/.well-known/jwks.json
           REDIS_URL=redis://redis:6379/0
           S3_ENDPOINT=${S3_ENDPOINT}
           S3_ACCESS_KEY=${S3_ACCESS_KEY}
@@ -120,29 +160,9 @@ jobs:
           NEXT_PUBLIC_SUPABASE_ANON_KEY=${NEXT_PUBLIC_SUPABASE_ANON_KEY:-$SUPABASE_ANON_KEY}
           SUPABASE_OAUTH_CLIENT_ID=${SUPABASE_OAUTH_CLIENT_ID:-}
           SUPABASE_OAUTH_CLIENT_SECRET=${SUPABASE_OAUTH_CLIENT_SECRET:-}
-          OWUI_SHIM_KEY=$(openssl rand -base64 32)
+          OWUI_SHIM_KEY=${OWUI_SHIM_KEY}
           EOF
           chmod 600 .env.ci
-      - name: Seed OWUI e2e test user
-        # Self-provisions the owui-e2e tenant, GoTrue user, and membership
-        # directly against the Supabase project (idempotent, password
-        # rotated every run). Removes the need for hand-managed
-        # OWUI_E2E_EMAIL / OWUI_E2E_PASSWORD repo secrets.
-        env:
-          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-        run: |
-          set -euo pipefail
-          out=$(python3 scripts/seed-owui-e2e-user.py)
-          email=$(printf '%s\n' "$out" | grep '^EMAIL=' | cut -d= -f2-)
-          password=$(printf '%s\n' "$out" | grep '^PASSWORD=' | cut -d= -f2-)
-          if [ -z "$email" ] || [ -z "$password" ]; then
-            echo "::error::seed-owui-e2e-user.py did not print EMAIL/PASSWORD"
-            exit 1
-          fi
-          echo "::add-mask::$password"
-          echo "OWUI_E2E_EMAIL=$email" >> "$GITHUB_ENV"
-          echo "OWUI_E2E_PASSWORD=$password" >> "$GITHUB_ENV"
       - name: Boot stack with test-owui + observability-langfuse profiles
         run: |
           cd deploy/docker
@@ -162,6 +182,28 @@ jobs:
             docker compose ps
             exit 1
           fi
+      - name: Diagnose model catalog layers
+        # Non-fatal (set +e / || true throughout): attributes an empty OWUI
+        # model list to one of three layers in a single glance --
+        # 1) LiteLLM has no model_list (env/config problem upstream of Hive)
+        # 2) edge-api /v1/models rejects the OWUI shim credential (auth problem)
+        # 3) both return models but OWUI still shows none (OWUI-side problem)
+        # Prints only counts/status codes, never secrets or response bodies.
+        env:
+          LITELLM_MASTER_KEY: ${{ secrets.LITELLM_MASTER_KEY }}
+        run: |
+          set +e
+          litellm_status=$(curl -s -o /tmp/litellm-models.json -w '%{http_code}' \
+            -H "Authorization: Bearer ${LITELLM_MASTER_KEY:-litellm-dev-key}" \
+            http://localhost:4000/v1/models)
+          litellm_count=$(jq -r 'if (.data | type) == "array" then (.data | length) else "parse-error" end' /tmp/litellm-models.json 2>/dev/null)
+          edge_status=$(curl -s -o /tmp/edge-models.json -w '%{http_code}' \
+            -H "Authorization: Bearer ${OWUI_SHIM_KEY}" \
+            http://localhost:8080/v1/models)
+          edge_count=$(jq -r 'if (.data | type) == "array" then (.data | length) else "parse-error" end' /tmp/edge-models.json 2>/dev/null)
+          echo "layer 1 (litellm /v1/models):  status=${litellm_status} count=${litellm_count:-parse-error}"
+          echo "layer 2 (edge-api /v1/models): status=${edge_status} count=${edge_count:-parse-error}"
+          exit 0
       - name: Probe Supabase token endpoint from OWUI container
         # Diagnostic only, non-fatal (|| true). Leading hypothesis for the
         # run 28676421973 callback hang: runner egress stall (IPv6/DNS

--- a/scripts/seed-owui-e2e-user.py
+++ b/scripts/seed-owui-e2e-user.py
@@ -7,13 +7,30 @@ re-run: the tenant and membership rows are upserted, the GoTrue user is
 found-or-created, and its password is always rotated to a fresh random
 value so no run reuses a prior credential.
 
+Also mints a real, resolvable Hive API key to use as OWUI_SHIM_KEY. OWUI's
+own GET /v1/models connection probe sends OPENAI_API_KEY with no request
+body, so edge-api's OWUIUnwrap middleware (which only swaps in a per-user
+JWT when the body carries __metadata) can never rewrite it -- see
+deploy/docker/pipelines/hive_jwt_forward.py's inlet comment. A random,
+unregistered shim value therefore always 401s model listing even on a
+healthy stack (run 28685935882). A real "hk_"-prefixed key routes straight
+through the existing API-key path for that bodyless call. This key lives on
+its own throwaway "owui-e2e-shim" billing account (the older accounts/
+api_keys schema, unrelated to the tenants/tenant_users rows below) with
+allow_all_models=true -- listing is not billable, so there is no reason to
+depend on default-policy-group alias membership. Rotated every run the same
+way the GoTrue password is.
+
 Required env: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY
 
-Prints exactly two lines to stdout (and nothing else):
+Prints exactly three lines to stdout (and nothing else):
   EMAIL=<email>
   PASSWORD=<password>
+  SHIM_KEY=<hk_ api key>
 Everything else (progress, errors) goes to stderr.
 """
+import base64
+import hashlib
 import json
 import os
 import secrets
@@ -25,6 +42,9 @@ import urllib.request
 
 TENANT_SLUG = "owui-e2e"
 TENANT_NAME = "OWUI E2E"
+SHIM_ACCOUNT_SLUG = "owui-e2e-shim"
+SHIM_ACCOUNT_NAME = "OWUI E2E Shim"
+SHIM_KEY_NICKNAME = "owui-e2e-shim-key"
 # ponytail: no Go code branches on tenants.deployment today (grep confirmed
 # clean). ENTERPRISE_EDGE picked as the closer conceptual fit for a
 # self-hosted OWUI chat front-end; revisit if that ever becomes load-bearing.
@@ -73,6 +93,16 @@ def random_password() -> str:
     # policy with room to spare, well under bcrypt's 72-byte limit.
     alphabet = string.ascii_letters + string.digits + "!@#$%^&*-_"
     return "Aa1!" + "".join(secrets.choice(alphabet) for _ in range(24))
+
+
+def random_api_key() -> tuple[str, str, str]:
+    """Mirrors generateSecret() in apps/control-plane/internal/apikeys/service.go:
+    32 random bytes, base64url (no padding), "hk_" prefix, sha256 hex hash.
+    Returns (raw_secret, token_hash, redacted_suffix)."""
+    encoded = base64.urlsafe_b64encode(secrets.token_bytes(32)).rstrip(b"=").decode()
+    raw_secret = "hk_" + encoded
+    token_hash = hashlib.sha256(raw_secret.encode()).hexdigest()
+    return raw_secret, token_hash, raw_secret[-6:]
 
 
 def main() -> None:
@@ -156,8 +186,64 @@ def main() -> None:
         print(f"error: membership upsert failed: {status} {body}", file=sys.stderr)
         sys.exit(1)
 
+    # 4. Upsert the throwaway shim billing account (older accounts/api_keys
+    # schema -- separate from the tenants/tenant_users rows above).
+    status, body = request(
+        rest, headers, "POST", "/accounts",
+        body={
+            "slug": SHIM_ACCOUNT_SLUG,
+            "display_name": SHIM_ACCOUNT_NAME,
+            "account_type": "business",
+            "owner_user_id": user_id,
+        },
+        params={"on_conflict": "slug"},
+        prefer="resolution=merge-duplicates,return=representation",
+    )
+    if status not in (200, 201) or not body:
+        print(f"error: shim account upsert failed: {status} {body}", file=sys.stderr)
+        sys.exit(1)
+    shim_account_id = body[0]["id"]
+
+    # 5. Rotate the shim API key: drop any previous key(s) for this account
+    # (cascades to their policy rows) then mint a fresh one, same rotate-
+    # every-run posture as the GoTrue password above.
+    status, body = request(
+        rest, headers, "DELETE", "/api_keys",
+        params={"account_id": f"eq.{shim_account_id}"},
+    )
+    if status not in (200, 204):
+        print(f"error: shim key cleanup failed: {status} {body}", file=sys.stderr)
+        sys.exit(1)
+
+    raw_secret, token_hash, redacted_suffix = random_api_key()
+    status, body = request(
+        rest, headers, "POST", "/api_keys",
+        body={
+            "account_id": shim_account_id,
+            "nickname": SHIM_KEY_NICKNAME,
+            "token_hash": token_hash,
+            "redacted_suffix": redacted_suffix,
+            "status": "active",
+            "created_by_user_id": user_id,
+        },
+        prefer="return=representation",
+    )
+    if status not in (200, 201) or not body:
+        print(f"error: shim key create failed: {status} {body}", file=sys.stderr)
+        sys.exit(1)
+    shim_key_id = body[0]["id"]
+
+    status, body = request(
+        rest, headers, "POST", "/api_key_policies",
+        body={"api_key_id": shim_key_id, "allow_all_models": True},
+    )
+    if status not in (200, 201, 204):
+        print(f"error: shim key policy create failed: {status} {body}", file=sys.stderr)
+        sys.exit(1)
+
     print(f"EMAIL={USER_EMAIL}")
     print(f"PASSWORD={password}")
+    print(f"SHIM_KEY={raw_secret}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Run 28685935882: OWUI's `GET /api/models` still returned `{"data": []}` even after PR #286 added `OPENROUTER_DEFAULT_MODEL` etc. to `.env.ci`. This confirms the empty catalog was never a LiteLLM config problem; the actual gap is in how the nightly workflow authenticates OWUI's own model-listing call to edge-api.

## Evidence chain

1. Compose logs (`owui-compose-logs/compose-logs.txt`) show LiteLLM starting cleanly this run ("Application startup complete", no `LLM Provider NOT provided` error), and edge-api starting healthy. No auth-layer errors appear anywhere in the captured logs.
2. `deploy/litellm/config.yaml` model_list resolves `OPENROUTER_DEFAULT_MODEL` / `OPENROUTER_AUTO_MODEL` / `GROQ_FAST_MODEL` from env, and `deploy/docker/docker-compose.yml`'s `litellm` service already passes all of these through — PR #286's values reach the container correctly. Layer 1 (LiteLLM catalog) is not the blocker.
3. `handleModels` in `apps/edge-api/cmd/server/main.go` requires a resolvable credential via `authorizer.Authorize` → `authz.Client.Resolve`, which hashes the raw bearer token and looks it up in `public.api_keys` by `token_hash`. OWUI's own `GET {OPENAI_API_BASE_URL}/models` connection probe (used to populate the chat model dropdown) sends `OPENAI_API_KEY` as a bare bearer token with **no request body**. `apps/edge-api/internal/auth/owui_unwrap.go`'s `OWUIUnwrap` middleware only rewrites `Authorization` to a per-user JWT when the body carries `__metadata.upstream_auth` (as `deploy/docker/pipelines/hive_jwt_forward.py`'s `inlet` injects for chat completions) — a bodyless GET can never carry that, so the shim key reaches the API-key path unchanged. The nightly workflow generated `OWUI_SHIM_KEY` with `openssl rand -base64 32` — a value never registered as a Hive API key — so `Resolve` always 401s and OWUI's own `get_all_models()` silently reports zero models. This is layer 3 ("shim auth quietly failing"), confirmed at the code level, not layer 2 (tenant filtering): `catalog.Service.GetSnapshot` (behind `/internal/catalog/snapshot`, what `handleModels` calls) takes no tenant parameter and is not filtered per caller today.
4. Separately, the nightly `.env.ci` never set `SUPABASE_JWT_ISSUER` / `SUPABASE_JWT_AUDIENCE` / `SUPABASE_JWKS_URL`. `loadJWTAuthEnv` in `main.go` requires all three; when missing, edge-api logs `WARNING: phase-19 JWT auth wiring skipped` (visible in the captured logs) and the entire `authSelectorMiddleware` (JWT validation + `OWUIUnwrap`) is never wired in at all, regardless of request shape. This is real drift from the values `.env.example` documents as required for production.

## Changes

- `scripts/seed-owui-e2e-user.py`: mints a real `hk_`-prefixed Hive API key (rotated every run, same posture as the GoTrue password) on a throwaway `owui-e2e-shim` billing account, using the identical `sha256("hk_" + 32 random bytes base64url)` hashing scheme as `apps/control-plane/internal/apikeys/service.go`'s `generateSecret`, with `allow_all_models=true` (listing is not billable, so there's no reason to depend on default-policy-group alias membership). Prints a third `SHIM_KEY=` line alongside the existing `EMAIL=`/`PASSWORD=`.
- `.github/workflows/phase-19-owui-nightly.yml`:
  - Moved the "Seed OWUI e2e test user" step before "Materialize .env.ci" (it now supplies `OWUI_SHIM_KEY`).
  - `.env.ci` now sets `OWUI_SHIM_KEY` from the minted key instead of `openssl rand -base64 32`.
  - `.env.ci` now sets `SUPABASE_JWT_ISSUER` / `SUPABASE_JWT_AUDIENCE` / `SUPABASE_JWKS_URL`, derived from the existing `SUPABASE_URL` secret per the convention in `.env.example` — no new secret required.
  - Added a non-fatal "Diagnose model catalog layers" step after boot (before the Playwright suite) that curls LiteLLM's and edge-api's `/v1/models` directly and prints only HTTP status + model count (via `jq`, no secrets or bodies logged), so the next failure attributes the empty-catalog symptom to a specific layer immediately.

## Known follow-up (out of scope here)

`catalog.Service.GetSnapshot` / `/internal/catalog/snapshot` is not tenant-scoped, and `apps/control-plane/internal/catalog/http.go`'s `VisibilityHandler` (the admin CRUD for `tenant_model_visibility`, which pushes per-group `access_control` into OWUI via `apps/control-plane/internal/owui/client.go`'s `SyncModelAccessControl`) is not mounted in `apps/control-plane/cmd/server/main.go`'s router. `06-tenant-model-visibility.spec.ts`'s "grok is excluded" assertion currently passes vacuously because grok isn't in this deployment's catalog at all, not because tenant filtering is enforced. Worth a follow-up issue if per-tenant model visibility needs to be exercised for real.

## Test plan

- [x] `python3 -m py_compile scripts/seed-owui-e2e-user.py`
- [x] YAML re-parsed with `yaml.safe_load` after edits (14 steps, correct order)
- [x] Manually traced the sha256/base64url hashing in the seed script against `generateSecret()` in `apps/control-plane/internal/apikeys/service.go` — byte-for-byte match
- [x] Manually traced `CheckAccess` (`apps/edge-api/internal/authz/authz.go`) to confirm the minted key resolves and passes for `handleModels`'s alias-less request
- [ ] Live nightly run (schedule/workflow_dispatch) — cannot execute from this sandbox; next scheduled/dispatched run is the real verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated setup for a real e2e test user and API access used by nightly runs.
  * Added a diagnostic check that reports model-catalog availability before tests continue.

* **Bug Fixes**
  * Restored required authentication settings in the test environment so model access works correctly during nightly validation.
  * Reused the seeded test key instead of generating a mismatched value, improving run consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->