### PR TITLE
chore: declare supabase auth hook and document HIVE_AGENT_ENGINE_* for demo host

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -147,6 +147,31 @@ BATCH_EXECUTOR_LINE_TIMEOUT_MS=60000
 # openai/azure/vertex/anthropic providers).
 BATCH_EXECUTOR_KIND=auto
 
+# ─── Agent task execution (issue #305) ───
+# control-plane's buildAgentEngine (cmd/server/main.go) gates the real
+# agent-engine sandbox on ALL FIVE of these being set. If any is empty,
+# control-plane falls back to agenttask.NotConfiguredEngine: agent tasks
+# still get created and persisted, they just stay queued forever and never
+# execute. Beyond these five env vars, the host process also needs Apptainer
+# installed and a built SIF file on disk at HIVE_AGENT_ENGINE_SIF_PATH,
+# because the real engine execs Apptainer directly. Apptainer only runs on
+# Linux x86-64, so this only works on a Linux x86-64 host, not WSL2 and not
+# macOS. Build/download the SIF from the agent-engine-sif CI workflow.
+#
+# Absolute path to the built agent runtime SIF image.
+HIVE_AGENT_ENGINE_SIF_PATH=
+# Directory holding agent capability packs the sandbox mounts read-only.
+HIVE_AGENT_ENGINE_PACKS_DIR=
+# Host directory the sandbox uses as the agent's writable workspace root.
+HIVE_AGENT_ENGINE_WORKSPACE_ROOT=
+# Host directory for per-run Apptainer instance/state files.
+HIVE_AGENT_ENGINE_RUN_DIR=
+# UUID of the agent profile row (public.agent_profiles) the engine runs as.
+HIVE_AGENT_ENGINE_PROFILE_ID=
+# Optional. Session API key the sandbox uses to call back into control-plane.
+# Leave blank only for local/dev; set a real value in any shared environment.
+HIVE_AGENT_ENGINE_SESSION_API_KEY=
+
 # Licensing entitlement seam (issue #304). Leave LICENSE_FILE_PATH empty for
 # Hive Cloud mode (sync-path placeholder, no file needed). Set it for Hive
 # Enterprise mode: an offline signed license file, verified locally against

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,16 @@
+# Supabase CLI declarative config. Minimal by design: this repo does not
+# run `supabase start` for local dev (Postgres is Supabase-hosted per
+# CLAUDE.md), so this file exists only to version-control settings that
+# must otherwise be clicked through the dashboard. Push with
+# `supabase config push` (or apply manually via the dashboard path noted
+# in the demo-host provisioning doc) after `supabase link`.
+project_id = "hive"
+
+# Registers migration 20260516_07_phase19_custom_access_token_hook.sql's
+# public.custom_access_token_hook as the project's active Auth Hook. Without
+# this, the function exists in the database but Supabase Auth never calls
+# it, so issued JWTs carry no tenant_id/tenants/role claims and every
+# tenant-scoped RLS policy and authz middleware check fails closed (401).
+[auth.hook.custom_access_token]
+enabled = true
+uri = "pg-functions://postgres/public/custom_access_token_hook"


### PR DESCRIPTION
## Summary

Two of the biggest demo blockers found during live verification are owner-side provisioning gaps, not code bugs. This PR makes both reproducible and documented.

- RAG and tenant-scoped flows return 401 because `public.custom_access_token_hook` (migration `20260516_07_phase19_custom_access_token_hook.sql`) exists in the database but was never registered as the project's active Supabase Auth Hook. Adds `supabase/config.toml` declaring it, so a CLI-linked project can apply the setting with `supabase config push` instead of relying on a manual dashboard click every time.
- Agent tasks never leave the `queued` state because control-plane's `buildAgentEngine` (`apps/control-plane/cmd/server/main.go`) needs all five `HIVE_AGENT_ENGINE_*` env vars set, plus Apptainer installed and a built SIF present on a Linux x86-64 host. Documents all five vars in `.env.example` with placeholders and comments; no real values invented.

Full owner runbook (dashboard steps, host provisioning steps, verification checklist) is in the vault: `hive/demo-host-provisioning-2026-07-17.md`.

## Test plan

- [ ] Owner enables the auth hook via Supabase Dashboard > Authentication > Hooks > Customize Access Token (JWT) Claims (or `supabase config push` once linked), then confirms a decoded JWT carries `tenant_id`/`tenants`/`role` claims and `/v1/rag/chat` returns citations instead of 401.
- [ ] Owner provisions a Linux x86-64 host with Apptainer and the `agent-engine-sif` CI artifact, sets the five `HIVE_AGENT_ENGINE_*` vars, and confirms a created agent task transitions past `queued`.
- [x] No behavior change in code paths that don't read these new config surfaces; diff is additive documentation/config only.