### PR TITLE
feat: admin-selectable embedding model and dimension with dynamic vector provisioning

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -97,19 +97,23 @@ EMBEDDING_BASE_URL=http://litellm:4000
 # qwen3-embedding-8b). Enterprise/Ollama alternative: bge-m3 (multilingual,
 # Bangla, native 1024-dim).
 EMBEDDING_MODEL=route-openrouter-embedding-fallback
-# EMBEDDING_DIM: the vector width EMBEDDING_MODEL is expected to produce
-# (after EMBEDDING_TRUNCATE_TO, if set). Must match rag_chunks.embedding's
-# column width -- today always 1024, so leave this at the default unless you
-# have also resized that column (a separate migration; not part of this env
-# var). At startup, packages/embedmodel cross-checks EMBEDDING_MODEL's known
-# native dimension against EMBEDDING_DIM + EMBEDDING_TRUNCATE_TO and disables
-# /v1/rag/* embedding rather than start with an inconsistent combination.
+# EMBEDDING_DIM: the vector width the RAG column is provisioned to and that
+# EMBEDDING_MODEL is served at. Demo default 1024 -> vector(1024) HNSW cosine,
+# matching rag_chunks.embedding. packages/embedmodel resolves EMBEDDING_MODEL +
+# EMBEDDING_DIM into a single plan at startup: it maps the dimension to the
+# pgvector type (1..2000 vector, 2001..4000 halfvec, >4000 brute-force opt-in),
+# derives any MRL reduction, and rejects non-selectable combinations (a non-MRL
+# model below its native width, a dim wider than native). There is NO separate
+# truncate knob: for the qwen3 demo (MRL, native 4096) the endpoint is asked
+# for `dimensions=1024` and a client-side MRL reduce is the fallback. A rejected
+# or config-mismatched combination disables /v1/rag/* rather than start
+# inconsistent. Changing this from the provisioned value re-provisions the
+# column and re-embeds the corpus (control-plane provisioning routine).
 EMBEDDING_DIM=1024
-# EMBEDDING_TRUNCATE_TO: set only for MRL-trained models whose native width
-# exceeds EMBEDDING_DIM (e.g. qwen3-embedding-8b and the Nemotron-Embed VL
-# primary both return 4096 natively). 0/unset keeps the strict reject so a
-# non-MRL model never gets silently truncated to the wrong width.
-EMBEDDING_TRUNCATE_TO=1024
+# EMBEDDING_ALLOW_UNINDEXED: set to 1 only to store a >4000-dim embedding as an
+# unindexed brute-force column (no ANN index, sequential-scan search, small
+# corpus only). Off by default; selectable indexed dims stay <=4000.
+EMBEDDING_ALLOW_UNINDEXED=0
 # EMBEDDING_LOCAL_BASE_URL: only used by the enterprise/self-host profile's
 # bge-m3 LiteLLM route (deploy/litellm/config.yaml). Point at wherever bge-m3
 # is actually served, e.g. http://ollama:11434/v1. Unused by the serverless

--- a/apps/control-plane/cmd/server/main.go
+++ b/apps/control-plane/cmd/server/main.go
@@ -969,7 +969,6 @@ func main() {
 		if ragEmbedBaseURL == "" {
 			log.Println("WARNING: EMBEDDING_BASE_URL not set; rag ingest route not registered (uploaded documents will stay pending)")
 		} else {
-			ragRepo := cprag.NewRepo(pool)
 			// EMBEDDING_DIM: overwrites cprag.EmbeddingDimension's default
 			// (1024) so ingest's dimension checks and rag_documents.embedding_dim
 			// provenance both follow config, not a compile-time constant.
@@ -1011,6 +1010,9 @@ func main() {
 			case !ragConfigMatches:
 				log.Printf("ERROR: RAG embedding config mismatch (env model=%s dim=%d) vs provisioned rag_embedding_config, rag ingest route not registered; provision + re-embed to switch models", ragEmbedModel, ragEmbedDim)
 			default:
+				// plan.PgType selects the SearchChunks query-vector cast so a
+				// halfvec-provisioned column is queried with ::halfvec.
+				ragRepo := cprag.NewRepo(pool, plan.PgType)
 				ragEmbedClient := cprag.NewHTTPEmbedClient(ragEmbedBaseURL, ragEmbedModel, plan.ReduceTo, resolveLiteLLMMasterKey())
 				ragIngester := cprag.NewIngester(ragRepo, ragEmbedClient, 0, ragEmbedModel)
 				cprag.RegisterRoutes(routerMux, func(ctx context.Context, tenantID, docID uuid.UUID, content string) error {

--- a/apps/control-plane/cmd/server/main.go
+++ b/apps/control-plane/cmd/server/main.go
@@ -970,16 +970,9 @@ func main() {
 			log.Println("WARNING: EMBEDDING_BASE_URL not set; rag ingest route not registered (uploaded documents will stay pending)")
 		} else {
 			ragRepo := cprag.NewRepo(pool)
-			ragEmbedTruncateToRaw := strings.TrimSpace(os.Getenv("EMBEDDING_TRUNCATE_TO"))
-			ragEmbedTruncateTo, err := strconv.Atoi(ragEmbedTruncateToRaw)
-			if ragEmbedTruncateToRaw != "" && err != nil {
-				log.Printf("WARNING: EMBEDDING_TRUNCATE_TO=%q is not a valid integer; truncation disabled (strict dimension reject applies)", ragEmbedTruncateToRaw)
-				ragEmbedTruncateTo = 0
-			}
-			// EMBEDDING_DIM: see the matching comment in edge-api/cmd/server/main.go.
-			// Overwrites cprag.EmbeddingDimension's default (1024) so ingest's
-			// dimension checks and rag_documents.embedding_dim provenance both
-			// follow config instead of a compile-time constant.
+			// EMBEDDING_DIM: overwrites cprag.EmbeddingDimension's default
+			// (1024) so ingest's dimension checks and rag_documents.embedding_dim
+			// provenance both follow config, not a compile-time constant.
 			ragEmbedDimRaw := strings.TrimSpace(os.Getenv("EMBEDDING_DIM"))
 			ragEmbedDim := cprag.EmbeddingDimension
 			if ragEmbedDimRaw != "" {
@@ -991,15 +984,34 @@ func main() {
 			}
 			cprag.EmbeddingDimension = ragEmbedDim
 
-			// embedmodel.Validate: see the matching comment in
-			// edge-api/cmd/server/main.go. A known but inconsistent
-			// model/dim/truncateTo combination disables ingestion the same way
-			// an unset EMBEDDING_BASE_URL does above, instead of embedding and
-			// storing vectors of the wrong width.
-			if err := embedmodel.Validate(ragEmbedModel, ragEmbedDim, ragEmbedTruncateTo); err != nil {
-				log.Printf("ERROR: RAG embedding configuration is inconsistent, rag ingest route not registered: %v", err)
-			} else {
-				ragEmbedClient := cprag.NewHTTPEmbedClient(ragEmbedBaseURL, ragEmbedModel, ragEmbedTruncateTo, resolveLiteLLMMasterKey())
+			// EMBEDDING_ALLOW_UNINDEXED: see edge-api/cmd/server/main.go. Opts a
+			// >4000-dim configuration into an unindexed brute-force column.
+			ragAllowUnindexedRaw := strings.TrimSpace(os.Getenv("EMBEDDING_ALLOW_UNINDEXED"))
+			ragEmbedAllowUnindexed := ragAllowUnindexedRaw == "1" || strings.EqualFold(ragAllowUnindexedRaw, "true")
+
+			// Cross-service reconcile (#368): compare env config against the
+			// active rag_embedding_config row the column was provisioned to.
+			ragConfigMatches := true
+			if active, found, cerr := cprag.LoadActiveConfig(runCtx, pool); cerr != nil {
+				log.Printf("WARNING: could not read rag_embedding_config, proceeding on env config only: %v", cerr)
+			} else if found && !embedmodel.SameConfig(ragEmbedModel, ragEmbedDim, active.Model, active.Dim) {
+				ragConfigMatches = false
+			}
+
+			// embedmodel.Resolve is the single source of truth: it derives the
+			// MRL reduction target (plan.ReduceTo) and rejects non-selectable
+			// combinations. There is no independent EMBEDDING_TRUNCATE_TO knob.
+			// A rejected or config-mismatched combination leaves the ingest
+			// route unmounted, the same fail-closed posture as an unset
+			// EMBEDDING_BASE_URL above.
+			plan, rerr := embedmodel.Resolve(ragEmbedModel, ragEmbedDim, ragEmbedAllowUnindexed)
+			switch {
+			case rerr != nil:
+				log.Printf("ERROR: RAG embedding configuration is inconsistent, rag ingest route not registered: %v", rerr)
+			case !ragConfigMatches:
+				log.Printf("ERROR: RAG embedding config mismatch (env model=%s dim=%d) vs provisioned rag_embedding_config, rag ingest route not registered; provision + re-embed to switch models", ragEmbedModel, ragEmbedDim)
+			default:
+				ragEmbedClient := cprag.NewHTTPEmbedClient(ragEmbedBaseURL, ragEmbedModel, plan.ReduceTo, resolveLiteLLMMasterKey())
 				ragIngester := cprag.NewIngester(ragRepo, ragEmbedClient, 0, ragEmbedModel)
 				cprag.RegisterRoutes(routerMux, func(ctx context.Context, tenantID, docID uuid.UUID, content string) error {
 					return ragIngester.Ingest(ctx, tenantID, docID, content)
@@ -1007,6 +1019,24 @@ func main() {
 					return platformhttp.RequireInternalToken(cfg.InternalToken, h)
 				})
 				log.Println("rag ingest route registered")
+
+				// Catch-up re-embed: provisioning a new model/dim marks the
+				// corpus pending; migrate any backlog onto the active config
+				// once at startup so the per-tenant fail-closed guard reopens.
+				// ponytail: single startup pass on the privileged pool (walks
+				// every tenant), not a scheduler; a full re-embed queue + admin
+				// trigger endpoint is the follow-up admin-surface PR.
+				go func() {
+					rb := cprag.NewReembedder(pool, ragEmbedClient, 0, ragEmbedModel, ragEmbedDim)
+					done, remaining, rbErr := rb.RunOnce(runCtx)
+					if rbErr != nil {
+						log.Printf("rag re-embed catch-up error: %v", rbErr)
+						return
+					}
+					if done > 0 || remaining > 0 {
+						log.Printf("rag re-embed catch-up: %d migrated, %d still pending", done, remaining)
+					}
+				}()
 			}
 		}
 	}

--- a/apps/control-plane/internal/rag/embed_test.go
+++ b/apps/control-plane/internal/rag/embed_test.go
@@ -44,7 +44,7 @@ func TestReduceEmbeddingNoop(t *testing.T) {
 }
 
 // TestHTTPEmbedClientTruncates drives a fake 4096-dim backend through
-// HTTPEmbedClient with truncateTo=1024 and expects a 1024-dim result per item.
+// HTTPEmbedClient with reduceTo=1024 and expects a 1024-dim result per item.
 func TestHTTPEmbedClientTruncates(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req embedRequest
@@ -78,7 +78,7 @@ func TestHTTPEmbedClientTruncates(t *testing.T) {
 	}
 }
 
-// TestHTTPEmbedClientStrictRejectByDefault confirms truncateTo=0 (unset) still
+// TestHTTPEmbedClientStrictRejectByDefault confirms reduceTo=0 (unset) still
 // rejects a non-EmbeddingDimension response instead of silently truncating.
 func TestHTTPEmbedClientStrictRejectByDefault(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/apps/control-plane/internal/rag/ingest.go
+++ b/apps/control-plane/internal/rag/ingest.go
@@ -26,10 +26,15 @@ type HTTPEmbedClient struct {
 	baseURL string
 	model   string
 	client  *http.Client
-	// truncateTo reduces a wider MRL-trained embedding (e.g. 4096-dim) to this
-	// many leading dimensions, then L2-renormalizes. 0 disables reduction: a
-	// non-EmbeddingDimension vector is rejected outright (see EMBEDDING_TRUNCATE_TO).
-	truncateTo int
+	// reduceTo is the MRL reduction target, derived from embedmodel.Resolve:
+	// EmbeddingDimension when the configured model is MRL-trained and its
+	// chosen dim is below its native width, else 0. Not an independent operator
+	// knob (the old EMBEDDING_TRUNCATE_TO): a non-MRL model at a non-native dim
+	// is rejected at config time, so reduceTo is only set where the reduction
+	// is legitimate. It doubles as the `dimensions` value requested from the
+	// endpoint; the client-side reduce is a no-op when the endpoint honors it.
+	// 0 means require the native width exactly.
+	reduceTo int
 	// apiKey authenticates to the backend (LiteLLM requires it; a local
 	// bge-m3/Ollama endpoint does not). Empty means send no Authorization header.
 	apiKey string
@@ -37,18 +42,20 @@ type HTTPEmbedClient struct {
 
 // NewHTTPEmbedClient constructs the production embed client.
 // baseURL example: "http://localhost:11434/v1" (Ollama) or "http://litellm:4000".
-// model must be the alias returning EmbeddingDimension (or truncateTo) vectors, e.g. "bge-m3".
-// truncateTo: 0 requires the backend already return EmbeddingDimension;
-// otherwise the target width for MRL truncation (must equal EmbeddingDimension).
+// model must be the alias returning EmbeddingDimension vectors, e.g. "bge-m3".
+// reduceTo: 0 requires the backend already return EmbeddingDimension; otherwise
+// the MRL reduction target (== EmbeddingDimension) derived from
+// embedmodel.Resolve, sent as `dimensions` and applied client-side only if the
+// endpoint ignores it.
 // apiKey is sent as a Bearer token when non-empty (LiteLLM's LITELLM_MASTER_KEY);
 // leave empty for backends that require no auth.
-func NewHTTPEmbedClient(baseURL, model string, truncateTo int, apiKey string) *HTTPEmbedClient {
+func NewHTTPEmbedClient(baseURL, model string, reduceTo int, apiKey string) *HTTPEmbedClient {
 	return &HTTPEmbedClient{
-		baseURL:    strings.TrimRight(baseURL, "/"),
-		model:      model,
-		client:     &http.Client{Timeout: 30 * time.Second},
-		truncateTo: truncateTo,
-		apiKey:     apiKey,
+		baseURL:  strings.TrimRight(baseURL, "/"),
+		model:    model,
+		client:   &http.Client{Timeout: 30 * time.Second},
+		reduceTo: reduceTo,
+		apiKey:   apiKey,
 	}
 }
 
@@ -79,6 +86,10 @@ func reduceEmbedding(vec []float32, target int) []float32 {
 type embedRequest struct {
 	Model string   `json:"model"`
 	Input []string `json:"input"`
+	// Dimensions requests a native N-wide vector from an MRL-capable endpoint
+	// (Qwen3 supports it). Omitted when 0; the reduceEmbedding fallback covers
+	// an endpoint that ignores it.
+	Dimensions int `json:"dimensions,omitempty"`
 }
 
 type embedResponse struct {
@@ -91,7 +102,7 @@ type embedResponse struct {
 // Errors are wrapped with a provider-blind message — callers must not
 // expose the raw error to customers.
 func (c *HTTPEmbedClient) Embed(ctx context.Context, inputs []string) ([][]float32, error) {
-	body, err := json.Marshal(embedRequest{Model: c.model, Input: inputs})
+	body, err := json.Marshal(embedRequest{Model: c.model, Input: inputs, Dimensions: c.reduceTo})
 	if err != nil {
 		return nil, fmt.Errorf("rag.embed: marshal: %w", err)
 	}
@@ -129,8 +140,9 @@ func (c *HTTPEmbedClient) Embed(ctx context.Context, inputs []string) ([][]float
 	out := make([][]float32, len(result.Data))
 	for i, d := range result.Data {
 		emb := d.Embedding
-		if c.truncateTo > 0 {
-			emb = reduceEmbedding(emb, c.truncateTo)
+		if c.reduceTo > 0 {
+			// No-op when the endpoint already returned a reduceTo-wide vector.
+			emb = reduceEmbedding(emb, c.reduceTo)
 		}
 		if len(emb) != EmbeddingDimension {
 			return nil, fmt.Errorf("rag.embed: item %d has dimension %d, want %d",
@@ -190,24 +202,16 @@ func (ing *Ingester) Ingest(ctx context.Context, tenantID, docID interface{ Stri
 		return fmt.Errorf("rag.ingest: document produced no text chunks")
 	}
 
-	// Embed in batches.
-	embeddings := make([][]float32, 0, len(chunks))
-	for start := 0; start < len(chunks); start += ing.batchSize {
-		end := start + ing.batchSize
-		if end > len(chunks) {
-			end = len(chunks)
-		}
-		batch := chunks[start:end]
-		texts := make([]string, len(batch))
-		for i, c := range batch {
-			texts[i] = c.Content
-		}
-		vecs, err := ing.embed.Embed(ctx, texts)
-		if err != nil {
-			_ = ing.repo.UpdateDocumentStatus(ctx, tid, did, StatusError, "embedding service unavailable")
-			return fmt.Errorf("rag.ingest: embed batch: embedding service unavailable")
-		}
-		embeddings = append(embeddings, vecs...)
+	// Embed in batches (shared with the re-embed worker: fail-closed on any
+	// batch error so a partial vector set is never stored).
+	texts := make([]string, len(chunks))
+	for i, c := range chunks {
+		texts[i] = c.Content
+	}
+	embeddings, err := embedInBatches(ctx, ing.embed, texts, ing.batchSize)
+	if err != nil {
+		_ = ing.repo.UpdateDocumentStatus(ctx, tid, did, StatusError, "embedding service unavailable")
+		return fmt.Errorf("rag.ingest: embed batch: embedding service unavailable")
 	}
 
 	if err := ing.repo.InsertChunks(ctx, tid, did, chunks, embeddings); err != nil {

--- a/apps/control-plane/internal/rag/provision.go
+++ b/apps/control-plane/internal/rag/provision.go
@@ -1,0 +1,222 @@
+package rag
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/sakibsadmanshajib/hive/packages/embedmodel"
+)
+
+// hnswIndexName is the single ANN index recreated on rag_chunks.embedding.
+// It is dropped and rebuilt to match the active (type, opclass); the name is
+// stable so idempotency and the base migration agree.
+const hnswIndexName = "rag_chunks_embedding_hnsw_idx"
+
+// ActiveConfig is the singleton public.rag_embedding_config row: the active,
+// provisioned embedding configuration both services reconcile against.
+type ActiveConfig struct {
+	Model     string
+	Dim       int
+	PgType    string
+	Opclass   string
+	Indexable bool
+}
+
+// LoadActiveConfig reads the singleton rag_embedding_config row (id = 1).
+// found is false when the table has no row yet (pre-seed / fresh schema),
+// which callers treat as "nothing to reconcile against," not an error.
+func LoadActiveConfig(ctx context.Context, pool *pgxpool.Pool) (cfg ActiveConfig, found bool, err error) {
+	row := pool.QueryRow(ctx, `
+		SELECT model, dim, pgvector_type, opclass, indexable
+		FROM public.rag_embedding_config WHERE id = 1`)
+	err = row.Scan(&cfg.Model, &cfg.Dim, &cfg.PgType, &cfg.Opclass, &cfg.Indexable)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return ActiveConfig{}, false, nil
+	}
+	if err != nil {
+		return ActiveConfig{}, false, fmt.Errorf("rag.provision: load active config: %w", err)
+	}
+	return cfg, true, nil
+}
+
+// currentEmbeddingColumnType returns the SQL type text of
+// public.rag_chunks.embedding, e.g. "vector(1024)" or "halfvec(3000)". found
+// is false when the column has been dropped (mid-provision) or never existed.
+func currentEmbeddingColumnType(ctx context.Context, tx pgx.Tx) (typeText string, found bool, err error) {
+	err = tx.QueryRow(ctx, `
+		SELECT format_type(a.atttypid, a.atttypmod)
+		FROM pg_attribute a
+		JOIN pg_class c     ON c.oid = a.attrelid
+		JOIN pg_namespace n ON n.oid = c.relnamespace
+		WHERE n.nspname = 'public'
+		  AND c.relname = 'rag_chunks'
+		  AND a.attname = 'embedding'
+		  AND NOT a.attisdropped`).Scan(&typeText)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, fmt.Errorf("rag.provision: read column type: %w", err)
+	}
+	return typeText, true, nil
+}
+
+// indexExists reports whether the HNSW index on rag_chunks.embedding is
+// present, so an already-typed-but-unindexed column is still (re)indexed.
+func indexExists(ctx context.Context, tx pgx.Tx) (bool, error) {
+	var exists bool
+	err := tx.QueryRow(ctx, `
+		SELECT EXISTS(
+			SELECT 1 FROM pg_indexes
+			WHERE schemaname = 'public' AND tablename = 'rag_chunks' AND indexname = $1)`,
+		hnswIndexName).Scan(&exists)
+	if err != nil {
+		return false, fmt.Errorf("rag.provision: check index: %w", err)
+	}
+	return exists, nil
+}
+
+// Provision makes public.rag_chunks.embedding and its ANN index match plan,
+// idempotently, then records the choice in rag_embedding_config. It must run
+// on a privileged (DDL-capable) connection, not the hive_app app role.
+//
+// Idempotency: if the column is already plan.ColumnType() AND the index state
+// already matches plan.Indexable, Provision only refreshes the config row and
+// returns without touching data. Otherwise it drops the index and column,
+// recreates the column at the target type (nullable, so the re-embed worker
+// can repopulate it incrementally), rebuilds the index for the resolved
+// opclass, re-asserts grants + RLS, and marks every previously embedded
+// document pending so the per-tenant guard fails closed until the re-embed
+// worker rewrites its vectors onto the new space.
+//
+// pgvector cannot ALTER a vector column's dimension in place, and two vector
+// spaces must never coexist in one ANN index, so a switch is deliberately a
+// destroy-and-re-embed, never a live cutover. Chunk text rows are preserved;
+// only the embedding column and its provenance are rewritten.
+func Provision(ctx context.Context, pool *pgxpool.Pool, plan embedmodel.Plan) error {
+	if plan.Dim <= 0 || plan.PgType == "" {
+		return fmt.Errorf("rag.provision: refusing to provision an unresolved plan (%+v)", plan)
+	}
+
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("rag.provision: begin: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	curType, colFound, err := currentEmbeddingColumnType(ctx, tx)
+	if err != nil {
+		return err
+	}
+	idxPresent, err := indexExists(ctx, tx)
+	if err != nil {
+		return err
+	}
+
+	target := plan.ColumnType()
+	alreadyProvisioned := colFound && curType == target && idxPresent == plan.Indexable
+	if !alreadyProvisioned {
+		if err := recreateEmbeddingColumn(ctx, tx, plan); err != nil {
+			return err
+		}
+		// Fail-closed: previously embedded documents live in the old vector
+		// space and must not be queried against the new column. Mark them
+		// pending; the per-tenant guard blocks those tenants until re-embed.
+		if _, err := tx.Exec(ctx, `
+			UPDATE public.rag_documents
+			SET status = 'pending', updated_at = now()
+			WHERE status IN ('embedded','processing')`); err != nil {
+			return fmt.Errorf("rag.provision: mark documents pending: %w", err)
+		}
+	}
+
+	if err := upsertActiveConfig(ctx, tx, plan); err != nil {
+		return err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("rag.provision: commit: %w", err)
+	}
+	return nil
+}
+
+// recreateEmbeddingColumn drops the index + embedding column and rebuilds them
+// to plan's (type, opclass). Column identifiers are never interpolated from
+// user input: pgType/opclass come only from embedmodel.ResolvePgvector and dim
+// is an int, so the formatted DDL cannot carry injection.
+func recreateEmbeddingColumn(ctx context.Context, tx pgx.Tx, plan embedmodel.Plan) error {
+	if _, err := tx.Exec(ctx, fmt.Sprintf(`DROP INDEX IF EXISTS public.%s`, hnswIndexName)); err != nil {
+		return fmt.Errorf("rag.provision: drop index: %w", err)
+	}
+	if _, err := tx.Exec(ctx, `ALTER TABLE public.rag_chunks DROP COLUMN IF EXISTS embedding`); err != nil {
+		return fmt.Errorf("rag.provision: drop column: %w", err)
+	}
+	// Nullable on purpose: existing chunk rows keep their content and get their
+	// vectors written by the re-embed worker; a NOT NULL add would fail on a
+	// non-empty table and forbid incremental repopulation.
+	if _, err := tx.Exec(ctx, fmt.Sprintf(
+		`ALTER TABLE public.rag_chunks ADD COLUMN embedding %s`, plan.ColumnType())); err != nil {
+		return fmt.Errorf("rag.provision: add column: %w", err)
+	}
+
+	if plan.Indexable {
+		// vector -> hnsw (embedding vector_cosine_ops); halfvec -> the halfvec
+		// opclass on the already-halfvec column. m/ef mirror the base migration.
+		if _, err := tx.Exec(ctx, fmt.Sprintf(
+			`CREATE INDEX %s ON public.rag_chunks USING hnsw (embedding %s) WITH (m = 16, ef_construction = 64)`,
+			hnswIndexName, plan.Opclass)); err != nil {
+			return fmt.Errorf("rag.provision: create index: %w", err)
+		}
+	}
+
+	// Re-assert privileges + tenant RLS on the recreated column. Table-level
+	// FOR ALL policies survive a column drop, but re-asserting is cheap and
+	// closes the schema-drift / RLS-gap risk the runtime-DDL path carries.
+	if _, err := tx.Exec(ctx, `GRANT SELECT, INSERT, UPDATE, DELETE ON public.rag_chunks TO hive_app`); err != nil {
+		return fmt.Errorf("rag.provision: re-grant hive_app: %w", err)
+	}
+	if _, err := tx.Exec(ctx, `GRANT SELECT ON public.rag_chunks TO auditor_ro`); err != nil {
+		return fmt.Errorf("rag.provision: re-grant auditor_ro: %w", err)
+	}
+	if _, err := tx.Exec(ctx, `
+		DO $$
+		BEGIN
+			IF NOT EXISTS (
+				SELECT 1 FROM pg_policies
+				WHERE schemaname = 'public' AND tablename = 'rag_chunks'
+				  AND policyname = 'rag_chunks_tenant_isolation'
+			) THEN
+				CREATE POLICY rag_chunks_tenant_isolation
+					ON public.rag_chunks AS PERMISSIVE FOR ALL TO hive_app
+					USING      (tenant_id = current_setting('app.current_tenant_id', true)::uuid)
+					WITH CHECK (tenant_id = current_setting('app.current_tenant_id', true)::uuid);
+			END IF;
+		END$$;`); err != nil {
+		return fmt.Errorf("rag.provision: re-assert rls: %w", err)
+	}
+	return nil
+}
+
+// upsertActiveConfig writes plan into the singleton rag_embedding_config row.
+func upsertActiveConfig(ctx context.Context, tx pgx.Tx, plan embedmodel.Plan) error {
+	_, err := tx.Exec(ctx, `
+		INSERT INTO public.rag_embedding_config
+			(id, model, dim, pgvector_type, opclass, indexable, provisioned_at, updated_at)
+		VALUES (1, $1, $2, $3, $4, $5, now(), now())
+		ON CONFLICT (id) DO UPDATE SET
+			model = EXCLUDED.model,
+			dim = EXCLUDED.dim,
+			pgvector_type = EXCLUDED.pgvector_type,
+			opclass = EXCLUDED.opclass,
+			indexable = EXCLUDED.indexable,
+			provisioned_at = now(),
+			updated_at = now()`,
+		plan.Model, plan.Dim, plan.PgType, plan.Opclass, plan.Indexable)
+	if err != nil {
+		return fmt.Errorf("rag.provision: upsert active config: %w", err)
+	}
+	return nil
+}

--- a/apps/control-plane/internal/rag/provision.go
+++ b/apps/control-plane/internal/rag/provision.go
@@ -16,6 +16,14 @@ import (
 // stable so idempotency and the base migration agree.
 const hnswIndexName = "rag_chunks_embedding_hnsw_idx"
 
+// provisionAdvisoryLockKey is a fixed, arbitrary key for the transaction-level
+// advisory lock that serializes Provision. Two concurrent provisions (e.g. two
+// control-plane replicas restarting at once) would otherwise interleave the
+// DROP INDEX / DROP COLUMN / ADD COLUMN / CREATE INDEX sequence and corrupt the
+// schema. pg_advisory_xact_lock blocks the second caller until the first
+// commits or rolls back, and auto-releases with the transaction.
+const provisionAdvisoryLockKey int64 = 0x726167656d626564 // "ragembed"
+
 // ActiveConfig is the singleton public.rag_embedding_config row: the active,
 // provisioned embedding configuration both services reconcile against.
 type ActiveConfig struct {
@@ -107,6 +115,14 @@ func Provision(ctx context.Context, pool *pgxpool.Pool, plan embedmodel.Plan) er
 		return fmt.Errorf("rag.provision: begin: %w", err)
 	}
 	defer tx.Rollback(ctx)
+
+	// Serialize concurrent provisions: hold a transaction-scoped advisory lock
+	// before the destructive DROP/CREATE sequence so two replicas cannot
+	// interleave and leave rag_chunks.embedding half-rebuilt. Released on
+	// commit/rollback.
+	if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock($1)`, provisionAdvisoryLockKey); err != nil {
+		return fmt.Errorf("rag.provision: acquire advisory lock: %w", err)
+	}
 
 	curType, colFound, err := currentEmbeddingColumnType(ctx, tx)
 	if err != nil {

--- a/apps/control-plane/internal/rag/provision_test.go
+++ b/apps/control-plane/internal/rag/provision_test.go
@@ -1,0 +1,113 @@
+package rag
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/sakibsadmanshajib/hive/packages/embedmodel"
+)
+
+// newProvisionTestPool connects as the privileged (DDL-capable) role the
+// control-plane provisioning routine uses in production. Skips when
+// HIVE_TEST_DB_URL is unset, and refuses a DSN that does not look like a test
+// database, mirroring repository_rls_test.go. This exercises the real column
+// recreate + index rebuild against a live Postgres+pgvector.
+func newProvisionTestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("HIVE_TEST_DB_URL")
+	if dsn == "" {
+		t.Skip("HIVE_TEST_DB_URL not set")
+	}
+	if !strings.Contains(strings.ToLower(dsn), "test") {
+		t.Fatalf("refusing to run: HIVE_TEST_DB_URL must point at a test database (DSN missing 'test' marker)")
+	}
+	pool, err := pgxpool.New(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+func embeddingColumnType(t *testing.T, pool *pgxpool.Pool) string {
+	t.Helper()
+	var typ string
+	err := pool.QueryRow(context.Background(), `
+		SELECT format_type(a.atttypid, a.atttypmod)
+		FROM pg_attribute a
+		JOIN pg_class c ON c.oid = a.attrelid
+		JOIN pg_namespace n ON n.oid = c.relnamespace
+		WHERE n.nspname='public' AND c.relname='rag_chunks' AND a.attname='embedding' AND NOT a.attisdropped`).Scan(&typ)
+	if err != nil {
+		t.Fatalf("read column type: %v", err)
+	}
+	return typ
+}
+
+func policyExists(t *testing.T, pool *pgxpool.Pool) bool {
+	t.Helper()
+	var ok bool
+	if err := pool.QueryRow(context.Background(), `
+		SELECT EXISTS(SELECT 1 FROM pg_policies
+			WHERE schemaname='public' AND tablename='rag_chunks'
+			  AND policyname='rag_chunks_tenant_isolation')`).Scan(&ok); err != nil {
+		t.Fatalf("check policy: %v", err)
+	}
+	return ok
+}
+
+// TestProvision_RecreatesColumnAndIndex drives the provisioning routine across
+// two dimension bands (vector then halfvec) and asserts idempotency, the
+// resolved column type, index presence, and that tenant RLS survives the
+// column recreation. Integration-gated on HIVE_TEST_DB_URL.
+func TestProvision_RecreatesColumnAndIndex(t *testing.T) {
+	pool := newProvisionTestPool(t)
+	ctx := context.Background()
+
+	// vector(1024) HNSW cosine (the clean demo target).
+	planVec, err := embedmodel.Resolve("qwen3-embedding-8b", 1024, false)
+	if err != nil {
+		t.Fatalf("resolve vec plan: %v", err)
+	}
+	if err := Provision(ctx, pool, planVec); err != nil {
+		t.Fatalf("provision vector(1024): %v", err)
+	}
+	if got := embeddingColumnType(t, pool); got != "vector(1024)" {
+		t.Fatalf("column type = %q, want vector(1024)", got)
+	}
+	if !policyExists(t, pool) {
+		t.Fatal("tenant RLS policy missing after provisioning")
+	}
+
+	// Idempotent: a second identical provision must not error.
+	if err := Provision(ctx, pool, planVec); err != nil {
+		t.Fatalf("re-provision (idempotent) vector(1024): %v", err)
+	}
+	if got := embeddingColumnType(t, pool); got != "vector(1024)" {
+		t.Fatalf("column type after re-provision = %q, want vector(1024)", got)
+	}
+
+	// Switch to halfvec(3000) (the 2001..4000 indexable band).
+	planHalf, err := embedmodel.Resolve("qwen3-embedding-8b", 3000, false)
+	if err != nil {
+		t.Fatalf("resolve halfvec plan: %v", err)
+	}
+	if err := Provision(ctx, pool, planHalf); err != nil {
+		t.Fatalf("provision halfvec(3000): %v", err)
+	}
+	if got := embeddingColumnType(t, pool); got != "halfvec(3000)" {
+		t.Fatalf("column type = %q, want halfvec(3000)", got)
+	}
+	if !policyExists(t, pool) {
+		t.Fatal("tenant RLS policy missing after halfvec provisioning")
+	}
+
+	// Restore the seed default so the test DB is left as it started.
+	if err := Provision(ctx, pool, planVec); err != nil {
+		t.Fatalf("restore vector(1024): %v", err)
+	}
+}

--- a/apps/control-plane/internal/rag/reembed.go
+++ b/apps/control-plane/internal/rag/reembed.go
@@ -2,13 +2,21 @@ package rag
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/sakibsadmanshajib/hive/packages/embedmodel"
 )
+
+// errDocClaimedElsewhere is returned by reembedDocument when another worker
+// already holds the document's row lock (FOR UPDATE SKIP LOCKED found no row),
+// so RunOnce skips it without counting a failure. Concurrent replicas therefore
+// never re-embed the same document.
+var errDocClaimedElsewhere = errors.New("rag.reembed: document claimed by another worker")
 
 // embedInBatches embeds texts in fixed-size batches through embed, preserving
 // input order. A single batch error fails the whole call (fail-closed): the
@@ -71,10 +79,14 @@ func NewReembedder(pool *pgxpool.Pool, embed EmbedClient, batchSize int, model s
 // candidate. Model comparison is canonical so a route alias and its canonical
 // id are treated as one model.
 func (rb *Reembedder) pendingDocIDs(ctx context.Context) ([]uuid.UUID, error) {
+	// SKIP LOCKED so a candidate another replica is actively re-embedding (its
+	// row held FOR UPDATE by reembedDocument) is not even listed here; the
+	// per-document claim in reembedDocument is the authoritative guard.
 	rows, err := rb.pool.Query(ctx, `
 		SELECT id FROM public.rag_documents
 		WHERE NOT (status = 'embedded' AND embedding_model = $1 AND embedding_dim = $2)
-		ORDER BY created_at ASC`,
+		ORDER BY created_at ASC
+		FOR UPDATE SKIP LOCKED`,
 		embedmodel.Canonical(rb.model), rb.dim)
 	if err != nil {
 		return nil, fmt.Errorf("rag.reembed: list pending: %w", err)
@@ -102,6 +114,11 @@ func (rb *Reembedder) RunOnce(ctx context.Context) (done int, remaining int, err
 	}
 	for _, id := range ids {
 		if rerr := rb.reembedDocument(ctx, id); rerr != nil {
+			if errors.Is(rerr, errDocClaimedElsewhere) {
+				// Another replica owns this document; not our failure and not
+				// our success. Skip without counting it.
+				continue
+			}
 			// Leave the document pending (guard stays closed) and continue;
 			// the next RunOnce retries it.
 			remaining++
@@ -121,6 +138,25 @@ func (rb *Reembedder) reembedDocument(ctx context.Context, docID uuid.UUID) erro
 		return fmt.Errorf("rag.reembed: begin: %w", err)
 	}
 	defer tx.Rollback(ctx)
+
+	// Claim the document by taking its row lock for the whole re-embed. If it is
+	// already at the active config, or another replica holds it (SKIP LOCKED),
+	// no row comes back and we skip: never re-embed a document twice. The lock
+	// is held until commit/rollback, so a concurrent worker's list + claim both
+	// pass this document over.
+	var claimed uuid.UUID
+	claimErr := tx.QueryRow(ctx, `
+		SELECT id FROM public.rag_documents
+		WHERE id = $1
+		  AND NOT (status = 'embedded' AND embedding_model = $2 AND embedding_dim = $3)
+		FOR UPDATE SKIP LOCKED`,
+		docID, embedmodel.Canonical(rb.model), rb.dim).Scan(&claimed)
+	if errors.Is(claimErr, pgx.ErrNoRows) {
+		return errDocClaimedElsewhere
+	}
+	if claimErr != nil {
+		return fmt.Errorf("rag.reembed: claim document: %w", claimErr)
+	}
 
 	rows, err := tx.Query(ctx, `
 		SELECT id, content FROM public.rag_chunks

--- a/apps/control-plane/internal/rag/reembed.go
+++ b/apps/control-plane/internal/rag/reembed.go
@@ -1,0 +1,175 @@
+package rag
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/sakibsadmanshajib/hive/packages/embedmodel"
+)
+
+// embedInBatches embeds texts in fixed-size batches through embed, preserving
+// input order. A single batch error fails the whole call (fail-closed): the
+// caller must not persist a partial vector set that would leave a document
+// half-migrated across two embedding spaces. batchSize <= 0 defaults to 32.
+func embedInBatches(ctx context.Context, embed EmbedClient, texts []string, batchSize int) ([][]float32, error) {
+	if batchSize <= 0 {
+		batchSize = 32
+	}
+	out := make([][]float32, 0, len(texts))
+	for start := 0; start < len(texts); start += batchSize {
+		end := start + batchSize
+		if end > len(texts) {
+			end = len(texts)
+		}
+		vecs, err := embed.Embed(ctx, texts[start:end])
+		if err != nil {
+			return nil, fmt.Errorf("rag.reembed: embed batch [%d:%d]: %w", start, end, err)
+		}
+		if len(vecs) != end-start {
+			return nil, fmt.Errorf("rag.reembed: embed batch [%d:%d] returned %d vectors, want %d", start, end, len(vecs), end-start)
+		}
+		out = append(out, vecs...)
+	}
+	return out, nil
+}
+
+// Reembedder rewrites the vectors of every document whose stored provenance
+// does not match the active (model, dim) onto that active configuration. It
+// runs on a privileged (RLS-bypassing owner) connection so it can walk every
+// tenant's corpus after a model/dimension switch.
+//
+// Each document is re-embedded in a single transaction (all its chunks plus
+// its provenance row), so a document is either fully migrated or left pending;
+// a partial document is never committed. A document already at the active
+// configuration is skipped, so RunOnce is idempotent and resumable after a
+// restart. A per-document failure leaves that document pending (the per-tenant
+// guard keeps its tenant fail-closed) and does not abort the whole run.
+type Reembedder struct {
+	pool      *pgxpool.Pool
+	embed     EmbedClient
+	batchSize int
+	model     string // canonical active model recorded as provenance
+	dim       int
+}
+
+// NewReembedder constructs a Reembedder. model should be the active
+// EMBEDDING_MODEL (stored as provenance) and dim the active EMBEDDING_DIM.
+// batchSize 0 defaults to 32.
+func NewReembedder(pool *pgxpool.Pool, embed EmbedClient, batchSize int, model string, dim int) *Reembedder {
+	if batchSize <= 0 {
+		batchSize = 32
+	}
+	return &Reembedder{pool: pool, embed: embed, batchSize: batchSize, model: model, dim: dim}
+}
+
+// pendingDocIDs returns the ids of documents not yet at the active (model,
+// dim), across all tenants. "Done" means status='embedded' with matching
+// provenance; everything else (pending, error, or a stale model/dim) is a
+// candidate. Model comparison is canonical so a route alias and its canonical
+// id are treated as one model.
+func (rb *Reembedder) pendingDocIDs(ctx context.Context) ([]uuid.UUID, error) {
+	rows, err := rb.pool.Query(ctx, `
+		SELECT id FROM public.rag_documents
+		WHERE NOT (status = 'embedded' AND embedding_model = $1 AND embedding_dim = $2)
+		ORDER BY created_at ASC`,
+		embedmodel.Canonical(rb.model), rb.dim)
+	if err != nil {
+		return nil, fmt.Errorf("rag.reembed: list pending: %w", err)
+	}
+	defer rows.Close()
+	var ids []uuid.UUID
+	for rows.Next() {
+		var id uuid.UUID
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("rag.reembed: scan id: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
+// RunOnce re-embeds every currently pending document and returns how many were
+// migrated in this pass and how many remain pending afterward (nonzero when
+// some documents failed and were left fail-closed). It is safe to call
+// repeatedly; each call skips documents already at the active configuration.
+func (rb *Reembedder) RunOnce(ctx context.Context) (done int, remaining int, err error) {
+	ids, err := rb.pendingDocIDs(ctx)
+	if err != nil {
+		return 0, 0, err
+	}
+	for _, id := range ids {
+		if rerr := rb.reembedDocument(ctx, id); rerr != nil {
+			// Leave the document pending (guard stays closed) and continue;
+			// the next RunOnce retries it.
+			remaining++
+			continue
+		}
+		done++
+	}
+	return done, remaining, nil
+}
+
+// reembedDocument re-embeds all chunk text of one document and stamps its
+// provenance, atomically. The canonical model is recorded so a later run
+// recognizes the document as done.
+func (rb *Reembedder) reembedDocument(ctx context.Context, docID uuid.UUID) error {
+	tx, err := rb.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("rag.reembed: begin: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	rows, err := tx.Query(ctx, `
+		SELECT id, content FROM public.rag_chunks
+		WHERE document_id = $1 ORDER BY chunk_index ASC`, docID)
+	if err != nil {
+		return fmt.Errorf("rag.reembed: load chunks: %w", err)
+	}
+	var chunkIDs []uuid.UUID
+	var texts []string
+	for rows.Next() {
+		var id uuid.UUID
+		var content string
+		if err := rows.Scan(&id, &content); err != nil {
+			rows.Close()
+			return fmt.Errorf("rag.reembed: scan chunk: %w", err)
+		}
+		chunkIDs = append(chunkIDs, id)
+		texts = append(texts, content)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("rag.reembed: iterate chunks: %w", err)
+	}
+
+	if len(chunkIDs) > 0 {
+		vecs, err := embedInBatches(ctx, rb.embed, texts, rb.batchSize)
+		if err != nil {
+			return err // fail-closed: nothing persisted
+		}
+		for i, cid := range chunkIDs {
+			enc, err := encodeVector(vecs[i])
+			if err != nil {
+				return fmt.Errorf("rag.reembed: encode chunk %d: %w", i, err)
+			}
+			if _, err := tx.Exec(ctx,
+				`UPDATE public.rag_chunks SET embedding = $1::vector WHERE id = $2`,
+				enc, cid); err != nil {
+				return fmt.Errorf("rag.reembed: update chunk: %w", err)
+			}
+		}
+	}
+
+	if _, err := tx.Exec(ctx, `
+		UPDATE public.rag_documents
+		SET status = 'embedded', error_msg = NULL,
+		    embedding_model = $1, embedding_dim = $2, updated_at = now()
+		WHERE id = $3`,
+		embedmodel.Canonical(rb.model), rb.dim, docID); err != nil {
+		return fmt.Errorf("rag.reembed: set provenance: %w", err)
+	}
+	return tx.Commit(ctx)
+}

--- a/apps/control-plane/internal/rag/reembed_test.go
+++ b/apps/control-plane/internal/rag/reembed_test.go
@@ -1,0 +1,100 @@
+package rag
+
+import (
+	"context"
+	"testing"
+)
+
+// orderedEmbedClient returns one vector per input whose first element encodes
+// a running counter, so batching order can be asserted end to end.
+type orderedEmbedClient struct {
+	calls   int
+	next    float32
+	failOn  int // 1-based call index to fail on; 0 never fails
+	batches []int
+}
+
+func (o *orderedEmbedClient) Embed(_ context.Context, inputs []string) ([][]float32, error) {
+	o.calls++
+	o.batches = append(o.batches, len(inputs))
+	if o.failOn > 0 && o.calls >= o.failOn {
+		return nil, context.DeadlineExceeded
+	}
+	out := make([][]float32, len(inputs))
+	for i := range inputs {
+		v := make([]float32, EmbeddingDimension)
+		v[0] = o.next
+		o.next++
+		out[i] = v
+	}
+	return out, nil
+}
+
+func TestEmbedInBatches_SplitsAndPreservesOrder(t *testing.T) {
+	e := &orderedEmbedClient{}
+	texts := []string{"a", "b", "c", "d", "e"}
+
+	vecs, err := embedInBatches(context.Background(), e, texts, 2)
+	if err != nil {
+		t.Fatalf("embedInBatches error: %v", err)
+	}
+	if len(vecs) != 5 {
+		t.Fatalf("got %d vectors, want 5", len(vecs))
+	}
+	// batchSize=2 over 5 items -> batches of 2,2,1.
+	wantBatches := []int{2, 2, 1}
+	if len(e.batches) != len(wantBatches) {
+		t.Fatalf("batches = %v, want %v", e.batches, wantBatches)
+	}
+	for i, b := range wantBatches {
+		if e.batches[i] != b {
+			t.Fatalf("batch %d size = %d, want %d (all: %v)", i, e.batches[i], b, e.batches)
+		}
+	}
+	// Order preserved: first element counts 0..4 across the flattened result.
+	for i, v := range vecs {
+		if v[0] != float32(i) {
+			t.Errorf("vector %d marker = %v, want %d (order not preserved)", i, v[0], i)
+		}
+	}
+}
+
+func TestEmbedInBatches_DefaultBatchSize(t *testing.T) {
+	e := &orderedEmbedClient{}
+	texts := make([]string, 40) // > default 32 -> exactly 2 batches
+	for i := range texts {
+		texts[i] = "x"
+	}
+	if _, err := embedInBatches(context.Background(), e, texts, 0); err != nil {
+		t.Fatalf("embedInBatches error: %v", err)
+	}
+	if e.calls != 2 {
+		t.Fatalf("calls = %d, want 2 (default batch size 32 over 40 items)", e.calls)
+	}
+}
+
+func TestEmbedInBatches_FailClosed(t *testing.T) {
+	e := &orderedEmbedClient{failOn: 2} // second batch errors
+	texts := []string{"a", "b", "c", "d"}
+	vecs, err := embedInBatches(context.Background(), e, texts, 2)
+	if err == nil {
+		t.Fatal("expected error on batch failure, got nil (must fail closed, not persist partial)")
+	}
+	if vecs != nil {
+		t.Errorf("expected nil vectors on failure, got %d (no partial result)", len(vecs))
+	}
+}
+
+func TestEmbedInBatches_Empty(t *testing.T) {
+	e := &orderedEmbedClient{}
+	vecs, err := embedInBatches(context.Background(), e, nil, 8)
+	if err != nil {
+		t.Fatalf("embedInBatches(nil) error: %v", err)
+	}
+	if len(vecs) != 0 {
+		t.Errorf("got %d vectors for empty input, want 0", len(vecs))
+	}
+	if e.calls != 0 {
+		t.Errorf("calls = %d, want 0 for empty input", e.calls)
+	}
+}

--- a/apps/control-plane/internal/rag/repository.go
+++ b/apps/control-plane/internal/rag/repository.go
@@ -10,6 +10,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/sakibsadmanshajib/hive/packages/embedmodel"
 )
 
 // DocumentStatus values mirror the rag_documents.status CHECK constraint.
@@ -50,10 +52,19 @@ type ChunkRow struct {
 // Postgres policy enforces tenant isolation automatically.
 type Repo struct {
 	pool *pgxpool.Pool
+	// pgType is the active rag_chunks.embedding pgvector column type
+	// ("vector" or "halfvec"), from the resolved embedding Plan. It selects
+	// the query-vector cast in SearchChunks so a halfvec column is never
+	// queried with ::vector (assignment-only cast -> no operator, runtime error).
+	pgType string
 }
 
-// NewRepo creates a Repo backed by the given pool.
-func NewRepo(pool *pgxpool.Pool) *Repo { return &Repo{pool: pool} }
+// NewRepo creates a Repo backed by the given pool. pgType is the provisioned
+// pgvector column type ("vector"/"halfvec"); an empty value defaults to
+// "vector" (the shipped column type) via embedmodel.Cast.
+func NewRepo(pool *pgxpool.Pool, pgType string) *Repo {
+	return &Repo{pool: pool, pgType: pgType}
+}
 
 // withTenantTx runs fn inside an explicit transaction with the RLS session
 // variable set LOCAL (transaction-scoped) to tenantID. hive_app is NOT
@@ -253,15 +264,7 @@ func (r *Repo) SearchChunks(ctx context.Context, tenantID uuid.UUID, queryVec []
 	err = r.withTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
 		// Explicit tenant_id filter is defense-in-depth alongside RLS:
 		// protects against SECURITY DEFINER / superuser-bypass scenarios.
-		rows, err := tx.Query(ctx, `
-			SELECT id, tenant_id, document_id, chunk_index, content, token_count,
-			       (embedding <=> $1::vector)::float4 AS score
-			FROM public.rag_chunks
-			WHERE tenant_id = $3
-			ORDER BY embedding <=> $1::vector
-			LIMIT $2`,
-			vec, topK, tenantID,
-		)
+		rows, err := tx.Query(ctx, searchChunksQuery(r.pgType), vec, topK, tenantID)
 		if err != nil {
 			return fmt.Errorf("rag.repo: search: %w", err)
 		}
@@ -281,6 +284,23 @@ func (r *Repo) SearchChunks(ctx context.Context, tenantID uuid.UUID, queryVec []
 		return nil, err
 	}
 	return results, nil
+}
+
+// searchChunksQuery builds the tenant-scoped cosine-search SQL with the
+// query-vector cast matched to the active embedding column type. The cast
+// suffix comes from embedmodel.Cast (an enum-constrained "::vector"/"::halfvec",
+// never user input), so interpolating it is injection-safe; the query vector
+// and all values remain bound parameters. Pure and side-effect free so the
+// cast selection is unit-testable without a live database.
+func searchChunksQuery(pgType string) string {
+	cast := embedmodel.Cast(pgType)
+	return fmt.Sprintf(`
+			SELECT id, tenant_id, document_id, chunk_index, content, token_count,
+			       (embedding <=> $1%[1]s)::float4 AS score
+			FROM public.rag_chunks
+			WHERE tenant_id = $3
+			ORDER BY embedding <=> $1%[1]s
+			LIMIT $2`, cast)
 }
 
 // encodeVector serialises []float32 to pgvector text format '[v1,v2,...]'.

--- a/apps/control-plane/internal/rag/repository.go
+++ b/apps/control-plane/internal/rag/repository.go
@@ -54,8 +54,10 @@ type Repo struct {
 	pool *pgxpool.Pool
 	// pgType is the active rag_chunks.embedding pgvector column type
 	// ("vector" or "halfvec"), from the resolved embedding Plan. It selects
-	// the query-vector cast in SearchChunks so a halfvec column is never
-	// queried with ::vector (assignment-only cast -> no operator, runtime error).
+	// the query-vector cast in SearchChunks so the cast matches the column
+	// type, keeping the HNSW index usable and avoiding a per-row cast that
+	// would force a sequential scan (a mismatched cast degrades, it does not
+	// error).
 	pgType string
 }
 

--- a/apps/control-plane/internal/rag/repository_rls_test.go
+++ b/apps/control-plane/internal/rag/repository_rls_test.go
@@ -81,7 +81,7 @@ func TestRepo_RLS_InsertThenGetRoundTripsUnderTenantContext(t *testing.T) {
 	tenantID := uuid.New()
 	seedRAGTenant(t, tenantID)
 
-	repo := NewRepo(pool)
+	repo := NewRepo(pool, "vector")
 	ctx := context.Background()
 
 	docID, err := repo.InsertDocument(ctx, Document{
@@ -115,7 +115,7 @@ func TestRepo_RLS_CrossTenantContextCannotReadRows(t *testing.T) {
 	seedRAGTenant(t, tenantA)
 	seedRAGTenant(t, tenantB)
 
-	repo := NewRepo(pool)
+	repo := NewRepo(pool, "vector")
 	ctx := context.Background()
 	docID, err := repo.InsertDocument(ctx, Document{
 		TenantID:    tenantA,
@@ -155,7 +155,7 @@ func TestRepo_RLS_NoSessionLeakAcrossBorrows(t *testing.T) {
 	tenantA := uuid.New()
 	seedRAGTenant(t, tenantA)
 
-	repo := NewRepo(pool)
+	repo := NewRepo(pool, "vector")
 	ctx := context.Background()
 	docID, err := repo.InsertDocument(ctx, Document{
 		TenantID:    tenantA,

--- a/apps/control-plane/internal/rag/search_query_test.go
+++ b/apps/control-plane/internal/rag/search_query_test.go
@@ -7,8 +7,9 @@ import (
 
 // TestSearchChunksQueryCast is the regression guard for the halfvec query path:
 // a halfvec-provisioned column must be queried with ::halfvec, a vector column
-// with ::vector. pgvector's vector<->halfvec cast is assignment-only, so the
-// wrong cast has no <=> operator and errors at query time. No live DB needed:
+// with ::vector. Matching the cast to the column type keeps the HNSW index
+// usable in both directions; a mismatched cast does not error but can force a
+// per-row cast that degrades to a sequential scan. No live DB needed:
 // searchChunksQuery is a pure builder over embedmodel.Cast.
 func TestSearchChunksQueryCast(t *testing.T) {
 	cases := []struct {

--- a/apps/control-plane/internal/rag/search_query_test.go
+++ b/apps/control-plane/internal/rag/search_query_test.go
@@ -1,0 +1,40 @@
+package rag
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSearchChunksQueryCast is the regression guard for the halfvec query path:
+// a halfvec-provisioned column must be queried with ::halfvec, a vector column
+// with ::vector. pgvector's vector<->halfvec cast is assignment-only, so the
+// wrong cast has no <=> operator and errors at query time. No live DB needed:
+// searchChunksQuery is a pure builder over embedmodel.Cast.
+func TestSearchChunksQueryCast(t *testing.T) {
+	cases := []struct {
+		name    string
+		pgType  string
+		want    string
+		notWant string
+	}{
+		{"halfvec column", "halfvec", "$1::halfvec", "$1::vector"},
+		{"vector column", "vector", "$1::vector", "$1::halfvec"},
+		{"empty defaults to vector", "", "$1::vector", "$1::halfvec"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			q := searchChunksQuery(tc.pgType)
+			if !strings.Contains(q, tc.want) {
+				t.Fatalf("searchChunksQuery(%q) missing %q:\n%s", tc.pgType, tc.want, q)
+			}
+			if strings.Contains(q, tc.notWant) {
+				t.Fatalf("searchChunksQuery(%q) unexpectedly contains %q:\n%s", tc.pgType, tc.notWant, q)
+			}
+			// Both distance references (SELECT score and ORDER BY) must carry
+			// the cast, else one side falls back to the column default type.
+			if got := strings.Count(q, tc.want); got != 2 {
+				t.Fatalf("searchChunksQuery(%q): want cast %q twice, got %d:\n%s", tc.pgType, tc.want, got, q)
+			}
+		})
+	}
+}

--- a/apps/edge-api/cmd/server/main.go
+++ b/apps/edge-api/cmd/server/main.go
@@ -291,6 +291,11 @@ func main() {
 		// EMBEDDING_BASE_URL does below (route stays registered, provider-blind
 		// 503), rather than serving vectors from a misconfigured width.
 		ragEmbedReduceTo := 0
+		// pgvector column type the query vector must be cast to in SearchChunks
+		// ("vector"/"halfvec"). Derived from the resolved Plan (dim -> type via
+		// embedmodel.ResolvePgvector), matching what provisioning built the
+		// column as. Defaults to "vector" (shipped column) when RAG is disabled.
+		ragPgType := "vector"
 		if ragEmbedBaseURL != "" {
 			plan, err := embedmodel.Resolve(ragEmbedModel, ragEmbedDim, ragEmbedAllowUnindexed)
 			if err != nil {
@@ -298,6 +303,7 @@ func main() {
 				ragEmbedBaseURL = ""
 			} else {
 				ragEmbedReduceTo = plan.ReduceTo
+				ragPgType = plan.PgType
 				// Cross-service reconcile: compare against the active
 				// rag_embedding_config row the live column was provisioned to.
 				// A mismatch (different model or dim) means our query vectors
@@ -316,7 +322,7 @@ func main() {
 
 		var ragRepo edgerag.Store
 		if dbPool != nil {
-			ragRepo = edgerag.NewRepo(dbPool)
+			ragRepo = edgerag.NewRepo(dbPool, ragPgType)
 		}
 		var ragEmbedder edgerag.Embedder
 		if ragEmbedBaseURL != "" {

--- a/apps/edge-api/cmd/server/main.go
+++ b/apps/edge-api/cmd/server/main.go
@@ -260,23 +260,10 @@ func main() {
 		if ragEmbedModel == "" {
 			ragEmbedModel = "bge-m3"
 		}
-		// EMBEDDING_TRUNCATE_TO: set only for MRL-trained models whose native
-		// width exceeds EmbeddingDimension (e.g. the serverless demo's
-		// route-openrouter-embedding-fallback returns 4096). Unset/0 keeps the
-		// strict reject so a non-MRL model never gets silently truncated.
-		ragEmbedTruncateToRaw := strings.TrimSpace(os.Getenv("EMBEDDING_TRUNCATE_TO"))
-		ragEmbedTruncateTo, err := strconv.Atoi(ragEmbedTruncateToRaw)
-		if ragEmbedTruncateToRaw != "" && err != nil {
-			log.Printf("WARNING: EMBEDDING_TRUNCATE_TO=%q is not a valid integer; truncation disabled (strict dimension reject applies)", ragEmbedTruncateToRaw)
-			ragEmbedTruncateTo = 0
-		}
-		// EMBEDDING_DIM: the vector width the admin-selected model is expected
-		// to produce (post-truncation). Overwrites the rag package's default
-		// (1024, matching today's rag_chunks.embedding column) so the dimension
-		// checks in embed.go compare against config, not a compile-time constant.
-		// Resizing the live column for a non-1024 value is a later PR; setting
-		// EMBEDDING_DIM to anything else today will surface as a Postgres
-		// insert error, not a graceful reject, until that PR lands.
+		// EMBEDDING_DIM: the vector width the admin-selected model produces.
+		// Overwrites the rag package's default (1024, matching today's
+		// rag_chunks.embedding column) so the dimension checks in embed.go
+		// compare against config, not a compile-time constant.
 		ragEmbedDimRaw := strings.TrimSpace(os.Getenv("EMBEDDING_DIM"))
 		ragEmbedDim := edgerag.EmbeddingDimension
 		if ragEmbedDimRaw != "" {
@@ -288,18 +275,42 @@ func main() {
 		}
 		edgerag.EmbeddingDimension = ragEmbedDim
 
-		// embedmodel.Validate cross-checks model/dim/truncateTo against the
-		// known dimension facts for ragEmbedModel (packages/embedmodel). An
-		// unknown model is skipped, not rejected -- an admin may be pointing at
-		// a custom model this build has no registry entry for. A known but
-		// inconsistent combination disables the embedding backend the same way
-		// an unset EMBEDDING_BASE_URL does below (route stays registered,
-		// returns a provider-blind 503), rather than serving vectors from a
-		// misconfigured width.
+		// EMBEDDING_ALLOW_UNINDEXED opts a >4000-dim configuration into an
+		// unindexed brute-force column (small-corpus only). Off by default.
+		ragAllowUnindexedRaw := strings.TrimSpace(os.Getenv("EMBEDDING_ALLOW_UNINDEXED"))
+		ragEmbedAllowUnindexed := ragAllowUnindexedRaw == "1" || strings.EqualFold(ragAllowUnindexedRaw, "true")
+
+		// embedmodel.Resolve is the single source of truth (#368): it enforces
+		// the selectable policy (no naive truncation of a non-MRL model, no dim
+		// wider than native, dimension -> pgvector (type, opclass)) and derives
+		// the MRL reduction target (plan.ReduceTo). There is no independent
+		// EMBEDDING_TRUNCATE_TO knob any more: whether and how far to reduce is
+		// derived from (model MRL?, chosen dim vs native). An unknown model
+		// still resolves its pgvector mapping by dimension. A rejected
+		// combination disables the embedding backend the same way an unset
+		// EMBEDDING_BASE_URL does below (route stays registered, provider-blind
+		// 503), rather than serving vectors from a misconfigured width.
+		ragEmbedReduceTo := 0
 		if ragEmbedBaseURL != "" {
-			if err := embedmodel.Validate(ragEmbedModel, ragEmbedDim, ragEmbedTruncateTo); err != nil {
+			plan, err := embedmodel.Resolve(ragEmbedModel, ragEmbedDim, ragEmbedAllowUnindexed)
+			if err != nil {
 				log.Printf("ERROR: RAG embedding configuration is inconsistent, disabling /v1/rag/* embedding: %v", err)
 				ragEmbedBaseURL = ""
+			} else {
+				ragEmbedReduceTo = plan.ReduceTo
+				// Cross-service reconcile: compare against the active
+				// rag_embedding_config row the live column was provisioned to.
+				// A mismatch (different model or dim) means our query vectors
+				// would hit a column built for a different embedding space, so
+				// disable RAG rather than serve cross-space results.
+				if dbPool != nil {
+					if rowModel, rowDim, found, cerr := edgerag.LoadActiveEmbeddingConfig(context.Background(), dbPool); cerr != nil {
+						log.Printf("WARNING: could not read rag_embedding_config, proceeding on env config only: %v", cerr)
+					} else if found && !embedmodel.SameConfig(ragEmbedModel, ragEmbedDim, rowModel, rowDim) {
+						log.Printf("ERROR: RAG embedding config mismatch (env model=%s dim=%d vs provisioned model=%s dim=%d), disabling /v1/rag/* embedding; provision + re-embed to switch models", ragEmbedModel, ragEmbedDim, rowModel, rowDim)
+						ragEmbedBaseURL = ""
+					}
+				}
 			}
 		}
 
@@ -309,7 +320,7 @@ func main() {
 		}
 		var ragEmbedder edgerag.Embedder
 		if ragEmbedBaseURL != "" {
-			ragEmbedder = edgerag.NewHTTPEmbedder(ragEmbedBaseURL, ragEmbedModel, ragEmbedTruncateTo, resolveLiteLLMMasterKey())
+			ragEmbedder = edgerag.NewHTTPEmbedder(ragEmbedBaseURL, ragEmbedModel, ragEmbedReduceTo, resolveLiteLLMMasterKey())
 		}
 		ragAudit := func(ctx context.Context, action, resourceType, resourceID, severity string,
 			tenantID, actorID uuid.UUID, userAgent string, after any) {

--- a/apps/edge-api/internal/rag/config.go
+++ b/apps/edge-api/internal/rag/config.go
@@ -1,0 +1,32 @@
+package rag
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// LoadActiveEmbeddingConfig reads the singleton public.rag_embedding_config
+// row (id = 1): the model + dim the live rag_chunks.embedding column was
+// provisioned to. control-plane owns writes to this row (it runs provisioning);
+// edge-api reads it at startup and reconciles its own resolved EMBEDDING_MODEL
+// / EMBEDDING_DIM against it (embedmodel.SameConfig), disabling RAG on a
+// mismatch instead of querying a column built for a different embedding space
+// (#368).
+//
+// found is false when the table has no row yet (fresh schema before the seed
+// migration), which the caller treats as "nothing to reconcile against."
+func LoadActiveEmbeddingConfig(ctx context.Context, pool *pgxpool.Pool) (model string, dim int, found bool, err error) {
+	err = pool.QueryRow(ctx, `
+		SELECT model, dim FROM public.rag_embedding_config WHERE id = 1`).Scan(&model, &dim)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", 0, false, nil
+	}
+	if err != nil {
+		return "", 0, false, fmt.Errorf("rag: load active embedding config: %w", err)
+	}
+	return model, dim, true, nil
+}

--- a/apps/edge-api/internal/rag/embed.go
+++ b/apps/edge-api/internal/rag/embed.go
@@ -24,31 +24,39 @@ type HTTPEmbedder struct {
 	baseURL string
 	model   string
 	client  *http.Client
-	// truncateTo reduces a wider MRL-trained embedding (e.g. 4096-dim) to this
-	// many leading dimensions, then L2-renormalizes. 0 disables reduction: a
-	// non-EmbeddingDimension vector is rejected outright (see EMBEDDING_TRUNCATE_TO).
-	truncateTo int
+	// reduceTo is the MRL reduction target, derived from embedmodel.Resolve:
+	// it is EmbeddingDimension when the configured model is MRL-trained and its
+	// chosen dim is below its native width, else 0. It is NOT an independent
+	// operator knob (the old EMBEDDING_TRUNCATE_TO): a non-MRL model at a
+	// non-native dim is rejected at config time, so reduceTo is only ever set
+	// for a model where the reduction is legitimate. It doubles as the
+	// `dimensions` value requested from the endpoint (preferred over client
+	// slicing); when the endpoint honors it and returns a dim-wide vector, the
+	// client-side reduce is a no-op. 0 means require the native width exactly.
+	reduceTo int
 	// apiKey authenticates to the backend (LiteLLM requires it; a local
 	// bge-m3/Ollama endpoint does not). Empty means send no Authorization header.
 	apiKey string
 }
 
 // NewHTTPEmbedder constructs the production embedder.
-// baseURL:    e.g. "http://ollama:11434/v1" or "http://litellm:4000".
-// model:      the alias returning EmbeddingDimension (or truncateTo) vectors, e.g. "bge-m3".
-// truncateTo: 0 to require the backend already return EmbeddingDimension;
+// baseURL:  e.g. "http://ollama:11434/v1" or "http://litellm:4000".
+// model:    the alias returning EmbeddingDimension vectors, e.g. "bge-m3".
+// reduceTo: 0 to require the backend already return EmbeddingDimension;
 //
-//	otherwise the target width for MRL truncation (must equal EmbeddingDimension).
+//	otherwise the MRL reduction target (== EmbeddingDimension), derived from
+//	embedmodel.Resolve, sent to the endpoint as `dimensions` and applied
+//	client-side only if the endpoint ignores it.
 //
 // apiKey is sent as a Bearer token when non-empty (LiteLLM's LITELLM_MASTER_KEY);
 // leave empty for backends that require no auth.
-func NewHTTPEmbedder(baseURL, model string, truncateTo int, apiKey string) *HTTPEmbedder {
+func NewHTTPEmbedder(baseURL, model string, reduceTo int, apiKey string) *HTTPEmbedder {
 	return &HTTPEmbedder{
-		baseURL:    strings.TrimRight(baseURL, "/"),
-		model:      model,
-		client:     &http.Client{Timeout: 30 * time.Second},
-		truncateTo: truncateTo,
-		apiKey:     apiKey,
+		baseURL:  strings.TrimRight(baseURL, "/"),
+		model:    model,
+		client:   &http.Client{Timeout: 30 * time.Second},
+		reduceTo: reduceTo,
+		apiKey:   apiKey,
 	}
 }
 
@@ -79,6 +87,11 @@ func reduceEmbedding(vec []float32, target int) []float32 {
 type embedReq struct {
 	Model string   `json:"model"`
 	Input []string `json:"input"`
+	// Dimensions requests a native N-wide vector from an MRL-capable endpoint
+	// (Qwen3 supports it). Omitted when 0 so non-MRL native-width models are
+	// unaffected. Preferred over client-side slicing; the reduceEmbedding
+	// fallback covers an endpoint that silently ignores the parameter.
+	Dimensions int `json:"dimensions,omitempty"`
 }
 
 type embedResp struct {
@@ -90,7 +103,7 @@ type embedResp struct {
 // Embed embeds a single text string and returns an EmbeddingDimension-wide vector.
 // Errors are provider-blind: no backend URL, model name, or upstream message.
 func (e *HTTPEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
-	body, err := json.Marshal(embedReq{Model: e.model, Input: []string{text}})
+	body, err := json.Marshal(embedReq{Model: e.model, Input: []string{text}, Dimensions: e.reduceTo})
 	if err != nil {
 		return nil, fmt.Errorf("rag.embed: marshal: %w", err)
 	}
@@ -125,8 +138,10 @@ func (e *HTTPEmbedder) Embed(ctx context.Context, text string) ([]float32, error
 		return nil, fmt.Errorf("rag: embedding service returned no data")
 	}
 	vec := result.Data[0].Embedding
-	if e.truncateTo > 0 {
-		vec = reduceEmbedding(vec, e.truncateTo)
+	if e.reduceTo > 0 {
+		// No-op when the endpoint already honored `dimensions` and returned a
+		// reduceTo-wide vector; a legitimate MRL slice otherwise.
+		vec = reduceEmbedding(vec, e.reduceTo)
 	}
 	if len(vec) != EmbeddingDimension {
 		return nil, fmt.Errorf("rag: unexpected embedding dimension %d", len(vec))

--- a/apps/edge-api/internal/rag/embed_test.go
+++ b/apps/edge-api/internal/rag/embed_test.go
@@ -55,13 +55,51 @@ func TestReduceEmbeddingNoop(t *testing.T) {
 	}
 }
 
-// TestHTTPEmbedderTruncates drives a fake 4096-dim backend through
-// HTTPEmbedder with truncateTo=1024 and expects a 1024-dim result.
-func TestHTTPEmbedderTruncates(t *testing.T) {
+// TestHTTPEmbedderReducesWhenEndpointIgnoresDimensions drives a fake backend
+// that ignores `dimensions` and returns 4096-dim; the client-side MRL reduce
+// fallback must bring it to EmbeddingDimension. It also asserts the client
+// asked for the narrower width via `dimensions` (preferred endpoint-native).
+func TestHTTPEmbedderReducesWhenEndpointIgnoresDimensions(t *testing.T) {
+	var gotDims int
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		vec := make([]float32, 4096)
+		var req embedReq
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		gotDims = req.Dimensions
+		vec := make([]float32, 4096) // endpoint ignores dimensions, returns native
 		for i := range vec {
 			vec[i] = 0.01
+		}
+		_ = json.NewEncoder(w).Encode(embedResp{
+			Data: []struct {
+				Embedding []float32 `json:"embedding"`
+			}{{Embedding: vec}},
+		})
+	}))
+	defer srv.Close()
+
+	e := NewHTTPEmbedder(srv.URL, "route-openrouter-embedding-fallback", 1024, "")
+	vec, err := e.Embed(context.Background(), "hello")
+	if err != nil {
+		t.Fatalf("Embed() error = %v", err)
+	}
+	if gotDims != 1024 {
+		t.Errorf("requested dimensions = %d, want 1024 (endpoint-native preferred)", gotDims)
+	}
+	if len(vec) != EmbeddingDimension {
+		t.Errorf("len = %d, want %d", len(vec), EmbeddingDimension)
+	}
+}
+
+// TestHTTPEmbedderEndpointHonorsDimensions covers the preferred path: the
+// endpoint honors `dimensions` and returns EmbeddingDimension natively, so the
+// client-side reduce is a no-op and the strict width check passes.
+func TestHTTPEmbedderEndpointHonorsDimensions(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req embedReq
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		vec := make([]float32, req.Dimensions) // honor the requested width
+		for i := range vec {
+			vec[i] = 0.02
 		}
 		_ = json.NewEncoder(w).Encode(embedResp{
 			Data: []struct {
@@ -81,7 +119,7 @@ func TestHTTPEmbedderTruncates(t *testing.T) {
 	}
 }
 
-// TestHTTPEmbedderStrictRejectByDefault confirms truncateTo=0 (unset) still
+// TestHTTPEmbedderStrictRejectByDefault confirms reduceTo=0 (unset) still
 // rejects a non-EmbeddingDimension response instead of silently truncating.
 func TestHTTPEmbedderStrictRejectByDefault(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/apps/edge-api/internal/rag/repository.go
+++ b/apps/edge-api/internal/rag/repository.go
@@ -10,6 +10,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/sakibsadmanshajib/hive/packages/embedmodel"
 )
 
 // DocRow mirrors rag_documents columns needed by the edge handler.
@@ -35,10 +37,19 @@ type ChunkRow struct {
 // RLS is enforced by setting app.current_tenant_id before every query.
 type Repo struct {
 	pool *pgxpool.Pool
+	// pgType is the active rag_chunks.embedding pgvector column type
+	// ("vector" or "halfvec"), from the resolved embedding Plan. It selects
+	// the query-vector cast in SearchChunks so a halfvec column is never
+	// queried with ::vector (assignment-only cast -> no operator, runtime error).
+	pgType string
 }
 
-// NewRepo creates a Repo backed by pool.
-func NewRepo(pool *pgxpool.Pool) *Repo { return &Repo{pool: pool} }
+// NewRepo creates a Repo backed by pool. pgType is the provisioned pgvector
+// column type ("vector"/"halfvec"); an empty value defaults to "vector" (the
+// shipped column type) via embedmodel.Cast.
+func NewRepo(pool *pgxpool.Pool, pgType string) *Repo {
+	return &Repo{pool: pool, pgType: pgType}
+}
 
 // withTenantTx runs fn inside an explicit transaction with the RLS session
 // variable set LOCAL (transaction-scoped) to tenantID. hive_app is NOT
@@ -192,15 +203,7 @@ func (r *Repo) SearchChunks(ctx context.Context, tenantID uuid.UUID, queryVec []
 	err = r.withTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
 		// Explicit tenant_id filter is defense-in-depth alongside RLS:
 		// protects against SECURITY DEFINER / superuser-bypass scenarios.
-		rows, err := tx.Query(ctx, `
-			SELECT id, document_id, content,
-			       (embedding <=> $1::vector)::float4 AS score
-			FROM public.rag_chunks
-			WHERE tenant_id = $3
-			ORDER BY embedding <=> $1::vector
-			LIMIT $2`,
-			vec, topK, tenantID,
-		)
+		rows, err := tx.Query(ctx, searchChunksQuery(r.pgType), vec, topK, tenantID)
 		if err != nil {
 			return fmt.Errorf("rag.repo: search: %w", err)
 		}
@@ -219,6 +222,23 @@ func (r *Repo) SearchChunks(ctx context.Context, tenantID uuid.UUID, queryVec []
 		return nil, err
 	}
 	return results, nil
+}
+
+// searchChunksQuery builds the tenant-scoped cosine-search SQL with the
+// query-vector cast matched to the active embedding column type. The cast
+// suffix comes from embedmodel.Cast (an enum-constrained "::vector"/"::halfvec",
+// never user input), so interpolating it is injection-safe; the query vector
+// and all values remain bound parameters. Pure and side-effect free so the
+// cast selection is unit-testable without a live database.
+func searchChunksQuery(pgType string) string {
+	cast := embedmodel.Cast(pgType)
+	return fmt.Sprintf(`
+			SELECT id, document_id, content,
+			       (embedding <=> $1%[1]s)::float4 AS score
+			FROM public.rag_chunks
+			WHERE tenant_id = $3
+			ORDER BY embedding <=> $1%[1]s
+			LIMIT $2`, cast)
 }
 
 // encodeVector serialises []float32 to pgvector text format '[v1,v2,...]'.

--- a/apps/edge-api/internal/rag/repository.go
+++ b/apps/edge-api/internal/rag/repository.go
@@ -39,8 +39,10 @@ type Repo struct {
 	pool *pgxpool.Pool
 	// pgType is the active rag_chunks.embedding pgvector column type
 	// ("vector" or "halfvec"), from the resolved embedding Plan. It selects
-	// the query-vector cast in SearchChunks so a halfvec column is never
-	// queried with ::vector (assignment-only cast -> no operator, runtime error).
+	// the query-vector cast in SearchChunks so the cast matches the column
+	// type, keeping the HNSW index usable and avoiding a per-row cast that
+	// would force a sequential scan (a mismatched cast degrades, it does not
+	// error).
 	pgType string
 }
 

--- a/apps/edge-api/internal/rag/repository_rls_test.go
+++ b/apps/edge-api/internal/rag/repository_rls_test.go
@@ -131,7 +131,7 @@ func TestRepo_RLS_InsertThenGetRoundTripsUnderTenantContext(t *testing.T) {
 	tenantID := uuid.New()
 	seedRAGTenant(t, tenantID)
 
-	repo := NewRepo(pool)
+	repo := NewRepo(pool, "vector")
 	ctx := context.Background()
 
 	docID, err := repo.InsertDocument(ctx, tenantID, "doc.txt", "text/plain", 3)
@@ -157,7 +157,7 @@ func TestRepo_RLS_CrossTenantContextCannotReadRows(t *testing.T) {
 	seedRAGTenant(t, tenantA)
 	seedRAGTenant(t, tenantB)
 
-	repo := NewRepo(pool)
+	repo := NewRepo(pool, "vector")
 	ctx := context.Background()
 	docID, err := repo.InsertDocument(ctx, tenantA, "tenant-a-only.txt", "text/plain", 1)
 	if err != nil {
@@ -187,7 +187,7 @@ func TestRepo_RLS_NoSessionLeakAcrossBorrows(t *testing.T) {
 	tenantA := uuid.New()
 	seedRAGTenant(t, tenantA)
 
-	repo := NewRepo(pool)
+	repo := NewRepo(pool, "vector")
 	ctx := context.Background()
 	docID, err := repo.InsertDocument(ctx, tenantA, "tenant-a-only.txt", "text/plain", 1)
 	if err != nil {
@@ -228,7 +228,7 @@ func TestRepo_RLS_SearchChunksCannotReadOtherTenantChunks(t *testing.T) {
 	chunkA := seedRAGChunk(t, tenantA, "tenant a content", vec)
 	chunkB := seedRAGChunk(t, tenantB, "tenant b content", vec)
 
-	repo := NewRepo(pool)
+	repo := NewRepo(pool, "vector")
 	ctx := context.Background()
 
 	results, err := repo.SearchChunks(ctx, tenantA, vec, 10)

--- a/apps/edge-api/internal/rag/search_query_test.go
+++ b/apps/edge-api/internal/rag/search_query_test.go
@@ -7,8 +7,9 @@ import (
 
 // TestSearchChunksQueryCast is the regression guard for the halfvec query path:
 // a halfvec-provisioned column must be queried with ::halfvec, a vector column
-// with ::vector. pgvector's vector<->halfvec cast is assignment-only, so the
-// wrong cast has no <=> operator and errors at query time. No live DB needed:
+// with ::vector. Matching the cast to the column type keeps the HNSW index
+// usable in both directions; a mismatched cast does not error but can force a
+// per-row cast that degrades to a sequential scan. No live DB needed:
 // searchChunksQuery is a pure builder over embedmodel.Cast.
 func TestSearchChunksQueryCast(t *testing.T) {
 	cases := []struct {

--- a/apps/edge-api/internal/rag/search_query_test.go
+++ b/apps/edge-api/internal/rag/search_query_test.go
@@ -1,0 +1,40 @@
+package rag
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSearchChunksQueryCast is the regression guard for the halfvec query path:
+// a halfvec-provisioned column must be queried with ::halfvec, a vector column
+// with ::vector. pgvector's vector<->halfvec cast is assignment-only, so the
+// wrong cast has no <=> operator and errors at query time. No live DB needed:
+// searchChunksQuery is a pure builder over embedmodel.Cast.
+func TestSearchChunksQueryCast(t *testing.T) {
+	cases := []struct {
+		name    string
+		pgType  string
+		want    string
+		notWant string
+	}{
+		{"halfvec column", "halfvec", "$1::halfvec", "$1::vector"},
+		{"vector column", "vector", "$1::vector", "$1::halfvec"},
+		{"empty defaults to vector", "", "$1::vector", "$1::halfvec"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			q := searchChunksQuery(tc.pgType)
+			if !strings.Contains(q, tc.want) {
+				t.Fatalf("searchChunksQuery(%q) missing %q:\n%s", tc.pgType, tc.want, q)
+			}
+			if strings.Contains(q, tc.notWant) {
+				t.Fatalf("searchChunksQuery(%q) unexpectedly contains %q:\n%s", tc.pgType, tc.notWant, q)
+			}
+			// Both distance references (SELECT score and ORDER BY) must carry
+			// the cast, else one side falls back to the column default type.
+			if got := strings.Count(q, tc.want); got != 2 {
+				t.Fatalf("searchChunksQuery(%q): want cast %q twice, got %d:\n%s", tc.pgType, tc.want, got, q)
+			}
+		})
+	}
+}

--- a/packages/embedmodel/registry.go
+++ b/packages/embedmodel/registry.go
@@ -156,12 +156,16 @@ func (p Plan) ColumnType() string {
 
 // Cast returns the pgvector cast suffix a query vector must carry to match a
 // column of the given pgvector type: "::halfvec" for a halfvec column, else
-// "::vector". pgvector's vector<->halfvec casts are assignment-only, so a
-// query written as `halfvec_col <=> $1::vector` has no operator and errors at
-// runtime; the query vector must be cast to the column's own type. pgType
-// originates only from ResolvePgvector (an enum-constrained "vector"/"halfvec"),
-// never user input, so the result is safe to interpolate into SQL. An unknown
-// or empty pgType falls back to "::vector", the shipped default column type.
+// "::vector". In pgvector, vector -> halfvec is an implicit cast and
+// halfvec -> vector is an assignment cast, so `halfvec_col <=> $1::vector` does
+// not error: the planner rewrites the literal to halfvec and still uses the
+// HNSW index. Matching the query vector to the column type is a performance
+// guarantee, not a correctness one: it keeps the HNSW index usable in both
+// column directions and avoids a per-row cast that would otherwise force a
+// sequential scan. pgType originates only from ResolvePgvector (an enum-
+// constrained "vector"/"halfvec"), never user input, so the result is safe to
+// interpolate into SQL. An unknown or empty pgType falls back to "::vector",
+// the shipped default column type.
 func Cast(pgType string) string {
 	if pgType == "halfvec" {
 		return "::halfvec"

--- a/packages/embedmodel/registry.go
+++ b/packages/embedmodel/registry.go
@@ -154,6 +154,21 @@ func (p Plan) ColumnType() string {
 	return fmt.Sprintf("%s(%d)", p.PgType, p.Dim)
 }
 
+// Cast returns the pgvector cast suffix a query vector must carry to match a
+// column of the given pgvector type: "::halfvec" for a halfvec column, else
+// "::vector". pgvector's vector<->halfvec casts are assignment-only, so a
+// query written as `halfvec_col <=> $1::vector` has no operator and errors at
+// runtime; the query vector must be cast to the column's own type. pgType
+// originates only from ResolvePgvector (an enum-constrained "vector"/"halfvec"),
+// never user input, so the result is safe to interpolate into SQL. An unknown
+// or empty pgType falls back to "::vector", the shipped default column type.
+func Cast(pgType string) string {
+	if pgType == "halfvec" {
+		return "::halfvec"
+	}
+	return "::vector"
+}
+
 // ResolvePgvector maps a dimension to its pgvector storage type, HNSW
 // operator class, and whether an ANN index is possible. It is model-
 // independent: it only encodes pgvector's own limits.

--- a/packages/embedmodel/registry.go
+++ b/packages/embedmodel/registry.go
@@ -1,25 +1,62 @@
 // Package embedmodel is the single source of truth for which embedding
-// models Hive knows about, how wide a vector each one natively produces, and
-// which LiteLLM route (if any) serves it. Both apps/edge-api and
+// models Hive knows about, how wide a vector each one natively produces,
+// whether it is Matryoshka-trained (so a shorter dimension is legitimate),
+// and which LiteLLM route (if any) serves it. Both apps/edge-api and
 // apps/control-plane import this instead of keeping their own copy, so the
 // bge-m3/nemotron/qwen3 dimension facts cannot drift between the query path
-// and the ingest path.
+// and the ingest path (#368).
 //
-// This is the foundation piece of the admin-controlled embedding redesign:
-// it lets EMBEDDING_MODEL / EMBEDDING_DIM / EMBEDDING_TRUNCATE_TO be
-// validated for mutual consistency at process startup instead of only
-// discovering a mismatch when a vector of the wrong width hits Postgres.
-// Choosing a model, resizing the live rag_chunks column, and re-embedding
-// existing documents onto a new model are later PRs; this package only
-// answers "are these three env vars consistent with each other."
+// This package answers three questions for the admin-selectable embedding
+// redesign:
+//
+//   - Is a chosen (model, dim) serviceable at all? (Resolve/Validate)
+//   - Which pgvector column type and HNSW opclass does that dimension map to?
+//     (ResolvePgvector)
+//   - Does the chosen dimension require a client-side MRL reduction, and to
+//     what width? (Plan.ReduceTo)
+//
+// The owner mandate is explicit: no naive truncation band-aid. A non-MRL
+// model at a non-native dimension is rejected here, at configuration time,
+// with a clear provider-blind error, rather than accepted and then silently
+// corrupted by slicing a vector space that has no valid lower-dimensional
+// projection. Actually resizing the live rag_chunks column and re-embedding
+// existing documents is done by the control-plane provisioning + re-embed
+// routines; this package only decides what is allowed and how it maps.
 package embedmodel
 
 import "fmt"
+
+// pgvector dimension ceilings, verified against /pgvector/pgvector
+// (_autodocs/types.md and README, "Half-Precision Indexing"):
+//
+//   - A vector column carries an HNSW or IVFFlat index up to 2000 dimensions.
+//   - A halfvec column (2-byte elements) halves the index tuple, raising the
+//     practical HNSW ceiling to ~4000 dimensions via halfvec_cosine_ops.
+//   - Both vector and halfvec store up to 16000 dimensions, but above ~4000
+//     no ANN index of any kind is possible; queries fall back to a brute-force
+//     sequential scan (small-corpus / demo only).
+const (
+	// HNSWVectorMaxDim is the largest dimension a vector column can be HNSW-
+	// (or IVFFlat-) indexed at.
+	HNSWVectorMaxDim = 2000
+	// HalfvecIndexMaxDim is the largest dimension a halfvec column can be
+	// HNSW-indexed at.
+	HalfvecIndexMaxDim = 4000
+	// VectorStorageMaxDim is the largest dimension pgvector will store in a
+	// vector or halfvec column, indexed or not.
+	VectorStorageMaxDim = 16000
+)
 
 // Model describes one embedding model this build knows natively.
 type Model struct {
 	// NativeDim is the vector width the model actually returns.
 	NativeDim int
+	// MRL reports whether the model was trained with Matryoshka
+	// Representation Learning, so that its leading N dimensions are a valid
+	// lower-dimensional embedding. Only an MRL model may be served at a
+	// dimension below its native width; a non-MRL model must use its native
+	// dimension.
+	MRL bool
 	// LiteLLMRoute is the model_name this model is served under in
 	// deploy/litellm/config.yaml, when routed through LiteLLM. Empty for a
 	// model only ever called directly (e.g. bge-m3 on a bare Ollama host).
@@ -34,21 +71,25 @@ var Registry = map[string]Model{
 	// bge-m3: multilingual (incl. Bangla), MRL-trained, native 1024-dim.
 	// Enterprise/Ollama default (#295); not wired through LiteLLM in the
 	// serverless demo today, so no LiteLLMRoute.
-	"bge-m3": {NativeDim: 1024},
+	"bge-m3": {NativeDim: 1024, MRL: true},
 
 	// NVIDIA Nemotron-Embed VL 1B: OpenRouter free-pool primary for the
-	// serverless demo, native 4096-dim.
-	"nemotron-embed-vl-1b": {NativeDim: 4096, LiteLLMRoute: "route-openrouter-embedding"},
+	// serverless demo, native 4096-dim. NOT documented as MRL, so it is not
+	// selectable for indexed RAG at any reduced dimension (4096 exceeds the
+	// halfvec index ceiling and it cannot be MRL-reduced) -- brute-force only.
+	"nemotron-embed-vl-1b": {NativeDim: 4096, MRL: false, LiteLLMRoute: "route-openrouter-embedding"},
 
 	// Qwen3 Embedding 8B: OpenRouter paid fallback for the serverless demo,
-	// MRL-trained, native 4096-dim. Today's demo default (docker-compose.yml).
-	"qwen3-embedding-8b": {NativeDim: 4096, LiteLLMRoute: "route-openrouter-embedding-fallback"},
+	// MRL-trained, native 4096-dim. Serviceable at an MRL-reduced supported
+	// dimension (e.g. 1024 -> vector(1024) HNSW, the clean demo target).
+	"qwen3-embedding-8b": {NativeDim: 4096, MRL: true, LiteLLMRoute: "route-openrouter-embedding-fallback"},
 }
 
 // Lookup finds a Model by canonical id or by LiteLLMRoute alias. ok is false
 // for a model this build has no dimension facts for; callers treat that as
-// "nothing to validate against," not as an error — an admin may point at a
-// custom model the registry does not know yet.
+// "nothing model-specific to validate," not as an error — an admin may point
+// at a custom model the registry does not know yet. The pgvector mapping
+// (ResolvePgvector) is model-independent and still applies.
 func Lookup(modelOrRoute string) (Model, bool) {
 	if m, ok := Registry[modelOrRoute]; ok {
 		return m, true
@@ -61,39 +102,154 @@ func Lookup(modelOrRoute string) (Model, bool) {
 	return Model{}, false
 }
 
-// Validate checks that model, dim (EMBEDDING_DIM), and truncateTo
-// (EMBEDDING_TRUNCATE_TO) are mutually consistent:
+// Canonical maps a model id or LiteLLM route alias to its canonical registry
+// id, so the startup env/config reconcile compares like with like: a service
+// configured with the route alias "route-openrouter-embedding-fallback" and a
+// config row holding the canonical "qwen3-embedding-8b" refer to the same
+// model and must not be treated as a mismatch. Unknown inputs are returned
+// unchanged (a custom model the registry does not know is its own canonical
+// form).
+func Canonical(modelOrRoute string) string {
+	if _, ok := Registry[modelOrRoute]; ok {
+		return modelOrRoute
+	}
+	for id, m := range Registry {
+		if m.LiteLLMRoute != "" && m.LiteLLMRoute == modelOrRoute {
+			return id
+		}
+	}
+	return modelOrRoute
+}
+
+// Plan is the fully resolved, provisionable embedding configuration for a
+// chosen (model, dim). It is what both services resolve their env config into
+// and what the control-plane provisioning routine builds the column + index
+// from, so the query path, the ingest path, and the physical schema are all
+// derived from one computation.
+type Plan struct {
+	Model      string
+	Dim        int
+	NativeDim  int  // 0 when the model is unknown to the registry
+	MRL        bool // false when the model is unknown
+	KnownModel bool
+	// PgType is the pgvector column type: "vector" or "halfvec".
+	PgType string
+	// Opclass is the HNSW operator class for the index: "vector_cosine_ops",
+	// "halfvec_cosine_ops", or "" when the dimension is not indexable.
+	Opclass string
+	// Indexable reports whether an ANN (HNSW) index can be built. When false
+	// the column stores vectors but search is a brute-force sequential scan.
+	Indexable bool
+	// ReduceTo is the client-side MRL reduction target: dim when an MRL
+	// model's chosen dim is below its native width, else 0 (the endpoint is
+	// expected to return exactly dim natively). Preferring the endpoint's
+	// native `dimensions=dim` is still correct: a no-op reduction of an
+	// already-dim-wide vector leaves it unchanged.
+	ReduceTo int
+}
+
+// ColumnType renders the SQL column type text, e.g. "vector(1024)" or
+// "halfvec(3000)".
+func (p Plan) ColumnType() string {
+	return fmt.Sprintf("%s(%d)", p.PgType, p.Dim)
+}
+
+// ResolvePgvector maps a dimension to its pgvector storage type, HNSW
+// operator class, and whether an ANN index is possible. It is model-
+// independent: it only encodes pgvector's own limits.
 //
-//   - model unknown to Registry: nothing to check, returns nil.
-//   - native dim == dim: truncateTo must be 0 (no truncation needed).
-//   - native dim >  dim: truncateTo must equal dim (MRL truncation required).
-//   - native dim <  dim: always an error; a narrower vector cannot be padded
-//     out to a wider column.
-func Validate(model string, dim, truncateTo int) error {
-	if dim <= 0 {
-		return fmt.Errorf("embedmodel: EMBEDDING_DIM must be strictly positive, got %d", dim)
-	}
-	if truncateTo < 0 {
-		return fmt.Errorf("embedmodel: EMBEDDING_TRUNCATE_TO cannot be negative, got %d", truncateTo)
-	}
-	m, ok := Lookup(model)
-	if !ok {
-		return nil
-	}
+//   - 1..2000       -> vector(N),  vector_cosine_ops,  indexable
+//   - 2001..4000    -> halfvec(N), halfvec_cosine_ops, indexable
+//   - 4001..16000   -> halfvec(N), (no index), brute-force ONLY, and only when
+//     allowUnindexed is set; otherwise rejected with a clear error
+//   - >16000        -> rejected (exceeds pgvector storage)
+func ResolvePgvector(dim int, allowUnindexed bool) (pgType, opclass string, indexable bool, err error) {
 	switch {
-	case m.NativeDim == dim:
-		if truncateTo != 0 {
-			return fmt.Errorf("embedmodel: model %q is native %d-dim, matching EMBEDDING_DIM=%d; EMBEDDING_TRUNCATE_TO must be 0, got %d",
-				model, m.NativeDim, dim, truncateTo)
+	case dim <= 0:
+		return "", "", false, fmt.Errorf("embedmodel: dimension must be strictly positive, got %d", dim)
+	case dim <= HNSWVectorMaxDim:
+		return "vector", "vector_cosine_ops", true, nil
+	case dim <= HalfvecIndexMaxDim:
+		return "halfvec", "halfvec_cosine_ops", true, nil
+	case dim <= VectorStorageMaxDim:
+		if !allowUnindexed {
+			return "", "", false, fmt.Errorf(
+				"embedmodel: dimension %d exceeds the %d-dim ANN-index ceiling; no HNSW index is possible, set EMBEDDING_ALLOW_UNINDEXED=1 to store it as an unindexed brute-force column (small-corpus only)",
+				dim, HalfvecIndexMaxDim)
 		}
-	case m.NativeDim > dim:
-		if truncateTo != dim {
-			return fmt.Errorf("embedmodel: model %q is native %d-dim, wider than EMBEDDING_DIM=%d; EMBEDDING_TRUNCATE_TO must equal %d, got %d",
-				model, m.NativeDim, dim, dim, truncateTo)
-		}
+		return "halfvec", "", false, nil
 	default:
-		return fmt.Errorf("embedmodel: model %q is native %d-dim, narrower than EMBEDDING_DIM=%d; cannot pad a narrower vector, pick a wider model or lower EMBEDDING_DIM",
-			model, m.NativeDim, dim)
+		return "", "", false, fmt.Errorf(
+			"embedmodel: dimension %d exceeds the pgvector storage ceiling of %d",
+			dim, VectorStorageMaxDim)
 	}
-	return nil
+}
+
+// Resolve validates a chosen (model, dim) against the selectable policy and
+// returns the full provisioning Plan. It is the single source of truth both
+// edge-api and control-plane resolve their embedding configuration through.
+//
+// Rejections (all at configuration time, provider-blind):
+//
+//   - dim <= 0.
+//   - dim greater than the model's native width (cannot invent dimensions).
+//   - dim below native on a NON-MRL model (naive truncation is banned).
+//   - dim that maps to no indexable pgvector type unless allowUnindexed is set.
+//
+// An unknown model skips the model-specific checks (native width and MRL are
+// unknown) but still resolves the pgvector mapping by dimension.
+func Resolve(model string, dim int, allowUnindexed bool) (Plan, error) {
+	if dim <= 0 {
+		return Plan{}, fmt.Errorf("embedmodel: EMBEDDING_DIM must be strictly positive, got %d", dim)
+	}
+
+	p := Plan{Model: model, Dim: dim}
+	if m, ok := Lookup(model); ok {
+		p.KnownModel = true
+		p.NativeDim = m.NativeDim
+		p.MRL = m.MRL
+		switch {
+		case dim > m.NativeDim:
+			return Plan{}, fmt.Errorf(
+				"embedmodel: model %q is native %d-dim; it cannot produce a wider %d-dim vector, choose a dimension <= %d",
+				model, m.NativeDim, dim, m.NativeDim)
+		case dim < m.NativeDim:
+			if !m.MRL {
+				return Plan{}, fmt.Errorf(
+					"embedmodel: model %q is not MRL-trained; it cannot be reduced to %d dimensions (native %d), choose its native dimension or an MRL-trained model",
+					model, dim, m.NativeDim)
+			}
+			p.ReduceTo = dim // legitimate MRL reduction to a supported width
+		default:
+			p.ReduceTo = 0 // dim == native: endpoint returns the full width
+		}
+	}
+
+	pgType, opclass, indexable, err := ResolvePgvector(dim, allowUnindexed)
+	if err != nil {
+		return Plan{}, err
+	}
+	p.PgType, p.Opclass, p.Indexable = pgType, opclass, indexable
+	return p, nil
+}
+
+// Validate reports whether a chosen (model, dim) is a serviceable
+// configuration, without returning the resolved Plan. It is a thin wrapper
+// over Resolve for call sites that only need the yes/no verdict.
+func Validate(model string, dim int, allowUnindexed bool) error {
+	_, err := Resolve(model, dim, allowUnindexed)
+	return err
+}
+
+// SameConfig reports whether two (model, dim) configurations refer to the same
+// embedding space: same dimension and same canonical model (route aliases
+// resolve to their canonical id first). Both edge-api and control-plane use it
+// at startup to reconcile their resolved env config against the active
+// rag_embedding_config row; a false result means the running config would
+// query a column provisioned for a different space, so RAG is disabled
+// (fail-closed) rather than serving cross-space results. This closes the
+// cross-service inconsistency #368: the same pure comparison runs in both
+// services, so they cannot disagree.
+func SameConfig(aModel string, aDim int, bModel string, bDim int) bool {
+	return aDim == bDim && Canonical(aModel) == Canonical(bModel)
 }

--- a/packages/embedmodel/registry_test.go
+++ b/packages/embedmodel/registry_test.go
@@ -229,3 +229,47 @@ func TestValidateWrapsResolve(t *testing.T) {
 		t.Fatalf("Validate(qwen3,1024) = %v; want nil (MRL reduction ok)", err)
 	}
 }
+
+func TestCast(t *testing.T) {
+	cases := []struct {
+		name   string
+		pgType string
+		want   string
+	}{
+		{"halfvec column casts query to halfvec", "halfvec", "::halfvec"},
+		{"vector column casts query to vector", "vector", "::vector"},
+		{"empty falls back to vector", "", "::vector"},
+		{"unknown falls back to vector", "bogus", "::vector"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Cast(tc.pgType); got != tc.want {
+				t.Fatalf("Cast(%q) = %q, want %q", tc.pgType, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCastMatchesResolvePgvector guards the invariant that every indexable
+// dimension band's pgType yields the matching query cast, so a halfvec column
+// (dim 2001..4000) is never queried with ::vector.
+func TestCastMatchesResolvePgvector(t *testing.T) {
+	cases := []struct {
+		dim  int
+		want string
+	}{
+		{1024, "::vector"},   // vector band
+		{2000, "::vector"},   // vector ceiling
+		{3000, "::halfvec"},  // halfvec indexed band
+		{4000, "::halfvec"},  // halfvec index ceiling
+	}
+	for _, tc := range cases {
+		pgType, _, _, err := ResolvePgvector(tc.dim, false)
+		if err != nil {
+			t.Fatalf("ResolvePgvector(%d): unexpected err %v", tc.dim, err)
+		}
+		if got := Cast(pgType); got != tc.want {
+			t.Fatalf("Cast(ResolvePgvector(%d))=%q, want %q", tc.dim, got, tc.want)
+		}
+	}
+}

--- a/packages/embedmodel/registry_test.go
+++ b/packages/embedmodel/registry_test.go
@@ -4,15 +4,22 @@ import "testing"
 
 func TestLookupByCanonicalID(t *testing.T) {
 	m, ok := Lookup("bge-m3")
-	if !ok || m.NativeDim != 1024 {
-		t.Fatalf("Lookup(bge-m3) = %+v, %v; want NativeDim=1024, ok=true", m, ok)
+	if !ok || m.NativeDim != 1024 || !m.MRL {
+		t.Fatalf("Lookup(bge-m3) = %+v, %v; want NativeDim=1024, MRL=true, ok=true", m, ok)
 	}
 }
 
 func TestLookupByLiteLLMRoute(t *testing.T) {
 	m, ok := Lookup("route-openrouter-embedding-fallback")
-	if !ok || m.NativeDim != 4096 {
-		t.Fatalf("Lookup(route-openrouter-embedding-fallback) = %+v, %v; want NativeDim=4096, ok=true", m, ok)
+	if !ok || m.NativeDim != 4096 || !m.MRL {
+		t.Fatalf("Lookup(route-openrouter-embedding-fallback) = %+v, %v; want NativeDim=4096, MRL=true, ok=true", m, ok)
+	}
+}
+
+func TestLookupNemotronNotMRL(t *testing.T) {
+	m, ok := Lookup("nemotron-embed-vl-1b")
+	if !ok || m.MRL {
+		t.Fatalf("Lookup(nemotron-embed-vl-1b) = %+v, %v; want MRL=false (non-MRL, not selectable for indexed RAG)", m, ok)
 	}
 }
 
@@ -22,37 +29,203 @@ func TestLookupUnknownModel(t *testing.T) {
 	}
 }
 
-func TestValidate(t *testing.T) {
+// TestResolvePgvector locks the pgvector dimension-band mapping.
+func TestResolvePgvector(t *testing.T) {
 	cases := []struct {
-		name       string
-		model      string
-		dim        int
-		truncateTo int
-		wantErr    bool
+		name           string
+		dim            int
+		allowUnindexed bool
+		wantType       string
+		wantOpclass    string
+		wantIndexable  bool
+		wantErr        bool
 	}{
-		{"native equals dim, no truncation: ok", "bge-m3", 1024, 0, false},
-		{"native equals dim, truncation set: error", "bge-m3", 1024, 1024, true},
-		{"native wider than dim, correct truncation: ok", "qwen3-embedding-8b", 1024, 1024, false},
-		{"native wider than dim, truncation unset: error", "qwen3-embedding-8b", 1024, 0, true},
-		{"native wider than dim, wrong truncation: error", "qwen3-embedding-8b", 1024, 512, true},
-		{"native narrower than dim: always an error", "bge-m3", 2048, 0, true},
-		{"native narrower than dim, truncation set: still an error", "bge-m3", 2048, 2048, true},
-		{"unknown model: nothing to validate, ok", "custom-model-not-in-registry", 999, 0, false},
-		{"lookup by LiteLLM route alias: ok", "route-openrouter-embedding-fallback", 1024, 1024, false},
-		{"dim zero: error even for unknown model", "custom-model-not-in-registry", 0, 0, true},
-		{"dim negative: error even for unknown model", "custom-model-not-in-registry", -1, 0, true},
-		{"truncateTo negative: error even for unknown model", "custom-model-not-in-registry", 999, -1, true},
-		{"unknown model, positive dim, zero truncateTo: still ok", "custom-model-not-in-registry", 1, 0, false},
+		{"1 -> vector indexable", 1, false, "vector", "vector_cosine_ops", true, false},
+		{"1024 -> vector indexable", 1024, false, "vector", "vector_cosine_ops", true, false},
+		{"2000 boundary -> vector indexable", 2000, false, "vector", "vector_cosine_ops", true, false},
+		{"2001 -> halfvec indexable", 2001, false, "halfvec", "halfvec_cosine_ops", true, false},
+		{"3000 -> halfvec indexable", 3000, false, "halfvec", "halfvec_cosine_ops", true, false},
+		{"4000 boundary -> halfvec indexable", 4000, false, "halfvec", "halfvec_cosine_ops", true, false},
+		{"4096 without opt-in -> reject", 4096, false, "", "", false, true},
+		{"4096 with opt-in -> halfvec unindexed", 4096, true, "halfvec", "", false, false},
+		{"16000 with opt-in -> halfvec unindexed", 16000, true, "halfvec", "", false, false},
+		{"16001 -> reject even with opt-in", 16001, true, "", "", false, true},
+		{"zero -> reject", 0, false, "", "", false, true},
+		{"negative -> reject", -5, false, "", "", false, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := Validate(tc.model, tc.dim, tc.truncateTo)
-			if tc.wantErr && err == nil {
-				t.Fatalf("Validate(%q, %d, %d) = nil, want an error", tc.model, tc.dim, tc.truncateTo)
+			pgType, opclass, indexable, err := ResolvePgvector(tc.dim, tc.allowUnindexed)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("ResolvePgvector(%d,%v) = nil error, want error", tc.dim, tc.allowUnindexed)
+				}
+				return
 			}
-			if !tc.wantErr && err != nil {
-				t.Fatalf("Validate(%q, %d, %d) = %v, want nil", tc.model, tc.dim, tc.truncateTo, err)
+			if err != nil {
+				t.Fatalf("ResolvePgvector(%d,%v) unexpected error: %v", tc.dim, tc.allowUnindexed, err)
+			}
+			if pgType != tc.wantType || opclass != tc.wantOpclass || indexable != tc.wantIndexable {
+				t.Fatalf("ResolvePgvector(%d,%v) = (%q,%q,%v), want (%q,%q,%v)",
+					tc.dim, tc.allowUnindexed, pgType, opclass, indexable,
+					tc.wantType, tc.wantOpclass, tc.wantIndexable)
 			}
 		})
+	}
+}
+
+// TestResolvePolicy is the selectable model/dimension policy table from the
+// plan: which (model, dim) combinations the system accepts, and what each
+// accepted one resolves to.
+func TestResolvePolicy(t *testing.T) {
+	cases := []struct {
+		name           string
+		model          string
+		dim            int
+		allowUnindexed bool
+		wantErr        bool
+		wantType       string
+		wantOpclass    string
+		wantReduceTo   int
+		wantIndexable  bool
+	}{
+		{
+			name: "bge-m3 native 1024 -> vector HNSW, no reduction",
+			model: "bge-m3", dim: 1024,
+			wantType: "vector", wantOpclass: "vector_cosine_ops", wantReduceTo: 0, wantIndexable: true,
+		},
+		{
+			name: "qwen3 @1024 (MRL reduce) -> vector HNSW, reduce to 1024 (clean demo target)",
+			model: "qwen3-embedding-8b", dim: 1024,
+			wantType: "vector", wantOpclass: "vector_cosine_ops", wantReduceTo: 1024, wantIndexable: true,
+		},
+		{
+			name: "qwen3 @3000 (MRL reduce) -> halfvec HNSW",
+			model: "qwen3-embedding-8b", dim: 3000,
+			wantType: "halfvec", wantOpclass: "halfvec_cosine_ops", wantReduceTo: 3000, wantIndexable: true,
+		},
+		{
+			name: "qwen3 @4096 native without opt-in -> reject (no index possible)",
+			model: "qwen3-embedding-8b", dim: 4096, wantErr: true,
+		},
+		{
+			name: "qwen3 @4096 native with opt-in -> halfvec brute-force",
+			model: "qwen3-embedding-8b", dim: 4096, allowUnindexed: true,
+			wantType: "halfvec", wantOpclass: "", wantReduceTo: 0, wantIndexable: false,
+		},
+		{
+			name: "nemotron @1024 (non-MRL reduce) -> REJECT (owner mandate: no naive truncation)",
+			model: "nemotron-embed-vl-1b", dim: 1024, wantErr: true,
+		},
+		{
+			name: "nemotron @4096 native without opt-in -> reject (non-MRL, no index)",
+			model: "nemotron-embed-vl-1b", dim: 4096, wantErr: true,
+		},
+		{
+			name: "qwen3 @8192 wider than native -> reject (cannot invent dimensions)",
+			model: "qwen3-embedding-8b", dim: 8192, allowUnindexed: true, wantErr: true,
+		},
+		{
+			name: "bge-m3 @2048 wider than native -> reject",
+			model: "bge-m3", dim: 2048, wantErr: true,
+		},
+		{
+			name: "unknown model @1024 -> accepted, resolves pgvector by dim, no reduction",
+			model: "custom-model-not-in-registry", dim: 1024,
+			wantType: "vector", wantOpclass: "vector_cosine_ops", wantReduceTo: 0, wantIndexable: true,
+		},
+		{
+			name: "dim zero -> reject even for unknown model",
+			model: "custom-model-not-in-registry", dim: 0, wantErr: true,
+		},
+		{
+			name: "route alias resolves to qwen3 facts (MRL reduce ok)",
+			model: "route-openrouter-embedding-fallback", dim: 1024,
+			wantType: "vector", wantOpclass: "vector_cosine_ops", wantReduceTo: 1024, wantIndexable: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p, err := Resolve(tc.model, tc.dim, tc.allowUnindexed)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("Resolve(%q,%d,%v) = %+v, nil error; want an error", tc.model, tc.dim, tc.allowUnindexed, p)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Resolve(%q,%d,%v) unexpected error: %v", tc.model, tc.dim, tc.allowUnindexed, err)
+			}
+			if p.PgType != tc.wantType || p.Opclass != tc.wantOpclass || p.ReduceTo != tc.wantReduceTo || p.Indexable != tc.wantIndexable {
+				t.Fatalf("Resolve(%q,%d,%v) = {PgType:%q Opclass:%q ReduceTo:%d Indexable:%v}, want {PgType:%q Opclass:%q ReduceTo:%d Indexable:%v}",
+					tc.model, tc.dim, tc.allowUnindexed,
+					p.PgType, p.Opclass, p.ReduceTo, p.Indexable,
+					tc.wantType, tc.wantOpclass, tc.wantReduceTo, tc.wantIndexable)
+			}
+		})
+	}
+}
+
+func TestCanonical(t *testing.T) {
+	cases := map[string]string{
+		"route-openrouter-embedding-fallback": "qwen3-embedding-8b",
+		"qwen3-embedding-8b":                  "qwen3-embedding-8b",
+		"route-openrouter-embedding":          "nemotron-embed-vl-1b",
+		"bge-m3":                              "bge-m3",
+		"some-unknown-model":                  "some-unknown-model",
+	}
+	for in, want := range cases {
+		if got := Canonical(in); got != want {
+			t.Errorf("Canonical(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestPlanColumnType(t *testing.T) {
+	p, err := Resolve("qwen3-embedding-8b", 3000, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := p.ColumnType(); got != "halfvec(3000)" {
+		t.Fatalf("ColumnType() = %q, want halfvec(3000)", got)
+	}
+}
+
+// TestValidateWrapsResolve confirms Validate agrees with Resolve on accept/
+// reject so the UI (which will call Validate) and the provisioning path (which
+// calls Resolve) can never disagree.
+// TestSameConfig is the #368 cross-service reconcile: both services run this
+// same comparison, so a matched pair keeps RAG enabled and a mismatched pair
+// (different model or dim) disables it. Route alias and canonical id match.
+func TestSameConfig(t *testing.T) {
+	cases := []struct {
+		name             string
+		aModel           string
+		aDim             int
+		bModel           string
+		bDim             int
+		want             bool
+	}{
+		{"identical", "bge-m3", 1024, "bge-m3", 1024, true},
+		{"route alias vs canonical, same model", "route-openrouter-embedding-fallback", 1024, "qwen3-embedding-8b", 1024, true},
+		{"different model, same dim -> mismatch", "bge-m3", 1024, "qwen3-embedding-8b", 1024, false},
+		{"same model, different dim -> mismatch", "qwen3-embedding-8b", 1024, "qwen3-embedding-8b", 1536, false},
+		{"two unknown equal customs", "custom-x", 768, "custom-x", 768, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := SameConfig(tc.aModel, tc.aDim, tc.bModel, tc.bDim); got != tc.want {
+				t.Fatalf("SameConfig(%q,%d,%q,%d) = %v, want %v", tc.aModel, tc.aDim, tc.bModel, tc.bDim, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidateWrapsResolve(t *testing.T) {
+	if err := Validate("nemotron-embed-vl-1b", 1024, false); err == nil {
+		t.Fatal("Validate(nemotron,1024) = nil; want reject (non-MRL reduction)")
+	}
+	if err := Validate("qwen3-embedding-8b", 1024, false); err != nil {
+		t.Fatalf("Validate(qwen3,1024) = %v; want nil (MRL reduction ok)", err)
 	}
 }

--- a/supabase/migrations/20260719_01_rag_embedding_config.sql
+++ b/supabase/migrations/20260719_01_rag_embedding_config.sql
@@ -94,14 +94,17 @@ CREATE INDEX IF NOT EXISTS rag_reembed_jobs_status_idx
 COMMENT ON TABLE public.rag_reembed_jobs IS
     'Progress ledger for corpus re-embed runs triggered by an embedding model/dim switch. Resumable after restart; append-only per run.';
 
--- Privileges. hive_app (the NOT BYPASSRLS app role) reads the active config
--- and updates job progress during a re-embed. The config row is written by the
--- provisioning routine, which connects with a privileged (DDL-capable) role,
--- so hive_app is granted SELECT + UPDATE on the config but the DDL that makes
--- the column match is out of its reach by design. auditor_ro reads both for
--- the audit trail.
-GRANT SELECT, UPDATE          ON public.rag_embedding_config TO hive_app;
-GRANT SELECT, INSERT, UPDATE  ON public.rag_reembed_jobs     TO hive_app;
+-- Privileges. hive_app (the NOT BYPASSRLS app role) only READS both tables:
+-- it reconciles its resolved env config against the active config row at
+-- startup. The config row is the fail-closed control record; it is written
+-- solely by the provisioning routine, which connects with a privileged
+-- (DDL-capable) role that also runs the matching column DDL, so hive_app must
+-- not be able to UPDATE it out from under the physical schema. The re-embed
+-- worker likewise runs on the privileged pool and does not write
+-- rag_reembed_jobs through hive_app, so no INSERT/UPDATE grant is needed there.
+-- auditor_ro reads both for the audit trail.
+GRANT SELECT ON public.rag_embedding_config TO hive_app;
+GRANT SELECT ON public.rag_reembed_jobs     TO hive_app;
 GRANT SELECT ON public.rag_embedding_config TO auditor_ro;
 GRANT SELECT ON public.rag_reembed_jobs     TO auditor_ro;
 

--- a/supabase/migrations/20260719_01_rag_embedding_config.sql
+++ b/supabase/migrations/20260719_01_rag_embedding_config.sql
@@ -1,0 +1,108 @@
+-- supabase/migrations/20260719_01_rag_embedding_config.sql
+--
+-- Single source of truth for the active RAG embedding configuration, plus a
+-- re-embed progress table (admin-selectable embedding dimension redesign, PR2;
+-- closes the cross-service inconsistency #368).
+--
+-- Why a config row: edge-api (query path) and control-plane (ingest + re-embed
+-- path) each resolve EMBEDDING_MODEL / EMBEDDING_DIM from the environment
+-- independently. Nothing forced them to agree, and nothing recorded which
+-- (model, dim, pgvector type, index) the live rag_chunks.embedding column was
+-- actually provisioned to. This singleton row is that record. Both services
+-- read it at startup and fail closed (disable the RAG feature gate) when their
+-- resolved env config does not match it, instead of serving cross-space
+-- queries against a column provisioned for a different model or dimension.
+--
+-- Why runtime provisioning, not a fixed migration, resizes the column: the
+-- embedding dimension is admin-chosen at runtime, so a static CHECK-in migration
+-- cannot express the target vector(N)/halfvec(N) type. The control-plane
+-- provisioning routine (apps/control-plane/internal/rag/provision.go) recreates
+-- rag_chunks.embedding to match this row's (pgvector_type, dim, opclass). This
+-- migration only creates the config + progress tables and seeds the default
+-- that matches the shipped column (vector(1024) HNSW cosine, per
+-- 20260625_05_carl_rag.sql).
+--
+-- Depends on: 20260625_05_carl_rag.sql (public.rag_chunks, hive_app, auditor_ro).
+
+BEGIN;
+
+-- Singleton: exactly one row, pinned to id = 1 by the PK + CHECK. Both
+-- services read this row; only the control-plane provisioning routine writes
+-- it (it runs the DDL that makes the column match), so writes are naturally
+-- serialized through that one code path.
+CREATE TABLE IF NOT EXISTS public.rag_embedding_config (
+    id             SMALLINT    PRIMARY KEY DEFAULT 1 CHECK (id = 1),
+    -- Canonical model id or LiteLLM route alias resolved by packages/embedmodel.
+    model          TEXT        NOT NULL,
+    -- Provisioned vector width. The rag_chunks.embedding column is
+    -- pgvector_type(dim); a service whose EMBEDDING_DIM differs disables RAG.
+    dim            INT         NOT NULL CHECK (dim > 0),
+    -- 'vector' (<=2000 indexed) or 'halfvec' (2001..4000 indexed, or
+    -- 4001..16000 brute-force). Matches embedmodel.ResolvePgvector.
+    pgvector_type  TEXT        NOT NULL DEFAULT 'vector'
+                               CHECK (pgvector_type IN ('vector','halfvec')),
+    -- HNSW operator class, or '' when the dimension is stored unindexed
+    -- (brute-force sequential scan, opt-in only).
+    opclass        TEXT        NOT NULL DEFAULT 'vector_cosine_ops',
+    -- Whether an ANN index backs the column (false = brute-force scan).
+    indexable      BOOLEAN     NOT NULL DEFAULT TRUE,
+    -- Set by the provisioning routine once the column + index actually match.
+    provisioned_at TIMESTAMPTZ,
+    updated_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Seed the shipped serverless-demo default, matching both .env.example and the
+-- column shipped by 20260625_05_carl_rag.sql: qwen3-embedding-8b via
+-- route-openrouter-embedding-fallback (MRL, native 4096) MRL-reduced to 1024,
+-- stored as vector(1024) with HNSW vector_cosine_ops. This equals the existing
+-- rag_chunks.embedding vector(1024) shape, so a fresh demo runs with zero
+-- provisioning and the startup env/config reconcile matches out of the box. An
+-- enterprise deployment on a different model (e.g. bge-m3, also 1024/vector)
+-- updates this row through the provisioning routine, which re-embeds the
+-- corpus; until then a mismatched EMBEDDING_MODEL fails RAG closed rather than
+-- querying across two vector spaces. INSERT ... ON CONFLICT DO NOTHING keeps
+-- re-runs idempotent without clobbering an admin-applied config.
+INSERT INTO public.rag_embedding_config
+    (id, model, dim, pgvector_type, opclass, indexable, provisioned_at)
+VALUES
+    (1, 'route-openrouter-embedding-fallback', 1024, 'vector', 'vector_cosine_ops', TRUE, now())
+ON CONFLICT (id) DO NOTHING;
+
+COMMENT ON TABLE public.rag_embedding_config IS
+    'Singleton active RAG embedding configuration (model, dim, pgvector type, index). Single source of truth read by edge-api and control-plane at startup; written only by the control-plane provisioning routine. Closes #368.';
+
+-- Re-embed progress. One row per provisioning-triggered corpus rebuild, so a
+-- re-embed that is interrupted (process restart) is resumable and observable.
+-- Not tenant-scoped: a model/dim switch is an operator action across the whole
+-- corpus, so this is an operational/global table, not RLS-guarded per tenant.
+CREATE TABLE IF NOT EXISTS public.rag_reembed_jobs (
+    id           UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    model        TEXT        NOT NULL,
+    dim          INT         NOT NULL CHECK (dim > 0),
+    total_docs   INT         NOT NULL DEFAULT 0,
+    done_docs    INT         NOT NULL DEFAULT 0,
+    status       TEXT        NOT NULL DEFAULT 'pending'
+                             CHECK (status IN ('pending','running','completed','failed')),
+    error_msg    TEXT,
+    started_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS rag_reembed_jobs_status_idx
+    ON public.rag_reembed_jobs (status, started_at DESC);
+
+COMMENT ON TABLE public.rag_reembed_jobs IS
+    'Progress ledger for corpus re-embed runs triggered by an embedding model/dim switch. Resumable after restart; append-only per run.';
+
+-- Privileges. hive_app (the NOT BYPASSRLS app role) reads the active config
+-- and updates job progress during a re-embed. The config row is written by the
+-- provisioning routine, which connects with a privileged (DDL-capable) role,
+-- so hive_app is granted SELECT + UPDATE on the config but the DDL that makes
+-- the column match is out of its reach by design. auditor_ro reads both for
+-- the audit trail.
+GRANT SELECT, UPDATE          ON public.rag_embedding_config TO hive_app;
+GRANT SELECT, INSERT, UPDATE  ON public.rag_reembed_jobs     TO hive_app;
+GRANT SELECT ON public.rag_embedding_config TO auditor_ro;
+GRANT SELECT ON public.rag_reembed_jobs     TO auditor_ro;
+
+COMMIT;


### PR DESCRIPTION
## Summary

Replaces the RAG embedding truncation band-aid with an admin-selectable model
plus dimension whose choice provisions the pgvector column and index to match.
Per the owner mandate there is no naive truncation: a model or dimension the
vector database cannot serve is rejected at configuration time with a clear
provider-blind error, never accepted and then silently corrupted.

Backend slice only. The web-console admin picker is a separate follow-up
(Phase 5 of the plan).

Closes #392. Addresses #368 (cross-service embedding-config inconsistency).

## What changed

- **Policy (`packages/embedmodel`)**: `Model` gains an MRL flag.
  `ResolvePgvector` maps a dimension to its pgvector type and HNSW opclass
  (1..2000 vector, 2001..4000 halfvec, 4001..16000 brute-force opt-in, above
  16000 rejected). `Resolve` enforces the selectable policy and returns a
  provisioning `Plan`; it rejects a non-MRL model below native width, a
  dimension wider than native, and an unindexable dimension without opt-in.
  `Canonical` plus `SameConfig` give both services one comparison.
- **Single source of truth**: new `public.rag_embedding_config` singleton row
  (model, dim, pgvector type, opclass, indexable) plus `public.rag_reembed_jobs`
  progress table (`supabase/migrations/20260719_01_rag_embedding_config.sql`).
  Both services read the row at startup and disable RAG on an env/config
  mismatch. This closes the #368 gap where edge-api and control-plane resolved
  the dimension independently.
- **Provisioning (`apps/control-plane/internal/rag/provision.go`)**: recreates
  `rag_chunks.embedding` as `vector(N)`/`halfvec(N)` with the resolved opclass,
  idempotently, preserving chunk text, re-asserting grants and tenant RLS,
  marking documents pending (fail-closed), and recording the choice.
- **Re-embed worker (`reembed.go`)**: rewrites vectors of documents not at the
  active config, one document per transaction (never half-migrated), idempotent
  and resumable, per-document fail-closed. Wired as a startup catch-up pass.
- **Truncation removed**: the embed clients no longer take a standalone truncate
  target; they request `dimensions=N` from the endpoint (MRL-native, preferred)
  and keep the client-side MRL reduce only as a fallback. `EMBEDDING_TRUNCATE_TO`
  is retired; `EMBEDDING_ALLOW_UNINDEXED` gates the >4000 brute-force band.
- **Demo config**: `.env.example` documents the derived reduction; the demo
  stays qwen3 at 1024 into `vector(1024)` HNSW cosine, no truncation. No
  `deploy/litellm/config.yaml` change was needed (the client now sends
  `dimensions`; LiteLLM forwards it, existing drop-param fallback covers a
  provider that rejects it).

## Verified (Docker toolchain, `go test ... -count=1`)

`go build` of both cmd servers and all three packages is green; `go vet` clean.

- `packages/embedmodel` plus `apps/edge-api/internal/rag` plus
  `apps/control-plane/internal/rag`: **95 PASS, 0 FAIL**.
- Policy table (bge-m3@1024 ok, qwen3@1024 MRL-reduce ok, qwen3@3000 halfvec,
  qwen3@4096 brute-force opt-in only, nemotron@1024 rejected non-MRL,
  dim>native rejected), pgvector band mapping, `SameConfig` reconcile,
  `Canonical` alias resolution.
- Truncation removal: `dimensions` is sent, endpoint-honored path passes, and
  the strict width reject still fires when the endpoint ignores it.
- Re-embed batching: split/order, default batch size, fail-closed (no partial),
  empty input.

## Needs live verification (cannot run in this environment)

- **pgvector integration** (`provision_test.go`, gated on `HIVE_TEST_DB_URL`):
  column recreate to `vector(1024)` and `halfvec(3000)`, idempotent
  re-provision, RLS survival. Compiles and skips cleanly here; run in the
  integration lane against a Postgres+pgvector container.
- **Re-embed end-to-end** against a live corpus.
- **Live OpenRouter/LiteLLM demo**: whether the qwen3 route honors
  `dimensions=1024` on the wire (fallback client-side MRL reduce is in place if
  not). Needs real `OPENROUTER_API_KEY` + `LITELLM_MASTER_KEY`.

## Follow-up (out of scope here)

- Web-console admin picker (model dropdown, derived dimension selector,
  destructive-confirm apply endpoint) and its Playwright coverage.
- A scheduled re-embed queue plus admin trigger endpoint (this PR runs a single
  startup catch-up pass).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added flexible embedding dimension support, including optimized storage for larger embeddings and optional unindexed storage.
  * Added automatic migration of existing document embeddings when the active model or dimensions change.
  * Improved vector search compatibility across supported embedding storage formats.

* **Bug Fixes**
  * Invalid or mismatched embedding configurations now disable RAG embedding safely instead of operating inconsistently.
  * Embedding failures no longer leave partially updated documents or vectors.

* **Tests**
  * Expanded coverage for dimension handling, configuration validation, search behavior, provisioning, and re-embedding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->