### PR TITLE
fix: serverless RAG embedding produces 1024-dim to match schema

### DIFF
--- a/apps/control-plane/cmd/server/main.go
+++ b/apps/control-plane/cmd/server/main.go
@@ -969,7 +969,12 @@ func main() {
 			log.Println("WARNING: EMBEDDING_BASE_URL not set; rag ingest route not registered (uploaded documents will stay pending)")
 		} else {
 			ragRepo := cprag.NewRepo(pool)
-			ragEmbedTruncateTo, _ := strconv.Atoi(strings.TrimSpace(os.Getenv("EMBEDDING_TRUNCATE_TO")))
+			ragEmbedTruncateToRaw := strings.TrimSpace(os.Getenv("EMBEDDING_TRUNCATE_TO"))
+			ragEmbedTruncateTo, err := strconv.Atoi(ragEmbedTruncateToRaw)
+			if ragEmbedTruncateToRaw != "" && err != nil {
+				log.Printf("WARNING: EMBEDDING_TRUNCATE_TO=%q is not a valid integer; truncation disabled (strict dimension reject applies)", ragEmbedTruncateToRaw)
+				ragEmbedTruncateTo = 0
+			}
 			ragEmbedClient := cprag.NewHTTPEmbedClient(ragEmbedBaseURL, ragEmbedModel, ragEmbedTruncateTo)
 			ragIngester := cprag.NewIngester(ragRepo, ragEmbedClient, 0)
 			cprag.RegisterRoutes(routerMux, func(ctx context.Context, tenantID, docID uuid.UUID, content string) error {

--- a/apps/control-plane/cmd/server/main.go
+++ b/apps/control-plane/cmd/server/main.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -968,7 +969,8 @@ func main() {
 			log.Println("WARNING: EMBEDDING_BASE_URL not set; rag ingest route not registered (uploaded documents will stay pending)")
 		} else {
 			ragRepo := cprag.NewRepo(pool)
-			ragEmbedClient := cprag.NewHTTPEmbedClient(ragEmbedBaseURL, ragEmbedModel)
+			ragEmbedTruncateTo, _ := strconv.Atoi(strings.TrimSpace(os.Getenv("EMBEDDING_TRUNCATE_TO")))
+			ragEmbedClient := cprag.NewHTTPEmbedClient(ragEmbedBaseURL, ragEmbedModel, ragEmbedTruncateTo)
 			ragIngester := cprag.NewIngester(ragRepo, ragEmbedClient, 0)
 			cprag.RegisterRoutes(routerMux, func(ctx context.Context, tenantID, docID uuid.UUID, content string) error {
 				return ragIngester.Ingest(ctx, tenantID, docID, content)

--- a/apps/control-plane/internal/rag/embed_test.go
+++ b/apps/control-plane/internal/rag/embed_test.go
@@ -1,0 +1,98 @@
+package rag
+
+import (
+	"context"
+	"encoding/json"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestReduceEmbedding verifies the MRL truncate-and-renormalize helper:
+// output has the target length and unit L2 norm.
+func TestReduceEmbedding(t *testing.T) {
+	vec := make([]float32, 4096)
+	for i := range vec {
+		vec[i] = float32(i%7) - 3 // arbitrary nonzero values
+	}
+
+	out := reduceEmbedding(vec, 1024)
+	if len(out) != 1024 {
+		t.Fatalf("len = %d, want 1024", len(out))
+	}
+
+	var sumSq float64
+	for _, v := range out {
+		sumSq += float64(v) * float64(v)
+	}
+	norm := math.Sqrt(sumSq)
+	if math.Abs(norm-1.0) > 1e-4 {
+		t.Errorf("L2 norm = %f, want ~1.0", norm)
+	}
+}
+
+// TestReduceEmbeddingNoop covers target<=0 and target>=len as no-ops.
+func TestReduceEmbeddingNoop(t *testing.T) {
+	vec := []float32{1, 2, 3}
+	if out := reduceEmbedding(vec, 0); len(out) != 3 {
+		t.Errorf("target=0: len = %d, want 3 (noop)", len(out))
+	}
+	if out := reduceEmbedding(vec, 10); len(out) != 3 {
+		t.Errorf("target>len: len = %d, want 3 (noop)", len(out))
+	}
+}
+
+// TestHTTPEmbedClientTruncates drives a fake 4096-dim backend through
+// HTTPEmbedClient with truncateTo=1024 and expects a 1024-dim result per item.
+func TestHTTPEmbedClientTruncates(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req embedRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		vec := make([]float32, 4096)
+		for i := range vec {
+			vec[i] = 0.01
+		}
+		data := make([]struct {
+			Embedding []float32 `json:"embedding"`
+		}, len(req.Input))
+		for i := range data {
+			data[i].Embedding = vec
+		}
+		_ = json.NewEncoder(w).Encode(embedResponse{Data: data})
+	}))
+	defer srv.Close()
+
+	c := NewHTTPEmbedClient(srv.URL, "route-openrouter-embedding-fallback", 1024)
+	vecs, err := c.Embed(context.Background(), []string{"a", "b"})
+	if err != nil {
+		t.Fatalf("Embed() error = %v", err)
+	}
+	if len(vecs) != 2 {
+		t.Fatalf("len(vecs) = %d, want 2", len(vecs))
+	}
+	for i, v := range vecs {
+		if len(v) != EmbeddingDimension {
+			t.Errorf("item %d: len = %d, want %d", i, len(v), EmbeddingDimension)
+		}
+	}
+}
+
+// TestHTTPEmbedClientStrictRejectByDefault confirms truncateTo=0 (unset) still
+// rejects a non-EmbeddingDimension response instead of silently truncating.
+func TestHTTPEmbedClientStrictRejectByDefault(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		vec := make([]float32, 4096)
+		_ = json.NewEncoder(w).Encode(embedResponse{
+			Data: []struct {
+				Embedding []float32 `json:"embedding"`
+			}{{Embedding: vec}},
+		})
+	}))
+	defer srv.Close()
+
+	c := NewHTTPEmbedClient(srv.URL, "bge-m3", 0)
+	if _, err := c.Embed(context.Background(), []string{"hello"}); err == nil {
+		t.Fatal("expected dimension-mismatch error, got nil")
+	}
+}

--- a/apps/control-plane/internal/rag/ingest.go
+++ b/apps/control-plane/internal/rag/ingest.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"strings"
 	"time"
@@ -25,17 +26,48 @@ type HTTPEmbedClient struct {
 	baseURL string
 	model   string
 	client  *http.Client
+	// truncateTo reduces a wider MRL-trained embedding (e.g. 4096-dim) to this
+	// many leading dimensions, then L2-renormalizes. 0 disables reduction: a
+	// non-EmbeddingDimension vector is rejected outright (see EMBEDDING_TRUNCATE_TO).
+	truncateTo int
 }
 
 // NewHTTPEmbedClient constructs the production embed client.
 // baseURL example: "http://localhost:11434/v1" (Ollama) or "http://litellm:4000".
-// model must be the alias that returns 1024-dim vectors, e.g. "bge-m3".
-func NewHTTPEmbedClient(baseURL, model string) *HTTPEmbedClient {
+// model must be the alias returning EmbeddingDimension (or truncateTo) vectors, e.g. "bge-m3".
+// truncateTo: 0 requires the backend already return EmbeddingDimension;
+// otherwise the target width for MRL truncation (must equal EmbeddingDimension).
+func NewHTTPEmbedClient(baseURL, model string, truncateTo int) *HTTPEmbedClient {
 	return &HTTPEmbedClient{
-		baseURL: strings.TrimRight(baseURL, "/"),
-		model:   model,
-		client:  &http.Client{Timeout: 30 * time.Second},
+		baseURL:    strings.TrimRight(baseURL, "/"),
+		model:      model,
+		client:     &http.Client{Timeout: 30 * time.Second},
+		truncateTo: truncateTo,
 	}
+}
+
+// reduceEmbedding implements Matryoshka Representation Learning (MRL)
+// truncation: keep the first `target` dimensions and L2-renormalize so the
+// result is a valid unit-ish vector for cosine similarity. Only correct for
+// MRL-trained embedding models; never apply to an arbitrary model.
+func reduceEmbedding(vec []float32, target int) []float32 {
+	if target <= 0 || target >= len(vec) {
+		return vec
+	}
+	out := make([]float32, target)
+	copy(out, vec[:target])
+	var sumSq float64
+	for _, v := range out {
+		sumSq += float64(v) * float64(v)
+	}
+	norm := math.Sqrt(sumSq)
+	if norm == 0 {
+		return out
+	}
+	for i, v := range out {
+		out[i] = float32(float64(v) / norm)
+	}
+	return out
 }
 
 type embedRequest struct {
@@ -87,11 +119,15 @@ func (c *HTTPEmbedClient) Embed(ctx context.Context, inputs []string) ([][]float
 
 	out := make([][]float32, len(result.Data))
 	for i, d := range result.Data {
-		if len(d.Embedding) != EmbeddingDimension {
-			return nil, fmt.Errorf("rag.embed: item %d has dimension %d, want %d",
-				i, len(d.Embedding), EmbeddingDimension)
+		emb := d.Embedding
+		if c.truncateTo > 0 {
+			emb = reduceEmbedding(emb, c.truncateTo)
 		}
-		out[i] = d.Embedding
+		if len(emb) != EmbeddingDimension {
+			return nil, fmt.Errorf("rag.embed: item %d has dimension %d, want %d",
+				i, len(emb), EmbeddingDimension)
+		}
+		out[i] = emb
 	}
 	return out, nil
 }

--- a/apps/edge-api/cmd/server/main.go
+++ b/apps/edge-api/cmd/server/main.go
@@ -248,7 +248,12 @@ func main() {
 		// width exceeds EmbeddingDimension (e.g. the serverless demo's
 		// route-openrouter-embedding-fallback returns 4096). Unset/0 keeps the
 		// strict reject so a non-MRL model never gets silently truncated.
-		ragEmbedTruncateTo, _ := strconv.Atoi(strings.TrimSpace(os.Getenv("EMBEDDING_TRUNCATE_TO")))
+		ragEmbedTruncateToRaw := strings.TrimSpace(os.Getenv("EMBEDDING_TRUNCATE_TO"))
+		ragEmbedTruncateTo, err := strconv.Atoi(ragEmbedTruncateToRaw)
+		if ragEmbedTruncateToRaw != "" && err != nil {
+			log.Printf("WARNING: EMBEDDING_TRUNCATE_TO=%q is not a valid integer; truncation disabled (strict dimension reject applies)", ragEmbedTruncateToRaw)
+			ragEmbedTruncateTo = 0
+		}
 		var ragRepo edgerag.Store
 		if dbPool != nil {
 			ragRepo = edgerag.NewRepo(dbPool)

--- a/apps/edge-api/cmd/server/main.go
+++ b/apps/edge-api/cmd/server/main.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -243,13 +244,18 @@ func main() {
 		if ragEmbedModel == "" {
 			ragEmbedModel = "bge-m3"
 		}
+		// EMBEDDING_TRUNCATE_TO: set only for MRL-trained models whose native
+		// width exceeds EmbeddingDimension (e.g. the serverless demo's
+		// route-openrouter-embedding-fallback returns 4096). Unset/0 keeps the
+		// strict reject so a non-MRL model never gets silently truncated.
+		ragEmbedTruncateTo, _ := strconv.Atoi(strings.TrimSpace(os.Getenv("EMBEDDING_TRUNCATE_TO")))
 		var ragRepo edgerag.Store
 		if dbPool != nil {
 			ragRepo = edgerag.NewRepo(dbPool)
 		}
 		var ragEmbedder edgerag.Embedder
 		if ragEmbedBaseURL != "" {
-			ragEmbedder = edgerag.NewHTTPEmbedder(ragEmbedBaseURL, ragEmbedModel)
+			ragEmbedder = edgerag.NewHTTPEmbedder(ragEmbedBaseURL, ragEmbedModel, ragEmbedTruncateTo)
 		}
 		ragAudit := func(ctx context.Context, action, resourceType, resourceID, severity string,
 			tenantID, actorID uuid.UUID, userAgent string, after any) {

--- a/apps/edge-api/internal/rag/embed.go
+++ b/apps/edge-api/internal/rag/embed.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"strings"
 	"time"
@@ -23,17 +24,49 @@ type HTTPEmbedder struct {
 	baseURL string
 	model   string
 	client  *http.Client
+	// truncateTo reduces a wider MRL-trained embedding (e.g. 4096-dim) to this
+	// many leading dimensions, then L2-renormalizes. 0 disables reduction: a
+	// non-EmbeddingDimension vector is rejected outright (see EMBEDDING_TRUNCATE_TO).
+	truncateTo int
 }
 
 // NewHTTPEmbedder constructs the production embedder.
-// baseURL: e.g. "http://ollama:11434/v1" or "http://litellm:4000".
-// model:   the alias that returns EmbeddingDimension vectors, e.g. "bge-m3".
-func NewHTTPEmbedder(baseURL, model string) *HTTPEmbedder {
+// baseURL:    e.g. "http://ollama:11434/v1" or "http://litellm:4000".
+// model:      the alias returning EmbeddingDimension (or truncateTo) vectors, e.g. "bge-m3".
+// truncateTo: 0 to require the backend already return EmbeddingDimension;
+//
+//	otherwise the target width for MRL truncation (must equal EmbeddingDimension).
+func NewHTTPEmbedder(baseURL, model string, truncateTo int) *HTTPEmbedder {
 	return &HTTPEmbedder{
-		baseURL: strings.TrimRight(baseURL, "/"),
-		model:   model,
-		client:  &http.Client{Timeout: 30 * time.Second},
+		baseURL:    strings.TrimRight(baseURL, "/"),
+		model:      model,
+		client:     &http.Client{Timeout: 30 * time.Second},
+		truncateTo: truncateTo,
 	}
+}
+
+// reduceEmbedding implements Matryoshka Representation Learning (MRL)
+// truncation: keep the first `target` dimensions and L2-renormalize so the
+// result is a valid unit-ish vector for cosine similarity. Only correct for
+// MRL-trained embedding models; never apply to an arbitrary model.
+func reduceEmbedding(vec []float32, target int) []float32 {
+	if target <= 0 || target >= len(vec) {
+		return vec
+	}
+	out := make([]float32, target)
+	copy(out, vec[:target])
+	var sumSq float64
+	for _, v := range out {
+		sumSq += float64(v) * float64(v)
+	}
+	norm := math.Sqrt(sumSq)
+	if norm == 0 {
+		return out
+	}
+	for i, v := range out {
+		out[i] = float32(float64(v) / norm)
+	}
+	return out
 }
 
 type embedReq struct {
@@ -82,6 +115,9 @@ func (e *HTTPEmbedder) Embed(ctx context.Context, text string) ([]float32, error
 		return nil, fmt.Errorf("rag: embedding service returned no data")
 	}
 	vec := result.Data[0].Embedding
+	if e.truncateTo > 0 {
+		vec = reduceEmbedding(vec, e.truncateTo)
+	}
 	if len(vec) != EmbeddingDimension {
 		return nil, fmt.Errorf("rag: unexpected embedding dimension %d", len(vec))
 	}

--- a/apps/edge-api/internal/rag/embed_test.go
+++ b/apps/edge-api/internal/rag/embed_test.go
@@ -1,0 +1,101 @@
+package rag
+
+import (
+	"context"
+	"encoding/json"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestReduceEmbedding verifies the MRL truncate-and-renormalize helper:
+// output has the target length and unit L2 norm.
+func TestReduceEmbedding(t *testing.T) {
+	vec := make([]float32, 4096)
+	for i := range vec {
+		vec[i] = float32(i%7) - 3 // arbitrary nonzero values
+	}
+
+	out := reduceEmbedding(vec, 1024)
+	if len(out) != 1024 {
+		t.Fatalf("len = %d, want 1024", len(out))
+	}
+
+	var sumSq float64
+	for _, v := range out {
+		sumSq += float64(v) * float64(v)
+	}
+	norm := math.Sqrt(sumSq)
+	if math.Abs(norm-1.0) > 1e-4 {
+		t.Errorf("L2 norm = %f, want ~1.0", norm)
+	}
+
+	// Leading dims are preserved up to the rescale factor.
+	scale := out[0] / vec[0]
+	for i := 1; i < len(out); i++ {
+		if vec[i] == 0 {
+			continue
+		}
+		got := out[i] / vec[i]
+		if math.Abs(float64(got-scale)) > 1e-3 {
+			t.Errorf("dim %d not proportionally scaled: got %f, want %f", i, got, scale)
+		}
+	}
+}
+
+// TestReduceEmbeddingNoop covers target<=0 and target>=len as no-ops.
+func TestReduceEmbeddingNoop(t *testing.T) {
+	vec := []float32{1, 2, 3}
+	if out := reduceEmbedding(vec, 0); len(out) != 3 {
+		t.Errorf("target=0: len = %d, want 3 (noop)", len(out))
+	}
+	if out := reduceEmbedding(vec, 10); len(out) != 3 {
+		t.Errorf("target>len: len = %d, want 3 (noop)", len(out))
+	}
+}
+
+// TestHTTPEmbedderTruncates drives a fake 4096-dim backend through
+// HTTPEmbedder with truncateTo=1024 and expects a 1024-dim result.
+func TestHTTPEmbedderTruncates(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		vec := make([]float32, 4096)
+		for i := range vec {
+			vec[i] = 0.01
+		}
+		_ = json.NewEncoder(w).Encode(embedResp{
+			Data: []struct {
+				Embedding []float32 `json:"embedding"`
+			}{{Embedding: vec}},
+		})
+	}))
+	defer srv.Close()
+
+	e := NewHTTPEmbedder(srv.URL, "route-openrouter-embedding-fallback", 1024)
+	vec, err := e.Embed(context.Background(), "hello")
+	if err != nil {
+		t.Fatalf("Embed() error = %v", err)
+	}
+	if len(vec) != EmbeddingDimension {
+		t.Errorf("len = %d, want %d", len(vec), EmbeddingDimension)
+	}
+}
+
+// TestHTTPEmbedderStrictRejectByDefault confirms truncateTo=0 (unset) still
+// rejects a non-EmbeddingDimension response instead of silently truncating.
+func TestHTTPEmbedderStrictRejectByDefault(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		vec := make([]float32, 4096)
+		_ = json.NewEncoder(w).Encode(embedResp{
+			Data: []struct {
+				Embedding []float32 `json:"embedding"`
+			}{{Embedding: vec}},
+		})
+	}))
+	defer srv.Close()
+
+	e := NewHTTPEmbedder(srv.URL, "bge-m3", 0)
+	if _, err := e.Embed(context.Background(), "hello"); err == nil {
+		t.Fatal("expected dimension-mismatch error, got nil")
+	}
+}

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -52,8 +52,10 @@ services:
       # this proxy config even with drop_params set, so EMBEDDING_TRUNCATE_TO
       # reduces the vector client-side (MRL truncation + L2 renormalize) instead
       # of asking the provider for a narrower width. Only qwen3 is MRL-verified;
-      # the free Nemotron primary is NOT used here for that reason, even though
-      # LiteLLM would fall back to it on qwen3 failure.
+      # the free Nemotron primary is NOT used here for that reason. Note the
+      # fallback chain is one-directional: route-openrouter-embedding-fallback
+      # (qwen3) is terminal in deploy/litellm/config.yaml, with no further
+      # fallback if it also fails.
       # Provider-swappable with no schema change: override in .env
       # (e.g. http://ollama:11434 + bge-m3 + EMBEDDING_TRUNCATE_TO=0 for the
       # enterprise profile's in-stack Ollama, which returns native 1024-dim).

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -43,14 +43,23 @@ services:
       # RAG query embeddings (#232). Without these the query embedder is nil and
       # POST /v1/rag/search + /v1/rag/chat return a provider-blind 503. The demo
       # uses SERVERLESS embeddings only (no local embedding model runs): point at
-      # LiteLLM, whose route-openrouter-embedding forwards to the OpenRouter
-      # serverless embedding pool (Nemotron-Embed free primary, qwen3 paid
-      # fallback). The embedder appends /v1/embeddings, so the base URL must NOT
-      # itself include /v1. Provider-swappable with no schema change: override
-      # both in .env (e.g. http://ollama:11434 + bge-m3 for the enterprise
-      # profile's in-stack Ollama).
+      # LiteLLM, whose route-openrouter-embedding-fallback forwards to OpenRouter's
+      # qwen3-embedding-8b (MRL-trained, native 4096-dim). The embedder appends
+      # /v1/embeddings, so the base URL must NOT itself include /v1.
+      # rag_chunks.embedding is vector(1024) NOT NULL (see EmbeddingDimension in
+      # apps/edge-api/internal/rag/types.go); neither serverless route natively
+      # returns 1024, and LiteLLM's `dimensions` request param is rejected by
+      # this proxy config even with drop_params set, so EMBEDDING_TRUNCATE_TO
+      # reduces the vector client-side (MRL truncation + L2 renormalize) instead
+      # of asking the provider for a narrower width. Only qwen3 is MRL-verified;
+      # the free Nemotron primary is NOT used here for that reason, even though
+      # LiteLLM would fall back to it on qwen3 failure.
+      # Provider-swappable with no schema change: override in .env
+      # (e.g. http://ollama:11434 + bge-m3 + EMBEDDING_TRUNCATE_TO=0 for the
+      # enterprise profile's in-stack Ollama, which returns native 1024-dim).
       EMBEDDING_BASE_URL: ${EMBEDDING_BASE_URL:-http://litellm:4000}
-      EMBEDDING_MODEL: ${EMBEDDING_MODEL:-route-openrouter-embedding}
+      EMBEDDING_MODEL: ${EMBEDDING_MODEL:-route-openrouter-embedding-fallback}
+      EMBEDDING_TRUNCATE_TO: ${EMBEDDING_TRUNCATE_TO:-1024}
     healthcheck:
       test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/health"]
       interval: 5s
@@ -257,6 +266,15 @@ services:
       OWUI_ADMIN_TOKEN: ${OWUI_ADMIN_TOKEN:-}
       SUPABASE_WEBHOOK_SECRET: ${SUPABASE_WEBHOOK_SECRET:-}
       AUDIT_WAL_DIR: ${AUDIT_WAL_DIR:-/var/lib/hive/audit-wal}
+      # RAG ingestion (#232). Without EMBEDDING_BASE_URL the ingest route is not
+      # registered and uploaded documents stay "pending" forever. Must match the
+      # edge-api query embedder (same model + same truncation) or search/chat
+      # retrieval silently returns nothing, since ingested and query vectors
+      # would live in incompatible embedding spaces. See the edge-api service's
+      # EMBEDDING_* comment above for why EMBEDDING_TRUNCATE_TO exists.
+      EMBEDDING_BASE_URL: ${EMBEDDING_BASE_URL:-http://litellm:4000}
+      EMBEDDING_MODEL: ${EMBEDDING_MODEL:-route-openrouter-embedding-fallback}
+      EMBEDDING_TRUNCATE_TO: ${EMBEDDING_TRUNCATE_TO:-1024}
       # Phase 20 Plan 03 — LiteLLM config generation and controlled restart.
       LITELLM_CONTAINER_NAME: ${LITELLM_CONTAINER_NAME:-litellm}
       LITELLM_CONFIG_PATH: ${LITELLM_CONFIG_PATH:-/etc/litellm/config.yaml}


### PR DESCRIPTION
## Problem

`rag_chunks.embedding` is `vector(1024) NOT NULL` (bge-m3 width; see `supabase/migrations/20260625_05_carl_rag*.sql` and `EmbeddingDimension` in both rag packages). In the serverless demo, LiteLLM has no bge-m3 route: both embedding routes (`route-openrouter-embedding` primary, `route-openrouter-embedding-fallback`) proxy to OpenRouter models that return 4096-dim vectors. `HTTPEmbedder.Embed` (edge-api) and `HTTPEmbedClient.Embed` (control-plane) both rejected any response whose length was not exactly 1024, so:

- `POST /v1/rag/search` and `POST /v1/rag/chat` returned a provider-blind 503 (query embedding rejected).
- Separately, `control-plane`'s rag ingest route was never registered in `deploy/docker/docker-compose.yml` at all (no `EMBEDDING_BASE_URL` was wired for that service), so uploaded documents stayed `pending` forever regardless of the dimension bug.

CI did not catch this because the web e2e suite runs without live provider keys and the live-integration RAG path is skipped there.

## Investigation

Brought up `litellm` + `redis` locally and probed both embedding routes directly:

- `route-openrouter-embedding` (Nemotron-Embed VL, free): 4096-dim, no `dimensions` support.
- `route-openrouter-embedding-fallback` (qwen3-embedding-8b, paid, MRL-trained): 4096-dim, no `dimensions` support.
- Passing the OpenAI-style `dimensions` request param to either route fails hard with `litellm.UnsupportedParamsError`, even though `litellm_settings.drop_params: true` is set in `deploy/litellm/config.yaml` — that setting does not cover this validation path for embeddings in the pinned LiteLLM version. So the fix cannot ask the provider for a narrower width.

## Fix

Client-side MRL (Matryoshka Representation Learning) truncation: keep the first N dimensions of the returned vector and L2-renormalize, applied identically in both `apps/edge-api/internal/rag/embed.go` and `apps/control-plane/internal/rag/ingest.go`. This is only mathematically valid for an MRL-trained model, so it is gated behind an explicit `EMBEDDING_TRUNCATE_TO` env var:

- Unset/`0` (existing behavior, unchanged): a non-`EmbeddingDimension` response is rejected outright.
- Set (e.g. `1024`): the vector is truncated to that width and renormalized before the dimension check.

`docker-compose.yml` now defaults `EMBEDDING_MODEL` to `route-openrouter-embedding-fallback` (qwen3, verified MRL-trained) with `EMBEDDING_TRUNCATE_TO=1024`, for both `edge-api` (query path) and `control-plane` (ingest path, which previously had no `EMBEDDING_*` vars at all). Both services must stay on the identical model + truncation width or ingested and query vectors would live in incompatible embedding spaces and retrieval would silently return nothing.

## Production / sovereignty recommendation

The serverless truncation is a demo-only workaround. For production or the sovereignty track, recommend switching to DeepInfra `BAAI/bge-m3` or the #295 local bge-m3 embedder — both return a native 1024-dim vector with no truncation needed. That requires an owner-provisioned key or deployment and is out of scope here.

## Test plan

- [x] `reduceEmbedding` unit tests (both packages): truncate 4096→1024, verify L2 norm ≈ 1.0, verify target<=0/target>=len are no-ops.
- [x] `HTTPEmbedder`/`HTTPEmbedClient` tests against a fake 4096-dim HTTP backend: `EMBEDDING_TRUNCATE_TO` set → 1024-dim result; unset → existing strict reject still fires.
- [x] `go build ./apps/edge-api/... ./apps/control-plane/...` — green.
- [x] `go test ./apps/edge-api/internal/rag/... ./apps/control-plane/internal/rag/...` — green, no regressions in existing rag tests.
- [ ] Live smoke of `POST /v1/rag/chat` end-to-end against the running compose stack (not run here; recommend before demo cutline).