### PR TITLE
fix: send LiteLLM auth header from RAG embed clients

### DIFF
--- a/apps/control-plane/cmd/server/main.go
+++ b/apps/control-plane/cmd/server/main.go
@@ -999,7 +999,7 @@ func main() {
 			if err := embedmodel.Validate(ragEmbedModel, ragEmbedDim, ragEmbedTruncateTo); err != nil {
 				log.Printf("ERROR: RAG embedding configuration is inconsistent, rag ingest route not registered: %v", err)
 			} else {
-				ragEmbedClient := cprag.NewHTTPEmbedClient(ragEmbedBaseURL, ragEmbedModel, ragEmbedTruncateTo)
+				ragEmbedClient := cprag.NewHTTPEmbedClient(ragEmbedBaseURL, ragEmbedModel, ragEmbedTruncateTo, resolveLiteLLMMasterKey())
 				ragIngester := cprag.NewIngester(ragRepo, ragEmbedClient, 0, ragEmbedModel)
 				cprag.RegisterRoutes(routerMux, func(ctx context.Context, tenantID, docID uuid.UUID, content string) error {
 					return ragIngester.Ingest(ctx, tenantID, docID, content)

--- a/apps/control-plane/internal/rag/embed_test.go
+++ b/apps/control-plane/internal/rag/embed_test.go
@@ -63,7 +63,7 @@ func TestHTTPEmbedClientTruncates(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewHTTPEmbedClient(srv.URL, "route-openrouter-embedding-fallback", 1024)
+	c := NewHTTPEmbedClient(srv.URL, "route-openrouter-embedding-fallback", 1024, "")
 	vecs, err := c.Embed(context.Background(), []string{"a", "b"})
 	if err != nil {
 		t.Fatalf("Embed() error = %v", err)
@@ -91,8 +91,56 @@ func TestHTTPEmbedClientStrictRejectByDefault(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewHTTPEmbedClient(srv.URL, "bge-m3", 0)
+	c := NewHTTPEmbedClient(srv.URL, "bge-m3", 0, "")
 	if _, err := c.Embed(context.Background(), []string{"hello"}); err == nil {
 		t.Fatal("expected dimension-mismatch error, got nil")
+	}
+}
+
+// TestHTTPEmbedClientSendsAuthHeaderWhenKeySet verifies the LiteLLM master key
+// is sent as a Bearer token so /v1/embeddings does not 401.
+func TestHTTPEmbedClientSendsAuthHeaderWhenKeySet(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		vec := make([]float32, EmbeddingDimension)
+		_ = json.NewEncoder(w).Encode(embedResponse{
+			Data: []struct {
+				Embedding []float32 `json:"embedding"`
+			}{{Embedding: vec}},
+		})
+	}))
+	defer srv.Close()
+
+	c := NewHTTPEmbedClient(srv.URL, "bge-m3", 0, "sk-test-key")
+	if _, err := c.Embed(context.Background(), []string{"hello"}); err != nil {
+		t.Fatalf("Embed() error = %v", err)
+	}
+	if gotAuth != "Bearer sk-test-key" {
+		t.Errorf("Authorization header = %q, want %q", gotAuth, "Bearer sk-test-key")
+	}
+}
+
+// TestHTTPEmbedClientOmitsAuthHeaderWhenKeyEmpty verifies a local backend
+// (e.g. Ollama) that needs no auth does not receive a bogus header.
+func TestHTTPEmbedClientOmitsAuthHeaderWhenKeyEmpty(t *testing.T) {
+	var sawAuth bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawAuth = r.Header.Get("Authorization") != ""
+		vec := make([]float32, EmbeddingDimension)
+		_ = json.NewEncoder(w).Encode(embedResponse{
+			Data: []struct {
+				Embedding []float32 `json:"embedding"`
+			}{{Embedding: vec}},
+		})
+	}))
+	defer srv.Close()
+
+	c := NewHTTPEmbedClient(srv.URL, "bge-m3", 0, "")
+	if _, err := c.Embed(context.Background(), []string{"hello"}); err != nil {
+		t.Fatalf("Embed() error = %v", err)
+	}
+	if sawAuth {
+		t.Error("expected no Authorization header when apiKey is empty")
 	}
 }

--- a/apps/control-plane/internal/rag/ingest.go
+++ b/apps/control-plane/internal/rag/ingest.go
@@ -30,6 +30,9 @@ type HTTPEmbedClient struct {
 	// many leading dimensions, then L2-renormalizes. 0 disables reduction: a
 	// non-EmbeddingDimension vector is rejected outright (see EMBEDDING_TRUNCATE_TO).
 	truncateTo int
+	// apiKey authenticates to the backend (LiteLLM requires it; a local
+	// bge-m3/Ollama endpoint does not). Empty means send no Authorization header.
+	apiKey string
 }
 
 // NewHTTPEmbedClient constructs the production embed client.
@@ -37,12 +40,15 @@ type HTTPEmbedClient struct {
 // model must be the alias returning EmbeddingDimension (or truncateTo) vectors, e.g. "bge-m3".
 // truncateTo: 0 requires the backend already return EmbeddingDimension;
 // otherwise the target width for MRL truncation (must equal EmbeddingDimension).
-func NewHTTPEmbedClient(baseURL, model string, truncateTo int) *HTTPEmbedClient {
+// apiKey is sent as a Bearer token when non-empty (LiteLLM's LITELLM_MASTER_KEY);
+// leave empty for backends that require no auth.
+func NewHTTPEmbedClient(baseURL, model string, truncateTo int, apiKey string) *HTTPEmbedClient {
 	return &HTTPEmbedClient{
 		baseURL:    strings.TrimRight(baseURL, "/"),
 		model:      model,
 		client:     &http.Client{Timeout: 30 * time.Second},
 		truncateTo: truncateTo,
+		apiKey:     apiKey,
 	}
 }
 
@@ -96,6 +102,9 @@ func (c *HTTPEmbedClient) Embed(ctx context.Context, inputs []string) ([][]float
 		return nil, fmt.Errorf("rag.embed: build request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
+	if c.apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	}
 
 	resp, err := c.client.Do(req)
 	if err != nil {

--- a/apps/edge-api/cmd/server/main.go
+++ b/apps/edge-api/cmd/server/main.go
@@ -309,7 +309,7 @@ func main() {
 		}
 		var ragEmbedder edgerag.Embedder
 		if ragEmbedBaseURL != "" {
-			ragEmbedder = edgerag.NewHTTPEmbedder(ragEmbedBaseURL, ragEmbedModel, ragEmbedTruncateTo)
+			ragEmbedder = edgerag.NewHTTPEmbedder(ragEmbedBaseURL, ragEmbedModel, ragEmbedTruncateTo, resolveLiteLLMMasterKey())
 		}
 		ragAudit := func(ctx context.Context, action, resourceType, resourceID, severity string,
 			tenantID, actorID uuid.UUID, userAgent string, after any) {

--- a/apps/edge-api/internal/rag/embed.go
+++ b/apps/edge-api/internal/rag/embed.go
@@ -28,6 +28,9 @@ type HTTPEmbedder struct {
 	// many leading dimensions, then L2-renormalizes. 0 disables reduction: a
 	// non-EmbeddingDimension vector is rejected outright (see EMBEDDING_TRUNCATE_TO).
 	truncateTo int
+	// apiKey authenticates to the backend (LiteLLM requires it; a local
+	// bge-m3/Ollama endpoint does not). Empty means send no Authorization header.
+	apiKey string
 }
 
 // NewHTTPEmbedder constructs the production embedder.
@@ -36,12 +39,16 @@ type HTTPEmbedder struct {
 // truncateTo: 0 to require the backend already return EmbeddingDimension;
 //
 //	otherwise the target width for MRL truncation (must equal EmbeddingDimension).
-func NewHTTPEmbedder(baseURL, model string, truncateTo int) *HTTPEmbedder {
+//
+// apiKey is sent as a Bearer token when non-empty (LiteLLM's LITELLM_MASTER_KEY);
+// leave empty for backends that require no auth.
+func NewHTTPEmbedder(baseURL, model string, truncateTo int, apiKey string) *HTTPEmbedder {
 	return &HTTPEmbedder{
 		baseURL:    strings.TrimRight(baseURL, "/"),
 		model:      model,
 		client:     &http.Client{Timeout: 30 * time.Second},
 		truncateTo: truncateTo,
+		apiKey:     apiKey,
 	}
 }
 
@@ -94,6 +101,9 @@ func (e *HTTPEmbedder) Embed(ctx context.Context, text string) ([]float32, error
 		return nil, fmt.Errorf("rag.embed: build request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
+	if e.apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+e.apiKey)
+	}
 
 	resp, err := e.client.Do(req)
 	if err != nil {

--- a/apps/edge-api/internal/rag/embed_test.go
+++ b/apps/edge-api/internal/rag/embed_test.go
@@ -71,7 +71,7 @@ func TestHTTPEmbedderTruncates(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	e := NewHTTPEmbedder(srv.URL, "route-openrouter-embedding-fallback", 1024)
+	e := NewHTTPEmbedder(srv.URL, "route-openrouter-embedding-fallback", 1024, "")
 	vec, err := e.Embed(context.Background(), "hello")
 	if err != nil {
 		t.Fatalf("Embed() error = %v", err)
@@ -94,8 +94,56 @@ func TestHTTPEmbedderStrictRejectByDefault(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	e := NewHTTPEmbedder(srv.URL, "bge-m3", 0)
+	e := NewHTTPEmbedder(srv.URL, "bge-m3", 0, "")
 	if _, err := e.Embed(context.Background(), "hello"); err == nil {
 		t.Fatal("expected dimension-mismatch error, got nil")
+	}
+}
+
+// TestHTTPEmbedderSendsAuthHeaderWhenKeySet verifies the LiteLLM master key
+// is sent as a Bearer token so /v1/embeddings does not 401.
+func TestHTTPEmbedderSendsAuthHeaderWhenKeySet(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		vec := make([]float32, EmbeddingDimension)
+		_ = json.NewEncoder(w).Encode(embedResp{
+			Data: []struct {
+				Embedding []float32 `json:"embedding"`
+			}{{Embedding: vec}},
+		})
+	}))
+	defer srv.Close()
+
+	e := NewHTTPEmbedder(srv.URL, "bge-m3", 0, "sk-test-key")
+	if _, err := e.Embed(context.Background(), "hello"); err != nil {
+		t.Fatalf("Embed() error = %v", err)
+	}
+	if gotAuth != "Bearer sk-test-key" {
+		t.Errorf("Authorization header = %q, want %q", gotAuth, "Bearer sk-test-key")
+	}
+}
+
+// TestHTTPEmbedderOmitsAuthHeaderWhenKeyEmpty verifies a local backend
+// (e.g. Ollama) that needs no auth does not receive a bogus header.
+func TestHTTPEmbedderOmitsAuthHeaderWhenKeyEmpty(t *testing.T) {
+	var sawAuth bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawAuth = r.Header.Get("Authorization") != ""
+		vec := make([]float32, EmbeddingDimension)
+		_ = json.NewEncoder(w).Encode(embedResp{
+			Data: []struct {
+				Embedding []float32 `json:"embedding"`
+			}{{Embedding: vec}},
+		})
+	}))
+	defer srv.Close()
+
+	e := NewHTTPEmbedder(srv.URL, "bge-m3", 0, "")
+	if _, err := e.Embed(context.Background(), "hello"); err != nil {
+		t.Fatalf("Embed() error = %v", err)
+	}
+	if sawAuth {
+		t.Error("expected no Authorization header when apiKey is empty")
 	}
 }


### PR DESCRIPTION
## Summary

RAG ingest and POST /v1/rag/chat were failing because LiteLLM requires an API key on every call. Neither RAG embed client sent one, so LiteLLM rejected the request with 401 No api key passed in, which the callers correctly turned into a provider-blind 503.

- Added an `apiKey` field to `HTTPEmbedClient` (control-plane, `apps/control-plane/internal/rag/ingest.go`) and `HTTPEmbedder` (edge-api, `apps/edge-api/internal/rag/embed.go`), threaded through their constructors.
- `Embed` now sets `Authorization: Bearer <apiKey>` only when apiKey is non-empty, so a local bge-m3/Ollama backend that needs no auth is never sent a bogus header.
- Both call sites (`apps/control-plane/cmd/server/main.go`, `apps/edge-api/cmd/server/main.go`) now pass `resolveLiteLLMMasterKey()`, the same resolver already used for the working batch store and inference clients in each service.
- Did not touch embedding dimension or registry logic (already covered by a separate, already-merged fix).

## Test plan

- [x] `go build ./apps/control-plane/... ./apps/edge-api/...` (toolchain container)
- [x] `go test ./apps/control-plane/internal/rag/... ./apps/edge-api/internal/rag/... -count=1` (toolchain container), all green
- [x] New tests in both packages assert the Authorization header is set when apiKey is non-empty and absent when apiKey is empty