### PR TITLE
feat: add embedding provenance metadata to rag_documents

### DIFF
--- a/supabase/migrations/20260715_01_rag_embedding_provenance.sql
+++ b/supabase/migrations/20260715_01_rag_embedding_provenance.sql
@@ -1,0 +1,61 @@
+-- supabase/migrations/20260715_01_rag_embedding_provenance.sql
+--
+-- Embedding provenance metadata for the RAG corpus (#232 follow-up,
+-- agent-subsystem blueprint Step 2.1).
+--
+-- Context: 20260625_05_carl_rag.sql (PR #256, merged, issue #232 closed)
+-- already ships public.rag_documents / public.rag_chunks with a fixed
+-- embedding vector(1024) column, an HNSW cosine index, and tenant RLS.
+-- That schema already lets the embedding provider swap (serverless today,
+-- local bge-m3 later per #295) with zero migration, because the column
+-- type pins the dimension. What it does not record is WHICH model
+-- produced a given document's vectors. Different models are different
+-- vector spaces even at the same dimension (OpenAI text-embedding-3-small
+-- truncated to 1024 dims is not comparable to bge-m3's native 1024 dims),
+-- so a future provider swap without provenance tracking would silently
+-- mix incompatible vector spaces in ANN search with no way to detect or
+-- selectively re-embed the stale rows. This migration adds document-level
+-- provenance columns so that gap is closeable later without another
+-- migration.
+--
+-- Granularity: per document (rag_documents), not per chunk. All chunks of
+-- one document are embedded together in one ingestion pass in the shipped
+-- ingestion code (apps/control-plane/internal/rag/ingest.go), so document
+-- level is the natural unit and avoids redundant per-row storage.
+--
+-- Depends on: 20260625_05_carl_rag.sql (public.rag_documents must exist).
+--
+-- Backfill note: existing rows predate this column. They are backfilled
+-- with the DEFAULT below because that is the only embedding route wired
+-- in deploy/litellm/config.yaml at the time of writing (route-openrouter-
+-- embedding, see apps/edge-api/internal/rag/embed.go). This is a
+-- best-effort label for historical rows, not a verified per-row fact;
+-- future ingestion code should write the real route name explicitly
+-- instead of relying on the default (endpoint-layer change, out of scope
+-- for this schema-only migration).
+--
+-- No RLS change needed: the existing rag_documents_tenant_isolation policy
+-- (20260625_05) is row-level (FOR ALL), so it already covers these new
+-- columns.
+
+BEGIN;
+
+ALTER TABLE public.rag_documents
+    ADD COLUMN IF NOT EXISTS embedding_model TEXT NOT NULL DEFAULT 'route-openrouter-embedding';
+
+ALTER TABLE public.rag_documents
+    ADD COLUMN IF NOT EXISTS embedding_dim INT NOT NULL DEFAULT 1024
+        CHECK (embedding_dim = 1024);
+
+COMMENT ON COLUMN public.rag_documents.embedding_model IS
+    'LiteLLM route/model id that produced this document''s chunk embeddings (e.g. route-openrouter-embedding today, bge-m3 post-#295). Provenance only; does not alter runtime behavior.';
+
+COMMENT ON COLUMN public.rag_documents.embedding_dim IS
+    'Embedding vector width in effect when this document was embedded. Pinned to 1024 to match rag_chunks.embedding vector(1024); changing the dimension is itself a schema migration, not a data update.';
+
+-- Documents grouped by embedding source, e.g. to find rows needing
+-- re-embedding after a provider swap.
+CREATE INDEX IF NOT EXISTS rag_documents_embedding_model_idx
+    ON public.rag_documents (embedding_model);
+
+COMMIT;


### PR DESCRIPTION
## Summary

Blueprint Step 2.1 (pgvector RAG schema, schema layer only) turned out to already be shipped: issue #232 is closed, merged via PR #256 (`20260625_01_enable_pgvector.sql`, `20260625_05_carl_rag.sql`). That migration already has `public.rag_documents`, `public.rag_chunks`, an HNSW cosine index (`m=16`, `ef_construction=64`), a `(tenant_id, document_id)` index, and tenant RLS on both tables, with `embedding vector(1024)` fixed for bge-m3. Since the dimension is pinned at the column-type level, provider swap (serverless today, local bge-m3 per #295) already needs zero schema change.

The one gap against this step's brief ("store model id + dimension metadata per corpus or per document set") is that no row records which model actually produced its vectors. Different embedding models are different, non-comparable vector spaces even at identical dimension (OpenAI `text-embedding-3-small` truncated to 1024 dims is not the same space as bge-m3's native 1024 dims). Without provenance, a future provider swap could silently mix incompatible vectors in ANN search with no way to detect or selectively re-embed stale rows.

This PR adds that missing metadata only, as a new migration on top of the already-applied schema. No existing migration is edited.

## Changes

- New file `supabase/migrations/20260715_01_rag_embedding_provenance.sql`:
  - `ALTER TABLE public.rag_documents ADD COLUMN embedding_model TEXT NOT NULL DEFAULT 'route-openrouter-embedding'`
  - `ALTER TABLE public.rag_documents ADD COLUMN embedding_dim INT NOT NULL DEFAULT 1024 CHECK (embedding_dim = 1024)`
  - Column comments documenting intent
  - `CREATE INDEX rag_documents_embedding_model_idx` for future admin tooling that needs to find documents embedded by a stale route after a provider swap

## Design notes

- Granularity is per document, not per chunk. The shipped ingestion code (`apps/control-plane/internal/rag/ingest.go`) embeds all chunks of one document in a single pass with one model, so document-level metadata is the natural unit and avoids redundant per-row storage. The step brief explicitly allows "per corpus or per document set."
- `NOT NULL DEFAULT` on an existing table is a metadata-only, non-locking change in Postgres 11+ (verified: no table rewrite for a constant default).
- Verified both existing INSERT statements (`apps/edge-api/internal/rag/repository.go`, `apps/control-plane/internal/rag/repository.go`) use explicit column lists that do not reference these new columns, so the default fills in automatically and nothing breaks without a Go change.
- Backfill for pre-existing rows uses the default value `route-openrouter-embedding` because that is the only wired route in `deploy/litellm/config.yaml` at the time of writing. This is a best-effort label for historical rows, not a verified per-row fact. A follow-up endpoint-layer change (out of scope here, since this PR is schema-only per the step brief) should have ingestion code write the real route name explicitly on each insert.
- `embedding_dim` is pinned via `CHECK (embedding_dim = 1024)` because the actual storage type is `vector(1024)`; a real dimension change is itself a schema migration, not a data update, so the constraint documents that this column tracks the schema's fixed contract rather than allowing per-row drift.

## Deviations from the original task brief

- No new `CREATE EXTENSION vector`, `rag_documents`, `rag_chunks`, HNSW index, or RLS policy was added, because all of that already exists and is closed under #232 / PR #256. Re-creating it would be a no-op at best (the existing statements are `IF NOT EXISTS`) and confusing at worst. This PR only adds the provenance metadata gap that was still open against the step's stated design goal.
- `CREATE INDEX rag_documents_embedding_model_idx` is not `CONCURRENTLY` and runs inside the same transaction as the `ALTER TABLE` statements, matching this repo's existing migration convention (see `20260625_05_carl_rag.sql`, also transactional with plain `CREATE INDEX IF NOT EXISTS`). `CONCURRENTLY` cannot run inside a transaction block. `rag_documents` is a demo-stage table with no production-scale row count yet, so the lock-during-build risk is negligible; flagging this trade-off per the database-migrations skill's safety checklist for the record.

## Test plan

- [x] Spun up a disposable `pgvector/pgvector:pg16` container (isolated, unrelated to any project data), applied `20260625_01_enable_pgvector.sql` + a minimal `tenants`/role stub + `20260625_05_carl_rag.sql`, then applied this migration: all statements succeeded.
- [x] Re-ran this migration a second time against the same database: every `ADD COLUMN` / `CREATE INDEX` reported `already exists, skipping` (idempotent, no error).
- [x] Ran the exact `INSERT INTO public.rag_documents (tenant_id, name, mime_type, size_bytes, status) VALUES (...)` shape used by `apps/edge-api/internal/rag/repository.go` against the migrated table: confirmed it proceeds past column-default population (fails only on an intentionally-absent FK test row, not on the new NOT NULL columns), proving existing Go code is unaffected.
- [ ] Not verified: behavior against a live Supabase-hosted instance (only tested against local `pgvector/pgvector:pg16`); Supabase-specific role/grant quirks (if any) are not covered by this local test.
- No Go code changed; no endpoints touched, per the step's schema-only scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added embedding provenance information to stored documents, including the embedding model and vector dimensions.
  * Added support for filtering and grouping documents by embedding model.
  * Enforced a consistent 1,024-dimension embedding format for new records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->