### PR TITLE
refactor: rename retired carl feature gate category

### DIFF
--- a/apps/control-plane/internal/featuregate/admin_test.go
+++ b/apps/control-plane/internal/featuregate/admin_test.go
@@ -69,7 +69,7 @@ func withViewer(req *http.Request, v auth.Viewer) *http.Request {
 func TestAdmin_List_MergesRegistryAndEnablement(t *testing.T) {
 	store := &fakeAdminStore{
 		registry: []settings.GateKey{
-			{Key: settings.EnableRAG, Label: "Carl.sh RAG capability", Category: "carl"},
+			{Key: settings.EnableRAG, Label: "Agent RAG capability", Category: "agents"},
 			{Key: settings.EnablePublicBilling, Label: "Public billing", Category: "billing"},
 		},
 		enabled: map[settings.Key]bool{settings.EnableRAG: true},
@@ -95,7 +95,7 @@ func TestAdmin_List_MergesRegistryAndEnablement(t *testing.T) {
 	if resp.Gates[0].Key != string(settings.EnableRAG) || !resp.Gates[0].Enabled {
 		t.Errorf("gate[0] = %+v, want RAG enabled", resp.Gates[0])
 	}
-	if resp.Gates[0].Label != "Carl.sh RAG capability" || resp.Gates[0].Category != "carl" {
+	if resp.Gates[0].Label != "Agent RAG capability" || resp.Gates[0].Category != "agents" {
 		t.Errorf("gate[0] label/category = %q/%q", resp.Gates[0].Label, resp.Gates[0].Category)
 	}
 	// A registered key with no tenant_settings row defaults to disabled.

--- a/apps/control-plane/internal/featuregate/handler.go
+++ b/apps/control-plane/internal/featuregate/handler.go
@@ -5,7 +5,7 @@
 // GET /internal/featuregate/{tenant_id}
 //
 // The tenant_id path segment is the UUID of the requesting tenant. The
-// handler resolves the client-visible gate keys (categories carl and sso)
+// handler resolves the client-visible gate keys (categories agents and sso)
 // from the tenant_settings table via the shared settings.Resolver in a
 // single call. The response is a flat key->bool map; unknown/unset keys
 // default to false. Admin, billing, and audit_sink gates are deliberately
@@ -41,7 +41,7 @@ type FlagsResponse struct {
 }
 
 // Resolver is the narrow interface the handler needs from settings.Resolver.
-// ClientVisibleEnabled resolves only the client-visible gate keys (carl, sso)
+// ClientVisibleEnabled resolves only the client-visible gate keys (agents, sso)
 // for tenantID in one call; see settings.Resolver.ClientVisibleEnabled. The
 // full set (settings.Resolver.AllEnabled) is intentionally not used here so
 // admin/billing/audit_sink gates cannot leak to the client.

--- a/apps/control-plane/internal/tenant/settings/keys.go
+++ b/apps/control-plane/internal/tenant/settings/keys.go
@@ -36,7 +36,8 @@ const (
 	EnableAdminConsole      Key = "ENABLE_ADMIN_CONSOLE"
 	EnableProviderCustom    Key = "ENABLE_PROVIDER_CUSTOM"
 
-	// Carl.sh sovereign workspace feature gates (issue #238).
+	// Agent-subsystem feature gates (issue #238; "carl" category retired,
+	// see 20260719_01_rename_carl_feature_category.sql).
 	EnableRAG    Key = "ENABLE_RAG"
 	EnableVoice  Key = "ENABLE_VOICE"
 	EnableRelay  Key = "ENABLE_RELAY"

--- a/apps/control-plane/internal/tenant/settings/resolver.go
+++ b/apps/control-plane/internal/tenant/settings/resolver.go
@@ -97,15 +97,16 @@ func (r *Resolver) refresh(ctx context.Context, tenantID uuid.UUID, key Key) (en
 // clientVisibleGateCategories is the allowlist of feature_gate_keys.category
 // values that are safe to expose to an authenticated end user or OWUI Function
 // (issue #293 security review). It covers only capability gates a client needs
-// to adapt its own UI: carl (the RAG/voice/relay/cowork feature keys) and sso.
+// to adapt its own UI: agents (the RAG/voice/relay/cowork feature keys, née
+// "carl" before the product-name retirement) and sso.
 // The admin, billing, and audit_sink categories are deliberately excluded:
 // exposing them would leak the deployment's commercial and operational posture
 // to any authenticated user, the same information-disclosure class the
 // 20260715_04 migration avoided by not granting feature_gate_keys to the
 // authenticated role. Fail-closed: a newly added category is excluded here
 // until it is explicitly listed, so a new admin/billing key never leaks by
-// default while a new carl/sso key is exposed automatically.
-var clientVisibleGateCategories = []string{"carl", "sso"}
+// default while a new agents/sso key is exposed automatically.
+var clientVisibleGateCategories = []string{"agents", "sso"}
 
 // AllEnabled resolves every gate key registered in public.feature_gate_keys
 // for tenantID in a single query, returning enabled=false for any key with no
@@ -122,13 +123,13 @@ func (r *Resolver) AllEnabled(ctx context.Context, tenantID uuid.UUID) (map[Key]
 }
 
 // ClientVisibleEnabled resolves only the gate keys whose
-// feature_gate_keys.category is in clientVisibleGateCategories (carl, sso):
+// feature_gate_keys.category is in clientVisibleGateCategories (agents, sso):
 // the subset safe to expose to an authenticated end user or OWUI Function
 // (issue #293 security review). It backs the control-plane featuregate
 // endpoint, which feeds edge-api's Gate/Require and the /v1/featuregate read
 // surface, so admin, billing, and audit_sink gates never leave control-plane.
 // Fail-closed: a new category is excluded until added to the allowlist, so a
-// new admin/billing key never leaks by default while a new carl/sso key is
+// new admin/billing key never leaks by default while a new agents/sso key is
 // exposed automatically.
 func (r *Resolver) ClientVisibleEnabled(ctx context.Context, tenantID uuid.UUID) (map[Key]bool, error) {
 	return r.gateMap(ctx, tenantID, clientVisibleGateCategories)

--- a/apps/control-plane/internal/tenant/settings/resolver_test.go
+++ b/apps/control-plane/internal/tenant/settings/resolver_test.go
@@ -46,7 +46,7 @@ func TestResolver_IsEnabled_ReadsValue(t *testing.T) {
 // TestResolver_ClientVisibleEnabled_ExcludesSensitiveCategories is the #293
 // security-review guard: ClientVisibleEnabled backs the featuregate response
 // that reaches Open WebUI via GET /v1/featuregate, so it must expose only
-// client-visible categories (carl, sso). Enabling one key in each sensitive
+// client-visible categories (agents, sso). Enabling one key in each sensitive
 // category proves none of admin, billing, or audit_sink ever appears in the
 // map, closing the information-disclosure blind spot.
 func TestResolver_ClientVisibleEnabled_ExcludesSensitiveCategories(t *testing.T) {
@@ -64,7 +64,7 @@ func TestResolver_ClientVisibleEnabled_ExcludesSensitiveCategories(t *testing.T)
 		settings.EnableAdminConsole,    // admin
 		settings.EnableStripe,          // billing
 		settings.EnableAuditSinkSentry, // audit_sink
-		settings.EnableRAG,             // carl (client-visible)
+		settings.EnableRAG,             // agents (client-visible)
 		settings.EnableSSOGoogle,       // sso (client-visible)
 	} {
 		_, err := pool.Exec(ctx,
@@ -77,7 +77,7 @@ func TestResolver_ClientVisibleEnabled_ExcludesSensitiveCategories(t *testing.T)
 	require.NoError(t, err)
 
 	// Client-visible categories are returned.
-	require.True(t, gates[settings.EnableRAG], "carl gate must be exposed")
+	require.True(t, gates[settings.EnableRAG], "agents gate must be exposed")
 	require.True(t, gates[settings.EnableSSOGoogle], "sso gate must be exposed")
 
 	// Sensitive categories must be absent entirely, not merely false.
@@ -114,7 +114,7 @@ func TestResolver_AllEnabled_ReturnsFullSet(t *testing.T) {
 		settings.EnableAdminConsole,    // admin
 		settings.EnableStripe,          // billing
 		settings.EnableAuditSinkSentry, // audit_sink
-		settings.EnableRAG,             // carl
+		settings.EnableRAG,             // agents
 	} {
 		_, err := pool.Exec(ctx,
 			`INSERT INTO public.tenant_settings(tenant_id, key, enabled) VALUES ($1, $2::public.tenant_setting_key, true)`,

--- a/apps/edge-api/internal/featuregate/handler.go
+++ b/apps/edge-api/internal/featuregate/handler.go
@@ -23,7 +23,7 @@ package featuregate
 // Client-safety (issue #293 security review): this endpoint returns the gate map
 // verbatim, so it must only ever contain client-visible gates. That guarantee is
 // enforced upstream in control-plane, settings.Resolver.ClientVisibleEnabled
-// filters to the client-visible category allowlist (carl, sso), so admin,
+// filters to the client-visible category allowlist (agents, sso), so admin,
 // billing, and audit_sink gates never reach edge-api and cannot leak here. This
 // handler adds no keys of its own.
 //

--- a/apps/web-console/components/feature-gates/feature-gate-manager.test.tsx
+++ b/apps/web-console/components/feature-gates/feature-gate-manager.test.tsx
@@ -5,7 +5,7 @@ import { FeatureGateManager } from "./feature-gate-manager";
 import type { FeatureGate } from "@/lib/control-plane/client";
 
 const GATES: FeatureGate[] = [
-  { key: "ENABLE_RAG", label: "Carl.sh RAG capability", category: "carl", enabled: false },
+  { key: "ENABLE_RAG", label: "Agent RAG capability", category: "agents", enabled: false },
   { key: "ENABLE_PUBLIC_BILLING", label: "Public billing", category: "billing", enabled: true },
 ];
 
@@ -18,7 +18,7 @@ describe("FeatureGateManager", () => {
   it("renders each gate label, raw key, and grouped category headings", () => {
     render(<FeatureGateManager gates={GATES} />);
     // getByText throws if absent, so the calls themselves assert presence.
-    expect(screen.getByText("Carl.sh RAG capability")).toBeTruthy();
+    expect(screen.getByText("Agent RAG capability")).toBeTruthy();
     expect(screen.getByText("ENABLE_RAG")).toBeTruthy();
     expect(screen.getByText("Sovereign workspace")).toBeTruthy();
     expect(screen.getByText("Billing & payments")).toBeTruthy();
@@ -26,7 +26,7 @@ describe("FeatureGateManager", () => {
 
   it("reflects initial enabled state on the switches", () => {
     render(<FeatureGateManager gates={GATES} />);
-    const rag = screen.getByRole("switch", { name: /Carl\.sh RAG capability/i });
+    const rag = screen.getByRole("switch", { name: /Agent RAG capability/i });
     const billing = screen.getByRole("switch", { name: /Public billing/i });
     expect(rag.getAttribute("aria-checked")).toBe("false");
     expect(billing.getAttribute("aria-checked")).toBe("true");
@@ -41,7 +41,7 @@ describe("FeatureGateManager", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     render(<FeatureGateManager gates={GATES} />);
-    const rag = screen.getByRole("switch", { name: /Carl\.sh RAG capability/i });
+    const rag = screen.getByRole("switch", { name: /Agent RAG capability/i });
     fireEvent.click(rag);
 
     await waitFor(() => {
@@ -63,7 +63,7 @@ describe("FeatureGateManager", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     render(<FeatureGateManager gates={GATES} />);
-    const rag = screen.getByRole("switch", { name: /Carl\.sh RAG capability/i });
+    const rag = screen.getByRole("switch", { name: /Agent RAG capability/i });
     fireEvent.click(rag);
 
     await waitFor(() => {

--- a/apps/web-console/components/feature-gates/feature-gate-manager.tsx
+++ b/apps/web-console/components/feature-gates/feature-gate-manager.tsx
@@ -17,7 +17,7 @@ type RowStatus = "idle" | "saving" | "error";
 // migration still renders sensibly without a code change.
 const CATEGORY_LABELS: Record<string, string> = {
   billing: "Billing & payments",
-  carl: "Sovereign workspace",
+  agents: "Sovereign workspace",
   audit: "Audit sinks",
   sso: "Single sign-on",
   feature: "Platform features",

--- a/supabase/migrations/20260719_01_rename_carl_feature_category.sql
+++ b/supabase/migrations/20260719_01_rename_carl_feature_category.sql
@@ -1,0 +1,49 @@
+-- Rename the retired "carl" feature-gate category to "agents" (owner
+-- decision: the Carl.sh product name is retired repo-wide; this is the last
+-- client-visible surface still carrying it).
+--
+-- public.feature_gate_keys.category = 'carl' groups ENABLE_RAG, ENABLE_VOICE,
+-- ENABLE_RELAY, ENABLE_COWORK (see 20260715_04_featuregate_dynamic_keys.sql).
+-- These are the agent-subsystem capability keys (RAG, voice, relay, cowork),
+-- so "agents" replaces "carl" as the category value. The per-row labels also
+-- carried the retired product name ("Carl.sh <x> capability") and are
+-- rewritten to match ("Agent <x> capability").
+--
+-- apps/control-plane/internal/tenant/settings/resolver.go's
+-- clientVisibleGateCategories allowlist is updated in the same PR to read
+-- "agents" instead of "carl"; this migration and that code change must ship
+-- together; a rollback of one requires reverting the other before the client
+-- endpoint (control-plane featuregate handler, edge-api /v1/featuregate) sees
+-- these keys reappear.
+--
+-- Breaking change: any consumer keyed off category="carl" (admin console
+-- category grouping, future third-party integrations) must be updated. No
+-- API shape change: keys, labels' meaning, and enabled state are unaffected,
+-- only the category string and label text.
+--
+-- Idempotent: both UPDATEs are no-ops once applied (WHERE clauses match
+-- nothing on a second run).
+
+BEGIN;
+
+UPDATE public.feature_gate_keys
+   SET category = 'agents'
+ WHERE category = 'carl';
+
+UPDATE public.feature_gate_keys
+   SET label = 'Agent RAG capability'
+ WHERE key = 'ENABLE_RAG' AND label = 'Carl.sh RAG capability';
+
+UPDATE public.feature_gate_keys
+   SET label = 'Agent voice capability'
+ WHERE key = 'ENABLE_VOICE' AND label = 'Carl.sh voice capability';
+
+UPDATE public.feature_gate_keys
+   SET label = 'Agent relay capability'
+ WHERE key = 'ENABLE_RELAY' AND label = 'Carl.sh relay capability';
+
+UPDATE public.feature_gate_keys
+   SET label = 'Agent cowork capability'
+ WHERE key = 'ENABLE_COWORK' AND label = 'Carl.sh cowork capability';
+
+COMMIT;


### PR DESCRIPTION
## Summary

The Carl.sh product name is retired repo-wide (owner decision). One client-visible surface still carried it: the feature-gate category `carl`, covering `ENABLE_RAG`, `ENABLE_VOICE`, `ENABLE_RELAY`, `ENABLE_COWORK` in `public.feature_gate_keys`, read by `apps/control-plane/internal/tenant/settings/resolver.go`'s `clientVisibleGateCategories` allowlist and surfaced to Open WebUI / the admin console.

## Blast radius investigated

Grepped `apps/`, `packages/`, `supabase/`, `deploy/`, `tools/`, and web-console source (excluding `node_modules`, `vendor`, `graphify-out`, `.git`, `.wolf`) case-insensitively for "carl". Only one literal code string, `apps/control-plane/internal/tenant/settings/resolver.go:108` (`clientVisibleGateCategories = []string{"carl", "sso"}`), plus comments referencing it and two test fixtures with hardcoded `"carl"` / `"Carl.sh <x> capability"` strings mirroring the DB row values. Historical migration files and `deploy/docker/docker-compose.yml` comments that mention "Carl.sh" as a past product name are left untouched: they document already-applied schema history, not the live feature-gate category, and are out of scope for this rename.

## New name: `agents`

The four keys this category gates (RAG, voice, relay, cowork) are exactly the agent-subsystem capability keys, so `agents` was chosen over `enterprise`.

## Changes

- `apps/control-plane/internal/tenant/settings/resolver.go`: `clientVisibleGateCategories` allowlist `"carl"` to `"agents"`, comments updated.
- `apps/control-plane/internal/tenant/settings/keys.go`, `apps/control-plane/internal/featuregate/handler.go`, `apps/edge-api/internal/featuregate/handler.go`: comments updated.
- `apps/web-console/components/feature-gates/feature-gate-manager.tsx`: `CATEGORY_LABELS` map key `carl` to `agents` (display value "Sovereign workspace" unchanged).
- Go tests (`resolver_test.go`, `admin_test.go`) and the Vitest suite (`feature-gate-manager.test.tsx`) updated first (TDD), then the implementation, to expect `agents` and the new `"Agent <x> capability"` labels.
- New migration `supabase/migrations/20260719_01_rename_carl_feature_category.sql`: idempotent `UPDATE` against `public.feature_gate_keys` that rewrites the stored `category` value and the four `"Carl.sh <x> capability"` labels to `"Agent <x> capability"`.

## Breaking change

This is a breaking API change (owner-approved): any consumer keyed off `category="carl"` (admin console grouping, any external integration) must move to `"agents"`. Gate keys, semantics, and enabled state are unaffected, only the category string and label text.

The migration and the code change in this PR must ship together; reverting one without the other will desync the DB-stored category from the Go allowlist.

## Test plan

- [x] `go test ./apps/control-plane/... ./apps/edge-api/... -count=1 -short` via `docker compose --profile tools run --rm --remove-orphans -T toolchain "cd /workspace && go test ..."` — all packages pass, no FAIL.
- [x] `npx vitest run components/feature-gates/feature-gate-manager.test.tsx` via `docker compose run --rm --build --entrypoint sh web-console` — 4/4 tests pass.
- [ ] Apply migration against a staging/test database and confirm existing `carl`-category rows read back as `agents` with updated labels.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>