### PR TITLE
feat: artifacts hosting for self-contained HTML blobs (#312)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -200,6 +200,20 @@ OWUI_E2E_MODE=false
 # must agree. Generate with: openssl rand -base64 32
 OWUI_SHIM_KEY=
 
+# ─── Artifacts hosting (#312) ───
+# Hostname the caddy-artifacts proxy (deploy/docker/Caddyfile.artifacts,
+# `chat`/`enterprise`/`local` profiles) answers on. Must be a distinct
+# origin from HIVE_CHAT_URL/OWUI so a served artifact's HTML can never read
+# the main app's cookies or session storage -- that origin split is the
+# actual isolation boundary, not just the CSP header. Point this DNS name
+# (or /etc/hosts entry for local dev) at the same host as caddy-artifacts.
+ARTIFACTS_DOMAIN=artifacts.localhost
+# CSP frame-ancestors value edge-api sets on every served artifact response
+# (apps/edge-api/internal/artifacts). Empty defaults to 'none' (no embedding
+# allowed anywhere) until explicitly opened up to the panel origin that is
+# allowed to iframe artifacts, e.g. the value of HIVE_CHAT_URL.
+ARTIFACTS_FRAME_ANCESTOR=
+
 # ─── Phase 19: audit sinks (all optional) ───
 AUDIT_SINK_FAILURE_GRACE_MINUTES=5
 AUDIT_SINK_ELK_URL=

--- a/apps/edge-api/cmd/server/main.go
+++ b/apps/edge-api/cmd/server/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/redis/go-redis/v9"
 	"github.com/sakibsadmanshajib/hive/apps/edge-api/docs"
 	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/anthropic"
+	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/artifacts"
 	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/audio"
 	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/auth"
 	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/authz"
@@ -322,10 +323,16 @@ func main() {
 	// for operators to catch.
 	jwtCfg, jwtCfgErr := loadJWTAuthEnv()
 	var jwtMW func(http.Handler) http.Handler
+	// Hoisted out of the else-branch (rather than :=-scoped to it) so the
+	// artifacts wiring below can reuse the same validator instance to
+	// optionally resolve a viewer's tenant on its anonymous-reachable
+	// serving routes. Stays nil when JWT wiring is skipped.
+	var jwtValidator *auth.SupabaseJWTValidator
 	if jwtCfgErr != nil {
 		log.Printf("WARNING: phase-19 JWT auth wiring skipped (%v)", jwtCfgErr)
 	} else {
-		jwtValidator, err := auth.NewSupabaseJWTValidator(rootCtx, auth.SupabaseJWTConfig{
+		var err error
+		jwtValidator, err = auth.NewSupabaseJWTValidator(rootCtx, auth.SupabaseJWTConfig{
 			Issuer:      jwtCfg.Issuer,
 			JWKSURL:     jwtCfg.JWKSURL,
 			JWTAudience: jwtCfg.Audience,
@@ -334,6 +341,49 @@ func main() {
 			log.Fatalf("failed to initialize Supabase JWT validator: %v", err)
 		}
 		jwtMW = auth.JWTMiddleware(jwtValidator, jwtAuditLogger(), auth.NewTenantFallback(dbPool))
+	}
+
+	// Artifacts hosting (#312, agent-subsystem blueprint Step 3.3).
+	// Management routes (/v1/artifacts/*) sit inside the /v1/ prefix, so
+	// they go through the JWT selector above exactly like RAG. The serving
+	// routes (/artifacts/{id}, /artifacts/{id}/v/{n}) sit outside it by
+	// design: a shared artifact must be reachable with no Authorization
+	// header at all, so the handler resolves an optional viewer tenant
+	// itself from the same jwtValidator instance and falls back to
+	// anonymous-only (public artifacts) when Supabase JWT env vars are
+	// absent, mirroring the jwtCfgErr graceful-degradation path.
+	{
+		var artifactsStore artifacts.Store
+		if dbPool != nil {
+			artifactsStore = artifacts.NewRepo(dbPool)
+		}
+		var artifactsClaimsParser artifacts.ClaimsParser
+		if jwtValidator != nil {
+			artifactsClaimsParser = jwtValidator
+		}
+		artifactsAudit := func(ctx context.Context, action, resourceType, resourceID, severity string,
+			tenantID, actorID uuid.UUID, userAgent string, after any) {
+			if dbPool == nil {
+				return
+			}
+			if err := chat.InsertAuditEvent(ctx, dbPool, chat.AuditEvent{
+				TenantID:     tenantID,
+				ActorID:      actorID,
+				Action:       action,
+				Severity:     severity,
+				ResourceType: resourceType,
+				ResourceID:   resourceID,
+				UserAgent:    userAgent,
+				After:        after,
+				DeploySHA:    os.Getenv("DEPLOY_SHA"),
+				Environment:  os.Getenv("HIVE_ENV"),
+			}); err != nil {
+				log.Printf("artifacts audit write failed: %v", err)
+			}
+		}
+		artifactsHandler := artifacts.NewHandler(artifactsStore, storageClient, storageCfg.FilesBucket,
+			artifactsClaimsParser, os.Getenv("ARTIFACTS_FRAME_ANCESTOR"), artifactsAudit)
+		artifactsHandler.Register(mux)
 	}
 
 	var handler http.Handler = mux

--- a/apps/edge-api/internal/artifacts/handler.go
+++ b/apps/edge-api/internal/artifacts/handler.go
@@ -314,7 +314,7 @@ func (h *Handler) routeServe(w http.ResponseWriter, r *http.Request) {
 	}
 	defer blob.Close()
 
-	h.writeArtifactHeaders(w)
+	h.writeArtifactHeaders(w, row.IsPublic)
 	w.WriteHeader(http.StatusOK)
 	if r.Method == http.MethodGet {
 		_, _ = io.Copy(w, blob)
@@ -369,9 +369,17 @@ func (h *Handler) optionalViewerTenant(r *http.Request) uuid.UUID {
 // the configured panel origin (or 'none' if unconfigured). The consuming
 // iframe (Wave 3.1/3.2 OWUI panel) must additionally set
 // sandbox="allow-scripts" with no allow-same-origin, per issue #312.
-func (h *Handler) writeArtifactHeaders(w http.ResponseWriter) {
+func (h *Handler) writeArtifactHeaders(w http.ResponseWriter, isPublic bool) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
+	if isPublic {
+		w.Header().Set("Cache-Control", "public, max-age=300")
+	} else {
+		// Private artifact served only because the viewer authenticated as
+		// the owning tenant: must never be cached by a shared proxy or
+		// left in a browser disk cache.
+		w.Header().Set("Cache-Control", "private, no-store")
+	}
 	w.Header().Set("Content-Security-Policy",
 		"default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; "+
 			"img-src data:; connect-src 'none'; base-uri 'none'; form-action 'none'; "+

--- a/apps/edge-api/internal/artifacts/handler.go
+++ b/apps/edge-api/internal/artifacts/handler.go
@@ -1,0 +1,386 @@
+package artifacts
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/auth"
+	apierrors "github.com/sakibsadmanshajib/hive/apps/edge-api/internal/errors"
+)
+
+// Store is the minimal interface the handler needs from Repo. Exported so
+// main.go can declare a typed nil when the DB pool is absent.
+type Store interface {
+	CreateArtifact(ctx context.Context, tenantID uuid.UUID, name string) (uuid.UUID, error)
+	AddVersion(ctx context.Context, tenantID, artifactID uuid.UUID, storagePath string, sizeBytes int64) (int, error)
+	SetPublic(ctx context.Context, tenantID, artifactID uuid.UUID, public bool) error
+	GetVersion(ctx context.Context, viewerTenantID, artifactID uuid.UUID, version *int) (VersionRow, error)
+}
+
+// BlobStorage is the minimal blob operations the handler needs, satisfied
+// by packages/storage.Storage (the same client apps/edge-api/internal/files
+// uses against the hive-files bucket).
+type BlobStorage interface {
+	Upload(ctx context.Context, bucket, key string, body io.Reader, size int64, contentType string) error
+	Download(ctx context.Context, bucket, key string) (io.ReadCloser, error)
+}
+
+// ClaimsParser is the subset of *auth.SupabaseJWTValidator used to
+// optionally resolve a viewer's tenant on the anonymous-reachable
+// /artifacts/* serving routes. Those routes sit outside the /v1/ prefix, so
+// main.go's authSelectorMiddleware never routes them through JWT
+// middleware -- a nil parser here means "always anonymous", matching the
+// jwtCfgErr graceful-degradation path already used in main.go when
+// Supabase JWT env vars are absent. Only public artifacts serve in that case.
+type ClaimsParser interface {
+	Parse(ctx context.Context, raw string) (auth.Claims, error)
+}
+
+// AuditFunc emits a durable audit event. main.go wires the real
+// chat.InsertAuditEvent; tests inject a recorder.
+type AuditFunc func(ctx context.Context, action, resourceType, resourceID, severity string,
+	tenantID, actorID uuid.UUID, userAgent string, after any)
+
+// Handler serves /v1/artifacts/* (management, tenant-authenticated) and
+// /artifacts/* (hosting, optionally anonymous).
+type Handler struct {
+	store          Store
+	blobs          BlobStorage
+	bucket         string
+	claimsParser   ClaimsParser
+	frameAncestors string
+	audit          AuditFunc
+}
+
+// NewHandler constructs a Handler. claimsParser may be nil (serving routes
+// then only ever admit public artifacts). frameAncestors is the CSP
+// frame-ancestors directive value for served artifact bytes; an empty
+// string defaults to "'none'" (fail-safe: no embedding until a deployment
+// explicitly configures the panel origin allowed to iframe artifacts).
+func NewHandler(store Store, blobs BlobStorage, bucket string, claimsParser ClaimsParser, frameAncestors string, audit AuditFunc) *Handler {
+	if frameAncestors == "" {
+		frameAncestors = "'none'"
+	}
+	if audit == nil {
+		audit = func(context.Context, string, string, string, string, uuid.UUID, uuid.UUID, string, any) {}
+	}
+	return &Handler{
+		store:          store,
+		blobs:          blobs,
+		bucket:         bucket,
+		claimsParser:   claimsParser,
+		frameAncestors: frameAncestors,
+		audit:          audit,
+	}
+}
+
+// Register mounts every artifacts route on mux.
+func (h *Handler) Register(mux *http.ServeMux) {
+	mux.HandleFunc("/v1/artifacts", h.handleCreate)
+	mux.HandleFunc("/v1/artifacts/", h.routeManage)
+	mux.HandleFunc("/artifacts/", h.routeServe)
+}
+
+// --- Management routes (JWT-authenticated, tenant-scoped) ---
+
+func (h *Handler) handleCreate(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		apierrors.Write(w, http.StatusMethodNotAllowed, apierrors.CodeInvalidRequest, "method not allowed")
+		return
+	}
+	user, ok := auth.UserFrom(r.Context())
+	if !ok || user == nil {
+		apierrors.Write(w, http.StatusUnauthorized, apierrors.CodeUnauthenticated, "unauthenticated")
+		return
+	}
+
+	var req CreateRequest
+	if err := json.NewDecoder(io.LimitReader(r.Body, MaxHTMLSize+4096)).Decode(&req); err != nil {
+		apierrors.Write(w, http.StatusBadRequest, apierrors.CodeInvalidRequest, "invalid request body")
+		return
+	}
+	if err := validateHTML(req.HTML); err != nil {
+		apierrors.Write(w, http.StatusBadRequest, apierrors.CodeInvalidRequest, err.Error())
+		return
+	}
+
+	artifactID, err := h.store.CreateArtifact(r.Context(), user.TenantID, req.Name)
+	if err != nil {
+		log.Printf("artifacts: create: %v", err)
+		apierrors.Write(w, http.StatusInternalServerError, apierrors.CodeInternal, "artifact creation failed")
+		return
+	}
+
+	resp, err := h.storeVersion(r.Context(), user.TenantID, artifactID, req.HTML)
+	if err != nil {
+		log.Printf("artifacts: store version: %v", err)
+		apierrors.Write(w, http.StatusInternalServerError, apierrors.CodeInternal, "artifact storage failed")
+		return
+	}
+
+	h.audit(r.Context(), "ARTIFACT_CREATE", "artifact", artifactID.String(), "INFO",
+		user.TenantID, user.ID, r.UserAgent(), map[string]any{"name": req.Name})
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+func (h *Handler) routeManage(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		apierrors.Write(w, http.StatusMethodNotAllowed, apierrors.CodeInvalidRequest, "method not allowed")
+		return
+	}
+	path := strings.TrimPrefix(r.URL.Path, "/v1/artifacts/")
+	switch {
+	case strings.HasSuffix(path, "/versions"):
+		h.handleAddVersion(w, r, strings.TrimSuffix(path, "/versions"))
+	case strings.HasSuffix(path, "/share"):
+		h.handleShare(w, r, strings.TrimSuffix(path, "/share"))
+	default:
+		apierrors.Write(w, http.StatusNotFound, apierrors.CodeInvalidRequest, "unknown route")
+	}
+}
+
+func (h *Handler) handleAddVersion(w http.ResponseWriter, r *http.Request, idStr string) {
+	user, ok := auth.UserFrom(r.Context())
+	if !ok || user == nil {
+		apierrors.Write(w, http.StatusUnauthorized, apierrors.CodeUnauthenticated, "unauthenticated")
+		return
+	}
+	artifactID, err := uuid.Parse(idStr)
+	if err != nil {
+		apierrors.Write(w, http.StatusBadRequest, apierrors.CodeInvalidRequest, "invalid artifact id")
+		return
+	}
+
+	var req AddVersionRequest
+	if err := json.NewDecoder(io.LimitReader(r.Body, MaxHTMLSize+4096)).Decode(&req); err != nil {
+		apierrors.Write(w, http.StatusBadRequest, apierrors.CodeInvalidRequest, "invalid request body")
+		return
+	}
+	if err := validateHTML(req.HTML); err != nil {
+		apierrors.Write(w, http.StatusBadRequest, apierrors.CodeInvalidRequest, err.Error())
+		return
+	}
+
+	resp, err := h.storeVersion(r.Context(), user.TenantID, artifactID, req.HTML)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			apierrors.Write(w, http.StatusNotFound, apierrors.CodeInvalidRequest, "artifact not found")
+			return
+		}
+		log.Printf("artifacts: add version: %v", err)
+		apierrors.Write(w, http.StatusInternalServerError, apierrors.CodeInternal, "artifact storage failed")
+		return
+	}
+
+	h.audit(r.Context(), "ARTIFACT_VERSION_ADD", "artifact", artifactID.String(), "INFO",
+		user.TenantID, user.ID, r.UserAgent(), map[string]any{"version": resp.Version})
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+func (h *Handler) handleShare(w http.ResponseWriter, r *http.Request, idStr string) {
+	user, ok := auth.UserFrom(r.Context())
+	if !ok || user == nil {
+		apierrors.Write(w, http.StatusUnauthorized, apierrors.CodeUnauthenticated, "unauthenticated")
+		return
+	}
+	artifactID, err := uuid.Parse(idStr)
+	if err != nil {
+		apierrors.Write(w, http.StatusBadRequest, apierrors.CodeInvalidRequest, "invalid artifact id")
+		return
+	}
+
+	var req ShareRequest
+	if err := json.NewDecoder(io.LimitReader(r.Body, 4096)).Decode(&req); err != nil {
+		apierrors.Write(w, http.StatusBadRequest, apierrors.CodeInvalidRequest, "invalid request body")
+		return
+	}
+
+	if err := h.store.SetPublic(r.Context(), user.TenantID, artifactID, req.Public); err != nil {
+		if errors.Is(err, ErrNotFound) {
+			apierrors.Write(w, http.StatusNotFound, apierrors.CodeInvalidRequest, "artifact not found")
+			return
+		}
+		log.Printf("artifacts: set public: %v", err)
+		apierrors.Write(w, http.StatusInternalServerError, apierrors.CodeInternal, "share update failed")
+		return
+	}
+
+	// Publicizing an artifact is the one action that turns a private
+	// resource world-readable, so it is audited at a higher severity than
+	// the reverse (revoking a share) or ordinary create/version writes.
+	severity := "INFO"
+	if req.Public {
+		severity = "WARNING"
+	}
+	h.audit(r.Context(), "ARTIFACT_SHARE", "artifact", artifactID.String(), severity,
+		user.TenantID, user.ID, r.UserAgent(), map[string]any{"public": req.Public})
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(ShareResponse{ID: artifactID.String(), Public: req.Public})
+}
+
+// storeVersion uploads the HTML blob under a version-independent random key
+// and then records the next sequential version in the same DB transaction
+// (Repo.AddVersion). The blob key does not need to encode the version
+// number: only the DB row does, so the upload can happen before the version
+// number is known.
+func (h *Handler) storeVersion(ctx context.Context, tenantID, artifactID uuid.UUID, html string) (VersionResponse, error) {
+	storagePath := fmt.Sprintf("%s/%s/%s.html", tenantID, artifactID, uuid.New())
+	size := int64(len(html))
+	if err := h.blobs.Upload(ctx, h.bucket, storagePath, strings.NewReader(html), size, "text/html; charset=utf-8"); err != nil {
+		return VersionResponse{}, fmt.Errorf("upload blob: %w", err)
+	}
+	version, err := h.store.AddVersion(ctx, tenantID, artifactID, storagePath, size)
+	if err != nil {
+		return VersionResponse{}, err
+	}
+	return VersionResponse{
+		ID:           artifactID.String(),
+		Version:      version,
+		URL:          "/artifacts/" + artifactID.String(),
+		VersionedURL: fmt.Sprintf("/artifacts/%s/v/%d", artifactID.String(), version),
+		CreatedAt:    time.Now().UTC(),
+	}, nil
+}
+
+func validateHTML(html string) error {
+	if strings.TrimSpace(html) == "" {
+		return errors.New("html required")
+	}
+	if len(html) > MaxHTMLSize {
+		return errors.New("html exceeds maximum artifact size")
+	}
+	return nil
+}
+
+// --- Serving routes (anonymous-reachable, RLS-gated at the query) ---
+
+func (h *Handler) routeServe(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		writeServeError(w, http.StatusMethodNotAllowed)
+		return
+	}
+
+	path := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/artifacts/"), "/")
+	idStr, versionStr, hasVersion := splitServePath(path)
+	artifactID, err := uuid.Parse(idStr)
+	if err != nil {
+		writeServeError(w, http.StatusNotFound)
+		return
+	}
+
+	var version *int
+	if hasVersion {
+		n, err := strconv.Atoi(versionStr)
+		if err != nil || n < 1 {
+			writeServeError(w, http.StatusNotFound)
+			return
+		}
+		version = &n
+	}
+
+	viewerTenantID := h.optionalViewerTenant(r)
+	row, err := h.store.GetVersion(r.Context(), viewerTenantID, artifactID, version)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			writeServeError(w, http.StatusNotFound)
+			return
+		}
+		log.Printf("artifacts: get version: %v", err)
+		writeServeError(w, http.StatusInternalServerError)
+		return
+	}
+
+	blob, err := h.blobs.Download(r.Context(), h.bucket, row.StoragePath)
+	if err != nil {
+		log.Printf("artifacts: download blob: %v", err)
+		writeServeError(w, http.StatusInternalServerError)
+		return
+	}
+	defer blob.Close()
+
+	h.writeArtifactHeaders(w)
+	w.WriteHeader(http.StatusOK)
+	if r.Method == http.MethodGet {
+		_, _ = io.Copy(w, blob)
+	}
+}
+
+// splitServePath parses "{id}" or "{id}/v/{n}" from the trimmed serve path.
+// Anything else reports hasVersion=false with an id that will fail
+// uuid.Parse, collapsing every malformed shape onto the same 404 path.
+func splitServePath(path string) (id, version string, hasVersion bool) {
+	parts := strings.Split(path, "/")
+	switch len(parts) {
+	case 1:
+		return parts[0], "", false
+	case 3:
+		if parts[1] != "v" {
+			return "", "", false
+		}
+		return parts[0], parts[2], true
+	default:
+		return "", "", false
+	}
+}
+
+// optionalViewerTenant resolves the caller's tenant from an optional bearer
+// JWT for the private-artifact case. Any missing header, missing parser, or
+// parse failure (expired/invalid token) falls back to uuid.Nil (anonymous)
+// rather than rejecting the request outright.
+//
+// ponytail: this route's entire purpose is the public fallback, so a bad
+// token still gets a fair shot at a public artifact instead of a hard 401 --
+// deliberately different from JWTMiddleware, which fails closed.
+func (h *Handler) optionalViewerTenant(r *http.Request) uuid.UUID {
+	if h.claimsParser == nil {
+		return uuid.Nil
+	}
+	scheme, raw, ok := strings.Cut(r.Header.Get("Authorization"), " ")
+	if !ok || !strings.EqualFold(scheme, "Bearer") || raw == "" {
+		return uuid.Nil
+	}
+	claims, err := h.claimsParser.Parse(r.Context(), raw)
+	if err != nil {
+		return uuid.Nil
+	}
+	return claims.TenantID
+}
+
+// writeArtifactHeaders sets the strict CSP + no-sniff posture required for
+// safely embedding untrusted artifact HTML: no external network of any kind
+// (default-src/connect-src 'none'), inline script/style allowed (artifacts
+// are self-contained single-file HTML), and frame-ancestors restricted to
+// the configured panel origin (or 'none' if unconfigured). The consuming
+// iframe (Wave 3.1/3.2 OWUI panel) must additionally set
+// sandbox="allow-scripts" with no allow-same-origin, per issue #312.
+func (h *Handler) writeArtifactHeaders(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("Content-Security-Policy",
+		"default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; "+
+			"img-src data:; connect-src 'none'; base-uri 'none'; form-action 'none'; "+
+			"frame-ancestors "+h.frameAncestors+";")
+}
+
+func writeServeError(w http.ResponseWriter, status int) {
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.WriteHeader(status)
+	_, _ = w.Write([]byte(http.StatusText(status)))
+}

--- a/apps/edge-api/internal/artifacts/handler_test.go
+++ b/apps/edge-api/internal/artifacts/handler_test.go
@@ -459,6 +459,9 @@ func TestRouteServe_CSPAndNoSniffHeaders(t *testing.T) {
 	if !strings.HasPrefix(rec.Header().Get("Content-Type"), "text/html") {
 		t.Fatalf("Content-Type = %q, want text/html", rec.Header().Get("Content-Type"))
 	}
+	if rec.Header().Get("Cache-Control") != "public, max-age=300" {
+		t.Fatalf("Cache-Control = %q, want public, max-age=300 for a public artifact", rec.Header().Get("Cache-Control"))
+	}
 }
 
 func TestRouteServe_CustomFrameAncestors(t *testing.T) {
@@ -567,6 +570,9 @@ func TestRouteServe_PrivateArtifact_AuthenticatedSameTenantOK(t *testing.T) {
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200 for same-tenant authenticated viewer, body=%s", rec.Code, rec.Body.String())
+	}
+	if rec.Header().Get("Cache-Control") != "private, no-store" {
+		t.Fatalf("Cache-Control = %q, want private, no-store for a private artifact", rec.Header().Get("Cache-Control"))
 	}
 }
 

--- a/apps/edge-api/internal/artifacts/handler_test.go
+++ b/apps/edge-api/internal/artifacts/handler_test.go
@@ -1,0 +1,629 @@
+package artifacts
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/auth"
+)
+
+// --- fakes ---
+
+type fakeArtifact struct {
+	tenantID      uuid.UUID
+	isPublic      bool
+	latestVersion int
+	versions      map[int]VersionRow
+}
+
+type fakeStore struct {
+	mu            sync.Mutex
+	artifacts     map[uuid.UUID]*fakeArtifact
+	createErr     error
+	addVersionErr error
+	setPublicErr  error
+	getVersionErr error
+}
+
+func newFakeStore() *fakeStore {
+	return &fakeStore{artifacts: map[uuid.UUID]*fakeArtifact{}}
+}
+
+func (f *fakeStore) CreateArtifact(ctx context.Context, tenantID uuid.UUID, name string) (uuid.UUID, error) {
+	if f.createErr != nil {
+		return uuid.Nil, f.createErr
+	}
+	id := uuid.New()
+	f.mu.Lock()
+	f.artifacts[id] = &fakeArtifact{tenantID: tenantID, versions: map[int]VersionRow{}}
+	f.mu.Unlock()
+	return id, nil
+}
+
+func (f *fakeStore) AddVersion(ctx context.Context, tenantID, artifactID uuid.UUID, storagePath string, sizeBytes int64) (int, error) {
+	if f.addVersionErr != nil {
+		return 0, f.addVersionErr
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	a, ok := f.artifacts[artifactID]
+	if !ok || a.tenantID != tenantID {
+		return 0, ErrNotFound
+	}
+	a.latestVersion++
+	v := a.latestVersion
+	a.versions[v] = VersionRow{ArtifactID: artifactID, Version: v, StoragePath: storagePath, SizeBytes: sizeBytes, IsPublic: a.isPublic}
+	return v, nil
+}
+
+func (f *fakeStore) SetPublic(ctx context.Context, tenantID, artifactID uuid.UUID, public bool) error {
+	if f.setPublicErr != nil {
+		return f.setPublicErr
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	a, ok := f.artifacts[artifactID]
+	if !ok || a.tenantID != tenantID {
+		return ErrNotFound
+	}
+	a.isPublic = public
+	for v, row := range a.versions {
+		row.IsPublic = public
+		a.versions[v] = row
+	}
+	return nil
+}
+
+func (f *fakeStore) GetVersion(ctx context.Context, viewerTenantID, artifactID uuid.UUID, version *int) (VersionRow, error) {
+	if f.getVersionErr != nil {
+		return VersionRow{}, f.getVersionErr
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	a, ok := f.artifacts[artifactID]
+	if !ok {
+		return VersionRow{}, ErrNotFound
+	}
+	// Mimics the RLS OR-combination the real Repo relies on: visible when
+	// the viewer's tenant matches, or the artifact is public, regardless
+	// of viewer tenant (including the anonymous uuid.Nil case).
+	if viewerTenantID != a.tenantID && !a.isPublic {
+		return VersionRow{}, ErrNotFound
+	}
+	v := a.latestVersion
+	if version != nil {
+		v = *version
+	}
+	row, ok := a.versions[v]
+	if !ok {
+		return VersionRow{}, ErrNotFound
+	}
+	return row, nil
+}
+
+type fakeBlobs struct {
+	mu          sync.Mutex
+	data        map[string][]byte
+	uploadErr   error
+	downloadErr error
+}
+
+func newFakeBlobs() *fakeBlobs { return &fakeBlobs{data: map[string][]byte{}} }
+
+func (f *fakeBlobs) Upload(ctx context.Context, bucket, key string, body io.Reader, size int64, contentType string) error {
+	if f.uploadErr != nil {
+		return f.uploadErr
+	}
+	b, err := io.ReadAll(body)
+	if err != nil {
+		return err
+	}
+	f.mu.Lock()
+	f.data[key] = b
+	f.mu.Unlock()
+	return nil
+}
+
+func (f *fakeBlobs) Download(ctx context.Context, bucket, key string) (io.ReadCloser, error) {
+	if f.downloadErr != nil {
+		return nil, f.downloadErr
+	}
+	f.mu.Lock()
+	b, ok := f.data[key]
+	f.mu.Unlock()
+	if !ok {
+		return nil, errors.New("blob not found")
+	}
+	return io.NopCloser(bytes.NewReader(b)), nil
+}
+
+type fakeClaimsParser struct {
+	claims auth.Claims
+	err    error
+}
+
+func (f *fakeClaimsParser) Parse(ctx context.Context, raw string) (auth.Claims, error) {
+	return f.claims, f.err
+}
+
+type recordedAudit struct {
+	action, resourceID, severity string
+	after                        any
+}
+
+func newHandlerForTest(store Store, blobs BlobStorage, parser ClaimsParser) (*Handler, *[]recordedAudit) {
+	var events []recordedAudit
+	audit := func(ctx context.Context, action, resourceType, resourceID, severity string, tenantID, actorID uuid.UUID, userAgent string, after any) {
+		events = append(events, recordedAudit{action: action, resourceID: resourceID, severity: severity, after: after})
+	}
+	h := NewHandler(store, blobs, "hive-files", parser, "", audit)
+	return h, &events
+}
+
+func withUser(r *http.Request, u *auth.User) *http.Request {
+	return r.WithContext(auth.WithUser(r.Context(), u))
+}
+
+func newMux(h *Handler) *http.ServeMux {
+	mux := http.NewServeMux()
+	h.Register(mux)
+	return mux
+}
+
+// --- create ---
+
+func TestHandleCreate_ReturnsVersionOneAndURLs(t *testing.T) {
+	h, audits := newHandlerForTest(newFakeStore(), newFakeBlobs(), nil)
+	user := &auth.User{ID: uuid.New(), TenantID: uuid.New()}
+
+	body, _ := json.Marshal(CreateRequest{Name: "demo", HTML: "<html>hi</html>"})
+	req := withUser(httptest.NewRequest(http.MethodPost, "/v1/artifacts", bytes.NewReader(body)), user)
+	rec := httptest.NewRecorder()
+	newMux(h).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201, body=%s", rec.Code, rec.Body.String())
+	}
+	var resp VersionResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Version != 1 {
+		t.Fatalf("Version = %d, want 1", resp.Version)
+	}
+	if resp.URL != "/artifacts/"+resp.ID {
+		t.Fatalf("URL = %q, want /artifacts/%s", resp.URL, resp.ID)
+	}
+	if resp.VersionedURL != "/artifacts/"+resp.ID+"/v/1" {
+		t.Fatalf("VersionedURL = %q, want /artifacts/%s/v/1", resp.VersionedURL, resp.ID)
+	}
+	if len(*audits) != 1 || (*audits)[0].action != "ARTIFACT_CREATE" {
+		t.Fatalf("expected one ARTIFACT_CREATE audit event, got %+v", *audits)
+	}
+}
+
+func TestHandleCreate_Unauthenticated401(t *testing.T) {
+	h, _ := newHandlerForTest(newFakeStore(), newFakeBlobs(), nil)
+	body, _ := json.Marshal(CreateRequest{HTML: "<html></html>"})
+	req := httptest.NewRequest(http.MethodPost, "/v1/artifacts", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	newMux(h).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+}
+
+func TestHandleCreate_EmptyHTML400(t *testing.T) {
+	h, _ := newHandlerForTest(newFakeStore(), newFakeBlobs(), nil)
+	user := &auth.User{ID: uuid.New(), TenantID: uuid.New()}
+	body, _ := json.Marshal(CreateRequest{Name: "demo", HTML: "   "})
+	req := withUser(httptest.NewRequest(http.MethodPost, "/v1/artifacts", bytes.NewReader(body)), user)
+	rec := httptest.NewRecorder()
+	newMux(h).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
+func TestHandleCreate_HTMLTooLarge400(t *testing.T) {
+	h, _ := newHandlerForTest(newFakeStore(), newFakeBlobs(), nil)
+	user := &auth.User{ID: uuid.New(), TenantID: uuid.New()}
+	oversized := strings.Repeat("a", MaxHTMLSize+1)
+	body, _ := json.Marshal(CreateRequest{Name: "demo", HTML: oversized})
+	req := withUser(httptest.NewRequest(http.MethodPost, "/v1/artifacts", bytes.NewReader(body)), user)
+	rec := httptest.NewRecorder()
+	newMux(h).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
+func TestHandleCreate_MethodNotAllowed(t *testing.T) {
+	h, _ := newHandlerForTest(newFakeStore(), newFakeBlobs(), nil)
+	req := httptest.NewRequest(http.MethodGet, "/v1/artifacts", nil)
+	rec := httptest.NewRecorder()
+	newMux(h).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", rec.Code)
+	}
+}
+
+// --- add version (redeploy) ---
+
+func createArtifact(t *testing.T, h *Handler, user *auth.User, html string) VersionResponse {
+	t.Helper()
+	body, _ := json.Marshal(CreateRequest{Name: "demo", HTML: html})
+	req := withUser(httptest.NewRequest(http.MethodPost, "/v1/artifacts", bytes.NewReader(body)), user)
+	rec := httptest.NewRecorder()
+	newMux(h).ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create setup failed: status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp VersionResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	return resp
+}
+
+func TestHandleAddVersion_MintsNextVersionSameURL(t *testing.T) {
+	store := newFakeStore()
+	h, _ := newHandlerForTest(store, newFakeBlobs(), nil)
+	user := &auth.User{ID: uuid.New(), TenantID: uuid.New()}
+
+	created := createArtifact(t, h, user, "<html>v1</html>")
+
+	body, _ := json.Marshal(AddVersionRequest{HTML: "<html>v2</html>"})
+	req := withUser(httptest.NewRequest(http.MethodPost, "/v1/artifacts/"+created.ID+"/versions", bytes.NewReader(body)), user)
+	rec := httptest.NewRecorder()
+	newMux(h).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201, body=%s", rec.Code, rec.Body.String())
+	}
+	var resp VersionResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Version != 2 {
+		t.Fatalf("Version = %d, want 2", resp.Version)
+	}
+	if resp.URL != created.URL {
+		t.Fatalf("redeploy URL = %q, want same stable URL %q", resp.URL, created.URL)
+	}
+}
+
+func TestHandleAddVersion_UnknownArtifact404(t *testing.T) {
+	h, _ := newHandlerForTest(newFakeStore(), newFakeBlobs(), nil)
+	user := &auth.User{ID: uuid.New(), TenantID: uuid.New()}
+	body, _ := json.Marshal(AddVersionRequest{HTML: "<html></html>"})
+	req := withUser(httptest.NewRequest(http.MethodPost, "/v1/artifacts/"+uuid.NewString()+"/versions", bytes.NewReader(body)), user)
+	rec := httptest.NewRecorder()
+	newMux(h).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestHandleAddVersion_InvalidArtifactID400(t *testing.T) {
+	h, _ := newHandlerForTest(newFakeStore(), newFakeBlobs(), nil)
+	user := &auth.User{ID: uuid.New(), TenantID: uuid.New()}
+	body, _ := json.Marshal(AddVersionRequest{HTML: "<html></html>"})
+	req := withUser(httptest.NewRequest(http.MethodPost, "/v1/artifacts/not-a-uuid/versions", bytes.NewReader(body)), user)
+	rec := httptest.NewRecorder()
+	newMux(h).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
+// --- share ---
+
+func TestHandleShare_TogglesPublic(t *testing.T) {
+	store := newFakeStore()
+	h, audits := newHandlerForTest(store, newFakeBlobs(), nil)
+	user := &auth.User{ID: uuid.New(), TenantID: uuid.New()}
+	created := createArtifact(t, h, user, "<html>v1</html>")
+
+	body, _ := json.Marshal(ShareRequest{Public: true})
+	req := withUser(httptest.NewRequest(http.MethodPost, "/v1/artifacts/"+created.ID+"/share", bytes.NewReader(body)), user)
+	rec := httptest.NewRecorder()
+	newMux(h).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body=%s", rec.Code, rec.Body.String())
+	}
+	var resp ShareResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !resp.Public {
+		t.Fatalf("Public = false, want true")
+	}
+	last := (*audits)[len(*audits)-1]
+	if last.action != "ARTIFACT_SHARE" || last.severity != "WARNING" {
+		t.Fatalf("expected WARNING ARTIFACT_SHARE audit on publicize, got %+v", last)
+	}
+}
+
+func TestHandleShare_UnknownArtifact404(t *testing.T) {
+	h, _ := newHandlerForTest(newFakeStore(), newFakeBlobs(), nil)
+	user := &auth.User{ID: uuid.New(), TenantID: uuid.New()}
+	body, _ := json.Marshal(ShareRequest{Public: true})
+	req := withUser(httptest.NewRequest(http.MethodPost, "/v1/artifacts/"+uuid.NewString()+"/share", bytes.NewReader(body)), user)
+	rec := httptest.NewRecorder()
+	newMux(h).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestHandleShare_Unauthenticated401(t *testing.T) {
+	h, _ := newHandlerForTest(newFakeStore(), newFakeBlobs(), nil)
+	body, _ := json.Marshal(ShareRequest{Public: true})
+	req := httptest.NewRequest(http.MethodPost, "/v1/artifacts/"+uuid.NewString()+"/share", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	newMux(h).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+}
+
+// --- serve ---
+
+func TestRouteServe_PrivateArtifact_NoAuth404(t *testing.T) {
+	store := newFakeStore()
+	h, _ := newHandlerForTest(store, newFakeBlobs(), nil)
+	user := &auth.User{ID: uuid.New(), TenantID: uuid.New()}
+	created := createArtifact(t, h, user, "<html>secret</html>")
+
+	req := httptest.NewRequest(http.MethodGet, created.URL, nil)
+	rec := httptest.NewRecorder()
+	newMux(h).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 for private artifact with no auth", rec.Code)
+	}
+}
+
+func TestRouteServe_PublicArtifact_NoAuthServesLatest(t *testing.T) {
+	store := newFakeStore()
+	h, _ := newHandlerForTest(store, newFakeBlobs(), nil)
+	user := &auth.User{ID: uuid.New(), TenantID: uuid.New()}
+	created := createArtifact(t, h, user, "<html>v1</html>")
+
+	shareBody, _ := json.Marshal(ShareRequest{Public: true})
+	shareReq := withUser(httptest.NewRequest(http.MethodPost, "/v1/artifacts/"+created.ID+"/share", bytes.NewReader(shareBody)), user)
+	shareRec := httptest.NewRecorder()
+	newMux(h).ServeHTTP(shareRec, shareReq)
+	if shareRec.Code != http.StatusOK {
+		t.Fatalf("share setup failed: %d", shareRec.Code)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, created.URL, nil)
+	rec := httptest.NewRecorder()
+	newMux(h).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body=%s", rec.Code, rec.Body.String())
+	}
+	if rec.Body.String() != "<html>v1</html>" {
+		t.Fatalf("body = %q, want the stored HTML", rec.Body.String())
+	}
+}
+
+func TestRouteServe_CSPAndNoSniffHeaders(t *testing.T) {
+	store := newFakeStore()
+	h, _ := newHandlerForTest(store, newFakeBlobs(), nil)
+	user := &auth.User{ID: uuid.New(), TenantID: uuid.New()}
+	created := createArtifact(t, h, user, "<html>v1</html>")
+
+	shareBody, _ := json.Marshal(ShareRequest{Public: true})
+	shareReq := withUser(httptest.NewRequest(http.MethodPost, "/v1/artifacts/"+created.ID+"/share", bytes.NewReader(shareBody)), user)
+	newMux(h).ServeHTTP(httptest.NewRecorder(), shareReq)
+
+	req := httptest.NewRequest(http.MethodGet, created.URL, nil)
+	rec := httptest.NewRecorder()
+	newMux(h).ServeHTTP(rec, req)
+
+	csp := rec.Header().Get("Content-Security-Policy")
+	if !strings.Contains(csp, "connect-src 'none'") {
+		t.Fatalf("CSP missing connect-src 'none': %q", csp)
+	}
+	if !strings.Contains(csp, "frame-ancestors 'none'") {
+		t.Fatalf("CSP missing default frame-ancestors 'none': %q", csp)
+	}
+	if !strings.Contains(csp, "default-src 'none'") {
+		t.Fatalf("CSP missing default-src 'none': %q", csp)
+	}
+	if rec.Header().Get("X-Content-Type-Options") != "nosniff" {
+		t.Fatalf("X-Content-Type-Options = %q, want nosniff", rec.Header().Get("X-Content-Type-Options"))
+	}
+	if !strings.HasPrefix(rec.Header().Get("Content-Type"), "text/html") {
+		t.Fatalf("Content-Type = %q, want text/html", rec.Header().Get("Content-Type"))
+	}
+}
+
+func TestRouteServe_CustomFrameAncestors(t *testing.T) {
+	store := newFakeStore()
+	audit := func(context.Context, string, string, string, string, uuid.UUID, uuid.UUID, string, any) {}
+	h := NewHandler(store, newFakeBlobs(), "hive-files", nil, "https://chat.hive.ai", audit)
+	user := &auth.User{ID: uuid.New(), TenantID: uuid.New()}
+	created := createArtifact(t, h, user, "<html>v1</html>")
+
+	shareBody, _ := json.Marshal(ShareRequest{Public: true})
+	shareReq := withUser(httptest.NewRequest(http.MethodPost, "/v1/artifacts/"+created.ID+"/share", bytes.NewReader(shareBody)), user)
+	newMux(h).ServeHTTP(httptest.NewRecorder(), shareReq)
+
+	req := httptest.NewRequest(http.MethodGet, created.URL, nil)
+	rec := httptest.NewRecorder()
+	newMux(h).ServeHTTP(rec, req)
+
+	csp := rec.Header().Get("Content-Security-Policy")
+	if !strings.Contains(csp, "frame-ancestors https://chat.hive.ai") {
+		t.Fatalf("CSP missing configured frame-ancestors: %q", csp)
+	}
+}
+
+func TestRouteServe_VersionedURLServesSpecificVersion(t *testing.T) {
+	store := newFakeStore()
+	h, _ := newHandlerForTest(store, newFakeBlobs(), nil)
+	user := &auth.User{ID: uuid.New(), TenantID: uuid.New()}
+	created := createArtifact(t, h, user, "<html>v1</html>")
+
+	verBody, _ := json.Marshal(AddVersionRequest{HTML: "<html>v2</html>"})
+	verReq := withUser(httptest.NewRequest(http.MethodPost, "/v1/artifacts/"+created.ID+"/versions", bytes.NewReader(verBody)), user)
+	newMux(h).ServeHTTP(httptest.NewRecorder(), verReq)
+
+	shareBody, _ := json.Marshal(ShareRequest{Public: true})
+	shareReq := withUser(httptest.NewRequest(http.MethodPost, "/v1/artifacts/"+created.ID+"/share", bytes.NewReader(shareBody)), user)
+	newMux(h).ServeHTTP(httptest.NewRecorder(), shareReq)
+
+	// v1 must still be reachable at its own versioned URL after redeploy.
+	req := httptest.NewRequest(http.MethodGet, created.VersionedURL, nil)
+	rec := httptest.NewRecorder()
+	newMux(h).ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK || rec.Body.String() != "<html>v1</html>" {
+		t.Fatalf("v1 fetch: status=%d body=%q", rec.Code, rec.Body.String())
+	}
+
+	// latest (no /v/) must now be v2.
+	latestReq := httptest.NewRequest(http.MethodGet, created.URL, nil)
+	latestRec := httptest.NewRecorder()
+	newMux(h).ServeHTTP(latestRec, latestReq)
+	if latestRec.Code != http.StatusOK || latestRec.Body.String() != "<html>v2</html>" {
+		t.Fatalf("latest fetch: status=%d body=%q", latestRec.Code, latestRec.Body.String())
+	}
+}
+
+func TestRouteServe_UnknownVersion404(t *testing.T) {
+	store := newFakeStore()
+	h, _ := newHandlerForTest(store, newFakeBlobs(), nil)
+	user := &auth.User{ID: uuid.New(), TenantID: uuid.New()}
+	created := createArtifact(t, h, user, "<html>v1</html>")
+	shareBody, _ := json.Marshal(ShareRequest{Public: true})
+	shareReq := withUser(httptest.NewRequest(http.MethodPost, "/v1/artifacts/"+created.ID+"/share", bytes.NewReader(shareBody)), user)
+	newMux(h).ServeHTTP(httptest.NewRecorder(), shareReq)
+
+	req := httptest.NewRequest(http.MethodGet, "/artifacts/"+created.ID+"/v/99", nil)
+	rec := httptest.NewRecorder()
+	newMux(h).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestRouteServe_InvalidArtifactID404(t *testing.T) {
+	h, _ := newHandlerForTest(newFakeStore(), newFakeBlobs(), nil)
+	req := httptest.NewRequest(http.MethodGet, "/artifacts/not-a-uuid", nil)
+	rec := httptest.NewRecorder()
+	newMux(h).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestRouteServe_MethodNotAllowed(t *testing.T) {
+	h, _ := newHandlerForTest(newFakeStore(), newFakeBlobs(), nil)
+	req := httptest.NewRequest(http.MethodPost, "/artifacts/"+uuid.NewString(), nil)
+	rec := httptest.NewRecorder()
+	newMux(h).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", rec.Code)
+	}
+}
+
+func TestRouteServe_PrivateArtifact_AuthenticatedSameTenantOK(t *testing.T) {
+	store := newFakeStore()
+	user := &auth.User{ID: uuid.New(), TenantID: uuid.New()}
+	parser := &fakeClaimsParser{claims: auth.Claims{Sub: user.ID, TenantID: user.TenantID}}
+	h, _ := newHandlerForTest(store, newFakeBlobs(), parser)
+	created := createArtifact(t, h, user, "<html>private</html>")
+
+	req := httptest.NewRequest(http.MethodGet, created.URL, nil)
+	req.Header.Set("Authorization", "Bearer sometoken")
+	rec := httptest.NewRecorder()
+	newMux(h).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 for same-tenant authenticated viewer, body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestRouteServe_PrivateArtifact_AuthenticatedOtherTenant404(t *testing.T) {
+	store := newFakeStore()
+	owner := &auth.User{ID: uuid.New(), TenantID: uuid.New()}
+	other := &auth.User{ID: uuid.New(), TenantID: uuid.New()}
+	parser := &fakeClaimsParser{claims: auth.Claims{Sub: other.ID, TenantID: other.TenantID}}
+	h, _ := newHandlerForTest(store, newFakeBlobs(), parser)
+	created := createArtifact(t, h, owner, "<html>private</html>")
+
+	req := httptest.NewRequest(http.MethodGet, created.URL, nil)
+	req.Header.Set("Authorization", "Bearer sometoken")
+	rec := httptest.NewRecorder()
+	newMux(h).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 for cross-tenant private access", rec.Code)
+	}
+}
+
+func TestRouteServe_InvalidTokenFallsBackToAnonymous(t *testing.T) {
+	store := newFakeStore()
+	owner := &auth.User{ID: uuid.New(), TenantID: uuid.New()}
+	parser := &fakeClaimsParser{err: errors.New("expired")}
+	h, _ := newHandlerForTest(store, newFakeBlobs(), parser)
+	created := createArtifact(t, h, owner, "<html>private</html>")
+
+	// Private artifact, bad token: falls back to anonymous, still 404 (not
+	// a hard auth failure) since the artifact is not public.
+	req := httptest.NewRequest(http.MethodGet, created.URL, nil)
+	req.Header.Set("Authorization", "Bearer garbage")
+	rec := httptest.NewRecorder()
+	newMux(h).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 (anonymous fallback, still private)", rec.Code)
+	}
+}
+
+func TestRouteServe_HeadRequestNoBody(t *testing.T) {
+	store := newFakeStore()
+	h, _ := newHandlerForTest(store, newFakeBlobs(), nil)
+	user := &auth.User{ID: uuid.New(), TenantID: uuid.New()}
+	created := createArtifact(t, h, user, "<html>v1</html>")
+	shareBody, _ := json.Marshal(ShareRequest{Public: true})
+	shareReq := withUser(httptest.NewRequest(http.MethodPost, "/v1/artifacts/"+created.ID+"/share", bytes.NewReader(shareBody)), user)
+	newMux(h).ServeHTTP(httptest.NewRecorder(), shareReq)
+
+	req := httptest.NewRequest(http.MethodHead, created.URL, nil)
+	rec := httptest.NewRecorder()
+	newMux(h).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if rec.Body.Len() != 0 {
+		t.Fatalf("HEAD response body length = %d, want 0", rec.Body.Len())
+	}
+}

--- a/apps/edge-api/internal/artifacts/repository.go
+++ b/apps/edge-api/internal/artifacts/repository.go
@@ -1,0 +1,192 @@
+package artifacts
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// VersionRow is one resolved artifact version, joined with its parent
+// artifact's visibility flag.
+type VersionRow struct {
+	ArtifactID  uuid.UUID
+	Version     int
+	StoragePath string
+	SizeBytes   int64
+	IsPublic    bool
+}
+
+// queryer is the minimal pgx surface shared by *pgxpool.Pool and pgx.Tx, so
+// queryVersion runs identically inside a tenant-scoped transaction (private
+// artifact reads) or directly against the pool with no transaction at all
+// (anonymous public reads, see Repo.GetVersion).
+type queryer interface {
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+}
+
+// Repo handles artifacts DB operations in the edge-api.
+// RLS is enforced by setting app.current_tenant_id before every
+// tenant-scoped query; see withTenantTx and GetVersion.
+type Repo struct {
+	pool *pgxpool.Pool
+}
+
+// NewRepo creates a Repo backed by pool.
+func NewRepo(pool *pgxpool.Pool) *Repo { return &Repo{pool: pool} }
+
+// withTenantTx runs fn inside an explicit transaction with the RLS session
+// variable set LOCAL (transaction-scoped) to tenantID. hive_app is NOT
+// BYPASSRLS, so every query against public.artifacts / public.artifact_versions
+// must see app.current_tenant_id set to the caller's tenant for the
+// tenant-isolation policy to admit rows. Mirrors
+// apps/edge-api/internal/rag/repository.go.withTenantTx.
+func (r *Repo) withTenantTx(ctx context.Context, tenantID uuid.UUID, fn func(tx pgx.Tx) error) error {
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("artifacts.repo: begin tx: %w", err)
+	}
+	defer tx.Rollback(ctx) // no-op once Commit has succeeded
+
+	if _, err := tx.Exec(ctx, "SELECT set_config('app.current_tenant_id', $1, true)", tenantID.String()); err != nil {
+		return fmt.Errorf("artifacts.repo: set tenant: %w", err)
+	}
+	if err := fn(tx); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}
+
+// CreateArtifact registers a new artifact (latest_version=0, no version rows
+// yet) and returns its assigned id.
+func (r *Repo) CreateArtifact(ctx context.Context, tenantID uuid.UUID, name string) (uuid.UUID, error) {
+	var id uuid.UUID
+	err := r.withTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `
+			INSERT INTO public.artifacts (tenant_id, name)
+			VALUES ($1, $2)
+			RETURNING id`,
+			tenantID, name,
+		).Scan(&id)
+	})
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("artifacts.repo: create artifact: %w", err)
+	}
+	return id, nil
+}
+
+// AddVersion inserts the next sequential version for artifactID and bumps
+// artifacts.latest_version in the same transaction, so a same-id redeploy
+// mints a new version at the same URL. SELECT ... FOR UPDATE on the
+// artifacts row serializes concurrent redeploys of the same artifact so two
+// requests never compute the same next version number.
+func (r *Repo) AddVersion(ctx context.Context, tenantID, artifactID uuid.UUID, storagePath string, sizeBytes int64) (int, error) {
+	var version int
+	err := r.withTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		var current int
+		if err := tx.QueryRow(ctx,
+			`SELECT latest_version FROM public.artifacts WHERE id = $1 FOR UPDATE`,
+			artifactID,
+		).Scan(&current); err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return ErrNotFound
+			}
+			return fmt.Errorf("artifacts.repo: lock artifact: %w", err)
+		}
+		version = current + 1
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO public.artifact_versions (artifact_id, tenant_id, version, storage_path, size_bytes)
+			VALUES ($1, $2, $3, $4, $5)`,
+			artifactID, tenantID, version, storagePath, sizeBytes,
+		); err != nil {
+			return fmt.Errorf("artifacts.repo: insert version: %w", err)
+		}
+		if _, err := tx.Exec(ctx,
+			`UPDATE public.artifacts SET latest_version = $1, updated_at = now() WHERE id = $2`,
+			version, artifactID,
+		); err != nil {
+			return fmt.Errorf("artifacts.repo: bump latest_version: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return 0, ErrNotFound
+		}
+		return 0, err
+	}
+	return version, nil
+}
+
+// SetPublic flips the share flag for artifactID, scoped to tenantID.
+// Returns ErrNotFound when no row matched (wrong tenant or unknown id).
+func (r *Repo) SetPublic(ctx context.Context, tenantID, artifactID uuid.UUID, public bool) error {
+	err := r.withTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		tag, err := tx.Exec(ctx,
+			`UPDATE public.artifacts SET is_public = $1, updated_at = now() WHERE id = $2`,
+			public, artifactID,
+		)
+		if err != nil {
+			return fmt.Errorf("artifacts.repo: set public: %w", err)
+		}
+		if tag.RowsAffected() == 0 {
+			return ErrNotFound
+		}
+		return nil
+	})
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return ErrNotFound
+		}
+		return err
+	}
+	return nil
+}
+
+// GetVersion resolves the version to serve for an artifact. version == nil
+// means "latest" (COALESCE to artifacts.latest_version).
+//
+// viewerTenantID is uuid.Nil for anonymous requests: the query then runs
+// with no app.current_tenant_id session variable set at all, so only the
+// public-read RLS policy (is_public = true) can admit the row -- the
+// tenant-isolation policy never matches a NULL current_tenant_id. An
+// authenticated viewerTenantID additionally sees their own tenant's private
+// artifacts, because Postgres OR-combines permissive RLS policies for
+// SELECT: either policy passing admits the row.
+func (r *Repo) GetVersion(ctx context.Context, viewerTenantID, artifactID uuid.UUID, version *int) (VersionRow, error) {
+	if viewerTenantID == uuid.Nil {
+		return r.queryVersion(ctx, r.pool, artifactID, version)
+	}
+	var row VersionRow
+	err := r.withTenantTx(ctx, viewerTenantID, func(tx pgx.Tx) error {
+		v, err := r.queryVersion(ctx, tx, artifactID, version)
+		row = v
+		return err
+	})
+	if err != nil {
+		return VersionRow{}, err
+	}
+	return row, nil
+}
+
+func (r *Repo) queryVersion(ctx context.Context, q queryer, artifactID uuid.UUID, version *int) (VersionRow, error) {
+	var v VersionRow
+	err := q.QueryRow(ctx, `
+		SELECT av.artifact_id, av.version, av.storage_path, av.size_bytes, a.is_public
+		FROM public.artifact_versions av
+		JOIN public.artifacts a ON a.id = av.artifact_id
+		WHERE av.artifact_id = $1
+		  AND av.version = COALESCE($2, a.latest_version)`,
+		artifactID, version,
+	).Scan(&v.ArtifactID, &v.Version, &v.StoragePath, &v.SizeBytes, &v.IsPublic)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return VersionRow{}, ErrNotFound
+		}
+		return VersionRow{}, fmt.Errorf("artifacts.repo: get version: %w", err)
+	}
+	return v, nil
+}

--- a/apps/edge-api/internal/artifacts/repository_rls_test.go
+++ b/apps/edge-api/internal/artifacts/repository_rls_test.go
@@ -1,0 +1,247 @@
+package artifacts
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// newRLSTestPool connects as the hive_app role -- NOT BYPASSRLS in
+// production -- so the artifacts / artifact_versions tenant-isolation and
+// public-read RLS policies are actually exercised. Mirrors
+// apps/edge-api/internal/rag/repository_rls_test.go.
+func newRLSTestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("HIVE_TEST_DB_URL")
+	if dsn == "" {
+		t.Skip("HIVE_TEST_DB_URL not set")
+	}
+	if !strings.Contains(strings.ToLower(dsn), "test") {
+		t.Fatalf("refusing to run: HIVE_TEST_DB_URL must point at a test database (DSN missing 'test' marker)")
+	}
+
+	cfg, err := pgxpool.ParseConfig(dsn)
+	if err != nil {
+		t.Fatalf("parse HIVE_TEST_DB_URL: %v", err)
+	}
+	cfg.MaxConns = 1
+
+	ctx := context.Background()
+	pool, err := pgxpool.NewWithConfig(ctx, cfg)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	if _, err := pool.Exec(ctx, "SET ROLE hive_app"); err != nil {
+		pool.Close()
+		t.Skipf("SET ROLE hive_app failed (is hive_app provisioned + migrations applied on this test DB?): %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+// seedArtifactTenant inserts an FK row into public.tenants via a
+// short-lived, unscoped connection (hive_app has no INSERT policy on
+// tenants).
+func seedArtifactTenant(t *testing.T, id uuid.UUID) {
+	t.Helper()
+	dsn := os.Getenv("HIVE_TEST_DB_URL")
+	ctx := context.Background()
+	setup, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("seed pool: %v", err)
+	}
+	defer setup.Close()
+	_, err = setup.Exec(ctx,
+		`INSERT INTO public.tenants (id, slug, name, deployment)
+		 VALUES ($1, $2, 'artifacts test tenant', 'HIVE_CLOUD')
+		 ON CONFLICT (id) DO NOTHING`,
+		id, "edge-artifacts-test-"+id.String())
+	if err != nil {
+		t.Fatalf("seed tenant: %v", err)
+	}
+	t.Cleanup(func() {
+		cleanup, err := pgxpool.New(context.Background(), dsn)
+		if err != nil {
+			return
+		}
+		defer cleanup.Close()
+		_, _ = cleanup.Exec(context.Background(), `DELETE FROM public.tenants WHERE id = $1`, id)
+	})
+}
+
+func TestRepo_RLS_CreateAddVersionThenGetRoundTrips(t *testing.T) {
+	pool := newRLSTestPool(t)
+	tenantID := uuid.New()
+	seedArtifactTenant(t, tenantID)
+
+	repo := NewRepo(pool)
+	ctx := context.Background()
+
+	artifactID, err := repo.CreateArtifact(ctx, tenantID, "demo")
+	if err != nil {
+		t.Fatalf("CreateArtifact: %v", err)
+	}
+
+	version, err := repo.AddVersion(ctx, tenantID, artifactID, "tenant/artifact/blob.html", 42)
+	if err != nil {
+		t.Fatalf("AddVersion: %v", err)
+	}
+	if version != 1 {
+		t.Fatalf("version = %d, want 1", version)
+	}
+
+	got, err := repo.GetVersion(ctx, tenantID, artifactID, nil)
+	if err != nil {
+		t.Fatalf("GetVersion: %v", err)
+	}
+	if got.StoragePath != "tenant/artifact/blob.html" || got.Version != 1 {
+		t.Fatalf("unexpected round-trip: %+v", got)
+	}
+}
+
+func TestRepo_RLS_AddVersionMintsSequentialVersionsAtSameID(t *testing.T) {
+	pool := newRLSTestPool(t)
+	tenantID := uuid.New()
+	seedArtifactTenant(t, tenantID)
+
+	repo := NewRepo(pool)
+	ctx := context.Background()
+	artifactID, err := repo.CreateArtifact(ctx, tenantID, "demo")
+	if err != nil {
+		t.Fatalf("CreateArtifact: %v", err)
+	}
+
+	if _, err := repo.AddVersion(ctx, tenantID, artifactID, "v1.html", 1); err != nil {
+		t.Fatalf("AddVersion v1: %v", err)
+	}
+	v2, err := repo.AddVersion(ctx, tenantID, artifactID, "v2.html", 2)
+	if err != nil {
+		t.Fatalf("AddVersion v2: %v", err)
+	}
+	if v2 != 2 {
+		t.Fatalf("second version = %d, want 2", v2)
+	}
+
+	// v1 must still be reachable at its own version, latest must be v2.
+	v1Row, err := repo.GetVersion(ctx, tenantID, artifactID, intPtr(1))
+	if err != nil {
+		t.Fatalf("GetVersion v1: %v", err)
+	}
+	if v1Row.StoragePath != "v1.html" {
+		t.Fatalf("v1 storage path = %q, want v1.html", v1Row.StoragePath)
+	}
+	latest, err := repo.GetVersion(ctx, tenantID, artifactID, nil)
+	if err != nil {
+		t.Fatalf("GetVersion latest: %v", err)
+	}
+	if latest.StoragePath != "v2.html" || latest.Version != 2 {
+		t.Fatalf("latest = %+v, want v2.html/2", latest)
+	}
+}
+
+// TestRepo_RLS_CrossTenantCannotReadPrivateArtifact proves the database
+// policy itself blocks cross-tenant reads of a private artifact.
+func TestRepo_RLS_CrossTenantCannotReadPrivateArtifact(t *testing.T) {
+	pool := newRLSTestPool(t)
+	tenantA, tenantB := uuid.New(), uuid.New()
+	seedArtifactTenant(t, tenantA)
+	seedArtifactTenant(t, tenantB)
+
+	repo := NewRepo(pool)
+	ctx := context.Background()
+	artifactID, err := repo.CreateArtifact(ctx, tenantA, "tenant-a-only")
+	if err != nil {
+		t.Fatalf("CreateArtifact: %v", err)
+	}
+	if _, err := repo.AddVersion(ctx, tenantA, artifactID, "secret.html", 1); err != nil {
+		t.Fatalf("AddVersion: %v", err)
+	}
+
+	if _, err := repo.GetVersion(ctx, tenantB, artifactID, nil); err != ErrNotFound {
+		t.Fatalf("GetVersion under tenant B context: err = %v, want ErrNotFound", err)
+	}
+}
+
+// TestRepo_RLS_PublicArtifactReadableWithNoTenantContext proves the
+// anonymous path (viewerTenantID = uuid.Nil, no app.current_tenant_id set
+// at all) can still read a version once its artifact is marked public,
+// while a private artifact stays unreadable in that same anonymous path.
+func TestRepo_RLS_PublicArtifactReadableWithNoTenantContext(t *testing.T) {
+	pool := newRLSTestPool(t)
+	tenantID := uuid.New()
+	seedArtifactTenant(t, tenantID)
+
+	repo := NewRepo(pool)
+	ctx := context.Background()
+
+	privateID, err := repo.CreateArtifact(ctx, tenantID, "private")
+	if err != nil {
+		t.Fatalf("CreateArtifact private: %v", err)
+	}
+	if _, err := repo.AddVersion(ctx, tenantID, privateID, "private.html", 1); err != nil {
+		t.Fatalf("AddVersion private: %v", err)
+	}
+
+	publicID, err := repo.CreateArtifact(ctx, tenantID, "public")
+	if err != nil {
+		t.Fatalf("CreateArtifact public: %v", err)
+	}
+	if _, err := repo.AddVersion(ctx, tenantID, publicID, "public.html", 1); err != nil {
+		t.Fatalf("AddVersion public: %v", err)
+	}
+	if err := repo.SetPublic(ctx, tenantID, publicID, true); err != nil {
+		t.Fatalf("SetPublic: %v", err)
+	}
+
+	if _, err := repo.GetVersion(ctx, uuid.Nil, privateID, nil); err != ErrNotFound {
+		t.Fatalf("anonymous read of private artifact: err = %v, want ErrNotFound", err)
+	}
+
+	got, err := repo.GetVersion(ctx, uuid.Nil, publicID, nil)
+	if err != nil {
+		t.Fatalf("anonymous read of public artifact: %v", err)
+	}
+	if got.StoragePath != "public.html" {
+		t.Fatalf("storage path = %q, want public.html", got.StoragePath)
+	}
+}
+
+// TestRepo_RLS_NoSessionLeakAcrossBorrows proves the tenant context set by
+// one repository call does not survive onto the pooled connection for
+// whoever borrows it next.
+func TestRepo_RLS_NoSessionLeakAcrossBorrows(t *testing.T) {
+	pool := newRLSTestPool(t)
+	tenantA := uuid.New()
+	seedArtifactTenant(t, tenantA)
+
+	repo := NewRepo(pool)
+	ctx := context.Background()
+	artifactID, err := repo.CreateArtifact(ctx, tenantA, "tenant-a-only")
+	if err != nil {
+		t.Fatalf("CreateArtifact: %v", err)
+	}
+
+	var setting string
+	if err := pool.QueryRow(ctx, "SELECT current_setting('app.current_tenant_id', true)").Scan(&setting); err != nil {
+		t.Fatalf("read current_setting: %v", err)
+	}
+	if setting != "" {
+		t.Fatalf("session leak: app.current_tenant_id still %q after CreateArtifact committed, want empty", setting)
+	}
+
+	var count int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM public.artifacts WHERE id = $1`,
+		artifactID).Scan(&count); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("session leak: bare borrow saw %d row(s) with no tenant context and is_public=false (RLS should fail-closed on NULL)", count)
+	}
+}
+
+func intPtr(v int) *int { return &v }

--- a/apps/edge-api/internal/artifacts/repository_rls_test.go
+++ b/apps/edge-api/internal/artifacts/repository_rls_test.go
@@ -244,4 +244,78 @@ func TestRepo_RLS_NoSessionLeakAcrossBorrows(t *testing.T) {
 	}
 }
 
+// TestRepo_RLS_CrossTenantCannotMutateOtherTenantArtifact proves the
+// tenant-isolation policy blocks writes too, not just reads: tenant B's
+// session cannot add a version to, or flip the share flag on, tenant A's
+// artifact, because the row is invisible under tenant B's RLS context in
+// the first place (the mutating queries are WHERE id = $1 scoped, and RLS
+// filters that row out before the WHERE clause ever matches it).
+func TestRepo_RLS_CrossTenantCannotMutateOtherTenantArtifact(t *testing.T) {
+	pool := newRLSTestPool(t)
+	tenantA, tenantB := uuid.New(), uuid.New()
+	seedArtifactTenant(t, tenantA)
+	seedArtifactTenant(t, tenantB)
+
+	repo := NewRepo(pool)
+	ctx := context.Background()
+	artifactID, err := repo.CreateArtifact(ctx, tenantA, "tenant-a-only")
+	if err != nil {
+		t.Fatalf("CreateArtifact: %v", err)
+	}
+	if _, err := repo.AddVersion(ctx, tenantA, artifactID, "v1.html", 1); err != nil {
+		t.Fatalf("AddVersion (tenant A): %v", err)
+	}
+
+	if _, err := repo.AddVersion(ctx, tenantB, artifactID, "hijacked.html", 999); err != ErrNotFound {
+		t.Fatalf("AddVersion under tenant B context: err = %v, want ErrNotFound", err)
+	}
+	if err := repo.SetPublic(ctx, tenantB, artifactID, true); err != ErrNotFound {
+		t.Fatalf("SetPublic under tenant B context: err = %v, want ErrNotFound", err)
+	}
+
+	// Tenant A's artifact must be untouched by tenant B's rejected attempts.
+	got, err := repo.GetVersion(ctx, tenantA, artifactID, nil)
+	if err != nil {
+		t.Fatalf("GetVersion (tenant A, after rejected tenant B writes): %v", err)
+	}
+	if got.Version != 1 || got.StoragePath != "v1.html" || got.IsPublic {
+		t.Fatalf("tenant A's artifact was mutated by a rejected cross-tenant write: %+v", got)
+	}
+}
+
+// TestRepo_RLS_ShareRevocationBlocksAnonymousRead proves that unsetting
+// is_public immediately closes the anonymous-read RLS policy again: a
+// previously public artifact stops being readable with no tenant context
+// the moment its owner revokes the share.
+func TestRepo_RLS_ShareRevocationBlocksAnonymousRead(t *testing.T) {
+	pool := newRLSTestPool(t)
+	tenantID := uuid.New()
+	seedArtifactTenant(t, tenantID)
+
+	repo := NewRepo(pool)
+	ctx := context.Background()
+	artifactID, err := repo.CreateArtifact(ctx, tenantID, "revocable")
+	if err != nil {
+		t.Fatalf("CreateArtifact: %v", err)
+	}
+	if _, err := repo.AddVersion(ctx, tenantID, artifactID, "shared.html", 1); err != nil {
+		t.Fatalf("AddVersion: %v", err)
+	}
+	if err := repo.SetPublic(ctx, tenantID, artifactID, true); err != nil {
+		t.Fatalf("SetPublic(true): %v", err)
+	}
+
+	if _, err := repo.GetVersion(ctx, uuid.Nil, artifactID, nil); err != nil {
+		t.Fatalf("anonymous read while public: %v", err)
+	}
+
+	if err := repo.SetPublic(ctx, tenantID, artifactID, false); err != nil {
+		t.Fatalf("SetPublic(false): %v", err)
+	}
+
+	if _, err := repo.GetVersion(ctx, uuid.Nil, artifactID, nil); err != ErrNotFound {
+		t.Fatalf("anonymous read after share revoked: err = %v, want ErrNotFound", err)
+	}
+}
+
 func intPtr(v int) *int { return &v }

--- a/apps/edge-api/internal/artifacts/types.go
+++ b/apps/edge-api/internal/artifacts/types.go
@@ -1,0 +1,55 @@
+// Package artifacts implements the /v1/artifacts/* management endpoints and
+// the /artifacts/* hosting endpoints (issue #312, agent-subsystem blueprint
+// Step 3.3). A self-contained HTML blob is stored keyed by artifact id and
+// version, served at a stable URL that survives redeploys, and stays
+// private until the owning tenant explicitly shares it.
+package artifacts
+
+import (
+	"errors"
+	"time"
+)
+
+// ErrNotFound is returned when an artifact or version does not exist, is
+// not visible to the caller under RLS, or (for management writes) is not
+// owned by the caller's tenant. Handlers map it to HTTP 404 uniformly so a
+// private artifact never distinguishes "does not exist" from "exists but
+// you cannot see it" for an unauthorized caller.
+var ErrNotFound = errors.New("not found")
+
+// MaxHTMLSize bounds the accepted artifact body (5 MiB). Artifacts are
+// self-contained HTML documents, not general file uploads (that is
+// apps/edge-api/internal/files); this cap is far below files.MaxFileSize
+// and exists to bound request-body decoding cost, not storage cost.
+const MaxHTMLSize = 5 << 20
+
+// CreateRequest is the JSON body for POST /v1/artifacts.
+type CreateRequest struct {
+	Name string `json:"name"`
+	HTML string `json:"html"`
+}
+
+// AddVersionRequest is the JSON body for POST /v1/artifacts/{id}/versions.
+type AddVersionRequest struct {
+	HTML string `json:"html"`
+}
+
+// ShareRequest is the JSON body for POST /v1/artifacts/{id}/share.
+type ShareRequest struct {
+	Public bool `json:"public"`
+}
+
+// VersionResponse is returned by create and add-version.
+type VersionResponse struct {
+	ID           string    `json:"id"`
+	Version      int       `json:"version"`
+	URL          string    `json:"url"`           // latest-version URL, stable across redeploys
+	VersionedURL string    `json:"versioned_url"` // this specific version's URL
+	CreatedAt    time.Time `json:"created_at"`
+}
+
+// ShareResponse is returned by the share endpoint.
+type ShareResponse struct {
+	ID     string `json:"id"`
+	Public bool   `json:"public"`
+}

--- a/deploy/docker/Caddyfile.artifacts
+++ b/deploy/docker/Caddyfile.artifacts
@@ -1,0 +1,23 @@
+# Artifacts hosting reverse proxy (issue #312).
+#
+# Origin isolation is the actual security boundary here, not just the CSP
+# header edge-api sets on the response body: this Caddyfile answers on
+# ARTIFACTS_DOMAIN, a hostname distinct from HIVE_CHAT_URL/OWUI, so a
+# browser's same-origin policy alone stops artifact HTML from ever reading
+# the main app's cookies or session storage, regardless of what the
+# artifact's own script tries. Only the /artifacts/* serving path is
+# proxied through; the /v1/artifacts/* management API stays on the main
+# edge-api origin and is never reachable from this host.
+{$ARTIFACTS_DOMAIN:artifacts.localhost} {
+  handle /artifacts/* {
+    reverse_proxy edge-api:8080 {
+      transport http {
+        response_header_timeout 30s
+        dial_timeout 5s
+      }
+    }
+  }
+  handle {
+    respond 404
+  }
+}

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -435,6 +435,32 @@ services:
       - caddy-config:/config
     restart: unless-stopped
 
+  # Artifacts hosting (#312) -- separate container, separate origin
+  # (ARTIFACTS_DOMAIN) from caddy-owui on purpose: the isolation guarantee
+  # that a served artifact's HTML cannot read the main app's cookies or
+  # session storage comes from the browser's same-origin policy, which only
+  # holds if this never shares a host with HIVE_CHAT_URL/OWUI. Same image
+  # and volume pattern as caddy-owui; own named volumes so cert/config state
+  # never mixes between the two origins.
+  caddy-artifacts:
+    image: caddy:2-alpine@sha256:86deaf5e3d3408a6ccec08fbb79989783dd26e206ae10bcf78a801dc8c9ab794
+    profiles:
+      - local
+      - enterprise
+      - chat
+    ports:
+      - "3004:80"
+    environment:
+      ARTIFACTS_DOMAIN: ${ARTIFACTS_DOMAIN:-artifacts.localhost}
+    depends_on:
+      edge-api:
+        condition: service_healthy
+    volumes:
+      - ./Caddyfile.artifacts:/etc/caddy/Caddyfile:ro
+      - caddy-artifacts-data:/data
+      - caddy-artifacts-config:/config
+    restart: unless-stopped
+
   # Hive EnterpriseEdge — optional local Ollama inference backend.
   # Active only under the `enterprise` profile. Serves keyless local models
   # (e.g. llama3, mistral) via the Ollama HTTP API on port 11434.
@@ -579,6 +605,8 @@ volumes:
   owui-data:
   caddy-data:
   caddy-config:
+  caddy-artifacts-data:
+  caddy-artifacts-config:
   # ollama-models persists pulled model weights across container recreates.
   # Active only when the `enterprise` profile is used.
   ollama-models:

--- a/supabase/migrations/20260716_02_artifacts.sql
+++ b/supabase/migrations/20260716_02_artifacts.sql
@@ -1,0 +1,143 @@
+-- supabase/migrations/20260716_02_artifacts.sql
+--
+-- Artifacts hosting (issue #312, agent-subsystem blueprint Step 3.3).
+-- Self-contained HTML blobs (Claude-Artifacts-style), persisted and served
+-- at a stable, versioned URL. The HTML bytes themselves live in the
+-- existing Supabase Storage `hive-files` bucket (packages/storage.Storage,
+-- same client the files/images/rag handlers use); only metadata + the
+-- storage_path pointer live here.
+--
+-- Two tables:
+--   public.artifacts          One row per artifact id. latest_version is a
+--                              denormalized counter bumped by
+--                              apps/edge-api/internal/artifacts.Repo.AddVersion
+--                              in the same transaction as the version insert,
+--                              so GET /artifacts/{id} (latest) never needs a
+--                              MAX(version) scan.
+--   public.artifact_versions  One immutable row per redeploy. A same-id
+--                              redeploy inserts a new row and mints a new
+--                              version at the same URL; existing versions
+--                              are never mutated or deleted individually.
+--
+-- Security: RLS on both tables, tenant-isolation policy mirrors
+-- public.marketplace_tenant_entries (20260716_01_marketplace_catalog.sql,
+-- NULLIF guard for the pooled-connection GUC quirk). A second PERMISSIVE
+-- SELECT-only policy on each table admits public artifacts to anonymous
+-- readers -- Postgres OR-combines permissive policies for the same command,
+-- so an anonymous request (no app.current_tenant_id set at all) can still
+-- read a row when is_public = true, while INSERT/UPDATE/DELETE remain
+-- governed solely by the tenant-isolation policy. This lets
+-- GET /artifacts/{id} serve a shared artifact with no service-role bypass
+-- or SECURITY DEFINER function required.
+--
+-- Depends on: 20260516_01_phase19_tenants.sql (public.tenants).
+
+BEGIN;
+
+CREATE TABLE public.artifacts (
+    id             UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id      UUID        NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+    created_by     UUID        REFERENCES auth.users(id),
+    name           TEXT        NOT NULL DEFAULT '',
+    is_public      BOOLEAN     NOT NULL DEFAULT false,
+    latest_version INT         NOT NULL DEFAULT 0,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE public.artifacts IS
+  'Claude-Artifacts-style hosted HTML blobs (issue #312). is_public gates the anonymous-read RLS policy on this table and public.artifact_versions; private by default. latest_version is bumped by artifacts.Repo.AddVersion in the same transaction as the version insert.';
+
+CREATE TABLE public.artifact_versions (
+    id           UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    artifact_id  UUID        NOT NULL REFERENCES public.artifacts(id) ON DELETE CASCADE,
+    -- Denormalized from artifacts.tenant_id (mirrors public.rag_chunks
+    -- alongside document_id): lets the tenant-isolation policy below apply
+    -- directly to this table without a subquery on every row.
+    tenant_id    UUID        NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+    version      INT         NOT NULL,
+    storage_path TEXT        NOT NULL,
+    size_bytes   BIGINT      NOT NULL DEFAULT 0,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (artifact_id, version)
+);
+
+COMMENT ON TABLE public.artifact_versions IS
+  'Immutable per-redeploy version rows for public.artifacts. storage_path points at the HTML blob in the hive-files Supabase Storage bucket.';
+
+CREATE INDEX artifacts_tenant_idx ON public.artifacts (tenant_id, created_at DESC);
+CREATE INDEX artifact_versions_artifact_idx ON public.artifact_versions (artifact_id, version DESC);
+CREATE INDEX artifact_versions_tenant_idx ON public.artifact_versions (tenant_id);
+
+ALTER TABLE public.artifacts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.artifact_versions ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public' AND tablename = 'artifacts'
+          AND policyname = 'artifacts_tenant_isolation'
+    ) THEN
+        CREATE POLICY artifacts_tenant_isolation
+            ON public.artifacts AS PERMISSIVE FOR ALL TO hive_app
+            USING      (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::uuid)
+            WITH CHECK (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::uuid);
+    END IF;
+END$$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public' AND tablename = 'artifacts'
+          AND policyname = 'artifacts_public_read'
+    ) THEN
+        -- SELECT-only permissive policy, OR-combined with the tenant
+        -- isolation policy above: lets anonymous readers (no
+        -- app.current_tenant_id set) see a row once its owner has shared
+        -- it, without ever granting them INSERT/UPDATE/DELETE.
+        CREATE POLICY artifacts_public_read
+            ON public.artifacts FOR SELECT TO hive_app
+            USING (is_public = true);
+    END IF;
+END$$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public' AND tablename = 'artifact_versions'
+          AND policyname = 'artifact_versions_tenant_isolation'
+    ) THEN
+        CREATE POLICY artifact_versions_tenant_isolation
+            ON public.artifact_versions AS PERMISSIVE FOR ALL TO hive_app
+            USING      (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::uuid)
+            WITH CHECK (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::uuid);
+    END IF;
+END$$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public' AND tablename = 'artifact_versions'
+          AND policyname = 'artifact_versions_public_read'
+    ) THEN
+        CREATE POLICY artifact_versions_public_read
+            ON public.artifact_versions FOR SELECT TO hive_app
+            USING (
+                EXISTS (
+                    SELECT 1 FROM public.artifacts a
+                    WHERE a.id = artifact_versions.artifact_id AND a.is_public = true
+                )
+            );
+    END IF;
+END$$;
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.artifacts         TO hive_app;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.artifact_versions TO hive_app;
+GRANT SELECT ON public.artifacts         TO auditor_ro;
+GRANT SELECT ON public.artifact_versions TO auditor_ro;
+
+COMMIT;


### PR DESCRIPTION
## Summary

Implements agent-subsystem blueprint Step 3.3 (issue #312): a self-hosted Claude-Artifacts equivalent. A self-contained HTML blob is stored keyed by artifact id and version, served at a stable URL that survives redeploys, and stays private until the owning tenant explicitly shares it.

- **Storage**: HTML blobs live in the existing `hive-files` Supabase Storage bucket via the shared `packages/storage.Storage` client (same pattern as `apps/edge-api/internal/files`). Only metadata and the storage path live in Postgres.
- **Schema** (`supabase/migrations/20260716_02_artifacts.sql`): `public.artifacts` (one row per artifact, `latest_version` counter) and `public.artifact_versions` (immutable per-redeploy rows). RLS on both tables: a tenant-isolation policy (NULLIF guard, mirrors `20260716_01_marketplace_catalog.sql`) plus a second `FOR SELECT`-only permissive policy admitting rows where `is_public = true`. Postgres OR-combines permissive policies for SELECT, so an anonymous request with no `app.current_tenant_id` set can read a shared artifact with no service-role bypass or `SECURITY DEFINER` function required, while every write stays governed solely by the tenant policy.
- **Endpoints**:
  - `POST /v1/artifacts`, `POST /v1/artifacts/{id}/versions`, `POST /v1/artifacts/{id}/share` — JWT-authenticated, tenant-scoped, mirror the RAG handler's `withTenantTx` pattern. `tenant_id` is never a client wire field.
  - `GET /artifacts/{id}` (latest) and `GET /artifacts/{id}/v/{n}` (versioned) — anonymous-reachable by design (a share link must work with no `Authorization` header). Visibility is resolved entirely by the RLS policy above; the handler optionally parses a bearer JWT to admit the owning tenant's own private artifacts, falling back to anonymous (public-only) on any missing/invalid token.
- **Security posture**: served bytes carry `Content-Security-Policy: default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data:; connect-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors <configured or 'none'>` plus `X-Content-Type-Options: nosniff`. A new `caddy-artifacts` reverse proxy (`deploy/docker/Caddyfile.artifacts`, `ARTIFACTS_DOMAIN`) puts the serving surface on its own origin, separate from `HIVE_CHAT_URL`/OWUI, so the same-origin policy itself (not just the CSP header) prevents artifact HTML from ever reading the main app's cookies or session storage.
- **Audit**: `ARTIFACT_CREATE` / `ARTIFACT_VERSION_ADD` at `INFO`, `ARTIFACT_SHARE` at `WARNING` when publicizing (`INFO` when revoking), written through the same `chat.InsertAuditEvent` path RAG uses.
- **Caching**: served bytes carry `Cache-Control: private, no-store` when private (viewer authenticated as the owning tenant) and `Cache-Control: public, max-age=300` when shared, so a private artifact is never retained by a shared proxy or browser disk cache.

## Out of scope / open risk

- The consuming iframe embed (Wave 3.1/3.2 OWUI panel, not yet built) must set `sandbox="allow-scripts"` with no `allow-same-origin`; this PR documents that requirement in code comments but cannot enforce it since no panel exists yet to review.
- No list/delete endpoints for artifacts — not required by the acceptance check; add if the panel needs artifact management UI.
- `ARTIFACTS_FRAME_ANCESTOR` defaults to `'none'` (no embedding anywhere) until a deployment explicitly sets it to the panel origin.

### Deferred follow-ups (security review, LOW severity — not built here)

- **Anonymous-path rate limiting.** `GET /artifacts/{id}` is unauthenticated by design (share links); nothing currently rate-limits scraping/enumeration attempts at the edge. Belongs at the `caddy-artifacts` layer (Caddy `rate_limit` or a fronting WAF rule), not in the Go handler. Track as a follow-up issue before wide public rollout.
- **Per-tenant aggregate storage quota.** Nothing currently bounds how much `hive-files` storage one tenant's artifacts can consume in total (only a per-artifact `MaxHTMLSize` cap exists). Needs a control-plane-side quota check, likely reusing the existing budget/quota infra (`apps/edge-api/internal/limits`). Follow-up issue, not blocking this PR.

## Test plan

- [x] `go test ./apps/edge-api/internal/artifacts/... -count=1 -short -v` — all handler unit tests green (create/version/share/serve, CSP + Cache-Control header assertions, private-vs-public RLS-equivalent fake-store behavior, invalid/expired-token anonymous fallback).
- [x] `go test ./apps/edge-api/... -count=1 -short` — full edge-api suite green, no regressions from `main.go` wiring.
- [x] `go build ./apps/edge-api/...` — clean.
- [x] `docker compose config --quiet` — new `caddy-artifacts` service and volumes validate.
- [x] `gofmt -l` — new files clean.
- [x] RLS integration tests (`repository_rls_test.go`, mirrors `apps/edge-api/internal/rag/repository_rls_test.go`) run live against a real `postgres:16` container with the real `20260516_01_phase19_tenants.sql` + `20260716_02_artifacts.sql` migrations applied (stub only for the Supabase-managed `auth.users`/roles those migrations assume exist). All 7 pass, including cross-tenant write denial and share-revocation-blocks-anonymous-read (added live, see PR comment for full log): https://github.com/sakibsadmanshajib/hive/pull/328#issuecomment-4989070517
- [x] CI: Go tests (edge-api/control-plane/storage), Web console, Repo policy lints, License gate, GitGuardian, CodeRabbit — all pass. Web E2E (full stack) reports its no-frontend-paths-changed shim success (correct for a Go-only change).
- [ ] Live smoke: create → share → fetch via `caddy-artifacts` origin → confirm iframe cannot read main app cookies (needs the Wave 3.1/3.2 panel to embed against).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
