### PR TITLE
feat: SSE streaming for POST /v1/rag/chat (#339)

### DIFF
--- a/apps/edge-api/internal/rag/chat_handler.go
+++ b/apps/edge-api/internal/rag/chat_handler.go
@@ -377,6 +377,7 @@ func (h *Handler) streamGroundedChat(w http.ResponseWriter, r *http.Request, res
 	}
 
 	var promptTokens, completionTokens, totalTokens int64
+	completed := false
 	scanner := bufio.NewScanner(resp.Body)
 	scanner.Buffer(make([]byte, 64*1024), 512*1024)
 	for scanner.Scan() {
@@ -389,6 +390,7 @@ func (h *Handler) streamGroundedChat(w http.ResponseWriter, r *http.Request, res
 		if line == "data: [DONE]" {
 			fmt.Fprint(w, "data: [DONE]\n\n")
 			flusher.Flush()
+			completed = true
 			break
 		}
 
@@ -416,18 +418,25 @@ func (h *Handler) streamGroundedChat(w http.ResponseWriter, r *http.Request, res
 			continue
 		}
 
-		// Blank separators are implied by our own framing; other SSE fields
-		// (event:, comments) carry no model name and pass through unchanged.
-		if line == "" {
-			continue
-		}
-		fmt.Fprintf(w, "%s\n", line)
-		flusher.Flush()
+		// Drop every other upstream line. event:, comment (":"), and blank
+		// separators are never forwarded: an "event: <provider>-error" line
+		// would leak the provider identity, and our own framing already emits
+		// the blank separators between data frames. Only sanitized data frames
+		// and our [DONE] reach the client (provider-blind).
 	}
 
-	// RAG_CHAT_COMPLETED is the accounting signal for this JWT-session path;
-	// see the non-streaming path's doc comment for why audit is the carrier.
-	// Token counts come from the terminal usage chunk (stream_options.include_usage).
+	if err := scanner.Err(); err != nil {
+		log.Printf("rag: chat stream read error: %v", err)
+	}
+
+	// RAG_CHAT_COMPLETED is the usage-accounting signal for this JWT-session
+	// path (see the non-streaming path's doc comment for why audit is the
+	// carrier). Emit it ONLY when the upstream stream genuinely finished with
+	// [DONE]: a client cancellation, scanner error, or truncation must not be
+	// billed as a completed stream with partial or zero usage.
+	if !completed {
+		return
+	}
 	h.audit(r.Context(), "RAG_CHAT_COMPLETED", "rag_document", tenantID.String(), "INFO",
 		tenantID, actorID, userAgent, map[string]any{
 			"model":             alias,

--- a/apps/edge-api/internal/rag/chat_handler.go
+++ b/apps/edge-api/internal/rag/chat_handler.go
@@ -1,6 +1,7 @@
 package rag
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
@@ -84,15 +85,6 @@ func (h *Handler) handleChat(w http.ResponseWriter, r *http.Request) {
 		apierrors.Write(w, http.StatusBadRequest, apierrors.CodeInvalidRequest, "model required")
 		return
 	}
-	// ponytail: streaming deferred, per issue #325's own scope note ("ship
-	// non-streaming first and note it"). Tracked as a separate, explicitly
-	// scoped follow-up in issue #339: SSE needs a trailing (or
-	// retrieval-first) citations frame on top of the existing stream.go
-	// plumbing, which is its own reviewable unit of work.
-	if req.Stream {
-		apierrors.Write(w, http.StatusBadRequest, apierrors.CodeInvalidRequest, "streaming is not yet supported for /v1/rag/chat")
-		return
-	}
 
 	// Drop any client-supplied "system" role message before it ever reaches
 	// lastUserMessage or the augmented request: the only system message in
@@ -167,10 +159,12 @@ func (h *Handler) handleChat(w http.ResponseWriter, r *http.Request) {
 	})
 	augmented = append(augmented, req.Messages...)
 
-	body, err := json.Marshal(struct {
-		Model    string        `json:"model"`
-		Messages []ChatMessage `json:"messages"`
-	}{Model: litellmModel, Messages: augmented})
+	body, err := json.Marshal(dispatchBody{
+		Model:         litellmModel,
+		Messages:      augmented,
+		Stream:        req.Stream,
+		StreamOptions: streamOptionsFor(req.Stream),
+	})
 	if err != nil {
 		apierrors.Write(w, http.StatusInternalServerError, apierrors.CodeInternal, "request build failed")
 		return
@@ -183,13 +177,23 @@ func (h *Handler) handleChat(w http.ResponseWriter, r *http.Request) {
 	}
 	defer resp.Body.Close()
 
+	// A non-2xx upstream is a provider-blind error on both paths. Check the
+	// status before consuming the body so the streaming path can relay the
+	// live SSE reader rather than a drained buffer.
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		errBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2*1024*1024))
+		apierrors.WriteProviderBlindUpstreamError(w, req.Model, resp.StatusCode, string(errBody))
+		return
+	}
+
+	if req.Stream {
+		h.streamGroundedChat(w, r, resp, req.Model, citations, user.TenantID, user.ID, r.UserAgent())
+		return
+	}
+
 	upstreamBody, err := io.ReadAll(io.LimitReader(resp.Body, 2*1024*1024))
 	if err != nil {
 		apierrors.Write(w, http.StatusInternalServerError, apierrors.CodeInternal, "failed to read upstream response")
-		return
-	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		apierrors.WriteProviderBlindUpstreamError(w, req.Model, resp.StatusCode, string(upstreamBody))
 		return
 	}
 
@@ -316,4 +320,128 @@ type upstreamChatResponse struct {
 		CompletionTokens int64 `json:"completion_tokens"`
 		TotalTokens      int64 `json:"total_tokens"`
 	} `json:"usage"`
+}
+
+// dispatchBody is the wire shape marshaled to the upstream chat-completion
+// endpoint. The streaming fields are omitempty so a non-streaming request is
+// byte-identical to what shipped in #325.
+type dispatchBody struct {
+	Model         string         `json:"model"`
+	Messages      []ChatMessage  `json:"messages"`
+	Stream        bool           `json:"stream,omitempty"`
+	StreamOptions *streamOptions `json:"stream_options,omitempty"`
+}
+
+// streamOptions asks the upstream to emit a terminal usage chunk so the
+// streaming path can record the same RAG_CHAT_COMPLETED token counts the
+// non-streaming path does.
+type streamOptions struct {
+	IncludeUsage bool `json:"include_usage"`
+}
+
+func streamOptionsFor(stream bool) *streamOptions {
+	if !stream {
+		return nil
+	}
+	return &streamOptions{IncludeUsage: true}
+}
+
+// streamGroundedChat relays the upstream SSE completion to the client. It
+// emits a retrieval-first "rag.citations" frame so a streaming client receives
+// the grounding sources before the first model token, rewrites each chunk's
+// "model" to the client alias (provider-blind: the concrete route name must
+// never reach the customer), and captures token usage from the terminal chunk
+// for the RAG_CHAT_COMPLETED accounting audit.
+func (h *Handler) streamGroundedChat(w http.ResponseWriter, r *http.Request, resp *http.Response,
+	alias string, citations []ChunkResult, tenantID, actorID uuid.UUID, userAgent string) {
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		apierrors.Write(w, http.StatusInternalServerError, apierrors.CodeInternal, "streaming unsupported")
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+	w.WriteHeader(http.StatusOK)
+
+	// Retrieval-first citations frame.
+	if b, err := json.Marshal(struct {
+		Object    string        `json:"object"`
+		Citations []ChunkResult `json:"citations"`
+	}{Object: "rag.citations", Citations: citations}); err == nil {
+		fmt.Fprintf(w, "data: %s\n\n", b)
+		flusher.Flush()
+	}
+
+	var promptTokens, completionTokens, totalTokens int64
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 64*1024), 512*1024)
+	for scanner.Scan() {
+		// Honor client disconnect / request cancellation.
+		if r.Context().Err() != nil {
+			break
+		}
+		line := scanner.Text()
+
+		if line == "data: [DONE]" {
+			fmt.Fprint(w, "data: [DONE]\n\n")
+			flusher.Flush()
+			break
+		}
+
+		if strings.HasPrefix(line, "data: ") {
+			var chunk map[string]any
+			if err := json.Unmarshal([]byte(line[6:]), &chunk); err != nil {
+				// Never forward an unparseable upstream data frame: it could
+				// carry unsanitized provider fields. Drop it.
+				continue
+			}
+			if _, ok := chunk["model"]; ok {
+				chunk["model"] = alias
+			}
+			if usage, ok := chunk["usage"].(map[string]any); ok {
+				promptTokens = asInt64(usage["prompt_tokens"])
+				completionTokens = asInt64(usage["completion_tokens"])
+				totalTokens = asInt64(usage["total_tokens"])
+			}
+			sanitized, err := json.Marshal(chunk)
+			if err != nil {
+				continue
+			}
+			fmt.Fprintf(w, "data: %s\n\n", sanitized)
+			flusher.Flush()
+			continue
+		}
+
+		// Blank separators are implied by our own framing; other SSE fields
+		// (event:, comments) carry no model name and pass through unchanged.
+		if line == "" {
+			continue
+		}
+		fmt.Fprintf(w, "%s\n", line)
+		flusher.Flush()
+	}
+
+	// RAG_CHAT_COMPLETED is the accounting signal for this JWT-session path;
+	// see the non-streaming path's doc comment for why audit is the carrier.
+	// Token counts come from the terminal usage chunk (stream_options.include_usage).
+	h.audit(r.Context(), "RAG_CHAT_COMPLETED", "rag_document", tenantID.String(), "INFO",
+		tenantID, actorID, userAgent, map[string]any{
+			"model":             alias,
+			"prompt_tokens":     promptTokens,
+			"completion_tokens": completionTokens,
+			"total_tokens":      totalTokens,
+		})
+}
+
+// asInt64 coerces a JSON number (decoded as float64 in a map[string]any) to
+// int64, returning 0 for any other shape.
+func asInt64(v any) int64 {
+	if f, ok := v.(float64); ok {
+		return int64(f)
+	}
+	return 0
 }

--- a/apps/edge-api/internal/rag/chat_handler_test.go
+++ b/apps/edge-api/internal/rag/chat_handler_test.go
@@ -243,7 +243,12 @@ func TestHandleChat_ChatNotConfigured_Returns503(t *testing.T) {
 // The upstream "model" is the concrete route name (route-groq-fast) so tests
 // can prove the relay rewrites it to the client alias (provider-blind), and
 // the terminal chunk carries usage so the accounting audit can capture tokens.
+// cannedSSEResponse includes an event: line carrying a provider name so the
+// test proves non-data upstream lines are dropped (never relayed): if the
+// relay forwarded it, assertNoLeak would catch "groq" in the response body.
 const cannedSSEResponse = `data: {"id":"up-1","object":"chat.completion.chunk","model":"route-groq-fast","choices":[{"index":0,"delta":{"content":"The answer"}}]}
+
+event: groq.internal.rate_notice
 
 data: {"id":"up-1","object":"chat.completion.chunk","model":"route-groq-fast","choices":[{"index":0,"delta":{"content":" is 42 [1]."}}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}
 
@@ -277,9 +282,13 @@ func TestHandleChat_StreamingRelaysCitationsAndChunks(t *testing.T) {
 		t.Fatalf("expected SSE content type, got %q", ct)
 	}
 
-	// The dispatched body must request streaming from upstream.
+	// The dispatched body must request streaming from upstream, with
+	// include_usage so the terminal chunk carries token counts for accounting.
 	if !strings.Contains(string(captured), `"stream":true`) {
 		t.Errorf("expected dispatched body to set stream:true, got %s", captured)
+	}
+	if !strings.Contains(string(captured), `"include_usage":true`) {
+		t.Errorf("expected dispatched body to set stream_options.include_usage:true, got %s", captured)
 	}
 
 	body := w.Body.String()
@@ -322,6 +331,64 @@ func TestHandleChat_StreamingRelaysCitationsAndChunks(t *testing.T) {
 	}
 	if got := completed["total_tokens"]; got != int64(15) {
 		t.Errorf("expected RAG_CHAT_COMPLETED total_tokens=15 from usage chunk, got %v (%T)", got, got)
+	}
+}
+
+func TestHandleChat_StreamingUpstreamNon2xx_StaysProviderBlindNoSSE(t *testing.T) {
+	var audits []auditRecord
+	h := newChatTestHandler(newFakeStore(), &fakeEmbedder{}, &audits,
+		fakeSelectRoute("route-groq-fast", nil),
+		fakeDispatch(http.StatusTooManyRequests, `{"error":{"message":"groq rate limit exceeded, retry after 2.5s"}}`, nil))
+
+	req := chatReq(t, ChatRequest{
+		Model:    "hive-fast",
+		Messages: []ChatMessage{{Role: "user", Content: "hi"}},
+		Stream:   true,
+	}, uuid.New())
+	w := httptest.NewRecorder()
+	h.handleChat(w, req)
+
+	// Even though the client asked to stream, a non-2xx upstream must be
+	// surfaced as a provider-blind JSON error and must NOT begin an SSE stream.
+	if w.Code != http.StatusTooManyRequests {
+		t.Errorf("expected 429 passthrough, got %d: %s", w.Code, w.Body.String())
+	}
+	if ct := w.Header().Get("Content-Type"); strings.HasPrefix(ct, "text/event-stream") {
+		t.Errorf("must not start an SSE stream on a non-2xx upstream, got content-type %q", ct)
+	}
+	if strings.Contains(w.Body.String(), "data:") {
+		t.Errorf("must not emit SSE frames on a non-2xx upstream, got: %s", w.Body.String())
+	}
+	assertNoLeak(t, w.Body.String())
+}
+
+func TestHandleChat_StreamingWithoutDoneDoesNotRecordCompleted(t *testing.T) {
+	store := newFakeStore()
+	store.chunks = []ChunkRow{{ID: uuid.New(), DocumentID: uuid.New(), Content: "ctx", Score: 0.1}}
+
+	// Upstream stream that ends WITHOUT a [DONE] (truncated / dropped mid-stream).
+	truncated := `data: {"id":"up-1","object":"chat.completion.chunk","model":"route-groq-fast","choices":[{"index":0,"delta":{"content":"partial"}}]}
+
+`
+	var audits []auditRecord
+	h := newChatTestHandler(store, &fakeEmbedder{}, &audits,
+		fakeSelectRoute("route-groq-fast", nil),
+		fakeDispatch(http.StatusOK, truncated, nil))
+
+	req := chatReq(t, ChatRequest{
+		Model:    "hive-fast",
+		Messages: []ChatMessage{{Role: "user", Content: "hi"}},
+		Stream:   true,
+	}, uuid.New())
+	w := httptest.NewRecorder()
+	h.handleChat(w, req)
+
+	// The partial content still relays, but a stream that never saw [DONE]
+	// must NOT be recorded as a completed (billable) stream.
+	for _, a := range audits {
+		if a.Action == "RAG_CHAT_COMPLETED" {
+			t.Error("RAG_CHAT_COMPLETED must not fire for a stream that never received [DONE]")
+		}
 	}
 }
 

--- a/apps/edge-api/internal/rag/chat_handler_test.go
+++ b/apps/edge-api/internal/rag/chat_handler_test.go
@@ -239,21 +239,89 @@ func TestHandleChat_ChatNotConfigured_Returns503(t *testing.T) {
 	}
 }
 
-func TestHandleChat_StreamingRejected(t *testing.T) {
+// cannedSSEResponse is a two-chunk streamed completion terminated by [DONE].
+// The upstream "model" is the concrete route name (route-groq-fast) so tests
+// can prove the relay rewrites it to the client alias (provider-blind), and
+// the terminal chunk carries usage so the accounting audit can capture tokens.
+const cannedSSEResponse = `data: {"id":"up-1","object":"chat.completion.chunk","model":"route-groq-fast","choices":[{"index":0,"delta":{"content":"The answer"}}]}
+
+data: {"id":"up-1","object":"chat.completion.chunk","model":"route-groq-fast","choices":[{"index":0,"delta":{"content":" is 42 [1]."}}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}
+
+data: [DONE]
+
+`
+
+func TestHandleChat_StreamingRelaysCitationsAndChunks(t *testing.T) {
+	store := newFakeStore()
+	docID := uuid.New()
+	store.chunks = []ChunkRow{{ID: uuid.New(), DocumentID: docID, Content: "relevant content", Score: 0.1}}
+
 	var audits []auditRecord
-	h := newChatTestHandler(newFakeStore(), &fakeEmbedder{}, &audits,
-		fakeSelectRoute("route-groq-fast", nil), fakeDispatch(http.StatusOK, canned200Response, nil))
+	var captured []byte
+	h := newChatTestHandler(store, &fakeEmbedder{}, &audits,
+		fakeSelectRoute("route-groq-fast", nil),
+		capturingDispatch(http.StatusOK, cannedSSEResponse, &captured))
 
 	req := chatReq(t, ChatRequest{
 		Model:    "hive-fast",
-		Messages: []ChatMessage{{Role: "user", Content: "hi"}},
+		Messages: []ChatMessage{{Role: "user", Content: "what is the answer?"}},
 		Stream:   true,
 	}, uuid.New())
 	w := httptest.NewRecorder()
 	h.handleChat(w, req)
 
-	if w.Code != http.StatusBadRequest {
-		t.Errorf("expected 400 for streaming request (deferred scope), got %d", w.Code)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for streaming, got %d: %s", w.Code, w.Body.String())
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/event-stream") {
+		t.Fatalf("expected SSE content type, got %q", ct)
+	}
+
+	// The dispatched body must request streaming from upstream.
+	if !strings.Contains(string(captured), `"stream":true`) {
+		t.Errorf("expected dispatched body to set stream:true, got %s", captured)
+	}
+
+	body := w.Body.String()
+	frames := strings.Split(strings.TrimSpace(body), "\n\n")
+	if len(frames) < 2 {
+		t.Fatalf("expected multiple SSE frames, got %q", body)
+	}
+
+	// Retrieval-first: the very first frame carries the citations so a
+	// streaming client gets grounding sources before any model token.
+	if !strings.Contains(frames[0], "rag.citations") || !strings.Contains(frames[0], docID.String()) {
+		t.Errorf("expected a leading citations frame naming document %s, got %q", docID, frames[0])
+	}
+
+	// Provider-blind: relayed chunks must be rewritten to the client alias,
+	// never expose the concrete upstream route name.
+	assertNoLeak(t, body)
+	if strings.Contains(body, "route-groq-fast") {
+		t.Errorf("upstream route name leaked into the stream:\n%s", body)
+	}
+	if !strings.Contains(body, "hive-fast") {
+		t.Errorf("expected relayed chunks rewritten to alias hive-fast, got:\n%s", body)
+	}
+
+	// Terminated with [DONE].
+	if !strings.HasSuffix(strings.TrimSpace(body), "data: [DONE]") {
+		t.Errorf("expected stream to end with data: [DONE], got:\n%s", body)
+	}
+
+	// Accounting parity with the non-streaming path: RAG_CHAT_COMPLETED must
+	// still fire, with token counts captured from the terminal usage chunk.
+	var completed map[string]any
+	for _, a := range audits {
+		if a.Action == "RAG_CHAT_COMPLETED" {
+			completed, _ = a.After.(map[string]any)
+		}
+	}
+	if completed == nil {
+		t.Fatal("RAG_CHAT_COMPLETED audit not emitted for streaming request")
+	}
+	if got := completed["total_tokens"]; got != int64(15) {
+		t.Errorf("expected RAG_CHAT_COMPLETED total_tokens=15 from usage chunk, got %v (%T)", got, got)
 	}
 }
 

--- a/apps/edge-api/internal/rag/types.go
+++ b/apps/edge-api/internal/rag/types.go
@@ -65,9 +65,9 @@ type ChatRequest struct {
 	Model    string        `json:"model"`
 	Messages []ChatMessage `json:"messages"`
 	TopK     int           `json:"top_k"` // defaults to 5 when zero, capped at maxTopK
-	// Stream is accepted but rejected with 400: SSE grounded generation is
-	// deferred (issue #325 scope note); a client that already sends
-	// stream:true gets a clear error instead of a silently ignored flag.
+	// Stream requests an SSE response (#339): a retrieval-first citations
+	// frame followed by the relayed upstream chat.completion.chunk frames and
+	// a terminating data: [DONE].
 	Stream bool `json:"stream,omitempty"`
 }
 


### PR DESCRIPTION
## What

Adds SSE streaming to `POST /v1/rag/chat`, closing #339. Previously the endpoint rejected `stream:true` with a 400 (deferred at #325 to keep the grounded-generation PR reviewable).

## How

When the request sets `stream:true`:

1. The dispatched upstream body gets `stream:true` plus `stream_options.include_usage` so the terminal chunk carries token counts.
2. The handler emits a retrieval-first `rag.citations` SSE frame before any model token, so a streaming client receives the grounding sources up front (the non-streaming response already returns a non-OpenAI `citations` field, so this stays consistent with the endpoint's own contract).
3. It then relays the upstream `chat.completion.chunk` frames, rewriting each chunk's `model` to the client alias (provider-blind: the concrete route name must never reach the customer, same reason `internal/inference/stream.go` rewrites it), and terminates with `data: [DONE]`.
4. `RAG_CHAT_COMPLETED` still fires as the accounting audit for this JWT-session path, with token counts captured from the terminal usage chunk, matching the non-streaming path.

Prompt-injection hardening from #325 (client system-message stripping, untrusted-context delimiting) is unchanged and runs before the stream branch. A non-2xx upstream is surfaced as a provider-blind error on both paths.

## Safety notes

- Unparseable upstream `data:` frames are dropped rather than forwarded, so no unsanitized upstream field can leak.
- Request cancellation is honored in the relay loop.
- No USD/FX language on any customer-visible surface.

## Test

New `TestHandleChat_StreamingRelaysCitationsAndChunks` (replaces the old streaming-rejected test) asserts: SSE content type, a leading citations frame naming the retrieved document, provider-blind alias rewrite (upstream route name absent), `stream:true` reached the dispatched body, terminal `[DONE]`, and token capture into the completion audit. Full `internal/rag` package passes.

Closes #339.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added streaming responses for RAG chat requests.
  * Streams begin with retrieval citations, followed by chat response chunks, and end with a completion marker.
  * Streamed responses now use the client-facing model name and include token usage accounting.

* **Documentation**
  * Updated chat request guidance to describe streaming response behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->