### PR TITLE
fix: copy packages/embedmodel into images (go.work build regression from #358)

### DIFF
--- a/deploy/docker/Dockerfile.agent-engine
+++ b/deploy/docker/Dockerfile.agent-engine
@@ -7,6 +7,7 @@ COPY apps/edge-api/go.mod apps/edge-api/go.sum* ./apps/edge-api/
 COPY apps/control-plane/go.mod apps/control-plane/go.sum* ./apps/control-plane/
 COPY packages/storage/go.mod packages/storage/go.sum* ./packages/storage/
 COPY packages/audit-canonical/go.mod packages/audit-canonical/go.sum* ./packages/audit-canonical/
+COPY packages/embedmodel/go.mod packages/embedmodel/go.sum* ./packages/embedmodel/
 RUN cd apps/agent-engine && go mod download
 COPY apps/agent-engine/ ./apps/agent-engine/
 RUN cd apps/agent-engine && go build -o /usr/local/bin/agent-engine ./cmd/agent-engine

--- a/deploy/docker/Dockerfile.control-plane
+++ b/deploy/docker/Dockerfile.control-plane
@@ -14,12 +14,14 @@ COPY apps/control-plane/go.mod apps/control-plane/go.sum* ./apps/control-plane/
 COPY apps/edge-api/go.mod apps/edge-api/go.sum* ./apps/edge-api/
 COPY packages/storage/go.mod packages/storage/go.sum* ./packages/storage/
 COPY packages/audit-canonical/go.mod packages/audit-canonical/go.sum* ./packages/audit-canonical/
+COPY packages/embedmodel/go.mod packages/embedmodel/go.sum* ./packages/embedmodel/
 COPY apps/agent-engine/go.mod apps/agent-engine/go.sum* ./apps/agent-engine/
 RUN cd apps/control-plane && go mod download
 
 COPY apps/control-plane/ ./apps/control-plane/
 COPY packages/storage/ ./packages/storage/
 COPY packages/audit-canonical/ ./packages/audit-canonical/
+COPY packages/embedmodel/ ./packages/embedmodel/
 # apps/agent-engine is a real module dependency of control-plane, not just a
 # manifest for module-cache warmup: apps/control-plane/go.mod replaces
 # github.com/sakibsadmanshajib/hive/apps/agent-engine with a local path

--- a/deploy/docker/Dockerfile.control-plane.prod
+++ b/deploy/docker/Dockerfile.control-plane.prod
@@ -24,12 +24,14 @@ COPY apps/control-plane/go.mod apps/control-plane/go.sum* ./apps/control-plane/
 COPY apps/edge-api/go.mod apps/edge-api/go.sum* ./apps/edge-api/
 COPY packages/storage/go.mod packages/storage/go.sum* ./packages/storage/
 COPY packages/audit-canonical/go.mod packages/audit-canonical/go.sum* ./packages/audit-canonical/
+COPY packages/embedmodel/go.mod packages/embedmodel/go.sum* ./packages/embedmodel/
 COPY apps/agent-engine/go.mod apps/agent-engine/go.sum* ./apps/agent-engine/
 RUN cd apps/control-plane && go mod download
 
 COPY apps/control-plane/ ./apps/control-plane/
 COPY packages/storage/ ./packages/storage/
 COPY packages/audit-canonical/ ./packages/audit-canonical/
+COPY packages/embedmodel/ ./packages/embedmodel/
 # apps/agent-engine is a real module dependency of control-plane, not just a
 # manifest for module-cache warmup: apps/control-plane/go.mod replaces
 # github.com/sakibsadmanshajib/hive/apps/agent-engine with a local path

--- a/deploy/docker/Dockerfile.edge-api
+++ b/deploy/docker/Dockerfile.edge-api
@@ -7,11 +7,13 @@ COPY apps/edge-api/go.mod apps/edge-api/go.sum* ./apps/edge-api/
 COPY apps/control-plane/go.mod apps/control-plane/go.sum* ./apps/control-plane/
 COPY packages/storage/go.mod packages/storage/go.sum* ./packages/storage/
 COPY packages/audit-canonical/go.mod packages/audit-canonical/go.sum* ./packages/audit-canonical/
+COPY packages/embedmodel/go.mod packages/embedmodel/go.sum* ./packages/embedmodel/
 COPY apps/agent-engine/go.mod apps/agent-engine/go.sum* ./apps/agent-engine/
 RUN cd apps/edge-api && go mod download
 COPY apps/edge-api/ ./apps/edge-api/
 COPY packages/storage/ ./packages/storage/
 COPY packages/audit-canonical/ ./packages/audit-canonical/
+COPY packages/embedmodel/ ./packages/embedmodel/
 COPY packages/openai-contract/matrix/support-matrix.json ./packages/openai-contract/matrix/support-matrix.json
 COPY packages/openai-contract/generated/hive-openapi.yaml ./packages/openai-contract/generated/hive-openapi.yaml
 EXPOSE 8080

--- a/deploy/docker/Dockerfile.edge-api.prod
+++ b/deploy/docker/Dockerfile.edge-api.prod
@@ -24,12 +24,14 @@ COPY apps/edge-api/go.mod apps/edge-api/go.sum* ./apps/edge-api/
 COPY apps/control-plane/go.mod apps/control-plane/go.sum* ./apps/control-plane/
 COPY packages/storage/go.mod packages/storage/go.sum* ./packages/storage/
 COPY packages/audit-canonical/go.mod packages/audit-canonical/go.sum* ./packages/audit-canonical/
+COPY packages/embedmodel/go.mod packages/embedmodel/go.sum* ./packages/embedmodel/
 COPY apps/agent-engine/go.mod apps/agent-engine/go.sum* ./apps/agent-engine/
 RUN cd apps/edge-api && go mod download
 
 COPY apps/edge-api/ ./apps/edge-api/
 COPY packages/storage/ ./packages/storage/
 COPY packages/audit-canonical/ ./packages/audit-canonical/
+COPY packages/embedmodel/ ./packages/embedmodel/
 COPY packages/openai-contract/matrix/support-matrix.json \
      ./packages/openai-contract/matrix/support-matrix.json
 COPY packages/openai-contract/generated/hive-openapi.yaml \


### PR DESCRIPTION
PR #358 added packages/embedmodel to go.work but not to the service Dockerfiles, so docker build fails with "cannot load module packages/embedmodel" on main. This blocks the compose stack, deploy-staging, and demo host builds. Same class as the agent-engine copy fixes in #340 and #343.

Adds the manifest and source COPY lines for packages/embedmodel, mirroring packages/audit-canonical, in all five affected Dockerfiles: Dockerfile.control-plane, Dockerfile.control-plane.prod, Dockerfile.edge-api, Dockerfile.edge-api.prod, Dockerfile.agent-engine.

Recommend a follow-up lint that fails when a go.work workspace package has no matching COPY in a service Dockerfile, since this regression class has now recurred three times (#340, #343, and this).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container builds for agent engine, control plane, and edge API services by ensuring all required embedded model dependencies are available during compilation.
  * Updated production and development build configurations to resolve dependencies consistently and reduce build failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->