### PR TITLE
fix: reconcile double-defined audit_cold_archive_manifest schema

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,20 +125,6 @@ jobs:
           dsn="postgresql://postgres:postgres@127.0.0.1:5432/hive_test?sslmode=disable"
           psql "$dsn" -v ON_ERROR_STOP=1 -f .github/ci/test-db-bootstrap.sql
           for f in supabase/migrations/*.sql; do
-            name=$(basename "$f")
-            # Pre-existing migration-ordering defect, tracked separately
-            # (not fixed here — CI wiring only, no product-code changes):
-            # 20260516_04_phase19_audit_log.sql and this later file both
-            # create a table named public.audit_cold_archive_manifest with
-            # different column shapes. CREATE TABLE IF NOT EXISTS here
-            # silently no-ops against the earlier (stale) shape on any
-            # from-scratch replay, so a later ALTER in this same file then
-            # fails against columns that don't exist. This drop is CI-only,
-            # against this run's throwaway database, never a real
-            # environment, and only unblocks this ephemeral replay.
-            if [ "$name" = "20260625_06_audit_cold_archive_manifest.sql" ]; then
-              psql "$dsn" -v ON_ERROR_STOP=1 -c "DROP TABLE IF EXISTS public.audit_cold_archive_manifest CASCADE;"
-            fi
             psql "$dsn" -v ON_ERROR_STOP=1 -f "$f"
           done
           echo "HIVE_TEST_DB_URL=$dsn" >> "$GITHUB_ENV"

--- a/.wolf/buglog.json
+++ b/.wolf/buglog.json
@@ -1878,6 +1878,20 @@
         "air",
         "healthcheck"
       ]
+    },
+    {
+      "date": "2026-07-17",
+      "error_message": "column \"tenant_id\" does not exist on clean supabase db push at 20260625_06_audit_cold_archive_manifest.sql (CREATE UNIQUE INDEX ... (tenant_id, partition_month))",
+      "root_cause": "audit_cold_archive_manifest defined twice with incompatible shapes: 20260516_04 (May, partition_name/parquet_path) and 20260625_06 (June, id/tenant_id/object_key). June used CREATE TABLE IF NOT EXISTS, so on a chained fresh apply it no-opped onto the May table, then its unique index on the June-only column tenant_id errored. A CI-only DROP TABLE band-aid in ci.yml masked it, and a stale compliance test (audit_retention_test.go) asserted May columns, so it only passed because the CI drop left the May table live. App code (auditarchive/pg_repository.go) and the 20260625_08 immutability trigger both use the June shape, so June is authoritative.",
+      "fix": "Made 20260625_06 self-healing (permitted: it was un-applied and always-failing): drop the stale May table and its May-era policies (manifest_service_role_all, manifest_auditor_select) then create the June table, with hive_app INSERT/SELECT/UPDATE and auditor_ro SELECT grants relocated in. Removed the CI DROP band-aid so CI validates the real chain. Fixed audit_retention_test.go to assert June columns. Stale May table provably empty everywhere (app writes June-only columns, so writes against the May shape always error; staging confirmed 0 rows), so the drop preserves all audit data. Validated: full migration chain applies cleanly on a fresh pgvector:pg17 with no drop hack, and the compliance + RLS suites pass against the June schema.",
+      "tags": [
+        "migration",
+        "rls",
+        "audit",
+        "compliance",
+        "ci-integrity",
+        "prod-only"
+      ]
     }
   ]
 }

--- a/apps/control-plane/internal/auditarchive/repository_rls_test.go
+++ b/apps/control-plane/internal/auditarchive/repository_rls_test.go
@@ -67,6 +67,16 @@ func newRLSTestPool(t *testing.T, role string) *pgxpool.Pool {
 func seedTenant(t *testing.T, id uuid.UUID) {
 	t.Helper()
 	dsn := os.Getenv("HIVE_TEST_DB_URL")
+	// Same guards as newRLSTestPool: skip when the suite is not DB-gated
+	// (unset env), and refuse to seed anything but a test database. Without
+	// the skip, an empty DSN falls back to a local unix socket and the seed
+	// fails in CI (which is TCP-only) instead of skipping like the pool helper.
+	if dsn == "" {
+		t.Skip("HIVE_TEST_DB_URL not set")
+	}
+	if !strings.Contains(strings.ToLower(dsn), "test") {
+		t.Fatalf("refusing to seed: HIVE_TEST_DB_URL must point at a test database (DSN missing 'test' marker)")
+	}
 	ctx := context.Background()
 	setup, err := pgxpool.New(ctx, dsn)
 	if err != nil {

--- a/apps/control-plane/internal/auditarchive/repository_rls_test.go
+++ b/apps/control-plane/internal/auditarchive/repository_rls_test.go
@@ -1,0 +1,255 @@
+package auditarchive_test
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/auditarchive"
+)
+
+// newRLSTestPool connects and SET ROLE hive_app -- the same NOT-BYPASSRLS role
+// the control-plane runs as in production (20260518_04_phase19_audit_rls_and_indexes.sql;
+// the platform pool does no SET ROLE, it connects as hive_app directly). This
+// makes the audit_cold_archive_manifest RLS policies actually apply instead of
+// being bypassed by whatever superuser HIVE_TEST_DB_URL otherwise connects as.
+// MaxConns is pinned to 1 so every Acquire returns the same physical connection
+// (the role change sticks), and the pool is closed at test end so the role
+// never leaks to another test. Mirrors internal/rag/repository_rls_test.go.
+//
+// These tests are the regression guard for the 20260625_06 schema reconcile:
+// that migration briefly replaced the hive_app service policy with a
+// tenant-scoped SELECT-only policy, which silently broke the cross-tenant
+// archiver (InsertManifest denied, FetchExpiredManifests returned zero rows,
+// DeleteManifest denied). The compliance suite did not catch it because it
+// connects as the raw superuser and bypasses RLS.
+func newRLSTestPool(t *testing.T, role string) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("HIVE_TEST_DB_URL")
+	if dsn == "" {
+		t.Skip("HIVE_TEST_DB_URL not set")
+	}
+	if !strings.Contains(strings.ToLower(dsn), "test") {
+		t.Fatalf("refusing to run: HIVE_TEST_DB_URL must point at a test database (DSN missing 'test' marker)")
+	}
+
+	cfg, err := pgxpool.ParseConfig(dsn)
+	if err != nil {
+		t.Fatalf("parse HIVE_TEST_DB_URL: %v", err)
+	}
+	cfg.MaxConns = 1
+
+	ctx := context.Background()
+	pool, err := pgxpool.NewWithConfig(ctx, cfg)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	if _, err := pool.Exec(ctx, "SET ROLE "+role); err != nil {
+		pool.Close()
+		t.Skipf("SET ROLE %s failed (is %s provisioned + migrations applied on this test DB?): %v", role, role, err)
+	}
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+// seedTenant inserts an FK row into public.tenants via a short-lived, unscoped
+// (superuser) connection, and registers cleanup that TRUNCATEs the manifest
+// then deletes the tenant. The manifest is TRUNCATEd rather than DELETEd
+// because the immutability trigger (20260625_08) blocks a row-level DELETE
+// while purge_after is in the future, and the manifest -> tenants FK is
+// ON DELETE RESTRICT, so tenant cleanup would otherwise fail. TRUNCATE does not
+// fire the BEFORE DELETE row trigger.
+func seedTenant(t *testing.T, id uuid.UUID) {
+	t.Helper()
+	dsn := os.Getenv("HIVE_TEST_DB_URL")
+	ctx := context.Background()
+	setup, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("seed pool: %v", err)
+	}
+	defer setup.Close()
+	_, err = setup.Exec(ctx,
+		`INSERT INTO public.tenants (id, slug, name, deployment)
+		 VALUES ($1, $2, 'auditarchive rls test tenant', 'HIVE_CLOUD')
+		 ON CONFLICT (id) DO NOTHING`,
+		id, "auditarchive-rls-"+id.String())
+	if err != nil {
+		t.Fatalf("seed tenant: %v", err)
+	}
+	t.Cleanup(func() {
+		cleanup, err := pgxpool.New(context.Background(), dsn)
+		if err != nil {
+			return
+		}
+		defer cleanup.Close()
+		_, _ = cleanup.Exec(context.Background(), `TRUNCATE public.audit_cold_archive_manifest`)
+		_, _ = cleanup.Exec(context.Background(), `DELETE FROM public.tenants WHERE id = $1`, id)
+	})
+}
+
+func manifestEntry(tenantID uuid.UUID, month time.Time, purgeAfter time.Time) auditarchive.ManifestEntry {
+	return auditarchive.ManifestEntry{
+		ID:             uuid.New(),
+		TenantID:       tenantID,
+		PartitionMonth: month,
+		ObjectKey:      "audit/cold/" + tenantID.String() + "/" + month.Format("2006-01") + ".jsonl.gz",
+		SHA256Hash:     make([]byte, 32),
+		RowCount:       1,
+		FirstSeq:       1,
+		LastSeq:        1,
+		ArchivedAt:     time.Now().UTC(),
+		PurgeAfter:     purgeAfter,
+	}
+}
+
+// TestRLS_HiveAppServiceRoleIsCrossTenant is the core regression guard. Running
+// as hive_app with NO app.current_tenant_id set (exactly how the archiver runs
+// on the shared pool), the service role must be able to INSERT manifest rows
+// for multiple tenants, read any tenant's row back, and have the purge scan see
+// every tenant's expired rows. Under the broken tenant-scoped model this test
+// fails: the INSERT is denied and the scan matches zero rows.
+func TestRLS_HiveAppServiceRoleIsCrossTenant(t *testing.T) {
+	pool := newRLSTestPool(t, "hive_app")
+	ctx := context.Background()
+
+	tenantA, tenantB := uuid.New(), uuid.New()
+	seedTenant(t, tenantA)
+	seedTenant(t, tenantB)
+
+	repo := auditarchive.NewPgRepository(pool)
+	month := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	past := time.Now().Add(-time.Hour).UTC()
+
+	// Cross-tenant INSERT with no tenant context set.
+	for _, tid := range []uuid.UUID{tenantA, tenantB} {
+		inserted, err := repo.InsertManifest(ctx, manifestEntry(tid, month, past))
+		if err != nil {
+			t.Fatalf("InsertManifest as hive_app (no tenant ctx) for %s: %v", tid, err)
+		}
+		if !inserted {
+			t.Fatalf("InsertManifest for %s reported not inserted", tid)
+		}
+	}
+
+	// Cross-tenant read: hive_app sees another tenant's row with no tenant ctx.
+	exists, err := repo.ManifestExists(ctx, tenantA, month)
+	if err != nil {
+		t.Fatalf("ManifestExists: %v", err)
+	}
+	if !exists {
+		t.Fatalf("hive_app could not read tenant A manifest row with no app.current_tenant_id set (tenant-scoped policy regression)")
+	}
+
+	// Cross-tenant purge scan returns both tenants' expired rows.
+	expired, err := repo.FetchExpiredManifests(ctx, time.Now())
+	if err != nil {
+		t.Fatalf("FetchExpiredManifests: %v", err)
+	}
+	seen := map[uuid.UUID]bool{}
+	for _, m := range expired {
+		seen[m.TenantID] = true
+	}
+	if !seen[tenantA] || !seen[tenantB] {
+		t.Fatalf("purge scan did not return both tenants' expired rows (got A=%v B=%v, %d rows total) -- archiver would never purge", seen[tenantA], seen[tenantB], len(expired))
+	}
+}
+
+// TestRLS_ImmutabilityTriggerGovernsDelete confirms the write-once semantics the
+// service model relies on instead of RLS: UPDATE is always blocked, DELETE is
+// blocked while purge_after is in the future, and DELETE is allowed once
+// purge_after has passed (the retention-expiry purge path).
+func TestRLS_ImmutabilityTriggerGovernsDelete(t *testing.T) {
+	pool := newRLSTestPool(t, "hive_app")
+	ctx := context.Background()
+
+	tenantID := uuid.New()
+	seedTenant(t, tenantID)
+	repo := auditarchive.NewPgRepository(pool)
+
+	// A future-purge row: DELETE must be blocked by the trigger.
+	future := manifestEntry(tenantID, time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC), time.Now().Add(24*time.Hour).UTC())
+	if _, err := repo.InsertManifest(ctx, future); err != nil {
+		t.Fatalf("insert future-purge row: %v", err)
+	}
+	if err := repo.DeleteManifest(ctx, future.ID); err == nil {
+		t.Fatalf("DeleteManifest of a future-purge row succeeded; immutability trigger should have blocked it")
+	}
+
+	// UPDATE is always blocked, even for the service role.
+	if _, err := pool.Exec(ctx,
+		`UPDATE public.audit_cold_archive_manifest SET row_count = row_count + 1 WHERE id = $1`,
+		future.ID); err == nil {
+		t.Fatalf("UPDATE of a manifest row succeeded; immutability trigger should have blocked it")
+	}
+
+	// A past-purge row: DELETE is the legitimate retention purge and must succeed.
+	pastEntry := manifestEntry(tenantID, time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC), time.Now().Add(-time.Hour).UTC())
+	if _, err := repo.InsertManifest(ctx, pastEntry); err != nil {
+		t.Fatalf("insert past-purge row: %v", err)
+	}
+	if err := repo.DeleteManifest(ctx, pastEntry.ID); err != nil {
+		t.Fatalf("DeleteManifest of an expired (past purge_after) row failed; purge path is broken: %v", err)
+	}
+	if exists, err := repo.ManifestExists(ctx, tenantID, pastEntry.PartitionMonth); err != nil {
+		t.Fatalf("ManifestExists after purge: %v", err)
+	} else if exists {
+		t.Fatalf("expired row still present after DeleteManifest")
+	}
+}
+
+// TestRLS_AuditorReadOnlyAndPublicDenied confirms the two other roles: auditor_ro
+// may read but not write, and PUBLIC has no grant at all (the M7 concern in
+// 20260518_04 -- schema USAGE must not expose manifest filenames or digests).
+func TestRLS_AuditorReadOnlyAndPublicDenied(t *testing.T) {
+	tenantID := uuid.New()
+	seedTenant(t, tenantID)
+
+	// Seed one row as the service role so the auditor has something to read.
+	hivePool := newRLSTestPool(t, "hive_app")
+	ctx := context.Background()
+	repo := auditarchive.NewPgRepository(hivePool)
+	month := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	if _, err := repo.InsertManifest(ctx, manifestEntry(tenantID, month, time.Now().Add(-time.Hour).UTC())); err != nil {
+		t.Fatalf("seed manifest row as hive_app: %v", err)
+	}
+
+	auditPool := newRLSTestPool(t, "auditor_ro")
+
+	// auditor_ro can read.
+	var count int
+	if err := auditPool.QueryRow(ctx,
+		`SELECT count(*) FROM public.audit_cold_archive_manifest WHERE tenant_id = $1`,
+		tenantID).Scan(&count); err != nil {
+		t.Fatalf("auditor_ro SELECT: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("auditor_ro read %d rows, want 1", count)
+	}
+
+	// auditor_ro cannot write (no INSERT grant).
+	if _, err := auditPool.Exec(ctx,
+		`INSERT INTO public.audit_cold_archive_manifest
+		   (tenant_id, partition_month, object_key, sha256_hash, row_count, first_seq, last_seq, purge_after)
+		 VALUES ($1, $2, 'x', '\x00', 0, 0, 0, now())`,
+		tenantID, month); err == nil {
+		t.Fatalf("auditor_ro INSERT succeeded; auditor must be read-only")
+	}
+
+	// PUBLIC has no grant on the table.
+	var pubGrants int
+	if err := auditPool.QueryRow(ctx,
+		`SELECT count(*) FROM information_schema.role_table_grants
+		  WHERE table_schema = 'public'
+		    AND table_name = 'audit_cold_archive_manifest'
+		    AND grantee = 'PUBLIC'`).Scan(&pubGrants); err != nil {
+		t.Fatalf("query PUBLIC grants: %v", err)
+	}
+	if pubGrants != 0 {
+		t.Fatalf("PUBLIC holds %d grant(s) on audit_cold_archive_manifest, want 0", pubGrants)
+	}
+}

--- a/apps/control-plane/tests/compliance/audit_retention_test.go
+++ b/apps/control-plane/tests/compliance/audit_retention_test.go
@@ -38,13 +38,16 @@ func TestAuditRetention_ColdArchiveManifestExists(t *testing.T) {
 	require.NoError(t, rows.Err())
 
 	expected := []string{
-		"partition_name",
-		"archived_at",
-		"parquet_path",
-		"parquet_sha256",
+		"id",
+		"tenant_id",
+		"partition_month",
+		"object_key",
+		"sha256_hash",
 		"row_count",
-		"last_prev_hash",
-		"last_row_hash",
+		"first_seq",
+		"last_seq",
+		"archived_at",
+		"purge_after",
 	}
 	for _, c := range expected {
 		require.True(t, got[c], "missing column %s on public.audit_cold_archive_manifest", c)

--- a/supabase/migrations/20260625_06_audit_cold_archive_manifest.sql
+++ b/supabase/migrations/20260625_06_audit_cold_archive_manifest.sql
@@ -10,6 +10,30 @@
 --       Rows are never updated or deleted by application code; the RLS
 --       policy enforces read-only access for tenant roles.
 --
+-- Schema reconciliation (compliance fix):
+--   An earlier migration, 20260516_04_phase19_audit_log.sql, also created a
+--   table named public.audit_cold_archive_manifest with a different, now
+--   superseded shape (partition_name / parquet_path / parquet_sha256 ...).
+--   That earlier shape is NOT the one the application uses: InsertManifest and
+--   the retention/purge queries in
+--   apps/control-plane/internal/auditarchive/pg_repository.go read and write
+--   the (id / tenant_id / partition_month / object_key / sha256_hash /
+--   first_seq / last_seq / purge_after) shape defined below, and the
+--   immutability trigger in 20260625_08 references the same columns.
+--
+--   Because this file was originally written with CREATE TABLE IF NOT EXISTS,
+--   on any from-scratch replay it silently no-opped onto the stale shape and
+--   then the UNIQUE INDEX on (tenant_id, partition_month) failed with
+--   "column tenant_id does not exist", breaking every clean `supabase db push`
+--   (fresh-DB init and enterprise self-host). This migration now explicitly
+--   drops the stale table and its May-era policies first, then creates the
+--   authoritative shape.
+--
+--   Data safety: the stale table can never hold rows. Every application write
+--   targets the columns defined below, which do not exist on the stale shape,
+--   so any INSERT against the stale table errors out before committing. The
+--   drop therefore loses no audit data (verified: 0 rows on staging).
+--
 -- Design notes:
 --   - object_key is the storage path (e.g. audit/cold/<tenant>/<YYYY-MM>.jsonl.gz).
 --   - sha256_hash (bytea, 32 bytes) covers the compressed JSONL object so
@@ -22,7 +46,14 @@
 
 BEGIN;
 
-CREATE TABLE IF NOT EXISTS public.audit_cold_archive_manifest (
+-- Remove the stale (20260516_04) shape and its May-era policies from
+-- 20260518_04 before recreating the authoritative table. IF EXISTS keeps this
+-- idempotent whether or not those objects are present in a given environment.
+DROP POLICY IF EXISTS manifest_service_role_all ON public.audit_cold_archive_manifest;
+DROP POLICY IF EXISTS manifest_auditor_select ON public.audit_cold_archive_manifest;
+DROP TABLE IF EXISTS public.audit_cold_archive_manifest CASCADE;
+
+CREATE TABLE public.audit_cold_archive_manifest (
     id              UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
     -- ON DELETE RESTRICT: tenant deletion must not silently orphan or destroy
     -- cold-archive objects. PHIPA / Law 25 require 10-year retention; a tenant
@@ -44,12 +75,22 @@ CREATE TABLE IF NOT EXISTS public.audit_cold_archive_manifest (
 );
 
 -- One manifest entry per (tenant, month).
-CREATE UNIQUE INDEX IF NOT EXISTS audit_cold_archive_manifest_tenant_month
+CREATE UNIQUE INDEX audit_cold_archive_manifest_tenant_month
     ON public.audit_cold_archive_manifest (tenant_id, partition_month);
 
 -- Covering index for the purge scan (purge_after ASC).
-CREATE INDEX IF NOT EXISTS audit_cold_archive_manifest_purge
+CREATE INDEX audit_cold_archive_manifest_purge
     ON public.audit_cold_archive_manifest (purge_after);
+
+-- ── Grants ───────────────────────────────────────────────────────────────────
+-- Relocated here from the removed 20260518_04 manifest block (that block
+-- targeted the stale table dropped above). The service role (control-plane)
+-- bypasses RLS for inserts and the purge scan; hive_app is a non-bypass
+-- application role that still needs explicit table privileges, and auditor_ro
+-- reads the manifest for chain spot-checks.
+REVOKE ALL ON public.audit_cold_archive_manifest FROM PUBLIC;
+GRANT INSERT, SELECT, UPDATE ON public.audit_cold_archive_manifest TO hive_app;
+GRANT SELECT ON public.audit_cold_archive_manifest TO auditor_ro;
 
 -- ── RLS ──────────────────────────────────────────────────────────────────────
 ALTER TABLE public.audit_cold_archive_manifest ENABLE ROW LEVEL SECURITY;

--- a/supabase/migrations/20260625_06_audit_cold_archive_manifest.sql
+++ b/supabase/migrations/20260625_06_audit_cold_archive_manifest.sql
@@ -6,9 +6,12 @@
 -- Tables:
 --   public.audit_cold_archive_manifest
 --       Tracks every JSONL+gzip batch archived to local cold storage.
---       One row per (tenant_id, partition month) -- immutable after insert.
---       Rows are never updated or deleted by application code; the RLS
---       policy enforces read-only access for tenant roles.
+--       One row per (tenant_id, partition month), write-once after insert.
+--       The DB-layer immutability trigger (20260625_08) blocks every UPDATE
+--       and blocks DELETE until purge_after; the only legitimate DELETE is the
+--       retention-expiry purge. RLS follows the audit_log service model: the
+--       archiver runs as hive_app across all tenants, so hive_app has full
+--       access and auditor_ro may read.
 --
 -- Schema reconciliation (compliance fix):
 --   An earlier migration, 20260516_04_phase19_audit_log.sql, also created a
@@ -84,29 +87,50 @@ CREATE INDEX audit_cold_archive_manifest_purge
 
 -- ── Grants ───────────────────────────────────────────────────────────────────
 -- Relocated here from the removed 20260518_04 manifest block (that block
--- targeted the stale table dropped above). The service role (control-plane)
--- bypasses RLS for inserts and the purge scan; hive_app is a non-bypass
--- application role that still needs explicit table privileges, and auditor_ro
--- reads the manifest for chain spot-checks.
+-- targeted the stale table dropped above). The control-plane connects as
+-- hive_app, which is NOT BYPASSRLS, so it needs explicit table privileges. The
+-- cold-archive job inserts new rows, updates none, and deletes rows once their
+-- purge_after has passed (auditarchive/pg_repository.go DeleteManifest), so
+-- hive_app needs DELETE as well as INSERT/SELECT. UPDATE is granted for parity
+-- with the sibling audit surfaces even though the immutability trigger
+-- (20260625_08) blocks every UPDATE. auditor_ro reads for chain spot-checks.
 REVOKE ALL ON public.audit_cold_archive_manifest FROM PUBLIC;
-GRANT INSERT, SELECT, UPDATE ON public.audit_cold_archive_manifest TO hive_app;
+GRANT INSERT, SELECT, UPDATE, DELETE ON public.audit_cold_archive_manifest TO hive_app;
 GRANT SELECT ON public.audit_cold_archive_manifest TO auditor_ro;
 
 -- ── RLS ──────────────────────────────────────────────────────────────────────
+-- Service model, matching the sibling audit surfaces in
+-- 20260518_04_phase19_audit_rls_and_indexes.sql. The control-plane connects as
+-- hive_app, which is NOT BYPASSRLS (the platform pool does no SET ROLE, it
+-- connects as hive_app directly). The cold-archive job in
+-- apps/control-plane/internal/auditarchive runs as a cross-tenant platform
+-- sweep on that pool: FetchExpiredManifests scans every tenant and
+-- InsertManifest / DeleteManifest run with no app.current_tenant_id set. A
+-- tenant-scoped policy would make those queries match zero rows and deny every
+-- write, breaking the archiver, so hive_app gets a FOR ALL policy here exactly
+-- as audit_log does. Any tenant-facing read of this manifest is scoped in the
+-- application layer, the same way audit_log is.
+--
+-- FORCE so the table owner is subject to RLS too, matching the sibling audit
+-- tables; the DB-layer immutability trigger (20260625_08) is what enforces
+-- write-once semantics for all roles including the service path.
 ALTER TABLE public.audit_cold_archive_manifest ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.audit_cold_archive_manifest FORCE  ROW LEVEL SECURITY;
 
--- Tenant users may list their own manifest entries (read-only).
--- The app sets app.current_tenant_id via SET LOCAL before queries.
-CREATE POLICY audit_cold_archive_manifest_tenant_read
+CREATE POLICY manifest_service_role_all
     ON public.audit_cold_archive_manifest
-    FOR SELECT
-    USING (
-        tenant_id::text = current_setting('app.current_tenant_id', true)
-    );
+    AS PERMISSIVE
+    FOR ALL
+    TO hive_app
+    USING (true)
+    WITH CHECK (true);
 
--- Service-role (control-plane) bypasses RLS for inserts and the purge scan.
--- No UPDATE / DELETE policy is defined for tenant roles -- manifest is
--- write-once from the application perspective.
+CREATE POLICY manifest_auditor_select
+    ON public.audit_cold_archive_manifest
+    AS PERMISSIVE
+    FOR SELECT
+    TO auditor_ro
+    USING (true);
 
 COMMENT ON TABLE public.audit_cold_archive_manifest IS
     'Immutable manifest of audit_log cold-archive batches. '


### PR DESCRIPTION
## Summary

`public.audit_cold_archive_manifest` was defined twice with incompatible shapes, which broke every clean `supabase db push` (fresh database init and enterprise self host). This PR reconciles the two definitions onto the single authoritative June shape, removes a CI band aid that had been hiding the failure, and fixes a stale compliance test.

This is a compliance critical table (PHIPA 10 year and Quebec Law 25 retention of the audit hash chain manifest), so the change was made conservatively and validated end to end.

## The defect

* `20260516_04_phase19_audit_log.sql` (May) created a manifest with a `partition_name` primary key plus `parquet_path` and hash chain columns.
* `20260625_06_audit_cold_archive_manifest.sql` (June, #241) created a different manifest with `id / tenant_id / partition_month / object_key / sha256_hash / first_seq / last_seq / purge_after`.
* June used `CREATE TABLE IF NOT EXISTS`, so on a chained fresh apply it silently no opped onto the May table, then its `CREATE UNIQUE INDEX ... (tenant_id, partition_month)` failed with `column "tenant_id" does not exist`.
* The application (`apps/control-plane/internal/auditarchive/pg_repository.go`) and the `20260625_08` immutability trigger both use the June shape, so June is authoritative.
* `.github/workflows/ci.yml` masked the failure with a mid apply `DROP TABLE IF EXISTS public.audit_cold_archive_manifest CASCADE` (self labelled a pre existing migration ordering defect), and `apps/control-plane/tests/compliance/audit_retention_test.go` asserted the May columns, so it passed only because that CI drop left the May table live.

## Ground truth (read only, staging)

Queried the live database before making any change:

* Live `audit_cold_archive_manifest` columns are the May shape: `partition_name, archived_at, parquet_path, parquet_sha256, row_count, last_prev_hash, last_row_hash`.
* `SELECT count(*)` returns **0 rows**.
* No RLS policies and no immutability trigger are present; grants are the raw Supabase defaults, so `20260518_04` (May manifest policies and grants) and the June `06` and `08` migrations are not applied.
* `supabase_migrations.schema_migrations` for the June and July window records only `20260611_01`, confirming `20260625_06` is not applied.

The stale May table is provably empty in every environment, not just staging: the application only ever writes the June columns via `InsertManifest`, and those columns do not exist on the May shape, so any write against the May table errors before committing. No audit data can exist in the stale table, so dropping it preserves the hash chain manifest data (data preservation constraint satisfied).

## Strategy and why

Because `20260625_06` is un applied and always failing, editing it is immutability safe (an applied migration would be off limits). It is also the only option that makes both cases clean at once:

* A fresh apply currently dies at the `20260625_06` index create, so a forward only July dated migration would not fix fresh applies (the chain never reaches it).
* Editing `06` to be self healing fixes fresh applies and, once applied, the staging chain, without touching the two already applied May migrations (`20260516_04`, `20260518_04`).

`06` now drops the stale table and its May era policies (`manifest_service_role_all`, `manifest_auditor_select`) first, then creates the authoritative June table. The `hive_app` (`INSERT, SELECT, UPDATE`) and `auditor_ro` (`SELECT`) grants that previously lived in the `20260518_04` manifest block are relocated into `06` so the correct table carries them; `20260518_04` is left untouched (it may be applied elsewhere) and its now redundant manifest block is cleaned up by the drop in `06`. RLS is left enabled and not forced, matching the June design where the service role bypasses RLS for inserts and the purge scan.

## Changes

* `supabase/migrations/20260625_06_audit_cold_archive_manifest.sql`: drop stale May table and May era policies, then create the authoritative June table, indexes, RLS `audit_cold_archive_manifest_tenant_read` policy, and the relocated grants.
* `.github/workflows/ci.yml`: remove the CI only DROP band aid so CI validates the real migration chain.
* `apps/control-plane/tests/compliance/audit_retention_test.go`: assert the June columns.
* `.wolf/buglog.json`: record the incident.

## Validation evidence

Fresh `pgvector/pgvector:pg17` scratch database, CI bootstrap plus all `supabase/migrations/*.sql` applied in order with **no** drop hack:

```
=== apply ALL migrations in order (NO drop hack) ===
...
ALL MIGRATIONS APPLIED CLEANLY
```

Resulting end state on the scratch database:

```
COLUMNS=id,tenant_id,partition_month,object_key,sha256_hash,row_count,first_seq,last_seq,archived_at,purge_after
POLICIES=audit_cold_archive_manifest_tenant_read
TRIGGERS=audit_manifest_immutability_trg
HIVE_APP_GRANTS=INSERT,SELECT,UPDATE
AUDITOR_GRANTS=SELECT
PUBLIC_GRANTS=<none>
RLS_ENABLED=true,FORCED=false
```

Go tests against the June schema (`HIVE_TEST_DB_URL` pointed at the scratch database):

```
--- PASS: TestAuditChainIntegrity_AcrossPartition
--- PASS: TestAuditRetention_ColdArchiveManifestExists
--- PASS: TestAuditSink_FailureDoesNotBlockChat
ok  .../tests/compliance
ok  .../internal/agenttask
ok  .../internal/egress
ok  .../internal/rag
```

(`TestAuditCoverage_AllControlsHaveEvents` was not run locally because it shells out to a `node` SOC2 checker that is not installed in the validation container; CI provides `node`.)

## Review

Compliance schema change: requesting independent `database-reviewer` and `security-reviewer` before merge. Not self merging.


## RLS model correction (added after the initial reconcile)

The initial reconcile replaced the removed `manifest_service_role_all` / `manifest_auditor_select` policies with a single tenant scoped SELECT policy. That was the wrong model for this table and would have broken the cold archive pipeline in production.

The control plane connects as `hive_app`, which is not `BYPASSRLS` (the platform pool does no `SET ROLE`, it connects as `hive_app` directly, per `20260518_04`). The cold archive job in `apps/control-plane/internal/auditarchive` runs as a cross tenant platform sweep on that shared pool: `FetchExpiredManifests` scans every tenant, and `InsertManifest` / `DeleteManifest` run with no `app.current_tenant_id` set. Under a tenant scoped policy those queries match zero rows and every write is denied, so the archiver silently stops inserting manifests and never purges expired cold objects. The existing compliance suite did not catch this because it connects as the superuser and bypasses RLS entirely.

This table therefore follows the same service model as `audit_log` and the other Phase 19 audit surfaces, not tenant isolation. Any tenant facing read of the manifest is scoped in the application layer, exactly as `audit_log` is.

Changes in this section:
* Re add `manifest_service_role_all` (`hive_app` `FOR ALL USING (true) WITH CHECK (true)`) and `manifest_auditor_select` (`auditor_ro` SELECT).
* Drop the tenant scoped `audit_cold_archive_manifest_tenant_read` policy. This supersedes it.
* Grant `DELETE` to `hive_app` so the post purge `DeleteManifest` can run (the grant was `INSERT/SELECT/UPDATE` only).
* `FORCE ROW LEVEL SECURITY` to match the sibling audit tables. Write once immutability for all roles including the service path is enforced by the `20260625_08` trigger, not by RLS.

New test `apps/control-plane/internal/auditarchive/repository_rls_test.go` runs under `SET ROLE hive_app` (the non bypass service role) and asserts the cross tenant archiver path, the immutability trigger DELETE and UPDATE rules, and the auditor read only plus PUBLIC denied guarantees. It fails against the tenant scoped model with a row-level security policy violation (SQLSTATE 42501), the exact error the archiver would hit in production.

Verification: the full 61 file migration chain applies cleanly on a fresh `pgvector/pgvector:pg17` cluster (bootstrap plus all `supabase/migrations/*.sql`), the new RLS suite and the compliance retention test pass against it, and the RLS suite was confirmed to fail against the pre correction tenant scoped policy.

Please re review the RLS model change (security review), since it broadens `hive_app` access on a PHIPA retention table, and validate on a fresh database.
