### PR TITLE
fix: wire RAG ingestion pipeline and fix edge-api tenant RLS bug (#232)

### DIFF
--- a/apps/control-plane/cmd/server/main.go
+++ b/apps/control-plane/cmd/server/main.go
@@ -55,6 +55,7 @@ import (
 	platformredis "github.com/sakibsadmanshajib/hive/apps/control-plane/internal/platform/redis"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/profiles"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/providers"
+	cprag "github.com/sakibsadmanshajib/hive/apps/control-plane/internal/rag"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/routing"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/signup"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/signupguard"
@@ -903,6 +904,29 @@ func main() {
 				return platformhttp.RequireInternalToken(cfg.InternalToken, h)
 			})
 			log.Println("filestore routes registered")
+		}
+
+		// RAG ingestion (#232): edge-api registers the rag_documents row, then
+		// calls this internal endpoint to chunk, embed, and store the content.
+		// Requires an embedding backend; without one the route is not mounted
+		// and uploaded documents simply stay "pending" (no partial pipeline).
+		ragEmbedBaseURL := strings.TrimSpace(os.Getenv("EMBEDDING_BASE_URL"))
+		ragEmbedModel := strings.TrimSpace(os.Getenv("EMBEDDING_MODEL"))
+		if ragEmbedModel == "" {
+			ragEmbedModel = "bge-m3"
+		}
+		if ragEmbedBaseURL == "" {
+			log.Println("WARNING: EMBEDDING_BASE_URL not set; rag ingest route not registered (uploaded documents will stay pending)")
+		} else {
+			ragRepo := cprag.NewRepo(pool)
+			ragEmbedClient := cprag.NewHTTPEmbedClient(ragEmbedBaseURL, ragEmbedModel)
+			ragIngester := cprag.NewIngester(ragRepo, ragEmbedClient, 0)
+			cprag.RegisterRoutes(routerMux, func(ctx context.Context, tenantID, docID uuid.UUID, content string) error {
+				return ragIngester.Ingest(ctx, tenantID, docID, content)
+			}, func(h http.Handler) http.Handler {
+				return platformhttp.RequireInternalToken(cfg.InternalToken, h)
+			})
+			log.Println("rag ingest route registered")
 		}
 	}
 

--- a/apps/control-plane/internal/rag/http.go
+++ b/apps/control-plane/internal/rag/http.go
@@ -3,11 +3,18 @@ package rag
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"log"
 	"net/http"
 	"strings"
 
 	"github.com/google/uuid"
 )
+
+// maxIngestBodyBytes bounds the ingest request body the same way edge-api's
+// own /v1/rag/documents upload handler bounds its body (10 MiB), so a caller
+// cannot force unbounded memory use and embedding work on control-plane.
+const maxIngestBodyBytes = 10 * 1024 * 1024
 
 // IngestFunc chunks, embeds, and stores a document. It matches the method
 // value of (*Ingester).Ingest, kept as a func type so tests can inject a fake
@@ -38,8 +45,14 @@ func (h *IngestHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	r.Body = http.MaxBytesReader(w, r.Body, maxIngestBodyBytes)
 	var req ingestRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			writeJSON(w, http.StatusRequestEntityTooLarge, map[string]string{"error": "request body too large"})
+			return
+		}
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON body"})
 		return
 	}
@@ -60,7 +73,11 @@ func (h *IngestHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.ingest(r.Context(), tenantID, docID, req.Content); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		// Provider-blind: log the real cause server-side, never echo it back --
+		// Ingester wraps some errors (e.g. DB failures) that are not yet
+		// sanitized text, so this boundary must not trust err.Error() as safe.
+		log.Printf("rag: ingest failed tenant=%s doc=%s: %v", tenantID, docID, err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "ingest failed"})
 		return
 	}
 

--- a/apps/control-plane/internal/rag/http.go
+++ b/apps/control-plane/internal/rag/http.go
@@ -1,0 +1,85 @@
+package rag
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// IngestFunc chunks, embeds, and stores a document. It matches the method
+// value of (*Ingester).Ingest, kept as a func type so tests can inject a fake
+// without a real database or embedding backend.
+type IngestFunc func(ctx context.Context, tenantID, docID uuid.UUID, content string) error
+
+// IngestHandler serves POST /internal/rag/ingest, the service-to-service
+// endpoint edge-api calls after registering a rag_documents row so the
+// document gets chunked, embedded, and stored (blueprint Step 2.1, #232).
+type IngestHandler struct {
+	ingest IngestFunc
+}
+
+// NewIngestHandler constructs an IngestHandler around ingest.
+func NewIngestHandler(ingest IngestFunc) *IngestHandler {
+	return &IngestHandler{ingest: ingest}
+}
+
+type ingestRequest struct {
+	TenantID   string `json:"tenant_id"`
+	DocumentID string `json:"document_id"`
+	Content    string `json:"content"`
+}
+
+func (h *IngestHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+
+	var req ingestRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON body"})
+		return
+	}
+
+	if strings.TrimSpace(req.Content) == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "content is required"})
+		return
+	}
+	tenantID, err := uuid.Parse(strings.TrimSpace(req.TenantID))
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "tenant_id must be a valid uuid"})
+		return
+	}
+	docID, err := uuid.Parse(strings.TrimSpace(req.DocumentID))
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "document_id must be a valid uuid"})
+		return
+	}
+
+	if err := h.ingest(r.Context(), tenantID, docID, req.Content); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+// RegisterRoutes mounts the /internal/rag/* routes on mux, wrapped by gate
+// (typically platformhttp.RequireInternalToken). A nil gate registers the
+// handler directly, matching filestore.RegisterRoutes.
+func RegisterRoutes(mux *http.ServeMux, ingest IngestFunc, gate func(http.Handler) http.Handler) {
+	h := NewIngestHandler(ingest)
+	if gate == nil {
+		gate = func(next http.Handler) http.Handler { return next }
+	}
+	mux.Handle("/internal/rag/ingest", gate(h))
+}
+
+func writeJSON(w http.ResponseWriter, status int, body interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}

--- a/apps/control-plane/internal/rag/http_test.go
+++ b/apps/control-plane/internal/rag/http_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -104,6 +105,27 @@ func TestHandleIngest(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestHandleIngest_RejectsOversizedBody(t *testing.T) {
+	var called bool
+	h := NewIngestHandler(func(context.Context, uuid.UUID, uuid.UUID, string) error {
+		called = true
+		return nil
+	})
+
+	oversized := strings.Repeat("a", maxIngestBodyBytes+1024)
+	body := `{"tenant_id":"` + uuid.New().String() + `","document_id":"` + uuid.New().String() + `","content":"` + oversized + `"}`
+	req := httptest.NewRequest(http.MethodPost, "/internal/rag/ingest", bytes.NewBufferString(body))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusRequestEntityTooLarge)
+	}
+	if called {
+		t.Fatal("ingest must not be called for an oversized body")
 	}
 }
 

--- a/apps/control-plane/internal/rag/http_test.go
+++ b/apps/control-plane/internal/rag/http_test.go
@@ -1,0 +1,162 @@
+package rag
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestHandleIngest(t *testing.T) {
+	validTenant := uuid.New()
+	validDoc := uuid.New()
+
+	tests := []struct {
+		name       string
+		body       string
+		ingestErr  error
+		wantStatus int
+		wantCalled bool
+	}{
+		{
+			name:       "valid request calls ingest and returns ok",
+			body:       `{"tenant_id":"` + validTenant.String() + `","document_id":"` + validDoc.String() + `","content":"hello world"}`,
+			wantStatus: http.StatusOK,
+			wantCalled: true,
+		},
+		{
+			name:       "missing tenant_id is rejected",
+			body:       `{"document_id":"` + validDoc.String() + `","content":"hello"}`,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "missing document_id is rejected",
+			body:       `{"tenant_id":"` + validTenant.String() + `","content":"hello"}`,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "empty content is rejected",
+			body:       `{"tenant_id":"` + validTenant.String() + `","document_id":"` + validDoc.String() + `","content":""}`,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "invalid tenant_id uuid is rejected",
+			body:       `{"tenant_id":"not-a-uuid","document_id":"` + validDoc.String() + `","content":"hello"}`,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "malformed json is rejected",
+			body:       `{not json`,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "ingest failure returns 500",
+			body:       `{"tenant_id":"` + validTenant.String() + `","document_id":"` + validDoc.String() + `","content":"hello"}`,
+			ingestErr:  errors.New("embedding service unavailable"),
+			wantStatus: http.StatusInternalServerError,
+			wantCalled: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var called bool
+			var gotTenant, gotDoc uuid.UUID
+			var gotContent string
+			fakeIngest := func(_ context.Context, tenantID, docID uuid.UUID, content string) error {
+				called = true
+				gotTenant, gotDoc, gotContent = tenantID, docID, content
+				return tc.ingestErr
+			}
+
+			h := NewIngestHandler(fakeIngest)
+			req := httptest.NewRequest(http.MethodPost, "/internal/rag/ingest", bytes.NewBufferString(tc.body))
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d (body: %s)", rec.Code, tc.wantStatus, rec.Body.String())
+			}
+			if called != tc.wantCalled {
+				t.Fatalf("ingest called = %v, want %v", called, tc.wantCalled)
+			}
+			if tc.wantCalled && tc.ingestErr == nil {
+				if gotTenant != validTenant {
+					t.Errorf("tenant_id = %v, want %v", gotTenant, validTenant)
+				}
+				if gotDoc != validDoc {
+					t.Errorf("document_id = %v, want %v", gotDoc, validDoc)
+				}
+				if gotContent != "hello world" {
+					t.Errorf("content = %q, want %q", gotContent, "hello world")
+				}
+				var resp map[string]string
+				if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+					t.Fatalf("decode response: %v", err)
+				}
+				if resp["status"] != "ok" {
+					t.Errorf("response status = %q, want %q", resp["status"], "ok")
+				}
+			}
+		})
+	}
+}
+
+func TestHandleIngest_RejectsWrongMethod(t *testing.T) {
+	h := NewIngestHandler(func(context.Context, uuid.UUID, uuid.UUID, string) error { return nil })
+	req := httptest.NewRequest(http.MethodGet, "/internal/rag/ingest", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusMethodNotAllowed)
+	}
+}
+
+func TestRegisterRoutes_MountsIngestRoute(t *testing.T) {
+	var called bool
+	fakeIngest := func(context.Context, uuid.UUID, uuid.UUID, string) error {
+		called = true
+		return nil
+	}
+
+	mux := http.NewServeMux()
+	RegisterRoutes(mux, fakeIngest, nil)
+
+	tenantID, docID := uuid.New(), uuid.New()
+	body := `{"tenant_id":"` + tenantID.String() + `","document_id":"` + docID.String() + `","content":"hi"}`
+	req := httptest.NewRequest(http.MethodPost, "/internal/rag/ingest", bytes.NewBufferString(body))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if !called {
+		t.Fatal("expected ingest to be called through the mounted route")
+	}
+}
+
+func TestRegisterRoutes_GateRejectsUnauthorized(t *testing.T) {
+	fakeIngest := func(context.Context, uuid.UUID, uuid.UUID, string) error { return nil }
+	denyGate := func(http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		})
+	}
+
+	mux := http.NewServeMux()
+	RegisterRoutes(mux, fakeIngest, denyGate)
+
+	req := httptest.NewRequest(http.MethodPost, "/internal/rag/ingest", bytes.NewBufferString(`{}`))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+}

--- a/apps/edge-api/cmd/server/main.go
+++ b/apps/edge-api/cmd/server/main.go
@@ -268,7 +268,13 @@ func main() {
 				log.Printf("rag audit write failed: %v", err)
 			}
 		}
-		ragHandler := edgerag.NewHandler(ragRepo, ragEmbedder, ragAudit, nil, rootCtx)
+		// Ingestion (chunk + embed + store) runs in control-plane, not here --
+		// edge-api calls the internal service-to-service endpoint the same way
+		// filestoreClient calls control-plane for file metadata (issue #232).
+		ragIngestClient := edgerag.NewIngestClient(resolveControlPlaneBaseURL())
+		ragIngest := ragIngestClient.AsIngestFunc(log.Printf)
+
+		ragHandler := edgerag.NewHandler(ragRepo, ragEmbedder, ragAudit, ragIngest, rootCtx)
 		ragMW := featureGate.Require(featuregate.FeatureRAG)
 		ragMux := http.NewServeMux()
 		ragHandler.Register(ragMux)

--- a/apps/edge-api/internal/rag/handler_test.go
+++ b/apps/edge-api/internal/rag/handler_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -406,5 +407,41 @@ func TestExtractDocID_TrailingSlash(t *testing.T) {
 	got, err := extractDocID("/v1/rag/documents/" + id.String() + "/")
 	if err != nil || got != id {
 		t.Errorf("extractDocID with trailing slash failed: err=%v", err)
+	}
+}
+
+// TestHandleUpload_IngestUsesAuthenticatedTenantOnly proves the tenant_id
+// forwarded to IngestFunc (and from there into the control-plane ingest
+// request body) always comes from the resolved auth context, never from
+// client input: UploadRequest has no tenant_id field at all, so there is no
+// wire path for a caller to influence which tenant the ingest call carries.
+func TestHandleUpload_IngestUsesAuthenticatedTenantOnly(t *testing.T) {
+	store := newFakeStore()
+	var audits []auditRecord
+	var mu sync.Mutex
+	var gotTenant uuid.UUID
+	var called bool
+	ingest := func(_ context.Context, tenantID, _ uuid.UUID, _ string) {
+		mu.Lock()
+		defer mu.Unlock()
+		gotTenant, called = tenantID, true
+	}
+	h := NewHandler(store, &fakeEmbedder{}, makeAuditCapture(&audits), ingest, context.Background())
+
+	authTenant := uuid.New()
+	body, _ := json.Marshal(UploadRequest{Name: "doc.txt", Content: "hello world"})
+	req := httptest.NewRequest(http.MethodPost, "/v1/rag/documents", bytes.NewReader(body))
+	req = req.WithContext(userCtx(authTenant))
+	w := httptest.NewRecorder()
+	h.handleUpload(w, req)
+	h.Shutdown() // wait for the async ingest goroutine before asserting
+
+	mu.Lock()
+	defer mu.Unlock()
+	if !called {
+		t.Fatal("expected ingest to be called")
+	}
+	if gotTenant != authTenant {
+		t.Fatalf("ingest tenant_id = %v, want authenticated tenant %v", gotTenant, authTenant)
 	}
 }

--- a/apps/edge-api/internal/rag/ingestclient.go
+++ b/apps/edge-api/internal/rag/ingestclient.go
@@ -62,9 +62,12 @@ func (c *IngestClient) Ingest(ctx context.Context, tenantID, docID uuid.UUID, co
 	}
 	defer resp.Body.Close()
 
-	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 65536))
+	// Drain and discard: the response body may carry control-plane's raw
+	// failure detail, which must not be threaded into this error (provider-blind
+	// boundary) or surfaced to whatever ends up logging it.
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 65536))
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("rag.ingestclient: status %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+		return fmt.Errorf("rag.ingestclient: ingest failed (status %d)", resp.StatusCode)
 	}
 	return nil
 }

--- a/apps/edge-api/internal/rag/ingestclient.go
+++ b/apps/edge-api/internal/rag/ingestclient.go
@@ -1,0 +1,84 @@
+package rag
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/cpauth"
+)
+
+// IngestClient calls the control-plane's internal RAG ingest endpoint so the
+// document uploaded through /v1/rag/documents gets chunked, embedded, and
+// stored (blueprint Step 2.1, #232). Mirrors files.FilestoreClient.
+type IngestClient struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+// NewIngestClient creates an IngestClient pointing at the control-plane base URL.
+func NewIngestClient(controlPlaneURL string) *IngestClient {
+	return &IngestClient{
+		baseURL:    strings.TrimRight(controlPlaneURL, "/"),
+		httpClient: &http.Client{Timeout: 120 * time.Second},
+	}
+}
+
+type ingestRequestBody struct {
+	TenantID   string `json:"tenant_id"`
+	DocumentID string `json:"document_id"`
+	Content    string `json:"content"`
+}
+
+// Ingest posts the document content to the control-plane for chunking,
+// embedding, and storage. POST /internal/rag/ingest.
+func (c *IngestClient) Ingest(ctx context.Context, tenantID, docID uuid.UUID, content string) error {
+	body, err := json.Marshal(ingestRequestBody{
+		TenantID:   tenantID.String(),
+		DocumentID: docID.String(),
+		Content:    content,
+	})
+	if err != nil {
+		return fmt.Errorf("rag.ingestclient: marshal: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		c.baseURL+"/internal/rag/ingest", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("rag.ingestclient: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	cpauth.SetHeader(req)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("rag.ingestclient: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 65536))
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("rag.ingestclient: status %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+	return nil
+}
+
+// AsIngestFunc adapts Ingest to the fire-and-forget IngestFunc signature the
+// Handler expects. Failures are logged by logf (main.go wires log.Printf) --
+// the document stays in "pending" status and never surfaces the raw error to
+// the customer, matching the provider-blind error contract elsewhere in rag.
+func (c *IngestClient) AsIngestFunc(logf func(format string, args ...any)) IngestFunc {
+	return func(ctx context.Context, tenantID, docID uuid.UUID, content string) {
+		if err := c.Ingest(ctx, tenantID, docID, content); err != nil {
+			if logf != nil {
+				logf("rag: ingest failed doc=%s: %v", docID, err)
+			}
+		}
+	}
+}

--- a/apps/edge-api/internal/rag/ingestclient_test.go
+++ b/apps/edge-api/internal/rag/ingestclient_test.go
@@ -1,0 +1,72 @@
+package rag
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestIngestClient_Ingest_PostsExpectedBody(t *testing.T) {
+	tenantID, docID := uuid.New(), uuid.New()
+	var gotPath, gotMethod string
+	var gotBody ingestRequestBody
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Errorf("decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	}))
+	defer srv.Close()
+
+	client := NewIngestClient(srv.URL)
+	if err := client.Ingest(context.Background(), tenantID, docID, "hello world"); err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	if gotPath != "/internal/rag/ingest" {
+		t.Errorf("path = %q, want /internal/rag/ingest", gotPath)
+	}
+	if gotBody.TenantID != tenantID.String() {
+		t.Errorf("tenant_id = %q, want %q", gotBody.TenantID, tenantID.String())
+	}
+	if gotBody.DocumentID != docID.String() {
+		t.Errorf("document_id = %q, want %q", gotBody.DocumentID, docID.String())
+	}
+	if gotBody.Content != "hello world" {
+		t.Errorf("content = %q, want %q", gotBody.Content, "hello world")
+	}
+}
+
+func TestIngestClient_Ingest_NonOKStatusReturnsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"embedding service unavailable"}`))
+	}))
+	defer srv.Close()
+
+	client := NewIngestClient(srv.URL)
+	err := client.Ingest(context.Background(), uuid.New(), uuid.New(), "hello")
+	if err == nil {
+		t.Fatal("expected error for non-OK status")
+	}
+}
+
+func TestIngestClient_Ingest_UnreachableServerReturnsError(t *testing.T) {
+	client := NewIngestClient("http://127.0.0.1:1")
+	err := client.Ingest(context.Background(), uuid.New(), uuid.New(), "hello")
+	if err == nil {
+		t.Fatal("expected error when control-plane is unreachable")
+	}
+}

--- a/apps/edge-api/internal/rag/ingestclient_test.go
+++ b/apps/edge-api/internal/rag/ingestclient_test.go
@@ -8,16 +8,21 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/cpauth"
 )
 
 func TestIngestClient_Ingest_PostsExpectedBody(t *testing.T) {
+	cpauth.SetTokenForTest("test-internal-token")
+	defer cpauth.SetTokenForTest("")
+
 	tenantID, docID := uuid.New(), uuid.New()
-	var gotPath, gotMethod string
+	var gotPath, gotMethod, gotToken string
 	var gotBody ingestRequestBody
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotPath = r.URL.Path
 		gotMethod = r.Method
+		gotToken = r.Header.Get(cpauth.Header)
 		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
 			t.Errorf("decode request body: %v", err)
 		}
@@ -37,6 +42,9 @@ func TestIngestClient_Ingest_PostsExpectedBody(t *testing.T) {
 	}
 	if gotPath != "/internal/rag/ingest" {
 		t.Errorf("path = %q, want /internal/rag/ingest", gotPath)
+	}
+	if gotToken != "test-internal-token" {
+		t.Errorf("internal auth header = %q, want %q", gotToken, "test-internal-token")
 	}
 	if gotBody.TenantID != tenantID.String() {
 		t.Errorf("tenant_id = %q, want %q", gotBody.TenantID, tenantID.String())

--- a/apps/edge-api/internal/rag/repository.go
+++ b/apps/edge-api/internal/rag/repository.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -39,28 +40,49 @@ type Repo struct {
 // NewRepo creates a Repo backed by pool.
 func NewRepo(pool *pgxpool.Pool) *Repo { return &Repo{pool: pool} }
 
+// withTenantTx runs fn inside an explicit transaction with the RLS session
+// variable set LOCAL (transaction-scoped) to tenantID. hive_app is NOT
+// BYPASSRLS (20260518_04_phase19_audit_rls_and_indexes.sql), so every query
+// against public.rag_documents / public.rag_chunks must see
+// app.current_tenant_id set to the caller's tenant.
+//
+// A bare conn.Exec(set_config(..., true)) followed by a separate
+// conn.QueryRow/Exec with no transaction does not work: LOCAL resets the
+// instant the Exec's own implicit (autocommit) transaction ends, so the
+// following query sees current_setting() back at NULL and the RLS policy
+// denies everything (reads return zero rows, writes fail WITH CHECK).
+// Wrapping in Begin/Commit makes LOCAL correct: it applies for exactly this
+// transaction's statements and is guaranteed to clear at Commit or Rollback,
+// so nothing survives onto the pooled connection for the next borrower.
+// Mirrors apps/control-plane/internal/rag/repository.go.
+func (r *Repo) withTenantTx(ctx context.Context, tenantID uuid.UUID, fn func(tx pgx.Tx) error) error {
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("rag.repo: begin tx: %w", err)
+	}
+	defer tx.Rollback(ctx) // no-op once Commit has succeeded
+
+	if _, err := tx.Exec(ctx, "SELECT set_config('app.current_tenant_id', $1, true)", tenantID.String()); err != nil {
+		return fmt.Errorf("rag.repo: set tenant: %w", err)
+	}
+	if err := fn(tx); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}
+
 // InsertDocument registers a new rag_document row (status=pending) and
 // returns its assigned id.
 func (r *Repo) InsertDocument(ctx context.Context, tenantID uuid.UUID, name, mimeType string, sizeBytes int64) (uuid.UUID, error) {
-	conn, err := r.pool.Acquire(ctx)
-	if err != nil {
-		return uuid.Nil, fmt.Errorf("rag.repo: acquire: %w", err)
-	}
-	defer conn.Release()
-
-	if _, err := conn.Exec(ctx,
-		"SELECT set_config('app.current_tenant_id', $1, true)",
-		tenantID.String()); err != nil {
-		return uuid.Nil, fmt.Errorf("rag.repo: set tenant: %w", err)
-	}
-
 	var id uuid.UUID
-	err = conn.QueryRow(ctx, `
-		INSERT INTO public.rag_documents (tenant_id, name, mime_type, size_bytes, status)
-		VALUES ($1, $2, $3, $4, 'pending')
-		RETURNING id`,
-		tenantID, name, mimeType, sizeBytes,
-	).Scan(&id)
+	err := r.withTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `
+			INSERT INTO public.rag_documents (tenant_id, name, mime_type, size_bytes, status)
+			VALUES ($1, $2, $3, $4, 'pending')
+			RETURNING id`,
+			tenantID, name, mimeType, sizeBytes,
+		).Scan(&id)
+	})
 	if err != nil {
 		return uuid.Nil, fmt.Errorf("rag.repo: insert document: %w", err)
 	}
@@ -69,24 +91,14 @@ func (r *Repo) InsertDocument(ctx context.Context, tenantID uuid.UUID, name, mim
 
 // GetDocument fetches one document by id scoped to tenantID.
 func (r *Repo) GetDocument(ctx context.Context, tenantID, docID uuid.UUID) (DocRow, error) {
-	conn, err := r.pool.Acquire(ctx)
-	if err != nil {
-		return DocRow{}, fmt.Errorf("rag.repo: acquire: %w", err)
-	}
-	defer conn.Release()
-
-	if _, err := conn.Exec(ctx,
-		"SELECT set_config('app.current_tenant_id', $1, true)",
-		tenantID.String()); err != nil {
-		return DocRow{}, fmt.Errorf("rag.repo: set tenant: %w", err)
-	}
-
 	var d DocRow
-	err = conn.QueryRow(ctx, `
-		SELECT id, tenant_id, name, mime_type, size_bytes, status, created_at
-		FROM public.rag_documents WHERE id = $1`,
-		docID,
-	).Scan(&d.ID, &d.TenantID, &d.Name, &d.MimeType, &d.SizeBytes, &d.Status, &d.CreatedAt)
+	err := r.withTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `
+			SELECT id, tenant_id, name, mime_type, size_bytes, status, created_at
+			FROM public.rag_documents WHERE id = $1`,
+			docID,
+		).Scan(&d.ID, &d.TenantID, &d.Name, &d.MimeType, &d.SizeBytes, &d.Status, &d.CreatedAt)
+	})
 	if err != nil {
 		return DocRow{}, fmt.Errorf("rag.repo: get document: %w", err)
 	}
@@ -95,58 +107,48 @@ func (r *Repo) GetDocument(ctx context.Context, tenantID, docID uuid.UUID) (DocR
 
 // ListDocuments returns all documents for a tenant, newest first.
 func (r *Repo) ListDocuments(ctx context.Context, tenantID uuid.UUID) ([]DocRow, error) {
-	conn, err := r.pool.Acquire(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("rag.repo: acquire: %w", err)
-	}
-	defer conn.Release()
-
-	if _, err := conn.Exec(ctx,
-		"SELECT set_config('app.current_tenant_id', $1, true)",
-		tenantID.String()); err != nil {
-		return nil, fmt.Errorf("rag.repo: set tenant: %w", err)
-	}
-
-	rows, err := conn.Query(ctx, `
-		SELECT id, tenant_id, name, mime_type, size_bytes, status, created_at
-		FROM public.rag_documents ORDER BY created_at DESC`)
-	if err != nil {
-		return nil, fmt.Errorf("rag.repo: list: %w", err)
-	}
-	defer rows.Close()
-
 	var docs []DocRow
-	for rows.Next() {
-		var d DocRow
-		if err := rows.Scan(&d.ID, &d.TenantID, &d.Name, &d.MimeType,
-			&d.SizeBytes, &d.Status, &d.CreatedAt); err != nil {
-			return nil, fmt.Errorf("rag.repo: scan: %w", err)
+	err := r.withTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `
+			SELECT id, tenant_id, name, mime_type, size_bytes, status, created_at
+			FROM public.rag_documents ORDER BY created_at DESC`)
+		if err != nil {
+			return fmt.Errorf("rag.repo: list: %w", err)
 		}
-		docs = append(docs, d)
+		defer rows.Close()
+
+		for rows.Next() {
+			var d DocRow
+			if err := rows.Scan(&d.ID, &d.TenantID, &d.Name, &d.MimeType,
+				&d.SizeBytes, &d.Status, &d.CreatedAt); err != nil {
+				return fmt.Errorf("rag.repo: scan: %w", err)
+			}
+			docs = append(docs, d)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
 	}
-	return docs, rows.Err()
+	return docs, nil
 }
 
 // DeleteDocument deletes a document (chunks cascade via FK).
 // Returns found=true when a row was actually removed, false when no row matched.
 func (r *Repo) DeleteDocument(ctx context.Context, tenantID, docID uuid.UUID) (bool, error) {
-	conn, err := r.pool.Acquire(ctx)
+	var found bool
+	err := r.withTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		tag, err := tx.Exec(ctx, `DELETE FROM public.rag_documents WHERE id = $1 AND tenant_id = $2`, docID, tenantID)
+		if err != nil {
+			return fmt.Errorf("rag.repo: delete: %w", err)
+		}
+		found = tag.RowsAffected() > 0
+		return nil
+	})
 	if err != nil {
-		return false, fmt.Errorf("rag.repo: acquire: %w", err)
+		return false, err
 	}
-	defer conn.Release()
-
-	if _, err := conn.Exec(ctx,
-		"SELECT set_config('app.current_tenant_id', $1, true)",
-		tenantID.String()); err != nil {
-		return false, fmt.Errorf("rag.repo: set tenant: %w", err)
-	}
-
-	tag, err := conn.Exec(ctx, `DELETE FROM public.rag_documents WHERE id = $1 AND tenant_id = $2`, docID, tenantID)
-	if err != nil {
-		return false, fmt.Errorf("rag.repo: delete: %w", err)
-	}
-	return tag.RowsAffected() > 0, nil
+	return found, nil
 }
 
 // SearchChunks performs cosine vector similarity search scoped to the tenant.
@@ -156,47 +158,42 @@ func (r *Repo) SearchChunks(ctx context.Context, tenantID uuid.UUID, queryVec []
 		topK = 5
 	}
 
-	conn, err := r.pool.Acquire(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("rag.repo: acquire: %w", err)
-	}
-	defer conn.Release()
-
-	if _, err := conn.Exec(ctx,
-		"SELECT set_config('app.current_tenant_id', $1, true)",
-		tenantID.String()); err != nil {
-		return nil, fmt.Errorf("rag.repo: set tenant: %w", err)
-	}
-
 	vec, err := encodeVector(queryVec)
 	if err != nil {
 		return nil, fmt.Errorf("rag.repo: encode vector: %w", err)
 	}
-	// Explicit tenant_id filter is defense-in-depth alongside RLS:
-	// protects against SECURITY DEFINER / superuser-bypass scenarios.
-	rows, err := conn.Query(ctx, `
-		SELECT id, document_id, content,
-		       (embedding <=> $1::vector)::float4 AS score
-		FROM public.rag_chunks
-		WHERE tenant_id = $3
-		ORDER BY embedding <=> $1::vector
-		LIMIT $2`,
-		vec, topK, tenantID,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("rag.repo: search: %w", err)
-	}
-	defer rows.Close()
 
 	var results []ChunkRow
-	for rows.Next() {
-		var c ChunkRow
-		if err := rows.Scan(&c.ID, &c.DocumentID, &c.Content, &c.Score); err != nil {
-			return nil, fmt.Errorf("rag.repo: scan: %w", err)
+	err = r.withTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		// Explicit tenant_id filter is defense-in-depth alongside RLS:
+		// protects against SECURITY DEFINER / superuser-bypass scenarios.
+		rows, err := tx.Query(ctx, `
+			SELECT id, document_id, content,
+			       (embedding <=> $1::vector)::float4 AS score
+			FROM public.rag_chunks
+			WHERE tenant_id = $3
+			ORDER BY embedding <=> $1::vector
+			LIMIT $2`,
+			vec, topK, tenantID,
+		)
+		if err != nil {
+			return fmt.Errorf("rag.repo: search: %w", err)
 		}
-		results = append(results, c)
+		defer rows.Close()
+
+		for rows.Next() {
+			var c ChunkRow
+			if err := rows.Scan(&c.ID, &c.DocumentID, &c.Content, &c.Score); err != nil {
+				return fmt.Errorf("rag.repo: scan: %w", err)
+			}
+			results = append(results, c)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
 	}
-	return results, rows.Err()
+	return results, nil
 }
 
 // encodeVector serialises []float32 to pgvector text format '[v1,v2,...]'.

--- a/apps/edge-api/internal/rag/repository_rls_test.go
+++ b/apps/edge-api/internal/rag/repository_rls_test.go
@@ -1,0 +1,249 @@
+package rag
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// newRLSTestPool connects as the hive_app role -- NOT BYPASSRLS in production
+// (see 20260518_04_phase19_audit_rls_and_indexes.sql) -- so the rag_documents
+// / rag_chunks tenant-isolation RLS policies are actually exercised rather
+// than bypassed by whatever superuser role HIVE_TEST_DB_URL otherwise
+// connects as. MaxConns is pinned to 1 so every Acquire inside a test returns
+// the same physical connection, and the pool is closed (not returned to a
+// shared pool) at test end so the role change never leaks to another test.
+// Mirrors apps/control-plane/internal/rag/repository_rls_test.go.
+func newRLSTestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("HIVE_TEST_DB_URL")
+	if dsn == "" {
+		t.Skip("HIVE_TEST_DB_URL not set")
+	}
+	if !strings.Contains(strings.ToLower(dsn), "test") {
+		t.Fatalf("refusing to run: HIVE_TEST_DB_URL must point at a test database (DSN missing 'test' marker)")
+	}
+
+	cfg, err := pgxpool.ParseConfig(dsn)
+	if err != nil {
+		t.Fatalf("parse HIVE_TEST_DB_URL: %v", err)
+	}
+	cfg.MaxConns = 1
+
+	ctx := context.Background()
+	pool, err := pgxpool.NewWithConfig(ctx, cfg)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	if _, err := pool.Exec(ctx, "SET ROLE hive_app"); err != nil {
+		pool.Close()
+		t.Skipf("SET ROLE hive_app failed (is hive_app provisioned + migrations applied on this test DB?): %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+// seedRAGTenant inserts an FK row into public.tenants via a short-lived,
+// unscoped connection (hive_app has no INSERT policy on tenants).
+func seedRAGTenant(t *testing.T, id uuid.UUID) {
+	t.Helper()
+	dsn := os.Getenv("HIVE_TEST_DB_URL")
+	ctx := context.Background()
+	setup, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("seed pool: %v", err)
+	}
+	defer setup.Close()
+	_, err = setup.Exec(ctx,
+		`INSERT INTO public.tenants (id, slug, name, deployment)
+		 VALUES ($1, $2, 'rag test tenant', 'HIVE_CLOUD')
+		 ON CONFLICT (id) DO NOTHING`,
+		id, "edge-rag-test-"+id.String())
+	if err != nil {
+		t.Fatalf("seed tenant: %v", err)
+	}
+	t.Cleanup(func() {
+		cleanup, err := pgxpool.New(context.Background(), dsn)
+		if err != nil {
+			return
+		}
+		defer cleanup.Close()
+		_, _ = cleanup.Exec(context.Background(), `DELETE FROM public.tenants WHERE id = $1`, id)
+	})
+}
+
+// seedRAGChunk inserts a document + one chunk directly via an unscoped
+// connection, bypassing RLS so cross-tenant fixtures can be planted without
+// going through the (tenant-scoped) Repo under test.
+func seedRAGChunk(t *testing.T, tenantID uuid.UUID, content string, vec []float32) uuid.UUID {
+	t.Helper()
+	dsn := os.Getenv("HIVE_TEST_DB_URL")
+	ctx := context.Background()
+	setup, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("seed pool: %v", err)
+	}
+	defer setup.Close()
+
+	var docID uuid.UUID
+	err = setup.QueryRow(ctx, `
+		INSERT INTO public.rag_documents (tenant_id, name, mime_type, size_bytes, status)
+		VALUES ($1, 'seed.txt', 'text/plain', $2, 'embedded')
+		RETURNING id`,
+		tenantID, len(content),
+	).Scan(&docID)
+	if err != nil {
+		t.Fatalf("seed document: %v", err)
+	}
+
+	encoded, err := encodeVector(vec)
+	if err != nil {
+		t.Fatalf("encode seed vector: %v", err)
+	}
+
+	var chunkID uuid.UUID
+	err = setup.QueryRow(ctx, `
+		INSERT INTO public.rag_chunks (tenant_id, document_id, chunk_index, content, token_count, embedding)
+		VALUES ($1, $2, 0, $3, 1, $4::vector)
+		RETURNING id`,
+		tenantID, docID, content, encoded,
+	).Scan(&chunkID)
+	if err != nil {
+		t.Fatalf("seed chunk: %v", err)
+	}
+	return chunkID
+}
+
+func fixedVector(v float32) []float32 {
+	out := make([]float32, EmbeddingDimension)
+	for i := range out {
+		out[i] = v
+	}
+	return out
+}
+
+func TestRepo_RLS_InsertThenGetRoundTripsUnderTenantContext(t *testing.T) {
+	pool := newRLSTestPool(t)
+	tenantID := uuid.New()
+	seedRAGTenant(t, tenantID)
+
+	repo := NewRepo(pool)
+	ctx := context.Background()
+
+	docID, err := repo.InsertDocument(ctx, tenantID, "doc.txt", "text/plain", 3)
+	if err != nil {
+		t.Fatalf("InsertDocument: %v", err)
+	}
+
+	got, err := repo.GetDocument(ctx, tenantID, docID)
+	if err != nil {
+		t.Fatalf("GetDocument: %v", err)
+	}
+	if got.Name != "doc.txt" {
+		t.Fatalf("expected round-tripped name %q, got %q", "doc.txt", got.Name)
+	}
+}
+
+// TestRepo_RLS_CrossTenantContextCannotReadRows proves the database policy
+// itself blocks cross-tenant reads, independent of the repository's own
+// tenant_id filter.
+func TestRepo_RLS_CrossTenantContextCannotReadRows(t *testing.T) {
+	pool := newRLSTestPool(t)
+	tenantA, tenantB := uuid.New(), uuid.New()
+	seedRAGTenant(t, tenantA)
+	seedRAGTenant(t, tenantB)
+
+	repo := NewRepo(pool)
+	ctx := context.Background()
+	docID, err := repo.InsertDocument(ctx, tenantA, "tenant-a-only.txt", "text/plain", 1)
+	if err != nil {
+		t.Fatalf("seed tenant A document: %v", err)
+	}
+
+	if _, err := pool.Exec(ctx, "SELECT set_config('app.current_tenant_id', $1, false)", tenantB.String()); err != nil {
+		t.Fatalf("set_config tenant B: %v", err)
+	}
+	var count int
+	err = pool.QueryRow(ctx,
+		`SELECT count(*) FROM public.rag_documents WHERE id = $1`,
+		docID).Scan(&count)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("RLS did not block cross-tenant read: got %d row(s) for tenant A's document while session claimed tenant B", count)
+	}
+}
+
+// TestRepo_RLS_NoSessionLeakAcrossBorrows proves the tenant context set by one
+// repository call does not survive onto the pooled connection for whoever
+// borrows it next.
+func TestRepo_RLS_NoSessionLeakAcrossBorrows(t *testing.T) {
+	pool := newRLSTestPool(t)
+	tenantA := uuid.New()
+	seedRAGTenant(t, tenantA)
+
+	repo := NewRepo(pool)
+	ctx := context.Background()
+	docID, err := repo.InsertDocument(ctx, tenantA, "tenant-a-only.txt", "text/plain", 1)
+	if err != nil {
+		t.Fatalf("seed tenant A document: %v", err)
+	}
+
+	var setting string
+	if err := pool.QueryRow(ctx, "SELECT current_setting('app.current_tenant_id', true)").Scan(&setting); err != nil {
+		t.Fatalf("read current_setting: %v", err)
+	}
+	if setting != "" {
+		t.Fatalf("session leak: app.current_tenant_id still %q after InsertDocument committed, want empty", setting)
+	}
+
+	var count int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM public.rag_documents WHERE id = $1`,
+		docID).Scan(&count); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("session leak: bare borrow saw %d row(s) for tenant A's document with no tenant context set (RLS should fail-closed on NULL)", count)
+	}
+}
+
+// TestRepo_RLS_SearchChunksCannotReadOtherTenantChunks proves that
+// SearchChunks scoped to tenant A never returns tenant B's chunks, even when
+// both chunks carry an identical embedding vector (so ANN proximity alone
+// would otherwise rank them the same) -- the boundary must be RLS, not
+// merely low vector similarity.
+func TestRepo_RLS_SearchChunksCannotReadOtherTenantChunks(t *testing.T) {
+	pool := newRLSTestPool(t)
+	tenantA, tenantB := uuid.New(), uuid.New()
+	seedRAGTenant(t, tenantA)
+	seedRAGTenant(t, tenantB)
+
+	vec := fixedVector(0.1)
+	chunkA := seedRAGChunk(t, tenantA, "tenant a content", vec)
+	chunkB := seedRAGChunk(t, tenantB, "tenant b content", vec)
+
+	repo := NewRepo(pool)
+	ctx := context.Background()
+
+	results, err := repo.SearchChunks(ctx, tenantA, vec, 10)
+	if err != nil {
+		t.Fatalf("SearchChunks: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected exactly 1 result scoped to tenant A, got %d", len(results))
+	}
+	if results[0].ID != chunkA {
+		t.Fatalf("expected tenant A's chunk %v, got %v", chunkA, results[0].ID)
+	}
+	for _, r := range results {
+		if r.ID == chunkB {
+			t.Fatalf("RLS did not block cross-tenant chunk read: tenant B's chunk %v leaked into tenant A's search results", chunkB)
+		}
+	}
+}

--- a/tools/lint-no-direct-tenant-id.mjs
+++ b/tools/lint-no-direct-tenant-id.mjs
@@ -13,6 +13,8 @@ const ALLOWLIST_DIRS = [
   'apps/edge-api/internal/auth/',                 // ctx writers
   'apps/control-plane/internal/auditarchive/',    // system cron job; iterates ALL tenants cross-tenant — no request auth context, tenant_id is internal archive struct field not wire input
   'apps/control-plane/internal/egress/',          // tenant_id in these structs is RESPONSE wire shape (egress-policy read/CRUD JSON output); the handler always resolves tenant_id by parsing the URL path segment via uuid.Parse, never FormValue/Query/Header/request-body — no violation of the auth.TenantID(ctx) input rule this lint enforces
+  'apps/control-plane/internal/rag/http.go',      // internal service-to-service /internal/rag/ingest endpoint, gated by RequireInternalToken shared secret (not a customer-facing route); tenant_id crosses the process boundary in the body because the authenticated user's request context cannot cross processes -- edge-api (the only caller) populates it solely from auth.TenantID(ctx), see TestHandleUpload_IngestUsesAuthenticatedTenantOnly; same trust shape as filestore's account_id-in-body pattern
+  'apps/edge-api/internal/rag/ingestclient.go',   // client-side counterpart of the above: marshals the tenant_id already resolved from auth.TenantID(ctx) by the caller into the internal ingest request body -- not a wire-input path, no client ever supplies this value (UploadRequest has no tenant_id field)
   'supabase/migrations/',
   'tools/lint-no-direct-tenant-id.mjs',
 ];


### PR DESCRIPTION
## Summary

Blueprint Step 2.1 (agent-subsystem, issue #232) called for the RAG data path to work end to end: upload, chunk, embed, store, search. The schema (#256), embedding provenance metadata (#316), and the control-plane RLS fix (#321) had already shipped. This PR closes the two remaining gaps that blocked the acceptance check.

- **Live RLS bug in edge-api's `rag.Repo`.** It called `set_config('app.current_tenant_id', ..., true)` on a bare acquired connection with no surrounding transaction, so the `LOCAL` setting reverted before the following query ran. Against a real RLS-enforced database this made every document upload fail with `new row violates row-level security policy` -- confirmed by running the new RLS test suite against a live `pgvector/pg16` instance before and after the fix. Fixed by adopting the same `withTenantTx` (Begin/Commit) pattern already used in `apps/control-plane/internal/rag/repository.go` and `apps/control-plane/internal/egress/repository.go`.
- **Ingestion was never wired.** `edge-api`'s upload handler passed `nil` as its `IngestFunc`, so uploaded documents stayed in `pending` status forever and `/v1/rag/search` always returned empty. Control-plane already had a working `Ingester` (chunk + embed + store) but no HTTP surface and no caller. Added `POST /internal/rag/ingest` on control-plane (gated by the existing `RequireInternalToken` shared secret, mirroring `filestore.RegisterRoutes`) and an `IngestClient` on edge-api that calls it the same way `FilestoreClient` already calls control-plane for file metadata.

No new migration was needed: the existing schema already ships `vector(1024)`, the HNSW cosine index (`m=16, ef_construction=64`), the `(tenant_id, document_id)` index, and RLS with the `NULLIF` empty-string guard. No LiteLLM config change was needed: `route-openrouter-embedding` is already the swappable serverless embedding route the blueprint describes.

**Out of scope:** grounded generation (`POST /v1/rag/chat` or a `rag` flag on chat completions) is listed in the blueprint's repo-areas bullet but is not part of the acceptance check (upload -> chunk -> embed -> store -> search), so it is left for a follow-up issue.

## Test plan

- [x] `go build ./apps/edge-api/... ./apps/control-plane/...` -- clean
- [x] `go vet ./apps/edge-api/... ./apps/control-plane/...` -- clean
- [x] `go test ./apps/edge-api/... -count=1 -short` -- all packages pass, including `internal/rag`
- [x] `go test ./apps/control-plane/... -count=1 -short` -- all packages pass, including `internal/rag`
- [x] New table-driven tests for the control-plane ingest handler (valid request, missing/invalid tenant_id or document_id, empty content, malformed JSON, ingest failure, wrong method, gate rejection)
- [x] New tests for the edge-api `IngestClient` (request body shape, non-OK status, unreachable server)
- [x] New RLS test suite for edge-api's `rag.Repo` (`HIVE_TEST_DB_URL`-gated, skips without a live DB): round-trip insert/get, cross-tenant read blocked, no session leak across pooled-connection borrows, and an explicit tenant-A-cannot-read-tenant-B-chunks proof using identical embedding vectors so the boundary is provably RLS and not vector distance
- [x] Ran the new RLS suite against a real `pgvector/pg16` container: reproduced the failure on the old code (every insert rejected by the RLS policy), then confirmed all four tests pass on the fixed code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic document ingestion for uploaded content, including chunking, embedding, and storage.
  - Added authenticated internal ingestion support between services.
- **Bug Fixes**
  - Improved tenant isolation so documents and search results cannot leak across tenants.
  - Added validation and clear error responses for malformed or incomplete ingestion requests.
  - Prevented tenant context from persisting between database operations.
- **Tests**
  - Added coverage for ingestion, authorization, error handling, and tenant isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->