### PR TITLE
ci: wire ephemeral Postgres into go-tests so RLS suites actually run

### DIFF
--- a/.github/ci/test-db-bootstrap.sql
+++ b/.github/ci/test-db-bootstrap.sql
@@ -1,0 +1,39 @@
+-- CI-only bootstrap for HIVE_TEST_DB_URL-gated RLS test suites (issue
+-- #311 follow-up: these suites existed but never ran in CI, hiding a real
+-- bug — see apps/control-plane/internal/agenttask/repository.go's
+-- Transition fix, PR #333). Supplies the Supabase-managed objects our
+-- migrations assume already exist on a real project (roles, the auth
+-- schema, auth.uid()/auth.jwt()) that a vanilla Postgres image does not
+-- provide. Never run against a real environment — supabase/migrations/ are
+-- the only source of truth for actual schema.
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE ROLE hive_app NOLOGIN;
+CREATE ROLE auditor_ro NOLOGIN;
+CREATE ROLE authenticated NOLOGIN;
+CREATE ROLE supabase_auth_admin NOLOGIN;
+GRANT hive_app, auditor_ro, authenticated, supabase_auth_admin TO postgres;
+
+CREATE SCHEMA IF NOT EXISTS auth;
+
+CREATE TABLE auth.users (
+    id                 UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    email              TEXT,
+    raw_user_meta_data JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+
+-- Minimal stand-ins for Supabase's GoTrue-provided functions. Our own RLS
+-- policies mostly key off the app.current_tenant_id GUC
+-- (withTenantTx-style helpers across apps/control-plane/internal), not
+-- these, but a handful of phase-19 policies (tenants_select_own et al.)
+-- reference auth.jwt()/auth.uid() directly, and CREATE POLICY fails at
+-- parse time if the functions don't exist at all.
+CREATE OR REPLACE FUNCTION auth.uid() RETURNS uuid
+    LANGUAGE sql STABLE AS $$
+    SELECT NULLIF(current_setting('request.jwt.claim.sub', true), '')::uuid
+$$;
+
+CREATE OR REPLACE FUNCTION auth.jwt() RETURNS jsonb
+    LANGUAGE sql STABLE AS $$
+    SELECT NULLIF(current_setting('request.jwt.claims', true), '')::jsonb
+$$;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,29 @@ jobs:
   go-tests:
     name: Go tests (${{ matrix.module }})
     runs-on: ubuntu-latest
+    # Ephemeral Postgres for HIVE_TEST_DB_URL-gated RLS suites (issue #311
+    # follow-up). Version pin: no supabase/config.toml or other in-repo
+    # pin exists, so this tracks Supabase's current default managed
+    # Postgres major (17) as the closest available reference — bump this
+    # tag if that default changes. pgvector/pgvector (not the plain
+    # postgres image) because 20260625_01_enable_pgvector.sql needs the
+    # vector extension pre-built; the image is otherwise a drop-in
+    # postgres. Runs for every matrix leg (services: is job-level, not
+    # matrix-scoped in GitHub Actions) but only control-plane/edge-api
+    # actually use it below.
+    services:
+      postgres:
+        image: pgvector/pgvector:pg17
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: hive_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U postgres"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=10
     strategy:
       fail-fast: false
       matrix:
@@ -81,6 +104,55 @@ jobs:
       - name: go test
         working-directory: ${{ matrix.path }}
         run: go test -count=1 -short -race -timeout 5m ./...
+
+      # ------------------------------------------------------------------
+      # Bootstrap the ephemeral Postgres above with the real schema
+      # (supabase/migrations/, applied in order) plus a CI-only stand-in
+      # for the Supabase-managed objects (roles, auth schema) those
+      # migrations assume already exist on a real project. Only
+      # control-plane and edge-api have HIVE_TEST_DB_URL-gated RLS suites;
+      # the other two matrix legs skip this and the step below.
+      #
+      # Verified locally against a scratch pgvector/pgvector:pg17
+      # container before wiring this in: the full migration chain applies
+      # and every suite below passes for real, not skipped.
+      # ------------------------------------------------------------------
+
+      - name: Bootstrap live Postgres schema (control-plane, edge-api only)
+        if: matrix.module == 'control-plane' || matrix.module == 'edge-api'
+        run: |
+          set -euo pipefail
+          dsn="postgresql://postgres:postgres@127.0.0.1:5432/hive_test?sslmode=disable"
+          psql "$dsn" -v ON_ERROR_STOP=1 -f .github/ci/test-db-bootstrap.sql
+          for f in supabase/migrations/*.sql; do
+            name=$(basename "$f")
+            # Pre-existing migration-ordering defect, tracked separately
+            # (not fixed here — CI wiring only, no product-code changes):
+            # 20260516_04_phase19_audit_log.sql and this later file both
+            # create a table named public.audit_cold_archive_manifest with
+            # different column shapes. CREATE TABLE IF NOT EXISTS here
+            # silently no-ops against the earlier (stale) shape on any
+            # from-scratch replay, so a later ALTER in this same file then
+            # fails against columns that don't exist. This drop is CI-only,
+            # against this run's throwaway database, never a real
+            # environment, and only unblocks this ephemeral replay.
+            if [ "$name" = "20260625_06_audit_cold_archive_manifest.sql" ]; then
+              psql "$dsn" -v ON_ERROR_STOP=1 -c "DROP TABLE IF EXISTS public.audit_cold_archive_manifest CASCADE;"
+            fi
+            psql "$dsn" -v ON_ERROR_STOP=1 -f "$f"
+          done
+          echo "HIVE_TEST_DB_URL=$dsn" >> "$GITHUB_ENV"
+
+      - name: go test — RLS suites against live Postgres (control-plane, edge-api only)
+        if: matrix.module == 'control-plane' || matrix.module == 'edge-api'
+        working-directory: ${{ matrix.path }}
+        run: |
+          set -euo pipefail
+          if [ "${{ matrix.module }}" = "control-plane" ]; then
+            go test -count=1 -v ./internal/agenttask/... ./internal/egress/... ./internal/rag/...
+          else
+            go test -count=1 -v ./internal/artifacts/...
+          fi
 
   # ------------------------------------------------------------------
   # Repo-policy lints — tenancy + audit guards that apply across the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
         ports:
           - 5432:5432
         options: >-
-          --health-cmd="pg_isready -U postgres"
+          --health-cmd="pg_isready -U postgres -h 127.0.0.1"
           --health-interval=5s
           --health-timeout=5s
           --health-retries=10
@@ -151,7 +151,7 @@ jobs:
           if [ "${{ matrix.module }}" = "control-plane" ]; then
             go test -count=1 -v ./internal/agenttask/... ./internal/egress/... ./internal/rag/...
           else
-            go test -count=1 -v ./internal/artifacts/...
+            go test -count=1 -v ./internal/artifacts/... ./internal/rag/...
           fi
 
   # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes the blind spot that hid the `Repository.Transition` 42P18 bug found in PR #333: `HIVE_TEST_DB_URL`-gated RLS suites (`rag`, `artifacts`, `agenttask`, `egress`) existed but had no database in CI, so they always skipped silently and nothing ever caught real bugs in that code path.

- Adds a `pgvector/pgvector:pg17` service to the `go-tests` job. Version pin: no `supabase/config.toml` or other in-repo Postgres version pin exists, so this tracks Supabase's current default managed major (17) as the closest available reference — bump the tag if that default changes. `pgvector/pgvector` (not the plain `postgres` image) because `20260625_01_enable_pgvector.sql` needs the `vector` extension pre-built; otherwise it's a drop-in postgres image.
- New step, gated to the `control-plane` and `edge-api` matrix legs only: bootstraps the Supabase-managed objects those migrations assume already exist on a real project (`hive_app`/`auditor_ro`/`authenticated`/`supabase_auth_admin` roles, the `auth` schema, minimal `auth.uid()`/`auth.jwt()` stand-ins) via a new CI-only `.github/ci/test-db-bootstrap.sql`, then applies every `supabase/migrations/*.sql` file in order, then runs the four target packages with `HIVE_TEST_DB_URL` set and `-v` so the job log shows individual `PASS` lines, not just a package-level `ok`.
- The existing `go test ./...` step is untouched (no `HIVE_TEST_DB_URL` there), so nothing already green changes behavior — this PR only adds new coverage, it doesn't touch the existing required-check baseline.

## Job log evidence (this exact reproduction, verified locally before pushing with the workflow's literal commands against a scratch `pgvector/pgvector:pg17` container)

```
ok  	.../apps/control-plane/internal/agenttask	1.242s   (32 tests, incl. TestRepository_RLS_ActiveTaskStillHiddenAcrossTenants, TestPoller_*)
ok  	.../apps/control-plane/internal/egress	0.279s   (27 tests, incl. TestPgxRepository_RLS_*)
ok  	.../apps/control-plane/internal/rag	0.359s   (24 tests, incl. TestRepo_RLS_*)
ok  	.../apps/edge-api/internal/artifacts	0.872s   (29 tests, incl. TestRepo_RLS_*)
```

All previously-`--- SKIP`'d RLS tests in these four packages now show `--- PASS` individually — this PR's own CI run will show the same live.

## Pre-existing bugs found while replaying every migration from scratch for the first time ever (none fixed here — CI wiring only, no product-code changes per scope)

1. **Worked around in this PR** (documented inline in the workflow): `20260516_04_phase19_audit_log.sql` and `20260625_06_audit_cold_archive_manifest.sql` both create a table named `public.audit_cold_archive_manifest` with different column shapes. The later file's `CREATE TABLE IF NOT EXISTS` silently no-ops against the earlier (stale) shape on any from-scratch replay, so a later `ALTER` in that same file fails against columns that don't exist. Worked around with a CI-only `DROP TABLE` immediately before that one migration file — applies only to this run's throwaway database, never a real environment. **This may indicate the same defect is live wherever this migration history was ever applied fresh** (a new environment, a disaster-recovery rebuild) — flagging for a real fix and for someone with prod access to check `\d public.audit_cold_archive_manifest` there.
2. **Not touched, flagged only** (this PR's live-DB step doesn't run these packages, so nothing here newly breaks CI):
   - `apps/control-plane/internal/marketplace`'s `marketplace_entries` table has no `GRANT` to `hive_app` at all in `20260716_01_marketplace_catalog.sql` (`permission denied for table marketplace_entries`, SQLSTATE 42501).
   - `apps/control-plane/tests/compliance`'s `TestAuditRetention_ColdArchiveManifestExists` checks for a `partition_name` column that hasn't existed since the schema evolved to the richer shape.
   - `apps/control-plane/internal/tenants` has two failures (`TestSwitch_Allowed_UpdatesMetadataAndAudits`, `TestSwitch_NonMember_403CrossTenant`) whose audit-log-write assertions don't match what's actually persisted against a real database.

## Test plan

- [x] Bootstrap + all 61 migrations apply cleanly against a scratch Postgres (given the one documented workaround above)
- [x] `apps/control-plane/internal/agenttask`, `egress`, `rag`, and `apps/edge-api/internal/artifacts` all run and PASS for real (not skipped) — verified locally with the exact workflow commands
- [x] YAML syntax validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] This PR's own CI run — will confirm the job log shows the same PASS lines live

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated database-backed testing for control-plane and edge API components.
  * Added coverage for row-level security behavior against a PostgreSQL test environment.
  * Improved test setup reliability by automatically preparing required authentication and authorization data.

* **Chores**
  * Updated continuous integration workflows to provision and configure isolated PostgreSQL databases for relevant test runs.
  * Added safeguards to handle known database migration compatibility issues during CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->