### PR TITLE
fix: agent-engine flag crash and vision hive-auto default-tier access

### DIFF
--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -85,6 +85,29 @@ services:
     # launches here fail at the `exec.LookPath("apptainer")` step; see
     # apps/agent-engine/internal/sandbox/apptainer_integration_test.go
     # (HIVE_APPTAINER_TEST=1) for the gated live-launch proof.
+    #
+    # cmd/agent-engine's -tenant/-user/-workspace/-sif flags are required and
+    # have no default (see cmd/agent-engine/main.go); this compose service
+    # supplied none of them, so the entrypoint hit uuid.Parse("") and
+    # log.Fatal'd immediately on every start. The command below is the
+    # manual smoke-test invocation the binary's package doc already
+    # describes: placeholder tenant/user UUIDs plus --dry-run take the
+    # binary past flag parsing and into its real egress-policy call to
+    # control-plane, proving the binary builds, starts, and reaches its
+    # dependency over the compose network. It still exits non-zero because
+    # the placeholder tenant/user do not exist in this database (egress
+    # policy resolution 500s for an unknown tenant) -- expected for a
+    # placeholder ID, not a regression. Real per-task sandbox launches do
+    # not go through this container at all: apps/control-plane embeds
+    # apps/agent-engine/engineapi in-process (see cmd/server/main.go's
+    # buildAgentEngine) and calls it directly on whatever host runs
+    # control-plane.
+    command:
+      - "-tenant=00000000-0000-0000-0000-000000000000"
+      - "-user=00000000-0000-0000-0000-000000000000"
+      - "-workspace=/tmp/agent-engine-smoke-test"
+      - "-sif=/tmp/agent-engine-smoke-test.sif"
+      - "-dry-run"
     volumes:
       - gomodcache:/go/pkg/mod
       - gobuildcache:/root/.cache/go-build

--- a/supabase/migrations/20260717_01_default_group_hive_auto.sql
+++ b/supabase/migrations/20260717_01_default_group_hive_auto.sql
@@ -1,0 +1,17 @@
+-- Add `hive-auto` to the `default` model policy group.
+--
+-- 20260331_03_api_key_policies.sql seeded `hive-auto` into the `premium` and
+-- `closed` groups only. api_key_policies.allowed_group_names defaults to
+-- ["default"], so any key on the default tier (including the demo's default
+-- API key) resolves its alias list from the `default` group alone and never
+-- sees `hive-auto` -- edge-api's authz layer then returns
+-- `404 The model 'hive-auto' does not exist or you do not have access to it`
+-- for any vision (or other hive-auto-routed) request from a default-tier
+-- key, even though the alias exists in the catalog.
+--
+-- Mirrors the existing `default` membership rows for hive-default/hive-fast;
+-- ON CONFLICT DO NOTHING keeps this safe to re-run.
+
+insert into public.model_policy_group_members (group_name, alias_id)
+values ('default', 'hive-auto')
+on conflict (group_name, alias_id) do nothing;


### PR DESCRIPTION
## Summary

Two of the five demo-blocking bugs assigned in this batch turned out to be real and fixable in this PR; the other three are documented below with root cause and, where relevant, the exact remediation needed (most require action outside this repo's code).

### Fixed here

**1. agent-engine crash on start.** `docker-compose.yml`'s `agent-engine` service supplied no `-tenant`/`-user`/`-workspace`/`-sif` flags. `cmd/agent-engine/main.go` requires all four with no default, so the entrypoint hit `uuid.Parse("")` and exited 1 immediately on every start. Gave it the manual smoke-test invocation the binary's own package doc already describes (placeholder UUIDs plus `--dry-run`). Verified live: the container now starts, reaches control-plane over the compose network, and gets as far as a real (500) response from the egress-policy endpoint for the placeholder tenant, which does not exist in the database, that's expected for a placeholder ID and is not a regression. Real per-task sandbox launches never went through this container: `apps/control-plane` embeds `apps/agent-engine/engineapi` in-process (`cmd/server/main.go`'s `buildAgentEngine`) and calls it directly, so this container's only job is proving the binary builds and starts.

**3. vision hive-auto 404 (model_not_allowed).** `hive-auto` was seeded into the `premium` and `closed` model policy groups only. Every `api_key_policies` row in this project (confirmed live) uses `allowed_group_names = ["default"]` with an empty `allowed_aliases` override, so the default tier never resolved `hive-auto`, and any vision (or other hive-auto-routed) request from a default-tier key 404'd. Added the missing `('default', 'hive-auto')` row to `model_policy_group_members`, mirroring the existing hive-default/hive-fast rows. Verified live against the demo Supabase database (before: closed/premium only; after: closed/default/premium; re-run is a no-op).

### Not fixable in this repo

**2. RAG 401 "missing principal claims".** Confirmed live with a real Supabase-issued JWT (via the `e2e-fixtures` edge function + a password-grant login) that the token carries no `tenant_id` or `tenants` custom claim, only the built-in GoTrue claims. `apps/edge-api/internal/auth/jwt_supabase.go` and `middleware.go` are correct: they read `tenant_id` from the JWT exactly as the `custom_access_token_hook` migration (`20260516_07_phase19_custom_access_token_hook.sql`) injects it. The migration only creates the Postgres function; nothing in this repo registers it as the project's active Auth Hook, that is a one-time Supabase project setting (Dashboard: Authentication > Hooks > Custom Access Token, pointing at `pg-functions://postgres/public/custom_access_token_hook`; or the Management API's `PATCH /v1/projects/{ref}/config/auth`). I don't have a Supabase management token or dashboard access in this session to flip it. Once enabled, this should resolve without further code changes, the extraction code already does the right thing.

**4. .env.example JWT vars / model slugs.** Already fixed in an earlier commit: `SUPABASE_JWT_ISSUER`/`AUDIENCE`/`JWKS_URL` are present with derivation comments, and `OPENROUTER_DEFAULT_MODEL`/`OPENROUTER_AUTO_MODEL` are already `openrouter/free` (not the malformed double-prefixed slug the original report described). No action needed.

**5. spend-alerts / featuregate 404s.** Both routes exist and are correctly registered: `/v1/featuregate` on edge-api (`apps/edge-api/cmd/server/main.go:348`) and `/api/v1/spend-alerts` on control-plane (`apps/control-plane/cmd/server/main.go:423`, note the `/api` prefix and that it's on control-plane's port, not edge-api's). The 404s in the original test were most likely a wrong path or wrong port, not a missing route. No code change made.

## Test plan

- [x] Live-verified: `docker build` + `docker compose --profile agent up agent-engine` against a real `control-plane` + `redis` in the compose network no longer crashes on flag parsing
- [x] Live-verified: applied the new migration against the demo Supabase DB directly, confirmed `hive-auto` gained the `default` group membership, confirmed re-running the migration is a no-op
- [x] Live-verified: probed a real Supabase JWT for a test user and confirmed the missing `tenant_id`/`tenants` claims, ruling out an edge-api code bug for issue 2
- [ ] Once the Supabase Auth Hook is enabled (issue 2, outside this PR), re-run the RAG ingest + chat flow to confirm citations return end to end

🤖 Generated with [Claude Code](https://claude.com/claude-code)