### PR TITLE
ci: reconcile branch protection config, staging triggers, and nightly workflow name

### DIFF
--- a/.github/MERGE-POLICY.md
+++ b/.github/MERGE-POLICY.md
@@ -20,13 +20,12 @@ bypassed from the CLI or UI.
 | `allow_deletions` | `false` | `main` cannot be deleted |
 
 ### Required status checks
+- `Go tests (agent-engine)`
 - `Go tests (control-plane)`
 - `Go tests (edge-api)`
 - `Go tests (storage)`
 - `Repo policy lints (tenant + audit)`
 - `Web console (type + unit + build)`
-- `Live integration (SDK tests + smoke)`
-- `Web E2E (full stack)`
 
 These are the jobs in `.github/workflows/ci.yml`, which runs on every
 same-repo pull request with no path filter (so it never deadlocks a PR).

--- a/.github/branch-protection-main.json
+++ b/.github/branch-protection-main.json
@@ -7,8 +7,7 @@
       "Go tests (edge-api)",
       "Go tests (storage)",
       "Repo policy lints (tenant + audit)",
-      "Web console (type + unit + build)",
-      "Web E2E (full stack)"
+      "Web console (type + unit + build)"
     ]
   },
   "enforce_admins": true,

--- a/.github/workflows/owui-nightly.yml
+++ b/.github/workflows/owui-nightly.yml
@@ -1,4 +1,4 @@
-name: phase-19-owui-nightly
+name: OWUI nightly e2e
 
 on:
   schedule:
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: phase-19-owui-${{ github.ref }}
+  group: owui-nightly-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -302,5 +302,5 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
           curl -fsSL -X POST -H 'Content-Type: application/json' \
-            -d '{"text":"phase-19-owui-nightly red — see GHA run"}' \
+            -d '{"text":"OWUI nightly e2e red, see GHA run"}' \
             "$SLACK_WEBHOOK_URL"


### PR DESCRIPTION
## Summary

Reconciles committed CI policy artifacts with the live GitHub configuration and cleans up a stale workflow name. Live branch protection was not modified; the committed config was relaxed to match it.

### 1. Branch protection config matches live protection

Live protection snapshot used (from `gh api repos/sakibsadmanshajib/hive/branches/main/protection`, 2026-07-19, strict=false):

- Go tests (control-plane)
- Go tests (edge-api)
- Go tests (storage)
- Go tests (agent-engine)
- Repo policy lints (tenant + audit)
- Web console (type + unit + build)

`.github/branch-protection-main.json` listed a seventh check, "Web E2E (full stack)", which is not required live. It is removed so re-applying the committed config does not accidentally tighten protection onto a check that no longer reports.

### 2. MERGE-POLICY.md required-check list corrected

The list dropped "Live integration (SDK tests + smoke)" and "Web E2E (full stack)" (not required live) and gained "Go tests (agent-engine)" (required live but missing from the doc). Policy prose is unchanged.

### 3. deploy-staging.yml triggers: verified, no change

All trigger paths were inspected against what the workflow actually builds and deploys, and none are no-ops:

- `apps/web-console/**` feeds the `deploy-workers` job, which builds and deploys the web console to Cloudflare Workers on every staging deploy.
- `packages/**` feeds the Go image builds through `go.work` use directives (`packages/storage`, `packages/audit-canonical`, `packages/embedmodel` are compiled into edge-api and control-plane images) and the `sdk-replay` job runs `packages/sdk-tests`.
- The remaining paths (`apps/edge-api`, `apps/control-plane`, `deploy/docker`, `deploy/litellm`, the workflow file itself) map directly to the images and configs shipped to the OCI VM.

Removing any of them would silently skip deploys for changes that ship to staging, so the trigger list stands as is.

### 4. Stale workflow renamed

`phase-19-owui-nightly.yml` is renamed to `owui-nightly.yml`, its `name:` is now "OWUI nightly e2e", and the internal concurrency group and Slack failure message no longer reference phase 19. A repo-wide search found no other references to the old filename or workflow name (only session memory files under `.wolf/`, which are not code).

## Test plan

- [x] `python3 yaml.safe_load` passes on the renamed workflow
- [x] `json.load` passes on the protection config
- [x] Committed protection config now equals the live required-check set exactly
- [x] No remaining references to the old workflow name in `.github/`, `scripts/`, `tools/`, or docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)