### PR TITLE
fix(owui): inject upstream auth metadata for edge-api shim chat (#269)

### DIFF
--- a/apps/web-console/e2e/phase-19/owui/owui.setup.ts
+++ b/apps/web-console/e2e/phase-19/owui/owui.setup.ts
@@ -1,7 +1,88 @@
-import { test as setup, expect } from "@playwright/test";
+import { test as setup, expect, type Page } from "@playwright/test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
 
 const STATE = "e2e/phase-19/owui/.auth/owui-user.json";
 const OWUI_URL = process.env.OWUI_URL ?? "http://localhost:3002";
+
+// #269: hive_jwt_forward is an Open WebUI Function (Admin > Functions), not
+// a file the container auto-loads; there is no mount or env var that
+// installs it. It must be created via the Functions REST API by an admin
+// session. Open WebUI auto-promotes the very first signed-in user to admin,
+// which this setup's OIDC login just did, so the authenticated `page`
+// below carries an admin session cookie.
+const HIVE_JWT_FORWARD_ID = "hive_jwt_forward";
+const HIVE_JWT_FORWARD_SOURCE = path.resolve(
+  __dirname,
+  "../../../../../deploy/docker/pipelines/hive_jwt_forward.py",
+);
+
+interface OwuiFunctionState {
+  is_active: boolean;
+  is_global: boolean;
+}
+
+/**
+ * Installs (idempotently) and fully activates the hive_jwt_forward Open
+ * WebUI Filter function using the already-authenticated `page`'s session
+ * cookie. A filter only runs when it is both active and global (see
+ * open_webui.utils.filter.get_sorted_filter_ids upstream), so both toggles
+ * are required in addition to creation.
+ */
+async function installHiveJwtForwardFilter(
+  page: Page,
+  owuiOrigin: string,
+): Promise<void> {
+  const content = readFileSync(HIVE_JWT_FORWARD_SOURCE, "utf8");
+  const functionUrl = `${owuiOrigin}/api/v1/functions/id/${HIVE_JWT_FORWARD_ID}`;
+
+  const existing = await page.request.get(functionUrl);
+  let state: OwuiFunctionState | null = null;
+  if (existing.ok()) {
+    state = await existing.json();
+  } else if (existing.status() !== 401 && existing.status() !== 404) {
+    throw new Error(
+      `hive_jwt_forward: unexpected status checking existing function: ${existing.status()} ${await existing.text()}`,
+    );
+  }
+
+  if (!state) {
+    const created = await page.request.post(`${owuiOrigin}/api/v1/functions/create`, {
+      data: {
+        id: HIVE_JWT_FORWARD_ID,
+        name: "Hive JWT Forward",
+        content,
+        meta: {
+          description:
+            "Injects the signed-in user's OAuth access token into __metadata.upstream_auth for edge-api's OWUI unwrap middleware (#269).",
+        },
+      },
+    });
+    if (!created.ok()) {
+      throw new Error(
+        `hive_jwt_forward: failed to create function: ${created.status()} ${await created.text()}`,
+      );
+    }
+  }
+
+  if (!state?.is_active) {
+    const toggled = await page.request.post(`${functionUrl}/toggle`);
+    if (!toggled.ok()) {
+      throw new Error(
+        `hive_jwt_forward: failed to activate function: ${toggled.status()} ${await toggled.text()}`,
+      );
+    }
+  }
+
+  if (!state?.is_global) {
+    const toggledGlobal = await page.request.post(`${functionUrl}/toggle/global`);
+    if (!toggledGlobal.ok()) {
+      throw new Error(
+        `hive_jwt_forward: failed to globalize function: ${toggledGlobal.status()} ${await toggledGlobal.text()}`,
+      );
+    }
+  }
+}
 
 setup("OWUI OIDC sign-in via Hive consent", async ({ page }) => {
   // Run 28681926134: consent can load first, then its client-side session
@@ -141,5 +222,6 @@ setup("OWUI OIDC sign-in via Hive consent", async ({ page }) => {
   await expect(
     page.getByRole("button", { name: /new chat/i }),
   ).toBeVisible({ timeout: 60_000 });
+  await installHiveJwtForwardFilter(page, owuiOrigin);
   await page.context().storageState({ path: STATE });
 });

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -355,14 +355,26 @@ services:
       PGVECTOR_DB_URL: ${SUPABASE_DB_URL:-}
       RAG_TOP_K: "5"
       ENABLE_RAG_HYBRID_SEARCH: "true"
-      ENABLE_PIPELINES: "true"
-      PIPELINES_URLS: "/app/pipelines/hive_jwt_forward.py"
       DATA_DIR: "/data"
       STATIC_DIR: "/data/static"
       OWUI_E2E_MODE: ${OWUI_E2E_MODE:-false}
     volumes:
       - owui-data:/data
-      - ./pipelines:/app/pipelines:ro
+      # NOTE (#269): ENABLE_PIPELINES/PIPELINES_URLS and a mounted
+      # ./pipelines volume used to sit here. Those are not real Open WebUI
+      # config keys on this image; they belong to the separate, deprecated
+      # "Pipelines" microservice (ghcr.io/open-webui/pipelines), which this
+      # compose file never runs. deploy/docker/pipelines/hive_jwt_forward.py
+      # was therefore never loaded. It is installed instead as a native Open
+      # WebUI Function via the Functions REST API (Admin > Functions),
+      # which requires an authenticated admin session and cannot run at
+      # container boot with no user yet signed in. CI installs it from
+      # apps/web-console/e2e/phase-19/owui/owui.setup.ts right after the
+      # e2e user's first OIDC login (which auto-promotes to admin as the
+      # first user). Production/EnterpriseEdge deployments must install it
+      # once via the same API after the first admin signs in; see that
+      # file for the request shape. Tracked as follow-up: automate this for
+      # non-CI deployments too.
     healthcheck:
       test: ["CMD", "curl", "-fsSL", "http://localhost:8080/health"]
       interval: 10s

--- a/deploy/docker/pipelines/hive_jwt_forward.py
+++ b/deploy/docker/pipelines/hive_jwt_forward.py
@@ -1,9 +1,32 @@
 """
-hive_jwt_forward - Open WebUI pipeline filter.
+hive_jwt_forward: Open WebUI Filter function.
 
-For every outgoing OpenAI-compatible request, copy the signed-in user's
-Supabase token into request metadata so the edge-api JWT path can validate the
-real user instead of the static Open WebUI shim key.
+For every outgoing OpenAI-compatible request, copies the signed-in user's
+OAuth access token into request metadata so edge-api's OWUI unwrap
+middleware (apps/edge-api/internal/auth/owui_unwrap.go) can validate the
+real user instead of the static Open WebUI shim key. Without this, every
+chat/embeddings request originating from OWUI carries the shim key in
+Authorization, routes through the API-key path, and binds to the shim's
+principal, defeating per-user audit attribution, RLS, and tenant scoping.
+
+Install target (#269): Open WebUI's native Functions system (Admin >
+Functions), NOT the separate, deprecated "Pipelines" microservice
+(ghcr.io/open-webui/pipelines) this file's name and prior docstring
+suggested. Open WebUI detects a Function's type purely by class name at
+exec time, one of `Filter`, `Pipe`, `Action`, or `Event` (see
+open_webui.utils.plugin.load_function_module_by_id), so a class named
+`Pipeline` is never picked up at all. The ENABLE_PIPELINES/PIPELINES_URLS
+docker-compose env vars this file used to be mounted alongside are also
+not real Open WebUI config keys on this image. Both facts combined meant
+this filter never ran, in production or in CI.
+
+Functions are installed via a database row created through the Functions
+REST API (POST /api/v1/functions/create, then POST .../toggle and
+.../toggle/global), authenticated as an Open WebUI admin; there is no
+file-mount or env-var based auto-load. See
+apps/web-console/e2e/phase-19/owui/owui.setup.ts for the reference
+installer used in CI, which runs right after the e2e user's first OIDC
+login (Open WebUI auto-promotes the very first signed-in user to admin).
 """
 
 from __future__ import annotations
@@ -11,45 +34,40 @@ from __future__ import annotations
 import os
 from typing import Any
 
+from pydantic import BaseModel
 
-class Pipeline:
-    class Valves:
+
+class Filter:
+    class Valves(BaseModel):
         priority: int = 0
 
     def __init__(self) -> None:
-        self.name = "hive_jwt_forward"
         self.valves = self.Valves()
         self.e2e_mode = os.environ.get("OWUI_E2E_MODE", "").lower() in ("1", "true")
 
-    async def on_startup(self) -> None:
-        return None
-
-    async def on_shutdown(self) -> None:
-        return None
-
-    async def inlet(self, body: dict[str, Any], user: dict[str, Any] | None = None) -> dict[str, Any]:
+    async def inlet(
+        self,
+        body: dict[str, Any],
+        __oauth_token__: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
         if not isinstance(body, dict):
             return body
 
-        # Forward ONLY the access_token. The previous code fell back to
-        # id_token, which carries different `aud` and lifetime semantics
-        # than an access_token and is intended for OIDC identity
-        # assertions — not resource-server authorization. Using id_token
-        # for API calls invites confused-deputy / audience-mismatch
-        # attacks. If no access_token is available we leave the body
-        # untouched; edge-api's OWUI unwrap then logs a warning and the
-        # selector routes the shim-key Authorization to the API-key
-        # path, which 401s loudly.
-        token = None
-        if user is not None:
-            oauth = user.get("oauth_sub") or {}
-            if isinstance(oauth, dict):
-                token = oauth.get("access_token")
-            token = token or user.get("token")
-
-        metadata = body.setdefault("__metadata", {})
-        if isinstance(metadata, dict) and token:
-            metadata["upstream_auth"] = f"Bearer {token}"
+        # __oauth_token__ is resolved by Open WebUI's OAuthManager from the
+        # signed-in user's stored OAuth session, auto-refreshing it if
+        # expired (see open_webui.utils.middleware.get_system_oauth_token).
+        # Forward ONLY the access_token. An id_token carries different `aud`
+        # and lifetime semantics than an access_token and is intended for
+        # OIDC identity assertions, not resource-server authorization; using
+        # it here would invite confused-deputy / audience-mismatch attacks.
+        # If no OAuth session is available (e.g. a non-OAuth admin account)
+        # leave the body untouched; edge-api's OWUI unwrap then logs a
+        # warning and the selector routes the shim-key Authorization to the
+        # API-key path, which 401s loudly instead of silently misattributing
+        # the request.
+        token = (__oauth_token__ or {}).get("access_token")
+        if token:
+            body.setdefault("__metadata", {})["upstream_auth"] = f"Bearer {token}"
 
         if self.e2e_mode:
             body.setdefault("temperature", 0)
@@ -57,7 +75,7 @@ class Pipeline:
 
         return body
 
-    async def outlet(self, body: Any, user: dict[str, Any] | None = None) -> Any:
+    async def outlet(self, body: Any) -> Any:
         # Strip the upstream auth header so the bearer token does not survive
         # into Open WebUI's response-side logging or get echoed back to the
         # browser. The inlet injects it; the outlet erases it.


### PR DESCRIPTION
## Summary

Nightly run 28687096528 got past OIDC login and model catalog, then edge-api rejected OWUI's first real chat completion with:

```
WARN owui shim request missing upstream_auth metadata path=/v1/chat/completions content_length=9401
```

`apps/edge-api/internal/auth/owui_unwrap.go` expects `__metadata.upstream_auth` in the JSON body (a per-user Supabase/OAuth token) to swap onto `Authorization` before the shim key reaches the API-key path. The design (`docs/superpowers/specs/2026-05-16-phase-19-foundation-design.md` section 6, `docs/superpowers/plans/2026-05-16-phase-19-03-deploy-and-chat.md` Task 3) called for an Open WebUI pipeline filter, `deploy/docker/pipelines/hive_jwt_forward.py`, to inject it.

**Root cause:** that filter never loaded. It defined `class Pipeline`, and `docker-compose.yml` set `ENABLE_PIPELINES`/`PIPELINES_URLS` on the `open-webui` service. Neither is real Open WebUI configuration on the pinned image (`ghcr.io/open-webui/open-webui:main`). That env var pair belongs to a separate, deprecated microservice (`ghcr.io/open-webui/pipelines`) this compose file never runs. Confirmed against upstream source (`open_webui/utils/plugin.py`, `load_function_module_by_id`): Open WebUI's native Functions system detects a function's type purely by class name at exec time (`Filter`, `Pipe`, `Action`, or `Event`) and functions are installed via a database row created through the Functions REST API, not a file mount or env var.

## Changes

- `deploy/docker/pipelines/hive_jwt_forward.py`: rewritten as a proper Open WebUI `Filter` function. Uses the `__oauth_token__` parameter, which Open WebUI's `OAuthManager` resolves natively from the signed-in user's stored OAuth session (auto-refreshed), instead of the previous manual `user.oauth_sub.access_token` read (whose parameter name, `user`, was also never actually bound by Open WebUI's filter dispatcher, since it only injects dunder-named parameters present in the handler signature).
- `deploy/docker/docker-compose.yml`: removed the dead `ENABLE_PIPELINES`/`PIPELINES_URLS`/`./pipelines` volume mount config, replaced with a note documenting the real installation path.
- `apps/web-console/e2e/phase-19/owui/owui.setup.ts`: after the e2e user's first successful OIDC login (Open WebUI auto-promotes the first signed-in user to admin), installs and fully activates the filter via the Functions REST API: `POST /api/v1/functions/create`, then `POST .../toggle` and `POST .../toggle/global`, idempotently (checks existing state first).

Production/EnterpriseEdge deployments still need a one-time equivalent installation after the first admin signs in; that automation is out of scope here and tracked as a follow-up in the docker-compose.yml note.

## Verification

- Go unit tests for `owui_unwrap.go` are unaffected (no changes to that file or its contract); the body-shape (`__metadata.upstream_auth`) it expects is unchanged.
- `python3 -c "import ast; ast.parse(...)"` and a runtime self-test (stubbed `pydantic`) confirm `Filter.inlet`/`outlet` behave correctly: injects `Bearer <token>` from `__oauth_token__`, no-ops when absent, strips `__metadata` in `outlet`.
- `node --check` on `owui.setup.ts` confirms valid syntax; path resolution from the test file to `deploy/docker/pipelines/hive_jwt_forward.py` verified programmatically.
- **Live end-to-end proof**: booted a standalone `ghcr.io/open-webui/open-webui` container (same pinned digest as compose), signed up the first user (auto-promoted to `admin`), and ran the exact create/toggle/toggle-global sequence used in `owui.setup.ts` against the real Functions API. Server log confirmed `Loaded module: function_hive_jwt_forward` with `type=filter`; final `GET /api/v1/functions/id/hive_jwt_forward` showed `is_active=true`, `is_global=true`, and content byte-identical to the committed file. Container torn down after the check.

## Test plan

- [ ] Nightly `phase-19-owui-nightly` run turns green past the chat-send step (no more `owui shim request missing upstream_auth metadata` WARN)
- [ ] `01-chat-send-stream.spec.ts` and the rest of the OWUI Playwright suite pass
- [ ] edge-api logs show a per-user JWT-authenticated request (not the shim key) for OWUI-originated chat completions

🤖 Generated with [Claude Code](https://claude.com/claude-code)