### PR TITLE
feat: task status poller advancing agent tasks to terminal state

### DIFF
--- a/.github/branch-protection-main.json
+++ b/.github/branch-protection-main.json
@@ -2,6 +2,7 @@
   "required_status_checks": {
     "strict": false,
     "contexts": [
+      "Go tests (agent-engine)",
       "Go tests (control-plane)",
       "Go tests (edge-api)",
       "Go tests (storage)",

--- a/apps/control-plane/cmd/server/main.go
+++ b/apps/control-plane/cmd/server/main.go
@@ -810,8 +810,25 @@ func main() {
 	var agentTaskHandler *agenttask.Handler
 	if pool != nil {
 		agentTaskRepo := agenttask.NewPgxRepository(pool)
-		agentTaskSvc := agenttask.NewService(agentTaskRepo, buildAgentEngine(egressSvc))
+		agentEngine, agentEngineStatus := buildAgentEngine(egressSvc)
+		agentTaskSvc := agenttask.NewService(agentTaskRepo, agentEngine)
 		agentTaskHandler = agenttask.NewHandler(agentTaskSvc)
+
+		// Poller needs a real StatusChecker to poll — NotConfiguredEngine has
+		// no Status method — so it is only started when the engine itself
+		// is (same HIVE_AGENT_ENGINE_* gate; see SYNC_CONTRACT.md's Engine
+		// seam section).
+		if agentEngineStatus != nil {
+			poller := agenttask.NewPoller(agentTaskRepo, agentEngineStatus, agenttask.PollerConfig{
+				Interval: parseDurationEnv("HIVE_AGENT_TASK_POLL_INTERVAL", 15*time.Second),
+				Logger:   slog.Default(),
+			})
+			// Bound to runCtx so it stops cleanly on shutdown, same as the
+			// other background workers below (spend-alert cron, WAL drainer).
+			poller.Start(runCtx)
+			defer poller.Stop()
+			log.Println("agent task status poller started")
+		}
 	}
 
 	router := platformhttp.NewRouter(platformhttp.RouterConfig{
@@ -1316,19 +1333,23 @@ func parseDurationEnv(key string, fallback time.Duration) time.Duration {
 // agent-engine on x86-64 host"). egressSvc is reused in-process rather than
 // calling apps/agent-engine/internal/egressclient's HTTP round-trip, since
 // the real Engine now runs inside this same control-plane process.
-func buildAgentEngine(egressSvc *egress.Service) agenttask.Engine {
+// buildAgentEngine's second return value is the same *agentengine.Engine as
+// a agenttask.StatusChecker (nil when unconfigured) — the seam
+// cmd/server/main.go's poller wiring uses, since NotConfiguredEngine has no
+// Status method to poll.
+func buildAgentEngine(egressSvc *egress.Service) (agenttask.Engine, agenttask.StatusChecker) {
 	sifPath := os.Getenv("HIVE_AGENT_ENGINE_SIF_PATH")
 	packsDir := os.Getenv("HIVE_AGENT_ENGINE_PACKS_DIR")
 	workspaceRoot := os.Getenv("HIVE_AGENT_ENGINE_WORKSPACE_ROOT")
 	runDir := os.Getenv("HIVE_AGENT_ENGINE_RUN_DIR")
 	profileIDRaw := os.Getenv("HIVE_AGENT_ENGINE_PROFILE_ID")
 	if egressSvc == nil || sifPath == "" || packsDir == "" || workspaceRoot == "" || runDir == "" || profileIDRaw == "" {
-		return agenttask.NotConfiguredEngine{}
+		return agenttask.NotConfiguredEngine{}, nil
 	}
 	profileID, err := uuid.Parse(profileIDRaw)
 	if err != nil {
 		log.Printf("control-plane: HIVE_AGENT_ENGINE_PROFILE_ID invalid, agent-engine stays unconfigured: %v", err)
-		return agenttask.NotConfiguredEngine{}
+		return agenttask.NotConfiguredEngine{}, nil
 	}
 
 	sandbox := engineapi.New(engineapi.Config{
@@ -1346,5 +1367,6 @@ func buildAgentEngine(egressSvc *egress.Service) agenttask.Engine {
 		AgentProfileID: profileID,
 		SessionAPIKey:  os.Getenv("HIVE_AGENT_ENGINE_SESSION_API_KEY"),
 	})
-	return agentengine.New(sandbox)
+	real := agentengine.New(sandbox)
+	return real, real
 }

--- a/apps/control-plane/internal/agenttask/SYNC_CONTRACT.md
+++ b/apps/control-plane/internal/agenttask/SYNC_CONTRACT.md
@@ -114,12 +114,24 @@ preserving today's queued-forever-but-not-failed behavior exactly. `Service`
 and the HTTP surface do not change either way; only the `Engine`
 implementation passed to `NewService` does.
 
-`Service`/`Status` polling from a queued/running task back to
-succeeded/failed/cancelled is not wired by this package itself yet: nothing
-here calls `SandboxEngine.Status`/`Cancel` on a timer. `Handler.handleGet`
-returns whatever `Repository.Get` currently has persisted; a background
-sync loop (or a webhook the engine calls back on) that periodically calls
-the adapter's `Status` and writes the result via `Repository.Transition` is
-the next piece needed to make status advance past `running` in production —
-tracked as a follow-up, same as the Status/Cancel plumbing on the engine
-side is already real and unit-tested.
+**Implemented** (issue #311 follow-up): `Poller` (`poller.go`) periodically
+advances every active task past `running`. It lists queued/running tasks
+with a non-empty `engine_session_ref` across every tenant
+(`Repository.ListActive`, cross-tenant by design — see
+`20260716_05_agent_tasks_service_scan.sql`'s `agent_tasks_service_scan`
+policy), calls `StatusChecker.Status(ctx, sessionRef)` for each (a narrow
+interface `apps/control-plane/internal/agentengine.Engine` already
+satisfies structurally, no adapter code needed), and atomically
+`Repository.Transition`s the terminal ones. A per-task engine error is
+logged and left for the next pass (retried, not failed); a concurrent
+`Cancel` winning the same task's `Transition` race returns
+`ErrTerminalState`, silently swallowed. The loop backs off exponentially
+(capped at 5 minutes) after a pass that had any error, resetting to the
+configured interval on the next clean pass.
+
+Wired in `cmd/server/main.go` behind the same `HIVE_AGENT_ENGINE_SIF_PATH`
+gate as the `Engine` itself (the poller needs a real `StatusChecker`, which
+only exists once the real `SandboxEngine` is configured) — interval via
+`HIVE_AGENT_TASK_POLL_INTERVAL` (Go duration string, default 15s), bound to
+the same process-lifetime context the other background workers use so it
+stops cleanly on shutdown.

--- a/apps/control-plane/internal/agenttask/poller.go
+++ b/apps/control-plane/internal/agenttask/poller.go
@@ -1,0 +1,201 @@
+package agenttask
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// StatusChecker is the narrow surface the Poller needs from an Engine
+// implementation. apps/control-plane/internal/agentengine.Engine already has
+// a method with this exact signature (agenttask.Status is its own return
+// type), so it satisfies this interface with no adapter code — Go
+// interfaces are structural.
+type StatusChecker interface {
+	Status(ctx context.Context, sessionRef string) (status Status, resultSummary, errMessage string, err error)
+}
+
+// maxPollerBackoff caps the exponential backoff RunOnce failures grow the
+// loop's interval to (see loop's doc comment).
+const maxPollerBackoff = 5 * time.Minute
+
+// PollerConfig controls Poller behaviour.
+type PollerConfig struct {
+	// Interval between poll passes when the previous pass had no errors.
+	// Zero defaults to 15s.
+	Interval time.Duration
+	// Logger; nil defaults to slog.Default().
+	Logger *slog.Logger
+}
+
+// Poller periodically advances every active (queued/running, launched) task
+// to its terminal state: lists them (Repository.ListActive), polls each
+// one's engine status (StatusChecker.Status), and atomically transitions
+// terminal ones (Repository.Transition). Mirrors
+// apps/control-plane/internal/spendalerts.Runner's Start/Stop/RunOnce shape.
+type Poller struct {
+	repo     Repository
+	checker  StatusChecker
+	interval time.Duration
+	logger   *slog.Logger
+
+	mu      sync.Mutex
+	cancel  context.CancelFunc
+	doneCh  chan struct{}
+	started bool
+}
+
+// NewPoller builds a Poller. repo and checker must be non-nil.
+func NewPoller(repo Repository, checker StatusChecker, cfg PollerConfig) *Poller {
+	if repo == nil {
+		panic("agenttask: nil repository")
+	}
+	if checker == nil {
+		panic("agenttask: nil status checker")
+	}
+	interval := cfg.Interval
+	if interval <= 0 {
+		interval = 15 * time.Second
+	}
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Poller{repo: repo, checker: checker, interval: interval, logger: logger}
+}
+
+// RunOnce performs exactly one poll pass: every active task gets exactly one
+// StatusChecker.Status call and, if terminal, one Repository.Transition
+// call. A single task's engine error is logged and skipped — it stays
+// active and is retried next pass, it does not abort the rest of the pass.
+// The returned error, when non-nil, reports that at least one task had a
+// problem this pass (see loop's backoff); it does not mean the pass failed
+// outright unless ListActive itself errored.
+func (p *Poller) RunOnce(ctx context.Context) (advanced int, err error) {
+	tasks, err := p.repo.ListActive(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("agenttask: poller list active: %w", err)
+	}
+
+	var errCount int
+	for _, t := range tasks {
+		status, resultSummary, errMessage, statusErr := p.checker.Status(ctx, t.EngineSessionRef)
+		if statusErr != nil {
+			errCount++
+			p.logger.WarnContext(ctx, "agenttask: poller status check failed, retrying next pass",
+				"task_id", t.ID, "error", statusErr)
+			continue
+		}
+		if status != StatusSucceeded && status != StatusFailed && status != StatusCancelled {
+			continue
+		}
+
+		if _, transErr := p.repo.Transition(ctx, t.TenantID, t.UserID, t.ID, status, "", resultSummary, errMessage); transErr != nil {
+			if errors.Is(transErr, ErrTerminalState) {
+				// Lost a race with a concurrent Cancel (or a previous pass
+				// that already advanced this task): already terminal,
+				// nothing left to do.
+				continue
+			}
+			errCount++
+			p.logger.WarnContext(ctx, "agenttask: poller transition failed, retrying next pass",
+				"task_id", t.ID, "error", transErr)
+			continue
+		}
+		advanced++
+	}
+
+	if errCount > 0 {
+		return advanced, fmt.Errorf("agenttask: poller pass had %d task-level error(s)", errCount)
+	}
+	return advanced, nil
+}
+
+// Start launches the poll loop on a background goroutine. Subsequent Start
+// calls are no-ops until Stop is called.
+func (p *Poller) Start(parent context.Context) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.started {
+		return
+	}
+	ctx, cancel := context.WithCancel(parent)
+	doneCh := make(chan struct{})
+	p.cancel = cancel
+	p.doneCh = doneCh
+	p.started = true
+
+	go p.loop(ctx, doneCh)
+}
+
+// Stop signals the loop to exit and waits for the in-flight pass to finish.
+// Safe to call multiple times.
+func (p *Poller) Stop() {
+	p.mu.Lock()
+	if !p.started {
+		p.mu.Unlock()
+		return
+	}
+	cancel := p.cancel
+	doneCh := p.doneCh
+	p.started = false
+	p.cancel = nil
+	p.doneCh = nil
+	p.mu.Unlock()
+
+	cancel()
+	<-doneCh
+}
+
+// loop ticks RunOnce on p.interval, doubling the delay (capped at
+// maxPollerBackoff) each pass that reports an error and resetting to
+// p.interval on the first clean pass — an engine outage or a run of DB
+// errors backs the poller off instead of hammering at full frequency, while
+// a single transient task-level error only costs one doubled wait, not a
+// standing degraded state.
+func (p *Poller) loop(ctx context.Context, doneCh chan<- struct{}) {
+	defer close(doneCh)
+
+	consecutiveFailures := 0
+	runPass := func() {
+		if _, err := p.RunOnce(ctx); err != nil {
+			consecutiveFailures++
+		} else {
+			consecutiveFailures = 0
+		}
+	}
+
+	// Eager first pass so a service start advances already-active tasks
+	// without waiting a full interval.
+	runPass()
+
+	timer := time.NewTimer(pollerBackoffDelay(p.interval, consecutiveFailures))
+	defer timer.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+			runPass()
+			timer.Reset(pollerBackoffDelay(p.interval, consecutiveFailures))
+		}
+	}
+}
+
+// pollerBackoffDelay returns the delay before the next pass:
+// consecutiveFailures 0 → base; each further failure doubles it, capped at
+// maxPollerBackoff. Pure function, kept separate from loop for testing
+// without timers.
+func pollerBackoffDelay(base time.Duration, consecutiveFailures int) time.Duration {
+	d := base
+	for i := 0; i < consecutiveFailures && d < maxPollerBackoff; i++ {
+		d *= 2
+	}
+	if d > maxPollerBackoff {
+		d = maxPollerBackoff
+	}
+	return d
+}

--- a/apps/control-plane/internal/agenttask/poller.go
+++ b/apps/control-plane/internal/agenttask/poller.go
@@ -93,6 +93,17 @@ func (p *Poller) RunOnce(ctx context.Context) (advanced int, err error) {
 			continue
 		}
 
+		// Provider-blind boundary: errMessage came from StatusChecker, an
+		// interface this package does not control the implementation of.
+		// error_message is customer-visible (Handler.handleGet), so a raw
+		// engine/provider detail must never reach it — log the real detail
+		// server-side, persist a generic message instead.
+		if errMessage != "" {
+			p.logger.WarnContext(ctx, "agenttask: task failed, engine detail",
+				"task_id", t.ID, "engine_detail", errMessage)
+			errMessage = "agent task failed"
+		}
+
 		if _, transErr := p.repo.Transition(ctx, t.TenantID, t.UserID, t.ID, status, "", resultSummary, errMessage); transErr != nil {
 			if errors.Is(transErr, ErrTerminalState) {
 				// Lost a race with a concurrent Cancel (or a previous pass
@@ -132,7 +143,12 @@ func (p *Poller) Start(parent context.Context) {
 }
 
 // Stop signals the loop to exit and waits for the in-flight pass to finish.
-// Safe to call multiple times.
+// Safe to call multiple times. started/cancel/doneCh are cleared only AFTER
+// the wait: clearing them first would let a concurrent Start launch a
+// second loop while the previous pass is still running (duplicate status
+// checks, competing terminal transitions). The p.doneCh == doneCh check
+// guards a concurrent second Stop from clearing state a subsequent
+// Start/Stop cycle has already replaced.
 func (p *Poller) Stop() {
 	p.mu.Lock()
 	if !p.started {
@@ -141,13 +157,18 @@ func (p *Poller) Stop() {
 	}
 	cancel := p.cancel
 	doneCh := p.doneCh
-	p.started = false
-	p.cancel = nil
-	p.doneCh = nil
 	p.mu.Unlock()
 
 	cancel()
 	<-doneCh
+
+	p.mu.Lock()
+	if p.doneCh == doneCh {
+		p.started = false
+		p.cancel = nil
+		p.doneCh = nil
+	}
+	p.mu.Unlock()
 }
 
 // loop ticks RunOnce on p.interval, doubling the delay (capped at

--- a/apps/control-plane/internal/agenttask/poller_internal_test.go
+++ b/apps/control-plane/internal/agenttask/poller_internal_test.go
@@ -1,0 +1,28 @@
+package agenttask
+
+import (
+	"testing"
+	"time"
+)
+
+func TestPollerBackoffDelay(t *testing.T) {
+	base := 15 * time.Second
+	cases := []struct {
+		consecutiveFailures int
+		want                time.Duration
+	}{
+		{0, 15 * time.Second},
+		{1, 30 * time.Second},
+		{2, 1 * time.Minute},
+		{3, 2 * time.Minute},
+		{4, 4 * time.Minute},
+		{5, maxPollerBackoff}, // 8m would exceed the 5m cap
+		{20, maxPollerBackoff},
+	}
+	for _, tc := range cases {
+		got := pollerBackoffDelay(base, tc.consecutiveFailures)
+		if got != tc.want {
+			t.Errorf("pollerBackoffDelay(%s, %d) = %s, want %s", base, tc.consecutiveFailures, got, tc.want)
+		}
+	}
+}

--- a/apps/control-plane/internal/agenttask/poller_test.go
+++ b/apps/control-plane/internal/agenttask/poller_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -137,21 +138,28 @@ func TestPoller_RunOnce_EngineErrorIsRetriedNotFailed(t *testing.T) {
 	}
 }
 
+// raceRepo simulates a task that ListActive still reports as active (it was
+// queued/running at the moment the poller listed it) but whose Transition
+// call loses a race to a concurrent Cancel landing in between — the actual
+// scenario Repository.Transition's atomic "not already terminal" guard
+// exists for.
+type raceRepo struct {
+	*fakeRepository
+	active agenttask.Task
+}
+
+func (r *raceRepo) ListActive(context.Context) ([]agenttask.Task, error) {
+	return []agenttask.Task{r.active}, nil
+}
+
+func (r *raceRepo) Transition(context.Context, uuid.UUID, uuid.UUID, uuid.UUID, agenttask.Status, string, string, string) (agenttask.Task, error) {
+	return agenttask.Task{}, agenttask.ErrTerminalState
+}
+
 func TestPoller_RunOnce_SwallowsTerminalStateRace(t *testing.T) {
-	repo := newFakeRepository()
-	// Simulates a concurrent Cancel winning the race before this pass's
-	// Transition call lands.
-	task := newActiveTask(repo, agenttask.StatusRunning, "session-1")
-	if _, err := repo.Transition(context.Background(), task.TenantID, task.UserID, task.ID, agenttask.StatusCancelled, "", "", ""); err != nil {
-		t.Fatalf("seed cancel: %v", err)
-	}
-	// The fake repo's ListActive filters on status queued/running, so a
-	// cancelled task would never surface here in practice; call RunOnce's
-	// building block directly isn't exposed, so instead exercise the same
-	// path ListActive would have skipped, confirming Transition's own
-	// ErrTerminalState guard (not RunOnce) is what protects a genuine race
-	// where the task was still active when listed but terminal by the time
-	// Transition runs.
+	inner := newFakeRepository()
+	task := newActiveTask(inner, agenttask.StatusRunning, "session-1")
+	repo := &raceRepo{fakeRepository: inner, active: task}
 	checker := &fakeStatusChecker{responses: map[string]checkerResponse{
 		"session-1": {status: agenttask.StatusFailed, errMessage: "too late"},
 	}}
@@ -163,6 +171,33 @@ func TestPoller_RunOnce_SwallowsTerminalStateRace(t *testing.T) {
 	}
 	if advanced != 0 {
 		t.Fatalf("advanced=%d want 0 (task was already terminal, not re-counted)", advanced)
+	}
+}
+
+func TestPoller_RunOnce_SanitizesErrorMessageBeforePersisting(t *testing.T) {
+	repo := newFakeRepository()
+	task := newActiveTask(repo, agenttask.StatusRunning, "session-1")
+	rawDetail := "raw provider detail: dial tcp 10.0.0.5:443: connection refused"
+	checker := &fakeStatusChecker{responses: map[string]checkerResponse{
+		"session-1": {status: agenttask.StatusFailed, errMessage: rawDetail},
+	}}
+	p := agenttask.NewPoller(repo, checker, agenttask.PollerConfig{Logger: quietPollerLogger()})
+
+	if _, err := p.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	got, err := repo.Get(context.Background(), task.TenantID, task.UserID, task.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Status != agenttask.StatusFailed {
+		t.Fatalf("status=%q want failed", got.Status)
+	}
+	if strings.Contains(got.ErrorMessage, "10.0.0.5") || strings.Contains(got.ErrorMessage, "dial tcp") {
+		t.Fatalf("error_message leaked raw engine/provider detail (provider-blind violation): %q", got.ErrorMessage)
+	}
+	if got.ErrorMessage == "" {
+		t.Fatal("expected a generic non-empty error_message, got empty")
 	}
 }
 
@@ -197,8 +232,11 @@ func TestPoller_StartStop_TicksAtInterval(t *testing.T) {
 	time.Sleep(80 * time.Millisecond)
 	p.Stop()
 
-	if calls := checker.Calls(); calls < 1 {
-		t.Fatalf("expected at least the eager first pass to have run, got %d calls", calls)
+	// Eager first pass + at least 2 tick-driven passes within 80ms at a 20ms
+	// interval: >=1 would also pass on the eager pass alone and never prove
+	// the ticker itself fires.
+	if calls := checker.Calls(); calls < 2 {
+		t.Fatalf("expected >=2 calls within window (eager pass + ticks), got %d", calls)
 	}
 }
 
@@ -215,6 +253,77 @@ func TestPoller_Start_DoubleCallIsNoop(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 	p.Stop()
 	p.Stop() // double-stop also safe
+}
+
+// blockingStatusChecker blocks each Status call on release, and records
+// whether more than one call was ever in flight at once — the signal a
+// concurrent Start racing an in-progress Stop would produce (a second loop
+// launched while the first pass is still running).
+type blockingStatusChecker struct {
+	mu          sync.Mutex
+	inFlight    int
+	maxInFlight int
+	release     <-chan struct{}
+	entered     chan<- struct{}
+}
+
+func (b *blockingStatusChecker) Status(context.Context, string) (agenttask.Status, string, string, error) {
+	b.mu.Lock()
+	b.inFlight++
+	if b.inFlight > b.maxInFlight {
+		b.maxInFlight = b.inFlight
+	}
+	b.mu.Unlock()
+
+	select {
+	case b.entered <- struct{}{}:
+	default:
+	}
+	<-b.release
+
+	b.mu.Lock()
+	b.inFlight--
+	b.mu.Unlock()
+	return agenttask.StatusRunning, "", "", nil
+}
+
+func (b *blockingStatusChecker) maxConcurrent() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.maxInFlight
+}
+
+func TestPoller_Stop_BlocksConcurrentStartUntilLoopExits(t *testing.T) {
+	repo := newFakeRepository()
+	newActiveTask(repo, agenttask.StatusRunning, "session-1")
+
+	release := make(chan struct{})
+	entered := make(chan struct{}, 1)
+	checker := &blockingStatusChecker{release: release, entered: entered}
+	// Long interval: only the eager first pass should ever run in this test.
+	p := agenttask.NewPoller(repo, checker, agenttask.PollerConfig{Interval: time.Hour, Logger: quietPollerLogger()})
+
+	p.Start(context.Background())
+	<-entered // eager first pass is now blocked inside Status
+
+	stopDone := make(chan struct{})
+	go func() {
+		p.Stop()
+		close(stopDone)
+	}()
+
+	// Give Stop time to reach its <-doneCh wait, then try Start again: with
+	// started cleared only after that wait, this must stay a no-op while
+	// the original pass is still blocked.
+	time.Sleep(20 * time.Millisecond)
+	p.Start(context.Background())
+
+	close(release) // let the blocked pass finish
+	<-stopDone
+
+	if max := checker.maxConcurrent(); max > 1 {
+		t.Fatalf("expected at most 1 concurrent Status call, got %d (a concurrent Start raced Stop-in-progress and launched a second loop)", max)
+	}
 }
 
 func TestNewPoller_PanicsOnNilDependencies(t *testing.T) {

--- a/apps/control-plane/internal/agenttask/poller_test.go
+++ b/apps/control-plane/internal/agenttask/poller_test.go
@@ -1,0 +1,236 @@
+package agenttask_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/agenttask"
+)
+
+// quietPollerLogger discards WARN logs from intentional-error test cases so
+// `go test` output isn't cluttered with expected failures.
+func quietPollerLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// fakeStatusChecker is a hand-built agenttask.StatusChecker stub: a fixed
+// per-sessionRef response table, with an optional call counter for the
+// Start/Stop loop tests.
+type fakeStatusChecker struct {
+	mu        sync.Mutex
+	responses map[string]checkerResponse
+	calls     int
+}
+
+type checkerResponse struct {
+	status        agenttask.Status
+	resultSummary string
+	errMessage    string
+	err           error
+}
+
+func (f *fakeStatusChecker) Status(_ context.Context, sessionRef string) (agenttask.Status, string, string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	resp, ok := f.responses[sessionRef]
+	if !ok {
+		return agenttask.StatusRunning, "", "", nil
+	}
+	return resp.status, resp.resultSummary, resp.errMessage, resp.err
+}
+
+func (f *fakeStatusChecker) Calls() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+func newActiveTask(repo *fakeRepository, status agenttask.Status, sessionRef string) agenttask.Task {
+	t, _ := repo.Create(context.Background(), uuid.New(), uuid.New(), agenttask.PackCoding, "")
+	t, _ = repo.Transition(context.Background(), t.TenantID, t.UserID, t.ID, status, sessionRef, "", "")
+	return t
+}
+
+func TestPoller_RunOnce_AdvancesRunningToSucceeded(t *testing.T) {
+	repo := newFakeRepository()
+	task := newActiveTask(repo, agenttask.StatusRunning, "session-1")
+	checker := &fakeStatusChecker{responses: map[string]checkerResponse{
+		"session-1": {status: agenttask.StatusSucceeded, resultSummary: "done"},
+	}}
+	p := agenttask.NewPoller(repo, checker, agenttask.PollerConfig{Logger: quietPollerLogger()})
+
+	advanced, err := p.RunOnce(context.Background())
+	if err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if advanced != 1 {
+		t.Fatalf("advanced=%d want 1", advanced)
+	}
+	got, err := repo.Get(context.Background(), task.TenantID, task.UserID, task.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Status != agenttask.StatusSucceeded {
+		t.Fatalf("status=%q want succeeded", got.Status)
+	}
+	if got.ResultSummaryRef != "done" {
+		t.Fatalf("result summary=%q want %q", got.ResultSummaryRef, "done")
+	}
+}
+
+func TestPoller_RunOnce_LeavesNonTerminalTasksAlone(t *testing.T) {
+	repo := newFakeRepository()
+	task := newActiveTask(repo, agenttask.StatusRunning, "session-1")
+	checker := &fakeStatusChecker{responses: map[string]checkerResponse{
+		"session-1": {status: agenttask.StatusRunning},
+	}}
+	p := agenttask.NewPoller(repo, checker, agenttask.PollerConfig{Logger: quietPollerLogger()})
+
+	advanced, err := p.RunOnce(context.Background())
+	if err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if advanced != 0 {
+		t.Fatalf("advanced=%d want 0", advanced)
+	}
+	got, _ := repo.Get(context.Background(), task.TenantID, task.UserID, task.ID)
+	if got.Status != agenttask.StatusRunning {
+		t.Fatalf("status=%q want still running", got.Status)
+	}
+}
+
+func TestPoller_RunOnce_EngineErrorIsRetriedNotFailed(t *testing.T) {
+	repo := newFakeRepository()
+	broken := newActiveTask(repo, agenttask.StatusRunning, "session-broken")
+	healthy := newActiveTask(repo, agenttask.StatusRunning, "session-healthy")
+	checker := &fakeStatusChecker{responses: map[string]checkerResponse{
+		"session-broken":  {err: errors.New("agent-server unreachable")},
+		"session-healthy": {status: agenttask.StatusSucceeded, resultSummary: "ok"},
+	}}
+	p := agenttask.NewPoller(repo, checker, agenttask.PollerConfig{Logger: quietPollerLogger()})
+
+	advanced, err := p.RunOnce(context.Background())
+	if err == nil {
+		t.Fatal("expected RunOnce to report the per-task engine error")
+	}
+	// "Retried not failed": the broken task is untouched (still active, will
+	// be retried next pass), and the healthy task in the same pass still
+	// advanced despite the other task's error.
+	if advanced != 1 {
+		t.Fatalf("advanced=%d want 1 (only the healthy task)", advanced)
+	}
+	gotBroken, _ := repo.Get(context.Background(), broken.TenantID, broken.UserID, broken.ID)
+	if gotBroken.Status != agenttask.StatusRunning {
+		t.Fatalf("broken task status=%q want unchanged (still running)", gotBroken.Status)
+	}
+	gotHealthy, _ := repo.Get(context.Background(), healthy.TenantID, healthy.UserID, healthy.ID)
+	if gotHealthy.Status != agenttask.StatusSucceeded {
+		t.Fatalf("healthy task status=%q want succeeded", gotHealthy.Status)
+	}
+}
+
+func TestPoller_RunOnce_SwallowsTerminalStateRace(t *testing.T) {
+	repo := newFakeRepository()
+	// Simulates a concurrent Cancel winning the race before this pass's
+	// Transition call lands.
+	task := newActiveTask(repo, agenttask.StatusRunning, "session-1")
+	if _, err := repo.Transition(context.Background(), task.TenantID, task.UserID, task.ID, agenttask.StatusCancelled, "", "", ""); err != nil {
+		t.Fatalf("seed cancel: %v", err)
+	}
+	// The fake repo's ListActive filters on status queued/running, so a
+	// cancelled task would never surface here in practice; call RunOnce's
+	// building block directly isn't exposed, so instead exercise the same
+	// path ListActive would have skipped, confirming Transition's own
+	// ErrTerminalState guard (not RunOnce) is what protects a genuine race
+	// where the task was still active when listed but terminal by the time
+	// Transition runs.
+	checker := &fakeStatusChecker{responses: map[string]checkerResponse{
+		"session-1": {status: agenttask.StatusFailed, errMessage: "too late"},
+	}}
+	p := agenttask.NewPoller(repo, checker, agenttask.PollerConfig{Logger: quietPollerLogger()})
+
+	advanced, err := p.RunOnce(context.Background())
+	if err != nil {
+		t.Fatalf("expected ErrTerminalState to be swallowed, not surfaced as a pass error, got %v", err)
+	}
+	if advanced != 0 {
+		t.Fatalf("advanced=%d want 0 (task was already terminal, not re-counted)", advanced)
+	}
+}
+
+func TestPoller_RunOnce_ListActiveErrorPropagates(t *testing.T) {
+	repo := &erroringListRepo{fakeRepository: newFakeRepository()}
+	checker := &fakeStatusChecker{}
+	p := agenttask.NewPoller(repo, checker, agenttask.PollerConfig{Logger: quietPollerLogger()})
+
+	if _, err := p.RunOnce(context.Background()); err == nil {
+		t.Fatal("expected ListActive failure to propagate")
+	}
+}
+
+type erroringListRepo struct {
+	*fakeRepository
+}
+
+func (e *erroringListRepo) ListActive(context.Context) ([]agenttask.Task, error) {
+	return nil, errors.New("db unavailable")
+}
+
+func TestPoller_StartStop_TicksAtInterval(t *testing.T) {
+	t.Parallel()
+	repo := newFakeRepository()
+	newActiveTask(repo, agenttask.StatusRunning, "session-1") // gives each pass something to check
+	checker := &fakeStatusChecker{}
+	p := agenttask.NewPoller(repo, checker, agenttask.PollerConfig{Interval: 20 * time.Millisecond, Logger: quietPollerLogger()})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	p.Start(ctx)
+	time.Sleep(80 * time.Millisecond)
+	p.Stop()
+
+	if calls := checker.Calls(); calls < 1 {
+		t.Fatalf("expected at least the eager first pass to have run, got %d calls", calls)
+	}
+}
+
+func TestPoller_Start_DoubleCallIsNoop(t *testing.T) {
+	t.Parallel()
+	repo := newFakeRepository()
+	checker := &fakeStatusChecker{}
+	p := agenttask.NewPoller(repo, checker, agenttask.PollerConfig{Interval: 50 * time.Millisecond})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	p.Start(ctx)
+	p.Start(ctx) // ignored
+	time.Sleep(10 * time.Millisecond)
+	p.Stop()
+	p.Stop() // double-stop also safe
+}
+
+func TestNewPoller_PanicsOnNilDependencies(t *testing.T) {
+	repo := newFakeRepository()
+	checker := &fakeStatusChecker{}
+
+	assertPanics(t, func() { agenttask.NewPoller(nil, checker, agenttask.PollerConfig{Logger: quietPollerLogger()}) })
+	assertPanics(t, func() { agenttask.NewPoller(repo, nil, agenttask.PollerConfig{Logger: quietPollerLogger()}) })
+}
+
+func assertPanics(t *testing.T, fn func()) {
+	t.Helper()
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic")
+		}
+	}()
+	fn()
+}

--- a/apps/control-plane/internal/agenttask/repository.go
+++ b/apps/control-plane/internal/agenttask/repository.go
@@ -18,6 +18,11 @@ type Repository interface {
 	// Transition updates status (and the fields that go with it) for a task
 	// already scoped to (tenantID, userID) by the caller.
 	Transition(ctx context.Context, tenantID, userID, id uuid.UUID, status Status, sessionRef, resultSummaryRef, errMsg string) (Task, error)
+	// ListActive returns every task across all tenants that is queued or
+	// running with a non-empty EngineSessionRef (i.e. actually launched
+	// somewhere) — the Poller's input. Cross-tenant by design; see
+	// 20260716_05_agent_tasks_service_scan.sql.
+	ListActive(ctx context.Context) ([]Task, error)
 }
 
 type pgxRepository struct {
@@ -180,6 +185,35 @@ func (r *pgxRepository) Transition(ctx context.Context, tenantID, userID, id uui
 		return Task{}, ErrTerminalState
 	}
 	return t, nil
+}
+
+// ListActive queries across all tenants (agent_tasks_service_scan,
+// 20260716_05_agent_tasks_service_scan.sql), deliberately outside
+// withTenantTx: no single app.current_tenant_id value could see every
+// tenant's rows.
+func (r *pgxRepository) ListActive(ctx context.Context) ([]Task, error) {
+	rows, err := r.pool.Query(ctx, `
+		SELECT id, tenant_id, user_id, pack, COALESCE(instructions, ''), status, engine_session_ref, result_summary_ref, error_message, created_at, updated_at, started_at, finished_at
+		  FROM public.agent_tasks
+		 WHERE status IN ('queued', 'running') AND engine_session_ref <> ''
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("agenttask: list active query: %w", err)
+	}
+	defer rows.Close()
+
+	var out []Task
+	for rows.Next() {
+		t, err := scanTask(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, t)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("agenttask: list active: %w", err)
+	}
+	return out, nil
 }
 
 type scanner interface {

--- a/apps/control-plane/internal/agenttask/repository.go
+++ b/apps/control-plane/internal/agenttask/repository.go
@@ -187,16 +187,18 @@ func (r *pgxRepository) Transition(ctx context.Context, tenantID, userID, id uui
 	return t, nil
 }
 
-// ListActive queries across all tenants (agent_tasks_service_scan,
-// 20260716_05_agent_tasks_service_scan.sql), deliberately outside
+// ListActive calls public.agent_tasks_list_active() — a SECURITY DEFINER
+// function (20260716_05_agent_tasks_service_scan.sql), NOT a table policy:
+// this is deliberately the only cross-tenant read path against
+// public.agent_tasks. An earlier version of this migration used a blanket
+// PERMISSIVE SELECT policy instead, which Postgres OR-combines with
+// agent_tasks_tenant_isolation and would have cancelled it for every
+// hive_app SELECT (a cross-tenant leak on the ordinary Get/List path) — see
+// the migration's own comment for the full account. Called outside
 // withTenantTx: no single app.current_tenant_id value could see every
-// tenant's rows.
+// tenant's rows, which is exactly why the function exists.
 func (r *pgxRepository) ListActive(ctx context.Context) ([]Task, error) {
-	rows, err := r.pool.Query(ctx, `
-		SELECT id, tenant_id, user_id, pack, COALESCE(instructions, ''), status, engine_session_ref, result_summary_ref, error_message, created_at, updated_at, started_at, finished_at
-		  FROM public.agent_tasks
-		 WHERE status IN ('queued', 'running') AND engine_session_ref <> ''
-	`)
+	rows, err := r.pool.Query(ctx, `SELECT * FROM public.agent_tasks_list_active()`)
 	if err != nil {
 		return nil, fmt.Errorf("agenttask: list active query: %w", err)
 	}

--- a/apps/control-plane/internal/agenttask/repository.go
+++ b/apps/control-plane/internal/agenttask/repository.go
@@ -135,19 +135,25 @@ func (r *pgxRepository) Transition(ctx context.Context, tenantID, userID, id uui
 	var t Task
 	var notFound, terminal bool
 	err := r.withTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		// tenantID is not a bind parameter here (tenant scoping is enforced
+		// solely by RLS via the app.current_tenant_id session variable
+		// withTenantTx already sets, same as Get/List): pgx's extended query
+		// protocol cannot infer a type for a parameter the query text never
+		// references, and fails closed with "could not determine data type
+		// of parameter" (SQLSTATE 42P18) rather than silently ignoring it.
 		row := tx.QueryRow(ctx, `
 			UPDATE public.agent_tasks
-			   SET status = $4,
-			       engine_session_ref = CASE WHEN $5 <> '' THEN $5 ELSE engine_session_ref END,
-			       result_summary_ref = CASE WHEN $6 <> '' THEN $6 ELSE result_summary_ref END,
-			       error_message = $7,
-			       started_at = CASE WHEN started_at IS NULL AND $4 = 'running' THEN now() ELSE started_at END,
-			       finished_at = CASE WHEN finished_at IS NULL AND $4 IN ('succeeded', 'failed', 'cancelled') THEN now() ELSE finished_at END,
+			   SET status = $3,
+			       engine_session_ref = CASE WHEN $4 <> '' THEN $4 ELSE engine_session_ref END,
+			       result_summary_ref = CASE WHEN $5 <> '' THEN $5 ELSE result_summary_ref END,
+			       error_message = $6,
+			       started_at = CASE WHEN started_at IS NULL AND $3 = 'running' THEN now() ELSE started_at END,
+			       finished_at = CASE WHEN finished_at IS NULL AND $3 IN ('succeeded', 'failed', 'cancelled') THEN now() ELSE finished_at END,
 			       updated_at = now()
 			 WHERE id = $1 AND user_id = $2
 			   AND status NOT IN ('succeeded', 'failed', 'cancelled')
 			RETURNING id, tenant_id, user_id, pack, COALESCE(instructions, ''), status, engine_session_ref, result_summary_ref, error_message, created_at, updated_at, started_at, finished_at
-		`, id, userID, tenantID, string(status), sessionRef, resultSummaryRef, errMsg)
+		`, id, userID, string(status), sessionRef, resultSummaryRef, errMsg)
 		var err error
 		t, err = scanTask(row)
 		if err == nil {

--- a/apps/control-plane/internal/agenttask/repository_test.go
+++ b/apps/control-plane/internal/agenttask/repository_test.go
@@ -238,6 +238,93 @@ func TestRepository_RLS_CrossTenantContextCannotReadRows(t *testing.T) {
 	}
 }
 
+// TestRepository_RLS_ActiveTaskStillHiddenAcrossTenants is the regression
+// guard for the reviewed CRITICAL finding on
+// 20260716_05_agent_tasks_service_scan.sql: a blanket PERMISSIVE SELECT
+// policy would have OR-combined with agent_tasks_tenant_isolation and
+// defeated it for every hive_app SELECT, including this ordinary Get/List
+// path. The fix (a SECURITY DEFINER function, agent_tasks_list_active,
+// scoped to exactly the poller's own query) must not touch this path at
+// all. Exercises exactly the row shape the poller's cross-tenant read
+// targets — running, with an engine_session_ref — since that is the case
+// most likely to regress if the table-level fix is ever loosened again.
+func TestRepository_RLS_ActiveTaskStillHiddenAcrossTenants(t *testing.T) {
+	pool := newRLSTestPool(t)
+	repo := agenttask.NewPgxRepository(pool)
+	ctx := context.Background()
+
+	tenantA, tenantB := uuid.New(), uuid.New()
+	seedTenant(t, tenantA)
+	seedTenant(t, tenantB)
+	userA := seedUser(t)
+	userB := seedUser(t)
+
+	created, err := repo.Create(ctx, tenantA, userA, agenttask.PackCoding, "")
+	if err != nil {
+		t.Fatalf("seed tenant A task: %v", err)
+	}
+	if _, err := repo.Transition(ctx, tenantA, userA, created.ID, agenttask.StatusRunning, "session-abc", "", ""); err != nil {
+		t.Fatalf("transition to running: %v", err)
+	}
+
+	if _, err := repo.Get(ctx, tenantB, userB, created.ID); err == nil {
+		t.Fatal("expected Get to fail for a different tenant, even for an active task with a session ref")
+	}
+	list, err := repo.List(ctx, tenantB, userB)
+	if err != nil {
+		t.Fatalf("List(tenantB): %v", err)
+	}
+	if len(list) != 0 {
+		t.Fatalf("expected tenant B's task list to be empty, got %d (cross-tenant leak)", len(list))
+	}
+}
+
+// TestRepository_ListActive_ReturnsAcrossTenants proves
+// agent_tasks_list_active's SECURITY DEFINER cross-tenant read actually
+// works: the poller's whole point is seeing every tenant's active tasks in
+// one call.
+func TestRepository_ListActive_ReturnsAcrossTenants(t *testing.T) {
+	pool := newRLSTestPool(t)
+	repo := agenttask.NewPgxRepository(pool)
+	ctx := context.Background()
+
+	tenantA, tenantB := uuid.New(), uuid.New()
+	seedTenant(t, tenantA)
+	seedTenant(t, tenantB)
+	userA := seedUser(t)
+	userB := seedUser(t)
+
+	taskA, err := repo.Create(ctx, tenantA, userA, agenttask.PackCoding, "")
+	if err != nil {
+		t.Fatalf("seed tenant A task: %v", err)
+	}
+	if _, err := repo.Transition(ctx, tenantA, userA, taskA.ID, agenttask.StatusRunning, "session-a", "", ""); err != nil {
+		t.Fatalf("transition tenant A task: %v", err)
+	}
+	taskB, err := repo.Create(ctx, tenantB, userB, agenttask.PackKnowledgeWork, "")
+	if err != nil {
+		t.Fatalf("seed tenant B task: %v", err)
+	}
+	if _, err := repo.Transition(ctx, tenantB, userB, taskB.ID, agenttask.StatusRunning, "session-b", "", ""); err != nil {
+		t.Fatalf("transition tenant B task: %v", err)
+	}
+
+	active, err := repo.ListActive(ctx)
+	if err != nil {
+		t.Fatalf("ListActive: %v", err)
+	}
+	seen := make(map[uuid.UUID]bool, len(active))
+	for _, task := range active {
+		seen[task.ID] = true
+	}
+	if !seen[taskA.ID] {
+		t.Errorf("expected tenant A's active task %s in ListActive result", taskA.ID)
+	}
+	if !seen[taskB.ID] {
+		t.Errorf("expected tenant B's active task %s in ListActive result", taskB.ID)
+	}
+}
+
 // TestRepository_ScopedByUser_OtherUserCannotSeeOrCancel proves the
 // application-layer user_id filter (not RLS) keeps a task private to the
 // user who started it within the same tenant.

--- a/apps/control-plane/internal/agenttask/repository_test.go
+++ b/apps/control-plane/internal/agenttask/repository_test.go
@@ -245,9 +245,20 @@ func TestRepository_RLS_CrossTenantContextCannotReadRows(t *testing.T) {
 // defeated it for every hive_app SELECT, including this ordinary Get/List
 // path. The fix (a SECURITY DEFINER function, agent_tasks_list_active,
 // scoped to exactly the poller's own query) must not touch this path at
-// all. Exercises exactly the row shape the poller's cross-tenant read
-// targets — running, with an engine_session_ref — since that is the case
-// most likely to regress if the table-level fix is ever loosened again.
+// all.
+//
+// Deliberately uses the SAME userID for both calls: Get/List already filter
+// on user_id in application-layer SQL
+// (`WHERE id = $1 AND user_id = $2`/`WHERE user_id = $1`), so two different
+// users would make this pass even against the broken blanket-policy
+// migration — the user_id mismatch alone would explain the denial, RLS
+// would never be exercised. Only changing tenant context while user_id
+// stays fixed isolates what this test is actually for: the
+// agent_tasks_tenant_isolation policy itself, independent of that
+// application-layer filter. Exercises exactly the row shape the poller's
+// cross-tenant read targets — running, with an engine_session_ref — since
+// that is the case most likely to regress if the table-level fix is ever
+// loosened again.
 func TestRepository_RLS_ActiveTaskStillHiddenAcrossTenants(t *testing.T) {
 	pool := newRLSTestPool(t)
 	repo := agenttask.NewPgxRepository(pool)
@@ -256,26 +267,25 @@ func TestRepository_RLS_ActiveTaskStillHiddenAcrossTenants(t *testing.T) {
 	tenantA, tenantB := uuid.New(), uuid.New()
 	seedTenant(t, tenantA)
 	seedTenant(t, tenantB)
-	userA := seedUser(t)
-	userB := seedUser(t)
+	userID := seedUser(t)
 
-	created, err := repo.Create(ctx, tenantA, userA, agenttask.PackCoding, "")
+	created, err := repo.Create(ctx, tenantA, userID, agenttask.PackCoding, "")
 	if err != nil {
 		t.Fatalf("seed tenant A task: %v", err)
 	}
-	if _, err := repo.Transition(ctx, tenantA, userA, created.ID, agenttask.StatusRunning, "session-abc", "", ""); err != nil {
+	if _, err := repo.Transition(ctx, tenantA, userID, created.ID, agenttask.StatusRunning, "session-abc", "", ""); err != nil {
 		t.Fatalf("transition to running: %v", err)
 	}
 
-	if _, err := repo.Get(ctx, tenantB, userB, created.ID); err == nil {
-		t.Fatal("expected Get to fail for a different tenant, even for an active task with a session ref")
+	if _, err := repo.Get(ctx, tenantB, userID, created.ID); err == nil {
+		t.Fatal("expected Get to fail under tenant B's context, even for the same user and an active task with a session ref")
 	}
-	list, err := repo.List(ctx, tenantB, userB)
+	list, err := repo.List(ctx, tenantB, userID)
 	if err != nil {
 		t.Fatalf("List(tenantB): %v", err)
 	}
 	if len(list) != 0 {
-		t.Fatalf("expected tenant B's task list to be empty, got %d (cross-tenant leak)", len(list))
+		t.Fatalf("expected the task list under tenant B's context to be empty, got %d (cross-tenant leak)", len(list))
 	}
 }
 

--- a/apps/control-plane/internal/agenttask/service_test.go
+++ b/apps/control-plane/internal/agenttask/service_test.go
@@ -73,6 +73,16 @@ func (f *fakeRepository) Transition(_ context.Context, tenantID, userID, id uuid
 	return t, nil
 }
 
+func (f *fakeRepository) ListActive(context.Context) ([]agenttask.Task, error) {
+	var out []agenttask.Task
+	for _, t := range f.tasks {
+		if (t.Status == agenttask.StatusQueued || t.Status == agenttask.StatusRunning) && t.EngineSessionRef != "" {
+			out = append(out, t)
+		}
+	}
+	return out, nil
+}
+
 // fakeEngine is a hand-built agenttask.Engine stub.
 type fakeEngine struct {
 	sessionRef string

--- a/supabase/migrations/20260716_05_agent_tasks_service_scan.sql
+++ b/supabase/migrations/20260716_05_agent_tasks_service_scan.sql
@@ -2,26 +2,79 @@
 --
 -- The task status poller (issue #311 follow-up, SYNC_CONTRACT.md's Engine
 -- seam section) needs to list active tasks across every tenant on an
--- interval. hive_app is NOT BYPASSRLS
--- (20260518_04_phase19_audit_rls_and_indexes.sql), so without this the
--- tenant-isolation policy on public.agent_tasks
--- (20260716_03_agent_tasks.sql) would return zero rows for a cross-tenant
--- scan: app.current_tenant_id is only ever set for one tenant at a time.
+-- interval.
 --
--- Mirrors audit_log_service_role_all's precedent exactly
--- (20260518_04_phase19_audit_rls_and_indexes.sql): PERMISSIVE policies OR
--- together, so this widens SELECT only. INSERT/UPDATE/DELETE still require
--- the correct app.current_tenant_id via the existing
--- agent_tasks_tenant_isolation policy — the poller's own writes go through
--- Repository.Transition, which already sets that per the task's own
--- tenant_id.
+-- CORRECTED after security review (2026-07-16): the first version of this
+-- migration added a table-level PERMISSIVE SELECT policy
+-- (`USING (true) TO hive_app`) alongside the existing tenant-isolation
+-- policy. Postgres OR-combines PERMISSIVE policies for the same command, so
+-- that policy did not just add a new cross-tenant read path — it CANCELLED
+-- agent_tasks_tenant_isolation for every hive_app SELECT, including the
+-- ordinary Get/List calls a customer request makes. A user in two or more
+-- tenants would have been able to read other tenants' tasks through the
+-- normal API. audit_log_service_role_all
+-- (20260518_04_phase19_audit_rls_and_indexes.sql) is not a valid precedent
+-- for this table: audit_log has no competing tenant-scoped hive_app policy
+-- to cancel, agent_tasks does.
 --
--- Depends on: 20260716_03_agent_tasks.sql.
+-- Fix: a SECURITY DEFINER function is the poller's ONLY cross-tenant read
+-- path. It runs with the function owner's privileges (the same role that
+-- ran this migration, which owns public.agent_tasks and was never given
+-- FORCE ROW LEVEL SECURITY), so it bypasses RLS internally without any
+-- table-level policy change at all — agent_tasks_tenant_isolation is
+-- completely untouched, exactly as it was before this migration. Mirrors
+-- 20260516_07_phase19_custom_access_token_hook.sql's
+-- custom_access_token_hook, this repo's existing precedent for "a narrow,
+-- unavoidably cross-tenant read inside a function, not a table policy".
+--
+-- The function returns the exact column list and order
+-- apps/control-plane/internal/agenttask's scanTask expects (mirroring the
+-- explicit column lists the rest of repository.go already uses, never
+-- `SELECT *`), is capped at 500 rows per call (a batch limit, not a hard
+-- correctness bound — a tenant with more than 500 simultaneously active
+-- tasks needs a paged poller, tracked as a follow-up if that ever happens),
+-- and is backed by a partial index matching its WHERE clause exactly.
+--
+-- Depends on: 20260716_03_agent_tasks.sql, 20260716_04_agent_tasks_instructions.sql.
 
 BEGIN;
 
-CREATE POLICY agent_tasks_service_scan
-    ON public.agent_tasks AS PERMISSIVE FOR SELECT TO hive_app
-    USING (true);
+CREATE INDEX agent_tasks_active_idx
+    ON public.agent_tasks (created_at)
+    WHERE status IN ('queued', 'running') AND engine_session_ref <> '';
+
+CREATE OR REPLACE FUNCTION public.agent_tasks_list_active()
+RETURNS TABLE (
+    id                 UUID,
+    tenant_id          UUID,
+    user_id            UUID,
+    pack               TEXT,
+    instructions       TEXT,
+    status             TEXT,
+    engine_session_ref TEXT,
+    result_summary_ref TEXT,
+    error_message      TEXT,
+    created_at         TIMESTAMPTZ,
+    updated_at         TIMESTAMPTZ,
+    started_at         TIMESTAMPTZ,
+    finished_at        TIMESTAMPTZ
+)
+LANGUAGE sql STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+    SELECT t.id, t.tenant_id, t.user_id, t.pack, COALESCE(t.instructions, ''),
+           t.status, t.engine_session_ref, t.result_summary_ref, t.error_message,
+           t.created_at, t.updated_at, t.started_at, t.finished_at
+      FROM public.agent_tasks t
+     WHERE t.status IN ('queued', 'running') AND t.engine_session_ref <> ''
+     ORDER BY t.created_at ASC
+     LIMIT 500;
+$$;
+
+COMMENT ON FUNCTION public.agent_tasks_list_active() IS
+  'Poller-only cross-tenant read (issue #311 follow-up). SECURITY DEFINER bypasses RLS internally for exactly this one fixed query; agent_tasks_tenant_isolation is never weakened at the table level. See apps/control-plane/internal/agenttask/poller.go.';
+
+GRANT EXECUTE ON FUNCTION public.agent_tasks_list_active() TO hive_app;
 
 COMMIT;

--- a/supabase/migrations/20260716_05_agent_tasks_service_scan.sql
+++ b/supabase/migrations/20260716_05_agent_tasks_service_scan.sql
@@ -1,0 +1,27 @@
+-- supabase/migrations/20260716_05_agent_tasks_service_scan.sql
+--
+-- The task status poller (issue #311 follow-up, SYNC_CONTRACT.md's Engine
+-- seam section) needs to list active tasks across every tenant on an
+-- interval. hive_app is NOT BYPASSRLS
+-- (20260518_04_phase19_audit_rls_and_indexes.sql), so without this the
+-- tenant-isolation policy on public.agent_tasks
+-- (20260716_03_agent_tasks.sql) would return zero rows for a cross-tenant
+-- scan: app.current_tenant_id is only ever set for one tenant at a time.
+--
+-- Mirrors audit_log_service_role_all's precedent exactly
+-- (20260518_04_phase19_audit_rls_and_indexes.sql): PERMISSIVE policies OR
+-- together, so this widens SELECT only. INSERT/UPDATE/DELETE still require
+-- the correct app.current_tenant_id via the existing
+-- agent_tasks_tenant_isolation policy — the poller's own writes go through
+-- Repository.Transition, which already sets that per the task's own
+-- tenant_id.
+--
+-- Depends on: 20260716_03_agent_tasks.sql.
+
+BEGIN;
+
+CREATE POLICY agent_tasks_service_scan
+    ON public.agent_tasks AS PERMISSIVE FOR SELECT TO hive_app
+    USING (true);
+
+COMMIT;


### PR DESCRIPTION
## Summary

- Closes the remaining half of the Engine seam gap PR #332's SYNC_CONTRACT.md flagged: `Service.CreateTask` launches a task but nothing advanced it past `running` once launched.
- Adds `agenttask.Poller`, mirroring `apps/control-plane/internal/spendalerts.Runner`'s `Start`/`Stop`/`RunOnce` shape exactly (same process-lifetime-context wiring convention already used for the spend-alert cron and audit workers).
- On an interval, it lists every `queued`/`running` task with a launched engine session across all tenants (`Repository.ListActive`), polls each one's engine status through a narrow `StatusChecker` interface, and atomically transitions terminal ones via the existing `Repository.Transition` (which already has the "not already terminal" guard).
- `apps/control-plane/internal/agentengine.Engine` (from PR #332) already has a `Status` method with the exact signature `StatusChecker` needs, so it satisfies the interface with zero adapter code (Go interfaces are structural).
- A per-task engine error is logged and left for the next pass (retried, not failed — the rest of that pass's tasks still get processed). A concurrent `Cancel` winning the same task's transition race returns `ErrTerminalState`, silently swallowed (not counted as an error). The loop backs off exponentially (capped at 5 minutes) after a pass that had any error, resetting to the configured interval on the next clean pass.

## Cross-tenant listing

`hive_app` is NOT `BYPASSRLS`, and `agent_tasks`'s existing tenant-isolation policy scopes every query to one `app.current_tenant_id` at a time — no single transaction can see every tenant's rows. `20260716_05_agent_tasks_service_scan.sql` adds a second PERMISSIVE `SELECT`-only policy (`USING (true)`) for `hive_app`, mirroring `audit_log_service_role_all`'s existing precedent exactly (PERMISSIVE policies OR together, so this only widens `SELECT`; `INSERT`/`UPDATE`/`DELETE` still require the correct tenant context via the original policy).

## Wiring

`cmd/server/main.go`: `buildAgentEngine` now also returns a `agenttask.StatusChecker` (nil when unconfigured, the same `*agentengine.Engine` value when real). The poller starts only when that's non-nil — same `HIVE_AGENT_ENGINE_SIF_PATH` gate as the engine itself, since there's nothing to poll otherwise. Interval is tunable via `HIVE_AGENT_TASK_POLL_INTERVAL` (Go duration string, default 15s), bound to `runCtx` (the same process-lifetime context the spend-alert cron and audit workers already use) so it stops cleanly on shutdown.

## Also included

One-line parity edit: added `"Go tests (agent-engine)"` to `.github/branch-protection-main.json`'s required-checks list (already applied live via the GitHub API per team lead; this keeps the source-of-truth file in sync).

## Test plan

- [x] `go test ./apps/control-plane/...` — full suite passes, including new `poller_test.go` (advance running→succeeded, engine error→retried not failed with another task in the same pass still advancing, concurrent-cancel race swallowed, ListActive failure propagates, Start/Stop/double-call-noop) and `poller_internal_test.go` (pure backoff-delay math, no timers)
- [x] `go vet` clean
- [x] `gofmt -l` clean
- [ ] Live cross-tenant RLS verification of `agent_tasks_service_scan` — same lab-network-reachability blocker as the rest of this subsystem; the existing `repository_test.go` RLS tests are `HIVE_TEST_DB_URL`-gated and already skip cleanly without a live DB, same convention this PR follows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Agent tasks now automatically refresh their status and advance to completed, failed, or cancelled states.
  - Status checks begin immediately and continue periodically, with automatic retry delays when errors occur.
  - Task status monitoring is enabled when the agent engine is configured.

- **Documentation**
  - Updated agent-task lifecycle documentation to describe background status monitoring and retry behavior.

- **Tests**
  - Added coverage for task progression, retries, scheduling, backoff, and concurrent state changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->