### PR TITLE
fix: copy agent-engine source into control-plane prod image

### DIFF
--- a/deploy/docker/Dockerfile.control-plane.prod
+++ b/deploy/docker/Dockerfile.control-plane.prod
@@ -30,6 +30,14 @@ RUN cd apps/control-plane && go mod download
 COPY apps/control-plane/ ./apps/control-plane/
 COPY packages/storage/ ./packages/storage/
 COPY packages/audit-canonical/ ./packages/audit-canonical/
+# apps/agent-engine is a real module dependency of control-plane, not just a
+# manifest for module-cache warmup: apps/control-plane/go.mod replaces
+# github.com/sakibsadmanshajib/hive/apps/agent-engine with a local path
+# (../agent-engine), and cmd/server/main.go imports its engineapi package
+# (added by #332, the host-to-agent-server control channel). Only the
+# go.mod/go.sum were copied above; without the actual source, `go build`
+# fails with "no required module provides package ... engineapi".
+COPY apps/agent-engine/ ./apps/agent-engine/
 
 WORKDIR /src/apps/control-plane
 


### PR DESCRIPTION
## Root cause

Same class of bug as #340, in the production Dockerfile this time. `apps/control-plane/go.mod` replaces `github.com/sakibsadmanshajib/hive/apps/agent-engine` with a local path (`../agent-engine`), and `apps/control-plane/cmd/server/main.go` imports its `engineapi` package (added in #332, the host-to-agent-server control channel). `deploy/docker/Dockerfile.control-plane.prod` copies `apps/agent-engine/go.mod` and `go.sum` for module-cache warmup, but never copies the actual `apps/agent-engine/` source before running `go build ./cmd/server`, so the build fails.

## Evidence

Run https://github.com/sakibsadmanshajib/hive/actions/runs/29524716871 (job 87710198894) built commit `2eddf301f952945de057b75e109d78aa73ba7e1c`, which already includes the #340 fix for the dev Dockerfile, and still failed with:

```
cmd/server/main.go:21:2: no required module provides package github.com/sakibsadmanshajib/hive/apps/agent-engine/engineapi; to add it:
Dockerfile.control-plane.prod:39
```

This confirms #340 addressed the CI dev-stack image only; the production multi-stage build has an independent copy of the same gap.

## Audit of all *.prod Dockerfiles in deploy/docker

Only two exist:

- `Dockerfile.control-plane.prod`: `apps/control-plane/go.mod` has a local `replace` for `apps/agent-engine`, and `cmd/server/main.go` imports its `engineapi` package. The full source copy was missing. Fixed here.
- `Dockerfile.edge-api.prod`: `apps/edge-api/go.mod` has no `replace` directive for `apps/agent-engine`, and nothing in `apps/edge-api` imports `engineapi`. Its existing `COPY apps/agent-engine/go.mod apps/agent-engine/go.sum* ./apps/agent-engine/` line is inert leftover from the shared manifest-caching pattern, not a bug. No change needed.

## Fix

Add `COPY apps/agent-engine/ ./apps/agent-engine/` to `Dockerfile.control-plane.prod`, in the same place and following the same pattern as the existing full-source copies for `apps/control-plane/`, `packages/storage/`, and `packages/audit-canonical/`, and matching the fix already merged for the dev Dockerfile in #340.

## Test plan

- [ ] `deploy-staging.yml` builds and pushes the `control-plane` prod image successfully on this branch.