### PR TITLE
feat: dimension-agnostic RAG embedding foundation (admin model+dim, registry, startup guard)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -93,10 +93,28 @@ GROQ_REASONING_MODEL=groq/openai/gpt-oss-120b
 # Leave blank to disable /v1/rag/* routes entirely.
 EMBEDDING_BASE_URL=http://litellm:4000
 # EMBEDDING_MODEL: alias passed as the "model" field in POST /v1/embeddings.
-# Must produce 1024-dim vectors to match the rag_chunks.embedding column.
-# Serverless default: route-openrouter-embedding (LiteLLM route #5).
-# Enterprise/Ollama alternative: bge-m3 (multilingual, Bangla, 1024 dims).
-EMBEDDING_MODEL=route-openrouter-embedding
+# Serverless default: route-openrouter-embedding-fallback (LiteLLM route #5,
+# qwen3-embedding-8b). Enterprise/Ollama alternative: bge-m3 (multilingual,
+# Bangla, native 1024-dim).
+EMBEDDING_MODEL=route-openrouter-embedding-fallback
+# EMBEDDING_DIM: the vector width EMBEDDING_MODEL is expected to produce
+# (after EMBEDDING_TRUNCATE_TO, if set). Must match rag_chunks.embedding's
+# column width -- today always 1024, so leave this at the default unless you
+# have also resized that column (a separate migration; not part of this env
+# var). At startup, packages/embedmodel cross-checks EMBEDDING_MODEL's known
+# native dimension against EMBEDDING_DIM + EMBEDDING_TRUNCATE_TO and disables
+# /v1/rag/* embedding rather than start with an inconsistent combination.
+EMBEDDING_DIM=1024
+# EMBEDDING_TRUNCATE_TO: set only for MRL-trained models whose native width
+# exceeds EMBEDDING_DIM (e.g. qwen3-embedding-8b and the Nemotron-Embed VL
+# primary both return 4096 natively). 0/unset keeps the strict reject so a
+# non-MRL model never gets silently truncated to the wrong width.
+EMBEDDING_TRUNCATE_TO=1024
+# EMBEDDING_LOCAL_BASE_URL: only used by the enterprise/self-host profile's
+# bge-m3 LiteLLM route (deploy/litellm/config.yaml). Point at wherever bge-m3
+# is actually served, e.g. http://ollama:11434/v1. Unused by the serverless
+# demo (route-openrouter-embedding[-fallback] instead).
+EMBEDDING_LOCAL_BASE_URL=
 
 # ─── Signup abuse prevention (issue #116) ───────────────────────────
 # Per-IP signup rate limit. Max attempts per IP per window before the

--- a/apps/control-plane/cmd/server/main.go
+++ b/apps/control-plane/cmd/server/main.go
@@ -70,6 +70,7 @@ import (
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/tenants"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/usage"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/waldrainer"
+	"github.com/sakibsadmanshajib/hive/packages/embedmodel"
 	"github.com/sakibsadmanshajib/hive/packages/storage"
 )
 
@@ -975,14 +976,38 @@ func main() {
 				log.Printf("WARNING: EMBEDDING_TRUNCATE_TO=%q is not a valid integer; truncation disabled (strict dimension reject applies)", ragEmbedTruncateToRaw)
 				ragEmbedTruncateTo = 0
 			}
-			ragEmbedClient := cprag.NewHTTPEmbedClient(ragEmbedBaseURL, ragEmbedModel, ragEmbedTruncateTo)
-			ragIngester := cprag.NewIngester(ragRepo, ragEmbedClient, 0)
-			cprag.RegisterRoutes(routerMux, func(ctx context.Context, tenantID, docID uuid.UUID, content string) error {
-				return ragIngester.Ingest(ctx, tenantID, docID, content)
-			}, func(h http.Handler) http.Handler {
-				return platformhttp.RequireInternalToken(cfg.InternalToken, h)
-			})
-			log.Println("rag ingest route registered")
+			// EMBEDDING_DIM: see the matching comment in edge-api/cmd/server/main.go.
+			// Overwrites cprag.EmbeddingDimension's default (1024) so ingest's
+			// dimension checks and rag_documents.embedding_dim provenance both
+			// follow config instead of a compile-time constant.
+			ragEmbedDimRaw := strings.TrimSpace(os.Getenv("EMBEDDING_DIM"))
+			ragEmbedDim := cprag.EmbeddingDimension
+			if ragEmbedDimRaw != "" {
+				if v, err := strconv.Atoi(ragEmbedDimRaw); err != nil {
+					log.Printf("WARNING: EMBEDDING_DIM=%q is not a valid integer; falling back to default %d", ragEmbedDimRaw, ragEmbedDim)
+				} else {
+					ragEmbedDim = v
+				}
+			}
+			cprag.EmbeddingDimension = ragEmbedDim
+
+			// embedmodel.Validate: see the matching comment in
+			// edge-api/cmd/server/main.go. A known but inconsistent
+			// model/dim/truncateTo combination disables ingestion the same way
+			// an unset EMBEDDING_BASE_URL does above, instead of embedding and
+			// storing vectors of the wrong width.
+			if err := embedmodel.Validate(ragEmbedModel, ragEmbedDim, ragEmbedTruncateTo); err != nil {
+				log.Printf("ERROR: RAG embedding configuration is inconsistent, rag ingest route not registered: %v", err)
+			} else {
+				ragEmbedClient := cprag.NewHTTPEmbedClient(ragEmbedBaseURL, ragEmbedModel, ragEmbedTruncateTo)
+				ragIngester := cprag.NewIngester(ragRepo, ragEmbedClient, 0, ragEmbedModel)
+				cprag.RegisterRoutes(routerMux, func(ctx context.Context, tenantID, docID uuid.UUID, content string) error {
+					return ragIngester.Ingest(ctx, tenantID, docID, content)
+				}, func(h http.Handler) http.Handler {
+					return platformhttp.RequireInternalToken(cfg.InternalToken, h)
+				})
+				log.Println("rag ingest route registered")
+			}
 		}
 	}
 

--- a/apps/control-plane/go.mod
+++ b/apps/control-plane/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/redis/go-redis/v9 v9.18.0
 	github.com/sakibsadmanshajib/hive/apps/agent-engine v0.0.0
 	github.com/sakibsadmanshajib/hive/packages/audit-canonical v0.0.0
+	github.com/sakibsadmanshajib/hive/packages/embedmodel v0.0.0
 	github.com/sakibsadmanshajib/hive/packages/storage v0.0.0
 	github.com/stripe/stripe-go/v84 v84.4.1
 )
@@ -59,5 +60,7 @@ require (
 replace github.com/sakibsadmanshajib/hive/packages/storage => ../../packages/storage
 
 replace github.com/sakibsadmanshajib/hive/packages/audit-canonical => ../../packages/audit-canonical
+
+replace github.com/sakibsadmanshajib/hive/packages/embedmodel => ../../packages/embedmodel
 
 replace github.com/sakibsadmanshajib/hive/apps/agent-engine => ../agent-engine

--- a/apps/control-plane/internal/rag/chunk.go
+++ b/apps/control-plane/internal/rag/chunk.go
@@ -7,11 +7,15 @@ import (
 	"unicode"
 )
 
-const (
-	// EmbeddingDimension is the vector size for bge-m3. Must agree with the
-	// rag_chunks.embedding column definition in the migration.
-	EmbeddingDimension = 1024
+// EmbeddingDimension is the configured embedding vector width. Defaults to
+// 1024 (rag_chunks.embedding's current column width). main.go overwrites
+// this once at process startup from EMBEDDING_DIM, before any ingest
+// traffic is served; the admin-chosen model + this value are validated for
+// consistency by packages/embedmodel at the same point. Do not mutate after
+// the server starts serving requests.
+var EmbeddingDimension = 1024
 
+const (
 	// DefaultChunkTokens is the target chunk size in approximate tokens.
 	// ~512 tokens at ~4 chars/token = ~2048 chars.
 	DefaultChunkTokens = 512

--- a/apps/control-plane/internal/rag/chunk_test.go
+++ b/apps/control-plane/internal/rag/chunk_test.go
@@ -91,8 +91,12 @@ func TestApproxTokens(t *testing.T) {
 	}
 }
 
-func TestEmbeddingDimensionConstant(t *testing.T) {
+func TestEmbeddingDimensionDefault(t *testing.T) {
+	// EmbeddingDimension is a config-driven var (set from EMBEDDING_DIM at
+	// startup, see main.go), not a hardcoded constant; this only pins the
+	// zero-value default so an accidental change to the fallback doesn't
+	// silently break the rag_chunks vector(1024) column it must match.
 	if EmbeddingDimension != 1024 {
-		t.Errorf("EmbeddingDimension must be 1024 for bge-m3, got %d", EmbeddingDimension)
+		t.Errorf("EmbeddingDimension default = %d, want 1024", EmbeddingDimension)
 	}
 }

--- a/apps/control-plane/internal/rag/ingest.go
+++ b/apps/control-plane/internal/rag/ingest.go
@@ -15,7 +15,7 @@ import (
 // EmbedClient calls the local embedding service (bge-m3 via Ollama/LiteLLM).
 // It is kept as an interface so tests can inject a fake without unsafe casts.
 type EmbedClient interface {
-	// Embed returns a 1024-dim vector for each input string.
+	// Embed returns an EmbeddingDimension-wide vector for each input string.
 	// Returns an error when the backend is unavailable (provider-blind to callers).
 	Embed(ctx context.Context, inputs []string) ([][]float32, error)
 }
@@ -134,19 +134,26 @@ func (c *HTTPEmbedClient) Embed(ctx context.Context, inputs []string) ([][]float
 
 // Ingester chunks a document, embeds each chunk, and stores results.
 type Ingester struct {
-	repo   *Repo
-	embed  EmbedClient
+	repo  *Repo
+	embed EmbedClient
 	// batchSize controls how many chunks are embedded in one HTTP call.
 	// ponytail: global constant, tune if embed service has payload limits.
 	batchSize int
+	// embedModel is recorded as rag_documents.embedding_model provenance for
+	// every document this Ingester embeds (see SetEmbeddedProvenance).
+	embedModel string
 }
 
-// NewIngester creates an Ingester. batchSize 0 defaults to 32.
-func NewIngester(repo *Repo, embed EmbedClient, batchSize int) *Ingester {
+// NewIngester creates an Ingester. batchSize 0 defaults to 32. embedModel is
+// the EMBEDDING_MODEL this Ingester's embed client was constructed with; it
+// is stamped onto every document as provenance (paired with the current
+// EmbeddingDimension) so a later model swap can find which documents still
+// need re-embedding.
+func NewIngester(repo *Repo, embed EmbedClient, batchSize int, embedModel string) *Ingester {
 	if batchSize <= 0 {
 		batchSize = 32
 	}
-	return &Ingester{repo: repo, embed: embed, batchSize: batchSize}
+	return &Ingester{repo: repo, embed: embed, batchSize: batchSize, embedModel: embedModel}
 }
 
 // Ingest chunks text, embeds all chunks, persists to rag_chunks, and
@@ -199,5 +206,5 @@ func (ing *Ingester) Ingest(ctx context.Context, tenantID, docID interface{ Stri
 		return fmt.Errorf("rag.ingest: store chunks: %w", err)
 	}
 
-	return ing.repo.UpdateDocumentStatus(ctx, tid, did, StatusEmbedded, "")
+	return ing.repo.SetEmbeddedProvenance(ctx, tid, did, ing.embedModel, EmbeddingDimension)
 }

--- a/apps/control-plane/internal/rag/repository.go
+++ b/apps/control-plane/internal/rag/repository.go
@@ -171,6 +171,27 @@ func (r *Repo) UpdateDocumentStatus(ctx context.Context, tenantID, docID uuid.UU
 	})
 }
 
+// SetEmbeddedProvenance marks a document embedded and records the model +
+// dimension that produced its vectors, in one statement. Ingester calls this
+// instead of UpdateDocumentStatus(..., StatusEmbedded, "") so provenance is
+// never left at the column DEFAULT for documents actually embedded under a
+// different, later configuration (needed to find stale rows once a re-embed
+// job exists — PR2, not built here).
+func (r *Repo) SetEmbeddedProvenance(ctx context.Context, tenantID, docID uuid.UUID, model string, dim int) error {
+	return r.withTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `
+			UPDATE public.rag_documents
+			SET status = $1, error_msg = NULL, embedding_model = $2, embedding_dim = $3, updated_at = now()
+			WHERE id = $4`,
+			StatusEmbedded, model, dim, docID,
+		)
+		if err != nil {
+			return fmt.Errorf("rag.repo: set embedded provenance: %w", err)
+		}
+		return nil
+	})
+}
+
 // DeleteDocument deletes a document and cascades to its chunks.
 func (r *Repo) DeleteDocument(ctx context.Context, tenantID, docID uuid.UUID) error {
 	return r.withTenantTx(ctx, tenantID, func(tx pgx.Tx) error {

--- a/apps/edge-api/cmd/server/main.go
+++ b/apps/edge-api/cmd/server/main.go
@@ -39,6 +39,7 @@ import (
 	edgerag "github.com/sakibsadmanshajib/hive/apps/edge-api/internal/rag"
 	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/sovereign"
 	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/stt"
+	"github.com/sakibsadmanshajib/hive/packages/embedmodel"
 	"github.com/sakibsadmanshajib/hive/packages/storage"
 )
 
@@ -269,6 +270,39 @@ func main() {
 			log.Printf("WARNING: EMBEDDING_TRUNCATE_TO=%q is not a valid integer; truncation disabled (strict dimension reject applies)", ragEmbedTruncateToRaw)
 			ragEmbedTruncateTo = 0
 		}
+		// EMBEDDING_DIM: the vector width the admin-selected model is expected
+		// to produce (post-truncation). Overwrites the rag package's default
+		// (1024, matching today's rag_chunks.embedding column) so the dimension
+		// checks in embed.go compare against config, not a compile-time constant.
+		// Resizing the live column for a non-1024 value is a later PR; setting
+		// EMBEDDING_DIM to anything else today will surface as a Postgres
+		// insert error, not a graceful reject, until that PR lands.
+		ragEmbedDimRaw := strings.TrimSpace(os.Getenv("EMBEDDING_DIM"))
+		ragEmbedDim := edgerag.EmbeddingDimension
+		if ragEmbedDimRaw != "" {
+			if v, err := strconv.Atoi(ragEmbedDimRaw); err != nil {
+				log.Printf("WARNING: EMBEDDING_DIM=%q is not a valid integer; falling back to default %d", ragEmbedDimRaw, ragEmbedDim)
+			} else {
+				ragEmbedDim = v
+			}
+		}
+		edgerag.EmbeddingDimension = ragEmbedDim
+
+		// embedmodel.Validate cross-checks model/dim/truncateTo against the
+		// known dimension facts for ragEmbedModel (packages/embedmodel). An
+		// unknown model is skipped, not rejected -- an admin may be pointing at
+		// a custom model this build has no registry entry for. A known but
+		// inconsistent combination disables the embedding backend the same way
+		// an unset EMBEDDING_BASE_URL does below (route stays registered,
+		// returns a provider-blind 503), rather than serving vectors from a
+		// misconfigured width.
+		if ragEmbedBaseURL != "" {
+			if err := embedmodel.Validate(ragEmbedModel, ragEmbedDim, ragEmbedTruncateTo); err != nil {
+				log.Printf("ERROR: RAG embedding configuration is inconsistent, disabling /v1/rag/* embedding: %v", err)
+				ragEmbedBaseURL = ""
+			}
+		}
+
 		var ragRepo edgerag.Store
 		if dbPool != nil {
 			ragRepo = edgerag.NewRepo(dbPool)
@@ -339,6 +373,12 @@ func main() {
 
 		ragHandler := edgerag.NewHandler(ragRepo, ragEmbedder, ragAudit, ragIngest, rootCtx).
 			WithChat(ragSelectRoute, litellmClient.ChatCompletion)
+		if ragRepo != nil {
+			// Fail RAG search closed for a tenant whose stored documents were
+			// embedded under a different model/dim than this process is
+			// configured for right now (see EmbeddingMismatch / checkEmbeddingGuard).
+			ragHandler = ragHandler.WithEmbeddingGuard(ragEmbedModel, ragEmbedDim)
+		}
 		ragMW := featureGate.Require(featuregate.FeatureRAG)
 		ragMux := http.NewServeMux()
 		ragHandler.Register(ragMux)

--- a/apps/edge-api/go.mod
+++ b/apps/edge-api/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
 	github.com/sakibsadmanshajib/hive/packages/audit-canonical v0.0.0
+	github.com/sakibsadmanshajib/hive/packages/embedmodel v0.0.0
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/sync v0.16.0
 )
@@ -57,3 +58,5 @@ require (
 replace github.com/sakibsadmanshajib/hive/packages/storage => ../../packages/storage
 
 replace github.com/sakibsadmanshajib/hive/packages/audit-canonical => ../../packages/audit-canonical
+
+replace github.com/sakibsadmanshajib/hive/packages/embedmodel => ../../packages/embedmodel

--- a/apps/edge-api/internal/rag/chat_handler.go
+++ b/apps/edge-api/internal/rag/chat_handler.go
@@ -108,6 +108,11 @@ func (h *Handler) handleChat(w http.ResponseWriter, r *http.Request) {
 		topK = maxTopK
 	}
 
+	if !h.checkEmbeddingGuard(r.Context(), user.TenantID) {
+		apierrors.Write(w, http.StatusServiceUnavailable, apierrors.CodeServiceUnavailable, "embedding model changed, re-embed required")
+		return
+	}
+
 	h.audit(r.Context(), "RAG_CHAT_QUERY", "rag_document", user.TenantID.String(), "INFO",
 		user.TenantID, user.ID, r.UserAgent(), map[string]any{"model": req.Model, "top_k": topK})
 

--- a/apps/edge-api/internal/rag/embed.go
+++ b/apps/edge-api/internal/rag/embed.go
@@ -12,7 +12,7 @@ import (
 	"time"
 )
 
-// Embedder produces 1024-dim vectors for text queries.
+// Embedder produces EmbeddingDimension-wide vectors for text queries.
 // The interface keeps the handler testable without a real HTTP backend.
 type Embedder interface {
 	Embed(ctx context.Context, text string) ([]float32, error)
@@ -80,7 +80,7 @@ type embedResp struct {
 	} `json:"data"`
 }
 
-// Embed embeds a single text string and returns a 1024-dim vector.
+// Embed embeds a single text string and returns an EmbeddingDimension-wide vector.
 // Errors are provider-blind: no backend URL, model name, or upstream message.
 func (e *HTTPEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
 	body, err := json.Marshal(embedReq{Model: e.model, Input: []string{text}})

--- a/apps/edge-api/internal/rag/handler.go
+++ b/apps/edge-api/internal/rag/handler.go
@@ -39,6 +39,10 @@ type Store interface {
 	// found=false means no row matched (caller should 404); error means infra failure.
 	DeleteDocument(ctx context.Context, tenantID, docID uuid.UUID) (found bool, err error)
 	SearchChunks(ctx context.Context, tenantID uuid.UUID, queryVec []float32, topK int) ([]ChunkRow, error)
+	// EmbeddingMismatch reports whether tenantID has embedded documents whose
+	// stored provenance differs from the model/dim passed in. See
+	// WithEmbeddingGuard for how the handler uses this.
+	EmbeddingMismatch(ctx context.Context, tenantID uuid.UUID, model string, dim int) (bool, error)
 }
 
 // store aliases Store for backward-compat with existing unexported references.
@@ -54,6 +58,50 @@ type Handler struct {
 	wg          sync.WaitGroup   // tracks in-flight ingest goroutines
 	selectRoute RouteSelectFunc  // nil until WithChat is called; POST /v1/rag/chat returns 503
 	dispatch    ChatDispatchFunc // nil until WithChat is called; POST /v1/rag/chat returns 503
+
+	// guardEnabled/guardModel/guardDim back the embedding-consistency guard;
+	// see WithEmbeddingGuard. Disabled by default so existing NewHandler
+	// call sites (and their tests) are unaffected.
+	guardEnabled bool
+	guardModel   string
+	guardDim     int
+}
+
+// WithEmbeddingGuard enables the fail-closed embedding-consistency guard on
+// this Handler and returns it for chaining. Once enabled, every
+// /v1/rag/search and /v1/rag/chat request first asks the store whether the
+// caller's tenant has any embedded document whose stored provenance
+// (embedding_model, embedding_dim) differs from model/dim; a mismatch fails
+// the request closed with a clear error instead of comparing today's query
+// vector against chunks from a different embedding space. Wired in main.go
+// with the same EMBEDDING_MODEL/EmbeddingDimension the process is configured
+// with; unwired (default) Handlers never check.
+func (h *Handler) WithEmbeddingGuard(model string, dim int) *Handler {
+	h.guardModel = model
+	h.guardDim = dim
+	h.guardEnabled = true
+	return h
+}
+
+// checkEmbeddingGuard reports whether the request should proceed. A store
+// error is logged and treated as pass-through -- the SearchChunks call that
+// follows would surface the same infra failure as its own 500, so this does
+// not invent a second failure mode for a transient DB hiccup; only a
+// confirmed mismatch fails the request closed.
+func (h *Handler) checkEmbeddingGuard(ctx context.Context, tenantID uuid.UUID) bool {
+	if !h.guardEnabled {
+		return true
+	}
+	mismatch, err := h.store.EmbeddingMismatch(ctx, tenantID, h.guardModel, h.guardDim)
+	if err != nil {
+		log.Printf("rag: embedding guard check failed, allowing request through: %v", err)
+		return true
+	}
+	if mismatch {
+		log.Printf("rag: embedding guard: tenant %s has documents embedded under a different model/dim than the current configuration (model=%s dim=%d); failing closed", tenantID, h.guardModel, h.guardDim)
+		return false
+	}
+	return true
 }
 
 // NewHandler constructs a Handler.
@@ -266,6 +314,11 @@ func (h *Handler) handleSearch(w http.ResponseWriter, r *http.Request) {
 	// ponytail: cap prevents huge vector scans and audit event floods.
 	if req.TopK > maxTopK {
 		req.TopK = maxTopK
+	}
+
+	if !h.checkEmbeddingGuard(r.Context(), user.TenantID) {
+		apierrors.Write(w, http.StatusServiceUnavailable, apierrors.CodeServiceUnavailable, "embedding model changed, re-embed required")
+		return
 	}
 
 	h.audit(r.Context(), "RAG_SEARCH", "rag_document", user.TenantID.String(), "INFO",

--- a/apps/edge-api/internal/rag/handler_test.go
+++ b/apps/edge-api/internal/rag/handler_test.go
@@ -26,6 +26,9 @@ type fakeStore struct {
 	deleteCalled bool
 	getErr       error // injected error for GetDocument
 	lastTopK     int   // records the topK SearchChunks actually received, for cap assertions
+
+	mismatch    bool  // EmbeddingMismatch return value
+	mismatchErr error // EmbeddingMismatch injected error
 }
 
 func newFakeStore() *fakeStore {
@@ -76,6 +79,10 @@ func (f *fakeStore) SearchChunks(_ context.Context, _ uuid.UUID, _ []float32, to
 		topK = len(f.chunks)
 	}
 	return f.chunks[:topK], nil
+}
+
+func (f *fakeStore) EmbeddingMismatch(_ context.Context, _ uuid.UUID, _ string, _ int) (bool, error) {
+	return f.mismatch, f.mismatchErr
 }
 
 type fakeEmbedder struct{ fail bool }
@@ -295,6 +302,99 @@ func TestHandleSearch_HappyPath(t *testing.T) {
 	}
 	if !sawChunk {
 		t.Error("RAG_CHUNK_RETRIEVED audit not emitted")
+	}
+}
+
+// TestHandleSearch_EmbeddingGuardBlocksOnMismatch verifies that a wired
+// embedding guard fails a search closed (503, no embed/search side effects)
+// when the store reports the tenant has documents embedded under a
+// different model/dim than the current configuration.
+func TestHandleSearch_EmbeddingGuardBlocksOnMismatch(t *testing.T) {
+	store := newFakeStore()
+	store.mismatch = true
+	embed := &fakeEmbedder{}
+
+	var audits []auditRecord
+	h := newTestHandler(store, embed, &audits).WithEmbeddingGuard("bge-m3", 1024)
+
+	body, _ := json.Marshal(SearchRequest{Query: "find me something", TopK: 1})
+	req := httptest.NewRequest(http.MethodPost, "/v1/rag/search", bytes.NewReader(body))
+	req = req.WithContext(userCtx(uuid.New()))
+	w := httptest.NewRecorder()
+	h.handleSearch(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "re-embed required") {
+		t.Errorf("expected re-embed-required message, got: %s", w.Body.String())
+	}
+	for _, a := range audits {
+		if a.Action == "RAG_SEARCH" {
+			t.Error("RAG_SEARCH audit fired for a request the guard should have blocked")
+		}
+	}
+}
+
+// TestHandleSearch_EmbeddingGuardAllowsOnMatch verifies the wired guard is a
+// no-op when the store reports no mismatch (the common case).
+func TestHandleSearch_EmbeddingGuardAllowsOnMatch(t *testing.T) {
+	store := newFakeStore()
+	store.mismatch = false
+
+	var audits []auditRecord
+	h := newTestHandler(store, &fakeEmbedder{}, &audits).WithEmbeddingGuard("bge-m3", 1024)
+
+	body, _ := json.Marshal(SearchRequest{Query: "find me something", TopK: 1})
+	req := httptest.NewRequest(http.MethodPost, "/v1/rag/search", bytes.NewReader(body))
+	req = req.WithContext(userCtx(uuid.New()))
+	w := httptest.NewRecorder()
+	h.handleSearch(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestHandleSearch_EmbeddingGuardDisabledByDefault verifies a Handler built
+// without WithEmbeddingGuard never checks the store's EmbeddingMismatch, so
+// every pre-existing NewHandler call site (and its tests) is unaffected.
+func TestHandleSearch_EmbeddingGuardDisabledByDefault(t *testing.T) {
+	store := newFakeStore()
+	store.mismatch = true // would fail closed if the guard were (wrongly) enabled
+
+	var audits []auditRecord
+	h := newTestHandler(store, &fakeEmbedder{}, &audits)
+
+	body, _ := json.Marshal(SearchRequest{Query: "find me something", TopK: 1})
+	req := httptest.NewRequest(http.MethodPost, "/v1/rag/search", bytes.NewReader(body))
+	req = req.WithContext(userCtx(uuid.New()))
+	w := httptest.NewRecorder()
+	h.handleSearch(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 (guard disabled by default), got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestHandleSearch_EmbeddingGuardErrorFailsOpen verifies a store error while
+// checking the guard does not itself block the request: the SearchChunks
+// call that follows would surface the same infra failure on its own.
+func TestHandleSearch_EmbeddingGuardErrorFailsOpen(t *testing.T) {
+	store := newFakeStore()
+	store.mismatchErr = errors.New("db unavailable")
+
+	var audits []auditRecord
+	h := newTestHandler(store, &fakeEmbedder{}, &audits).WithEmbeddingGuard("bge-m3", 1024)
+
+	body, _ := json.Marshal(SearchRequest{Query: "find me something", TopK: 1})
+	req := httptest.NewRequest(http.MethodPost, "/v1/rag/search", bytes.NewReader(body))
+	req = req.WithContext(userCtx(uuid.New()))
+	w := httptest.NewRecorder()
+	h.handleSearch(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 (guard check error fails open), got %d: %s", w.Code, w.Body.String())
 	}
 }
 

--- a/apps/edge-api/internal/rag/repository.go
+++ b/apps/edge-api/internal/rag/repository.go
@@ -151,6 +151,31 @@ func (r *Repo) DeleteDocument(ctx context.Context, tenantID, docID uuid.UUID) (b
 	return found, nil
 }
 
+// EmbeddingMismatch reports whether tenantID has any embedded document whose
+// stored provenance (embedding_model, embedding_dim) differs from the
+// currently configured model + dim. A true result means at least one of the
+// tenant's documents was embedded under a different model/dimension than
+// this process is configured for right now -- comparing today's query vector
+// against those chunks would silently mix two incompatible vector spaces.
+// The handler uses this to fail RAG search closed instead (WithEmbeddingGuard);
+// this package does not re-embed anything (PR2).
+func (r *Repo) EmbeddingMismatch(ctx context.Context, tenantID uuid.UUID, model string, dim int) (bool, error) {
+	var mismatch bool
+	err := r.withTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `
+			SELECT EXISTS(
+				SELECT 1 FROM public.rag_documents
+				WHERE status = 'embedded' AND (embedding_model != $1 OR embedding_dim != $2)
+			)`,
+			model, dim,
+		).Scan(&mismatch)
+	})
+	if err != nil {
+		return false, fmt.Errorf("rag.repo: embedding mismatch check: %w", err)
+	}
+	return mismatch, nil
+}
+
 // SearchChunks performs cosine vector similarity search scoped to the tenant.
 // queryVec must be EmbeddingDimension floats. Results are ordered most similar first.
 func (r *Repo) SearchChunks(ctx context.Context, tenantID uuid.UUID, queryVec []float32, topK int) ([]ChunkRow, error) {

--- a/apps/edge-api/internal/rag/types.go
+++ b/apps/edge-api/internal/rag/types.go
@@ -13,8 +13,14 @@ const (
 	StatusError      = "error"
 )
 
-// EmbeddingDimension is 1024 (bge-m3). Must agree with the migration.
-const EmbeddingDimension = 1024
+// EmbeddingDimension is the configured embedding vector width. Defaults to
+// 1024 (rag_chunks.embedding's current column width and the serverless
+// demo's MRL-truncation target). main.go overwrites this once at process
+// startup from EMBEDDING_DIM, before any request handling begins; the
+// admin-chosen model + this value are validated for consistency by
+// packages/embedmodel at the same point. Do not mutate after the server
+// starts serving requests.
+var EmbeddingDimension = 1024
 
 // UploadRequest is the JSON body for POST /v1/rag/documents.
 type UploadRequest struct {

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -61,6 +61,7 @@ services:
       # enterprise profile's in-stack Ollama, which returns native 1024-dim).
       EMBEDDING_BASE_URL: ${EMBEDDING_BASE_URL:-http://litellm:4000}
       EMBEDDING_MODEL: ${EMBEDDING_MODEL:-route-openrouter-embedding-fallback}
+      EMBEDDING_DIM: ${EMBEDDING_DIM:-1024}
       EMBEDDING_TRUNCATE_TO: ${EMBEDDING_TRUNCATE_TO:-1024}
     healthcheck:
       test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/health"]
@@ -150,6 +151,10 @@ services:
       OPENROUTER_FAST_FALLBACK_MODEL: ${OPENROUTER_FAST_FALLBACK_MODEL}
       OPENROUTER_EMBEDDING_MODEL: ${OPENROUTER_EMBEDDING_MODEL}
       OPENROUTER_EMBEDDING_FALLBACK_MODEL: ${OPENROUTER_EMBEDDING_FALLBACK_MODEL}
+      # Enterprise/self-host only: bge-m3 LiteLLM route (deploy/litellm/config.yaml,
+      # model_name "bge-m3"). Unset in the serverless demo, which never selects
+      # that route (EMBEDDING_MODEL defaults to route-openrouter-embedding-fallback).
+      EMBEDDING_LOCAL_BASE_URL: ${EMBEDDING_LOCAL_BASE_URL:-}
       GROQ_FAST_MODEL: ${GROQ_FAST_MODEL}
       GROQ_REASONING_MODEL: ${GROQ_REASONING_MODEL}
       # EnterpriseEdge: set to http://ollama:11434 when using the enterprise
@@ -299,6 +304,7 @@ services:
       # EMBEDDING_* comment above for why EMBEDDING_TRUNCATE_TO exists.
       EMBEDDING_BASE_URL: ${EMBEDDING_BASE_URL:-http://litellm:4000}
       EMBEDDING_MODEL: ${EMBEDDING_MODEL:-route-openrouter-embedding-fallback}
+      EMBEDDING_DIM: ${EMBEDDING_DIM:-1024}
       EMBEDDING_TRUNCATE_TO: ${EMBEDDING_TRUNCATE_TO:-1024}
       # Phase 20 Plan 03 — LiteLLM config generation and controlled restart.
       LITELLM_CONTAINER_NAME: ${LITELLM_CONTAINER_NAME:-litellm}

--- a/deploy/litellm/config.yaml
+++ b/deploy/litellm/config.yaml
@@ -104,6 +104,21 @@ model_list:
     model_info:
       mode: embedding
 
+  # ── 5b. Embedding: bge-m3 (Enterprise/Ollama local, native 1024-dim) ────────
+  # Not active in the serverless cloud demo -- no bge-m3 server runs there.
+  # This route lets the enterprise/self-host profile point EMBEDDING_MODEL at
+  # "bge-m3" through LiteLLM instead of hitting Ollama directly, once an
+  # operator sets EMBEDDING_LOCAL_BASE_URL to their bge-m3-serving endpoint
+  # (e.g. http://ollama:11434/v1). Native 1024-dim: no EMBEDDING_TRUNCATE_TO
+  # needed when EMBEDDING_DIM=1024 (the default, matching rag_chunks today).
+  - model_name: bge-m3
+    litellm_params:
+      model: openai/bge-m3
+      api_base: os.environ/EMBEDDING_LOCAL_BASE_URL
+      api_key: "none"
+    model_info:
+      mode: embedding
+
   # ── 6. Voice: speech-to-text (Groq Whisper, free tier) ──────────────────────
   # Groq: whisper-large-v3 — serverless STT for the demo. edge-api's audio
   # handler forwards POST /v1/audio/transcriptions here whenever no local

--- a/go.work
+++ b/go.work
@@ -10,4 +10,6 @@ use ./packages/storage
 
 use ./packages/audit-canonical
 
+use ./packages/embedmodel
+
 use ./apps/agent-engine

--- a/packages/embedmodel/go.mod
+++ b/packages/embedmodel/go.mod
@@ -1,0 +1,5 @@
+module github.com/sakibsadmanshajib/hive/packages/embedmodel
+
+go 1.24.0
+
+toolchain go1.24.13

--- a/packages/embedmodel/registry.go
+++ b/packages/embedmodel/registry.go
@@ -70,6 +70,12 @@ func Lookup(modelOrRoute string) (Model, bool) {
 //   - native dim <  dim: always an error; a narrower vector cannot be padded
 //     out to a wider column.
 func Validate(model string, dim, truncateTo int) error {
+	if dim <= 0 {
+		return fmt.Errorf("embedmodel: EMBEDDING_DIM must be strictly positive, got %d", dim)
+	}
+	if truncateTo < 0 {
+		return fmt.Errorf("embedmodel: EMBEDDING_TRUNCATE_TO cannot be negative, got %d", truncateTo)
+	}
 	m, ok := Lookup(model)
 	if !ok {
 		return nil

--- a/packages/embedmodel/registry.go
+++ b/packages/embedmodel/registry.go
@@ -1,0 +1,93 @@
+// Package embedmodel is the single source of truth for which embedding
+// models Hive knows about, how wide a vector each one natively produces, and
+// which LiteLLM route (if any) serves it. Both apps/edge-api and
+// apps/control-plane import this instead of keeping their own copy, so the
+// bge-m3/nemotron/qwen3 dimension facts cannot drift between the query path
+// and the ingest path.
+//
+// This is the foundation piece of the admin-controlled embedding redesign:
+// it lets EMBEDDING_MODEL / EMBEDDING_DIM / EMBEDDING_TRUNCATE_TO be
+// validated for mutual consistency at process startup instead of only
+// discovering a mismatch when a vector of the wrong width hits Postgres.
+// Choosing a model, resizing the live rag_chunks column, and re-embedding
+// existing documents onto a new model are later PRs; this package only
+// answers "are these three env vars consistent with each other."
+package embedmodel
+
+import "fmt"
+
+// Model describes one embedding model this build knows natively.
+type Model struct {
+	// NativeDim is the vector width the model actually returns.
+	NativeDim int
+	// LiteLLMRoute is the model_name this model is served under in
+	// deploy/litellm/config.yaml, when routed through LiteLLM. Empty for a
+	// model only ever called directly (e.g. bge-m3 on a bare Ollama host).
+	LiteLLMRoute string
+}
+
+// Registry lists every embedding model this build has verified dimension
+// facts for, keyed by canonical model id. EMBEDDING_MODEL may be set to
+// either a canonical id here or to one of the LiteLLMRoute values below;
+// Lookup resolves both forms.
+var Registry = map[string]Model{
+	// bge-m3: multilingual (incl. Bangla), MRL-trained, native 1024-dim.
+	// Enterprise/Ollama default (#295); not wired through LiteLLM in the
+	// serverless demo today, so no LiteLLMRoute.
+	"bge-m3": {NativeDim: 1024},
+
+	// NVIDIA Nemotron-Embed VL 1B: OpenRouter free-pool primary for the
+	// serverless demo, native 4096-dim.
+	"nemotron-embed-vl-1b": {NativeDim: 4096, LiteLLMRoute: "route-openrouter-embedding"},
+
+	// Qwen3 Embedding 8B: OpenRouter paid fallback for the serverless demo,
+	// MRL-trained, native 4096-dim. Today's demo default (docker-compose.yml).
+	"qwen3-embedding-8b": {NativeDim: 4096, LiteLLMRoute: "route-openrouter-embedding-fallback"},
+}
+
+// Lookup finds a Model by canonical id or by LiteLLMRoute alias. ok is false
+// for a model this build has no dimension facts for; callers treat that as
+// "nothing to validate against," not as an error — an admin may point at a
+// custom model the registry does not know yet.
+func Lookup(modelOrRoute string) (Model, bool) {
+	if m, ok := Registry[modelOrRoute]; ok {
+		return m, true
+	}
+	for _, m := range Registry {
+		if m.LiteLLMRoute != "" && m.LiteLLMRoute == modelOrRoute {
+			return m, true
+		}
+	}
+	return Model{}, false
+}
+
+// Validate checks that model, dim (EMBEDDING_DIM), and truncateTo
+// (EMBEDDING_TRUNCATE_TO) are mutually consistent:
+//
+//   - model unknown to Registry: nothing to check, returns nil.
+//   - native dim == dim: truncateTo must be 0 (no truncation needed).
+//   - native dim >  dim: truncateTo must equal dim (MRL truncation required).
+//   - native dim <  dim: always an error; a narrower vector cannot be padded
+//     out to a wider column.
+func Validate(model string, dim, truncateTo int) error {
+	m, ok := Lookup(model)
+	if !ok {
+		return nil
+	}
+	switch {
+	case m.NativeDim == dim:
+		if truncateTo != 0 {
+			return fmt.Errorf("embedmodel: model %q is native %d-dim, matching EMBEDDING_DIM=%d; EMBEDDING_TRUNCATE_TO must be 0, got %d",
+				model, m.NativeDim, dim, truncateTo)
+		}
+	case m.NativeDim > dim:
+		if truncateTo != dim {
+			return fmt.Errorf("embedmodel: model %q is native %d-dim, wider than EMBEDDING_DIM=%d; EMBEDDING_TRUNCATE_TO must equal %d, got %d",
+				model, m.NativeDim, dim, dim, truncateTo)
+		}
+	default:
+		return fmt.Errorf("embedmodel: model %q is native %d-dim, narrower than EMBEDDING_DIM=%d; cannot pad a narrower vector, pick a wider model or lower EMBEDDING_DIM",
+			model, m.NativeDim, dim)
+	}
+	return nil
+}

--- a/packages/embedmodel/registry_test.go
+++ b/packages/embedmodel/registry_test.go
@@ -1,0 +1,54 @@
+package embedmodel
+
+import "testing"
+
+func TestLookupByCanonicalID(t *testing.T) {
+	m, ok := Lookup("bge-m3")
+	if !ok || m.NativeDim != 1024 {
+		t.Fatalf("Lookup(bge-m3) = %+v, %v; want NativeDim=1024, ok=true", m, ok)
+	}
+}
+
+func TestLookupByLiteLLMRoute(t *testing.T) {
+	m, ok := Lookup("route-openrouter-embedding-fallback")
+	if !ok || m.NativeDim != 4096 {
+		t.Fatalf("Lookup(route-openrouter-embedding-fallback) = %+v, %v; want NativeDim=4096, ok=true", m, ok)
+	}
+}
+
+func TestLookupUnknownModel(t *testing.T) {
+	if _, ok := Lookup("some-custom-model"); ok {
+		t.Fatal("Lookup(some-custom-model) ok=true; want false for an unregistered model")
+	}
+}
+
+func TestValidate(t *testing.T) {
+	cases := []struct {
+		name       string
+		model      string
+		dim        int
+		truncateTo int
+		wantErr    bool
+	}{
+		{"native equals dim, no truncation: ok", "bge-m3", 1024, 0, false},
+		{"native equals dim, truncation set: error", "bge-m3", 1024, 1024, true},
+		{"native wider than dim, correct truncation: ok", "qwen3-embedding-8b", 1024, 1024, false},
+		{"native wider than dim, truncation unset: error", "qwen3-embedding-8b", 1024, 0, true},
+		{"native wider than dim, wrong truncation: error", "qwen3-embedding-8b", 1024, 512, true},
+		{"native narrower than dim: always an error", "bge-m3", 2048, 0, true},
+		{"native narrower than dim, truncation set: still an error", "bge-m3", 2048, 2048, true},
+		{"unknown model: nothing to validate, ok", "custom-model-not-in-registry", 999, 0, false},
+		{"lookup by LiteLLM route alias: ok", "route-openrouter-embedding-fallback", 1024, 1024, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := Validate(tc.model, tc.dim, tc.truncateTo)
+			if tc.wantErr && err == nil {
+				t.Fatalf("Validate(%q, %d, %d) = nil, want an error", tc.model, tc.dim, tc.truncateTo)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("Validate(%q, %d, %d) = %v, want nil", tc.model, tc.dim, tc.truncateTo, err)
+			}
+		})
+	}
+}

--- a/packages/embedmodel/registry_test.go
+++ b/packages/embedmodel/registry_test.go
@@ -39,6 +39,10 @@ func TestValidate(t *testing.T) {
 		{"native narrower than dim, truncation set: still an error", "bge-m3", 2048, 2048, true},
 		{"unknown model: nothing to validate, ok", "custom-model-not-in-registry", 999, 0, false},
 		{"lookup by LiteLLM route alias: ok", "route-openrouter-embedding-fallback", 1024, 1024, false},
+		{"dim zero: error even for unknown model", "custom-model-not-in-registry", 0, 0, true},
+		{"dim negative: error even for unknown model", "custom-model-not-in-registry", -1, 0, true},
+		{"truncateTo negative: error even for unknown model", "custom-model-not-in-registry", 999, -1, true},
+		{"unknown model, positive dim, zero truncateTo: still ok", "custom-model-not-in-registry", 1, 0, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/supabase/migrations/20260717_03_rag_embedding_dim_drop_check.sql
+++ b/supabase/migrations/20260717_03_rag_embedding_dim_drop_check.sql
@@ -1,0 +1,33 @@
+-- supabase/migrations/20260717_03_rag_embedding_dim_drop_check.sql
+--
+-- Dimension-agnostic RAG embedding foundation (admin-controlled embedding
+-- redesign, PR1). 20260715_01_rag_embedding_provenance.sql pinned
+-- rag_documents.embedding_dim to CHECK (embedding_dim = 1024), matching the
+-- one dimension the Go code assumed at the time. That code now reads its
+-- expected width from EMBEDDING_DIM (see apps/edge-api/internal/rag/types.go
+-- and apps/control-plane/internal/rag/chunk.go), so a deployment configured
+-- for a different embedding model must be able to write a different value
+-- into this column without a schema change.
+--
+-- Scope: this migration only drops the CHECK constraint. It does NOT alter
+-- rag_chunks.embedding's column type (still vector(1024)) and does NOT
+-- backfill or re-embed any row -- resizing the live vector column and
+-- migrating existing documents onto a new model is the re-embed job (PR2),
+-- not built here. Until that job exists, running with EMBEDDING_DIM != 1024
+-- will surface as a pgvector dimension-mismatch error on insert, not a
+-- graceful application-level reject; the Go-side embedmodel registry guard
+-- (packages/embedmodel) exists to catch an inconsistent config before that
+-- point, not to make the column itself elastic.
+--
+-- Depends on: 20260715_01_rag_embedding_provenance.sql (adds the column and
+-- constraint this migration removes).
+
+BEGIN;
+
+ALTER TABLE public.rag_documents
+    DROP CONSTRAINT IF EXISTS rag_documents_embedding_dim_check;
+
+COMMENT ON COLUMN public.rag_documents.embedding_dim IS
+    'Embedding vector width in effect when this document was embedded, taken from EMBEDDING_DIM at ingest time. No longer CHECKed to a fixed value (see 20260717_03): rag_chunks.embedding is still a fixed vector(1024) column today, so a value other than 1024 here means this document''s vectors do not fit that column until the re-embed job (PR2) resizes it and migrates the row.';
+
+COMMIT;


### PR DESCRIPTION
## Summary

PR 1 (foundation) of the admin-controlled embedding redesign. Makes the RAG embedding pipeline dimension-agnostic and model-registry-driven, removing the hardcoded-1024 assumptions in Go code, without breaking the serverless demo.

- `EmbeddingDimension` changes from a `const` to a package `var` in both `apps/edge-api/internal/rag` and `apps/control-plane/internal/rag`, set once at startup from `EMBEDDING_DIM` (default 1024) instead of being compiled in.
- New `packages/embedmodel` package: a registry of known embedding models (`bge-m3` to 1024, `nemotron-embed-vl-1b` to 4096, `qwen3-embedding-8b` to 4096) with native dimensions and LiteLLM route aliases, plus `Validate()` to check `EMBEDDING_MODEL`/`EMBEDDING_DIM`/`EMBEDDING_TRUNCATE_TO` are mutually consistent. Both apps call this at startup; an inconsistent combination disables RAG embedding the same way an unset `EMBEDDING_BASE_URL` already does, rather than serving vectors of the wrong width.
- Ingest now stamps `rag_documents.embedding_model`/`embedding_dim` with the actually configured values on every successful embed (`SetEmbeddedProvenance`), instead of leaving them at the column DEFAULT.
- Query-path fail-closed guard: edge-api's `Handler` gains `WithEmbeddingGuard`, wired whenever a DB repo is available. Before running a search or grounded-chat retrieval, it asks the store whether the caller's tenant has any embedded document whose stored provenance differs from the currently configured model/dim (`Repo.EmbeddingMismatch`); on a mismatch the request fails closed with "embedding model changed, re-embed required" instead of comparing vectors from two different embedding spaces.
- Drops the `CHECK (embedding_dim = 1024)` constraint added in `20260715_01_rag_embedding_provenance.sql` via a new migration, so a non-1024 `EMBEDDING_DIM` is not rejected outright by Postgres.
- Adds a `bge-m3` LiteLLM route (`deploy/litellm/config.yaml`) for the enterprise/self-host profile, gated behind `EMBEDDING_LOCAL_BASE_URL`; unused by the serverless demo.
- `.env.example` and `docker-compose.yml`: documents/wires `EMBEDDING_DIM`, `EMBEDDING_TRUNCATE_TO`, and `EMBEDDING_LOCAL_BASE_URL`, and aligns the documented `EMBEDDING_MODEL` default with `docker-compose.yml`'s actual default (`route-openrouter-embedding-fallback`) -- the two had drifted before this PR.

## Design deviation from the original brief, and why

The brief asked for the model/dim consistency check "at control-plane and edge-api startup" against what is already stored in the database. I implemented it per-tenant at request time instead of as a single global startup check, because `rag_documents`/`rag_chunks` RLS policies are fail-closed with no `BYPASSRLS` role available to the `hive_app` connection the services use (see `20260715_05_rag_rls_nullif_guard.sql`): there is no way for the app to query "any tenant's history" in one global check without a new SQL role or `SECURITY DEFINER` function, which felt like real scope creep for a PR meant to stay low-risk. A per-tenant check at request time is also the more correct behavior for a genuinely multi-tenant deployment, where different tenants could plausibly be re-embedded on different schedules. Control-plane's ingest path does not additionally block on this (that would prevent onboarding a tenant onto a new model, which is exactly how a migration is supposed to start); only the edge-api query path fails closed.

## Deferred to later PRs

- Resizing `rag_chunks.embedding` for a non-1024 dimension.
- Re-embedding existing documents onto a new model (the re-embed job).
- The admin-facing model-selection UI.

The demo's default configuration (`EMBEDDING_DIM=1024`, `qwen3-embedding-8b` route with `EMBEDDING_TRUNCATE_TO=1024`) is unchanged and still validates cleanly end to end.

## Test plan

- [x] `go build` for `apps/edge-api`, `apps/control-plane`, `packages/embedmodel` (via toolchain container)
- [x] `go vet` for the same packages
- [x] `go test ./apps/edge-api/internal/rag/... ./apps/control-plane/internal/rag/... ./packages/embedmodel/... -count=1` (all pass)
- [x] Full `go test ./apps/edge-api/... -short` and `./apps/control-plane/... -short` (all pass, no regressions)
- [x] `docker compose config` renders cleanly with `.env.example`, confirming `EMBEDDING_DIM`/`EMBEDDING_LOCAL_BASE_URL` resolve correctly for edge-api, control-plane, and litellm
- [x] `deploy/litellm/config.yaml` YAML syntax validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable embedding dimensions and truncation settings.
  * Added support for local or self-hosted embedding providers.
  * Added embedding model and dimension validation at startup.
  * Recorded embedding provenance for ingested documents.
  * Added safeguards that return a service-unavailable response when existing embeddings require re-embedding.

* **Documentation**
  * Expanded environment configuration guidance for embedding providers and routing.

* **Database**
  * Removed the fixed embedding-dimension constraint from document metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->