### PR TITLE
fix: make desktop sandbox pre_exec allocator-safe (#342 item 1)

### DIFF
--- a/.wolf/buglog.json
+++ b/.wolf/buglog.json
@@ -1878,6 +1878,19 @@
         "air",
         "healthcheck"
       ]
+    },
+    {
+      "id": "preexec-allocator-unsafe",
+      "date": "2026-07-17",
+      "error_message": "Desktop sandbox launch() could hang the whole app (once a 15+ minute cargo test hang) inside the Command::pre_exec closure",
+      "root_cause": "The pre_exec closure ran after fork() and before execve() in a child of a multithreaded process but was not async-signal-safe: it built the Landlock ruleset (Ruleset build, PathFd::new), compiled the seccomp BPF program, ran codex pre_main_hardening (std::env::remove_var over vars_os), and used format! on error paths. Allocating in a forked child can deadlock forever if another thread held the allocator lock at fork, and std makes the parent spawn() block until the child execs or errors, so the parent hangs too.",
+      "fix": "Hoist all allocation and fd setup before the fork: build_landlock_ruleset returns a RulesetCreated (converted to OwnedFd) and build_seccomp_filter returns the compiled BpfProgram, both in the parent. Strip LD_* env on the Command before fork instead of via std::env in the child. The closure now performs only raw async-signal-safe syscalls on pre-built values: prctl(PR_SET_DUMPABLE) via codex disable_process_dumping, setrlimit(RLIMIT_CORE), prctl(PR_SET_NO_NEW_PRIVS), raw landlock_restrict_self on the pre-built fd, and seccompiler::apply_filter over the pre-compiled program; error paths map to allocation-free io::Errors. Added tests/launch_spawn.rs end-to-end regression guard. The #341 10s spawn timeout stays as defense in depth.",
+      "tags": [
+        "rust",
+        "sandbox",
+        "fork-safety",
+        "security"
+      ]
     }
   ]
 }

--- a/apps/desktop-sandbox/hive-desktop-sandbox/src/linux.rs
+++ b/apps/desktop-sandbox/hive-desktop-sandbox/src/linux.rs
@@ -22,10 +22,12 @@ use crate::policy::NetworkPolicy;
 use crate::{LaunchError, SandboxPolicy};
 use landlock::{
     ABI, Access, AccessFs, CompatLevel, Compatible, PathBeneath, PathFd, Ruleset, RulesetAttr,
-    RulesetCreatedAttr,
+    RulesetCreated, RulesetCreatedAttr,
 };
 use seccompiler::{BpfProgram, SeccompAction, SeccompFilter};
 use std::convert::TryInto;
+use std::os::fd::{AsRawFd, OwnedFd};
+use std::os::unix::ffi::OsStrExt;
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command};
@@ -176,23 +178,94 @@ pub(crate) fn launch(
 
     let bwrap_path = locate_bwrap_binary();
     let argv = build_bwrap_argv(policy, &wrapped_command, cwd, egress.as_ref());
-    let policy_for_child = policy.clone();
+
+    // Everything that allocates or opens file descriptors for the sandbox
+    // is done HERE, in the parent, before the fork: build the Landlock
+    // ruleset (opens an O_PATH fd per bound path, creates the ruleset fd,
+    // adds every rule) and compile the seccomp-BPF program. See the
+    // pre_exec SAFETY comment below for why this split is mandatory. The
+    // ruleset fd is held open by `landlock_fd` until `cmd` is dropped after
+    // spawn; it survives the fork and is applied (not created) in the child.
+    let landlock_fd: OwnedFd = Option::<OwnedFd>::from(
+        build_landlock_ruleset(policy, &extra_landlock_paths)
+            .map_err(|err| LaunchError::Confinement(format!("landlock: {err}")))?,
+    )
+    .ok_or_else(|| {
+        LaunchError::Confinement(
+            "landlock ruleset produced no file descriptor (kernel lacks Landlock support)"
+                .to_string(),
+        )
+    })?;
+    let seccomp_filter = build_seccomp_filter()
+        .map_err(|err| LaunchError::Confinement(format!("seccomp: {err}")))?;
 
     let mut cmd = Command::new(bwrap_path);
     cmd.args(&argv);
-    // SAFETY: the closure only calls into `codex_process_hardening`,
-    // `landlock`, and `seccompiler`, all of which perform their own
-    // syscalls directly and do not allocate in a way that is unsafe
-    // between fork and exec.
+
+    // Strip LD_* from the child's environment before the fork. Codex's
+    // `pre_main_hardening` does this after fork via `std::env::remove_var`,
+    // which allocates and takes a process-global lock -- both unsafe between
+    // fork and exec. Doing it on the `Command` here is equivalent for the
+    // exec'd process (Command builds its envp in the parent) and keeps the
+    // pre_exec closure allocation-free.
+    for (key, _) in std::env::vars_os() {
+        if key.as_bytes().starts_with(b"LD_") {
+            cmd.env_remove(&key);
+        }
+    }
+
+    // SAFETY: `pre_exec` runs this closure in the child after `fork()` and
+    // before `execve()`. The parent is multithreaded (the desktop app, plus
+    // AllowlistProxy's accept-loop threads), so the forked child has exactly
+    // one running thread and the closure MUST be async-signal-safe: no heap
+    // allocation, no lock, no non-reentrant libc. If another thread held the
+    // allocator lock at the instant of fork, a `malloc` in the child would
+    // deadlock forever, and because std makes the parent's `spawn()` block on
+    // a pipe until the child execs or reports an error, that hangs the parent
+    // too (observed directly: a 15+ minute `cargo test` hang before this was
+    // made alloc-free). Every allocation and fd open was therefore hoisted
+    // above, before the fork; this closure performs ONLY raw
+    // prctl/setrlimit/landlock_restrict_self syscalls plus
+    // `seccompiler::apply_filter`, whose success path is itself just a prctl
+    // and the seccomp syscall over the already-compiled program. Its error
+    // paths map to allocation-free `io::Error`s.
+    let restrict = move || -> std::io::Result<()> {
+        // Mark the child non-dumpable (matches codex `pre_main_hardening`):
+        // a raw prctl, allocation-free.
+        codex_process_hardening::disable_process_dumping()?;
+        // Defense in depth: no core dumps of the sandboxed process.
+        let rlim = libc::rlimit {
+            rlim_cur: 0,
+            rlim_max: 0,
+        };
+        // SAFETY: raw setrlimit over a stack-local rlimit; no allocation.
+        if unsafe { libc::setrlimit(libc::RLIMIT_CORE, &rlim) } != 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        // Landlock and seccomp both require NO_NEW_PRIVS (or CAP_SYS_ADMIN).
+        // SAFETY: raw prctl; no allocation.
+        if unsafe { libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) } != 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        // Enforce the pre-built Landlock ruleset on this (child) thread so it
+        // is inherited across the coming execve. Flags 0 = no audit logging,
+        // matching the `landlock` crate's default `restrict_self`.
+        // SAFETY: raw landlock_restrict_self on the fd built before fork; no
+        // allocation.
+        if unsafe { libc::syscall(libc::SYS_landlock_restrict_self, landlock_fd.as_raw_fd(), 0) }
+            != 0
+        {
+            return Err(std::io::Error::last_os_error());
+        }
+        // Install the pre-compiled seccomp denylist. `apply_filter` borrows
+        // the program (no allocation) and issues prctl + the seccomp syscall.
+        seccompiler::apply_filter(&seccomp_filter)
+            .map_err(|_| std::io::Error::from(std::io::ErrorKind::Other))?;
+        Ok(())
+    };
+    // SAFETY: see the comment above -- the closure is async-signal-safe.
     unsafe {
-        cmd.pre_exec(move || {
-            codex_process_hardening::pre_main_hardening();
-            apply_landlock_ruleset(&policy_for_child, &extra_landlock_paths)
-                .map_err(|err| std::io::Error::other(format!("landlock: {err}")))?;
-            apply_seccomp_denylist()
-                .map_err(|err| std::io::Error::other(format!("seccomp: {err}")))?;
-            Ok(())
-        });
+        cmd.pre_exec(restrict);
     }
 
     let child = cmd.spawn().map_err(LaunchError::from)?;
@@ -307,6 +380,13 @@ fn read_only_paths(policy: &SandboxPolicy) -> impl Iterator<Item = &Path> {
         .chain(policy.readonly_roots().iter().map(PathBuf::as_path))
 }
 
+/// Builds (but does not enforce) the Landlock ruleset. All allocation and
+/// file-descriptor opening lives here so it runs in the parent, before the
+/// fork: [`launch`] applies the returned ruleset in its `pre_exec` closure
+/// with a single raw `landlock_restrict_self` syscall (see that closure's
+/// SAFETY comment). Returning the [`RulesetCreated`] rather than calling
+/// `restrict_self` here is what keeps the post-fork path allocation-free.
+///
 /// `extra_full_access` grants the same (full) access level as
 /// `policy.writable_roots()` -- used for the egress socket and shim binary
 /// paths on an `AllowHosts` launch (see [`setup_egress`]). These are not
@@ -316,10 +396,10 @@ fn read_only_paths(policy: &SandboxPolicy) -> impl Iterator<Item = &Path> {
 /// mount flag in [`build_bwrap_argv`], a stronger guarantee than Landlock
 /// could add on top since it applies inside the sandbox's own mount
 /// namespace, not just to the host-side process this ruleset restricts.
-fn apply_landlock_ruleset(
+fn build_landlock_ruleset(
     policy: &SandboxPolicy,
     extra_full_access: &[PathBuf],
-) -> Result<(), String> {
+) -> Result<RulesetCreated, String> {
     let abi = ABI::V5;
     let access_all = AccessFs::from_all(abi);
     let access_read = AccessFs::from_read(abi);
@@ -354,11 +434,17 @@ fn apply_landlock_ruleset(
             .map_err(|err| format!("{err:?}"))?;
     }
 
-    ruleset.restrict_self().map_err(|err| format!("{err:?}"))?;
-    Ok(())
+    // Deliberately does NOT call `restrict_self` here: enforcement is the
+    // caller's job, inside the fork()ed child, via a raw syscall. See the
+    // function doc.
+    Ok(ruleset)
 }
 
-fn apply_seccomp_denylist() -> Result<(), String> {
+/// Compiles (but does not install) the seccomp-BPF denylist. Like
+/// [`build_landlock_ruleset`], all the allocation happens here, in the
+/// parent, before the fork; [`launch`]'s `pre_exec` closure installs the
+/// returned program with an allocation-free `seccompiler::apply_filter`.
+fn build_seccomp_filter() -> Result<BpfProgram, String> {
     let rules = DENIED_SYSCALLS
         .iter()
         .map(|&syscall| (syscall, Vec::new()))
@@ -381,7 +467,7 @@ fn apply_seccomp_denylist() -> Result<(), String> {
     .try_into()
     .map_err(|err| format!("{err:?}"))?;
 
-    seccompiler::apply_filter(&filter).map_err(|err| format!("{err:?}"))
+    Ok(filter)
 }
 
 #[cfg(test)]
@@ -637,36 +723,24 @@ mod tests {
         assert_eq!(found, Some(shim));
     }
 
-    // No test here calls the real launch() end to end (i.e. all the way
-    // through Command::spawn()'s pre_exec) -- and that is deliberate, not
-    // an oversight. This crate's own test binary is multithreaded (many
-    // concurrent #[test] functions, plus AllowlistProxy's own leaked
-    // accept-loop threads from earlier tests); pre_exec's closure runs in
-    // the forked child via a raw fork() (required so pre_exec can run
-    // arbitrary code before exec), and `apply_landlock_ruleset` /
-    // `apply_seccomp_denylist` both allocate (Vec, PathFd::new, format!).
-    // Allocating in a fork()ed child of a multithreaded process is a
-    // textbook post-fork deadlock hazard: if another thread held the
-    // allocator's lock at the instant of fork, the single surviving child
-    // thread can block on malloc forever, and because Rust's pre_exec
-    // machinery has the parent's spawn() block on a pipe read until the
-    // child either execs or reports an error, THAT hangs too -- observed
-    // directly in this session (a first attempt at an end-to-end launch()
-    // test hung `cargo test` for 15+ minutes; `timeout` plus
-    // `--test-threads=1` plus reading `/proc/<pid>/task/*/comm` confirmed
-    // it was blocked inside the forked child, not anywhere in this crate's
-    // own logic). Fixing pre_exec to be genuinely alloc-free (or moving off
-    // fork+pre_exec entirely, e.g. toward `posix_spawn`-style APIs) is a
-    // real, pre-existing gap this discovery surfaced -- out of scope for
-    // this pass; tracked as a VENDORING.md open risk. Argv construction
-    // (`egress_bind_adds_ro_bind_shim_and_bind_socket`,
-    // `egress_bind_wraps_command_with_shim_and_separator`,
-    // `allow_hosts_also_unshares_net_now_that_the_egress_proxy_gates_it`
-    // above) and the actual enforcement point (`egress_proxy.rs`'s own
-    // tests, which never fork) are both real and tested; only the
-    // OS-process-spawn plumbing in between is untested here, matching this
-    // crate's pre-existing posture (no test before this pass exercised
-    // launch()'s real spawn path either).
+    // launch()'s real spawn path (fork -> pre_exec closure -> execve) is
+    // exercised end to end by tests/launch_spawn.rs, deliberately a SEPARATE
+    // integration binary rather than a #[test] here. The reason is the
+    // landlock_hard_requirement_never_silently_no_ops test below: it calls
+    // restrict_self on its own (test-pool) thread, a one-way confinement, and
+    // if cargo reused that OS thread for a test doing real filesystem I/O
+    // (spawn, tempdir) the confinement would break it. A separate binary
+    // never runs restrict_self, so its threads stay unconfined.
+    //
+    // That end-to-end test is what proves this rewrite: before it, the
+    // pre_exec closure allocated (Ruleset build, PathFd::new, the seccomp BPF
+    // compile, format!) inside a raw fork()ed child of a multithreaded test
+    // binary -- a textbook post-fork allocator-deadlock hazard that hung
+    // `cargo test` for 15+ minutes when first tried. All allocation now
+    // happens in the parent before the fork (build_landlock_ruleset /
+    // build_seccomp_filter), so the closure is async-signal-safe and the
+    // spawn returns promptly. Argv construction and the egress enforcement
+    // point keep their own tests above / in egress_proxy.rs.
 
     // ponytail: calls Ruleset::restrict_self, a one-way, per-thread kernel
     // restriction (like seccomp, Landlock confines the calling thread, not
@@ -686,10 +760,16 @@ mod tests {
             hooks.path().to_path_buf(),
         );
 
-        match apply_landlock_ruleset(&p, &[]) {
-            Ok(()) => {
-                // CompatLevel::HardRequirement means Ok(()) here only
-                // happens when the kernel actually enforced the ruleset.
+        // build_landlock_ruleset does the allocation/fd work; restrict_self
+        // (the one-way, calling-thread confinement) is invoked here exactly
+        // as launch()'s pre_exec does it in the child, so this test still
+        // exercises real enforcement.
+        let restricted = build_landlock_ruleset(&p, &[])
+            .and_then(|ruleset| ruleset.restrict_self().map_err(|err| format!("{err:?}")));
+        match restricted {
+            Ok(_) => {
+                // CompatLevel::HardRequirement means Ok here only happens
+                // when the kernel actually enforced the ruleset.
                 // Prove it behaviorally rather than trusting the return
                 // value alone.
                 let blocked = outside.path().join("blocked");

--- a/apps/desktop-sandbox/hive-desktop-sandbox/tests/launch_spawn.rs
+++ b/apps/desktop-sandbox/hive-desktop-sandbox/tests/launch_spawn.rs
@@ -1,0 +1,72 @@
+//! End-to-end regression guard for the desktop sandbox's post-fork
+//! allocator-deadlock hazard (issue #342 item 1, VENDORING.md open risk #7).
+//!
+//! `hive_desktop_sandbox::launch` confines the child via a `pre_exec` closure
+//! that runs after `fork()` and before `execve()`. That closure MUST be
+//! async-signal-safe: allocating in a `fork()`ed child of a multithreaded
+//! process can deadlock on the allocator lock, and std makes the parent's
+//! `spawn()` block until the child execs or reports an error, so the whole
+//! process hangs. This test drives `launch` all the way through that closure
+//! from a multithreaded test harness and asserts it RETURNS (Ok or Err)
+//! instead of hanging. If a future change reintroduces an allocation in the
+//! closure, this test times out.
+//!
+//! It lives in its own integration binary on purpose: the crate's in-module
+//! `landlock_hard_requirement_never_silently_no_ops` test calls
+//! `restrict_self` on its own test-pool thread (a one-way confinement), and
+//! reusing a Landlock-confined thread for the real filesystem I/O this test
+//! needs would break it. A separate binary never runs `restrict_self`, so its
+//! threads stay unconfined.
+
+#![cfg(target_os = "linux")]
+
+use hive_desktop_sandbox::{NetworkPolicy, SandboxPolicy, launch};
+use std::path::PathBuf;
+
+#[test]
+fn launch_returns_without_hanging_on_alloc_free_pre_exec() {
+    let workspace = tempfile::tempdir().expect("workspace tempdir");
+    let hooks = tempfile::tempdir().expect("hooks tempdir");
+
+    // Readonly `/` keeps the dynamic loader and /bin/true readable and
+    // executable inside the ruleset; the workspace is the one writable root;
+    // hooks is the always-ro-bound hook/config dir the policy requires.
+    let policy = SandboxPolicy::build(
+        vec![workspace.path().to_path_buf()],
+        vec![PathBuf::from("/")],
+        hooks.path().to_path_buf(),
+        NetworkPolicy::DenyAll,
+    )
+    .expect("valid policy");
+
+    // Point the bwrap lookup at /bin/true: the child applies Landlock +
+    // seccomp in pre_exec, then execs a real always-present binary. No actual
+    // bwrap needed -- this test is about the fork/pre_exec plumbing, not
+    // bubblewrap.
+    //
+    // SAFETY: this binary holds a single test, so nothing else mutates or
+    // reads the environment concurrently; `launch` reads HIVE_BWRAP_PATH
+    // synchronously on this thread before the variable is restored.
+    unsafe {
+        std::env::set_var("HIVE_BWRAP_PATH", "/bin/true");
+    }
+    let result = launch(&policy, &["ignored-by-true".to_string()], workspace.path());
+    unsafe {
+        std::env::remove_var("HIVE_BWRAP_PATH");
+    }
+
+    match result {
+        Ok(mut child) => {
+            // The alloc-free closure ran in the forked child and the spawn
+            // resolved. Reap it rather than leaking a zombie; its exit status
+            // is not asserted (confinement and exec specifics vary by kernel
+            // and environment). The guard is purely "launch returned".
+            let _ = child.wait();
+        }
+        Err(_) => {
+            // Acceptable: a kernel without Landlock v5 (CompatLevel::
+            // HardRequirement) fails closed before the fork. Still no hang,
+            // which is the whole point of this guard.
+        }
+    }
+}

--- a/apps/desktop/src-tauri/src/local_tasks.rs
+++ b/apps/desktop/src-tauri/src/local_tasks.rs
@@ -78,16 +78,18 @@ pub trait SandboxLauncher: Send + Sync {
 }
 
 /// Timeout guard for the real OS-level spawn (VENDORING.md open risk #7,
-/// `apps/desktop-sandbox`): `hive_desktop_sandbox::launch`'s `pre_exec`
-/// closure allocates inside a raw-`fork()`ed child of this (multithreaded)
-/// process, a known post-fork allocator-deadlock hazard. That hazard hung
-/// `cargo test` for 15+ minutes when first exercised end to end (see that
-/// crate's `linux.rs` test module comment) -- this is the same call, now on
-/// a live path (every "Run a task locally" click). This is a containment
-/// guard, not the fix: it stops one stuck spawn from hanging the whole
-/// app, it does not make `pre_exec` alloc-free. The real fix (pre-allocate
-/// before fork, or move off fork+pre_exec) is tracked as a follow-up, not
-/// attempted here.
+/// `apps/desktop-sandbox`). `hive_desktop_sandbox::launch`'s `pre_exec`
+/// closure runs in a raw-`fork()`ed child of this (multithreaded) process; a
+/// closure that allocated there would be a post-fork allocator-deadlock
+/// hazard, and one did once hang `cargo test` for 15+ minutes when first
+/// exercised end to end. That closure is now allocation-free -- all
+/// allocation and fd setup was hoisted before the fork (see that crate's
+/// `linux.rs` launch() and its `tests/launch_spawn.rs` regression guard) --
+/// so the hazard is fixed at the source. This timeout stays as defense in
+/// depth: it stops any other stuck spawn (a third-party binary that never
+/// execs, a kernel edge case) from hanging the whole app on the live path
+/// (every "Run a task locally" click), which the source fix alone does not
+/// cover.
 const SPAWN_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Something `spawn_with_timeout` can kill if the underlying spawn call


### PR DESCRIPTION
## What

Proper fix for #342 item 1: the Linux desktop sandbox `pre_exec` closure was not async-signal-safe. It ran after `fork()` and before `execve()` in a child of a multithreaded parent, yet it allocated on the heap (Landlock ruleset build, `PathFd::new`, seccomp BPF compile, codex `pre_main_hardening`'s `std::env::remove_var` over `vars_os`, and `format!` on error paths). Allocating in a forked child can deadlock forever if another thread held the allocator lock at the instant of fork, and std blocks the parent's `spawn()` until the child execs or errors, so the parent hangs too. This was observed once as a 15+ minute `cargo test` hang and is the fork hazard PR #341 contained with a 10s spawn timeout.

## How

All allocation and file-descriptor setup is hoisted into the parent, before the fork:

- `build_landlock_ruleset` (renamed from `apply_landlock_ruleset`) returns the built `RulesetCreated` instead of calling `restrict_self`; `launch()` converts it to an `OwnedFd` held open across the fork.
- `build_seccomp_filter` (renamed from `apply_seccomp_denylist`) returns the compiled `BpfProgram` instead of installing it.
- `LD_*` environment stripping is applied on the `Command` before fork, matching codex `pre_main_hardening`'s intent without its post-fork `std::env` mutation.

The `pre_exec` closure now performs only raw, async-signal-safe syscalls on those pre-built values: `prctl(PR_SET_DUMPABLE)` via codex `disable_process_dumping`, `setrlimit(RLIMIT_CORE)`, `prctl(PR_SET_NO_NEW_PRIVS)`, a raw `landlock_restrict_self` on the pre-built fd, and `seccompiler::apply_filter` over the pre-compiled program (its success path is itself just prctl plus the seccomp syscall). Error paths map to allocation-free `io::Error`s.

Sandbox semantics are unchanged: same namespaces, mounts, Landlock rules, seccomp denylist, and hardening; only the allocation moves ahead of the fork.

The #341 spawn timeout is kept as defense in depth; its doc comment now records that the source hazard is fixed.

## Tests

- `cargo fmt --check` clean, `cargo clippy --all-targets -- -D warnings` clean (scoped to `hive-desktop-sandbox`; the unrelated `codex-bwrap` crate needs system `pkg-config` to build, absent in this environment).
- `cargo test -p hive-desktop-sandbox`: 35 unit tests pass (including the updated `landlock_hard_requirement_never_silently_no_ops`, now split into build + restrict_self).
- New `tests/launch_spawn.rs` integration binary drives `launch()` end to end through fork/pre_exec/execve (via `HIVE_BWRAP_PATH=/bin/true`) and asserts it returns instead of hanging. It is a separate binary so it never shares a process with the in-module test that calls `restrict_self` on its own thread. Passes in 0.00s (no hang).

## Note on #346

PR #346 (`fix/342-desktop-sandbox-hardening`) is in flight touching nearby desktop sandbox files. This PR edits `apps/desktop-sandbox/hive-desktop-sandbox/src/linux.rs` and `apps/desktop/src-tauri/src/local_tasks.rs`; if #346 touches either, a rebase will be needed after it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a potential hang when launching sandboxed processes.
  * Improved process startup reliability by preparing sandbox security settings before launch.
  * Continued stripping unsafe environment variables during process startup.

* **Tests**
  * Added an end-to-end regression test to verify sandbox launches return instead of hanging.
  * Retained timeout protection for additional spawn failures.

* **Documentation**
  * Updated local task execution guidance to reflect the improved launch safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->