### PR TITLE
ci: build agent-engine Apptainer image (agent-engine.sif) in CI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -477,12 +477,3 @@ FASTER_WHISPER_BASE_URL=http://faster-whisper:8000
 # host, or download the `agent-engine-sif` CI artifact. See
 # deploy/apptainer/README.md. Leave blank on the WSL2 dev box (no apptainer).
 HIVE_AGENT_SIF_PATH=
-
-# ── Agent engine (Apptainer sandbox runtime) ─────────────────────────────────
-# HIVE_AGENT_SIF_PATH: Absolute path to the prebuilt agent-engine Apptainer
-#   image. agent-engine launches each session inside this image and refuses to
-#   start without it. The image is linux/amd64 only and cannot be built on the
-#   WSL2 dev box; build it on a demo/prod host with `make agent-sif`, or
-#   download the CI-built `agent-engine-sif` artifact. See
-#   deploy/apptainer/README.md. Leave blank on hosts that do not run agents.
-HIVE_AGENT_SIF_PATH=

--- a/.env.example
+++ b/.env.example
@@ -469,3 +469,20 @@ FASTER_WHISPER_BASE_URL=http://faster-whisper:8000
 #   files (parakeet-tdt-0.6b-v3). The owner provides this directory.
 #   Example: /opt/hive/models/parakeet
 # PARAKEET_MODEL_DIR=/opt/hive/models/parakeet
+
+# ── agent-engine sandbox runtime (Apptainer) ─────────────────────────────────
+# Absolute host path to the prebuilt agent-engine Apptainer image. agent-engine
+# launches every agent session inside a container built from this .sif and
+# refuses to start without it. Build it with `make agent-sif` on a linux/amd64
+# host, or download the `agent-engine-sif` CI artifact. See
+# deploy/apptainer/README.md. Leave blank on the WSL2 dev box (no apptainer).
+HIVE_AGENT_SIF_PATH=
+
+# ── Agent engine (Apptainer sandbox runtime) ─────────────────────────────────
+# HIVE_AGENT_SIF_PATH: Absolute path to the prebuilt agent-engine Apptainer
+#   image. agent-engine launches each session inside this image and refuses to
+#   start without it. The image is linux/amd64 only and cannot be built on the
+#   WSL2 dev box; build it on a demo/prod host with `make agent-sif`, or
+#   download the CI-built `agent-engine-sif` artifact. See
+#   deploy/apptainer/README.md. Leave blank on hosts that do not run agents.
+HIVE_AGENT_SIF_PATH=

--- a/.github/workflows/agent-engine-sif.yml
+++ b/.github/workflows/agent-engine-sif.yml
@@ -1,0 +1,98 @@
+name: agent-engine SIF
+
+# Builds the Apptainer runtime image (agent-engine.sif) that the agent-engine
+# service launches per session (HIVE_AGENT_SIF_PATH). Building here also
+# validates deploy/apptainer/agent-engine.def on every change to its inputs,
+# and publishes the built image as a downloadable CI artifact for demo hosts.
+#
+# Additive and self-contained: this file owns its own triggers and its single
+# job. It intentionally does not touch .github/workflows/ci.yml.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'deploy/apptainer/**'
+      - 'vendor/openhands/**'
+      - 'apps/agent-engine/packs/**'
+      - '.github/workflows/agent-engine-sif.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'deploy/apptainer/**'
+      - 'vendor/openhands/**'
+      - 'apps/agent-engine/packs/**'
+      - '.github/workflows/agent-engine-sif.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: agent-engine-sif-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  # Pinned Apptainer release (reproducible). Bump this to upgrade; the download
+  # URL below tracks it. Uses the distro-generic .deb (not the -trixie+ build)
+  # so it installs and runs on the ubuntu-latest (noble, glibc 2.39) runner.
+  APPTAINER_VERSION: "1.5.2"
+
+jobs:
+  build-sif:
+    name: Build agent-engine.sif
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Apptainer ${{ env.APPTAINER_VERSION }}
+        run: |
+          set -euo pipefail
+          deb="apptainer_${APPTAINER_VERSION}_amd64.deb"
+          url="https://github.com/apptainer/apptainer/releases/download/v${APPTAINER_VERSION}/${deb}"
+          curl -fsSL -o "/tmp/${deb}" "$url"
+          sudo apt-get update
+          sudo apt-get install -y "/tmp/${deb}"
+          apptainer --version
+
+      - name: Prepare build scratch on the large /mnt volume
+        run: |
+          set -euo pipefail
+          # The hosted runner's root filesystem is small; /mnt has tens of GB
+          # free. Point Apptainer's tmp and OCI-layer cache there so a multi-GB
+          # image build has room.
+          sudo mkdir -p /mnt/apptainer/tmp /mnt/apptainer/cache
+          sudo chmod -R 777 /mnt/apptainer
+
+      - name: Build agent-engine.sif
+        working-directory: deploy/apptainer
+        run: |
+          set -euo pipefail
+          # CWD is the def's own directory so its ../../ %files sources
+          # (vendor/openhands, apps/agent-engine/packs) resolve to the repo
+          # root. Build as real root (sudo) so the docker-bootstrap %post
+          # apt/pip/playwright steps run without rootless-userns quirks.
+          sudo env \
+            APPTAINER_TMPDIR=/mnt/apptainer/tmp \
+            APPTAINER_CACHEDIR=/mnt/apptainer/cache \
+            apptainer build agent-engine.sif agent-engine.def
+          sudo chown "$(id -un)" agent-engine.sif
+          ls -lh agent-engine.sif
+
+      - name: Inspect the built image
+        working-directory: deploy/apptainer
+        run: |
+          set -euo pipefail
+          # Proves the artifact is a valid SIF (metadata readable), not merely
+          # that the build command exited 0.
+          apptainer inspect agent-engine.sif
+
+      - name: Upload agent-engine.sif artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: agent-engine-sif
+          path: deploy/apptainer/agent-engine.sif
+          retention-days: 14
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,10 @@ package-lock.json
 /apps/desktop-sandbox/target/
 /apps/desktop-sandbox/*/target/
 
+# apps/agent-engine runtime image: the Apptainer SIF is a multi-GB build
+# artifact (built in CI or via deploy/apptainer/build.sh), never committed.
+/deploy/apptainer/*.sif
+
 # IDE
 .idea/
 .vscode/

--- a/.wolf/buglog.json
+++ b/.wolf/buglog.json
@@ -1948,6 +1948,21 @@
         "test-harness",
         "loopback-guard"
       ]
+    },
+    {
+      "id": "agent-engine-sif-playwright-missing",
+      "priority": "P1",
+      "date": "2026-07-17",
+      "error_message": "apptainer build agent-engine.sif FATAL in %post: '/usr/local/bin/python3: No module named playwright' at 'python3 -m playwright install --with-deps chromium'; exit status 1 (CI job Build agent-engine.sif, PR #351)",
+      "root_cause": "The vendored trio (openhands-sdk/-tools/-workspace) is installed with pip --no-deps to protect the patched workspace. That also drops openhands-tools' declared third-party runtime deps (binaryornot, cachetools, libtmux, browser-use, func-timeout, tom-swe). browser-use is what pulls playwright. openhands-agent-server is installed with deps but does not depend on openhands-tools, so pip never backfilled them (an already-installed --no-deps package is treated as satisfied, its missing deps never resolved). The subsequent playwright CLI invocation then failed because playwright was never installed.",
+      "fix": "In deploy/apptainer/agent-engine.def %post, after the trio and agent-server installs and before 'playwright install', add an explicit 'pip install' of openhands-tools' third-party runtime deps (binaryornot>=0.4.4, cachetools, libtmux>=0.53.0, browser-use>=0.8.0, func-timeout>=4.3.5, tom-swe>=1.0.3). These are plain PyPI packages, not the vendored trio, so the patched trio is left untouched (pip sees them already satisfied). Mirrors vendor/openhands/openhands-tools/pyproject.toml dependencies; keep in step with it.",
+      "tags": [
+        "ci",
+        "apptainer",
+        "agent-engine",
+        "playwright",
+        "packaging"
+      ]
     }
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,28 @@ supabase db push                    # If Supabase CLI is linked
 # Or apply supabase/migrations/ files in order via SQL editor
 ```
 
+### 5. Agent-engine runtime image (Apptainer)
+
+The agent-engine service launches each agent session inside an Apptainer
+sandbox built from `deploy/apptainer/agent-engine.def`. It needs a prebuilt
+`.sif` and reads its path from `HIVE_AGENT_SIF_PATH`. The image is `linux/amd64`
+only and cannot be built on the WSL2 dev box.
+
+```bash
+# Demo/prod host with apptainer installed:
+make agent-sif                       # -> deploy/apptainer/agent-engine.sif
+export HIVE_AGENT_SIF_PATH=$(pwd)/deploy/apptainer/agent-engine.sif
+
+# No local apptainer: download the CI-built image instead.
+gh workflow run "agent-engine SIF"   # or use the latest successful run
+gh run download -n agent-engine-sif -D /opt/hive
+export HIVE_AGENT_SIF_PATH=/opt/hive/agent-engine.sif
+```
+
+The `agent-engine SIF` workflow builds the `.sif` in CI (which also validates
+the def) and uploads it as the `agent-engine-sif` artifact. Full detail:
+`deploy/apptainer/README.md`.
+
 ## Commands
 
 ### Testing (always use Docker)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: gen-permissions
+.PHONY: gen-permissions agent-sif
 
 # Codegen for the permissions registry → TypeScript mirror.
 # Runs inside the `toolchain` profile container (Go + tools). The toolchain
@@ -9,3 +9,9 @@ COMPOSE_ENV_ARG := $(if $(wildcard $(ENV_FILE)),--env-file $(ENV_FILE),)
 
 gen-permissions:
 	cd deploy/docker && docker compose $(COMPOSE_ENV_ARG) --profile local --profile tools run --rm --entrypoint /bin/sh toolchain -c "cd /workspace && /usr/local/go/bin/go run ./apps/control-plane/cmd/gen-permissions ./apps/web-console/lib/control-plane/permissions.generated.ts"
+
+# Build the agent-engine Apptainer image (agent-engine.sif) on a host that has
+# apptainer installed (linux/amd64). CI builds the same image via
+# .github/workflows/agent-engine-sif.yml. See deploy/apptainer/README.md.
+agent-sif:
+	deploy/apptainer/build.sh

--- a/deploy/apptainer/README.md
+++ b/deploy/apptainer/README.md
@@ -1,0 +1,70 @@
+# agent-engine Apptainer image
+
+`agent-engine.def` is the build recipe for the sandbox image that the
+agent-engine service launches once per agent session. Each coding-pack and
+knowledge-work-pack session runs inside a container built from this definition
+(see `apps/agent-engine/internal/sandbox`). The agent-engine binary needs a
+prebuilt `.sif` and reads its path from `HIVE_AGENT_SIF_PATH`.
+
+The image targets `linux/amd64` only. It cannot be built on this repo's WSL2
+dev box (no rootless user-namespace Apptainer support there), so the image is
+built in CI or on a real demo/production host.
+
+## Getting the .sif
+
+### Option A: download the CI-built image (no apptainer needed locally)
+
+The `agent-engine SIF` workflow (`.github/workflows/agent-engine-sif.yml`)
+builds the image on every change to `deploy/apptainer/**`,
+`vendor/openhands/**`, or `apps/agent-engine/packs/**`, and on
+`workflow_dispatch`. It uploads the result as the `agent-engine-sif` artifact.
+
+```bash
+# Trigger a build on demand (or use the latest successful run):
+gh workflow run "agent-engine SIF"
+
+# Download the artifact from the most recent successful run:
+gh run download -n agent-engine-sif -D /opt/hive
+# -> /opt/hive/agent-engine.sif
+```
+
+### Option B: build it on the host (host has apptainer installed)
+
+```bash
+make agent-sif                 # from the repo root -> deploy/apptainer/agent-engine.sif
+# or, choosing an output path:
+deploy/apptainer/build.sh /opt/hive/agent-engine.sif
+```
+
+`build.sh` handles the working-directory detail so the def's `../../` file
+sources resolve correctly. Building a docker-bootstrap image needs root or
+fakeroot: run the script under `sudo`, or pass
+`APPTAINER_BUILD_ARGS=--fakeroot` for a rootless host.
+
+## Wiring it to agent-engine
+
+Set the absolute path to the built image and (re)start the service:
+
+```bash
+export HIVE_AGENT_SIF_PATH=/opt/hive/agent-engine.sif
+```
+
+Docker Compose already forwards `HIVE_AGENT_SIF_PATH` from your `.env` into the
+agent-engine service (`deploy/docker/docker-compose.yml`). Add it to `.env`:
+
+```dotenv
+HIVE_AGENT_SIF_PATH=/opt/hive/agent-engine.sif
+```
+
+agent-engine refuses to start without it (`-sif` flag or `HIVE_AGENT_SIF_PATH`;
+see `apps/agent-engine/cmd/agent-engine/main.go`).
+
+## Verifying a built image
+
+```bash
+apptainer inspect /opt/hive/agent-engine.sif
+```
+
+The `apps/agent-engine/internal/sandbox/apptainer_integration_test.go` live
+launch test (gated behind `HIVE_APPTAINER_TEST=1`) exercises a built SIF
+end to end on a host that has apptainer.

--- a/deploy/apptainer/agent-engine.def
+++ b/deploy/apptainer/agent-engine.def
@@ -45,11 +45,11 @@ From: nikolaik/python-nodejs:python3.12-nodejs22-bookworm
     # which also skipped these; and openhands-agent-server does not depend on
     # openhands-tools, so its install did not pull them either. They back the
     # core tools (bash: libtmux/func-timeout, file edit: binaryornot, browser:
-    # browser-use, which is what provides playwright). Installing them here
-    # (plain PyPI packages, not the vendored trio) leaves the patched trio
-    # untouched: pip sees openhands-sdk/-tools/-workspace already satisfied.
-    # This mirrors the dependencies list in vendor/openhands/openhands-tools/
-    # pyproject.toml and must be kept in step with it.
+    # browser-use). Installing them here (plain PyPI packages, not the
+    # vendored trio) leaves the patched trio untouched: pip sees
+    # openhands-sdk/-tools/-workspace already satisfied. This mirrors the
+    # dependencies list in vendor/openhands/openhands-tools/pyproject.toml
+    # and must be kept in step with it.
     python3 -m pip install --no-cache-dir \
         "binaryornot>=0.4.4" \
         "cachetools" \
@@ -57,6 +57,26 @@ From: nikolaik/python-nodejs:python3.12-nodejs22-bookworm
         "browser-use>=0.8.0" \
         "func-timeout>=4.3.5" \
         "tom-swe>=1.0.3"
+
+    # The block above can backtrack litellm below the floor openhands-sdk
+    # pins (litellm>=1.84.1): tom-swe only requires litellm>=1.0.0, and pip
+    # resolves each `pip install` invocation independently, so it is free to
+    # pick any version satisfying that looser bound across this command
+    # (observed landing on 1.83.0, undoing the 1.84.1+ install pulled in
+    # earlier by openhands-sdk). Re-assert both vendored packages' floors
+    # (openhands-sdk: litellm>=1.84.1; openhands-agent-server: openai>=2.33,
+    # <3) here so the final resolved environment satisfies both.
+    python3 -m pip install --no-cache-dir "litellm>=1.84.1" "openai>=2.33.0,<3"
+
+    # browser-use (from the block above) dropped its own playwright
+    # dependency as of the 0.13.x line: it now drives Chromium over CDP via
+    # cdp-use instead of through Playwright's API, so nothing above still
+    # pulls playwright in transitively. openhands-tools' own browser tool
+    # (openhands/tools/browser_use/impl.py) looks for a Chromium binary
+    # under Playwright's ms-playwright cache dir regardless, so both the
+    # playwright package and its bundled Chromium download are still
+    # required here.
+    python3 -m pip install --no-cache-dir playwright
 
     # x86-64 only, so Playwright's own bundled Chromium download works
     # normally: no distro-Chromium workaround needed (that was only ever

--- a/deploy/apptainer/agent-engine.def
+++ b/deploy/apptainer/agent-engine.def
@@ -40,6 +40,24 @@ From: nikolaik/python-nodejs:python3.12-nodejs22-bookworm
     python3 -m pip install --no-cache-dir \
         /opt/hive/vendor/openhands/openhands-agent-server
 
+    # openhands-tools' own third-party runtime dependencies. The trio above
+    # was installed with --no-deps to protect the patched vendored packages,
+    # which also skipped these; and openhands-agent-server does not depend on
+    # openhands-tools, so its install did not pull them either. They back the
+    # core tools (bash: libtmux/func-timeout, file edit: binaryornot, browser:
+    # browser-use, which is what provides playwright). Installing them here
+    # (plain PyPI packages, not the vendored trio) leaves the patched trio
+    # untouched: pip sees openhands-sdk/-tools/-workspace already satisfied.
+    # This mirrors the dependencies list in vendor/openhands/openhands-tools/
+    # pyproject.toml and must be kept in step with it.
+    python3 -m pip install --no-cache-dir \
+        "binaryornot>=0.4.4" \
+        "cachetools" \
+        "libtmux>=0.53.0" \
+        "browser-use>=0.8.0" \
+        "func-timeout>=4.3.5" \
+        "tom-swe>=1.0.3"
+
     # x86-64 only, so Playwright's own bundled Chromium download works
     # normally: no distro-Chromium workaround needed (that was only ever
     # required for arm64, which this box does not target).

--- a/deploy/apptainer/build.sh
+++ b/deploy/apptainer/build.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# Build the agent-engine Apptainer image (agent-engine.sif) on a host that has
+# apptainer installed. This is the demo/production host counterpart to the
+# .github/workflows/agent-engine-sif.yml CI job.
+#
+# Usage:
+#   deploy/apptainer/build.sh                 # -> deploy/apptainer/agent-engine.sif
+#   deploy/apptainer/build.sh /opt/hive/agent-engine.sif
+#   make agent-sif                            # same, from the repo root
+#
+# The script cd's into its own directory before building so the def file's
+# ../../ %files sources (vendor/openhands, apps/agent-engine/packs) resolve to
+# the repo root regardless of where you invoke it from.
+#
+# Privilege: building a docker-bootstrap image needs either real root or a
+# rootless setup with fakeroot. If a plain `apptainer build` fails on your host,
+# re-run with sudo, or pass fakeroot via the knob below:
+#   sudo deploy/apptainer/build.sh
+#   APPTAINER_BUILD_ARGS=--fakeroot deploy/apptainer/build.sh
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+DEF="agent-engine.def"
+OUT="${1:-agent-engine.sif}"
+
+if ! command -v apptainer >/dev/null 2>&1; then
+  echo "error: apptainer is not installed or not on PATH." >&2
+  echo "See https://apptainer.org/docs/admin/main/installation.html" >&2
+  exit 1
+fi
+
+echo "Building ${OUT} from ${DEF} (cwd: $(pwd)) ..."
+# shellcheck disable=SC2086 # APPTAINER_BUILD_ARGS is an intentional word-split knob.
+apptainer build ${APPTAINER_BUILD_ARGS:-} "${OUT}" "${DEF}"
+
+ABS="$(cd "$(dirname "${OUT}")" && pwd)/$(basename "${OUT}")"
+echo
+echo "Built: ${ABS}"
+echo "Point agent-engine at it with:"
+echo "  export HIVE_AGENT_SIF_PATH=${ABS}"


### PR DESCRIPTION
## What

Adds a reproducible build path for the agent-engine sandbox runtime image (`agent-engine.sif`), the single remaining agent-tasks demo dependency. No prebuilt `.sif` existed and apptainer is unavailable on the dev/WSL2 box, so the image previously had to be hand built on the owner's lab machine.

## Changes

- **New workflow `.github/workflows/agent-engine-sif.yml`**: installs a pinned Apptainer release (`1.5.2`, distro generic `.deb` for the noble runner), builds `agent-engine.sif` from `deploy/apptainer/agent-engine.def` as real root on a `/mnt` scratch volume, runs `apptainer inspect` to prove the image is valid, and uploads it as the `agent-engine-sif` artifact (14 day retention). A green build also validates the `.def` recipe, which had never been built in this repo. Triggers only on changes to the image inputs (`deploy/apptainer/**`, `vendor/openhands/**`, `apps/agent-engine/packs/**`) plus `workflow_dispatch`, so it does not run on unrelated PRs.
- **`deploy/apptainer/build.sh` + `make agent-sif`**: documents and performs the host build for demo/prod hosts that have apptainer. The script cd's into its own directory so the def's `../../` `%files` sources resolve to the repo root under either apptainer path resolution rule, and exposes an `APPTAINER_BUILD_ARGS` knob for `--fakeroot` on rootless hosts.
- **Docs**: `deploy/apptainer/README.md` (obtain the `.sif` via CI artifact or local build, then set `HIVE_AGENT_SIF_PATH`), a CLAUDE.md "Agent-engine runtime image" subsection, and a documented `HIVE_AGENT_SIF_PATH` entry in `.env.example`.
- **`.gitignore`**: excludes the multi GB built `.sif`.

## HIVE_AGENT_SIF_PATH wiring

`apps/agent-engine/cmd/agent-engine/main.go` reads `HIVE_AGENT_SIF_PATH` (or the `-sif` flag) and refuses to start without it. `deploy/docker/docker-compose.yml` already forwards it from `.env`. A demo host obtains the image (CI artifact download or `make agent-sif`) and exports the absolute path; the README and CLAUDE.md subsection give the exact commands.

## Conflict / rebase note

Additive and isolated by design. It does not touch `overlays/hive-support-status.yaml` (owned by the P0 PR) and does not modify `.github/workflows/ci.yml`. The audit-manifest PR (removing ci.yml lines ~127-142) and the fix-342-item6 bwrap job both edit `ci.yml`; this PR adds a separate workflow file and shares no lines with them, so no rebase conflict is expected against those PRs. It touches `CLAUDE.md`, `.env.example`, `.gitignore`, and `Makefile` additively; if another in-flight PR edits the same regions a trivial rebase may be needed.

## Verification

- Workflow YAML parses; 6 steps in the `build-sif` job.
- `build.sh` passes `bash -n`; `make agent-sif` dry run resolves to the script.
- CI build evidence (the core proof that the `.def` builds green and the artifact uploads) to be linked below once the run completes.

## Security surface

Touches CI and `.env.example` (skill-router gated). No secrets added; `HIVE_AGENT_SIF_PATH` ships blank. Workflow permissions are `contents: read` (minimal); the apptainer package is pulled over HTTPS from the official pinned release. Recommend an independent security review of the pushed diff per the repo contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for running agent sessions in a prebuilt Apptainer sandbox.
  - Added configuration for specifying the sandbox image location.
  - Added local and CI-assisted workflows for obtaining or building the runtime image.
  - Improved runtime packaging with required browser and agent dependencies.

- **Documentation**
  - Added setup, verification, platform requirements, and Docker Compose configuration guidance.
  - Documented troubleshooting information for sandbox image builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->