### PR TITLE
fix: make request-attempt insert idempotent to stop duplicate-key 23505

### DIFF
--- a/.wolf/buglog.json
+++ b/.wolf/buglog.json
@@ -1878,6 +1878,20 @@
         "air",
         "healthcheck"
       ]
+    },
+    {
+      "date": "2026-07-17",
+      "id": "reservation-duplicate-key-23505",
+      "severity": "P2",
+      "error_message": "duplicate key value violates unique constraint \"idx_request_attempts_account_request_attempt\" (SQLSTATE 23505) on chat dispatch",
+      "root_cause": "Non-idempotent request-attempt insert. A single edge-api chat request starts the same attempt twice for one (account_id, request_id, attempt_number=1): the orchestrator calls StartAttempt directly (status dispatching), then CreateReservation internally calls usage.StartAttempt again (accounting/service.go). usage/repository.go CreateAttempt used a plain INSERT, so the second insert hit the unique index and raised 23505. Non-fatal to the served request (errors were logged as non-fatal), but the error aborted the reservation transaction, silently dropping the credit hold, and polluted logs.",
+      "fix": "Make CreateAttempt idempotent with INSERT ... ON CONFLICT (account_id, request_id, attempt_number) DO UPDATE SET status = request_attempts.status RETURNING ... The no-op SET returns the pre-existing attempt (first write wins); status transitions stay owned by UpdateAttemptStatus so an attempt never moves backward. Preserves append-only semantics and money-path correctness (single attempt, single reservation, no double-charge). Added DB-backed regression test TestCreateAttemptIsIdempotentOnAccountRequestAttempt in apps/control-plane/internal/usage/repository_test.go asserting no 23505, same row returned, exactly one row.",
+      "tags": [
+        "billing",
+        "idempotency",
+        "edge-api",
+        "db"
+      ]
     }
   ]
 }

--- a/apps/control-plane/internal/usage/repository.go
+++ b/apps/control-plane/internal/usage/repository.go
@@ -37,10 +37,21 @@ func (r *pgxRepository) CreateAttempt(ctx context.Context, input StartAttemptInp
 		return RequestAttempt{}, fmt.Errorf("usage: marshal customer tags: %w", err)
 	}
 
+	// Idempotent on (account_id, request_id, attempt_number). A single request
+	// starts the same attempt twice: the edge-api orchestrator calls StartAttempt
+	// directly, and the reservation path (accounting.CreateReservation) starts it
+	// again to link the hold. A plain INSERT collided on
+	// idx_request_attempts_account_request_attempt (23505), which aborted the
+	// reservation transaction and silently dropped the credit hold. ON CONFLICT
+	// returns the pre-existing attempt unchanged (first write wins); the no-op SET
+	// is only there so RETURNING yields the existing row. Status transitions stay
+	// owned by UpdateAttemptStatus, so this never moves an attempt backward.
 	row := r.pool.QueryRow(ctx, `
 		INSERT INTO public.request_attempts
 			(account_id, request_id, attempt_number, endpoint, model_alias, status, user_id, team_id, service_account_id, api_key_id, customer_tags)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11::jsonb)
+		ON CONFLICT (account_id, request_id, attempt_number)
+		DO UPDATE SET status = request_attempts.status
 		RETURNING id, account_id, request_id, attempt_number, endpoint, model_alias, status, user_id, team_id, service_account_id, api_key_id, customer_tags, started_at, completed_at
 	`, input.AccountID, input.RequestID, input.AttemptNumber, input.Endpoint, input.ModelAlias, string(input.Status), input.UserID, input.TeamID, input.ServiceAccountID, input.APIKeyID, customerTags)
 

--- a/apps/control-plane/internal/usage/repository_test.go
+++ b/apps/control-plane/internal/usage/repository_test.go
@@ -1,0 +1,127 @@
+package usage
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// newAttemptTestPool connects with the privileged role that HIVE_TEST_DB_URL
+// carries (matching how control-plane runs in production), so the
+// request_attempts unique index is actually exercised. The pool is closed at
+// test end.
+func newAttemptTestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("HIVE_TEST_DB_URL")
+	if dsn == "" {
+		t.Skip("HIVE_TEST_DB_URL not set")
+	}
+	if !strings.Contains(strings.ToLower(dsn), "test") {
+		t.Fatalf("refusing to run: HIVE_TEST_DB_URL must point at a test database (DSN missing 'test' marker)")
+	}
+
+	pool, err := pgxpool.New(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+// seedAttemptAccount inserts an auth.users row and the public.accounts row it
+// owns so request_attempts.account_id has a valid FK target, then registers
+// cleanup (deleting the account cascades any attempts, then the user).
+func seedAttemptAccount(t *testing.T, pool *pgxpool.Pool) uuid.UUID {
+	t.Helper()
+	ctx := context.Background()
+
+	var userID uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO auth.users (id, email, raw_user_meta_data)
+		 VALUES (gen_random_uuid(), $1, '{}'::jsonb) RETURNING id`,
+		"attempt-idem-"+uuid.NewString()+"@test.local",
+	).Scan(&userID); err != nil {
+		t.Skipf("seed auth.users failed (is this a migrated test DB?): %v", err)
+	}
+
+	var accountID uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO public.accounts (id, slug, display_name, account_type, owner_user_id)
+		 VALUES (gen_random_uuid(), $1, 'attempt idem test', 'personal', $2) RETURNING id`,
+		"attempt-idem-"+uuid.NewString(), userID,
+	).Scan(&accountID); err != nil {
+		t.Fatalf("seed account: %v", err)
+	}
+
+	t.Cleanup(func() {
+		c := context.Background()
+		_, _ = pool.Exec(c, `DELETE FROM public.accounts WHERE id = $1`, accountID)
+		_, _ = pool.Exec(c, `DELETE FROM auth.users WHERE id = $1`, userID)
+	})
+	return accountID
+}
+
+// TestCreateAttemptIsIdempotentOnAccountRequestAttempt reproduces the duplicate
+// request-attempt insert seen during chat dispatch: the orchestrator starts an
+// attempt, then the reservation path starts the same (account, request, attempt)
+// again. Before the ON CONFLICT fix the second insert raised
+// "duplicate key value violates unique constraint
+// idx_request_attempts_account_request_attempt" (SQLSTATE 23505), which aborted
+// the reservation transaction. The insert must instead be idempotent: return
+// the existing attempt, leave exactly one row, and never double-count.
+func TestCreateAttemptIsIdempotentOnAccountRequestAttempt(t *testing.T) {
+	pool := newAttemptTestPool(t)
+	accountID := seedAttemptAccount(t, pool)
+	repo := NewPgxRepository(pool)
+	ctx := context.Background()
+
+	requestID := "req-" + uuid.NewString()
+	input := StartAttemptInput{
+		AccountID:     accountID,
+		RequestID:     requestID,
+		AttemptNumber: 1,
+		Endpoint:      "/v1/chat/completions",
+		ModelAlias:    "gpt-test",
+		Status:        AttemptStatusDispatching,
+		CustomerTags:  map[string]any{},
+	}
+
+	first, err := repo.CreateAttempt(ctx, input)
+	if err != nil {
+		t.Fatalf("first CreateAttempt: %v", err)
+	}
+
+	// Second call mirrors the reservation path's internal StartAttempt for the
+	// same request. It may carry a different status; the insert must not error.
+	input.Status = AttemptStatusAccepted
+	second, err := repo.CreateAttempt(ctx, input)
+	if err != nil {
+		t.Fatalf("second CreateAttempt must be idempotent (no 23505), got: %v", err)
+	}
+
+	if second.ID != first.ID {
+		t.Fatalf("expected the same attempt row on conflict, first=%s second=%s", first.ID, second.ID)
+	}
+	// First write wins: the durable fact is unchanged, so the status stays
+	// dispatching rather than moving backward to accepted.
+	if second.Status != AttemptStatusDispatching {
+		t.Fatalf("expected preserved status %q, got %q", AttemptStatusDispatching, second.Status)
+	}
+
+	// No double reservation: exactly one attempt row exists for the key.
+	var count int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM public.request_attempts
+		 WHERE account_id = $1 AND request_id = $2 AND attempt_number = 1`,
+		accountID, requestID,
+	).Scan(&count); err != nil {
+		t.Fatalf("count attempts: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly 1 request_attempts row, got %d", count)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a non-fatal accounting idempotency defect: during edge-api chat dispatch the logs showed

```
duplicate key value violates unique constraint "idx_request_attempts_account_request_attempt" (SQLSTATE 23505)
```

### Root cause

A single edge-api request starts the same request-attempt twice for one `(account_id, request_id, attempt_number=1)`:

1. The inference orchestrator calls `StartAttempt` directly (`apps/edge-api/internal/inference/orchestrator.go`, also `stream.go` / `stream_responses.go`), inserting the attempt row.
2. It then calls `CreateReservation`, which internally calls `usage.StartAttempt` again to link the credit hold (`apps/control-plane/internal/accounting/service.go`).

`usage.CreateAttempt` used a plain `INSERT`, so the second insert collided on the unique index. The error was logged as non-fatal, so the request was still served, but it aborted the reservation transaction under the account lock, which silently dropped the credit hold and polluted the logs. `CreateAttempt` is the single chokepoint every attempt-creating caller (inference, images, audio, batches, reservation) routes through.

### Fix

Make `CreateAttempt` idempotent:

```sql
INSERT INTO public.request_attempts (...)
VALUES (...)
ON CONFLICT (account_id, request_id, attempt_number)
DO UPDATE SET status = request_attempts.status
RETURNING ...
```

The no-op `SET status = request_attempts.status` returns the pre-existing attempt (first write wins) so the reservation path gets the same attempt id instead of a 23505. Status transitions remain owned by `UpdateAttemptStatus`, so an attempt never moves backward. Append-only ledger semantics and money-path correctness are preserved: one attempt, one reservation, no double-charge. Fixing the shared function covers every caller, not just the chat path.

### Tests

Added a DB-backed regression test `TestCreateAttemptIsIdempotentOnAccountRequestAttempt` in `apps/control-plane/internal/usage/repository_test.go` that seeds an account, calls `CreateAttempt` twice for the same key, and asserts:

- no 23505 on the second insert,
- the same attempt row is returned (first-write-wins status preserved),
- exactly one `request_attempts` row exists (no double reservation).

## Test plan

- [x] `go build ./apps/control-plane/...` (via Docker toolchain) — green
- [x] `go vet` + `go test ./apps/control-plane/internal/usage/...` (via Docker toolchain) — green; regression test skips locally without `HIVE_TEST_DB_URL`
- [ ] CI runs the regression test against the provisioned test DB (exercises the 23505 path)
