### PR TITLE
fix: wire demo agent-subsystem compose surface (embeddings, profiles)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,16 +83,20 @@ OPENROUTER_EMBEDDING_FALLBACK_MODEL=openrouter/qwen/qwen3-embedding-8b
 GROQ_FAST_MODEL=groq/openai/gpt-oss-20b
 GROQ_REASONING_MODEL=groq/openai/gpt-oss-120b
 
-# ─── RAG local embedding service (issue #232) ───────────────────────
-# EMBEDDING_BASE_URL: OpenAI-compatible embeddings endpoint on the
-# enterprise edge box. Typically Ollama (http://ollama:11434/v1) or
-# LiteLLM (http://litellm:4000). Must not point at any external SaaS.
-# Leave blank to disable /v1/rag/* routes (non-enterprise deployments).
-EMBEDDING_BASE_URL=http://ollama:11434/v1
+# ─── RAG query embeddings (issue #232) ──────────────────────────────
+# EMBEDDING_BASE_URL: OpenAI-compatible embeddings endpoint. The demo and
+# Hive Cloud use SERVERLESS embeddings via LiteLLM (http://litellm:4000),
+# whose route-openrouter-embedding forwards to the OpenRouter embedding pool.
+# The enterprise profile may instead point at its in-stack Ollama
+# (http://ollama:11434). Must not point at any external SaaS directly.
+# The embedder appends /v1/embeddings, so do NOT include /v1 in the value.
+# Leave blank to disable /v1/rag/* routes entirely.
+EMBEDDING_BASE_URL=http://litellm:4000
 # EMBEDDING_MODEL: alias passed as the "model" field in POST /v1/embeddings.
 # Must produce 1024-dim vectors to match the rag_chunks.embedding column.
-# Default: bge-m3 (multilingual, Bangla coverage, 1024 dims).
-EMBEDDING_MODEL=bge-m3
+# Serverless default: route-openrouter-embedding (LiteLLM route #5).
+# Enterprise/Ollama alternative: bge-m3 (multilingual, Bangla, 1024 dims).
+EMBEDDING_MODEL=route-openrouter-embedding
 
 # ─── Signup abuse prevention (issue #116) ───────────────────────────
 # Per-IP signup rate limit. Max attempts per IP per window before the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,14 @@ cd deploy/docker
 # Local dev: core stack with in-stack Redis.
 docker compose --env-file ../../.env --profile local up --build
 
+# Full demo surface (agent subsystem): core + agent-console sidecar (chat) +
+# agent-engine (agent) + in-stack Redis (local), in ONE command. RAG query
+# embeddings run serverless via LiteLLM (EMBEDDING_BASE_URL default). Live
+# agent-task sandbox launch additionally needs a built Apptainer runtime image
+# (HIVE_AGENT_SIF_PATH); build it from deploy/apptainer/agent-engine.def on a
+# host with apptainer (unavailable on WSL2), then set HIVE_AGENT_SIF_PATH in .env.
+docker compose --env-file ../../.env --profile local --profile chat --profile agent up --build
+
 # Hive Cloud (hosted SaaS): core services expecting managed Upstash Redis.
 # Set REDIS_URL=rediss://... in .env before running.
 docker compose --env-file ../../.env --profile cloud up --build

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -40,6 +40,17 @@ services:
       SUPABASE_JWT_AUDIENCE: ${SUPABASE_JWT_AUDIENCE:-authenticated}
       SUPABASE_JWKS_URL: ${SUPABASE_JWKS_URL:-}
       OWUI_SHIM_KEY: ${OWUI_SHIM_KEY:-}
+      # RAG query embeddings (#232). Without these the query embedder is nil and
+      # POST /v1/rag/search + /v1/rag/chat return a provider-blind 503. The demo
+      # uses SERVERLESS embeddings only (no local embedding model runs): point at
+      # LiteLLM, whose route-openrouter-embedding forwards to the OpenRouter
+      # serverless embedding pool (Nemotron-Embed free primary, qwen3 paid
+      # fallback). The embedder appends /v1/embeddings, so the base URL must NOT
+      # itself include /v1. Provider-swappable with no schema change: override
+      # both in .env (e.g. http://ollama:11434 + bge-m3 for the enterprise
+      # profile's in-stack Ollama).
+      EMBEDDING_BASE_URL: ${EMBEDDING_BASE_URL:-http://litellm:4000}
+      EMBEDDING_MODEL: ${EMBEDDING_MODEL:-route-openrouter-embedding}
     healthcheck:
       test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/health"]
       interval: 5s


### PR DESCRIPTION
## Summary

P1 demo readiness: make the compose stack actually serve the full agent-subsystem surface. Closes three self-contained rehearsal gaps found in the demo profiles. Does not touch `overlays/hive-support-status.yaml` or the support matrix (owned by the separate P0 PR).

## What changed

**1. RAG query embeddings wired into edge-api (was nil, returned 503).**
`apps/edge-api/cmd/server/main.go` reads `EMBEDDING_BASE_URL` and `EMBEDDING_MODEL`; when the base URL is empty the query embedder is nil and `POST /v1/rag/search` plus `POST /v1/rag/chat` return a provider-blind 503. Both vars were missing from the edge-api compose service. Added them, defaulting to the serverless path:

```
EMBEDDING_BASE_URL: ${EMBEDDING_BASE_URL:-http://litellm:4000}
EMBEDDING_MODEL: ${EMBEDDING_MODEL:-route-openrouter-embedding}
```

The demo uses serverless embeddings only (no local embedding model). `route-openrouter-embedding` is LiteLLM route #5, which forwards to the OpenRouter serverless embedding pool (Nemotron-Embed free primary, qwen3 paid fallback). The base URL omits `/v1` because the embedder appends `/v1/embeddings` (see `internal/rag/embed.go`). The pair is provider-swappable via `.env` with no schema change (for example `http://ollama:11434` plus `bge-m3` for the enterprise profile).

**2. `.env.example` serverless default.**
The RAG embedding block previously defaulted `EMBEDDING_BASE_URL` to `http://ollama:11434/v1`. Ollama is not present in the demo profiles, so a copied `.env` would have overridden the compose default and broken RAG in the demo. Flipped the default to the serverless LiteLLM path and kept the enterprise Ollama override documented in the comment. Also removed the stray `/v1` (the embedder appends it).

**3. One documented command for the whole demo surface.**
The agent-console sidecar lives in the `chat` profile and agent-engine in the `agent` profile; core services are profile-less. Documented in CLAUDE.md the single invocation that brings up core plus agent-console plus agent-engine plus in-stack Redis:

```
docker compose --env-file ../../.env --profile local --profile chat --profile agent up --build
```

## Apptainer runtime image (.sif) status

Agent tasks need `HIVE_AGENT_SIF_PATH`, a built Apptainer `.sif`. The compose service already passes the env through (`HIVE_AGENT_SIF_PATH: ${HIVE_AGENT_SIF_PATH:-}`). The build recipe exists at `deploy/apptainer/agent-engine.def` (bootstraps a Debian image, installs the vendored OpenHands packages and Playwright Chromium). No pre-built `.sif` ships in the repo, and `apptainer` is unavailable on the WSL2 dev host, so building it is a substantial separate lift. This is the single remaining dependency for live agent-task sandbox launch; everything else in the demo surface is wired. The rest of the demo wiring is not blocked on it.

## Validation

`docker compose --profile local --profile chat --profile agent config` against the real `.env`, run against this branch's compose file:

- Enabled services resolve to exactly the demo surface: `agent-console, agent-engine, caddy-artifacts, caddy-owui, control-plane, edge-api, litellm, open-webui, redis, web-console`.
- edge-api renders `EMBEDDING_BASE_URL = http://litellm:4000` and `EMBEDDING_MODEL = route-openrouter-embedding` (the real `.env` sets neither, so the serverless default lands).
- agent-engine renders `HIVE_AGENT_SIF_PATH = ''` (empty, the unbuilt-SIF dependency above).

## Live 200 dependencies (out of this PR's scope)

A full `200` from `/v1/rag/search` and `/v1/rag/chat` additionally needs, and was not exercisable in the dev environment:

1. Full stack build plus Supabase JWT plus the `rag_*` migrations applied plus a Hive API key.
2. The P0 support-matrix change (separate PR) to route the RAG chat model past 404.
3. LiteLLM must not enforce master-key auth on `/v1/embeddings`. The embedders in edge-api and control-plane send no Authorization header by design, and the current `deploy/litellm/config.yaml` has no `general_settings.master_key`, so auth should not be enforced. Worth a live confirm; if a future config enables enforcement, the embedders need the master key added.
4. The chosen serverless embedding model must emit 1024-dim vectors to match the `rag_chunks.embedding` column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
