### PR TITLE
feat: vendor codex windows-sandbox elevated-helper transport and account layer inert (Step 3 wave 2)

### DIFF
--- a/apps/desktop-sandbox/Cargo.lock
+++ b/apps/desktop-sandbox/Cargo.lock
@@ -9,6 +9,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,6 +58,7 @@ name = "codex-windows-sandbox"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base64",
  "dirs-next",
  "dunce",
  "pretty_assertions",

--- a/apps/desktop-sandbox/VENDORING.md
+++ b/apps/desktop-sandbox/VENDORING.md
@@ -341,8 +341,74 @@ read-modify-write.
   touches `cap.rs`'s already-documented unsynchronized `cap_sid` file, open
   risk #8 below, unchanged).
 
-No new bugs found; nothing required a deviation beyond the ones already
-documented above.
+No new bugs found by this self-audit; nothing required a deviation beyond the
+ones already documented above. The automated CodeRabbit/Greptile review pass
+on PR #399 (below) found three more, after this self-audit had already
+landed.
+
+### Local deviations from upstream (CodeRabbit/Greptile findings, PR #399)
+
+Three more small bug fixes on top of the byte-for-byte copy, found by the
+automated review pass rather than the self-audit above. Same re-vendoring
+note as Wave 1's equivalent section: re-copying these files verbatim from
+upstream on a future pass should check whether upstream independently fixed
+the same bugs, and if not, re-apply these fixes.
+
+- `elevated/runner_client.rs::spawn_runner_transport`: the inbound server
+  pipe (`h_pipe_in`) was created, then the outbound server pipe
+  (`h_pipe_out`)'s creation used `?`, which returned without closing
+  `h_pipe_in` on failure. Every failed launch attempt (for example, a second
+  `create_named_pipe` call racing an already-in-use pipe name) leaked one
+  server-pipe HANDLE. Fixed to explicitly `CloseHandle(h_pipe_in)` before
+  returning the outbound-pipe error, matching the `CloseHandle`-on-cleanup
+  idiom this same function already uses everywhere else (see the self-audit
+  above).
+- `sandbox_users.rs::ensure_local_group_member`: discarded every
+  `NetLocalGroupAddMembers` result (`let _ = NetLocalGroupAddMembers(...)`),
+  not only the expected "already a member" result. Access denied, a missing
+  group, or an invalid account therefore made `ensure_sandbox_user` return
+  `Ok(())` while the account was never actually added to
+  `CodexSandboxUsers`, silently defeating the group-membership half of the
+  sandbox-user provisioning contract. Fixed to check the status code against
+  `NERR_Success` and `ERROR_MEMBER_IN_ALIAS` (1378; verified against the
+  `windows-sys` 0.52 `Foundation` module this crate already depends on) only,
+  returning a `SetupFailure` for any other code.
+- `helper_materialization.rs::copy_helper_if_needed`: once a helper path was
+  cached in the process-lifetime `HELPER_PATH_CACHE`, later calls returned it
+  without checking the file still existed. Antivirus quarantine, cleanup, or
+  a concurrent replacement removing the helper after it was cached would make
+  every subsequent runner launch in the process keep using the missing path
+  instead of recopying it. Fixed by gating the cache hit on `path.is_file()`;
+  a miss now falls through to the existing copy-if-needed path below it
+  (which already re-populates the cache once the copy succeeds again), so no
+  other control flow changed.
+
+Three further findings from the same review pass are genuine but were NOT
+fixed this pass, deliberately: they fall inside latent hardening items an
+independent security review of this same PR had already catalogued as
+MUST-FIX-during-Integration-A (open risk #6 below), not new findings, and
+fixing them piecemeal on still-inert code risks being redone or reshaped once
+the transport is actually wired and lab-tested. Each gets one line here; open
+risk #6 is the tracking entry.
+
+- `helper_materialization.rs::legacy_lookup`'s fallback to the bare
+  `codex-command-runner.exe` name (not an absolute path) lets
+  `CreateProcessWithLogonW` fall back to executable search instead of
+  failing closed when the packaged helper cannot be found or copied. Same
+  bucket as the security review's "absolute-path guard" item.
+- `elevated/ipc_framed.rs::read_frame` deserializes a `FramedMessage` without
+  checking `msg.version` against `IPC_PROTOCOL_VERSION`, so a stale runner
+  sending an older-versioned message with overlapping JSON fields would be
+  treated as current. Same bucket as the security review's `ipc_framed`/nonce
+  item.
+- `identity.rs::SandboxCreds` derives `Debug` over its cleartext `password`
+  field, so any future `{:?}` on the struct (log line, error context, panic)
+  would leak it. No current call site formats `SandboxCreds` with `{:?}`
+  (verified by grep), so this is latent, not live. Same underlying
+  cleartext-logon-password concern the security review already flagged for
+  `identity.rs`/`sandbox_users.rs`/`runner_client.rs` (the zeroize-on-drop
+  item); bundling the Debug redaction with that pass avoids fixing the same
+  struct's credential hygiene in two uncoordinated passes.
 
 ### Why not `codex-rs/windows-sandbox-rs` for the Windows backend (historical, #395 wave; superseded in part by Step 3 above)
 
@@ -520,6 +586,19 @@ crate deliberately does not inherit the workspace's Apache-2.0
    binaries, and the actual launch-path wiring) stays open. Mark RESOLVED
    only when a later wave lab-validates the isolation matrix on
    `spike307-win` (assertions L7 to L12 in the blueprint).
+
+   **Known issues, fix in Integration A (CodeRabbit/Greptile, PR #399; see
+   this file's Wave 2 "Local deviations" section above for the three that
+   were fixed instead):** (a) `helper_materialization.rs::legacy_lookup`'s
+   bare-executable-name fallback lets `CreateProcessWithLogonW` fall back to
+   executable search instead of failing closed; needs an absolute-path
+   guard once a real launch path calls it. (b) `elevated/ipc_framed.rs`'s
+   `read_frame` does not check `msg.version` against `IPC_PROTOCOL_VERSION`,
+   so a stale runner's older-versioned message would be accepted as current.
+   (c) `identity.rs::SandboxCreds` derives `Debug` over its cleartext
+   `password` field (latent only, no current `{:?}` call site); bundle a
+   redacting `Debug` impl with the zeroize-on-drop hardening this item
+   already tracks for the same struct.
 7. **RESOLVED (#350).** The Linux `pre_exec` post-fork allocator-deadlock
    hazard below was fixed by #350 (merged), which moved `linux::launch`'s
    `pre_exec` closure to an allocation-free path so no thread can deadlock on

--- a/apps/desktop-sandbox/VENDORING.md
+++ b/apps/desktop-sandbox/VENDORING.md
@@ -182,6 +182,168 @@ independently fixed the same bugs, and if not, re-apply these fixes.
 - `codex-windows-sandbox/src/setup.rs` and `codex-windows-sandbox/src/logging.rs`:
   the two minimal stand-ins described above, not part of the verbatim vendor.
 
+## `codex-windows-sandbox/` Step 3 Wave 2 (elevated-helper IPC mechanism)
+
+Wave 2 vendors the elevated runner's named-pipe IPC mechanism into the same
+inert `codex-windows-sandbox/` subcrate Wave 1 created. NOTHING from this wave
+is wired into `windows::launch`. Same pinned commit as the rest of this file.
+
+### What was vendored (verbatim, byte-for-byte except two documented import swaps)
+
+- `elevated/mod.rs`, `elevated/runner_pipe.rs`, `elevated/runner_client.rs`
+  (visibility bumped `pub(crate)` -> `pub` throughout, see `elevated/mod.rs`'s
+  and `lib.rs`'s own comments: this crate's convention is fully `pub`
+  mod-nested, not upstream's curated `pub(crate)` surface, and unused
+  `pub(crate)` items fail `-D warnings` dead_code when this wave's vendor set
+  gives them no caller).
+- `elevated/ipc_framed.rs`: verbatim except swapping
+  `codex_protocol::models::PermissionProfile` for
+  `crate::permission_profile::PermissionProfile` and
+  `codex_utils_absolute_path::AbsolutePathBuf` for
+  `crate::absolute_path::AbsolutePathBuf` (both new local stand-ins, see
+  below). One test, `spawn_request_serializes_permission_profile`, is excluded
+  (not faked) because it asserts the real upstream `PermissionProfile`'s
+  tagged-enum JSON shape, which the stand-in does not reproduce; see the
+  file's own module doc and test-module comment.
+- `helper_materialization.rs`: verbatim except two import-path edits
+  (`crate::sandbox_bin_dir` -> `crate::setup::sandbox_bin_dir`,
+  `crate::sandbox_dir` -> `crate::setup::sandbox_dir`), since this crate does
+  not replicate upstream's flat crate-root re-export surface for `setup.rs`'s
+  helpers (see `lib.rs`'s comment).
+- `setup_error.rs`: verbatim except inlining `codex_utils_string::sanitize_metric_tag_value`
+  (a ~20-line pure function) as a private fn instead of adding a new crate
+  dependency for one function.
+- `sandbox_users.rs`: relocated from upstream's
+  `bin/setup_main/win/sandbox_users.rs` into this crate's library (top-level
+  `src/`, not a `bin/`), TRIMMED to the OS-account/SID Win32 primitives only:
+  `ensure_sandbox_users_group`, `resolve_sandbox_users_group_sid`,
+  `ensure_sandbox_user`, `ensure_local_user`, `ensure_local_group`,
+  `ensure_local_group_member`, `resolve_sid`, `well_known_sid_str`,
+  `sid_bytes_from_string`, `lookup_account_name_for_sid`, `sid_bytes_to_psid`.
+  See "Deliberately NOT vendored this wave" below for what was cut and why.
+- `setup.rs` (the Wave 1 one-function stand-in) gains one more verbatim
+  extraction, `sandbox_bin_dir`, needed by `helper_materialization.rs`.
+
+### New, Hive-authored stand-ins (NOT vendored from upstream)
+
+- `permission_profile.rs`: a minimal pure-data mirror of upstream
+  `codex_protocol::models::PermissionProfile`, reproducing only the
+  `read_only()` constructor `elevated/ipc_framed.rs`'s own test exercises.
+  The real type is a much larger legacy-serde-compat tagged enum
+  (`Managed`/`Disabled`/`External` variants, a hand-rolled `Deserialize` for
+  old rollout files); interpreting it meaningfully requires
+  `ResolvedWindowsSandboxPermissions::try_from_permission_profile*`
+  (upstream's `resolved_permissions.rs`), which Wave 1 ported to Hive-native
+  types instead of vendoring (Q1 decision), specifically to keep
+  `codex_protocol` out of this tree. See "Deliberately NOT vendored this
+  wave" below for the investigation that found `PermissionProfile` threaded
+  far deeper into the elevated-helper modules than the blueprint's Wave 2
+  module list assumed.
+- `absolute_path.rs`: a minimal pure-data mirror of upstream
+  `codex_utils_absolute_path::AbsolutePathBuf` (a real ~900-line crate with
+  `schemars`/`ts-rs` TypeScript-binding dependencies and a thread-local
+  base-path deserialization guard, none of which is load-bearing for an
+  inert, unexercised struct field this wave).
+- `identity.rs`: a one-struct (`SandboxCreds`) extraction from upstream's real
+  `identity.rs`, the same treatment Wave 1 gave `setup.rs`. The rest of
+  upstream's `identity.rs` (`sandbox_setup_is_complete`,
+  `require_logon_sandbox_creds`, `refresh_logon_sandbox_creds`) takes or
+  returns `&ResolvedWindowsSandboxPermissions` and is excluded for the same
+  reason as `permission_profile.rs` above.
+
+### Deliberately NOT vendored this wave (deviations from the mission's Wave 2 module list, found while fetching the actual upstream source)
+
+Investigating the actual upstream source (not just the blueprint's module
+table) found the `codex_protocol`/`resolved_permissions.rs` coupling is far
+more pervasive across the "elevated helper" modules than Step 0.2's "one
+seam" framing suggested. Concretely:
+
+- **`spawn_prep.rs`**: every substantive function
+  (`prepare_spawn_context_common`, `prepare_legacy_spawn_context`, etc.) takes
+  `&PermissionProfile` and immediately calls
+  `ResolvedWindowsSandboxPermissions::try_from_permission_profile_for_workspace_roots`.
+  It also depends on `allow.rs` (also `codex_protocol`-coupled, never in
+  scope) and `identity.rs`'s resolver-coupled functions. Not vendorable
+  without also vendoring upstream's real `resolved_permissions.rs` (banned:
+  no `codex_protocol` dependency) or duplicating Wave 1's Hive-native port a
+  second time inside this Apache-2.0 crate (a maintenance/correctness
+  hazard, not a thin adapter).
+- **`wrapper.rs`** (+ `wrapper_tests.rs`): the CLI-argv wrapper threads
+  `PermissionProfile`/`WindowsSandboxLevel` (`codex_protocol::config_types`)
+  through its public entry points; same exclusion reason as `spawn_prep.rs`.
+- **`elevated_impl.rs`**: its one substantive function,
+  `run_windows_sandbox_capture_for_permission_profile`, calls
+  `ResolvedWindowsSandboxPermissions::try_from_permission_profile_for_workspace_roots`
+  directly; excluded whole-file (nearly the entire file is this one function
+  plus its non-Windows stub).
+- **`identity.rs`** (full file) and **`setup.rs`** (full file): both mix a
+  few primitive path/marker helpers with resolver-coupled orchestration
+  (`require_logon_sandbox_creds`, `refresh_logon_sandbox_creds`,
+  `run_setup_refresh*`, `run_elevated_setup*`,
+  `run_elevated_provisioning_setup`, `gather_write_roots_for_permissions`).
+  Only the non-coupled pieces are extracted as stand-ins (see above); the
+  rest belongs to whichever later wave ports the provisioning orchestration
+  into `hive-desktop-sandbox`'s proprietary `windows_elevated.rs`, matching
+  the blueprint's own original Wave 3 assignment for this exact content.
+- **`bin/setup_main/` and `bin/command_runner/` (the two binaries)**: fetching
+  their actual source found both `win.rs` files pull in scope well beyond
+  Step 3: `bin/setup_main/win.rs` calls `install_wfp_filters` and declares
+  `mod firewall;` (`bin/setup_main/win/firewall.rs` is genuine Windows
+  Firewall/WFP management via COM `INetFwPolicy2` — Step 4 scope, explicitly
+  out per the blueprint's own "Explicitly OUT of Step 3" list) and depends on
+  a brand-new external crate, `codex-otel` (telemetry), not otherwise needed.
+  `bin/command_runner/win.rs` depends on `ConptyInstance`/
+  `spawn_conpty_process_as_user` (Step 5, ConPTY, explicitly out of scope),
+  `process.rs` (deferred in Wave 1 for its own `desktop.rs` coupling), and
+  `token_mode_for_permission_profile`/`WindowsSandboxTokenMode`
+  (`resolved_permissions.rs` again). Both binaries are the fully-integrated
+  END STATE of Steps 3+4+5 combined, not separable at the Step 3 boundary as
+  written upstream. Vendoring them now would mean pulling in WFP, ConPTY, the
+  resolver, and a new telemetry dependency all at once — the opposite of a
+  staged, reviewable wave. Deferred as binaries; the one clean, self-contained
+  primitive module living under `bin/setup_main/win/`
+  (`sandbox_users.rs`) is salvaged and relocated into the library instead (see
+  above). `bin/setup_main/win/read_acl_mutex.rs` and
+  `bin/setup_main/win/setup_runtime_bin.rs` are individually clean too but are
+  ONLY consumed by the excluded `win.rs`; no other Wave 2 file needs them, so
+  they are excluded as orphans, not because they are themselves coupled.
+- **`sandbox_users.rs`'s own `provision_sandbox_users`, `write_secrets`,
+  `prepare_setup_marker`, `commit_setup_marker`, and `random_password`**:
+  orchestration coupled to the excluded `win.rs`'s specific setup flow
+  (`super::log_line`, a sibling fn on the excluded parent module) and,
+  for the marker functions, a `chrono` dependency not otherwise needed. The
+  remaining primitives get a local, timestamp-free `log_line` stand-in
+  instead of upstream's real one (which itself needs `chrono`).
+
+### Self-audit of newly vendored code (same bug classes CodeRabbit found in Wave 1)
+
+Checked every newly vendored/relocated file for: raw-string/byte-string path
+escaping bugs, Win32 HANDLE leaks on error paths, and unsynchronized file
+read-modify-write.
+
+- `runner_pipe.rs`'s named-pipe path (`format!(r"\\.\pipe\codex-runner-{nonce:x}")`)
+  has the correct backslash count for the Win32 pipe namespace prefix
+  (`\\.\pipe\`) when the raw string is decoded; unlike Wave 1's `acl.rs` NUL
+  bug, this one is correct as vendored.
+- `runner_pipe.rs::create_named_pipe` frees the security descriptor
+  (`LocalFree(sd)`) unconditionally before checking `CreateNamedPipeW`'s
+  return value, so the error path does not leak it.
+- `runner_client.rs::spawn_runner_transport` closes `h_pipe_in`/`h_pipe_out`
+  on the `CreateProcessWithLogonW` failure path, closes `pi.hThread`
+  unconditionally right after the connect attempt (success or failure), and
+  closes `pi.hProcess` on both the connect-failure and startup-failure paths
+  (after `TerminateProcess`); the transport's own `File`s close their handles
+  via `Drop` when `startup_result` fails and `transport` is dropped. No leak
+  found on any traced path.
+- `connect_pipe_with_timeout`'s `thread_handle` is closed unconditionally
+  after the match, on every branch.
+- No file-based read-modify-write was introduced this wave (no new code
+  touches `cap.rs`'s already-documented unsynchronized `cap_sid` file, open
+  risk #8 below, unchanged).
+
+No new bugs found; nothing required a deviation beyond the ones already
+documented above.
+
 ### Why not `codex-rs/windows-sandbox-rs` for the Windows backend (historical, #395 wave; superseded in part by Step 3 above)
 
 This section predates Step 3 and explains why the #395 wave (the base,
@@ -341,13 +503,23 @@ crate deliberately does not inherit the workspace's Apache-2.0
    process's token rather than provisioning a dedicated low-privilege sandbox
    OS user. `codex-rs/windows-sandbox-rs`'s elevated-helper-user pattern (see
    above) is the precedent for that variant. Execution is
-   `blueprint-step3-elevated-windows-sandbox.md` (project vault): Wave 1 (this
-   PR) vendors the mechanism primitives (`codex-windows-sandbox/`) and ports
-   the policy adapter (`windows_resolve.rs`), both inert and not yet wired
-   into `windows::launch`. Waves 2 to 4 (elevated helper and provisioning,
-   then the actual launch-path wiring) remain open. Mark RESOLVED only when
-   Wave 4 lab-validates the isolation matrix on `spike307-win` (assertions L7
-   to L12 in the blueprint).
+   `blueprint-step3-elevated-windows-sandbox.md` (project vault): Wave 1
+   vendored the mechanism primitives (`codex-windows-sandbox/`) and ported
+   the policy adapter (`windows_resolve.rs`). Wave 2 (this PR) vendors the
+   elevated-helper IPC mechanism (`elevated/{ipc_framed,runner_pipe,
+   runner_client}`, `helper_materialization.rs`, `setup_error.rs`, a trimmed
+   `sandbox_users.rs`), all still inert and not wired into `windows::launch`.
+   Wave 2 also found the `codex_protocol`/`resolved_permissions.rs` coupling
+   is deeper than originally scoped: `spawn_prep.rs`, `wrapper.rs`,
+   `elevated_impl.rs`, the full `identity.rs`, the full `setup.rs`, and both
+   binaries (`setup_main`, `command_runner`, which additionally pull in WFP,
+   ConPTY, and a new `codex-otel` telemetry dependency) are deferred to a
+   later wave that ports them into `hive-desktop-sandbox`'s proprietary
+   `windows_elevated.rs`, per this file's own "Deliberately NOT vendored this
+   wave" section above. Remaining work (provisioning/identity port, the two
+   binaries, and the actual launch-path wiring) stays open. Mark RESOLVED
+   only when a later wave lab-validates the isolation matrix on
+   `spike307-win` (assertions L7 to L12 in the blueprint).
 7. **RESOLVED (#350).** The Linux `pre_exec` post-fork allocator-deadlock
    hazard below was fixed by #350 (merged), which moved `linux::launch`'s
    `pre_exec` closure to an allocation-free path so no thread can deadlock on
@@ -408,6 +580,20 @@ crate deliberately does not inherit the workspace's Apache-2.0
    "Deliberately NOT vendored this wave" above), re-check their dependency
    graph against `desktop.rs`/`logging.rs`/`codex_protocol` again; upstream
    may have changed the coupling.
+3a. Re-copy `codex-rs/windows-sandbox-rs/src/{elevated/ipc_framed,
+   elevated/runner_pipe,elevated/runner_client,elevated/mod,
+   helper_materialization,setup_error}.rs` verbatim into
+   `codex-windows-sandbox/src/` (Step 3 Wave 2), re-applying the same small
+   deviations documented in this file's Wave 2 section (the
+   `permission_profile`/`absolute_path` stand-in swap in `ipc_framed.rs`, the
+   `crate::setup::X` import-path fix in `helper_materialization.rs`, the
+   inlined `sanitize_metric_tag_value` in `setup_error.rs`). Re-copy
+   `bin/setup_main/win/sandbox_users.rs` into `codex-windows-sandbox/src/sandbox_users.rs`,
+   re-trimming to the OS-account primitives and re-applying the local
+   `log_line` stand-in. Re-check whether `spawn_prep.rs`, `wrapper.rs`,
+   `elevated_impl.rs`, `identity.rs`, `setup.rs`, or the two binaries have
+   become separable from `resolved_permissions.rs`/WFP/ConPTY upstream; if
+   so, that is the trigger to plan the next wave, not to vendor them here.
 4. Re-copy the repo-root `LICENSE`/`NOTICE` if changed.
 5. Re-run `cargo fmt --check && cargo clippy --all-targets -- -D warnings &&
    cargo test`, plus the `x86_64-pc-windows-gnu` cross-check (now also run by

--- a/apps/desktop-sandbox/codex-windows-sandbox/Cargo.toml
+++ b/apps/desktop-sandbox/codex-windows-sandbox/Cargo.toml
@@ -14,10 +14,15 @@ workspace = true
 
 [dependencies]
 anyhow = "1.0"
+base64 = "0.22"
 dunce = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 dirs-next = "2.0"
+# Real (not dev-only) dependency: helper_materialization.rs's
+# `copy_from_source_if_needed` uses `NamedTempFile` in production code, not
+# just tests (see that file for the write-into-temp-then-rename pattern).
+tempfile = { workspace = true }
 
 [dependencies.rand]
 version = "0.8"
@@ -32,15 +37,17 @@ features = ["std", "small_rng"]
 version = "0.52"
 features = [
     "Win32_Foundation",
+    "Win32_NetworkManagement_NetManagement",
     "Win32_Security",
     "Win32_Security_Authorization",
     "Win32_Security_Cryptography",
     "Win32_Storage_FileSystem",
-    "Win32_System_Threading",
-    "Win32_System_Registry",
     "Win32_System_Diagnostics_Debug",
+    "Win32_System_IO",
+    "Win32_System_Pipes",
+    "Win32_System_Registry",
+    "Win32_System_Threading",
 ]
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }
-tempfile = { workspace = true }

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/absolute_path.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/absolute_path.rs
@@ -1,0 +1,20 @@
+//! Minimal, Hive-authored stand-in for upstream `codex_utils_absolute_path::AbsolutePathBuf`.
+//!
+//! NOT vendored from upstream. The real `codex-utils-absolute-path` crate is ~900 lines with
+//! `schemars`/`ts-rs` (TypeScript binding generation) dependencies, a thread-local base-path
+//! guard for deserialization, and home-directory expansion, none of which is load-bearing for
+//! this wave: `elevated/ipc_framed.rs`'s `SpawnRequest.workspace_roots: Vec<AbsolutePathBuf>`
+//! field is inert (nothing constructs a real value this wave; the one upstream test that did,
+//! `spawn_request_serializes_permission_profile`, is excluded, see that file's module doc).
+//! This stand-in exists only so the struct field type resolves and (de)serializes.
+//!
+//! Pulling in the real crate's `schemars`/`ts-rs` dependency chain for a single opaque,
+//! unexercised field would be scope creep for an explicitly inert vendor wave; revisit if a
+//! later wave actually constructs or inspects workspace roots through this type.
+
+use serde::Deserialize;
+use serde::Serialize;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AbsolutePathBuf(PathBuf);

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/elevated/ipc_framed.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/elevated/ipc_framed.rs
@@ -1,0 +1,257 @@
+//! Framed IPC protocol used between the parent (CLI) and the elevated command runner.
+//!
+//! This module defines the JSON message schema (spawn request/ready, output, stdin,
+//! exit, error, terminate) plus length‑prefixed framing helpers for a byte stream.
+//! It is **elevated-path only**: the parent uses it to bootstrap the runner and
+//! stream unified_exec I/O over named pipes. The legacy restricted‑token path does
+//! not use this protocol, and non‑unified exec capture uses it only when running
+//! through the elevated runner.
+//!
+//! Local deviation from upstream (Step 3 Wave 2, see `../../VENDORING.md`):
+//! `SpawnRequest.permission_profile` is upstream `codex_protocol::models::PermissionProfile`
+//! and `SpawnRequest.workspace_roots` is upstream `codex_utils_absolute_path::AbsolutePathBuf`.
+//! Neither crate is a dependency of this crate (Step 3 Wave 2 dependency-tangle rule: no
+//! `codex_protocol` dependency may be added). Both are replaced with minimal, Hive-authored
+//! pure-data stand-ins (`crate::permission_profile::PermissionProfile`,
+//! `crate::absolute_path::AbsolutePathBuf`) that reproduce only the shape this inert wave
+//! exercises (construction via `PermissionProfile::read_only()`, opaque carry-through of an
+//! absolute path list). The real upstream `PermissionProfile` is a much richer, legacy-serde
+//! tagged enum (see `resolved_permissions.rs`'s consumers, deliberately excluded this wave);
+//! see VENDORING.md's "Deliberately NOT vendored this wave" section for the full rationale.
+
+use crate::absolute_path::AbsolutePathBuf;
+use crate::permission_profile::PermissionProfile;
+use anyhow::Result;
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD;
+use serde::Deserialize;
+use serde::Serialize;
+use std::collections::HashMap;
+use std::io::Read;
+use std::io::Write;
+use std::path::PathBuf;
+
+/// Safety cap for a single framed message payload.
+///
+/// This is not a protocol requirement; it simply bounds memory use and rejects
+/// obviously invalid frames.
+const MAX_FRAME_LEN: usize = 8 * 1024 * 1024;
+
+/// Protocol version shared by the parent process and elevated command runner.
+pub const IPC_PROTOCOL_VERSION: u8 = 4;
+
+/// Length-prefixed, JSON-encoded frame.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct FramedMessage {
+    pub version: u8,
+    #[serde(flatten)]
+    pub message: Message,
+}
+
+/// IPC message variants exchanged between parent and runner.
+///
+/// `SpawnRequest`, `Stdin`, `CloseStdin`, `Resize`, and `Terminate` are parent->runner commands.
+/// `SpawnReady`, `Output`, `Exit`, and `Error` are runner->parent events/results.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Message {
+    SpawnRequest { payload: Box<SpawnRequest> },
+    SpawnReady { payload: SpawnReady },
+    Output { payload: OutputPayload },
+    Stdin { payload: StdinPayload },
+    CloseStdin { payload: EmptyPayload },
+    Resize { payload: ResizePayload },
+    Exit { payload: ExitPayload },
+    Error { payload: ErrorPayload },
+    Terminate { payload: EmptyPayload },
+}
+
+/// Spawn parameters sent from parent to runner.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct SpawnRequest {
+    pub command: Vec<String>,
+    pub cwd: PathBuf,
+    pub env: HashMap<String, String>,
+    pub permission_profile: PermissionProfile,
+    pub workspace_roots: Vec<AbsolutePathBuf>,
+    pub codex_home: PathBuf,
+    pub real_codex_home: PathBuf,
+    pub cap_sids: Vec<String>,
+    pub timeout_ms: Option<u64>,
+    pub tty: bool,
+    #[serde(default)]
+    pub stdin_open: bool,
+    #[serde(default)]
+    pub use_private_desktop: bool,
+}
+
+/// Ack from runner after it spawns the child process.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct SpawnReady {
+    pub process_id: u32,
+}
+
+/// Output data sent from runner to parent.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct OutputPayload {
+    pub data_b64: String,
+    pub stream: OutputStream,
+}
+
+/// Output stream identifier for `OutputPayload`.
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum OutputStream {
+    Stdout,
+    Stderr,
+}
+
+/// Stdin bytes sent from parent to runner.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct StdinPayload {
+    pub data_b64: String,
+}
+
+/// PTY resize request sent from parent to runner.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ResizePayload {
+    pub rows: u16,
+    pub cols: u16,
+}
+
+/// Exit status sent from runner to parent.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ExitPayload {
+    pub exit_code: i32,
+    pub timed_out: bool,
+}
+
+/// Error payload sent when the runner fails to spawn or stream.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ErrorPayload {
+    pub message: String,
+    pub stage: ErrorStage,
+    pub windows_error_code: Option<u32>,
+}
+
+/// Runner startup stage that produced an error.
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ErrorStage {
+    ReadSpawnRequest,
+    SpawnChild,
+    WriteSpawnReady,
+}
+
+/// Empty payload for control messages.
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+pub struct EmptyPayload {}
+
+/// Base64-encode raw bytes for IPC payloads.
+pub fn encode_bytes(data: &[u8]) -> String {
+    STANDARD.encode(data)
+}
+
+/// Decode base64 payload data into raw bytes.
+pub fn decode_bytes(data: &str) -> Result<Vec<u8>> {
+    Ok(STANDARD.decode(data.as_bytes())?)
+}
+
+/// Write a length-prefixed JSON frame.
+pub fn write_frame<W: Write>(mut writer: W, msg: &FramedMessage) -> Result<()> {
+    let payload = serde_json::to_vec(msg)?;
+    if payload.len() > MAX_FRAME_LEN {
+        anyhow::bail!("frame too large: {}", payload.len());
+    }
+    let len = payload.len() as u32;
+    writer.write_all(&len.to_le_bytes())?;
+    writer.write_all(&payload)?;
+    writer.flush()?;
+    Ok(())
+}
+
+/// Read a length-prefixed JSON frame; returns `Ok(None)` on EOF.
+pub fn read_frame<R: Read>(mut reader: R) -> Result<Option<FramedMessage>> {
+    let mut len_buf = [0u8; 4];
+    match reader.read_exact(&mut len_buf) {
+        Ok(()) => {}
+        Err(err) if err.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
+        Err(err) => return Err(err.into()),
+    }
+    let len = u32::from_le_bytes(len_buf) as usize;
+    if len > MAX_FRAME_LEN {
+        anyhow::bail!("frame too large: {len}");
+    }
+    let mut payload = vec![0u8; len];
+    reader.read_exact(&mut payload)?;
+    let msg: FramedMessage = serde_json::from_slice(&payload)?;
+    Ok(Some(msg))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn framed_round_trip() {
+        let msg = FramedMessage {
+            version: IPC_PROTOCOL_VERSION,
+            message: Message::Output {
+                payload: OutputPayload {
+                    data_b64: encode_bytes(b"hello"),
+                    stream: OutputStream::Stdout,
+                },
+            },
+        };
+        let mut buf = Vec::new();
+        write_frame(&mut buf, &msg).expect("write");
+        let decoded = read_frame(buf.as_slice()).expect("read").expect("some");
+        assert_eq!(decoded.version, IPC_PROTOCOL_VERSION);
+        match decoded.message {
+            Message::Output { payload } => {
+                assert_eq!(payload.stream, OutputStream::Stdout);
+                let data = decode_bytes(&payload.data_b64).expect("decode");
+                assert_eq!(data, b"hello");
+            }
+            other => panic!("unexpected message: {other:?}"),
+        }
+    }
+
+    // Upstream also has `spawn_request_serializes_permission_profile`, asserting the exact
+    // tagged-enum JSON shape of the REAL `codex_protocol::models::PermissionProfile`
+    // (`encoded["payload"]["permission_profile"]["type"] == "managed"`). That assertion is
+    // specific to upstream's legacy-serde-compat enum, which this wave's minimal
+    // `crate::permission_profile::PermissionProfile` stand-in does not reproduce (see the
+    // module doc above and VENDORING.md). Excluded rather than faked; re-add once
+    // `resolved_permissions.rs`'s consumers are ported in a later wave and a faithful
+    // `PermissionProfile` exists in this tree.
+
+    #[test]
+    fn error_payload_serializes_stage_and_windows_error_code() {
+        let msg = FramedMessage {
+            version: IPC_PROTOCOL_VERSION,
+            message: Message::Error {
+                payload: ErrorPayload {
+                    message: "CreateProcessAsUserW failed".to_string(),
+                    stage: ErrorStage::SpawnChild,
+                    windows_error_code: Some(1312),
+                },
+            },
+        };
+
+        let encoded = serde_json::to_value(&msg).expect("serialize");
+        assert_eq!(
+            serde_json::json!({
+                "version": IPC_PROTOCOL_VERSION,
+                "type": "error",
+                "payload": {
+                    "message": "CreateProcessAsUserW failed",
+                    "stage": "spawn_child",
+                    "windows_error_code": 1312,
+                }
+            }),
+            encoded
+        );
+    }
+}

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/elevated/mod.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/elevated/mod.rs
@@ -1,0 +1,8 @@
+// Local deviation from upstream (`pub(crate) mod` there): `pub` here so lib.rs's
+// `pub use elevated::X;` re-exports (see lib.rs) do not leak a lower-visibility
+// module through a higher-visibility re-export. See lib.rs's comment for why
+// this crate uses `pub` throughout rather than upstream's curated `pub(crate)`
+// surface.
+pub mod ipc_framed;
+pub mod runner_client;
+pub mod runner_pipe;

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/elevated/runner_client.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/elevated/runner_client.rs
@@ -1,0 +1,555 @@
+use crate::identity::SandboxCreds;
+use crate::ipc_framed::ErrorPayload;
+use crate::ipc_framed::ErrorStage;
+use crate::ipc_framed::FramedMessage;
+use crate::ipc_framed::IPC_PROTOCOL_VERSION;
+use crate::ipc_framed::Message;
+use crate::ipc_framed::SpawnRequest;
+use crate::ipc_framed::read_frame;
+use crate::ipc_framed::write_frame;
+use crate::runner_pipe::PIPE_ACCESS_INBOUND;
+use crate::runner_pipe::PIPE_ACCESS_OUTBOUND;
+use crate::runner_pipe::connect_pipe;
+use crate::runner_pipe::create_named_pipe;
+use crate::runner_pipe::find_runner_exe;
+use crate::runner_pipe::pipe_pair;
+use crate::winutil::quote_windows_arg;
+use crate::winutil::to_wide;
+use anyhow::Context;
+use anyhow::Result;
+use std::ffi::c_void;
+use std::fs::File;
+use std::os::windows::io::AsRawHandle;
+use std::os::windows::io::FromRawHandle;
+use std::path::Path;
+use std::ptr;
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+use std::time::Instant;
+use windows_sys::Win32::Foundation::CloseHandle;
+use windows_sys::Win32::Foundation::DUPLICATE_SAME_ACCESS;
+use windows_sys::Win32::Foundation::DuplicateHandle;
+use windows_sys::Win32::Foundation::ERROR_LOGON_FAILURE;
+use windows_sys::Win32::Foundation::ERROR_NO_SUCH_LOGON_SESSION;
+use windows_sys::Win32::Foundation::ERROR_NOT_FOUND;
+use windows_sys::Win32::Foundation::GetLastError;
+use windows_sys::Win32::Foundation::HANDLE;
+use windows_sys::Win32::System::Diagnostics::Debug::SetErrorMode;
+use windows_sys::Win32::System::IO::CancelSynchronousIo;
+use windows_sys::Win32::System::Pipes::PeekNamedPipe;
+use windows_sys::Win32::System::Threading::CreateProcessWithLogonW;
+use windows_sys::Win32::System::Threading::GetCurrentProcess;
+use windows_sys::Win32::System::Threading::GetCurrentThread;
+use windows_sys::Win32::System::Threading::LOGON_WITH_PROFILE;
+use windows_sys::Win32::System::Threading::PROCESS_INFORMATION;
+use windows_sys::Win32::System::Threading::STARTUPINFOW;
+use windows_sys::Win32::System::Threading::TerminateProcess;
+use windows_sys::Win32::System::Threading::WaitForSingleObject;
+
+const RUNNER_SPAWN_READY_TIMEOUT: Duration = Duration::from_secs(15);
+const RUNNER_PIPE_CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
+const RUNNER_SPAWN_READY_POLL_INTERVAL: Duration = Duration::from_millis(50);
+const RUNNER_ERROR_MODE_FLAGS: u32 = 0x0001 | 0x0002;
+const WAIT_OBJECT_0: u32 = 0;
+
+#[derive(Debug)]
+struct RunnerLogonError {
+    code: u32,
+}
+
+impl std::fmt::Display for RunnerLogonError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "CreateProcessWithLogonW failed: {}", self.code)
+    }
+}
+
+impl std::error::Error for RunnerLogonError {}
+
+#[derive(Debug)]
+pub struct RunnerStartupError {
+    payload: ErrorPayload,
+}
+
+impl RunnerStartupError {
+    pub fn new(payload: ErrorPayload) -> Self {
+        Self { payload }
+    }
+}
+
+impl std::fmt::Display for RunnerStartupError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "runner failed during {:?}: {}",
+            self.payload.stage, self.payload.message
+        )?;
+        if let Some(code) = self.payload.windows_error_code {
+            write!(f, " (Windows error {code})")?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for RunnerStartupError {}
+
+pub struct RunnerTransport {
+    pipe_write: File,
+    pipe_read: File,
+}
+
+fn is_refreshable_windows_error(code: u32) -> bool {
+    matches!(code, ERROR_LOGON_FAILURE | ERROR_NO_SUCH_LOGON_SESSION)
+}
+
+fn command_targets_windows_apps(command: &[String]) -> bool {
+    command.first().is_some_and(|program| {
+        Path::new(program).components().any(|component| {
+            component
+                .as_os_str()
+                .to_string_lossy()
+                .eq_ignore_ascii_case("WindowsApps")
+        })
+    })
+}
+
+pub fn is_refreshable_sandbox_creds_error(err: &anyhow::Error, command: &[String]) -> bool {
+    if err
+        .downcast_ref::<RunnerLogonError>()
+        .is_some_and(|err| is_refreshable_windows_error(err.code))
+    {
+        return true;
+    }
+
+    err.downcast_ref::<RunnerStartupError>().is_some_and(|err| {
+        err.payload.stage == ErrorStage::SpawnChild
+            && err.payload.windows_error_code.is_some_and(|code| {
+                // AppX activation can return 1312 for a healthy sandbox token. Rotating the
+                // account password cannot make the same WindowsApps command launch.
+                is_refreshable_windows_error(code)
+                    && (code != ERROR_NO_SUCH_LOGON_SESSION
+                        || !command_targets_windows_apps(command))
+            })
+    })
+}
+
+pub fn retry_runner_spawn_once<T>(
+    sandbox_creds: SandboxCreds,
+    command: &[String],
+    mut spawn: impl FnMut(SandboxCreds) -> Result<T>,
+    refresh: impl FnOnce() -> Result<SandboxCreds>,
+) -> Result<T> {
+    match spawn(sandbox_creds) {
+        Ok(result) => Ok(result),
+        Err(err) if is_refreshable_sandbox_creds_error(&err, command) => spawn(refresh()?),
+        Err(err) => Err(err),
+    }
+}
+
+impl RunnerTransport {
+    pub fn send_spawn_request(&mut self, request: SpawnRequest) -> Result<()> {
+        let spawn_request = FramedMessage {
+            version: IPC_PROTOCOL_VERSION,
+            message: Message::SpawnRequest {
+                payload: Box::new(request),
+            },
+        };
+        write_frame(&mut self.pipe_write, &spawn_request)
+    }
+
+    pub fn read_spawn_ready(&mut self) -> Result<()> {
+        wait_for_complete_frame(&self.pipe_read, RUNNER_SPAWN_READY_TIMEOUT)?;
+        let msg = read_frame(&mut self.pipe_read)?
+            .ok_or_else(|| anyhow::anyhow!("runner pipe closed before spawn_ready"))?;
+        match msg.message {
+            Message::SpawnReady { .. } => Ok(()),
+            Message::Error { payload } => Err(RunnerStartupError::new(payload).into()),
+            other => Err(anyhow::anyhow!(
+                "expected spawn_ready from runner, got {other:?}"
+            )),
+        }
+    }
+
+    pub fn into_files(self) -> (File, File) {
+        (self.pipe_write, self.pipe_read)
+    }
+}
+
+fn try_take_completed_connect_result(
+    connect_thread: &mut Option<thread::JoinHandle<()>>,
+    connect_result_rx: &mpsc::Receiver<Result<()>>,
+    thread_handle: HANDLE,
+    pipe_label: &str,
+) -> Result<Option<Result<()>>> {
+    let thread_wait = unsafe { WaitForSingleObject(thread_handle, 0) };
+    if thread_wait != WAIT_OBJECT_0 {
+        return Ok(None);
+    }
+
+    if let Some(connect_thread) = connect_thread.take() {
+        let _ = connect_thread.join();
+    }
+
+    let result = connect_result_rx.recv().map_err(|_| {
+        anyhow::anyhow!("runner {pipe_label} connect thread exited before reporting its result")
+    })?;
+    Ok(Some(result))
+}
+
+fn connect_pipe_with_timeout(
+    h_pipe: HANDLE,
+    expected_runner_pid: u32,
+    pipe_label: &str,
+) -> Result<()> {
+    let pipe_label = pipe_label.to_string();
+    let pipe_label_for_thread = pipe_label.clone();
+    let (thread_handle_tx, thread_handle_rx) = mpsc::sync_channel(1);
+    let (connect_result_tx, connect_result_rx) = mpsc::sync_channel(1);
+    let mut connect_thread = Some(
+        thread::Builder::new()
+            .name(format!("codex-runner-connect-{pipe_label}"))
+            .spawn(move || {
+                let current_process = unsafe { GetCurrentProcess() };
+                let mut thread_handle = 0;
+                let duplicate_ok = unsafe {
+                    DuplicateHandle(
+                        current_process,
+                        GetCurrentThread(),
+                        current_process,
+                        &mut thread_handle,
+                        0,
+                        0,
+                        DUPLICATE_SAME_ACCESS,
+                    )
+                };
+                if duplicate_ok == 0 {
+                    let _ = thread_handle_tx.send(Err(anyhow::anyhow!(
+                        "DuplicateHandle failed for runner {pipe_label_for_thread} connect thread: {}",
+                        unsafe { GetLastError() }
+                    )));
+                    return;
+                }
+
+                // Publish the helper thread HANDLE before the blocking pipe connect so the
+                // parent can cancel this specific operation if it times out.
+                let _ = thread_handle_tx.send(Ok(thread_handle));
+
+                let result = connect_pipe(h_pipe, expected_runner_pid)
+                    .map_err(anyhow::Error::from)
+                    .context(format!("connect {pipe_label_for_thread}"));
+                let _ = connect_result_tx.send(result);
+            })?,
+    );
+    let thread_handle = thread_handle_rx.recv().map_err(|_| {
+        anyhow::anyhow!("runner {pipe_label} connect thread exited before publishing its handle")
+    })??;
+
+    let result = match connect_result_rx.recv_timeout(RUNNER_PIPE_CONNECT_TIMEOUT) {
+        Ok(result) => {
+            if let Some(connect_thread) = connect_thread.take() {
+                let _ = connect_thread.join();
+            }
+            result
+        }
+        Err(mpsc::RecvTimeoutError::Timeout) => {
+            if let Some(result) = try_take_completed_connect_result(
+                &mut connect_thread,
+                &connect_result_rx,
+                thread_handle,
+                &pipe_label,
+            )? {
+                result
+            } else {
+                let cancel_ok = unsafe { CancelSynchronousIo(thread_handle) };
+                if cancel_ok == 0 {
+                    let err = unsafe { GetLastError() };
+                    if err != ERROR_NOT_FOUND {
+                        Err(anyhow::anyhow!(
+                            "CancelSynchronousIo failed for runner {pipe_label} connect thread: {err}"
+                        ))
+                    } else if let Some(result) = try_take_completed_connect_result(
+                        &mut connect_thread,
+                        &connect_result_rx,
+                        thread_handle,
+                        &pipe_label,
+                    )? {
+                        result
+                    } else {
+                        Err(anyhow::anyhow!(
+                            "timed out after {}ms connecting runner {pipe_label}",
+                            RUNNER_PIPE_CONNECT_TIMEOUT.as_millis()
+                        ))
+                    }
+                } else {
+                    // Do not join the helper thread on the timeout path. Parent-side cleanup will
+                    // close the pipe handles, which lets the blocked connect unwind without
+                    // risking another indefinite wait here.
+                    Err(anyhow::anyhow!(
+                        "timed out after {}ms connecting runner {pipe_label}",
+                        RUNNER_PIPE_CONNECT_TIMEOUT.as_millis()
+                    ))
+                }
+            }
+        }
+        Err(mpsc::RecvTimeoutError::Disconnected) => {
+            if let Some(connect_thread) = connect_thread.take() {
+                let _ = connect_thread.join();
+            }
+            Err(anyhow::anyhow!(
+                "runner {pipe_label} connect thread exited before reporting its result"
+            ))
+        }
+    };
+
+    unsafe {
+        CloseHandle(thread_handle);
+    }
+
+    result
+}
+
+pub fn spawn_runner_transport(
+    codex_home: &Path,
+    cwd: &Path,
+    sandbox_creds: &SandboxCreds,
+    log_dir: Option<&Path>,
+    spawn_request: SpawnRequest,
+) -> Result<RunnerTransport> {
+    let (pipe_in_name, pipe_out_name) = pipe_pair();
+    let h_pipe_in =
+        create_named_pipe(&pipe_in_name, PIPE_ACCESS_OUTBOUND, &sandbox_creds.username)?;
+    let h_pipe_out =
+        create_named_pipe(&pipe_out_name, PIPE_ACCESS_INBOUND, &sandbox_creds.username)?;
+
+    let runner_exe = find_runner_exe(codex_home, log_dir);
+    let runner_cmdline = runner_exe
+        .to_str()
+        .map(str::to_owned)
+        .unwrap_or_else(|| "codex-command-runner.exe".to_string());
+    let runner_full_cmd = format!(
+        "{} {} {}",
+        quote_windows_arg(&runner_cmdline),
+        quote_windows_arg(&format!("--pipe-in={pipe_in_name}")),
+        quote_windows_arg(&format!("--pipe-out={pipe_out_name}"))
+    );
+    let mut cmdline_vec = to_wide(&runner_full_cmd);
+    let exe_w = to_wide(&runner_cmdline);
+    let cwd_w = to_wide(cwd);
+    let user_w = to_wide(&sandbox_creds.username);
+    let domain_w = to_wide(".");
+    let password_w = to_wide(&sandbox_creds.password);
+    let mut si: STARTUPINFOW = unsafe { std::mem::zeroed() };
+    si.cb = std::mem::size_of::<STARTUPINFOW>() as u32;
+    let mut pi: PROCESS_INFORMATION = unsafe { std::mem::zeroed() };
+    let env_block: Option<Vec<u16>> = None;
+
+    let previous_error_mode = unsafe { SetErrorMode(RUNNER_ERROR_MODE_FLAGS) };
+    let spawn_res = unsafe {
+        CreateProcessWithLogonW(
+            user_w.as_ptr(),
+            domain_w.as_ptr(),
+            password_w.as_ptr(),
+            LOGON_WITH_PROFILE,
+            exe_w.as_ptr(),
+            cmdline_vec.as_mut_ptr(),
+            windows_sys::Win32::System::Threading::CREATE_NO_WINDOW
+                | windows_sys::Win32::System::Threading::CREATE_UNICODE_ENVIRONMENT,
+            env_block
+                .as_ref()
+                .map(|block| block.as_ptr() as *const c_void)
+                .unwrap_or(ptr::null()),
+            cwd_w.as_ptr(),
+            &si,
+            &mut pi,
+        )
+    };
+    unsafe {
+        SetErrorMode(previous_error_mode);
+    }
+    if spawn_res == 0 {
+        let err = unsafe { GetLastError() };
+        unsafe {
+            CloseHandle(h_pipe_in);
+            CloseHandle(h_pipe_out);
+        }
+        return Err(RunnerLogonError { code: err }.into());
+    }
+    let expected_runner_pid = pi.dwProcessId;
+
+    let connect_result = (|| -> Result<()> {
+        connect_pipe_with_timeout(h_pipe_in, expected_runner_pid, "pipe-in")?;
+        connect_pipe_with_timeout(h_pipe_out, expected_runner_pid, "pipe-out")?;
+        Ok(())
+    })();
+
+    unsafe {
+        if pi.hThread != 0 {
+            CloseHandle(pi.hThread);
+        }
+    }
+
+    if let Err(err) = connect_result {
+        unsafe {
+            // Keep the process handle alive until the pipe handshake finishes. If the handshake
+            // fails after the runner process has already launched, we still need a way to stop
+            // that child instead of leaking a stray `codex-command-runner.exe`.
+            if pi.hProcess != 0 {
+                let _ = TerminateProcess(pi.hProcess, 1);
+                CloseHandle(pi.hProcess);
+            }
+            CloseHandle(h_pipe_in);
+            CloseHandle(h_pipe_out);
+        }
+        return Err(err);
+    }
+
+    let mut transport = RunnerTransport {
+        // Once the pipe connect phase succeeds we can transfer the raw HANDLEs into `File`s.
+        // From here on, the `RunnerTransport` owns closing the pipes on every success/error path.
+        pipe_write: unsafe { File::from_raw_handle(h_pipe_in as _) },
+        pipe_read: unsafe { File::from_raw_handle(h_pipe_out as _) },
+    };
+    let startup_result = (|| -> Result<()> {
+        // Keep the runner process HANDLE alive until the *entire* startup handshake finishes.
+        // That way, a later `send_spawn_request` or `spawn_ready` failure can still terminate the
+        // runner instead of leaving a stray `codex-command-runner.exe` behind.
+        transport.send_spawn_request(spawn_request)?;
+        transport.read_spawn_ready()?;
+        Ok(())
+    })();
+    if let Err(err) = startup_result {
+        unsafe {
+            if pi.hProcess != 0 {
+                let _ = TerminateProcess(pi.hProcess, 1);
+                CloseHandle(pi.hProcess);
+            }
+        }
+        drop(transport);
+        return Err(err);
+    }
+
+    unsafe {
+        if pi.hProcess != 0 {
+            // The runner has now connected both pipes *and* acknowledged the spawn request, so
+            // startup is complete. At that point the transport pipes become the only lifetime
+            // anchor we need to keep the session alive.
+            CloseHandle(pi.hProcess);
+        }
+    }
+
+    Ok(transport)
+}
+
+fn wait_for_complete_frame(pipe_read: &File, timeout: Duration) -> Result<()> {
+    let handle = pipe_read.as_raw_handle() as HANDLE;
+    let deadline = Instant::now() + timeout;
+    let mut len_buf = [0u8; 4];
+
+    loop {
+        let mut bytes_read = 0u32;
+        let mut total_available = 0u32;
+        let ok = unsafe {
+            PeekNamedPipe(
+                handle,
+                len_buf.as_mut_ptr() as *mut c_void,
+                len_buf.len() as u32,
+                &mut bytes_read,
+                &mut total_available,
+                ptr::null_mut(),
+            )
+        };
+        if ok == 0 {
+            let err = unsafe { GetLastError() } as i32;
+            return Err(anyhow::anyhow!(
+                "PeekNamedPipe failed while waiting for spawn_ready: {err}"
+            ));
+        }
+
+        if bytes_read == len_buf.len() as u32 {
+            let frame_len = u32::from_le_bytes(len_buf) as usize;
+            let total_len = frame_len
+                .checked_add(len_buf.len())
+                .ok_or_else(|| anyhow::anyhow!("runner frame length overflow"))?;
+            if total_available as usize >= total_len {
+                return Ok(());
+            }
+        }
+
+        if Instant::now() >= deadline {
+            return Err(anyhow::anyhow!(
+                "timed out after {}ms waiting for runner spawn_ready",
+                timeout.as_millis()
+            ));
+        }
+
+        std::thread::sleep(RUNNER_SPAWN_READY_POLL_INTERVAL);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RunnerLogonError;
+    use super::RunnerStartupError;
+    use super::is_refreshable_sandbox_creds_error;
+    use crate::ipc_framed::ErrorPayload;
+    use crate::ipc_framed::ErrorStage;
+    use pretty_assertions::assert_eq;
+    use windows_sys::Win32::Foundation::ERROR_LOGON_FAILURE;
+    use windows_sys::Win32::Foundation::ERROR_NO_SUCH_LOGON_SESSION;
+    use windows_sys::Win32::Foundation::ERROR_NOT_FOUND;
+
+    #[test]
+    fn refreshable_sandbox_creds_error_recognizes_credential_and_child_start_failures() {
+        assert_eq!(
+            [
+                ERROR_LOGON_FAILURE,
+                ERROR_NO_SUCH_LOGON_SESSION,
+                ERROR_NOT_FOUND,
+            ]
+            .map(|code| {
+                let err =
+                    anyhow::Error::new(RunnerLogonError { code }).context("runner launch failed");
+                is_refreshable_sandbox_creds_error(&err, &[])
+            }),
+            [true, true, false]
+        );
+
+        assert_eq!(
+            [
+                (ErrorStage::SpawnChild, ERROR_NO_SUCH_LOGON_SESSION),
+                (ErrorStage::SpawnChild, ERROR_NOT_FOUND),
+                (ErrorStage::ReadSpawnRequest, ERROR_NO_SUCH_LOGON_SESSION),
+            ]
+            .map(|(stage, windows_error_code)| {
+                let err = anyhow::Error::new(RunnerStartupError::new(ErrorPayload {
+                    message: "runner startup failed".to_string(),
+                    stage,
+                    windows_error_code: Some(windows_error_code),
+                }));
+                is_refreshable_sandbox_creds_error(&err, &["cmd.exe".to_string()])
+            }),
+            [true, false, false]
+        );
+
+        let windows_apps_commands = [
+            vec![
+                r"C:\Users\user\AppData\Local\Microsoft\WindowsApps\pwsh.exe".to_string(),
+            ],
+            vec![
+                r"C:\Program Files\WindowsApps\Microsoft.PowerShell_7.6.3.0_x64__8wekyb3d8bbwe\pwsh.exe"
+                    .to_string(),
+            ],
+        ];
+        assert_eq!(
+            windows_apps_commands.map(|command| {
+                let err = anyhow::Error::new(RunnerStartupError::new(ErrorPayload {
+                    message: "runner startup failed".to_string(),
+                    stage: ErrorStage::SpawnChild,
+                    windows_error_code: Some(ERROR_NO_SUCH_LOGON_SESSION),
+                }));
+                is_refreshable_sandbox_creds_error(&err, &command)
+            }),
+            [false, false]
+        );
+    }
+}

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/elevated/runner_client.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/elevated/runner_client.rs
@@ -318,8 +318,19 @@ pub fn spawn_runner_transport(
     let (pipe_in_name, pipe_out_name) = pipe_pair();
     let h_pipe_in =
         create_named_pipe(&pipe_in_name, PIPE_ACCESS_OUTBOUND, &sandbox_creds.username)?;
+    // If the outbound pipe fails to create, close the inbound pipe already created above
+    // before returning; otherwise every failed launch attempt leaks one server-pipe handle
+    // (CodeRabbit/Greptile finding, PR #399, see ../../VENDORING.md).
     let h_pipe_out =
-        create_named_pipe(&pipe_out_name, PIPE_ACCESS_INBOUND, &sandbox_creds.username)?;
+        match create_named_pipe(&pipe_out_name, PIPE_ACCESS_INBOUND, &sandbox_creds.username) {
+            Ok(handle) => handle,
+            Err(err) => {
+                unsafe {
+                    CloseHandle(h_pipe_in);
+                }
+                return Err(err.into());
+            }
+        };
 
     let runner_exe = find_runner_exe(codex_home, log_dir);
     let runner_cmdline = runner_exe

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/elevated/runner_pipe.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/elevated/runner_pipe.rs
@@ -1,0 +1,135 @@
+//! Named pipe helpers for the elevated Windows sandbox runner.
+//!
+//! This module generates paired pipe names, creates server‑side pipes with
+//! sandbox-user-scoped ACLs, and waits for the runner to connect. It is
+//! **elevated-path only** and is
+//! used by the parent to establish the IPC channel for both unified_exec sessions
+//! and elevated capture. The legacy restricted‑token path spawns the child directly
+//! and does not use these helpers.
+
+use crate::helper_materialization::HelperExecutable;
+use crate::helper_materialization::resolve_helper_for_launch;
+use crate::winutil::resolve_sid;
+use crate::winutil::string_from_sid_bytes;
+use crate::winutil::to_wide;
+use rand::Rng;
+use rand::SeedableRng;
+use rand::rngs::SmallRng;
+use std::io;
+use std::path::Path;
+use std::path::PathBuf;
+use std::ptr;
+use windows_sys::Win32::Foundation::GetLastError;
+use windows_sys::Win32::Foundation::HANDLE;
+use windows_sys::Win32::Foundation::HLOCAL;
+use windows_sys::Win32::Foundation::LocalFree;
+use windows_sys::Win32::Security::Authorization::ConvertStringSecurityDescriptorToSecurityDescriptorW;
+use windows_sys::Win32::Security::PSECURITY_DESCRIPTOR;
+use windows_sys::Win32::Security::SECURITY_ATTRIBUTES;
+use windows_sys::Win32::System::Pipes::ConnectNamedPipe;
+use windows_sys::Win32::System::Pipes::CreateNamedPipeW;
+use windows_sys::Win32::System::Pipes::GetNamedPipeClientProcessId;
+use windows_sys::Win32::System::Pipes::PIPE_READMODE_BYTE;
+use windows_sys::Win32::System::Pipes::PIPE_TYPE_BYTE;
+use windows_sys::Win32::System::Pipes::PIPE_WAIT;
+
+/// PIPE_ACCESS_INBOUND (win32 constant), not exposed in windows-sys 0.52.
+pub const PIPE_ACCESS_INBOUND: u32 = 0x0000_0001;
+/// PIPE_ACCESS_OUTBOUND (win32 constant), not exposed in windows-sys 0.52.
+pub const PIPE_ACCESS_OUTBOUND: u32 = 0x0000_0002;
+
+/// Resolves the elevated command runner path, preferring the copied helper under
+/// `.sandbox-bin` and falling back to the legacy sibling lookup when needed.
+pub fn find_runner_exe(codex_home: &Path, log_dir: Option<&Path>) -> PathBuf {
+    resolve_helper_for_launch(HelperExecutable::CommandRunner, codex_home, log_dir)
+}
+
+/// Generates a unique named-pipe path used to communicate with the runner process.
+pub fn pipe_pair() -> (String, String) {
+    let mut rng = SmallRng::from_entropy();
+    let nonce: u128 = rng.r#gen();
+    let base = format!(r"\\.\pipe\codex-runner-{nonce:x}");
+    (format!("{base}-in"), format!("{base}-out"))
+}
+
+/// Creates a named pipe whose DACL only allows the sandbox user to connect.
+pub fn create_named_pipe(name: &str, access: u32, sandbox_username: &str) -> io::Result<HANDLE> {
+    let sandbox_sid = resolve_sid(sandbox_username)
+        .map_err(|err| io::Error::new(io::ErrorKind::PermissionDenied, err.to_string()))?;
+    let sandbox_sid = string_from_sid_bytes(&sandbox_sid)
+        .map_err(|err| io::Error::new(io::ErrorKind::PermissionDenied, err))?;
+    let sddl = to_wide(format!("D:(A;;GA;;;{sandbox_sid})"));
+    let mut sd: PSECURITY_DESCRIPTOR = ptr::null_mut();
+    let ok = unsafe {
+        ConvertStringSecurityDescriptorToSecurityDescriptorW(
+            sddl.as_ptr(),
+            1, // SDDL_REVISION_1
+            &mut sd,
+            ptr::null_mut(),
+        )
+    };
+    if ok == 0 {
+        return Err(io::Error::from_raw_os_error(unsafe {
+            GetLastError() as i32
+        }));
+    }
+    let mut sa = SECURITY_ATTRIBUTES {
+        nLength: std::mem::size_of::<SECURITY_ATTRIBUTES>() as u32,
+        lpSecurityDescriptor: sd,
+        bInheritHandle: 0,
+    };
+    let wide = to_wide(name);
+    let h = unsafe {
+        CreateNamedPipeW(
+            wide.as_ptr(),
+            access,
+            PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT,
+            1,
+            65536,
+            65536,
+            0,
+            &mut sa as *mut SECURITY_ATTRIBUTES,
+        )
+    };
+    unsafe {
+        LocalFree(sd as HLOCAL);
+    }
+    if h == 0 || h == windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE {
+        return Err(io::Error::from_raw_os_error(unsafe {
+            GetLastError() as i32
+        }));
+    }
+    Ok(h)
+}
+
+/// Waits for the runner to connect to a parent-created server pipe.
+///
+/// This is parent-side only: the runner opens the pipe with `CreateFileW`, while the
+/// parent calls `ConnectNamedPipe`, tolerates the already-connected case, and
+/// verifies that the connected client is the runner process we just spawned.
+pub fn connect_pipe(h: HANDLE, expected_runner_pid: u32) -> io::Result<()> {
+    let ok = unsafe { ConnectNamedPipe(h, ptr::null_mut()) };
+    if ok == 0 {
+        let err = unsafe { GetLastError() };
+        const ERROR_PIPE_CONNECTED: u32 = 535;
+        if err != ERROR_PIPE_CONNECTED {
+            return Err(io::Error::from_raw_os_error(err as i32));
+        }
+    }
+    let mut client_pid = 0;
+    let ok = unsafe { GetNamedPipeClientProcessId(h, &mut client_pid) };
+    if ok == 0 {
+        return Err(io::Error::from_raw_os_error(unsafe {
+            GetLastError() as i32
+        }));
+    }
+    if client_pid != expected_runner_pid {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!(
+                "named pipe client pid {client_pid} did not match runner pid {expected_runner_pid}"
+            ),
+        ));
+    }
+    Ok(())
+}

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/helper_materialization.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/helper_materialization.rs
@@ -132,7 +132,14 @@ pub(crate) fn copy_helper_if_needed(
     log_dir: Option<&Path>,
 ) -> Result<PathBuf> {
     let cache_key = format!("{}|{}", kind.file_name(), codex_home.display());
-    if let Some(path) = cached_helper_path(&cache_key) {
+    // Re-validate the cached path is still on disk before trusting it: antivirus
+    // quarantine, cleanup, or a concurrent replacement can remove the helper after it was
+    // cached, and a stale in-memory hit must not paper over that (CodeRabbit/Greptile
+    // finding, PR #399, see ../VENDORING.md). Falling through re-runs the normal
+    // copy-if-needed path below, which re-populates the cache once the copy succeeds again.
+    if let Some(path) = cached_helper_path(&cache_key)
+        && path.is_file()
+    {
         log_note(
             &format!(
                 "helper copy: using in-memory cache for {} -> {}",

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/helper_materialization.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/helper_materialization.rs
@@ -1,0 +1,572 @@
+// Local deviation from upstream (Step 3 Wave 2, see ../VENDORING.md): upstream's real lib.rs
+// re-exports `setup::sandbox_bin_dir` and `setup::sandbox_dir` flat at the crate root
+// (`pub use setup::sandbox_bin_dir;`), so upstream's own internal files reference them as
+// `crate::sandbox_bin_dir`/`crate::sandbox_dir`. This crate does not replicate that flat
+// re-export surface (see lib.rs); the two call sites below are module-qualified
+// (`crate::setup::X`) instead. Function bodies are otherwise byte-for-byte upstream.
+use anyhow::Context;
+use anyhow::Result;
+use anyhow::anyhow;
+use std::collections::HashMap;
+use std::ffi::OsStr;
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+use std::path::PathBuf;
+use std::sync::Mutex;
+use std::sync::OnceLock;
+use std::time::UNIX_EPOCH;
+use tempfile::NamedTempFile;
+
+use crate::logging::log_note;
+use crate::setup::sandbox_bin_dir;
+
+const DEV_BUILD_VERSION_SENTINEL: &str = "0.0.0";
+pub(crate) const BIN_DIRNAME: &str = "bin";
+pub(crate) const RESOURCES_DIRNAME: &str = "codex-resources";
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) enum HelperExecutable {
+    CommandRunner,
+}
+
+impl HelperExecutable {
+    fn file_name(self) -> &'static str {
+        match self {
+            Self::CommandRunner => "codex-command-runner.exe",
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::CommandRunner => "command-runner",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum CopyOutcome {
+    Reused,
+    ReCopied,
+}
+
+static HELPER_PATH_CACHE: OnceLock<Mutex<HashMap<String, PathBuf>>> = OnceLock::new();
+
+pub(crate) fn helper_bin_dir(codex_home: &Path) -> PathBuf {
+    sandbox_bin_dir(codex_home)
+}
+
+pub(crate) fn legacy_lookup(kind: HelperExecutable) -> PathBuf {
+    if let Ok(exe) = std::env::current_exe()
+        && let Some(candidate) = bundled_executable_path_for_exe(&exe, kind.file_name())
+    {
+        return candidate;
+    }
+    PathBuf::from(kind.file_name())
+}
+
+pub(crate) fn resolve_helper_for_launch(
+    kind: HelperExecutable,
+    codex_home: &Path,
+    log_dir: Option<&Path>,
+) -> PathBuf {
+    match copy_helper_if_needed(kind, codex_home, log_dir) {
+        Ok(path) => {
+            log_note(
+                &format!(
+                    "helper launch resolution: using copied {} path {}",
+                    kind.label(),
+                    path.display()
+                ),
+                log_dir,
+            );
+            path
+        }
+        Err(err) => {
+            let fallback = legacy_lookup(kind);
+            log_note(
+                &format!(
+                    "helper copy failed for {}: {err:#}; falling back to legacy path {}",
+                    kind.label(),
+                    fallback.display()
+                ),
+                log_dir,
+            );
+            fallback
+        }
+    }
+}
+
+pub fn resolve_current_exe_for_launch(codex_home: &Path, fallback_executable: &str) -> PathBuf {
+    let source = match std::env::current_exe() {
+        Ok(path) => path,
+        Err(_) => return PathBuf::from(fallback_executable),
+    };
+    resolve_exe_for_launch(&source, codex_home)
+}
+
+pub fn resolve_exe_for_launch(source: &Path, codex_home: &Path) -> PathBuf {
+    let Some(file_name) = source.file_name() else {
+        return source.to_path_buf();
+    };
+    let destination = helper_bin_dir(codex_home).join(file_name);
+    match copy_from_source_if_needed(source, &destination) {
+        Ok(_) => destination,
+        Err(err) => {
+            let sandbox_log_dir = crate::setup::sandbox_dir(codex_home);
+            log_note(
+                &format!(
+                    "helper copy failed for executable: {err:#}; falling back to legacy path {}",
+                    source.display()
+                ),
+                Some(&sandbox_log_dir),
+            );
+            source.to_path_buf()
+        }
+    }
+}
+
+pub(crate) fn copy_helper_if_needed(
+    kind: HelperExecutable,
+    codex_home: &Path,
+    log_dir: Option<&Path>,
+) -> Result<PathBuf> {
+    let cache_key = format!("{}|{}", kind.file_name(), codex_home.display());
+    if let Some(path) = cached_helper_path(&cache_key) {
+        log_note(
+            &format!(
+                "helper copy: using in-memory cache for {} -> {}",
+                kind.label(),
+                path.display()
+            ),
+            log_dir,
+        );
+        return Ok(path);
+    }
+
+    let source = sibling_source_path(kind)?;
+    let destination = helper_destination_for_source(kind, codex_home, &source)?;
+    log_note(
+        &format!(
+            "helper copy: validating {} source={} destination={}",
+            kind.label(),
+            source.display(),
+            destination.display()
+        ),
+        log_dir,
+    );
+    let outcome = copy_from_source_if_needed(&source, &destination)?;
+    let action = match outcome {
+        CopyOutcome::Reused => "reused",
+        CopyOutcome::ReCopied => "recopied",
+    };
+    log_note(
+        &format!(
+            "helper copy: {} {} source={} destination={}",
+            action,
+            kind.label(),
+            source.display(),
+            destination.display()
+        ),
+        log_dir,
+    );
+    store_helper_path(cache_key, destination.clone());
+    Ok(destination)
+}
+
+fn cached_helper_path(cache_key: &str) -> Option<PathBuf> {
+    let cache = HELPER_PATH_CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+    let guard = cache.lock().ok()?;
+    guard.get(cache_key).cloned()
+}
+
+fn store_helper_path(cache_key: String, path: PathBuf) {
+    let cache = HELPER_PATH_CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+    if let Ok(mut guard) = cache.lock() {
+        guard.insert(cache_key, path);
+    }
+}
+
+fn sibling_source_path(kind: HelperExecutable) -> Result<PathBuf> {
+    let exe = std::env::current_exe().context("resolve current executable for helper lookup")?;
+    bundled_executable_path_for_exe(&exe, kind.file_name()).ok_or_else(|| {
+        anyhow!(
+            "helper not found next to current executable or under {RESOURCES_DIRNAME}: {}",
+            exe.display()
+        )
+    })
+}
+
+pub(crate) fn bundled_executable_path_for_exe(exe: &Path, file_name: &str) -> Option<PathBuf> {
+    let dir = exe.parent()?;
+    let direct_candidate = dir.join(file_name);
+    if direct_candidate.is_file() {
+        return Some(direct_candidate);
+    }
+
+    if dir.file_name() == Some(OsStr::new(BIN_DIRNAME))
+        && let Some(package_dir) = dir.parent()
+    {
+        let package_resource_candidate = package_dir.join(RESOURCES_DIRNAME).join(file_name);
+        if package_resource_candidate.is_file() {
+            return Some(package_resource_candidate);
+        }
+    }
+
+    let resource_candidate = dir.join(RESOURCES_DIRNAME).join(file_name);
+    resource_candidate.is_file().then_some(resource_candidate)
+}
+
+fn helper_destination_for_source(
+    kind: HelperExecutable,
+    codex_home: &Path,
+    source: &Path,
+) -> Result<PathBuf> {
+    let suffix = helper_version_suffix(source)?;
+    let file_name = materialized_file_name(kind, &suffix);
+    Ok(helper_bin_dir(codex_home).join(file_name))
+}
+
+fn materialized_file_name(kind: HelperExecutable, suffix: &str) -> String {
+    let source_name = kind.file_name();
+    let path = Path::new(source_name);
+    let stem = path
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .unwrap_or(source_name);
+    let extension = path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| format!(".{ext}"))
+        .unwrap_or_default();
+    format!("{stem}-{suffix}{extension}")
+}
+
+fn helper_version_suffix(source: &Path) -> Result<String> {
+    let version = env!("CARGO_PKG_VERSION");
+    if version == DEV_BUILD_VERSION_SENTINEL {
+        dev_build_suffix(source)
+    } else {
+        Ok(version.to_string())
+    }
+}
+
+fn dev_build_suffix(source: &Path) -> Result<String> {
+    let metadata = fs::metadata(source)
+        .with_context(|| format!("read helper source metadata {}", source.display()))?;
+    let modified = metadata
+        .modified()
+        .with_context(|| format!("read helper source mtime {}", source.display()))?;
+    let duration = modified
+        .duration_since(UNIX_EPOCH)
+        .with_context(|| format!("convert helper source mtime {}", source.display()))?;
+    Ok(format!("{}-{:x}", metadata.len(), duration.as_secs(),))
+}
+
+fn copy_from_source_if_needed(source: &Path, destination: &Path) -> Result<CopyOutcome> {
+    if destination_is_fresh(source, destination)? {
+        return Ok(CopyOutcome::Reused);
+    }
+
+    let destination_dir = destination.parent().ok_or_else(|| {
+        anyhow!(
+            "helper destination has no parent: {}",
+            destination.display()
+        )
+    })?;
+    fs::create_dir_all(destination_dir).with_context(|| {
+        format!(
+            "create helper destination directory {}",
+            destination_dir.display()
+        )
+    })?;
+
+    let temp_path = NamedTempFile::new_in(destination_dir)
+        .with_context(|| {
+            format!(
+                "create temporary helper file in {}",
+                destination_dir.display()
+            )
+        })?
+        .into_temp_path();
+    let temp_path_buf = temp_path.to_path_buf();
+
+    let mut source_file = fs::File::open(source)
+        .with_context(|| format!("open helper source for read {}", source.display()))?;
+    let mut temp_file = fs::OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .open(&temp_path_buf)
+        .with_context(|| format!("open temporary helper file {}", temp_path_buf.display()))?;
+
+    // Write into a temp file created inside `.sandbox-bin` so the copied helper keeps the
+    // destination directory's inherited ACLs instead of reusing the source file's descriptor.
+    std::io::copy(&mut source_file, &mut temp_file).with_context(|| {
+        format!(
+            "copy helper from {} to {}",
+            source.display(),
+            temp_path_buf.display()
+        )
+    })?;
+    temp_file
+        .flush()
+        .with_context(|| format!("flush temporary helper file {}", temp_path_buf.display()))?;
+    drop(temp_file);
+
+    if destination.exists() {
+        fs::remove_file(destination).with_context(|| {
+            format!("remove stale helper destination {}", destination.display())
+        })?;
+    }
+
+    match fs::rename(&temp_path_buf, destination) {
+        Ok(()) => Ok(CopyOutcome::ReCopied),
+        Err(rename_err) => {
+            if destination_is_fresh(source, destination)? {
+                Ok(CopyOutcome::Reused)
+            } else {
+                Err(rename_err).with_context(|| {
+                    format!(
+                        "rename helper temp file {} to {}",
+                        temp_path_buf.display(),
+                        destination.display()
+                    )
+                })
+            }
+        }
+    }
+}
+
+fn destination_is_fresh(source: &Path, destination: &Path) -> Result<bool> {
+    let source_meta = fs::metadata(source)
+        .with_context(|| format!("read helper source metadata {}", source.display()))?;
+    let destination_meta = match fs::metadata(destination) {
+        Ok(meta) => meta,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(err) => {
+            return Err(err).with_context(|| {
+                format!("read helper destination metadata {}", destination.display())
+            });
+        }
+    };
+
+    if source_meta.len() != destination_meta.len() {
+        return Ok(false);
+    }
+
+    let source_modified = source_meta
+        .modified()
+        .with_context(|| format!("read helper source mtime {}", source.display()))?;
+    let destination_modified = destination_meta
+        .modified()
+        .with_context(|| format!("read helper destination mtime {}", destination.display()))?;
+
+    Ok(destination_modified >= source_modified)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::BIN_DIRNAME;
+    use super::CopyOutcome;
+    use super::DEV_BUILD_VERSION_SENTINEL;
+    use super::HelperExecutable;
+    use super::RESOURCES_DIRNAME;
+    use super::bundled_executable_path_for_exe;
+    use super::copy_from_source_if_needed;
+    use super::destination_is_fresh;
+    use super::dev_build_suffix;
+    use super::helper_bin_dir;
+    use super::helper_version_suffix;
+    use super::materialized_file_name;
+    use pretty_assertions::assert_eq;
+    use std::fs;
+    use std::path::Path;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    #[test]
+    fn copy_from_source_if_needed_copies_missing_destination() {
+        let tmp = TempDir::new().expect("tempdir");
+        let source = tmp.path().join("source.exe");
+        let destination = tmp.path().join("bin").join("helper.exe");
+
+        fs::write(&source, b"runner-v1").expect("write source");
+
+        let outcome = copy_from_source_if_needed(&source, &destination).expect("copy helper");
+
+        assert_eq!(CopyOutcome::ReCopied, outcome);
+        assert_eq!(
+            b"runner-v1".as_slice(),
+            fs::read(&destination).expect("read destination")
+        );
+    }
+
+    #[test]
+    fn destination_is_fresh_uses_size_and_mtime() {
+        let tmp = TempDir::new().expect("tempdir");
+        let source = tmp.path().join("source.exe");
+        let destination = tmp.path().join("destination.exe");
+
+        fs::write(&destination, b"same-size").expect("write destination");
+        std::thread::sleep(std::time::Duration::from_secs(1));
+        fs::write(&source, b"same-size").expect("write source");
+        assert!(!destination_is_fresh(&source, &destination).expect("stale metadata"));
+
+        fs::write(&destination, b"same-size").expect("rewrite destination");
+        assert!(destination_is_fresh(&source, &destination).expect("fresh metadata"));
+    }
+
+    #[test]
+    fn copy_from_source_if_needed_reuses_fresh_destination() {
+        let tmp = TempDir::new().expect("tempdir");
+        let source = tmp.path().join("source.exe");
+        let destination = tmp.path().join("bin").join("helper.exe");
+
+        fs::write(&source, b"runner-v1").expect("write source");
+        copy_from_source_if_needed(&source, &destination).expect("initial copy");
+
+        let outcome = copy_from_source_if_needed(&source, &destination).expect("revalidate helper");
+
+        assert_eq!(CopyOutcome::Reused, outcome);
+        assert_eq!(
+            b"runner-v1".as_slice(),
+            fs::read(&destination).expect("read destination")
+        );
+    }
+
+    #[test]
+    fn helper_bin_dir_is_under_sandbox_bin() {
+        let codex_home = Path::new(r"C:\Users\example\.codex");
+
+        assert_eq!(
+            PathBuf::from(r"C:\Users\example\.codex\.sandbox-bin"),
+            helper_bin_dir(codex_home)
+        );
+    }
+
+    #[test]
+    fn copy_runner_into_shared_bin_dir() {
+        let tmp = TempDir::new().expect("tempdir");
+        let codex_home = tmp.path().join("codex-home");
+        let source_dir = tmp.path().join("sibling-source");
+        fs::create_dir_all(&source_dir).expect("create source dir");
+        let runner_source = source_dir.join("codex-command-runner.exe");
+        fs::write(&runner_source, b"runner").expect("runner");
+        let runner_suffix = helper_version_suffix(&runner_source).expect("runner suffix");
+        let runner_destination = helper_bin_dir(&codex_home).join(materialized_file_name(
+            HelperExecutable::CommandRunner,
+            &runner_suffix,
+        ));
+
+        let runner_outcome =
+            copy_from_source_if_needed(&runner_source, &runner_destination).expect("runner copy");
+
+        assert_eq!(CopyOutcome::ReCopied, runner_outcome);
+        assert_eq!(
+            b"runner".as_slice(),
+            fs::read(&runner_destination).expect("read runner")
+        );
+    }
+
+    #[test]
+    fn helper_source_lookup_checks_resource_dir() {
+        let tmp = TempDir::new().expect("tempdir");
+        let release_dir = tmp.path().join("release");
+        let resources_dir = release_dir.join(RESOURCES_DIRNAME);
+        fs::create_dir_all(&resources_dir).expect("create resources dir");
+        let exe = release_dir.join("codex.exe");
+        let helper = resources_dir.join("codex-command-runner.exe");
+        fs::write(&exe, b"codex").expect("write exe");
+        fs::write(&helper, b"runner").expect("write helper");
+
+        let resolved =
+            bundled_executable_path_for_exe(&exe, /*file_name*/ "codex-command-runner.exe")
+                .expect("helper path");
+
+        assert_eq!(resolved, helper);
+    }
+
+    #[test]
+    fn helper_source_lookup_checks_package_resource_dir_for_bin_exe() {
+        let tmp = TempDir::new().expect("tempdir");
+        let package_dir = tmp.path().join("package");
+        let bin_dir = package_dir.join(BIN_DIRNAME);
+        let resources_dir = package_dir.join(RESOURCES_DIRNAME);
+        fs::create_dir_all(&bin_dir).expect("create bin dir");
+        fs::create_dir_all(&resources_dir).expect("create resources dir");
+        let exe = bin_dir.join("codex.exe");
+        let helper = resources_dir.join("codex-command-runner.exe");
+        fs::write(&exe, b"codex").expect("write exe");
+        fs::write(&helper, b"runner").expect("write helper");
+
+        let resolved =
+            bundled_executable_path_for_exe(&exe, /*file_name*/ "codex-command-runner.exe")
+                .expect("helper path");
+
+        assert_eq!(resolved, helper);
+    }
+
+    #[test]
+    fn helper_source_lookup_prefers_package_resource_dir_over_bin_resource_dir() {
+        let tmp = TempDir::new().expect("tempdir");
+        let package_dir = tmp.path().join("package");
+        let bin_dir = package_dir.join(BIN_DIRNAME);
+        let package_resources_dir = package_dir.join(RESOURCES_DIRNAME);
+        let bin_resources_dir = bin_dir.join(RESOURCES_DIRNAME);
+        fs::create_dir_all(&package_resources_dir).expect("create package resources dir");
+        fs::create_dir_all(&bin_resources_dir).expect("create bin resources dir");
+        let exe = bin_dir.join("codex.exe");
+        let package_helper = package_resources_dir.join("codex-command-runner.exe");
+        let bin_helper = bin_resources_dir.join("codex-command-runner.exe");
+        fs::write(&exe, b"codex").expect("write exe");
+        fs::write(&package_helper, b"package runner").expect("write package helper");
+        fs::write(&bin_helper, b"bin runner").expect("write bin helper");
+
+        let resolved =
+            bundled_executable_path_for_exe(&exe, /*file_name*/ "codex-command-runner.exe")
+                .expect("helper path");
+
+        assert_eq!(resolved, package_helper);
+    }
+
+    #[test]
+    fn helper_source_lookup_prefers_direct_sibling_over_resource_dir() {
+        let tmp = TempDir::new().expect("tempdir");
+        let release_dir = tmp.path().join("release");
+        let resources_dir = release_dir.join(RESOURCES_DIRNAME);
+        fs::create_dir_all(&resources_dir).expect("create resources dir");
+        let exe = release_dir.join("codex.exe");
+        let sibling_helper = release_dir.join("codex-command-runner.exe");
+        let resource_helper = resources_dir.join("codex-command-runner.exe");
+        fs::write(&exe, b"codex").expect("write exe");
+        fs::write(&sibling_helper, b"sibling runner").expect("write sibling helper");
+        fs::write(&resource_helper, b"resource runner").expect("write resource helper");
+
+        let resolved =
+            bundled_executable_path_for_exe(&exe, /*file_name*/ "codex-command-runner.exe")
+                .expect("helper path");
+
+        assert_eq!(resolved, sibling_helper);
+    }
+
+    #[test]
+    fn helper_version_suffix_uses_cli_version_or_dev_build_metadata() {
+        let tmp = TempDir::new().expect("tempdir");
+        let source = tmp.path().join("source.exe");
+        fs::write(&source, b"runner-v1").expect("write source");
+        let suffix = helper_version_suffix(&source).expect("suffix");
+
+        if env!("CARGO_PKG_VERSION") == DEV_BUILD_VERSION_SENTINEL {
+            assert_eq!(suffix, dev_build_suffix(&source).expect("dev build suffix"));
+        } else {
+            assert_eq!(suffix, env!("CARGO_PKG_VERSION"));
+        }
+    }
+
+    #[test]
+    fn materialized_file_name_adds_suffix_before_extension() {
+        let file_name = materialized_file_name(HelperExecutable::CommandRunner, "test-suffix");
+
+        assert_eq!(file_name, "codex-command-runner-test-suffix.exe");
+    }
+}

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/identity.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/identity.rs
@@ -1,0 +1,19 @@
+//! Minimal, verbatim ONE-STRUCT subset of upstream `identity.rs`
+//! (`codex-rs/windows-sandbox-rs/src/identity.rs`, commit `a47c661…`, see
+//! `../VENDORING.md`), extracted so `elevated/runner_client.rs` and `elevated/runner_pipe.rs`'s
+//! consumers (`retry_runner_spawn_once`, `spawn_runner_transport`) compile without pulling in
+//! the rest of upstream's `identity.rs`: `sandbox_setup_is_complete`, `require_logon_sandbox_creds`,
+//! and `refresh_logon_sandbox_creds` all take or return `&ResolvedWindowsSandboxPermissions`
+//! (upstream's `resolved_permissions.rs`, deliberately not vendored this wave, see
+//! `permission_profile.rs`'s module doc and `VENDORING.md`'s "Deliberately NOT vendored this
+//! wave" section), so the rest of `identity.rs` is excluded, not vendored here.
+//!
+//! `SandboxCreds` itself is copied byte-for-byte from upstream; only the surrounding file
+//! (credential loading, DPAPI unseal, setup-marker readiness checks) is trimmed away.
+
+/// Decoded sandbox-account logon credentials (username + cleartext password).
+#[derive(Debug, Clone)]
+pub struct SandboxCreds {
+    pub username: String,
+    pub password: String,
+}

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/lib.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/lib.rs
@@ -24,15 +24,16 @@
 //! Verbatim-vendored Windows sandbox mechanism primitives from
 //! `openai/codex`'s `codex-rs/windows-sandbox-rs` crate (Apache-2.0). See
 //! `../VENDORING.md` for the pinned commit, the full file-by-file provenance,
-//! and the two modules deliberately NOT vendored this wave
-//! (`deny_read_resolver.rs`'s glob-scan resolver and `process.rs`'s
-//! `CreateProcessAsUserW` wrapper) and why.
+//! and the modules deliberately NOT vendored (`deny_read_resolver.rs`'s
+//! glob-scan resolver, `process.rs`'s `CreateProcessAsUserW` wrapper,
+//! `spawn_prep.rs`, `wrapper.rs`, `elevated_impl.rs`, the full `identity.rs`
+//! and `setup.rs`, and the `setup_main`/`command_runner` binaries) and why.
 //!
-//! This crate is inert this wave (Step 3 Wave 1 of
-//! `plan-codex-crossplatform-desktop.md`): nothing here is called from
-//! `hive-desktop-sandbox`'s `launch` path yet. It exists so the vendored
-//! primitives are vendored, compiled, and unit-tested on their own, ahead of
-//! the elevated-helper and launch-wiring waves that will actually call them.
+//! This crate is inert (Step 3 Waves 1-2 of `plan-codex-crossplatform-desktop.md`):
+//! nothing here is called from `hive-desktop-sandbox`'s `launch` path yet. It
+//! exists so the vendored primitives and elevated-helper IPC mechanism are
+//! vendored, compiled, and unit-tested on their own, ahead of the
+//! provisioning-port and launch-wiring waves that will actually call them.
 //!
 //! Every module below is real Win32 FFI (via `windows-sys`) with no
 //! `#[cfg(windows)]` gate of its own (matching upstream, which is a
@@ -57,13 +58,21 @@ pub mod dpapi;
 #[cfg(windows)]
 pub mod env;
 #[cfg(windows)]
+pub mod helper_materialization;
+#[cfg(windows)]
 pub mod hide_users;
+#[cfg(windows)]
+pub mod identity;
 #[cfg(windows)]
 pub mod path_normalization;
 #[cfg(windows)]
 pub mod proc_thread_attr;
 #[cfg(windows)]
+pub mod sandbox_users;
+#[cfg(windows)]
 pub mod sandbox_utils;
+#[cfg(windows)]
+pub mod setup_error;
 #[cfg(windows)]
 pub mod token;
 #[cfg(windows)]
@@ -71,13 +80,38 @@ pub mod winutil;
 #[cfg(windows)]
 pub mod workspace_acl;
 
-// Not vendored from upstream: minimal, Hive-authored stand-ins so the two
-// verbatim modules above that need them (`deny_read_state::sync_persistent_deny_read_acls`
-// needs `setup::sandbox_dir`; `hide_users` needs `logging::log_note`) compile
-// without pulling in upstream's CODEX_HOME-coupled `setup.rs` or the
-// `tracing-appender`/`codex-utils-string`-coupled `logging.rs`. See
+// Elevated-helper IPC mechanism (Step 3 Wave 2). Upstream's own real lib.rs
+// declares `elevated` as a private module and re-exports its three
+// sub-modules flat at the crate root (`pub(crate) use elevated::ipc_framed;`
+// etc.); vendored files below reference them via that same flat `crate::X`
+// path, so the re-exports are reproduced here rather than switching those
+// files to `crate::elevated::X` paths. Local deviation from upstream: `pub`
+// rather than `pub(crate)`, matching this crate's own "everything pub,
+// mod-nested" convention (every other module in this file is `pub mod`) so
+// the re-export is exempt from `unused_imports` even though nothing in this
+// wave's vendor set calls into `runner_client` yet (its only upstream callers,
+// `elevated_impl.rs`/`wrapper.rs`/`command_runner/win.rs`, are excluded this
+// wave; see `../VENDORING.md`).
+#[cfg(windows)]
+mod elevated;
+#[cfg(windows)]
+pub use elevated::ipc_framed;
+#[cfg(windows)]
+pub use elevated::runner_client;
+#[cfg(windows)]
+pub use elevated::runner_pipe;
+
+// Not vendored from upstream: minimal, Hive-authored stand-ins so vendored
+// modules that need them compile without pulling in upstream's
+// CODEX_HOME-coupled `setup.rs`/`identity.rs`, the
+// `tracing-appender`/`codex-utils-string`-coupled `logging.rs`, or a
+// `codex_protocol`/`codex_utils_absolute_path` dependency. See
 // `../VENDORING.md` for what each stand-in does and does not do.
 #[cfg(windows)]
+pub mod absolute_path;
+#[cfg(windows)]
 mod logging;
+#[cfg(windows)]
+pub mod permission_profile;
 #[cfg(windows)]
 mod setup;

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/permission_profile.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/permission_profile.rs
@@ -1,0 +1,35 @@
+//! Minimal, Hive-authored stand-in for upstream `codex_protocol::models::PermissionProfile`.
+//!
+//! NOT vendored from upstream. `elevated/ipc_framed.rs`'s `SpawnRequest` struct carries a
+//! `permission_profile` field of this type as part of the wire schema (see that file's own
+//! module doc). Upstream's real `PermissionProfile` is a much larger tagged enum with legacy
+//! serde-migration variants (`Managed`, `Disabled`, `External`, plus a hand-rolled
+//! `Deserialize` impl for backward compatibility with older rollout files); consuming its
+//! variants meaningfully requires `ResolvedWindowsSandboxPermissions::try_from_permission_profile*`
+//! (upstream's `resolved_permissions.rs`), which Wave 1 deliberately ported to Hive-native
+//! types (`hive-desktop-sandbox/src/windows_resolve.rs`) rather than vendoring, to avoid a
+//! `codex_protocol` dependency anywhere in this tree (Step 3 Wave 2 dependency-tangle rule).
+//!
+//! This stand-in exists ONLY so `elevated/ipc_framed.rs`'s struct definition and its
+//! `PermissionProfile::read_only()` test construction compile; nothing in this wave resolves
+//! or interprets a `PermissionProfile` value (`spawn_prep.rs`, `wrapper.rs`, `elevated_impl.rs`,
+//! `identity.rs`'s resolver-coupled functions, and the full `setup.rs` are excluded this wave;
+//! see `VENDORING.md`). Do not extend this type's variants to match upstream without also
+//! porting a real resolver for it, or it will silently misrepresent the vendored wire format.
+
+use serde::Deserialize;
+use serde::Serialize;
+
+/// Placeholder shape for the real upstream `PermissionProfile` tagged enum. Only the
+/// `read_only()` constructor upstream's own `elevated/ipc_framed.rs` test exercises is
+/// reproduced.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PermissionProfile {
+    pub read_only: bool,
+}
+
+impl PermissionProfile {
+    pub fn read_only() -> Self {
+        Self { read_only: true }
+    }
+}

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/sandbox_users.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/sandbox_users.rs
@@ -188,21 +188,32 @@ pub fn ensure_local_group(name: &str, comment: &str, log: &mut dyn Write) -> Res
 }
 
 pub fn ensure_local_group_member(group_name: &str, member_name: &str) -> Result<()> {
-    // If the member is already in the group, NetLocalGroupAddMembers may
-    // return an error code. We don't care.
+    // If the member is already in the group, NetLocalGroupAddMembers returns
+    // ERROR_MEMBER_IN_ALIAS; treat that (and NERR_Success) as success. Any other code
+    // (access denied, missing group, invalid account, ...) must fail instead of being
+    // silently discarded, otherwise this reports success while the account never actually
+    // joined the group (CodeRabbit/Greptile finding, PR #399, see ../VENDORING.md).
+    const ERROR_MEMBER_IN_ALIAS: u32 = 1378;
+
     let group_w = to_wide(OsStr::new(group_name));
     let member_w = to_wide(OsStr::new(member_name));
-    unsafe {
+    let status = unsafe {
         let member = LOCALGROUP_MEMBERS_INFO_3 {
             lgrmi3_domainandname: member_w.as_ptr() as *mut u16,
         };
-        let _ = NetLocalGroupAddMembers(
+        NetLocalGroupAddMembers(
             std::ptr::null(),
             group_w.as_ptr(),
             3,
             &member as *const _ as *mut u8,
             1,
-        );
+        )
+    };
+    if status != NERR_Success && status != ERROR_MEMBER_IN_ALIAS {
+        return Err(anyhow::Error::new(SetupFailure::new(
+            SetupErrorCode::HelperUserProvisionFailed,
+            format!("failed to add {member_name} to group {group_name}, code {status}"),
+        )));
     }
     Ok(())
 }

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/sandbox_users.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/sandbox_users.rs
@@ -1,0 +1,357 @@
+//! OS-account create/enumerate/delete primitives for the elevated Windows sandbox helper.
+//!
+//! Relocated + trimmed from upstream `bin/setup_main/win/sandbox_users.rs`
+//! (`codex-rs/windows-sandbox-rs/src/bin/setup_main/win/sandbox_users.rs`, commit
+//! `a47c661…`, see `../VENDORING.md`) into this crate's library (`codex-windows-sandbox`)
+//! rather than the excluded `setup_main` binary, since the mechanism itself (local
+//! group/user creation, SID lookups) has no dependency on the excluded binary's WFP/ConPTY
+//! surface. Two classes of upstream content are excluded, not vendored, here:
+//!
+//! 1. `provision_sandbox_users`, `write_secrets`, `prepare_setup_marker`, and
+//!    `commit_setup_marker` (plus their private `SandboxUserRecord`/`SandboxUsersFile`/
+//!    `SetupMarker` structs): these are orchestration coupled to the excluded `win.rs`'s
+//!    specific setup flow, and additionally require a `chrono` dependency
+//!    (`prepare_setup_marker`) not otherwise needed by this wave. `random_password` is excluded
+//!    alongside them: its only upstream caller was `provision_sandbox_users`, so with that
+//!    excluded it would be dead code under `-D warnings`; re-add together when a later wave
+//!    ports the provisioning orchestration.
+//! 2. Every remaining function's calls to upstream's `super::log_line` (a sibling function on
+//!    `win.rs`, the excluded parent module) are replaced with a minimal local `log_line` below
+//!    (verbatim primitive logic, no timestamp, since this module no longer has a `win.rs`
+//!    parent to borrow the real upstream `log_line` — which itself needs `chrono` too — from).
+//!
+//! Import paths are module-qualified (`crate::setup_error::X`, `crate::winutil::X`) rather than
+//! the flat `codex_windows_sandbox::X` paths upstream's binary crate used, since this file now
+//! lives inside the crate that defines those items. Function bodies are otherwise byte-for-byte
+//! upstream.
+
+use anyhow::Result;
+use std::ffi::OsStr;
+use std::ffi::c_void;
+use std::io::Write;
+use windows_sys::Win32::Foundation::ERROR_INSUFFICIENT_BUFFER;
+use windows_sys::Win32::Foundation::GetLastError;
+use windows_sys::Win32::Foundation::LocalFree;
+use windows_sys::Win32::NetworkManagement::NetManagement::LOCALGROUP_INFO_1;
+use windows_sys::Win32::NetworkManagement::NetManagement::LOCALGROUP_MEMBERS_INFO_3;
+use windows_sys::Win32::NetworkManagement::NetManagement::NERR_Success;
+use windows_sys::Win32::NetworkManagement::NetManagement::NetLocalGroupAdd;
+use windows_sys::Win32::NetworkManagement::NetManagement::NetLocalGroupAddMembers;
+use windows_sys::Win32::NetworkManagement::NetManagement::NetUserAdd;
+use windows_sys::Win32::NetworkManagement::NetManagement::NetUserSetInfo;
+use windows_sys::Win32::NetworkManagement::NetManagement::UF_DONT_EXPIRE_PASSWD;
+use windows_sys::Win32::NetworkManagement::NetManagement::UF_SCRIPT;
+use windows_sys::Win32::NetworkManagement::NetManagement::USER_INFO_1;
+use windows_sys::Win32::NetworkManagement::NetManagement::USER_INFO_1003;
+use windows_sys::Win32::NetworkManagement::NetManagement::USER_PRIV_USER;
+use windows_sys::Win32::Security::Authorization::ConvertStringSidToSidW;
+use windows_sys::Win32::Security::CopySid;
+use windows_sys::Win32::Security::GetLengthSid;
+use windows_sys::Win32::Security::LookupAccountNameW;
+use windows_sys::Win32::Security::LookupAccountSidW;
+use windows_sys::Win32::Security::SID_NAME_USE;
+
+use crate::setup_error::SetupErrorCode;
+use crate::setup_error::SetupFailure;
+use crate::winutil::string_from_sid_bytes;
+use crate::winutil::to_wide;
+
+pub const SANDBOX_USERS_GROUP: &str = "CodexSandboxUsers";
+const SANDBOX_USERS_GROUP_COMMENT: &str = "Codex sandbox internal group (managed)";
+const SID_ADMINISTRATORS: &str = "S-1-5-32-544";
+const SID_USERS: &str = "S-1-5-32-545";
+const SID_AUTHENTICATED_USERS: &str = "S-1-5-11";
+const SID_EVERYONE: &str = "S-1-1-0";
+const SID_SYSTEM: &str = "S-1-5-18";
+
+/// Local stand-in for upstream `win.rs::log_line` (see this file's module doc): writes one
+/// line without a timestamp, avoiding a `chrono` dependency for a log helper this wave has no
+/// caller for beyond the primitives below.
+fn log_line(log: &mut dyn Write, msg: &str) -> Result<()> {
+    writeln!(log, "{msg}").map_err(|err| {
+        anyhow::Error::new(SetupFailure::new(
+            SetupErrorCode::HelperLogFailed,
+            format!("failed to write setup log line: {err}"),
+        ))
+    })?;
+    Ok(())
+}
+
+pub fn ensure_sandbox_users_group(log: &mut dyn Write) -> Result<()> {
+    ensure_local_group(SANDBOX_USERS_GROUP, SANDBOX_USERS_GROUP_COMMENT, log)
+}
+
+pub fn resolve_sandbox_users_group_sid() -> Result<Vec<u8>> {
+    resolve_sid(SANDBOX_USERS_GROUP)
+}
+
+pub fn ensure_sandbox_user(username: &str, password: &str, log: &mut dyn Write) -> Result<()> {
+    ensure_local_user(username, password, log)?;
+    ensure_local_group_member(SANDBOX_USERS_GROUP, username)?;
+    Ok(())
+}
+
+pub fn ensure_local_user(name: &str, password: &str, log: &mut dyn Write) -> Result<()> {
+    let name_w = to_wide(OsStr::new(name));
+    let pwd_w = to_wide(OsStr::new(password));
+    unsafe {
+        let info = USER_INFO_1 {
+            usri1_name: name_w.as_ptr() as *mut u16,
+            usri1_password: pwd_w.as_ptr() as *mut u16,
+            usri1_password_age: 0,
+            usri1_priv: USER_PRIV_USER,
+            usri1_home_dir: std::ptr::null_mut(),
+            usri1_comment: std::ptr::null_mut(),
+            usri1_flags: UF_SCRIPT | UF_DONT_EXPIRE_PASSWD,
+            usri1_script_path: std::ptr::null_mut(),
+        };
+        let status = NetUserAdd(
+            std::ptr::null(),
+            1,
+            &info as *const _ as *mut u8,
+            std::ptr::null_mut(),
+        );
+        if status != NERR_Success {
+            // Try update password via level 1003.
+            let pw_info = USER_INFO_1003 {
+                usri1003_password: pwd_w.as_ptr() as *mut u16,
+            };
+            let upd = NetUserSetInfo(
+                std::ptr::null(),
+                name_w.as_ptr(),
+                1003,
+                &pw_info as *const _ as *mut u8,
+                std::ptr::null_mut(),
+            );
+            if upd != NERR_Success {
+                log_line(log, &format!("NetUserSetInfo failed for {name} code {upd}"))?;
+                return Err(anyhow::Error::new(SetupFailure::new(
+                    SetupErrorCode::HelperUserCreateOrUpdateFailed,
+                    format!("failed to create/update user {name}, code {status}/{upd}"),
+                )));
+            }
+        }
+
+        // Ensure the principal is a regular local user account.
+        if let Ok(group_name) = lookup_account_name_for_sid(SID_USERS) {
+            let group = to_wide(OsStr::new(&group_name));
+            let member = LOCALGROUP_MEMBERS_INFO_3 {
+                lgrmi3_domainandname: name_w.as_ptr() as *mut u16,
+            };
+            let _ = NetLocalGroupAddMembers(
+                std::ptr::null(),
+                group.as_ptr(),
+                3,
+                &member as *const _ as *mut u8,
+                1,
+            );
+        } else {
+            log_line(
+                log,
+                "LookupAccountSidW failed for Users SID; skipping Users group membership",
+            )?;
+        }
+    }
+    Ok(())
+}
+
+pub fn ensure_local_group(name: &str, comment: &str, log: &mut dyn Write) -> Result<()> {
+    const ERROR_ALIAS_EXISTS: u32 = 1379;
+    const NERR_GROUP_EXISTS: u32 = 2223;
+
+    let name_w = to_wide(OsStr::new(name));
+    let comment_w = to_wide(OsStr::new(comment));
+    unsafe {
+        let info = LOCALGROUP_INFO_1 {
+            lgrpi1_name: name_w.as_ptr() as *mut u16,
+            lgrpi1_comment: comment_w.as_ptr() as *mut u16,
+        };
+        let mut parm_err: u32 = 0;
+        let status = NetLocalGroupAdd(
+            std::ptr::null(),
+            1,
+            &info as *const _ as *mut u8,
+            &mut parm_err as *mut _,
+        );
+        if status != NERR_Success && status != ERROR_ALIAS_EXISTS && status != NERR_GROUP_EXISTS {
+            log_line(
+                log,
+                &format!("NetLocalGroupAdd failed for {name} code {status} parm_err={parm_err}"),
+            )?;
+            return Err(anyhow::Error::new(SetupFailure::new(
+                SetupErrorCode::HelperUsersGroupCreateFailed,
+                format!("failed to create local group {name}, code {status}"),
+            )));
+        }
+    }
+    Ok(())
+}
+
+pub fn ensure_local_group_member(group_name: &str, member_name: &str) -> Result<()> {
+    // If the member is already in the group, NetLocalGroupAddMembers may
+    // return an error code. We don't care.
+    let group_w = to_wide(OsStr::new(group_name));
+    let member_w = to_wide(OsStr::new(member_name));
+    unsafe {
+        let member = LOCALGROUP_MEMBERS_INFO_3 {
+            lgrmi3_domainandname: member_w.as_ptr() as *mut u16,
+        };
+        let _ = NetLocalGroupAddMembers(
+            std::ptr::null(),
+            group_w.as_ptr(),
+            3,
+            &member as *const _ as *mut u8,
+            1,
+        );
+    }
+    Ok(())
+}
+
+pub fn resolve_sid(name: &str) -> Result<Vec<u8>> {
+    if let Some(sid_str) = well_known_sid_str(name) {
+        return sid_bytes_from_string(sid_str);
+    }
+    let name_w = to_wide(OsStr::new(name));
+    let mut sid_buffer = vec![0u8; 68];
+    let mut sid_len: u32 = sid_buffer.len() as u32;
+    let mut domain: Vec<u16> = Vec::new();
+    let mut domain_len: u32 = 0;
+    let mut use_type: SID_NAME_USE = 0;
+    loop {
+        let ok = unsafe {
+            LookupAccountNameW(
+                std::ptr::null(),
+                name_w.as_ptr(),
+                sid_buffer.as_mut_ptr() as *mut c_void,
+                &mut sid_len,
+                domain.as_mut_ptr(),
+                &mut domain_len,
+                &mut use_type,
+            )
+        };
+        if ok != 0 {
+            sid_buffer.truncate(sid_len as usize);
+            return Ok(sid_buffer);
+        }
+        let err = unsafe { GetLastError() };
+        if err == ERROR_INSUFFICIENT_BUFFER {
+            sid_buffer.resize(sid_len as usize, 0);
+            domain.resize(domain_len as usize, 0);
+            continue;
+        }
+        return Err(anyhow::anyhow!(
+            "LookupAccountNameW failed for {name}: {err}"
+        ));
+    }
+}
+
+fn well_known_sid_str(name: &str) -> Option<&'static str> {
+    match name {
+        "Administrators" => Some(SID_ADMINISTRATORS),
+        "Users" => Some(SID_USERS),
+        "Authenticated Users" => Some(SID_AUTHENTICATED_USERS),
+        "Everyone" => Some(SID_EVERYONE),
+        "SYSTEM" => Some(SID_SYSTEM),
+        _ => None,
+    }
+}
+
+fn sid_bytes_from_string(sid_str: &str) -> Result<Vec<u8>> {
+    let sid_w = to_wide(OsStr::new(sid_str));
+    let mut psid: *mut c_void = std::ptr::null_mut();
+    if unsafe { ConvertStringSidToSidW(sid_w.as_ptr(), &mut psid) } == 0 {
+        return Err(anyhow::anyhow!(
+            "ConvertStringSidToSidW failed for {sid_str}: {}",
+            unsafe { GetLastError() }
+        ));
+    }
+    let sid_len = unsafe { GetLengthSid(psid) };
+    if sid_len == 0 {
+        unsafe {
+            LocalFree(psid as _);
+        }
+        return Err(anyhow::anyhow!("GetLengthSid failed for {sid_str}"));
+    }
+    let mut out = vec![0u8; sid_len as usize];
+    let ok = unsafe { CopySid(sid_len, out.as_mut_ptr() as *mut c_void, psid) };
+    unsafe {
+        LocalFree(psid as _);
+    }
+    if ok == 0 {
+        return Err(anyhow::anyhow!("CopySid failed for {sid_str}"));
+    }
+    Ok(out)
+}
+
+fn lookup_account_name_for_sid(sid_str: &str) -> Result<String> {
+    let sid_w = to_wide(OsStr::new(sid_str));
+    let mut psid: *mut c_void = std::ptr::null_mut();
+    if unsafe { ConvertStringSidToSidW(sid_w.as_ptr(), &mut psid) } == 0 {
+        return Err(anyhow::anyhow!(
+            "ConvertStringSidToSidW failed for {sid_str}: {}",
+            unsafe { GetLastError() }
+        ));
+    }
+    let mut name_len: u32 = 0;
+    let mut domain_len: u32 = 0;
+    let mut use_type: SID_NAME_USE = 0;
+    let ok = unsafe {
+        LookupAccountSidW(
+            std::ptr::null(),
+            psid,
+            std::ptr::null_mut(),
+            &mut name_len,
+            std::ptr::null_mut(),
+            &mut domain_len,
+            &mut use_type,
+        )
+    };
+    if ok == 0 {
+        let err = unsafe { GetLastError() };
+        if err != ERROR_INSUFFICIENT_BUFFER {
+            unsafe {
+                LocalFree(psid as _);
+            }
+            return Err(anyhow::anyhow!(
+                "LookupAccountSidW preflight failed for {sid_str}: {err}"
+            ));
+        }
+    }
+    let mut name_buf: Vec<u16> = vec![0u16; name_len as usize];
+    let mut domain_buf: Vec<u16> = vec![0u16; domain_len as usize];
+    let ok = unsafe {
+        LookupAccountSidW(
+            std::ptr::null(),
+            psid,
+            name_buf.as_mut_ptr(),
+            &mut name_len,
+            domain_buf.as_mut_ptr(),
+            &mut domain_len,
+            &mut use_type,
+        )
+    };
+    unsafe {
+        LocalFree(psid as _);
+    }
+    if ok == 0 {
+        return Err(anyhow::anyhow!(
+            "LookupAccountSidW failed for {sid_str}: {}",
+            unsafe { GetLastError() }
+        ));
+    }
+    let name = String::from_utf16_lossy(&name_buf);
+    Ok(name.trim_end_matches('\0').to_string())
+}
+
+pub fn sid_bytes_to_psid(sid: &[u8]) -> Result<*mut c_void> {
+    let sid_str = string_from_sid_bytes(sid).map_err(anyhow::Error::msg)?;
+    let sid_w = to_wide(OsStr::new(&sid_str));
+    let mut psid: *mut c_void = std::ptr::null_mut();
+    if unsafe { ConvertStringSidToSidW(sid_w.as_ptr(), &mut psid) } == 0 {
+        return Err(anyhow::anyhow!(
+            "ConvertStringSidToSidW failed: {}",
+            unsafe { GetLastError() }
+        ));
+    }
+    Ok(psid)
+}

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/setup.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/setup.rs
@@ -1,21 +1,35 @@
-//! Minimal, verbatim ONE-FUNCTION subset of upstream `setup.rs`
+//! Minimal, verbatim FEW-FUNCTION subset of upstream `setup.rs`
 //! (`codex-rs/windows-sandbox-rs/src/setup.rs`, commit `a47c661…`, see
-//! `../VENDORING.md`), extracted so `deny_read_state.rs`'s
-//! `sync_persistent_deny_read_acls` (which needs a base directory to persist
-//! its state file under) compiles without pulling in the rest of upstream's
-//! `setup.rs`: OS-account provisioning, `SandboxUsersFile`,
-//! `run_elevated_provisioning_setup`, and the setup-marker machinery, all of
-//! which are CODEX_HOME-coupled and belong to the Step 3 elevated-helper wave
-//! (ported into `hive-desktop-sandbox`'s `windows_elevated.rs`, not vendored
-//! here), per the module list in `../VENDORING.md`.
+//! `../VENDORING.md`), extracted so a handful of vendored mechanism modules
+//! compile without pulling in the rest of upstream's `setup.rs`: OS-account
+//! provisioning, `SandboxUsersFile`, `run_elevated_provisioning_setup`,
+//! `run_setup_refresh*`, and the setup-marker machinery all call
+//! `ResolvedWindowsSandboxPermissions::try_from_permission_profile*`
+//! (upstream's `resolved_permissions.rs`, deliberately not vendored, see
+//! `permission_profile.rs`'s module doc), so the rest of `setup.rs` is
+//! excluded, belonging to a later wave that ports the resolver-coupled
+//! orchestration into `hive-desktop-sandbox`'s proprietary code.
 //!
-//! `sandbox_dir` itself is copied byte-for-byte from upstream; only the
+//! Each function below is copied byte-for-byte from upstream; only the
 //! surrounding file (which upstream calls `codex_home`, Codex's config
-//! directory) is trimmed to this one function.
+//! directory) is trimmed to these few path-helper functions:
+//! - `sandbox_dir`: needed by `deny_read_state.rs` (Wave 1) and
+//!   `helper_materialization.rs`/`sandbox_users.rs` (Wave 2).
+//! - `sandbox_bin_dir`: needed by `helper_materialization.rs` (Wave 2).
+//!
+//! `sandbox_secrets_dir` is NOT included: its only upstream caller,
+//! `write_secrets`, is excluded (see `sandbox_users.rs`'s module doc), and an
+//! unused `pub fn` inside this private module still fails `-D warnings`
+//! dead_code (module privacy, not just item privacy, gates reachability).
+//! Add it back together with whichever wave ports `write_secrets`.
 
 use std::path::Path;
 use std::path::PathBuf;
 
 pub fn sandbox_dir(codex_home: &Path) -> PathBuf {
     codex_home.join(".sandbox")
+}
+
+pub fn sandbox_bin_dir(codex_home: &Path) -> PathBuf {
+    codex_home.join(".sandbox-bin")
 }

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/setup_error.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/setup_error.rs
@@ -1,0 +1,318 @@
+// Local deviation from upstream (Step 3 Wave 2, see ../VENDORING.md): upstream imports
+// `codex_utils_string::sanitize_metric_tag_value` from a separate crate. Rather than add a new
+// crate dependency for one ~20-line pure function, it is extracted verbatim below as a private
+// fn (byte-identical body, from `codex-rs/utils/string/src/lib.rs`, commit `a47c661…`). Every
+// other function in this file is byte-for-byte upstream.
+use anyhow::Context;
+use anyhow::Result;
+use serde::Deserialize;
+use serde::Serialize;
+use std::fs;
+use std::io::ErrorKind;
+use std::path::Path;
+use std::path::PathBuf;
+
+/// These represent the most common failures for the elevated sandbox setup.
+///
+/// Codes are used as metric tags.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SetupErrorCode {
+    // Orchestrator (run in CLI) failures.
+    /// Failed to create `codex_home/.sandbox` in the orchestrator.
+    OrchestratorSandboxDirCreateFailed,
+    /// Failed to determine whether the current process is elevated.
+    OrchestratorElevationCheckFailed,
+    /// The setup command requires an already elevated process.
+    OrchestratorElevationRequired,
+    /// Failed to serialize the elevation payload before launching the helper.
+    OrchestratorPayloadSerializeFailed,
+    /// Failed to launch the setup helper process (spawn or ShellExecuteExW).
+    OrchestratorHelperLaunchFailed,
+    /// User canceled the UAC prompt while launching the helper.
+    OrchestratorHelperLaunchCanceled,
+    /// Helper exited non-zero and no structured report was available.
+    OrchestratorHelperExitNonzero,
+    /// Helper exited non-zero and reading `setup_error.json` failed.
+    OrchestratorHelperReportReadFailed,
+    /// Helper exited successfully before setup completed.
+    OrchestratorHelperIncomplete,
+    // Helper (elevated process) failures.
+    /// Helper failed while validating or decoding the request payload.
+    HelperRequestArgsFailed,
+    /// Helper failed to create `codex_home/.sandbox`.
+    HelperSandboxDirCreateFailed,
+    /// Helper failed to open or write the setup log.
+    HelperLogFailed,
+    /// Helper failed in the provisioning phase (fallback bucket).
+    HelperUserProvisionFailed,
+    /// Helper failed to create the sandbox users local group.
+    HelperUsersGroupCreateFailed,
+    /// Helper failed to create or update a sandbox user account.
+    HelperUserCreateOrUpdateFailed,
+    /// Helper failed to protect user passwords with DPAPI.
+    HelperDpapiProtectFailed,
+    /// Helper failed to write the sandbox users secrets file.
+    HelperUsersFileWriteFailed,
+    /// Helper failed to write or protect the setup marker file.
+    HelperSetupMarkerWriteFailed,
+    /// Helper failed to resolve a SID or convert it to a PSID.
+    HelperSidResolveFailed,
+    /// Helper failed to load or convert capability SIDs.
+    HelperCapabilitySidFailed,
+    /// Helper failed to initialize COM for firewall configuration.
+    HelperFirewallComInitFailed,
+    /// Helper failed to access firewall policy or rule collections.
+    HelperFirewallPolicyAccessFailed,
+    /// Helper detected that local firewall policy changes will not fully take effect.
+    HelperFirewallPolicyIneffective,
+    /// Helper failed to create, update, or add the firewall rule.
+    HelperFirewallRuleCreateOrAddFailed,
+    /// Helper failed to verify the configured firewall rule scope.
+    HelperFirewallRuleVerifyFailed,
+    /// Helper failed to spawn the read-ACL helper process.
+    HelperReadAclHelperSpawnFailed,
+    /// Helper failed to lock down sandbox directories via ACLs.
+    HelperSandboxLockFailed,
+    /// Helper failed for an unmapped or unexpected reason.
+    HelperUnknownError,
+}
+
+impl SetupErrorCode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::OrchestratorSandboxDirCreateFailed => "orchestrator_sandbox_dir_create_failed",
+            Self::OrchestratorElevationCheckFailed => "orchestrator_elevation_check_failed",
+            Self::OrchestratorElevationRequired => "orchestrator_elevation_required",
+            Self::OrchestratorPayloadSerializeFailed => "orchestrator_payload_serialize_failed",
+            Self::OrchestratorHelperLaunchFailed => "orchestrator_helper_launch_failed",
+            Self::OrchestratorHelperLaunchCanceled => "orchestrator_helper_launch_canceled",
+            Self::OrchestratorHelperExitNonzero => "orchestrator_helper_exit_nonzero",
+            Self::OrchestratorHelperReportReadFailed => "orchestrator_helper_report_read_failed",
+            Self::OrchestratorHelperIncomplete => "orchestrator_helper_incomplete",
+            Self::HelperRequestArgsFailed => "helper_request_args_failed",
+            Self::HelperSandboxDirCreateFailed => "helper_sandbox_dir_create_failed",
+            Self::HelperLogFailed => "helper_log_failed",
+            Self::HelperUserProvisionFailed => "helper_user_provision_failed",
+            Self::HelperUsersGroupCreateFailed => "helper_users_group_create_failed",
+            Self::HelperUserCreateOrUpdateFailed => "helper_user_create_or_update_failed",
+            Self::HelperDpapiProtectFailed => "helper_dpapi_protect_failed",
+            Self::HelperUsersFileWriteFailed => "helper_users_file_write_failed",
+            Self::HelperSetupMarkerWriteFailed => "helper_setup_marker_write_failed",
+            Self::HelperSidResolveFailed => "helper_sid_resolve_failed",
+            Self::HelperCapabilitySidFailed => "helper_capability_sid_failed",
+            Self::HelperFirewallComInitFailed => "helper_firewall_com_init_failed",
+            Self::HelperFirewallPolicyAccessFailed => "helper_firewall_policy_access_failed",
+            Self::HelperFirewallPolicyIneffective => "helper_firewall_policy_ineffective",
+            Self::HelperFirewallRuleCreateOrAddFailed => {
+                "helper_firewall_rule_create_or_add_failed"
+            }
+            Self::HelperFirewallRuleVerifyFailed => "helper_firewall_rule_verify_failed",
+            Self::HelperReadAclHelperSpawnFailed => "helper_read_acl_helper_spawn_failed",
+            Self::HelperSandboxLockFailed => "helper_sandbox_lock_failed",
+            Self::HelperUnknownError => "helper_unknown_error",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SetupErrorReport {
+    pub code: SetupErrorCode,
+    pub message: String,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct SetupFailure {
+    pub code: SetupErrorCode,
+    pub message: String,
+}
+
+impl SetupFailure {
+    pub fn new(code: SetupErrorCode, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+        }
+    }
+
+    pub fn from_report(report: SetupErrorReport) -> Self {
+        Self::new(report.code, report.message)
+    }
+
+    pub fn metric_message(&self) -> String {
+        sanitize_setup_metric_tag_value(&self.message)
+    }
+}
+
+impl std::fmt::Display for SetupFailure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.code.as_str(), self.message)
+    }
+}
+
+impl std::error::Error for SetupFailure {}
+
+pub fn failure(code: SetupErrorCode, message: impl Into<String>) -> anyhow::Error {
+    anyhow::Error::new(SetupFailure::new(code, message))
+}
+
+pub fn extract_failure(err: &anyhow::Error) -> Option<&SetupFailure> {
+    err.downcast_ref::<SetupFailure>()
+}
+
+pub fn setup_error_path(codex_home: &Path) -> PathBuf {
+    codex_home.join(".sandbox").join("setup_error.json")
+}
+
+pub fn clear_setup_error_report(codex_home: &Path) -> Result<()> {
+    let path = setup_error_path(codex_home);
+    match fs::remove_file(&path) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(err).with_context(|| format!("remove {}", path.display())),
+    }
+}
+
+pub fn write_setup_error_report(codex_home: &Path, report: &SetupErrorReport) -> Result<()> {
+    let sandbox_dir = codex_home.join(".sandbox");
+    fs::create_dir_all(&sandbox_dir)
+        .with_context(|| format!("create sandbox dir {}", sandbox_dir.display()))?;
+    let path = setup_error_path(codex_home);
+    let json = serde_json::to_vec_pretty(report)?;
+    fs::write(&path, json).with_context(|| format!("write {}", path.display()))?;
+    Ok(())
+}
+
+pub fn read_setup_error_report(codex_home: &Path) -> Result<Option<SetupErrorReport>> {
+    let path = setup_error_path(codex_home);
+    let bytes = match fs::read(&path) {
+        Ok(bytes) => bytes,
+        Err(err) if err.kind() == ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(err).with_context(|| format!("read {}", path.display())),
+    };
+    let report = serde_json::from_slice::<SetupErrorReport>(&bytes)
+        .with_context(|| format!("parse {}", path.display()))?;
+    Ok(Some(report))
+}
+
+/// Sanitize a setup error message for use as a metric tag.
+pub fn sanitize_setup_metric_tag_value(value: &str) -> String {
+    sanitize_metric_tag_value(redact_home_paths(value).as_str())
+}
+
+/// Verbatim extraction of `codex_utils_string::sanitize_metric_tag_value`
+/// (`codex-rs/utils/string/src/lib.rs`, commit `a47c661…`). See this file's top-of-file note.
+fn sanitize_metric_tag_value(value: &str) -> String {
+    const MAX_LEN: usize = 256;
+    let sanitized: String = value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '-' | '/') {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    let trimmed = sanitized.trim_matches('_');
+    if trimmed.is_empty() || trimmed.chars().all(|ch| !ch.is_ascii_alphanumeric()) {
+        return "unspecified".to_string();
+    }
+    if trimmed.len() <= MAX_LEN {
+        trimmed.to_string()
+    } else {
+        trimmed[..MAX_LEN].to_string()
+    }
+}
+
+fn redact_home_paths(value: &str) -> String {
+    let mut usernames: Vec<String> = Vec::new();
+    if let Ok(username) = std::env::var("USERNAME")
+        && !username.trim().is_empty()
+    {
+        usernames.push(username);
+    }
+    if let Ok(user) = std::env::var("USER")
+        && !user.trim().is_empty()
+        && !usernames.iter().any(|v| v.eq_ignore_ascii_case(&user))
+    {
+        usernames.push(user);
+    }
+
+    redact_username_segments(value, &usernames)
+}
+
+fn redact_username_segments(value: &str, usernames: &[String]) -> String {
+    if usernames.is_empty() {
+        return value.to_string();
+    }
+
+    let mut segments: Vec<String> = Vec::new();
+    let mut separators: Vec<char> = Vec::new();
+    let mut current = String::new();
+
+    for ch in value.chars() {
+        if ch == '\\' || ch == '/' {
+            segments.push(std::mem::take(&mut current));
+            separators.push(ch);
+        } else {
+            current.push(ch);
+        }
+    }
+    segments.push(current);
+
+    for segment in &mut segments {
+        let matches = if cfg!(windows) {
+            usernames
+                .iter()
+                .any(|name| segment.eq_ignore_ascii_case(name))
+        } else {
+            usernames.iter().any(|name| segment == name)
+        };
+        if matches {
+            *segment = "<user>".to_string();
+        }
+    }
+
+    let mut out = String::new();
+    for (idx, segment) in segments.iter().enumerate() {
+        out.push_str(segment);
+        if let Some(sep) = separators.get(idx) {
+            out.push(*sep);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::redact_username_segments;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn sanitize_tag_value_redacts_username_segments() {
+        let usernames = vec!["Alice".to_string(), "Bob".to_string()];
+        let msg = "failed to write C:\\Users\\Alice\\file.txt; fallback D:\\Profiles\\Bob\\x";
+        let redacted = redact_username_segments(msg, &usernames);
+        assert_eq!(
+            redacted,
+            "failed to write C:\\Users\\<user>\\file.txt; fallback D:\\Profiles\\<user>\\x"
+        );
+    }
+
+    #[test]
+    fn sanitize_tag_value_leaves_unknown_segments() {
+        let usernames = vec!["Alice".to_string()];
+        let msg = "failed to write E:\\data\\file.txt";
+        let redacted = redact_username_segments(msg, &usernames);
+        assert_eq!(redacted, msg);
+    }
+
+    #[test]
+    fn sanitize_tag_value_redacts_multiple_occurrences() {
+        let usernames = vec!["Alice".to_string()];
+        let msg = "C:\\Users\\Alice\\a and C:\\Users\\Alice\\b";
+        let redacted = redact_username_segments(msg, &usernames);
+        assert_eq!(redacted, "C:\\Users\\<user>\\a and C:\\Users\\<user>\\b");
+    }
+}


### PR DESCRIPTION
## Summary

Step 3 Wave 2. Vendors the INERT transport and account layer of the codex windows-sandbox elevated helper into the existing `codex-windows-sandbox` subcrate (landed by #398). Adds the named-pipe IPC framing (`elevated/{mod,ipc_framed,runner_pipe,runner_client}`), `helper_materialization`, `sandbox_users` (trimmed to OS-account primitives), `setup_error`, and minimal local stand-ins (`permission_profile`, `absolute_path`, `identity` = SandboxCreds only). No bins. Nothing wired into `launch()`. All inert.

## Scope

The elevated helper's spawning logic (spawn_prep, elevated_impl, wrapper, the setup_main and command_runner bins) is intentionally NOT in this PR. It is coupled to the ported resolver plus WFP plus ConPTY, and upstream fuses those together, so it lands in the lab-gated Integration A (Step 3 core wiring). This PR is the reviewable inert transport substrate that A builds on.

## codex_protocol

Fully excluded (decision Q1). The coupled modules that import it are deferred to the porting integration, where the needed types get ported to Hive types.

## Verification

- `cargo check` and `cargo clippy -D warnings` on `x86_64-pc-windows-gnu` clean for both crates.
- 63 native tests pass, `cargo fmt --check` clean.
- Inert: no `launch()` path reaches this code, so there is no lab gate here. D-004 lab validation applies from Integration A.

## Test plan

- [x] cross-compile check and clippy -D warnings on windows-gnu
- [x] 63 native tests pass
- [ ] CI required checks green
- [ ] security-reviewer clean (IPC framing, Win32 handle safety, no codex_protocol)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Windows elevated sandbox support for securely launching commands through a dedicated helper process.
  * Added reliable framed communication for process startup, input, output, resizing, termination, and error reporting.
  * Added helper executable discovery, caching, and safe materialization with legacy fallback support.
  * Added sandbox account and permission setup utilities, including structured setup-error reports with sanitized diagnostic messages.

* **Documentation**
  * Documented the expanded vendoring scope, update checklist, audit requirements, and remaining follow-up items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds an inert transport and account layer for the Windows elevated sandbox helper. The main changes are:

- Length-prefixed JSON messaging over named pipes.
- Runner startup, connection, timeout, and cleanup handling.
- Helper discovery, caching, and materialization.
- Windows sandbox user and group primitives.
- Local stand-ins for permission, path, identity, and setup types.
- Required dependencies, Windows API features, and public module exports.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- The updated pipe cleanup keeps raw handle ownership separate from Rust file ownership.
- Missing cached helper files now fall through to materialization.
- Unexpected group membership results now return an error.
- No blocking issue was found in the updated code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/desktop-sandbox/codex-windows-sandbox/src/elevated/runner_client.rs | Adds runner transport and closes the first pipe when creation of the second pipe fails. |
| apps/desktop-sandbox/codex-windows-sandbox/src/helper_materialization.rs | Adds helper discovery and materialization while revalidating cached helper paths. |
| apps/desktop-sandbox/codex-windows-sandbox/src/sandbox_users.rs | Adds sandbox account primitives and propagates unexpected group membership errors. |
| apps/desktop-sandbox/codex-windows-sandbox/src/elevated/ipc_framed.rs | Defines the bounded framed IPC schema and serialization helpers. |
| apps/desktop-sandbox/codex-windows-sandbox/Cargo.toml | Adds dependencies and Windows API features required by the new modules. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: address CodeRabbit and Greptile fin..."](https://github.com/sakibsadmanshajib/hive/commit/e694c5ff27614b65948488b62b9c4c1ab0d27b34) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45525381)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - .claude/rules/openwolf.md ([source](https://app.greptile.com/scubed/github/sakibsadmanshajib/hive/-/custom-context?memory=3e51a3b4-2091-4dce-8aad-9423a1f1db38))
- Context used - CLAUDE.md ([source](https://app.greptile.com/scubed/github/sakibsadmanshajib/hive/-/custom-context?memory=a5912a3f-0055-4d8a-86c1-fedc669ad56e))
- Context used - .claude/rules/orchestrator.md ([source](https://app.greptile.com/scubed/github/sakibsadmanshajib/hive/-/custom-context?memory=7e0c2dc0-c014-43b2-9dbd-46ae72a640d0))
</details>

<!-- /greptile_comment -->