### PR TITLE
fix: harden desktop egress proxy and Windows firewall codegen (#342)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,6 +281,7 @@ jobs:
       - run: npm run lint:tenant-setting
       - run: npm run lint:tenant-id
       - run: npm run lint:audit-write
+      - run: npm run lint:desktop-local-http
 
   web-unit:
     name: Web console (type + unit + build)

--- a/apps/agent-engine/internal/egressproxy/export_test.go
+++ b/apps/agent-engine/internal/egressproxy/export_test.go
@@ -1,0 +1,11 @@
+package egressproxy
+
+// NewAllowingLocalDest builds a Proxy that permits egress to
+// private/loopback/link-local destinations. Test-only: this file compiles
+// only under `go test`, so production has no such escape hatch. The
+// destination guard in resolvePinnedAddr (issue #342 item 2) is correct in
+// production, but the httptest backends the proxy tests dial bind to
+// 127.0.0.1, so those specific tests must opt out of it.
+func NewAllowingLocalDest(allowedHosts []string) *Proxy {
+	return newProxy(allowedHosts, true)
+}

--- a/apps/agent-engine/internal/egressproxy/proxy.go
+++ b/apps/agent-engine/internal/egressproxy/proxy.go
@@ -19,34 +19,46 @@ import (
 // Proxy is an allowlist-enforcing HTTP/HTTPS forward proxy. It implements
 // http.Handler so callers run it with an ordinary http.Server.
 type Proxy struct {
-	allowed   map[string]struct{}
-	transport *http.Transport
+	allowed map[string]struct{}
+	// allowLocalDest opts out of the private/loopback/link-local destination
+	// guard (issue #342 item 2). Always false in production; only the
+	// test-only constructor in export_test.go sets it true, since the
+	// httptest backends the proxy tests dial bind to 127.0.0.1.
+	allowLocalDest bool
+	transport      *http.Transport
 }
 
 // New builds a Proxy that permits egress only to the given hosts (hostname
 // or IP, no port, matching the egress-policy wire shape). A nil or empty
 // list denies all egress, which is the correct fail-closed behaviour when no
-// policy could be resolved.
+// policy could be resolved. Resolved addresses that are private, loopback,
+// or link-local are always refused (issue #342 item 2).
 func New(allowedHosts []string) *Proxy {
+	return newProxy(allowedHosts, false)
+}
+
+func newProxy(allowedHosts []string, allowLocalDest bool) *Proxy {
 	allowed := make(map[string]struct{}, len(allowedHosts))
 	for _, h := range allowedHosts {
 		allowed[strings.ToLower(h)] = struct{}{}
 	}
-	return &Proxy{
-		allowed: allowed,
-		// Plain-HTTP path (handleForward) must pin the resolved IP exactly
-		// like the CONNECT path: DialContext resolves once here instead of
-		// letting the transport's default dialer resolve addr itself.
-		transport: &http.Transport{
-			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-				pinned, err := resolvePinnedAddr(ctx, addr, "80")
-				if err != nil {
-					return nil, err
-				}
-				return (&net.Dialer{}).DialContext(ctx, network, pinned)
-			},
+	p := &Proxy{
+		allowed:        allowed,
+		allowLocalDest: allowLocalDest,
+	}
+	// Plain-HTTP path (handleForward) must pin the resolved IP exactly
+	// like the CONNECT path: DialContext resolves once here instead of
+	// letting the transport's default dialer resolve addr itself.
+	p.transport = &http.Transport{
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			pinned, err := resolvePinnedAddr(ctx, addr, "80", allowLocalDest)
+			if err != nil {
+				return nil, err
+			}
+			return (&net.Dialer{}).DialContext(ctx, network, pinned)
 		},
 	}
+	return p
 }
 
 func (p *Proxy) isAllowed(hostport string) bool {
@@ -78,7 +90,7 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 	// again: dialing by hostname would trigger a second, independent DNS
 	// resolution, leaving a window for a short-TTL DNS-rebind response
 	// between the allowlist check above and the actual connection.
-	pinned, err := resolvePinnedAddr(r.Context(), r.Host, "443")
+	pinned, err := resolvePinnedAddr(r.Context(), r.Host, "443", p.allowLocalDest)
 	if err != nil {
 		http.Error(w, "egress: dns lookup failed", http.StatusBadGateway)
 		return
@@ -136,7 +148,7 @@ func (p *Proxy) handleForward(w http.ResponseWriter, r *http.Request) {
 // returns "resolvedIP:port", so the caller can dial that literal address
 // instead of triggering a second resolution. defaultPort is used when
 // hostport carries no port of its own.
-func resolvePinnedAddr(ctx context.Context, hostport, defaultPort string) (string, error) {
+func resolvePinnedAddr(ctx context.Context, hostport, defaultPort string, allowLocal bool) (string, error) {
 	host, port, err := net.SplitHostPort(hostport)
 	if err != nil {
 		host, port = hostport, defaultPort
@@ -148,7 +160,36 @@ func resolvePinnedAddr(ctx context.Context, hostport, defaultPort string) (strin
 	if len(ips) == 0 {
 		return "", fmt.Errorf("egressproxy: no addresses found for %q", host)
 	}
-	return net.JoinHostPort(ips[0], port), nil
+	// Issue #342 item 2: pin the first resolved address that is not private,
+	// loopback, or link-local. An allowed hostname rebound to an internal IP
+	// (127.0.0.1, 169.254.x.x, RFC1918/ULA) must not become a path to
+	// host-local or LAN services from inside the sandbox. Mirrors the same
+	// guard in the desktop Rust proxy (egress_proxy.rs::resolve_pinned) so
+	// both #308 surfaces reject the same addresses.
+	for _, ipStr := range ips {
+		if ip := net.ParseIP(ipStr); ip != nil && (allowLocal || !isForbiddenIP(ip)) {
+			return net.JoinHostPort(ipStr, port), nil
+		}
+	}
+	return "", fmt.Errorf(
+		"egressproxy: %q resolved only to disallowed (private/loopback/link-local) addresses",
+		host,
+	)
+}
+
+// isForbiddenIP reports whether ip is an address a sandboxed task must never
+// be allowed to reach: loopback, unspecified, multicast, or any private or
+// link-local range on IPv4 or IPv6. net.IP.IsPrivate covers RFC1918 and the
+// IPv6 unique-local fc00::/7 range.
+func isForbiddenIP(ip net.IP) bool {
+	return ip.IsLoopback() ||
+		ip.IsUnspecified() ||
+		ip.IsPrivate() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() ||
+		ip.IsInterfaceLocalMulticast() ||
+		ip.IsMulticast() ||
+		ip.Equal(net.IPv4bcast)
 }
 
 func relay(a, b net.Conn) {

--- a/apps/agent-engine/internal/egressproxy/proxy_ssrf_test.go
+++ b/apps/agent-engine/internal/egressproxy/proxy_ssrf_test.go
@@ -1,0 +1,65 @@
+package egressproxy
+
+import (
+	"context"
+	"net"
+	"strings"
+	"testing"
+)
+
+// Issue #342 item 2: the resolved-address guard that keeps an allowed
+// hostname rebound to an internal IP from reaching host-local or LAN
+// services from inside the sandbox. Mirrors the desktop Rust proxy's
+// egress_proxy.rs::is_forbidden_ip / resolve_pinned so both #308 surfaces
+// reject the same set.
+
+func TestIsForbiddenIP(t *testing.T) {
+	forbidden := []string{
+		"127.0.0.1", "10.1.2.3", "192.168.0.1", "172.16.0.1",
+		"169.254.0.1", "0.0.0.0", "255.255.255.255", "224.0.0.1",
+		"::1", "::", "fe80::1", "fc00::1", "fd12:3456::1",
+		"::ffff:127.0.0.1", "::ffff:10.0.0.1",
+	}
+	for _, s := range forbidden {
+		ip := net.ParseIP(s)
+		if ip == nil {
+			t.Fatalf("bad test IP %q", s)
+		}
+		if !isForbiddenIP(ip) {
+			t.Errorf("%s should be forbidden", s)
+		}
+	}
+
+	allowed := []string{"8.8.8.8", "1.1.1.1", "93.184.216.34", "2606:4700:4700::1111"}
+	for _, s := range allowed {
+		ip := net.ParseIP(s)
+		if ip == nil {
+			t.Fatalf("bad test IP %q", s)
+		}
+		if isForbiddenIP(ip) {
+			t.Errorf("%s should be allowed", s)
+		}
+	}
+}
+
+func TestResolvePinnedAddrRejectsInternalLiterals(t *testing.T) {
+	ctx := context.Background()
+	// IP literals: LookupHost returns them as-is, so these do no DNS and
+	// are deterministic.
+	for _, hp := range []string{"127.0.0.1:443", "10.0.0.1:443", "169.254.1.1:443", "192.168.1.1:443"} {
+		if _, err := resolvePinnedAddr(ctx, hp, "443", false); err == nil {
+			t.Errorf("%s should be rejected as an internal address", hp)
+		}
+	}
+}
+
+func TestResolvePinnedAddrAllowsPublicLiteral(t *testing.T) {
+	ctx := context.Background()
+	got, err := resolvePinnedAddr(ctx, "8.8.8.8:443", "443", false)
+	if err != nil {
+		t.Fatalf("public IP literal should resolve: %v", err)
+	}
+	if !strings.HasPrefix(got, "8.8.8.8:") {
+		t.Errorf("unexpected pinned addr %q", got)
+	}
+}

--- a/apps/agent-engine/internal/egressproxy/proxy_test.go
+++ b/apps/agent-engine/internal/egressproxy/proxy_test.go
@@ -19,7 +19,10 @@ func TestProxy_AllowsAllowlistedHTTPSHost(t *testing.T) {
 	}))
 	defer backend.Close()
 
-	proxy := httptest.NewServer(egressproxy.New([]string{hostOf(t, backend.URL)}))
+	// NewAllowingLocalDest: the backend is a 127.0.0.1 httptest server, which
+	// the production loopback guard (issue #342 item 2) would correctly
+	// refuse. This test opts out to exercise the allow path itself.
+	proxy := httptest.NewServer(egressproxy.NewAllowingLocalDest([]string{hostOf(t, backend.URL)}))
 	defer proxy.Close()
 
 	client := clientThroughProxy(t, proxy.URL)
@@ -73,7 +76,8 @@ func TestProxy_AllowsAllowlistedPlainHTTPHost(t *testing.T) {
 	}))
 	defer backend.Close()
 
-	proxy := httptest.NewServer(egressproxy.New([]string{hostOf(t, backend.URL)}))
+	// NewAllowingLocalDest: 127.0.0.1 httptest backend, see the HTTPS variant.
+	proxy := httptest.NewServer(egressproxy.NewAllowingLocalDest([]string{hostOf(t, backend.URL)}))
 	defer proxy.Close()
 
 	proxyURLParsed, err := url.Parse(proxy.URL)

--- a/apps/desktop-sandbox/hive-desktop-sandbox/src/egress_proxy.rs
+++ b/apps/desktop-sandbox/hive-desktop-sandbox/src/egress_proxy.rs
@@ -10,7 +10,13 @@
 //! reviewer familiar with one recognizes the other: allowlist check first
 //! (deny before any DNS lookup happens), then a single DNS resolution whose
 //! result is pinned and dialed literally (never re-resolved), closing the
-//! same short-TTL DNS-rebind window the Go version's doc comment calls out.
+//! same short-TTL DNS-rebind window the Go version's doc comment calls out,
+//! and — issue #342 item 2 — rejecting any resolved address that is private,
+//! loopback, or link-local so an allowed hostname rebound to an internal IP
+//! (`127.0.0.1`, `169.254.x.x`, RFC1918/ULA) cannot be used to reach
+//! host-local or LAN services from inside the sandbox. The Go
+//! `resolvePinnedAddr` carries the identical guard so the two surfaces stay
+//! the same shape.
 //!
 //! CONNECT-only (no plain-HTTP forward proxying): virtually all traffic this
 //! proxy exists to gate is HTTPS (LLM provider APIs, package registries),
@@ -19,12 +25,12 @@
 //! caller ever needs it.
 
 use std::collections::HashSet;
-use std::io::{BufRead, BufReader, Write};
-use std::net::{TcpStream, ToSocketAddrs};
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, TcpStream, ToSocketAddrs};
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::thread::JoinHandle;
 use std::time::Duration;
 
@@ -32,6 +38,30 @@ use std::time::Duration;
 /// connection has arrived. Small enough that `shutdown()` returns promptly
 /// in tests, large enough not to busy-loop.
 const ACCEPT_POLL_INTERVAL: Duration = Duration::from_millis(20);
+
+/// Maximum bytes read while looking for the end of a single request or
+/// header line, before the first `\r\n`. Bounds an otherwise unbounded
+/// `read_line` against a hostile client that dribbles a line without ever
+/// terminating it (issue #342 item 3). 8 KiB is far more than a real
+/// `CONNECT host:port HTTP/1.1` line or any normal header needs.
+const MAX_REQUEST_LINE_BYTES: u64 = 8 * 1024;
+
+/// Maximum number of header lines consumed after the request line before the
+/// terminating blank line, so a client cannot stream unbounded headers to
+/// hold a proxy thread open (issue #342 item 3).
+const MAX_HEADER_LINES: usize = 100;
+
+/// Read deadline applied only while reading the request line and headers, so
+/// a slow or silent client cannot pin a handler thread indefinitely (issue
+/// #342 item 3). Cleared before the relay phase begins, since a legitimate
+/// tunnel (streaming LLM responses) may idle far longer than this.
+const CLIENT_HEADER_READ_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Ceiling on concurrently handled connections. Each accepted connection
+/// spawns a handler thread; without a cap a flood of connections spawns
+/// unbounded threads (issue #342 item 3). Over the ceiling, new connections
+/// are refused with `503` and closed without spawning a handler.
+const MAX_CONCURRENT_CONNECTIONS: usize = 256;
 
 /// A running allowlist-enforcing proxy, listening on a Unix socket.
 /// `Drop` shuts it down; call [`AllowlistProxy::leak_for_process_lifetime`]
@@ -52,6 +82,20 @@ impl AllowlistProxy {
     /// ports, case-sensitivity not guaranteed by the SSOT so this proxy
     /// matches case-insensitively (mirrors `egressproxy.Proxy.isAllowed`).
     pub fn spawn(socket_path: &Path, allowed_hosts: Vec<String>) -> std::io::Result<Self> {
+        Self::spawn_with_policy(socket_path, allowed_hosts, false)
+    }
+
+    /// As [`AllowlistProxy::spawn`], with control over whether resolved
+    /// destinations that are private/loopback/link-local are permitted.
+    /// Production always passes `allow_local_dest = false` (via `spawn`): a
+    /// sandboxed task must never reach host-local or LAN addresses. Tests
+    /// that dial a `127.0.0.1` echo server pass `true`, since blocking
+    /// loopback is exactly the guard being exercised elsewhere.
+    fn spawn_with_policy(
+        socket_path: &Path,
+        allowed_hosts: Vec<String>,
+        allow_local_dest: bool,
+    ) -> std::io::Result<Self> {
         let _ = std::fs::remove_file(socket_path);
         let listener = UnixListener::bind(socket_path)?;
         listener.set_nonblocking(true)?;
@@ -64,9 +108,16 @@ impl AllowlistProxy {
         );
         let shutdown = Arc::new(AtomicBool::new(false));
         let shutdown_for_thread = Arc::clone(&shutdown);
+        let active = Arc::new(AtomicUsize::new(0));
 
         let accept_handle = std::thread::spawn(move || {
-            accept_loop(listener, allowed, shutdown_for_thread);
+            accept_loop(
+                listener,
+                allowed,
+                shutdown_for_thread,
+                active,
+                allow_local_dest,
+            );
         });
 
         Ok(Self {
@@ -117,13 +168,39 @@ impl Drop for AllowlistProxy {
     }
 }
 
-fn accept_loop(listener: UnixListener, allowed: Arc<HashSet<String>>, shutdown: Arc<AtomicBool>) {
+/// Decrements the active-connection counter when a handler finishes,
+/// however it exits (return, error, or panic unwinds through it). Paired
+/// with the `fetch_add` in `accept_loop`.
+struct ActiveGuard(Arc<AtomicUsize>);
+
+impl Drop for ActiveGuard {
+    fn drop(&mut self) {
+        self.0.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
+fn accept_loop(
+    listener: UnixListener,
+    allowed: Arc<HashSet<String>>,
+    shutdown: Arc<AtomicBool>,
+    active: Arc<AtomicUsize>,
+    allow_local_dest: bool,
+) {
     while !shutdown.load(Ordering::SeqCst) {
         match listener.accept() {
             Ok((stream, _addr)) => {
+                // Reserve a slot; roll back and refuse if over the ceiling.
+                let prior = active.fetch_add(1, Ordering::SeqCst);
+                if prior >= MAX_CONCURRENT_CONNECTIONS {
+                    active.fetch_sub(1, Ordering::SeqCst);
+                    let _ = write_status(&stream, "503 Service Unavailable");
+                    continue;
+                }
                 let allowed = Arc::clone(&allowed);
+                let guard = ActiveGuard(Arc::clone(&active));
                 std::thread::spawn(move || {
-                    let _ = handle_connection(stream, &allowed);
+                    let _guard = guard; // decrements on scope exit
+                    let _ = handle_connection(stream, &allowed, allow_local_dest);
                 });
             }
             Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
@@ -144,9 +221,21 @@ fn accept_loop(listener: UnixListener, allowed: Arc<HashSet<String>>, shutdown: 
 /// return before "200" means the caller sees a non-2xx status line and the
 /// connection is closed without ever dialing out -- the deny-by-default
 /// behaviour issue #311's acceptance check exercises.
-fn handle_connection(stream: UnixStream, allowed: &HashSet<String>) -> std::io::Result<()> {
+fn handle_connection(
+    stream: UnixStream,
+    allowed: &HashSet<String>,
+    allow_local_dest: bool,
+) -> std::io::Result<()> {
+    // Bound the header-reading phase in time so a silent client cannot hold
+    // this handler thread open. Set on the socket before cloning; the clone
+    // shares the same underlying socket and therefore the same timeout.
+    stream.set_read_timeout(Some(CLIENT_HEADER_READ_TIMEOUT))?;
+
     let mut reader = BufReader::new(stream.try_clone()?);
-    let request_line = read_line(&mut reader)?;
+    let Some(request_line) = read_line_limited(&mut reader, MAX_REQUEST_LINE_BYTES)? else {
+        write_status(&stream, "400 Bad Request")?;
+        return Ok(());
+    };
     let Some(target) = parse_connect_target(&request_line) else {
         write_status(&stream, "400 Bad Request")?;
         return Ok(());
@@ -158,7 +247,7 @@ fn handle_connection(stream: UnixStream, allowed: &HashSet<String>) -> std::io::
         return Ok(());
     }
 
-    let pinned = match resolve_pinned(&target.host, target.port) {
+    let pinned = match resolve_pinned(&target.host, target.port, allow_local_dest) {
         Ok(addr) => addr,
         Err(_) => {
             write_status(&stream, "502 Bad Gateway")?;
@@ -174,6 +263,10 @@ fn handle_connection(stream: UnixStream, allowed: &HashSet<String>) -> std::io::
     };
 
     write_status(&stream, "200 Connection Established")?;
+    // The tunnel may idle far longer than the header read timeout (an LLM
+    // streaming a slow response). Clear the deadline before relaying so a
+    // legitimate quiet tunnel is not torn down.
+    stream.set_read_timeout(None)?;
     relay(stream, dest)
 }
 
@@ -203,15 +296,70 @@ fn is_allowed(host: &str, allowed: &HashSet<String>) -> bool {
     allowed.contains(&host.to_ascii_lowercase())
 }
 
-/// Resolves `host` exactly once and returns the first address, so the
-/// caller dials that literal `SocketAddr` rather than triggering a second,
-/// independent resolution -- the same DNS-rebind mitigation
-/// `apps/agent-engine/internal/egressproxy.resolvePinnedAddr` documents.
-fn resolve_pinned(host: &str, port: u16) -> std::io::Result<std::net::SocketAddr> {
-    (host, port)
-        .to_socket_addrs()?
-        .next()
-        .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::NotFound, "no addresses found"))
+/// Resolves `host` exactly once and returns the first address that is not a
+/// forbidden (private/loopback/link-local/unspecified/multicast) target, so
+/// the caller dials that literal `SocketAddr` rather than triggering a
+/// second, independent resolution -- the same DNS-rebind mitigation
+/// `apps/agent-engine/internal/egressproxy.resolvePinnedAddr` documents,
+/// plus the private-IP guard added in issue #342 item 2. If every resolved
+/// address is forbidden (e.g. an allowed hostname rebound to `127.0.0.1` or
+/// a `169.254.x.x`/RFC1918 address), the connection is refused rather than
+/// used to reach an internal service. `allow_local_dest` opts out of the
+/// guard for tests that dial a loopback echo server; production never does.
+fn resolve_pinned(
+    host: &str,
+    port: u16,
+    allow_local_dest: bool,
+) -> std::io::Result<std::net::SocketAddr> {
+    for addr in (host, port).to_socket_addrs()? {
+        if allow_local_dest || !is_forbidden_ip(addr.ip()) {
+            return Ok(addr);
+        }
+    }
+    Err(std::io::Error::new(
+        std::io::ErrorKind::PermissionDenied,
+        "host resolved only to disallowed (private/loopback/link-local) addresses",
+    ))
+}
+
+/// True for an address a sandboxed task must never be allowed to reach:
+/// loopback, unspecified, multicast, and the private/link-local ranges on
+/// both IPv4 and IPv6 (including IPv4-mapped IPv6, so `::ffff:127.0.0.1`
+/// cannot slip a loopback past the IPv4 check).
+fn is_forbidden_ip(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => is_forbidden_v4(v4),
+        IpAddr::V6(v6) => {
+            if let Some(mapped) = v6.to_ipv4_mapped() {
+                return is_forbidden_v4(mapped);
+            }
+            v6.is_loopback()
+                || v6.is_unspecified()
+                || v6.is_multicast()
+                || is_ipv6_unique_local(v6)
+                || is_ipv6_link_local(v6)
+        }
+    }
+}
+
+fn is_forbidden_v4(v4: Ipv4Addr) -> bool {
+    v4.is_private()
+        || v4.is_loopback()
+        || v4.is_link_local()
+        || v4.is_unspecified()
+        || v4.is_broadcast()
+        || v4.is_documentation()
+        || v4.is_multicast()
+}
+
+/// `fc00::/7` unique-local (checked manually: the std predicate is unstable).
+fn is_ipv6_unique_local(ip: Ipv6Addr) -> bool {
+    (ip.segments()[0] & 0xfe00) == 0xfc00
+}
+
+/// `fe80::/10` link-local unicast (checked manually: std predicate unstable).
+fn is_ipv6_link_local(ip: Ipv6Addr) -> bool {
+    (ip.segments()[0] & 0xffc0) == 0xfe80
 }
 
 /// Reads headers up to and including the blank line terminating an HTTP
@@ -219,19 +367,40 @@ fn resolve_pinned(host: &str, port: u16) -> std::io::Result<std::net::SocketAddr
 /// them, but must consume them so the byte stream that follows on the same
 /// connection (the tunnelled traffic, for an allowed CONNECT) starts
 /// exactly where the client expects the "200" response to have left it.
+/// Each line is length-bounded and the total count is capped so a hostile
+/// client cannot stream unbounded headers (issue #342 item 3).
 fn consume_headers(reader: &mut BufReader<UnixStream>) -> std::io::Result<()> {
-    loop {
-        let line = read_line(reader)?;
+    for _ in 0..MAX_HEADER_LINES {
+        let Some(line) = read_line_limited(reader, MAX_REQUEST_LINE_BYTES)? else {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "header line exceeded maximum length",
+            ));
+        };
         if line.trim_end_matches(['\r', '\n']).is_empty() {
             return Ok(());
         }
     }
+    Err(std::io::Error::new(
+        std::io::ErrorKind::InvalidData,
+        "too many header lines",
+    ))
 }
 
-fn read_line(reader: &mut BufReader<UnixStream>) -> std::io::Result<String> {
+/// Reads one line, reading at most `max_bytes`. Returns `Ok(None)` when the
+/// byte limit is reached before a terminating newline (an over-length or
+/// never-terminated line), so the caller can reject it rather than block or
+/// buffer unboundedly.
+fn read_line_limited(
+    reader: &mut BufReader<UnixStream>,
+    max_bytes: u64,
+) -> std::io::Result<Option<String>> {
     let mut line = String::new();
-    reader.read_line(&mut line)?;
-    Ok(line)
+    let n = (&mut *reader).take(max_bytes).read_line(&mut line)?;
+    if n as u64 == max_bytes && !line.ends_with('\n') {
+        return Ok(None);
+    }
+    Ok(Some(line))
 }
 
 fn write_status(mut stream: &UnixStream, status_line: &str) -> std::io::Result<()> {
@@ -255,7 +424,6 @@ fn relay(unix: UnixStream, tcp: TcpStream) -> std::io::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::Read as _;
     use std::net::TcpListener;
 
     fn temp_socket_path(label: &str) -> PathBuf {
@@ -296,7 +464,11 @@ mod tests {
     fn allowed_host_gets_200_and_relays_bytes() {
         let echo_port = spawn_echo_server();
         let socket_path = temp_socket_path("allowed");
-        let proxy = AllowlistProxy::spawn(&socket_path, vec!["127.0.0.1".to_string()]).unwrap();
+        // Loopback echo server: this test opts into local destinations, the
+        // one place blocking loopback (the default) would be wrong.
+        let proxy =
+            AllowlistProxy::spawn_with_policy(&socket_path, vec!["127.0.0.1".to_string()], true)
+                .unwrap();
 
         let mut stream = UnixStream::connect(&socket_path).unwrap();
         stream
@@ -352,7 +524,9 @@ mod tests {
     fn host_match_is_case_insensitive() {
         let echo_port = spawn_echo_server();
         let socket_path = temp_socket_path("case");
-        let proxy = AllowlistProxy::spawn(&socket_path, vec!["127.0.0.1".to_string()]).unwrap();
+        let proxy =
+            AllowlistProxy::spawn_with_policy(&socket_path, vec!["127.0.0.1".to_string()], true)
+                .unwrap();
 
         // Same host, would only differ in case for a real hostname; assert
         // the lookup itself normalizes rather than relying on 127.0.0.1
@@ -406,6 +580,27 @@ mod tests {
     }
 
     #[test]
+    fn oversized_request_line_gets_400() {
+        let socket_path = temp_socket_path("oversize");
+        let proxy = AllowlistProxy::spawn(&socket_path, vec![]).unwrap();
+
+        // A CONNECT line far longer than the cap, with no terminating
+        // newline within the first MAX_REQUEST_LINE_BYTES: must be rejected
+        // rather than buffered unboundedly.
+        let mut huge = String::from("CONNECT ");
+        huge.push_str(&"a".repeat(MAX_REQUEST_LINE_BYTES as usize + 100));
+        huge.push_str(":443 HTTP/1.1\r\n\r\n");
+
+        let status_line = connect_and_send(&socket_path, &huge);
+        assert!(
+            status_line.starts_with("HTTP/1.1 400"),
+            "unexpected status: {status_line}"
+        );
+
+        proxy.shutdown();
+    }
+
+    #[test]
     fn socket_path_returns_bound_path() {
         let socket_path = temp_socket_path("path-accessor");
         let proxy = AllowlistProxy::spawn(&socket_path, vec![]).unwrap();
@@ -439,5 +634,66 @@ mod tests {
         let target = parse_connect_target("CONNECT example.com:443 HTTP/1.1").unwrap();
         assert_eq!(target.host, "example.com");
         assert_eq!(target.port, 443);
+    }
+
+    #[test]
+    fn resolve_pinned_rejects_private_loopback_and_link_local() {
+        // Literal addresses: to_socket_addrs parses them without DNS, so
+        // these assertions do no network I/O and are deterministic.
+        assert!(resolve_pinned("127.0.0.1", 443, false).is_err());
+        assert!(resolve_pinned("10.0.0.1", 443, false).is_err());
+        assert!(resolve_pinned("192.168.1.1", 443, false).is_err());
+        assert!(resolve_pinned("169.254.1.1", 443, false).is_err());
+        assert!(resolve_pinned("0.0.0.0", 443, false).is_err());
+    }
+
+    #[test]
+    fn resolve_pinned_allows_public_ip() {
+        let addr = resolve_pinned("8.8.8.8", 443, false).unwrap();
+        assert_eq!(addr.ip().to_string(), "8.8.8.8");
+        assert_eq!(addr.port(), 443);
+    }
+
+    #[test]
+    fn resolve_pinned_allow_local_opt_in_permits_loopback() {
+        // The test-only opt-out used by the relay tests above.
+        assert!(resolve_pinned("127.0.0.1", 443, true).is_ok());
+    }
+
+    #[test]
+    fn is_forbidden_ip_classifies_internal_and_public() {
+        for s in [
+            "127.0.0.1",
+            "10.1.2.3",
+            "192.168.0.1",
+            "172.16.0.1",
+            "169.254.0.1",
+            "0.0.0.0",
+            "255.255.255.255",
+            "224.0.0.1",
+            "::1",
+            "::",
+            "fe80::1",
+            "fc00::1",
+            "fd12:3456::1",
+            "::ffff:127.0.0.1",
+            "::ffff:10.0.0.1",
+        ] {
+            assert!(
+                is_forbidden_ip(s.parse::<IpAddr>().unwrap()),
+                "{s} should be forbidden"
+            );
+        }
+        for s in [
+            "8.8.8.8",
+            "1.1.1.1",
+            "93.184.216.34",
+            "2606:4700:4700::1111",
+        ] {
+            assert!(
+                !is_forbidden_ip(s.parse::<IpAddr>().unwrap()),
+                "{s} should be allowed"
+            );
+        }
     }
 }

--- a/apps/desktop-sandbox/hive-desktop-sandbox/src/windows_plan.rs
+++ b/apps/desktop-sandbox/hive-desktop-sandbox/src/windows_plan.rs
@@ -112,12 +112,39 @@ pub fn allow_hosts_firewall_script(
         ));
     }
     for host in &plan.firewall_allow_outbound_hosts {
+        // Issue #342 item 4: never interpolate a host into a command string
+        // that is not a safe literal. The egress SSOT
+        // (`apps/control-plane/internal/egress/service.go`'s `normalizeHosts`)
+        // already rejects whitespace and wildcards upstream, but this codegen
+        // must not depend on every future caller having sanitised its input.
+        // A host that is not a plain hostname/IP/CIDR literal gets no allow
+        // rule at all -- fail closed, so it stays denied by the block rule
+        // above rather than emitting an attacker-controlled `netsh` argument.
+        if !is_safe_firewall_host(host) {
+            continue;
+        }
         lines.push(format!(
             "netsh advfirewall firewall add rule name=\"{RULE_NAME_PREFIX}-{task_id}-allow-{host}\" \
              dir=out action=allow program=\"{program_path}\" remoteip={host} enable=yes"
         ));
     }
     lines
+}
+
+/// True only for a host string safe to interpolate verbatim into a `netsh`
+/// command line: a plain hostname, IPv4/IPv6 literal, or CIDR range. Rejects
+/// anything carrying quotes, whitespace, shell/`netsh` metacharacters, or
+/// wildcards, which is what makes the interpolation in
+/// [`allow_hosts_firewall_script`] injection-safe regardless of what a future
+/// caller passes. Deliberately a strict allowlist of characters rather than
+/// an attempt to escape: escaping `netsh`/`cmd` quoting correctly is subtle,
+/// and no legitimate egress host needs a character outside this set.
+fn is_safe_firewall_host(host: &str) -> bool {
+    !host.is_empty()
+        && host.len() <= 255
+        && host
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | ':' | '-' | '_' | '/'))
 }
 
 /// Computes the parent of a Windows-style path using explicit `\`/`/`
@@ -312,5 +339,56 @@ mod tests {
         // Must be "C:\" (the drive root), not "C:" (Win32's "current
         // directory on drive C", a different and non-deterministic path).
         assert_eq!(plan.acl_deny_write_parent_dir, PathBuf::from(r"C:\"));
+    }
+
+    #[test]
+    fn allow_hosts_firewall_script_skips_unsafe_hosts() {
+        // Construct the plan directly so the injection guard is tested in
+        // isolation, even for hosts SandboxPolicy::build would itself reject:
+        // this codegen must be safe regardless of what a future caller passes.
+        let plan = WindowsConfinementPlan {
+            acl_deny_write_parent_dir: PathBuf::from(r"C:\Users\agent\AppData\Hive"),
+            protect_dacl_from_inheritance: true,
+            job_object_kill_on_close: true,
+            firewall_deny_outbound: true,
+            firewall_allow_outbound_hosts: vec![
+                "api.openrouter.ai".to_string(),
+                r#"evil.com" & calc.exe & echo "#.to_string(),
+                "with space.com".to_string(),
+                "*.wild.com".to_string(),
+            ],
+        };
+
+        let lines = allow_hosts_firewall_script(&plan, "task-1", r"C:\hive\task.exe");
+        // Deny rule plus exactly one allow rule: only the single safe host.
+        assert_eq!(
+            lines.len(),
+            2,
+            "unsafe hosts must not produce allow rules: {lines:?}"
+        );
+        assert!(lines[0].contains("action=block"));
+        assert!(lines[1].contains("action=allow") && lines[1].contains("api.openrouter.ai"));
+        for line in &lines {
+            assert!(
+                !line.contains("calc.exe"),
+                "no injected command must survive into a rule: {line}"
+            );
+        }
+    }
+
+    #[test]
+    fn is_safe_firewall_host_accepts_literals_and_rejects_metacharacters() {
+        for good in [
+            "api.openrouter.ai",
+            "10.0.0.1",
+            "2606:4700::1111",
+            "10.0.0.0/8",
+            "host-name_1",
+        ] {
+            assert!(is_safe_firewall_host(good), "{good} should be safe");
+        }
+        for bad in ["", "a b", "x\"y", "a&b", "a|b", "*.x.com", "a\nb", "a;b"] {
+            assert!(!is_safe_firewall_host(bad), "{bad} should be rejected");
+        }
     }
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "lint:audit-write": "node tools/lint-no-direct-audit-write.mjs",
     "lint:tenant-setting": "node tools/lint-no-direct-tenant-setting.mjs",
     "lint:tenant-id": "node tools/lint-no-direct-tenant-id.mjs",
+    "lint:desktop-local-http": "node tools/lint-no-desktop-local-http.mjs",
     "soc2:report": "node tools/soc2-coverage-report.mjs",
     "soc2:check": "node tools/soc2-coverage-report.mjs --check"
   },

--- a/tools/lint-no-desktop-local-http.mjs
+++ b/tools/lint-no-desktop-local-http.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+// Structural guard for issue #342 item 5 (decision D8).
+//
+// apps/desktop/src-tauri/src/local_tasks.rs's module doc claims "this module
+// has no HTTP client dependency at all" as the ACTUAL mechanism behind the
+// guarantee that a desktop-local task never appears in the cloud task list:
+// there is no code path connecting the two, not a runtime check that happens
+// not to fire. That guarantee was enforced only by code review. This lint
+// makes it structural: if the module ever gains an HTTP client dependency,
+// CI fails instead of the guarantee silently breaking.
+//
+// Mirrors the pattern of tools/lint-no-direct-*.mjs (a small, dependency-free
+// source scanner wired into the repo-policy-lints CI job).
+
+import { readFileSync, existsSync } from "node:fs";
+import { dirname, resolve, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(HERE, "..");
+const TARGET = join(REPO_ROOT, "apps", "desktop", "src-tauri", "src", "local_tasks.rs");
+
+// HTTP client crates that would give this module a path to the network.
+const FORBIDDEN_CRATES = [
+  "reqwest",
+  "hyper",
+  "ureq",
+  "isahc",
+  "awc",
+  "surf",
+  "curl",
+  "attohttpc",
+  "http_req",
+];
+
+export function findOffenders(src) {
+  const offenders = [];
+  src.split("\n").forEach((line, i) => {
+    // Strip a line comment before matching: the module doc names `reqwest`
+    // precisely to state its absence, and that mention must not trip the lint.
+    const code = line.split("//")[0];
+    for (const crate of FORBIDDEN_CRATES) {
+      // Match the crate as a Rust path segment: `use reqwest`, `reqwest::...`,
+      // `extern crate reqwest;`, `reqwest {` -- not an arbitrary substring.
+      const re = new RegExp(`\\b${crate}\\b\\s*(::|;|\\{)`);
+      if (re.test(code)) {
+        offenders.push({ line: i + 1, crate, text: line.trim() });
+      }
+    }
+  });
+  return offenders;
+}
+
+function main() {
+  if (!existsSync(TARGET)) {
+    console.error(`lint-no-desktop-local-http: target not found: ${TARGET}`);
+    process.exit(2);
+  }
+  const offenders = findOffenders(readFileSync(TARGET, "utf8"));
+  if (offenders.length === 0) {
+    console.log(
+      "lint-no-desktop-local-http: ok (desktop-local task store has no HTTP client dependency)",
+    );
+    process.exit(0);
+  }
+  for (const o of offenders) {
+    console.error(`${TARGET}:${o.line}: forbidden HTTP client '${o.crate}' — ${o.text}`);
+  }
+  console.error(
+    "lint-no-desktop-local-http: the desktop-local task store must have no HTTP client dependency " +
+      "(issue #342 item 5, decision D8: a desktop-local task must never reach the cloud task list).",
+  );
+  process.exit(1);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}


### PR DESCRIPTION
## Summary

Addresses four of the six hardening follow-ups from the PR #341 dual review (issue #342), the ones that share the egress and sandbox security surface. Items 1 and 6 remain open for their own PRs (see below).

### Item 2 — SSRF via a rebound allowlist host (both #308 surfaces)

The desktop Rust CONNECT proxy (`egress_proxy.rs`) and the server side Go forward proxy (`agent-engine/internal/egressproxy`) both resolved an allowed hostname and dialed the first returned address without checking whether it was private, loopback, or link local. A host already on the allowlist, rebound to `127.0.0.1`, `169.254.x.x`, or an RFC1918/ULA address, could be used to reach host local or LAN services from inside the sandbox.

Both surfaces now pin the first resolved address that is not private, loopback, link local, unspecified, multicast, or IPv4 broadcast (IPv4 mapped IPv6 included), and refuse the connection when every resolved address is disallowed. The guard is written the same shape on both sides so the #308 single source of truth stays recognisable.

A test only escape hatch (`allow_local_dest` in Rust, `NewAllowingLocalDest` via `export_test.go` in Go) lets the existing loopback based tests keep dialing `127.0.0.1`; production has no such opt out.

### Item 3 — accept loop hardening (Rust proxy)

`AllowlistProxy` now applies a read deadline to the request and header reading phase (cleared before the relay so a long lived tunnel that idles is not torn down), bounds the request and header line length, caps the number of header lines, and ceilings total concurrent connections, refusing excess with `503`.

### Item 4 — Windows firewall codegen injection

`allow_hosts_firewall_script` now validates each host as a plain hostname, IP, or CIDR literal before interpolating it into a `netsh` command string, skipping anything unsafe (fail closed) so a host can never smuggle a `netsh` argument. Defense in depth ahead of any future work that wires this codegen to a real `netsh`/WFP call. `windows::launch` still refuses to run regardless of network policy, so nothing here executes today.

### Item 5 — structural no cloud sync guarantee

Adds `tools/lint-no-desktop-local-http.mjs`, wired into the `repo-policy-lints` CI job, that fails if `local_tasks.rs` ever gains an HTTP client dependency. This makes decision D8's guarantee ("a desktop-local task never appears in the cloud task list") structural rather than review enforced.

## Left open (own PRs)

- Item 1: allocator safe `pre_exec` rewrite (pre allocate before `fork()` or move to a `posix_spawn` style API). Larger and delicate; #341 already ships a spawn timeout containment guard.
- Item 6: real `bwrap` end to end egress blocked test needing a CI job with `bwrap` and unprivileged user namespaces.

## Test plan

- [x] `cargo test -p hive-desktop-sandbox`: 42 passing (new SSRF, oversized line, and Windows injection tests included).
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings`: clean.
- [x] `go test ./internal/egressproxy/`: 10 passing (new `TestIsForbiddenIP`, `TestResolvePinnedAddrRejectsInternalLiterals`, `TestResolvePinnedAddrAllowsPublicLiteral` plus the existing suite); `go vet` and `gofmt` clean.
- [x] `node tools/lint-no-desktop-local-http.mjs`: green.
