### PR TITLE
feat: host to agent-server control channel and real agent-engine

### DIFF
--- a/apps/agent-engine/cmd/agent-engine/main.go
+++ b/apps/agent-engine/cmd/agent-engine/main.go
@@ -41,6 +41,7 @@ func main() {
 	sifPath := flag.String("sif", os.Getenv("HIVE_AGENT_SIF_PATH"), "path to the built agent-server SIF")
 	workingDir := flag.String("workspace", "", "host directory bind-mounted as /workspace")
 	hostPort := flag.Int("port", 38080, "host port the agent-server listens on")
+	controlSocketDir := flag.String("control-socket-dir", "", "host directory bind-mounted for the host<->agent-server control channel (issue #305); auto-created under a temp dir when empty")
 	controlPlaneURL := flag.String("control-plane-url", envOr("CONTROL_PLANE_URL", "http://control-plane:8081"), "control-plane base URL")
 	controlPlaneToken := flag.String("control-plane-token", os.Getenv("CONTROL_PLANE_INTERNAL_TOKEN"), "shared internal-service token")
 	dryRun := flag.Bool("dry-run", false, "print the constructed apptainer argv and exit without launching")
@@ -116,6 +117,20 @@ func main() {
 	// configured.
 	mcpConfigPath := resolveMCPConfigPath(ctx, *controlPlaneURL, *controlPlaneToken, tenant, sockDir)
 
+	// Host<->agent-server control channel (issue #305): a directory, empty
+	// at launch time, bind-mounted read-write into the sandbox so the
+	// in-SIF shim can create its listening socket inside it after start.
+	// See apps/agent-engine/internal/sandbox's package doc and
+	// apps/agent-engine/internal/controlclient.
+	ctlDir := *controlSocketDir
+	if ctlDir == "" {
+		ctlDir, err = os.MkdirTemp("", "hive-agent-engine-control-*")
+		if err != nil {
+			log.Fatalf("agent-engine: could not create control socket dir: %v", err)
+		}
+		defer os.RemoveAll(ctlDir)
+	}
+
 	cfg := sandbox.LaunchConfig{
 		TenantID: tenant,
 		UserID:   user,
@@ -124,10 +139,11 @@ func main() {
 			ConfigDir:  "packs/" + *pack,
 			WorkingDir: *workingDir,
 		},
-		SIFPath:         *sifPath,
-		HostPort:        *hostPort,
-		ProxySocketPath: proxySocketPath,
-		MCPConfigPath:   mcpConfigPath,
+		SIFPath:          *sifPath,
+		HostPort:         *hostPort,
+		ProxySocketPath:  proxySocketPath,
+		ControlSocketDir: ctlDir,
+		MCPConfigPath:    mcpConfigPath,
 	}
 
 	argv, err := sandbox.BuildArgv(cfg)

--- a/apps/agent-engine/engineapi/engineapi.go
+++ b/apps/agent-engine/engineapi/engineapi.go
@@ -1,0 +1,43 @@
+// Package engineapi is the one sanctioned public door into
+// apps/agent-engine/internal/engine.SandboxEngine for other modules in this
+// repo (issue #305). Go's internal-package visibility rule is scoped to the
+// directory tree rooted at the parent of "internal" — here, anything under
+// apps/agent-engine/* — so this package (a sibling of internal/engine, not
+// itself under internal/) may import it and re-export what callers outside
+// apps/agent-engine need, while everything else in internal/ stays
+// encapsulated. apps/control-plane/internal/agentengine is the intended
+// caller: it adapts SandboxEngine to apps/control-plane/internal/agenttask's
+// Engine interface.
+//
+// Every exported name here is a type alias or trivial wrapper — no logic
+// lives in this package, only the door.
+package engineapi
+
+import "github.com/sakibsadmanshajib/hive/apps/agent-engine/internal/engine"
+
+type (
+	// Task is engine.Task.
+	Task = engine.Task
+	// Status is engine.Status.
+	Status = engine.Status
+	// Config is engine.Config.
+	Config = engine.Config
+	// SandboxEngine is engine.SandboxEngine.
+	SandboxEngine = engine.SandboxEngine
+)
+
+const (
+	StatusQueued    = engine.StatusQueued
+	StatusRunning   = engine.StatusRunning
+	StatusSucceeded = engine.StatusSucceeded
+	StatusFailed    = engine.StatusFailed
+	StatusCancelled = engine.StatusCancelled
+)
+
+// ErrUnknownSession is engine.ErrUnknownSession.
+var ErrUnknownSession = engine.ErrUnknownSession
+
+// New constructs a SandboxEngine from cfg.
+func New(cfg Config) *SandboxEngine {
+	return engine.New(cfg)
+}

--- a/apps/agent-engine/internal/controlclient/client.go
+++ b/apps/agent-engine/internal/controlclient/client.go
@@ -1,0 +1,295 @@
+// Package controlclient is the host-side HTTP client for the OpenHands
+// agent-server's REST API (vendor/openhands/openhands-agent-server), reached
+// over the Unix socket apps/agent-engine/internal/sandbox's control channel
+// bind-mounts into the sandbox (issue #305). Every route below is verified
+// against the vendored FastAPI router source, not guessed:
+//
+//   - POST /api/conversations                          - conversation_router.start_conversation
+//   - POST /api/conversations/{id}/run                  - conversation_router.run_conversation
+//   - GET  /api/conversations/{id}                       - conversation_router.get_conversation
+//   - POST /api/conversations/{id}/interrupt             - conversation_router.interrupt_conversation
+//   - GET  /api/conversations/{id}/agent_final_response  - conversation_router.get_conversation_agent_final_response
+//   - DELETE /api/conversations/{id}                     - conversation_router.delete_conversation
+//
+// (vendor/openhands/openhands-agent-server/openhands/agent_server/conversation_router.py;
+// api.py mounts conversation_router under the "/api" prefix behind the
+// check_session_api_key + require_initialized dependencies).
+//
+// Auth: the agent-server accepts an optional X-Session-API-Key header
+// (openhands/agent_server/dependencies.py: _SESSION_API_KEY_HEADER). When
+// the server has no configured session_api_keys the check passes regardless
+// of the header (openhands/agent_server/config.py); this client sends the
+// header only when SessionAPIKey is non-empty.
+package controlclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// SessionAPIKeyHeader mirrors vendor/openhands/openhands-agent-server's
+// openhands/agent_server/dependencies.py _SESSION_API_KEY_HEADER.
+const SessionAPIKeyHeader = "X-Session-API-Key"
+
+// controlBaseURL is a placeholder base URL: Client's http.Transport always
+// dials the configured Unix socket regardless of host, so the scheme/host
+// here are never actually resolved over the network.
+const controlBaseURL = "http://agent-server.control"
+
+// Client talks to one agent-server instance over a Unix socket.
+type Client struct {
+	http          *http.Client
+	sessionAPIKey string
+}
+
+// New builds a Client that dials socketPath for every request. sessionAPIKey
+// may be empty (no auth enforced server-side, e.g. local/dev).
+func New(socketPath string, sessionAPIKey string) *Client {
+	dialer := &net.Dialer{}
+	return &Client{
+		sessionAPIKey: sessionAPIKey,
+		http: &http.Client{
+			Transport: &http.Transport{
+				DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+					return dialer.DialContext(ctx, "unix", socketPath)
+				},
+			},
+		},
+	}
+}
+
+// WaitReady blocks until socketPath is dialable (the in-SIF shim has
+// created its listening socket, see apps/agent-engine/internal/sandbox's
+// package doc) or ctx is done, whichever comes first. The shim's startup
+// time is unpredictable but usually sub-second, so this retries on a short
+// fixed interval rather than anything more elaborate.
+func WaitReady(ctx context.Context, socketPath string) error {
+	dialer := &net.Dialer{}
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		conn, err := dialer.DialContext(ctx, "unix", socketPath)
+		if err == nil {
+			_ = conn.Close()
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("controlclient: control socket %s never became ready: %w", socketPath, ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
+// ExecutionStatus mirrors
+// vendor/openhands/openhands-sdk/openhands/sdk/conversation/state.py's
+// ConversationExecutionStatus enum values.
+type ExecutionStatus string
+
+const (
+	StatusIdle                   ExecutionStatus = "idle"
+	StatusRunning                ExecutionStatus = "running"
+	StatusPaused                 ExecutionStatus = "paused"
+	StatusWaitingForConfirmation ExecutionStatus = "waiting_for_confirmation"
+	StatusFinished               ExecutionStatus = "finished"
+	StatusErrored                ExecutionStatus = "error"
+	StatusStuck                  ExecutionStatus = "stuck"
+	StatusDeleting               ExecutionStatus = "deleting"
+)
+
+// Workspace is the wire shape of
+// vendor/openhands/openhands-sdk/openhands/sdk/workspace/local.py's
+// LocalWorkspace: {"kind": "LocalWorkspace", "working_dir": "..."}. kind is
+// a Pydantic DiscriminatedUnionMixin computed field equal to the class name
+// (openhands/sdk/utils/models.py DiscriminatedUnionMixin.kind).
+type Workspace struct {
+	Kind       string `json:"kind"`
+	WorkingDir string `json:"working_dir"`
+}
+
+// LocalWorkspace builds a Workspace pointing at workingDir (the sandbox's
+// fixed /workspace bind mount, see apps/agent-engine/internal/sandbox).
+func LocalWorkspace(workingDir string) Workspace {
+	return Workspace{Kind: "LocalWorkspace", WorkingDir: workingDir}
+}
+
+// TextContent mirrors
+// vendor/openhands/openhands-sdk/openhands/sdk/llm/message.py's TextContent.
+type TextContent struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// Text builds a TextContent from plain text.
+func Text(text string) TextContent {
+	return TextContent{Type: "text", Text: text}
+}
+
+// SendMessageRequest mirrors
+// vendor/openhands/openhands-sdk/openhands/sdk/conversation/request.py's
+// SendMessageRequest.
+type SendMessageRequest struct {
+	Role    string        `json:"role"`
+	Content []TextContent `json:"content"`
+	Run     bool          `json:"run"`
+}
+
+// StartConversationRequest is the subset of
+// vendor/openhands/openhands-sdk/openhands/sdk/conversation/request.py's
+// StartConversationRequest fields this client populates.
+//
+// AgentProfileID selects a server-side-resolved agent profile (LLM + tools
+// + confirmation policy); building a full inline `agent` payload here would
+// require plumbing LLM credentials through this client, which is out of
+// scope — issue #311's agenttask.Task carries no prompt or LLM/profile
+// reference yet (SYNC_CONTRACT.md), so callers of this package must resolve
+// AgentProfileID some other way until that lands. See the engine package's
+// doc comment for this known gap.
+type StartConversationRequest struct {
+	Workspace      Workspace           `json:"workspace"`
+	AgentProfileID *uuid.UUID          `json:"agent_profile_id,omitempty"`
+	InitialMessage *SendMessageRequest `json:"initial_message,omitempty"`
+}
+
+// ConversationInfo is the subset of
+// openhands/agent_server/models.py's ConversationInfo response fields this
+// client reads.
+type ConversationInfo struct {
+	ID              uuid.UUID       `json:"id"`
+	ExecutionStatus ExecutionStatus `json:"execution_status"`
+}
+
+type finalResponseBody struct {
+	Response string `json:"response"`
+}
+
+// StatusError is returned when the agent-server responds with an HTTP
+// status this client did not treat as success. Callers that need to
+// special-case a status (e.g. 409 on an already-running conversation) can
+// errors.As into this type.
+type StatusError struct {
+	StatusCode int
+	Detail     string
+}
+
+func (e *StatusError) Error() string {
+	return fmt.Sprintf("controlclient: unexpected status %d: %s", e.StatusCode, e.Detail)
+}
+
+// StartConversation calls POST /api/conversations
+// (conversation_router.start_conversation), creating a new conversation in
+// the idle state. It does not start the agent loop; call Run afterward.
+func (c *Client) StartConversation(ctx context.Context, req StartConversationRequest) (ConversationInfo, error) {
+	var info ConversationInfo
+	if err := c.doJSON(ctx, http.MethodPost, "/api/conversations", req, &info); err != nil {
+		return ConversationInfo{}, err
+	}
+	return info, nil
+}
+
+// Run calls POST /api/conversations/{id}/run
+// (conversation_router.run_conversation), starting the agent loop in the
+// background. A 409 (conversation already running) is treated as success:
+// idempotent from this client's point of view.
+func (c *Client) Run(ctx context.Context, conversationID uuid.UUID) error {
+	path := fmt.Sprintf("/api/conversations/%s/run", conversationID)
+	err := c.doJSON(ctx, http.MethodPost, path, nil, nil)
+	var statusErr *StatusError
+	if errors.As(err, &statusErr) && statusErr.StatusCode == http.StatusConflict {
+		return nil
+	}
+	return err
+}
+
+// GetConversation calls GET /api/conversations/{id}
+// (conversation_router.get_conversation) — the poll path for the
+// conversation's current execution_status.
+func (c *Client) GetConversation(ctx context.Context, conversationID uuid.UUID) (ConversationInfo, error) {
+	var info ConversationInfo
+	path := fmt.Sprintf("/api/conversations/%s", conversationID)
+	if err := c.doJSON(ctx, http.MethodGet, path, nil, &info); err != nil {
+		return ConversationInfo{}, err
+	}
+	return info, nil
+}
+
+// Interrupt calls POST /api/conversations/{id}/interrupt
+// (conversation_router.interrupt_conversation): cancels the in-flight
+// request immediately rather than waiting for it to finish (unlike pause),
+// transitioning the conversation to paused.
+func (c *Client) Interrupt(ctx context.Context, conversationID uuid.UUID) error {
+	path := fmt.Sprintf("/api/conversations/%s/interrupt", conversationID)
+	return c.doJSON(ctx, http.MethodPost, path, nil, nil)
+}
+
+// FinalResponse calls GET /api/conversations/{id}/agent_final_response
+// (conversation_router.get_conversation_agent_final_response): the agent's
+// last finish/text message, empty if none yet.
+func (c *Client) FinalResponse(ctx context.Context, conversationID uuid.UUID) (string, error) {
+	var body finalResponseBody
+	path := fmt.Sprintf("/api/conversations/%s/agent_final_response", conversationID)
+	if err := c.doJSON(ctx, http.MethodGet, path, nil, &body); err != nil {
+		return "", err
+	}
+	return body.Response, nil
+}
+
+// Delete calls DELETE /api/conversations/{id}
+// (conversation_router.delete_conversation): permanently removes the
+// conversation, freeing its resources inside the sandbox.
+func (c *Client) Delete(ctx context.Context, conversationID uuid.UUID) error {
+	path := fmt.Sprintf("/api/conversations/%s", conversationID)
+	return c.doJSON(ctx, http.MethodDelete, path, nil, nil)
+}
+
+// doJSON issues one request. body is JSON-encoded when non-nil; out is
+// JSON-decoded from the response body when non-nil. Any non-2xx status
+// becomes a *StatusError.
+func (c *Client) doJSON(ctx context.Context, method, path string, body, out any) error {
+	var reader io.Reader
+	if body != nil {
+		encoded, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("controlclient: encode request body: %w", err)
+		}
+		reader = bytes.NewReader(encoded)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, controlBaseURL+path, reader)
+	if err != nil {
+		return fmt.Errorf("controlclient: build request: %w", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if c.sessionAPIKey != "" {
+		req.Header.Set(SessionAPIKeyHeader, c.sessionAPIKey)
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("controlclient: request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		detail, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return &StatusError{StatusCode: resp.StatusCode, Detail: string(detail)}
+	}
+	if out == nil {
+		return nil
+	}
+	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+		return fmt.Errorf("controlclient: decode response: %w", err)
+	}
+	return nil
+}

--- a/apps/agent-engine/internal/controlclient/client.go
+++ b/apps/agent-engine/internal/controlclient/client.go
@@ -45,6 +45,9 @@ const SessionAPIKeyHeader = "X-Session-API-Key"
 // here are never actually resolved over the network.
 const controlBaseURL = "http://agent-server.control"
 
+// maxSuccessBodyBytes caps a 2xx response body this client decodes.
+const maxSuccessBodyBytes = 10 << 20 // 10 MiB
+
 // Client talks to one agent-server instance over a Unix socket.
 type Client struct {
 	http          *http.Client
@@ -288,7 +291,10 @@ func (c *Client) doJSON(ctx context.Context, method, path string, body, out any)
 	if out == nil {
 		return nil
 	}
-	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+	// maxSuccessBodyBytes: a conversation's own state is small JSON; capped
+	// the same way the error path already is so a misbehaving agent-server
+	// can't make this client buffer an unbounded response.
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxSuccessBodyBytes)).Decode(out); err != nil {
 		return fmt.Errorf("controlclient: decode response: %w", err)
 	}
 	return nil

--- a/apps/agent-engine/internal/controlclient/client_test.go
+++ b/apps/agent-engine/internal/controlclient/client_test.go
@@ -1,0 +1,229 @@
+package controlclient_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/sakibsadmanshajib/hive/apps/agent-engine/internal/controlclient"
+)
+
+// newFakeAgentServer starts an httptest.Server bound to a Unix socket at
+// socketPath instead of the usual TCP listener, so tests exercise the exact
+// transport apps/agent-engine/internal/sandbox's control channel uses
+// (Client.New dials socketPath directly).
+func newFakeAgentServer(t *testing.T, handler http.Handler) (socketPath string) {
+	t.Helper()
+	socketPath = filepath.Join(t.TempDir(), "agent.sock")
+	l, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen unix: %v", err)
+	}
+	srv := httptest.NewUnstartedServer(handler)
+	srv.Listener = l
+	srv.Start()
+	t.Cleanup(srv.Close)
+	return socketPath
+}
+
+func TestWaitReady_SucceedsOnceSocketExists(t *testing.T) {
+	handler := http.NewServeMux()
+	socketPath := newFakeAgentServer(t, handler)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := controlclient.WaitReady(ctx, socketPath); err != nil {
+		t.Fatalf("WaitReady: %v", err)
+	}
+}
+
+func TestWaitReady_TimesOutWhenSocketNeverAppears(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+	err := controlclient.WaitReady(ctx, filepath.Join(t.TempDir(), "never.sock"))
+	if err == nil {
+		t.Fatal("expected WaitReady to time out for a socket that never appears")
+	}
+}
+
+func TestClient_StartConversation(t *testing.T) {
+	convoID := uuid.New()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/conversations", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", r.Method)
+		}
+		var req controlclient.StartConversationRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if req.Workspace.Kind != "LocalWorkspace" || req.Workspace.WorkingDir != "/workspace" {
+			t.Fatalf("unexpected workspace in request: %+v", req.Workspace)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(controlclient.ConversationInfo{
+			ID:              convoID,
+			ExecutionStatus: controlclient.StatusIdle,
+		})
+	})
+	socketPath := newFakeAgentServer(t, mux)
+	client := controlclient.New(socketPath, "")
+
+	info, err := client.StartConversation(context.Background(), controlclient.StartConversationRequest{
+		Workspace: controlclient.LocalWorkspace("/workspace"),
+	})
+	if err != nil {
+		t.Fatalf("StartConversation: %v", err)
+	}
+	if info.ID != convoID {
+		t.Fatalf("got ID %s, want %s", info.ID, convoID)
+	}
+	if info.ExecutionStatus != controlclient.StatusIdle {
+		t.Fatalf("got status %q, want idle", info.ExecutionStatus)
+	}
+}
+
+func TestClient_Run_TreatsConflictAsSuccess(t *testing.T) {
+	convoID := uuid.New()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/conversations/"+convoID.String()+"/run", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_ = json.NewEncoder(w).Encode(map[string]string{"detail": "already running"})
+	})
+	socketPath := newFakeAgentServer(t, mux)
+	client := controlclient.New(socketPath, "")
+
+	if err := client.Run(context.Background(), convoID); err != nil {
+		t.Fatalf("expected 409 to be treated as success, got %v", err)
+	}
+}
+
+func TestClient_Run_PropagatesOtherErrors(t *testing.T) {
+	convoID := uuid.New()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/conversations/"+convoID.String()+"/run", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	socketPath := newFakeAgentServer(t, mux)
+	client := controlclient.New(socketPath, "")
+
+	err := client.Run(context.Background(), convoID)
+	if err == nil {
+		t.Fatal("expected error for 404")
+	}
+	var statusErr *controlclient.StatusError
+	if !errors.As(err, &statusErr) || statusErr.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected *StatusError with 404, got %v", err)
+	}
+}
+
+func TestClient_GetConversation(t *testing.T) {
+	convoID := uuid.New()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/conversations/"+convoID.String(), func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", r.Method)
+		}
+		_ = json.NewEncoder(w).Encode(controlclient.ConversationInfo{
+			ID:              convoID,
+			ExecutionStatus: controlclient.StatusRunning,
+		})
+	})
+	socketPath := newFakeAgentServer(t, mux)
+	client := controlclient.New(socketPath, "")
+
+	info, err := client.GetConversation(context.Background(), convoID)
+	if err != nil {
+		t.Fatalf("GetConversation: %v", err)
+	}
+	if info.ExecutionStatus != controlclient.StatusRunning {
+		t.Fatalf("got status %q, want running", info.ExecutionStatus)
+	}
+}
+
+func TestClient_Interrupt(t *testing.T) {
+	convoID := uuid.New()
+	called := false
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/conversations/"+convoID.String()+"/interrupt", func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		if r.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", r.Method)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]bool{"success": true})
+	})
+	socketPath := newFakeAgentServer(t, mux)
+	client := controlclient.New(socketPath, "")
+
+	if err := client.Interrupt(context.Background(), convoID); err != nil {
+		t.Fatalf("Interrupt: %v", err)
+	}
+	if !called {
+		t.Fatal("expected interrupt endpoint to be called")
+	}
+}
+
+func TestClient_FinalResponse(t *testing.T) {
+	convoID := uuid.New()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/conversations/"+convoID.String()+"/agent_final_response", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{"response": "done"})
+	})
+	socketPath := newFakeAgentServer(t, mux)
+	client := controlclient.New(socketPath, "")
+
+	got, err := client.FinalResponse(context.Background(), convoID)
+	if err != nil {
+		t.Fatalf("FinalResponse: %v", err)
+	}
+	if got != "done" {
+		t.Fatalf("got %q, want %q", got, "done")
+	}
+}
+
+func TestClient_SendsSessionAPIKeyHeaderWhenSet(t *testing.T) {
+	convoID := uuid.New()
+	var gotHeader string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/conversations/"+convoID.String(), func(w http.ResponseWriter, r *http.Request) {
+		gotHeader = r.Header.Get(controlclient.SessionAPIKeyHeader)
+		_ = json.NewEncoder(w).Encode(controlclient.ConversationInfo{ID: convoID})
+	})
+	socketPath := newFakeAgentServer(t, mux)
+	client := controlclient.New(socketPath, "secret-key")
+
+	if _, err := client.GetConversation(context.Background(), convoID); err != nil {
+		t.Fatalf("GetConversation: %v", err)
+	}
+	if gotHeader != "secret-key" {
+		t.Fatalf("got %s header %q, want %q", controlclient.SessionAPIKeyHeader, gotHeader, "secret-key")
+	}
+}
+
+func TestClient_OmitsSessionAPIKeyHeaderWhenEmpty(t *testing.T) {
+	convoID := uuid.New()
+	var sawHeader bool
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/conversations/"+convoID.String(), func(w http.ResponseWriter, r *http.Request) {
+		_, sawHeader = r.Header[controlclient.SessionAPIKeyHeader]
+		_ = json.NewEncoder(w).Encode(controlclient.ConversationInfo{ID: convoID})
+	})
+	socketPath := newFakeAgentServer(t, mux)
+	client := controlclient.New(socketPath, "")
+
+	if _, err := client.GetConversation(context.Background(), convoID); err != nil {
+		t.Fatalf("GetConversation: %v", err)
+	}
+	if sawHeader {
+		t.Fatal("expected no session API key header when Client was constructed with an empty key")
+	}
+}

--- a/apps/agent-engine/internal/engine/engine.go
+++ b/apps/agent-engine/internal/engine/engine.go
@@ -99,7 +99,11 @@ type Config struct {
 	// conversation uses (see the package doc's "known gap" section).
 	AgentProfileID uuid.UUID
 
-	// SessionAPIKey, when set, is sent as controlclient.SessionAPIKeyHeader.
+	// SessionAPIKey, when set, is both passed to the sandbox
+	// (sandbox.LaunchConfig.SessionAPIKey, actually enforced server-side)
+	// and sent by the control client as controlclient.SessionAPIKeyHeader.
+	// Optional: empty means the control socket's filesystem permissions are
+	// the only trust boundary.
 	SessionAPIKey string
 
 	// ControlReadyTimeout bounds how long Launch waits for the in-SIF shim
@@ -147,6 +151,8 @@ type session struct {
 	proc           process
 	proxySrv       *http.Server
 	proxyListener  net.Listener
+	sessionDir     string // removed on Cancel; holds only Unix sockets
+	workingDir     string // removed on Cancel; the sandbox's /workspace bind mount
 }
 
 // SandboxEngine launches, polls, and cancels agent-engine sandbox sessions.
@@ -209,6 +215,29 @@ func (e *SandboxEngine) Launch(ctx context.Context, t Task) (sessionRef string, 
 	}
 	controlDir := filepath.Join(sessionDir, "c")
 	workingDir := filepath.Join(e.cfg.WorkspaceRoot, t.ID.String())
+
+	// Single deferred cleanup for every failure branch below: closes
+	// whatever got started so far and removes both directories. succeeded
+	// flips true only on the return at the very end of this function.
+	var (
+		proxySrv *http.Server
+		proc     process
+	)
+	succeeded := false
+	defer func() {
+		if succeeded {
+			return
+		}
+		if proc != nil {
+			_ = proc.Kill()
+		}
+		if proxySrv != nil {
+			_ = proxySrv.Close()
+		}
+		_ = os.RemoveAll(sessionDir)
+		_ = os.RemoveAll(workingDir)
+	}()
+
 	for _, dir := range []string{controlDir, workingDir} {
 		if err := os.MkdirAll(dir, 0o700); err != nil {
 			return "", fmt.Errorf("engine: create session directory %s: %w", dir, err)
@@ -220,16 +249,11 @@ func (e *SandboxEngine) Launch(ctx context.Context, t Task) (sessionRef string, 
 	if err != nil {
 		return "", fmt.Errorf("engine: start egress proxy listener: %w", err)
 	}
-	proxySrv := &http.Server{Handler: egressproxy.New(allowedHosts)}
+	proxySrv = &http.Server{Handler: egressproxy.New(allowedHosts)}
 	go func() { _ = proxySrv.Serve(proxyListener) }()
-
-	cleanupProxy := func() {
-		_ = proxySrv.Close()
-	}
 
 	hostPort, err := freePort()
 	if err != nil {
-		cleanupProxy()
 		return "", err
 	}
 
@@ -245,17 +269,16 @@ func (e *SandboxEngine) Launch(ctx context.Context, t Task) (sessionRef string, 
 		HostPort:         hostPort,
 		ProxySocketPath:  egressSocketPath,
 		ControlSocketDir: controlDir,
+		SessionAPIKey:    e.cfg.SessionAPIKey,
 	}
 
 	argv, err := sandbox.BuildArgv(lc)
 	if err != nil {
-		cleanupProxy()
 		return "", fmt.Errorf("engine: build sandbox argv: %w", err)
 	}
 
-	proc, err := e.start(argv)
+	proc, err = e.start(argv)
 	if err != nil {
-		cleanupProxy()
 		return "", err
 	}
 
@@ -263,8 +286,6 @@ func (e *SandboxEngine) Launch(ctx context.Context, t Task) (sessionRef string, 
 	defer cancel()
 	controlSocketPath := sandbox.ControlSocketPath(lc)
 	if err := controlclient.WaitReady(readyCtx, controlSocketPath); err != nil {
-		_ = proc.Kill()
-		cleanupProxy()
 		return "", err
 	}
 
@@ -282,13 +303,9 @@ func (e *SandboxEngine) Launch(ctx context.Context, t Task) (sessionRef string, 
 	}
 	convo, err := client.StartConversation(ctx, req)
 	if err != nil {
-		_ = proc.Kill()
-		cleanupProxy()
 		return "", fmt.Errorf("engine: start conversation: %w", err)
 	}
 	if err := client.Run(ctx, convo.ID); err != nil {
-		_ = proc.Kill()
-		cleanupProxy()
 		return "", fmt.Errorf("engine: run conversation: %w", err)
 	}
 
@@ -298,11 +315,14 @@ func (e *SandboxEngine) Launch(ctx context.Context, t Task) (sessionRef string, 
 		proc:           proc,
 		proxySrv:       proxySrv,
 		proxyListener:  proxyListener,
+		sessionDir:     sessionDir,
+		workingDir:     workingDir,
 	}
 	e.mu.Lock()
 	e.sessions[convo.ID.String()] = sess
 	e.mu.Unlock()
 
+	succeeded = true
 	return convo.ID.String(), nil
 }
 
@@ -354,6 +374,8 @@ func (e *SandboxEngine) Cancel(ctx context.Context, sessionRef string) error {
 	interruptErr := sess.client.Interrupt(ctx, id)
 	killErr := sess.proc.Kill()
 	_ = sess.proxySrv.Close()
+	_ = os.RemoveAll(sess.sessionDir)
+	_ = os.RemoveAll(sess.workingDir)
 
 	e.mu.Lock()
 	delete(e.sessions, sessionRef)

--- a/apps/agent-engine/internal/engine/engine.go
+++ b/apps/agent-engine/internal/engine/engine.go
@@ -1,0 +1,383 @@
+// Package engine composes apps/agent-engine/internal/sandbox (the Apptainer
+// launcher) and apps/agent-engine/internal/controlclient (the host<->agent-
+// server control channel, issue #305) into one Launch/Status/Cancel session
+// lifecycle: SandboxEngine.Launch starts a sandbox, waits for its control
+// socket to come up, and submits the task; Status polls the agent-server's
+// conversation state and maps it onto the queued/running/succeeded/failed/
+// cancelled vocabulary apps/control-plane/internal/agenttask's
+// SYNC_CONTRACT.md defines; Cancel interrupts the conversation and
+// terminates the sandbox process.
+//
+// This package does not implement agenttask.Engine directly, and cannot:
+// agenttask lives under apps/control-plane/internal (a different Go
+// module), and Go's internal-package visibility does not cross module
+// boundaries — apps/agent-engine/internal/egressclient documents the exact
+// same limitation and works around it by redeclaring the one constant it
+// needs rather than importing across the boundary. SandboxEngine's Task and
+// Status types below deliberately mirror agenttask.Task and agenttask.Status
+// field-for-field for the same reason. Once issue #311's agenttask package
+// merges, control-plane's own Engine adapter wraps a *SandboxEngine: it
+// translates agenttask.Task -> engine.Task on the way in and the Launch
+// return value plus subsequent Status polls back onto agenttask.Status /
+// EngineSessionRef / ResultSummaryRef / ErrorMessage on the way out. That
+// adapter is a thin (~20 line) translation layer, not duplicated business
+// logic — the actual launch/poll/cancel logic lives here, once.
+//
+// Known gap this package does not attempt to close: agenttask.Task (as of
+// issue #311) carries no prompt or LLM/agent-profile reference, only an ID
+// and a Pack. Launch therefore starts every conversation against
+// Config.AgentProfileID, one profile shared by the whole engine instance
+// (ponytail: no per-task profile selection exists to wire yet; add a
+// per-task profile lookup once agenttask or a sibling table carries one).
+package engine
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/sakibsadmanshajib/hive/apps/agent-engine/internal/controlclient"
+	"github.com/sakibsadmanshajib/hive/apps/agent-engine/internal/egressproxy"
+	"github.com/sakibsadmanshajib/hive/apps/agent-engine/internal/sandbox"
+)
+
+// Task is the minimal shape SandboxEngine needs from a queued task. It
+// mirrors apps/control-plane/internal/agenttask.Task's ID/TenantID/UserID/
+// Pack fields (see the package doc for why it cannot just be that type).
+type Task struct {
+	ID           uuid.UUID
+	TenantID     uuid.UUID
+	UserID       uuid.UUID
+	Pack         string
+	Instructions string // free-text prompt/goal; empty means no initial message is sent
+}
+
+// Status mirrors apps/control-plane/internal/agenttask.Status's values
+// (SYNC_CONTRACT.md's state machine).
+type Status string
+
+const (
+	StatusQueued    Status = "queued"
+	StatusRunning   Status = "running"
+	StatusSucceeded Status = "succeeded"
+	StatusFailed    Status = "failed"
+	StatusCancelled Status = "cancelled"
+)
+
+// ErrUnknownSession is returned by Status/Cancel when sessionRef does not
+// match a session this SandboxEngine instance launched. Sessions are held
+// in memory only (ponytail: no disk-persisted session registry — a process
+// restart loses the ability to Status/Cancel an in-flight session, but the
+// sandbox process is a child of this one and would not survive the restart
+// either, so persistence buys nothing until sandbox processes outlive this
+// process; add a registry if/when that changes).
+var ErrUnknownSession = fmt.Errorf("engine: unknown session reference")
+
+// Config is the per-process configuration shared by every session a
+// SandboxEngine launches.
+type Config struct {
+	SIFPath       string // built agent-server SIF (HIVE_AGENT_SIF_PATH)
+	PacksDir      string // parent dir of "<pack>/" AGENTS.md config dirs, e.g. "packs"
+	WorkspaceRoot string // parent dir; each session gets WorkspaceRoot/<task-id> as its /workspace bind mount
+	RunDir        string // parent dir for per-session egress+control socket dirs
+
+	// ResolveEgressHosts resolves the effective egress allowlist for a
+	// tenant/user (apps/agent-engine/internal/egressclient.Client.Effective
+	// has this exact signature). A returned error fails the launch outright
+	// rather than launching with an unknown policy.
+	ResolveEgressHosts func(ctx context.Context, tenantID, userID uuid.UUID) ([]string, error)
+
+	// AgentProfileID is the server-side agent profile every launched
+	// conversation uses (see the package doc's "known gap" section).
+	AgentProfileID uuid.UUID
+
+	// SessionAPIKey, when set, is sent as controlclient.SessionAPIKeyHeader.
+	SessionAPIKey string
+
+	// ControlReadyTimeout bounds how long Launch waits for the in-SIF shim
+	// to create its control socket. Defaults to 30s.
+	ControlReadyTimeout time.Duration
+}
+
+func (c Config) withDefaults() Config {
+	if c.ControlReadyTimeout <= 0 {
+		c.ControlReadyTimeout = 30 * time.Second
+	}
+	return c
+}
+
+// process abstracts the running sandbox subprocess so tests can substitute
+// a fake that never actually execs apptainer.
+type process interface {
+	Kill() error
+}
+
+type osProcess struct{ cmd *exec.Cmd }
+
+func (p *osProcess) Kill() error {
+	if p.cmd.Process == nil {
+		return nil
+	}
+	return p.cmd.Process.Kill()
+}
+
+// realStart execs argv (sandbox.BuildArgv's output) as a background
+// subprocess.
+func realStart(argv []string) (process, error) {
+	cmd := exec.Command(argv[0], argv[1:]...) // #nosec G204 -- argv is built entirely by sandbox.BuildArgv from validated, non-shell-interpreted config
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("engine: start sandbox process: %w", err)
+	}
+	return &osProcess{cmd: cmd}, nil
+}
+
+type session struct {
+	conversationID uuid.UUID
+	client         *controlclient.Client
+	proc           process
+	proxySrv       *http.Server
+	proxyListener  net.Listener
+}
+
+// SandboxEngine launches, polls, and cancels agent-engine sandbox sessions.
+// The zero value is not usable; construct with New.
+type SandboxEngine struct {
+	cfg   Config
+	start func(argv []string) (process, error)
+
+	mu       sync.Mutex
+	sessions map[string]*session
+}
+
+// New constructs a SandboxEngine from cfg.
+func New(cfg Config) *SandboxEngine {
+	return &SandboxEngine{
+		cfg:      cfg.withDefaults(),
+		start:    realStart,
+		sessions: make(map[string]*session),
+	}
+}
+
+// freePort asks the OS for an ephemeral TCP port and immediately releases
+// it, for use as the agent-server's --port. Racy in theory (another process
+// could grab it first) but standard practice for this and acceptable here:
+// the window is a few milliseconds before apptainer binds it.
+func freePort() (int, error) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, fmt.Errorf("engine: allocate free port: %w", err)
+	}
+	defer func() { _ = l.Close() }()
+	return l.Addr().(*net.TCPAddr).Port, nil
+}
+
+// Launch starts a sandbox session for t: stands up the egress proxy,
+// builds and starts the Apptainer sandbox (apps/agent-engine/internal/
+// sandbox), waits for the in-SIF shim's control socket to come up, then
+// submits and runs the conversation over that socket. The returned
+// sessionRef (the agent-server's conversation id) is what Status/Cancel
+// take.
+func (e *SandboxEngine) Launch(ctx context.Context, t Task) (sessionRef string, err error) {
+	if t.Pack == "" {
+		return "", fmt.Errorf("engine: Task.Pack is required")
+	}
+
+	allowedHosts, err := e.cfg.ResolveEgressHosts(ctx, t.TenantID, t.UserID)
+	if err != nil {
+		return "", fmt.Errorf("engine: resolve egress policy, refusing to launch: %w", err)
+	}
+
+	// sessionDir deliberately does NOT embed t.ID (a 36-char UUID): it only
+	// ever holds Unix domain sockets, whose sun_path is capped at ~108
+	// bytes on Linux, so os.MkdirTemp's short auto-generated name is used
+	// instead of anything human-readable. workingDir has no such
+	// constraint (a regular bind-mounted directory, not a socket path) and
+	// keeps the task ID for operator readability.
+	sessionDir, err := os.MkdirTemp(e.cfg.RunDir, "")
+	if err != nil {
+		return "", fmt.Errorf("engine: create session directory under %s: %w", e.cfg.RunDir, err)
+	}
+	controlDir := filepath.Join(sessionDir, "c")
+	workingDir := filepath.Join(e.cfg.WorkspaceRoot, t.ID.String())
+	for _, dir := range []string{controlDir, workingDir} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			return "", fmt.Errorf("engine: create session directory %s: %w", dir, err)
+		}
+	}
+
+	egressSocketPath := filepath.Join(sessionDir, "e.sock")
+	proxyListener, err := net.Listen("unix", egressSocketPath)
+	if err != nil {
+		return "", fmt.Errorf("engine: start egress proxy listener: %w", err)
+	}
+	proxySrv := &http.Server{Handler: egressproxy.New(allowedHosts)}
+	go func() { _ = proxySrv.Serve(proxyListener) }()
+
+	cleanupProxy := func() {
+		_ = proxySrv.Close()
+	}
+
+	hostPort, err := freePort()
+	if err != nil {
+		cleanupProxy()
+		return "", err
+	}
+
+	lc := sandbox.LaunchConfig{
+		TenantID: t.TenantID,
+		UserID:   t.UserID,
+		Pack: sandbox.Pack{
+			Name:       t.Pack,
+			ConfigDir:  filepath.Join(e.cfg.PacksDir, t.Pack),
+			WorkingDir: workingDir,
+		},
+		SIFPath:          e.cfg.SIFPath,
+		HostPort:         hostPort,
+		ProxySocketPath:  egressSocketPath,
+		ControlSocketDir: controlDir,
+	}
+
+	argv, err := sandbox.BuildArgv(lc)
+	if err != nil {
+		cleanupProxy()
+		return "", fmt.Errorf("engine: build sandbox argv: %w", err)
+	}
+
+	proc, err := e.start(argv)
+	if err != nil {
+		cleanupProxy()
+		return "", err
+	}
+
+	readyCtx, cancel := context.WithTimeout(ctx, e.cfg.ControlReadyTimeout)
+	defer cancel()
+	controlSocketPath := sandbox.ControlSocketPath(lc)
+	if err := controlclient.WaitReady(readyCtx, controlSocketPath); err != nil {
+		_ = proc.Kill()
+		cleanupProxy()
+		return "", err
+	}
+
+	client := controlclient.New(controlSocketPath, e.cfg.SessionAPIKey)
+	profileID := e.cfg.AgentProfileID
+	req := controlclient.StartConversationRequest{
+		Workspace:      controlclient.LocalWorkspace("/workspace"),
+		AgentProfileID: &profileID,
+	}
+	if t.Instructions != "" {
+		req.InitialMessage = &controlclient.SendMessageRequest{
+			Role:    "user",
+			Content: []controlclient.TextContent{controlclient.Text(t.Instructions)},
+		}
+	}
+	convo, err := client.StartConversation(ctx, req)
+	if err != nil {
+		_ = proc.Kill()
+		cleanupProxy()
+		return "", fmt.Errorf("engine: start conversation: %w", err)
+	}
+	if err := client.Run(ctx, convo.ID); err != nil {
+		_ = proc.Kill()
+		cleanupProxy()
+		return "", fmt.Errorf("engine: run conversation: %w", err)
+	}
+
+	sess := &session{
+		conversationID: convo.ID,
+		client:         client,
+		proc:           proc,
+		proxySrv:       proxySrv,
+		proxyListener:  proxyListener,
+	}
+	e.mu.Lock()
+	e.sessions[convo.ID.String()] = sess
+	e.mu.Unlock()
+
+	return convo.ID.String(), nil
+}
+
+// Status polls sessionRef's current state and maps it onto the
+// queued/running/succeeded/failed/cancelled vocabulary
+// apps/control-plane/internal/agenttask's SYNC_CONTRACT.md defines.
+// resultSummary is populated only when status is StatusSucceeded;
+// errMessage only when StatusFailed.
+func (e *SandboxEngine) Status(ctx context.Context, sessionRef string) (status Status, resultSummary, errMessage string, err error) {
+	sess, id, err := e.lookup(sessionRef)
+	if err != nil {
+		return "", "", "", err
+	}
+
+	info, err := sess.client.GetConversation(ctx, id)
+	if err != nil {
+		return "", "", "", fmt.Errorf("engine: get conversation: %w", err)
+	}
+
+	switch info.ExecutionStatus {
+	case controlclient.StatusFinished:
+		summary, err := sess.client.FinalResponse(ctx, id)
+		if err != nil {
+			return "", "", "", fmt.Errorf("engine: get final response: %w", err)
+		}
+		return StatusSucceeded, summary, "", nil
+	case controlclient.StatusErrored, controlclient.StatusStuck:
+		return StatusFailed, "", fmt.Sprintf("agent-server execution_status=%s", info.ExecutionStatus), nil
+	case controlclient.StatusPaused, controlclient.StatusDeleting:
+		// paused only ever happens via this package's own Cancel today
+		// (ponytail: an externally-triggered pause would also read as
+		// cancelled here — no other component pauses a conversation yet).
+		return StatusCancelled, "", "", nil
+	case controlclient.StatusIdle:
+		return StatusQueued, "", "", nil
+	default: // running, waiting_for_confirmation, or a future value
+		return StatusRunning, "", "", nil
+	}
+}
+
+// Cancel interrupts sessionRef's conversation and terminates its sandbox
+// process, freeing the session's resources.
+func (e *SandboxEngine) Cancel(ctx context.Context, sessionRef string) error {
+	sess, id, err := e.lookup(sessionRef)
+	if err != nil {
+		return err
+	}
+
+	interruptErr := sess.client.Interrupt(ctx, id)
+	killErr := sess.proc.Kill()
+	_ = sess.proxySrv.Close()
+
+	e.mu.Lock()
+	delete(e.sessions, sessionRef)
+	e.mu.Unlock()
+
+	if interruptErr != nil {
+		return fmt.Errorf("engine: interrupt conversation: %w", interruptErr)
+	}
+	if killErr != nil {
+		return fmt.Errorf("engine: kill sandbox process: %w", killErr)
+	}
+	return nil
+}
+
+func (e *SandboxEngine) lookup(sessionRef string) (*session, uuid.UUID, error) {
+	id, err := uuid.Parse(sessionRef)
+	if err != nil {
+		return nil, uuid.Nil, fmt.Errorf("%w: %s", ErrUnknownSession, sessionRef)
+	}
+	e.mu.Lock()
+	sess, ok := e.sessions[sessionRef]
+	e.mu.Unlock()
+	if !ok {
+		return nil, uuid.Nil, fmt.Errorf("%w: %s", ErrUnknownSession, sessionRef)
+	}
+	return sess, id, nil
+}

--- a/apps/agent-engine/internal/engine/engine_test.go
+++ b/apps/agent-engine/internal/engine/engine_test.go
@@ -1,0 +1,389 @@
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/sakibsadmanshajib/hive/apps/agent-engine/internal/controlclient"
+	"github.com/sakibsadmanshajib/hive/apps/agent-engine/internal/sandbox"
+)
+
+// fakeAgentServer stands in for the real OpenHands agent-server (Python,
+// unavailable in this test environment) behind the control socket, so
+// SandboxEngine's control-channel wiring is exercised without Apptainer.
+// It also implements process, acting as the fake sandbox subprocess's
+// handle: Kill tears down the fake server the same way killing the real
+// sandbox process would take the agent-server down with it.
+type fakeAgentServer struct {
+	mu              sync.Mutex
+	conversationID  uuid.UUID
+	executionStatus controlclient.ExecutionStatus
+	finalResponse   string
+	ran             bool
+	interrupted     bool
+	killed          bool
+	startReq        controlclient.StartConversationRequest
+
+	listener net.Listener
+	srv      *http.Server
+}
+
+func newFakeAgentServer(controlDir string) (*fakeAgentServer, error) {
+	f := &fakeAgentServer{
+		conversationID:  uuid.New(),
+		executionStatus: controlclient.StatusIdle,
+	}
+	l, err := net.Listen("unix", filepath.Join(controlDir, sandbox.ControlSocketFileName))
+	if err != nil {
+		return nil, err
+	}
+	f.listener = l
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/conversations", func(w http.ResponseWriter, r *http.Request) {
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		_ = json.NewDecoder(r.Body).Decode(&f.startReq)
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(controlclient.ConversationInfo{
+			ID:              f.conversationID,
+			ExecutionStatus: f.executionStatus,
+		})
+	})
+	convoPrefix := "/api/conversations/" + f.conversationID.String()
+	mux.HandleFunc(convoPrefix+"/run", func(w http.ResponseWriter, r *http.Request) {
+		f.mu.Lock()
+		f.ran = true
+		f.executionStatus = controlclient.StatusRunning
+		f.mu.Unlock()
+		_ = json.NewEncoder(w).Encode(map[string]bool{"success": true})
+	})
+	mux.HandleFunc(convoPrefix+"/interrupt", func(w http.ResponseWriter, r *http.Request) {
+		f.mu.Lock()
+		f.interrupted = true
+		f.executionStatus = controlclient.StatusPaused
+		f.mu.Unlock()
+		_ = json.NewEncoder(w).Encode(map[string]bool{"success": true})
+	})
+	mux.HandleFunc(convoPrefix+"/agent_final_response", func(w http.ResponseWriter, r *http.Request) {
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		_ = json.NewEncoder(w).Encode(map[string]string{"response": f.finalResponse})
+	})
+	mux.HandleFunc(convoPrefix, func(w http.ResponseWriter, r *http.Request) {
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		_ = json.NewEncoder(w).Encode(controlclient.ConversationInfo{
+			ID:              f.conversationID,
+			ExecutionStatus: f.executionStatus,
+		})
+	})
+
+	f.srv = &http.Server{Handler: mux}
+	go func() { _ = f.srv.Serve(l) }()
+	return f, nil
+}
+
+func (f *fakeAgentServer) setStatus(s controlclient.ExecutionStatus) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.executionStatus = s
+}
+
+func (f *fakeAgentServer) setFinalResponse(s string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.finalResponse = s
+}
+
+func (f *fakeAgentServer) wasRun() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.ran
+}
+
+func (f *fakeAgentServer) wasInterrupted() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.interrupted
+}
+
+func (f *fakeAgentServer) wasKilled() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.killed
+}
+
+func (f *fakeAgentServer) startConversationRequest() controlclient.StartConversationRequest {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.startReq
+}
+
+func (f *fakeAgentServer) Kill() error {
+	f.mu.Lock()
+	f.killed = true
+	f.mu.Unlock()
+	return f.srv.Close()
+}
+
+// extractControlDir recovers the host-side control socket directory Launch
+// passed to sandbox.BuildArgv, by finding the --bind pair whose container
+// target is sandbox.ControlSocketContainerDir. Mirrors how the real in-SIF
+// shim would learn nothing from argv at all (it only knows its own fixed
+// container-side path) — this is test-only plumbing to let the fake stand
+// in for both the shim and the agent-server behind it.
+func extractControlDir(argv []string) (string, error) {
+	suffix := ":" + sandbox.ControlSocketContainerDir
+	for _, a := range argv {
+		if strings.HasSuffix(a, suffix) {
+			return strings.TrimSuffix(a, suffix), nil
+		}
+	}
+	return "", fmt.Errorf("test: no control socket bind found in argv: %v", argv)
+}
+
+// shortTempDir creates a temp directory with a short auto-generated name
+// directly under os.TempDir(), not nested under t.TempDir()'s test-name-
+// derived path: Config.RunDir only ever holds Unix domain sockets, whose
+// sun_path is capped at ~108 bytes on Linux, and a long test function name
+// nested several directories deep blows that budget in practice.
+func shortTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
+func newTestEngine(t *testing.T, captured **fakeAgentServer) *SandboxEngine {
+	t.Helper()
+	cfg := Config{
+		SIFPath:       "/fake/agent-server.sif",
+		PacksDir:      t.TempDir(),
+		WorkspaceRoot: t.TempDir(),
+		RunDir:        shortTempDir(t),
+		ResolveEgressHosts: func(ctx context.Context, tenantID, userID uuid.UUID) ([]string, error) {
+			return nil, nil
+		},
+		AgentProfileID:      uuid.New(),
+		ControlReadyTimeout: 5 * time.Second,
+	}
+	e := New(cfg)
+	e.start = func(argv []string) (process, error) {
+		controlDir, err := extractControlDir(argv)
+		if err != nil {
+			return nil, err
+		}
+		f, err := newFakeAgentServer(controlDir)
+		if err != nil {
+			return nil, err
+		}
+		*captured = f
+		return f, nil
+	}
+	return e
+}
+
+func testTask() Task {
+	return Task{ID: uuid.New(), TenantID: uuid.New(), UserID: uuid.New(), Pack: "coding-pack"}
+}
+
+func TestSandboxEngine_Launch_StartsAndRunsConversation(t *testing.T) {
+	var fake *fakeAgentServer
+	e := newTestEngine(t, &fake)
+
+	sessionRef, err := e.Launch(context.Background(), testTask())
+	if err != nil {
+		t.Fatalf("Launch: %v", err)
+	}
+	if _, err := uuid.Parse(sessionRef); err != nil {
+		t.Fatalf("expected sessionRef to be a UUID, got %q: %v", sessionRef, err)
+	}
+	if !fake.wasRun() {
+		t.Fatal("expected Launch to call POST .../run")
+	}
+}
+
+func TestSandboxEngine_Launch_PassesInstructionsAsInitialMessage(t *testing.T) {
+	var fake *fakeAgentServer
+	e := newTestEngine(t, &fake)
+
+	task := testTask()
+	task.Instructions = "Skill: refactor\nClean up the auth module."
+	if _, err := e.Launch(context.Background(), task); err != nil {
+		t.Fatalf("Launch: %v", err)
+	}
+
+	req := fake.startConversationRequest()
+	if req.InitialMessage == nil {
+		t.Fatal("expected StartConversation to carry an initial_message")
+	}
+	if len(req.InitialMessage.Content) != 1 || req.InitialMessage.Content[0].Text != task.Instructions {
+		t.Fatalf("got initial_message content %+v, want text %q", req.InitialMessage.Content, task.Instructions)
+	}
+}
+
+func TestSandboxEngine_Launch_OmitsInitialMessageWhenNoInstructions(t *testing.T) {
+	var fake *fakeAgentServer
+	e := newTestEngine(t, &fake)
+
+	if _, err := e.Launch(context.Background(), testTask()); err != nil {
+		t.Fatalf("Launch: %v", err)
+	}
+
+	if req := fake.startConversationRequest(); req.InitialMessage != nil {
+		t.Fatalf("expected no initial_message when Task.Instructions is empty, got %+v", req.InitialMessage)
+	}
+}
+
+func TestSandboxEngine_Launch_RequiresPack(t *testing.T) {
+	var fake *fakeAgentServer
+	e := newTestEngine(t, &fake)
+
+	task := testTask()
+	task.Pack = ""
+	if _, err := e.Launch(context.Background(), task); err == nil {
+		t.Fatal("expected error for empty Task.Pack")
+	}
+	if fake != nil {
+		t.Fatal("expected no sandbox process to start for an invalid task")
+	}
+}
+
+func TestSandboxEngine_Launch_FailsClosedWhenEgressResolutionFails(t *testing.T) {
+	e := New(Config{
+		SIFPath:       "/fake/agent-server.sif",
+		PacksDir:      t.TempDir(),
+		WorkspaceRoot: t.TempDir(),
+		RunDir:        t.TempDir(),
+		ResolveEgressHosts: func(ctx context.Context, tenantID, userID uuid.UUID) ([]string, error) {
+			return nil, errors.New("control-plane unreachable")
+		},
+	})
+	started := false
+	e.start = func(argv []string) (process, error) {
+		started = true
+		return nil, nil
+	}
+
+	if _, err := e.Launch(context.Background(), testTask()); err == nil {
+		t.Fatal("expected Launch to fail closed when egress policy cannot be resolved")
+	}
+	if started {
+		t.Fatal("expected sandbox not to start when egress policy resolution fails")
+	}
+}
+
+func TestSandboxEngine_Status_MapsFinishedToSucceeded(t *testing.T) {
+	var fake *fakeAgentServer
+	e := newTestEngine(t, &fake)
+	sessionRef, err := e.Launch(context.Background(), testTask())
+	if err != nil {
+		t.Fatalf("Launch: %v", err)
+	}
+
+	fake.setStatus(controlclient.StatusFinished)
+	fake.setFinalResponse("all done")
+
+	status, summary, errMsg, err := e.Status(context.Background(), sessionRef)
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if status != StatusSucceeded {
+		t.Fatalf("got status %q, want %q", status, StatusSucceeded)
+	}
+	if summary != "all done" {
+		t.Fatalf("got summary %q, want %q", summary, "all done")
+	}
+	if errMsg != "" {
+		t.Fatalf("expected no error message on success, got %q", errMsg)
+	}
+}
+
+func TestSandboxEngine_Status_MapsErrorToFailed(t *testing.T) {
+	var fake *fakeAgentServer
+	e := newTestEngine(t, &fake)
+	sessionRef, err := e.Launch(context.Background(), testTask())
+	if err != nil {
+		t.Fatalf("Launch: %v", err)
+	}
+
+	fake.setStatus(controlclient.StatusErrored)
+
+	status, _, errMsg, err := e.Status(context.Background(), sessionRef)
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if status != StatusFailed {
+		t.Fatalf("got status %q, want %q", status, StatusFailed)
+	}
+	if errMsg == "" {
+		t.Fatal("expected a non-empty error message for a failed session")
+	}
+}
+
+func TestSandboxEngine_Status_DefaultsRunningWhileInProgress(t *testing.T) {
+	var fake *fakeAgentServer
+	e := newTestEngine(t, &fake)
+	sessionRef, err := e.Launch(context.Background(), testTask())
+	if err != nil {
+		t.Fatalf("Launch: %v", err)
+	}
+
+	// Launch already called Run, which the fake server maps to "running".
+	status, _, _, err := e.Status(context.Background(), sessionRef)
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if status != StatusRunning {
+		t.Fatalf("got status %q, want %q", status, StatusRunning)
+	}
+}
+
+func TestSandboxEngine_Status_UnknownSessionRef(t *testing.T) {
+	var fake *fakeAgentServer
+	e := newTestEngine(t, &fake)
+
+	_, _, _, err := e.Status(context.Background(), uuid.New().String())
+	if !errors.Is(err, ErrUnknownSession) {
+		t.Fatalf("expected ErrUnknownSession, got %v", err)
+	}
+}
+
+func TestSandboxEngine_Cancel_InterruptsAndKillsProcess(t *testing.T) {
+	var fake *fakeAgentServer
+	e := newTestEngine(t, &fake)
+	sessionRef, err := e.Launch(context.Background(), testTask())
+	if err != nil {
+		t.Fatalf("Launch: %v", err)
+	}
+
+	if err := e.Cancel(context.Background(), sessionRef); err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+	if !fake.wasInterrupted() {
+		t.Fatal("expected Cancel to call POST .../interrupt")
+	}
+	if !fake.wasKilled() {
+		t.Fatal("expected Cancel to kill the sandbox process")
+	}
+
+	if _, _, _, err := e.Status(context.Background(), sessionRef); !errors.Is(err, ErrUnknownSession) {
+		t.Fatalf("expected session to be forgotten after Cancel, got %v", err)
+	}
+}

--- a/apps/agent-engine/internal/engine/engine_test.go
+++ b/apps/agent-engine/internal/engine/engine_test.go
@@ -365,6 +365,48 @@ func TestSandboxEngine_Status_UnknownSessionRef(t *testing.T) {
 	}
 }
 
+func TestSandboxEngine_Launch_CleansUpDirsOnFailure(t *testing.T) {
+	var fake *fakeAgentServer
+	e := newTestEngine(t, &fake)
+	e.start = func(argv []string) (process, error) {
+		return nil, errors.New("boom")
+	}
+
+	if _, err := e.Launch(context.Background(), testTask()); err == nil {
+		t.Fatal("expected Launch to fail")
+	}
+
+	assertDirEmpty(t, e.cfg.RunDir)
+	assertDirEmpty(t, e.cfg.WorkspaceRoot)
+}
+
+func TestSandboxEngine_Cancel_CleansUpDirs(t *testing.T) {
+	var fake *fakeAgentServer
+	e := newTestEngine(t, &fake)
+	sessionRef, err := e.Launch(context.Background(), testTask())
+	if err != nil {
+		t.Fatalf("Launch: %v", err)
+	}
+
+	if err := e.Cancel(context.Background(), sessionRef); err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+
+	assertDirEmpty(t, e.cfg.RunDir)
+	assertDirEmpty(t, e.cfg.WorkspaceRoot)
+}
+
+func assertDirEmpty(t *testing.T, dir string) {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir %s: %v", dir, err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected %s empty, got %v", dir, entries)
+	}
+}
+
 func TestSandboxEngine_Cancel_InterruptsAndKillsProcess(t *testing.T) {
 	var fake *fakeAgentServer
 	e := newTestEngine(t, &fake)

--- a/apps/agent-engine/internal/sandbox/launcher.go
+++ b/apps/agent-engine/internal/sandbox/launcher.go
@@ -27,14 +27,22 @@
 //     sandbox's own isolated netns, to that bind-mounted socket. HTTP_PROXY
 //     and HTTPS_PROXY point at that loopback port.
 //
-// Known follow-up (Wave 3, not this PR): with --network none the host can
-// no longer reach the agent-server's own --host/--port over TCP either,
-// since that TCP path required the network-namespace sharing this package
-// now deliberately removes. Nothing in this repo today calls the
-// agent-server's HTTP API (cmd/agent-engine only execs and waits on the
-// process), so this is not a regression yet, but Wave 3's task-lifecycle
-// wiring will need its own bind-mounted Unix socket (uvicorn supports
-// uds=... natively) rather than --host/--port for that control channel.
+// Host <-> agent-server control channel (issue #305, closing the Wave 3 gap
+// the paragraph above used to describe): with --network none the host
+// cannot reach the agent-server's own --host/--port over TCP, since that
+// path required the network-namespace sharing this package deliberately
+// removes. The control channel mirrors the egress relay but in the opposite
+// direction: LaunchConfig.ControlSocketDir is a host directory, empty at
+// launch time and bind-mounted (read-write — see ControlSocketContainerDir's
+// doc comment for why it cannot be read-only) into the sandbox. The in-SIF
+// shim (deploy/apptainer/agent-engine.def) creates its own listening Unix
+// socket inside that mounted directory, forwarding each connection to
+// 127.0.0.1:<HostPort> (the agent-server's own loopback bind) inside the
+// sandbox's netns. Because the mount is a directory, not a single
+// pre-existing file, the socket file the shim creates becomes visible at the
+// mirrored host path once the shim starts, and the host can dial it
+// directly with no route through the egress proxy at all. See
+// apps/agent-engine/internal/controlclient for the host-side client.
 //
 // BuildArgv also refuses to launch if any bind mount or working directory in
 // the constructed command references the Docker socket (spike rows 8/9,
@@ -45,6 +53,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -61,6 +70,33 @@ const ProxyShimPort = 3128
 // ProxySocketContainerPath is the fixed path, inside the sandbox, that the
 // host's per-session egressproxy.Proxy Unix socket is bind-mounted to.
 const ProxySocketContainerPath = "/opt/hive/egress.sock"
+
+// ControlSocketContainerDir is the fixed path, inside the sandbox, that
+// LaunchConfig.ControlSocketDir is bind-mounted to. Unlike
+// ProxySocketContainerPath (a single socket file the host creates before
+// launch), this bind mount is a directory and must stay read-write: the
+// in-SIF shim creates its listening socket file inside it only after the
+// sandbox starts, and creating a new directory entry needs write access to
+// the directory itself. ValidateSecurityDefaults still asserts the mount is
+// scoped to exactly this one directory pair — a read-write directory bind
+// is only as safe as what else lives in it, and nothing else is bind-mounted
+// there.
+const ControlSocketContainerDir = "/opt/hive/control"
+
+// ControlSocketFileName is the file name the in-SIF shim binds its listening
+// Unix socket to, inside ControlSocketContainerDir. The mirrored host path
+// (for apps/agent-engine/internal/controlclient to dial) is
+// filepath.Join(cfg.ControlSocketDir, ControlSocketFileName); see
+// ControlSocketPath.
+const ControlSocketFileName = "agent.sock"
+
+// ControlSocketPath returns the host-side path of the control channel's Unix
+// socket for cfg: the path apps/agent-engine/internal/controlclient dials
+// once the in-SIF shim has created it. The file does not exist until the
+// sandbox process has started and the shim has run.
+func ControlSocketPath(cfg LaunchConfig) string {
+	return filepath.Join(cfg.ControlSocketDir, ControlSocketFileName)
+}
 
 // Pack identifies which microagent pack config the sandbox mounts. Coding
 // and knowledge-work packs share the identical sandbox trust tier — both may
@@ -80,8 +116,14 @@ type LaunchConfig struct {
 	UserID          uuid.UUID
 	Pack            Pack
 	SIFPath         string
-	HostPort        int    // passed to the agent-server's own --host/--port; not yet reachable from the host, see package doc
+	HostPort        int    // passed to the agent-server's own --host/--port; reachable from the host only via ControlSocketDir, see package doc
 	ProxySocketPath string // host path of the per-session egressproxy.Proxy's Unix socket listener
+
+	// ControlSocketDir is a host directory, created empty by the caller
+	// before launch, bind-mounted read-write into the sandbox at
+	// ControlSocketContainerDir. See the package doc and
+	// apps/agent-engine/internal/controlclient.
+	ControlSocketDir string
 
 	// MCPConfigPath is the host path of the generated OpenHands-native
 	// {"mcpServers": {...}} JSON document (issue #309, blueprint Step 2.3;
@@ -97,13 +139,14 @@ type LaunchConfig struct {
 const MCPConfigContainerPath = "/opt/hive/mcp_config.json"
 
 var (
-	ErrMissingSIFPath         = errors.New("sandbox: SIFPath is required")
-	ErrMissingProxySocketPath = errors.New("sandbox: ProxySocketPath is required")
-	ErrMissingConfigDir       = errors.New("sandbox: Pack.ConfigDir is required")
-	ErrMissingWorkingDir      = errors.New("sandbox: Pack.WorkingDir is required")
-	ErrInvalidHostPort        = errors.New("sandbox: HostPort must be positive")
-	ErrNilTenant              = errors.New("sandbox: TenantID must not be uuid.Nil")
-	ErrNilUser                = errors.New("sandbox: UserID must not be uuid.Nil")
+	ErrMissingSIFPath          = errors.New("sandbox: SIFPath is required")
+	ErrMissingProxySocketPath  = errors.New("sandbox: ProxySocketPath is required")
+	ErrMissingControlSocketDir = errors.New("sandbox: ControlSocketDir is required")
+	ErrMissingConfigDir        = errors.New("sandbox: Pack.ConfigDir is required")
+	ErrMissingWorkingDir       = errors.New("sandbox: Pack.WorkingDir is required")
+	ErrInvalidHostPort         = errors.New("sandbox: HostPort must be positive")
+	ErrNilTenant               = errors.New("sandbox: TenantID must not be uuid.Nil")
+	ErrNilUser                 = errors.New("sandbox: UserID must not be uuid.Nil")
 
 	// ErrDockerSocketReferenced is returned when a constructed command
 	// references the Docker socket by path or well-known env var — this
@@ -121,6 +164,8 @@ func (c LaunchConfig) validate() error {
 		return ErrMissingSIFPath
 	case c.ProxySocketPath == "":
 		return ErrMissingProxySocketPath
+	case c.ControlSocketDir == "":
+		return ErrMissingControlSocketDir
 	case c.Pack.ConfigDir == "":
 		return ErrMissingConfigDir
 	case c.Pack.WorkingDir == "":
@@ -155,6 +200,9 @@ func ValidateSecurityDefaults(argv []string) error {
 	if !hasAdjacentPair(argv, "--network", "none") {
 		missing = append(missing, `--network none`)
 	}
+	if !hasBindTargetingContainerPath(argv, ControlSocketContainerDir) {
+		missing = append(missing, "--bind <dir>:"+ControlSocketContainerDir)
+	}
 	if len(missing) > 0 {
 		return fmt.Errorf("sandbox: missing required security flags: %s", strings.Join(missing, ", "))
 	}
@@ -166,6 +214,23 @@ func ValidateSecurityDefaults(argv []string) error {
 func hasAdjacentPair(argv []string, flag, value string) bool {
 	for i := 0; i+1 < len(argv); i++ {
 		if argv[i] == flag && argv[i+1] == value {
+			return true
+		}
+	}
+	return false
+}
+
+// hasBindTargetingContainerPath reports whether argv contains a --bind
+// <host>:<containerPath>[:opts] pair whose container-side target is exactly
+// containerPath. Used to assert the control-socket bind mount is present
+// without hard-coding the host-side directory, which varies per launch.
+func hasBindTargetingContainerPath(argv []string, containerPath string) bool {
+	for i := 0; i+1 < len(argv); i++ {
+		if argv[i] != "--bind" {
+			continue
+		}
+		parts := strings.SplitN(argv[i+1], ":", 3)
+		if len(parts) >= 2 && parts[1] == containerPath {
 			return true
 		}
 	}
@@ -212,7 +277,9 @@ func BuildArgv(cfg LaunchConfig) (argv []string, err error) {
 		"--env", "HTTP_PROXY=" + proxyURL,
 		"--env", "HTTPS_PROXY=" + proxyURL,
 		"--env", "NO_PROXY=127.0.0.1,localhost",
+		"--env", "HIVE_CONTROL_TARGET_PORT=" + strconv.Itoa(cfg.HostPort),
 		"--bind", cfg.ProxySocketPath + ":" + ProxySocketContainerPath,
+		"--bind", cfg.ControlSocketDir + ":" + ControlSocketContainerDir,
 		"--bind", cfg.Pack.ConfigDir + ":/opt/hive/pack:ro",
 		"--bind", cfg.Pack.WorkingDir + ":/workspace",
 	}

--- a/apps/agent-engine/internal/sandbox/launcher.go
+++ b/apps/agent-engine/internal/sandbox/launcher.go
@@ -125,6 +125,16 @@ type LaunchConfig struct {
 	// apps/agent-engine/internal/controlclient.
 	ControlSocketDir string
 
+	// SessionAPIKey, when set, is passed to the agent-server as the
+	// SESSION_API_KEY env var (vendor/openhands/openhands-agent-server's
+	// openhands/agent_server/config.py V0_SESSION_API_KEY_ENV), so it
+	// actually enforces apps/agent-engine/internal/controlclient's
+	// X-Session-API-Key header instead of that header being a no-op.
+	// Optional: empty means the agent-server enforces no session key at
+	// all — the control socket's filesystem permissions are the only trust
+	// boundary in that case.
+	SessionAPIKey string
+
 	// MCPConfigPath is the host path of the generated OpenHands-native
 	// {"mcpServers": {...}} JSON document (issue #309, blueprint Step 2.3;
 	// see apps/agent-engine/internal/marketplaceclient.BuildConfig and
@@ -282,6 +292,13 @@ func BuildArgv(cfg LaunchConfig) (argv []string, err error) {
 		"--bind", cfg.ControlSocketDir + ":" + ControlSocketContainerDir,
 		"--bind", cfg.Pack.ConfigDir + ":/opt/hive/pack:ro",
 		"--bind", cfg.Pack.WorkingDir + ":/workspace",
+	}
+
+	// Optional: when set, actually enforces
+	// apps/agent-engine/internal/controlclient's X-Session-API-Key header
+	// (see LaunchConfig.SessionAPIKey's doc comment).
+	if cfg.SessionAPIKey != "" {
+		argv = append(argv, "--env", "SESSION_API_KEY="+cfg.SessionAPIKey)
 	}
 
 	// Issue #309 (blueprint Step 2.3) — bind-mount the tenant's enabled MCP

--- a/apps/agent-engine/internal/sandbox/launcher_test.go
+++ b/apps/agent-engine/internal/sandbox/launcher_test.go
@@ -91,6 +91,28 @@ func TestBuildArgv_WiresControlSocket(t *testing.T) {
 	}
 }
 
+func TestBuildArgv_OmitsSessionAPIKeyEnvWhenUnset(t *testing.T) {
+	argv, err := sandbox.BuildArgv(validConfig())
+	if err != nil {
+		t.Fatalf("BuildArgv: %v", err)
+	}
+	if strings.Contains(strings.Join(argv, " "), "SESSION_API_KEY=") {
+		t.Fatalf("expected no SESSION_API_KEY env when unset, got argv: %v", argv)
+	}
+}
+
+func TestBuildArgv_WiresSessionAPIKeyEnvWhenSet(t *testing.T) {
+	cfg := validConfig()
+	cfg.SessionAPIKey = "s3cr3t"
+	argv, err := sandbox.BuildArgv(cfg)
+	if err != nil {
+		t.Fatalf("BuildArgv: %v", err)
+	}
+	if !strings.Contains(strings.Join(argv, " "), "SESSION_API_KEY=s3cr3t") {
+		t.Fatalf("expected SESSION_API_KEY=s3cr3t in argv, got: %v", argv)
+	}
+}
+
 func TestControlSocketPath(t *testing.T) {
 	cfg := validConfig()
 	got := sandbox.ControlSocketPath(cfg)

--- a/apps/agent-engine/internal/sandbox/launcher_test.go
+++ b/apps/agent-engine/internal/sandbox/launcher_test.go
@@ -19,9 +19,10 @@ func validConfig() sandbox.LaunchConfig {
 			ConfigDir:  "/srv/hive/packs/coding-pack",
 			WorkingDir: "/srv/hive/workspaces/t1",
 		},
-		SIFPath:         "/srv/hive/sif/agent-server.sif",
-		HostPort:        38080,
-		ProxySocketPath: "/srv/hive/run/t1/egress.sock",
+		SIFPath:          "/srv/hive/sif/agent-server.sif",
+		HostPort:         38080,
+		ProxySocketPath:  "/srv/hive/run/t1/egress.sock",
+		ControlSocketDir: "/srv/hive/run/t1/control",
 	}
 }
 
@@ -70,6 +71,35 @@ func TestBuildArgv_WiresProxyEnv(t *testing.T) {
 	}
 }
 
+func TestBuildArgv_WiresControlSocket(t *testing.T) {
+	cfg := validConfig()
+	argv, err := sandbox.BuildArgv(cfg)
+	if err != nil {
+		t.Fatalf("BuildArgv: %v", err)
+	}
+	joined := strings.Join(argv, " ")
+	wantBind := cfg.ControlSocketDir + ":" + sandbox.ControlSocketContainerDir
+	if !strings.Contains(joined, wantBind) {
+		t.Fatalf("expected control socket bind mount %s, got argv: %v", wantBind, argv)
+	}
+	wantEnv := fmt.Sprintf("HIVE_CONTROL_TARGET_PORT=%d", cfg.HostPort)
+	if !strings.Contains(joined, wantEnv) {
+		t.Fatalf("expected control target port env %s, got argv: %v", wantEnv, argv)
+	}
+	if err := sandbox.ValidateSecurityDefaults(argv); err != nil {
+		t.Fatalf("expected control socket bind to satisfy ValidateSecurityDefaults: %v", err)
+	}
+}
+
+func TestControlSocketPath(t *testing.T) {
+	cfg := validConfig()
+	got := sandbox.ControlSocketPath(cfg)
+	want := cfg.ControlSocketDir + "/" + sandbox.ControlSocketFileName
+	if got != want {
+		t.Fatalf("ControlSocketPath = %q, want %q", got, want)
+	}
+}
+
 func TestBuildArgv_OmitsMCPConfigBindWhenPathEmpty(t *testing.T) {
 	argv, err := sandbox.BuildArgv(validConfig())
 	if err != nil {
@@ -111,6 +141,7 @@ func TestBuildArgv_RejectsInvalidConfig(t *testing.T) {
 		{"nil user", func(c *sandbox.LaunchConfig) { c.UserID = uuid.Nil }, sandbox.ErrNilUser},
 		{"empty SIF path", func(c *sandbox.LaunchConfig) { c.SIFPath = "" }, sandbox.ErrMissingSIFPath},
 		{"empty proxy socket path", func(c *sandbox.LaunchConfig) { c.ProxySocketPath = "" }, sandbox.ErrMissingProxySocketPath},
+		{"empty control socket dir", func(c *sandbox.LaunchConfig) { c.ControlSocketDir = "" }, sandbox.ErrMissingControlSocketDir},
 		{"empty pack config dir", func(c *sandbox.LaunchConfig) { c.Pack.ConfigDir = "" }, sandbox.ErrMissingConfigDir},
 		{"empty pack working dir", func(c *sandbox.LaunchConfig) { c.Pack.WorkingDir = "" }, sandbox.ErrMissingWorkingDir},
 		{"zero host port", func(c *sandbox.LaunchConfig) { c.HostPort = 0 }, sandbox.ErrInvalidHostPort},
@@ -151,6 +182,14 @@ func TestBuildArgv_RejectsDockerSocketInProxySocketPath(t *testing.T) {
 	}
 }
 
+func TestBuildArgv_RejectsDockerSocketInControlSocketDir(t *testing.T) {
+	cfg := validConfig()
+	cfg.ControlSocketDir = "/var/run/docker.sock"
+	if _, err := sandbox.BuildArgv(cfg); !errors.Is(err, sandbox.ErrDockerSocketReferenced) {
+		t.Fatalf("expected ErrDockerSocketReferenced, got %v", err)
+	}
+}
+
 func TestValidateSecurityDefaults_CatchesMissingFlags(t *testing.T) {
 	// Proves the validator would have caught the exact gap security spike
 	// #307 found in upstream's ApptainerWorkspace._start_container(), which
@@ -167,7 +206,10 @@ func TestValidateSecurityDefaults_CatchesMissingFlags(t *testing.T) {
 }
 
 func TestValidateSecurityDefaults_PassesCompleteArgv(t *testing.T) {
-	argv := []string{"apptainer", "run", "--pid", "--containall", "--net", "--network", "none"}
+	argv := []string{
+		"apptainer", "run", "--pid", "--containall", "--net", "--network", "none",
+		"--bind", "/srv/hive/run/t1/control:" + sandbox.ControlSocketContainerDir,
+	}
 	if err := sandbox.ValidateSecurityDefaults(argv); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -195,6 +237,20 @@ func TestValidateSecurityDefaults_RejectsNonNoneNetwork(t *testing.T) {
 	argv := []string{"apptainer", "run", "--pid", "--containall", "--net", "--network", "bridge"}
 	if err := sandbox.ValidateSecurityDefaults(argv); err == nil {
 		t.Fatal("expected error for --network bridge (only \"none\" is permitted)")
+	}
+}
+
+func TestValidateSecurityDefaults_CatchesMissingControlSocketBind(t *testing.T) {
+	// Proves the validator would catch a future edit accidentally dropping
+	// the control-channel bind mount (issue #305 Wave 3 gap) the same way it
+	// already catches a dropped --pid/--containall/--network isolation flag.
+	argv := []string{"apptainer", "run", "--pid", "--containall", "--net", "--network", "none"}
+	err := sandbox.ValidateSecurityDefaults(argv)
+	if err == nil {
+		t.Fatal("expected error for argv missing the control socket bind mount")
+	}
+	if !strings.Contains(err.Error(), sandbox.ControlSocketContainerDir) {
+		t.Fatalf("expected error to name the missing control socket bind target, got: %v", err)
 	}
 }
 

--- a/apps/control-plane/cmd/server/main.go
+++ b/apps/control-plane/cmd/server/main.go
@@ -18,8 +18,10 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	goredis "github.com/redis/go-redis/v9"
+	"github.com/sakibsadmanshajib/hive/apps/agent-engine/engineapi"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/accounting"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/accounts"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/agentengine"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/agenttask"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/apikeys"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/audit"
@@ -780,9 +782,10 @@ func main() {
 	// whenever pool != nil). Neither the server-side OpenHands allowed_hosts
 	// consumer nor the desktop firewall rule generator is wired here.
 	var egressPolicyHandler *egress.Handler
+	var egressSvc *egress.Service
 	if pool != nil && roleSvc != nil {
 		egressRepo := egress.NewPgxRepository(pool)
-		egressSvc := egress.NewService(egressRepo, roleSvc)
+		egressSvc = egress.NewService(egressRepo, roleSvc)
 		egressPolicyHandler = egress.NewHandler(egressSvc)
 	}
 
@@ -798,16 +801,16 @@ func main() {
 		marketplaceHandler = marketplace.NewHandler(marketplaceSvc)
 	}
 
-	// Issue #311 (blueprint Step 3.4) — agent task persistence, web side. No
-	// live agent-engine control channel exists yet (Wave 3 gap: the sandbox's
-	// --network none profile cuts off the host <-> agent-server channel this
-	// would need), so agenttask.NotConfiguredEngine is wired: task creation
-	// still succeeds and persists, it just stays queued until a real Engine
-	// lands. See apps/control-plane/internal/agenttask/SYNC_CONTRACT.md.
+	// Issue #311 (blueprint Step 3.4) — agent task persistence, web side.
+	// Issue #305 closes the control-channel half of the Wave 3 gap; see
+	// buildAgentEngine's doc comment and
+	// apps/control-plane/internal/agenttask/SYNC_CONTRACT.md's Engine seam
+	// section for why the real Engine is still conditional on deployment
+	// env vars rather than unconditionally wired.
 	var agentTaskHandler *agenttask.Handler
 	if pool != nil {
 		agentTaskRepo := agenttask.NewPgxRepository(pool)
-		agentTaskSvc := agenttask.NewService(agentTaskRepo, agenttask.NotConfiguredEngine{})
+		agentTaskSvc := agenttask.NewService(agentTaskRepo, buildAgentEngine(egressSvc))
 		agentTaskHandler = agenttask.NewHandler(agentTaskSvc)
 	}
 
@@ -1300,4 +1303,48 @@ func parseDurationEnv(key string, fallback time.Duration) time.Duration {
 		return fallback
 	}
 	return d
+}
+
+// buildAgentEngine wires the real host<->agent-server control channel
+// (issue #305) when its deployment-specific paths are all configured via
+// env, falling back to agenttask.NotConfiguredEngine{} (today's safe
+// default: task creation still succeeds and persists, it just stays queued)
+// otherwise. The real SandboxEngine (apps/agent-engine/engineapi) execs
+// Apptainer directly, which requires an Apptainer install and a built SIF
+// on whatever host runs this process — not true of every control-plane
+// deployment yet (tracked separately: "Live Apptainer validation of
+// agent-engine on x86-64 host"). egressSvc is reused in-process rather than
+// calling apps/agent-engine/internal/egressclient's HTTP round-trip, since
+// the real Engine now runs inside this same control-plane process.
+func buildAgentEngine(egressSvc *egress.Service) agenttask.Engine {
+	sifPath := os.Getenv("HIVE_AGENT_ENGINE_SIF_PATH")
+	packsDir := os.Getenv("HIVE_AGENT_ENGINE_PACKS_DIR")
+	workspaceRoot := os.Getenv("HIVE_AGENT_ENGINE_WORKSPACE_ROOT")
+	runDir := os.Getenv("HIVE_AGENT_ENGINE_RUN_DIR")
+	profileIDRaw := os.Getenv("HIVE_AGENT_ENGINE_PROFILE_ID")
+	if egressSvc == nil || sifPath == "" || packsDir == "" || workspaceRoot == "" || runDir == "" || profileIDRaw == "" {
+		return agenttask.NotConfiguredEngine{}
+	}
+	profileID, err := uuid.Parse(profileIDRaw)
+	if err != nil {
+		log.Printf("control-plane: HIVE_AGENT_ENGINE_PROFILE_ID invalid, agent-engine stays unconfigured: %v", err)
+		return agenttask.NotConfiguredEngine{}
+	}
+
+	sandbox := engineapi.New(engineapi.Config{
+		SIFPath:       sifPath,
+		PacksDir:      packsDir,
+		WorkspaceRoot: workspaceRoot,
+		RunDir:        runDir,
+		ResolveEgressHosts: func(ctx context.Context, tenantID, userID uuid.UUID) ([]string, error) {
+			policy, err := egressSvc.Effective(ctx, tenantID, userID)
+			if err != nil {
+				return nil, err
+			}
+			return policy.AllowedHosts, nil
+		},
+		AgentProfileID: profileID,
+		SessionAPIKey:  os.Getenv("HIVE_AGENT_ENGINE_SESSION_API_KEY"),
+	})
+	return agentengine.New(sandbox)
 }

--- a/apps/control-plane/go.mod
+++ b/apps/control-plane/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/jackc/pgx/v5 v5.7.2
 	github.com/prometheus/client_golang v1.23.2
 	github.com/redis/go-redis/v9 v9.18.0
+	github.com/sakibsadmanshajib/hive/apps/agent-engine v0.0.0
 	github.com/sakibsadmanshajib/hive/packages/audit-canonical v0.0.0
 	github.com/sakibsadmanshajib/hive/packages/storage v0.0.0
 	github.com/stripe/stripe-go/v84 v84.4.1
@@ -58,3 +59,5 @@ require (
 replace github.com/sakibsadmanshajib/hive/packages/storage => ../../packages/storage
 
 replace github.com/sakibsadmanshajib/hive/packages/audit-canonical => ../../packages/audit-canonical
+
+replace github.com/sakibsadmanshajib/hive/apps/agent-engine => ../agent-engine

--- a/apps/control-plane/internal/agentengine/engine.go
+++ b/apps/control-plane/internal/agentengine/engine.go
@@ -1,0 +1,56 @@
+// Package agentengine adapts apps/agent-engine's SandboxEngine
+// (apps/agent-engine/engineapi, issue #305) to
+// apps/control-plane/internal/agenttask's Engine seam. This is the thin
+// translation layer apps/agent-engine/engineapi's doc comment describes:
+// agenttask.Task converts to engineapi.Task on the way in, engineapi's
+// returned session reference goes straight back out. All the actual launch/
+// control-channel/state-mapping logic lives in
+// apps/agent-engine/internal/engine; nothing here duplicates it.
+package agentengine
+
+import (
+	"context"
+
+	"github.com/sakibsadmanshajib/hive/apps/agent-engine/engineapi"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/agenttask"
+)
+
+// Engine implements agenttask.Engine on top of a *engineapi.SandboxEngine.
+type Engine struct {
+	sandbox *engineapi.SandboxEngine
+}
+
+// New constructs an Engine wrapping sandbox.
+func New(sandbox *engineapi.SandboxEngine) *Engine {
+	return &Engine{sandbox: sandbox}
+}
+
+// Launch adapts t and delegates to the wrapped SandboxEngine.
+func (e *Engine) Launch(ctx context.Context, t agenttask.Task) (string, error) {
+	return e.sandbox.Launch(ctx, engineapi.Task{
+		ID:           t.ID,
+		TenantID:     t.TenantID,
+		UserID:       t.UserID,
+		Pack:         string(t.Pack),
+		Instructions: t.Instructions,
+	})
+}
+
+// Status polls sessionRef and maps it onto agenttask.Status. Status and
+// Status share identical string values (SYNC_CONTRACT.md's state machine),
+// so the conversion is a plain cast. Not called by anything in this package
+// yet — it is what a future background sync loop
+// (SYNC_CONTRACT.md's Engine seam section) would call to advance a task
+// past running.
+func (e *Engine) Status(ctx context.Context, sessionRef string) (status agenttask.Status, resultSummary, errMessage string, err error) {
+	s, resultSummary, errMessage, err := e.sandbox.Status(ctx, sessionRef)
+	return agenttask.Status(s), resultSummary, errMessage, err
+}
+
+// Cancel interrupts sessionRef's conversation and terminates its sandbox
+// process. Not called by agenttask.Service.Cancel yet (that method only
+// transitions the DB row today); wiring it in is the same follow-up as
+// Status above.
+func (e *Engine) Cancel(ctx context.Context, sessionRef string) error {
+	return e.sandbox.Cancel(ctx, sessionRef)
+}

--- a/apps/control-plane/internal/agenttask/SYNC_CONTRACT.md
+++ b/apps/control-plane/internal/agenttask/SYNC_CONTRACT.md
@@ -26,6 +26,7 @@ Task, as returned by every endpoint below:
 {
   "id": "uuid",
   "pack": "coding-pack | knowledge-work-pack",
+  "instructions": "string, empty when none were given",
   "status": "queued | running | succeeded | failed | cancelled",
   "engine_session_ref": "string, empty until running",
   "result_summary_ref": "string, empty until succeeded (or failed with partial output)",
@@ -37,6 +38,15 @@ Task, as returned by every endpoint below:
 }
 ```
 
+`instructions` (issue #311 contract gap, closed alongside issue #305's Engine)
+is the free-text prompt/goal the task's conversation starts from — passed as
+the agent-server conversation's `initial_message` (see the Engine seam
+section below). Optional: an empty string means the task carries no prompt.
+Stored as a nullable column (`public.agent_tasks.instructions`); the read
+path always returns `""` for `NULL`, never `null`, so every consumer of this
+contract can treat it as a plain string. Skills (issue #300) route on a
+`"Skill: X"` prefix inside this text; no separate skill field exists.
+
 `tenant_id` and `user_id` never appear in a response body: both are implied
 by the authenticated caller, never round-tripped.
 
@@ -45,7 +55,7 @@ by the authenticated caller, never round-tripped.
 
 | Method | Path | Body | Notes |
 |---|---|---|---|
-| POST | `/v1/agent/tasks` | `{"pack": "..."}` | 201 with the created Task |
+| POST | `/v1/agent/tasks` | `{"pack": "...", "instructions": "..."}` | 201 with the created Task; `instructions` is optional |
 | GET | `/v1/agent/tasks` | — | `{"tasks": [Task, ...]}`, newest first, scoped to the caller |
 | GET | `/v1/agent/tasks/{id}` | — | 404 if the task belongs to a different user or does not exist |
 | POST | `/v1/agent/tasks/{id}/cancel` | — | 409 if the task already reached a terminal state |
@@ -70,22 +80,46 @@ untrusted client input.
 
 | Method | Path | Body |
 |---|---|---|
-| POST | `/internal/agent-tasks/{tenant_id}/{user_id}` | `{"pack": "..."}` |
+| POST | `/internal/agent-tasks/{tenant_id}/{user_id}` | `{"pack": "...", "instructions": "..."}` |
 | GET | `/internal/agent-tasks/{tenant_id}/{user_id}` | — |
 | GET | `/internal/agent-tasks/{tenant_id}/{user_id}/{task_id}` | — |
 | POST | `/internal/agent-tasks/{tenant_id}/{user_id}/{task_id}/cancel` | — |
 
-## Engine seam (known gap)
+## Engine seam
 
 `Service.CreateTask` calls `Engine.Launch(ctx, task)` right after persisting
-a `queued` row. The only `Engine` wired today is `NotConfiguredEngine`,
-which returns `ErrEngineNotConfigured` and leaves the task `queued` — that is
-treated as an open seam, not a task failure. `apps/agent-engine`'s Wave 2.2
-CLI binds a host port for one sandbox session, but the control channel this
-package needs (submit a task, get a session reference back, later learn
-success/failure) requires a second host <-> agent-server channel that the
-sandbox's `--network none` egress profile currently cuts off. Wiring a real
-`Engine` that talks to that channel is Wave 4 work (desktop control channel)
-or a follow-up once a server-side equivalent exists; `Service` and the HTTP
-surface do not need to change when that lands, only the `Engine`
-implementation passed to `NewService`.
+a `queued` row. Issue #305 closes the control-channel half of this gap:
+`apps/agent-engine/internal/sandbox` bind-mounts a second Unix socket (the
+control channel) alongside the existing egress-proxy one, so the host can
+now reach the agent-server's REST API inside the sandbox
+(`apps/agent-engine/internal/controlclient`), and
+`apps/agent-engine/internal/engine.SandboxEngine` composes that into a full
+Launch/Status/Cancel session lifecycle, mapped onto this package's
+queued/running/succeeded/failed/cancelled vocabulary.
+`apps/agent-engine/engineapi` re-exports that type for cross-module use (Go's
+internal-package visibility does not cross module boundaries, the same
+limitation `apps/agent-engine/internal/egressclient`'s doc comment already
+covers), and `apps/control-plane/internal/agentengine.Engine` adapts it to
+this package's `Engine` interface, translating `agenttask.Task` (including
+`Instructions`, passed through as the conversation's `initial_message`) into
+`engineapi.Task` and back.
+
+That adapter is wired in `cmd/server/main.go` only when
+`HIVE_AGENT_ENGINE_SIF_PATH` is set: the real `SandboxEngine` execs
+Apptainer, which requires an Apptainer install and a built SIF on whatever
+host runs this process — not true of every `control-plane` deployment today
+(task tracked separately: "Live Apptainer validation of agent-engine on
+x86-64 host"). Without that env var, `NotConfiguredEngine` is still wired,
+preserving today's queued-forever-but-not-failed behavior exactly. `Service`
+and the HTTP surface do not change either way; only the `Engine`
+implementation passed to `NewService` does.
+
+`Service`/`Status` polling from a queued/running task back to
+succeeded/failed/cancelled is not wired by this package itself yet: nothing
+here calls `SandboxEngine.Status`/`Cancel` on a timer. `Handler.handleGet`
+returns whatever `Repository.Get` currently has persisted; a background
+sync loop (or a webhook the engine calls back on) that periodically calls
+the adapter's `Status` and writes the result via `Repository.Transition` is
+the next piece needed to make status advance past `running` in production —
+tracked as a follow-up, same as the Status/Cancel plumbing on the engine
+side is already real and unit-tested.

--- a/apps/control-plane/internal/agenttask/http.go
+++ b/apps/control-plane/internal/agenttask/http.go
@@ -42,9 +42,10 @@ func (h *Handler) InternalMux() http.Handler {
 const internalPrefix = "/internal/agent-tasks/"
 
 // maxBodyBytes caps request bodies this handler decodes. A create request
-// carries one field (pack); there is no legitimate reason for it to
-// approach this size.
-const maxBodyBytes = 4 << 10 // 4 KiB
+// carries pack plus a free-text instructions/prompt field, which needs more
+// headroom than a bare pack name; other bodies on this handler (cancel) send
+// none at all.
+const maxBodyBytes = 64 << 10 // 64 KiB
 
 func (h *Handler) serveInternal(w http.ResponseWriter, r *http.Request) {
 	rest := strings.Trim(strings.TrimPrefix(r.URL.Path, internalPrefix), "/")
@@ -102,7 +103,8 @@ func (h *Handler) serveInternal(w http.ResponseWriter, r *http.Request) {
 }
 
 type createRequest struct {
-	Pack string `json:"pack"`
+	Pack         string `json:"pack"`
+	Instructions string `json:"instructions"`
 }
 
 func (h *Handler) handleCreate(w http.ResponseWriter, r *http.Request, tenantID, userID uuid.UUID) {
@@ -112,7 +114,7 @@ func (h *Handler) handleCreate(w http.ResponseWriter, r *http.Request, tenantID,
 		writeJSON(w, http.StatusBadRequest, errBody("invalid JSON body"))
 		return
 	}
-	task, err := h.svc.CreateTask(r.Context(), tenantID, userID, Pack(req.Pack))
+	task, err := h.svc.CreateTask(r.Context(), tenantID, userID, Pack(req.Pack), req.Instructions)
 	if err != nil {
 		writeTaskError(w, err)
 		return
@@ -170,6 +172,7 @@ func writeTaskError(w http.ResponseWriter, err error) {
 type taskWire struct {
 	ID               string     `json:"id"`
 	Pack             string     `json:"pack"`
+	Instructions     string     `json:"instructions"`
 	Status           string     `json:"status"`
 	EngineSessionRef string     `json:"engine_session_ref"`
 	ResultSummaryRef string     `json:"result_summary_ref"`
@@ -188,6 +191,7 @@ func newTaskWire(t Task) taskWire {
 	return taskWire{
 		ID:               t.ID.String(),
 		Pack:             string(t.Pack),
+		Instructions:     t.Instructions,
 		Status:           string(t.Status),
 		EngineSessionRef: t.EngineSessionRef,
 		ResultSummaryRef: t.ResultSummaryRef,

--- a/apps/control-plane/internal/agenttask/repository.go
+++ b/apps/control-plane/internal/agenttask/repository.go
@@ -12,7 +12,7 @@ import (
 
 // Repository is the narrow data-access port for public.agent_tasks.
 type Repository interface {
-	Create(ctx context.Context, tenantID, userID uuid.UUID, pack Pack) (Task, error)
+	Create(ctx context.Context, tenantID, userID uuid.UUID, pack Pack, instructions string) (Task, error)
 	Get(ctx context.Context, tenantID, userID, id uuid.UUID) (Task, error)
 	List(ctx context.Context, tenantID, userID uuid.UUID) ([]Task, error)
 	// Transition updates status (and the fields that go with it) for a task
@@ -52,14 +52,14 @@ func (r *pgxRepository) withTenantTx(ctx context.Context, tenantID uuid.UUID, fn
 	return tx.Commit(ctx)
 }
 
-func (r *pgxRepository) Create(ctx context.Context, tenantID, userID uuid.UUID, pack Pack) (Task, error) {
+func (r *pgxRepository) Create(ctx context.Context, tenantID, userID uuid.UUID, pack Pack, instructions string) (Task, error) {
 	var t Task
 	err := r.withTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
 		row := tx.QueryRow(ctx, `
-			INSERT INTO public.agent_tasks (tenant_id, user_id, pack)
-			VALUES ($1, $2, $3)
-			RETURNING id, tenant_id, user_id, pack, status, engine_session_ref, result_summary_ref, error_message, created_at, updated_at, started_at, finished_at
-		`, tenantID, userID, string(pack))
+			INSERT INTO public.agent_tasks (tenant_id, user_id, pack, instructions)
+			VALUES ($1, $2, $3, NULLIF($4, ''))
+			RETURNING id, tenant_id, user_id, pack, COALESCE(instructions, ''), status, engine_session_ref, result_summary_ref, error_message, created_at, updated_at, started_at, finished_at
+		`, tenantID, userID, string(pack), instructions)
 		var err error
 		t, err = scanTask(row)
 		return err
@@ -74,7 +74,7 @@ func (r *pgxRepository) Get(ctx context.Context, tenantID, userID, id uuid.UUID)
 	var t Task
 	err := r.withTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
 		row := tx.QueryRow(ctx, `
-			SELECT id, tenant_id, user_id, pack, status, engine_session_ref, result_summary_ref, error_message, created_at, updated_at, started_at, finished_at
+			SELECT id, tenant_id, user_id, pack, COALESCE(instructions, ''), status, engine_session_ref, result_summary_ref, error_message, created_at, updated_at, started_at, finished_at
 			  FROM public.agent_tasks
 			 WHERE id = $1 AND user_id = $2
 		`, id, userID)
@@ -95,7 +95,7 @@ func (r *pgxRepository) List(ctx context.Context, tenantID, userID uuid.UUID) ([
 	var out []Task
 	err := r.withTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, `
-			SELECT id, tenant_id, user_id, pack, status, engine_session_ref, result_summary_ref, error_message, created_at, updated_at, started_at, finished_at
+			SELECT id, tenant_id, user_id, pack, COALESCE(instructions, ''), status, engine_session_ref, result_summary_ref, error_message, created_at, updated_at, started_at, finished_at
 			  FROM public.agent_tasks
 			 WHERE user_id = $1
 			 ORDER BY created_at DESC
@@ -141,7 +141,7 @@ func (r *pgxRepository) Transition(ctx context.Context, tenantID, userID, id uui
 			       updated_at = now()
 			 WHERE id = $1 AND user_id = $2
 			   AND status NOT IN ('succeeded', 'failed', 'cancelled')
-			RETURNING id, tenant_id, user_id, pack, status, engine_session_ref, result_summary_ref, error_message, created_at, updated_at, started_at, finished_at
+			RETURNING id, tenant_id, user_id, pack, COALESCE(instructions, ''), status, engine_session_ref, result_summary_ref, error_message, created_at, updated_at, started_at, finished_at
 		`, id, userID, tenantID, string(status), sessionRef, resultSummaryRef, errMsg)
 		var err error
 		t, err = scanTask(row)
@@ -189,7 +189,7 @@ type scanner interface {
 func scanTask(s scanner) (Task, error) {
 	var t Task
 	var pack, status string
-	if err := s.Scan(&t.ID, &t.TenantID, &t.UserID, &pack, &status,
+	if err := s.Scan(&t.ID, &t.TenantID, &t.UserID, &pack, &t.Instructions, &status,
 		&t.EngineSessionRef, &t.ResultSummaryRef, &t.ErrorMessage,
 		&t.CreatedAt, &t.UpdatedAt, &t.StartedAt, &t.FinishedAt); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {

--- a/apps/control-plane/internal/agenttask/repository_test.go
+++ b/apps/control-plane/internal/agenttask/repository_test.go
@@ -118,7 +118,7 @@ func TestRepository_CreateGetTransition_RoundTrip(t *testing.T) {
 	seedTenant(t, tenantID)
 	userID := seedUser(t)
 
-	created, err := repo.Create(ctx, tenantID, userID, agenttask.PackCoding)
+	created, err := repo.Create(ctx, tenantID, userID, agenttask.PackCoding, "")
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -176,7 +176,7 @@ func TestRepository_Transition_AtomicGuardRejectsAlreadyTerminal(t *testing.T) {
 	seedTenant(t, tenantID)
 	userID := seedUser(t)
 
-	created, err := repo.Create(ctx, tenantID, userID, agenttask.PackCoding)
+	created, err := repo.Create(ctx, tenantID, userID, agenttask.PackCoding, "")
 	if err != nil {
 		t.Fatalf("seed task: %v", err)
 	}
@@ -220,7 +220,7 @@ func TestRepository_RLS_CrossTenantContextCannotReadRows(t *testing.T) {
 	seedTenant(t, tenantB)
 	userID := seedUser(t)
 
-	created, err := repo.Create(ctx, tenantA, userID, agenttask.PackCoding)
+	created, err := repo.Create(ctx, tenantA, userID, agenttask.PackCoding, "")
 	if err != nil {
 		t.Fatalf("seed tenant A task: %v", err)
 	}
@@ -251,7 +251,7 @@ func TestRepository_ScopedByUser_OtherUserCannotSeeOrCancel(t *testing.T) {
 	owner := seedUser(t)
 	other := seedUser(t)
 
-	created, err := repo.Create(ctx, tenantID, owner, agenttask.PackKnowledgeWork)
+	created, err := repo.Create(ctx, tenantID, owner, agenttask.PackKnowledgeWork, "")
 	if err != nil {
 		t.Fatalf("seed owner task: %v", err)
 	}
@@ -285,7 +285,7 @@ func TestRepository_RLS_NoSessionLeakAcrossBorrows(t *testing.T) {
 	seedTenant(t, tenantID)
 	userID := seedUser(t)
 
-	created, err := repo.Create(ctx, tenantID, userID, agenttask.PackCoding)
+	created, err := repo.Create(ctx, tenantID, userID, agenttask.PackCoding, "")
 	if err != nil {
 		t.Fatalf("seed task: %v", err)
 	}

--- a/apps/control-plane/internal/agenttask/service.go
+++ b/apps/control-plane/internal/agenttask/service.go
@@ -30,12 +30,12 @@ func NewService(repo Repository, engine Engine) *Service {
 // failed — that is a documented seam gap, not a task failure. Any other
 // Launch error transitions the task straight to StatusFailed so the caller
 // never has to poll a task that can never progress.
-func (s *Service) CreateTask(ctx context.Context, tenantID, userID uuid.UUID, pack Pack) (Task, error) {
+func (s *Service) CreateTask(ctx context.Context, tenantID, userID uuid.UUID, pack Pack, instructions string) (Task, error) {
 	if !pack.Valid() {
 		return Task{}, ErrInvalidPack
 	}
 
-	t, err := s.repo.Create(ctx, tenantID, userID, pack)
+	t, err := s.repo.Create(ctx, tenantID, userID, pack, instructions)
 	if err != nil {
 		return Task{}, err
 	}

--- a/apps/control-plane/internal/agenttask/service_test.go
+++ b/apps/control-plane/internal/agenttask/service_test.go
@@ -22,9 +22,9 @@ func newFakeRepository() *fakeRepository {
 	return &fakeRepository{tasks: make(map[uuid.UUID]agenttask.Task)}
 }
 
-func (f *fakeRepository) Create(_ context.Context, tenantID, userID uuid.UUID, pack agenttask.Pack) (agenttask.Task, error) {
+func (f *fakeRepository) Create(_ context.Context, tenantID, userID uuid.UUID, pack agenttask.Pack, instructions string) (agenttask.Task, error) {
 	t := agenttask.Task{
-		ID: uuid.New(), TenantID: tenantID, UserID: userID, Pack: pack,
+		ID: uuid.New(), TenantID: tenantID, UserID: userID, Pack: pack, Instructions: instructions,
 		Status: agenttask.StatusQueued, CreatedAt: time.Now(), UpdatedAt: time.Now(),
 	}
 	f.tasks[t.ID] = t
@@ -85,7 +85,7 @@ func (f *fakeEngine) Launch(context.Context, agenttask.Task) (string, error) {
 
 func TestService_CreateTask_InvalidPack(t *testing.T) {
 	svc := agenttask.NewService(newFakeRepository(), &fakeEngine{})
-	_, err := svc.CreateTask(context.Background(), uuid.New(), uuid.New(), agenttask.Pack("not-a-pack"))
+	_, err := svc.CreateTask(context.Background(), uuid.New(), uuid.New(), agenttask.Pack("not-a-pack"), "")
 	if !errors.Is(err, agenttask.ErrInvalidPack) {
 		t.Fatalf("expected ErrInvalidPack, got %v", err)
 	}
@@ -93,7 +93,7 @@ func TestService_CreateTask_InvalidPack(t *testing.T) {
 
 func TestService_CreateTask_EngineNotConfigured_StaysQueued(t *testing.T) {
 	svc := agenttask.NewService(newFakeRepository(), agenttask.NotConfiguredEngine{})
-	task, err := svc.CreateTask(context.Background(), uuid.New(), uuid.New(), agenttask.PackCoding)
+	task, err := svc.CreateTask(context.Background(), uuid.New(), uuid.New(), agenttask.PackCoding, "")
 	if err != nil {
 		t.Fatalf("CreateTask() unexpected err: %v", err)
 	}
@@ -104,7 +104,7 @@ func TestService_CreateTask_EngineNotConfigured_StaysQueued(t *testing.T) {
 
 func TestService_CreateTask_NilEngineDefaultsToNotConfigured(t *testing.T) {
 	svc := agenttask.NewService(newFakeRepository(), nil)
-	task, err := svc.CreateTask(context.Background(), uuid.New(), uuid.New(), agenttask.PackKnowledgeWork)
+	task, err := svc.CreateTask(context.Background(), uuid.New(), uuid.New(), agenttask.PackKnowledgeWork, "")
 	if err != nil {
 		t.Fatalf("CreateTask() unexpected err: %v", err)
 	}
@@ -115,7 +115,7 @@ func TestService_CreateTask_NilEngineDefaultsToNotConfigured(t *testing.T) {
 
 func TestService_CreateTask_EngineLaunchSucceeds_TransitionsToRunning(t *testing.T) {
 	svc := agenttask.NewService(newFakeRepository(), &fakeEngine{sessionRef: "session-123"})
-	task, err := svc.CreateTask(context.Background(), uuid.New(), uuid.New(), agenttask.PackCoding)
+	task, err := svc.CreateTask(context.Background(), uuid.New(), uuid.New(), agenttask.PackCoding, "")
 	if err != nil {
 		t.Fatalf("CreateTask() unexpected err: %v", err)
 	}
@@ -129,7 +129,7 @@ func TestService_CreateTask_EngineLaunchSucceeds_TransitionsToRunning(t *testing
 
 func TestService_CreateTask_EngineLaunchFails_TransitionsToFailed(t *testing.T) {
 	svc := agenttask.NewService(newFakeRepository(), &fakeEngine{err: errors.New("sandbox unavailable")})
-	task, err := svc.CreateTask(context.Background(), uuid.New(), uuid.New(), agenttask.PackCoding)
+	task, err := svc.CreateTask(context.Background(), uuid.New(), uuid.New(), agenttask.PackCoding, "")
 	if err != nil {
 		t.Fatalf("CreateTask() unexpected err: %v", err)
 	}
@@ -146,7 +146,7 @@ func TestService_Get_WrongUserReturnsNotFound(t *testing.T) {
 	svc := agenttask.NewService(repo, &fakeEngine{})
 	tenantID, ownerID, otherID := uuid.New(), uuid.New(), uuid.New()
 
-	created, err := svc.CreateTask(context.Background(), tenantID, ownerID, agenttask.PackCoding)
+	created, err := svc.CreateTask(context.Background(), tenantID, ownerID, agenttask.PackCoding, "")
 	if err != nil {
 		t.Fatalf("seed CreateTask: %v", err)
 	}
@@ -165,10 +165,10 @@ func TestService_List_ScopedToTenantAndUser(t *testing.T) {
 	svc := agenttask.NewService(repo, &fakeEngine{})
 	tenantID, userA, userB := uuid.New(), uuid.New(), uuid.New()
 
-	if _, err := svc.CreateTask(context.Background(), tenantID, userA, agenttask.PackCoding); err != nil {
+	if _, err := svc.CreateTask(context.Background(), tenantID, userA, agenttask.PackCoding, ""); err != nil {
 		t.Fatalf("seed userA task: %v", err)
 	}
-	if _, err := svc.CreateTask(context.Background(), tenantID, userB, agenttask.PackCoding); err != nil {
+	if _, err := svc.CreateTask(context.Background(), tenantID, userB, agenttask.PackCoding, ""); err != nil {
 		t.Fatalf("seed userB task: %v", err)
 	}
 
@@ -184,7 +184,7 @@ func TestService_List_ScopedToTenantAndUser(t *testing.T) {
 func TestService_Cancel_FromQueued(t *testing.T) {
 	svc := agenttask.NewService(newFakeRepository(), agenttask.NotConfiguredEngine{})
 	tenantID, userID := uuid.New(), uuid.New()
-	created, err := svc.CreateTask(context.Background(), tenantID, userID, agenttask.PackCoding)
+	created, err := svc.CreateTask(context.Background(), tenantID, userID, agenttask.PackCoding, "")
 	if err != nil {
 		t.Fatalf("seed CreateTask: %v", err)
 	}
@@ -201,7 +201,7 @@ func TestService_Cancel_FromQueued(t *testing.T) {
 func TestService_Cancel_TerminalStateRejected(t *testing.T) {
 	svc := agenttask.NewService(newFakeRepository(), &fakeEngine{sessionRef: "s1"})
 	tenantID, userID := uuid.New(), uuid.New()
-	created, err := svc.CreateTask(context.Background(), tenantID, userID, agenttask.PackCoding)
+	created, err := svc.CreateTask(context.Background(), tenantID, userID, agenttask.PackCoding, "")
 	if err != nil {
 		t.Fatalf("seed CreateTask: %v", err)
 	}

--- a/apps/control-plane/internal/agenttask/types.go
+++ b/apps/control-plane/internal/agenttask/types.go
@@ -50,6 +50,7 @@ type Task struct {
 	TenantID         uuid.UUID
 	UserID           uuid.UUID
 	Pack             Pack
+	Instructions     string
 	Status           Status
 	EngineSessionRef string
 	ResultSummaryRef string

--- a/apps/edge-api/internal/agenttask/client.go
+++ b/apps/edge-api/internal/agenttask/client.go
@@ -32,10 +32,11 @@ func NewClient(controlPlaneURL string) *Client {
 }
 
 // Create posts a new task. POST /internal/agent-tasks/{tenant_id}/{user_id}.
-func (c *Client) Create(ctx context.Context, tenantID, userID uuid.UUID, pack string) (Task, error) {
+func (c *Client) Create(ctx context.Context, tenantID, userID uuid.UUID, pack, instructions string) (Task, error) {
 	body, err := json.Marshal(struct {
-		Pack string `json:"pack"`
-	}{Pack: pack})
+		Pack         string `json:"pack"`
+		Instructions string `json:"instructions"`
+	}{Pack: pack, Instructions: instructions})
 	if err != nil {
 		return Task{}, fmt.Errorf("agenttask.client: marshal: %w", err)
 	}

--- a/apps/edge-api/internal/agenttask/client_test.go
+++ b/apps/edge-api/internal/agenttask/client_test.go
@@ -33,7 +33,7 @@ func TestClient_Create_PostsExpectedPathAndBody(t *testing.T) {
 	defer srv.Close()
 
 	client := NewClient(srv.URL)
-	task, err := client.Create(context.Background(), tenantID, userID, "coding-pack")
+	task, err := client.Create(context.Background(), tenantID, userID, "coding-pack", "")
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -64,7 +64,7 @@ func TestClient_Create_BadRequestMapsToErrInvalidPack(t *testing.T) {
 	defer srv.Close()
 
 	client := NewClient(srv.URL)
-	_, err := client.Create(context.Background(), uuid.New(), uuid.New(), "not-a-pack")
+	_, err := client.Create(context.Background(), uuid.New(), uuid.New(), "not-a-pack", "")
 	if err != ErrInvalidPack {
 		t.Fatalf("expected ErrInvalidPack, got %v", err)
 	}

--- a/apps/edge-api/internal/agenttask/handler.go
+++ b/apps/edge-api/internal/agenttask/handler.go
@@ -16,7 +16,7 @@ import (
 // TaskClient is the minimal interface the handler needs from Client.
 // Exported so tests can inject a fake without a real control-plane.
 type TaskClient interface {
-	Create(ctx context.Context, tenantID, userID uuid.UUID, pack string) (Task, error)
+	Create(ctx context.Context, tenantID, userID uuid.UUID, pack, instructions string) (Task, error)
 	List(ctx context.Context, tenantID, userID uuid.UUID) ([]Task, error)
 	Get(ctx context.Context, tenantID, userID, taskID uuid.UUID) (Task, error)
 	Cancel(ctx context.Context, tenantID, userID, taskID uuid.UUID) (Task, error)
@@ -74,7 +74,8 @@ func (h *Handler) routeTaskByID(w http.ResponseWriter, r *http.Request) {
 }
 
 type createTaskRequest struct {
-	Pack string `json:"pack"`
+	Pack         string `json:"pack"`
+	Instructions string `json:"instructions"`
 }
 
 func (h *Handler) handleCreate(w http.ResponseWriter, r *http.Request) {
@@ -85,7 +86,7 @@ func (h *Handler) handleCreate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req createTaskRequest
-	if err := json.NewDecoder(io.LimitReader(r.Body, 4096)).Decode(&req); err != nil {
+	if err := json.NewDecoder(io.LimitReader(r.Body, 64<<10)).Decode(&req); err != nil {
 		apierrors.Write(w, http.StatusBadRequest, apierrors.CodeInvalidRequest, "invalid request body")
 		return
 	}
@@ -94,7 +95,7 @@ func (h *Handler) handleCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	task, err := h.client.Create(r.Context(), user.TenantID, user.ID, req.Pack)
+	task, err := h.client.Create(r.Context(), user.TenantID, user.ID, req.Pack, req.Instructions)
 	if err != nil {
 		writeTaskError(w, err)
 		return

--- a/apps/edge-api/internal/agenttask/handler_test.go
+++ b/apps/edge-api/internal/agenttask/handler_test.go
@@ -24,12 +24,12 @@ func newFakeClient() *fakeClient {
 	return &fakeClient{tasks: make(map[uuid.UUID]Task)}
 }
 
-func (f *fakeClient) Create(_ context.Context, _, _ uuid.UUID, pack string) (Task, error) {
+func (f *fakeClient) Create(_ context.Context, _, _ uuid.UUID, pack, instructions string) (Task, error) {
 	if f.createErr != nil {
 		return Task{}, f.createErr
 	}
 	id := uuid.New()
-	t := Task{ID: id.String(), Pack: pack, Status: "queued"}
+	t := Task{ID: id.String(), Pack: pack, Instructions: instructions, Status: "queued"}
 	f.tasks[id] = t
 	return t, nil
 }

--- a/apps/edge-api/internal/agenttask/types.go
+++ b/apps/edge-api/internal/agenttask/types.go
@@ -18,6 +18,7 @@ import (
 type Task struct {
 	ID               string     `json:"id"`
 	Pack             string     `json:"pack"`
+	Instructions     string     `json:"instructions"`
 	Status           string     `json:"status"`
 	EngineSessionRef string     `json:"engine_session_ref"`
 	ResultSummaryRef string     `json:"result_summary_ref"`

--- a/deploy/apptainer/agent-engine.def
+++ b/deploy/apptainer/agent-engine.def
@@ -13,10 +13,12 @@ From: nikolaik/python-nodejs:python3.12-nodejs22-bookworm
     set -eu
 
     apt-get update
-    # socat: the shim in %runscript forwarding the sandbox's own loopback
-    # (its only interface once launched with --net --network none) to the
-    # bind-mounted egress-proxy Unix socket. This is the one relay path;
-    # see apps/agent-engine/internal/sandbox package doc.
+    # socat: the two shims in %runscript. One forwards the sandbox's own
+    # loopback (its only interface once launched with --net --network none)
+    # to the bind-mounted egress-proxy Unix socket — the one relay path out.
+    # The other listens on the bind-mounted control-channel Unix socket and
+    # forwards into the agent-server's own loopback port — the one relay
+    # path in. See apps/agent-engine/internal/sandbox package doc.
     apt-get install -y --no-install-recommends ca-certificates git build-essential socat
     rm -rf /var/lib/apt/lists/*
 
@@ -54,16 +56,25 @@ From: nikolaik/python-nodejs:python3.12-nodejs22-bookworm
     # (apps/agent-engine/internal/sandbox): its only interface is loopback.
     # This shim forwards that loopback port (ProxyShimPort, 3128) to the
     # egress-proxy Unix socket bind-mounted at ProxySocketContainerPath —
-    # the one relay path HTTP_PROXY/HTTPS_PROXY route through. Backgrounded
-    # so the agent-server below still becomes PID 1 inside --pid.
+    # the one relay path out (HTTP_PROXY/HTTPS_PROXY route through it).
+    # Backgrounded so the agent-server below still becomes PID 1 inside --pid.
     socat TCP-LISTEN:3128,bind=127.0.0.1,fork,reuseaddr UNIX-CONNECT:/opt/hive/egress.sock &
+
+    # Host <-> agent-server control channel (issue #305): the reverse
+    # direction of the shim above. HIVE_CONTROL_TARGET_PORT is set by
+    # apps/agent-engine/internal/sandbox.BuildArgv to the same --port value
+    # passed to openhands.agent_server below. unlink-early removes any
+    # stale socket file left at that path (should not happen — each session
+    # gets a fresh empty ControlSocketDir — but a stale file would otherwise
+    # make this bind fail rather than fail loud). The host dials the
+    # bind-mounted directory side of this same socket directly; see
+    # apps/agent-engine/internal/controlclient.
+    socat UNIX-LISTEN:/opt/hive/control/agent.sock,fork,unlink-early TCP-CONNECT:127.0.0.1:${HIVE_CONTROL_TARGET_PORT} &
 
     # Mirrors the entrypoint upstream's ApptainerWorkspace._start_container()
     # expects to run (`apptainer run ... <sif> --host 0.0.0.0 --port <n>`):
     # apps/agent-engine/internal/sandbox.BuildArgv appends `--host`/`--port`
-    # after the SIF path, which land here as "$@". Not yet reachable from the
-    # host with network isolation on — see the sandbox package doc for the
-    # Wave 3 follow-up (a bind-mounted Unix socket control channel).
+    # after the SIF path, which land here as "$@".
     exec python3 -m openhands.agent_server "$@"
 
 %labels
@@ -77,11 +88,14 @@ From: nikolaik/python-nodejs:python3.12-nodejs22-bookworm
     apps/agent-engine/internal/sandbox.BuildArgv, which unconditionally adds
     --pid, --containall, and --net --network none (security spike #307 plus
     team-lead security review of this package), leaving the sandbox with no
-    network interface but loopback. The only relay to the outside world is
-    the socat shim in %runscript, forwarding that loopback to a bind-mounted
-    Unix socket where a per-session allowlist proxy enforces the tenant/
-    user's effective egress policy (apps/control-plane/internal/egress,
-    issue #308).
+    network interface but loopback. Two socat shims in %runscript relay
+    across that isolation in each direction: one forwards the loopback to a
+    bind-mounted Unix socket where a per-session allowlist proxy enforces
+    the tenant/user's effective egress policy (apps/control-plane/internal/
+    egress, issue #308); the other listens on a second bind-mounted Unix
+    socket (the control channel, issue #305) and forwards into the
+    agent-server's own loopback port, so the host can reach its REST API
+    (apps/agent-engine/internal/controlclient) despite --network none.
 
     Build (on a host with apptainer installed):
         apptainer build agent-engine.sif deploy/apptainer/agent-engine.def

--- a/supabase/migrations/20260716_04_agent_tasks_instructions.sql
+++ b/supabase/migrations/20260716_04_agent_tasks_instructions.sql
@@ -1,0 +1,24 @@
+-- supabase/migrations/20260716_04_agent_tasks_instructions.sql
+--
+-- Adds the free-text instructions/prompt a task's conversation starts from
+-- (issue #311 contract gap: agent_tasks had no way to tell the agent-engine
+-- what to do). Nullable: a task created with no instructions is a valid
+-- state (e.g. a workspace-only session), read back as '' at the application
+-- layer via COALESCE rather than a Go *string, matching how the other
+-- optional text columns on this table already read (engine_session_ref,
+-- result_summary_ref, error_message) — the difference here is only that
+-- those default to '' at the DB level and this one allows NULL, since a
+-- blank vs. absent prompt is a meaningful distinction for future callers
+-- even though today's read path collapses both to "".
+--
+-- Depends on: 20260716_03_agent_tasks.sql.
+
+BEGIN;
+
+ALTER TABLE public.agent_tasks
+    ADD COLUMN instructions TEXT;
+
+COMMENT ON COLUMN public.agent_tasks.instructions IS
+  'Free-text prompt/goal the task''s conversation starts from (apps/agent-engine/internal/controlclient''s initial_message). NULL means no instructions were provided. Skills (issue #300) route on a "Skill: X" prefix inside this text.';
+
+COMMIT;


### PR DESCRIPTION
## Summary

- Closes the Wave 3 control-channel gap left by PR #326: adds a second bind-mounted Unix socket (reverse direction of the existing egress-proxy relay) plus an in-SIF socat shim so the host can reach the agent-server's REST API inside the sandbox despite `--network none`.
- Adds `apps/agent-engine/internal/controlclient`, a host-side HTTP-over-unix-socket client for the vendored OpenHands agent-server's conversation API. Routes verified directly against `vendor/openhands/openhands-agent-server` source (`conversation_router.py`, `api.py`, `dependencies.py`), not guessed.
- Adds `apps/agent-engine/internal/engine.SandboxEngine`, composing the sandbox launcher and controlclient into a full launch/status/cancel session lifecycle, mapped onto the queued/running/succeeded/failed/cancelled vocabulary from `apps/control-plane/internal/agenttask` (PR #329, now merged).
- Adds `apps/agent-engine/engineapi` (public re-export) and `apps/control-plane/internal/agentengine` (thin adapter) so control-plane can construct and wire a real `agenttask.Engine` despite the internal-package boundary between the two modules — mirrors the pattern `egressclient`'s doc comment already documents for this repo.
- Wires the real engine into `cmd/server/main.go`, gated on `HIVE_AGENT_ENGINE_SIF_PATH` (and sibling env vars) being set; `NotConfiguredEngine` stays the default otherwise, unchanged from today.
- Threads a new `instructions` field through agent task creation (edge-api request body, control-plane schema/service, engine's initial conversation message) — the contract gap the agent console's prompt input needs once it lands.

## Design notes

- Control socket direction is the reverse of egress: `LaunchConfig.ControlSocketDir` is an empty host directory bind-mounted read-write into the sandbox; the in-SIF shim creates its listening socket inside it after the sandbox starts, so the socket file becomes visible at the mirrored host path for the host to dial directly. Read-write is required (not read-only) because the shim needs to create the socket file inside the mount.
- `ValidateSecurityDefaults` now also asserts the control-socket bind mount is present, so a future edit that drops it fails closed the same way a dropped `--network none` already does.
- Session state (running sandbox process, control client) lives in an in-memory map inside `SandboxEngine`, not persisted to disk — a process restart loses the ability to `Status`/`Cancel` an in-flight session, but the sandbox process is a child of this one and wouldn't survive the restart either, so persistence buys nothing yet.
- `agenttask.Task` has no prompt/LLM-profile field beyond the new `instructions` string; `Engine.Launch` uses one shared `Config.AgentProfileID` for every session (no per-task profile selection exists to wire yet).

## Known follow-up (documented in SYNC_CONTRACT.md's Engine seam section)

Nothing yet polls `SandboxEngine.Status` on a timer to advance a task past `running` to `succeeded`/`failed`/`cancelled` in the database — `Status` and `Cancel` are implemented and unit tested on the engine side, but no scheduler calls them. A background sync loop (or an agent-server-side webhook) is the next piece.

## Test plan

- [x] `go test ./apps/agent-engine/...` — all packages pass, including new `controlclient` and `engine` suites (fake unix-socket agent-server, no live Apptainer)
- [x] `go test ./apps/control-plane/...` — full suite passes, including `agenttask` and new `agentengine`
- [x] `go test ./apps/edge-api/...` — full suite passes, including `agenttask`
- [x] `go vet` clean on all three modules
- [x] `gofmt -l` clean on all touched files
- [ ] Live Apptainer control-channel smoke test — blocked on the same lab network-reachability issue tracked separately ("Live Apptainer validation of agent-engine on x86-64 host"); `HIVE_APPTAINER_TEST=1`-gated live tests already exist in `apps/agent-engine/internal/sandbox` for when that unblocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)