### PR TITLE
feat: egress policy single source of truth (#308)

### DIFF
--- a/apps/control-plane/cmd/server/main.go
+++ b/apps/control-plane/cmd/server/main.go
@@ -15,6 +15,9 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hibiken/asynq"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	goredis "github.com/redis/go-redis/v9"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/accounting"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/accounts"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/apikeys"
@@ -29,10 +32,13 @@ import (
 	batchexecutor "github.com/sakibsadmanshajib/hive/apps/control-plane/internal/batchstore/executor"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/budgets"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/catalog"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/egress"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/featuregate"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/filestore"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/grants"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/identity"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/ledger"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/litellmconfig"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/owui"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/payments"
 	bkashRail "github.com/sakibsadmanshajib/hive/apps/control-plane/internal/payments/bkash"
@@ -47,22 +53,17 @@ import (
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/platform/metrics"
 	platformredis "github.com/sakibsadmanshajib/hive/apps/control-plane/internal/platform/redis"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/profiles"
-	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/litellmconfig"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/providers"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/routing"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/signup"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/signupguard"
-	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/spendalerts"
-	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/featuregate"
-	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/tenants"
-	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/tenant/settings"
-	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/usage"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/sovereign"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/spendalerts"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/tenant/settings"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/tenants"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/usage"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/waldrainer"
 	"github.com/sakibsadmanshajib/hive/packages/storage"
-	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
-	goredis "github.com/redis/go-redis/v9"
 )
 
 // ledgerGrantAdapter wraps *ledger.Service to satisfy the paymentStub.LedgerGranter
@@ -766,27 +767,39 @@ func main() {
 		featureGateHandler = featuregate.NewHandler(settingsResolver)
 	}
 
+	// Issue #308 — egress policy single source of truth. Admin CRUD is
+	// owner-gated via roleSvc.IsWorkspaceOwner (constructed above, in scope
+	// whenever pool != nil). Neither the server-side OpenHands allowed_hosts
+	// consumer nor the desktop firewall rule generator is wired here.
+	var egressPolicyHandler *egress.Handler
+	if pool != nil && roleSvc != nil {
+		egressRepo := egress.NewPgxRepository(pool)
+		egressSvc := egress.NewService(egressRepo, roleSvc)
+		egressPolicyHandler = egress.NewHandler(egressSvc)
+	}
+
 	router := platformhttp.NewRouter(platformhttp.RouterConfig{
-		AuthMiddleware:     authMiddleware,
-		AccountsHandler:    accountsHandler,
-		IdentityHandler:    identityHandler,
-		AccountingHandler:  accountingHandler,
-		APIKeysHandler:     apikeysHandler,
-		BudgetsHandler:     budgetsHandler,
-		CatalogHandler:     catalogHandler,
-		LedgerHandler:      ledgerHandler,
-		PaymentsHandler:    paymentsHandler,
-		ProfilesHandler:    profilesHandler,
-		ProvidersRouter:    providersHandler,
-		LiteLLMSyncHandler: litellmSyncHandler,
-		FeatureGateHandler: featureGateHandler,
-		RoutingHandler:     routingHandler,
-		UsageHandler:       usageHandler,
-		MetricsRegistry:    metricsRegistry,
-		PrometheusRegistry: promRegistry,
-		Mux:                routerMux,
-		InternalToken:      cfg.InternalToken,
-		RoleSvc:            roleSvc,
+		AuthMiddleware:      authMiddleware,
+		AccountsHandler:     accountsHandler,
+		IdentityHandler:     identityHandler,
+		AccountingHandler:   accountingHandler,
+		APIKeysHandler:      apikeysHandler,
+		BudgetsHandler:      budgetsHandler,
+		CatalogHandler:      catalogHandler,
+		LedgerHandler:       ledgerHandler,
+		PaymentsHandler:     paymentsHandler,
+		ProfilesHandler:     profilesHandler,
+		ProvidersRouter:     providersHandler,
+		LiteLLMSyncHandler:  litellmSyncHandler,
+		FeatureGateHandler:  featureGateHandler,
+		EgressPolicyHandler: egressPolicyHandler,
+		RoutingHandler:      routingHandler,
+		UsageHandler:        usageHandler,
+		MetricsRegistry:     metricsRegistry,
+		PrometheusRegistry:  promRegistry,
+		Mux:                 routerMux,
+		InternalToken:       cfg.InternalToken,
+		RoleSvc:             roleSvc,
 	})
 
 	// Wire filestore internal endpoints if the database pool is available.

--- a/apps/control-plane/internal/egress/http.go
+++ b/apps/control-plane/internal/egress/http.go
@@ -194,7 +194,14 @@ func (h *Handler) handleDeleteUserOverride(w http.ResponseWriter, r *http.Reques
 	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted"})
 }
 
+// maxHostsBodyBytes caps the request body a caller may submit to
+// PUT /api/v1/egress-policy/... — an allowlist has no legitimate reason to
+// approach this size; it exists to stop an oversized body from being decoded
+// into memory at all.
+const maxHostsBodyBytes = 1 << 20 // 1 MiB
+
 func decodeHostsBody(w http.ResponseWriter, r *http.Request) ([]string, bool) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxHostsBodyBytes)
 	var body struct {
 		AllowedHosts []string `json:"allowed_hosts"`
 	}

--- a/apps/control-plane/internal/egress/http.go
+++ b/apps/control-plane/internal/egress/http.go
@@ -1,0 +1,280 @@
+package egress
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/auth"
+)
+
+// Handler serves the egress-policy admin CRUD surface and the internal
+// service-to-service read endpoint.
+//
+// Admin surface (owner-gated, mounted behind auth middleware):
+//
+//	GET    /api/v1/egress-policy/{tenant_id}
+//	PUT    /api/v1/egress-policy/{tenant_id}
+//	GET    /api/v1/egress-policy/{tenant_id}/users/{user_id}
+//	PUT    /api/v1/egress-policy/{tenant_id}/users/{user_id}
+//	DELETE /api/v1/egress-policy/{tenant_id}/users/{user_id}
+//
+// Internal surface (shared-secret token, mounted behind RequireInternalToken):
+//
+//	GET /internal/egress-policy/{tenant_id}
+//	GET /internal/egress-policy/{tenant_id}/{user_id}
+//
+// The internal surface is the single read consumed identically by the
+// server-side OpenHands allowed_hosts workspace config and the desktop
+// firewall rule generator (issue #308). Neither consumer is wired here.
+type Handler struct {
+	svc *Service
+}
+
+// NewHandler constructs the egress-policy HTTP handler.
+func NewHandler(svc *Service) *Handler {
+	return &Handler{svc: svc}
+}
+
+// AdminMux returns the owner-gated admin CRUD surface. Wrap with
+// auth.Middleware.Require in router wiring.
+func (h *Handler) AdminMux() http.Handler {
+	return http.HandlerFunc(h.serveAdmin)
+}
+
+// InternalMux returns the service-to-service read surface. Wrap with
+// RequireInternalToken in router wiring.
+func (h *Handler) InternalMux() http.Handler {
+	return http.HandlerFunc(h.serveInternal)
+}
+
+const adminPrefix = "/api/v1/egress-policy/"
+const internalPrefix = "/internal/egress-policy/"
+
+func (h *Handler) serveAdmin(w http.ResponseWriter, r *http.Request) {
+	viewer, ok := auth.ViewerFromContext(r.Context())
+	if !ok {
+		writeJSON(w, http.StatusUnauthorized, errBody("unauthorized"))
+		return
+	}
+
+	rest := strings.TrimPrefix(r.URL.Path, adminPrefix)
+	parts := strings.Split(strings.Trim(rest, "/"), "/")
+	if len(parts) == 0 || parts[0] == "" {
+		writeJSON(w, http.StatusBadRequest, errBody("tenant_id required"))
+		return
+	}
+	tenantID, err := uuid.Parse(parts[0])
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, errBody("invalid tenant_id"))
+		return
+	}
+
+	switch {
+	case len(parts) == 1 && r.Method == http.MethodGet:
+		h.handleGetTenantDefault(w, r, viewer.UserID, tenantID)
+	case len(parts) == 1 && r.Method == http.MethodPut:
+		h.handlePutTenantDefault(w, r, viewer.UserID, tenantID)
+	case len(parts) == 3 && parts[1] == "users" && r.Method == http.MethodGet:
+		h.handleGetUserOverride(w, r, viewer.UserID, tenantID, parts[2])
+	case len(parts) == 3 && parts[1] == "users" && r.Method == http.MethodPut:
+		h.handlePutUserOverride(w, r, viewer.UserID, tenantID, parts[2])
+	case len(parts) == 3 && parts[1] == "users" && r.Method == http.MethodDelete:
+		h.handleDeleteUserOverride(w, r, viewer.UserID, tenantID, parts[2])
+	default:
+		writeJSON(w, http.StatusNotFound, errBody("not found"))
+	}
+}
+
+func (h *Handler) serveInternal(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeJSON(w, http.StatusMethodNotAllowed, errBody("method not allowed"))
+		return
+	}
+
+	rest := strings.TrimPrefix(r.URL.Path, internalPrefix)
+	parts := strings.Split(strings.Trim(rest, "/"), "/")
+	if len(parts) == 0 || parts[0] == "" {
+		writeJSON(w, http.StatusBadRequest, errBody("tenant_id required"))
+		return
+	}
+	tenantID, err := uuid.Parse(parts[0])
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, errBody("invalid tenant_id"))
+		return
+	}
+
+	userID := uuid.Nil
+	if len(parts) == 2 && parts[1] != "" {
+		userID, err = uuid.Parse(parts[1])
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, errBody("invalid user_id"))
+			return
+		}
+	} else if len(parts) > 2 {
+		writeJSON(w, http.StatusNotFound, errBody("not found"))
+		return
+	}
+
+	p, err := h.svc.Effective(r.Context(), tenantID, userID)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, errBody("egress policy resolution failed"))
+		return
+	}
+	writeJSON(w, http.StatusOK, effectiveWire(p))
+}
+
+func (h *Handler) handleGetTenantDefault(w http.ResponseWriter, r *http.Request, callerID, tenantID uuid.UUID) {
+	p, err := h.svc.GetTenantDefault(r.Context(), callerID, tenantID)
+	if err != nil {
+		writePolicyError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, tenantDefaultWire(p))
+}
+
+func (h *Handler) handlePutTenantDefault(w http.ResponseWriter, r *http.Request, callerID, tenantID uuid.UUID) {
+	hosts, ok := decodeHostsBody(w, r)
+	if !ok {
+		return
+	}
+	p, err := h.svc.SetTenantDefault(r.Context(), callerID, tenantID, hosts)
+	if err != nil {
+		writePolicyError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, tenantDefaultWire(p))
+}
+
+func (h *Handler) handleGetUserOverride(w http.ResponseWriter, r *http.Request, callerID, tenantID uuid.UUID, userIDStr string) {
+	targetUserID, err := uuid.Parse(userIDStr)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, errBody("invalid user_id"))
+		return
+	}
+	p, err := h.svc.GetUserOverride(r.Context(), callerID, tenantID, targetUserID)
+	if err != nil {
+		writePolicyError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, userOverrideWire(p))
+}
+
+func (h *Handler) handlePutUserOverride(w http.ResponseWriter, r *http.Request, callerID, tenantID uuid.UUID, userIDStr string) {
+	targetUserID, err := uuid.Parse(userIDStr)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, errBody("invalid user_id"))
+		return
+	}
+	hosts, ok := decodeHostsBody(w, r)
+	if !ok {
+		return
+	}
+	p, err := h.svc.SetUserOverride(r.Context(), callerID, tenantID, targetUserID, hosts)
+	if err != nil {
+		writePolicyError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, userOverrideWire(p))
+}
+
+func (h *Handler) handleDeleteUserOverride(w http.ResponseWriter, r *http.Request, callerID, tenantID uuid.UUID, userIDStr string) {
+	targetUserID, err := uuid.Parse(userIDStr)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, errBody("invalid user_id"))
+		return
+	}
+	if err := h.svc.DeleteUserOverride(r.Context(), callerID, tenantID, targetUserID); err != nil {
+		writePolicyError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted"})
+}
+
+func decodeHostsBody(w http.ResponseWriter, r *http.Request) ([]string, bool) {
+	var body struct {
+		AllowedHosts []string `json:"allowed_hosts"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, errBody("invalid JSON body"))
+		return nil, false
+	}
+	return body.AllowedHosts, true
+}
+
+func writePolicyError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, ErrForbidden):
+		writeJSON(w, http.StatusForbidden, errBody("workspace owner permission required"))
+	case errors.Is(err, ErrNotFound):
+		writeJSON(w, http.StatusNotFound, errBody("egress policy not found"))
+	case errors.Is(err, ErrInvalidHosts):
+		writeJSON(w, http.StatusBadRequest, errBody(ErrInvalidHosts.Error()))
+	default:
+		// Provider-blind: the underlying error (DB failure, owner-check
+		// transport failure) is never echoed to the caller.
+		writeJSON(w, http.StatusInternalServerError, errBody("egress policy request failed"))
+	}
+}
+
+// =============================================================================
+// Wire shapes
+// =============================================================================
+
+type tenantDefaultResponse struct {
+	TenantID     uuid.UUID `json:"tenant_id"`
+	AllowedHosts []string  `json:"allowed_hosts"`
+	UpdatedAt    time.Time `json:"updated_at,omitempty"`
+}
+
+type userOverrideResponse struct {
+	TenantID     uuid.UUID `json:"tenant_id"`
+	UserID       uuid.UUID `json:"user_id"`
+	AllowedHosts []string  `json:"allowed_hosts"`
+	UpdatedAt    time.Time `json:"updated_at,omitempty"`
+}
+
+// effectiveResponse is the canonical shape served over
+// GET /internal/egress-policy/{tenant_id}[/{user_id}] — the exact shape both
+// the OpenHands allowed_hosts workspace config and the desktop firewall rule
+// generator consume (issue #308 acceptance check).
+type effectiveResponse struct {
+	TenantID     uuid.UUID `json:"tenant_id"`
+	UserID       uuid.UUID `json:"user_id"`
+	AllowedHosts []string  `json:"allowed_hosts"`
+}
+
+func tenantDefaultWire(p Policy) tenantDefaultResponse {
+	return tenantDefaultResponse{TenantID: p.TenantID, AllowedHosts: hostsOrEmpty(p.AllowedHosts), UpdatedAt: p.UpdatedAt}
+}
+
+func userOverrideWire(p Policy) userOverrideResponse {
+	return userOverrideResponse{TenantID: p.TenantID, UserID: p.UserID, AllowedHosts: hostsOrEmpty(p.AllowedHosts), UpdatedAt: p.UpdatedAt}
+}
+
+func effectiveWire(p Policy) effectiveResponse {
+	return effectiveResponse{TenantID: p.TenantID, UserID: p.UserID, AllowedHosts: hostsOrEmpty(p.AllowedHosts)}
+}
+
+// hostsOrEmpty ensures the wire array is `[]` rather than `null` when empty —
+// consumers (OpenHands config loader, firewall rule generator) should not
+// need a nil check.
+func hostsOrEmpty(hosts []string) []string {
+	if hosts == nil {
+		return []string{}
+	}
+	return hosts
+}
+
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+func errBody(msg string) map[string]string {
+	return map[string]string{"error": msg}
+}

--- a/apps/control-plane/internal/egress/http_test.go
+++ b/apps/control-plane/internal/egress/http_test.go
@@ -1,0 +1,265 @@
+package egress_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/auth"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/egress"
+)
+
+func withViewer(r *http.Request, userID uuid.UUID) *http.Request {
+	ctx := auth.WithViewer(r.Context(), auth.Viewer{UserID: userID, EmailVerified: true})
+	return r.WithContext(ctx)
+}
+
+func TestHandler_AdminPutTenantDefault_OwnerSetsHosts(t *testing.T) {
+	repo := newFakeRepo()
+	callerID, tenantID := uuid.New(), uuid.New()
+	svc := egress.NewService(repo, &fakeOwner{isOwner: true})
+	h := egress.NewHandler(svc)
+
+	body := `{"allowed_hosts":["pypi.org","github.com"]}`
+	req := withViewer(httptest.NewRequest(http.MethodPut, "/api/v1/egress-policy/"+tenantID.String(), strings.NewReader(body)), callerID)
+	rec := httptest.NewRecorder()
+	h.AdminMux().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		AllowedHosts []string `json:"allowed_hosts"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.AllowedHosts) != 2 {
+		t.Fatalf("expected 2 hosts, got %v", resp.AllowedHosts)
+	}
+}
+
+func TestHandler_AdminPutTenantDefault_NonOwnerForbidden(t *testing.T) {
+	repo := newFakeRepo()
+	callerID, tenantID := uuid.New(), uuid.New()
+	svc := egress.NewService(repo, &fakeOwner{isOwner: false})
+	h := egress.NewHandler(svc)
+
+	body := `{"allowed_hosts":["pypi.org"]}`
+	req := withViewer(httptest.NewRequest(http.MethodPut, "/api/v1/egress-policy/"+tenantID.String(), strings.NewReader(body)), callerID)
+	rec := httptest.NewRecorder()
+	h.AdminMux().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", rec.Code)
+	}
+}
+
+func TestHandler_AdminPutTenantDefault_Unauthenticated_Returns401(t *testing.T) {
+	repo := newFakeRepo()
+	tenantID := uuid.New()
+	svc := egress.NewService(repo, &fakeOwner{isOwner: true})
+	h := egress.NewHandler(svc)
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/egress-policy/"+tenantID.String(), strings.NewReader(`{}`))
+	rec := httptest.NewRecorder()
+	h.AdminMux().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rec.Code)
+	}
+}
+
+func TestHandler_AdminPutTenantDefault_InvalidJSON_Returns400(t *testing.T) {
+	repo := newFakeRepo()
+	callerID, tenantID := uuid.New(), uuid.New()
+	svc := egress.NewService(repo, &fakeOwner{isOwner: true})
+	h := egress.NewHandler(svc)
+
+	req := withViewer(httptest.NewRequest(http.MethodPut, "/api/v1/egress-policy/"+tenantID.String(), strings.NewReader("not json")), callerID)
+	rec := httptest.NewRecorder()
+	h.AdminMux().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestHandler_AdminGetTenantDefault_InvalidTenantID_Returns400(t *testing.T) {
+	repo := newFakeRepo()
+	callerID := uuid.New()
+	svc := egress.NewService(repo, &fakeOwner{isOwner: true})
+	h := egress.NewHandler(svc)
+
+	req := withViewer(httptest.NewRequest(http.MethodGet, "/api/v1/egress-policy/not-a-uuid", nil), callerID)
+	rec := httptest.NewRecorder()
+	h.AdminMux().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestHandler_AdminGetTenantDefault_NotFound(t *testing.T) {
+	repo := newFakeRepo()
+	callerID, tenantID := uuid.New(), uuid.New()
+	svc := egress.NewService(repo, &fakeOwner{isOwner: true})
+	h := egress.NewHandler(svc)
+
+	req := withViewer(httptest.NewRequest(http.MethodGet, "/api/v1/egress-policy/"+tenantID.String(), nil), callerID)
+	rec := httptest.NewRecorder()
+	h.AdminMux().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
+func TestHandler_AdminUserOverride_PutGetDelete(t *testing.T) {
+	repo := newFakeRepo()
+	callerID, tenantID, targetUserID := uuid.New(), uuid.New(), uuid.New()
+	svc := egress.NewService(repo, &fakeOwner{isOwner: true})
+	h := egress.NewHandler(svc)
+	base := "/api/v1/egress-policy/" + tenantID.String() + "/users/" + targetUserID.String()
+
+	putReq := withViewer(httptest.NewRequest(http.MethodPut, base, strings.NewReader(`{"allowed_hosts":["docs.python.org"]}`)), callerID)
+	putRec := httptest.NewRecorder()
+	h.AdminMux().ServeHTTP(putRec, putReq)
+	if putRec.Code != http.StatusOK {
+		t.Fatalf("PUT expected 200, got %d: %s", putRec.Code, putRec.Body.String())
+	}
+
+	getReq := withViewer(httptest.NewRequest(http.MethodGet, base, nil), callerID)
+	getRec := httptest.NewRecorder()
+	h.AdminMux().ServeHTTP(getRec, getReq)
+	if getRec.Code != http.StatusOK {
+		t.Fatalf("GET expected 200, got %d", getRec.Code)
+	}
+	var resp struct {
+		UserID       string   `json:"user_id"`
+		AllowedHosts []string `json:"allowed_hosts"`
+	}
+	if err := json.NewDecoder(getRec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.UserID != targetUserID.String() || len(resp.AllowedHosts) != 1 {
+		t.Fatalf("unexpected override body: %+v", resp)
+	}
+
+	delReq := withViewer(httptest.NewRequest(http.MethodDelete, base, nil), callerID)
+	delRec := httptest.NewRecorder()
+	h.AdminMux().ServeHTTP(delRec, delReq)
+	if delRec.Code != http.StatusOK {
+		t.Fatalf("DELETE expected 200, got %d", delRec.Code)
+	}
+
+	getAfterDelete := withViewer(httptest.NewRequest(http.MethodGet, base, nil), callerID)
+	getAfterRec := httptest.NewRecorder()
+	h.AdminMux().ServeHTTP(getAfterRec, getAfterDelete)
+	if getAfterRec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 after delete, got %d", getAfterRec.Code)
+	}
+}
+
+func TestHandler_InternalEffective_ReturnsAllowedHostsShape(t *testing.T) {
+	repo := newFakeRepo()
+	tenantID, userID := uuid.New(), uuid.New()
+	repo.overrides[[2]uuid.UUID{tenantID, userID}] = egress.Policy{TenantID: tenantID, UserID: userID, AllowedHosts: []string{"pypi.org"}}
+	svc := egress.NewService(repo, &fakeOwner{isOwner: true})
+	h := egress.NewHandler(svc)
+
+	req := httptest.NewRequest(http.MethodGet, "/internal/egress-policy/"+tenantID.String()+"/"+userID.String(), nil)
+	rec := httptest.NewRecorder()
+	h.InternalMux().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		TenantID     string   `json:"tenant_id"`
+		UserID       string   `json:"user_id"`
+		AllowedHosts []string `json:"allowed_hosts"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.TenantID != tenantID.String() || resp.UserID != userID.String() {
+		t.Fatalf("unexpected scope echoed back: %+v", resp)
+	}
+	if len(resp.AllowedHosts) != 1 || resp.AllowedHosts[0] != "pypi.org" {
+		t.Fatalf("expected [pypi.org], got %v", resp.AllowedHosts)
+	}
+}
+
+func TestHandler_InternalEffective_TenantOnly_NoUserSegment(t *testing.T) {
+	repo := newFakeRepo()
+	tenantID := uuid.New()
+	repo.defaults[tenantID] = egress.Policy{TenantID: tenantID, AllowedHosts: []string{"github.com"}}
+	svc := egress.NewService(repo, &fakeOwner{isOwner: true})
+	h := egress.NewHandler(svc)
+
+	req := httptest.NewRequest(http.MethodGet, "/internal/egress-policy/"+tenantID.String(), nil)
+	rec := httptest.NewRecorder()
+	h.InternalMux().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	var resp struct {
+		AllowedHosts []string `json:"allowed_hosts"`
+	}
+	_ = json.NewDecoder(rec.Body).Decode(&resp)
+	if len(resp.AllowedHosts) != 1 || resp.AllowedHosts[0] != "github.com" {
+		t.Fatalf("expected [github.com], got %v", resp.AllowedHosts)
+	}
+}
+
+func TestHandler_InternalEffective_NothingSet_ReturnsEmptyArrayNotNull(t *testing.T) {
+	repo := newFakeRepo()
+	tenantID, userID := uuid.New(), uuid.New()
+	svc := egress.NewService(repo, &fakeOwner{isOwner: true})
+	h := egress.NewHandler(svc)
+
+	req := httptest.NewRequest(http.MethodGet, "/internal/egress-policy/"+tenantID.String()+"/"+userID.String(), nil)
+	rec := httptest.NewRecorder()
+	h.InternalMux().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if strings.Contains(rec.Body.String(), `"allowed_hosts":null`) {
+		t.Fatalf("expected [] not null in body: %s", rec.Body.String())
+	}
+}
+
+func TestHandler_InternalEffective_InvalidTenantID_Returns400(t *testing.T) {
+	repo := newFakeRepo()
+	svc := egress.NewService(repo, &fakeOwner{isOwner: true})
+	h := egress.NewHandler(svc)
+
+	req := httptest.NewRequest(http.MethodGet, "/internal/egress-policy/not-a-uuid", nil)
+	rec := httptest.NewRecorder()
+	h.InternalMux().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestHandler_InternalEffective_MethodNotAllowed(t *testing.T) {
+	repo := newFakeRepo()
+	tenantID := uuid.New()
+	svc := egress.NewService(repo, &fakeOwner{isOwner: true})
+	h := egress.NewHandler(svc)
+
+	req := httptest.NewRequest(http.MethodPost, "/internal/egress-policy/"+tenantID.String(), nil)
+	rec := httptest.NewRecorder()
+	h.InternalMux().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", rec.Code)
+	}
+}

--- a/apps/control-plane/internal/egress/repository.go
+++ b/apps/control-plane/internal/egress/repository.go
@@ -31,45 +31,49 @@ func NewPgxRepository(pool *pgxpool.Pool) Repository {
 	return &pgxRepository{pool: pool}
 }
 
-// withTenantConn acquires a dedicated connection, sets the RLS session
-// variable the egress_policies tenant-isolation policy checks, and runs fn on
-// that SAME connection before releasing it. hive_app is NOT BYPASSRLS (see
-// 20260518_04_phase19_audit_rls_and_indexes.sql), so every query against
-// public.egress_policies MUST run on a connection with app.current_tenant_id
-// set — using r.pool.QueryRow/Exec directly evaluates the RLS policy against
-// NULL and silently returns zero rows / fails every write.
+// withTenantTx runs fn inside an explicit transaction with the RLS session
+// variable set LOCAL (transaction-scoped) to tenantID. hive_app is NOT
+// BYPASSRLS (20260518_04_phase19_audit_rls_and_indexes.sql), so every query
+// against public.egress_policies must see app.current_tenant_id set to the
+// caller's tenant.
 //
-// is_local is FALSE (session-scoped), not true. A bare conn.Exec followed by
-// a separate conn.QueryRow — with no explicit BEGIN — are two independent
-// autocommit transactions on the wire; set_config(..., true) (transaction-
-// local) resets the moment the Exec's implicit transaction completes, so the
-// following query would see current_setting() back at NULL. Verified
-// empirically against a real Postgres 16 instance (psql -c set_config(...,
-// true) followed by a separate -c current_setting() returns empty; the same
-// with false returns the value). Session scope is still safe here because
-// this is the ONLY code path that touches public.egress_policies, and every
-// call re-sets app.current_tenant_id before it queries, so a pooled
-// connection recycled for a different tenant can never read with a stale
-// value. internal/rag/repository.go uses is_local=true across separate
-// Exec/QueryRow calls with no explicit transaction — that looks like the
-// same bug, but it is out of scope here; flagged separately.
-func (r *pgxRepository) withTenantConn(ctx context.Context, tenantID uuid.UUID, fn func(conn *pgxpool.Conn) error) error {
-	conn, err := r.pool.Acquire(ctx)
+// LOCAL (is_local=true), not session scope, and inside an explicit
+// transaction — two prior attempts got this wrong:
+//   - A bare conn.Exec(set_config(..., true)) followed by a separate
+//     conn.QueryRow with no transaction: LOCAL resets the instant the Exec's
+//     own implicit (autocommit) transaction ends, so the following query saw
+//     current_setting() back at NULL. Verified against live Postgres 16:
+//     RLS's own tenant_id = current_setting(...)::uuid cast then errors on
+//     an empty string.
+//   - Switching is_local to false (session scope) "fixed" that, but this
+//     repo's pgxpool has no AfterRelease reset hook, so the setting survives
+//     Release and leaks to whatever tenant's request borrows that physical
+//     connection next — a cross-tenant data leak, worse than the original
+//     bug on a data-sovereignty product.
+//
+// Wrapping in Begin/Commit makes LOCAL correct: it applies for exactly this
+// transaction's statements and is guaranteed to clear at Commit or Rollback,
+// so nothing survives onto the pooled connection for the next borrower.
+func (r *pgxRepository) withTenantTx(ctx context.Context, tenantID uuid.UUID, fn func(tx pgx.Tx) error) error {
+	tx, err := r.pool.Begin(ctx)
 	if err != nil {
-		return fmt.Errorf("egress: acquire conn: %w", err)
+		return fmt.Errorf("egress: begin tx: %w", err)
 	}
-	defer conn.Release()
+	defer tx.Rollback(ctx) // no-op once Commit has succeeded
 
-	if _, err := conn.Exec(ctx, "SELECT set_config('app.current_tenant_id', $1, false)", tenantID.String()); err != nil {
+	if _, err := tx.Exec(ctx, "SELECT set_config('app.current_tenant_id', $1, true)", tenantID.String()); err != nil {
 		return fmt.Errorf("egress: set tenant: %w", err)
 	}
-	return fn(conn)
+	if err := fn(tx); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
 }
 
 func (r *pgxRepository) GetTenantDefault(ctx context.Context, tenantID uuid.UUID) (Policy, error) {
 	var p Policy
-	err := r.withTenantConn(ctx, tenantID, func(conn *pgxpool.Conn) error {
-		row := conn.QueryRow(ctx, `
+	err := r.withTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		row := tx.QueryRow(ctx, `
 			SELECT tenant_id, allowed_hosts, updated_at
 			  FROM public.egress_policies
 			 WHERE tenant_id = $1 AND user_id IS NULL
@@ -86,8 +90,8 @@ func (r *pgxRepository) GetTenantDefault(ctx context.Context, tenantID uuid.UUID
 
 func (r *pgxRepository) GetUserOverride(ctx context.Context, tenantID, userID uuid.UUID) (Policy, error) {
 	var p Policy
-	err := r.withTenantConn(ctx, tenantID, func(conn *pgxpool.Conn) error {
-		row := conn.QueryRow(ctx, `
+	err := r.withTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		row := tx.QueryRow(ctx, `
 			SELECT tenant_id, user_id, allowed_hosts, updated_at
 			  FROM public.egress_policies
 			 WHERE tenant_id = $1 AND user_id = $2
@@ -104,8 +108,8 @@ func (r *pgxRepository) GetUserOverride(ctx context.Context, tenantID, userID uu
 
 func (r *pgxRepository) UpsertTenantDefault(ctx context.Context, tenantID uuid.UUID, allowedHosts []string) (Policy, error) {
 	var p Policy
-	err := r.withTenantConn(ctx, tenantID, func(conn *pgxpool.Conn) error {
-		row := conn.QueryRow(ctx, `
+	err := r.withTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		row := tx.QueryRow(ctx, `
 			INSERT INTO public.egress_policies (tenant_id, user_id, allowed_hosts)
 			VALUES ($1, NULL, $2)
 			ON CONFLICT (tenant_id) WHERE user_id IS NULL
@@ -124,8 +128,8 @@ func (r *pgxRepository) UpsertTenantDefault(ctx context.Context, tenantID uuid.U
 
 func (r *pgxRepository) UpsertUserOverride(ctx context.Context, tenantID, userID uuid.UUID, allowedHosts []string) (Policy, error) {
 	var p Policy
-	err := r.withTenantConn(ctx, tenantID, func(conn *pgxpool.Conn) error {
-		row := conn.QueryRow(ctx, `
+	err := r.withTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		row := tx.QueryRow(ctx, `
 			INSERT INTO public.egress_policies (tenant_id, user_id, allowed_hosts)
 			VALUES ($1, $2, $3)
 			ON CONFLICT (tenant_id, user_id) WHERE user_id IS NOT NULL
@@ -143,8 +147,8 @@ func (r *pgxRepository) UpsertUserOverride(ctx context.Context, tenantID, userID
 }
 
 func (r *pgxRepository) DeleteUserOverride(ctx context.Context, tenantID, userID uuid.UUID) error {
-	return r.withTenantConn(ctx, tenantID, func(conn *pgxpool.Conn) error {
-		_, err := conn.Exec(ctx, `
+	return r.withTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `
 			DELETE FROM public.egress_policies WHERE tenant_id = $1 AND user_id = $2
 		`, tenantID, userID)
 		if err != nil {

--- a/apps/control-plane/internal/egress/repository.go
+++ b/apps/control-plane/internal/egress/repository.go
@@ -31,54 +31,127 @@ func NewPgxRepository(pool *pgxpool.Pool) Repository {
 	return &pgxRepository{pool: pool}
 }
 
+// withTenantConn acquires a dedicated connection, sets the RLS session
+// variable the egress_policies tenant-isolation policy checks, and runs fn on
+// that SAME connection before releasing it. hive_app is NOT BYPASSRLS (see
+// 20260518_04_phase19_audit_rls_and_indexes.sql), so every query against
+// public.egress_policies MUST run on a connection with app.current_tenant_id
+// set — using r.pool.QueryRow/Exec directly evaluates the RLS policy against
+// NULL and silently returns zero rows / fails every write.
+//
+// is_local is FALSE (session-scoped), not true. A bare conn.Exec followed by
+// a separate conn.QueryRow — with no explicit BEGIN — are two independent
+// autocommit transactions on the wire; set_config(..., true) (transaction-
+// local) resets the moment the Exec's implicit transaction completes, so the
+// following query would see current_setting() back at NULL. Verified
+// empirically against a real Postgres 16 instance (psql -c set_config(...,
+// true) followed by a separate -c current_setting() returns empty; the same
+// with false returns the value). Session scope is still safe here because
+// this is the ONLY code path that touches public.egress_policies, and every
+// call re-sets app.current_tenant_id before it queries, so a pooled
+// connection recycled for a different tenant can never read with a stale
+// value. internal/rag/repository.go uses is_local=true across separate
+// Exec/QueryRow calls with no explicit transaction — that looks like the
+// same bug, but it is out of scope here; flagged separately.
+func (r *pgxRepository) withTenantConn(ctx context.Context, tenantID uuid.UUID, fn func(conn *pgxpool.Conn) error) error {
+	conn, err := r.pool.Acquire(ctx)
+	if err != nil {
+		return fmt.Errorf("egress: acquire conn: %w", err)
+	}
+	defer conn.Release()
+
+	if _, err := conn.Exec(ctx, "SELECT set_config('app.current_tenant_id', $1, false)", tenantID.String()); err != nil {
+		return fmt.Errorf("egress: set tenant: %w", err)
+	}
+	return fn(conn)
+}
+
 func (r *pgxRepository) GetTenantDefault(ctx context.Context, tenantID uuid.UUID) (Policy, error) {
-	row := r.pool.QueryRow(ctx, `
-		SELECT tenant_id, allowed_hosts, updated_at
-		  FROM public.egress_policies
-		 WHERE tenant_id = $1 AND user_id IS NULL
-	`, tenantID)
-	return scanTenantDefault(row)
+	var p Policy
+	err := r.withTenantConn(ctx, tenantID, func(conn *pgxpool.Conn) error {
+		row := conn.QueryRow(ctx, `
+			SELECT tenant_id, allowed_hosts, updated_at
+			  FROM public.egress_policies
+			 WHERE tenant_id = $1 AND user_id IS NULL
+		`, tenantID)
+		got, err := scanTenantDefault(row)
+		p = got
+		return err
+	})
+	if err != nil {
+		return Policy{}, err
+	}
+	return p, nil
 }
 
 func (r *pgxRepository) GetUserOverride(ctx context.Context, tenantID, userID uuid.UUID) (Policy, error) {
-	row := r.pool.QueryRow(ctx, `
-		SELECT tenant_id, user_id, allowed_hosts, updated_at
-		  FROM public.egress_policies
-		 WHERE tenant_id = $1 AND user_id = $2
-	`, tenantID, userID)
-	return scanUserOverride(row)
+	var p Policy
+	err := r.withTenantConn(ctx, tenantID, func(conn *pgxpool.Conn) error {
+		row := conn.QueryRow(ctx, `
+			SELECT tenant_id, user_id, allowed_hosts, updated_at
+			  FROM public.egress_policies
+			 WHERE tenant_id = $1 AND user_id = $2
+		`, tenantID, userID)
+		got, err := scanUserOverride(row)
+		p = got
+		return err
+	})
+	if err != nil {
+		return Policy{}, err
+	}
+	return p, nil
 }
 
 func (r *pgxRepository) UpsertTenantDefault(ctx context.Context, tenantID uuid.UUID, allowedHosts []string) (Policy, error) {
-	row := r.pool.QueryRow(ctx, `
-		INSERT INTO public.egress_policies (tenant_id, user_id, allowed_hosts)
-		VALUES ($1, NULL, $2)
-		ON CONFLICT (tenant_id) WHERE user_id IS NULL
-		DO UPDATE SET allowed_hosts = EXCLUDED.allowed_hosts, updated_at = now()
-		RETURNING tenant_id, allowed_hosts, updated_at
-	`, tenantID, allowedHosts)
-	return scanTenantDefault(row)
+	var p Policy
+	err := r.withTenantConn(ctx, tenantID, func(conn *pgxpool.Conn) error {
+		row := conn.QueryRow(ctx, `
+			INSERT INTO public.egress_policies (tenant_id, user_id, allowed_hosts)
+			VALUES ($1, NULL, $2)
+			ON CONFLICT (tenant_id) WHERE user_id IS NULL
+			DO UPDATE SET allowed_hosts = EXCLUDED.allowed_hosts, updated_at = now()
+			RETURNING tenant_id, allowed_hosts, updated_at
+		`, tenantID, allowedHosts)
+		got, err := scanTenantDefault(row)
+		p = got
+		return err
+	})
+	if err != nil {
+		return Policy{}, err
+	}
+	return p, nil
 }
 
 func (r *pgxRepository) UpsertUserOverride(ctx context.Context, tenantID, userID uuid.UUID, allowedHosts []string) (Policy, error) {
-	row := r.pool.QueryRow(ctx, `
-		INSERT INTO public.egress_policies (tenant_id, user_id, allowed_hosts)
-		VALUES ($1, $2, $3)
-		ON CONFLICT (tenant_id, user_id) WHERE user_id IS NOT NULL
-		DO UPDATE SET allowed_hosts = EXCLUDED.allowed_hosts, updated_at = now()
-		RETURNING tenant_id, user_id, allowed_hosts, updated_at
-	`, tenantID, userID, allowedHosts)
-	return scanUserOverride(row)
+	var p Policy
+	err := r.withTenantConn(ctx, tenantID, func(conn *pgxpool.Conn) error {
+		row := conn.QueryRow(ctx, `
+			INSERT INTO public.egress_policies (tenant_id, user_id, allowed_hosts)
+			VALUES ($1, $2, $3)
+			ON CONFLICT (tenant_id, user_id) WHERE user_id IS NOT NULL
+			DO UPDATE SET allowed_hosts = EXCLUDED.allowed_hosts, updated_at = now()
+			RETURNING tenant_id, user_id, allowed_hosts, updated_at
+		`, tenantID, userID, allowedHosts)
+		got, err := scanUserOverride(row)
+		p = got
+		return err
+	})
+	if err != nil {
+		return Policy{}, err
+	}
+	return p, nil
 }
 
 func (r *pgxRepository) DeleteUserOverride(ctx context.Context, tenantID, userID uuid.UUID) error {
-	_, err := r.pool.Exec(ctx, `
-		DELETE FROM public.egress_policies WHERE tenant_id = $1 AND user_id = $2
-	`, tenantID, userID)
-	if err != nil {
-		return fmt.Errorf("egress: delete user override: %w", err)
-	}
-	return nil
+	return r.withTenantConn(ctx, tenantID, func(conn *pgxpool.Conn) error {
+		_, err := conn.Exec(ctx, `
+			DELETE FROM public.egress_policies WHERE tenant_id = $1 AND user_id = $2
+		`, tenantID, userID)
+		if err != nil {
+			return fmt.Errorf("egress: delete user override: %w", err)
+		}
+		return nil
+	})
 }
 
 type scanner interface {

--- a/apps/control-plane/internal/egress/repository.go
+++ b/apps/control-plane/internal/egress/repository.go
@@ -1,0 +1,110 @@
+package egress
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Repository is the narrow data-access port for the egress policy store.
+// GetTenantDefault and GetUserOverride return ErrNotFound when the row is
+// absent; the merge into an effective policy is Service's job, not the
+// repository's.
+type Repository interface {
+	GetTenantDefault(ctx context.Context, tenantID uuid.UUID) (Policy, error)
+	GetUserOverride(ctx context.Context, tenantID, userID uuid.UUID) (Policy, error)
+	UpsertTenantDefault(ctx context.Context, tenantID uuid.UUID, allowedHosts []string) (Policy, error)
+	UpsertUserOverride(ctx context.Context, tenantID, userID uuid.UUID, allowedHosts []string) (Policy, error)
+	DeleteUserOverride(ctx context.Context, tenantID, userID uuid.UUID) error
+}
+
+type pgxRepository struct {
+	pool *pgxpool.Pool
+}
+
+// NewPgxRepository constructs a pgxpool-backed Repository.
+func NewPgxRepository(pool *pgxpool.Pool) Repository {
+	return &pgxRepository{pool: pool}
+}
+
+func (r *pgxRepository) GetTenantDefault(ctx context.Context, tenantID uuid.UUID) (Policy, error) {
+	row := r.pool.QueryRow(ctx, `
+		SELECT tenant_id, allowed_hosts, updated_at
+		  FROM public.egress_policies
+		 WHERE tenant_id = $1 AND user_id IS NULL
+	`, tenantID)
+	return scanTenantDefault(row)
+}
+
+func (r *pgxRepository) GetUserOverride(ctx context.Context, tenantID, userID uuid.UUID) (Policy, error) {
+	row := r.pool.QueryRow(ctx, `
+		SELECT tenant_id, user_id, allowed_hosts, updated_at
+		  FROM public.egress_policies
+		 WHERE tenant_id = $1 AND user_id = $2
+	`, tenantID, userID)
+	return scanUserOverride(row)
+}
+
+func (r *pgxRepository) UpsertTenantDefault(ctx context.Context, tenantID uuid.UUID, allowedHosts []string) (Policy, error) {
+	row := r.pool.QueryRow(ctx, `
+		INSERT INTO public.egress_policies (tenant_id, user_id, allowed_hosts)
+		VALUES ($1, NULL, $2)
+		ON CONFLICT (tenant_id) WHERE user_id IS NULL
+		DO UPDATE SET allowed_hosts = EXCLUDED.allowed_hosts, updated_at = now()
+		RETURNING tenant_id, allowed_hosts, updated_at
+	`, tenantID, allowedHosts)
+	return scanTenantDefault(row)
+}
+
+func (r *pgxRepository) UpsertUserOverride(ctx context.Context, tenantID, userID uuid.UUID, allowedHosts []string) (Policy, error) {
+	row := r.pool.QueryRow(ctx, `
+		INSERT INTO public.egress_policies (tenant_id, user_id, allowed_hosts)
+		VALUES ($1, $2, $3)
+		ON CONFLICT (tenant_id, user_id) WHERE user_id IS NOT NULL
+		DO UPDATE SET allowed_hosts = EXCLUDED.allowed_hosts, updated_at = now()
+		RETURNING tenant_id, user_id, allowed_hosts, updated_at
+	`, tenantID, userID, allowedHosts)
+	return scanUserOverride(row)
+}
+
+func (r *pgxRepository) DeleteUserOverride(ctx context.Context, tenantID, userID uuid.UUID) error {
+	_, err := r.pool.Exec(ctx, `
+		DELETE FROM public.egress_policies WHERE tenant_id = $1 AND user_id = $2
+	`, tenantID, userID)
+	if err != nil {
+		return fmt.Errorf("egress: delete user override: %w", err)
+	}
+	return nil
+}
+
+type scanner interface {
+	Scan(dest ...any) error
+}
+
+// scanTenantDefault scans a row with no user_id column selected — the tenant
+// default row always has UserID == uuid.Nil by construction.
+func scanTenantDefault(s scanner) (Policy, error) {
+	var p Policy
+	if err := s.Scan(&p.TenantID, &p.AllowedHosts, &p.UpdatedAt); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return Policy{}, ErrNotFound
+		}
+		return Policy{}, fmt.Errorf("egress: scan tenant default: %w", err)
+	}
+	return p, nil
+}
+
+func scanUserOverride(s scanner) (Policy, error) {
+	var p Policy
+	if err := s.Scan(&p.TenantID, &p.UserID, &p.AllowedHosts, &p.UpdatedAt); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return Policy{}, ErrNotFound
+		}
+		return Policy{}, fmt.Errorf("egress: scan user override: %w", err)
+	}
+	return p, nil
+}

--- a/apps/control-plane/internal/egress/repository_test.go
+++ b/apps/control-plane/internal/egress/repository_test.go
@@ -1,0 +1,134 @@
+package egress_test
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/egress"
+)
+
+// newRLSTestPool connects as the hive_app role — NOT BYPASSRLS in production
+// (see 20260518_04_phase19_audit_rls_and_indexes.sql) — so the
+// egress_policies tenant-isolation RLS policy is actually exercised rather
+// than bypassed by whatever superuser role HIVE_TEST_DB_URL otherwise
+// connects as. MaxConns is pinned to 1 so every Acquire inside a test
+// returns the same physical connection the SET ROLE was issued on; the pool
+// is closed (not returned to a shared pool) at test end so the role change
+// never leaks to another test.
+func newRLSTestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("HIVE_TEST_DB_URL")
+	if dsn == "" {
+		t.Skip("HIVE_TEST_DB_URL not set")
+	}
+	if !strings.Contains(strings.ToLower(dsn), "test") {
+		t.Fatalf("refusing to run: HIVE_TEST_DB_URL must point at a test database (DSN missing 'test' marker)")
+	}
+
+	cfg, err := pgxpool.ParseConfig(dsn)
+	if err != nil {
+		t.Fatalf("parse HIVE_TEST_DB_URL: %v", err)
+	}
+	cfg.MaxConns = 1
+
+	ctx := context.Background()
+	pool, err := pgxpool.NewWithConfig(ctx, cfg)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	if _, err := pool.Exec(ctx, "SET ROLE hive_app"); err != nil {
+		pool.Close()
+		t.Skipf("SET ROLE hive_app failed (is hive_app provisioned + migrations applied on this test DB?): %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+// seedTenant inserts an FK row into public.tenants via a short-lived,
+// unscoped connection (hive_app has no INSERT policy on tenants — only the
+// authenticated-role self-read policy from 20260516_01_phase19_tenants.sql —
+// so RLS setup for this table is not this package's concern to exercise).
+func seedTenant(t *testing.T, id uuid.UUID) {
+	t.Helper()
+	dsn := os.Getenv("HIVE_TEST_DB_URL")
+	ctx := context.Background()
+	setup, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("seed pool: %v", err)
+	}
+	defer setup.Close()
+	_, err = setup.Exec(ctx,
+		`INSERT INTO public.tenants (id, slug, name, deployment)
+		 VALUES ($1, $2, 'egress test tenant', 'HIVE_CLOUD')
+		 ON CONFLICT (id) DO NOTHING`,
+		id, "egress-test-"+id.String())
+	if err != nil {
+		t.Fatalf("seed tenant: %v", err)
+	}
+	t.Cleanup(func() {
+		cleanup, err := pgxpool.New(context.Background(), dsn)
+		if err != nil {
+			return
+		}
+		defer cleanup.Close()
+		_, _ = cleanup.Exec(context.Background(), `DELETE FROM public.tenants WHERE id = $1`, id)
+	})
+}
+
+func TestPgxRepository_RLS_PutThenGetRoundTripsUnderTenantContext(t *testing.T) {
+	pool := newRLSTestPool(t)
+	tenantID := uuid.New()
+	seedTenant(t, tenantID)
+
+	repo := egress.NewPgxRepository(pool)
+	ctx := context.Background()
+
+	if _, err := repo.UpsertTenantDefault(ctx, tenantID, []string{"pypi.org", "github.com"}); err != nil {
+		t.Fatalf("UpsertTenantDefault: %v", err)
+	}
+
+	got, err := repo.GetTenantDefault(ctx, tenantID)
+	if err != nil {
+		t.Fatalf("GetTenantDefault: %v", err)
+	}
+	if len(got.AllowedHosts) != 2 {
+		t.Fatalf("expected 2 hosts round-tripped, got %v", got.AllowedHosts)
+	}
+}
+
+// TestPgxRepository_RLS_CrossTenantContextCannotReadRows proves the database
+// policy itself blocks cross-tenant reads, independent of the application's
+// own WHERE clause. It sets the session to tenant B's context directly (not
+// via the Repository, which always keeps the session var and the WHERE
+// clause in lockstep) and queries for tenant A's row by id — the row exists,
+// but RLS must still hide it.
+func TestPgxRepository_RLS_CrossTenantContextCannotReadRows(t *testing.T) {
+	pool := newRLSTestPool(t)
+	tenantA, tenantB := uuid.New(), uuid.New()
+	seedTenant(t, tenantA)
+	seedTenant(t, tenantB)
+
+	repo := egress.NewPgxRepository(pool)
+	ctx := context.Background()
+	if _, err := repo.UpsertTenantDefault(ctx, tenantA, []string{"tenant-a-only.example"}); err != nil {
+		t.Fatalf("seed tenant A row: %v", err)
+	}
+
+	if _, err := pool.Exec(ctx, "SELECT set_config('app.current_tenant_id', $1, false)", tenantB.String()); err != nil {
+		t.Fatalf("set_config tenant B: %v", err)
+	}
+	var count int
+	err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM public.egress_policies WHERE tenant_id = $1 AND user_id IS NULL`,
+		tenantA).Scan(&count)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("RLS did not block cross-tenant read: got %d row(s) for tenant A while session claimed tenant B", count)
+	}
+}

--- a/apps/control-plane/internal/egress/repository_test.go
+++ b/apps/control-plane/internal/egress/repository_test.go
@@ -132,3 +132,45 @@ func TestPgxRepository_RLS_CrossTenantContextCannotReadRows(t *testing.T) {
 		t.Fatalf("RLS did not block cross-tenant read: got %d row(s) for tenant A while session claimed tenant B", count)
 	}
 }
+
+// TestPgxRepository_RLS_NoSessionLeakAcrossBorrows proves the tenant context
+// set by one repository call does not survive onto the pooled connection for
+// whoever borrows it next. The pool is pinned to MaxConns=1, so this test's
+// second query physically reuses the exact same connection
+// UpsertTenantDefault just ran on and committed — with no set_config call of
+// its own (a "bare borrow", simulating a future request that reuses the
+// connection before its own tenant-scoping code runs). Two prior repository
+// implementations failed this: LOCAL-with-no-transaction (which failed a
+// different way, RLS saw NULL) and session-scoped set_config (is_local=false)
+// (which would have current_setting still returning tenant A's id here,
+// since nothing ever cleared it — the leak this test exists to catch).
+func TestPgxRepository_RLS_NoSessionLeakAcrossBorrows(t *testing.T) {
+	pool := newRLSTestPool(t)
+	tenantA := uuid.New()
+	seedTenant(t, tenantA)
+
+	repo := egress.NewPgxRepository(pool)
+	ctx := context.Background()
+	if _, err := repo.UpsertTenantDefault(ctx, tenantA, []string{"tenant-a-only.example"}); err != nil {
+		t.Fatalf("seed tenant A row: %v", err)
+	}
+
+	// Bare borrow: no set_config call at all on this connection.
+	var setting string
+	if err := pool.QueryRow(ctx, "SELECT current_setting('app.current_tenant_id', true)").Scan(&setting); err != nil {
+		t.Fatalf("read current_setting: %v", err)
+	}
+	if setting != "" {
+		t.Fatalf("session leak: app.current_tenant_id still %q after UpsertTenantDefault committed, want empty", setting)
+	}
+
+	var count int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM public.egress_policies WHERE tenant_id = $1 AND user_id IS NULL`,
+		tenantA).Scan(&count); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("session leak: bare borrow saw %d row(s) for tenant A with no tenant context set (RLS should fail-closed on NULL)", count)
+	}
+}

--- a/apps/control-plane/internal/egress/service.go
+++ b/apps/control-plane/internal/egress/service.go
@@ -1,0 +1,151 @@
+package egress
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// OwnerChecker is the narrow port the service uses to verify the caller owns
+// the workspace being configured. *platform.RoleService satisfies this
+// interface structurally — accepting the interface here (rather than the
+// concrete type) avoids a package dependency and keeps unit tests DB-free
+// (mirrors internal/grants/service.go's AdminChecker).
+type OwnerChecker interface {
+	IsWorkspaceOwner(ctx context.Context, userID, workspaceID uuid.UUID) (bool, error)
+}
+
+// Service holds the egress-policy business logic: host-list validation, the
+// tenant-default/user-override merge, and the workspace-owner write gate.
+type Service struct {
+	repo  Repository
+	owner OwnerChecker
+}
+
+// NewService constructs the egress policy service.
+func NewService(repo Repository, owner OwnerChecker) *Service {
+	return &Service{repo: repo, owner: owner}
+}
+
+// Effective resolves the policy that actually applies to tenantID+userID: a
+// per-user override replaces the tenant default outright (no merge — the
+// admin who sets a user override is making an explicit, complete decision
+// for that user, not layering on top of the tenant baseline). Falling back to
+// the tenant default, and further to an empty allowlist (implicit deny-all)
+// when neither row exists, keeps the resolution total: this is the single
+// call both the OpenHands allowed_hosts config and the desktop firewall rule
+// generator make (issue #308).
+func (s *Service) Effective(ctx context.Context, tenantID, userID uuid.UUID) (Policy, error) {
+	if userID != uuid.Nil {
+		override, err := s.repo.GetUserOverride(ctx, tenantID, userID)
+		if err == nil {
+			return override, nil
+		}
+		if !errors.Is(err, ErrNotFound) {
+			return Policy{}, err
+		}
+	}
+
+	def, err := s.repo.GetTenantDefault(ctx, tenantID)
+	if err == nil {
+		return def, nil
+	}
+	if !errors.Is(err, ErrNotFound) {
+		return Policy{}, err
+	}
+
+	// Neither a user override nor a tenant default exists: fail closed.
+	return Policy{TenantID: tenantID, UserID: userID}, nil
+}
+
+// GetTenantDefault returns the tenant-wide default row. Owner-gated.
+func (s *Service) GetTenantDefault(ctx context.Context, callerID, tenantID uuid.UUID) (Policy, error) {
+	if err := s.requireOwner(ctx, callerID, tenantID); err != nil {
+		return Policy{}, err
+	}
+	return s.repo.GetTenantDefault(ctx, tenantID)
+}
+
+// GetUserOverride returns a single user's override row (not merged with the
+// tenant default — callers that want the resolved policy call Effective).
+// Owner-gated.
+func (s *Service) GetUserOverride(ctx context.Context, callerID, tenantID, targetUserID uuid.UUID) (Policy, error) {
+	if err := s.requireOwner(ctx, callerID, tenantID); err != nil {
+		return Policy{}, err
+	}
+	return s.repo.GetUserOverride(ctx, tenantID, targetUserID)
+}
+
+// SetTenantDefault validates hosts and upserts the tenant-wide default.
+// Owner-gated.
+func (s *Service) SetTenantDefault(ctx context.Context, callerID, tenantID uuid.UUID, hosts []string) (Policy, error) {
+	if err := s.requireOwner(ctx, callerID, tenantID); err != nil {
+		return Policy{}, err
+	}
+	clean, err := normalizeHosts(hosts)
+	if err != nil {
+		return Policy{}, err
+	}
+	return s.repo.UpsertTenantDefault(ctx, tenantID, clean)
+}
+
+// SetUserOverride validates hosts and upserts a per-user override. Owner-gated.
+func (s *Service) SetUserOverride(ctx context.Context, callerID, tenantID, targetUserID uuid.UUID, hosts []string) (Policy, error) {
+	if targetUserID == uuid.Nil {
+		return Policy{}, errors.New("egress: target user_id required")
+	}
+	if err := s.requireOwner(ctx, callerID, tenantID); err != nil {
+		return Policy{}, err
+	}
+	clean, err := normalizeHosts(hosts)
+	if err != nil {
+		return Policy{}, err
+	}
+	return s.repo.UpsertUserOverride(ctx, tenantID, targetUserID, clean)
+}
+
+// DeleteUserOverride removes a per-user override, reverting that user to the
+// tenant default on their next Effective lookup. Owner-gated.
+func (s *Service) DeleteUserOverride(ctx context.Context, callerID, tenantID, targetUserID uuid.UUID) error {
+	if err := s.requireOwner(ctx, callerID, tenantID); err != nil {
+		return err
+	}
+	return s.repo.DeleteUserOverride(ctx, tenantID, targetUserID)
+}
+
+func (s *Service) requireOwner(ctx context.Context, callerID, tenantID uuid.UUID) error {
+	isOwner, err := s.owner.IsWorkspaceOwner(ctx, callerID, tenantID)
+	if err != nil {
+		return err
+	}
+	if !isOwner {
+		return ErrForbidden
+	}
+	return nil
+}
+
+// normalizeHosts trims, drops empties, and dedupes hostnames while rejecting
+// any entry that still contains whitespace after trimming (a host/glob
+// pattern has no legitimate use for embedded whitespace; catching it here is
+// cheaper than debugging a firewall rule generator choking on it later).
+func normalizeHosts(hosts []string) ([]string, error) {
+	seen := make(map[string]struct{}, len(hosts))
+	out := make([]string, 0, len(hosts))
+	for _, h := range hosts {
+		h = strings.TrimSpace(h)
+		if h == "" {
+			continue
+		}
+		if strings.ContainsAny(h, " \t\n\r") {
+			return nil, ErrInvalidHosts
+		}
+		if _, dup := seen[h]; dup {
+			continue
+		}
+		seen[h] = struct{}{}
+		out = append(out, h)
+	}
+	return out, nil
+}

--- a/apps/control-plane/internal/egress/service.go
+++ b/apps/control-plane/internal/egress/service.go
@@ -3,10 +3,17 @@ package egress
 import (
 	"context"
 	"errors"
+	"regexp"
 	"strings"
 
 	"github.com/google/uuid"
 )
+
+// hostCharPattern restricts an allowlist entry to hostname/IPv4/IPv6
+// characters only. Combined with the wildcard/CIDR rejection below, this
+// keeps every stored entry a concrete, single address — an egress ALLOWLIST
+// with a glob or a "0.0.0.0/0"-shaped CIDR is an allow-all in disguise.
+var hostCharPattern = regexp.MustCompile(`^[a-zA-Z0-9.:-]+$`)
 
 // OwnerChecker is the narrow port the service uses to verify the caller owns
 // the workspace being configured. *platform.RoleService satisfies this
@@ -126,10 +133,13 @@ func (s *Service) requireOwner(ctx context.Context, callerID, tenantID uuid.UUID
 	return nil
 }
 
-// normalizeHosts trims, drops empties, and dedupes hostnames while rejecting
-// any entry that still contains whitespace after trimming (a host/glob
-// pattern has no legitimate use for embedded whitespace; catching it here is
-// cheaper than debugging a firewall rule generator choking on it later).
+// normalizeHosts trims, drops empties, dedupes, and validates hostnames.
+// Rejects: embedded whitespace, any wildcard ("*", "*.example.com", ...),
+// any CIDR notation ("0.0.0.0/0", "::/0", or any other "/"-bearing entry —
+// this package does not support CIDR ranges), and any character outside the
+// hostname/IPv4/IPv6 charset. This is an egress ALLOWLIST: a wildcard or a
+// broad CIDR is an allow-all in disguise and defeats the control entirely,
+// so every entry must resolve to one concrete host or IP, never a pattern.
 func normalizeHosts(hosts []string) ([]string, error) {
 	seen := make(map[string]struct{}, len(hosts))
 	out := make([]string, 0, len(hosts))
@@ -139,6 +149,12 @@ func normalizeHosts(hosts []string) ([]string, error) {
 			continue
 		}
 		if strings.ContainsAny(h, " \t\n\r") {
+			return nil, ErrInvalidHosts
+		}
+		if strings.Contains(h, "*") || strings.Contains(h, "/") {
+			return nil, ErrInvalidHosts
+		}
+		if !hostCharPattern.MatchString(h) {
 			return nil, ErrInvalidHosts
 		}
 		if _, dup := seen[h]; dup {

--- a/apps/control-plane/internal/egress/service_test.go
+++ b/apps/control-plane/internal/egress/service_test.go
@@ -1,0 +1,267 @@
+package egress_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/egress"
+)
+
+// fakeRepo implements egress.Repository in memory for unit tests.
+type fakeRepo struct {
+	defaults  map[uuid.UUID]egress.Policy
+	overrides map[[2]uuid.UUID]egress.Policy
+}
+
+func newFakeRepo() *fakeRepo {
+	return &fakeRepo{
+		defaults:  make(map[uuid.UUID]egress.Policy),
+		overrides: make(map[[2]uuid.UUID]egress.Policy),
+	}
+}
+
+func (f *fakeRepo) GetTenantDefault(_ context.Context, tenantID uuid.UUID) (egress.Policy, error) {
+	p, ok := f.defaults[tenantID]
+	if !ok {
+		return egress.Policy{}, egress.ErrNotFound
+	}
+	return p, nil
+}
+
+func (f *fakeRepo) GetUserOverride(_ context.Context, tenantID, userID uuid.UUID) (egress.Policy, error) {
+	p, ok := f.overrides[[2]uuid.UUID{tenantID, userID}]
+	if !ok {
+		return egress.Policy{}, egress.ErrNotFound
+	}
+	return p, nil
+}
+
+func (f *fakeRepo) UpsertTenantDefault(_ context.Context, tenantID uuid.UUID, hosts []string) (egress.Policy, error) {
+	p := egress.Policy{TenantID: tenantID, AllowedHosts: hosts, UpdatedAt: time.Now()}
+	f.defaults[tenantID] = p
+	return p, nil
+}
+
+func (f *fakeRepo) UpsertUserOverride(_ context.Context, tenantID, userID uuid.UUID, hosts []string) (egress.Policy, error) {
+	p := egress.Policy{TenantID: tenantID, UserID: userID, AllowedHosts: hosts, UpdatedAt: time.Now()}
+	f.overrides[[2]uuid.UUID{tenantID, userID}] = p
+	return p, nil
+}
+
+func (f *fakeRepo) DeleteUserOverride(_ context.Context, tenantID, userID uuid.UUID) error {
+	delete(f.overrides, [2]uuid.UUID{tenantID, userID})
+	return nil
+}
+
+// fakeOwner reports a fixed owner decision, optionally erroring.
+type fakeOwner struct {
+	isOwner bool
+	err     error
+}
+
+func (f *fakeOwner) IsWorkspaceOwner(_ context.Context, _, _ uuid.UUID) (bool, error) {
+	return f.isOwner, f.err
+}
+
+func TestService_Effective_UserOverridePresent_ReturnsOverrideNotMerged(t *testing.T) {
+	repo := newFakeRepo()
+	tenantID, userID := uuid.New(), uuid.New()
+	repo.defaults[tenantID] = egress.Policy{TenantID: tenantID, AllowedHosts: []string{"tenant-default.example"}}
+	repo.overrides[[2]uuid.UUID{tenantID, userID}] = egress.Policy{TenantID: tenantID, UserID: userID, AllowedHosts: []string{"user-only.example"}}
+
+	svc := egress.NewService(repo, &fakeOwner{isOwner: true})
+	p, err := svc.Effective(context.Background(), tenantID, userID)
+	if err != nil {
+		t.Fatalf("Effective: %v", err)
+	}
+	if len(p.AllowedHosts) != 1 || p.AllowedHosts[0] != "user-only.example" {
+		t.Fatalf("expected override to fully replace tenant default, got %v", p.AllowedHosts)
+	}
+}
+
+func TestService_Effective_NoOverride_FallsBackToTenantDefault(t *testing.T) {
+	repo := newFakeRepo()
+	tenantID, userID := uuid.New(), uuid.New()
+	repo.defaults[tenantID] = egress.Policy{TenantID: tenantID, AllowedHosts: []string{"tenant-default.example"}}
+
+	svc := egress.NewService(repo, &fakeOwner{isOwner: true})
+	p, err := svc.Effective(context.Background(), tenantID, userID)
+	if err != nil {
+		t.Fatalf("Effective: %v", err)
+	}
+	if len(p.AllowedHosts) != 1 || p.AllowedHosts[0] != "tenant-default.example" {
+		t.Fatalf("expected tenant default fallback, got %v", p.AllowedHosts)
+	}
+}
+
+func TestService_Effective_NothingSet_FailsClosedToEmptyList(t *testing.T) {
+	repo := newFakeRepo()
+	tenantID, userID := uuid.New(), uuid.New()
+
+	svc := egress.NewService(repo, &fakeOwner{isOwner: true})
+	p, err := svc.Effective(context.Background(), tenantID, userID)
+	if err != nil {
+		t.Fatalf("Effective: %v", err)
+	}
+	if len(p.AllowedHosts) != 0 {
+		t.Fatalf("expected empty deny-all allowlist, got %v", p.AllowedHosts)
+	}
+}
+
+func TestService_Effective_NilUserID_UsesTenantDefaultOnly(t *testing.T) {
+	repo := newFakeRepo()
+	tenantID := uuid.New()
+	repo.defaults[tenantID] = egress.Policy{TenantID: tenantID, AllowedHosts: []string{"tenant-default.example"}}
+
+	svc := egress.NewService(repo, &fakeOwner{isOwner: true})
+	p, err := svc.Effective(context.Background(), tenantID, uuid.Nil)
+	if err != nil {
+		t.Fatalf("Effective: %v", err)
+	}
+	if len(p.AllowedHosts) != 1 || p.AllowedHosts[0] != "tenant-default.example" {
+		t.Fatalf("expected tenant default for nil user_id, got %v", p.AllowedHosts)
+	}
+}
+
+func TestService_SetTenantDefault_OwnerAllowed(t *testing.T) {
+	repo := newFakeRepo()
+	tenantID, callerID := uuid.New(), uuid.New()
+	svc := egress.NewService(repo, &fakeOwner{isOwner: true})
+
+	p, err := svc.SetTenantDefault(context.Background(), callerID, tenantID, []string{"pypi.org", "github.com"})
+	if err != nil {
+		t.Fatalf("SetTenantDefault: %v", err)
+	}
+	if len(p.AllowedHosts) != 2 {
+		t.Fatalf("expected 2 hosts, got %v", p.AllowedHosts)
+	}
+}
+
+func TestService_SetTenantDefault_NonOwnerForbidden(t *testing.T) {
+	repo := newFakeRepo()
+	tenantID, callerID := uuid.New(), uuid.New()
+	svc := egress.NewService(repo, &fakeOwner{isOwner: false})
+
+	_, err := svc.SetTenantDefault(context.Background(), callerID, tenantID, []string{"pypi.org"})
+	if !errors.Is(err, egress.ErrForbidden) {
+		t.Fatalf("expected ErrForbidden, got %v", err)
+	}
+}
+
+func TestService_SetTenantDefault_OwnerCheckError_Propagates(t *testing.T) {
+	repo := newFakeRepo()
+	tenantID, callerID := uuid.New(), uuid.New()
+	boom := errors.New("db unreachable")
+	svc := egress.NewService(repo, &fakeOwner{err: boom})
+
+	_, err := svc.SetTenantDefault(context.Background(), callerID, tenantID, []string{"pypi.org"})
+	if !errors.Is(err, boom) {
+		t.Fatalf("expected owner-check error to propagate, got %v", err)
+	}
+}
+
+func TestService_SetTenantDefault_RejectsWhitespaceHost(t *testing.T) {
+	repo := newFakeRepo()
+	tenantID, callerID := uuid.New(), uuid.New()
+	svc := egress.NewService(repo, &fakeOwner{isOwner: true})
+
+	_, err := svc.SetTenantDefault(context.Background(), callerID, tenantID, []string{"bad host.example"})
+	if !errors.Is(err, egress.ErrInvalidHosts) {
+		t.Fatalf("expected ErrInvalidHosts, got %v", err)
+	}
+}
+
+func TestService_SetTenantDefault_DropsEmptyAndDupesHosts(t *testing.T) {
+	repo := newFakeRepo()
+	tenantID, callerID := uuid.New(), uuid.New()
+	svc := egress.NewService(repo, &fakeOwner{isOwner: true})
+
+	p, err := svc.SetTenantDefault(context.Background(), callerID, tenantID, []string{"  ", "github.com", "github.com", ""})
+	if err != nil {
+		t.Fatalf("SetTenantDefault: %v", err)
+	}
+	if len(p.AllowedHosts) != 1 || p.AllowedHosts[0] != "github.com" {
+		t.Fatalf("expected deduped single host, got %v", p.AllowedHosts)
+	}
+}
+
+func TestService_SetUserOverride_OwnerAllowed(t *testing.T) {
+	repo := newFakeRepo()
+	tenantID, callerID, targetUserID := uuid.New(), uuid.New(), uuid.New()
+	svc := egress.NewService(repo, &fakeOwner{isOwner: true})
+
+	p, err := svc.SetUserOverride(context.Background(), callerID, tenantID, targetUserID, []string{"docs.python.org"})
+	if err != nil {
+		t.Fatalf("SetUserOverride: %v", err)
+	}
+	if p.UserID != targetUserID {
+		t.Fatalf("expected override scoped to target user, got %v", p.UserID)
+	}
+}
+
+func TestService_SetUserOverride_NonOwnerForbidden(t *testing.T) {
+	repo := newFakeRepo()
+	tenantID, callerID, targetUserID := uuid.New(), uuid.New(), uuid.New()
+	svc := egress.NewService(repo, &fakeOwner{isOwner: false})
+
+	_, err := svc.SetUserOverride(context.Background(), callerID, tenantID, targetUserID, []string{"docs.python.org"})
+	if !errors.Is(err, egress.ErrForbidden) {
+		t.Fatalf("expected ErrForbidden, got %v", err)
+	}
+}
+
+func TestService_SetUserOverride_NilTargetUserID_Rejected(t *testing.T) {
+	repo := newFakeRepo()
+	tenantID, callerID := uuid.New(), uuid.New()
+	svc := egress.NewService(repo, &fakeOwner{isOwner: true})
+
+	_, err := svc.SetUserOverride(context.Background(), callerID, tenantID, uuid.Nil, []string{"docs.python.org"})
+	if err == nil {
+		t.Fatal("expected error for nil target user_id")
+	}
+}
+
+func TestService_DeleteUserOverride_OwnerAllowed_RevertsToTenantDefault(t *testing.T) {
+	repo := newFakeRepo()
+	tenantID, callerID, targetUserID := uuid.New(), uuid.New(), uuid.New()
+	repo.defaults[tenantID] = egress.Policy{TenantID: tenantID, AllowedHosts: []string{"tenant-default.example"}}
+	repo.overrides[[2]uuid.UUID{tenantID, targetUserID}] = egress.Policy{TenantID: tenantID, UserID: targetUserID, AllowedHosts: []string{"user-only.example"}}
+
+	svc := egress.NewService(repo, &fakeOwner{isOwner: true})
+	if err := svc.DeleteUserOverride(context.Background(), callerID, tenantID, targetUserID); err != nil {
+		t.Fatalf("DeleteUserOverride: %v", err)
+	}
+
+	p, err := svc.Effective(context.Background(), tenantID, targetUserID)
+	if err != nil {
+		t.Fatalf("Effective after delete: %v", err)
+	}
+	if len(p.AllowedHosts) != 1 || p.AllowedHosts[0] != "tenant-default.example" {
+		t.Fatalf("expected fallback to tenant default after override delete, got %v", p.AllowedHosts)
+	}
+}
+
+func TestService_DeleteUserOverride_NonOwnerForbidden(t *testing.T) {
+	repo := newFakeRepo()
+	tenantID, callerID, targetUserID := uuid.New(), uuid.New(), uuid.New()
+	svc := egress.NewService(repo, &fakeOwner{isOwner: false})
+
+	err := svc.DeleteUserOverride(context.Background(), callerID, tenantID, targetUserID)
+	if !errors.Is(err, egress.ErrForbidden) {
+		t.Fatalf("expected ErrForbidden, got %v", err)
+	}
+}
+
+func TestService_GetTenantDefault_NotFound(t *testing.T) {
+	repo := newFakeRepo()
+	tenantID, callerID := uuid.New(), uuid.New()
+	svc := egress.NewService(repo, &fakeOwner{isOwner: true})
+
+	_, err := svc.GetTenantDefault(context.Background(), callerID, tenantID)
+	if !errors.Is(err, egress.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}

--- a/apps/control-plane/internal/egress/service_test.go
+++ b/apps/control-plane/internal/egress/service_test.go
@@ -174,6 +174,37 @@ func TestService_SetTenantDefault_RejectsWhitespaceHost(t *testing.T) {
 	}
 }
 
+func TestService_SetTenantDefault_RejectsWildcardAndCIDR(t *testing.T) {
+	tenantID, callerID := uuid.New(), uuid.New()
+	svc := egress.NewService(newFakeRepo(), &fakeOwner{isOwner: true})
+
+	for _, bad := range []string{
+		"*",
+		"*.example.com",
+		"github.*",
+		"0.0.0.0/0",
+		"::/0",
+		"10.0.0.0/8",
+	} {
+		if _, err := svc.SetTenantDefault(context.Background(), callerID, tenantID, []string{bad}); !errors.Is(err, egress.ErrInvalidHosts) {
+			t.Errorf("host %q: expected ErrInvalidHosts, got %v", bad, err)
+		}
+	}
+}
+
+func TestService_SetTenantDefault_AcceptsConcreteHostnamesAndIPs(t *testing.T) {
+	tenantID, callerID := uuid.New(), uuid.New()
+	svc := egress.NewService(newFakeRepo(), &fakeOwner{isOwner: true})
+
+	p, err := svc.SetTenantDefault(context.Background(), callerID, tenantID, []string{"pypi.org", "192.0.2.1", "2001:db8::1"})
+	if err != nil {
+		t.Fatalf("expected concrete hosts/IPs to be accepted, got %v", err)
+	}
+	if len(p.AllowedHosts) != 3 {
+		t.Fatalf("expected 3 hosts, got %v", p.AllowedHosts)
+	}
+}
+
 func TestService_SetTenantDefault_DropsEmptyAndDupesHosts(t *testing.T) {
 	repo := newFakeRepo()
 	tenantID, callerID := uuid.New(), uuid.New()

--- a/apps/control-plane/internal/egress/types.go
+++ b/apps/control-plane/internal/egress/types.go
@@ -1,0 +1,43 @@
+// Package egress owns the single source of truth for agent-sandbox network
+// egress allowlists (issue #308). One control-plane-owned policy store, admin
+// configurable per tenant AND per user, exposed over HTTP for two future
+// consumers that must never drift apart the way the HIVE_SOVEREIGN guard did
+// (see #245):
+//
+//   - Server-side OpenHands workspace config (`allowed_hosts`), wave 2.
+//   - Desktop firewall rule generator, wave 4.
+//
+// This package builds the store, the admin CRUD surface, and the read
+// endpoint only. Neither consumer is wired here.
+package egress
+
+import (
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Policy is one row of egress allowlist configuration. UserID is uuid.Nil for
+// the tenant-wide default row; a non-nil UserID is a per-user override.
+type Policy struct {
+	TenantID     uuid.UUID
+	UserID       uuid.UUID
+	AllowedHosts []string
+	UpdatedAt    time.Time
+}
+
+// IsTenantDefault reports whether p is the tenant-wide default row.
+func (p Policy) IsTenantDefault() bool { return p.UserID == uuid.Nil }
+
+var (
+	// ErrNotFound is returned when no policy row exists for the requested scope.
+	ErrNotFound = errors.New("egress: policy not found")
+
+	// ErrForbidden is returned when the caller is not the workspace owner.
+	ErrForbidden = errors.New("egress: caller is not the workspace owner")
+
+	// ErrInvalidHosts is returned when the submitted allowed-hosts list fails
+	// validation (empty entries or entries containing whitespace).
+	ErrInvalidHosts = errors.New("egress: allowed_hosts entries must be non-empty and contain no whitespace")
+)

--- a/apps/control-plane/internal/platform/http/router.go
+++ b/apps/control-plane/internal/platform/http/router.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/auth"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/budgets"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/catalog"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/egress"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/identity"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/ledger"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/payments"
@@ -29,17 +30,17 @@ type healthResponse struct {
 
 // RouterConfig holds dependencies for building the HTTP router.
 type RouterConfig struct {
-	AuthMiddleware    *auth.Middleware
-	AccountsHandler   *accounts.Handler
-	AccountingHandler *accounting.Handler
-	APIKeysHandler    *apikeys.Handler
+	AuthMiddleware           *auth.Middleware
+	AccountsHandler          *accounts.Handler
+	AccountingHandler        *accounting.Handler
+	APIKeysHandler           *apikeys.Handler
 	CatalogHandler           *catalog.Handler
 	CatalogVisibilityHandler *catalog.VisibilityHandler
-	LedgerHandler     *ledger.Handler
-	PaymentsHandler   *payments.Handler
-	ProfilesHandler   *profiles.Handler
-	RoutingHandler    *routing.Handler
-	UsageHandler      *usage.Handler
+	LedgerHandler            *ledger.Handler
+	PaymentsHandler          *payments.Handler
+	ProfilesHandler          *profiles.Handler
+	RoutingHandler           *routing.Handler
+	UsageHandler             *usage.Handler
 
 	// IdentityHandler finalizes email verification for the authenticated caller
 	// (issue #112). Registered under /api/v1 behind the auth middleware.
@@ -88,6 +89,12 @@ type RouterConfig struct {
 	// FeatureGateHandler handles GET /internal/featuregate/{tenant_id}.
 	// Guarded by the shared-secret token. When nil the route is not registered.
 	FeatureGateHandler http.Handler
+
+	// EgressPolicyHandler serves the egress-policy single source of truth
+	// (issue #308): the owner-gated admin CRUD surface at
+	// /api/v1/egress-policy/ and the shared-secret-guarded read surface at
+	// /internal/egress-policy/. When nil neither route is registered.
+	EgressPolicyHandler *egress.Handler
 }
 
 // NewRouter returns a configured http.Handler with all platform routes registered.
@@ -252,6 +259,18 @@ func NewRouter(cfg RouterConfig) http.Handler {
 	// GET /internal/featuregate/{tenant_id} returns flags for edge-api gate middleware.
 	if cfg.FeatureGateHandler != nil {
 		mux.Handle("/internal/featuregate/", internal(cfg.FeatureGateHandler))
+	}
+
+	// Issue #308 — egress policy single source of truth. Admin CRUD is
+	// owner-gated (auth middleware; the handler itself checks
+	// IsWorkspaceOwner). The internal read surface is the single resolution
+	// both the OpenHands allowed_hosts config and the desktop firewall rule
+	// generator will consume (neither is wired yet).
+	if cfg.EgressPolicyHandler != nil {
+		mux.Handle("/internal/egress-policy/", internal(cfg.EgressPolicyHandler.InternalMux()))
+		if cfg.AuthMiddleware != nil {
+			mux.Handle("/api/v1/egress-policy/", cfg.AuthMiddleware.Require(cfg.EgressPolicyHandler.AdminMux()))
+		}
 	}
 
 	// Wrap the mux with Prometheus HTTP instrumentation if a metrics registry is provided.

--- a/supabase/migrations/20260715_03_egress_policy_ssot.sql
+++ b/supabase/migrations/20260715_03_egress_policy_ssot.sql
@@ -1,0 +1,62 @@
+-- supabase/migrations/20260715_03_egress_policy_ssot.sql
+--
+-- Egress policy single source of truth (#308). One control-plane-owned
+-- allowlist per tenant, with an optional per-user override — admin
+-- configurable per tenant AND per user (some users need internet access for
+-- web search, package downloads, and doc lookups; others don't). Read by two
+-- future consumers behind one API so the policy never drifts between
+-- surfaces the way HIVE_SOVEREIGN already has (#245): the server-side
+-- OpenHands allowed_hosts workspace config (wave 2) and the desktop firewall
+-- rule generator (wave 4). Neither consumer is wired by this migration.
+--
+-- Depends on: 20260516_01_phase19_tenants.sql (public.tenants)
+--
+-- Row shape:
+--   user_id IS NULL      -> the tenant-wide default row (at most one per tenant)
+--   user_id IS NOT NULL  -> a per-user override row (at most one per tenant+user)
+-- A present user override fully replaces the tenant default for that user
+-- (application-layer decision in apps/control-plane/internal/egress); this
+-- migration only enforces "at most one row per scope".
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.egress_policies (
+    id            UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id     UUID        NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+    user_id       UUID        NULL,
+    allowed_hosts TEXT[]      NOT NULL DEFAULT '{}',
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- At most one tenant-wide default row (user_id IS NULL) per tenant.
+CREATE UNIQUE INDEX IF NOT EXISTS egress_policies_tenant_default_uidx
+    ON public.egress_policies (tenant_id)
+    WHERE user_id IS NULL;
+
+-- At most one override row per (tenant, user).
+CREATE UNIQUE INDEX IF NOT EXISTS egress_policies_tenant_user_uidx
+    ON public.egress_policies (tenant_id, user_id)
+    WHERE user_id IS NOT NULL;
+
+-- Row Level Security: no cross-tenant reads or writes (mirrors 20260625_05_carl_rag.sql).
+ALTER TABLE public.egress_policies ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public' AND tablename = 'egress_policies'
+          AND policyname = 'egress_policies_tenant_isolation'
+    ) THEN
+        CREATE POLICY egress_policies_tenant_isolation
+            ON public.egress_policies AS PERMISSIVE FOR ALL TO hive_app
+            USING      (tenant_id = current_setting('app.current_tenant_id', true)::uuid)
+            WITH CHECK (tenant_id = current_setting('app.current_tenant_id', true)::uuid);
+    END IF;
+END$$;
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.egress_policies TO hive_app;
+GRANT SELECT ON public.egress_policies TO auditor_ro;
+
+COMMIT;

--- a/supabase/migrations/20260715_03_egress_policy_ssot.sql
+++ b/supabase/migrations/20260715_03_egress_policy_ssot.sql
@@ -49,10 +49,21 @@ BEGIN
         WHERE schemaname = 'public' AND tablename = 'egress_policies'
           AND policyname = 'egress_policies_tenant_isolation'
     ) THEN
+        -- NULLIF(..., '') guards a Postgres GUC placeholder quirk: once a
+        -- session has called set_config('app.current_tenant_id', ..., true)
+        -- at least once, current_setting(name, true) on that same
+        -- connection returns '' (not NULL) after the LOCAL scope ends,
+        -- rather than reverting to "never defined". Casting '' straight to
+        -- ::uuid raises invalid input syntax instead of cleanly filtering
+        -- rows, which turns a bare/unscoped query on a reused pooled
+        -- connection into a 500 instead of a fail-closed empty result.
+        -- NULLIF folds that '' case to NULL first so the comparison (and
+        -- therefore the whole USING/WITH CHECK expression) evaluates to
+        -- NULL, which Postgres treats as false — deny by default either way.
         CREATE POLICY egress_policies_tenant_isolation
             ON public.egress_policies AS PERMISSIVE FOR ALL TO hive_app
-            USING      (tenant_id = current_setting('app.current_tenant_id', true)::uuid)
-            WITH CHECK (tenant_id = current_setting('app.current_tenant_id', true)::uuid);
+            USING      (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::uuid)
+            WITH CHECK (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::uuid);
     END IF;
 END$$;
 

--- a/tools/lint-no-direct-tenant-id.mjs
+++ b/tools/lint-no-direct-tenant-id.mjs
@@ -12,6 +12,7 @@ const ALLOWLIST_DIRS = [
   'apps/control-plane/internal/tenant/settings/', // LISTEN/NOTIFY payload, not HTTP request
   'apps/edge-api/internal/auth/',                 // ctx writers
   'apps/control-plane/internal/auditarchive/',    // system cron job; iterates ALL tenants cross-tenant — no request auth context, tenant_id is internal archive struct field not wire input
+  'apps/control-plane/internal/egress/',          // tenant_id in these structs is RESPONSE wire shape (egress-policy read/CRUD JSON output); the handler always resolves tenant_id by parsing the URL path segment via uuid.Parse, never FormValue/Query/Header/request-body — no violation of the auth.TenantID(ctx) input rule this lint enforces
   'supabase/migrations/',
   'tools/lint-no-direct-tenant-id.mjs',
 ];


### PR DESCRIPTION
## Summary

- Adds `apps/control-plane/internal/egress`: a control-plane-owned egress-allowlist store, admin-configurable per tenant AND per user (per-user override fully replaces the tenant default, not merged).
- Owner-gated admin CRUD surface (`/api/v1/egress-policy/...`) and an internal service-to-service read surface (`/internal/egress-policy/...`) that resolves the effective policy for a tenant+user pair.
- New migration `supabase/migrations/20260715_03_egress_policy_ssot.sql`: `public.egress_policies` table with partial unique indexes (one tenant-default row, one row per user override) and tenant-isolation RLS mirroring the RAG schema migration.
- Wired into `router.go` / `main.go` following the existing `featuregate` handler pattern (`RequireInternalToken` for the internal read, `auth.Middleware.Require` for the admin surface).

Scope is deliberately limited to Step 1.3 of the agent-subsystem blueprint (issue #308): the policy store, CRUD, and read endpoint only. Neither consumer (server-side OpenHands `allowed_hosts` workspace config, wave 2; desktop firewall rule generator, wave 4) is wired in this PR.

## API surface added

- `GET/PUT /api/v1/egress-policy/{tenant_id}` — tenant-wide default allowlist (owner-gated)
- `GET/PUT/DELETE /api/v1/egress-policy/{tenant_id}/users/{user_id}` — per-user override (owner-gated)
- `GET /internal/egress-policy/{tenant_id}[/{user_id}]` — effective resolved policy (shared-secret token), the single shape both future consumers will read

## Test plan

- [x] `go test ./apps/control-plane/internal/egress/... -count=1 -short -v` — 26 tests pass (service + handler layers)
- [x] RED verified manually: broke the override-priority branch in `Service.Effective`, confirmed the corresponding test failed, then reverted
- [x] `go test ./apps/control-plane/... -count=1 -short` — full control-plane suite green, no regressions
- [x] `go build ./apps/control-plane/...` and `go vet ./apps/control-plane/...` clean
- [ ] Migration applied against a live Supabase instance (not run in this PR; apply via `supabase db push` or SQL editor before the server/desktop consumers land)

Coverage: 70.8% for the new package (service.go/http.go 80-100%, pgx repository at 0% by repo convention — mirrors `grants` (38%) and `budgets` (18.6%), which also leave the pgx layer to migration-level integration checks rather than unit tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)