### PR TITLE
feat: elevated-helper capture primitives and close W2 security findings inert (Step 3 A1)

### DIFF
--- a/apps/desktop-sandbox/Cargo.lock
+++ b/apps/desktop-sandbox/Cargo.lock
@@ -67,6 +67,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "windows-sys 0.52.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -676,6 +677,12 @@ dependencies = [
  "quote",
  "syn 2.0.119",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zmij"

--- a/apps/desktop-sandbox/VENDORING.md
+++ b/apps/desktop-sandbox/VENDORING.md
@@ -410,6 +410,91 @@ risk #6 is the tracking entry.
   item); bundling the Debug redaction with that pass avoids fixing the same
   struct's credential hygiene in two uncoordinated passes.
 
+## `codex-windows-sandbox/` Step 3 Integration A1 (capture-path primitives + W2 security hardening)
+
+Integration A1 adds the two remaining capture-path Win32 primitives Wave 1
+deferred and applies the module-internal security must-fixes the PR #398/#399
+review passes catalogued for "fix during Integration A" (open risk #6). Still
+INERT: nothing added here is wired into `windows::launch`; the resolver-coupled
+port (`spawn_prep`, `allow`, `elevated_impl` capture, the full `identity`/`setup`
+provisioning, and the two binaries) and the launch wiring itself remain deferred
+to Integration A2, which is lab-gated on `spike307-win` (blueprint L7 to L12).
+Same pinned commit as the rest of this file.
+
+### What was vendored (verbatim, byte-for-byte)
+
+- `process.rs`: the `CreateProcessAsUserW` wrapper (`create_process_as_user`,
+  `spawn_process_with_pipes`, `make_env_block`, `read_handle_loop`,
+  `ConsoleMode`/`StdinMode`/`StderrMode`/`PipeSpawnHandles`). Wave 1 deferred it
+  for its `crate::desktop::LaunchDesktop` and `crate::logging` coupling; both are
+  now satisfied (see next). No `codex_protocol`, no `conpty`; vendored whole.
+- `desktop.rs`: `LaunchDesktop` window-station/desktop handling. Vendored whole,
+  including the `PrivateDesktop` private-desktop path, which stays DORMANT for
+  A: the capture path always calls `LaunchDesktop::prepare(false, ..)` (the
+  interactive desktop, no new isolation surface). The private-desktop hardening
+  is a genuine Step 5 (ConPTY) feature, vendored-but-unused, not a lying stub.
+
+`process.rs` calls `crate::logging::debug_log`; the Wave 1 `logging.rs` stand-in
+gained a matching `debug_log` (SBX_DEBUG-gated stderr, no CODEX_HOME file
+rotation), the same stand-in treatment `log_note` already had. `Cargo.toml`
+gains the `Win32_System_Console`, `Win32_System_StationsAndDesktops`, and
+`Win32_Graphics_Gdi` windows-sys features these two files need
+(`CreateDesktopW` requires `Win32_Graphics_Gdi` in windows-sys 0.52).
+
+### Local deviations from upstream (Integration A1 security must-fixes)
+
+These edit files vendored in Waves 1/2, so they are no longer byte-identical to
+upstream; the re-vendoring steps below note them. Each closes a specific W2
+review finding (PR #398/#399) or open risk #6/#8 item. `zeroize = "1"` is added
+to `Cargo.toml` for the password-scrubbing fixes.
+
+- `elevated/ipc_framed.rs::read_frame` (W2 finding 5): now rejects a frame whose
+  `version != IPC_PROTOCOL_VERSION` (fail closed, blueprint 3.3 "a mismatch must
+  fail closed, never fall back"), at the single read choke point. `MAX_FRAME_LEN`
+  is made `pub` so the parent-side pre-check below can reuse it. Test added.
+- `elevated/runner_client.rs::wait_for_complete_frame` (W2 finding 1): pre-checks
+  the peeked, attacker-influenceable declared frame length against
+  `MAX_FRAME_LEN` before waiting for the rest of the frame, so an over-large
+  length prefix fails closed immediately instead of spinning to the spawn-ready
+  timeout.
+- `elevated/runner_client.rs::spawn_runner_transport` (W2 finding 6): the
+  cleartext password wide buffer (`password_w`) is `zeroize`d immediately after
+  `CreateProcessWithLogonW` returns, so it does not linger in freed heap.
+- `identity.rs::SandboxCreds` (W2 findings 3/6): `Debug` is now hand-written to
+  redact the password (was a derive that would leak it via any `{:?}`), and the
+  cleartext password is zeroized on drop.
+- `sandbox_users.rs::ensure_local_user` (W2 finding 6): the password wide buffer
+  (`pwd_w`) is `zeroize`d after the `NetUserAdd`/`NetUserSetInfo` calls complete
+  (body wrapped in a closure so every return path scrubs it).
+- `cap.rs` (open risk #8, intra-process half): `load_or_create_cap_sids`,
+  `workspace_cap_sid_for_cwd`, and `writable_root_cap_sid_for_path` now hold a
+  process-wide `Mutex` across the file read-modify-write and re-read under the
+  lock, so two concurrent same-process callers cannot persist divergent SIDs or
+  return a SID that does not match disk. A concurrency regression test is added.
+  Cross-PROCESS serialization (the elevated setup binary racing the runner; a
+  named OS mutex like upstream `setup_main`'s `read_acl_mutex`) is still open and
+  belongs to the wired provisioning path (A2); open risk #8 stays open for that
+  half.
+- `absolute_path.rs` (W2 finding 4): the opaque `AbsolutePathBuf(PathBuf)`
+  stand-in is now a validating newtype. `new`/`Deserialize` reject any path that
+  is not an absolute Windows path or that contains a `..` traversal segment, so a
+  crafted `SpawnRequest.workspace_roots` frame carrying `C:\ws\..\..\Windows`
+  cannot reach the ACL grant path. The inner `PathBuf` is private, read via
+  `as_path()`. Tests added.
+
+### Still deferred after A1 (unchanged from Wave 2)
+
+`deny_read_resolver.rs` (still `codex_protocol`/`codex_utils_absolute_path`
+coupled AND still with no secret-path source to resolve, so `windows_resolve`'s
+deny-read set stays legitimately empty), `spawn_prep.rs`, `allow.rs`,
+`elevated_impl.rs` (capture), the full `identity.rs`/`setup.rs` provisioning
+orchestration, and the two binaries (`setup_main`, `command_runner`). These are
+the resolver-coupled port that consumes the thin Hive `windows_resolve`
+`ResolvedWindowsSandboxPermissions` (a real rewrite, not a mechanical retarget,
+against a resolver far thinner than upstream's) plus the launch wiring, and their
+confinement correctness is only validatable in the A2 `spike307-win` lab (D-004),
+so they are not hand-ported blind on inert code here. See open risk #6.
+
 ### Why not `codex-rs/windows-sandbox-rs` for the Windows backend (historical, #395 wave; superseded in part by Step 3 above)
 
 This section predates Step 3 and explains why the #395 wave (the base,
@@ -587,18 +672,19 @@ crate deliberately does not inherit the workspace's Apache-2.0
    only when a later wave lab-validates the isolation matrix on
    `spike307-win` (assertions L7 to L12 in the blueprint).
 
-   **Known issues, fix in Integration A (CodeRabbit/Greptile, PR #399; see
-   this file's Wave 2 "Local deviations" section above for the three that
-   were fixed instead):** (a) `helper_materialization.rs::legacy_lookup`'s
-   bare-executable-name fallback lets `CreateProcessWithLogonW` fall back to
-   executable search instead of failing closed; needs an absolute-path
-   guard once a real launch path calls it. (b) `elevated/ipc_framed.rs`'s
-   `read_frame` does not check `msg.version` against `IPC_PROTOCOL_VERSION`,
-   so a stale runner's older-versioned message would be accepted as current.
-   (c) `identity.rs::SandboxCreds` derives `Debug` over its cleartext
-   `password` field (latent only, no current `{:?}` call site); bundle a
-   redacting `Debug` impl with the zeroize-on-drop hardening this item
-   already tracks for the same struct.
+   **Known issues, fix in Integration A (CodeRabbit/Greptile, PR #399):**
+   (b) and (c) plus the wider security-review hardening were FIXED in
+   Integration A1 (see this file's "Integration A1" section: `read_frame`
+   version gate, `SandboxCreds` redacting `Debug` + zeroize-on-drop, password
+   buffer zeroize in `runner_client`/`sandbox_users`, `runner_client` frame
+   pre-check, `absolute_path` traversal guard, and the intra-process half of
+   the `cap.rs` open-risk-#8 lock). Still OPEN after A1:
+   (a) `helper_materialization.rs::legacy_lookup`'s bare-executable-name
+   fallback lets `CreateProcessWithLogonW` fall back to executable search
+   instead of failing closed; it needs an absolute-path guard, but only matters
+   once a real launch path calls it, so it is fixed with the A2 launch wiring
+   (its correctness depends on the resolved helper-materialization directory,
+   which the wired path establishes).
 7. **RESOLVED (#350).** The Linux `pre_exec` post-fork allocator-deadlock
    hazard below was fixed by #350 (merged), which moved `linux::launch`'s
    `pre_exec` closure to an allocation-free path so no thread can deadlock on
@@ -619,8 +705,19 @@ crate deliberately does not inherit the workspace's Apache-2.0
    this crate's own (multithreaded) test binary. Pre-existing at the time: no
    test before that pass ever exercised the real spawn path, so nothing
    surfaced it earlier.
-8. **Known upstream issue, deferred (`cap.rs`, CodeRabbit finding, PR #398):
-   the `cap_sid` file is an unsynchronized read-modify-write.**
+8. **PARTIALLY RESOLVED (Integration A1: intra-process lock landed). Original
+   issue (`cap.rs`, CodeRabbit finding, PR #398): the `cap_sid` file is an
+   unsynchronized read-modify-write.** Integration A1 added a process-wide
+   `Mutex` (`CAP_SID_LOCK`) that serializes the read-modify-write and re-reads
+   under the lock in `load_or_create_cap_sids`, `workspace_cap_sid_for_cwd`, and
+   `writable_root_cap_sid_for_path`, closing the intra-process race (a
+   concurrency regression test proves 8 concurrent first-touches share one SID
+   and persist exactly one entry). The CROSS-PROCESS race (the elevated setup
+   binary racing the runner against the same `codex_home`) is still open: it
+   needs a named OS mutex or `LockFileEx`, like upstream `setup_main`'s
+   `read_acl_mutex`, and a real concurrent-launch test on Windows to trust the
+   approach, so it is fixed together with the wave that wires the actual
+   `cap.rs` launch-path call sites (A2). Original detail retained below.
    `workspace_cap_sid_for_cwd` and `writable_root_cap_sid_for_path` both
    `load_or_create_cap_sids` (read + parse JSON), mutate the in-memory
    `CapSids`, then `persist_caps` (serialize + `fs::write`) the whole file
@@ -654,11 +751,17 @@ crate deliberately does not inherit the workspace's Apache-2.0
    sandbox_utils,env,path_normalization}.rs` verbatim into
    `codex-windows-sandbox/src/`. Re-diff `resolved_permissions.rs` against
    `hive-desktop-sandbox/src/windows_resolve.rs` by hand (it is a port, not a
-   verbatim copy) for any new upstream fields/accessors worth porting. If
-   `process.rs` or `deny_read_resolver.rs` are ever vendored/ported (see
-   "Deliberately NOT vendored this wave" above), re-check their dependency
-   graph against `desktop.rs`/`logging.rs`/`codex_protocol` again; upstream
-   may have changed the coupling.
+   verbatim copy) for any new upstream fields/accessors worth porting.
+   Also re-copy `codex-rs/windows-sandbox-rs/src/{process,desktop}.rs` verbatim
+   (Integration A1); they are byte-for-byte upstream. If `deny_read_resolver.rs`
+   is ever vendored/ported (see "Still deferred after A1" above), re-check its
+   dependency graph against `codex_protocol`/`codex_utils_absolute_path` again;
+   upstream may have changed the coupling. NOTE the Integration A1 security
+   deviations that make several Wave 1/2 files no longer byte-identical to
+   upstream (`elevated/ipc_framed.rs`, `elevated/runner_client.rs`,
+   `identity.rs`, `sandbox_users.rs`, `cap.rs`, `absolute_path.rs`); re-apply
+   them the same way as the other documented deviations, checking first whether
+   upstream fixed the same items.
 3a. Re-copy `codex-rs/windows-sandbox-rs/src/{elevated/ipc_framed,
    elevated/runner_pipe,elevated/runner_client,elevated/mod,
    helper_materialization,setup_error}.rs` verbatim into

--- a/apps/desktop-sandbox/VENDORING.md
+++ b/apps/desktop-sandbox/VENDORING.md
@@ -480,7 +480,43 @@ to `Cargo.toml` for the password-scrubbing fixes.
   is not an absolute Windows path or that contains a `..` traversal segment, so a
   crafted `SpawnRequest.workspace_roots` frame carrying `C:\ws\..\..\Windows`
   cannot reach the ACL grant path. The inner `PathBuf` is private, read via
-  `as_path()`. Tests added.
+  `as_path()`. Tests added. Hardened further in PR #400 below (embedded-NUL
+  rejection) since it is Hive-authored, not vendored.
+
+### Local deviations from upstream (Greptile findings, PR #400)
+
+Two more fixes on top of the byte-for-byte `process.rs` vendor copy (see
+"Integration A1" above), found by the automated Greptile review pass on PR
+#400. Same re-vendoring note as the other deviation sections: re-copying
+`process.rs` verbatim from upstream on a future pass should check whether
+upstream independently fixed the same bugs, and if not, re-apply these fixes.
+
+- `process.rs::make_env_block` (NUL-terminator bug): when `env` is empty, the
+  function returned a single NUL, but `CreateProcessAsUserW` requires the
+  environment block to end in two consecutive NULs (one ending the last
+  string, one ending the block). A one-NUL block is malformed; the API can
+  read past the end of the buffer looking for the second terminator. Fixed to
+  push an extra NUL when the block would otherwise be empty, so it always
+  ends in two. Two tests added (`make_env_block_empty_env_is_double_nul_terminated`,
+  `make_env_block_nonempty_env_ends_in_double_nul`).
+- `process.rs::create_process_as_user`'s no-explicit-stdio (`None`) branch
+  (unrestricted child handle inheritance): this branch called
+  `CreateProcessAsUserW` with `bInheritHandles = 1` via a plain `STARTUPINFOW`,
+  with no `PROC_THREAD_ATTRIBUTE_HANDLE_LIST` restricting which handles are
+  inherited, unlike the explicit-stdio (`Some(..)`) branch a few lines above it
+  in the same function, which already restricts inheritance to exactly the
+  stdio handles it hands the child via `ProcThreadAttributeList::set_handle_list`.
+  Without that restriction, any other inheritable handle open in the process at
+  spawn time (pipe, file, event, IPC handle unrelated to stdio) is also
+  silently inherited by the sandboxed child. Fixed by switching this branch to
+  `STARTUPINFOEXW` + `EXTENDED_STARTUPINFO_PRESENT` and restricting the handle
+  list to the three std handles `ensure_inheritable_stdio` already sets, the
+  same pattern the `Some(..)` branch uses. Verified against the actual
+  `codex-windows-sandbox` call graph: this `None` branch has no caller anywhere
+  in this repo yet (`spawn_process_with_pipes`, the only caller of
+  `create_process_as_user` in the vendored/authored tree, always passes
+  `Some(..)`), so this is a preventive fix on still-inert code, not a behavior
+  change to any live path.
 
 ### Still deferred after A1 (unchanged from Wave 2)
 
@@ -753,15 +789,18 @@ crate deliberately does not inherit the workspace's Apache-2.0
    `hive-desktop-sandbox/src/windows_resolve.rs` by hand (it is a port, not a
    verbatim copy) for any new upstream fields/accessors worth porting.
    Also re-copy `codex-rs/windows-sandbox-rs/src/{process,desktop}.rs` verbatim
-   (Integration A1); they are byte-for-byte upstream. If `deny_read_resolver.rs`
+   (Integration A1); `desktop.rs` is byte-for-byte upstream, `process.rs` is
+   NOT (see the PR #400 deviations below). If `deny_read_resolver.rs`
    is ever vendored/ported (see "Still deferred after A1" above), re-check its
    dependency graph against `codex_protocol`/`codex_utils_absolute_path` again;
    upstream may have changed the coupling. NOTE the Integration A1 security
    deviations that make several Wave 1/2 files no longer byte-identical to
    upstream (`elevated/ipc_framed.rs`, `elevated/runner_client.rs`,
-   `identity.rs`, `sandbox_users.rs`, `cap.rs`, `absolute_path.rs`); re-apply
-   them the same way as the other documented deviations, checking first whether
-   upstream fixed the same items.
+   `identity.rs`, `sandbox_users.rs`, `cap.rs`, `absolute_path.rs`), PLUS the
+   PR #400 `process.rs` deviations (`make_env_block`'s empty-environment
+   double-NUL terminator, `create_process_as_user`'s `None`-branch handle-list
+   restriction); re-apply them the same way as the other documented
+   deviations, checking first whether upstream fixed the same items.
 3a. Re-copy `codex-rs/windows-sandbox-rs/src/{elevated/ipc_framed,
    elevated/runner_pipe,elevated/runner_client,elevated/mod,
    helper_materialization,setup_error}.rs` verbatim into

--- a/apps/desktop-sandbox/codex-windows-sandbox/Cargo.toml
+++ b/apps/desktop-sandbox/codex-windows-sandbox/Cargo.toml
@@ -19,6 +19,9 @@ dunce = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 dirs-next = "2.0"
+# Zeroize cleartext sandbox-account logon-password buffers after use and on drop
+# (Integration A1 security hardening, W2 review findings 3/6; see VENDORING.md).
+zeroize = "1"
 # Real (not dev-only) dependency: helper_materialization.rs's
 # `copy_from_source_if_needed` uses `NamedTempFile` in production code, not
 # just tests (see that file for the write-into-temp-then-rename pattern).
@@ -42,10 +45,13 @@ features = [
     "Win32_Security_Authorization",
     "Win32_Security_Cryptography",
     "Win32_Storage_FileSystem",
+    "Win32_Graphics_Gdi",
+    "Win32_System_Console",
     "Win32_System_Diagnostics_Debug",
     "Win32_System_IO",
     "Win32_System_Pipes",
     "Win32_System_Registry",
+    "Win32_System_StationsAndDesktops",
     "Win32_System_Threading",
 ]
 

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/absolute_path.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/absolute_path.rs
@@ -14,10 +14,15 @@
 //! this type is now a validating newtype rather than an opaque wrapper. Every
 //! value, however constructed (including via `serde` from an inbound frame), is
 //! checked to be an absolute Windows path (drive-absolute `C:\...`/`C:/...` or
-//! UNC/device `\\...`) that contains no `..` traversal segment. A crafted frame
-//! carrying `C:\ws\..\..\Windows\System32` is therefore rejected at the
-//! deserialization boundary, before it can widen an ACL grant. The inner
-//! `PathBuf` is private; callers read it through [`AbsolutePathBuf::as_path`].
+//! UNC/device `\\...`) that contains no `..` traversal segment and no
+//! embedded NUL byte. A crafted frame carrying `C:\ws\..\..\Windows\System32`
+//! is therefore rejected at the deserialization boundary, before it can widen
+//! an ACL grant. The NUL check closes a truncation bypass: a Rust string may
+//! contain an embedded NUL that a later NUL-terminating Win32 call would not
+//! see, so a segment such as `..\0suffix` (not equal to `..`) could otherwise
+//! pass the traversal scan while resolving, downstream, to the shorter,
+//! traversal-containing string up to the NUL. The inner `PathBuf` is private;
+//! callers read it through [`AbsolutePathBuf::as_path`].
 
 use serde::Deserialize;
 use serde::Serialize;
@@ -31,6 +36,8 @@ pub enum AbsolutePathError {
     NotAbsolute(PathBuf),
     /// Path contains a `..` traversal segment.
     Traversal(PathBuf),
+    /// Path contains an embedded NUL byte.
+    ContainsNul(PathBuf),
 }
 
 impl std::fmt::Display for AbsolutePathError {
@@ -45,6 +52,9 @@ impl std::fmt::Display for AbsolutePathError {
                     "path contains a `..` traversal segment: {}",
                     path.display()
                 )
+            }
+            AbsolutePathError::ContainsNul(path) => {
+                write!(f, "path contains an embedded NUL byte: {}", path.display())
             }
         }
     }
@@ -62,6 +72,16 @@ impl AbsolutePathBuf {
     pub fn new(path: impl Into<PathBuf>) -> Result<Self, AbsolutePathError> {
         let path = path.into();
         let raw = path.to_string_lossy();
+        // Reject an embedded NUL byte before any other check. Rust strings
+        // (unlike C strings) do not stop at NUL, so a segment such as
+        // `..\0suffix` is not equal to `..` and would otherwise slip past the
+        // traversal-segment scan below. A later Win32 call that NUL-terminates
+        // the string (as a C API must) would see only the text up to the NUL,
+        // i.e. `..`, so it would resolve to the parent directory even though
+        // this validator saw the full, longer string and let it through.
+        if raw.contains('\0') {
+            return Err(AbsolutePathError::ContainsNul(path));
+        }
         if !is_windows_absolute(&raw) {
             return Err(AbsolutePathError::NotAbsolute(path));
         }
@@ -146,6 +166,17 @@ mod tests {
             AbsolutePathBuf::new(PathBuf::from("C:/ws/../secret")),
             Err(AbsolutePathError::Traversal(_))
         ));
+    }
+
+    #[test]
+    fn rejects_nul_truncation_traversal_bypass() {
+        // `..` followed by an embedded NUL is not the literal segment `..`,
+        // so it must be caught by an explicit NUL check, not the segment scan.
+        let raw = "C:\\allowed\\..\u{0}suffix";
+        assert_eq!(
+            AbsolutePathBuf::new(PathBuf::from(raw)),
+            Err(AbsolutePathError::ContainsNul(PathBuf::from(raw)))
+        );
     }
 
     #[test]

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/absolute_path.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/absolute_path.rs
@@ -1,20 +1,171 @@
-//! Minimal, Hive-authored stand-in for upstream `codex_utils_absolute_path::AbsolutePathBuf`.
+//! Hive-authored, traversal-guarded stand-in for upstream
+//! `codex_utils_absolute_path::AbsolutePathBuf`.
 //!
-//! NOT vendored from upstream. The real `codex-utils-absolute-path` crate is ~900 lines with
-//! `schemars`/`ts-rs` (TypeScript binding generation) dependencies, a thread-local base-path
-//! guard for deserialization, and home-directory expansion, none of which is load-bearing for
-//! this wave: `elevated/ipc_framed.rs`'s `SpawnRequest.workspace_roots: Vec<AbsolutePathBuf>`
-//! field is inert (nothing constructs a real value this wave; the one upstream test that did,
-//! `spawn_request_serializes_permission_profile`, is excluded, see that file's module doc).
-//! This stand-in exists only so the struct field type resolves and (de)serializes.
+//! NOT vendored from upstream. The real `codex-utils-absolute-path` crate is
+//! ~900 lines with `schemars`/`ts-rs` (TypeScript binding generation)
+//! dependencies, a thread-local base-path guard for deserialization, and
+//! home-directory expansion, none of which is load-bearing here. This
+//! stand-in exists so `elevated/ipc_framed.rs`'s
+//! `SpawnRequest.workspace_roots: Vec<AbsolutePathBuf>` field resolves and
+//! (de)serializes.
 //!
-//! Pulling in the real crate's `schemars`/`ts-rs` dependency chain for a single opaque,
-//! unexercised field would be scope creep for an explicitly inert vendor wave; revisit if a
-//! later wave actually constructs or inspects workspace roots through this type.
+//! Integration A1 hardening (W2 review finding 4): workspace roots ride into
+//! the elevated runner over IPC and are later handed to the ACL grant path, so
+//! this type is now a validating newtype rather than an opaque wrapper. Every
+//! value, however constructed (including via `serde` from an inbound frame), is
+//! checked to be an absolute Windows path (drive-absolute `C:\...`/`C:/...` or
+//! UNC/device `\\...`) that contains no `..` traversal segment. A crafted frame
+//! carrying `C:\ws\..\..\Windows\System32` is therefore rejected at the
+//! deserialization boundary, before it can widen an ACL grant. The inner
+//! `PathBuf` is private; callers read it through [`AbsolutePathBuf::as_path`].
 
 use serde::Deserialize;
 use serde::Serialize;
+use std::path::Path;
 use std::path::PathBuf;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// Rejected [`AbsolutePathBuf`] input.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AbsolutePathError {
+    /// Path is not an absolute Windows path (drive-absolute or UNC/device).
+    NotAbsolute(PathBuf),
+    /// Path contains a `..` traversal segment.
+    Traversal(PathBuf),
+}
+
+impl std::fmt::Display for AbsolutePathError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AbsolutePathError::NotAbsolute(path) => {
+                write!(f, "not an absolute Windows path: {}", path.display())
+            }
+            AbsolutePathError::Traversal(path) => {
+                write!(
+                    f,
+                    "path contains a `..` traversal segment: {}",
+                    path.display()
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for AbsolutePathError {}
+
+/// An absolute, traversal-free Windows path.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct AbsolutePathBuf(PathBuf);
+
+impl AbsolutePathBuf {
+    /// Validates `path` and wraps it, or rejects it. Enforced invariants:
+    /// the path is an absolute Windows path and contains no `..` segment.
+    pub fn new(path: impl Into<PathBuf>) -> Result<Self, AbsolutePathError> {
+        let path = path.into();
+        let raw = path.to_string_lossy();
+        if !is_windows_absolute(&raw) {
+            return Err(AbsolutePathError::NotAbsolute(path));
+        }
+        // String-based segment scan: `Path::components` uses HOST separator
+        // rules, so on this crate's Linux CI a Windows path's `\` segments are
+        // not split and a `..` would slip through. Split on both separators.
+        if raw.split(['/', '\\']).any(|seg| seg == "..") {
+            return Err(AbsolutePathError::Traversal(path));
+        }
+        Ok(Self(path))
+    }
+
+    /// Borrow the validated path.
+    pub fn as_path(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for AbsolutePathBuf {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // Validate at the trust boundary: an inbound IPC frame is untrusted.
+        let path = PathBuf::deserialize(deserializer)?;
+        AbsolutePathBuf::new(path).map_err(serde::de::Error::custom)
+    }
+}
+
+/// True for a drive-absolute (`C:\...`, `C:/...`) or UNC/device
+/// (`\\server\share`, `\\?\C:\...`) Windows path. Deliberately not
+/// `Path::is_absolute()`, which uses HOST conventions and would reject every
+/// Windows path on this crate's Linux CI. Same technique as
+/// `hive_desktop_sandbox::windows_resolve::is_windows_absolute`.
+fn is_windows_absolute(raw: &str) -> bool {
+    let bytes = raw.as_bytes();
+    let is_sep = |b: u8| b == b'\\' || b == b'/';
+    if bytes.len() >= 2 && is_sep(bytes[0]) && is_sep(bytes[1]) {
+        return true;
+    }
+    bytes.len() >= 3 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':' && is_sep(bytes[2])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_drive_absolute_path() {
+        let abs = AbsolutePathBuf::new(PathBuf::from(r"C:\workspace\project")).expect("valid");
+        assert_eq!(abs.as_path(), Path::new(r"C:\workspace\project"));
+    }
+
+    #[test]
+    fn accepts_unc_path() {
+        assert!(AbsolutePathBuf::new(PathBuf::from(r"\\server\share\work")).is_ok());
+    }
+
+    #[test]
+    fn rejects_relative_path() {
+        assert_eq!(
+            AbsolutePathBuf::new(PathBuf::from(r"workspace\project")),
+            Err(AbsolutePathError::NotAbsolute(PathBuf::from(
+                r"workspace\project"
+            )))
+        );
+    }
+
+    #[test]
+    fn rejects_backslash_traversal_segment() {
+        assert_eq!(
+            AbsolutePathBuf::new(PathBuf::from(r"C:\ws\..\..\Windows\System32")),
+            Err(AbsolutePathError::Traversal(PathBuf::from(
+                r"C:\ws\..\..\Windows\System32"
+            )))
+        );
+    }
+
+    #[test]
+    fn rejects_forward_slash_traversal_segment() {
+        assert!(matches!(
+            AbsolutePathBuf::new(PathBuf::from("C:/ws/../secret")),
+            Err(AbsolutePathError::Traversal(_))
+        ));
+    }
+
+    #[test]
+    fn deserialize_rejects_traversal_from_untrusted_frame() {
+        let err = serde_json::from_str::<AbsolutePathBuf>(r#""C:\\ws\\..\\etc""#)
+            .expect_err("a `..` path from an inbound frame must be rejected");
+        assert!(err.to_string().contains("traversal"), "unexpected: {err}");
+    }
+
+    #[test]
+    fn deserialize_accepts_valid_absolute_path() {
+        let abs = serde_json::from_str::<AbsolutePathBuf>(r#""C:\\workspace""#).expect("valid");
+        assert_eq!(abs.as_path(), Path::new(r"C:\workspace"));
+    }
+
+    #[test]
+    fn round_trips_through_serde() {
+        let abs = AbsolutePathBuf::new(PathBuf::from(r"C:\workspace")).expect("valid");
+        let json = serde_json::to_string(&abs).expect("serialize");
+        let back: AbsolutePathBuf = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(abs, back);
+    }
+}

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/cap.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/cap.rs
@@ -11,6 +11,21 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
+use std::sync::Mutex;
+
+/// Serializes the cap-SID file read-modify-write so two concurrent callers that
+/// both miss a per-cwd or per-write-root key cannot persist divergent SIDs and
+/// hand a caller a SID that does not match what landed on disk (Integration A1,
+/// VENDORING open risk 8). Each mutating accessor re-reads the file under this
+/// guard before inserting.
+///
+// ponytail: process-wide lock, coarse (serializes across every codex_home).
+// Fine for the desktop's single shared sandbox user (Q3). Cross-PROCESS races
+// (the elevated setup binary racing the runner) still need a named OS mutex,
+// like upstream setup_main's read_acl_mutex; that belongs to the wired
+// provisioning path and is deferred to A2. Per-codex_home locks if throughput
+// ever matters.
+static CAP_SID_LOCK: Mutex<()> = Mutex::new(());
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct CapSids {
@@ -55,9 +70,19 @@ fn persist_caps(path: &Path, caps: &CapSids) -> Result<()> {
 }
 
 pub fn load_or_create_cap_sids(codex_home: &Path) -> Result<CapSids> {
-    let path = cap_sid_file(codex_home);
+    let _guard = CAP_SID_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    load_or_create_cap_sids_locked(&cap_sid_file(codex_home))
+}
+
+/// Read-or-create the cap-SID file. Callers MUST hold [`CAP_SID_LOCK`]; the
+/// public [`load_or_create_cap_sids`] and the per-key accessors acquire it
+/// before calling here so the whole read-modify-write is atomic within the
+/// process.
+fn load_or_create_cap_sids_locked(path: &Path) -> Result<CapSids> {
     if path.exists() {
-        let txt = fs::read_to_string(&path)
+        let txt = fs::read_to_string(path)
             .with_context(|| format!("read cap sid file {}", path.display()))?;
         let t = txt.trim();
         if t.starts_with('{') && t.ends_with('}') {
@@ -71,7 +96,7 @@ pub fn load_or_create_cap_sids(codex_home: &Path) -> Result<CapSids> {
                 workspace_by_cwd: HashMap::new(),
                 writable_root_by_path: HashMap::new(),
             };
-            persist_caps(&path, &caps)?;
+            persist_caps(path, &caps)?;
             return Ok(caps);
         }
     }
@@ -81,14 +106,17 @@ pub fn load_or_create_cap_sids(codex_home: &Path) -> Result<CapSids> {
         workspace_by_cwd: HashMap::new(),
         writable_root_by_path: HashMap::new(),
     };
-    persist_caps(&path, &caps)?;
+    persist_caps(path, &caps)?;
     Ok(caps)
 }
 
 /// Returns the workspace-specific capability SID for `cwd`, creating and persisting it if missing.
 pub fn workspace_cap_sid_for_cwd(codex_home: &Path, cwd: &Path) -> Result<String> {
     let path = cap_sid_file(codex_home);
-    let mut caps = load_or_create_cap_sids(codex_home)?;
+    let _guard = CAP_SID_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let mut caps = load_or_create_cap_sids_locked(&path)?;
     let key = canonical_path_key(cwd);
     if let Some(sid) = caps.workspace_by_cwd.get(&key) {
         return Ok(sid.clone());
@@ -102,7 +130,10 @@ pub fn workspace_cap_sid_for_cwd(codex_home: &Path, cwd: &Path) -> Result<String
 /// Returns the capability SID for an additional writable root, creating and persisting it if missing.
 pub fn writable_root_cap_sid_for_path(codex_home: &Path, root: &Path) -> Result<String> {
     let path = cap_sid_file(codex_home);
-    let mut caps = load_or_create_cap_sids(codex_home)?;
+    let _guard = CAP_SID_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let mut caps = load_or_create_cap_sids_locked(&path)?;
     let key = canonical_path_key(root);
     if let Some(sid) = caps.writable_root_by_path.get(&key) {
         return Ok(sid.clone());
@@ -199,5 +230,41 @@ mod tests {
         let caps = load_or_create_cap_sids(&codex_home).expect("load caps");
         assert_eq!(caps.workspace_by_cwd.len(), 1);
         assert_eq!(caps.writable_root_by_path.len(), 1);
+    }
+
+    #[test]
+    fn concurrent_first_touch_of_same_cwd_yields_one_stable_sid() {
+        use std::sync::Arc;
+        use std::thread;
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let codex_home = Arc::new(temp.path().join("codex-home"));
+        std::fs::create_dir_all(codex_home.as_path()).expect("create codex home");
+        let cwd = Arc::new(temp.path().join("workspace"));
+        std::fs::create_dir_all(cwd.as_path()).expect("create workspace");
+
+        let handles: Vec<_> = (0..8)
+            .map(|_| {
+                let codex_home = Arc::clone(&codex_home);
+                let cwd = Arc::clone(&cwd);
+                thread::spawn(move || workspace_cap_sid_for_cwd(&codex_home, &cwd).expect("sid"))
+            })
+            .collect();
+        let sids: Vec<String> = handles
+            .into_iter()
+            .map(|handle| handle.join().expect("join"))
+            .collect();
+
+        let first = &sids[0];
+        assert!(
+            sids.iter().all(|sid| sid == first),
+            "all concurrent callers must observe the same workspace SID: {sids:?}"
+        );
+        let caps = load_or_create_cap_sids(&codex_home).expect("load caps");
+        assert_eq!(
+            caps.workspace_by_cwd.len(),
+            1,
+            "exactly one workspace SID must be persisted after a concurrent first touch"
+        );
     }
 }

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/desktop.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/desktop.rs
@@ -1,0 +1,196 @@
+use crate::logging;
+use crate::token::get_current_token_for_restriction;
+use crate::token::get_logon_sid_bytes;
+use crate::winutil::format_last_error;
+use crate::winutil::to_wide;
+use anyhow::Result;
+use rand::Rng;
+use rand::SeedableRng;
+use rand::rngs::SmallRng;
+use std::ffi::c_void;
+use std::path::Path;
+use std::ptr;
+use windows_sys::Win32::Foundation::CloseHandle;
+use windows_sys::Win32::Foundation::ERROR_SUCCESS;
+use windows_sys::Win32::Foundation::GetLastError;
+use windows_sys::Win32::Foundation::HLOCAL;
+use windows_sys::Win32::Foundation::LocalFree;
+use windows_sys::Win32::Security::Authorization::EXPLICIT_ACCESS_W;
+use windows_sys::Win32::Security::Authorization::GRANT_ACCESS;
+use windows_sys::Win32::Security::Authorization::SE_WINDOW_OBJECT;
+use windows_sys::Win32::Security::Authorization::SetEntriesInAclW;
+use windows_sys::Win32::Security::Authorization::SetSecurityInfo;
+use windows_sys::Win32::Security::Authorization::TRUSTEE_IS_SID;
+use windows_sys::Win32::Security::Authorization::TRUSTEE_IS_UNKNOWN;
+use windows_sys::Win32::Security::Authorization::TRUSTEE_W;
+use windows_sys::Win32::Security::DACL_SECURITY_INFORMATION;
+use windows_sys::Win32::System::StationsAndDesktops::CloseDesktop;
+use windows_sys::Win32::System::StationsAndDesktops::CreateDesktopW;
+use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_CREATEMENU;
+use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_CREATEWINDOW;
+use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_DELETE;
+use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_ENUMERATE;
+use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_HOOKCONTROL;
+use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_JOURNALPLAYBACK;
+use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_JOURNALRECORD;
+use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_READ_CONTROL;
+use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_READOBJECTS;
+use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_SWITCHDESKTOP;
+use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_WRITE_DAC;
+use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_WRITE_OWNER;
+use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_WRITEOBJECTS;
+
+const DESKTOP_ALL_ACCESS: u32 = DESKTOP_READOBJECTS
+    | DESKTOP_CREATEWINDOW
+    | DESKTOP_CREATEMENU
+    | DESKTOP_HOOKCONTROL
+    | DESKTOP_JOURNALRECORD
+    | DESKTOP_JOURNALPLAYBACK
+    | DESKTOP_ENUMERATE
+    | DESKTOP_WRITEOBJECTS
+    | DESKTOP_SWITCHDESKTOP
+    | DESKTOP_DELETE
+    | DESKTOP_READ_CONTROL
+    | DESKTOP_WRITE_DAC
+    | DESKTOP_WRITE_OWNER;
+
+pub struct LaunchDesktop {
+    _private_desktop: Option<PrivateDesktop>,
+    startup_name: Vec<u16>,
+}
+
+impl LaunchDesktop {
+    pub fn prepare(use_private_desktop: bool, logs_base_dir: Option<&Path>) -> Result<Self> {
+        if use_private_desktop {
+            let private_desktop = PrivateDesktop::create(logs_base_dir)?;
+            let startup_name = to_wide(format!("Winsta0\\{}", private_desktop.name));
+            Ok(Self {
+                _private_desktop: Some(private_desktop),
+                startup_name,
+            })
+        } else {
+            Ok(Self {
+                _private_desktop: None,
+                startup_name: to_wide("Winsta0\\Default"),
+            })
+        }
+    }
+
+    pub fn startup_info_desktop(&self) -> *mut u16 {
+        self.startup_name.as_ptr() as *mut u16
+    }
+}
+
+struct PrivateDesktop {
+    handle: isize,
+    name: String,
+}
+
+impl PrivateDesktop {
+    fn create(logs_base_dir: Option<&Path>) -> Result<Self> {
+        let mut rng = SmallRng::from_entropy();
+        let name = format!("CodexSandboxDesktop-{:x}", rng.r#gen::<u128>());
+        let name_wide = to_wide(&name);
+        let handle = unsafe {
+            CreateDesktopW(
+                name_wide.as_ptr(),
+                ptr::null(),
+                ptr::null_mut(),
+                0,
+                DESKTOP_ALL_ACCESS,
+                ptr::null_mut(),
+            )
+        };
+        if handle == 0 {
+            let err = unsafe { GetLastError() } as i32;
+            logging::debug_log(
+                &format!(
+                    "CreateDesktopW failed for {name}: {} ({})",
+                    err,
+                    format_last_error(err),
+                ),
+                logs_base_dir,
+            );
+            return Err(anyhow::anyhow!("CreateDesktopW failed: {err}"));
+        }
+
+        unsafe {
+            if let Err(err) = grant_desktop_access(handle, logs_base_dir) {
+                let _ = CloseDesktop(handle);
+                return Err(err);
+            }
+        }
+
+        Ok(Self { handle, name })
+    }
+}
+
+unsafe fn grant_desktop_access(handle: isize, logs_base_dir: Option<&Path>) -> Result<()> {
+    let token = get_current_token_for_restriction()?;
+    let mut logon_sid = get_logon_sid_bytes(token)?;
+    CloseHandle(token);
+
+    let entries = [EXPLICIT_ACCESS_W {
+        grfAccessPermissions: DESKTOP_ALL_ACCESS,
+        grfAccessMode: GRANT_ACCESS,
+        grfInheritance: 0,
+        Trustee: TRUSTEE_W {
+            pMultipleTrustee: ptr::null_mut(),
+            MultipleTrusteeOperation: 0,
+            TrusteeForm: TRUSTEE_IS_SID,
+            TrusteeType: TRUSTEE_IS_UNKNOWN,
+            ptstrName: logon_sid.as_mut_ptr() as *mut c_void as *mut u16,
+        },
+    }];
+
+    let mut updated_dacl = ptr::null_mut();
+    let set_entries_code = SetEntriesInAclW(
+        entries.len() as u32,
+        entries.as_ptr(),
+        ptr::null_mut(),
+        &mut updated_dacl,
+    );
+    if set_entries_code != ERROR_SUCCESS {
+        logging::debug_log(
+            &format!("SetEntriesInAclW failed for private desktop: {set_entries_code}"),
+            logs_base_dir,
+        );
+        return Err(anyhow::anyhow!(
+            "SetEntriesInAclW failed for private desktop: {set_entries_code}"
+        ));
+    }
+
+    let set_security_code = SetSecurityInfo(
+        handle,
+        SE_WINDOW_OBJECT,
+        DACL_SECURITY_INFORMATION,
+        ptr::null_mut(),
+        ptr::null_mut(),
+        updated_dacl,
+        ptr::null_mut(),
+    );
+    if !updated_dacl.is_null() {
+        LocalFree(updated_dacl as HLOCAL);
+    }
+    if set_security_code != ERROR_SUCCESS {
+        logging::debug_log(
+            &format!("SetSecurityInfo failed for private desktop: {set_security_code}"),
+            logs_base_dir,
+        );
+        return Err(anyhow::anyhow!(
+            "SetSecurityInfo failed for private desktop: {set_security_code}"
+        ));
+    }
+
+    Ok(())
+}
+
+impl Drop for PrivateDesktop {
+    fn drop(&mut self) {
+        unsafe {
+            if self.handle != 0 {
+                let _ = CloseDesktop(self.handle);
+            }
+        }
+    }
+}

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/elevated/ipc_framed.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/elevated/ipc_framed.rs
@@ -34,8 +34,11 @@ use std::path::PathBuf;
 /// Safety cap for a single framed message payload.
 ///
 /// This is not a protocol requirement; it simply bounds memory use and rejects
-/// obviously invalid frames.
-const MAX_FRAME_LEN: usize = 8 * 1024 * 1024;
+/// obviously invalid frames. Exposed (Integration A1) so the parent-side
+/// `runner_client::wait_for_complete_frame` can reject an over-large declared
+/// length as soon as it peeks the length prefix, instead of spinning until the
+/// spawn-ready timeout on an attacker-controlled length (W2 review finding 1).
+pub const MAX_FRAME_LEN: usize = 8 * 1024 * 1024;
 
 /// Protocol version shared by the parent process and elevated command runner.
 pub const IPC_PROTOCOL_VERSION: u8 = 4;
@@ -185,6 +188,18 @@ pub fn read_frame<R: Read>(mut reader: R) -> Result<Option<FramedMessage>> {
     let mut payload = vec![0u8; len];
     reader.read_exact(&mut payload)?;
     let msg: FramedMessage = serde_json::from_slice(&payload)?;
+    // Fail closed on a protocol-version mismatch (Integration A1, W2 review
+    // finding 5; blueprint section 3.3: "a mismatch must fail closed, never
+    // fall back"). Every legitimate frame carries `IPC_PROTOCOL_VERSION`
+    // (see `write_frame`'s callers), so rejecting here at the single read
+    // choke point rejects any peer speaking a different framing contract
+    // before its `message` is ever acted on.
+    if msg.version != IPC_PROTOCOL_VERSION {
+        anyhow::bail!(
+            "unsupported IPC protocol version {} (expected {IPC_PROTOCOL_VERSION})",
+            msg.version
+        );
+    }
     Ok(Some(msg))
 }
 
@@ -252,6 +267,28 @@ mod tests {
                 }
             }),
             encoded
+        );
+    }
+
+    #[test]
+    fn read_frame_rejects_protocol_version_mismatch() {
+        // A well-formed frame that merely carries the wrong version must be
+        // rejected, not acted on (fail closed, W2 finding 5). `write_frame`
+        // does not enforce the version, so this simulates a peer speaking a
+        // different framing contract.
+        let msg = FramedMessage {
+            version: IPC_PROTOCOL_VERSION.wrapping_add(1),
+            message: Message::Terminate {
+                payload: EmptyPayload {},
+            },
+        };
+        let mut buf = Vec::new();
+        write_frame(&mut buf, &msg).expect("write");
+
+        let err = read_frame(buf.as_slice()).expect_err("version mismatch must be rejected");
+        assert!(
+            err.to_string().contains("unsupported IPC protocol version"),
+            "unexpected error: {err}"
         );
     }
 }

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/elevated/runner_client.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/elevated/runner_client.rs
@@ -3,6 +3,7 @@ use crate::ipc_framed::ErrorPayload;
 use crate::ipc_framed::ErrorStage;
 use crate::ipc_framed::FramedMessage;
 use crate::ipc_framed::IPC_PROTOCOL_VERSION;
+use crate::ipc_framed::MAX_FRAME_LEN;
 use crate::ipc_framed::Message;
 use crate::ipc_framed::SpawnRequest;
 use crate::ipc_framed::read_frame;
@@ -46,6 +47,7 @@ use windows_sys::Win32::System::Threading::PROCESS_INFORMATION;
 use windows_sys::Win32::System::Threading::STARTUPINFOW;
 use windows_sys::Win32::System::Threading::TerminateProcess;
 use windows_sys::Win32::System::Threading::WaitForSingleObject;
+use zeroize::Zeroize;
 
 const RUNNER_SPAWN_READY_TIMEOUT: Duration = Duration::from_secs(15);
 const RUNNER_PIPE_CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
@@ -348,7 +350,11 @@ pub fn spawn_runner_transport(
     let cwd_w = to_wide(cwd);
     let user_w = to_wide(&sandbox_creds.username);
     let domain_w = to_wide(".");
-    let password_w = to_wide(&sandbox_creds.password);
+    // Cleartext logon password materialized as a wide buffer for
+    // CreateProcessWithLogonW. Zeroized immediately after the call returns
+    // (below) so it does not linger in freed heap (Integration A1, W2 review
+    // finding 6). `SandboxCreds::password` itself is zeroize-on-drop (identity.rs).
+    let mut password_w = to_wide(&sandbox_creds.password);
     let mut si: STARTUPINFOW = unsafe { std::mem::zeroed() };
     si.cb = std::mem::size_of::<STARTUPINFOW>() as u32;
     let mut pi: PROCESS_INFORMATION = unsafe { std::mem::zeroed() };
@@ -377,6 +383,9 @@ pub fn spawn_runner_transport(
     unsafe {
         SetErrorMode(previous_error_mode);
     }
+    // The password wide buffer is no longer needed once CreateProcessWithLogonW
+    // has returned; scrub it before it is freed (W2 review finding 6).
+    password_w.zeroize();
     if spawn_res == 0 {
         let err = unsafe { GetLastError() };
         unsafe {
@@ -478,6 +487,17 @@ fn wait_for_complete_frame(pipe_read: &File, timeout: Duration) -> Result<()> {
 
         if bytes_read == len_buf.len() as u32 {
             let frame_len = u32::from_le_bytes(len_buf) as usize;
+            // Pre-check the peeked, attacker-influenceable declared length
+            // against the same cap `read_frame` enforces, BEFORE waiting for
+            // the rest of the frame to arrive (W2 review finding 1). Without
+            // this, an oversized length prefix makes this loop spin until the
+            // spawn-ready timeout waiting for bytes that will never come;
+            // rejecting it here fails closed immediately.
+            if frame_len > MAX_FRAME_LEN {
+                return Err(anyhow::anyhow!(
+                    "runner frame length {frame_len} exceeds maximum {MAX_FRAME_LEN}"
+                ));
+            }
             let total_len = frame_len
                 .checked_add(len_buf.len())
                 .ok_or_else(|| anyhow::anyhow!("runner frame length overflow"))?;

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/identity.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/identity.rs
@@ -11,9 +11,32 @@
 //! `SandboxCreds` itself is copied byte-for-byte from upstream; only the surrounding file
 //! (credential loading, DPAPI unseal, setup-marker readiness checks) is trimmed away.
 
+use zeroize::Zeroize;
+
 /// Decoded sandbox-account logon credentials (username + cleartext password).
-#[derive(Debug, Clone)]
+///
+/// Integration A1 hardening (W2 review findings 3/6): `Debug` is hand-written
+/// to redact the password so it never lands in a log line or panic message,
+/// and the cleartext password is zeroized on drop so it does not linger in
+/// freed heap. `Clone` is retained (the retry path clones creds); each clone
+/// zeroizes its own copy on drop.
+#[derive(Clone)]
 pub struct SandboxCreds {
     pub username: String,
     pub password: String,
+}
+
+impl std::fmt::Debug for SandboxCreds {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SandboxCreds")
+            .field("username", &self.username)
+            .field("password", &"<redacted>")
+            .finish()
+    }
+}
+
+impl Drop for SandboxCreds {
+    fn drop(&mut self) {
+        self.password.zeroize();
+    }
 }

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/lib.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/lib.rs
@@ -25,11 +25,14 @@
 //! `openai/codex`'s `codex-rs/windows-sandbox-rs` crate (Apache-2.0). See
 //! `../VENDORING.md` for the pinned commit, the full file-by-file provenance,
 //! and the modules deliberately NOT vendored (`deny_read_resolver.rs`'s
-//! glob-scan resolver, `process.rs`'s `CreateProcessAsUserW` wrapper,
-//! `spawn_prep.rs`, `wrapper.rs`, `elevated_impl.rs`, the full `identity.rs`
-//! and `setup.rs`, and the `setup_main`/`command_runner` binaries) and why.
+//! glob-scan resolver, `spawn_prep.rs`, `allow.rs`, `wrapper.rs`,
+//! `elevated_impl.rs`, the full `identity.rs` and `setup.rs`, and the
+//! `setup_main`/`command_runner` binaries) and why. Integration A1 added the
+//! `process.rs` (`CreateProcessAsUserW`) and `desktop.rs` capture-path
+//! primitives that Wave 1 had deferred, and applied the W2 review security
+//! must-fixes (see `../VENDORING.md`'s "Integration A1" section).
 //!
-//! This crate is inert (Step 3 Waves 1-2 of `plan-codex-crossplatform-desktop.md`):
+//! This crate is inert (Step 3 Waves 1-2 + Integration A1 of `plan-codex-crossplatform-desktop.md`):
 //! nothing here is called from `hive-desktop-sandbox`'s `launch` path yet. It
 //! exists so the vendored primitives and elevated-helper IPC mechanism are
 //! vendored, compiled, and unit-tested on their own, ahead of the
@@ -54,6 +57,8 @@ pub mod deny_read_acl;
 #[cfg(windows)]
 pub mod deny_read_state;
 #[cfg(windows)]
+pub mod desktop;
+#[cfg(windows)]
 pub mod dpapi;
 #[cfg(windows)]
 pub mod env;
@@ -67,6 +72,8 @@ pub mod identity;
 pub mod path_normalization;
 #[cfg(windows)]
 pub mod proc_thread_attr;
+#[cfg(windows)]
+pub mod process;
 #[cfg(windows)]
 pub mod sandbox_users;
 #[cfg(windows)]

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/logging.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/logging.rs
@@ -21,3 +21,15 @@ use std::path::Path;
 pub fn log_note(msg: &str, _base_dir: Option<&Path>) {
     eprintln!("[codex-windows-sandbox] {msg}");
 }
+
+/// Stand-in for upstream `logging::debug_log`. Consumed by the verbatim-vendored
+/// `process.rs` and `desktop.rs` (Integration A1). Upstream gates the file write
+/// on the `SBX_DEBUG=1` env var and also mirrors to stderr; this stand-in keeps
+/// the same gate and stderr mirror but performs no CODEX_HOME file rotation
+/// (matching `log_note` above). `base_dir` is accepted for signature parity but
+/// unused. See `../VENDORING.md`.
+pub fn debug_log(msg: &str, _base_dir: Option<&Path>) {
+    if std::env::var("SBX_DEBUG").ok().as_deref() == Some("1") {
+        eprintln!("[codex-windows-sandbox] DEBUG: {msg}");
+    }
+}

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/process.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/process.rs
@@ -1,0 +1,373 @@
+use crate::desktop::LaunchDesktop;
+use crate::logging;
+use crate::proc_thread_attr::ProcThreadAttributeList;
+use crate::winutil::argv_to_command_line;
+use crate::winutil::format_last_error;
+use crate::winutil::to_wide;
+use anyhow::Context;
+use anyhow::Result;
+use anyhow::anyhow;
+use std::collections::HashMap;
+use std::ffi::c_void;
+use std::path::Path;
+use std::ptr;
+use windows_sys::Win32::Foundation::CloseHandle;
+use windows_sys::Win32::Foundation::GetLastError;
+use windows_sys::Win32::Foundation::HANDLE;
+use windows_sys::Win32::Foundation::HANDLE_FLAG_INHERIT;
+use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
+use windows_sys::Win32::Foundation::SetHandleInformation;
+use windows_sys::Win32::Storage::FileSystem::ReadFile;
+use windows_sys::Win32::System::Console::GetStdHandle;
+use windows_sys::Win32::System::Console::STD_ERROR_HANDLE;
+use windows_sys::Win32::System::Console::STD_INPUT_HANDLE;
+use windows_sys::Win32::System::Console::STD_OUTPUT_HANDLE;
+use windows_sys::Win32::System::Pipes::CreatePipe;
+use windows_sys::Win32::System::Threading::CREATE_NO_WINDOW;
+use windows_sys::Win32::System::Threading::CREATE_UNICODE_ENVIRONMENT;
+use windows_sys::Win32::System::Threading::CreateProcessAsUserW;
+use windows_sys::Win32::System::Threading::EXTENDED_STARTUPINFO_PRESENT;
+use windows_sys::Win32::System::Threading::PROCESS_INFORMATION;
+use windows_sys::Win32::System::Threading::STARTF_USESTDHANDLES;
+use windows_sys::Win32::System::Threading::STARTUPINFOEXW;
+use windows_sys::Win32::System::Threading::STARTUPINFOW;
+
+pub struct CreatedProcess {
+    pub process_info: PROCESS_INFORMATION,
+    pub startup_info: STARTUPINFOW,
+    _desktop: LaunchDesktop,
+}
+
+/// Controls console creation for pipe-backed child processes.
+pub enum ConsoleMode {
+    Inherit,
+    NoWindow,
+}
+
+pub fn make_env_block(env: &HashMap<String, String>) -> Vec<u16> {
+    let mut items: Vec<(String, String)> =
+        env.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+    items.sort_by(|a, b| {
+        a.0.to_uppercase()
+            .cmp(&b.0.to_uppercase())
+            .then(a.0.cmp(&b.0))
+    });
+    let mut w: Vec<u16> = Vec::new();
+    for (k, v) in items {
+        let mut s = to_wide(format!("{k}={v}"));
+        s.pop();
+        w.extend_from_slice(&s);
+        w.push(0);
+    }
+    w.push(0);
+    w
+}
+
+unsafe fn ensure_inheritable_stdio(si: &mut STARTUPINFOW) -> Result<()> {
+    for kind in [STD_INPUT_HANDLE, STD_OUTPUT_HANDLE, STD_ERROR_HANDLE] {
+        let h = GetStdHandle(kind);
+        if h == 0 || h == INVALID_HANDLE_VALUE {
+            return Err(anyhow!("GetStdHandle failed: {}", GetLastError()));
+        }
+        if SetHandleInformation(h, HANDLE_FLAG_INHERIT, HANDLE_FLAG_INHERIT) == 0 {
+            return Err(anyhow!("SetHandleInformation failed: {}", GetLastError()));
+        }
+    }
+    si.dwFlags |= STARTF_USESTDHANDLES;
+    si.hStdInput = GetStdHandle(STD_INPUT_HANDLE);
+    si.hStdOutput = GetStdHandle(STD_OUTPUT_HANDLE);
+    si.hStdError = GetStdHandle(STD_ERROR_HANDLE);
+    Ok(())
+}
+
+/// # Safety
+/// Caller must provide a valid primary token handle (`h_token`) with appropriate access,
+/// and the `argv`, `cwd`, and `env_map` must remain valid for the duration of the call.
+// Low-level CreateProcessAsUserW wrapper mirrors the Windows API shape.
+#[allow(clippy::too_many_arguments)]
+pub unsafe fn create_process_as_user(
+    h_token: HANDLE,
+    argv: &[String],
+    cwd: &Path,
+    env_map: &HashMap<String, String>,
+    logs_base_dir: Option<&Path>,
+    stdio: Option<(HANDLE, HANDLE, HANDLE)>,
+    console_mode: ConsoleMode,
+    use_private_desktop: bool,
+) -> Result<CreatedProcess> {
+    let cmdline_str = argv_to_command_line(argv);
+    let mut cmdline: Vec<u16> = to_wide(&cmdline_str);
+    let env_block = make_env_block(env_map);
+    let desktop = LaunchDesktop::prepare(use_private_desktop, logs_base_dir)?;
+    let mut pi: PROCESS_INFORMATION = std::mem::zeroed();
+    let cwd_wide = to_wide(cwd);
+    let env_block_len = env_block.len();
+    match stdio {
+        Some((stdin_h, stdout_h, stderr_h)) => {
+            let mut si: STARTUPINFOEXW = std::mem::zeroed();
+            si.StartupInfo.cb = std::mem::size_of::<STARTUPINFOEXW>() as u32;
+            // Some processes (e.g., PowerShell) can fail with STATUS_DLL_INIT_FAILED
+            // if lpDesktop is not set when launching with a restricted token.
+            // Point explicitly at the interactive desktop or a private desktop.
+            si.StartupInfo.lpDesktop = desktop.startup_info_desktop();
+            si.StartupInfo.dwFlags |= STARTF_USESTDHANDLES;
+            si.StartupInfo.hStdInput = stdin_h;
+            si.StartupInfo.hStdOutput = stdout_h;
+            si.StartupInfo.hStdError = stderr_h;
+            let mut inherited_handles = vec![stdin_h, stdout_h];
+            if !inherited_handles.contains(&stderr_h) {
+                inherited_handles.push(stderr_h);
+            }
+            for &handle in &inherited_handles {
+                if SetHandleInformation(handle, HANDLE_FLAG_INHERIT, HANDLE_FLAG_INHERIT) == 0 {
+                    return Err(anyhow!(
+                        "SetHandleInformation failed for stdio handle: {}",
+                        GetLastError()
+                    ));
+                }
+            }
+            let mut attrs = ProcThreadAttributeList::new(/*attr_count*/ 1)?;
+            attrs.set_handle_list(inherited_handles)?;
+            si.lpAttributeList = attrs.as_mut_ptr();
+
+            let creation_flags = CREATE_UNICODE_ENVIRONMENT
+                | EXTENDED_STARTUPINFO_PRESENT
+                | match console_mode {
+                    ConsoleMode::Inherit => 0,
+                    ConsoleMode::NoWindow => CREATE_NO_WINDOW,
+                };
+            let ok = CreateProcessAsUserW(
+                h_token,
+                std::ptr::null(),
+                cmdline.as_mut_ptr(),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                1,
+                creation_flags,
+                env_block.as_ptr() as *mut c_void,
+                cwd_wide.as_ptr(),
+                &si.StartupInfo,
+                &mut pi,
+            );
+            if ok == 0 {
+                let err = GetLastError() as i32;
+                let msg = format!(
+                    "CreateProcessAsUserW failed: {} ({}) | cwd={} | cmd={} | env_u16_len={} | si_flags={} | creation_flags={}",
+                    err,
+                    format_last_error(err),
+                    cwd.display(),
+                    cmdline_str,
+                    env_block_len,
+                    si.StartupInfo.dwFlags,
+                    creation_flags,
+                );
+                logging::debug_log(&msg, logs_base_dir);
+                return Err(std::io::Error::from_raw_os_error(err)).context(msg);
+            }
+            Ok(CreatedProcess {
+                process_info: pi,
+                startup_info: si.StartupInfo,
+                _desktop: desktop,
+            })
+        }
+        None => {
+            let mut si: STARTUPINFOW = std::mem::zeroed();
+            si.cb = std::mem::size_of::<STARTUPINFOW>() as u32;
+            si.lpDesktop = desktop.startup_info_desktop();
+            ensure_inheritable_stdio(&mut si)?;
+
+            let creation_flags = CREATE_UNICODE_ENVIRONMENT;
+            let ok = CreateProcessAsUserW(
+                h_token,
+                std::ptr::null(),
+                cmdline.as_mut_ptr(),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                1,
+                creation_flags,
+                env_block.as_ptr() as *mut c_void,
+                cwd_wide.as_ptr(),
+                &si,
+                &mut pi,
+            );
+            if ok == 0 {
+                let err = GetLastError() as i32;
+                let msg = format!(
+                    "CreateProcessAsUserW failed: {} ({}) | cwd={} | cmd={} | env_u16_len={} | si_flags={} | creation_flags={}",
+                    err,
+                    format_last_error(err),
+                    cwd.display(),
+                    cmdline_str,
+                    env_block_len,
+                    si.dwFlags,
+                    creation_flags,
+                );
+                logging::debug_log(&msg, logs_base_dir);
+                return Err(std::io::Error::from_raw_os_error(err)).context(msg);
+            }
+            Ok(CreatedProcess {
+                process_info: pi,
+                startup_info: si,
+                _desktop: desktop,
+            })
+        }
+    }
+}
+
+/// Controls whether the child's stdin handle is kept open for writing.
+#[allow(dead_code)]
+pub enum StdinMode {
+    Closed,
+    Open,
+}
+
+/// Controls how stderr is wired for a pipe-spawned process.
+#[allow(dead_code)]
+pub enum StderrMode {
+    MergeStdout,
+    Separate,
+}
+
+/// Handles returned by `spawn_process_with_pipes`.
+#[allow(dead_code)]
+pub struct PipeSpawnHandles {
+    pub process: PROCESS_INFORMATION,
+    pub stdin_write: Option<HANDLE>,
+    pub stdout_read: HANDLE,
+    pub stderr_read: Option<HANDLE>,
+    pub(crate) desktop: LaunchDesktop,
+}
+
+/// Spawns a process with anonymous pipes and returns the relevant handles.
+#[allow(clippy::too_many_arguments)]
+pub fn spawn_process_with_pipes(
+    h_token: HANDLE,
+    argv: &[String],
+    cwd: &Path,
+    env_map: &HashMap<String, String>,
+    stdin_mode: StdinMode,
+    stderr_mode: StderrMode,
+    console_mode: ConsoleMode,
+    use_private_desktop: bool,
+    logs_base_dir: Option<&Path>,
+) -> Result<PipeSpawnHandles> {
+    let mut in_r: HANDLE = 0;
+    let mut in_w: HANDLE = 0;
+    let mut out_r: HANDLE = 0;
+    let mut out_w: HANDLE = 0;
+    let mut err_r: HANDLE = 0;
+    let mut err_w: HANDLE = 0;
+    unsafe {
+        if CreatePipe(&mut in_r, &mut in_w, ptr::null_mut(), 0) == 0 {
+            return Err(anyhow!("CreatePipe stdin failed: {}", GetLastError()));
+        }
+        if CreatePipe(&mut out_r, &mut out_w, ptr::null_mut(), 0) == 0 {
+            CloseHandle(in_r);
+            CloseHandle(in_w);
+            return Err(anyhow!("CreatePipe stdout failed: {}", GetLastError()));
+        }
+        if matches!(stderr_mode, StderrMode::Separate)
+            && CreatePipe(&mut err_r, &mut err_w, ptr::null_mut(), 0) == 0
+        {
+            CloseHandle(in_r);
+            CloseHandle(in_w);
+            CloseHandle(out_r);
+            CloseHandle(out_w);
+            return Err(anyhow!("CreatePipe stderr failed: {}", GetLastError()));
+        }
+    }
+
+    let stderr_handle = match stderr_mode {
+        StderrMode::MergeStdout => out_w,
+        StderrMode::Separate => err_w,
+    };
+
+    let stdio = Some((in_r, out_w, stderr_handle));
+    let spawn_result = unsafe {
+        create_process_as_user(
+            h_token,
+            argv,
+            cwd,
+            env_map,
+            logs_base_dir,
+            stdio,
+            console_mode,
+            use_private_desktop,
+        )
+    };
+    let created = match spawn_result {
+        Ok(v) => v,
+        Err(err) => {
+            unsafe {
+                CloseHandle(in_r);
+                CloseHandle(in_w);
+                CloseHandle(out_r);
+                CloseHandle(out_w);
+                if matches!(stderr_mode, StderrMode::Separate) {
+                    CloseHandle(err_r);
+                    CloseHandle(err_w);
+                }
+            }
+            return Err(err);
+        }
+    };
+    let CreatedProcess {
+        process_info: pi,
+        _desktop: desktop,
+        ..
+    } = created;
+
+    unsafe {
+        CloseHandle(in_r);
+        CloseHandle(out_w);
+        if matches!(stderr_mode, StderrMode::Separate) {
+            CloseHandle(err_w);
+        }
+        if matches!(stdin_mode, StdinMode::Closed) {
+            CloseHandle(in_w);
+        }
+    }
+
+    Ok(PipeSpawnHandles {
+        process: pi,
+        stdin_write: match stdin_mode {
+            StdinMode::Open => Some(in_w),
+            StdinMode::Closed => None,
+        },
+        stdout_read: out_r,
+        stderr_read: match stderr_mode {
+            StderrMode::Separate => Some(err_r),
+            StderrMode::MergeStdout => None,
+        },
+        desktop,
+    })
+}
+
+/// Reads a HANDLE until EOF and invokes `on_chunk` for each read.
+pub fn read_handle_loop<F>(handle: HANDLE, mut on_chunk: F) -> std::thread::JoinHandle<()>
+where
+    F: FnMut(&[u8]) + Send + 'static,
+{
+    std::thread::spawn(move || {
+        let mut buf = [0u8; 8192];
+        loop {
+            let mut read_bytes: u32 = 0;
+            let ok = unsafe {
+                ReadFile(
+                    handle,
+                    buf.as_mut_ptr(),
+                    buf.len() as u32,
+                    &mut read_bytes,
+                    ptr::null_mut(),
+                )
+            };
+            if ok == 0 || read_bytes == 0 {
+                break;
+            }
+            on_chunk(&buf[..read_bytes as usize]);
+        }
+        unsafe {
+            CloseHandle(handle);
+        }
+    })
+}

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/process.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/process.rs
@@ -59,6 +59,14 @@ pub fn make_env_block(env: &HashMap<String, String>) -> Vec<u16> {
         w.extend_from_slice(&s);
         w.push(0);
     }
+    // `CreateProcessAsUserW` requires the environment block to end in two
+    // consecutive NULs (one ending the last string, one ending the block).
+    // When `env` is empty the loop above never runs, so `w` is still empty;
+    // pushing only the single block-terminator NUL below would leave a
+    // one-NUL block instead of the required two.
+    if w.is_empty() {
+        w.push(0);
+    }
     w.push(0);
     w
 }
@@ -171,12 +179,30 @@ pub unsafe fn create_process_as_user(
             })
         }
         None => {
-            let mut si: STARTUPINFOW = std::mem::zeroed();
-            si.cb = std::mem::size_of::<STARTUPINFOW>() as u32;
-            si.lpDesktop = desktop.startup_info_desktop();
-            ensure_inheritable_stdio(&mut si)?;
+            let mut si: STARTUPINFOEXW = std::mem::zeroed();
+            si.StartupInfo.cb = std::mem::size_of::<STARTUPINFOEXW>() as u32;
+            si.StartupInfo.lpDesktop = desktop.startup_info_desktop();
+            ensure_inheritable_stdio(&mut si.StartupInfo)?;
 
-            let creation_flags = CREATE_UNICODE_ENVIRONMENT;
+            // `bInheritHandles` below must be paired with an explicit handle
+            // list (`PROC_THREAD_ATTRIBUTE_HANDLE_LIST`), same as the
+            // explicit-stdio branch above. Without it, every OTHER
+            // inheritable handle open in this process (pipes, files, events,
+            // IPC handles unrelated to stdio) is also inherited by the
+            // sandboxed child, not only the three std handles this function
+            // intends to hand it.
+            let stdin_h = si.StartupInfo.hStdInput;
+            let stdout_h = si.StartupInfo.hStdOutput;
+            let stderr_h = si.StartupInfo.hStdError;
+            let mut inherited_handles = vec![stdin_h, stdout_h];
+            if !inherited_handles.contains(&stderr_h) {
+                inherited_handles.push(stderr_h);
+            }
+            let mut attrs = ProcThreadAttributeList::new(/*attr_count*/ 1)?;
+            attrs.set_handle_list(inherited_handles)?;
+            si.lpAttributeList = attrs.as_mut_ptr();
+
+            let creation_flags = CREATE_UNICODE_ENVIRONMENT | EXTENDED_STARTUPINFO_PRESENT;
             let ok = CreateProcessAsUserW(
                 h_token,
                 std::ptr::null(),
@@ -187,7 +213,7 @@ pub unsafe fn create_process_as_user(
                 creation_flags,
                 env_block.as_ptr() as *mut c_void,
                 cwd_wide.as_ptr(),
-                &si,
+                &si.StartupInfo,
                 &mut pi,
             );
             if ok == 0 {
@@ -199,7 +225,7 @@ pub unsafe fn create_process_as_user(
                     cwd.display(),
                     cmdline_str,
                     env_block_len,
-                    si.dwFlags,
+                    si.StartupInfo.dwFlags,
                     creation_flags,
                 );
                 logging::debug_log(&msg, logs_base_dir);
@@ -207,7 +233,7 @@ pub unsafe fn create_process_as_user(
             }
             Ok(CreatedProcess {
                 process_info: pi,
-                startup_info: si,
+                startup_info: si.StartupInfo,
                 _desktop: desktop,
             })
         }
@@ -370,4 +396,25 @@ where
             CloseHandle(handle);
         }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn make_env_block_empty_env_is_double_nul_terminated() {
+        // `CreateProcessAsUserW` requires the block to end in two NULs even
+        // when there are no entries; a single-NUL block is malformed.
+        let block = make_env_block(&HashMap::new());
+        assert_eq!(block, vec![0u16, 0u16]);
+    }
+
+    #[test]
+    fn make_env_block_nonempty_env_ends_in_double_nul() {
+        let mut env = HashMap::new();
+        env.insert("FOO".to_string(), "bar".to_string());
+        let block = make_env_block(&env);
+        assert_eq!(&block[block.len() - 2..], &[0u16, 0u16]);
+    }
 }

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/sandbox_users.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/sandbox_users.rs
@@ -55,6 +55,7 @@ use crate::setup_error::SetupErrorCode;
 use crate::setup_error::SetupFailure;
 use crate::winutil::string_from_sid_bytes;
 use crate::winutil::to_wide;
+use zeroize::Zeroize;
 
 pub const SANDBOX_USERS_GROUP: &str = "CodexSandboxUsers";
 const SANDBOX_USERS_GROUP_COMMENT: &str = "Codex sandbox internal group (managed)";
@@ -93,66 +94,74 @@ pub fn ensure_sandbox_user(username: &str, password: &str, log: &mut dyn Write) 
 
 pub fn ensure_local_user(name: &str, password: &str, log: &mut dyn Write) -> Result<()> {
     let name_w = to_wide(OsStr::new(name));
-    let pwd_w = to_wide(OsStr::new(password));
-    unsafe {
-        let info = USER_INFO_1 {
-            usri1_name: name_w.as_ptr() as *mut u16,
-            usri1_password: pwd_w.as_ptr() as *mut u16,
-            usri1_password_age: 0,
-            usri1_priv: USER_PRIV_USER,
-            usri1_home_dir: std::ptr::null_mut(),
-            usri1_comment: std::ptr::null_mut(),
-            usri1_flags: UF_SCRIPT | UF_DONT_EXPIRE_PASSWD,
-            usri1_script_path: std::ptr::null_mut(),
-        };
-        let status = NetUserAdd(
-            std::ptr::null(),
-            1,
-            &info as *const _ as *mut u8,
-            std::ptr::null_mut(),
-        );
-        if status != NERR_Success {
-            // Try update password via level 1003.
-            let pw_info = USER_INFO_1003 {
-                usri1003_password: pwd_w.as_ptr() as *mut u16,
+    // Cleartext password wide buffer for NetUserAdd / NetUserSetInfo. Zeroized
+    // after the account API calls complete (Integration A1, W2 review finding 6)
+    // so it does not linger in freed heap; the raw pointers into it are only
+    // dereferenced inside the `unsafe` block below.
+    let mut pwd_w = to_wide(OsStr::new(password));
+    let result = (|| {
+        unsafe {
+            let info = USER_INFO_1 {
+                usri1_name: name_w.as_ptr() as *mut u16,
+                usri1_password: pwd_w.as_ptr() as *mut u16,
+                usri1_password_age: 0,
+                usri1_priv: USER_PRIV_USER,
+                usri1_home_dir: std::ptr::null_mut(),
+                usri1_comment: std::ptr::null_mut(),
+                usri1_flags: UF_SCRIPT | UF_DONT_EXPIRE_PASSWD,
+                usri1_script_path: std::ptr::null_mut(),
             };
-            let upd = NetUserSetInfo(
+            let status = NetUserAdd(
                 std::ptr::null(),
-                name_w.as_ptr(),
-                1003,
-                &pw_info as *const _ as *mut u8,
+                1,
+                &info as *const _ as *mut u8,
                 std::ptr::null_mut(),
             );
-            if upd != NERR_Success {
-                log_line(log, &format!("NetUserSetInfo failed for {name} code {upd}"))?;
-                return Err(anyhow::Error::new(SetupFailure::new(
-                    SetupErrorCode::HelperUserCreateOrUpdateFailed,
-                    format!("failed to create/update user {name}, code {status}/{upd}"),
-                )));
+            if status != NERR_Success {
+                // Try update password via level 1003.
+                let pw_info = USER_INFO_1003 {
+                    usri1003_password: pwd_w.as_ptr() as *mut u16,
+                };
+                let upd = NetUserSetInfo(
+                    std::ptr::null(),
+                    name_w.as_ptr(),
+                    1003,
+                    &pw_info as *const _ as *mut u8,
+                    std::ptr::null_mut(),
+                );
+                if upd != NERR_Success {
+                    log_line(log, &format!("NetUserSetInfo failed for {name} code {upd}"))?;
+                    return Err(anyhow::Error::new(SetupFailure::new(
+                        SetupErrorCode::HelperUserCreateOrUpdateFailed,
+                        format!("failed to create/update user {name}, code {status}/{upd}"),
+                    )));
+                }
+            }
+
+            // Ensure the principal is a regular local user account.
+            if let Ok(group_name) = lookup_account_name_for_sid(SID_USERS) {
+                let group = to_wide(OsStr::new(&group_name));
+                let member = LOCALGROUP_MEMBERS_INFO_3 {
+                    lgrmi3_domainandname: name_w.as_ptr() as *mut u16,
+                };
+                let _ = NetLocalGroupAddMembers(
+                    std::ptr::null(),
+                    group.as_ptr(),
+                    3,
+                    &member as *const _ as *mut u8,
+                    1,
+                );
+            } else {
+                log_line(
+                    log,
+                    "LookupAccountSidW failed for Users SID; skipping Users group membership",
+                )?;
             }
         }
-
-        // Ensure the principal is a regular local user account.
-        if let Ok(group_name) = lookup_account_name_for_sid(SID_USERS) {
-            let group = to_wide(OsStr::new(&group_name));
-            let member = LOCALGROUP_MEMBERS_INFO_3 {
-                lgrmi3_domainandname: name_w.as_ptr() as *mut u16,
-            };
-            let _ = NetLocalGroupAddMembers(
-                std::ptr::null(),
-                group.as_ptr(),
-                3,
-                &member as *const _ as *mut u8,
-                1,
-            );
-        } else {
-            log_line(
-                log,
-                "LookupAccountSidW failed for Users SID; skipping Users group membership",
-            )?;
-        }
-    }
-    Ok(())
+        Ok(())
+    })();
+    pwd_w.zeroize();
+    result
 }
 
 pub fn ensure_local_group(name: &str, comment: &str, log: &mut dyn Write) -> Result<()> {


### PR DESCRIPTION
## Summary

Integration A part 1. A safe, inert, CI-gated increment on the Step 3 elevated Windows sandbox. It vendors the non-ConPTY capture primitives and closes every latent security finding deferred from Wave 2, so those fixes bank now rather than riding the larger lab-gated core.

## Landed

- Vendored verbatim: `process.rs` (`CreateProcessAsUserW`, `spawn_process_with_pipes`, non-ConPTY capture primitive) and `desktop.rs` (private-desktop path, dormant), plus a `logging::debug_log` stand-in and 3 windows-sys features.
- W2 security must-fixes applied (module-internal, no wiring needed):
  - `ipc_framed` protocol-version gate, fail closed.
  - `runner_client` frame-length pre-check against MAX_FRAME_LEN before the peek loop.
  - `SandboxCreds` redacting `Debug` plus `zeroize` on drop, and password-buffer zeroize in `runner_client` and `sandbox_users` (adds the `zeroize` dep).
  - `cap.rs` intra-process mutex on the cap_sid read-modify-write, with a concurrency test.
  - `absolute_path` validating newtype that rejects non-absolute and `..` paths on construct and deserialize.
- `codex_protocol` absent (no import, no dep).

## Explicitly NOT here (deliberate scope call)

The core port (`spawn_prep`, `allow`, `elevated_impl` capture, full `identity`/`setup`, `deny_read_resolver`, and the `setup_main`/`command_runner` bins) is a large coupled unsafe Win32 rewrite against a resolver much thinner than upstream. Its confinement correctness is only validatable on the `spike307-win` lab (D-004), so it lands as the lab-co-developed core wave, not as blind inert code. The existing `windows.rs::launch` network-refuse guards are untouched and still fail closed. Nothing here is wired into `launch()`.

## Verification

- `cargo check` and `cargo clippy --all-targets -D warnings` on `x86_64-pc-windows-gnu` clean (subcrate and whole workspace); `cargo fmt --check` clean.
- Native `cargo test -p hive-desktop-sandbox` 63 pass. The new hardening tests are `cfg(windows)`, so they type-check under windows-gnu but execute only on a Windows host or in the lab, not on the Linux CI runner.

## Test plan

- [x] windows-gnu cross-compile check and clippy -D warnings
- [x] 63 native resolver tests pass
- [ ] CI required checks green
- [ ] rust-reviewer clean
- [ ] security-reviewer clean (the 5 closed findings + zeroize + cap mutex)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Windows sandbox support for private desktop creation and controlled process launching.
  * Added configurable process pipes and environment handling for sandboxed applications.
  * Added Windows path validation to reject relative paths and traversal attempts.

* **Security Improvements**
  * Sensitive passwords are now redacted in diagnostics and cleared from memory after use.
  * IPC frames are validated against protocol and size limits.
  * Improved consistency when generating workspace capability identifiers.

* **Documentation**
  * Updated Windows sandbox integration guidance, known risks, and maintenance instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds inert Windows sandbox capture primitives and hardens the elevated-helper boundary. The main changes are:

- Adds process capture and private-desktop primitives.
- Validates absolute IPC paths and rejects traversal and embedded NULs.
- Enforces IPC version and frame-size limits.
- Redacts and clears sandbox passwords.
- Serializes capability SID updates within the process.
- Restricts child handle inheritance and fixes empty environment blocks.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- The embedded-NUL path bypass is rejected during construction and deserialization.
- Empty environment blocks now have the required two terminators.
- The no-explicit-stdio branch limits inheritance to its standard handles.
- No blocking issue was found in the updated code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/desktop-sandbox/codex-windows-sandbox/src/absolute_path.rs | Adds validated construction and deserialization for absolute Windows paths, including traversal and embedded-NUL rejection. |
| apps/desktop-sandbox/codex-windows-sandbox/src/process.rs | Adds process capture primitives, double-NUL environment termination, and restricted standard-handle inheritance. |
| apps/desktop-sandbox/codex-windows-sandbox/src/elevated/ipc_framed.rs | Rejects incompatible protocol versions and exposes the shared frame-size limit. |
| apps/desktop-sandbox/codex-windows-sandbox/src/elevated/runner_client.rs | Rejects oversized frame declarations early and clears the temporary logon-password buffer. |
| apps/desktop-sandbox/codex-windows-sandbox/src/identity.rs | Redacts credentials from debug output and clears password storage on drop. |
| apps/desktop-sandbox/codex-windows-sandbox/src/cap.rs | Adds process-wide serialization around capability SID file updates. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: address Greptile P1 findings on A1 ..."](https://github.com/sakibsadmanshajib/hive/commit/702cf7816b724de219e75c29401a8d1e63fa3691) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45538805)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - .claude/rules/openwolf.md ([source](https://app.greptile.com/scubed/github/sakibsadmanshajib/hive/-/custom-context?memory=3e51a3b4-2091-4dce-8aad-9423a1f1db38))
- Context used - CLAUDE.md ([source](https://app.greptile.com/scubed/github/sakibsadmanshajib/hive/-/custom-context?memory=a5912a3f-0055-4d8a-86c1-fedc669ad56e))
- Context used - .claude/rules/orchestrator.md ([source](https://app.greptile.com/scubed/github/sakibsadmanshajib/hive/-/custom-context?memory=7e0c2dc0-c014-43b2-9dbd-46ae72a640d0))
</details>

<!-- /greptile_comment -->