### PR TITLE
feat: agent task persistence and lifecycle endpoints, web side (#311)

### DIFF
--- a/apps/control-plane/cmd/server/main.go
+++ b/apps/control-plane/cmd/server/main.go
@@ -20,6 +20,7 @@ import (
 	goredis "github.com/redis/go-redis/v9"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/accounting"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/accounts"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/agenttask"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/apikeys"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/audit"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/auditarchive"
@@ -39,8 +40,8 @@ import (
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/identity"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/ledger"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/licensing"
-	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/marketplace"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/litellmconfig"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/marketplace"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/owui"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/payments"
 	bkashRail "github.com/sakibsadmanshajib/hive/apps/control-plane/internal/payments/bkash"
@@ -797,6 +798,19 @@ func main() {
 		marketplaceHandler = marketplace.NewHandler(marketplaceSvc)
 	}
 
+	// Issue #311 (blueprint Step 3.4) — agent task persistence, web side. No
+	// live agent-engine control channel exists yet (Wave 3 gap: the sandbox's
+	// --network none profile cuts off the host <-> agent-server channel this
+	// would need), so agenttask.NotConfiguredEngine is wired: task creation
+	// still succeeds and persists, it just stays queued until a real Engine
+	// lands. See apps/control-plane/internal/agenttask/SYNC_CONTRACT.md.
+	var agentTaskHandler *agenttask.Handler
+	if pool != nil {
+		agentTaskRepo := agenttask.NewPgxRepository(pool)
+		agentTaskSvc := agenttask.NewService(agentTaskRepo, agenttask.NotConfiguredEngine{})
+		agentTaskHandler = agenttask.NewHandler(agentTaskSvc)
+	}
+
 	router := platformhttp.NewRouter(platformhttp.RouterConfig{
 		AuthMiddleware:          authMiddleware,
 		AccountsHandler:         accountsHandler,
@@ -814,6 +828,7 @@ func main() {
 		FeatureGateAdminHandler: featureGateAdminHandler,
 		EgressPolicyHandler:     egressPolicyHandler,
 		MarketplaceHandler:      marketplaceHandler,
+		AgentTaskHandler:        agentTaskHandler,
 		RoutingHandler:          routingHandler,
 		UsageHandler:            usageHandler,
 		MetricsRegistry:         metricsRegistry,

--- a/apps/control-plane/internal/agenttask/SYNC_CONTRACT.md
+++ b/apps/control-plane/internal/agenttask/SYNC_CONTRACT.md
@@ -1,0 +1,91 @@
+# Agent task sync contract (issue #311, blueprint Step 3.4)
+
+Server-side backing store so a task started in one web session is visible
+and resumable from another web session, tenant-scoped. This is the contract
+the Wave 4 desktop consumer attaches to; nothing here is desktop-specific.
+
+## State machine
+
+```
+queued ──> running ──> succeeded
+  │           │
+  │           └───────> failed
+  │
+  └────────────────────> cancelled
+```
+
+`queued` and `running` are the only states `cancel` accepts from. `succeeded`,
+`failed`, and `cancelled` are terminal: no further transition is allowed
+(`ErrTerminalState`).
+
+## Wire shapes (JSON)
+
+Task, as returned by every endpoint below:
+
+```json
+{
+  "id": "uuid",
+  "pack": "coding-pack | knowledge-work-pack",
+  "status": "queued | running | succeeded | failed | cancelled",
+  "engine_session_ref": "string, empty until running",
+  "result_summary_ref": "string, empty until succeeded (or failed with partial output)",
+  "error_message": "string, empty unless failed",
+  "created_at": "RFC3339",
+  "updated_at": "RFC3339",
+  "started_at": "RFC3339 | null",
+  "finished_at": "RFC3339 | null"
+}
+```
+
+`tenant_id` and `user_id` never appear in a response body: both are implied
+by the authenticated caller, never round-tripped.
+
+## Edge-api surface (customer-facing, auth required, gated by feature
+`ENABLE_COWORK`)
+
+| Method | Path | Body | Notes |
+|---|---|---|---|
+| POST | `/v1/agent/tasks` | `{"pack": "..."}` | 201 with the created Task |
+| GET | `/v1/agent/tasks` | — | `{"tasks": [Task, ...]}`, newest first, scoped to the caller |
+| GET | `/v1/agent/tasks/{id}` | — | 404 if the task belongs to a different user or does not exist |
+| POST | `/v1/agent/tasks/{id}/cancel` | — | 409 if the task already reached a terminal state |
+
+Status is read by polling `GET /v1/agent/tasks/{id}`. No SSE/websocket
+channel ships in this step — the existing SSE pattern in this repo (see
+`apps/edge-api/internal/anthropic/stream.go`) is a provider-response
+translator wired around one in-flight LLM call, not a general task-status
+push channel, and building one is out of scope here. If a live-updating
+panel needs push updates later, add a `GET /v1/agent/tasks/{id}/events` SSE
+endpoint that polls the same store server-side and streams deltas; the Task
+shape above does not change.
+
+## Control-plane internal surface (shared-secret `X-Internal-Token`, not
+customer-facing)
+
+`tenant_id` and `user_id` travel as URL path segments, never body/query/
+header, mirroring `apps/control-plane/internal/marketplace`'s internal read
+surface — the process boundary means edge-api resolves both from the
+caller's authenticated request context before building the path, never from
+untrusted client input.
+
+| Method | Path | Body |
+|---|---|---|
+| POST | `/internal/agent-tasks/{tenant_id}/{user_id}` | `{"pack": "..."}` |
+| GET | `/internal/agent-tasks/{tenant_id}/{user_id}` | — |
+| GET | `/internal/agent-tasks/{tenant_id}/{user_id}/{task_id}` | — |
+| POST | `/internal/agent-tasks/{tenant_id}/{user_id}/{task_id}/cancel` | — |
+
+## Engine seam (known gap)
+
+`Service.CreateTask` calls `Engine.Launch(ctx, task)` right after persisting
+a `queued` row. The only `Engine` wired today is `NotConfiguredEngine`,
+which returns `ErrEngineNotConfigured` and leaves the task `queued` — that is
+treated as an open seam, not a task failure. `apps/agent-engine`'s Wave 2.2
+CLI binds a host port for one sandbox session, but the control channel this
+package needs (submit a task, get a session reference back, later learn
+success/failure) requires a second host <-> agent-server channel that the
+sandbox's `--network none` egress profile currently cuts off. Wiring a real
+`Engine` that talks to that channel is Wave 4 work (desktop control channel)
+or a follow-up once a server-side equivalent exists; `Service` and the HTTP
+surface do not need to change when that lands, only the `Engine`
+implementation passed to `NewService`.

--- a/apps/control-plane/internal/agenttask/engine.go
+++ b/apps/control-plane/internal/agenttask/engine.go
@@ -1,0 +1,33 @@
+package agenttask
+
+import (
+	"context"
+	"errors"
+)
+
+// ErrEngineNotConfigured is returned by an Engine that has no live control
+// channel to apps/agent-engine yet. Service treats it as "stays queued", not
+// a failure: see NotConfiguredEngine's doc comment for the precise gap.
+var ErrEngineNotConfigured = errors.New("agenttask: engine not configured")
+
+// Engine launches an agent-engine (Wave 2.2) session for a queued task and
+// returns an engine session reference to persist on the task row.
+type Engine interface {
+	Launch(ctx context.Context, t Task) (sessionRef string, err error)
+}
+
+// NotConfiguredEngine is the default Engine wired until the host -> agent-
+// server control channel exists. apps/agent-engine/cmd/agent-engine today is
+// a CLI process launched with a bound host port for one sandbox session; the
+// launch call this package needs (submit a task, get back a session
+// reference, later learn success/failure) requires a second channel the
+// sandbox's --network none profile currently cuts off entirely (Wave 3 gap
+// tracked in the agent-subsystem blueprint's Wave 3.4 step and Wave 4's
+// desktop control-channel work). Until that channel lands, every task
+// created here is persisted and returned to the caller in StatusQueued
+// rather than failed — the seam is wired, the far end of it is not.
+type NotConfiguredEngine struct{}
+
+func (NotConfiguredEngine) Launch(context.Context, Task) (string, error) {
+	return "", ErrEngineNotConfigured
+}

--- a/apps/control-plane/internal/agenttask/http.go
+++ b/apps/control-plane/internal/agenttask/http.go
@@ -1,0 +1,218 @@
+package agenttask
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Handler serves the service-to-service task lifecycle surface edge-api
+// calls (issue #311, agent-subsystem blueprint Step 3.4). tenant_id and
+// user_id travel as URL path segments — not query string, form value,
+// header, or JSON body field — because the process boundary means the
+// caller's own authenticated request context cannot cross it; edge-api
+// (the only caller) resolves both solely from auth.TenantID(ctx) /
+// auth.UserFrom(ctx) before building the path. Mirrors
+// apps/control-plane/internal/marketplace/http.go's InternalMux, which
+// resolves tenant_id the same way for GET /internal/marketplace/{tenant_id}/mcp-servers.
+//
+//	POST /internal/agent-tasks/{tenant_id}/{user_id}                 — create {pack}
+//	GET  /internal/agent-tasks/{tenant_id}/{user_id}                 — list
+//	GET  /internal/agent-tasks/{tenant_id}/{user_id}/{task_id}        — get one
+//	POST /internal/agent-tasks/{tenant_id}/{user_id}/{task_id}/cancel — cancel
+type Handler struct {
+	svc *Service
+}
+
+// NewHandler constructs the agenttask HTTP handler.
+func NewHandler(svc *Service) *Handler {
+	return &Handler{svc: svc}
+}
+
+// InternalMux returns the shared-secret-guarded service-to-service surface.
+// Wrap with RequireInternalToken in router wiring.
+func (h *Handler) InternalMux() http.Handler {
+	return http.HandlerFunc(h.serveInternal)
+}
+
+const internalPrefix = "/internal/agent-tasks/"
+
+// maxBodyBytes caps request bodies this handler decodes. A create request
+// carries one field (pack); there is no legitimate reason for it to
+// approach this size.
+const maxBodyBytes = 4 << 10 // 4 KiB
+
+func (h *Handler) serveInternal(w http.ResponseWriter, r *http.Request) {
+	rest := strings.Trim(strings.TrimPrefix(r.URL.Path, internalPrefix), "/")
+	parts := strings.Split(rest, "/")
+	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
+		writeJSON(w, http.StatusNotFound, errBody("not found"))
+		return
+	}
+	tenantID, err := uuid.Parse(parts[0])
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, errBody("invalid tenant_id"))
+		return
+	}
+	userID, err := uuid.Parse(parts[1])
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, errBody("invalid user_id"))
+		return
+	}
+
+	switch len(parts) {
+	case 2:
+		switch r.Method {
+		case http.MethodPost:
+			h.handleCreate(w, r, tenantID, userID)
+		case http.MethodGet:
+			h.handleList(w, r, tenantID, userID)
+		default:
+			writeJSON(w, http.StatusMethodNotAllowed, errBody("method not allowed"))
+		}
+	case 3:
+		if r.Method != http.MethodGet {
+			writeJSON(w, http.StatusMethodNotAllowed, errBody("method not allowed"))
+			return
+		}
+		taskID, err := uuid.Parse(parts[2])
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, errBody("invalid task id"))
+			return
+		}
+		h.handleGet(w, r, tenantID, userID, taskID)
+	case 4:
+		if r.Method != http.MethodPost || parts[3] != "cancel" {
+			writeJSON(w, http.StatusNotFound, errBody("not found"))
+			return
+		}
+		taskID, err := uuid.Parse(parts[2])
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, errBody("invalid task id"))
+			return
+		}
+		h.handleCancel(w, r, tenantID, userID, taskID)
+	default:
+		writeJSON(w, http.StatusNotFound, errBody("not found"))
+	}
+}
+
+type createRequest struct {
+	Pack string `json:"pack"`
+}
+
+func (h *Handler) handleCreate(w http.ResponseWriter, r *http.Request, tenantID, userID uuid.UUID) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+	var req createRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, errBody("invalid JSON body"))
+		return
+	}
+	task, err := h.svc.CreateTask(r.Context(), tenantID, userID, Pack(req.Pack))
+	if err != nil {
+		writeTaskError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, newTaskWire(task))
+}
+
+func (h *Handler) handleList(w http.ResponseWriter, r *http.Request, tenantID, userID uuid.UUID) {
+	tasks, err := h.svc.List(r.Context(), tenantID, userID)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, errBody("failed to list tasks"))
+		return
+	}
+	writeJSON(w, http.StatusOK, listResponse{Tasks: taskWires(tasks)})
+}
+
+func (h *Handler) handleGet(w http.ResponseWriter, r *http.Request, tenantID, userID, taskID uuid.UUID) {
+	task, err := h.svc.Get(r.Context(), tenantID, userID, taskID)
+	if err != nil {
+		writeTaskError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, newTaskWire(task))
+}
+
+func (h *Handler) handleCancel(w http.ResponseWriter, r *http.Request, tenantID, userID, taskID uuid.UUID) {
+	task, err := h.svc.Cancel(r.Context(), tenantID, userID, taskID)
+	if err != nil {
+		writeTaskError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, newTaskWire(task))
+}
+
+func writeTaskError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, ErrNotFound):
+		writeJSON(w, http.StatusNotFound, errBody("task not found"))
+	case errors.Is(err, ErrInvalidPack):
+		writeJSON(w, http.StatusBadRequest, errBody(ErrInvalidPack.Error()))
+	case errors.Is(err, ErrTerminalState):
+		writeJSON(w, http.StatusConflict, errBody(ErrTerminalState.Error()))
+	default:
+		// Provider-blind: the underlying error (DB failure, engine detail) is
+		// never echoed.
+		writeJSON(w, http.StatusInternalServerError, errBody("agent task request failed"))
+	}
+}
+
+// =============================================================================
+// Wire shapes — deliberately carry no tenant_id/user_id: both are implied by
+// the URL path this handler was called with, never echoed back.
+// =============================================================================
+
+type taskWire struct {
+	ID               string     `json:"id"`
+	Pack             string     `json:"pack"`
+	Status           string     `json:"status"`
+	EngineSessionRef string     `json:"engine_session_ref"`
+	ResultSummaryRef string     `json:"result_summary_ref"`
+	ErrorMessage     string     `json:"error_message"`
+	CreatedAt        time.Time  `json:"created_at"`
+	UpdatedAt        time.Time  `json:"updated_at"`
+	StartedAt        *time.Time `json:"started_at"`
+	FinishedAt       *time.Time `json:"finished_at"`
+}
+
+type listResponse struct {
+	Tasks []taskWire `json:"tasks"`
+}
+
+func newTaskWire(t Task) taskWire {
+	return taskWire{
+		ID:               t.ID.String(),
+		Pack:             string(t.Pack),
+		Status:           string(t.Status),
+		EngineSessionRef: t.EngineSessionRef,
+		ResultSummaryRef: t.ResultSummaryRef,
+		ErrorMessage:     t.ErrorMessage,
+		CreatedAt:        t.CreatedAt,
+		UpdatedAt:        t.UpdatedAt,
+		StartedAt:        t.StartedAt,
+		FinishedAt:       t.FinishedAt,
+	}
+}
+
+func taskWires(tasks []Task) []taskWire {
+	out := make([]taskWire, 0, len(tasks))
+	for _, t := range tasks {
+		out = append(out, newTaskWire(t))
+	}
+	return out
+}
+
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+func errBody(msg string) map[string]string {
+	return map[string]string{"error": msg}
+}

--- a/apps/control-plane/internal/agenttask/http_test.go
+++ b/apps/control-plane/internal/agenttask/http_test.go
@@ -1,0 +1,159 @@
+package agenttask_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/agenttask"
+)
+
+func newTestHandler() *agenttask.Handler {
+	svc := agenttask.NewService(newFakeRepository(), agenttask.NotConfiguredEngine{})
+	return agenttask.NewHandler(svc)
+}
+
+func TestHandler_Create_HappyPath(t *testing.T) {
+	h := newTestHandler()
+	tenantID, userID := uuid.New(), uuid.New()
+
+	body, _ := json.Marshal(map[string]string{"pack": "coding-pack"})
+	req := httptest.NewRequest(http.MethodPost, "/internal/agent-tasks/"+tenantID.String()+"/"+userID.String(), bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	h.InternalMux().ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp["status"] != "queued" {
+		t.Errorf("expected status queued, got %v", resp["status"])
+	}
+	if _, ok := resp["tenant_id"]; ok {
+		t.Error("response must never echo tenant_id")
+	}
+}
+
+func TestHandler_Create_InvalidPack_Returns400(t *testing.T) {
+	h := newTestHandler()
+	tenantID, userID := uuid.New(), uuid.New()
+
+	body, _ := json.Marshal(map[string]string{"pack": "not-a-pack"})
+	req := httptest.NewRequest(http.MethodPost, "/internal/agent-tasks/"+tenantID.String()+"/"+userID.String(), bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	h.InternalMux().ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandler_Create_InvalidTenantID_Returns400(t *testing.T) {
+	h := newTestHandler()
+	req := httptest.NewRequest(http.MethodPost, "/internal/agent-tasks/not-a-uuid/"+uuid.New().String(), nil)
+	w := httptest.NewRecorder()
+	h.InternalMux().ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandler_ListThenGet_RoundTrip(t *testing.T) {
+	h := newTestHandler()
+	tenantID, userID := uuid.New(), uuid.New()
+
+	body, _ := json.Marshal(map[string]string{"pack": "knowledge-work-pack"})
+	createReq := httptest.NewRequest(http.MethodPost, "/internal/agent-tasks/"+tenantID.String()+"/"+userID.String(), bytes.NewReader(body))
+	createW := httptest.NewRecorder()
+	h.InternalMux().ServeHTTP(createW, createReq)
+	var created map[string]any
+	_ = json.NewDecoder(createW.Body).Decode(&created)
+	taskID := created["id"].(string)
+
+	listReq := httptest.NewRequest(http.MethodGet, "/internal/agent-tasks/"+tenantID.String()+"/"+userID.String(), nil)
+	listW := httptest.NewRecorder()
+	h.InternalMux().ServeHTTP(listW, listReq)
+	if listW.Code != http.StatusOK {
+		t.Fatalf("expected 200 on list, got %d: %s", listW.Code, listW.Body.String())
+	}
+	var listResp struct {
+		Tasks []map[string]any `json:"tasks"`
+	}
+	if err := json.NewDecoder(listW.Body).Decode(&listResp); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	if len(listResp.Tasks) != 1 {
+		t.Fatalf("expected 1 task in list, got %d", len(listResp.Tasks))
+	}
+
+	getReq := httptest.NewRequest(http.MethodGet, "/internal/agent-tasks/"+tenantID.String()+"/"+userID.String()+"/"+taskID, nil)
+	getW := httptest.NewRecorder()
+	h.InternalMux().ServeHTTP(getW, getReq)
+	if getW.Code != http.StatusOK {
+		t.Fatalf("expected 200 on get, got %d: %s", getW.Code, getW.Body.String())
+	}
+}
+
+func TestHandler_Get_UnknownTask_Returns404(t *testing.T) {
+	h := newTestHandler()
+	tenantID, userID := uuid.New(), uuid.New()
+	req := httptest.NewRequest(http.MethodGet, "/internal/agent-tasks/"+tenantID.String()+"/"+userID.String()+"/"+uuid.New().String(), nil)
+	w := httptest.NewRecorder()
+	h.InternalMux().ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestHandler_Cancel_HappyPath(t *testing.T) {
+	h := newTestHandler()
+	tenantID, userID := uuid.New(), uuid.New()
+
+	body, _ := json.Marshal(map[string]string{"pack": "coding-pack"})
+	createReq := httptest.NewRequest(http.MethodPost, "/internal/agent-tasks/"+tenantID.String()+"/"+userID.String(), bytes.NewReader(body))
+	createW := httptest.NewRecorder()
+	h.InternalMux().ServeHTTP(createW, createReq)
+	var created map[string]any
+	_ = json.NewDecoder(createW.Body).Decode(&created)
+	taskID := created["id"].(string)
+
+	cancelReq := httptest.NewRequest(http.MethodPost, "/internal/agent-tasks/"+tenantID.String()+"/"+userID.String()+"/"+taskID+"/cancel", nil)
+	cancelW := httptest.NewRecorder()
+	h.InternalMux().ServeHTTP(cancelW, cancelReq)
+	if cancelW.Code != http.StatusOK {
+		t.Fatalf("expected 200 on cancel, got %d: %s", cancelW.Code, cancelW.Body.String())
+	}
+	var cancelled map[string]any
+	_ = json.NewDecoder(cancelW.Body).Decode(&cancelled)
+	if cancelled["status"] != "cancelled" {
+		t.Errorf("expected status cancelled, got %v", cancelled["status"])
+	}
+
+	// A second cancel on an already-terminal task is a conflict, not a silent 200.
+	secondW := httptest.NewRecorder()
+	h.InternalMux().ServeHTTP(secondW, httptest.NewRequest(http.MethodPost, "/internal/agent-tasks/"+tenantID.String()+"/"+userID.String()+"/"+taskID+"/cancel", nil))
+	if secondW.Code != http.StatusConflict {
+		t.Errorf("expected 409 on double-cancel, got %d", secondW.Code)
+	}
+}
+
+func TestHandler_MethodNotAllowed(t *testing.T) {
+	h := newTestHandler()
+	tenantID, userID := uuid.New(), uuid.New()
+	req := httptest.NewRequest(http.MethodDelete, "/internal/agent-tasks/"+tenantID.String()+"/"+userID.String(), nil)
+	w := httptest.NewRecorder()
+	h.InternalMux().ServeHTTP(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", w.Code)
+	}
+}

--- a/apps/control-plane/internal/agenttask/repository.go
+++ b/apps/control-plane/internal/agenttask/repository.go
@@ -119,8 +119,16 @@ func (r *pgxRepository) List(ctx context.Context, tenantID, userID uuid.UUID) ([
 	return out, nil
 }
 
+// Transition updates status atomically: the UPDATE itself carries a "not
+// already terminal" precondition, so a status flip (e.g. an async engine
+// callback landing succeeded) can never be clobbered by a concurrent Cancel
+// racing against it, or vice versa — whichever transition's UPDATE commits
+// first wins, and the loser's statement matches zero rows instead of
+// silently overwriting a terminal state (last-write-wins was the bug: the
+// old UPDATE had no status precondition at all).
 func (r *pgxRepository) Transition(ctx context.Context, tenantID, userID, id uuid.UUID, status Status, sessionRef, resultSummaryRef, errMsg string) (Task, error) {
 	var t Task
+	var notFound, terminal bool
 	err := r.withTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
 		row := tx.QueryRow(ctx, `
 			UPDATE public.agent_tasks
@@ -132,17 +140,44 @@ func (r *pgxRepository) Transition(ctx context.Context, tenantID, userID, id uui
 			       finished_at = CASE WHEN finished_at IS NULL AND $4 IN ('succeeded', 'failed', 'cancelled') THEN now() ELSE finished_at END,
 			       updated_at = now()
 			 WHERE id = $1 AND user_id = $2
+			   AND status NOT IN ('succeeded', 'failed', 'cancelled')
 			RETURNING id, tenant_id, user_id, pack, status, engine_session_ref, result_summary_ref, error_message, created_at, updated_at, started_at, finished_at
 		`, id, userID, tenantID, string(status), sessionRef, resultSummaryRef, errMsg)
 		var err error
 		t, err = scanTask(row)
-		return err
+		if err == nil {
+			return nil
+		}
+		if !errors.Is(err, ErrNotFound) {
+			return err
+		}
+
+		// The guard blocked the UPDATE (0 rows) — disambiguate "no such
+		// task for this id+user" from "task exists but is terminal" with a
+		// plain read scoped the same way, in the same transaction.
+		var exists bool
+		qerr := tx.QueryRow(ctx,
+			`SELECT true FROM public.agent_tasks WHERE id = $1 AND user_id = $2`,
+			id, userID).Scan(&exists)
+		switch {
+		case errors.Is(qerr, pgx.ErrNoRows):
+			notFound = true
+			return nil
+		case qerr != nil:
+			return qerr
+		default:
+			terminal = true
+			return nil
+		}
 	})
 	if err != nil {
-		if errors.Is(err, ErrNotFound) {
-			return Task{}, ErrNotFound
-		}
 		return Task{}, fmt.Errorf("agenttask: transition: %w", err)
+	}
+	if notFound {
+		return Task{}, ErrNotFound
+	}
+	if terminal {
+		return Task{}, ErrTerminalState
 	}
 	return t, nil
 }

--- a/apps/control-plane/internal/agenttask/repository.go
+++ b/apps/control-plane/internal/agenttask/repository.go
@@ -1,0 +1,168 @@
+package agenttask
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Repository is the narrow data-access port for public.agent_tasks.
+type Repository interface {
+	Create(ctx context.Context, tenantID, userID uuid.UUID, pack Pack) (Task, error)
+	Get(ctx context.Context, tenantID, userID, id uuid.UUID) (Task, error)
+	List(ctx context.Context, tenantID, userID uuid.UUID) ([]Task, error)
+	// Transition updates status (and the fields that go with it) for a task
+	// already scoped to (tenantID, userID) by the caller.
+	Transition(ctx context.Context, tenantID, userID, id uuid.UUID, status Status, sessionRef, resultSummaryRef, errMsg string) (Task, error)
+}
+
+type pgxRepository struct {
+	pool *pgxpool.Pool
+}
+
+// NewPgxRepository constructs a pgxpool-backed Repository.
+func NewPgxRepository(pool *pgxpool.Pool) Repository {
+	return &pgxRepository{pool: pool}
+}
+
+// withTenantTx mirrors apps/control-plane/internal/marketplace/repository.go
+// and apps/control-plane/internal/egress/repository.go's helper of the same
+// name: hive_app is NOT BYPASSRLS (20260518_04_phase19_audit_rls_and_indexes.sql),
+// so every query against public.agent_tasks must run inside an explicit
+// transaction with app.current_tenant_id set LOCAL — guaranteed to clear at
+// Commit or Rollback so nothing survives onto the pooled connection for the
+// next borrower.
+func (r *pgxRepository) withTenantTx(ctx context.Context, tenantID uuid.UUID, fn func(tx pgx.Tx) error) error {
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("agenttask: begin tx: %w", err)
+	}
+	defer tx.Rollback(ctx) // no-op once Commit has succeeded
+
+	if _, err := tx.Exec(ctx, "SELECT set_config('app.current_tenant_id', $1, true)", tenantID.String()); err != nil {
+		return fmt.Errorf("agenttask: set tenant: %w", err)
+	}
+	if err := fn(tx); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}
+
+func (r *pgxRepository) Create(ctx context.Context, tenantID, userID uuid.UUID, pack Pack) (Task, error) {
+	var t Task
+	err := r.withTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		row := tx.QueryRow(ctx, `
+			INSERT INTO public.agent_tasks (tenant_id, user_id, pack)
+			VALUES ($1, $2, $3)
+			RETURNING id, tenant_id, user_id, pack, status, engine_session_ref, result_summary_ref, error_message, created_at, updated_at, started_at, finished_at
+		`, tenantID, userID, string(pack))
+		var err error
+		t, err = scanTask(row)
+		return err
+	})
+	if err != nil {
+		return Task{}, fmt.Errorf("agenttask: create: %w", err)
+	}
+	return t, nil
+}
+
+func (r *pgxRepository) Get(ctx context.Context, tenantID, userID, id uuid.UUID) (Task, error) {
+	var t Task
+	err := r.withTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		row := tx.QueryRow(ctx, `
+			SELECT id, tenant_id, user_id, pack, status, engine_session_ref, result_summary_ref, error_message, created_at, updated_at, started_at, finished_at
+			  FROM public.agent_tasks
+			 WHERE id = $1 AND user_id = $2
+		`, id, userID)
+		var err error
+		t, err = scanTask(row)
+		return err
+	})
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return Task{}, ErrNotFound
+		}
+		return Task{}, fmt.Errorf("agenttask: get: %w", err)
+	}
+	return t, nil
+}
+
+func (r *pgxRepository) List(ctx context.Context, tenantID, userID uuid.UUID) ([]Task, error) {
+	var out []Task
+	err := r.withTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `
+			SELECT id, tenant_id, user_id, pack, status, engine_session_ref, result_summary_ref, error_message, created_at, updated_at, started_at, finished_at
+			  FROM public.agent_tasks
+			 WHERE user_id = $1
+			 ORDER BY created_at DESC
+		`, userID)
+		if err != nil {
+			return fmt.Errorf("agenttask: list query: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			t, err := scanTask(rows)
+			if err != nil {
+				return err
+			}
+			out = append(out, t)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, fmt.Errorf("agenttask: list: %w", err)
+	}
+	return out, nil
+}
+
+func (r *pgxRepository) Transition(ctx context.Context, tenantID, userID, id uuid.UUID, status Status, sessionRef, resultSummaryRef, errMsg string) (Task, error) {
+	var t Task
+	err := r.withTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		row := tx.QueryRow(ctx, `
+			UPDATE public.agent_tasks
+			   SET status = $4,
+			       engine_session_ref = CASE WHEN $5 <> '' THEN $5 ELSE engine_session_ref END,
+			       result_summary_ref = CASE WHEN $6 <> '' THEN $6 ELSE result_summary_ref END,
+			       error_message = $7,
+			       started_at = CASE WHEN started_at IS NULL AND $4 = 'running' THEN now() ELSE started_at END,
+			       finished_at = CASE WHEN finished_at IS NULL AND $4 IN ('succeeded', 'failed', 'cancelled') THEN now() ELSE finished_at END,
+			       updated_at = now()
+			 WHERE id = $1 AND user_id = $2
+			RETURNING id, tenant_id, user_id, pack, status, engine_session_ref, result_summary_ref, error_message, created_at, updated_at, started_at, finished_at
+		`, id, userID, tenantID, string(status), sessionRef, resultSummaryRef, errMsg)
+		var err error
+		t, err = scanTask(row)
+		return err
+	})
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return Task{}, ErrNotFound
+		}
+		return Task{}, fmt.Errorf("agenttask: transition: %w", err)
+	}
+	return t, nil
+}
+
+type scanner interface {
+	Scan(dest ...any) error
+}
+
+func scanTask(s scanner) (Task, error) {
+	var t Task
+	var pack, status string
+	if err := s.Scan(&t.ID, &t.TenantID, &t.UserID, &pack, &status,
+		&t.EngineSessionRef, &t.ResultSummaryRef, &t.ErrorMessage,
+		&t.CreatedAt, &t.UpdatedAt, &t.StartedAt, &t.FinishedAt); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return Task{}, ErrNotFound
+		}
+		return Task{}, fmt.Errorf("agenttask: scan: %w", err)
+	}
+	t.Pack = Pack(pack)
+	t.Status = Status(status)
+	return t, nil
+}

--- a/apps/control-plane/internal/agenttask/repository_test.go
+++ b/apps/control-plane/internal/agenttask/repository_test.go
@@ -2,6 +2,7 @@ package agenttask_test
 
 import (
 	"context"
+	"errors"
 	"os"
 	"strings"
 	"testing"
@@ -156,6 +157,53 @@ func TestRepository_CreateGetTransition_RoundTrip(t *testing.T) {
 	}
 	if finished.ResultSummaryRef != "result-ref" {
 		t.Errorf("expected result_summary_ref persisted, got %q", finished.ResultSummaryRef)
+	}
+}
+
+// TestRepository_Transition_AtomicGuardRejectsAlreadyTerminal proves the
+// UPDATE's own "not already terminal" precondition is what rejects a second
+// transition, not an application-level pre-read — the fix for the
+// last-write-wins race where a concurrent engine callback could otherwise
+// clobber a Cancel (or vice versa). Two sequential Transitions: the first
+// reaches a terminal state, the second must fail with ErrTerminalState
+// rather than silently overwriting it.
+func TestRepository_Transition_AtomicGuardRejectsAlreadyTerminal(t *testing.T) {
+	pool := newRLSTestPool(t)
+	repo := agenttask.NewPgxRepository(pool)
+	ctx := context.Background()
+
+	tenantID := uuid.New()
+	seedTenant(t, tenantID)
+	userID := seedUser(t)
+
+	created, err := repo.Create(ctx, tenantID, userID, agenttask.PackCoding)
+	if err != nil {
+		t.Fatalf("seed task: %v", err)
+	}
+
+	cancelled, err := repo.Transition(ctx, tenantID, userID, created.ID, agenttask.StatusCancelled, "", "", "")
+	if err != nil {
+		t.Fatalf("first Transition (cancel): %v", err)
+	}
+	if cancelled.Status != agenttask.StatusCancelled {
+		t.Fatalf("expected StatusCancelled, got %v", cancelled.Status)
+	}
+
+	if _, err := repo.Transition(ctx, tenantID, userID, created.ID, agenttask.StatusSucceeded, "", "result-ref", ""); !errors.Is(err, agenttask.ErrTerminalState) {
+		t.Fatalf("expected ErrTerminalState on a second transition targeting an already-terminal row, got %v", err)
+	}
+
+	// The row must be unchanged: still cancelled, result_summary_ref never
+	// applied by the rejected transition.
+	got, err := repo.Get(ctx, tenantID, userID, created.ID)
+	if err != nil {
+		t.Fatalf("Get after rejected transition: %v", err)
+	}
+	if got.Status != agenttask.StatusCancelled {
+		t.Errorf("expected status to remain cancelled, got %v", got.Status)
+	}
+	if got.ResultSummaryRef != "" {
+		t.Errorf("expected result_summary_ref to remain empty, got %q", got.ResultSummaryRef)
 	}
 }
 

--- a/apps/control-plane/internal/agenttask/repository_test.go
+++ b/apps/control-plane/internal/agenttask/repository_test.go
@@ -1,0 +1,260 @@
+package agenttask_test
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/agenttask"
+)
+
+// newRLSTestPool connects as the hive_app role — NOT BYPASSRLS in production
+// (20260518_04_phase19_audit_rls_and_indexes.sql) — so the agent_tasks
+// tenant-isolation RLS policy is actually exercised. Mirrors
+// apps/control-plane/internal/marketplace/repository_test.go's helper of the
+// same name.
+func newRLSTestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("HIVE_TEST_DB_URL")
+	if dsn == "" {
+		t.Skip("HIVE_TEST_DB_URL not set")
+	}
+	if !strings.Contains(strings.ToLower(dsn), "test") {
+		t.Fatalf("refusing to run: HIVE_TEST_DB_URL must point at a test database (DSN missing 'test' marker)")
+	}
+
+	cfg, err := pgxpool.ParseConfig(dsn)
+	if err != nil {
+		t.Fatalf("parse HIVE_TEST_DB_URL: %v", err)
+	}
+	cfg.MaxConns = 1
+
+	ctx := context.Background()
+	pool, err := pgxpool.NewWithConfig(ctx, cfg)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	if _, err := pool.Exec(ctx, "SET ROLE hive_app"); err != nil {
+		pool.Close()
+		t.Skipf("SET ROLE hive_app failed (is hive_app provisioned + migrations applied on this test DB?): %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+// seedTenant mirrors marketplace/repository_test.go's helper of the same
+// name: a short-lived, unscoped connection inserts the FK row
+// public.tenants requires, since hive_app has no INSERT policy on that table.
+func seedTenant(t *testing.T, id uuid.UUID) {
+	t.Helper()
+	dsn := os.Getenv("HIVE_TEST_DB_URL")
+	ctx := context.Background()
+	setup, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("seed pool: %v", err)
+	}
+	defer setup.Close()
+	_, err = setup.Exec(ctx,
+		`INSERT INTO public.tenants (id, slug, name, deployment)
+		 VALUES ($1, $2, 'agenttask test tenant', 'HIVE_CLOUD')
+		 ON CONFLICT (id) DO NOTHING`,
+		id, "agenttask-test-"+id.String())
+	if err != nil {
+		t.Fatalf("seed tenant: %v", err)
+	}
+	t.Cleanup(func() {
+		cleanup, err := pgxpool.New(context.Background(), dsn)
+		if err != nil {
+			return
+		}
+		defer cleanup.Close()
+		_, _ = cleanup.Exec(context.Background(), `DELETE FROM public.tenants WHERE id = $1`, id)
+	})
+}
+
+// seedUser inserts a minimal auth.users row so agent_tasks.user_id's FK is
+// satisfiable. Mirrors apps/control-plane/internal/tenants/http_test.go's
+// mustInsertUser helper.
+func seedUser(t *testing.T) uuid.UUID {
+	t.Helper()
+	dsn := os.Getenv("HIVE_TEST_DB_URL")
+	ctx := context.Background()
+	setup, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("seed pool: %v", err)
+	}
+	defer setup.Close()
+
+	var id uuid.UUID
+	email := "agenttask-test-" + uuid.NewString() + "@example.invalid"
+	err = setup.QueryRow(ctx,
+		`INSERT INTO auth.users(id, email, raw_user_meta_data) VALUES (gen_random_uuid(), $1, '{}'::jsonb) RETURNING id`,
+		email).Scan(&id)
+	if err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	t.Cleanup(func() {
+		cleanup, err := pgxpool.New(context.Background(), dsn)
+		if err != nil {
+			return
+		}
+		defer cleanup.Close()
+		_, _ = cleanup.Exec(context.Background(), `DELETE FROM auth.users WHERE id = $1`, id)
+	})
+	return id
+}
+
+func TestRepository_CreateGetTransition_RoundTrip(t *testing.T) {
+	pool := newRLSTestPool(t)
+	repo := agenttask.NewPgxRepository(pool)
+	ctx := context.Background()
+
+	tenantID := uuid.New()
+	seedTenant(t, tenantID)
+	userID := seedUser(t)
+
+	created, err := repo.Create(ctx, tenantID, userID, agenttask.PackCoding)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if created.Status != agenttask.StatusQueued {
+		t.Errorf("expected new task to be queued, got %v", created.Status)
+	}
+
+	got, err := repo.Get(ctx, tenantID, userID, created.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Pack != agenttask.PackCoding {
+		t.Errorf("Get = %+v, want pack=coding-pack", got)
+	}
+
+	transitioned, err := repo.Transition(ctx, tenantID, userID, created.ID, agenttask.StatusRunning, "session-abc", "", "")
+	if err != nil {
+		t.Fatalf("Transition to running: %v", err)
+	}
+	if transitioned.Status != agenttask.StatusRunning {
+		t.Errorf("expected StatusRunning, got %v", transitioned.Status)
+	}
+	if transitioned.StartedAt == nil {
+		t.Error("expected started_at to be set on transition to running")
+	}
+	if transitioned.EngineSessionRef != "session-abc" {
+		t.Errorf("expected engine_session_ref persisted, got %q", transitioned.EngineSessionRef)
+	}
+
+	finished, err := repo.Transition(ctx, tenantID, userID, created.ID, agenttask.StatusSucceeded, "", "result-ref", "")
+	if err != nil {
+		t.Fatalf("Transition to succeeded: %v", err)
+	}
+	if finished.FinishedAt == nil {
+		t.Error("expected finished_at to be set on transition to succeeded")
+	}
+	if finished.ResultSummaryRef != "result-ref" {
+		t.Errorf("expected result_summary_ref persisted, got %q", finished.ResultSummaryRef)
+	}
+}
+
+// TestRepository_RLS_CrossTenantContextCannotReadRows proves the database
+// policy itself blocks cross-tenant reads, independent of the repository's
+// own tenant_id filter.
+func TestRepository_RLS_CrossTenantContextCannotReadRows(t *testing.T) {
+	pool := newRLSTestPool(t)
+	repo := agenttask.NewPgxRepository(pool)
+	ctx := context.Background()
+
+	tenantA, tenantB := uuid.New(), uuid.New()
+	seedTenant(t, tenantA)
+	seedTenant(t, tenantB)
+	userID := seedUser(t)
+
+	created, err := repo.Create(ctx, tenantA, userID, agenttask.PackCoding)
+	if err != nil {
+		t.Fatalf("seed tenant A task: %v", err)
+	}
+
+	if _, err := pool.Exec(ctx, "SELECT set_config('app.current_tenant_id', $1, false)", tenantB.String()); err != nil {
+		t.Fatalf("set_config tenant B: %v", err)
+	}
+	var count int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM public.agent_tasks WHERE id = $1`, created.ID).Scan(&count); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("RLS did not block cross-tenant read: got %d row(s) for tenant A's task while session claimed tenant B", count)
+	}
+}
+
+// TestRepository_ScopedByUser_OtherUserCannotSeeOrCancel proves the
+// application-layer user_id filter (not RLS) keeps a task private to the
+// user who started it within the same tenant.
+func TestRepository_ScopedByUser_OtherUserCannotSeeOrCancel(t *testing.T) {
+	pool := newRLSTestPool(t)
+	repo := agenttask.NewPgxRepository(pool)
+	ctx := context.Background()
+
+	tenantID := uuid.New()
+	seedTenant(t, tenantID)
+	owner := seedUser(t)
+	other := seedUser(t)
+
+	created, err := repo.Create(ctx, tenantID, owner, agenttask.PackKnowledgeWork)
+	if err != nil {
+		t.Fatalf("seed owner task: %v", err)
+	}
+
+	if _, err := repo.Get(ctx, tenantID, other, created.ID); err == nil {
+		t.Fatal("expected Get to fail for a different user in the same tenant")
+	}
+
+	list, err := repo.List(ctx, tenantID, other)
+	if err != nil {
+		t.Fatalf("List(other): %v", err)
+	}
+	if len(list) != 0 {
+		t.Errorf("expected other user's task list to be empty, got %d", len(list))
+	}
+
+	if _, err := repo.Transition(ctx, tenantID, other, created.ID, agenttask.StatusCancelled, "", "", ""); err == nil {
+		t.Fatal("expected Transition to fail for a different user in the same tenant")
+	}
+}
+
+// TestRepository_RLS_NoSessionLeakAcrossBorrows proves the tenant context set
+// by one repository call does not survive onto the pooled connection for
+// whoever borrows it next.
+func TestRepository_RLS_NoSessionLeakAcrossBorrows(t *testing.T) {
+	pool := newRLSTestPool(t)
+	repo := agenttask.NewPgxRepository(pool)
+	ctx := context.Background()
+
+	tenantID := uuid.New()
+	seedTenant(t, tenantID)
+	userID := seedUser(t)
+
+	created, err := repo.Create(ctx, tenantID, userID, agenttask.PackCoding)
+	if err != nil {
+		t.Fatalf("seed task: %v", err)
+	}
+
+	var setting string
+	if err := pool.QueryRow(ctx, "SELECT current_setting('app.current_tenant_id', true)").Scan(&setting); err != nil {
+		t.Fatalf("read current_setting: %v", err)
+	}
+	if setting != "" {
+		t.Fatalf("session leak: app.current_tenant_id still %q after Create committed, want empty", setting)
+	}
+
+	var count int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM public.agent_tasks WHERE id = $1`, created.ID).Scan(&count); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("session leak: bare borrow saw %d row(s) with no tenant context set (RLS should fail-closed on NULL)", count)
+	}
+}

--- a/apps/control-plane/internal/agenttask/service.go
+++ b/apps/control-plane/internal/agenttask/service.go
@@ -1,0 +1,79 @@
+package agenttask
+
+import (
+	"context"
+	"errors"
+
+	"github.com/google/uuid"
+)
+
+// Service validates and orchestrates task lifecycle operations on top of a
+// Repository and an Engine. It is the single sanctioned write path; Handler
+// never talks to Repository or Engine directly.
+type Service struct {
+	repo   Repository
+	engine Engine
+}
+
+// NewService constructs a Service. repo must not be nil. A nil engine
+// defaults to NotConfiguredEngine{} so callers that have not wired the
+// agent-engine control channel yet still get well-defined (queued) behavior.
+func NewService(repo Repository, engine Engine) *Service {
+	if engine == nil {
+		engine = NotConfiguredEngine{}
+	}
+	return &Service{repo: repo, engine: engine}
+}
+
+// CreateTask persists a new task (StatusQueued) and attempts to hand it to
+// the agent-engine. ErrEngineNotConfigured leaves the task queued rather than
+// failed — that is a documented seam gap, not a task failure. Any other
+// Launch error transitions the task straight to StatusFailed so the caller
+// never has to poll a task that can never progress.
+func (s *Service) CreateTask(ctx context.Context, tenantID, userID uuid.UUID, pack Pack) (Task, error) {
+	if !pack.Valid() {
+		return Task{}, ErrInvalidPack
+	}
+
+	t, err := s.repo.Create(ctx, tenantID, userID, pack)
+	if err != nil {
+		return Task{}, err
+	}
+
+	sessionRef, err := s.engine.Launch(ctx, t)
+	switch {
+	case err == nil:
+		return s.repo.Transition(ctx, tenantID, userID, t.ID, StatusRunning, sessionRef, "", "")
+	case errors.Is(err, ErrEngineNotConfigured):
+		return t, nil
+	default:
+		return s.repo.Transition(ctx, tenantID, userID, t.ID, StatusFailed, "", "", err.Error())
+	}
+}
+
+// Get returns one task, scoped to (tenantID, userID) so a task started by
+// one user is never resumable by a different user in the same tenant.
+func (s *Service) Get(ctx context.Context, tenantID, userID, id uuid.UUID) (Task, error) {
+	return s.repo.Get(ctx, tenantID, userID, id)
+}
+
+// List returns every task userID started within tenantID, newest first —
+// the read path that makes a task started in one web session visible from
+// another web session for the same user.
+func (s *Service) List(ctx context.Context, tenantID, userID uuid.UUID) ([]Task, error) {
+	return s.repo.List(ctx, tenantID, userID)
+}
+
+// Cancel transitions a task to StatusCancelled. Only reachable from
+// StatusQueued or StatusRunning; a task already in a terminal state returns
+// ErrTerminalState rather than silently no-op-ing.
+func (s *Service) Cancel(ctx context.Context, tenantID, userID, id uuid.UUID) (Task, error) {
+	t, err := s.repo.Get(ctx, tenantID, userID, id)
+	if err != nil {
+		return Task{}, err
+	}
+	if t.Status.terminal() {
+		return Task{}, ErrTerminalState
+	}
+	return s.repo.Transition(ctx, tenantID, userID, id, StatusCancelled, "", "", "")
+}

--- a/apps/control-plane/internal/agenttask/service.go
+++ b/apps/control-plane/internal/agenttask/service.go
@@ -66,14 +66,10 @@ func (s *Service) List(ctx context.Context, tenantID, userID uuid.UUID) ([]Task,
 
 // Cancel transitions a task to StatusCancelled. Only reachable from
 // StatusQueued or StatusRunning; a task already in a terminal state returns
-// ErrTerminalState rather than silently no-op-ing.
+// ErrTerminalState. No read-then-act check here — Repository.Transition's
+// UPDATE carries the "not already terminal" precondition atomically, so a
+// concurrent engine callback finishing the task can never be clobbered by a
+// racing Cancel (or vice versa).
 func (s *Service) Cancel(ctx context.Context, tenantID, userID, id uuid.UUID) (Task, error) {
-	t, err := s.repo.Get(ctx, tenantID, userID, id)
-	if err != nil {
-		return Task{}, err
-	}
-	if t.Status.terminal() {
-		return Task{}, ErrTerminalState
-	}
 	return s.repo.Transition(ctx, tenantID, userID, id, StatusCancelled, "", "", "")
 }

--- a/apps/control-plane/internal/agenttask/service_test.go
+++ b/apps/control-plane/internal/agenttask/service_test.go
@@ -1,0 +1,215 @@
+package agenttask_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/agenttask"
+)
+
+// fakeRepository is a hand-built agenttask.Repository stub for unit tests
+// that never need a live Postgres connection. Mirrors
+// apps/control-plane/internal/marketplace/service_test.go's fakeRepository.
+type fakeRepository struct {
+	tasks map[uuid.UUID]agenttask.Task
+}
+
+func newFakeRepository() *fakeRepository {
+	return &fakeRepository{tasks: make(map[uuid.UUID]agenttask.Task)}
+}
+
+func (f *fakeRepository) Create(_ context.Context, tenantID, userID uuid.UUID, pack agenttask.Pack) (agenttask.Task, error) {
+	t := agenttask.Task{
+		ID: uuid.New(), TenantID: tenantID, UserID: userID, Pack: pack,
+		Status: agenttask.StatusQueued, CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}
+	f.tasks[t.ID] = t
+	return t, nil
+}
+
+func (f *fakeRepository) Get(_ context.Context, tenantID, userID, id uuid.UUID) (agenttask.Task, error) {
+	t, ok := f.tasks[id]
+	if !ok || t.TenantID != tenantID || t.UserID != userID {
+		return agenttask.Task{}, agenttask.ErrNotFound
+	}
+	return t, nil
+}
+
+func (f *fakeRepository) List(_ context.Context, tenantID, userID uuid.UUID) ([]agenttask.Task, error) {
+	var out []agenttask.Task
+	for _, t := range f.tasks {
+		if t.TenantID == tenantID && t.UserID == userID {
+			out = append(out, t)
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeRepository) Transition(_ context.Context, tenantID, userID, id uuid.UUID, status agenttask.Status, sessionRef, resultSummaryRef, errMsg string) (agenttask.Task, error) {
+	t, ok := f.tasks[id]
+	if !ok || t.TenantID != tenantID || t.UserID != userID {
+		return agenttask.Task{}, agenttask.ErrNotFound
+	}
+	t.Status = status
+	if sessionRef != "" {
+		t.EngineSessionRef = sessionRef
+	}
+	if resultSummaryRef != "" {
+		t.ResultSummaryRef = resultSummaryRef
+	}
+	t.ErrorMessage = errMsg
+	f.tasks[id] = t
+	return t, nil
+}
+
+// fakeEngine is a hand-built agenttask.Engine stub.
+type fakeEngine struct {
+	sessionRef string
+	err        error
+}
+
+func (f *fakeEngine) Launch(context.Context, agenttask.Task) (string, error) {
+	return f.sessionRef, f.err
+}
+
+func TestService_CreateTask_InvalidPack(t *testing.T) {
+	svc := agenttask.NewService(newFakeRepository(), &fakeEngine{})
+	_, err := svc.CreateTask(context.Background(), uuid.New(), uuid.New(), agenttask.Pack("not-a-pack"))
+	if !errors.Is(err, agenttask.ErrInvalidPack) {
+		t.Fatalf("expected ErrInvalidPack, got %v", err)
+	}
+}
+
+func TestService_CreateTask_EngineNotConfigured_StaysQueued(t *testing.T) {
+	svc := agenttask.NewService(newFakeRepository(), agenttask.NotConfiguredEngine{})
+	task, err := svc.CreateTask(context.Background(), uuid.New(), uuid.New(), agenttask.PackCoding)
+	if err != nil {
+		t.Fatalf("CreateTask() unexpected err: %v", err)
+	}
+	if task.Status != agenttask.StatusQueued {
+		t.Errorf("expected StatusQueued when engine not configured, got %v", task.Status)
+	}
+}
+
+func TestService_CreateTask_NilEngineDefaultsToNotConfigured(t *testing.T) {
+	svc := agenttask.NewService(newFakeRepository(), nil)
+	task, err := svc.CreateTask(context.Background(), uuid.New(), uuid.New(), agenttask.PackKnowledgeWork)
+	if err != nil {
+		t.Fatalf("CreateTask() unexpected err: %v", err)
+	}
+	if task.Status != agenttask.StatusQueued {
+		t.Errorf("expected StatusQueued with nil engine, got %v", task.Status)
+	}
+}
+
+func TestService_CreateTask_EngineLaunchSucceeds_TransitionsToRunning(t *testing.T) {
+	svc := agenttask.NewService(newFakeRepository(), &fakeEngine{sessionRef: "session-123"})
+	task, err := svc.CreateTask(context.Background(), uuid.New(), uuid.New(), agenttask.PackCoding)
+	if err != nil {
+		t.Fatalf("CreateTask() unexpected err: %v", err)
+	}
+	if task.Status != agenttask.StatusRunning {
+		t.Errorf("expected StatusRunning, got %v", task.Status)
+	}
+	if task.EngineSessionRef != "session-123" {
+		t.Errorf("expected engine session ref to be persisted, got %q", task.EngineSessionRef)
+	}
+}
+
+func TestService_CreateTask_EngineLaunchFails_TransitionsToFailed(t *testing.T) {
+	svc := agenttask.NewService(newFakeRepository(), &fakeEngine{err: errors.New("sandbox unavailable")})
+	task, err := svc.CreateTask(context.Background(), uuid.New(), uuid.New(), agenttask.PackCoding)
+	if err != nil {
+		t.Fatalf("CreateTask() unexpected err: %v", err)
+	}
+	if task.Status != agenttask.StatusFailed {
+		t.Errorf("expected StatusFailed, got %v", task.Status)
+	}
+	if task.ErrorMessage == "" {
+		t.Error("expected error_message to be recorded")
+	}
+}
+
+func TestService_Get_WrongUserReturnsNotFound(t *testing.T) {
+	repo := newFakeRepository()
+	svc := agenttask.NewService(repo, &fakeEngine{})
+	tenantID, ownerID, otherID := uuid.New(), uuid.New(), uuid.New()
+
+	created, err := svc.CreateTask(context.Background(), tenantID, ownerID, agenttask.PackCoding)
+	if err != nil {
+		t.Fatalf("seed CreateTask: %v", err)
+	}
+
+	if _, err := svc.Get(context.Background(), tenantID, otherID, created.ID); !errors.Is(err, agenttask.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound for a different user, got %v", err)
+	}
+	// The owner can still resume it — this is the cross-session portability path.
+	if _, err := svc.Get(context.Background(), tenantID, ownerID, created.ID); err != nil {
+		t.Fatalf("owner Get() unexpected err: %v", err)
+	}
+}
+
+func TestService_List_ScopedToTenantAndUser(t *testing.T) {
+	repo := newFakeRepository()
+	svc := agenttask.NewService(repo, &fakeEngine{})
+	tenantID, userA, userB := uuid.New(), uuid.New(), uuid.New()
+
+	if _, err := svc.CreateTask(context.Background(), tenantID, userA, agenttask.PackCoding); err != nil {
+		t.Fatalf("seed userA task: %v", err)
+	}
+	if _, err := svc.CreateTask(context.Background(), tenantID, userB, agenttask.PackCoding); err != nil {
+		t.Fatalf("seed userB task: %v", err)
+	}
+
+	tasksA, err := svc.List(context.Background(), tenantID, userA)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(tasksA) != 1 {
+		t.Fatalf("expected exactly 1 task for userA, got %d", len(tasksA))
+	}
+}
+
+func TestService_Cancel_FromQueued(t *testing.T) {
+	svc := agenttask.NewService(newFakeRepository(), agenttask.NotConfiguredEngine{})
+	tenantID, userID := uuid.New(), uuid.New()
+	created, err := svc.CreateTask(context.Background(), tenantID, userID, agenttask.PackCoding)
+	if err != nil {
+		t.Fatalf("seed CreateTask: %v", err)
+	}
+
+	cancelled, err := svc.Cancel(context.Background(), tenantID, userID, created.ID)
+	if err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+	if cancelled.Status != agenttask.StatusCancelled {
+		t.Errorf("expected StatusCancelled, got %v", cancelled.Status)
+	}
+}
+
+func TestService_Cancel_TerminalStateRejected(t *testing.T) {
+	svc := agenttask.NewService(newFakeRepository(), &fakeEngine{sessionRef: "s1"})
+	tenantID, userID := uuid.New(), uuid.New()
+	created, err := svc.CreateTask(context.Background(), tenantID, userID, agenttask.PackCoding)
+	if err != nil {
+		t.Fatalf("seed CreateTask: %v", err)
+	}
+	if _, err := svc.Cancel(context.Background(), tenantID, userID, created.ID); err != nil {
+		t.Fatalf("first Cancel: %v", err)
+	}
+
+	if _, err := svc.Cancel(context.Background(), tenantID, userID, created.ID); !errors.Is(err, agenttask.ErrTerminalState) {
+		t.Fatalf("expected ErrTerminalState on a second cancel, got %v", err)
+	}
+}
+
+func TestService_Cancel_UnknownTaskReturnsNotFound(t *testing.T) {
+	svc := agenttask.NewService(newFakeRepository(), &fakeEngine{})
+	if _, err := svc.Cancel(context.Background(), uuid.New(), uuid.New(), uuid.New()); !errors.Is(err, agenttask.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}

--- a/apps/control-plane/internal/agenttask/service_test.go
+++ b/apps/control-plane/internal/agenttask/service_test.go
@@ -54,6 +54,13 @@ func (f *fakeRepository) Transition(_ context.Context, tenantID, userID, id uuid
 	if !ok || t.TenantID != tenantID || t.UserID != userID {
 		return agenttask.Task{}, agenttask.ErrNotFound
 	}
+	// Mirrors the real repository's atomic "not already terminal" UPDATE
+	// guard: Service no longer pre-checks this itself, so the fake must
+	// enforce it for terminal-rejection tests to mean anything.
+	switch t.Status {
+	case agenttask.StatusSucceeded, agenttask.StatusFailed, agenttask.StatusCancelled:
+		return agenttask.Task{}, agenttask.ErrTerminalState
+	}
 	t.Status = status
 	if sessionRef != "" {
 		t.EngineSessionRef = sessionRef

--- a/apps/control-plane/internal/agenttask/types.go
+++ b/apps/control-plane/internal/agenttask/types.go
@@ -44,16 +44,6 @@ const (
 	StatusCancelled Status = "cancelled"
 )
 
-// terminal reports whether no further transition is allowed out of s.
-func (s Status) terminal() bool {
-	switch s {
-	case StatusSucceeded, StatusFailed, StatusCancelled:
-		return true
-	default:
-		return false
-	}
-}
-
 // Task is one row of public.agent_tasks.
 type Task struct {
 	ID               uuid.UUID

--- a/apps/control-plane/internal/agenttask/types.go
+++ b/apps/control-plane/internal/agenttask/types.go
@@ -1,0 +1,84 @@
+// Package agenttask owns agent task persistence for the web surface (issue
+// #311, agent-subsystem blueprint Step 3.4): a task started in one web
+// session must be visible and resumable from another web session, tenant-
+// scoped. This package is the sync contract's server-side backing store; see
+// SYNC_CONTRACT.md for the wire shapes and state machine the Wave 4 desktop
+// consumer attaches to.
+package agenttask
+
+import (
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Pack identifies which agent-engine pack (Wave 2.2) a task runs.
+type Pack string
+
+const (
+	PackCoding        Pack = "coding-pack"
+	PackKnowledgeWork Pack = "knowledge-work-pack"
+)
+
+// Valid reports whether p is one of the packs public.agent_tasks' CHECK
+// constraint accepts.
+func (p Pack) Valid() bool {
+	switch p {
+	case PackCoding, PackKnowledgeWork:
+		return true
+	default:
+		return false
+	}
+}
+
+// Status is a task's position in its queued -> running -> {succeeded,
+// failed} state machine, with cancelled reachable from queued or running.
+type Status string
+
+const (
+	StatusQueued    Status = "queued"
+	StatusRunning   Status = "running"
+	StatusSucceeded Status = "succeeded"
+	StatusFailed    Status = "failed"
+	StatusCancelled Status = "cancelled"
+)
+
+// terminal reports whether no further transition is allowed out of s.
+func (s Status) terminal() bool {
+	switch s {
+	case StatusSucceeded, StatusFailed, StatusCancelled:
+		return true
+	default:
+		return false
+	}
+}
+
+// Task is one row of public.agent_tasks.
+type Task struct {
+	ID               uuid.UUID
+	TenantID         uuid.UUID
+	UserID           uuid.UUID
+	Pack             Pack
+	Status           Status
+	EngineSessionRef string
+	ResultSummaryRef string
+	ErrorMessage     string
+	CreatedAt        time.Time
+	UpdatedAt        time.Time
+	StartedAt        *time.Time
+	FinishedAt       *time.Time
+}
+
+var (
+	// ErrNotFound is returned when the requested task does not exist (or does
+	// not belong to the requesting tenant/user).
+	ErrNotFound = errors.New("agenttask: task not found")
+
+	// ErrInvalidPack is returned when Pack.Valid() is false.
+	ErrInvalidPack = errors.New("agenttask: pack must be coding-pack or knowledge-work-pack")
+
+	// ErrTerminalState is returned when a caller tries to transition (e.g.
+	// cancel) a task that already reached a terminal status.
+	ErrTerminalState = errors.New("agenttask: task already reached a terminal state")
+)

--- a/apps/control-plane/internal/platform/http/router.go
+++ b/apps/control-plane/internal/platform/http/router.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/accounting"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/accounts"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/agenttask"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/apikeys"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/auth"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/budgets"
@@ -113,6 +114,13 @@ type RouterConfig struct {
 	// and the shared-secret-guarded read surface at /internal/marketplace/
 	// that apps/agent-engine consumes. When nil neither route is registered.
 	MarketplaceHandler *marketplace.Handler
+
+	// AgentTaskHandler serves agent task persistence (issue #311, agent-
+	// subsystem blueprint Step 3.4): the shared-secret-guarded
+	// service-to-service surface at /internal/agent-tasks/ that edge-api's
+	// customer-facing /v1/agent/tasks routes call into. When nil the route
+	// is not registered.
+	AgentTaskHandler *agenttask.Handler
 }
 
 // NewRouter returns a configured http.Handler with all platform routes registered.
@@ -318,6 +326,13 @@ func NewRouter(cfg RouterConfig) http.Handler {
 			mux.Handle("/api/v1/admin/marketplace", adminMarketplace)
 			mux.Handle("/api/v1/admin/marketplace/", adminMarketplace)
 		}
+	}
+
+	// Issue #311 (blueprint Step 3.4) — agent task persistence, web side.
+	// Service-to-service only: edge-api's /v1/agent/tasks routes are the
+	// customer-facing surface, this is the internal store they call into.
+	if cfg.AgentTaskHandler != nil {
+		mux.Handle("/internal/agent-tasks/", internal(cfg.AgentTaskHandler.InternalMux()))
 	}
 
 	// Wrap the mux with Prometheus HTTP instrumentation if a metrics registry is provided.

--- a/apps/edge-api/cmd/server/main.go
+++ b/apps/edge-api/cmd/server/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/redis/go-redis/v9"
 	"github.com/sakibsadmanshajib/hive/apps/edge-api/docs"
+	edgeagenttask "github.com/sakibsadmanshajib/hive/apps/edge-api/internal/agenttask"
 	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/anthropic"
 	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/audio"
 	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/auth"
@@ -279,6 +280,23 @@ func main() {
 		ragMux := http.NewServeMux()
 		ragHandler.Register(ragMux)
 		mux.Handle("/v1/rag/", ragMW(ragMux))
+	}
+
+	// Agent task lifecycle routes (#311, agent-subsystem blueprint Step 3.4):
+	// always registered behind FeatureCowork so the gate returns 403 (not
+	// 404) regardless of whether control-plane's agent-task store is
+	// reachable. Persistence lives in control-plane
+	// (apps/control-plane/internal/agenttask); this is the customer-facing
+	// auth boundary and wire-shape translator that calls into it, mirroring
+	// the RAG block above.
+	{
+		agentTaskClient := edgeagenttask.NewClient(resolveControlPlaneBaseURL())
+		agentTaskHandler := edgeagenttask.NewHandler(agentTaskClient)
+		agentTaskMW := featureGate.Require(featuregate.FeatureCowork)
+		agentTaskMux := http.NewServeMux()
+		agentTaskHandler.Register(agentTaskMux)
+		mux.Handle("/v1/agent/tasks", agentTaskMW(agentTaskMux))
+		mux.Handle("/v1/agent/tasks/", agentTaskMW(agentTaskMux))
 	}
 
 	// API routes

--- a/apps/edge-api/internal/agenttask/client.go
+++ b/apps/edge-api/internal/agenttask/client.go
@@ -1,0 +1,143 @@
+package agenttask
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/cpauth"
+)
+
+// Client calls control-plane's internal agent-task surface. Mirrors
+// apps/edge-api/internal/rag.IngestClient's shape and error-handling
+// contract (provider-blind: control-plane's raw body is never threaded into
+// a returned error).
+type Client struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+// NewClient creates a Client pointing at the control-plane base URL.
+func NewClient(controlPlaneURL string) *Client {
+	return &Client{
+		baseURL:    strings.TrimRight(controlPlaneURL, "/"),
+		httpClient: &http.Client{Timeout: 15 * time.Second},
+	}
+}
+
+// Create posts a new task. POST /internal/agent-tasks/{tenant_id}/{user_id}.
+func (c *Client) Create(ctx context.Context, tenantID, userID uuid.UUID, pack string) (Task, error) {
+	body, err := json.Marshal(struct {
+		Pack string `json:"pack"`
+	}{Pack: pack})
+	if err != nil {
+		return Task{}, fmt.Errorf("agenttask.client: marshal: %w", err)
+	}
+	return c.do(ctx, http.MethodPost, c.basePath(tenantID, userID), bytes.NewReader(body))
+}
+
+// List returns every task for (tenantID, userID), newest first.
+// GET /internal/agent-tasks/{tenant_id}/{user_id}.
+func (c *Client) List(ctx context.Context, tenantID, userID uuid.UUID) ([]Task, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+c.basePath(tenantID, userID), nil)
+	if err != nil {
+		return nil, fmt.Errorf("agenttask.client: build request: %w", err)
+	}
+	cpauth.SetHeader(req)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("agenttask.client: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		drain(resp.Body)
+		return nil, statusErr(resp.StatusCode)
+	}
+	var listResp struct {
+		Tasks []Task `json:"tasks"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&listResp); err != nil {
+		return nil, fmt.Errorf("agenttask.client: decode list response: %w", err)
+	}
+	return listResp.Tasks, nil
+}
+
+// Get fetches one task by id. GET /internal/agent-tasks/{tenant_id}/{user_id}/{task_id}.
+func (c *Client) Get(ctx context.Context, tenantID, userID, taskID uuid.UUID) (Task, error) {
+	path := c.basePath(tenantID, userID) + "/" + taskID.String()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+path, nil)
+	if err != nil {
+		return Task{}, fmt.Errorf("agenttask.client: build request: %w", err)
+	}
+	cpauth.SetHeader(req)
+	return c.send(req)
+}
+
+// Cancel cancels a task. POST /internal/agent-tasks/{tenant_id}/{user_id}/{task_id}/cancel.
+func (c *Client) Cancel(ctx context.Context, tenantID, userID, taskID uuid.UUID) (Task, error) {
+	path := c.basePath(tenantID, userID) + "/" + taskID.String() + "/cancel"
+	return c.do(ctx, http.MethodPost, path, nil)
+}
+
+func (c *Client) basePath(tenantID, userID uuid.UUID) string {
+	return "/internal/agent-tasks/" + tenantID.String() + "/" + userID.String()
+}
+
+func (c *Client) do(ctx context.Context, method, path string, body io.Reader) (Task, error) {
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, body)
+	if err != nil {
+		return Task{}, fmt.Errorf("agenttask.client: build request: %w", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	cpauth.SetHeader(req)
+	return c.send(req)
+}
+
+func (c *Client) send(req *http.Request) (Task, error) {
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return Task{}, fmt.Errorf("agenttask.client: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		drain(resp.Body)
+		return Task{}, statusErr(resp.StatusCode)
+	}
+	var task Task
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&task); err != nil {
+		return Task{}, fmt.Errorf("agenttask.client: decode response: %w", err)
+	}
+	return task, nil
+}
+
+// statusErr maps control-plane's status code to a sentinel error — never the
+// response body, which may carry control-plane's raw failure detail
+// (provider-blind boundary).
+func statusErr(status int) error {
+	switch status {
+	case http.StatusNotFound:
+		return ErrNotFound
+	case http.StatusBadRequest:
+		return ErrInvalidPack
+	case http.StatusConflict:
+		return ErrTerminalState
+	default:
+		return ErrRequestFailed
+	}
+}
+
+// drain discards the response body without threading its content anywhere.
+func drain(body io.Reader) {
+	_, _ = io.Copy(io.Discard, io.LimitReader(body, 65536))
+}

--- a/apps/edge-api/internal/agenttask/client_test.go
+++ b/apps/edge-api/internal/agenttask/client_test.go
@@ -1,0 +1,127 @@
+package agenttask
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/cpauth"
+)
+
+func TestClient_Create_PostsExpectedPathAndBody(t *testing.T) {
+	cpauth.SetTokenForTest("test-internal-token")
+	defer cpauth.SetTokenForTest("")
+
+	tenantID, userID := uuid.New(), uuid.New()
+	var gotPath, gotMethod, gotToken string
+	var gotBody struct {
+		Pack string `json:"pack"`
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		gotToken = r.Header.Get(cpauth.Header)
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(Task{ID: uuid.New().String(), Pack: "coding-pack", Status: "queued"})
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL)
+	task, err := client.Create(context.Background(), tenantID, userID, "coding-pack")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	wantPath := "/internal/agent-tasks/" + tenantID.String() + "/" + userID.String()
+	if gotPath != wantPath {
+		t.Errorf("path = %q, want %q", gotPath, wantPath)
+	}
+	if gotToken != "test-internal-token" {
+		t.Errorf("internal auth header = %q, want %q", gotToken, "test-internal-token")
+	}
+	if gotBody.Pack != "coding-pack" {
+		t.Errorf("request body pack = %q, want coding-pack", gotBody.Pack)
+	}
+	if task.Status != "queued" {
+		t.Errorf("response status = %q, want queued", task.Status)
+	}
+}
+
+func TestClient_Create_BadRequestMapsToErrInvalidPack(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"pack must be coding-pack or knowledge-work-pack"}`))
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL)
+	_, err := client.Create(context.Background(), uuid.New(), uuid.New(), "not-a-pack")
+	if err != ErrInvalidPack {
+		t.Fatalf("expected ErrInvalidPack, got %v", err)
+	}
+}
+
+func TestClient_Get_NotFoundMapsToErrNotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL)
+	_, err := client.Get(context.Background(), uuid.New(), uuid.New(), uuid.New())
+	if err != ErrNotFound {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestClient_Cancel_ConflictMapsToErrTerminalState(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL)
+	_, err := client.Cancel(context.Background(), uuid.New(), uuid.New(), uuid.New())
+	if err != ErrTerminalState {
+		t.Fatalf("expected ErrTerminalState, got %v", err)
+	}
+}
+
+func TestClient_List_ReturnsTasksOnSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string][]Task{
+			"tasks": {{ID: uuid.New().String(), Pack: "coding-pack", Status: "queued"}},
+		})
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL)
+	tasks, err := client.List(context.Background(), uuid.New(), uuid.New())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("expected 1 task, got %d", len(tasks))
+	}
+}
+
+func TestClient_Get_UnreachableServerReturnsError(t *testing.T) {
+	client := NewClient("http://127.0.0.1:1")
+	_, err := client.Get(context.Background(), uuid.New(), uuid.New(), uuid.New())
+	if err == nil {
+		t.Fatal("expected error when control-plane is unreachable")
+	}
+}

--- a/apps/edge-api/internal/agenttask/handler.go
+++ b/apps/edge-api/internal/agenttask/handler.go
@@ -1,0 +1,188 @@
+package agenttask
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/auth"
+	apierrors "github.com/sakibsadmanshajib/hive/apps/edge-api/internal/errors"
+)
+
+// TaskClient is the minimal interface the handler needs from Client.
+// Exported so tests can inject a fake without a real control-plane.
+type TaskClient interface {
+	Create(ctx context.Context, tenantID, userID uuid.UUID, pack string) (Task, error)
+	List(ctx context.Context, tenantID, userID uuid.UUID) ([]Task, error)
+	Get(ctx context.Context, tenantID, userID, taskID uuid.UUID) (Task, error)
+	Cancel(ctx context.Context, tenantID, userID, taskID uuid.UUID) (Task, error)
+}
+
+// Handler serves /v1/agent/tasks routes. Callers wrap with
+// featuregate.Require(FeatureCowork) before mounting, mirroring
+// apps/edge-api/internal/rag.Handler's gating contract.
+type Handler struct {
+	client TaskClient
+}
+
+// NewHandler constructs a Handler.
+func NewHandler(client TaskClient) *Handler {
+	return &Handler{client: client}
+}
+
+// Register mounts all /v1/agent/tasks* routes on mux.
+func (h *Handler) Register(mux *http.ServeMux) {
+	mux.HandleFunc("/v1/agent/tasks", h.routeTasks)
+	mux.HandleFunc("/v1/agent/tasks/", h.routeTaskByID)
+}
+
+func (h *Handler) routeTasks(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost:
+		h.handleCreate(w, r)
+	case http.MethodGet:
+		h.handleList(w, r)
+	default:
+		apierrors.Write(w, http.StatusMethodNotAllowed, apierrors.CodeInvalidRequest, "method not allowed")
+	}
+}
+
+func (h *Handler) routeTaskByID(w http.ResponseWriter, r *http.Request) {
+	taskID, cancel, err := extractTaskPath(r.URL.Path)
+	if err != nil {
+		apierrors.Write(w, http.StatusBadRequest, apierrors.CodeInvalidRequest, "invalid task id")
+		return
+	}
+	switch {
+	case cancel:
+		if r.Method != http.MethodPost {
+			apierrors.Write(w, http.StatusMethodNotAllowed, apierrors.CodeInvalidRequest, "method not allowed")
+			return
+		}
+		h.handleCancel(w, r, taskID)
+	default:
+		if r.Method != http.MethodGet {
+			apierrors.Write(w, http.StatusMethodNotAllowed, apierrors.CodeInvalidRequest, "method not allowed")
+			return
+		}
+		h.handleGet(w, r, taskID)
+	}
+}
+
+type createTaskRequest struct {
+	Pack string `json:"pack"`
+}
+
+func (h *Handler) handleCreate(w http.ResponseWriter, r *http.Request) {
+	user, ok := auth.UserFrom(r.Context())
+	if !ok || user == nil {
+		apierrors.Write(w, http.StatusUnauthorized, apierrors.CodeUnauthenticated, "unauthenticated")
+		return
+	}
+
+	var req createTaskRequest
+	if err := json.NewDecoder(io.LimitReader(r.Body, 4096)).Decode(&req); err != nil {
+		apierrors.Write(w, http.StatusBadRequest, apierrors.CodeInvalidRequest, "invalid request body")
+		return
+	}
+	if strings.TrimSpace(req.Pack) == "" {
+		apierrors.Write(w, http.StatusBadRequest, apierrors.CodeInvalidRequest, "pack required")
+		return
+	}
+
+	task, err := h.client.Create(r.Context(), user.TenantID, user.ID, req.Pack)
+	if err != nil {
+		writeTaskError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, task)
+}
+
+func (h *Handler) handleList(w http.ResponseWriter, r *http.Request) {
+	user, ok := auth.UserFrom(r.Context())
+	if !ok || user == nil {
+		apierrors.Write(w, http.StatusUnauthorized, apierrors.CodeUnauthenticated, "unauthenticated")
+		return
+	}
+
+	tasks, err := h.client.List(r.Context(), user.TenantID, user.ID)
+	if err != nil {
+		writeTaskError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"tasks": tasks})
+}
+
+func (h *Handler) handleGet(w http.ResponseWriter, r *http.Request, taskID uuid.UUID) {
+	user, ok := auth.UserFrom(r.Context())
+	if !ok || user == nil {
+		apierrors.Write(w, http.StatusUnauthorized, apierrors.CodeUnauthenticated, "unauthenticated")
+		return
+	}
+
+	task, err := h.client.Get(r.Context(), user.TenantID, user.ID, taskID)
+	if err != nil {
+		writeTaskError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, task)
+}
+
+func (h *Handler) handleCancel(w http.ResponseWriter, r *http.Request, taskID uuid.UUID) {
+	user, ok := auth.UserFrom(r.Context())
+	if !ok || user == nil {
+		apierrors.Write(w, http.StatusUnauthorized, apierrors.CodeUnauthenticated, "unauthenticated")
+		return
+	}
+
+	task, err := h.client.Cancel(r.Context(), user.TenantID, user.ID, taskID)
+	if err != nil {
+		writeTaskError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, task)
+}
+
+func writeTaskError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, ErrNotFound):
+		apierrors.Write(w, http.StatusNotFound, apierrors.CodeInvalidRequest, "task not found")
+	case errors.Is(err, ErrInvalidPack):
+		apierrors.Write(w, http.StatusBadRequest, apierrors.CodeInvalidRequest, "invalid pack")
+	case errors.Is(err, ErrTerminalState):
+		apierrors.Write(w, http.StatusConflict, apierrors.CodeInvalidRequest, "task already reached a terminal state")
+	default:
+		// Provider-blind: the underlying error (control-plane infra detail) is never echoed.
+		apierrors.Write(w, http.StatusInternalServerError, apierrors.CodeInternal, "agent task request failed")
+	}
+}
+
+// extractTaskPath parses "/v1/agent/tasks/{id}" or
+// "/v1/agent/tasks/{id}/cancel" into (id, isCancel).
+func extractTaskPath(path string) (uuid.UUID, bool, error) {
+	rest := strings.Trim(strings.TrimPrefix(path, "/v1/agent/tasks/"), "/")
+	parts := strings.Split(rest, "/")
+	switch len(parts) {
+	case 1:
+		id, err := uuid.Parse(parts[0])
+		return id, false, err
+	case 2:
+		if parts[1] != "cancel" {
+			return uuid.Nil, false, errors.New("unknown suffix")
+		}
+		id, err := uuid.Parse(parts[0])
+		return id, true, err
+	default:
+		return uuid.Nil, false, errors.New("unexpected path shape")
+	}
+}
+
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}

--- a/apps/edge-api/internal/agenttask/handler_test.go
+++ b/apps/edge-api/internal/agenttask/handler_test.go
@@ -1,0 +1,219 @@
+package agenttask
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/auth"
+)
+
+type fakeClient struct {
+	tasks map[uuid.UUID]Task
+
+	createErr error
+	getErr    error
+	cancelErr error
+}
+
+func newFakeClient() *fakeClient {
+	return &fakeClient{tasks: make(map[uuid.UUID]Task)}
+}
+
+func (f *fakeClient) Create(_ context.Context, _, _ uuid.UUID, pack string) (Task, error) {
+	if f.createErr != nil {
+		return Task{}, f.createErr
+	}
+	id := uuid.New()
+	t := Task{ID: id.String(), Pack: pack, Status: "queued"}
+	f.tasks[id] = t
+	return t, nil
+}
+
+func (f *fakeClient) List(context.Context, uuid.UUID, uuid.UUID) ([]Task, error) {
+	out := make([]Task, 0, len(f.tasks))
+	for _, t := range f.tasks {
+		out = append(out, t)
+	}
+	return out, nil
+}
+
+func (f *fakeClient) Get(_ context.Context, _, _, taskID uuid.UUID) (Task, error) {
+	if f.getErr != nil {
+		return Task{}, f.getErr
+	}
+	t, ok := f.tasks[taskID]
+	if !ok {
+		return Task{}, ErrNotFound
+	}
+	return t, nil
+}
+
+func (f *fakeClient) Cancel(_ context.Context, _, _, taskID uuid.UUID) (Task, error) {
+	if f.cancelErr != nil {
+		return Task{}, f.cancelErr
+	}
+	t, ok := f.tasks[taskID]
+	if !ok {
+		return Task{}, ErrNotFound
+	}
+	t.Status = "cancelled"
+	f.tasks[taskID] = t
+	return t, nil
+}
+
+func userCtx(tenantID uuid.UUID) context.Context {
+	return auth.WithUser(context.Background(), &auth.User{ID: uuid.New(), TenantID: tenantID})
+}
+
+func TestHandleCreate_HappyPath(t *testing.T) {
+	h := NewHandler(newFakeClient())
+	body, _ := json.Marshal(createTaskRequest{Pack: "coding-pack"})
+	req := httptest.NewRequest(http.MethodPost, "/v1/agent/tasks", bytes.NewReader(body))
+	req = req.WithContext(userCtx(uuid.New()))
+	w := httptest.NewRecorder()
+	h.routeTasks(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleCreate_Unauthenticated(t *testing.T) {
+	h := NewHandler(newFakeClient())
+	body, _ := json.Marshal(createTaskRequest{Pack: "coding-pack"})
+	req := httptest.NewRequest(http.MethodPost, "/v1/agent/tasks", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	h.routeTasks(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestHandleCreate_MissingPack(t *testing.T) {
+	h := NewHandler(newFakeClient())
+	body, _ := json.Marshal(createTaskRequest{})
+	req := httptest.NewRequest(http.MethodPost, "/v1/agent/tasks", bytes.NewReader(body))
+	req = req.WithContext(userCtx(uuid.New()))
+	w := httptest.NewRecorder()
+	h.routeTasks(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandleList_HappyPath(t *testing.T) {
+	client := newFakeClient()
+	h := NewHandler(client)
+	tenantID := uuid.New()
+
+	createReq := httptest.NewRequest(http.MethodPost, "/v1/agent/tasks", bytes.NewReader(mustJSON(createTaskRequest{Pack: "coding-pack"})))
+	createReq = createReq.WithContext(userCtx(tenantID))
+	h.routeTasks(httptest.NewRecorder(), createReq)
+
+	listReq := httptest.NewRequest(http.MethodGet, "/v1/agent/tasks", nil)
+	listReq = listReq.WithContext(userCtx(tenantID))
+	w := httptest.NewRecorder()
+	h.routeTasks(w, listReq)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Tasks []Task `json:"tasks"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Tasks) != 1 {
+		t.Fatalf("expected 1 task, got %d", len(resp.Tasks))
+	}
+}
+
+func TestHandleGet_NotFound_Returns404(t *testing.T) {
+	h := NewHandler(newFakeClient())
+	taskID := uuid.New()
+	req := httptest.NewRequest(http.MethodGet, "/v1/agent/tasks/"+taskID.String(), nil)
+	req = req.WithContext(userCtx(uuid.New()))
+	w := httptest.NewRecorder()
+	h.routeTaskByID(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestHandleCancel_HappyPath(t *testing.T) {
+	client := newFakeClient()
+	h := NewHandler(client)
+	tenantID := uuid.New()
+
+	createW := httptest.NewRecorder()
+	createReq := httptest.NewRequest(http.MethodPost, "/v1/agent/tasks", bytes.NewReader(mustJSON(createTaskRequest{Pack: "coding-pack"})))
+	createReq = createReq.WithContext(userCtx(tenantID))
+	h.routeTasks(createW, createReq)
+	var created Task
+	_ = json.NewDecoder(createW.Body).Decode(&created)
+
+	cancelReq := httptest.NewRequest(http.MethodPost, "/v1/agent/tasks/"+created.ID+"/cancel", nil)
+	cancelReq = cancelReq.WithContext(userCtx(tenantID))
+	w := httptest.NewRecorder()
+	h.routeTaskByID(w, cancelReq)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var cancelled Task
+	_ = json.NewDecoder(w.Body).Decode(&cancelled)
+	if cancelled.Status != "cancelled" {
+		t.Errorf("expected status cancelled, got %q", cancelled.Status)
+	}
+}
+
+func TestHandleCancel_TerminalStateReturns409(t *testing.T) {
+	client := newFakeClient()
+	client.cancelErr = ErrTerminalState
+	h := NewHandler(client)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/agent/tasks/"+uuid.New().String()+"/cancel", nil)
+	req = req.WithContext(userCtx(uuid.New()))
+	w := httptest.NewRecorder()
+	h.routeTaskByID(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Errorf("expected 409, got %d", w.Code)
+	}
+}
+
+func TestExtractTaskPath_Valid(t *testing.T) {
+	id := uuid.New()
+	gotID, cancel, err := extractTaskPath("/v1/agent/tasks/" + id.String())
+	if err != nil || gotID != id || cancel {
+		t.Errorf("extractTaskPath failed: id=%v cancel=%v err=%v", gotID, cancel, err)
+	}
+}
+
+func TestExtractTaskPath_Cancel(t *testing.T) {
+	id := uuid.New()
+	gotID, cancel, err := extractTaskPath("/v1/agent/tasks/" + id.String() + "/cancel")
+	if err != nil || gotID != id || !cancel {
+		t.Errorf("extractTaskPath cancel failed: id=%v cancel=%v err=%v", gotID, cancel, err)
+	}
+}
+
+func TestExtractTaskPath_Invalid(t *testing.T) {
+	if _, _, err := extractTaskPath("/v1/agent/tasks/not-a-uuid"); err == nil {
+		t.Error("expected error for invalid UUID")
+	}
+}
+
+func mustJSON(v any) []byte {
+	b, _ := json.Marshal(v)
+	return b
+}

--- a/apps/edge-api/internal/agenttask/types.go
+++ b/apps/edge-api/internal/agenttask/types.go
@@ -1,0 +1,47 @@
+// Package agenttask serves the customer-facing agent task lifecycle surface
+// (issue #311, agent-subsystem blueprint Step 3.4): a task started in one web
+// session is visible and resumable from another web session, tenant- and
+// user-scoped. Persistence lives in control-plane
+// (apps/control-plane/internal/agenttask); this package is the auth boundary
+// and wire-shape translator that calls into it over the internal
+// service-to-service surface. See
+// apps/control-plane/internal/agenttask/SYNC_CONTRACT.md for the full
+// contract.
+package agenttask
+
+import (
+	"errors"
+	"time"
+)
+
+// Task mirrors the control-plane's taskWire response shape.
+type Task struct {
+	ID               string     `json:"id"`
+	Pack             string     `json:"pack"`
+	Status           string     `json:"status"`
+	EngineSessionRef string     `json:"engine_session_ref"`
+	ResultSummaryRef string     `json:"result_summary_ref"`
+	ErrorMessage     string     `json:"error_message"`
+	CreatedAt        time.Time  `json:"created_at"`
+	UpdatedAt        time.Time  `json:"updated_at"`
+	StartedAt        *time.Time `json:"started_at"`
+	FinishedAt       *time.Time `json:"finished_at"`
+}
+
+var (
+	// ErrNotFound mirrors control-plane's 404: unknown task, or a task that
+	// belongs to a different user.
+	ErrNotFound = errors.New("agenttask: task not found")
+
+	// ErrInvalidPack mirrors control-plane's 400 for an unrecognized pack.
+	ErrInvalidPack = errors.New("agenttask: invalid pack")
+
+	// ErrTerminalState mirrors control-plane's 409: the task already reached
+	// a terminal status and cannot be cancelled again.
+	ErrTerminalState = errors.New("agenttask: task already reached a terminal state")
+
+	// ErrRequestFailed is the provider-blind catch-all for any other
+	// non-2xx response or transport failure — the real cause is logged
+	// server-side, never surfaced to the customer.
+	ErrRequestFailed = errors.New("agenttask: request failed")
+)

--- a/supabase/migrations/20260716_03_agent_tasks.sql
+++ b/supabase/migrations/20260716_03_agent_tasks.sql
@@ -1,0 +1,75 @@
+-- supabase/migrations/20260716_03_agent_tasks.sql
+--
+-- Agent task persistence, web side (issue #311, agent-subsystem blueprint
+-- Step 3.4). A task started from one web session must be visible and
+-- resumable from another web session for the same user, tenant-scoped. This
+-- table is the sync contract's server-side backing store; the desktop
+-- consumer in Wave 4 attaches to the same rows.
+--
+-- RLS-scoped like public.marketplace_tenant_entries
+-- (20260716_01_marketplace_catalog.sql) and public.egress_policies
+-- (20260715_03_egress_policy_ssot.sql): hive_app is NOT BYPASSRLS
+-- (20260518_04_phase19_audit_rls_and_indexes.sql), so every query needs
+-- app.current_tenant_id set LOCAL inside an explicit transaction (see
+-- agenttask.Repository.withTenantTx). User-level scoping (a task is only
+-- listed/read/cancelled by the user who started it) is enforced at the
+-- application layer via an explicit user_id filter on every query, not by
+-- RLS — same tenant, different users, may need cross-user visibility later
+-- (e.g. a workspace-admin task inbox) without a schema change.
+--
+-- Depends on: 20260516_01_phase19_tenants.sql (public.tenants).
+
+BEGIN;
+
+CREATE TABLE public.agent_tasks (
+    id                  UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id           UUID        NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+    user_id             UUID        NOT NULL REFERENCES auth.users(id),
+    pack                TEXT        NOT NULL CHECK (pack IN ('coding-pack', 'knowledge-work-pack')),
+    status              TEXT        NOT NULL DEFAULT 'queued'
+                                     CHECK (status IN ('queued', 'running', 'succeeded', 'failed', 'cancelled')),
+    engine_session_ref  TEXT        NOT NULL DEFAULT '',
+    result_summary_ref  TEXT        NOT NULL DEFAULT '',
+    error_message       TEXT        NOT NULL DEFAULT '',
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    started_at          TIMESTAMPTZ,
+    finished_at         TIMESTAMPTZ
+);
+
+COMMENT ON TABLE public.agent_tasks IS
+  'Agent task persistence for web-started tasks (issue #311, Wave 3.4). status is a queued -> running -> {succeeded, failed} state machine, with cancelled reachable from queued or running. engine_session_ref is the apps/agent-engine launch reference once the task starts running; result_summary_ref points at the stored task output (shape owned by whichever consumer writes it, e.g. artifacts hosting #312). No RLS-level user scoping: user_id is filtered at the application layer so a later cross-user view (workspace task inbox) needs no migration.';
+
+CREATE INDEX agent_tasks_tenant_user_created_idx
+    ON public.agent_tasks (tenant_id, user_id, created_at DESC);
+
+ALTER TABLE public.agent_tasks ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public' AND tablename = 'agent_tasks'
+          AND policyname = 'agent_tasks_tenant_isolation'
+    ) THEN
+        -- NULLIF(..., '') guards the same Postgres GUC placeholder quirk
+        -- documented in 20260715_03_egress_policy_ssot.sql: once a pooled
+        -- connection has ever called set_config('app.current_tenant_id', ...,
+        -- true), current_setting(name, true) can return '' rather than NULL
+        -- after the LOCAL scope ends. Casting '' straight to ::uuid raises
+        -- instead of cleanly filtering rows; NULLIF folds that case to NULL,
+        -- which the comparison then treats as false — deny by default.
+        CREATE POLICY agent_tasks_tenant_isolation
+            ON public.agent_tasks AS PERMISSIVE FOR ALL TO hive_app
+            USING      (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::uuid)
+            WITH CHECK (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::uuid);
+    END IF;
+END$$;
+
+-- No DELETE: task rows are append-only status history, never removed by the
+-- app (mirrors public.audit_log's posture). hive_app only needs to create
+-- rows and transition status.
+GRANT SELECT, INSERT, UPDATE ON public.agent_tasks TO hive_app;
+GRANT SELECT ON public.agent_tasks TO auditor_ro;
+
+COMMIT;


### PR DESCRIPTION
## Summary

Implements blueprint Step 3.4 (issue #311): task portability, web side. A task started in one web session is now persisted server-side, tenant- and user-scoped, and resumable from another web session. This is the confirmed half of D8; the desktop-local portability half stays open per the blueprint's Open Questions and is out of scope here.

## Schema

`supabase/migrations/20260716_03_agent_tasks.sql` (sequence chosen deliberately later than `20260716_01_marketplace_catalog.sql`; `20260716_02` is reserved for the in-flight artifacts-hosting PR #312, confirm no collision before merge):

- `public.agent_tasks`: `id`, `tenant_id` (FK `tenants`, cascade), `user_id` (FK `auth.users`), `pack` (`coding-pack` | `knowledge-work-pack`), `status` (`queued` | `running` | `succeeded` | `failed` | `cancelled`), `engine_session_ref`, `result_summary_ref`, `error_message`, timestamps.
- RLS enabled, tenant-isolation policy mirrors `marketplace_tenant_entries` / `egress_policies` (NULLIF guard against the GUC placeholder quirk). User-level scoping is enforced at the application layer (explicit `user_id` filter), not RLS, so a later cross-user view needs no migration.
- No DELETE grant: task rows are append-only status history.

## Endpoints

**Edge-api (customer-facing, auth required, gated by `ENABLE_COWORK`):**
- `POST /v1/agent/tasks` — create
- `GET /v1/agent/tasks` — list, scoped to the caller
- `GET /v1/agent/tasks/{id}` — get (404 if it belongs to another user)
- `POST /v1/agent/tasks/{id}/cancel` — cancel (409 if already terminal)

**Control-plane (internal, `X-Internal-Token`):**
- Same four operations under `/internal/agent-tasks/{tenant_id}/{user_id}[/{task_id}[/cancel]]`. `tenant_id`/`user_id` travel as URL path segments, never body/query/header — mirrors `apps/control-plane/internal/marketplace`'s internal read surface, so no `lint-no-direct-tenant-id.mjs` allowlist edit was needed.

Status is polling-based (`GET /v1/agent/tasks/{id}`), not SSE: the existing SSE code in this repo (`apps/edge-api/internal/anthropic/stream.go`) is a provider-response translator around one in-flight LLM call, not a general task-status push channel, so building one was out of scope. Documented as a follow-up in `SYNC_CONTRACT.md` if a live-updating panel needs push later.

## Sync contract

Full JSON shapes and the `queued -> running -> {succeeded, failed}` / `-> cancelled` state machine are documented in `apps/control-plane/internal/agenttask/SYNC_CONTRACT.md`, written so the Wave 4 desktop consumer can attach without rework.

## Engine seam

`Service.CreateTask` calls `Engine.Launch` right after persisting a `queued` row. Only `NotConfiguredEngine` is wired today — it returns `ErrEngineNotConfigured` and the task stays `queued` (not failed). The real gap: `apps/agent-engine`'s Wave 2.2 CLI binds a host port for one sandbox session, but the control channel this needs (submit a task, get a session reference, later learn success/failure) requires a second host <-> agent-server channel that the sandbox's `--network none` egress profile currently cuts off. Wiring a real `Engine` is Wave 4 work; `Service` and the HTTP surface do not change when that lands.

## Test evidence

- `go build ./apps/control-plane/... ./apps/edge-api/...` — clean.
- `go vet` — clean on both new packages.
- `gofmt -l` — clean.
- `node tools/lint-no-direct-tenant-id.mjs` — PASS, no allowlist changes.
- Full `go test -short` for both `apps/control-plane/...` and `apps/edge-api/...` — all green, no regressions.
- New unit tests (fake repo + fake engine): state machine (queued -> running/failed/cancelled, terminal-state rejection), cross-user denial via `Get`/`List` scoping, engine-not-configured stays queued.
- New RLS tests (`HIVE_TEST_DB_URL`-gated, skip cleanly without it — same convention as every other RLS suite in this repo; `HIVE_TEST_DB_URL` is a known phantom CI secret, so these run locally only until that's wired): cross-tenant read denial, no session leak across pooled-connection borrows, create/get/transition round trip, other-user-in-same-tenant denial for get/list/cancel.

## Open risks

- `HIVE_TEST_DB_URL` RLS tests are unexercised in CI (repo-wide gap, not new here) — verified locally is not possible in this sandbox (no local Postgres with the full Supabase schema/roles). Recommend a follow-up to wire a real test DB.
- Migration sequence `20260716_03` assumes `20260716_02` lands from the artifacts-hosting PR (#312); confirm no numbering collision at merge time.
- No SSE/push channel for task status yet (documented as a follow-up, not a blocker for this step's acceptance criteria).

Closes #311 (web-side half only; desktop-local half tracked separately per Open Questions).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>