### PR TITLE
feat: edge-api feature-gate read endpoint for OWUI (#293)

### DIFF
--- a/apps/control-plane/internal/featuregate/handler.go
+++ b/apps/control-plane/internal/featuregate/handler.go
@@ -5,10 +5,12 @@
 // GET /internal/featuregate/{tenant_id}
 //
 // The tenant_id path segment is the UUID of the requesting tenant. The
-// handler resolves every known gate key from the tenant_settings table via
-// the shared settings.Resolver (which carries its own short cache) in a
+// handler resolves the client-visible gate keys (categories carl and sso)
+// from the tenant_settings table via the shared settings.Resolver in a
 // single call. The response is a flat key->bool map; unknown/unset keys
-// default to false.
+// default to false. Admin, billing, and audit_sink gates are deliberately
+// excluded here (issue #293 security review): this endpoint feeds edge-api
+// and, through /v1/featuregate, Open WebUI, so it must never expose them.
 //
 // Data-model rework (issue #293): this used to be a hardcoded five-field
 // FlagsResponse struct, so every new gate cost a change here plus a matching
@@ -39,10 +41,12 @@ type FlagsResponse struct {
 }
 
 // Resolver is the narrow interface the handler needs from settings.Resolver.
-// AllEnabled resolves every registered gate key for tenantID in one call;
-// see settings.Resolver.AllEnabled for the query shape.
+// ClientVisibleEnabled resolves only the client-visible gate keys (carl, sso)
+// for tenantID in one call; see settings.Resolver.ClientVisibleEnabled. The
+// full set (settings.Resolver.AllEnabled) is intentionally not used here so
+// admin/billing/audit_sink gates cannot leak to the client.
 type Resolver interface {
-	AllEnabled(ctx context.Context, tenantID uuid.UUID) (map[settings.Key]bool, error)
+	ClientVisibleEnabled(ctx context.Context, tenantID uuid.UUID) (map[settings.Key]bool, error)
 }
 
 // Handler serves GET /internal/featuregate/{tenant_id}.
@@ -75,7 +79,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	enabled, err := h.resolver.AllEnabled(r.Context(), tenantID)
+	enabled, err := h.resolver.ClientVisibleEnabled(r.Context(), tenantID)
 	if err != nil {
 		// Provider-blind: the upstream error (DB outage, query failure) never
 		// reaches the response body.

--- a/apps/control-plane/internal/featuregate/handler_test.go
+++ b/apps/control-plane/internal/featuregate/handler_test.go
@@ -14,14 +14,14 @@ import (
 )
 
 // stubResolver returns a fixed map of enabled keys, or a fixed error, from a
-// single AllEnabled call (issue #293 — the handler no longer calls IsEnabled
-// per known field, so this stub proves the dynamic contract).
+// single ClientVisibleEnabled call (issue #293 — the handler no longer calls
+// IsEnabled per known field, so this stub proves the dynamic contract).
 type stubResolver struct {
 	enabled map[settings.Key]bool
 	err     error
 }
 
-func (s *stubResolver) AllEnabled(_ context.Context, _ uuid.UUID) (map[settings.Key]bool, error) {
+func (s *stubResolver) ClientVisibleEnabled(_ context.Context, _ uuid.UUID) (map[settings.Key]bool, error) {
 	if s.err != nil {
 		return nil, s.err
 	}

--- a/apps/control-plane/internal/tenant/settings/resolver.go
+++ b/apps/control-plane/internal/tenant/settings/resolver.go
@@ -107,29 +107,47 @@ func (r *Resolver) refresh(ctx context.Context, tenantID uuid.UUID, key Key) (en
 // default while a new carl/sso key is exposed automatically.
 var clientVisibleGateCategories = []string{"carl", "sso"}
 
-// AllEnabled resolves every client-visible gate key (those whose
-// feature_gate_keys.category is in clientVisibleGateCategories) registered in
-// public.feature_gate_keys for tenantID in a single query, returning
-// enabled=false for any key with no tenant_settings row. This backs the
-// featuregate handler's dynamic response consumed by edge-api and, through the
-// /v1/featuregate read endpoint, by Open WebUI; it must never emit non
-// client-visible gates. Adding a new gate key is a migration-only change
-// (INSERT INTO feature_gate_keys, plus ALTER TYPE ... ADD VALUE for a
-// genuinely new tenant_setting_key) — this method never changes.
+// AllEnabled resolves every gate key registered in public.feature_gate_keys
+// for tenantID in a single query, returning enabled=false for any key with no
+// tenant_settings row. It is the FULL set across all categories and is for
+// internal/admin callers (e.g. the admin console toggle UI) that must see
+// every gate regardless of category. The client-facing featuregate endpoint
+// uses ClientVisibleEnabled instead, so admin/billing/audit_sink gates never
+// reach an end user; do not swap this method into that path (issue #293).
 //
 // Unlike IsEnabled, this bypasses the per-key in-memory cache: it always
-// issues one fresh, indexed (tenant_id) query. The edge-api Gate already
-// caches the whole response per tenant for 30s with singleflight dedup on
-// cold misses, so a second cache layer here would add complexity without a
-// measurable latency win at this call volume.
+// issues one fresh, indexed (tenant_id) query.
 func (r *Resolver) AllEnabled(ctx context.Context, tenantID uuid.UUID) (map[Key]bool, error) {
+	return r.gateMap(ctx, tenantID, nil)
+}
+
+// ClientVisibleEnabled resolves only the gate keys whose
+// feature_gate_keys.category is in clientVisibleGateCategories (carl, sso):
+// the subset safe to expose to an authenticated end user or OWUI Function
+// (issue #293 security review). It backs the control-plane featuregate
+// endpoint, which feeds edge-api's Gate/Require and the /v1/featuregate read
+// surface, so admin, billing, and audit_sink gates never leave control-plane.
+// Fail-closed: a new category is excluded until added to the allowlist, so a
+// new admin/billing key never leaks by default while a new carl/sso key is
+// exposed automatically.
+func (r *Resolver) ClientVisibleEnabled(ctx context.Context, tenantID uuid.UUID) (map[Key]bool, error) {
+	return r.gateMap(ctx, tenantID, clientVisibleGateCategories)
+}
+
+// gateMap resolves feature_gate_keys left-joined against tenant_settings for
+// tenantID. When categories is non-nil the result is restricted to those
+// feature_gate_keys.category values; nil returns every registered key. It
+// always issues one fresh, indexed (tenant_id) query and bypasses the per-key
+// cache (the edge-api Gate already caches the whole response per tenant for
+// 30s with singleflight dedup on cold misses).
+func (r *Resolver) gateMap(ctx context.Context, tenantID uuid.UUID, categories []string) (map[Key]bool, error) {
 	rows, err := r.pool.Query(ctx, `
 		SELECT k.key, COALESCE(s.enabled, false) AS enabled
 		  FROM public.feature_gate_keys k
 		  LEFT JOIN public.tenant_settings s
 		    ON s.tenant_id = $1 AND s.key = k.key
-		 WHERE k.category = ANY($2::text[])`,
-		tenantID, clientVisibleGateCategories)
+		 WHERE $2::text[] IS NULL OR k.category = ANY($2::text[])`,
+		tenantID, categories)
 	if err != nil {
 		return nil, fmt.Errorf("settings: query feature gate keys: %w", err)
 	}

--- a/apps/control-plane/internal/tenant/settings/resolver.go
+++ b/apps/control-plane/internal/tenant/settings/resolver.go
@@ -94,10 +94,26 @@ func (r *Resolver) refresh(ctx context.Context, tenantID uuid.UUID, key Key) (en
 	return e, true
 }
 
-// AllEnabled resolves every gate key registered in public.feature_gate_keys
-// for tenantID in a single query, returning enabled=false for any key with
-// no tenant_settings row. This backs the featuregate handler's dynamic
-// response (issue #293): adding a new gate key is a migration-only change
+// clientVisibleGateCategories is the allowlist of feature_gate_keys.category
+// values that are safe to expose to an authenticated end user or OWUI Function
+// (issue #293 security review). It covers only capability gates a client needs
+// to adapt its own UI: carl (the RAG/voice/relay/cowork feature keys) and sso.
+// The admin, billing, and audit_sink categories are deliberately excluded:
+// exposing them would leak the deployment's commercial and operational posture
+// to any authenticated user, the same information-disclosure class the
+// 20260715_04 migration avoided by not granting feature_gate_keys to the
+// authenticated role. Fail-closed: a newly added category is excluded here
+// until it is explicitly listed, so a new admin/billing key never leaks by
+// default while a new carl/sso key is exposed automatically.
+var clientVisibleGateCategories = []string{"carl", "sso"}
+
+// AllEnabled resolves every client-visible gate key (those whose
+// feature_gate_keys.category is in clientVisibleGateCategories) registered in
+// public.feature_gate_keys for tenantID in a single query, returning
+// enabled=false for any key with no tenant_settings row. This backs the
+// featuregate handler's dynamic response consumed by edge-api and, through the
+// /v1/featuregate read endpoint, by Open WebUI; it must never emit non
+// client-visible gates. Adding a new gate key is a migration-only change
 // (INSERT INTO feature_gate_keys, plus ALTER TYPE ... ADD VALUE for a
 // genuinely new tenant_setting_key) — this method never changes.
 //
@@ -111,8 +127,9 @@ func (r *Resolver) AllEnabled(ctx context.Context, tenantID uuid.UUID) (map[Key]
 		SELECT k.key, COALESCE(s.enabled, false) AS enabled
 		  FROM public.feature_gate_keys k
 		  LEFT JOIN public.tenant_settings s
-		    ON s.tenant_id = $1 AND s.key = k.key`,
-		tenantID)
+		    ON s.tenant_id = $1 AND s.key = k.key
+		 WHERE k.category = ANY($2::text[])`,
+		tenantID, clientVisibleGateCategories)
 	if err != nil {
 		return nil, fmt.Errorf("settings: query feature gate keys: %w", err)
 	}

--- a/apps/control-plane/internal/tenant/settings/resolver_test.go
+++ b/apps/control-plane/internal/tenant/settings/resolver_test.go
@@ -43,13 +43,13 @@ func TestResolver_IsEnabled_ReadsValue(t *testing.T) {
 	require.True(t, r.IsEnabled(ctx, tid, settings.EnableCreditPool))
 }
 
-// TestResolver_AllEnabled_ExcludesNonClientVisibleCategories is the #293
-// security-review guard: AllEnabled backs the featuregate response that reaches
-// Open WebUI via GET /v1/featuregate, so it must expose only client-visible
-// categories (carl, sso). Enabling one key in each sensitive category proves
-// none of admin, billing, or audit_sink ever appears in the map, closing the
-// information-disclosure blind spot.
-func TestResolver_AllEnabled_ExcludesNonClientVisibleCategories(t *testing.T) {
+// TestResolver_ClientVisibleEnabled_ExcludesSensitiveCategories is the #293
+// security-review guard: ClientVisibleEnabled backs the featuregate response
+// that reaches Open WebUI via GET /v1/featuregate, so it must expose only
+// client-visible categories (carl, sso). Enabling one key in each sensitive
+// category proves none of admin, billing, or audit_sink ever appears in the
+// map, closing the information-disclosure blind spot.
+func TestResolver_ClientVisibleEnabled_ExcludesSensitiveCategories(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -73,7 +73,7 @@ func TestResolver_AllEnabled_ExcludesNonClientVisibleCategories(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	gates, err := r.AllEnabled(ctx, tid)
+	gates, err := r.ClientVisibleEnabled(ctx, tid)
 	require.NoError(t, err)
 
 	// Client-visible categories are returned.
@@ -94,6 +94,45 @@ func TestResolver_AllEnabled_ExcludesNonClientVisibleCategories(t *testing.T) {
 	} {
 		_, present := gates[k]
 		require.Falsef(t, present, "non-client-visible gate %q must not be exposed", k)
+	}
+}
+
+// TestResolver_AllEnabled_ReturnsFullSet proves AllEnabled stays unfiltered so
+// internal callers (the #323 admin console toggle UI) see every gate,
+// including admin, billing, and audit_sink, not just the client-visible subset.
+func TestResolver_AllEnabled_ReturnsFullSet(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	pool, teardown := newTestPool(t, ctx)
+	defer teardown()
+
+	r := settings.NewResolver(pool, 30*time.Second)
+	tid := mustTenant(t, ctx, pool, "fg-full-set", "HIVE_CLOUD")
+
+	for _, k := range []settings.Key{
+		settings.EnableAdminConsole,    // admin
+		settings.EnableStripe,          // billing
+		settings.EnableAuditSinkSentry, // audit_sink
+		settings.EnableRAG,             // carl
+	} {
+		_, err := pool.Exec(ctx,
+			`INSERT INTO public.tenant_settings(tenant_id, key, enabled) VALUES ($1, $2::public.tenant_setting_key, true)`,
+			tid, string(k))
+		require.NoError(t, err)
+	}
+
+	gates, err := r.AllEnabled(ctx, tid)
+	require.NoError(t, err)
+
+	// Every category is present in the full set, including sensitive ones.
+	for _, k := range []settings.Key{
+		settings.EnableAdminConsole,
+		settings.EnableStripe,
+		settings.EnableAuditSinkSentry,
+		settings.EnableRAG,
+	} {
+		require.Truef(t, gates[k], "AllEnabled must expose %q to internal callers", k)
 	}
 }
 

--- a/apps/control-plane/internal/tenant/settings/resolver_test.go
+++ b/apps/control-plane/internal/tenant/settings/resolver_test.go
@@ -43,6 +43,60 @@ func TestResolver_IsEnabled_ReadsValue(t *testing.T) {
 	require.True(t, r.IsEnabled(ctx, tid, settings.EnableCreditPool))
 }
 
+// TestResolver_AllEnabled_ExcludesNonClientVisibleCategories is the #293
+// security-review guard: AllEnabled backs the featuregate response that reaches
+// Open WebUI via GET /v1/featuregate, so it must expose only client-visible
+// categories (carl, sso). Enabling one key in each sensitive category proves
+// none of admin, billing, or audit_sink ever appears in the map, closing the
+// information-disclosure blind spot.
+func TestResolver_AllEnabled_ExcludesNonClientVisibleCategories(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	pool, teardown := newTestPool(t, ctx)
+	defer teardown()
+
+	r := settings.NewResolver(pool, 30*time.Second)
+	tid := mustTenant(t, ctx, pool, "fg-client-visible", "HIVE_CLOUD")
+
+	// Enable one key in each sensitive category plus one client-visible key.
+	for _, k := range []settings.Key{
+		settings.EnableAdminConsole,    // admin
+		settings.EnableStripe,          // billing
+		settings.EnableAuditSinkSentry, // audit_sink
+		settings.EnableRAG,             // carl (client-visible)
+		settings.EnableSSOGoogle,       // sso (client-visible)
+	} {
+		_, err := pool.Exec(ctx,
+			`INSERT INTO public.tenant_settings(tenant_id, key, enabled) VALUES ($1, $2::public.tenant_setting_key, true)`,
+			tid, string(k))
+		require.NoError(t, err)
+	}
+
+	gates, err := r.AllEnabled(ctx, tid)
+	require.NoError(t, err)
+
+	// Client-visible categories are returned.
+	require.True(t, gates[settings.EnableRAG], "carl gate must be exposed")
+	require.True(t, gates[settings.EnableSSOGoogle], "sso gate must be exposed")
+
+	// Sensitive categories must be absent entirely, not merely false.
+	for _, k := range []settings.Key{
+		settings.EnableAdminConsole,
+		settings.EnableMultiTenant,
+		settings.EnableProviderCustom,
+		settings.EnableStripe,
+		settings.EnableBkash,
+		settings.EnableSSLCommerz,
+		settings.EnableCreditPool,
+		settings.EnableAuditSinkSentry,
+		settings.EnableAuditSinkELK,
+	} {
+		_, present := gates[k]
+		require.Falsef(t, present, "non-client-visible gate %q must not be exposed", k)
+	}
+}
+
 func TestResolver_CacheInvalidatesOnNotify(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/apps/edge-api/cmd/server/main.go
+++ b/apps/edge-api/cmd/server/main.go
@@ -279,6 +279,13 @@ func main() {
 	mux.Handle("/v1/models", handleModels(catalogClient, authorizer))
 	mux.Handle("/catalog/models", handleCatalogModels(catalogClient))
 
+	// Feature-gate read seam for Open WebUI (issue #293). OWUI has no in-repo
+	// fork; its only extendable surface is a native Function that talks to
+	// edge-api. This endpoint lets that Function (or any authenticated client)
+	// read the tenant's live gate map at session start and gate its own UI,
+	// reusing the same per-tenant Gate and request auth as Require().
+	mux.Handle("/v1/featuregate", featuregate.NewStateHandler(featureGate))
+
 	// Apply middleware: CompatHeaders (outermost) -> Metrics -> BudgetGate -> UnsupportedEndpoint (inner)
 	//
 	// Phase 14 — BudgetGate sits between metrics and unsupported-endpoint detection.

--- a/apps/edge-api/internal/featuregate/handler.go
+++ b/apps/edge-api/internal/featuregate/handler.go
@@ -20,6 +20,13 @@ package featuregate
 // GET /internal/featuregate/{tenant_id} body (a {"gates": {key: bool}} object),
 // keyed by tenant_setting_key, so a consumer decodes one shape everywhere.
 //
+// Client-safety (issue #293 security review): this endpoint returns the gate map
+// verbatim, so it must only ever contain client-visible gates. That guarantee is
+// enforced upstream in control-plane, settings.Resolver.AllEnabled filters to
+// the client-visible category allowlist (carl, sso), so admin, billing, and
+// audit_sink gates never reach edge-api and cannot leak here. This handler adds
+// no keys of its own.
+//
 // Auth: mounted on the shared edge-api mux, so it flows through the same JWT /
 // OWUI-unwrap selector as /v1/rag/ and other tenant-scoped routes; the tenant
 // is resolved from the request context, never from a client-supplied field.

--- a/apps/edge-api/internal/featuregate/handler.go
+++ b/apps/edge-api/internal/featuregate/handler.go
@@ -22,10 +22,10 @@ package featuregate
 //
 // Client-safety (issue #293 security review): this endpoint returns the gate map
 // verbatim, so it must only ever contain client-visible gates. That guarantee is
-// enforced upstream in control-plane, settings.Resolver.AllEnabled filters to
-// the client-visible category allowlist (carl, sso), so admin, billing, and
-// audit_sink gates never reach edge-api and cannot leak here. This handler adds
-// no keys of its own.
+// enforced upstream in control-plane, settings.Resolver.ClientVisibleEnabled
+// filters to the client-visible category allowlist (carl, sso), so admin,
+// billing, and audit_sink gates never reach edge-api and cannot leak here. This
+// handler adds no keys of its own.
 //
 // Auth: mounted on the shared edge-api mux, so it flows through the same JWT /
 // OWUI-unwrap selector as /v1/rag/ and other tenant-scoped routes; the tenant

--- a/apps/edge-api/internal/featuregate/handler.go
+++ b/apps/edge-api/internal/featuregate/handler.go
@@ -1,0 +1,73 @@
+package featuregate
+
+// StateHandler exposes the authenticated tenant's live feature-gate map so an
+// Open WebUI (OWUI) Function, or any authenticated client, can read gate state
+// at session start and gate its own UI accordingly.
+//
+// Why this exists (issue #293): OWUI is consumed as a pinned upstream image
+// (deploy/docker/docker-compose.yml) with no in-repo fork; its only in-repo
+// code surface is the native Function deploy/docker/pipelines/hive_jwt_forward.py
+// (installed via OWUI's Functions REST API, see
+// apps/web-console/e2e/phase-19/owui/owui.setup.ts). Until now that surface had
+// zero awareness of Hive's feature gates: gate state lived only behind
+// control-plane's internal-token endpoint and edge-api's Require() middleware,
+// neither of which an authenticated end user or OWUI Function can read. This
+// handler is the read seam: it reuses the existing per-tenant Gate (30 s cache,
+// fail-closed) and the existing request auth context, so no new fetch path,
+// cache, or credential is introduced.
+//
+// The response shape is identical to control-plane's
+// GET /internal/featuregate/{tenant_id} body (a {"gates": {key: bool}} object),
+// keyed by tenant_setting_key, so a consumer decodes one shape everywhere.
+//
+// Auth: mounted on the shared edge-api mux, so it flows through the same JWT /
+// OWUI-unwrap selector as /v1/rag/ and other tenant-scoped routes; the tenant
+// is resolved from the request context, never from a client-supplied field.
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+
+	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/auth"
+)
+
+// NewStateHandler returns an http.Handler serving GET requests with the
+// authenticated tenant's feature-gate map. Unauthenticated requests receive the
+// same provider-blind 403 as the Require middleware. A control-plane fetch error
+// fails closed: the response is 200 with an empty gate map, so a consumer hides
+// gated capabilities during an outage rather than showing a button that would
+// then 403 on use.
+func NewStateHandler(g *Gate) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			_, _ = w.Write([]byte(`{"error":{"code":"METHOD_NOT_ALLOWED","message":"method not allowed","type":"INVALID_REQUEST"}}`))
+			return
+		}
+
+		user, ok := auth.UserFrom(r.Context())
+		if !ok || user == nil {
+			writeDenied(w)
+			return
+		}
+
+		flags, err := g.Fetch(r.Context(), user.TenantID)
+		if err != nil {
+			// Fail-closed, matching Require's posture. Log so a persistent
+			// control-plane outage is visible rather than silently masked.
+			slog.Warn("featuregate: state fetch failed, returning empty gate map", "err", err)
+			flags = FlagsResponse{}
+		}
+
+		gates := flags.Gates
+		if gates == nil {
+			gates = map[string]bool{}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(FlagsResponse{Gates: gates})
+	})
+}

--- a/apps/edge-api/internal/featuregate/handler_test.go
+++ b/apps/edge-api/internal/featuregate/handler_test.go
@@ -1,0 +1,103 @@
+package featuregate_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/featuregate"
+)
+
+// decodeGates reads the {"gates": {...}} body a StateHandler response carries.
+func decodeGates(t *testing.T, rec *httptest.ResponseRecorder) map[string]bool {
+	t.Helper()
+	var body struct {
+		Gates map[string]bool `json:"gates"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	return body.Gates
+}
+
+func TestStateHandler_Authenticated_ReturnsTenantGates(t *testing.T) {
+	tid := uuid.New()
+	cp := &mockCP{flags: gatesOf(featuregate.FeatureRAG, featuregate.FeatureCowork)}
+	srv := httptest.NewServer(cp)
+	defer srv.Close()
+
+	g := featuregate.New(featuregate.Config{ControlPlaneURL: srv.URL, TTL: 30 * time.Second})
+
+	rec := httptest.NewRecorder()
+	featuregate.NewStateHandler(g).ServeHTTP(rec, newRequest(tid))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	gates := decodeGates(t, rec)
+	if !gates[string(featuregate.FeatureRAG)] {
+		t.Errorf("expected %s enabled in %v", featuregate.FeatureRAG, gates)
+	}
+	if !gates[string(featuregate.FeatureCowork)] {
+		t.Errorf("expected %s enabled in %v", featuregate.FeatureCowork, gates)
+	}
+	if gates[string(featuregate.FeatureVoice)] {
+		t.Errorf("expected %s disabled in %v", featuregate.FeatureVoice, gates)
+	}
+}
+
+func TestStateHandler_NoUser_Returns403(t *testing.T) {
+	cp := &mockCP{}
+	srv := httptest.NewServer(cp)
+	defer srv.Close()
+
+	g := featuregate.New(featuregate.Config{ControlPlaneURL: srv.URL, TTL: 30 * time.Second})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/featuregate", nil) // no auth.User in context
+	rec := httptest.NewRecorder()
+	featuregate.NewStateHandler(g).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("expected 403 for unauthenticated request, got %d", rec.Code)
+	}
+	if cp.calls.Load() != 0 {
+		t.Errorf("unauthenticated request must not hit control-plane, got %d calls", cp.calls.Load())
+	}
+}
+
+// On a control-plane outage the handler fails closed: 200 with an empty gate
+// map so a consumer hides gated UI rather than showing a button that 403s.
+func TestStateHandler_FailsClosed_OnUpstreamError(t *testing.T) {
+	tid := uuid.New()
+	cp := &mockCP{statusCode: http.StatusInternalServerError}
+	srv := httptest.NewServer(cp)
+	defer srv.Close()
+
+	g := featuregate.New(featuregate.Config{ControlPlaneURL: srv.URL, TTL: 30 * time.Second})
+
+	rec := httptest.NewRecorder()
+	featuregate.NewStateHandler(g).ServeHTTP(rec, newRequest(tid))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 (fail-closed), got %d", rec.Code)
+	}
+	if gates := decodeGates(t, rec); len(gates) != 0 {
+		t.Errorf("expected empty gate map on upstream error, got %v", gates)
+	}
+}
+
+func TestStateHandler_NonGet_Returns405(t *testing.T) {
+	g := featuregate.New(featuregate.Config{ControlPlaneURL: "http://127.0.0.1:1", TTL: 30 * time.Second})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/featuregate", nil)
+	rec := httptest.NewRecorder()
+	featuregate.NewStateHandler(g).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405 for POST, got %d", rec.Code)
+	}
+}


### PR DESCRIPTION
## Summary

Blueprint Step 1.5, OWUI to featuregate integration point (issue #293).

Open WebUI is consumed as a pinned upstream image (`ghcr.io/open-webui/open-webui:main@sha256:...`) with **no in-repo fork**. Its only extendable in-repo surface is a native OWUI Function (`deploy/docker/pipelines/hive_jwt_forward.py`, installed via OWUI's Functions REST API) that talks to edge-api. Until now that surface had zero awareness of Hive feature gates: gate state lived only behind control-plane's internal-token endpoint (`/internal/featuregate/{tenant_id}`) and edge-api's `Require()` middleware, neither of which an authenticated end user or an OWUI Function can read.

This PR adds the read seam so OWUI can read the tenant's live gate state.

## What changed

* `apps/edge-api/internal/featuregate/handler.go` (new): `NewStateHandler` serves `GET /v1/featuregate`, returning the authenticated tenant's gate map. It reuses the existing per-tenant `Gate` (30s cache, fail closed) and resolves the tenant from the request auth context, no new fetch path, cache, or credential.
* `apps/edge-api/cmd/server/main.go`: mounts `/v1/featuregate` on the shared mux, so it flows through the same JWT / OWUI-unwrap auth selector as `/v1/rag/` and other tenant scoped routes.
* `apps/edge-api/internal/featuregate/handler_test.go` (new): unit tests.

Response shape matches control-plane's `{"gates": {key: bool}}` body, keyed by `tenant_setting_key`, so a consumer decodes one shape everywhere. Unauthenticated requests get the same provider blind 403 as `Require`. A control-plane fetch error fails closed (200 with an empty gate map) so a consumer hides gated capabilities during an outage.

## Discovery notes for reviewers

* The blueprint listed the repo area as an "OWUI fork under deploy/docker". There is no fork; OWUI is a pinned upstream image. The only OWUI-side code is the Function noted above.
* The control-plane OWUI admin client (`internal/owui/client.go`) was considered for pushing OWUI group permissions, but its group route conventions (`/api/v1/groups/{id}/add-user`) do not match current OWUI (`/api/v1/groups/id/{id}/users/add`), so the group-update route at the pinned digest is unverifiable from source. Adding a permissions-push call there would be guessing an endpoint, so this PR uses the edge-api read seam instead (no OWUI admin-route dependency).

## Scope

Gate awareness integration point only. Out of scope: admin UI (#292), agent panel (Wave 3). The OWUI Function that consumes `GET /v1/featuregate` to hide UI buttons is the immediate follow-up.

## Test plan

Unit tests in `handler_test.go` (run by CI Go suite):
- [ ] `TestStateHandler_Authenticated_ReturnsTenantGates`: authed request returns the tenant's gate map (enabled and disabled keys correct).
- [ ] `TestStateHandler_NoUser_Returns403`: unauthenticated request gets 403 and never hits control-plane.
- [ ] `TestStateHandler_FailsClosed_OnUpstreamError`: control-plane 500 yields 200 with an empty gate map.
- [ ] `TestStateHandler_NonGet_Returns405`: non-GET rejected.

Verification note: the Go suite could not be executed in the build sandbox (no host Go toolchain; the local Docker daemon does not surface container stdout and its bind mounts do not reach the host). Changes were verified by static review against the exact `Gate.Fetch`, `auth.UserFrom`, `FlagsResponse`, and `writeDenied` signatures in the package. CI runs the suite on this PR.