### PR TITLE
feat: admin feature-gate toggle UI and control-plane admin API (#292)

### DIFF
--- a/apps/control-plane/cmd/server/main.go
+++ b/apps/control-plane/cmd/server/main.go
@@ -763,9 +763,13 @@ func main() {
 	// Edge-api calls GET /internal/featuregate/{tenant_id} to populate its own
 	// 30 s edge cache, giving end-to-end revocation in under 60 s.
 	var featureGateHandler *featuregate.Handler
+	var featureGateAdminHandler *featuregate.AdminHandler
 	if pool != nil {
 		settingsResolver := settings.NewResolver(pool, 30*time.Second)
 		featureGateHandler = featuregate.NewHandler(settingsResolver)
+		// Issue #292 (blueprint Step 1.2) — admin feature-gate CRUD reuses the
+		// same resolver so a PUT invalidates the cache the internal GET reads.
+		featureGateAdminHandler = featuregate.NewAdminHandler(settingsResolver)
 	}
 
 	// Issue #308 — egress policy single source of truth. Admin CRUD is
@@ -780,27 +784,28 @@ func main() {
 	}
 
 	router := platformhttp.NewRouter(platformhttp.RouterConfig{
-		AuthMiddleware:      authMiddleware,
-		AccountsHandler:     accountsHandler,
-		IdentityHandler:     identityHandler,
-		AccountingHandler:   accountingHandler,
-		APIKeysHandler:      apikeysHandler,
-		BudgetsHandler:      budgetsHandler,
-		CatalogHandler:      catalogHandler,
-		LedgerHandler:       ledgerHandler,
-		PaymentsHandler:     paymentsHandler,
-		ProfilesHandler:     profilesHandler,
-		ProvidersRouter:     providersHandler,
-		LiteLLMSyncHandler:  litellmSyncHandler,
-		FeatureGateHandler:  featureGateHandler,
-		EgressPolicyHandler: egressPolicyHandler,
-		RoutingHandler:      routingHandler,
-		UsageHandler:        usageHandler,
-		MetricsRegistry:     metricsRegistry,
-		PrometheusRegistry:  promRegistry,
-		Mux:                 routerMux,
-		InternalToken:       cfg.InternalToken,
-		RoleSvc:             roleSvc,
+		AuthMiddleware:          authMiddleware,
+		AccountsHandler:         accountsHandler,
+		IdentityHandler:         identityHandler,
+		AccountingHandler:       accountingHandler,
+		APIKeysHandler:          apikeysHandler,
+		BudgetsHandler:          budgetsHandler,
+		CatalogHandler:          catalogHandler,
+		LedgerHandler:           ledgerHandler,
+		PaymentsHandler:         paymentsHandler,
+		ProfilesHandler:         profilesHandler,
+		ProvidersRouter:         providersHandler,
+		LiteLLMSyncHandler:      litellmSyncHandler,
+		FeatureGateHandler:      featureGateHandler,
+		FeatureGateAdminHandler: featureGateAdminHandler,
+		EgressPolicyHandler:     egressPolicyHandler,
+		RoutingHandler:          routingHandler,
+		UsageHandler:            usageHandler,
+		MetricsRegistry:         metricsRegistry,
+		PrometheusRegistry:      promRegistry,
+		Mux:                     routerMux,
+		InternalToken:           cfg.InternalToken,
+		RoleSvc:                 roleSvc,
 	})
 
 	// Wire filestore internal endpoints if the database pool is available.

--- a/apps/control-plane/internal/featuregate/admin.go
+++ b/apps/control-plane/internal/featuregate/admin.go
@@ -68,8 +68,7 @@ type adminGate struct {
 }
 
 type adminGatesResponse struct {
-	TenantID string      `json:"tenant_id"`
-	Gates    []adminGate `json:"gates"`
+	Gates []adminGate `json:"gates"`
 }
 
 type setGateRequest struct {
@@ -116,7 +115,7 @@ func (h *AdminHandler) handleCollection(w http.ResponseWriter, r *http.Request) 
 		})
 	}
 
-	writeJSON(w, http.StatusOK, adminGatesResponse{TenantID: tenantID.String(), Gates: gates})
+	writeJSON(w, http.StatusOK, adminGatesResponse{Gates: gates})
 }
 
 // handleItem serves PUT /api/v1/admin/feature-gates/{key}.

--- a/apps/control-plane/internal/featuregate/admin.go
+++ b/apps/control-plane/internal/featuregate/admin.go
@@ -1,0 +1,181 @@
+// Admin feature-gate surface (issue #292, agent-subsystem blueprint Step 1.2).
+//
+// The internal handler in handler.go answers edge-api service-to-service reads.
+// This file is the human-facing side: an owner-gated admin API the web-console
+// admin page uses to list every registered gate and flip it per tenant.
+//
+//	GET /api/v1/admin/feature-gates          — registry joined with this
+//	                                            tenant's enablement
+//	PUT /api/v1/admin/feature-gates/{key}    — toggle one gate for this tenant
+//
+// The tenant is the caller's selected tenant (auth.Viewer.TenantID) and the
+// write is attributed to the caller (auth.Viewer.UserID). Both routes are
+// mounted behind auth.Middleware.Require + RoleService.RequirePlatformAdmin in
+// router.go, so this handler assumes an authenticated platform admin; it reads
+// the viewer only for the tenant scope and write attribution.
+package featuregate
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/auth"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/tenant/settings"
+)
+
+// adminPrefix is the exact collection path; the item path is adminPrefix+"/{key}".
+const adminPrefix = "/api/v1/admin/feature-gates"
+
+// AdminStore is the narrow settings surface the admin handler needs.
+// *settings.Resolver satisfies it.
+type AdminStore interface {
+	Registry(ctx context.Context) ([]settings.GateKey, error)
+	AllEnabled(ctx context.Context, tenantID uuid.UUID) (map[settings.Key]bool, error)
+	Set(ctx context.Context, tenantID uuid.UUID, key settings.Key, enabled bool, updatedBy uuid.UUID) error
+}
+
+// AdminHandler serves the owner-gated admin feature-gate routes.
+type AdminHandler struct {
+	store AdminStore
+}
+
+// NewAdminHandler constructs an AdminHandler. store must not be nil.
+func NewAdminHandler(store AdminStore) *AdminHandler {
+	return &AdminHandler{store: store}
+}
+
+// AdminMux routes the collection and item paths. Callers mount it behind the
+// auth + platform-admin middleware (see router.go).
+func (h *AdminHandler) AdminMux() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc(adminPrefix, h.handleCollection)
+	mux.HandleFunc(adminPrefix+"/", h.handleItem)
+	return mux
+}
+
+// adminGate is one row the admin UI renders: the key, its human label and
+// category, and whether it is enabled for the current tenant.
+type adminGate struct {
+	Key      string `json:"key"`
+	Label    string `json:"label"`
+	Category string `json:"category"`
+	Enabled  bool   `json:"enabled"`
+}
+
+type adminGatesResponse struct {
+	TenantID string      `json:"tenant_id"`
+	Gates    []adminGate `json:"gates"`
+}
+
+type setGateRequest struct {
+	Enabled bool `json:"enabled"`
+}
+
+type setGateResponse struct {
+	Key     string `json:"key"`
+	Enabled bool   `json:"enabled"`
+}
+
+// handleCollection serves GET /api/v1/admin/feature-gates.
+func (h *AdminHandler) handleCollection(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	tenantID, _, ok := requireTenant(w, r)
+	if !ok {
+		return
+	}
+
+	ctx := r.Context()
+	registry, err := h.store.Registry(ctx)
+	if err != nil {
+		// Provider-blind: the upstream error never reaches the response body.
+		writeError(w, http.StatusInternalServerError, "failed to load feature gate registry")
+		return
+	}
+	enabled, err := h.store.AllEnabled(ctx, tenantID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to resolve feature gates")
+		return
+	}
+
+	// Registry is already ordered by (category, label); preserve that order.
+	gates := make([]adminGate, 0, len(registry))
+	for _, g := range registry {
+		gates = append(gates, adminGate{
+			Key:      string(g.Key),
+			Label:    g.Label,
+			Category: g.Category,
+			Enabled:  enabled[g.Key],
+		})
+	}
+
+	writeJSON(w, http.StatusOK, adminGatesResponse{TenantID: tenantID.String(), Gates: gates})
+}
+
+// handleItem serves PUT /api/v1/admin/feature-gates/{key}.
+func (h *AdminHandler) handleItem(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPut {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	tenantID, userID, ok := requireTenant(w, r)
+	if !ok {
+		return
+	}
+
+	key := strings.Trim(strings.TrimPrefix(r.URL.Path, adminPrefix+"/"), "/")
+	if key == "" {
+		writeError(w, http.StatusBadRequest, "missing gate key")
+		return
+	}
+
+	var req setGateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "request body must be valid JSON")
+		return
+	}
+
+	err := h.store.Set(r.Context(), tenantID, settings.Key(key), req.Enabled, userID)
+	if errors.Is(err, settings.ErrUnknownGateKey) {
+		writeError(w, http.StatusBadRequest, "unknown feature gate key")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to update feature gate")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, setGateResponse{Key: key, Enabled: req.Enabled})
+}
+
+// requireTenant pulls the viewer from context and returns its tenant + user id.
+// The middleware guarantees an authenticated platform admin, but the viewer may
+// still have no selected tenant (uuid.Nil), which is a 400 the operator fixes by
+// switching workspace.
+func requireTenant(w http.ResponseWriter, r *http.Request) (tenantID, userID uuid.UUID, ok bool) {
+	viewer, present := auth.ViewerFromContext(r.Context())
+	if !present {
+		writeError(w, http.StatusUnauthorized, "authentication required")
+		return uuid.Nil, uuid.Nil, false
+	}
+	if viewer.TenantID == uuid.Nil {
+		writeError(w, http.StatusBadRequest, "no tenant selected")
+		return uuid.Nil, uuid.Nil, false
+	}
+	return viewer.TenantID, viewer.UserID, true
+}
+
+// writeJSON emits a JSON body with a matching Content-Type header, mirroring
+// writeError in handler.go.
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}

--- a/apps/control-plane/internal/featuregate/admin_test.go
+++ b/apps/control-plane/internal/featuregate/admin_test.go
@@ -55,8 +55,7 @@ type gateRow struct {
 }
 
 type gatesResp struct {
-	TenantID string    `json:"tenant_id"`
-	Gates    []gateRow `json:"gates"`
+	Gates []gateRow `json:"gates"`
 }
 
 func adminViewer() auth.Viewer {
@@ -88,9 +87,6 @@ func TestAdmin_List_MergesRegistryAndEnablement(t *testing.T) {
 	var resp gatesResp
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 		t.Fatalf("decode: %v", err)
-	}
-	if resp.TenantID != v.TenantID.String() {
-		t.Errorf("tenant_id = %q, want %q", resp.TenantID, v.TenantID.String())
 	}
 	if len(resp.Gates) != 2 {
 		t.Fatalf("expected 2 gates, got %d", len(resp.Gates))

--- a/apps/control-plane/internal/featuregate/admin_test.go
+++ b/apps/control-plane/internal/featuregate/admin_test.go
@@ -1,0 +1,221 @@
+package featuregate_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/auth"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/featuregate"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/tenant/settings"
+)
+
+// fakeAdminStore is a hand-built AdminStore stub. It records the last Set call
+// so tests can assert the handler forwarded tenant, key, enabled, and the
+// attributed user id unchanged.
+type fakeAdminStore struct {
+	registry []settings.GateKey
+	enabled  map[settings.Key]bool
+	setErr   error
+
+	setCalled  bool
+	setTenant  uuid.UUID
+	setKey     settings.Key
+	setEnabled bool
+	setBy      uuid.UUID
+}
+
+func (f *fakeAdminStore) Registry(context.Context) ([]settings.GateKey, error) {
+	return f.registry, nil
+}
+
+func (f *fakeAdminStore) AllEnabled(context.Context, uuid.UUID) (map[settings.Key]bool, error) {
+	return f.enabled, nil
+}
+
+func (f *fakeAdminStore) Set(_ context.Context, tenantID uuid.UUID, key settings.Key, enabled bool, updatedBy uuid.UUID) error {
+	f.setCalled = true
+	f.setTenant = tenantID
+	f.setKey = key
+	f.setEnabled = enabled
+	f.setBy = updatedBy
+	return f.setErr
+}
+
+type gateRow struct {
+	Key      string `json:"key"`
+	Label    string `json:"label"`
+	Category string `json:"category"`
+	Enabled  bool   `json:"enabled"`
+}
+
+type gatesResp struct {
+	TenantID string    `json:"tenant_id"`
+	Gates    []gateRow `json:"gates"`
+}
+
+func adminViewer() auth.Viewer {
+	return auth.Viewer{UserID: uuid.New(), TenantID: uuid.New()}
+}
+
+func withViewer(req *http.Request, v auth.Viewer) *http.Request {
+	return req.WithContext(auth.WithViewer(req.Context(), v))
+}
+
+func TestAdmin_List_MergesRegistryAndEnablement(t *testing.T) {
+	store := &fakeAdminStore{
+		registry: []settings.GateKey{
+			{Key: settings.EnableRAG, Label: "Carl.sh RAG capability", Category: "carl"},
+			{Key: settings.EnablePublicBilling, Label: "Public billing", Category: "billing"},
+		},
+		enabled: map[settings.Key]bool{settings.EnableRAG: true},
+	}
+	h := featuregate.NewAdminHandler(store).AdminMux()
+
+	v := adminViewer()
+	req := withViewer(httptest.NewRequest(http.MethodGet, "/api/v1/admin/feature-gates", nil), v)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	var resp gatesResp
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.TenantID != v.TenantID.String() {
+		t.Errorf("tenant_id = %q, want %q", resp.TenantID, v.TenantID.String())
+	}
+	if len(resp.Gates) != 2 {
+		t.Fatalf("expected 2 gates, got %d", len(resp.Gates))
+	}
+	// Registry order is preserved: RAG first, billing second.
+	if resp.Gates[0].Key != string(settings.EnableRAG) || !resp.Gates[0].Enabled {
+		t.Errorf("gate[0] = %+v, want RAG enabled", resp.Gates[0])
+	}
+	if resp.Gates[0].Label != "Carl.sh RAG capability" || resp.Gates[0].Category != "carl" {
+		t.Errorf("gate[0] label/category = %q/%q", resp.Gates[0].Label, resp.Gates[0].Category)
+	}
+	// A registered key with no tenant_settings row defaults to disabled.
+	if resp.Gates[1].Key != string(settings.EnablePublicBilling) || resp.Gates[1].Enabled {
+		t.Errorf("gate[1] = %+v, want billing disabled", resp.Gates[1])
+	}
+}
+
+func TestAdmin_List_Unauthenticated(t *testing.T) {
+	h := featuregate.NewAdminHandler(&fakeAdminStore{}).AdminMux()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/feature-gates", nil) // no viewer in context
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rec.Code)
+	}
+}
+
+func TestAdmin_List_NoTenantSelected(t *testing.T) {
+	h := featuregate.NewAdminHandler(&fakeAdminStore{}).AdminMux()
+	req := withViewer(
+		httptest.NewRequest(http.MethodGet, "/api/v1/admin/feature-gates", nil),
+		auth.Viewer{UserID: uuid.New()}, // TenantID is uuid.Nil
+	)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestAdmin_Set_TogglesGate(t *testing.T) {
+	store := &fakeAdminStore{}
+	h := featuregate.NewAdminHandler(store).AdminMux()
+
+	v := adminViewer()
+	req := withViewer(
+		httptest.NewRequest(http.MethodPut, "/api/v1/admin/feature-gates/ENABLE_RAG",
+			strings.NewReader(`{"enabled":true}`)),
+		v,
+	)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if !store.setCalled {
+		t.Fatal("Set was not called")
+	}
+	if store.setTenant != v.TenantID || store.setBy != v.UserID {
+		t.Errorf("Set attribution: tenant=%v by=%v, want tenant=%v by=%v", store.setTenant, store.setBy, v.TenantID, v.UserID)
+	}
+	if store.setKey != settings.EnableRAG || !store.setEnabled {
+		t.Errorf("Set(key=%q, enabled=%v), want (ENABLE_RAG, true)", store.setKey, store.setEnabled)
+	}
+	var resp setResp
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Key != "ENABLE_RAG" || !resp.Enabled {
+		t.Errorf("response = %+v, want ENABLE_RAG enabled", resp)
+	}
+}
+
+type setResp struct {
+	Key     string `json:"key"`
+	Enabled bool   `json:"enabled"`
+}
+
+func TestAdmin_Set_UnknownKey(t *testing.T) {
+	store := &fakeAdminStore{setErr: settings.ErrUnknownGateKey}
+	h := featuregate.NewAdminHandler(store).AdminMux()
+
+	req := withViewer(
+		httptest.NewRequest(http.MethodPut, "/api/v1/admin/feature-gates/NOT_A_REAL_KEY",
+			strings.NewReader(`{"enabled":true}`)),
+		adminViewer(),
+	)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for unknown key, got %d", rec.Code)
+	}
+}
+
+func TestAdmin_Set_InvalidBody(t *testing.T) {
+	h := featuregate.NewAdminHandler(&fakeAdminStore{}).AdminMux()
+	req := withViewer(
+		httptest.NewRequest(http.MethodPut, "/api/v1/admin/feature-gates/ENABLE_RAG",
+			strings.NewReader("not json")),
+		adminViewer(),
+	)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid body, got %d", rec.Code)
+	}
+}
+
+func TestAdmin_MethodNotAllowed(t *testing.T) {
+	h := featuregate.NewAdminHandler(&fakeAdminStore{}).AdminMux()
+	cases := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodPost, "/api/v1/admin/feature-gates"},
+		{http.MethodDelete, "/api/v1/admin/feature-gates/ENABLE_RAG"},
+	}
+	for _, c := range cases {
+		req := withViewer(httptest.NewRequest(c.method, c.path, nil), adminViewer())
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusMethodNotAllowed {
+			t.Errorf("%s %s: expected 405, got %d", c.method, c.path, rec.Code)
+		}
+	}
+}

--- a/apps/control-plane/internal/platform/http/router.go
+++ b/apps/control-plane/internal/platform/http/router.go
@@ -90,6 +90,16 @@ type RouterConfig struct {
 	// Guarded by the shared-secret token. When nil the route is not registered.
 	FeatureGateHandler http.Handler
 
+	// FeatureGateAdminHandler exposes the owner-gated admin feature-gate CRUD
+	// surface (issue #292, agent-subsystem blueprint Step 1.2): AdminMux()
+	// routes GET/PUT under /api/v1/admin/feature-gates. Mounted behind
+	// AuthMiddleware.Require + RoleSvc.RequirePlatformAdmin (JWT path). A narrow
+	// interface avoids an import cycle between platform/http and featuregate.
+	// When nil (or RoleSvc/AuthMiddleware nil) the routes are not registered.
+	FeatureGateAdminHandler interface {
+		AdminMux() http.Handler
+	}
+
 	// EgressPolicyHandler serves the egress-policy single source of truth
 	// (issue #308): the owner-gated admin CRUD surface at
 	// /api/v1/egress-policy/ and the shared-secret-guarded read surface at
@@ -259,6 +269,18 @@ func NewRouter(cfg RouterConfig) http.Handler {
 	// GET /internal/featuregate/{tenant_id} returns flags for edge-api gate middleware.
 	if cfg.FeatureGateHandler != nil {
 		mux.Handle("/internal/featuregate/", internal(cfg.FeatureGateHandler))
+	}
+
+	// Issue #292 (blueprint Step 1.2) — admin feature-gate CRUD, platform-admin
+	// gated (JWT path). GET lists the registry joined with the caller's tenant
+	// enablement; PUT toggles one gate for the caller's selected tenant. Mirrors
+	// the /api/v1/admin/providers gating above.
+	if cfg.FeatureGateAdminHandler != nil && cfg.RoleSvc != nil && cfg.AuthMiddleware != nil {
+		adminFeatureGates := cfg.AuthMiddleware.Require(
+			cfg.RoleSvc.RequirePlatformAdmin(cfg.FeatureGateAdminHandler.AdminMux()),
+		)
+		mux.Handle("/api/v1/admin/feature-gates", adminFeatureGates)
+		mux.Handle("/api/v1/admin/feature-gates/", adminFeatureGates)
 	}
 
 	// Issue #308 — egress policy single source of truth. Admin CRUD is

--- a/apps/control-plane/internal/tenant/settings/resolver.go
+++ b/apps/control-plane/internal/tenant/settings/resolver.go
@@ -133,6 +133,95 @@ func (r *Resolver) AllEnabled(ctx context.Context, tenantID uuid.UUID) (map[Key]
 	return out, nil
 }
 
+// ErrUnknownGateKey is returned by Set when key is not registered in
+// public.feature_gate_keys. Callers should map it to a 400 rather than a 500:
+// it means the caller asked to toggle a key the registry does not expose, not
+// that anything failed.
+var ErrUnknownGateKey = errors.New("settings: unknown feature gate key")
+
+// GateKey is one row of the public.feature_gate_keys registry: the tenant
+// setting key plus its human label and grouping category. It is the shape the
+// admin feature-gate UI (issue #292) lists so a non-technical operator sees
+// "Public billing" grouped under "billing" rather than the raw enum symbol.
+type GateKey struct {
+	Key      Key
+	Label    string
+	Category string
+}
+
+// Registry returns every gate key registered in public.feature_gate_keys,
+// ordered by category then label so the admin UI groups them stably. Like
+// AllEnabled it reads through the service-role pool (feature_gate_keys grants
+// nothing to the authenticated role by design); the owner gate lives at the
+// HTTP layer.
+func (r *Resolver) Registry(ctx context.Context) ([]GateKey, error) {
+	rows, err := r.pool.Query(ctx, `
+		SELECT key, label, category
+		  FROM public.feature_gate_keys
+		 ORDER BY category, label`)
+	if err != nil {
+		return nil, fmt.Errorf("settings: query feature gate registry: %w", err)
+	}
+	defer rows.Close()
+
+	var out []GateKey
+	for rows.Next() {
+		var g GateKey
+		if err := rows.Scan(&g.Key, &g.Label, &g.Category); err != nil {
+			return nil, fmt.Errorf("settings: scan feature gate registry: %w", err)
+		}
+		out = append(out, g)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("settings: iterate feature gate registry: %w", err)
+	}
+	return out, nil
+}
+
+// Set upserts the enabled state of a single gate key for a tenant and records
+// updatedBy (an auth.users id, or uuid.Nil to leave updated_by null). key must
+// be registered in public.feature_gate_keys or ErrUnknownGateKey is returned;
+// this both gives the admin UI a clean 400 and keeps the enum cast below from
+// ever seeing an arbitrary string.
+//
+// The write fires the tenant_settings_changed NOTIFY trigger, so every
+// control-plane and edge-api cache converges within its TTL. Set also
+// invalidates the local per-key cache immediately so a read on this instance is
+// fresh at once.
+//
+// This is the single sanctioned write path for tenant_settings; direct queries
+// against the table from other packages are blocked by lint.
+func (r *Resolver) Set(ctx context.Context, tenantID uuid.UUID, key Key, enabled bool, updatedBy uuid.UUID) error {
+	var known bool
+	if err := r.pool.QueryRow(ctx,
+		`SELECT EXISTS(SELECT 1 FROM public.feature_gate_keys WHERE key::text = $1)`,
+		string(key)).Scan(&known); err != nil {
+		return fmt.Errorf("settings: check feature gate key: %w", err)
+	}
+	if !known {
+		return ErrUnknownGateKey
+	}
+
+	var updatedByArg any
+	if updatedBy != uuid.Nil {
+		updatedByArg = updatedBy
+	}
+
+	if _, err := r.pool.Exec(ctx, `
+		INSERT INTO public.tenant_settings (tenant_id, key, enabled, updated_by, updated_at)
+		VALUES ($1, $2::public.tenant_setting_key, $3, $4, now())
+		ON CONFLICT (tenant_id, key)
+		DO UPDATE SET enabled = EXCLUDED.enabled,
+		              updated_by = EXCLUDED.updated_by,
+		              updated_at = now()`,
+		tenantID, string(key), enabled, updatedByArg); err != nil {
+		return fmt.Errorf("settings: upsert tenant setting: %w", err)
+	}
+
+	r.Invalidate(tenantID, key)
+	return nil
+}
+
 // Invalidate drops cached entries for a tenant + key. Used by the LISTEN
 // callback (see listener.go).
 func (r *Resolver) Invalidate(tenantID uuid.UUID, key Key) {

--- a/apps/web-console/app/api/console/feature-gates/route.ts
+++ b/apps/web-console/app/api/console/feature-gates/route.ts
@@ -1,0 +1,67 @@
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+
+import { createClient } from "@/lib/supabase/server";
+import { ControlPlaneError, setFeatureGate } from "@/lib/control-plane/client";
+
+interface PutBody {
+  key?: string;
+  enabled?: boolean;
+}
+
+// Server-side proxy for toggling a feature gate (issue #292). Keeps the
+// internal CONTROL_PLANE_BASE_URL server-only and attaches the caller's session
+// bearer. The control-plane is the authority on permission (platform-admin) and
+// on which keys exist; this handler only shape-checks and maps the upstream
+// status class to a generic, customer-safe message.
+export async function PUT(request: Request): Promise<Response> {
+  const cookieStore = await cookies();
+  const supabase = createClient(cookieStore);
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser();
+  if (error || !user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body: PutBody = await request.json().catch((): PutBody => ({}));
+  if (typeof body.key !== "string" || body.key.length === 0) {
+    return NextResponse.json({ error: "A gate key is required" }, { status: 400 });
+  }
+  if (typeof body.enabled !== "boolean") {
+    return NextResponse.json({ error: "enabled must be a boolean" }, { status: 400 });
+  }
+
+  try {
+    const result = await setFeatureGate(body.key, body.enabled);
+    return NextResponse.json(result);
+  } catch (err) {
+    if (err instanceof ControlPlaneError) {
+      const status =
+        err.status === 400 || err.status === 403 || err.status === 404
+          ? err.status
+          : 502;
+      return NextResponse.json({ error: gateErrorMessage(err.status) }, { status });
+    }
+    return NextResponse.json(
+      { error: "Could not update the feature gate. Please try again." },
+      { status: 500 },
+    );
+  }
+}
+
+// gateErrorMessage maps an upstream status class to a generic, customer-safe
+// message. It never forwards raw upstream or internal text.
+function gateErrorMessage(status: number): string {
+  switch (status) {
+    case 400:
+      return "That feature gate is not recognized.";
+    case 403:
+      return "You do not have permission to change feature gates.";
+    case 404:
+      return "That feature gate could not be found.";
+    default:
+      return "Could not update the feature gate. Please try again.";
+  }
+}

--- a/apps/web-console/app/console/feature-gates/page.tsx
+++ b/apps/web-console/app/console/feature-gates/page.tsx
@@ -1,0 +1,87 @@
+import { redirect } from "next/navigation";
+import { ShieldAlert } from "lucide-react";
+
+import {
+  getViewer,
+  getAccountProfile,
+  getFeatureGates,
+  type FeatureGates,
+} from "@/lib/control-plane/client";
+import { can } from "@/lib/viewer-gates";
+import { ConsoleShell } from "@/components/app-shell/console-shell";
+import { PageHeader } from "@/components/ui/page-header";
+import { EmptyState } from "@/components/ui/empty-state";
+import { FeatureGateManager } from "@/components/feature-gates/feature-gate-manager";
+
+// Admin feature-gate page (issue #292, agent-subsystem blueprint Step 1.2).
+// Lists every registered gate for the current workspace and lets a platform
+// admin toggle each one; the control-plane enforces platform-admin, so this is
+// defence in depth: non-admins get an access state without an upstream call.
+//
+// ponytail: the nav link is shown to everyone (the shared shell has no viewer
+// permissions); gating it per-item is a follow-up. Access itself is enforced
+// here and again at the control-plane.
+export default async function FeatureGatesPage() {
+  const viewer = await getViewer();
+  if (viewer.user.email_verified === false) {
+    redirect("/console/settings/profile");
+  }
+
+  const profile = await getAccountProfile().catch(
+    (): { owner_name: string } => ({ owner_name: "" }),
+  );
+
+  const isAdmin = can(viewer, "platform.admin");
+
+  let gates: FeatureGates | null = null;
+  let loadFailed = false;
+  if (isAdmin) {
+    try {
+      gates = await getFeatureGates();
+    } catch {
+      loadFailed = true;
+    }
+  }
+
+  return (
+    <ConsoleShell
+      workspace={{
+        name: viewer.current_account.display_name,
+        slug: viewer.current_account.slug,
+      }}
+      user={{ email: viewer.user.email, name: profile.owner_name || null }}
+      active="/console/feature-gates"
+      topbar={
+        <span className="font-medium text-[var(--color-ink-2)]">
+          Feature gates
+        </span>
+      }
+    >
+      <PageHeader
+        eyebrow="Admin"
+        title="Feature gates"
+        description="Turn capabilities on or off for this workspace. Changes take effect across the API and apps within about a minute."
+      />
+
+      {!isAdmin ? (
+        <EmptyState
+          icon={<ShieldAlert size={20} />}
+          title="Admin access required"
+          description="Only platform admins can view and change feature gates. Ask an admin if you need a capability turned on."
+        />
+      ) : loadFailed || !gates ? (
+        <EmptyState
+          title="Could not load feature gates"
+          description="Something went wrong loading the gate list. Refresh to try again."
+        />
+      ) : gates.gates.length === 0 ? (
+        <EmptyState
+          title="No feature gates"
+          description="No gate keys are registered yet."
+        />
+      ) : (
+        <FeatureGateManager gates={gates.gates} />
+      )}
+    </ConsoleShell>
+  );
+}

--- a/apps/web-console/components/app-shell/console-shell.tsx
+++ b/apps/web-console/components/app-shell/console-shell.tsx
@@ -9,6 +9,7 @@ import {
   Users,
   Settings,
   Wallet,
+  ToggleRight,
   LogOut,
 } from "lucide-react";
 
@@ -33,6 +34,16 @@ const NAV_GROUPS: ReadonlyArray<{
       { href: "/console/billing", label: "Billing", icon: <Wallet size={14} /> },
       { href: "/console/members", label: "Members", icon: <Users size={14} /> },
       { href: "/console/settings/profile", label: "Settings", icon: <Settings size={14} /> },
+    ],
+  },
+  {
+    label: "Admin",
+    items: [
+      {
+        href: "/console/feature-gates",
+        label: "Feature gates",
+        icon: <ToggleRight size={14} />,
+      },
     ],
   },
 ];

--- a/apps/web-console/components/feature-gates/feature-gate-manager.test.tsx
+++ b/apps/web-console/components/feature-gates/feature-gate-manager.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
+
+import { FeatureGateManager } from "./feature-gate-manager";
+import type { FeatureGate } from "@/lib/control-plane/client";
+
+const GATES: FeatureGate[] = [
+  { key: "ENABLE_RAG", label: "Carl.sh RAG capability", category: "carl", enabled: false },
+  { key: "ENABLE_PUBLIC_BILLING", label: "Public billing", category: "billing", enabled: true },
+];
+
+describe("FeatureGateManager", () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("renders each gate label, raw key, and grouped category headings", () => {
+    render(<FeatureGateManager gates={GATES} />);
+    // getByText throws if absent, so the calls themselves assert presence.
+    expect(screen.getByText("Carl.sh RAG capability")).toBeTruthy();
+    expect(screen.getByText("ENABLE_RAG")).toBeTruthy();
+    expect(screen.getByText("Sovereign workspace")).toBeTruthy();
+    expect(screen.getByText("Billing & payments")).toBeTruthy();
+  });
+
+  it("reflects initial enabled state on the switches", () => {
+    render(<FeatureGateManager gates={GATES} />);
+    const rag = screen.getByRole("switch", { name: /Carl\.sh RAG capability/i });
+    const billing = screen.getByRole("switch", { name: /Public billing/i });
+    expect(rag.getAttribute("aria-checked")).toBe("false");
+    expect(billing.getAttribute("aria-checked")).toBe("true");
+  });
+
+  it("optimistically flips and PUTs to the BFF route on toggle", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ key: "ENABLE_RAG", enabled: true }), {
+        status: 200,
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<FeatureGateManager gates={GATES} />);
+    const rag = screen.getByRole("switch", { name: /Carl\.sh RAG capability/i });
+    fireEvent.click(rag);
+
+    await waitFor(() => {
+      expect(rag.getAttribute("aria-checked")).toBe("true");
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const call = fetchMock.mock.calls[0];
+    expect(call[0]).toBe("/api/console/feature-gates");
+    const init = call[1];
+    expect(init?.method).toBe("PUT");
+    expect(JSON.parse(String(init?.body))).toEqual({
+      key: "ENABLE_RAG",
+      enabled: true,
+    });
+  });
+
+  it("reverts the switch and shows an error when the request fails", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("nope", { status: 500 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<FeatureGateManager gates={GATES} />);
+    const rag = screen.getByRole("switch", { name: /Carl\.sh RAG capability/i });
+    fireEvent.click(rag);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Could not save/i)).toBeTruthy();
+    });
+    expect(rag.getAttribute("aria-checked")).toBe("false");
+  });
+});

--- a/apps/web-console/components/feature-gates/feature-gate-manager.tsx
+++ b/apps/web-console/components/feature-gates/feature-gate-manager.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import * as React from "react";
+import { AlertCircle } from "lucide-react";
+
+import { cn } from "@/lib/cn";
+import type { FeatureGate } from "@/lib/control-plane/client";
+
+interface FeatureGateManagerProps {
+  gates: FeatureGate[];
+}
+
+type RowStatus = "idle" | "saving" | "error";
+
+// Nicer section headings for known categories; unknown categories fall back to
+// a title-cased version of the raw category so a new gate group added by a
+// migration still renders sensibly without a code change.
+const CATEGORY_LABELS: Record<string, string> = {
+  billing: "Billing & payments",
+  carl: "Sovereign workspace",
+  audit: "Audit sinks",
+  sso: "Single sign-on",
+  feature: "Platform features",
+};
+
+function formatCategory(category: string): string {
+  const known = CATEGORY_LABELS[category];
+  if (known) {
+    return known;
+  }
+  const spaced = category.replace(/_/g, " ");
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
+
+interface GateGroup {
+  category: string;
+  gates: FeatureGate[];
+}
+
+// groupByCategory keeps the server's (category, label) order: gates arrive
+// pre-sorted, so first-seen category order is the display order.
+function groupByCategory(gates: FeatureGate[]): GateGroup[] {
+  const groups: GateGroup[] = [];
+  for (const gate of gates) {
+    const existing = groups.find((group) => group.category === gate.category);
+    if (existing) {
+      existing.gates = [...existing.gates, gate];
+    } else {
+      groups.push({ category: gate.category, gates: [gate] });
+    }
+  }
+  return groups;
+}
+
+export function FeatureGateManager({ gates: initialGates }: FeatureGateManagerProps) {
+  const [gates, setGates] = React.useState<FeatureGate[]>(initialGates);
+  const [status, setStatus] = React.useState<Record<string, RowStatus>>({});
+
+  async function toggle(gate: FeatureGate): Promise<void> {
+    const next = !gate.enabled;
+
+    // Optimistic flip; revert on failure.
+    setGates((prev) =>
+      prev.map((g) => (g.key === gate.key ? { ...g, enabled: next } : g)),
+    );
+    setStatus((prev) => ({ ...prev, [gate.key]: "saving" }));
+
+    try {
+      const response = await fetch("/api/console/feature-gates", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ key: gate.key, enabled: next }),
+      });
+      if (!response.ok) {
+        throw new Error("request failed");
+      }
+      setStatus((prev) => ({ ...prev, [gate.key]: "idle" }));
+    } catch {
+      setGates((prev) =>
+        prev.map((g) => (g.key === gate.key ? { ...g, enabled: gate.enabled } : g)),
+      );
+      setStatus((prev) => ({ ...prev, [gate.key]: "error" }));
+    }
+  }
+
+  const groups = groupByCategory(gates);
+
+  return (
+    <div className="flex flex-col gap-10">
+      {groups.map((group) => (
+        <section key={group.category} className="flex flex-col gap-3">
+          <h2 className="text-2xs font-medium uppercase tracking-[0.14em] text-[var(--color-ink-3)]">
+            {formatCategory(group.category)}
+          </h2>
+          <ul className="flex flex-col rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] divide-y divide-[var(--color-border)]">
+            {group.gates.map((gate) => {
+              const rowStatus = status[gate.key] ?? "idle";
+              return (
+                <li
+                  key={gate.key}
+                  className="flex items-center justify-between gap-4 px-4 py-3.5"
+                >
+                  <div className="flex min-w-0 flex-col gap-0.5">
+                    <span className="text-sm text-[var(--color-ink)]">
+                      {gate.label}
+                    </span>
+                    <span className="font-mono text-2xs text-[var(--color-ink-3)]">
+                      {gate.key}
+                    </span>
+                    {rowStatus === "error" ? (
+                      <span className="mt-0.5 flex items-center gap-1 text-2xs text-[var(--color-danger,#d64545)]">
+                        <AlertCircle size={12} />
+                        Could not save. Try again.
+                      </span>
+                    ) : null}
+                  </div>
+                  <div className="flex shrink-0 items-center gap-3">
+                    <span
+                      className={cn(
+                        "text-2xs tabular-nums transition-opacity",
+                        rowStatus === "saving"
+                          ? "text-[var(--color-ink-3)] opacity-100"
+                          : "opacity-0",
+                      )}
+                      aria-hidden="true"
+                    >
+                      Saving…
+                    </span>
+                    <GateSwitch
+                      checked={gate.enabled}
+                      saving={rowStatus === "saving"}
+                      label={gate.label}
+                      onToggle={() => {
+                        void toggle(gate);
+                      }}
+                    />
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+      ))}
+    </div>
+  );
+}
+
+interface GateSwitchProps {
+  checked: boolean;
+  saving: boolean;
+  label: string;
+  onToggle: () => void;
+}
+
+function GateSwitch({ checked, saving, label, onToggle }: GateSwitchProps) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={`${label}: ${checked ? "enabled" : "disabled"}`}
+      disabled={saving}
+      onClick={onToggle}
+      className={cn(
+        "relative inline-flex h-6 w-11 shrink-0 items-center rounded-full",
+        "transition-colors duration-[var(--duration-fast)]",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-surface)]",
+        checked
+          ? "bg-[var(--color-accent)]"
+          : "bg-[var(--color-border-strong,#c9c9c9)]",
+        saving ? "cursor-wait opacity-70" : "cursor-pointer",
+      )}
+    >
+      <span
+        className={cn(
+          "inline-block h-5 w-5 transform rounded-full bg-white shadow-sm",
+          "transition-transform duration-[var(--duration-fast)]",
+          checked ? "translate-x-[22px]" : "translate-x-0.5",
+        )}
+      />
+    </button>
+  );
+}

--- a/apps/web-console/components/feature-gates/feature-gate-manager.tsx
+++ b/apps/web-console/components/feature-gates/feature-gate-manager.tsx
@@ -74,6 +74,15 @@ export function FeatureGateManager({ gates: initialGates }: FeatureGateManagerPr
       if (!response.ok) {
         throw new Error("request failed");
       }
+      // Reconcile with the state the server actually applied, in case it
+      // diverged from the request (e.g. a concurrent admin edit), rather than
+      // trusting the optimistic value.
+      const result: { key?: string; enabled?: boolean } = await response.json();
+      const appliedKey = result.key ?? gate.key;
+      const applied = typeof result.enabled === "boolean" ? result.enabled : next;
+      setGates((prev) =>
+        prev.map((g) => (g.key === appliedKey ? { ...g, enabled: applied } : g)),
+      );
       setStatus((prev) => ({ ...prev, [gate.key]: "idle" }));
     } catch {
       setGates((prev) =>

--- a/apps/web-console/lib/control-plane/client.ts
+++ b/apps/web-console/lib/control-plane/client.ts
@@ -460,6 +460,112 @@ export async function getViewer(): Promise<Viewer> {
   };
 }
 
+// FeatureGate is one row of the admin feature-gate table (issue #292): a
+// gate key, its human label + category, and whether it is enabled for the
+// current tenant.
+export interface FeatureGate {
+  key: string;
+  label: string;
+  category: string;
+  enabled: boolean;
+}
+
+// FeatureGates is the control-plane response for the admin feature-gate list:
+// the tenant the gates apply to plus the gate rows.
+export interface FeatureGates {
+  tenant_id: string;
+  gates: FeatureGate[];
+}
+
+function decodeFeatureGates(payload: JsonObject): FeatureGates | null {
+  const tenantId = readStringField(payload, "tenant_id");
+  const gatesValue = readArrayField(payload, "gates");
+  if (tenantId === null || gatesValue === null) {
+    return null;
+  }
+
+  const gates: FeatureGate[] = [];
+  for (const item of gatesValue) {
+    if (!isJsonObject(item)) {
+      return null;
+    }
+    const key = readStringField(item, "key");
+    const label = readStringField(item, "label");
+    const category = readStringField(item, "category");
+    const enabled = readBooleanField(item, "enabled");
+    if (key === null || label === null || category === null || enabled === null) {
+      return null;
+    }
+    gates.push({ key, label, category, enabled });
+  }
+
+  return { tenant_id: tenantId, gates };
+}
+
+// getFeatureGates lists every registered feature gate joined with the current
+// tenant's enablement. Server-only (uses the session bearer); the control-plane
+// gates this on platform-admin and returns 403 for non-admins, surfaced here as
+// a ControlPlaneError so the caller can render an access state.
+export async function getFeatureGates(): Promise<FeatureGates> {
+  const { baseUrl, headers } = await getRequestContext();
+  const response = await fetch(`${baseUrl}/api/v1/admin/feature-gates`, {
+    headers,
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    await throwControlPlaneError(response, "Failed to load feature gates");
+  }
+
+  const payload = parseJsonValue(await readResponseText(response));
+  if (!isJsonObject(payload)) {
+    throw new Error("Failed to parse feature gates response");
+  }
+
+  const decoded = decodeFeatureGates(payload);
+  if (!decoded) {
+    throw new Error("Failed to parse feature gates response");
+  }
+
+  return decoded;
+}
+
+// setFeatureGate toggles a single gate for the current tenant. Server-only;
+// throws ControlPlaneError so a Route Handler can map the upstream status to a
+// customer-safe message.
+export async function setFeatureGate(
+  key: string,
+  enabled: boolean,
+): Promise<{ key: string; enabled: boolean }> {
+  const { baseUrl, headers } = await getRequestContext();
+  const response = await fetch(
+    `${baseUrl}/api/v1/admin/feature-gates/${encodeURIComponent(key)}`,
+    {
+      method: "PUT",
+      headers,
+      cache: "no-store",
+      body: JSON.stringify({ enabled }),
+    },
+  );
+
+  if (!response.ok) {
+    await throwControlPlaneError(response, "Failed to update feature gate");
+  }
+
+  const payload = parseJsonValue(await readResponseText(response));
+  if (!isJsonObject(payload)) {
+    throw new Error("Failed to parse feature gate response");
+  }
+
+  const outKey = readStringField(payload, "key");
+  const outEnabled = readBooleanField(payload, "enabled");
+  if (outKey === null || outEnabled === null) {
+    throw new Error("Failed to parse feature gate response");
+  }
+
+  return { key: outKey, enabled: outEnabled };
+}
+
 export async function getAccountProfile(): Promise<AccountProfile> {
   const { baseUrl, headers } = await getRequestContext();
   const response = await fetch(`${baseUrl}/api/v1/accounts/current/profile`, {

--- a/apps/web-console/lib/control-plane/client.ts
+++ b/apps/web-console/lib/control-plane/client.ts
@@ -470,17 +470,16 @@ export interface FeatureGate {
   enabled: boolean;
 }
 
-// FeatureGates is the control-plane response for the admin feature-gate list:
-// the tenant the gates apply to plus the gate rows.
+// FeatureGates is the control-plane response for the admin feature-gate list.
+// Gates are scoped server-side to the caller's selected tenant; the tenant id
+// is deliberately not echoed on the wire.
 export interface FeatureGates {
-  tenant_id: string;
   gates: FeatureGate[];
 }
 
 function decodeFeatureGates(payload: JsonObject): FeatureGates | null {
-  const tenantId = readStringField(payload, "tenant_id");
   const gatesValue = readArrayField(payload, "gates");
-  if (tenantId === null || gatesValue === null) {
+  if (gatesValue === null) {
     return null;
   }
 
@@ -499,7 +498,7 @@ function decodeFeatureGates(payload: JsonObject): FeatureGates | null {
     gates.push({ key, label, category, enabled });
   }
 
-  return { tenant_id: tenantId, gates };
+  return { gates };
 }
 
 // getFeatureGates lists every registered feature gate joined with the current


### PR DESCRIPTION
## What

Builds Step 1.2 of the agent-subsystem blueprint (issue #292): the web-console admin page for per-tenant feature gate toggles, plus the owner-gated control-plane admin API it depends on. PR #318 built the dynamic `feature_gate_keys` registry and the internal read endpoint but left the admin CRUD surface unbuilt, so this adds it.

## Control plane

- `settings.Resolver.Registry` reads `public.feature_gate_keys` (key, label, category) through the service-role pool.
- `settings.Resolver.Set` upserts one gate into `tenant_settings`, records `updated_by`, invalidates the local cache, and rejects unregistered keys with `ErrUnknownGateKey`. This is the single sanctioned write path (direct table writes stay lint-blocked elsewhere).
- `featuregate.AdminHandler` serves `GET /api/v1/admin/feature-gates` (registry joined with the caller's tenant enablement) and `PUT /api/v1/admin/feature-gates/{key}` (toggle). Tenant scope is the caller's selected tenant (`auth.Viewer.TenantID`); writes are attributed to `auth.Viewer.UserID`.
- Routes mount behind `AuthMiddleware.Require` plus `RoleSvc.RequirePlatformAdmin`, mirroring the existing `/api/v1/admin/providers` gating. No migration is needed: the service-role pool reads `feature_gate_keys` and writes `tenant_settings` directly, and the `tenant_settings_changed` NOTIFY trigger propagates changes to every cache within its TTL.

## Web console

- `getFeatureGates` and `setFeatureGate` control-plane client helpers (server-only, strict decoders, no `as`/`any`/`unknown`).
- `/console/feature-gates` page, platform-admin gated (`can(viewer, "platform.admin")`), grouping gates by category with accessible toggle switches and optimistic save.
- `/api/console/feature-gates` BFF route keeps the control-plane URL server side and maps upstream status to customer-safe messages.
- Feature gates entry added to the console navigation.

## Scope notes

- Toggles operate on the caller's currently selected tenant (reuses the existing workspace switcher) rather than a platform-wide tenant directory. A directory picker is a follow-up if managing arbitrary tenants from one screen is needed.
- The nav item is visible to all users; access is enforced server-side (the page renders an access state and the control-plane returns 403 for non-admins).
- Does not include the OWUI shim (Step 1.5) or inference-posture gate logic.

## Test plan

- [x] Control-plane Go build green.
- [x] Control-plane tests green, including new `featuregate` admin handler suite (list merge, toggle attribution, unknown key 400, no-tenant 400, unauthenticated 401, method not allowed) and existing `tenant/settings` and `platform/http` suites.
- [x] `gofmt` clean and `go vet` clean on changed packages.
- [x] Web-console `next build` succeeds with both new routes present (`/console/feature-gates`, `/api/console/feature-gates`).
- [x] Web-console `vitest` suite green (217 tests), including the new feature-gate toggle component test (render, initial state, optimistic PUT, revert on failure).
- [ ] Manual end-to-end acceptance (blueprint acceptance): admin toggles a gate in the UI and the change is observed enforced on an edge route. Deferred to a live stack run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an admin-only Feature Gates page to the web console.
  * Admins can view gates by category and enable or disable them with toggle controls.
  * Added validation, access control, and clear error states for unauthorized users, invalid requests, and failed updates.
  * Added a Feature gates link to the Admin navigation.
* **Bug Fixes**
  * Gate changes now refresh immediately and safely revert if saving fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->