### PR TITLE
feat: vendor codex windows-sandbox FS/token primitives and port policy resolver (Step 3 wave 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,14 +186,18 @@ jobs:
       # so no MinGW linker is needed; adding the target's std is enough. Scoped
       # to -p hive-desktop-sandbox to skip the vendored bwrap C build. MSVC is
       # not cross-checkable here (no linker); see VENDORING.md open risk #2.
+      #
+      # -p codex-windows-sandbox is included from Step 3 Wave 1 onward: its
+      # vendored modules are ALSO #[cfg(windows)]-gated (see its lib.rs) and
+      # need the same cross-compile to be exercised at all in CI.
       - name: Add Windows cross target
         run: rustup target add x86_64-pc-windows-gnu
 
       - name: cargo check (Windows FFI cross-compile)
-        run: cargo check --target x86_64-pc-windows-gnu -p hive-desktop-sandbox
+        run: cargo check --target x86_64-pc-windows-gnu -p hive-desktop-sandbox -p codex-windows-sandbox
 
       - name: cargo clippy (Windows FFI cross-compile)
-        run: cargo clippy --target x86_64-pc-windows-gnu -p hive-desktop-sandbox -- -D warnings
+        run: cargo clippy --target x86_64-pc-windows-gnu -p hive-desktop-sandbox -p codex-windows-sandbox -- -D warnings
 
   # ------------------------------------------------------------------
   # Desktop app (Tauri shell, issue #310/#311). Toolchain version comes

--- a/apps/desktop-sandbox/Cargo.lock
+++ b/apps/desktop-sandbox/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "anyhow"
+version = "1.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
+
+[[package]]
 name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -42,10 +48,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "codex-windows-sandbox"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "dirs-next",
+ "dunce",
+ "pretty_assertions",
+ "rand",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "enumflags2"
@@ -64,7 +112,7 @@ checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -74,7 +122,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -88,6 +136,17 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
 
 [[package]]
 name = "getrandom"
@@ -114,6 +173,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
 name = "landlock"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,7 +186,7 @@ checksum = "635839550ae8b90d9fd2571460a6645dc0aec070225956ca7a2831ed31d2795d"
 dependencies = [
  "enumflags2",
  "libc",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -131,10 +196,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libredox"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "memchr"
+version = "2.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "once_cell"
@@ -147,6 +227,15 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "pretty_assertions"
@@ -183,6 +272,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "rand"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,7 +322,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -202,6 +332,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae55de56877481d112a559bbc12667635fdaf5e005712fd4e2b2fa50ffc884"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.0",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -222,16 +395,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fac314a64dc9a36e61a9eb4261a5e9bbfbc922b27e518af97bc32b926cf967"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
@@ -240,7 +433,18 @@ version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -251,7 +455,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -259,6 +463,34 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
@@ -291,7 +523,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -302,7 +534,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -327,6 +559,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
  "windows-result",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
  "windows-targets",
 ]
 
@@ -408,3 +649,29 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/apps/desktop-sandbox/Cargo.toml
+++ b/apps/desktop-sandbox/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "codex-bwrap",
     "codex-process-hardening",
+    "codex-windows-sandbox",
     "hive-desktop-sandbox",
 ]
 

--- a/apps/desktop-sandbox/VENDORING.md
+++ b/apps/desktop-sandbox/VENDORING.md
@@ -81,6 +81,52 @@ body) rather than any bug. Allowed at the crate level, not patched
 per-callsite, specifically so the vendored files stay byte-for-byte
 diffable against upstream for future re-vendoring passes.
 
+### Local deviations from upstream (CodeRabbit findings, PR #398)
+
+Four of the vendored files above received small bug fixes on top of the
+byte-for-byte copy, so they are no longer byte-identical to upstream. Step 3
+of "Updating this vendor copy" below re-copies these files verbatim from
+upstream on any future re-vendoring pass; check whether upstream has
+independently fixed the same bugs, and if not, re-apply these fixes.
+
+- `acl.rs:675` (`allow_null_device`): the null-device path was
+  `r"\\\\.\\NUL"`, a raw string literal, so the backslashes are taken
+  literally rather than un-escaped. That produced 4 backslashes before the
+  dot and 2 after (`\\\\.\\NUL`) as the actual `CreateFileW` path argument,
+  instead of the documented Win32 device-namespace path `\\.\NUL` (2
+  backslashes before the dot, 1 after). Fixed to `r"\\.\NUL"`. CodeRabbit's
+  major finding asked whether `\\.\NUL` or bare `NUL` is the correct form;
+  the bug here was the raw-string escaping, not the device-path convention
+  itself (`\\.\<name>` is the standard, well-documented Win32 device
+  namespace prefix), so this was verified by static byte-level inspection of
+  the literal and needs no Windows lab run to trust.
+- `env.rs:119` (`ensure_denybin`): the deny-stub `.bat`/`.cmd` files were
+  written with `b"@echo off\\r\\nexit /b 1\\r\\n"`. In a normal (non-raw)
+  byte-string literal, `\\r` decodes to the two literal ASCII characters
+  backslash and `r`, not a carriage-return byte, so the file lands as one
+  line with no real line breaks, and `exit /b 1` never runs as its own
+  statement (defeating the deny-stub's job of making blocked tools fail with
+  a distinct exit code). Fixed to `b"@echo off\r\nexit /b 1\r\n"` (single
+  backslash, so Rust's escape processing emits real CR (0x0D) and LF (0x0A)
+  bytes).
+- `sandbox_utils.rs:42` and its test helper at `sandbox_utils.rs:66`
+  (`inject_git_safe_directory` / `safe_directory_value`): both called
+  `.replace("\\\\", "/")`, which matches a literal two-backslash sequence.
+  `PathBuf::to_string_lossy()` on Windows returns single backslashes as path
+  separators (e.g. `C:\Users\foo`), so the replace was a no-op and the
+  `GIT_CONFIG_VALUE_*` env var kept native backslashes instead of the
+  intended forward-slash form. Fixed both call sites to
+  `.replace('\\', "/")` (single-backslash-char pattern). Both sites shared
+  the identical bug, so the existing tests (which build their expected value
+  with the same helper) still pass unchanged once both are fixed together.
+- `token.rs:479-482` (`create_token_with_caps_from`): after
+  `CreateRestrictedToken` succeeds, a later failure in `set_default_dacl` or
+  `enable_single_privilege` returned `Err` via `?` without closing
+  `new_token`, leaking the HANDLE. Fixed to explicitly `CloseHandle(new_token)`
+  on both error paths before returning, matching the `CloseHandle`-on-cleanup
+  idiom already used elsewhere in this file (line 357) and in `acl.rs`
+  (lines 88, 732).
+
 ### Deliberately NOT vendored this wave (deviations from the blueprint's Wave 1/2 module list, found while fetching the actual upstream source)
 
 - **`process.rs`** (the `CreateProcessAsUserW` wrapper). The blueprint
@@ -322,6 +368,29 @@ crate deliberately does not inherit the workspace's Apache-2.0
    this crate's own (multithreaded) test binary. Pre-existing at the time: no
    test before that pass ever exercised the real spawn path, so nothing
    surfaced it earlier.
+8. **Known upstream issue, deferred (`cap.rs`, CodeRabbit finding, PR #398):
+   the `cap_sid` file is an unsynchronized read-modify-write.**
+   `workspace_cap_sid_for_cwd` and `writable_root_cap_sid_for_path` both
+   `load_or_create_cap_sids` (read + parse JSON), mutate the in-memory
+   `CapSids`, then `persist_caps` (serialize + `fs::write`) the whole file
+   back, with no file lock, mutex, or atomic replace between the read and
+   the write. Two concurrent callers against the same `codex_home` can race:
+   both read the same base state, each adds its own
+   `workspace_by_cwd`/`writable_root_by_path` entry, and whichever
+   `persist_caps` writes last silently drops the other's entry (and its
+   already-applied ACL SID becomes orphaned). This is reachable in the
+   intended production design, not merely theoretical: under the Step 3
+   Q1/Q3 decision (one shared low-privilege sandbox OS user, not one per
+   session), concurrent agent-engine sandbox launches on Windows share that
+   one user's `codex_home`, hence one `cap_sid` file. Not guess-fixed this
+   pass: `cap.rs` is still fully inert (nothing calls it from
+   `windows::launch` yet, see item #6), and the right fix (`LockFileEx`
+   around the read-modify-write, a named mutex, or an atomic
+   rename-based compare-and-swap) needs a real concurrent-launch test on
+   Windows to trust the chosen approach. Fix and lab-validate together with
+   whichever of Wave 3 or Wave 4 first makes concurrent launches reachable
+   (the same wave that wires the sandbox-user provisioning and the actual
+   `cap.rs` launch-path call sites).
 
 ## Updating this vendor copy
 

--- a/apps/desktop-sandbox/VENDORING.md
+++ b/apps/desktop-sandbox/VENDORING.md
@@ -37,7 +37,113 @@ use -- `hive-desktop-sandbox`'s `policy.rs`/`linux.rs` are a from-scratch,
 narrower replacement for the parts we need) and `sandboxing/` (Codex's
 higher-level policy abstraction, same reason).
 
-## Why not `codex-rs/windows-sandbox-rs` for the Windows backend
+## `codex-windows-sandbox/` (Step 3 Wave 1, blueprint `blueprint-step3-elevated-windows-sandbox.md`)
+
+Blueprint Step 3 takes the base non-elevated Windows sandbox above (#395,
+`c8c1434b`) toward the elevated variant: a dedicated low-privilege sandbox OS
+user, ACL filesystem confinement, and a UAC-elevated helper. Wave 1 (this
+pass) vendors the mechanism primitives and ports the one policy seam; it does
+NOT wire anything into `windows::launch` yet (see "Newly authored" below and
+the crate's own `lib.rs` doc). Same pinned commit as the rest of this file's
+vendored code, so the whole vendored `codex-rs` tree stays on one SHA:
+
+- Upstream: `codex-rs/windows-sandbox-rs` (package `codex-windows-sandbox`,
+  Apache-2.0).
+- Commit: `a47c661ea9e226fe65e46cf9dbc5c5ed75c2c762` (2026-07-16).
+
+### What was vendored (verbatim, byte-for-byte)
+
+Into the new `codex-windows-sandbox/` subcrate (own `Cargo.toml`, own
+Apache-2.0 licence inherited from `[workspace.package]`, same reason as
+`codex-bwrap`: keeps the licence boundary crisp against
+`hive-desktop-sandbox`'s proprietary code):
+
+`token.rs`, `cap.rs`, `proc_thread_attr.rs`, `acl.rs`, `workspace_acl.rs`,
+`deny_read_acl.rs`, `deny_read_state.rs`, `dpapi.rs`, `hide_users.rs`,
+`winutil.rs`, `sandbox_utils.rs`, `env.rs`, `path_normalization.rs`. Every
+module here takes primitive arguments (paths, masks, SID pointers, token
+handles) and does not import `codex_protocol`; `codex_protocol` is not a
+dependency of this crate. Every `mod` declaration in `lib.rs` is
+`#[cfg(windows)]`-gated (matching how `hive-desktop-sandbox`'s own `windows.rs`
+is gated), so this crate compiles to an empty crate on non-Windows hosts and
+is exercised only by the `-p codex-windows-sandbox` leg of the
+`x86_64-pc-windows-gnu` cross-compile CI step below.
+
+`lib.rs` also carries two crate-level `#![allow(...)]`s
+(`unsafe_op_in_unsafe_fn`, `clippy::missing_safety_doc`) found necessary by
+actually running `cargo clippy --target x86_64-pc-windows-gnu -p
+codex-windows-sandbox -- -D warnings` this pass: without them the cross-compile
+CI step below fails with 143 errors, ALL from these two lint classes (135
+`unsafe_op_in_unsafe_fn`, 8 `missing_safety_doc`; verified no other clippy
+lint fired), caused by an edition mismatch (upstream predates edition 2024's
+requirement for an explicit `unsafe {}` block inside an `unsafe fn`'s own
+body) rather than any bug. Allowed at the crate level, not patched
+per-callsite, specifically so the vendored files stay byte-for-byte
+diffable against upstream for future re-vendoring passes.
+
+### Deliberately NOT vendored this wave (deviations from the blueprint's Wave 1/2 module list, found while fetching the actual upstream source)
+
+- **`process.rs`** (the `CreateProcessAsUserW` wrapper). The blueprint
+  describes it as "verbatim-vendorable... no `codex_protocol` coupling," which
+  is true, but it is NOT self-contained: it imports `crate::desktop::LaunchDesktop`
+  (constructs one, holds it as a field of its returned spawn handle) and
+  `crate::logging` for debug logging. `desktop.rs` is explicitly Step 5
+  (CLI/ConPTY) scope, out of bounds for this wave. Vendoring `process.rs` now
+  would mean either vendoring `desktop.rs` early or inventing a fake
+  `LaunchDesktop` stub that misrepresents a real upstream type -- both worse
+  than deferring. `process.rs` is deferred to whichever wave vendors or ports
+  `desktop.rs` (Step 5, or whenever a real caller needs it); `hive-desktop-sandbox`'s
+  own `windows.rs` already has its own working `CreateProcessAsUserW` call from
+  issue #395 for what this wave needs.
+- **`deny_read_resolver.rs`** (`resolve_windows_deny_read_paths`, the
+  glob-scan-based deny-read carve-out selector). The blueprint's section 0.2
+  claims `resolved_permissions.rs` is "the ONLY windows-sandbox module that
+  imports `codex_protocol`"; that is incorrect; `deny_read_resolver.rs` also
+  imports `codex_protocol::permissions::*` and `codex_utils_absolute_path::AbsolutePathBuf`.
+  It is a policy-resolution module (decides WHICH paths get denied), not a
+  Win32 mechanism primitive, so it belongs with `resolved_permissions.rs`'s
+  port treatment, not the verbatim vendor set -- and porting it is unnecessary
+  this wave: `SandboxPolicy` has no secret-path input source yet, so
+  `windows_resolve.rs`'s adapter returns an empty deny-read carve-out set (a
+  correct, honest default per the blueprint's own mapping table: "secret paths
+  (future, from hook/config) -> deny-read carveout set; empty set is valid").
+  Note that `deny_read_acl.rs`/`deny_read_state.rs` (vendored) take a plain
+  `&[PathBuf]` and never depend on `deny_read_resolver.rs`'s output type, so
+  excluding it does not affect what was vendored.
+- `deny_read_state.rs`'s one CODEX_HOME-coupled dependency
+  (`crate::setup::sandbox_dir`) is satisfied by a ONE-FUNCTION verbatim
+  extraction into a local `setup.rs` (just `sandbox_dir(codex_home) -> PathBuf`,
+  byte-identical to upstream); the rest of upstream's `setup.rs` (OS-account
+  provisioning, `SandboxUsersFile`, elevated setup) is Wave 3 scope, ported
+  into `hive-desktop-sandbox`'s `windows_elevated.rs`, not vendored here.
+- `hide_users.rs`'s one dependency on `crate::logging::log_note` is satisfied
+  by a minimal, Hive-authored (NOT vendored) `logging.rs` stand-in (writes to
+  stderr) instead of upstream's real `logging.rs`, which pulls in
+  `tracing-appender`, `chrono`, and the `codex-utils-string` crate for
+  CODEX_HOME-scoped rotating log files -- none of that is load-bearing while
+  `hide_users.rs` itself is not called from any Hive launch path yet.
+
+### Newly authored (Hive-proprietary, ported from upstream's one policy seam)
+
+- `hive-desktop-sandbox/src/windows_resolve.rs`: the port of
+  `resolved_permissions.rs` to Hive-native types.
+  `ResolvedWindowsSandboxPermissions::from_policy(&SandboxPolicy, cwd)` drops
+  `codex_protocol` entirely and returns Hive types
+  (`crate::policy::NetworkPolicy`, `Vec<PathBuf>`, a Hive `WindowsSandboxTokenMode`
+  with a single `ElevatedSandboxUser` variant per the Step 3 Q1/Q3 decisions).
+  Pure, no Win32 calls, unit-tested on Linux CI exactly like `windows_plan.rs`.
+  Not called from `windows::launch` this wave.
+- `codex-windows-sandbox/src/setup.rs` and `codex-windows-sandbox/src/logging.rs`:
+  the two minimal stand-ins described above, not part of the verbatim vendor.
+
+### Why not `codex-rs/windows-sandbox-rs` for the Windows backend (historical, #395 wave; superseded in part by Step 3 above)
+
+This section predates Step 3 and explains why the #395 wave (the base,
+non-elevated Windows backend) did not vendor `windows-sandbox-rs` at all. Step
+3 Wave 1 above now vendors a real subset of it. The reasoning below (WFP,
+DPAPI, elevated helper, ConPTY, a dedicated setup binary are out of scope for
+the BASE variant) still holds for why #395 itself stayed hand-authored; it is
+Step 3, not #395, that draws on this upstream crate.
 
 `codex-rs/windows-sandbox-rs` (`codex-windows-sandbox`) exists upstream and is
 Apache-2.0, but it is a much larger, Codex-CLI-specific system: Windows
@@ -114,8 +220,10 @@ crate deliberately does not inherit the workspace's Apache-2.0
 
 ## Open risks / follow-up (not this wave's scope)
 
-1. **Step 1 launch seam wired; confinement strength explicitly PARTIAL
-   (plan-codex-crossplatform-desktop.md).** `windows::launch` was disabled
+1. **RESOLVED (Step 1, `c8c1434b` / #395): launch seam wired.** Confinement
+   strength beyond the seam itself is explicitly PARTIAL and tracked
+   separately below (items #3 and #6), not reopened here.
+   `windows::launch` was disabled
    because `std::process::Command` cannot spawn under an alternate token. It
    now calls `CreateProcessAsUserW` directly under a distinct primary token,
    applies the directory ACL, creates the child `CREATE_SUSPENDED`, assigns it
@@ -181,31 +289,39 @@ crate deliberately does not inherit the workspace's Apache-2.0
    bubblewrap's `--unshare-user` for any process without an explicit `userns`
    grant. Written against the documented Ubuntu pattern but not loaded and
    exercised against a real restricted-userns box in this session.
-6. **Windows restricted token is the base variant only.** No SIDs disabled,
-   no privileges deleted beyond `CreateRestrictedToken`'s own defaults, and it
-   restricts the *current* process's token rather than provisioning a
-   dedicated low-privilege sandbox OS user. `codex-rs/windows-sandbox-rs`'s
-   elevated-helper-user pattern (see above) is the precedent for that
-   variant when it's prioritized. Item 1 is now wired, so this is the next
-   Windows hardening step (a dedicated later step of the cross-platform plan).
-7. **`linux::launch`'s real `Command::spawn()` + `pre_exec` path is a
-   post-fork allocator-deadlock hazard, discovered this pass (#308/#311).**
-   `pre_exec`'s closure runs in a raw-`fork()`ed child (required so it can
-   run arbitrary code before `exec`); `apply_landlock_ruleset` and
-   `apply_seccomp_denylist` both allocate (`Vec`, `PathFd::new`, `format!`).
+6. **IN PROGRESS (Step 3): Windows restricted token is the base variant
+   only.** No SIDs disabled, no privileges deleted beyond
+   `CreateRestrictedToken`'s own defaults, and it restricts the *current*
+   process's token rather than provisioning a dedicated low-privilege sandbox
+   OS user. `codex-rs/windows-sandbox-rs`'s elevated-helper-user pattern (see
+   above) is the precedent for that variant. Execution is
+   `blueprint-step3-elevated-windows-sandbox.md` (project vault): Wave 1 (this
+   PR) vendors the mechanism primitives (`codex-windows-sandbox/`) and ports
+   the policy adapter (`windows_resolve.rs`), both inert and not yet wired
+   into `windows::launch`. Waves 2 to 4 (elevated helper and provisioning,
+   then the actual launch-path wiring) remain open. Mark RESOLVED only when
+   Wave 4 lab-validates the isolation matrix on `spike307-win` (assertions L7
+   to L12 in the blueprint).
+7. **RESOLVED (#350).** The Linux `pre_exec` post-fork allocator-deadlock
+   hazard below was fixed by #350 (merged), which moved `linux::launch`'s
+   `pre_exec` closure to an allocation-free path so no thread can deadlock on
+   the allocator's lock immediately after `fork()`. Original hazard, kept for
+   the regression record: `linux::launch`'s real `Command::spawn()` +
+   `pre_exec` path was a post-fork allocator-deadlock hazard, discovered in
+   the #308/#311 pass. `pre_exec`'s closure runs in a raw-`fork()`ed child
+   (required so it can run arbitrary code before `exec`); `apply_landlock_ruleset`
+   and `apply_seccomp_denylist` both allocated (`Vec`, `PathFd::new`, `format!`).
    Allocating in a forked child of a multithreaded parent risks the classic
    post-fork malloc deadlock (another thread can hold the allocator's lock
    at the instant of `fork()`, and the single surviving child thread then
    blocks on it forever) -- and because Rust's `pre_exec` machinery makes
    the *parent's* `spawn()` block on a pipe read until the child execs or
-   reports an error, that hang propagates back to the caller too. Directly
-   observed this pass: an end-to-end `launch()` test (removed, see
+   reports an error, that hang propagated back to the caller too. Directly
+   observed at the time: an end-to-end `launch()` test (removed, see
    `linux.rs`'s test module comment) hung `cargo test` for 15+ minutes in
-   this crate's own (multithreaded) test binary. Pre-existing: no test
-   before this pass ever exercised the real spawn path, so nothing
-   surfaced it earlier; it is not new in this pass, only newly visible.
-   Fix needs either an alloc-free `pre_exec` closure or moving off
-   fork+pre_exec toward a `posix_spawn`-style API -- out of scope here.
+   this crate's own (multithreaded) test binary. Pre-existing at the time: no
+   test before that pass ever exercised the real spawn path, so nothing
+   surfaced it earlier.
 
 ## Updating this vendor copy
 
@@ -213,8 +329,22 @@ crate deliberately does not inherit the workspace's Apache-2.0
 2. Re-copy `codex-rs/bwrap/`, `codex-rs/process-hardening/`, and
    `codex-rs/vendor/bubblewrap/` verbatim (package names and `Cargo.toml`
    should not need renaming; they already match upstream).
-3. Re-copy the repo-root `LICENSE`/`NOTICE` if changed.
-4. Re-run `cargo fmt --check && cargo clippy --all-targets -- -D warnings &&
+3. Re-copy `codex-rs/windows-sandbox-rs/src/{token,cap,proc_thread_attr,acl,
+   workspace_acl,deny_read_acl,deny_read_state,dpapi,hide_users,winutil,
+   sandbox_utils,env,path_normalization}.rs` verbatim into
+   `codex-windows-sandbox/src/`. Re-diff `resolved_permissions.rs` against
+   `hive-desktop-sandbox/src/windows_resolve.rs` by hand (it is a port, not a
+   verbatim copy) for any new upstream fields/accessors worth porting. If
+   `process.rs` or `deny_read_resolver.rs` are ever vendored/ported (see
+   "Deliberately NOT vendored this wave" above), re-check their dependency
+   graph against `desktop.rs`/`logging.rs`/`codex_protocol` again; upstream
+   may have changed the coupling.
+4. Re-copy the repo-root `LICENSE`/`NOTICE` if changed.
+5. Re-run `cargo fmt --check && cargo clippy --all-targets -- -D warnings &&
    cargo test`, plus the `x86_64-pc-windows-gnu` cross-check (now also run by
-   the `rust-tests` CI job), before merging.
-5. Update the commit SHA/date at the top of this file.
+   the `rust-tests` CI job, scoped to `-p hive-desktop-sandbox -p
+   codex-windows-sandbox`), and the MSVC cross-check
+   (`cargo check --target x86_64-pc-windows-msvc -p hive-desktop-sandbox -p
+   codex-windows-sandbox`, lab or a Windows host only; CI still cannot link
+   MSVC) before merging.
+6. Update the commit SHA/date at the top of this file.

--- a/apps/desktop-sandbox/codex-windows-sandbox/Cargo.toml
+++ b/apps/desktop-sandbox/codex-windows-sandbox/Cargo.toml
@@ -1,0 +1,46 @@
+[package]
+name = "codex-windows-sandbox"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[lib]
+name = "codex_windows_sandbox"
+path = "src/lib.rs"
+doctest = false
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow = "1.0"
+dunce = "1.0"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+dirs-next = "2.0"
+
+[dependencies.rand]
+version = "0.8"
+default-features = false
+features = ["std", "small_rng"]
+
+# Verbatim-vendored modules are Windows-only Win32 FFI (see VENDORING.md); this
+# crate compiles to an empty crate on non-Windows hosts (every `mod` in lib.rs
+# is `#[cfg(windows)]`-gated), so windows-sys is only ever actually built when
+# targeting Windows.
+[target.'cfg(windows)'.dependencies.windows-sys]
+version = "0.52"
+features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_Security_Authorization",
+    "Win32_Security_Cryptography",
+    "Win32_Storage_FileSystem",
+    "Win32_System_Threading",
+    "Win32_System_Registry",
+    "Win32_System_Diagnostics_Debug",
+]
+
+[dev-dependencies]
+pretty_assertions = { workspace = true }
+tempfile = { workspace = true }

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/acl.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/acl.rs
@@ -1,0 +1,735 @@
+use crate::winutil::to_wide;
+use anyhow::Result;
+use anyhow::anyhow;
+use std::ffi::c_void;
+use std::path::Path;
+use windows_sys::Win32::Foundation::CloseHandle;
+use windows_sys::Win32::Foundation::ERROR_SUCCESS;
+use windows_sys::Win32::Foundation::HLOCAL;
+use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
+use windows_sys::Win32::Foundation::LocalFree;
+use windows_sys::Win32::Security::ACCESS_ALLOWED_ACE;
+use windows_sys::Win32::Security::ACCESS_DENIED_ACE;
+use windows_sys::Win32::Security::ACE_HEADER;
+use windows_sys::Win32::Security::ACL;
+use windows_sys::Win32::Security::ACL_SIZE_INFORMATION;
+use windows_sys::Win32::Security::AclSizeInformation;
+use windows_sys::Win32::Security::Authorization::EXPLICIT_ACCESS_W;
+use windows_sys::Win32::Security::Authorization::GetNamedSecurityInfoW;
+use windows_sys::Win32::Security::Authorization::GetSecurityInfo;
+use windows_sys::Win32::Security::Authorization::SetEntriesInAclW;
+use windows_sys::Win32::Security::Authorization::SetNamedSecurityInfoW;
+use windows_sys::Win32::Security::Authorization::SetSecurityInfo;
+use windows_sys::Win32::Security::Authorization::TRUSTEE_IS_SID;
+use windows_sys::Win32::Security::Authorization::TRUSTEE_IS_UNKNOWN;
+use windows_sys::Win32::Security::Authorization::TRUSTEE_W;
+use windows_sys::Win32::Security::DACL_SECURITY_INFORMATION;
+use windows_sys::Win32::Security::EqualSid;
+use windows_sys::Win32::Security::GENERIC_MAPPING;
+use windows_sys::Win32::Security::GetAce;
+use windows_sys::Win32::Security::GetAclInformation;
+use windows_sys::Win32::Security::MapGenericMask;
+use windows_sys::Win32::Storage::FileSystem::CreateFileW;
+use windows_sys::Win32::Storage::FileSystem::DELETE;
+use windows_sys::Win32::Storage::FileSystem::FILE_ALL_ACCESS;
+use windows_sys::Win32::Storage::FileSystem::FILE_APPEND_DATA;
+use windows_sys::Win32::Storage::FileSystem::FILE_ATTRIBUTE_NORMAL;
+use windows_sys::Win32::Storage::FileSystem::FILE_DELETE_CHILD;
+use windows_sys::Win32::Storage::FileSystem::FILE_FLAG_BACKUP_SEMANTICS;
+use windows_sys::Win32::Storage::FileSystem::FILE_GENERIC_EXECUTE;
+use windows_sys::Win32::Storage::FileSystem::FILE_GENERIC_READ;
+use windows_sys::Win32::Storage::FileSystem::FILE_GENERIC_WRITE;
+use windows_sys::Win32::Storage::FileSystem::FILE_SHARE_DELETE;
+use windows_sys::Win32::Storage::FileSystem::FILE_SHARE_READ;
+use windows_sys::Win32::Storage::FileSystem::FILE_SHARE_WRITE;
+use windows_sys::Win32::Storage::FileSystem::FILE_WRITE_ATTRIBUTES;
+use windows_sys::Win32::Storage::FileSystem::FILE_WRITE_DATA;
+use windows_sys::Win32::Storage::FileSystem::FILE_WRITE_EA;
+use windows_sys::Win32::Storage::FileSystem::OPEN_EXISTING;
+use windows_sys::Win32::Storage::FileSystem::READ_CONTROL;
+const SE_KERNEL_OBJECT: u32 = 6;
+const INHERIT_ONLY_ACE: u8 = 0x08;
+const ACCESS_ALLOWED_ACE_TYPE: u8 = 0;
+const ACCESS_DENIED_ACE_TYPE: u8 = 1;
+const GENERIC_READ_MASK: u32 = 0x8000_0000;
+const GENERIC_WRITE_MASK: u32 = 0x4000_0000;
+const DENY_ACCESS: i32 = 3;
+
+/// Fetch DACL via handle-based query; caller must LocalFree the returned SD.
+///
+/// # Safety
+/// Caller must free the returned security descriptor with `LocalFree` and pass an existing path.
+pub unsafe fn fetch_dacl_handle(path: &Path) -> Result<(*mut ACL, *mut c_void)> {
+    let wpath = to_wide(path);
+    let h = CreateFileW(
+        wpath.as_ptr(),
+        READ_CONTROL,
+        FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+        std::ptr::null_mut(),
+        OPEN_EXISTING,
+        FILE_FLAG_BACKUP_SEMANTICS,
+        0,
+    );
+    if h == INVALID_HANDLE_VALUE {
+        return Err(anyhow!("CreateFileW failed for {}", path.display()));
+    }
+    let mut p_sd: *mut c_void = std::ptr::null_mut();
+    let mut p_dacl: *mut ACL = std::ptr::null_mut();
+    let code = GetSecurityInfo(
+        h,
+        1, // SE_FILE_OBJECT
+        DACL_SECURITY_INFORMATION,
+        std::ptr::null_mut(),
+        std::ptr::null_mut(),
+        &mut p_dacl,
+        std::ptr::null_mut(),
+        &mut p_sd,
+    );
+    CloseHandle(h);
+    if code != ERROR_SUCCESS {
+        return Err(anyhow!(
+            "GetSecurityInfo failed for {}: {}",
+            path.display(),
+            code
+        ));
+    }
+    Ok((p_dacl, p_sd))
+}
+
+/// Fast mask-based check: does an ACE for provided SIDs grant the desired mask? Skips inherit-only.
+/// When `require_all_bits` is true, all bits in `desired_mask` must be present; otherwise any bit suffices.
+pub unsafe fn dacl_mask_allows(
+    p_dacl: *mut ACL,
+    psids: &[*mut c_void],
+    desired_mask: u32,
+    require_all_bits: bool,
+) -> bool {
+    if p_dacl.is_null() {
+        return false;
+    }
+    let mut info: ACL_SIZE_INFORMATION = std::mem::zeroed();
+    let ok = GetAclInformation(
+        p_dacl as *const ACL,
+        &mut info as *mut _ as *mut c_void,
+        std::mem::size_of::<ACL_SIZE_INFORMATION>() as u32,
+        AclSizeInformation,
+    );
+    if ok == 0 {
+        return false;
+    }
+    let mapping = GENERIC_MAPPING {
+        GenericRead: FILE_GENERIC_READ,
+        GenericWrite: FILE_GENERIC_WRITE,
+        GenericExecute: FILE_GENERIC_EXECUTE,
+        GenericAll: FILE_ALL_ACCESS,
+    };
+    for i in 0..(info.AceCount as usize) {
+        let mut p_ace: *mut c_void = std::ptr::null_mut();
+        if GetAce(p_dacl as *const ACL, i as u32, &mut p_ace) == 0 {
+            continue;
+        }
+        let hdr = &*(p_ace as *const ACE_HEADER);
+        if hdr.AceType != ACCESS_ALLOWED_ACE_TYPE {
+            continue; // not ACCESS_ALLOWED
+        }
+        if (hdr.AceFlags & INHERIT_ONLY_ACE) != 0 {
+            continue;
+        }
+        let base = p_ace as usize;
+        let sid_ptr =
+            (base + std::mem::size_of::<ACE_HEADER>() + std::mem::size_of::<u32>()) as *mut c_void;
+        let mut matched = false;
+        for sid in psids {
+            if EqualSid(sid_ptr, *sid) != 0 {
+                matched = true;
+                break;
+            }
+        }
+        if !matched {
+            continue;
+        }
+        let ace = &*(p_ace as *const ACCESS_ALLOWED_ACE);
+        let mut mask = ace.Mask;
+        MapGenericMask(&mut mask, &mapping);
+        if (require_all_bits && (mask & desired_mask) == desired_mask)
+            || (!require_all_bits && (mask & desired_mask) != 0)
+        {
+            return true;
+        }
+    }
+    false
+}
+
+/// Path-based wrapper around the mask check (single DACL fetch).
+pub fn path_mask_allows(
+    path: &Path,
+    psids: &[*mut c_void],
+    desired_mask: u32,
+    require_all_bits: bool,
+) -> Result<bool> {
+    unsafe {
+        let (p_dacl, sd) = fetch_dacl_handle(path)?;
+        let has = dacl_mask_allows(p_dacl, psids, desired_mask, require_all_bits);
+        if !sd.is_null() {
+            LocalFree(sd as HLOCAL);
+        }
+        Ok(has)
+    }
+}
+
+pub unsafe fn dacl_has_write_allow_for_sid(p_dacl: *mut ACL, psid: *mut c_void) -> bool {
+    if p_dacl.is_null() {
+        return false;
+    }
+    let mut info: ACL_SIZE_INFORMATION = std::mem::zeroed();
+    let ok = GetAclInformation(
+        p_dacl as *const ACL,
+        &mut info as *mut _ as *mut c_void,
+        std::mem::size_of::<ACL_SIZE_INFORMATION>() as u32,
+        AclSizeInformation,
+    );
+    if ok == 0 {
+        return false;
+    }
+    let count = info.AceCount as usize;
+    for i in 0..count {
+        let mut p_ace: *mut c_void = std::ptr::null_mut();
+        if GetAce(p_dacl as *const ACL, i as u32, &mut p_ace) == 0 {
+            continue;
+        }
+        let hdr = &*(p_ace as *const ACE_HEADER);
+        if hdr.AceType != ACCESS_ALLOWED_ACE_TYPE {
+            continue; // ACCESS_ALLOWED_ACE_TYPE
+        }
+        // Ignore ACEs that are inherit-only (do not apply to the current object)
+        if (hdr.AceFlags & INHERIT_ONLY_ACE) != 0 {
+            continue;
+        }
+        let ace = &*(p_ace as *const ACCESS_ALLOWED_ACE);
+        let mask = ace.Mask;
+        let base = p_ace as usize;
+        let sid_ptr =
+            (base + std::mem::size_of::<ACE_HEADER>() + std::mem::size_of::<u32>()) as *mut c_void;
+        let eq = EqualSid(sid_ptr, psid);
+        if eq != 0 && (mask & FILE_GENERIC_WRITE) != 0 {
+            return true;
+        }
+    }
+    false
+}
+
+pub unsafe fn dacl_has_write_deny_for_sid(p_dacl: *mut ACL, psid: *mut c_void) -> bool {
+    if p_dacl.is_null() {
+        return false;
+    }
+    let mut info: ACL_SIZE_INFORMATION = std::mem::zeroed();
+    let ok = GetAclInformation(
+        p_dacl as *const ACL,
+        &mut info as *mut _ as *mut c_void,
+        std::mem::size_of::<ACL_SIZE_INFORMATION>() as u32,
+        AclSizeInformation,
+    );
+    if ok == 0 {
+        return false;
+    }
+    let deny_write_mask = FILE_GENERIC_WRITE
+        | FILE_WRITE_DATA
+        | FILE_APPEND_DATA
+        | FILE_WRITE_EA
+        | FILE_WRITE_ATTRIBUTES
+        | GENERIC_WRITE_MASK
+        | DELETE
+        | FILE_DELETE_CHILD;
+    for i in 0..info.AceCount {
+        let mut p_ace: *mut c_void = std::ptr::null_mut();
+        if GetAce(p_dacl as *const ACL, i, &mut p_ace) == 0 {
+            continue;
+        }
+        let hdr = &*(p_ace as *const ACE_HEADER);
+        if hdr.AceType != ACCESS_DENIED_ACE_TYPE {
+            continue; // ACCESS_DENIED_ACE_TYPE
+        }
+        if (hdr.AceFlags & INHERIT_ONLY_ACE) != 0 {
+            continue;
+        }
+        let ace = &*(p_ace as *const ACCESS_DENIED_ACE);
+        let base = p_ace as usize;
+        let sid_ptr =
+            (base + std::mem::size_of::<ACE_HEADER>() + std::mem::size_of::<u32>()) as *mut c_void;
+        if EqualSid(sid_ptr, psid) != 0 && (ace.Mask & deny_write_mask) != 0 {
+            return true;
+        }
+    }
+    false
+}
+
+pub unsafe fn dacl_has_read_deny_for_sid(p_dacl: *mut ACL, psid: *mut c_void) -> bool {
+    if p_dacl.is_null() {
+        return false;
+    }
+    let mut info: ACL_SIZE_INFORMATION = std::mem::zeroed();
+    let ok = GetAclInformation(
+        p_dacl as *const ACL,
+        &mut info as *mut _ as *mut c_void,
+        std::mem::size_of::<ACL_SIZE_INFORMATION>() as u32,
+        AclSizeInformation,
+    );
+    if ok == 0 {
+        return false;
+    }
+    let deny_read_mask = FILE_GENERIC_READ | GENERIC_READ_MASK;
+    for i in 0..info.AceCount {
+        let mut p_ace: *mut c_void = std::ptr::null_mut();
+        if GetAce(p_dacl as *const ACL, i, &mut p_ace) == 0 {
+            continue;
+        }
+        let hdr = &*(p_ace as *const ACE_HEADER);
+        if hdr.AceType != ACCESS_DENIED_ACE_TYPE {
+            continue; // ACCESS_DENIED_ACE_TYPE
+        }
+        if (hdr.AceFlags & INHERIT_ONLY_ACE) != 0 {
+            continue;
+        }
+        let ace = &*(p_ace as *const ACCESS_DENIED_ACE);
+        let base = p_ace as usize;
+        let sid_ptr =
+            (base + std::mem::size_of::<ACE_HEADER>() + std::mem::size_of::<u32>()) as *mut c_void;
+        if EqualSid(sid_ptr, psid) != 0 && (ace.Mask & deny_read_mask) != 0 {
+            return true;
+        }
+    }
+    false
+}
+
+// Grant DELETE on each inheriting descendant instead of FILE_DELETE_CHILD on
+// its parent. A parent delete-child grant would bypass a direct deny-write ACE
+// on protected children such as `.git` or an explicit read-only subpath.
+const WRITE_ALLOW_MASK: u32 =
+    FILE_GENERIC_READ | FILE_GENERIC_WRITE | FILE_GENERIC_EXECUTE | DELETE;
+
+unsafe fn ensure_allow_mask_aces_with_inheritance_impl(
+    path: &Path,
+    sids: &[*mut c_void],
+    allow_mask: u32,
+    disallow_mask: u32,
+    inheritance: u32,
+) -> Result<bool> {
+    let (p_dacl, p_sd) = fetch_dacl_handle(path)?;
+    let mut entries: Vec<EXPLICIT_ACCESS_W> = Vec::new();
+    for sid in sids {
+        if dacl_mask_allows(p_dacl, &[*sid], allow_mask, /*require_all_bits*/ true)
+            && !dacl_mask_allows(
+                p_dacl,
+                &[*sid],
+                disallow_mask,
+                /*require_all_bits*/ false,
+            )
+        {
+            continue;
+        }
+        entries.push(EXPLICIT_ACCESS_W {
+            grfAccessPermissions: allow_mask,
+            grfAccessMode: 2, // SET_ACCESS
+            grfInheritance: inheritance,
+            Trustee: TRUSTEE_W {
+                pMultipleTrustee: std::ptr::null_mut(),
+                MultipleTrusteeOperation: 0,
+                TrusteeForm: TRUSTEE_IS_SID,
+                TrusteeType: TRUSTEE_IS_UNKNOWN,
+                ptstrName: *sid as *mut u16,
+            },
+        });
+    }
+    let mut added = false;
+    if !entries.is_empty() {
+        let mut p_new_dacl: *mut ACL = std::ptr::null_mut();
+        let code2 = SetEntriesInAclW(
+            entries.len() as u32,
+            entries.as_ptr(),
+            p_dacl,
+            &mut p_new_dacl,
+        );
+        if code2 == ERROR_SUCCESS {
+            let code3 = SetNamedSecurityInfoW(
+                to_wide(path).as_ptr() as *mut u16,
+                1,
+                DACL_SECURITY_INFORMATION,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                p_new_dacl,
+                std::ptr::null_mut(),
+            );
+            if code3 == ERROR_SUCCESS {
+                added = true;
+                if !p_new_dacl.is_null() {
+                    LocalFree(p_new_dacl as HLOCAL);
+                }
+            } else {
+                if !p_new_dacl.is_null() {
+                    LocalFree(p_new_dacl as HLOCAL);
+                }
+                if !p_sd.is_null() {
+                    LocalFree(p_sd as HLOCAL);
+                }
+                return Err(anyhow!("SetNamedSecurityInfoW failed: {code3}"));
+            }
+        } else {
+            if !p_sd.is_null() {
+                LocalFree(p_sd as HLOCAL);
+            }
+            return Err(anyhow!("SetEntriesInAclW failed: {code2}"));
+        }
+    }
+    if !p_sd.is_null() {
+        LocalFree(p_sd as HLOCAL);
+    }
+    Ok(added)
+}
+
+/// Ensure all provided SIDs have an allow ACE with the requested mask on the path.
+/// Returns true if any ACE was added.
+///
+/// # Safety
+/// Caller must pass valid SID pointers and an existing path; free the returned security descriptor with `LocalFree`.
+pub unsafe fn ensure_allow_mask_aces_with_inheritance(
+    path: &Path,
+    sids: &[*mut c_void],
+    allow_mask: u32,
+    inheritance: u32,
+) -> Result<bool> {
+    ensure_allow_mask_aces_with_inheritance_impl(
+        path,
+        sids,
+        allow_mask,
+        /*disallow_mask*/ 0,
+        inheritance,
+    )
+}
+
+/// Ensure all provided SIDs have an allow ACE with the requested mask on the path.
+/// Returns true if any ACE was added.
+///
+/// # Safety
+/// Caller must pass valid SID pointers and an existing path; free the returned security descriptor with `LocalFree`.
+pub unsafe fn ensure_allow_mask_aces(
+    path: &Path,
+    sids: &[*mut c_void],
+    allow_mask: u32,
+) -> Result<bool> {
+    ensure_allow_mask_aces_with_inheritance(
+        path,
+        sids,
+        allow_mask,
+        CONTAINER_INHERIT_ACE | OBJECT_INHERIT_ACE,
+    )
+}
+
+/// Ensure all provided SIDs have a write-capable allow ACE on the path.
+/// Returns true if any ACE was added.
+///
+/// # Safety
+/// Caller must pass valid SID pointers and an existing path; free the returned security descriptor with `LocalFree`.
+pub unsafe fn ensure_allow_write_aces(path: &Path, sids: &[*mut c_void]) -> Result<bool> {
+    ensure_allow_mask_aces_with_inheritance_impl(
+        path,
+        sids,
+        WRITE_ALLOW_MASK,
+        FILE_DELETE_CHILD,
+        CONTAINER_INHERIT_ACE | OBJECT_INHERIT_ACE,
+    )
+}
+
+/// Adds an allow ACE granting read/write/execute to the given SID on the target path.
+///
+/// # Safety
+/// Caller must ensure `psid` points to a valid SID and `path` refers to an existing file or directory.
+pub unsafe fn add_allow_ace(path: &Path, psid: *mut c_void) -> Result<bool> {
+    let mut p_sd: *mut c_void = std::ptr::null_mut();
+    let mut p_dacl: *mut ACL = std::ptr::null_mut();
+    let code = GetNamedSecurityInfoW(
+        to_wide(path).as_ptr(),
+        1,
+        DACL_SECURITY_INFORMATION,
+        std::ptr::null_mut(),
+        std::ptr::null_mut(),
+        &mut p_dacl,
+        std::ptr::null_mut(),
+        &mut p_sd,
+    );
+    if code != ERROR_SUCCESS {
+        return Err(anyhow!("GetNamedSecurityInfoW failed: {code}"));
+    }
+    // Already has write? Skip costly DACL rewrite.
+    if dacl_has_write_allow_for_sid(p_dacl, psid) {
+        if !p_sd.is_null() {
+            LocalFree(p_sd as HLOCAL);
+        }
+        return Ok(false);
+    }
+    let mut added = false;
+    // Always ensure write is present: if an allow ACE exists without write, add one with write+RX.
+    let trustee = TRUSTEE_W {
+        pMultipleTrustee: std::ptr::null_mut(),
+        MultipleTrusteeOperation: 0,
+        TrusteeForm: TRUSTEE_IS_SID,
+        TrusteeType: TRUSTEE_IS_UNKNOWN,
+        ptstrName: psid as *mut u16,
+    };
+    let mut explicit: EXPLICIT_ACCESS_W = std::mem::zeroed();
+    explicit.grfAccessPermissions = FILE_GENERIC_READ | FILE_GENERIC_WRITE | FILE_GENERIC_EXECUTE;
+    explicit.grfAccessMode = 2; // SET_ACCESS
+    explicit.grfInheritance = CONTAINER_INHERIT_ACE | OBJECT_INHERIT_ACE;
+    explicit.Trustee = trustee;
+    let mut p_new_dacl: *mut ACL = std::ptr::null_mut();
+    let code2 = SetEntriesInAclW(1, &explicit, p_dacl, &mut p_new_dacl);
+    if code2 == ERROR_SUCCESS {
+        let code3 = SetNamedSecurityInfoW(
+            to_wide(path).as_ptr() as *mut u16,
+            1,
+            DACL_SECURITY_INFORMATION,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            p_new_dacl,
+            std::ptr::null_mut(),
+        );
+        if code3 == ERROR_SUCCESS {
+            added = !dacl_has_write_allow_for_sid(p_dacl, psid);
+        }
+        if !p_new_dacl.is_null() {
+            LocalFree(p_new_dacl as HLOCAL);
+        }
+    }
+    if !p_sd.is_null() {
+        LocalFree(p_sd as HLOCAL);
+    }
+    Ok(added)
+}
+
+/// Adds a deny ACE to prevent write/append/delete for the given SID on the target path.
+///
+/// # Safety
+/// Caller must ensure `psid` points to a valid SID and `path` refers to an existing file or directory.
+pub unsafe fn add_deny_write_ace(path: &Path, psid: *mut c_void) -> Result<bool> {
+    add_deny_ace(path, psid, DenyAceKind::Write)
+}
+
+#[derive(Clone, Copy)]
+enum DenyAceKind {
+    Read,
+    Write,
+}
+
+impl DenyAceKind {
+    fn mask(self) -> u32 {
+        match self {
+            Self::Read => FILE_GENERIC_READ | GENERIC_READ_MASK,
+            Self::Write => {
+                FILE_GENERIC_WRITE
+                    | FILE_WRITE_DATA
+                    | FILE_APPEND_DATA
+                    | FILE_WRITE_EA
+                    | FILE_WRITE_ATTRIBUTES
+                    | GENERIC_WRITE_MASK
+                    | DELETE
+                    | FILE_DELETE_CHILD
+            }
+        }
+    }
+
+    unsafe fn already_present(self, p_dacl: *mut ACL, psid: *mut c_void) -> bool {
+        match self {
+            Self::Read => dacl_has_read_deny_for_sid(p_dacl, psid),
+            Self::Write => dacl_has_write_deny_for_sid(p_dacl, psid),
+        }
+    }
+}
+
+unsafe fn add_deny_ace(path: &Path, psid: *mut c_void, kind: DenyAceKind) -> Result<bool> {
+    let mut p_sd: *mut c_void = std::ptr::null_mut();
+    let mut p_dacl: *mut ACL = std::ptr::null_mut();
+    let code = GetNamedSecurityInfoW(
+        to_wide(path).as_ptr(),
+        1,
+        DACL_SECURITY_INFORMATION,
+        std::ptr::null_mut(),
+        std::ptr::null_mut(),
+        &mut p_dacl,
+        std::ptr::null_mut(),
+        &mut p_sd,
+    );
+    if code != ERROR_SUCCESS {
+        return Err(anyhow!("GetNamedSecurityInfoW failed: {code}"));
+    }
+    let mut added = false;
+    if !kind.already_present(p_dacl, psid) {
+        let trustee = TRUSTEE_W {
+            pMultipleTrustee: std::ptr::null_mut(),
+            MultipleTrusteeOperation: 0,
+            TrusteeForm: TRUSTEE_IS_SID,
+            TrusteeType: TRUSTEE_IS_UNKNOWN,
+            ptstrName: psid as *mut u16,
+        };
+        let mut explicit: EXPLICIT_ACCESS_W = std::mem::zeroed();
+        explicit.grfAccessPermissions = kind.mask();
+        explicit.grfAccessMode = DENY_ACCESS;
+        explicit.grfInheritance = CONTAINER_INHERIT_ACE | OBJECT_INHERIT_ACE;
+        explicit.Trustee = trustee;
+        let mut p_new_dacl: *mut ACL = std::ptr::null_mut();
+        let code2 = SetEntriesInAclW(1, &explicit, p_dacl, &mut p_new_dacl);
+        if code2 == ERROR_SUCCESS {
+            let code3 = SetNamedSecurityInfoW(
+                to_wide(path).as_ptr() as *mut u16,
+                1,
+                DACL_SECURITY_INFORMATION,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                p_new_dacl,
+                std::ptr::null_mut(),
+            );
+            if code3 == ERROR_SUCCESS {
+                added = true;
+            }
+            if !p_new_dacl.is_null() {
+                LocalFree(p_new_dacl as HLOCAL);
+            }
+        }
+    }
+    if !p_sd.is_null() {
+        LocalFree(p_sd as HLOCAL);
+    }
+    Ok(added)
+}
+
+/// Adds a deny ACE to prevent reads for the given SID on the target path.
+///
+/// `SetEntriesInAclW` places newly-created deny ACEs before allow ACEs, which
+/// keeps the resulting DACL in the order Windows expects for denies to win.
+/// The ACE is inheritable so a deny applied to a materialized directory also
+/// covers files and directories later created underneath it.
+///
+/// # Safety
+/// Caller must ensure `psid` points to a valid SID and `path` refers to an existing file or directory.
+pub unsafe fn add_deny_read_ace(path: &Path, psid: *mut c_void) -> Result<bool> {
+    add_deny_ace(path, psid, DenyAceKind::Read)
+}
+
+pub unsafe fn revoke_ace(path: &Path, psid: *mut c_void) {
+    let mut p_sd: *mut c_void = std::ptr::null_mut();
+    let mut p_dacl: *mut ACL = std::ptr::null_mut();
+    let code = GetNamedSecurityInfoW(
+        to_wide(path).as_ptr(),
+        1,
+        DACL_SECURITY_INFORMATION,
+        std::ptr::null_mut(),
+        std::ptr::null_mut(),
+        &mut p_dacl,
+        std::ptr::null_mut(),
+        &mut p_sd,
+    );
+    if code != ERROR_SUCCESS {
+        if !p_sd.is_null() {
+            LocalFree(p_sd as HLOCAL);
+        }
+        return;
+    }
+    let trustee = TRUSTEE_W {
+        pMultipleTrustee: std::ptr::null_mut(),
+        MultipleTrusteeOperation: 0,
+        TrusteeForm: TRUSTEE_IS_SID,
+        TrusteeType: TRUSTEE_IS_UNKNOWN,
+        ptstrName: psid as *mut u16,
+    };
+    let mut explicit: EXPLICIT_ACCESS_W = std::mem::zeroed();
+    explicit.grfAccessPermissions = 0;
+    explicit.grfAccessMode = 4; // REVOKE_ACCESS
+    explicit.grfInheritance = CONTAINER_INHERIT_ACE | OBJECT_INHERIT_ACE;
+    explicit.Trustee = trustee;
+    let mut p_new_dacl: *mut ACL = std::ptr::null_mut();
+    let code2 = SetEntriesInAclW(1, &explicit, p_dacl, &mut p_new_dacl);
+    if code2 == ERROR_SUCCESS {
+        let _ = SetNamedSecurityInfoW(
+            to_wide(path).as_ptr() as *mut u16,
+            1,
+            DACL_SECURITY_INFORMATION,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            p_new_dacl,
+            std::ptr::null_mut(),
+        );
+        if !p_new_dacl.is_null() {
+            LocalFree(p_new_dacl as HLOCAL);
+        }
+    }
+    if !p_sd.is_null() {
+        LocalFree(p_sd as HLOCAL);
+    }
+}
+
+/// Grants RX to the null device for the given SID to support stdout/stderr redirection.
+///
+/// # Safety
+/// Caller must ensure `psid` is a valid SID pointer.
+pub unsafe fn allow_null_device(psid: *mut c_void) {
+    let desired = 0x00020000 | 0x00040000; // READ_CONTROL | WRITE_DAC
+    let h = CreateFileW(
+        to_wide(r"\\\\.\\NUL").as_ptr(),
+        desired,
+        FILE_SHARE_READ | FILE_SHARE_WRITE,
+        std::ptr::null_mut(),
+        OPEN_EXISTING,
+        FILE_ATTRIBUTE_NORMAL,
+        0,
+    );
+    if h == 0 || h == INVALID_HANDLE_VALUE {
+        return;
+    }
+    let mut p_sd: *mut c_void = std::ptr::null_mut();
+    let mut p_dacl: *mut ACL = std::ptr::null_mut();
+    let code = GetSecurityInfo(
+        h,
+        SE_KERNEL_OBJECT as i32,
+        DACL_SECURITY_INFORMATION,
+        std::ptr::null_mut(),
+        std::ptr::null_mut(),
+        &mut p_dacl,
+        std::ptr::null_mut(),
+        &mut p_sd,
+    );
+    if code == ERROR_SUCCESS {
+        let trustee = TRUSTEE_W {
+            pMultipleTrustee: std::ptr::null_mut(),
+            MultipleTrusteeOperation: 0,
+            TrusteeForm: TRUSTEE_IS_SID,
+            TrusteeType: TRUSTEE_IS_UNKNOWN,
+            ptstrName: psid as *mut u16,
+        };
+        let mut explicit: EXPLICIT_ACCESS_W = std::mem::zeroed();
+        explicit.grfAccessPermissions =
+            FILE_GENERIC_READ | FILE_GENERIC_WRITE | FILE_GENERIC_EXECUTE;
+        explicit.grfAccessMode = 2; // SET_ACCESS
+        explicit.grfInheritance = 0;
+        explicit.Trustee = trustee;
+        let mut p_new_dacl: *mut ACL = std::ptr::null_mut();
+        let code2 = SetEntriesInAclW(1, &explicit, p_dacl, &mut p_new_dacl);
+        if code2 == ERROR_SUCCESS {
+            let _ = SetSecurityInfo(
+                h,
+                SE_KERNEL_OBJECT as i32,
+                DACL_SECURITY_INFORMATION,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                p_new_dacl,
+                std::ptr::null_mut(),
+            );
+            if !p_new_dacl.is_null() {
+                LocalFree(p_new_dacl as HLOCAL);
+            }
+        }
+    }
+    if !p_sd.is_null() {
+        LocalFree(p_sd as HLOCAL);
+    }
+    CloseHandle(h);
+}
+const CONTAINER_INHERIT_ACE: u32 = 0x2;
+const OBJECT_INHERIT_ACE: u32 = 0x1;

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/acl.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/acl.rs
@@ -672,7 +672,7 @@ pub unsafe fn revoke_ace(path: &Path, psid: *mut c_void) {
 pub unsafe fn allow_null_device(psid: *mut c_void) {
     let desired = 0x00020000 | 0x00040000; // READ_CONTROL | WRITE_DAC
     let h = CreateFileW(
-        to_wide(r"\\\\.\\NUL").as_ptr(),
+        to_wide(r"\\.\NUL").as_ptr(),
         desired,
         FILE_SHARE_READ | FILE_SHARE_WRITE,
         std::ptr::null_mut(),

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/cap.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/cap.rs
@@ -1,0 +1,203 @@
+use crate::path_normalization::canonical_path_key;
+use crate::path_normalization::canonicalize_path;
+use anyhow::Context;
+use anyhow::Result;
+use rand::RngCore;
+use rand::SeedableRng;
+use rand::rngs::SmallRng;
+use serde::Deserialize;
+use serde::Serialize;
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+use std::path::PathBuf;
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct CapSids {
+    pub workspace: String,
+    pub readonly: String,
+    /// Per-workspace capability SIDs keyed by canonicalized CWD string.
+    ///
+    /// This is used to isolate workspaces from other workspace sandbox writes and to
+    /// apply per-workspace denies (e.g. protect `CWD/.codex`)
+    /// without permanently affecting other workspaces.
+    #[serde(default)]
+    pub workspace_by_cwd: HashMap<String, String>,
+    /// Per-write-root capability SIDs keyed by canonicalized write-root path.
+    ///
+    /// These are included in a workspace-write token only when the root is
+    /// currently allowed, so stale ACLs from earlier extra roots do not expand
+    /// later workspace sandboxes.
+    #[serde(default)]
+    pub writable_root_by_path: HashMap<String, String>,
+}
+
+pub fn cap_sid_file(codex_home: &Path) -> PathBuf {
+    codex_home.join("cap_sid")
+}
+
+fn make_random_cap_sid_string() -> String {
+    let mut rng = SmallRng::from_entropy();
+    let a = rng.next_u32();
+    let b = rng.next_u32();
+    let c = rng.next_u32();
+    let d = rng.next_u32();
+    format!("S-1-5-21-{a}-{b}-{c}-{d}")
+}
+
+fn persist_caps(path: &Path, caps: &CapSids) -> Result<()> {
+    if let Some(dir) = path.parent() {
+        fs::create_dir_all(dir).with_context(|| format!("create cap sid dir {}", dir.display()))?;
+    }
+    let json = serde_json::to_string(caps)?;
+    fs::write(path, json).with_context(|| format!("write cap sid file {}", path.display()))?;
+    Ok(())
+}
+
+pub fn load_or_create_cap_sids(codex_home: &Path) -> Result<CapSids> {
+    let path = cap_sid_file(codex_home);
+    if path.exists() {
+        let txt = fs::read_to_string(&path)
+            .with_context(|| format!("read cap sid file {}", path.display()))?;
+        let t = txt.trim();
+        if t.starts_with('{') && t.ends_with('}') {
+            if let Ok(obj) = serde_json::from_str::<CapSids>(t) {
+                return Ok(obj);
+            }
+        } else if !t.is_empty() {
+            let caps = CapSids {
+                workspace: t.to_string(),
+                readonly: make_random_cap_sid_string(),
+                workspace_by_cwd: HashMap::new(),
+                writable_root_by_path: HashMap::new(),
+            };
+            persist_caps(&path, &caps)?;
+            return Ok(caps);
+        }
+    }
+    let caps = CapSids {
+        workspace: make_random_cap_sid_string(),
+        readonly: make_random_cap_sid_string(),
+        workspace_by_cwd: HashMap::new(),
+        writable_root_by_path: HashMap::new(),
+    };
+    persist_caps(&path, &caps)?;
+    Ok(caps)
+}
+
+/// Returns the workspace-specific capability SID for `cwd`, creating and persisting it if missing.
+pub fn workspace_cap_sid_for_cwd(codex_home: &Path, cwd: &Path) -> Result<String> {
+    let path = cap_sid_file(codex_home);
+    let mut caps = load_or_create_cap_sids(codex_home)?;
+    let key = canonical_path_key(cwd);
+    if let Some(sid) = caps.workspace_by_cwd.get(&key) {
+        return Ok(sid.clone());
+    }
+    let sid = make_random_cap_sid_string();
+    caps.workspace_by_cwd.insert(key, sid.clone());
+    persist_caps(&path, &caps)?;
+    Ok(sid)
+}
+
+/// Returns the capability SID for an additional writable root, creating and persisting it if missing.
+pub fn writable_root_cap_sid_for_path(codex_home: &Path, root: &Path) -> Result<String> {
+    let path = cap_sid_file(codex_home);
+    let mut caps = load_or_create_cap_sids(codex_home)?;
+    let key = canonical_path_key(root);
+    if let Some(sid) = caps.writable_root_by_path.get(&key) {
+        return Ok(sid.clone());
+    }
+    let sid = make_random_cap_sid_string();
+    caps.writable_root_by_path.insert(key, sid.clone());
+    persist_caps(&path, &caps)?;
+    Ok(sid)
+}
+
+pub fn workspace_write_cap_sid_for_root(
+    codex_home: &Path,
+    cwd: &Path,
+    root: &Path,
+) -> Result<String> {
+    if canonical_path_key(root) == canonical_path_key(cwd) {
+        workspace_cap_sid_for_cwd(codex_home, cwd)
+    } else {
+        writable_root_cap_sid_for_path(codex_home, root)
+    }
+}
+
+pub fn workspace_write_root_contains_path(root: &Path, path: &Path) -> bool {
+    canonicalize_path(path).starts_with(canonicalize_path(root))
+}
+
+pub fn workspace_write_root_overlaps_path(root: &Path, path: &Path) -> bool {
+    workspace_write_root_contains_path(root, path) || workspace_write_root_contains_path(path, root)
+}
+
+pub fn workspace_write_root_specificity(root: &Path) -> usize {
+    canonicalize_path(root).components().count()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::load_or_create_cap_sids;
+    use super::workspace_cap_sid_for_cwd;
+    use super::workspace_write_cap_sid_for_root;
+    use super::writable_root_cap_sid_for_path;
+    use pretty_assertions::assert_eq;
+    use std::path::PathBuf;
+
+    #[test]
+    fn equivalent_cwd_spellings_share_workspace_sid_key() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let codex_home = temp.path().join("codex-home");
+        std::fs::create_dir_all(&codex_home).expect("create codex home");
+
+        let workspace = temp.path().join("WorkspaceRoot");
+        std::fs::create_dir_all(&workspace).expect("create workspace root");
+
+        let canonical = dunce::canonicalize(&workspace).expect("canonical workspace root");
+        let alt_spelling = PathBuf::from(
+            canonical
+                .to_string_lossy()
+                .replace('\\', "/")
+                .to_ascii_uppercase(),
+        );
+
+        let first_sid =
+            workspace_cap_sid_for_cwd(&codex_home, canonical.as_path()).expect("first sid");
+        let second_sid =
+            workspace_cap_sid_for_cwd(&codex_home, alt_spelling.as_path()).expect("second sid");
+
+        assert_eq!(first_sid, second_sid);
+
+        let caps = load_or_create_cap_sids(&codex_home).expect("load caps");
+        assert_eq!(caps.workspace_by_cwd.len(), 1);
+    }
+
+    #[test]
+    fn write_roots_get_path_scoped_sids() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let codex_home = temp.path().join("codex-home");
+        std::fs::create_dir_all(&codex_home).expect("create codex home");
+
+        let workspace = temp.path().join("workspace");
+        let extra_root = temp.path().join("extra-root");
+        std::fs::create_dir_all(&workspace).expect("create workspace");
+        std::fs::create_dir_all(&extra_root).expect("create extra root");
+
+        let workspace_sid = workspace_write_cap_sid_for_root(&codex_home, &workspace, &workspace)
+            .expect("workspace sid");
+        let extra_sid = workspace_write_cap_sid_for_root(&codex_home, &workspace, &extra_root)
+            .expect("extra root sid");
+
+        assert_ne!(workspace_sid, extra_sid);
+        assert_eq!(
+            extra_sid,
+            writable_root_cap_sid_for_path(&codex_home, &extra_root).expect("extra root sid again")
+        );
+
+        let caps = load_or_create_cap_sids(&codex_home).expect("load caps");
+        assert_eq!(caps.workspace_by_cwd.len(), 1);
+        assert_eq!(caps.writable_root_by_path.len(), 1);
+    }
+}

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/deny_read_acl.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/deny_read_acl.rs
@@ -1,0 +1,119 @@
+use crate::acl::add_deny_read_ace;
+use crate::acl::revoke_ace;
+use crate::path_normalization::canonicalize_path;
+use anyhow::Context;
+use anyhow::Result;
+use std::collections::HashSet;
+use std::ffi::c_void;
+use std::path::Path;
+use std::path::PathBuf;
+
+/// Build the exact ACL paths that should receive a deny-read ACE.
+///
+/// We keep both the lexical policy path and, when it already exists, the
+/// canonical target. The lexical path covers the path users configured and lets
+/// missing exact denies be materialized later; the canonical path also covers
+/// an existing reparse-point target so a sandbox cannot read the same object
+/// through the resolved location.
+pub fn plan_deny_read_acl_paths(paths: &[PathBuf]) -> Vec<PathBuf> {
+    let mut planned = Vec::new();
+    let mut seen = HashSet::new();
+    for path in paths {
+        push_planned_path(&mut planned, &mut seen, path.to_path_buf());
+        if path.exists() {
+            push_planned_path(&mut planned, &mut seen, canonicalize_path(path));
+        }
+    }
+    planned
+}
+
+fn push_planned_path(planned: &mut Vec<PathBuf>, seen: &mut HashSet<String>, path: PathBuf) {
+    if seen.insert(lexical_path_key(&path)) {
+        planned.push(path);
+    }
+}
+
+pub(crate) fn lexical_path_key(path: &Path) -> String {
+    path.to_string_lossy()
+        .replace('\\', "/")
+        .trim_end_matches('/')
+        .to_ascii_lowercase()
+}
+
+/// Applies deny-read ACEs to explicit paths. Missing paths are materialized as
+/// directories before the ACE is applied so a sandboxed command cannot create a
+/// previously absent denied path and then read from it in the same run.
+/// If any path fails, deny ACEs applied by this call are revoked before the
+/// error is returned so a one-shot sandbox run does not leave partial state.
+///
+/// # Safety
+/// Caller must pass a valid SID pointer for the sandbox principal being denied.
+pub unsafe fn apply_deny_read_acls(paths: &[PathBuf], psid: *mut c_void) -> Result<Vec<PathBuf>> {
+    let planned = plan_deny_read_acl_paths(paths);
+    let mut applied = Vec::new();
+    let mut seen = HashSet::new();
+    let mut added_in_this_call: Vec<PathBuf> = Vec::new();
+    for path in planned {
+        let result = (|| -> Result<bool> {
+            if !path.exists() {
+                std::fs::create_dir_all(&path)
+                    .with_context(|| format!("create deny-read path {}", path.display()))?;
+            }
+            add_deny_read_ace(&path, psid)
+                .with_context(|| format!("apply deny-read ACE to {}", path.display()))
+        })();
+        let added = match result {
+            Ok(added) => added,
+            Err(err) => {
+                for added_path in &added_in_this_call {
+                    revoke_ace(added_path, psid);
+                }
+                return Err(err);
+            }
+        };
+        if added {
+            added_in_this_call.push(path.clone());
+        }
+        push_planned_path(&mut applied, &mut seen, path);
+    }
+    Ok(applied)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::plan_deny_read_acl_paths;
+    use pretty_assertions::assert_eq;
+    use std::collections::HashSet;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    #[test]
+    fn plan_preserves_missing_paths() {
+        let tmp = TempDir::new().expect("tempdir");
+        let missing = tmp.path().join("future-secret.env");
+
+        assert_eq!(
+            plan_deny_read_acl_paths(std::slice::from_ref(&missing)),
+            vec![missing]
+        );
+    }
+
+    #[test]
+    fn plan_includes_existing_canonical_targets() {
+        let tmp = TempDir::new().expect("tempdir");
+        let existing = tmp.path().join("secret.env");
+        std::fs::write(&existing, "secret").expect("write secret");
+
+        let planned: HashSet<PathBuf> = plan_deny_read_acl_paths(std::slice::from_ref(&existing))
+            .into_iter()
+            .collect();
+        let expected: HashSet<PathBuf> = [
+            existing.clone(),
+            dunce::canonicalize(&existing).expect("canonical path"),
+        ]
+        .into_iter()
+        .collect();
+
+        assert_eq!(planned, expected);
+    }
+}

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/deny_read_state.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/deny_read_state.rs
@@ -1,0 +1,87 @@
+use crate::acl::revoke_ace;
+use crate::deny_read_acl::apply_deny_read_acls;
+use crate::deny_read_acl::lexical_path_key;
+use crate::setup::sandbox_dir;
+use anyhow::Context;
+use anyhow::Result;
+use serde::Deserialize;
+use serde::Serialize;
+use std::collections::BTreeMap;
+use std::collections::HashSet;
+use std::ffi::c_void;
+use std::path::Path;
+use std::path::PathBuf;
+
+const DENY_READ_ACL_STATE_FILE: &str = "deny_read_acl_state.json";
+
+#[derive(Default, Deserialize, Serialize)]
+struct PersistentDenyReadAclState {
+    principals: BTreeMap<String, Vec<PathBuf>>,
+}
+
+/// Reconciles the persistent deny-read ACEs owned by one sandbox principal.
+///
+/// Workspace-write and elevated sandbox sessions intentionally leave ACLs in
+/// place after a command exits, because descendants may outlive the launcher.
+/// That makes the ACL set stateful across runs. Persist the paths applied for
+/// each SID, apply the new desired set first, and only then revoke stale paths
+/// from the same SID so profile changes do not leave old deny-read ACEs behind.
+///
+/// # Safety
+/// Caller must pass a valid SID pointer matching `principal_sid`.
+pub unsafe fn sync_persistent_deny_read_acls(
+    codex_home: &Path,
+    principal_sid: &str,
+    desired_paths: &[PathBuf],
+    psid: *mut c_void,
+) -> Result<Vec<PathBuf>> {
+    let state_path = sandbox_dir(codex_home).join(DENY_READ_ACL_STATE_FILE);
+    let mut state = load_state(&state_path)?;
+    let previous_paths = state
+        .principals
+        .get(principal_sid)
+        .cloned()
+        .unwrap_or_default();
+
+    let applied_paths = unsafe { apply_deny_read_acls(desired_paths, psid) }?;
+    let desired_keys = applied_paths
+        .iter()
+        .map(|path| lexical_path_key(path))
+        .collect::<HashSet<_>>();
+
+    for path in previous_paths {
+        if !desired_keys.contains(&lexical_path_key(&path)) {
+            revoke_ace(&path, psid);
+        }
+    }
+
+    if applied_paths.is_empty() {
+        state.principals.remove(principal_sid);
+    } else {
+        state
+            .principals
+            .insert(principal_sid.to_string(), applied_paths.clone());
+    }
+    store_state(&state_path, &state)?;
+
+    Ok(applied_paths)
+}
+
+fn load_state(path: &Path) -> Result<PersistentDenyReadAclState> {
+    match std::fs::read(path) {
+        Ok(bytes) => serde_json::from_slice(&bytes)
+            .with_context(|| format!("parse deny-read ACL state {}", path.display())),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            Ok(PersistentDenyReadAclState::default())
+        }
+        Err(err) => {
+            Err(err).with_context(|| format!("read deny-read ACL state {}", path.display()))
+        }
+    }
+}
+
+fn store_state(path: &Path, state: &PersistentDenyReadAclState) -> Result<()> {
+    let bytes = serde_json::to_vec_pretty(state).context("serialize deny-read ACL state")?;
+    std::fs::write(path, bytes)
+        .with_context(|| format!("write deny-read ACL state {}", path.display()))
+}

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/dpapi.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/dpapi.rs
@@ -1,0 +1,85 @@
+use anyhow::Result;
+use anyhow::anyhow;
+use windows_sys::Win32::Foundation::GetLastError;
+use windows_sys::Win32::Foundation::HLOCAL;
+use windows_sys::Win32::Foundation::LocalFree;
+use windows_sys::Win32::Security::Cryptography::CRYPT_INTEGER_BLOB;
+use windows_sys::Win32::Security::Cryptography::CRYPTPROTECT_LOCAL_MACHINE;
+use windows_sys::Win32::Security::Cryptography::CRYPTPROTECT_UI_FORBIDDEN;
+use windows_sys::Win32::Security::Cryptography::CryptProtectData;
+use windows_sys::Win32::Security::Cryptography::CryptUnprotectData;
+
+fn make_blob(data: &[u8]) -> CRYPT_INTEGER_BLOB {
+    CRYPT_INTEGER_BLOB {
+        cbData: data.len() as u32,
+        pbData: data.as_ptr() as *mut u8,
+    }
+}
+
+#[allow(clippy::unnecessary_mut_passed)]
+pub fn protect(data: &[u8]) -> Result<Vec<u8>> {
+    let mut in_blob = make_blob(data);
+    let mut out_blob = CRYPT_INTEGER_BLOB {
+        cbData: 0,
+        pbData: std::ptr::null_mut(),
+    };
+    let ok = unsafe {
+        CryptProtectData(
+            &mut in_blob,
+            std::ptr::null(),
+            std::ptr::null(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            // Use machine scope so elevated and non-elevated processes can decrypt.
+            CRYPTPROTECT_UI_FORBIDDEN | CRYPTPROTECT_LOCAL_MACHINE,
+            &mut out_blob,
+        )
+    };
+    if ok == 0 {
+        return Err(anyhow!("CryptProtectData failed: {}", unsafe {
+            GetLastError()
+        }));
+    }
+    let slice =
+        unsafe { std::slice::from_raw_parts(out_blob.pbData, out_blob.cbData as usize) }.to_vec();
+    unsafe {
+        if !out_blob.pbData.is_null() {
+            LocalFree(out_blob.pbData as HLOCAL);
+        }
+    }
+    Ok(slice)
+}
+
+#[allow(clippy::unnecessary_mut_passed)]
+pub fn unprotect(blob: &[u8]) -> Result<Vec<u8>> {
+    let mut in_blob = make_blob(blob);
+    let mut out_blob = CRYPT_INTEGER_BLOB {
+        cbData: 0,
+        pbData: std::ptr::null_mut(),
+    };
+    let ok = unsafe {
+        CryptUnprotectData(
+            &mut in_blob,
+            std::ptr::null_mut(),
+            std::ptr::null(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            // Use machine scope so elevated and non-elevated processes can decrypt.
+            CRYPTPROTECT_UI_FORBIDDEN | CRYPTPROTECT_LOCAL_MACHINE,
+            &mut out_blob,
+        )
+    };
+    if ok == 0 {
+        return Err(anyhow!("CryptUnprotectData failed: {}", unsafe {
+            GetLastError()
+        }));
+    }
+    let slice =
+        unsafe { std::slice::from_raw_parts(out_blob.pbData, out_blob.cbData as usize) }.to_vec();
+    unsafe {
+        if !out_blob.pbData.is_null() {
+            LocalFree(out_blob.pbData as HLOCAL);
+        }
+    }
+    Ok(slice)
+}

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/env.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/env.rs
@@ -1,0 +1,177 @@
+use anyhow::Result;
+use anyhow::anyhow;
+use dirs_next::home_dir;
+use std::collections::HashMap;
+use std::env;
+use std::fs::File;
+use std::fs::{self};
+use std::io::Write;
+use std::path::Path;
+use std::path::PathBuf;
+
+pub fn normalize_null_device_env(env_map: &mut HashMap<String, String>) {
+    let keys: Vec<String> = env_map.keys().cloned().collect();
+    for k in keys {
+        if let Some(v) = env_map.get(&k).cloned() {
+            let t = v.trim().to_ascii_lowercase();
+            if t == "/dev/null" || t == "\\\\\\\\dev\\\\\\\\null" {
+                env_map.insert(k, "NUL".to_string());
+            }
+        }
+    }
+}
+
+pub fn ensure_non_interactive_pager(env_map: &mut HashMap<String, String>) {
+    env_map
+        .entry("GIT_PAGER".into())
+        .or_insert_with(|| "more.com".into());
+    env_map
+        .entry("PAGER".into())
+        .or_insert_with(|| "more.com".into());
+    env_map.entry("LESS".into()).or_insert_with(|| "".into());
+}
+
+// Keep PATH and PATHEXT stable for callers that rely on inheriting the parent process env.
+pub fn inherit_path_env(env_map: &mut HashMap<String, String>) {
+    if !env_map.contains_key("PATH")
+        && let Ok(path) = env::var("PATH")
+    {
+        env_map.insert("PATH".into(), path);
+    }
+    if !env_map.contains_key("PATHEXT")
+        && let Ok(pathext) = env::var("PATHEXT")
+    {
+        env_map.insert("PATHEXT".into(), pathext);
+    }
+}
+
+fn prepend_path(env_map: &mut HashMap<String, String>, prefix: &str) {
+    let existing = env_map
+        .get("PATH")
+        .cloned()
+        .or_else(|| env::var("PATH").ok())
+        .unwrap_or_default();
+    let parts: Vec<String> = existing.split(';').map(ToString::to_string).collect();
+    if parts
+        .first()
+        .map(|p| p.eq_ignore_ascii_case(prefix))
+        .unwrap_or(false)
+    {
+        return;
+    }
+    let mut new_path = String::new();
+    new_path.push_str(prefix);
+    if !existing.is_empty() {
+        new_path.push(';');
+        new_path.push_str(&existing);
+    }
+    env_map.insert("PATH".into(), new_path);
+}
+
+fn reorder_pathext_for_stubs(env_map: &mut HashMap<String, String>) {
+    let default = env_map
+        .get("PATHEXT")
+        .cloned()
+        .or_else(|| env::var("PATHEXT").ok())
+        .unwrap_or(".COM;.EXE;.BAT;.CMD".to_string());
+    let exts: Vec<String> = default
+        .split(';')
+        .filter(|e| !e.is_empty())
+        .map(ToString::to_string)
+        .collect();
+    let exts_norm: Vec<String> = exts.iter().map(|e| e.to_ascii_uppercase()).collect();
+    let want = [".BAT", ".CMD"];
+    let mut front: Vec<String> = Vec::new();
+    for w in want {
+        if let Some(idx) = exts_norm.iter().position(|e| e == w) {
+            front.push(exts[idx].clone());
+        }
+    }
+    let rest: Vec<String> = exts
+        .into_iter()
+        .enumerate()
+        .filter(|(i, _)| {
+            let up = &exts_norm[*i];
+            up != ".BAT" && up != ".CMD"
+        })
+        .map(|(_, e)| e)
+        .collect();
+    let mut combined = Vec::new();
+    combined.extend(front);
+    combined.extend(rest);
+    env_map.insert("PATHEXT".into(), combined.join(";"));
+}
+
+fn ensure_denybin(tools: &[&str], denybin_dir: Option<&Path>) -> Result<PathBuf> {
+    let base = match denybin_dir {
+        Some(p) => p.to_path_buf(),
+        None => {
+            let home = home_dir().ok_or_else(|| anyhow!("no home dir"))?;
+            home.join(".sbx-denybin")
+        }
+    };
+    fs::create_dir_all(&base)?;
+    for tool in tools {
+        for ext in [".bat", ".cmd"] {
+            let path = base.join(format!("{tool}{ext}"));
+            if !path.exists() {
+                let mut f = File::create(&path)?;
+                f.write_all(b"@echo off\\r\\nexit /b 1\\r\\n")?;
+            }
+        }
+    }
+    Ok(base)
+}
+
+pub fn apply_no_network_to_env(env_map: &mut HashMap<String, String>) -> Result<()> {
+    env_map.insert("SBX_NONET_ACTIVE".into(), "1".into());
+    env_map
+        .entry("HTTP_PROXY".into())
+        .or_insert_with(|| "http://127.0.0.1:9".into());
+    env_map
+        .entry("HTTPS_PROXY".into())
+        .or_insert_with(|| "http://127.0.0.1:9".into());
+    env_map
+        .entry("ALL_PROXY".into())
+        .or_insert_with(|| "http://127.0.0.1:9".into());
+    env_map
+        .entry("NO_PROXY".into())
+        .or_insert_with(|| "localhost,127.0.0.1,::1".into());
+    env_map
+        .entry("PIP_NO_INDEX".into())
+        .or_insert_with(|| "1".into());
+    env_map
+        .entry("PIP_DISABLE_PIP_VERSION_CHECK".into())
+        .or_insert_with(|| "1".into());
+    env_map
+        .entry("NPM_CONFIG_OFFLINE".into())
+        .or_insert_with(|| "true".into());
+    env_map
+        .entry("CARGO_NET_OFFLINE".into())
+        .or_insert_with(|| "true".into());
+    env_map
+        .entry("GIT_HTTP_PROXY".into())
+        .or_insert_with(|| "http://127.0.0.1:9".into());
+    env_map
+        .entry("GIT_HTTPS_PROXY".into())
+        .or_insert_with(|| "http://127.0.0.1:9".into());
+    env_map
+        .entry("GIT_SSH_COMMAND".into())
+        .or_insert_with(|| "cmd /c exit 1".into());
+    env_map
+        .entry("GIT_ALLOW_PROTOCOLS".into())
+        .or_insert_with(|| "".into());
+
+    let base = ensure_denybin(&["ssh", "scp"], /*denybin_dir*/ None)?;
+    for tool in ["curl", "wget"] {
+        for ext in [".bat", ".cmd"] {
+            let p = base.join(format!("{tool}{ext}"));
+            if p.exists() {
+                let _ = fs::remove_file(&p);
+            }
+        }
+    }
+    prepend_path(env_map, &base.to_string_lossy());
+    reorder_pathext_for_stubs(env_map);
+    Ok(())
+}

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/env.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/env.rs
@@ -116,7 +116,7 @@ fn ensure_denybin(tools: &[&str], denybin_dir: Option<&Path>) -> Result<PathBuf>
             let path = base.join(format!("{tool}{ext}"));
             if !path.exists() {
                 let mut f = File::create(&path)?;
-                f.write_all(b"@echo off\\r\\nexit /b 1\\r\\n")?;
+                f.write_all(b"@echo off\r\nexit /b 1\r\n")?;
             }
         }
     }

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/hide_users.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/hide_users.rs
@@ -1,0 +1,158 @@
+use crate::logging::log_note;
+use crate::winutil::format_last_error;
+use crate::winutil::to_wide;
+use anyhow::anyhow;
+use std::ffi::OsStr;
+use std::path::Path;
+use std::path::PathBuf;
+use windows_sys::Win32::Foundation::GetLastError;
+use windows_sys::Win32::Storage::FileSystem::FILE_ATTRIBUTE_HIDDEN;
+use windows_sys::Win32::Storage::FileSystem::FILE_ATTRIBUTE_SYSTEM;
+use windows_sys::Win32::Storage::FileSystem::GetFileAttributesW;
+use windows_sys::Win32::Storage::FileSystem::INVALID_FILE_ATTRIBUTES;
+use windows_sys::Win32::Storage::FileSystem::SetFileAttributesW;
+use windows_sys::Win32::System::Registry::HKEY;
+use windows_sys::Win32::System::Registry::HKEY_LOCAL_MACHINE;
+use windows_sys::Win32::System::Registry::KEY_WRITE;
+use windows_sys::Win32::System::Registry::REG_DWORD;
+use windows_sys::Win32::System::Registry::REG_OPTION_NON_VOLATILE;
+use windows_sys::Win32::System::Registry::RegCloseKey;
+use windows_sys::Win32::System::Registry::RegCreateKeyExW;
+use windows_sys::Win32::System::Registry::RegSetValueExW;
+
+const USERLIST_KEY_PATH: &str =
+    r"SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon\SpecialAccounts\UserList";
+
+pub fn hide_newly_created_users(usernames: &[String], log_base: &Path) {
+    if usernames.is_empty() {
+        return;
+    }
+    if let Err(err) = hide_users_in_winlogon(usernames, log_base) {
+        log_note(
+            &format!("hide users: failed to update Winlogon UserList: {err}"),
+            Some(log_base),
+        );
+    }
+}
+
+/// Best-effort: hides the current sandbox user's profile directory once it exists.
+///
+/// Windows only creates profile directories when that user first logs in.
+/// This intentionally runs in the command-runner (as the sandbox user) because
+/// command running is what causes us to log in as a particular sandbox user.
+pub fn hide_current_user_profile_dir(log_base: &Path) {
+    let Some(profile) = std::env::var_os("USERPROFILE") else {
+        return;
+    };
+    let profile_dir = PathBuf::from(profile);
+    if !profile_dir.exists() {
+        return;
+    }
+
+    match hide_directory(&profile_dir) {
+        Ok(true) => {
+            // Log only when we actually change attributes, so this stays one-time per profile dir.
+            log_note(
+                &format!(
+                    "hide users: profile dir hidden for current user ({})",
+                    profile_dir.display()
+                ),
+                Some(log_base),
+            );
+        }
+        Ok(false) => {}
+        Err(err) => {
+            log_note(
+                &format!(
+                    "hide users: failed to hide current user profile dir ({}): {err}",
+                    profile_dir.display()
+                ),
+                Some(log_base),
+            );
+        }
+    }
+}
+
+fn hide_users_in_winlogon(usernames: &[String], log_base: &Path) -> anyhow::Result<()> {
+    let key = create_userlist_key()?;
+    for username in usernames {
+        let name_w = to_wide(OsStr::new(username));
+        let value: u32 = 0;
+        let status = unsafe {
+            RegSetValueExW(
+                key,
+                name_w.as_ptr(),
+                0,
+                REG_DWORD,
+                &value as *const u32 as *const u8,
+                std::mem::size_of_val(&value) as u32,
+            )
+        };
+        if status != 0 {
+            log_note(
+                &format!(
+                    "hide users: failed to set UserList value for {username}: {status} ({error})",
+                    error = format_last_error(status as i32)
+                ),
+                Some(log_base),
+            );
+        }
+    }
+    unsafe {
+        RegCloseKey(key);
+    }
+    Ok(())
+}
+
+fn create_userlist_key() -> anyhow::Result<HKEY> {
+    let key_path = to_wide(USERLIST_KEY_PATH);
+    let mut key: HKEY = 0;
+    let status = unsafe {
+        RegCreateKeyExW(
+            HKEY_LOCAL_MACHINE,
+            key_path.as_ptr(),
+            0,
+            std::ptr::null_mut(),
+            REG_OPTION_NON_VOLATILE,
+            KEY_WRITE,
+            std::ptr::null_mut(),
+            &mut key,
+            std::ptr::null_mut(),
+        )
+    };
+    if status != 0 {
+        return Err(anyhow!(
+            "RegCreateKeyExW failed: {status} ({error})",
+            error = format_last_error(status as i32)
+        ));
+    }
+    Ok(key)
+}
+
+/// Sets HIDDEN|SYSTEM on `path` if needed, returning whether it changed anything.
+fn hide_directory(path: &Path) -> anyhow::Result<bool> {
+    let wide = to_wide(path);
+    let attrs = unsafe { GetFileAttributesW(wide.as_ptr()) };
+    if attrs == INVALID_FILE_ATTRIBUTES {
+        let err = unsafe { GetLastError() } as i32;
+        return Err(anyhow!(
+            "GetFileAttributesW failed for {}: {err} ({error})",
+            path.display(),
+            error = format_last_error(err)
+        ));
+    }
+    let new_attrs = attrs | FILE_ATTRIBUTE_HIDDEN | FILE_ATTRIBUTE_SYSTEM;
+    if new_attrs == attrs {
+        return Ok(false);
+    }
+    let ok = unsafe { SetFileAttributesW(wide.as_ptr(), new_attrs) };
+    if ok == 0 {
+        let err = unsafe { GetLastError() } as i32;
+        return Err(anyhow!(
+            "SetFileAttributesW failed for {}: {err} ({error})",
+            path.display(),
+            error = format_last_error(err)
+        ));
+    }
+    Ok(true)
+}

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/lib.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/lib.rs
@@ -1,0 +1,83 @@
+// Vendored files below are byte-for-byte upstream (see VENDORING.md); do not
+// hand-edit them to satisfy lints, since that would defeat the point of
+// verbatim vendoring (every future re-vendoring pass would need to re-apply
+// the same patches by hand). Two lint classes fire purely from an edition
+// mismatch between upstream's authoring edition and this workspace's
+// `edition = "2024"`, not from any bug in the vendored code, and are allowed
+// here instead:
+// - `unsafe_op_in_unsafe_fn`: edition 2024 requires an explicit `unsafe {}`
+//   block for every unsafe call even inside an `unsafe fn`'s own body (edition
+//   2021 and earlier treat the whole body as an implicit unsafe context).
+//   Upstream code predates this requirement; 135 call sites would need a
+//   wrapping `unsafe {}` added to satisfy it under this workspace's edition.
+// - `clippy::missing_safety_doc`: upstream documents `# Safety` on some but
+//   not all `pub unsafe fn`s (this repo's own `rules/rust/coding-style.md`
+//   requires a `// SAFETY:` comment on every `unsafe` block; upstream's own
+//   convention is close but not total coverage).
+// Verified via `cargo clippy --target x86_64-pc-windows-gnu -p
+// codex-windows-sandbox -- -D warnings` (see VENDORING.md): every failure
+// without these two allows is one of these two lints, none are a deeper
+// clippy correctness lint.
+#![allow(unsafe_op_in_unsafe_fn)]
+#![allow(clippy::missing_safety_doc)]
+
+//! Verbatim-vendored Windows sandbox mechanism primitives from
+//! `openai/codex`'s `codex-rs/windows-sandbox-rs` crate (Apache-2.0). See
+//! `../VENDORING.md` for the pinned commit, the full file-by-file provenance,
+//! and the two modules deliberately NOT vendored this wave
+//! (`deny_read_resolver.rs`'s glob-scan resolver and `process.rs`'s
+//! `CreateProcessAsUserW` wrapper) and why.
+//!
+//! This crate is inert this wave (Step 3 Wave 1 of
+//! `plan-codex-crossplatform-desktop.md`): nothing here is called from
+//! `hive-desktop-sandbox`'s `launch` path yet. It exists so the vendored
+//! primitives are vendored, compiled, and unit-tested on their own, ahead of
+//! the elevated-helper and launch-wiring waves that will actually call them.
+//!
+//! Every module below is real Win32 FFI (via `windows-sys`) with no
+//! `#[cfg(windows)]` gate of its own (matching upstream, which is a
+//! Windows-only crate). The gate is applied HERE, once, per module
+//! declaration, so this crate compiles to an empty, valid crate on
+//! non-Windows hosts (this repository's CI and dev environment are Linux) and
+//! is exercised for real only by the dedicated
+//! `cargo check --target x86_64-pc-windows-gnu -p codex-windows-sandbox` CI
+//! step (see `../../.github/workflows/ci.yml`), mirroring how
+//! `hive-desktop-sandbox`'s own `windows.rs` is gated and cross-checked.
+
+#[cfg(windows)]
+pub mod acl;
+#[cfg(windows)]
+pub mod cap;
+#[cfg(windows)]
+pub mod deny_read_acl;
+#[cfg(windows)]
+pub mod deny_read_state;
+#[cfg(windows)]
+pub mod dpapi;
+#[cfg(windows)]
+pub mod env;
+#[cfg(windows)]
+pub mod hide_users;
+#[cfg(windows)]
+pub mod path_normalization;
+#[cfg(windows)]
+pub mod proc_thread_attr;
+#[cfg(windows)]
+pub mod sandbox_utils;
+#[cfg(windows)]
+pub mod token;
+#[cfg(windows)]
+pub mod winutil;
+#[cfg(windows)]
+pub mod workspace_acl;
+
+// Not vendored from upstream: minimal, Hive-authored stand-ins so the two
+// verbatim modules above that need them (`deny_read_state::sync_persistent_deny_read_acls`
+// needs `setup::sandbox_dir`; `hide_users` needs `logging::log_note`) compile
+// without pulling in upstream's CODEX_HOME-coupled `setup.rs` or the
+// `tracing-appender`/`codex-utils-string`-coupled `logging.rs`. See
+// `../VENDORING.md` for what each stand-in does and does not do.
+#[cfg(windows)]
+mod logging;
+#[cfg(windows)]
+mod setup;

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/logging.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/logging.rs
@@ -1,0 +1,23 @@
+//! Minimal, Hive-authored stand-in for upstream `logging.rs`
+//! (`codex-rs/windows-sandbox-rs/src/logging.rs`). NOT vendored: upstream's
+//! real version pulls in `tracing-appender`, `chrono`, and the
+//! `codex-utils-string` crate to write rotating, CODEX_HOME-scoped log files.
+//! None of that is wired to anything in this wave (`hide_users.rs` is
+//! vendored but not yet called from any Hive launch path), so this stand-in
+//! only needs to preserve `log_note`'s call shape for `hide_users.rs` to
+//! compile, not its rotating-file persistence.
+//!
+//! Real logging (matching whatever Hive's own agent-engine/desktop logging
+//! convention turns out to be, not upstream's CODEX_HOME file rotation) is
+//! deferred to whichever later wave first calls `hide_users::hide_newly_created_users`
+//! or `hide_users::hide_current_user_profile_dir` for real. See
+//! `../VENDORING.md`.
+
+use std::path::Path;
+
+/// Writes `msg` to stderr. `base_dir` is accepted (matching upstream's
+/// signature so `hide_users.rs` stays byte-for-byte) but unused: this
+/// stand-in never writes to a log file.
+pub fn log_note(msg: &str, _base_dir: Option<&Path>) {
+    eprintln!("[codex-windows-sandbox] {msg}");
+}

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/path_normalization.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/path_normalization.rs
@@ -1,0 +1,31 @@
+use std::path::Path;
+use std::path::PathBuf;
+
+pub fn canonicalize_path(path: &Path) -> PathBuf {
+    dunce::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+pub fn canonical_path_key(path: &Path) -> String {
+    canonicalize_path(path)
+        .to_string_lossy()
+        .replace('\\', "/")
+        .to_ascii_lowercase()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::canonical_path_key;
+    use pretty_assertions::assert_eq;
+    use std::path::Path;
+
+    #[test]
+    fn canonical_path_key_normalizes_case_and_separators() {
+        let windows_style = Path::new(r"C:\Users\Dev\Repo");
+        let slash_style = Path::new("c:/users/dev/repo");
+
+        assert_eq!(
+            canonical_path_key(windows_style),
+            canonical_path_key(slash_style)
+        );
+    }
+}

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/proc_thread_attr.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/proc_thread_attr.rs
@@ -1,0 +1,100 @@
+use std::ffi::c_void;
+use std::io;
+use windows_sys::Win32::Foundation::GetLastError;
+use windows_sys::Win32::Foundation::HANDLE;
+use windows_sys::Win32::System::Threading::DeleteProcThreadAttributeList;
+use windows_sys::Win32::System::Threading::InitializeProcThreadAttributeList;
+use windows_sys::Win32::System::Threading::LPPROC_THREAD_ATTRIBUTE_LIST;
+use windows_sys::Win32::System::Threading::UpdateProcThreadAttribute;
+
+const PROC_THREAD_ATTRIBUTE_HANDLE_LIST: usize = 0x0002_0002;
+const PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE: usize = 0x0002_0016;
+
+pub struct ProcThreadAttributeList {
+    buffer: Vec<u8>,
+    handle_list: Option<Vec<HANDLE>>,
+}
+
+impl ProcThreadAttributeList {
+    pub fn new(attr_count: u32) -> io::Result<Self> {
+        let mut size: usize = 0;
+        unsafe {
+            InitializeProcThreadAttributeList(std::ptr::null_mut(), attr_count, 0, &mut size);
+        }
+        if size == 0 {
+            return Err(io::Error::from_raw_os_error(unsafe {
+                GetLastError() as i32
+            }));
+        }
+        let mut buffer = vec![0u8; size];
+        let list = buffer.as_mut_ptr() as LPPROC_THREAD_ATTRIBUTE_LIST;
+        let ok = unsafe { InitializeProcThreadAttributeList(list, attr_count, 0, &mut size) };
+        if ok == 0 {
+            return Err(io::Error::from_raw_os_error(unsafe {
+                GetLastError() as i32
+            }));
+        }
+        Ok(Self {
+            buffer,
+            handle_list: None,
+        })
+    }
+
+    pub fn as_mut_ptr(&mut self) -> LPPROC_THREAD_ATTRIBUTE_LIST {
+        self.buffer.as_mut_ptr() as LPPROC_THREAD_ATTRIBUTE_LIST
+    }
+
+    pub fn set_pseudoconsole(&mut self, hpc: isize) -> io::Result<()> {
+        let list = self.as_mut_ptr();
+        let ok = unsafe {
+            UpdateProcThreadAttribute(
+                list,
+                0,
+                PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE,
+                hpc as *mut c_void,
+                std::mem::size_of::<HANDLE>(),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+            )
+        };
+        if ok == 0 {
+            return Err(io::Error::from_raw_os_error(unsafe {
+                GetLastError() as i32
+            }));
+        }
+        Ok(())
+    }
+
+    pub fn set_handle_list(&mut self, handles: Vec<HANDLE>) -> io::Result<()> {
+        self.handle_list = Some(handles);
+        let list = self.as_mut_ptr();
+        let Some(handle_list) = self.handle_list.as_mut() else {
+            return Err(io::Error::other("handle list missing after initialization"));
+        };
+        let ok = unsafe {
+            UpdateProcThreadAttribute(
+                list,
+                0,
+                PROC_THREAD_ATTRIBUTE_HANDLE_LIST,
+                handle_list.as_mut_ptr().cast(),
+                std::mem::size_of_val(handle_list.as_slice()),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+            )
+        };
+        if ok == 0 {
+            return Err(io::Error::from_raw_os_error(unsafe {
+                GetLastError() as i32
+            }));
+        }
+        Ok(())
+    }
+}
+
+impl Drop for ProcThreadAttributeList {
+    fn drop(&mut self) {
+        unsafe {
+            DeleteProcThreadAttributeList(self.as_mut_ptr());
+        }
+    }
+}

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/sandbox_utils.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/sandbox_utils.rs
@@ -1,0 +1,116 @@
+//! Shared helper utilities for Windows sandbox setup.
+//!
+//! These helpers centralize small pieces of setup logic used across both legacy and
+//! elevated paths, including unified_exec sessions and capture flows. They cover
+//! codex home directory creation and git safe.directory injection so sandboxed
+//! users can run git inside a repo owned by the primary user.
+
+use anyhow::Result;
+use std::collections::HashMap;
+use std::path::Path;
+
+/// Walk upward from `start` to locate the git worktree root for `safe.directory`.
+fn find_git_worktree_root_for_safe_directory(start: &Path) -> Option<std::path::PathBuf> {
+    let mut cur = dunce::canonicalize(start).ok()?;
+    loop {
+        if cur.join(".git").exists() {
+            return Some(cur);
+        }
+        let parent = cur.parent()?;
+        if parent == cur {
+            return None;
+        }
+        cur = parent.to_path_buf();
+    }
+}
+
+/// Ensure the sandbox codex home directory exists.
+pub fn ensure_codex_home_exists(p: &Path) -> Result<()> {
+    std::fs::create_dir_all(p)?;
+    Ok(())
+}
+
+/// Adds a git safe.directory entry to the environment when running inside a repository.
+/// git will not otherwise allow the Sandbox user to run git commands on the repo directory
+/// which is owned by the primary user.
+pub fn inject_git_safe_directory(env_map: &mut HashMap<String, String>, cwd: &Path) {
+    if let Some(git_root) = find_git_worktree_root_for_safe_directory(cwd) {
+        let mut cfg_count: usize = env_map
+            .get("GIT_CONFIG_COUNT")
+            .and_then(|v| v.parse::<usize>().ok())
+            .unwrap_or(0);
+        let git_path = git_root.to_string_lossy().replace("\\\\", "/");
+        env_map.insert(
+            format!("GIT_CONFIG_KEY_{cfg_count}"),
+            "safe.directory".to_string(),
+        );
+        env_map.insert(format!("GIT_CONFIG_VALUE_{cfg_count}"), git_path);
+        cfg_count += 1;
+        env_map.insert("GIT_CONFIG_COUNT".to_string(), cfg_count.to_string());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::inject_git_safe_directory;
+    use pretty_assertions::assert_eq;
+    use std::collections::HashMap;
+    use std::fs;
+    use std::path::Path;
+    use tempfile::TempDir;
+
+    fn safe_directory_value(path: &Path) -> String {
+        dunce::canonicalize(path)
+            .expect("canonicalize path")
+            .to_string_lossy()
+            .replace("\\\\", "/")
+    }
+
+    #[test]
+    fn injects_safe_directory_for_git_directory() {
+        let temp = TempDir::new().expect("tempdir");
+        let repo = temp.path().join("repo");
+        let nested = repo.join("nested");
+        fs::create_dir_all(repo.join(".git")).expect("create .git");
+        fs::create_dir_all(&nested).expect("create nested dir");
+
+        let mut env_map = HashMap::new();
+        inject_git_safe_directory(&mut env_map, &nested);
+
+        let expected = HashMap::from([
+            ("GIT_CONFIG_COUNT".to_string(), "1".to_string()),
+            ("GIT_CONFIG_KEY_0".to_string(), "safe.directory".to_string()),
+            (
+                "GIT_CONFIG_VALUE_0".to_string(),
+                safe_directory_value(&repo),
+            ),
+        ]);
+        assert_eq!(env_map, expected);
+    }
+
+    #[test]
+    fn injects_worktree_root_for_gitfile() {
+        let temp = TempDir::new().expect("tempdir");
+        let repo = temp.path().join("repo");
+        let nested = repo.join("nested");
+        fs::create_dir_all(&nested).expect("create nested dir");
+        fs::write(
+            repo.join(".git"),
+            "gitdir: C:/Users/example/repo/.git/worktrees/codex3\n",
+        )
+        .expect("write .git file");
+
+        let mut env_map = HashMap::new();
+        inject_git_safe_directory(&mut env_map, &nested);
+
+        let expected = HashMap::from([
+            ("GIT_CONFIG_COUNT".to_string(), "1".to_string()),
+            ("GIT_CONFIG_KEY_0".to_string(), "safe.directory".to_string()),
+            (
+                "GIT_CONFIG_VALUE_0".to_string(),
+                safe_directory_value(&repo),
+            ),
+        ]);
+        assert_eq!(env_map, expected);
+    }
+}

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/sandbox_utils.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/sandbox_utils.rs
@@ -39,7 +39,7 @@ pub fn inject_git_safe_directory(env_map: &mut HashMap<String, String>, cwd: &Pa
             .get("GIT_CONFIG_COUNT")
             .and_then(|v| v.parse::<usize>().ok())
             .unwrap_or(0);
-        let git_path = git_root.to_string_lossy().replace("\\\\", "/");
+        let git_path = git_root.to_string_lossy().replace('\\', "/");
         env_map.insert(
             format!("GIT_CONFIG_KEY_{cfg_count}"),
             "safe.directory".to_string(),
@@ -63,7 +63,7 @@ mod tests {
         dunce::canonicalize(path)
             .expect("canonicalize path")
             .to_string_lossy()
-            .replace("\\\\", "/")
+            .replace('\\', "/")
     }
 
     #[test]

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/setup.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/setup.rs
@@ -1,0 +1,21 @@
+//! Minimal, verbatim ONE-FUNCTION subset of upstream `setup.rs`
+//! (`codex-rs/windows-sandbox-rs/src/setup.rs`, commit `a47c661…`, see
+//! `../VENDORING.md`), extracted so `deny_read_state.rs`'s
+//! `sync_persistent_deny_read_acls` (which needs a base directory to persist
+//! its state file under) compiles without pulling in the rest of upstream's
+//! `setup.rs`: OS-account provisioning, `SandboxUsersFile`,
+//! `run_elevated_provisioning_setup`, and the setup-marker machinery, all of
+//! which are CODEX_HOME-coupled and belong to the Step 3 elevated-helper wave
+//! (ported into `hive-desktop-sandbox`'s `windows_elevated.rs`, not vendored
+//! here), per the module list in `../VENDORING.md`.
+//!
+//! `sandbox_dir` itself is copied byte-for-byte from upstream; only the
+//! surrounding file (which upstream calls `codex_home`, Codex's config
+//! directory) is trimmed to this one function.
+
+use std::path::Path;
+use std::path::PathBuf;
+
+pub fn sandbox_dir(codex_home: &Path) -> PathBuf {
+    codex_home.join(".sandbox")
+}

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/token.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/token.rs
@@ -1,0 +1,483 @@
+use crate::winutil::to_wide;
+use anyhow::Result;
+use anyhow::anyhow;
+use std::ffi::c_void;
+use windows_sys::Win32::Foundation::CloseHandle;
+use windows_sys::Win32::Foundation::ERROR_SUCCESS;
+use windows_sys::Win32::Foundation::GetLastError;
+use windows_sys::Win32::Foundation::HANDLE;
+use windows_sys::Win32::Foundation::HLOCAL;
+use windows_sys::Win32::Foundation::LUID;
+use windows_sys::Win32::Foundation::LocalFree;
+use windows_sys::Win32::Security::AdjustTokenPrivileges;
+use windows_sys::Win32::Security::Authorization::EXPLICIT_ACCESS_W;
+use windows_sys::Win32::Security::Authorization::GRANT_ACCESS;
+use windows_sys::Win32::Security::Authorization::SetEntriesInAclW;
+use windows_sys::Win32::Security::Authorization::TRUSTEE_IS_SID;
+use windows_sys::Win32::Security::Authorization::TRUSTEE_IS_UNKNOWN;
+use windows_sys::Win32::Security::Authorization::TRUSTEE_W;
+use windows_sys::Win32::Security::CopySid;
+use windows_sys::Win32::Security::CreateRestrictedToken;
+use windows_sys::Win32::Security::CreateWellKnownSid;
+use windows_sys::Win32::Security::GetLengthSid;
+use windows_sys::Win32::Security::GetTokenInformation;
+use windows_sys::Win32::Security::LookupPrivilegeValueW;
+use windows_sys::Win32::Security::SetTokenInformation;
+
+use windows_sys::Win32::Security::ACL;
+use windows_sys::Win32::Security::SID_AND_ATTRIBUTES;
+use windows_sys::Win32::Security::TOKEN_ADJUST_DEFAULT;
+use windows_sys::Win32::Security::TOKEN_ADJUST_PRIVILEGES;
+use windows_sys::Win32::Security::TOKEN_ADJUST_SESSIONID;
+use windows_sys::Win32::Security::TOKEN_ASSIGN_PRIMARY;
+use windows_sys::Win32::Security::TOKEN_DUPLICATE;
+use windows_sys::Win32::Security::TOKEN_PRIVILEGES;
+use windows_sys::Win32::Security::TOKEN_QUERY;
+use windows_sys::Win32::Security::TOKEN_USER;
+use windows_sys::Win32::Security::TokenDefaultDacl;
+use windows_sys::Win32::Security::TokenGroups;
+use windows_sys::Win32::Security::TokenUser;
+use windows_sys::Win32::System::Threading::GetCurrentProcess;
+
+const DISABLE_MAX_PRIVILEGE: u32 = 0x01;
+const LUA_TOKEN: u32 = 0x04;
+const WRITE_RESTRICTED: u32 = 0x08;
+const GENERIC_ALL: u32 = 0x1000_0000;
+const WIN_WORLD_SID: i32 = 1;
+const SE_GROUP_LOGON_ID: u32 = 0xC0000000;
+
+#[repr(C)]
+struct TokenDefaultDaclInfo {
+    default_dacl: *mut ACL,
+}
+
+/// Sets a permissive default DACL so sandboxed processes can create pipes/IPC objects
+/// without hitting ACCESS_DENIED when PowerShell builds pipelines.
+unsafe fn set_default_dacl(h_token: HANDLE, sids: &[*mut c_void]) -> Result<()> {
+    if sids.is_empty() {
+        return Ok(());
+    }
+    let entries: Vec<EXPLICIT_ACCESS_W> = sids
+        .iter()
+        .map(|sid| EXPLICIT_ACCESS_W {
+            grfAccessPermissions: GENERIC_ALL,
+            grfAccessMode: GRANT_ACCESS,
+            grfInheritance: 0,
+            Trustee: TRUSTEE_W {
+                pMultipleTrustee: std::ptr::null_mut(),
+                MultipleTrusteeOperation: 0,
+                TrusteeForm: TRUSTEE_IS_SID,
+                TrusteeType: TRUSTEE_IS_UNKNOWN,
+                ptstrName: *sid as *mut u16,
+            },
+        })
+        .collect();
+    let mut p_new_dacl: *mut ACL = std::ptr::null_mut();
+    let res = SetEntriesInAclW(
+        entries.len() as u32,
+        entries.as_ptr(),
+        std::ptr::null_mut(),
+        &mut p_new_dacl,
+    );
+    if res != ERROR_SUCCESS {
+        return Err(anyhow!("SetEntriesInAclW failed: {res}"));
+    }
+    let mut info = TokenDefaultDaclInfo {
+        default_dacl: p_new_dacl,
+    };
+    let ok = SetTokenInformation(
+        h_token,
+        TokenDefaultDacl,
+        &mut info as *mut _ as *mut c_void,
+        std::mem::size_of::<TokenDefaultDaclInfo>() as u32,
+    );
+    if ok == 0 {
+        let err = GetLastError();
+        if !p_new_dacl.is_null() {
+            LocalFree(p_new_dacl as HLOCAL);
+        }
+        return Err(anyhow!(
+            "SetTokenInformation(TokenDefaultDacl) failed: {err}",
+        ));
+    }
+    if !p_new_dacl.is_null() {
+        LocalFree(p_new_dacl as HLOCAL);
+    }
+    Ok(())
+}
+
+pub unsafe fn world_sid() -> Result<Vec<u8>> {
+    let mut size: u32 = 0;
+    CreateWellKnownSid(
+        WIN_WORLD_SID,
+        std::ptr::null_mut(),
+        std::ptr::null_mut(),
+        &mut size,
+    );
+    let mut buf: Vec<u8> = vec![0u8; size as usize];
+    let ok = CreateWellKnownSid(
+        WIN_WORLD_SID,
+        std::ptr::null_mut(),
+        buf.as_mut_ptr() as *mut c_void,
+        &mut size,
+    );
+    if ok == 0 {
+        return Err(anyhow!("CreateWellKnownSid failed: {}", GetLastError()));
+    }
+    Ok(buf)
+}
+
+/// # Safety
+/// Caller is responsible for freeing the returned SID with `LocalFree`.
+pub unsafe fn convert_string_sid_to_sid(s: &str) -> Option<*mut c_void> {
+    #[link(name = "advapi32")]
+    unsafe extern "system" {
+        fn ConvertStringSidToSidW(StringSid: *const u16, Sid: *mut *mut c_void) -> i32;
+    }
+    let mut psid: *mut c_void = std::ptr::null_mut();
+    let ok = unsafe { ConvertStringSidToSidW(to_wide(s).as_ptr(), &mut psid) };
+    if ok != 0 { Some(psid) } else { None }
+}
+
+/// Owns a SID allocated by `ConvertStringSidToSidW` and releases it with `LocalFree`.
+pub struct LocalSid {
+    psid: *mut c_void,
+}
+
+impl LocalSid {
+    pub fn from_string(sid: &str) -> Result<Self> {
+        let psid = unsafe { convert_string_sid_to_sid(sid) }
+            .ok_or_else(|| anyhow!("invalid SID string: {sid}"))?;
+        Ok(Self { psid })
+    }
+
+    pub fn as_ptr(&self) -> *mut c_void {
+        self.psid
+    }
+}
+
+impl Drop for LocalSid {
+    fn drop(&mut self) {
+        if !self.psid.is_null() {
+            unsafe {
+                LocalFree(self.psid as HLOCAL);
+            }
+        }
+    }
+}
+
+/// # Safety
+/// Caller must close the returned token handle.
+pub unsafe fn get_current_token_for_restriction() -> Result<HANDLE> {
+    let desired = TOKEN_DUPLICATE
+        | TOKEN_QUERY
+        | TOKEN_ASSIGN_PRIMARY
+        | TOKEN_ADJUST_DEFAULT
+        | TOKEN_ADJUST_SESSIONID
+        | TOKEN_ADJUST_PRIVILEGES;
+    let mut h: HANDLE = 0;
+    #[link(name = "advapi32")]
+    unsafe extern "system" {
+        fn OpenProcessToken(
+            ProcessHandle: HANDLE,
+            DesiredAccess: u32,
+            TokenHandle: *mut HANDLE,
+        ) -> i32;
+    }
+    let ok = unsafe { OpenProcessToken(GetCurrentProcess(), desired, &mut h) };
+    if ok == 0 {
+        return Err(anyhow!("OpenProcessToken failed: {}", GetLastError()));
+    }
+    Ok(h)
+}
+
+pub unsafe fn get_logon_sid_bytes(h_token: HANDLE) -> Result<Vec<u8>> {
+    unsafe fn scan_token_groups_for_logon(h: HANDLE) -> Option<Vec<u8>> {
+        let mut needed: u32 = 0;
+        GetTokenInformation(h, TokenGroups, std::ptr::null_mut(), 0, &mut needed);
+        if needed == 0 {
+            return None;
+        }
+        let mut buf: Vec<u8> = vec![0u8; needed as usize];
+        let ok = GetTokenInformation(
+            h,
+            TokenGroups,
+            buf.as_mut_ptr() as *mut c_void,
+            needed,
+            &mut needed,
+        );
+        if ok == 0 || (needed as usize) < std::mem::size_of::<u32>() {
+            return None;
+        }
+        let group_count = std::ptr::read_unaligned(buf.as_ptr() as *const u32) as usize;
+        // TOKEN_GROUPS layout is: DWORD GroupCount; SID_AND_ATTRIBUTES Groups[];
+        // On 64-bit, Groups is aligned to pointer alignment after 4-byte GroupCount.
+        let after_count = unsafe { buf.as_ptr().add(std::mem::size_of::<u32>()) } as usize;
+        let align = std::mem::align_of::<SID_AND_ATTRIBUTES>();
+        let aligned = (after_count + (align - 1)) & !(align - 1);
+        let groups_ptr = aligned as *const SID_AND_ATTRIBUTES;
+        for i in 0..group_count {
+            let entry: SID_AND_ATTRIBUTES = std::ptr::read_unaligned(groups_ptr.add(i));
+            if (entry.Attributes & SE_GROUP_LOGON_ID) == SE_GROUP_LOGON_ID {
+                let sid = entry.Sid;
+                let sid_len = GetLengthSid(sid);
+                if sid_len == 0 {
+                    return None;
+                }
+                let mut out = vec![0u8; sid_len as usize];
+                if CopySid(sid_len, out.as_mut_ptr() as *mut c_void, sid) == 0 {
+                    return None;
+                }
+                return Some(out);
+            }
+        }
+        None
+    }
+
+    if let Some(v) = scan_token_groups_for_logon(h_token) {
+        return Ok(v);
+    }
+
+    #[repr(C)]
+    struct TOKEN_LINKED_TOKEN {
+        linked_token: HANDLE,
+    }
+    const TOKEN_LINKED_TOKEN_CLASS: i32 = 19; // TokenLinkedToken
+    let mut ln_needed: u32 = 0;
+    GetTokenInformation(
+        h_token,
+        TOKEN_LINKED_TOKEN_CLASS,
+        std::ptr::null_mut(),
+        0,
+        &mut ln_needed,
+    );
+    if ln_needed >= std::mem::size_of::<TOKEN_LINKED_TOKEN>() as u32 {
+        let mut ln_buf: Vec<u8> = vec![0u8; ln_needed as usize];
+        let ok = GetTokenInformation(
+            h_token,
+            TOKEN_LINKED_TOKEN_CLASS,
+            ln_buf.as_mut_ptr() as *mut c_void,
+            ln_needed,
+            &mut ln_needed,
+        );
+        if ok != 0 {
+            let lt: TOKEN_LINKED_TOKEN =
+                std::ptr::read_unaligned(ln_buf.as_ptr() as *const TOKEN_LINKED_TOKEN);
+            if lt.linked_token != 0 {
+                let res = scan_token_groups_for_logon(lt.linked_token);
+                CloseHandle(lt.linked_token);
+                if let Some(v) = res {
+                    return Ok(v);
+                }
+            }
+        }
+    }
+
+    Err(anyhow!("Logon SID not present on token"))
+}
+
+unsafe fn get_user_sid_bytes(h_token: HANDLE) -> Result<Vec<u8>> {
+    let mut needed: u32 = 0;
+    GetTokenInformation(h_token, TokenUser, std::ptr::null_mut(), 0, &mut needed);
+    if needed == 0 {
+        return Err(anyhow!("TokenUser size query returned 0"));
+    }
+    let mut user_buf: Vec<u8> = vec![0u8; needed as usize];
+    let ok = GetTokenInformation(
+        h_token,
+        TokenUser,
+        user_buf.as_mut_ptr() as *mut c_void,
+        needed,
+        &mut needed,
+    );
+    if ok == 0 || (needed as usize) < std::mem::size_of::<TOKEN_USER>() {
+        return Err(anyhow!(
+            "GetTokenInformation(TokenUser) failed: {}",
+            GetLastError()
+        ));
+    }
+    let token_user: TOKEN_USER = std::ptr::read_unaligned(user_buf.as_ptr() as *const TOKEN_USER);
+    let sid_len = GetLengthSid(token_user.User.Sid);
+    if sid_len == 0 {
+        return Err(anyhow!(
+            "GetLengthSid(TokenUser) failed: {}",
+            GetLastError()
+        ));
+    }
+    let mut user_sid_bytes = vec![0u8; sid_len as usize];
+    if CopySid(
+        sid_len,
+        user_sid_bytes.as_mut_ptr() as *mut c_void,
+        token_user.User.Sid,
+    ) == 0
+    {
+        return Err(anyhow!("CopySid(TokenUser) failed: {}", GetLastError()));
+    }
+    Ok(user_sid_bytes)
+}
+
+unsafe fn enable_single_privilege(h_token: HANDLE, name: &str) -> Result<()> {
+    let mut luid = LUID {
+        LowPart: 0,
+        HighPart: 0,
+    };
+    let ok = LookupPrivilegeValueW(std::ptr::null(), to_wide(name).as_ptr(), &mut luid);
+    if ok == 0 {
+        return Err(anyhow!("LookupPrivilegeValueW failed: {}", GetLastError()));
+    }
+    let mut tp: TOKEN_PRIVILEGES = std::mem::zeroed();
+    tp.PrivilegeCount = 1;
+    tp.Privileges[0].Luid = luid;
+    tp.Privileges[0].Attributes = 0x00000002; // SE_PRIVILEGE_ENABLED
+    let ok2 = AdjustTokenPrivileges(
+        h_token,
+        0,
+        &tp,
+        0,
+        std::ptr::null_mut(),
+        std::ptr::null_mut(),
+    );
+    if ok2 == 0 {
+        return Err(anyhow!("AdjustTokenPrivileges failed: {}", GetLastError()));
+    }
+    let err = GetLastError();
+    if err != 0 {
+        return Err(anyhow!("AdjustTokenPrivileges error {err}"));
+    }
+    Ok(())
+}
+
+/// # Safety
+/// Caller must close the returned token handle.
+pub unsafe fn create_readonly_token_with_cap(
+    psid_capability: *mut c_void,
+) -> Result<(HANDLE, *mut c_void)> {
+    let base = get_current_token_for_restriction()?;
+    let res = create_readonly_token_with_cap_from(base, psid_capability);
+    CloseHandle(base);
+    res
+}
+
+/// # Safety
+/// Caller must close the returned token handle; base_token must be a valid primary token.
+/// # Safety
+/// Caller must close the returned token handle; base_token must be a valid primary token.
+pub unsafe fn create_readonly_token_with_cap_from(
+    base_token: HANDLE,
+    psid_capability: *mut c_void,
+) -> Result<(HANDLE, *mut c_void)> {
+    let new_token = create_token_with_caps_from(base_token, &[psid_capability], &[])?;
+    Ok((new_token, psid_capability))
+}
+
+/// Create a restricted token that includes all provided capability SIDs.
+///
+/// # Safety
+/// Caller must close the returned token handle; base_token must be a valid primary token.
+pub unsafe fn create_workspace_write_token_with_caps_from(
+    base_token: HANDLE,
+    psid_capabilities: &[*mut c_void],
+) -> Result<HANDLE> {
+    create_token_with_caps_from(base_token, psid_capabilities, &[])
+}
+
+/// Create a restricted token that includes all provided capability SIDs plus the token user SID.
+///
+/// This is intended for the elevated sandbox backend, where the token user is the dedicated
+/// sandbox account rather than the real signed-in user.
+///
+/// # Safety
+/// Caller must close the returned token handle; base_token must be a valid primary token.
+pub unsafe fn create_workspace_write_token_with_caps_and_user_from(
+    base_token: HANDLE,
+    psid_capabilities: &[*mut c_void],
+) -> Result<HANDLE> {
+    let mut user_sid_bytes = get_user_sid_bytes(base_token)?;
+    let psid_user = user_sid_bytes.as_mut_ptr() as *mut c_void;
+    create_token_with_caps_from(base_token, psid_capabilities, &[psid_user])
+}
+
+/// Create a restricted token that includes all provided capability SIDs.
+///
+/// # Safety
+/// Caller must close the returned token handle; base_token must be a valid primary token.
+pub unsafe fn create_readonly_token_with_caps_from(
+    base_token: HANDLE,
+    psid_capabilities: &[*mut c_void],
+) -> Result<HANDLE> {
+    create_token_with_caps_from(base_token, psid_capabilities, &[])
+}
+
+/// Create a restricted token that includes all provided capability SIDs plus the token user SID.
+///
+/// This is intended for the elevated sandbox backend, where the token user is the dedicated
+/// sandbox account rather than the real signed-in user.
+///
+/// # Safety
+/// Caller must close the returned token handle; base_token must be a valid primary token.
+pub unsafe fn create_readonly_token_with_caps_and_user_from(
+    base_token: HANDLE,
+    psid_capabilities: &[*mut c_void],
+) -> Result<HANDLE> {
+    let mut user_sid_bytes = get_user_sid_bytes(base_token)?;
+    let psid_user = user_sid_bytes.as_mut_ptr() as *mut c_void;
+    create_token_with_caps_from(base_token, psid_capabilities, &[psid_user])
+}
+
+unsafe fn create_token_with_caps_from(
+    base_token: HANDLE,
+    psid_capabilities: &[*mut c_void],
+    extra_restricting_sids: &[*mut c_void],
+) -> Result<HANDLE> {
+    if psid_capabilities.is_empty() {
+        return Err(anyhow!("no capability SIDs provided"));
+    }
+    let mut logon_sid_bytes = get_logon_sid_bytes(base_token)?;
+    let psid_logon = logon_sid_bytes.as_mut_ptr() as *mut c_void;
+    let mut everyone = world_sid()?;
+    let psid_everyone = everyone.as_mut_ptr() as *mut c_void;
+
+    // Exact order: Capabilities..., ExtraRestricting..., Logon, Everyone
+    let mut entries: Vec<SID_AND_ATTRIBUTES> =
+        vec![std::mem::zeroed(); psid_capabilities.len() + extra_restricting_sids.len() + 2];
+    for (i, psid) in psid_capabilities.iter().enumerate() {
+        entries[i].Sid = *psid;
+        entries[i].Attributes = 0;
+    }
+    let extras_idx = psid_capabilities.len();
+    for (i, psid) in extra_restricting_sids.iter().enumerate() {
+        entries[extras_idx + i].Sid = *psid;
+        entries[extras_idx + i].Attributes = 0;
+    }
+    let logon_idx = extras_idx + extra_restricting_sids.len();
+    entries[logon_idx].Sid = psid_logon;
+    entries[logon_idx].Attributes = 0;
+    entries[logon_idx + 1].Sid = psid_everyone;
+    entries[logon_idx + 1].Attributes = 0;
+
+    let mut new_token: HANDLE = 0;
+    let flags = DISABLE_MAX_PRIVILEGE | LUA_TOKEN | WRITE_RESTRICTED;
+    let ok = CreateRestrictedToken(
+        base_token,
+        flags,
+        0,
+        std::ptr::null(),
+        0,
+        std::ptr::null(),
+        entries.len() as u32,
+        entries.as_mut_ptr(),
+        &mut new_token,
+    );
+    if ok == 0 {
+        return Err(anyhow!("CreateRestrictedToken failed: {}", GetLastError()));
+    }
+
+    let mut dacl_sids: Vec<*mut c_void> = Vec::with_capacity(psid_capabilities.len() + 2);
+    dacl_sids.push(psid_logon);
+    dacl_sids.push(psid_everyone);
+    dacl_sids.extend_from_slice(psid_capabilities);
+    set_default_dacl(new_token, &dacl_sids)?;
+
+    enable_single_privilege(new_token, "SeChangeNotifyPrivilege")?;
+    Ok(new_token)
+}

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/token.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/token.rs
@@ -476,8 +476,14 @@ unsafe fn create_token_with_caps_from(
     dacl_sids.push(psid_logon);
     dacl_sids.push(psid_everyone);
     dacl_sids.extend_from_slice(psid_capabilities);
-    set_default_dacl(new_token, &dacl_sids)?;
+    if let Err(e) = set_default_dacl(new_token, &dacl_sids) {
+        CloseHandle(new_token);
+        return Err(e);
+    }
 
-    enable_single_privilege(new_token, "SeChangeNotifyPrivilege")?;
+    if let Err(e) = enable_single_privilege(new_token, "SeChangeNotifyPrivilege") {
+        CloseHandle(new_token);
+        return Err(e);
+    }
     Ok(new_token)
 }

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/winutil.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/winutil.rs
@@ -1,0 +1,241 @@
+use anyhow::Result;
+use std::ffi::OsStr;
+use std::os::windows::ffi::OsStrExt;
+use windows_sys::Win32::Foundation::ERROR_INSUFFICIENT_BUFFER;
+use windows_sys::Win32::Foundation::GetLastError;
+use windows_sys::Win32::Foundation::HLOCAL;
+use windows_sys::Win32::Foundation::LocalFree;
+use windows_sys::Win32::Security::Authorization::ConvertSidToStringSidW;
+use windows_sys::Win32::Security::Authorization::ConvertStringSidToSidW;
+use windows_sys::Win32::Security::CopySid;
+use windows_sys::Win32::Security::GetLengthSid;
+use windows_sys::Win32::Security::LookupAccountNameW;
+use windows_sys::Win32::Security::SID_NAME_USE;
+use windows_sys::Win32::System::Diagnostics::Debug::FORMAT_MESSAGE_ALLOCATE_BUFFER;
+use windows_sys::Win32::System::Diagnostics::Debug::FORMAT_MESSAGE_FROM_SYSTEM;
+use windows_sys::Win32::System::Diagnostics::Debug::FORMAT_MESSAGE_IGNORE_INSERTS;
+use windows_sys::Win32::System::Diagnostics::Debug::FormatMessageW;
+
+pub fn to_wide<S: AsRef<OsStr>>(s: S) -> Vec<u16> {
+    let mut v: Vec<u16> = s.as_ref().encode_wide().collect();
+    v.push(0);
+    v
+}
+
+/// Quote a single Windows command-line argument following the rules used by
+/// CommandLineToArgvW/CRT so that spaces, quotes, and backslashes are preserved.
+/// Reference behavior matches Rust std::process::Command on Windows.
+#[cfg(target_os = "windows")]
+pub fn quote_windows_arg(arg: &str) -> String {
+    let needs_quotes = arg.is_empty()
+        || arg
+            .chars()
+            .any(|c| matches!(c, ' ' | '\t' | '\n' | '\r' | '"'));
+    if !needs_quotes {
+        return arg.to_string();
+    }
+
+    let mut quoted = String::with_capacity(arg.len() + 2);
+    quoted.push('"');
+    let mut backslashes = 0;
+    for ch in arg.chars() {
+        match ch {
+            '\\' => {
+                backslashes += 1;
+            }
+            '"' => {
+                quoted.push_str(&"\\".repeat(backslashes * 2 + 1));
+                quoted.push('"');
+                backslashes = 0;
+            }
+            _ => {
+                if backslashes > 0 {
+                    quoted.push_str(&"\\".repeat(backslashes));
+                    backslashes = 0;
+                }
+                quoted.push(ch);
+            }
+        }
+    }
+    if backslashes > 0 {
+        quoted.push_str(&"\\".repeat(backslashes * 2));
+    }
+    quoted.push('"');
+    quoted
+}
+
+/// Build a Windows command line for CreateProcess-style APIs.
+#[cfg(target_os = "windows")]
+pub fn argv_to_command_line(argv: &[String]) -> String {
+    argv.iter()
+        .map(|arg| quote_windows_arg(arg))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+// Produce a readable description for a Win32 error code.
+pub fn format_last_error(err: i32) -> String {
+    unsafe {
+        let mut buf_ptr: *mut u16 = std::ptr::null_mut();
+        let flags = FORMAT_MESSAGE_ALLOCATE_BUFFER
+            | FORMAT_MESSAGE_FROM_SYSTEM
+            | FORMAT_MESSAGE_IGNORE_INSERTS;
+        let len = FormatMessageW(
+            flags,
+            std::ptr::null(),
+            err as u32,
+            0,
+            // FORMAT_MESSAGE_ALLOCATE_BUFFER expects a pointer to receive the allocated buffer.
+            // Cast &mut *mut u16 to *mut u16 as required by windows-sys.
+            (&mut buf_ptr as *mut *mut u16) as *mut u16,
+            0,
+            std::ptr::null_mut(),
+        );
+        if len == 0 || buf_ptr.is_null() {
+            return format!("Win32 error {err}");
+        }
+        let slice = std::slice::from_raw_parts(buf_ptr, len as usize);
+        let mut s = String::from_utf16_lossy(slice);
+        s = s.trim().to_string();
+        let _ = LocalFree(buf_ptr as HLOCAL);
+        s
+    }
+}
+
+pub fn string_from_sid_bytes(sid: &[u8]) -> Result<String, String> {
+    unsafe {
+        let mut str_ptr: *mut u16 = std::ptr::null_mut();
+        let ok = ConvertSidToStringSidW(sid.as_ptr() as *mut std::ffi::c_void, &mut str_ptr);
+        if ok == 0 || str_ptr.is_null() {
+            return Err(format!(
+                "ConvertSidToStringSidW failed: {}",
+                std::io::Error::last_os_error()
+            ));
+        }
+        let mut len = 0;
+        while *str_ptr.add(len) != 0 {
+            len += 1;
+        }
+        let slice = std::slice::from_raw_parts(str_ptr, len);
+        let out = String::from_utf16_lossy(slice);
+        let _ = LocalFree(str_ptr as HLOCAL);
+        Ok(out)
+    }
+}
+
+const SID_ADMINISTRATORS: &str = "S-1-5-32-544";
+const SID_USERS: &str = "S-1-5-32-545";
+const SID_AUTHENTICATED_USERS: &str = "S-1-5-11";
+const SID_EVERYONE: &str = "S-1-1-0";
+const SID_SYSTEM: &str = "S-1-5-18";
+
+pub fn resolve_sid(name: &str) -> Result<Vec<u8>> {
+    if let Some(sid_str) = well_known_sid_str(name) {
+        return sid_bytes_from_string(sid_str);
+    }
+    let name_w = to_wide(OsStr::new(name));
+    let mut sid_buffer = vec![0u8; 68];
+    let mut sid_len: u32 = sid_buffer.len() as u32;
+    let mut domain: Vec<u16> = Vec::new();
+    let mut domain_len: u32 = 0;
+    let mut use_type: SID_NAME_USE = 0;
+    loop {
+        let ok = unsafe {
+            LookupAccountNameW(
+                std::ptr::null(),
+                name_w.as_ptr(),
+                sid_buffer.as_mut_ptr() as *mut std::ffi::c_void,
+                &mut sid_len,
+                domain.as_mut_ptr(),
+                &mut domain_len,
+                &mut use_type,
+            )
+        };
+        if ok != 0 {
+            sid_buffer.truncate(sid_len as usize);
+            return Ok(sid_buffer);
+        }
+        let err = unsafe { GetLastError() };
+        if err == ERROR_INSUFFICIENT_BUFFER {
+            sid_buffer.resize(sid_len as usize, 0);
+            domain.resize(domain_len as usize, 0);
+            continue;
+        }
+        return Err(anyhow::anyhow!(
+            "LookupAccountNameW failed for {name}: {err}"
+        ));
+    }
+}
+
+fn well_known_sid_str(name: &str) -> Option<&'static str> {
+    match name {
+        "Administrators" => Some(SID_ADMINISTRATORS),
+        "Users" => Some(SID_USERS),
+        "Authenticated Users" => Some(SID_AUTHENTICATED_USERS),
+        "Everyone" => Some(SID_EVERYONE),
+        "SYSTEM" => Some(SID_SYSTEM),
+        _ => None,
+    }
+}
+
+fn sid_bytes_from_string(sid_str: &str) -> Result<Vec<u8>> {
+    let sid_w = to_wide(OsStr::new(sid_str));
+    let mut psid: *mut std::ffi::c_void = std::ptr::null_mut();
+    if unsafe { ConvertStringSidToSidW(sid_w.as_ptr(), &mut psid) } == 0 {
+        return Err(anyhow::anyhow!(
+            "ConvertStringSidToSidW failed for {sid_str}: {}",
+            unsafe { GetLastError() }
+        ));
+    }
+    let sid_len = unsafe { GetLengthSid(psid) };
+    if sid_len == 0 {
+        unsafe {
+            LocalFree(psid as _);
+        }
+        return Err(anyhow::anyhow!("GetLengthSid failed for {sid_str}"));
+    }
+    let mut out = vec![0u8; sid_len as usize];
+    let ok = unsafe { CopySid(sid_len, out.as_mut_ptr() as *mut std::ffi::c_void, psid) };
+    unsafe {
+        LocalFree(psid as _);
+    }
+    if ok == 0 {
+        return Err(anyhow::anyhow!("CopySid failed for {sid_str}"));
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::argv_to_command_line;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn argv_to_command_line_quotes_each_argument_independently() {
+        let argv = vec![
+            "cmd.exe".to_string(),
+            "/c".to_string(),
+            "\"C:\\Program Files\\PowerShell\\7\\pwsh.exe\" -NoProfile -EncodedCommand abc=="
+                .to_string(),
+        ];
+
+        assert_eq!(
+            argv_to_command_line(&argv),
+            "cmd.exe /c \"\\\"C:\\Program Files\\PowerShell\\7\\pwsh.exe\\\" -NoProfile -EncodedCommand abc==\""
+        );
+    }
+
+    #[test]
+    fn argv_to_command_line_quotes_regular_program_args() {
+        let argv = vec![
+            "pwsh.exe".to_string(),
+            "-Command".to_string(),
+            "Write-Output \"hello world\"".to_string(),
+        ];
+
+        assert_eq!(
+            argv_to_command_line(&argv),
+            "pwsh.exe -Command \"Write-Output \\\"hello world\\\"\""
+        );
+    }
+}

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/workspace_acl.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/workspace_acl.rs
@@ -1,0 +1,30 @@
+use crate::acl::add_deny_write_ace;
+use crate::path_normalization::canonicalize_path;
+use anyhow::Result;
+use std::ffi::c_void;
+use std::path::Path;
+
+pub fn is_command_cwd_root(root: &Path, canonical_command_cwd: &Path) -> bool {
+    canonicalize_path(root) == canonical_command_cwd
+}
+
+/// # Safety
+/// Caller must ensure `psid` is a valid SID pointer.
+pub unsafe fn protect_workspace_codex_dir(cwd: &Path, psid: *mut c_void) -> Result<bool> {
+    protect_workspace_subdir(cwd, psid, ".codex")
+}
+
+/// # Safety
+/// Caller must ensure `psid` is a valid SID pointer.
+pub unsafe fn protect_workspace_agents_dir(cwd: &Path, psid: *mut c_void) -> Result<bool> {
+    protect_workspace_subdir(cwd, psid, ".agents")
+}
+
+unsafe fn protect_workspace_subdir(cwd: &Path, psid: *mut c_void, subdir: &str) -> Result<bool> {
+    let path = cwd.join(subdir);
+    if path.is_dir() {
+        add_deny_write_ace(&path, psid)
+    } else {
+        Ok(false)
+    }
+}

--- a/apps/desktop-sandbox/hive-desktop-sandbox/src/lib.rs
+++ b/apps/desktop-sandbox/hive-desktop-sandbox/src/lib.rs
@@ -13,6 +13,7 @@
 
 pub mod policy;
 pub mod windows_plan;
+pub mod windows_resolve;
 
 #[cfg(target_os = "linux")]
 pub mod egress_proxy;

--- a/apps/desktop-sandbox/hive-desktop-sandbox/src/windows_resolve.rs
+++ b/apps/desktop-sandbox/hive-desktop-sandbox/src/windows_resolve.rs
@@ -156,7 +156,15 @@ impl ResolvedWindowsSandboxPermissions {
             .collect();
 
         let mut readonly_roots: Vec<PathBuf> = policy.readonly_roots().to_vec();
-        readonly_roots.push(policy.hook_config_dir().to_path_buf());
+        let hook_config_dir = policy.hook_config_dir().to_path_buf();
+        // `SandboxPolicy::build` only guards writable roots against overlapping
+        // `hook_config_dir` (see policy.rs); it does not guard `readonly_roots`
+        // against already containing it. Dedupe here so a caller that happens
+        // to pass the hook/config directory as one of its readonly roots does
+        // not end up with it listed twice in the resolved view.
+        if !readonly_roots.contains(&hook_config_dir) {
+            readonly_roots.push(hook_config_dir);
+        }
 
         Ok(Self {
             writable_roots,
@@ -356,6 +364,78 @@ mod tests {
         assert_eq!(
             resolved.token_mode(),
             WindowsSandboxTokenMode::ElevatedSandboxUser
+        );
+    }
+
+    #[test]
+    fn from_policy_empty_readonly_roots_yields_only_hook_config_dir() {
+        let hook_dir = PathBuf::from(r"C:\hive\hooks");
+        let policy = policy_with(vec![], vec![], hook_dir.clone(), NetworkPolicy::DenyAll);
+
+        let resolved =
+            ResolvedWindowsSandboxPermissions::from_policy(&policy, Path::new(r"C:\workspace"))
+                .expect("resolves");
+
+        assert_eq!(resolved.readonly_roots(), &[hook_dir]);
+    }
+
+    #[test]
+    fn from_policy_dedupes_hook_config_dir_already_present_in_readonly_roots() {
+        let hook_dir = PathBuf::from(r"C:\hive\hooks");
+        let policy = policy_with(
+            vec![],
+            vec![hook_dir.clone()],
+            hook_dir.clone(),
+            NetworkPolicy::DenyAll,
+        );
+
+        let resolved =
+            ResolvedWindowsSandboxPermissions::from_policy(&policy, Path::new(r"C:\workspace"))
+                .expect("resolves");
+
+        assert_eq!(
+            resolved.readonly_roots(),
+            &[hook_dir],
+            "hook_config_dir must not be duplicated when the caller already listed it as a readonly root"
+        );
+    }
+
+    #[test]
+    fn from_policy_accepts_unc_cwd() {
+        let policy = policy_with(
+            vec![],
+            vec![],
+            PathBuf::from(r"C:\hive\hooks"),
+            NetworkPolicy::DenyAll,
+        );
+
+        let resolved = ResolvedWindowsSandboxPermissions::from_policy(
+            &policy,
+            Path::new(r"\\server\share\work"),
+        );
+
+        assert!(
+            resolved.is_ok(),
+            "a UNC path is a legitimately absolute Windows cwd and must be accepted: {resolved:?}"
+        );
+    }
+
+    #[test]
+    fn from_policy_accepts_forward_slash_drive_absolute_cwd() {
+        let policy = policy_with(
+            vec![],
+            vec![],
+            PathBuf::from(r"C:\hive\hooks"),
+            NetworkPolicy::DenyAll,
+        );
+
+        let resolved =
+            ResolvedWindowsSandboxPermissions::from_policy(&policy, Path::new("C:/workspace"));
+
+        assert!(
+            resolved.is_ok(),
+            "a forward-slash drive-absolute path (C:/...) is a legitimately absolute Windows cwd \
+             and must be accepted: {resolved:?}"
         );
     }
 

--- a/apps/desktop-sandbox/hive-desktop-sandbox/src/windows_resolve.rs
+++ b/apps/desktop-sandbox/hive-desktop-sandbox/src/windows_resolve.rs
@@ -1,0 +1,384 @@
+//! Port of upstream `resolved_permissions.rs`
+//! (`codex-rs/windows-sandbox-rs/src/resolved_permissions.rs`, commit
+//! `a47c661…`, see `../../VENDORING.md`) to Hive-native types.
+//!
+//! This is the ONE adapter seam blueprint Step 3 identifies: upstream's
+//! `ResolvedWindowsSandboxPermissions` is the only windows-sandbox module that
+//! imports `codex_protocol` (`PermissionProfile`, `FileSystemSandboxPolicy`,
+//! `NetworkSandboxPolicy`, ...). Every vendored mechanism module in
+//! `codex-windows-sandbox` (ACLs, tokens, capability SIDs, ...) takes
+//! primitive arguments (paths, masks, SID handles) and never speaks
+//! `codex_protocol`, so replacing this one seam is what lets the rest of the
+//! upstream crate be vendored byte-for-byte instead of ported. `codex_protocol`
+//! is deliberately NOT a dependency of this crate or of `codex-windows-sandbox`
+//! (see `Cargo.toml`): every type below is Hive-native.
+//!
+//! Unlike upstream, [`SandboxPolicy`] is already a fully resolved, concrete
+//! policy (explicit `PathBuf` roots, no globs, no symbolic `:workspace_roots`
+//! placeholders, no Managed/Disabled/Unrestricted profile distinction), so
+//! this port is much thinner than upstream's `try_from_permission_profile*`:
+//! there is no glob expansion, no project-roots symbolic-path materialization,
+//! and no "full disk write" rejection to replicate, because Hive's policy
+//! model cannot express any of those in the first place. Three upstream
+//! accessors have no Hive equivalent and are deliberately NOT ported:
+//! `is_enforceable_by_windows_sandbox`, `has_full_disk_read_access`, and
+//! `include_platform_defaults` all distinguish between profile KINDS
+//! (Managed/Disabled/Unrestricted, Restricted/Unrestricted filesystem) that
+//! [`SandboxPolicy`] does not have; every [`SandboxPolicy`] is, in upstream's
+//! terms, already the single concrete "restricted, managed" case.
+//!
+//! This module has no Win32 dependency and is pure, host-independent
+//! computation: it compiles and its tests run on every platform, including
+//! this crate's Linux CI job, exactly like `windows_plan.rs`. It performs no
+//! Win32 calls and is not wired into `windows::launch` this wave (Step 3 Wave
+//! 1); see `../../VENDORING.md`.
+
+use crate::SandboxPolicy;
+use crate::policy::NetworkPolicy;
+use std::path::{Path, PathBuf};
+
+/// A single writable root and any read-only carve-outs nested inside it.
+///
+/// Mirrors upstream's `WindowsWritableRoot` shape (kept for continuity with
+/// the vendored mechanism modules' naming and for future extension), but
+/// `read_only_subpaths` is always empty from [`ResolvedWindowsSandboxPermissions::from_policy`]
+/// today: `SandboxPolicy` has no concept yet of a read-only carve-out nested
+/// inside an otherwise-writable root (upstream derives this from per-entry
+/// glob/path deny overrides within a Managed profile, which `SandboxPolicy`
+/// does not model). A future `SandboxPolicy` extension can populate this
+/// field without changing this type's shape.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WindowsWritableRoot {
+    pub root: PathBuf,
+    pub read_only_subpaths: Vec<PathBuf>,
+}
+
+/// Restricted-token family to enforce a resolved policy under.
+///
+/// Upstream chooses between `ReadOnlyCapability` and `WritableRootsCapability`
+/// per launch (`token_mode_for_permission_profile`), because its base
+/// (non-elevated) token variant is the only one it has. Hive's Step 3 scope
+/// is the elevated sandbox-user variant exclusively (see the blueprint's Q1/Q3
+/// resolution): the base non-elevated restricted token from issue #395 is not
+/// reused here, so there is exactly one variant to select today. This enum
+/// exists (rather than hardcoding the value inline) so a future elevated-vs-
+/// unprivileged distinction has somewhere to go without changing every call
+/// site.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WindowsSandboxTokenMode {
+    /// The Step 3 elevated helper's dedicated low-privilege sandbox OS-user
+    /// token (see the blueprint's section 3, "Elevated-runner architecture").
+    /// Not implemented yet (Wave 3); this variant exists so callers can match
+    /// on it ahead of that wave.
+    ElevatedSandboxUser,
+}
+
+/// Rejected [`ResolvedWindowsSandboxPermissions::from_policy`] input. Mirrors
+/// [`crate::policy::PolicyError`]'s philosophy: fail loudly rather than
+/// resolve a policy with a weaker guarantee than requested (D-005).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ResolveError {
+    /// `cwd` was not an absolute path. Every root this type hands back is
+    /// meant to be a concrete ACL target; a relative `cwd` would make
+    /// [`ResolvedWindowsSandboxPermissions::readonly_roots`] silently resolve
+    /// against whatever the current process's working directory happens to be
+    /// at ACL-apply time, instead of the caller's intended directory. Upstream
+    /// enforces the equivalent invariant at the type level (`AbsolutePathBuf`
+    /// for `cwd`/workspace roots); `SandboxPolicy` has no such newtype, so this
+    /// is a runtime check instead.
+    CwdNotAbsolute { cwd: PathBuf },
+}
+
+impl std::fmt::Display for ResolveError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ResolveError::CwdNotAbsolute { cwd } => {
+                write!(f, "cwd must be an absolute path, got: {}", cwd.display())
+            }
+        }
+    }
+}
+
+impl std::error::Error for ResolveError {}
+
+/// Hive-native replacement for upstream's `ResolvedWindowsSandboxPermissions`.
+/// The internal resolved view every Windows mechanism module should consume
+/// (once wired: this wave stops at the adapter, see the module doc).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedWindowsSandboxPermissions {
+    writable_roots: Vec<WindowsWritableRoot>,
+    readonly_roots: Vec<PathBuf>,
+    deny_read_paths: Vec<PathBuf>,
+    network: NetworkPolicy,
+    token_mode: WindowsSandboxTokenMode,
+}
+
+impl ResolvedWindowsSandboxPermissions {
+    /// Resolves a [`SandboxPolicy`] into the Windows-specific view. See the
+    /// field-by-field mapping table in the blueprint (section 2).
+    ///
+    /// - `policy.writable_roots()` -> [`Self::writable_roots`], one
+    ///   [`WindowsWritableRoot`] per root (no nested read-only carve-outs yet).
+    /// - `policy.readonly_roots()` PLUS `policy.hook_config_dir()` ->
+    ///   [`Self::readonly_roots`]. The hook/config directory is always
+    ///   readable; the deny-write ACE on its PARENT (the #307 CBSE
+    ///   invariant) is a separate, out-of-band control `windows.rs` applies
+    ///   directly (see [`crate::windows_plan::WindowsConfinementPlan`]), not
+    ///   part of this resolved-permissions type.
+    /// - Secret/deny-read paths -> [`Self::deny_read_paths`]. Always empty
+    ///   today: `SandboxPolicy` has no secret-path input source yet (the
+    ///   blueprint notes this is a future hook/config-derived input), so an
+    ///   empty carve-out set is the honest default rather than inventing one.
+    ///   Upstream's `deny_read_resolver.rs` (glob-scan-based carve-out
+    ///   selection) is deliberately NOT ported this wave for the same reason
+    ///   this field is always empty: there is nothing yet to resolve.
+    /// - `policy.network()` -> [`Self::network`], carried through unchanged
+    ///   (both variants; enforcement stays deferred to Step 4/the elevated
+    ///   wave, this is just the adapter).
+    /// - Token mode is constant: [`WindowsSandboxTokenMode::ElevatedSandboxUser`].
+    ///   Hive always selects the sandbox-account token mode for Step 3; the
+    ///   base non-elevated restricted-token mode from #395 is not selectable
+    ///   through this adapter.
+    pub fn from_policy(policy: &SandboxPolicy, cwd: &Path) -> Result<Self, ResolveError> {
+        if !is_windows_absolute(cwd) {
+            return Err(ResolveError::CwdNotAbsolute {
+                cwd: cwd.to_path_buf(),
+            });
+        }
+
+        let writable_roots = policy
+            .writable_roots()
+            .iter()
+            .map(|root| WindowsWritableRoot {
+                root: root.clone(),
+                read_only_subpaths: Vec::new(),
+            })
+            .collect();
+
+        let mut readonly_roots: Vec<PathBuf> = policy.readonly_roots().to_vec();
+        readonly_roots.push(policy.hook_config_dir().to_path_buf());
+
+        Ok(Self {
+            writable_roots,
+            readonly_roots,
+            deny_read_paths: Vec::new(),
+            network: policy.network().clone(),
+            token_mode: WindowsSandboxTokenMode::ElevatedSandboxUser,
+        })
+    }
+
+    /// `true` for [`NetworkPolicy::DenyAll`]: the resolved policy wants
+    /// network confinement applied. Step 3 does not yet apply it (WFP is Step
+    /// 4); see `windows.rs`'s existing network-refusal guards, which this
+    /// accessor does not change.
+    pub fn should_apply_network_block(&self) -> bool {
+        matches!(self.network, NetworkPolicy::DenyAll)
+    }
+
+    pub fn network_policy(&self) -> &NetworkPolicy {
+        &self.network
+    }
+
+    /// Every directory the sandboxed task may read: the caller's read-only
+    /// roots plus the always-readable hook/config directory.
+    pub fn readonly_roots(&self) -> &[PathBuf] {
+        &self.readonly_roots
+    }
+
+    pub fn writable_roots(&self) -> &[WindowsWritableRoot] {
+        &self.writable_roots
+    }
+
+    pub fn uses_write_capabilities(&self) -> bool {
+        !self.writable_roots.is_empty()
+    }
+
+    /// Paths that should receive a deny-read ACE (fed to
+    /// `codex_windows_sandbox::deny_read_acl` once wired). Always empty this
+    /// wave; see [`Self::from_policy`]'s doc.
+    pub fn deny_read_paths(&self) -> &[PathBuf] {
+        &self.deny_read_paths
+    }
+
+    pub fn token_mode(&self) -> WindowsSandboxTokenMode {
+        self.token_mode
+    }
+}
+
+/// True for a drive-absolute (`C:\...`, `C:/...`) or UNC/device
+/// (`\\server\share\...`, `\\?\C:\...`) Windows path. Deliberately NOT
+/// `Path::is_absolute()`: this crate's tests run on Linux CI (see the module
+/// doc), and `Path::is_absolute()` uses HOST path conventions, so on a Unix
+/// host it evaluates `C:\workspace` as relative (no leading `/`), which would
+/// make [`ResolvedWindowsSandboxPermissions::from_policy`] reject every
+/// Windows-shaped test path when run on this crate's own Linux CI job. Parsed
+/// with explicit `\`/`/` handling instead, same technique and same rationale
+/// as `windows_plan::is_fully_qualified_program` and `windows_plan::parent_dir`
+/// (see that module's doc for the `Path::parent()` bug this pattern avoids).
+fn is_windows_absolute(path: &Path) -> bool {
+    let raw = path.to_string_lossy();
+    let bytes = raw.as_bytes();
+    let is_sep = |b: u8| b == b'\\' || b == b'/';
+    if bytes.len() >= 2 && is_sep(bytes[0]) && is_sep(bytes[1]) {
+        // UNC or device path.
+        return true;
+    }
+    // Drive-absolute: drive letter, `:`, then a separator.
+    bytes.len() >= 3 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':' && is_sep(bytes[2])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::policy::SandboxPolicy;
+    use pretty_assertions::assert_eq;
+
+    fn policy_with(
+        writable_roots: Vec<PathBuf>,
+        readonly_roots: Vec<PathBuf>,
+        hook_config_dir: PathBuf,
+        network: NetworkPolicy,
+    ) -> SandboxPolicy {
+        SandboxPolicy::build(writable_roots, readonly_roots, hook_config_dir, network)
+            .expect("valid policy")
+    }
+
+    #[test]
+    fn from_policy_maps_writable_roots_one_to_one() {
+        let policy = policy_with(
+            vec![PathBuf::from(r"C:\workspace")],
+            vec![],
+            PathBuf::from(r"C:\hive\hooks"),
+            NetworkPolicy::DenyAll,
+        );
+
+        let resolved =
+            ResolvedWindowsSandboxPermissions::from_policy(&policy, Path::new(r"C:\workspace"))
+                .expect("resolves");
+
+        assert_eq!(
+            resolved.writable_roots(),
+            &[WindowsWritableRoot {
+                root: PathBuf::from(r"C:\workspace"),
+                read_only_subpaths: Vec::new(),
+            }]
+        );
+        assert!(resolved.uses_write_capabilities());
+    }
+
+    #[test]
+    fn from_policy_readonly_roots_include_hook_config_dir() {
+        let policy = policy_with(
+            vec![],
+            vec![PathBuf::from(r"C:\usr\share")],
+            PathBuf::from(r"C:\hive\hooks"),
+            NetworkPolicy::DenyAll,
+        );
+
+        let resolved =
+            ResolvedWindowsSandboxPermissions::from_policy(&policy, Path::new(r"C:\workspace"))
+                .expect("resolves");
+
+        assert_eq!(
+            resolved.readonly_roots(),
+            &[
+                PathBuf::from(r"C:\usr\share"),
+                PathBuf::from(r"C:\hive\hooks")
+            ]
+        );
+        assert!(!resolved.uses_write_capabilities());
+    }
+
+    #[test]
+    fn from_policy_carries_deny_all_network_and_requests_block() {
+        let policy = policy_with(
+            vec![],
+            vec![],
+            PathBuf::from(r"C:\hive\hooks"),
+            NetworkPolicy::DenyAll,
+        );
+
+        let resolved =
+            ResolvedWindowsSandboxPermissions::from_policy(&policy, Path::new(r"C:\workspace"))
+                .expect("resolves");
+
+        assert_eq!(resolved.network_policy(), &NetworkPolicy::DenyAll);
+        assert!(resolved.should_apply_network_block());
+    }
+
+    #[test]
+    fn from_policy_carries_allow_hosts_network_without_requesting_block() {
+        let hosts = vec!["api.openrouter.ai".to_string()];
+        let policy = policy_with(
+            vec![],
+            vec![],
+            PathBuf::from(r"C:\hive\hooks"),
+            NetworkPolicy::AllowHosts(hosts.clone()),
+        );
+
+        let resolved =
+            ResolvedWindowsSandboxPermissions::from_policy(&policy, Path::new(r"C:\workspace"))
+                .expect("resolves");
+
+        assert_eq!(resolved.network_policy(), &NetworkPolicy::AllowHosts(hosts));
+        assert!(!resolved.should_apply_network_block());
+    }
+
+    #[test]
+    fn from_policy_deny_read_paths_are_empty_until_a_secret_path_source_exists() {
+        let policy = policy_with(
+            vec![],
+            vec![],
+            PathBuf::from(r"C:\hive\hooks"),
+            NetworkPolicy::DenyAll,
+        );
+
+        let resolved =
+            ResolvedWindowsSandboxPermissions::from_policy(&policy, Path::new(r"C:\workspace"))
+                .expect("resolves");
+
+        assert!(resolved.deny_read_paths().is_empty());
+    }
+
+    #[test]
+    fn from_policy_always_selects_elevated_sandbox_user_token_mode() {
+        let policy = policy_with(
+            vec![PathBuf::from(r"C:\workspace")],
+            vec![],
+            PathBuf::from(r"C:\hive\hooks"),
+            NetworkPolicy::DenyAll,
+        );
+
+        let resolved =
+            ResolvedWindowsSandboxPermissions::from_policy(&policy, Path::new(r"C:\workspace"))
+                .expect("resolves");
+
+        assert_eq!(
+            resolved.token_mode(),
+            WindowsSandboxTokenMode::ElevatedSandboxUser
+        );
+    }
+
+    #[test]
+    fn from_policy_rejects_relative_cwd() {
+        let policy = policy_with(
+            vec![],
+            vec![],
+            PathBuf::from(r"C:\hive\hooks"),
+            NetworkPolicy::DenyAll,
+        );
+
+        let err = ResolvedWindowsSandboxPermissions::from_policy(
+            &policy,
+            Path::new(r"relative\workspace"),
+        )
+        .expect_err("relative cwd must be rejected");
+
+        assert_eq!(
+            err,
+            ResolveError::CwdNotAbsolute {
+                cwd: PathBuf::from(r"relative\workspace")
+            }
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Wave 1 of Step 3 (elevated Windows sandbox adoption, decision D-003). Vendors the codex `windows-sandbox-rs` filesystem and token primitive modules at the pinned SHA `a47c661ea9e226fe65e46cf9dbc5c5ed75c2c762` (the same commit as the existing `codex-bwrap` and `codex-process-hardening` vendors, keeping one tree) into a new subcrate `apps/desktop-sandbox/codex-windows-sandbox/`. Ports the policy resolver to Hive's own `SandboxPolicy` types (`ResolvedWindowsSandboxPermissions::from_policy`), dropping the `codex_protocol` dependency entirely. All code lands inert: nothing is wired into `launch()` in this wave.

13 modules vendored verbatim (token, cap, proc_thread_attr, acl, workspace_acl, deny_read_acl, deny_read_state, dpapi, hide_users, winutil, sandbox_utils, env, path_normalization) plus two small locally authored shims (setup fn extract, logging stand-in) so the vendored set compiles standalone.

## Scope deviations from the blueprint (documented, found against real upstream)

- `process.rs` deferred: it depends on `desktop.rs`, which is Step 5 (ConPTY) scope. It will be vendored with the ConPTY wave.
- `deny_read_resolver.rs` excluded: it also imports `codex_protocol` (the blueprint expected `resolved_permissions.rs` to be the only such module). Its output is unused today because `SandboxPolicy` has no secret-path source yet, so the adapter returns an empty deny-read set intentionally, documented in code rather than silently.

## Decisions applied (see vault blueprint)

- Q1: port `resolved_permissions.rs` to Hive types, drop `codex_protocol`.
- Q2: `DenyAll` stays refuse-until-WFP (Step 4); no capability-SID network claim without proof.
- Q3: one shared low-priv sandbox user for the desktop surface; provisioning kept abstract.

## Verification

- CI cross-compiles the new subcrate on `x86_64-pc-windows-gnu` (`cargo check` and `cargo clippy -D warnings`), scoped alongside `hive-desktop-sandbox`. Both green locally.
- 59 native tests pass (58 lib plus 1 integration), covering the ported resolver and the pure adapter.
- MSVC target stays lab and host only (no MSVC linker in CI), unchanged from the #395 precedent.
- No behavioral confinement is active in this wave, so there is no lab gate here. D-004 lab validation applies from Wave 3.

## Unsafe hygiene note for reviewers

Two crate-level `#![allow]` attributes (`unsafe_op_in_unsafe_fn`, `missing_safety_doc`) keep the vendored files byte-for-byte diffable against upstream under edition 2024. These are lint suppressions on a security-relevant FFI crate and are called out here for the security review.

## Test plan

- [x] `cargo check` and `cargo clippy -D warnings` on `x86_64-pc-windows-gnu` green (local)
- [x] 59 native tests pass (resolver port and adapter)
- [ ] CI required checks green
- [ ] rust-reviewer clean
- [ ] security-reviewer clean (unsafe suppressions, empty deny-read honesty, no codex_protocol leak)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Windows sandbox support with isolated workspace permissions and restricted access controls.
  * Added persistent capability management for workspaces and additional writable directories.
  * Improved protection for sensitive workspace folders and configured deny-read paths.
  * Added Windows-specific network blocking, environment safeguards, and non-interactive command behavior.
  * Added secure handling for sandbox users, tokens, credentials, and encrypted data.

* **Documentation**
  * Updated Windows sandbox vendoring guidance, implementation status, risks, and maintenance procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->