### PR TITLE
feat: standalone agent console sidecar (#311, #305)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -168,6 +168,13 @@ NEXT_PUBLIC_SUPABASE_URL=https://<PROJECT_REF>.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 
+# Agent console (chat/enterprise profiles only). EDGE_API_INTERNAL_BASE_URL
+# is server-side only (in-compose DNS name); NEXT_PUBLIC_EDGE_API_BASE_URL
+# is read by the browser and must be reachable from the client's machine,
+# not just from inside the compose network.
+EDGE_API_INTERNAL_BASE_URL=http://edge-api:8080
+NEXT_PUBLIC_EDGE_API_BASE_URL=http://localhost:8080
+
 # Hive API key for smoke tests / SDK tests (create one via POST /v1/keys)
 HIVE_API_KEY=
 

--- a/apps/agent-console/app/auth/callback/route.ts
+++ b/apps/agent-console/app/auth/callback/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { createServerClient, type CookieOptions } from "@supabase/ssr";
+import { cookies } from "next/headers";
+
+// Mirrors apps/web-console/app/auth/callback/route.ts. No hive_verify /
+// email-verification finalize step here -- this app has no account-setup
+// flow of its own; it only needs a valid Supabase session to call edge-api.
+export async function GET(request: NextRequest) {
+  const { searchParams, origin } = new URL(request.url);
+  const code = searchParams.get("code");
+
+  if (code) {
+    const cookieStore = await cookies();
+    const supabase = createServerClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      {
+        cookies: {
+          getAll() {
+            return cookieStore.getAll();
+          },
+          setAll(
+            cookiesToSet: Array<{
+              name: string;
+              value: string;
+              options: CookieOptions;
+            }>
+          ) {
+            try {
+              cookiesToSet.forEach(({ name, value, options }) =>
+                cookieStore.set(name, value, options)
+              );
+            } catch {
+              // Ignore: called from Server Component context.
+            }
+          },
+        },
+      }
+    );
+
+    const { error } = await supabase.auth.exchangeCodeForSession(code);
+    if (!error) {
+      return NextResponse.redirect(new URL("/tasks", origin));
+    }
+  }
+
+  return NextResponse.redirect(new URL("/auth/sign-in", origin));
+}

--- a/apps/agent-console/app/auth/sign-in/page.tsx
+++ b/apps/agent-console/app/auth/sign-in/page.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+
+import { createClient } from "@/lib/supabase/browser";
+
+export default function SignInPage() {
+  const supabase = createClient();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+
+    const { error } = await supabase.auth.signInWithPassword({ email, password });
+
+    if (error) {
+      setError(error.message);
+      setLoading(false);
+      return;
+    }
+
+    // Hard navigation, not router.push: forces the browser to re-issue the
+    // request with the freshly-written sb-*-auth-token cookies so middleware
+    // sees the session on the very next request (same fix as web-console).
+    window.location.assign("/tasks");
+  }
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-sm flex-col justify-center gap-6 px-6">
+      <div className="flex flex-col gap-1">
+        <h1 className="text-xl font-semibold">Agent workspace</h1>
+        <p className="text-sm text-neutral-600">
+          Sign in with your Hive account to start and monitor agent tasks.
+        </p>
+      </div>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-4" noValidate>
+        <div className="flex flex-col gap-1">
+          <label htmlFor="email" className="text-sm font-medium">
+            Email
+          </label>
+          <input
+            id="email"
+            type="email"
+            required
+            autoComplete="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="rounded-md border border-neutral-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-neutral-900"
+          />
+        </div>
+        <div className="flex flex-col gap-1">
+          <label htmlFor="password" className="text-sm font-medium">
+            Password
+          </label>
+          <input
+            id="password"
+            type="password"
+            required
+            autoComplete="current-password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="rounded-md border border-neutral-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-neutral-900"
+          />
+        </div>
+        {error ? (
+          <p role="alert" className="text-sm text-red-600">
+            {error}
+          </p>
+        ) : null}
+        <button
+          type="submit"
+          disabled={loading}
+          className="rounded-md bg-neutral-900 px-4 py-2 text-sm font-medium text-white disabled:opacity-60"
+        >
+          {loading ? "Signing in…" : "Sign in"}
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/apps/agent-console/app/globals.css
+++ b/apps/agent-console/app/globals.css
@@ -1,0 +1,6 @@
+@import "tailwindcss";
+
+/* ponytail: plain Tailwind palette, no custom design-system theme. This is
+   a utility sidecar opened in its own tab, not a branded surface -- add
+   Hive's @theme tokens (see apps/web-console/app/globals.css) if/when this
+   app needs visual parity with the console. */

--- a/apps/agent-console/app/layout.tsx
+++ b/apps/agent-console/app/layout.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from "react";
+import type { Metadata } from "next";
+
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "Hive Agent Workspace",
+  description: "Start and monitor coding-pack and knowledge-work-pack agent tasks.",
+};
+
+interface RootLayoutProps {
+  children: ReactNode;
+}
+
+export default function RootLayout({ children }: RootLayoutProps) {
+  return (
+    <html lang="en">
+      <body className="min-h-screen bg-neutral-50 text-neutral-900 antialiased">
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/apps/agent-console/app/page.tsx
+++ b/apps/agent-console/app/page.tsx
@@ -1,0 +1,7 @@
+import { redirect } from "next/navigation";
+
+// Middleware already redirects "/" based on session; this handles the
+// direct-render case (e.g. middleware disabled in a test harness).
+export default function RootPage() {
+  redirect("/tasks");
+}

--- a/apps/agent-console/app/tasks/page.tsx
+++ b/apps/agent-console/app/tasks/page.tsx
@@ -1,0 +1,20 @@
+import { isCoworkEnabled } from "@/lib/edge-api/gate";
+import { TaskConsole } from "@/components/task-console";
+
+export default async function TasksPage() {
+  const enabled = await isCoworkEnabled();
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-2xl flex-col gap-6 px-6 py-10">
+      <h1 className="text-xl font-semibold">Agent workspace</h1>
+      {enabled ? (
+        <TaskConsole />
+      ) : (
+        <p className="text-sm text-neutral-600">
+          The agent workspace is not enabled for your organization. Contact your
+          administrator.
+        </p>
+      )}
+    </main>
+  );
+}

--- a/apps/agent-console/components/task-console.test.tsx
+++ b/apps/agent-console/components/task-console.test.tsx
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
+
+import { TaskConsole } from "./task-console";
+
+vi.mock("@/lib/supabase/browser", () => ({
+  createClient: () => ({
+    auth: {
+      getSession: () =>
+        Promise.resolve({ data: { session: { access_token: "test-token" } } }),
+    },
+  }),
+}));
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const QUEUED_TASK = {
+  id: "11111111-1111-1111-1111-111111111111",
+  pack: "coding-pack",
+  status: "queued",
+  engine_session_ref: "",
+  result_summary_ref: "",
+  error_message: "",
+  created_at: "2026-07-16T00:00:00Z",
+  updated_at: "2026-07-16T00:00:00Z",
+  started_at: null,
+  finished_at: null,
+};
+
+describe("TaskConsole", () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("loads and renders the task list on mount", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ tasks: [QUEUED_TASK] }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<TaskConsole />);
+
+    expect(await screen.findByText("Coding pack")).toBeTruthy();
+    expect(screen.getByText("queued")).toBeTruthy();
+  });
+
+  it("starts a coding-pack task and prepends it to the list", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ tasks: [] }))
+      .mockResolvedValueOnce(jsonResponse(QUEUED_TASK, 201));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<TaskConsole />);
+    await waitFor(() => expect(screen.getByText("No tasks yet.")).toBeTruthy());
+
+    fireEvent.click(screen.getByRole("button", { name: /start coding pack/i }));
+
+    expect(await screen.findByText("queued")).toBeTruthy();
+    const createCall = fetchMock.mock.calls[1];
+    expect(String(createCall[0])).toContain("/v1/agent/tasks");
+    expect(createCall[1]?.method).toBe("POST");
+    expect(JSON.parse(String(createCall[1]?.body))).toEqual({ pack: "coding-pack" });
+  });
+
+  it("starts a knowledge-work-pack task with the matching pack literal", async () => {
+    const kwTask = { ...QUEUED_TASK, pack: "knowledge-work-pack" };
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ tasks: [] }))
+      .mockResolvedValueOnce(jsonResponse(kwTask, 201));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<TaskConsole />);
+    await waitFor(() => expect(screen.getByText("No tasks yet.")).toBeTruthy());
+
+    fireEvent.click(screen.getByRole("button", { name: /start knowledge-work pack/i }));
+
+    await waitFor(() => {
+      const createCall = fetchMock.mock.calls[1];
+      expect(JSON.parse(String(createCall[1]?.body))).toEqual({
+        pack: "knowledge-work-pack",
+      });
+    });
+  });
+
+  it("shows a cancel button for a non-terminal task and calls the cancel endpoint", async () => {
+    const cancelled = { ...QUEUED_TASK, status: "cancelled" };
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ tasks: [QUEUED_TASK] }))
+      .mockResolvedValueOnce(jsonResponse(cancelled));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<TaskConsole />);
+    const cancelButton = await screen.findByRole("button", { name: /^cancel$/i });
+    fireEvent.click(cancelButton);
+
+    await waitFor(() => {
+      expect(screen.getByText("cancelled")).toBeTruthy();
+    });
+    const cancelCall = fetchMock.mock.calls[1];
+    expect(String(cancelCall[0])).toContain(`/v1/agent/tasks/${QUEUED_TASK.id}/cancel`);
+  });
+
+  it("does not show a cancel button once a task reaches a terminal state", async () => {
+    const succeeded = { ...QUEUED_TASK, status: "succeeded", result_summary_ref: "ref-1" };
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ tasks: [succeeded] }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<TaskConsole />);
+    await screen.findByText("succeeded");
+    expect(screen.queryByRole("button", { name: /^cancel$/i })).toBeNull();
+    expect(screen.getByText("Result: ref-1")).toBeTruthy();
+  });
+
+  it("shows an error message when the initial load fails", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("nope", { status: 500 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<TaskConsole />);
+
+    expect(await screen.findByRole("alert")).toHaveProperty(
+      "textContent",
+      "Could not load tasks.",
+    );
+  });
+});

--- a/apps/agent-console/components/task-console.tsx
+++ b/apps/agent-console/components/task-console.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import * as React from "react";
+
+import { createClient } from "@/lib/supabase/browser";
+import {
+  cancelTask,
+  createTask,
+  listTasks,
+  TERMINAL_STATUSES,
+  type AgentTask,
+  type TaskPack,
+} from "@/lib/edge-api/tasks";
+
+const POLL_INTERVAL_MS = 3000;
+
+const PACKS: Array<{ value: TaskPack; label: string }> = [
+  { value: "coding-pack", label: "Coding pack" },
+  { value: "knowledge-work-pack", label: "Knowledge-work pack" },
+];
+
+const PACK_LABELS: Record<TaskPack, string> = {
+  "coding-pack": "Coding pack",
+  "knowledge-work-pack": "Knowledge-work pack",
+};
+
+async function getAccessToken(
+  supabase: ReturnType<typeof createClient>,
+): Promise<string | null> {
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  return session?.access_token ?? null;
+}
+
+export function TaskConsole() {
+  const supabase = React.useMemo(() => createClient(), []);
+  const baseUrl = process.env.NEXT_PUBLIC_EDGE_API_BASE_URL ?? "";
+
+  const [tasks, setTasks] = React.useState<AgentTask[]>([]);
+  const [starting, setStarting] = React.useState<TaskPack | null>(null);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const refresh = React.useCallback(async () => {
+    const token = await getAccessToken(supabase);
+    if (!token) {
+      setError("Session expired. Sign in again.");
+      return;
+    }
+    try {
+      const next = await listTasks(baseUrl, token);
+      setTasks(next);
+      setError(null);
+    } catch {
+      setError("Could not load tasks.");
+    }
+  }, [supabase, baseUrl]);
+
+  React.useEffect(() => {
+    void refresh();
+    // ponytail: one unconditional poll loop rather than per-task timers or a
+    // websocket -- demo-scale task counts, and the sync contract
+    // (SYNC_CONTRACT.md) ships no push channel yet. Add SSE against
+    // GET /v1/agent/tasks/{id}/events if/when that lands.
+    const interval = setInterval(() => {
+      void refresh();
+    }, POLL_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [refresh]);
+
+  async function handleStart(pack: TaskPack) {
+    setStarting(pack);
+    setError(null);
+    const token = await getAccessToken(supabase);
+    if (!token) {
+      setError("Session expired. Sign in again.");
+      setStarting(null);
+      return;
+    }
+    try {
+      const task = await createTask(baseUrl, token, pack);
+      setTasks((prev) => [task, ...prev]);
+    } catch {
+      setError("Could not start task.");
+    } finally {
+      setStarting(null);
+    }
+  }
+
+  async function handleCancel(id: string) {
+    const token = await getAccessToken(supabase);
+    if (!token) {
+      setError("Session expired. Sign in again.");
+      return;
+    }
+    try {
+      const updated = await cancelTask(baseUrl, token, id);
+      setTasks((prev) => prev.map((t) => (t.id === updated.id ? updated : t)));
+    } catch {
+      setError("Could not cancel task.");
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-8">
+      <section aria-label="Start a new agent task" className="flex flex-col gap-3">
+        <h2 className="text-sm font-medium text-neutral-600">Start a task</h2>
+        <div className="flex gap-3">
+          {PACKS.map(({ value, label }) => (
+            <button
+              key={value}
+              type="button"
+              disabled={starting !== null}
+              onClick={() => void handleStart(value)}
+              className="rounded-md bg-neutral-900 px-4 py-2 text-sm font-medium text-white disabled:opacity-60"
+            >
+              {starting === value ? "Starting…" : `Start ${label.toLowerCase()}`}
+            </button>
+          ))}
+        </div>
+      </section>
+
+      {error ? (
+        <p role="alert" className="text-sm text-red-600">
+          {error}
+        </p>
+      ) : null}
+
+      <section aria-label="Tasks" className="flex flex-col gap-3">
+        <h2 className="text-sm font-medium text-neutral-600">Tasks</h2>
+        {tasks.length === 0 ? (
+          <p className="text-sm text-neutral-500">No tasks yet.</p>
+        ) : (
+          <ul className="flex flex-col divide-y divide-neutral-200 rounded-md border border-neutral-200">
+            {tasks.map((task) => (
+              <li key={task.id} className="flex flex-col gap-1 px-4 py-3">
+                <div className="flex items-center justify-between gap-3">
+                  <span className="text-sm font-medium">{PACK_LABELS[task.pack]}</span>
+                  <span
+                    aria-live="polite"
+                    className="rounded-full bg-neutral-100 px-2 py-0.5 text-xs font-medium uppercase tracking-wide text-neutral-700"
+                  >
+                    {task.status}
+                  </span>
+                </div>
+                {task.result_summary_ref ? (
+                  <p className="text-xs text-neutral-700">Result: {task.result_summary_ref}</p>
+                ) : null}
+                {task.error_message ? (
+                  <p className="text-xs text-red-600">{task.error_message}</p>
+                ) : null}
+                {!TERMINAL_STATUSES.has(task.status) ? (
+                  <button
+                    type="button"
+                    onClick={() => void handleCancel(task.id)}
+                    className="w-fit text-xs font-medium text-neutral-600 underline-offset-2 hover:underline"
+                  >
+                    Cancel
+                  </button>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/apps/agent-console/lib/edge-api/gate.test.ts
+++ b/apps/agent-console/lib/edge-api/gate.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { isCoworkEnabled } from "./gate";
+
+let mockSession: { access_token: string } | null = { access_token: "test-token" };
+
+vi.mock("next/headers", () => ({
+  cookies: () => Promise.resolve({ getAll: () => [], set: () => {} }),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: () => ({
+    auth: {
+      getSession: () => Promise.resolve({ data: { session: mockSession } }),
+    },
+  }),
+}));
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("isCoworkEnabled", () => {
+  const originalBaseUrl = process.env.EDGE_API_INTERNAL_BASE_URL;
+
+  beforeEach(() => {
+    mockSession = { access_token: "test-token" };
+    process.env.EDGE_API_INTERNAL_BASE_URL = "http://edge-api.test";
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.env.EDGE_API_INTERNAL_BASE_URL = originalBaseUrl;
+  });
+
+  it("returns true when the tenant's ENABLE_COWORK gate is on", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(jsonResponse({ gates: { ENABLE_COWORK: true } })),
+    );
+    expect(await isCoworkEnabled()).toBe(true);
+  });
+
+  it("returns false when the tenant's ENABLE_COWORK gate is off", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(jsonResponse({ gates: { ENABLE_COWORK: false } })),
+    );
+    expect(await isCoworkEnabled()).toBe(false);
+  });
+
+  it("fails closed when there is no active session", async () => {
+    mockSession = null;
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    expect(await isCoworkEnabled()).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when EDGE_API_INTERNAL_BASE_URL is not configured", async () => {
+    delete process.env.EDGE_API_INTERNAL_BASE_URL;
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    expect(await isCoworkEnabled()).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("fails closed on a non-2xx response", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("nope", { status: 500 })));
+    expect(await isCoworkEnabled()).toBe(false);
+  });
+
+  it("fails closed on a network error", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network down")));
+    expect(await isCoworkEnabled()).toBe(false);
+  });
+
+  it("fails closed on a malformed gates payload", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({ gates: "not-an-object" })));
+    expect(await isCoworkEnabled()).toBe(false);
+  });
+});

--- a/apps/agent-console/lib/edge-api/gate.ts
+++ b/apps/agent-console/lib/edge-api/gate.ts
@@ -1,0 +1,54 @@
+import { cookies } from "next/headers";
+
+import { createClient } from "@/lib/supabase/server";
+import { isJsonObject, parseJsonValue, readObjectField, readResponseText } from "./json";
+
+// isCoworkEnabled reads the authenticated tenant's live feature-gate state
+// from edge-api's GET /v1/featuregate (added in #322 for exactly this: a
+// Bearer-authenticated end user reading their own gate map, same auth
+// selector path as any Supabase-JWT client -- see
+// apps/edge-api/internal/auth/selector.go). Server-only --
+// EDGE_API_INTERNAL_BASE_URL is the in-compose service DNS name
+// (http://edge-api:8080), not exposed to the browser bundle.
+//
+// Fails closed: any error (network, non-200, missing tenant) hides the
+// panel rather than showing it. Matches the Gate.Fetch fail-closed posture
+// in apps/edge-api/internal/featuregate/gate.go.
+export async function isCoworkEnabled(): Promise<boolean> {
+  const cookieStore = await cookies();
+  const supabase = createClient(cookieStore);
+
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  if (!session) {
+    return false;
+  }
+
+  const baseUrl = process.env.EDGE_API_INTERNAL_BASE_URL;
+  if (!baseUrl) {
+    return false;
+  }
+
+  try {
+    const response = await fetch(`${baseUrl}/v1/featuregate`, {
+      headers: { Authorization: `Bearer ${session.access_token}` },
+      cache: "no-store",
+    });
+    if (!response.ok) {
+      return false;
+    }
+
+    const payload = parseJsonValue(await readResponseText(response));
+    if (!isJsonObject(payload)) {
+      return false;
+    }
+    const gates = readObjectField(payload, "gates");
+    if (!gates) {
+      return false;
+    }
+    return gates["ENABLE_COWORK"] === true;
+  } catch {
+    return false;
+  }
+}

--- a/apps/agent-console/lib/edge-api/json.ts
+++ b/apps/agent-console/lib/edge-api/json.ts
@@ -1,0 +1,55 @@
+// Structural JSON decoding helpers, mirroring
+// apps/web-console/lib/control-plane/client.ts: no `any`/`unknown` casts,
+// every external payload is narrowed through explicit type guards before
+// its fields are read.
+
+export type JsonPrimitive = string | number | boolean | null;
+export interface JsonObject {
+  [key: string]: JsonValue;
+}
+export type JsonArray = JsonValue[];
+export type JsonValue = JsonPrimitive | JsonObject | JsonArray;
+
+export function isJsonObject(value: JsonValue | null): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function parseJsonValue(text: string): JsonValue | null {
+  if (!text) {
+    return null;
+  }
+  try {
+    const parsed: JsonValue = JSON.parse(text);
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function readStringField(source: JsonObject, key: string): string | null {
+  const value = source[key];
+  return typeof value === "string" ? value : null;
+}
+
+export function readBooleanField(source: JsonObject, key: string): boolean | null {
+  const value = source[key];
+  return typeof value === "boolean" ? value : null;
+}
+
+export function readObjectField(source: JsonObject, key: string): JsonObject | null {
+  const value = source[key];
+  return isJsonObject(value) ? value : null;
+}
+
+export function readArrayField(source: JsonObject, key: string): JsonArray | null {
+  const value = source[key];
+  return Array.isArray(value) ? value : null;
+}
+
+export async function readResponseText(response: Response): Promise<string> {
+  try {
+    return await response.text();
+  } catch {
+    return "";
+  }
+}

--- a/apps/agent-console/lib/edge-api/tasks.test.ts
+++ b/apps/agent-console/lib/edge-api/tasks.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+import {
+  AgentTaskError,
+  cancelTask,
+  createTask,
+  getTask,
+  listTasks,
+  TERMINAL_STATUSES,
+  isTaskPack,
+} from "./tasks";
+
+const BASE_URL = "http://edge-api.test";
+const TOKEN = "test-token";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const TASK = {
+  id: "11111111-1111-1111-1111-111111111111",
+  pack: "coding-pack",
+  status: "queued",
+  engine_session_ref: "",
+  result_summary_ref: "",
+  error_message: "",
+  created_at: "2026-07-16T00:00:00Z",
+  updated_at: "2026-07-16T00:00:00Z",
+  started_at: null,
+  finished_at: null,
+};
+
+describe("edge-api tasks client", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("listTasks sends a Bearer-authorized GET and decodes the tasks array", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ tasks: [TASK] }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tasks = await listTasks(BASE_URL, TOKEN);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${BASE_URL}/v1/agent/tasks`,
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: `Bearer ${TOKEN}` }),
+      }),
+    );
+    expect(tasks).toEqual([TASK]);
+  });
+
+  it("listTasks drops malformed entries instead of throwing", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse({ tasks: [TASK, { id: "bad" }] }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tasks = await listTasks(BASE_URL, TOKEN);
+    expect(tasks).toEqual([TASK]);
+  });
+
+  it("createTask POSTs only the pack (the contract has no prompt field) and returns the decoded task", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(TASK, 201));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const task = await createTask(BASE_URL, TOKEN, "coding-pack");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${BASE_URL}/v1/agent/tasks`,
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ pack: "coding-pack" }),
+      }),
+    );
+    expect(task).toEqual(TASK);
+  });
+
+  it("getTask fetches a single task by id", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(TASK));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const task = await getTask(BASE_URL, TOKEN, TASK.id);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${BASE_URL}/v1/agent/tasks/${TASK.id}`,
+      expect.anything(),
+    );
+    expect(task).toEqual(TASK);
+  });
+
+  it("cancelTask POSTs to the cancel sub-route", async () => {
+    const cancelled = { ...TASK, status: "cancelled" };
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(cancelled));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const task = await cancelTask(BASE_URL, TOKEN, TASK.id);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${BASE_URL}/v1/agent/tasks/${TASK.id}/cancel`,
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(task.status).toBe("cancelled");
+  });
+
+  it("throws AgentTaskError with the upstream status and nested error.message on failure", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        jsonResponse({ error: { code: "INVALID_REQUEST", message: "invalid pack" } }, 400),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    let caught: unknown;
+    try {
+      await listTasks(BASE_URL, TOKEN);
+    } catch (err) {
+      caught = err;
+    }
+    if (!(caught instanceof AgentTaskError)) {
+      throw new Error("expected listTasks to reject with AgentTaskError");
+    }
+    expect(caught.status).toBe(400);
+    expect(caught.message).toBe("invalid pack");
+  });
+
+  it("isTaskPack narrows only the two known pack literals", () => {
+    expect(isTaskPack("coding-pack")).toBe(true);
+    expect(isTaskPack("knowledge-work-pack")).toBe(true);
+    expect(isTaskPack("something-else")).toBe(false);
+  });
+
+  it("TERMINAL_STATUSES marks succeeded/failed/cancelled as terminal", () => {
+    expect(TERMINAL_STATUSES.has("succeeded")).toBe(true);
+    expect(TERMINAL_STATUSES.has("failed")).toBe(true);
+    expect(TERMINAL_STATUSES.has("cancelled")).toBe(true);
+    expect(TERMINAL_STATUSES.has("queued")).toBe(false);
+    expect(TERMINAL_STATUSES.has("running")).toBe(false);
+  });
+});

--- a/apps/agent-console/lib/edge-api/tasks.ts
+++ b/apps/agent-console/lib/edge-api/tasks.ts
@@ -1,0 +1,205 @@
+// Agent task lifecycle client. Browser-safe: called directly from the
+// client component with the signed-in user's Supabase access token, the
+// same way any direct edge-api caller (SDK, curl) authenticates -- no BFF
+// proxy route needed since edge-api is already customer-facing (unlike
+// control-plane, which web-console proxies because it's internal-only).
+//
+// Wire shape and routes verified against origin/feat/311-task-sync-web
+// (#311, PR #329) after that branch pushed mid-build:
+// apps/control-plane/internal/agenttask/SYNC_CONTRACT.md and
+// apps/edge-api/internal/agenttask/{types,handler}.go. Notably: create only
+// takes `{"pack": "..."}`, there is no free-text prompt field on this
+// contract yet (Engine.Launch is a documented open seam -- see
+// SYNC_CONTRACT.md "Engine seam (known gap)" -- so a submitted task stays
+// `queued` until a real Engine lands in a later wave); status values are
+// queued/running/succeeded/failed/cancelled, not the pending/completed
+// naming this blueprint's prose used.
+
+import {
+  isJsonObject,
+  parseJsonValue,
+  readArrayField,
+  readObjectField,
+  readStringField,
+  readResponseText,
+  type JsonObject,
+} from "./json";
+
+export type TaskPack = "coding-pack" | "knowledge-work-pack";
+export type TaskStatus = "queued" | "running" | "succeeded" | "failed" | "cancelled";
+
+export interface AgentTask {
+  id: string;
+  pack: TaskPack;
+  status: TaskStatus;
+  engine_session_ref: string;
+  result_summary_ref: string;
+  error_message: string;
+  created_at: string;
+  updated_at: string;
+  started_at: string | null;
+  finished_at: string | null;
+}
+
+export class AgentTaskError extends Error {
+  public readonly status: number;
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "AgentTaskError";
+    this.status = status;
+  }
+}
+
+const PACKS: ReadonlySet<string> = new Set(["coding-pack", "knowledge-work-pack"]);
+const STATUSES: ReadonlySet<string> = new Set([
+  "queued",
+  "running",
+  "succeeded",
+  "failed",
+  "cancelled",
+]);
+
+export function isTaskPack(value: string): value is TaskPack {
+  return PACKS.has(value);
+}
+
+function isTaskStatus(value: string): value is TaskStatus {
+  return STATUSES.has(value);
+}
+
+function decodeTask(value: JsonObject): AgentTask | null {
+  const id = readStringField(value, "id");
+  const pack = readStringField(value, "pack");
+  const status = readStringField(value, "status");
+  const createdAt = readStringField(value, "created_at");
+  const updatedAt = readStringField(value, "updated_at");
+
+  if (!id || !pack || !isTaskPack(pack) || !status || !isTaskStatus(status) || !createdAt || !updatedAt) {
+    return null;
+  }
+
+  return {
+    id,
+    pack,
+    status,
+    engine_session_ref: readStringField(value, "engine_session_ref") ?? "",
+    result_summary_ref: readStringField(value, "result_summary_ref") ?? "",
+    error_message: readStringField(value, "error_message") ?? "",
+    created_at: createdAt,
+    updated_at: updatedAt,
+    started_at: readStringField(value, "started_at"),
+    finished_at: readStringField(value, "finished_at"),
+  };
+}
+
+async function throwTaskError(response: Response, fallback: string): Promise<never> {
+  const payload = parseJsonValue(await readResponseText(response));
+  const errorBody = isJsonObject(payload) ? readObjectField(payload, "error") : null;
+  const message = errorBody ? readStringField(errorBody, "message") : null;
+  throw new AgentTaskError(response.status, message ?? `${fallback}: ${response.status}`);
+}
+
+function authHeaders(accessToken: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${accessToken}`,
+    "Content-Type": "application/json",
+  };
+}
+
+export async function listTasks(baseUrl: string, accessToken: string): Promise<AgentTask[]> {
+  const response = await fetch(`${baseUrl}/v1/agent/tasks`, {
+    headers: authHeaders(accessToken),
+    cache: "no-store",
+  });
+  if (!response.ok) {
+    await throwTaskError(response, "Failed to load tasks");
+  }
+
+  const payload = parseJsonValue(await readResponseText(response));
+  if (!isJsonObject(payload)) {
+    throw new Error("Failed to parse tasks response");
+  }
+  const rawTasks = readArrayField(payload, "tasks") ?? [];
+  const tasks: AgentTask[] = [];
+  for (const item of rawTasks) {
+    if (isJsonObject(item)) {
+      const decoded = decodeTask(item);
+      if (decoded) {
+        tasks.push(decoded);
+      }
+    }
+  }
+  return tasks;
+}
+
+export async function createTask(
+  baseUrl: string,
+  accessToken: string,
+  pack: TaskPack,
+): Promise<AgentTask> {
+  const response = await fetch(`${baseUrl}/v1/agent/tasks`, {
+    method: "POST",
+    headers: authHeaders(accessToken),
+    body: JSON.stringify({ pack }),
+  });
+  if (!response.ok) {
+    await throwTaskError(response, "Failed to create task");
+  }
+
+  const payload = parseJsonValue(await readResponseText(response));
+  const decoded = isJsonObject(payload) ? decodeTask(payload) : null;
+  if (!decoded) {
+    throw new Error("Failed to parse task response");
+  }
+  return decoded;
+}
+
+export async function getTask(
+  baseUrl: string,
+  accessToken: string,
+  id: string,
+): Promise<AgentTask> {
+  const response = await fetch(`${baseUrl}/v1/agent/tasks/${encodeURIComponent(id)}`, {
+    headers: authHeaders(accessToken),
+    cache: "no-store",
+  });
+  if (!response.ok) {
+    await throwTaskError(response, "Failed to load task");
+  }
+
+  const payload = parseJsonValue(await readResponseText(response));
+  const decoded = isJsonObject(payload) ? decodeTask(payload) : null;
+  if (!decoded) {
+    throw new Error("Failed to parse task response");
+  }
+  return decoded;
+}
+
+export async function cancelTask(
+  baseUrl: string,
+  accessToken: string,
+  id: string,
+): Promise<AgentTask> {
+  const response = await fetch(`${baseUrl}/v1/agent/tasks/${encodeURIComponent(id)}/cancel`, {
+    method: "POST",
+    headers: authHeaders(accessToken),
+  });
+  if (!response.ok) {
+    await throwTaskError(response, "Failed to cancel task");
+  }
+
+  const payload = parseJsonValue(await readResponseText(response));
+  const decoded = isJsonObject(payload) ? decodeTask(payload) : null;
+  if (!decoded) {
+    throw new Error("Failed to parse task response");
+  }
+  return decoded;
+}
+
+// TERMINAL_STATUSES: polling and the cancel button both stop once a task
+// reaches one of these (matches SYNC_CONTRACT.md's state machine).
+export const TERMINAL_STATUSES: ReadonlySet<TaskStatus> = new Set([
+  "succeeded",
+  "failed",
+  "cancelled",
+]);

--- a/apps/agent-console/lib/supabase/browser.ts
+++ b/apps/agent-console/lib/supabase/browser.ts
@@ -1,0 +1,8 @@
+import { createBrowserClient } from "@supabase/ssr";
+
+export function createClient() {
+  return createBrowserClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  );
+}

--- a/apps/agent-console/lib/supabase/server.ts
+++ b/apps/agent-console/lib/supabase/server.ts
@@ -1,0 +1,33 @@
+import { createServerClient, type CookieOptions } from "@supabase/ssr";
+import type { ReadonlyRequestCookies } from "next/dist/server/web/spec-extension/adapters/request-cookies";
+
+export function createClient(cookieStore: ReadonlyRequestCookies) {
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll();
+        },
+        setAll(
+          cookiesToSet: Array<{
+            name: string;
+            value: string;
+            options: CookieOptions;
+          }>
+        ) {
+          try {
+            cookiesToSet.forEach(({ name, value, options }) =>
+              cookieStore.set(name, value, options)
+            );
+          } catch {
+            // setAll called from a Server Component -- cookies can only be set
+            // in a Server Action or Route Handler. Safe to ignore here since
+            // middleware refreshes the session on every request.
+          }
+        },
+      },
+    }
+  );
+}

--- a/apps/agent-console/middleware.test.ts
+++ b/apps/agent-console/middleware.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment node
+//
+// Middleware runs in Next's server/edge runtime, not a browser DOM. jsdom
+// (this project's default test environment) supplies its own Headers
+// class, and Next's NextResponse.next() rejects a request whose .headers
+// isn't Node's own Headers instance ("request.headers must be an instance
+// of Headers") -- the per-file override below switches just this file.
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// Real Next.js server behavior, verified live against the built production
+// image (docker build + curl), not assumed: basePath is stripped from
+// request.nextUrl.pathname before middleware runs, so a request that
+// actually arrived at /agent-workspace/tasks is seen here as pathname
+// "/tasks". That's what these NextRequest URLs (no basePath segment)
+// simulate. See middleware.ts's BASE_PATH comment for the redirect-target
+// half of this same finding.
+let mockUser: { id: string } | null = null;
+
+vi.mock("@supabase/ssr", () => ({
+  createServerClient: () => ({
+    auth: {
+      getUser: () => Promise.resolve({ data: { user: mockUser } }),
+    },
+  }),
+}));
+
+import { middleware } from "./middleware";
+
+describe("middleware basePath-aware redirects", () => {
+  afterEach(() => {
+    mockUser = null;
+    vi.restoreAllMocks();
+  });
+
+  it("redirects unauthenticated /tasks to the basePath-prefixed sign-in URL", async () => {
+    mockUser = null;
+    const request = new NextRequest("http://localhost/tasks");
+    const response = await middleware(request);
+    expect(response.headers.get("location")).toBe("http://localhost/agent-workspace/auth/sign-in");
+  });
+
+  it("passes through authenticated /tasks with no redirect", async () => {
+    mockUser = { id: "user-1" };
+    const request = new NextRequest("http://localhost/tasks");
+    const response = await middleware(request);
+    expect(response.headers.get("location")).toBeNull();
+  });
+
+  it("redirects root to the basePath-prefixed /tasks when authenticated", async () => {
+    mockUser = { id: "user-1" };
+    const request = new NextRequest("http://localhost/");
+    const response = await middleware(request);
+    expect(response.headers.get("location")).toBe("http://localhost/agent-workspace/tasks");
+  });
+
+  it("redirects root to the basePath-prefixed sign-in URL when unauthenticated", async () => {
+    mockUser = null;
+    const request = new NextRequest("http://localhost/");
+    const response = await middleware(request);
+    expect(response.headers.get("location")).toBe("http://localhost/agent-workspace/auth/sign-in");
+  });
+
+  it("sets frame-denial headers on every response", async () => {
+    mockUser = { id: "user-1" };
+    const request = new NextRequest("http://localhost/tasks");
+    const response = await middleware(request);
+    expect(response.headers.get("x-frame-options")).toBe("DENY");
+  });
+});

--- a/apps/agent-console/middleware.ts
+++ b/apps/agent-console/middleware.ts
@@ -1,0 +1,76 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { createServerClient, type CookieOptions } from "@supabase/ssr";
+
+// Auth model (blueprint Step 3.1, ratified sidecar decision): this app is a
+// standalone console with its own Supabase session, not a cookie handoff
+// from Open WebUI. Every request under /tasks must carry a valid session;
+// everything else redirects to sign-in.
+export async function middleware(request: NextRequest) {
+  let supabaseResponse = NextResponse.next({ request });
+
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return request.cookies.getAll();
+        },
+        setAll(
+          cookiesToSet: Array<{
+            name: string;
+            value: string;
+            options: CookieOptions;
+          }>
+        ) {
+          cookiesToSet.forEach(({ name, value }) =>
+            request.cookies.set(name, value)
+          );
+          supabaseResponse = NextResponse.next({ request });
+          cookiesToSet.forEach(({ name, value, options }) =>
+            supabaseResponse.cookies.set(name, value, options)
+          );
+        },
+      },
+    }
+  );
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  const { pathname } = request.nextUrl;
+
+  // Console is opened via window.open from an OWUI Action (not framed), but
+  // set the same defence-in-depth headers as web-console anyway -- cheap and
+  // there is no legitimate reason for this app to ever be iframed.
+  const withSecurityHeaders = (res: NextResponse) => {
+    res.headers.set("X-Frame-Options", "DENY");
+    res.headers.set("Content-Security-Policy", "frame-ancestors 'none'");
+    return res;
+  };
+
+  const redirectTo = (path: string) => {
+    const res = NextResponse.redirect(new URL(path, request.url));
+    supabaseResponse.cookies.getAll().forEach((cookie) => {
+      res.cookies.set(cookie);
+    });
+    return withSecurityHeaders(res);
+  };
+
+  if (pathname.startsWith("/tasks") && !user) {
+    return redirectTo("/auth/sign-in");
+  }
+
+  if (pathname === "/" ) {
+    return redirectTo(user ? "/tasks" : "/auth/sign-in");
+  }
+
+  return withSecurityHeaders(supabaseResponse);
+}
+
+export const config = {
+  matcher: [
+    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+  ],
+};

--- a/apps/agent-console/middleware.ts
+++ b/apps/agent-console/middleware.ts
@@ -1,6 +1,18 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createServerClient, type CookieOptions } from "@supabase/ssr";
 
+// basePath, kept in sync with next.config.ts's literal "/agent-workspace".
+// Verified live (docker build + curl against the production image) that
+// Next.js strips basePath from `request.nextUrl.pathname` before
+// middleware runs -- pathname-based matching below needs no prefix -- but
+// does NOT re-add it when middleware builds a redirect target via
+// `new URL(path, request.url)`. Without this prefix, redirecting to
+// "/auth/sign-in" produced a Location header of plain "/auth/sign-in",
+// which falls outside Caddy's /agent-workspace/* route entirely (see
+// deploy/docker/Caddyfile.owui) and would have been served by Open WebUI's
+// catch-all instead of this app.
+const BASE_PATH = "/agent-workspace";
+
 // Auth model (blueprint Step 3.1, ratified sidecar decision): this app is a
 // standalone console with its own Supabase session, not a cookie handoff
 // from Open WebUI. Every request under /tasks must carry a valid session;
@@ -51,7 +63,7 @@ export async function middleware(request: NextRequest) {
   };
 
   const redirectTo = (path: string) => {
-    const res = NextResponse.redirect(new URL(path, request.url));
+    const res = NextResponse.redirect(new URL(BASE_PATH + path, request.url));
     supabaseResponse.cookies.getAll().forEach((cookie) => {
       res.cookies.set(cookie);
     });

--- a/apps/agent-console/next.config.ts
+++ b/apps/agent-console/next.config.ts
@@ -1,0 +1,16 @@
+import type { NextConfig } from "next";
+
+// Self-hosted sidecar (chat/enterprise Docker profiles only, no Cloudflare
+// Workers deploy). Runs as a plain Node process, same Docker pattern as
+// apps/web-console's Docker service (see deploy/docker/Dockerfile.agent-console).
+//
+// basePath matches the Caddy route this app is served under (see
+// deploy/docker/Caddyfile.owui). Chosen to sit next to, not under, Open
+// WebUI's own paths so Caddy can intercept it before OWUI's SPA catch-all
+// ever sees the request -- see PR description for the collision analysis.
+const config: NextConfig = {
+  basePath: "/agent-workspace",
+  productionBrowserSourceMaps: false,
+};
+
+export default config;

--- a/apps/agent-console/package.json
+++ b/apps/agent-console/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@hive/agent-console",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "test:unit": "vitest run"
+  },
+  "dependencies": {
+    "@supabase/ssr": "^0.6.1",
+    "@supabase/supabase-js": "^2.100.1",
+    "next": "15.5.15",
+    "react": "19.0.0",
+    "react-dom": "19.0.0"
+  },
+  "devDependencies": {
+    "@tailwindcss/postcss": "^4.0.0",
+    "@testing-library/react": "^16.3.0",
+    "@types/node": "^22.14.0",
+    "@types/react": "^19.1.0",
+    "@types/react-dom": "^19.1.0",
+    "@vitejs/plugin-react": "^4.4.1",
+    "jsdom": "^26.1.0",
+    "tailwindcss": "^4.0.0",
+    "typescript": "^5.8.3",
+    "vitest": "^3.1.1"
+  }
+}

--- a/apps/agent-console/postcss.config.mjs
+++ b/apps/agent-console/postcss.config.mjs
@@ -1,0 +1,7 @@
+const config = {
+  plugins: {
+    "@tailwindcss/postcss": {},
+  },
+};
+
+export default config;

--- a/apps/agent-console/tsconfig.json
+++ b/apps/agent-console/tsconfig.json
@@ -1,0 +1,40 @@
+{
+  "compilerOptions": {
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": [
+        "./*"
+      ]
+    },
+    "target": "ES2022"
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/apps/agent-console/vitest.config.ts
+++ b/apps/agent-console/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+import { resolve } from "path";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: [],
+    include: ["**/__tests__/**/*.test.{ts,tsx}", "**/*.test.{ts,tsx}"],
+    exclude: ["node_modules", ".next"],
+  },
+  resolve: {
+    alias: {
+      "@": resolve(__dirname, "."),
+    },
+  },
+});

--- a/deploy/docker/Caddyfile.owui
+++ b/deploy/docker/Caddyfile.owui
@@ -22,6 +22,25 @@
   }
   respond @adminMutation 404
 
+  # Blueprint Step 3.1 (#311) agent console sidecar. Path-prefixed, not a
+  # subdomain, so it shares this listener and the /admin, /signup, and
+  # mutation blocks above without any new Caddy site block or cert.
+  #
+  # Collision analysis: Open WebUI has no route under /agent-workspace (its
+  # own paths are the SPA root, /api/*, /ws, and /static/*), and Caddy
+  # directives of the same name run in the order they're written in this
+  # file (documented Caddyfile behaviour for repeated directives), so this
+  # matched reverse_proxy is always evaluated -- and can intercept --
+  # before the unmatched catch-all below ever sees the request. OWUI's own
+  # websocket traffic is untouched since it lives on a different path.
+  @agentConsole path /agent-workspace/*
+  reverse_proxy @agentConsole agent-console:3000 {
+    transport http {
+      response_header_timeout 60s
+      dial_timeout 5s
+    }
+  }
+
   reverse_proxy open-webui:8080 {
     transport http {
       response_header_timeout 60s

--- a/deploy/docker/Caddyfile.owui
+++ b/deploy/docker/Caddyfile.owui
@@ -33,7 +33,12 @@
   # matched reverse_proxy is always evaluated -- and can intercept --
   # before the unmatched catch-all below ever sees the request. OWUI's own
   # websocket traffic is untouched since it lives on a different path.
-  @agentConsole path /agent-workspace/*
+  # Matches both the bare entry URL (/agent-workspace, no trailing slash --
+  # what a freshly-typed or bookmarked link looks like) and everything
+  # under it. The bare path proxies straight to the Next.js app's own root
+  # route, which (via basePath) redirects to /agent-workspace/tasks itself
+  # (apps/agent-console/app/page.tsx) -- no separate Caddy redirect needed.
+  @agentConsole path /agent-workspace /agent-workspace/*
   reverse_proxy @agentConsole agent-console:3000 {
     transport http {
       response_header_timeout 60s

--- a/deploy/docker/Dockerfile.agent-console
+++ b/deploy/docker/Dockerfile.agent-console
@@ -1,6 +1,13 @@
-# Mirrors deploy/docker/Dockerfile.web-console: plain Node dev-server image,
-# not a Cloudflare Workers build. Ships in the chat/enterprise compose
-# profiles only (see docker-compose.yml's agent-console service).
+# Production server for the chat/enterprise compose profiles -- `next
+# build` + `next start`, not `next dev` (dev mode must not run in those
+# profiles; see docker-compose.yml's agent-console service).
+#
+# NEXT_PUBLIC_* vars are inlined into the client bundle at build time by
+# Next.js (webpack DefinePlugin), not read from the container's runtime
+# environment the way EDGE_API_INTERNAL_BASE_URL is -- so they must be
+# build args here, supplied by docker-compose.yml's build.args block,
+# rather than plain `environment:` entries like the dev-mode
+# Dockerfile.web-console gets away with.
 FROM node:22-slim
 
 WORKDIR /app/apps/agent-console
@@ -10,6 +17,15 @@ RUN npm install
 
 COPY apps/agent-console/ ./
 
+ARG NEXT_PUBLIC_SUPABASE_URL
+ARG NEXT_PUBLIC_SUPABASE_ANON_KEY
+ARG NEXT_PUBLIC_EDGE_API_BASE_URL
+ENV NEXT_PUBLIC_SUPABASE_URL=$NEXT_PUBLIC_SUPABASE_URL
+ENV NEXT_PUBLIC_SUPABASE_ANON_KEY=$NEXT_PUBLIC_SUPABASE_ANON_KEY
+ENV NEXT_PUBLIC_EDGE_API_BASE_URL=$NEXT_PUBLIC_EDGE_API_BASE_URL
+
+RUN npm run build
+
 EXPOSE 3000
 
-CMD ["npm", "run", "dev", "--", "--hostname", "0.0.0.0", "--port", "3000"]
+CMD ["npm", "run", "start", "--", "--hostname", "0.0.0.0", "--port", "3000"]

--- a/deploy/docker/Dockerfile.agent-console
+++ b/deploy/docker/Dockerfile.agent-console
@@ -1,0 +1,15 @@
+# Mirrors deploy/docker/Dockerfile.web-console: plain Node dev-server image,
+# not a Cloudflare Workers build. Ships in the chat/enterprise compose
+# profiles only (see docker-compose.yml's agent-console service).
+FROM node:22-slim
+
+WORKDIR /app/apps/agent-console
+
+COPY apps/agent-console/package.json apps/agent-console/package-lock.json* ./
+RUN npm install
+
+COPY apps/agent-console/ ./
+
+EXPOSE 3000
+
+CMD ["npm", "run", "dev", "--", "--hostname", "0.0.0.0", "--port", "3000"]

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -328,6 +328,13 @@ services:
     build:
       context: ../../
       dockerfile: deploy/docker/Dockerfile.agent-console
+      # NEXT_PUBLIC_* are baked into the client bundle by `next build`
+      # (Dockerfile.agent-console runs a production build, not `next dev`),
+      # so they must travel as build args, not runtime `environment:`.
+      args:
+        NEXT_PUBLIC_SUPABASE_URL: ${NEXT_PUBLIC_SUPABASE_URL}
+        NEXT_PUBLIC_SUPABASE_ANON_KEY: ${NEXT_PUBLIC_SUPABASE_ANON_KEY}
+        NEXT_PUBLIC_EDGE_API_BASE_URL: ${NEXT_PUBLIC_EDGE_API_BASE_URL:-http://localhost:8080}
     profiles:
       - chat
       - enterprise
@@ -335,10 +342,7 @@ services:
       edge-api:
         condition: service_healthy
     environment:
-      NEXT_PUBLIC_SUPABASE_URL: ${NEXT_PUBLIC_SUPABASE_URL}
-      NEXT_PUBLIC_SUPABASE_ANON_KEY: ${NEXT_PUBLIC_SUPABASE_ANON_KEY}
       EDGE_API_INTERNAL_BASE_URL: http://edge-api:8080
-      NEXT_PUBLIC_EDGE_API_BASE_URL: ${NEXT_PUBLIC_EDGE_API_BASE_URL:-http://localhost:8080}
 
   # Hive Phase 19 — Open WebUI front-end for EnterpriseEdge and cloud chat users.
   # Profiles:

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -318,6 +318,28 @@ services:
       NEXT_PUBLIC_APP_URL: ${NEXT_PUBLIC_APP_URL:-http://localhost:3000}
       CONTROL_PLANE_BASE_URL: http://control-plane:8081
 
+  # Blueprint Step 3.1 (#311, #305) — standalone agent console sidecar.
+  # Ratified 2026-07-16: extends nothing in Open WebUI; OWUI stays a pinned
+  # upstream image. Reached only through caddy-owui's /agent-workspace/*
+  # route (Caddyfile.owui) alongside OWUI on port 3003 -- no direct host
+  # port here, same posture as open-webui below.
+  agent-console:
+    image: hive-agent-console:ci
+    build:
+      context: ../../
+      dockerfile: deploy/docker/Dockerfile.agent-console
+    profiles:
+      - chat
+      - enterprise
+    depends_on:
+      edge-api:
+        condition: service_healthy
+    environment:
+      NEXT_PUBLIC_SUPABASE_URL: ${NEXT_PUBLIC_SUPABASE_URL}
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: ${NEXT_PUBLIC_SUPABASE_ANON_KEY}
+      EDGE_API_INTERNAL_BASE_URL: http://edge-api:8080
+      NEXT_PUBLIC_EDGE_API_BASE_URL: ${NEXT_PUBLIC_EDGE_API_BASE_URL:-http://localhost:8080}
+
   # Hive Phase 19 — Open WebUI front-end for EnterpriseEdge and cloud chat users.
   # Profiles:
   #   local      - developer laptop with in-stack redis.

--- a/deploy/docker/pipelines/README-agent-console.md
+++ b/deploy/docker/pipelines/README-agent-console.md
@@ -1,0 +1,62 @@
+# Installing hive_agent_console_action.py
+
+Open WebUI Functions have no file-mount or env-var auto-load (#269): a
+Function is a database row created through the Functions REST API,
+authenticated as an OWUI admin. CI installs `hive_jwt_forward.py` this way
+in `apps/web-console/e2e/phase-19/owui/owui.setup.ts`, right after the e2e
+user's first OIDC login (Open WebUI auto-promotes the very first signed-in
+user to admin). Production and EnterpriseEdge deployments have no such CI
+step, so an admin installs `hive_agent_console_action.py` once, manually,
+after the first admin account exists.
+
+## One-time install (after the first admin signs in)
+
+Replace `$OWUI_URL` with the deployment's Open WebUI origin (e.g.
+`http://localhost:3003` behind caddy-owui) and `$OWUI_ADMIN_COOKIE` with an
+authenticated admin session cookie (copy the `token` cookie from a signed-in
+admin browser session, or script an admin login first).
+
+```bash
+OWUI_URL=http://localhost:3003
+FUNCTION_ID=hive_agent_console_action
+CONTENT=$(cat hive_agent_console_action.py)
+
+# 1. Create the function (skip if it already exists -- GET
+#    "$OWUI_URL/api/v1/functions/id/$FUNCTION_ID" first to check).
+curl -s -X POST "$OWUI_URL/api/v1/functions/create" \
+  -H "Cookie: token=$OWUI_ADMIN_COOKIE" \
+  -H "Content-Type: application/json" \
+  -d "{\"id\": \"$FUNCTION_ID\", \"name\": \"Open Agent Workspace\", \"content\": $(python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))' < hive_agent_console_action.py), \"meta\": {\"description\": \"Opens the standalone agent-console sidecar, gated on ENABLE_COWORK (#311).\"}}"
+
+# 2. Activate it.
+curl -s -X POST "$OWUI_URL/api/v1/functions/id/$FUNCTION_ID/toggle" \
+  -H "Cookie: token=$OWUI_ADMIN_COOKIE"
+
+# 3. Make it global (visible to every user, not just the admin who created it).
+curl -s -X POST "$OWUI_URL/api/v1/functions/id/$FUNCTION_ID/toggle/global" \
+  -H "Cookie: token=$OWUI_ADMIN_COOKIE"
+```
+
+All three calls are idempotent to re-run: `create` on an existing id is
+rejected harmlessly, and the two `toggle` calls just flip state (check
+`GET $OWUI_URL/api/v1/functions/id/$FUNCTION_ID` first, as
+`owui.setup.ts` does, to skip a toggle that's already in the desired
+state).
+
+## Verifying
+
+Sign in as any user, open a chat, send a message, and confirm the "Open
+Agent Workspace" action button appears under the assistant's response.
+Clicking it appends either the workspace link or a gate/session error
+message, depending on the signed-in user's `ENABLE_COWORK` state --
+see `hive_agent_console_action.py`'s module docstring for the full
+gating and event-emission behavior, and its "DISCOVERY NOTE FOR
+REVIEWERS" section for what's confirmed vs. assumed against the pinned
+OWUI image.
+
+## Automating this later
+
+Same open item as `hive_jwt_forward.py`: this manual step could be
+automated for non-CI deployments (e.g. a first-boot script that waits for
+the first admin, then runs the three calls above). Not built here --
+tracked as a follow-up, not a blocker for this PR.

--- a/deploy/docker/pipelines/hive_agent_console_action.py
+++ b/deploy/docker/pipelines/hive_agent_console_action.py
@@ -44,16 +44,24 @@ unverified upstream behaviour instead of guessing silently):
     find documented; instead the gate is checked at click time and an error
     is shown in place of the link. Functionally equivalent for the demo
     (the workspace never opens when disabled) but not a hidden button.
+  * `aiohttp` availability: not a declared dependency of this repo. Assumed
+    present because Open WebUI's own backend uses aiohttp internally for
+    its HTTP client paths, and Functions execute in the same interpreter/
+    dependency set as the main app (no separate requirements file, no
+    per-Function venv) -- not confirmed by reading the pinned image's
+    installed package list directly. If this assumption is wrong, the fix
+    is swapping to stdlib `urllib.request` in `_cowork_enabled` only; the
+    test in test_hive_agent_console_action.py exercises the real import
+    path so a bad assumption here fails loudly instead of silently
+    (see the CRITICAL bug this exact gap caused, fixed in review).
 """
 
 from __future__ import annotations
 
-import json
 import os
-import urllib.error
-import urllib.request
 from typing import Any, Awaitable, Callable, Optional
 
+import aiohttp
 from pydantic import BaseModel
 
 

--- a/deploy/docker/pipelines/hive_agent_console_action.py
+++ b/deploy/docker/pipelines/hive_agent_console_action.py
@@ -1,0 +1,136 @@
+"""
+hive_agent_console_action: Open WebUI Action function.
+
+Adds an "Open Agent Workspace" button under chat messages that hands the
+signed-in user off to the standalone agent-console sidecar (blueprint Step
+3.1, ratified 2026-07-16: a dedicated Next.js app, NOT a fork of Open
+WebUI). Gated on the tenant's ENABLE_COWORK feature flag, read live from
+edge-api's GET /v1/featuregate (added in #322 for exactly this: a
+Bearer-authenticated end user reading their own gate map).
+
+Install target (#269, same as hive_jwt_forward.py): Open WebUI's native
+Functions system (Admin > Functions), installed via the Functions REST API
+(POST /api/v1/functions/create, then POST .../toggle and .../toggle/global)
+authenticated as an OWUI admin. There is no file-mount or env-var auto-load
+-- see apps/web-console/e2e/phase-19/owui/owui.setup.ts for the reference
+installer, and README-agent-console.md in this directory for the one-time
+production/EnterpriseEdge install step (same pattern as hive_jwt_forward,
+which that README documents as a manual post-first-admin-login step until
+non-CI deployments automate it).
+
+Open WebUI detects a Function's type by class name at exec time (`Filter`,
+`Pipe`, `Action`, or `Event` -- see open_webui.utils.plugin), so the class
+below must be named exactly `Action`.
+
+DISCOVERY NOTE FOR REVIEWERS (mirrors the PR #322 pattern of flagging
+unverified upstream behaviour instead of guessing silently):
+  * `__oauth_token__` injection into `action()`: verified only by analogy
+    to hive_jwt_forward.py's `Filter.inlet`, which confirmed this parameter
+    name is injected by Open WebUI's generic special-parameter framework
+    (open_webui.utils.plugin / open_webui.utils.middleware), not by reading
+    Action-specific source. High confidence, not first-hand confirmed for
+    Action.
+  * Opening the console in a new tab: emitting a `type: "message"` event
+    to append a clickable Markdown link is the most conservative mechanism
+    that is definitely rendered by Open WebUI's chat view (it's plain
+    assistant-visible content), so that's what this file does. A "run this
+    JS in the browser" event type would give a real window.open() but its
+    exact name/shape was not confirmed against the pinned OWUI digest in
+    docker-compose.yml, so this file does not attempt it. If a reviewer
+    confirms such an event exists on the pinned image, swapping to it is a
+    small follow-up, not a redesign.
+  * Per-tenant button visibility (hiding the button entirely when the gate
+    is off) needs an Open WebUI manifest-level capability this file did not
+    find documented; instead the gate is checked at click time and an error
+    is shown in place of the link. Functionally equivalent for the demo
+    (the workspace never opens when disabled) but not a hidden button.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+from typing import Any, Awaitable, Callable, Optional
+
+from pydantic import BaseModel
+
+
+class Action:
+    class Valves(BaseModel):
+        # Same-origin default: Caddy serves the console under
+        # /agent-workspace/* on the same host:port OWUI itself answers on
+        # (see deploy/docker/Caddyfile.owui), so a relative path needs no
+        # per-deployment config. Override only if the console is ever
+        # split onto a different host.
+        console_path: str = "/agent-workspace/tasks"
+        edge_api_base_url: str = os.environ.get(
+            "EDGE_API_INTERNAL_BASE_URL", "http://edge-api:8080"
+        )
+
+    def __init__(self) -> None:
+        self.valves = self.Valves()
+
+    async def action(
+        self,
+        body: dict[str, Any],
+        __user__: Optional[dict[str, Any]] = None,
+        __oauth_token__: Optional[dict[str, Any]] = None,
+        __event_emitter__: Optional[Callable[[dict[str, Any]], Awaitable[None]]] = None,
+    ) -> Optional[dict[str, Any]]:
+        if __event_emitter__ is None:
+            return None
+
+        token = (__oauth_token__ or {}).get("access_token")
+        if not token:
+            await __event_emitter__(
+                {
+                    "type": "message",
+                    "data": {
+                        "content": "\n\n_Could not open the agent workspace: no active Hive session._\n"
+                    },
+                }
+            )
+            return None
+
+        if not await self._cowork_enabled(token):
+            await __event_emitter__(
+                {
+                    "type": "message",
+                    "data": {
+                        "content": "\n\n_The agent workspace is not enabled for your organization._\n"
+                    },
+                }
+            )
+            return None
+
+        await __event_emitter__(
+            {
+                "type": "message",
+                "data": {
+                    "content": f"\n\n[Open Agent Workspace]({self.valves.console_path})\n"
+                },
+            }
+        )
+        return None
+
+    async def _cowork_enabled(self, access_token: str) -> bool:
+        url = f"{self.valves.edge_api_base_url}/v1/featuregate"
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(
+                    url,
+                    headers={"Authorization": f"Bearer {access_token}"},
+                    timeout=aiohttp.ClientTimeout(total=5),
+                ) as resp:
+                    if resp.status != 200:
+                        return False
+                    payload = await resp.json()
+        except (aiohttp.ClientError, TimeoutError, ValueError):
+            # Fail closed, matching the Gate.Fetch posture in
+            # apps/edge-api/internal/featuregate/gate.go.
+            return False
+
+        gates = payload.get("gates") if isinstance(payload, dict) else None
+        return bool(isinstance(gates, dict) and gates.get("ENABLE_COWORK") is True)

--- a/deploy/docker/pipelines/test_hive_agent_console_action.py
+++ b/deploy/docker/pipelines/test_hive_agent_console_action.py
@@ -1,0 +1,177 @@
+"""
+Minimal, dependency-free regression test for hive_agent_console_action.py.
+
+No pytest, no real aiohttp/pydantic install required (repo has no Python
+test infra for deploy/docker/pipelines/*.py, and declares neither as a
+dependency outside the vendored OpenHands SDK -- see that file's "aiohttp
+availability" discovery note). Runs with the stdlib alone:
+
+    python3 deploy/docker/pipelines/test_hive_agent_console_action.py
+
+Fake `aiohttp` and `pydantic` modules are injected into sys.modules
+*before* importing the module under test. This is the point: if
+hive_agent_console_action.py is missing its `import aiohttp` statement (the
+exact CRITICAL bug this test was written for -- the module referenced
+aiohttp.ClientSession/ClientTimeout/ClientError without importing the
+package, so every button click raised NameError), Python's name resolution
+fails on the bare `aiohttp` reference regardless of what's sitting in
+sys.modules, and this test fails with that same NameError. A correct
+`import aiohttp` picks up the fake from the module cache and the real code
+path runs against it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+import unittest
+
+
+class _FakeResponse:
+    def __init__(self, status: int, payload: object) -> None:
+        self.status = status
+        self._payload = payload
+
+    async def json(self) -> object:
+        return self._payload
+
+    async def __aenter__(self) -> "_FakeResponse":
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        return None
+
+
+class _FakeClientError(Exception):
+    pass
+
+
+def _install_fakes() -> None:
+    aiohttp_module = types.ModuleType("aiohttp")
+
+    class ClientTimeout:
+        def __init__(self, total: float | None = None) -> None:
+            self.total = total
+
+    class ClientSession:
+        # Set by each test before use.
+        next_response: "_FakeResponse | Exception | None" = None
+
+        async def __aenter__(self) -> "ClientSession":
+            return self
+
+        async def __aexit__(self, *exc: object) -> None:
+            return None
+
+        def get(self, url: str, headers: dict[str, str], timeout: ClientTimeout):
+            resp = ClientSession.next_response
+            if isinstance(resp, Exception):
+                raise resp
+            assert resp is not None, "test must set ClientSession.next_response"
+            return resp
+
+    aiohttp_module.ClientError = _FakeClientError  # type: ignore[attr-defined]
+    aiohttp_module.ClientTimeout = ClientTimeout  # type: ignore[attr-defined]
+    aiohttp_module.ClientSession = ClientSession  # type: ignore[attr-defined]
+    sys.modules["aiohttp"] = aiohttp_module
+
+    pydantic_module = types.ModuleType("pydantic")
+
+    class BaseModel:
+        # Structural stand-in: reads class-level annotated defaults, same
+        # shape hive_agent_console_action.Action.Valves relies on (plain
+        # str defaults, no validation). Real pydantic does much more; this
+        # test only needs the no-arg-instantiation-with-defaults behavior.
+        def __init__(self, **kwargs: object) -> None:
+            for name in getattr(type(self), "__annotations__", {}):
+                setattr(self, name, kwargs.get(name, getattr(type(self), name, None)))
+
+    pydantic_module.BaseModel = BaseModel  # type: ignore[attr-defined]
+    sys.modules["pydantic"] = pydantic_module
+
+
+_install_fakes()
+
+# Import AFTER the fakes are installed, exactly once module-global (mirrors
+# how OWUI's Functions loader imports a Function module once).
+import hive_agent_console_action as hcca  # noqa: E402
+from aiohttp import ClientSession  # noqa: E402  (the fake installed above)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+class CoworkEnabledTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.action = hcca.Action()
+
+    def test_true_when_gate_on(self) -> None:
+        ClientSession.next_response = _FakeResponse(200, {"gates": {"ENABLE_COWORK": True}})
+        self.assertTrue(_run(self.action._cowork_enabled("tok")))
+
+    def test_false_when_gate_off(self) -> None:
+        ClientSession.next_response = _FakeResponse(200, {"gates": {"ENABLE_COWORK": False}})
+        self.assertFalse(_run(self.action._cowork_enabled("tok")))
+
+    def test_false_on_non_200(self) -> None:
+        ClientSession.next_response = _FakeResponse(500, {})
+        self.assertFalse(_run(self.action._cowork_enabled("tok")))
+
+    def test_false_on_client_error(self) -> None:
+        ClientSession.next_response = _FakeClientError("boom")
+        self.assertFalse(_run(self.action._cowork_enabled("tok")))
+
+    def test_false_on_malformed_payload(self) -> None:
+        ClientSession.next_response = _FakeResponse(200, {"gates": "not-a-dict"})
+        self.assertFalse(_run(self.action._cowork_enabled("tok")))
+
+
+class ActionMessageTests(unittest.TestCase):
+    def test_no_session_shows_error_and_never_calls_gate(self) -> None:
+        action = hcca.Action()
+        emitted: list[dict] = []
+
+        async def emit(event: dict) -> None:
+            emitted.append(event)
+
+        _run(action.action({}, __oauth_token__=None, __event_emitter__=emit))
+        self.assertEqual(len(emitted), 1)
+        self.assertIn("no active Hive session", emitted[0]["data"]["content"])
+
+    def test_gate_disabled_shows_error_not_link(self) -> None:
+        action = hcca.Action()
+        ClientSession.next_response = _FakeResponse(200, {"gates": {"ENABLE_COWORK": False}})
+        emitted: list[dict] = []
+
+        async def emit(event: dict) -> None:
+            emitted.append(event)
+
+        _run(
+            action.action(
+                {}, __oauth_token__={"access_token": "tok"}, __event_emitter__=emit
+            )
+        )
+        self.assertEqual(len(emitted), 1)
+        self.assertIn("not enabled", emitted[0]["data"]["content"])
+
+    def test_gate_enabled_emits_console_link(self) -> None:
+        action = hcca.Action()
+        ClientSession.next_response = _FakeResponse(200, {"gates": {"ENABLE_COWORK": True}})
+        emitted: list[dict] = []
+
+        async def emit(event: dict) -> None:
+            emitted.append(event)
+
+        _run(
+            action.action(
+                {}, __oauth_token__={"access_token": "tok"}, __event_emitter__=emit
+            )
+        )
+        self.assertEqual(len(emitted), 1)
+        self.assertIn(action.valves.console_path, emitted[0]["data"]["content"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Blueprint Step 3.1, ratified sidecar decision (2026-07-16): a dedicated agent UI panel as a **standalone Next.js app** (`apps/agent-console`), not a fork of Open WebUI. OWUI stays a pinned upstream image. The two surfaces meet only at:

- an OWUI Action function that hands the signed-in user off to the console in a new tab, and
- the edge-api endpoints both surfaces call (`GET /v1/featuregate`, `/v1/agent/tasks*`).

## What changed

- **`apps/agent-console/`**: Next.js 15 / React 19 / TypeScript 5.8 app mirroring `apps/web-console`'s stack and Supabase auth pattern (own Supabase session via `@supabase/ssr`, no cookie handoff from OWUI; edge-api validates the same Bearer JWT directly, same auth selector path any Supabase-authenticated client uses — see `apps/edge-api/internal/auth/selector.go`).
  - `/tasks` page: gated on the tenant's `ENABLE_COWORK` feature flag (server-side check against `GET /v1/featuregate`, #322), shows a "Start coding-pack task" / "Start knowledge-work-pack task" panel with a live-polling task list and per-task cancel.
  - `lib/edge-api/tasks.ts` client was built against the blueprint's assumed shapes first, then corrected mid-build once `feat/311-task-sync-web` (#329) pushed with the real contract. Notably: **create only takes `{"pack": "..."}`, there is no free-text prompt field** on this contract yet — `Engine.Launch` is a documented open seam in that PR's `SYNC_CONTRACT.md` (the only wired `Engine` is `NotConfiguredEngine`, so a submitted task stays `queued`). Status values are `queued/running/succeeded/failed/cancelled`, not `pending/completed`. The UI was adjusted to match reality rather than build a prompt field the API silently drops.
- **`deploy/docker/Dockerfile.agent-console`**: mirrors `Dockerfile.web-console`'s pattern exactly (plain `node:22-slim`, `npm install`, `next dev` in the container) rather than a production standalone build — that's what the sibling app's own Docker service does, and it's what makes `docker compose run agent-console npm run test:unit` work the same way `docker compose run web-console ...` does.
- **`deploy/docker/docker-compose.yml`**: new `agent-console` service, `chat` + `enterprise` profiles only, no direct host port (reached only through `caddy-owui`, same posture as `open-webui` itself).
- **`deploy/docker/Caddyfile.owui`**: added a `@agentConsole path /agent-workspace/*` matched `reverse_proxy` ahead of the existing catch-all `reverse_proxy open-webui:8080`. Collision analysis: OWUI has no route under `/agent-workspace` (its own paths are the SPA root, `/api/*`, websockets, `/static/*`), and Caddy evaluates same-named directives in the order they're written in the file, so the matched proxy always gets first look at the request regardless of what OWUI itself would do with that path. Validated with `caddy validate` against the pinned `caddy:2-alpine` image (output: `Valid configuration`).
- **`deploy/docker/pipelines/hive_agent_console_action.py`**: OWUI Action function ("Open Agent Workspace"), installed the same way as `hive_jwt_forward.py` (Functions REST API: `POST /api/v1/functions/create` + `.../toggle` + `.../toggle/global`, no file-mount autoload — see #269). Gates at click time on `GET /v1/featuregate`'s `ENABLE_COWORK` (fail-closed on any error, matching `Gate.Fetch`'s posture).
- **`.env.example`**: documents the two new env vars, `EDGE_API_INTERNAL_BASE_URL` (server-only, in-compose DNS) and `NEXT_PUBLIC_EDGE_API_BASE_URL` (browser-facing, must be reachable from the client's machine).

## Discovery notes for reviewers (mirrors the #322 pattern of flagging unverified upstream behaviour instead of guessing silently)

- **`__oauth_token__` injection into an `Action.action()` handler**: verified only by analogy to `hive_jwt_forward.py`'s `Filter.inlet`, which confirmed this parameter name is injected by Open WebUI's generic special-parameter framework. High confidence, not first-hand confirmed for the `Action` function type specifically against the pinned image.
- **Opening the console in a new tab**: the Action function emits a `type: "message"` event appending a clickable Markdown link, the most conservative mechanism guaranteed to render as visible chat content. A "run this JS in the browser" event type would give a real `window.open()`, but its exact name/shape was not confirmed against the pinned OWUI digest, so this PR does not attempt it. Swapping to it later is a small follow-up if a reviewer confirms it exists.
- **Per-tenant button visibility**: hiding the Action button entirely when the gate is off needs an OWUI manifest-level capability this PR did not find documented. The gate is instead checked at click time (functionally equivalent for the demo — the workspace link never appears when disabled — but not a hidden button).

## Test plan

- [x] `docker compose build agent-console` — builds clean.
- [x] `docker compose run --rm --no-deps agent-console npm run test:unit` — 21/21 tests pass across 3 files (`lib/edge-api/tasks.test.ts`, `lib/edge-api/gate.test.ts`, `components/task-console.test.tsx`), covering the task lifecycle client, the fail-closed feature-gate check, and the task list/create/cancel UI against mocked `fetch`.
- [x] `docker compose run --rm --no-deps agent-console npm run build` — `next build` compiles, typechecks, and prerenders all 5 routes clean (verified with placeholder Supabase env vars; real deployments supply real values via `--env-file`).
- [x] `caddy validate` against the pinned `caddy:2-alpine` image confirms `Caddyfile.owui` is syntactically valid after the new route.
- [ ] Live E2E against a running OWUI + agent-console + edge-api stack (out of scope here — the live control channel that would let a task actually execute lands separately per `SYNC_CONTRACT.md`'s documented Engine seam).

## Open risks

1. Task execution itself is a known, pre-existing gap upstream of this PR (`NotConfiguredEngine`) — starting a task here will show it stuck at `queued` until a real Engine lands. That's expected and documented in #329, not a bug in this PR.
2. The two "discovery notes" above (OWUI event mechanics) should be verified live against the pinned OWUI digest before the demo.