### PR TITLE
fix: RAG repository RLS tenant-context bug (#320)

### DIFF
--- a/apps/control-plane/internal/rag/repository.go
+++ b/apps/control-plane/internal/rag/repository.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -54,26 +55,49 @@ type Repo struct {
 // NewRepo creates a Repo backed by the given pool.
 func NewRepo(pool *pgxpool.Pool) *Repo { return &Repo{pool: pool} }
 
+// withTenantTx runs fn inside an explicit transaction with the RLS session
+// variable set LOCAL (transaction-scoped) to tenantID. hive_app is NOT
+// BYPASSRLS (20260518_04_phase19_audit_rls_and_indexes.sql), so every query
+// against public.rag_documents / public.rag_chunks must see
+// app.current_tenant_id set to the caller's tenant.
+//
+// A bare conn.Exec(set_config(..., true)) followed by a separate
+// conn.QueryRow/Exec with no transaction does not work: LOCAL resets the
+// instant the Exec's own implicit (autocommit) transaction ends, so the
+// following query sees current_setting() back at NULL and the RLS policy
+// denies everything (reads return zero rows, writes fail WITH CHECK).
+// Wrapping in Begin/Commit makes LOCAL correct: it applies for exactly this
+// transaction's statements and is guaranteed to clear at Commit or Rollback,
+// so nothing survives onto the pooled connection for the next borrower.
+// Mirrors apps/control-plane/internal/egress/repository.go.
+func (r *Repo) withTenantTx(ctx context.Context, tenantID uuid.UUID, fn func(tx pgx.Tx) error) error {
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("rag.repo: begin tx: %w", err)
+	}
+	defer tx.Rollback(ctx) // no-op once Commit has succeeded
+
+	if _, err := tx.Exec(ctx, "SELECT set_config('app.current_tenant_id', $1, true)", tenantID.String()); err != nil {
+		return fmt.Errorf("rag.repo: set tenant: %w", err)
+	}
+	if err := fn(tx); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}
+
 // InsertDocument creates a new rag_document row and returns the assigned id.
 func (r *Repo) InsertDocument(ctx context.Context, d Document) (uuid.UUID, error) {
-	conn, err := r.pool.Acquire(ctx)
-	if err != nil {
-		return uuid.Nil, fmt.Errorf("rag.repo: acquire: %w", err)
-	}
-	defer conn.Release()
-
-	if _, err := conn.Exec(ctx, "SELECT set_config('app.current_tenant_id', $1, true)", d.TenantID.String()); err != nil {
-		return uuid.Nil, fmt.Errorf("rag.repo: set tenant: %w", err)
-	}
-
 	var id uuid.UUID
-	err = conn.QueryRow(ctx, `
-		INSERT INTO public.rag_documents
-		    (tenant_id, name, mime_type, size_bytes, status, storage_path)
-		VALUES ($1, $2, $3, $4, $5, $6)
-		RETURNING id`,
-		d.TenantID, d.Name, d.MimeType, d.SizeBytes, StatusPending, d.StoragePath,
-	).Scan(&id)
+	err := r.withTenantTx(ctx, d.TenantID, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `
+			INSERT INTO public.rag_documents
+			    (tenant_id, name, mime_type, size_bytes, status, storage_path)
+			VALUES ($1, $2, $3, $4, $5, $6)
+			RETURNING id`,
+			d.TenantID, d.Name, d.MimeType, d.SizeBytes, StatusPending, d.StoragePath,
+		).Scan(&id)
+	})
 	if err != nil {
 		return uuid.Nil, fmt.Errorf("rag.repo: insert document: %w", err)
 	}
@@ -82,26 +106,18 @@ func (r *Repo) InsertDocument(ctx context.Context, d Document) (uuid.UUID, error
 
 // GetDocument fetches a single document by id, scoped to tenantID via RLS.
 func (r *Repo) GetDocument(ctx context.Context, tenantID, docID uuid.UUID) (Document, error) {
-	conn, err := r.pool.Acquire(ctx)
-	if err != nil {
-		return Document{}, fmt.Errorf("rag.repo: acquire: %w", err)
-	}
-	defer conn.Release()
-
-	if _, err := conn.Exec(ctx, "SELECT set_config('app.current_tenant_id', $1, true)", tenantID.String()); err != nil {
-		return Document{}, fmt.Errorf("rag.repo: set tenant: %w", err)
-	}
-
 	var d Document
-	err = conn.QueryRow(ctx, `
-		SELECT id, tenant_id, name, mime_type, size_bytes, status,
-		       COALESCE(error_msg,''), COALESCE(storage_path,''),
-		       created_at, updated_at
-		FROM public.rag_documents
-		WHERE id = $1`,
-		docID,
-	).Scan(&d.ID, &d.TenantID, &d.Name, &d.MimeType, &d.SizeBytes,
-		&d.Status, &d.ErrorMsg, &d.StoragePath, &d.CreatedAt, &d.UpdatedAt)
+	err := r.withTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `
+			SELECT id, tenant_id, name, mime_type, size_bytes, status,
+			       COALESCE(error_msg,''), COALESCE(storage_path,''),
+			       created_at, updated_at
+			FROM public.rag_documents
+			WHERE id = $1`,
+			docID,
+		).Scan(&d.ID, &d.TenantID, &d.Name, &d.MimeType, &d.SizeBytes,
+			&d.Status, &d.ErrorMsg, &d.StoragePath, &d.CreatedAt, &d.UpdatedAt)
+	})
 	if err != nil {
 		return Document{}, fmt.Errorf("rag.repo: get document: %w", err)
 	}
@@ -110,83 +126,63 @@ func (r *Repo) GetDocument(ctx context.Context, tenantID, docID uuid.UUID) (Docu
 
 // ListDocuments returns all documents for a tenant, newest first.
 func (r *Repo) ListDocuments(ctx context.Context, tenantID uuid.UUID) ([]Document, error) {
-	conn, err := r.pool.Acquire(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("rag.repo: acquire: %w", err)
-	}
-	defer conn.Release()
-
-	if _, err := conn.Exec(ctx, "SELECT set_config('app.current_tenant_id', $1, true)", tenantID.String()); err != nil {
-		return nil, fmt.Errorf("rag.repo: set tenant: %w", err)
-	}
-
-	rows, err := conn.Query(ctx, `
-		SELECT id, tenant_id, name, mime_type, size_bytes, status,
-		       COALESCE(error_msg,''), COALESCE(storage_path,''),
-		       created_at, updated_at
-		FROM public.rag_documents
-		ORDER BY created_at DESC`)
-	if err != nil {
-		return nil, fmt.Errorf("rag.repo: list documents: %w", err)
-	}
-	defer rows.Close()
-
 	var docs []Document
-	for rows.Next() {
-		var d Document
-		if err := rows.Scan(&d.ID, &d.TenantID, &d.Name, &d.MimeType, &d.SizeBytes,
-			&d.Status, &d.ErrorMsg, &d.StoragePath, &d.CreatedAt, &d.UpdatedAt); err != nil {
-			return nil, fmt.Errorf("rag.repo: scan document: %w", err)
+	err := r.withTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `
+			SELECT id, tenant_id, name, mime_type, size_bytes, status,
+			       COALESCE(error_msg,''), COALESCE(storage_path,''),
+			       created_at, updated_at
+			FROM public.rag_documents
+			ORDER BY created_at DESC`)
+		if err != nil {
+			return fmt.Errorf("rag.repo: list documents: %w", err)
 		}
-		docs = append(docs, d)
+		defer rows.Close()
+
+		for rows.Next() {
+			var d Document
+			if err := rows.Scan(&d.ID, &d.TenantID, &d.Name, &d.MimeType, &d.SizeBytes,
+				&d.Status, &d.ErrorMsg, &d.StoragePath, &d.CreatedAt, &d.UpdatedAt); err != nil {
+				return fmt.Errorf("rag.repo: scan document: %w", err)
+			}
+			docs = append(docs, d)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
 	}
-	return docs, rows.Err()
+	return docs, nil
 }
 
 // UpdateDocumentStatus updates the status (and optionally error_msg) of a document.
 func (r *Repo) UpdateDocumentStatus(ctx context.Context, tenantID, docID uuid.UUID, status, errMsg string) error {
-	conn, err := r.pool.Acquire(ctx)
-	if err != nil {
-		return fmt.Errorf("rag.repo: acquire: %w", err)
-	}
-	defer conn.Release()
-
-	if _, err := conn.Exec(ctx, "SELECT set_config('app.current_tenant_id', $1, true)", tenantID.String()); err != nil {
-		return fmt.Errorf("rag.repo: set tenant: %w", err)
-	}
-
-	_, err = conn.Exec(ctx, `
-		UPDATE public.rag_documents
-		SET status = $1, error_msg = NULLIF($2,''), updated_at = now()
-		WHERE id = $3`,
-		status, errMsg, docID,
-	)
-	if err != nil {
-		return fmt.Errorf("rag.repo: update document status: %w", err)
-	}
-	return nil
+	return r.withTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `
+			UPDATE public.rag_documents
+			SET status = $1, error_msg = NULLIF($2,''), updated_at = now()
+			WHERE id = $3`,
+			status, errMsg, docID,
+		)
+		if err != nil {
+			return fmt.Errorf("rag.repo: update document status: %w", err)
+		}
+		return nil
+	})
 }
 
 // DeleteDocument deletes a document and cascades to its chunks.
 func (r *Repo) DeleteDocument(ctx context.Context, tenantID, docID uuid.UUID) error {
-	conn, err := r.pool.Acquire(ctx)
-	if err != nil {
-		return fmt.Errorf("rag.repo: acquire: %w", err)
-	}
-	defer conn.Release()
-
-	if _, err := conn.Exec(ctx, "SELECT set_config('app.current_tenant_id', $1, true)", tenantID.String()); err != nil {
-		return fmt.Errorf("rag.repo: set tenant: %w", err)
-	}
-
-	_, err = conn.Exec(ctx,
-		`DELETE FROM public.rag_documents WHERE id = $1`,
-		docID,
-	)
-	if err != nil {
-		return fmt.Errorf("rag.repo: delete document: %w", err)
-	}
-	return nil
+	return r.withTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx,
+			`DELETE FROM public.rag_documents WHERE id = $1`,
+			docID,
+		)
+		if err != nil {
+			return fmt.Errorf("rag.repo: delete document: %w", err)
+		}
+		return nil
+	})
 }
 
 // InsertChunks bulk-inserts chunk rows. Embeddings are stored via pgvector
@@ -196,32 +192,24 @@ func (r *Repo) InsertChunks(ctx context.Context, tenantID, docID uuid.UUID, chun
 		return fmt.Errorf("rag.repo: chunks/embeddings length mismatch: %d vs %d", len(chunks), len(embeddings))
 	}
 
-	conn, err := r.pool.Acquire(ctx)
-	if err != nil {
-		return fmt.Errorf("rag.repo: acquire: %w", err)
-	}
-	defer conn.Release()
-
-	if _, err := conn.Exec(ctx, "SELECT set_config('app.current_tenant_id', $1, true)", tenantID.String()); err != nil {
-		return fmt.Errorf("rag.repo: set tenant: %w", err)
-	}
-
-	for i, ch := range chunks {
-		vec, err := encodeVector(embeddings[i])
-		if err != nil {
-			return fmt.Errorf("rag.repo: encode chunk %d vector: %w", i, err)
+	return r.withTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		for i, ch := range chunks {
+			vec, err := encodeVector(embeddings[i])
+			if err != nil {
+				return fmt.Errorf("rag.repo: encode chunk %d vector: %w", i, err)
+			}
+			_, err = tx.Exec(ctx, `
+				INSERT INTO public.rag_chunks
+				    (tenant_id, document_id, chunk_index, content, token_count, embedding)
+				VALUES ($1, $2, $3, $4, $5, $6::vector)`,
+				tenantID, docID, ch.Index, ch.Content, ch.TokenCount, vec,
+			)
+			if err != nil {
+				return fmt.Errorf("rag.repo: insert chunk %d: %w", i, err)
+			}
 		}
-		_, err = conn.Exec(ctx, `
-			INSERT INTO public.rag_chunks
-			    (tenant_id, document_id, chunk_index, content, token_count, embedding)
-			VALUES ($1, $2, $3, $4, $5, $6::vector)`,
-			tenantID, docID, ch.Index, ch.Content, ch.TokenCount, vec,
-		)
-		if err != nil {
-			return fmt.Errorf("rag.repo: insert chunk %d: %w", i, err)
-		}
-	}
-	return nil
+		return nil
+	})
 }
 
 // SearchChunks runs a cosine-distance vector search returning up to topK
@@ -235,46 +223,43 @@ func (r *Repo) SearchChunks(ctx context.Context, tenantID uuid.UUID, queryVec []
 		topK = 5
 	}
 
-	conn, err := r.pool.Acquire(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("rag.repo: acquire: %w", err)
-	}
-	defer conn.Release()
-
-	if _, err := conn.Exec(ctx, "SELECT set_config('app.current_tenant_id', $1, true)", tenantID.String()); err != nil {
-		return nil, fmt.Errorf("rag.repo: set tenant: %w", err)
-	}
-
 	vec, err := encodeVector(queryVec)
 	if err != nil {
 		return nil, fmt.Errorf("rag.repo: encode query vector: %w", err)
 	}
-	// Explicit tenant_id filter is defense-in-depth alongside RLS:
-	// protects against SECURITY DEFINER / superuser-bypass scenarios.
-	rows, err := conn.Query(ctx, `
-		SELECT id, tenant_id, document_id, chunk_index, content, token_count,
-		       (embedding <=> $1::vector)::float4 AS score
-		FROM public.rag_chunks
-		WHERE tenant_id = $3
-		ORDER BY embedding <=> $1::vector
-		LIMIT $2`,
-		vec, topK, tenantID,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("rag.repo: search: %w", err)
-	}
-	defer rows.Close()
 
 	var results []ChunkRow
-	for rows.Next() {
-		var c ChunkRow
-		if err := rows.Scan(&c.ID, &c.TenantID, &c.DocumentID,
-			&c.ChunkIndex, &c.Content, &c.TokenCount, &c.Score); err != nil {
-			return nil, fmt.Errorf("rag.repo: scan chunk: %w", err)
+	err = r.withTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		// Explicit tenant_id filter is defense-in-depth alongside RLS:
+		// protects against SECURITY DEFINER / superuser-bypass scenarios.
+		rows, err := tx.Query(ctx, `
+			SELECT id, tenant_id, document_id, chunk_index, content, token_count,
+			       (embedding <=> $1::vector)::float4 AS score
+			FROM public.rag_chunks
+			WHERE tenant_id = $3
+			ORDER BY embedding <=> $1::vector
+			LIMIT $2`,
+			vec, topK, tenantID,
+		)
+		if err != nil {
+			return fmt.Errorf("rag.repo: search: %w", err)
 		}
-		results = append(results, c)
+		defer rows.Close()
+
+		for rows.Next() {
+			var c ChunkRow
+			if err := rows.Scan(&c.ID, &c.TenantID, &c.DocumentID,
+				&c.ChunkIndex, &c.Content, &c.TokenCount, &c.Score); err != nil {
+				return fmt.Errorf("rag.repo: scan chunk: %w", err)
+			}
+			results = append(results, c)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
 	}
-	return results, rows.Err()
+	return results, nil
 }
 
 // encodeVector serialises []float32 to pgvector text format '[v1,v2,...]'.

--- a/apps/control-plane/internal/rag/repository_rls_test.go
+++ b/apps/control-plane/internal/rag/repository_rls_test.go
@@ -1,0 +1,189 @@
+package rag
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// newRLSTestPool connects as the hive_app role -- NOT BYPASSRLS in production
+// (see 20260518_04_phase19_audit_rls_and_indexes.sql) -- so the rag_documents
+// / rag_chunks tenant-isolation RLS policies are actually exercised rather
+// than bypassed by whatever superuser role HIVE_TEST_DB_URL otherwise
+// connects as. MaxConns is pinned to 1 so every Acquire inside a test returns
+// the same physical connection, and the pool is closed (not returned to a
+// shared pool) at test end so the role change never leaks to another test.
+// Mirrors apps/control-plane/internal/egress/repository_test.go.
+func newRLSTestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("HIVE_TEST_DB_URL")
+	if dsn == "" {
+		t.Skip("HIVE_TEST_DB_URL not set")
+	}
+	if !strings.Contains(strings.ToLower(dsn), "test") {
+		t.Fatalf("refusing to run: HIVE_TEST_DB_URL must point at a test database (DSN missing 'test' marker)")
+	}
+
+	cfg, err := pgxpool.ParseConfig(dsn)
+	if err != nil {
+		t.Fatalf("parse HIVE_TEST_DB_URL: %v", err)
+	}
+	cfg.MaxConns = 1
+
+	ctx := context.Background()
+	pool, err := pgxpool.NewWithConfig(ctx, cfg)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	if _, err := pool.Exec(ctx, "SET ROLE hive_app"); err != nil {
+		pool.Close()
+		t.Skipf("SET ROLE hive_app failed (is hive_app provisioned + migrations applied on this test DB?): %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+// seedRAGTenant inserts an FK row into public.tenants via a short-lived,
+// unscoped connection (hive_app has no INSERT policy on tenants).
+func seedRAGTenant(t *testing.T, id uuid.UUID) {
+	t.Helper()
+	dsn := os.Getenv("HIVE_TEST_DB_URL")
+	ctx := context.Background()
+	setup, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("seed pool: %v", err)
+	}
+	defer setup.Close()
+	_, err = setup.Exec(ctx,
+		`INSERT INTO public.tenants (id, slug, name, deployment)
+		 VALUES ($1, $2, 'rag test tenant', 'HIVE_CLOUD')
+		 ON CONFLICT (id) DO NOTHING`,
+		id, "rag-test-"+id.String())
+	if err != nil {
+		t.Fatalf("seed tenant: %v", err)
+	}
+	t.Cleanup(func() {
+		cleanup, err := pgxpool.New(context.Background(), dsn)
+		if err != nil {
+			return
+		}
+		defer cleanup.Close()
+		_, _ = cleanup.Exec(context.Background(), `DELETE FROM public.tenants WHERE id = $1`, id)
+	})
+}
+
+func TestRepo_RLS_InsertThenGetRoundTripsUnderTenantContext(t *testing.T) {
+	pool := newRLSTestPool(t)
+	tenantID := uuid.New()
+	seedRAGTenant(t, tenantID)
+
+	repo := NewRepo(pool)
+	ctx := context.Background()
+
+	docID, err := repo.InsertDocument(ctx, Document{
+		TenantID:    tenantID,
+		Name:        "doc.txt",
+		MimeType:    "text/plain",
+		SizeBytes:   3,
+		StoragePath: "docs/doc.txt",
+	})
+	if err != nil {
+		t.Fatalf("InsertDocument: %v", err)
+	}
+
+	got, err := repo.GetDocument(ctx, tenantID, docID)
+	if err != nil {
+		t.Fatalf("GetDocument: %v", err)
+	}
+	if got.Name != "doc.txt" {
+		t.Fatalf("expected round-tripped name %q, got %q", "doc.txt", got.Name)
+	}
+}
+
+// TestRepo_RLS_CrossTenantContextCannotReadRows proves the database policy
+// itself blocks cross-tenant reads, independent of the repository's own
+// tenant_id filter. It sets the session to tenant B's context directly (not
+// via the Repo) and queries for tenant A's row by id -- the row exists, but
+// RLS must still hide it.
+func TestRepo_RLS_CrossTenantContextCannotReadRows(t *testing.T) {
+	pool := newRLSTestPool(t)
+	tenantA, tenantB := uuid.New(), uuid.New()
+	seedRAGTenant(t, tenantA)
+	seedRAGTenant(t, tenantB)
+
+	repo := NewRepo(pool)
+	ctx := context.Background()
+	docID, err := repo.InsertDocument(ctx, Document{
+		TenantID:    tenantA,
+		Name:        "tenant-a-only.txt",
+		MimeType:    "text/plain",
+		SizeBytes:   1,
+		StoragePath: "docs/a.txt",
+	})
+	if err != nil {
+		t.Fatalf("seed tenant A document: %v", err)
+	}
+
+	if _, err := pool.Exec(ctx, "SELECT set_config('app.current_tenant_id', $1, false)", tenantB.String()); err != nil {
+		t.Fatalf("set_config tenant B: %v", err)
+	}
+	var count int
+	err = pool.QueryRow(ctx,
+		`SELECT count(*) FROM public.rag_documents WHERE id = $1`,
+		docID).Scan(&count)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("RLS did not block cross-tenant read: got %d row(s) for tenant A's document while session claimed tenant B", count)
+	}
+}
+
+// TestRepo_RLS_NoSessionLeakAcrossBorrows proves the tenant context set by
+// one repository call does not survive onto the pooled connection for
+// whoever borrows it next. The pool is pinned to MaxConns=1, so this test's
+// second query physically reuses the exact same connection InsertDocument
+// just ran on and committed -- with no set_config call of its own (a "bare
+// borrow", simulating a future request that reuses the connection before its
+// own tenant-scoping code runs).
+func TestRepo_RLS_NoSessionLeakAcrossBorrows(t *testing.T) {
+	pool := newRLSTestPool(t)
+	tenantA := uuid.New()
+	seedRAGTenant(t, tenantA)
+
+	repo := NewRepo(pool)
+	ctx := context.Background()
+	docID, err := repo.InsertDocument(ctx, Document{
+		TenantID:    tenantA,
+		Name:        "tenant-a-only.txt",
+		MimeType:    "text/plain",
+		SizeBytes:   1,
+		StoragePath: "docs/a.txt",
+	})
+	if err != nil {
+		t.Fatalf("seed tenant A document: %v", err)
+	}
+
+	// Bare borrow: no set_config call at all on this connection.
+	var setting string
+	if err := pool.QueryRow(ctx, "SELECT current_setting('app.current_tenant_id', true)").Scan(&setting); err != nil {
+		t.Fatalf("read current_setting: %v", err)
+	}
+	if setting != "" {
+		t.Fatalf("session leak: app.current_tenant_id still %q after InsertDocument committed, want empty", setting)
+	}
+
+	var count int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM public.rag_documents WHERE id = $1`,
+		docID).Scan(&count); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("session leak: bare borrow saw %d row(s) for tenant A's document with no tenant context set (RLS should fail-closed on NULL)", count)
+	}
+}

--- a/supabase/migrations/20260715_05_rag_rls_nullif_guard.sql
+++ b/supabase/migrations/20260715_05_rag_rls_nullif_guard.sql
@@ -1,0 +1,35 @@
+-- supabase/migrations/20260715_05_rag_rls_nullif_guard.sql
+--
+-- Fix #320: harden the rag_documents / rag_chunks RLS policies with the same
+-- NULLIF(..., '')::uuid guard adopted by 20260715_03_egress_policy_ssot.sql.
+--
+-- 20260625_05_carl_rag.sql compares tenant_id directly against
+-- current_setting('app.current_tenant_id', true)::uuid. Once a session has
+-- called set_config('app.current_tenant_id', ..., true) at least once,
+-- current_setting(name, true) on that same connection returns '' (not NULL)
+-- after the LOCAL scope ends, rather than reverting to "never defined".
+-- Casting '' straight to ::uuid raises invalid input syntax instead of
+-- cleanly filtering rows, turning a bare/unscoped query on a reused pooled
+-- connection into a 500 instead of a fail-closed empty result. NULLIF folds
+-- that '' case to NULL first, so the comparison evaluates to NULL (Postgres
+-- treats NULL as false) and access is denied -- fail closed either way,
+-- never allow-all.
+--
+-- Does not edit the already-applied 20260625_05_carl_rag.sql; this migration
+-- only replaces the two policies it created.
+
+BEGIN;
+
+DROP POLICY IF EXISTS rag_documents_tenant_isolation ON public.rag_documents;
+CREATE POLICY rag_documents_tenant_isolation
+    ON public.rag_documents AS PERMISSIVE FOR ALL TO hive_app
+    USING      (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::uuid)
+    WITH CHECK (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::uuid);
+
+DROP POLICY IF EXISTS rag_chunks_tenant_isolation ON public.rag_chunks;
+CREATE POLICY rag_chunks_tenant_isolation
+    ON public.rag_chunks AS PERMISSIVE FOR ALL TO hive_app
+    USING      (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::uuid)
+    WITH CHECK (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::uuid);
+
+COMMIT;


### PR DESCRIPTION
## Summary

- Fixes #320: `apps/control-plane/internal/rag/repository.go` set the RLS session variable with `set_config('app.current_tenant_id', $1, true)` (LOCAL scope) but ran it and the following query as two separate autocommit statements on the acquired connection. LOCAL resets the instant the `set_config` statement's own implicit transaction ends, so every subsequent query ran with `app.current_tenant_id` unset. Since `hive_app` is not BYPASSRLS, the `rag_documents` / `rag_chunks` RLS policy then evaluated against a NULL tenant id: reads returned zero rows and writes failed `WITH CHECK`, regardless of stored data. This is the same defect class already caught and fixed in the egress policy repository (#308, PR #319).
- All seven `Repo` methods (`InsertDocument`, `GetDocument`, `ListDocuments`, `UpdateDocumentStatus`, `DeleteDocument`, `InsertChunks`, `SearchChunks`) now route through a shared `withTenantTx` helper: `pool.Begin`, `set_config(..., true)` on the transaction, the query on that same transaction, `Commit`, with a deferred `Rollback` as a safety net. Mirrors `apps/control-plane/internal/egress/repository.go` exactly.
- New migration `supabase/migrations/20260715_05_rag_rls_nullif_guard.sql` replaces the `rag_documents_tenant_isolation` and `rag_chunks_tenant_isolation` policies with a `NULLIF(current_setting('app.current_tenant_id', true), '')::uuid` guard, matching `20260715_03_egress_policy_ssot.sql`, so a residual empty-string GUC value folds to NULL and denies access (fail closed) instead of raising an invalid `::uuid` cast error. Does not edit the already-applied `20260625_05_carl_rag.sql`.
- Adds `HIVE_TEST_DB_URL`-guarded RLS tests in `apps/control-plane/internal/rag/repository_rls_test.go`, mirroring `egress/repository_test.go`: an insert-then-get round trip under one tenant's context, proof a different tenant's session cannot read those rows, and a no-session-leak check on a `MaxConns=1` pool (a bare borrow after a tenant-A write sees zero rows and an empty `current_setting`).

## Test plan

- [x] `go build ./apps/control-plane/...` (Docker toolchain) — green
- [x] `go vet ./apps/control-plane/...` (Docker toolchain) — clean
- [x] `gofmt -l` on changed files — no diffs (pre-existing drift on unrelated `ingest.go`/`ingest_test.go` is untouched by this change)
- [x] `go test ./apps/control-plane/... -count=1 -short` (Docker toolchain) — all packages pass, including `internal/rag` and `internal/egress`
- [x] New RLS tests in `repository_rls_test.go` compile and run (skip locally: no `HIVE_TEST_DB_URL` wired in this environment, same posture as the existing `egress` RLS suite); need to run against a real `HIVE_TEST_DB_URL` (e.g. the nightly/staging test DB secret) to exercise them live before merge
- [x] `npm run lint:tenant-setting`, `npm run lint:tenant-id`, `npm run lint:audit-write` — all pass

Fixes #320

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Strengthened tenant data isolation for documents and chunks.
  - Prevented tenant context from leaking between database operations.
  - Ensured missing or invalid tenant context fails closed rather than exposing data.
  - Preserved reliable document and chunk operations within the correct tenant scope.

- **Tests**
  - Added coverage for tenant-scoped document access, cross-tenant read prevention, and context cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->