### PR TITLE
fix: copy agent-engine source into control-plane image for engineapi build

### DIFF
--- a/deploy/docker/Dockerfile.control-plane
+++ b/deploy/docker/Dockerfile.control-plane
@@ -20,6 +20,16 @@ RUN cd apps/control-plane && go mod download
 COPY apps/control-plane/ ./apps/control-plane/
 COPY packages/storage/ ./packages/storage/
 COPY packages/audit-canonical/ ./packages/audit-canonical/
+# apps/agent-engine is a real module dependency of control-plane, not just a
+# manifest for module-cache warmup: apps/control-plane/go.mod replaces
+# github.com/sakibsadmanshajib/hive/apps/agent-engine with a local path
+# (../agent-engine), and cmd/server/main.go imports its engineapi package
+# (added by #332, the host-to-agent-server control channel). Only the
+# go.mod/go.sum were copied above; without the actual source, air's
+# build-on-boot step fails with "no required module provides package
+# ... engineapi", the binary never builds, and the container never passes
+# its healthcheck.
+COPY apps/agent-engine/ ./apps/agent-engine/
 
 EXPOSE 8081
 


### PR DESCRIPTION
## Root cause

PR #332 (host to agent-server control channel and real agent-engine) added an import of `github.com/sakibsadmanshajib/hive/apps/agent-engine/engineapi` to `apps/control-plane/cmd/server/main.go`, resolved through the existing local `replace github.com/sakibsadmanshajib/hive/apps/agent-engine => ../agent-engine` directive in `apps/control-plane/go.mod`.

`deploy/docker/Dockerfile.control-plane` already copied `apps/agent-engine/go.mod` and `go.sum` into the image, but only for module-cache warmup ahead of `go mod download`. It never copied the actual `apps/agent-engine/` source tree, unlike the other three local workspace modules control-plane depends on (`apps/control-plane/`, `packages/storage/`, `packages/audit-canonical/`), which are all copied in full a few lines below.

Because the control-plane container runs via `air` (hot reload, building the binary on every container start rather than at image-build time), the missing source surfaces at container boot:

```
control-plane-1  | apps/control-plane/cmd/server/main.go:21:2: no required module provides package github.com/sakibsadmanshajib/hive/apps/agent-engine/engineapi; to add it:
control-plane-1  | 	cd /app/apps/control-plane
control-plane-1  | 	go get github.com/sakibsadmanshajib/hive/apps/agent-engine/engineapi
control-plane-1  | failed to build, error: exit status 1
control-plane-1  | running...
control-plane-1  | /bin/sh: /app/tmp/main: not found
control-plane-1  | Process Exit with Code: 127
```

The binary never exists, so `/health` never responds, and Docker Compose marks the container unhealthy once `start_period` (120s) plus `retries` (5 x 5s interval) expire. The `Web E2E (full stack)` job's `Start core stack` step then aborts with `dependency failed to start: container hive-control-plane-1 is unhealthy`, and Playwright never runs.

## Evidence

Every `Web E2E (full stack)` run on `main` since #332 merged has failed with this exact signature:

- Run 29517363994 (#337, feature-gate fetch): https://github.com/sakibsadmanshajib/hive/actions/runs/29517363994
- Run 29507378129 (#333, task status poller): https://github.com/sakibsadmanshajib/hive/actions/runs/29507378129
- Run 29502942393 (#332 itself, control channel): https://github.com/sakibsadmanshajib/hive/actions/runs/29502942393

The `compose-logs-web-e2e-api` artifact on each of these runs contains the `no required module provides package ... engineapi` line above. An earlier, unrelated string of intermittent E2E failures on the morning of 2026-07-16 (before #332 merged) is a separate flake and out of scope here; the run immediately before #332 landed (29501684401, `b74455a2`) passed cleanly.

## Fix

Add `COPY apps/agent-engine/ ./apps/agent-engine/` to `Dockerfile.control-plane`, in the same place and following the same pattern as the existing full-source copies for `apps/control-plane/`, `packages/storage/`, and `packages/audit-canonical/`.

## Verification

- Confirmed the exact failure line (`no required module provides package ... engineapi`) in the downloaded `compose-logs-web-e2e-api` artifacts for three separate red runs on `main`, all postdating #332.
- Confirmed `apps/control-plane/go.mod` requires and locally replaces `apps/agent-engine`, and that `cmd/server/main.go` imports `engineapi`, added in #332's diff.
- Confirmed no other local module is missing its full-source `COPY` in this Dockerfile; `apps/agent-engine` was the only gap.
- Attempted a local `docker build` of the fixed image to fully reproduce and confirm; this sandbox's container network egress blocked `go mod download` mid-build (host-level curl to proxy.golang.org succeeded, but the build container hung), so the fix is verified by exact log-signature match against the failing CI runs and structural parity with the Dockerfile's existing copy pattern, not a completed local image build.

## Test plan

- [ ] CI's `Web E2E (full stack)` job passes `Start core stack` and Playwright runs to completion on this branch.