### PR TITLE
feat: elevated Windows sandbox core, launch wiring, lab-validated confinement (Step 3 Integration A)

### DIFF
--- a/apps/desktop-sandbox/Cargo.lock
+++ b/apps/desktop-sandbox/Cargo.lock
@@ -171,13 +171,20 @@ dependencies = [
 name = "hive-desktop-sandbox"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "codex-process-hardening",
+ "codex-windows-sandbox",
+ "dunce",
  "landlock",
  "libc",
  "pretty_assertions",
+ "rand",
  "seccompiler",
+ "serde",
+ "serde_json",
  "tempfile",
  "windows",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/apps/desktop-sandbox/Cargo.lock
+++ b/apps/desktop-sandbox/Cargo.lock
@@ -185,6 +185,7 @@ dependencies = [
  "tempfile",
  "windows",
  "windows-sys 0.52.0",
+ "zeroize",
 ]
 
 [[package]]

--- a/apps/desktop-sandbox/VENDORING.md
+++ b/apps/desktop-sandbox/VENDORING.md
@@ -531,6 +531,88 @@ against a resolver far thinner than upstream's) plus the launch wiring, and thei
 confinement correctness is only validatable in the A2 `spike307-win` lab (D-004),
 so they are not hand-ported blind on inert code here. See open risk #6.
 
+## Step 3 Integration A2 (launch wiring + provisioning + two Hive binaries)
+
+Integration A2 lands the resolver-coupled port that A1 deferred, plus the
+launch wiring and the two Hive binaries. It drops `codex_protocol` entirely
+(Q1): the ports consume the Hive-native
+`hive_desktop_sandbox::windows_resolve::ResolvedWindowsSandboxPermissions`, not
+upstream's `resolved_permissions.rs`. Network stays refuse-until-WFP (Q2/D-005):
+`windows::launch` keeps refusing both `NetworkPolicy` variants, and the elevated
+compose is reachable only through the lab-only
+`windows_elevated::spawn_confined_for_validation` entry point. ConPTY (Step 5)
+and WFP/firewall (Integration B) are stubbed fail-closed, not vendored.
+
+### Newly authored (Hive-proprietary, not Apache-2.0)
+
+- `hive-desktop-sandbox/src/windows_elevated.rs`: the port of
+  `allow.rs::compute_allow_paths_for_permissions` (`compute_allow_paths`,
+  retargeted to the pre-resolved Hive resolver, six upstream cwd/env call sites
+  collapsed to one per blueprint A.Q2), the `tty = false` CAPTURE half of
+  `elevated_impl.rs::run_windows_sandbox_capture_for_permission_profile`
+  (`run_windows_sandbox_capture`), the provisioning-readiness and
+  credential-load logic of `identity.rs`/`setup.rs`
+  (`sandbox_setup_is_complete`, `load_logon_sandbox_creds`,
+  `provision_sandbox_account`), the token/ACL assembly of `spawn_prep.rs` plus
+  the `command_runner/win.rs` `tty = false` branch (`run_command_runner`), and
+  the pure `LaunchDecision`. It authors its own net-new Win32 in `windows-sys`
+  0.52 (to interoperate natively with the subcrate's `HANDLE`/SID types): the
+  LSA `SeInteractiveLogonRight` grant and the `seclogon` service check (the
+  blueprint A.Q1 provisioning invariant that makes `CreateProcessWithLogonW`
+  work for the hidden account), plus the child `WaitForSingleObject` /
+  `GetExitCodeProcess`. `deny_read_resolver.rs` is still NOT ported: the Hive
+  resolver's deny-read set is legitimately empty (no secret-path source yet), so
+  there is nothing to resolve; `compute_allow_paths` propagates carve-outs
+  already, for when a future `SandboxPolicy` extension adds them.
+- `hive-desktop-sandbox/src/bin/hive-command-runner.rs`: the per-task runner
+  binary (`tty = false` only; `tty = true` is refused fail-closed, ConPTY is
+  Step 5). Port of the `bin/command_runner/win.rs` `tty = false` branch.
+- `hive-desktop-sandbox/src/bin/hive-sandbox-provision.rs`: the elevated
+  provisioning worker (port of `bin/setup_main` intent). It OMITS upstream
+  `setup_main/win.rs`'s WFP + COM-firewall call sites (`install_wfp_filters`,
+  `ensure_offline_proxy_allowlist`, `ensure_offline_outbound_block`); those are
+  Integration B. It is deliberately NOT named `*-setup`/`*-install`: an
+  unmanifested exe whose filename matches Windows installer-detection heuristics
+  is auto-elevated by the OS, so the name avoids those trigger words to keep the
+  correct default `asInvoker` behaviour without an embedded manifest.
+- `hive-desktop-sandbox/src/windows.rs`: doc-only wiring pointing `launch` at
+  the A2 elevated compose and the lab-only validation entry point; the two
+  network-refusal guards are unchanged and are the `LaunchDecision` made real.
+
+### Local deviations from upstream (Integration A2, subcrate)
+
+Two now-wired-path items the A1 pass explicitly deferred to A2. Both are
+`#[cfg(windows)]`-only, cross-checked by the `x86_64-pc-windows-gnu` CI step,
+and lab-gated on `spike307-win`. Re-vendoring note: re-copying these two files
+must re-apply these deviations (checking first whether upstream added an
+equivalent).
+
+- `cap.rs` (open risk #8, cross-process half): `load_or_create_cap_sids` and
+  the two per-key accessors now also hold a named OS mutex
+  (`CreateMutexW`/`WaitForSingleObject`/`ReleaseMutex`, keyed to a stable hash of
+  the canonical `cap_sid` path) for the same critical section as the A1
+  intra-process `CAP_SID_LOCK`. This closes the elevated-provisioning-binary vs
+  runner cross-process race that A1 left open. Open risk #8 is now RESOLVED.
+- `helper_materialization.rs` (blueprint security boundary #8, absolute-path
+  guard): added `is_fully_qualified_launch_path` and routed the two fallback
+  branches of `resolve_current_exe_for_launch`/`resolve_exe_for_launch` through
+  it, so a resolution failure can never hand back a bare, cwd/PATH-resolvable
+  runner name for elevated execution (a plant there is a direct escalation); the
+  fallback is anchored under the trusted helper bin dir instead.
+
+### Deliberately NOT done in A2 (fail-closed stubs, honest)
+
+- WFP / firewall egress (Integration B): the two `windows::launch`
+  network-refusal guards stay; no egress control is authored. `DenyAll` under a
+  standard sandbox user can still open sockets, so refusing (not spawning) is
+  the only D-005-safe behaviour until WFP lands.
+- ConPTY (`tty = true`, Step 5): the command runner refuses a `tty = true`
+  request with an `Error` frame, never a silent downgrade to pipes.
+- App-side `ShellExecute "runas"` elevation trigger (the single UAC consent): it
+  lives in the desktop shell (Tauri), not in this OS-mechanism crate. The
+  provisioning binary is the elevated worker; `windows_elevated` only gates on
+  `sandbox_setup_is_complete` and errors if unprovisioned.
+
 ### Why not `codex-rs/windows-sandbox-rs` for the Windows backend (historical, #395 wave; superseded in part by Step 3 above)
 
 This section predates Step 3 and explains why the #395 wave (the base,
@@ -741,19 +823,20 @@ crate deliberately does not inherit the workspace's Apache-2.0
    this crate's own (multithreaded) test binary. Pre-existing at the time: no
    test before that pass ever exercised the real spawn path, so nothing
    surfaced it earlier.
-8. **PARTIALLY RESOLVED (Integration A1: intra-process lock landed). Original
-   issue (`cap.rs`, CodeRabbit finding, PR #398): the `cap_sid` file is an
-   unsynchronized read-modify-write.** Integration A1 added a process-wide
-   `Mutex` (`CAP_SID_LOCK`) that serializes the read-modify-write and re-reads
-   under the lock in `load_or_create_cap_sids`, `workspace_cap_sid_for_cwd`, and
-   `writable_root_cap_sid_for_path`, closing the intra-process race (a
-   concurrency regression test proves 8 concurrent first-touches share one SID
-   and persist exactly one entry). The CROSS-PROCESS race (the elevated setup
-   binary racing the runner against the same `codex_home`) is still open: it
-   needs a named OS mutex or `LockFileEx`, like upstream `setup_main`'s
-   `read_acl_mutex`, and a real concurrent-launch test on Windows to trust the
-   approach, so it is fixed together with the wave that wires the actual
-   `cap.rs` launch-path call sites (A2). Original detail retained below.
+8. **RESOLVED (Integration A1: intra-process lock; Integration A2: cross-process
+   mutex). Original issue (`cap.rs`, CodeRabbit finding, PR #398): the `cap_sid`
+   file is an unsynchronized read-modify-write.** Integration A1 added a
+   process-wide `Mutex` (`CAP_SID_LOCK`) that serializes the read-modify-write
+   and re-reads under the lock in `load_or_create_cap_sids`,
+   `workspace_cap_sid_for_cwd`, and `writable_root_cap_sid_for_path`, closing the
+   intra-process race (a concurrency regression test proves 8 concurrent
+   first-touches share one SID and persist exactly one entry). Integration A2
+   added a named OS mutex (`CreateMutexW`, keyed to a stable hash of the
+   canonical `cap_sid` path) held for the same critical section at all three
+   sites, closing the CROSS-PROCESS race (the elevated provisioning binary
+   racing the runner against the same sandbox home), as upstream `setup_main`
+   does with its `read_acl_mutex`. Its behavioural proof (a real concurrent
+   launch) is a `spike307-win` lab item. Original detail retained below.
    `workspace_cap_sid_for_cwd` and `writable_root_cap_sid_for_path` both
    `load_or_create_cap_sids` (read + parse JSON), mutate the in-memory
    `CapSids`, then `persist_caps` (serialize + `fs::write`) the whole file

--- a/apps/desktop-sandbox/VENDORING.md
+++ b/apps/desktop-sandbox/VENDORING.md
@@ -600,6 +600,91 @@ equivalent).
   runner name for elevated execution (a plant there is a direct escalation); the
   fallback is anchored under the trusted helper bin dir instead.
 
+### PR #401 review round (CodeRabbit/Greptile findings, Integration A2 launch wiring)
+
+An opus security review PASSED PR #401 MERGE-WITH-TRACKED-FOLLOWUP before this
+round; the items below are the bot findings triaged against that disposition.
+Each is either fixed (additive, does not alter the D-004 lab-validated
+spawn/confinement path for the already-passing case) or explicitly deferred
+with the reason a blind fix would risk invalidating that lab run.
+
+**Fixed this round:**
+
+- `cap.rs`'s cross-process mutex now fails CLOSED instead of open:
+  `acquire_cross_process_cap_lock` returns `std::io::Result` instead of
+  `Option`, propagating `CreateMutexW` failure and a `WAIT_FAILED` result from
+  `WaitForSingleObject` as errors (previously both were silently swallowed,
+  the callers proceeded under only the intra-process lock, and a second
+  concurrent racer could overwrite the other's `cap_sid` entry). All three
+  call sites (`load_or_create_cap_sids`, `workspace_cap_sid_for_cwd`,
+  `writable_root_cap_sid_for_path`) now propagate the error with `?` and abort
+  the read-modify-write on lock failure. Refines, not reopens, open risk #8
+  below (still RESOLVED; this closes the fail-open edge of that fix).
+- `helper_materialization.rs::resolve_helper_for_launch`'s failure branch
+  still called `legacy_lookup` directly, which is exactly the bare-name gap
+  item #6(a) below said would be "fixed with the A2 launch wiring" -- this IS
+  that wiring, and the guard was missing. Now routes the legacy fallback
+  through `is_fully_qualified_launch_path` (the same guard
+  `resolve_exe_for_launch` already used) and anchors a non-qualified result
+  under the trusted helper bin dir instead of handing `CreateProcessWithLogonW`
+  a bare, cwd/PATH-resolvable name. Closes item #6(a).
+- `windows_elevated.rs`'s elevated spawn path had no Job Object at all (unlike
+  the base variant's Step 1 `windows.rs::create_job_object`), so an IPC write
+  failure (the `SpawnReady` frame) or a parent disconnect after spawn orphaned
+  the restricted child with nothing left to stop it. Added
+  `confine_child_to_job`/`ChildJobGuard` in `spawn_and_stream`: assigns the
+  child to a `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` job immediately after spawn,
+  RAII-closed (and thus kill-on-close) on any early return, a no-op close once
+  `stream_child` returns normally (the child has already exited by then). Adds
+  the `Win32_System_JobObjects` windows-sys feature to
+  `hive-desktop-sandbox/Cargo.toml`. Residual: the child is not
+  `CREATE_SUSPENDED` (upstream `create_process_as_user` never suspends it, and
+  patching that vendored primitive is out of scope here), so a narrow
+  spawn-to-assign window without job containment remains; unchanged from
+  before this fix and far smaller than the gap closed.
+- `hive-sandbox-validate.rs`: added a fail-closed input guard rejecting
+  `HIVE_SANDBOX_HOME`/`HIVE_VALIDATE_WS` values containing whitespace or
+  `cmd.exe` metacharacters (`& | < > ^ % "`) before they reach the unescaped
+  `cmd.exe /c` script (see that file's own comment on why proper escaping is
+  not attempted there). Not a full escaping fix: this is lab-only tooling
+  whose env vars are operator-supplied, not attacker input, so failing closed
+  on a bad value fully closes the risk without solving general `cmd.exe`
+  quoting. The existing lab-validated paths (no whitespace/metacharacters, per
+  that file's own comment) pass the guard unchanged.
+
+**Deferred this round (tracked, not silently ignored):**
+
+- `desktop.rs::grant_winsta_desktop_access` (Greptile "Desktop Grant Outlives
+  Runner"): the persistent `WINSTA_ALL_ACCESS`/`GENERIC_ALL`/`DESKTOP_ALL_ACCESS`
+  grant to the shared sandbox account is never revoked, so a later process
+  running as that account on the same station/desktop also inherits it. This
+  is the disposition the opus security review already accepted as a known,
+  non-blocking gap for Integration A (unreachable today: `windows::launch`
+  refuses every network policy, so nothing reaches this grant outside the
+  lab-only validation entry). Documented as a HARD GATE on Integration B in
+  the function's own doc comment: do not remove the network-refusal guards
+  until the runner moves to a dedicated, non-shared private window station.
+  Not re-fixed here per that disposition.
+- `windows_elevated.rs::stream_child`'s sequential stdout-then-stderr drain
+  (CodeRabbit "Sequential stdout-then-stderr drain can deadlock", Greptile
+  "Sequential Pipe Drain Deadlocks", both on the same code): draining stdout
+  to EOF before touching stderr can deadlock if the child fills the stderr
+  pipe buffer while stdout stays open. The correct fix, a concurrent
+  two-thread drain with the frame writer behind a shared lock, changes this
+  exact D-004 lab-validated spawn/stream path from single- to multi-threaded
+  framing. Deferred rather than blind-rewritten; needs a fresh spike307-win
+  run once implemented. Inline comment added at the call site so this is
+  tracked, not silently missed.
+- `windows_elevated.rs::stream_child`'s ignored `timeout_ms` (Greptile
+  "Request Timeout Is Ignored"): the wait is always `INFINITE` and
+  `timed_out` is always `false`. Currently dormant, not reachable: the sole
+  `SpawnRequest` construction site (`run_windows_sandbox_capture`, this file)
+  always sets `timeout_ms: None`. A correct fix needs a watchdog concurrent
+  with the drains (coupled to the drain-deadlock deferral above, since a hang
+  during drain must also be bounded), so it is tracked with that fix rather
+  than half-implemented as a bare final-wait timeout that a stuck drain would
+  never reach. Inline comment added at the call site.
+
 ### Deliberately NOT done in A2 (fail-closed stubs, honest)
 
 - WFP / firewall egress (Integration B): the two `windows::launch`
@@ -796,13 +881,15 @@ crate deliberately does not inherit the workspace's Apache-2.0
    version gate, `SandboxCreds` redacting `Debug` + zeroize-on-drop, password
    buffer zeroize in `runner_client`/`sandbox_users`, `runner_client` frame
    pre-check, `absolute_path` traversal guard, and the intra-process half of
-   the `cap.rs` open-risk-#8 lock). Still OPEN after A1:
-   (a) `helper_materialization.rs::legacy_lookup`'s bare-executable-name
-   fallback lets `CreateProcessWithLogonW` fall back to executable search
-   instead of failing closed; it needs an absolute-path guard, but only matters
-   once a real launch path calls it, so it is fixed with the A2 launch wiring
-   (its correctness depends on the resolved helper-materialization directory,
-   which the wired path establishes).
+   the `cap.rs` open-risk-#8 lock).
+   (a) **RESOLVED (PR #401 review round, see "PR #401 review round" section
+   above).** `helper_materialization.rs::legacy_lookup`'s bare-executable-name
+   fallback let `CreateProcessWithLogonW` fall back to executable search
+   instead of failing closed. The A2 launch wiring itself (this PR) called
+   `legacy_lookup` from `resolve_helper_for_launch` without the absolute-path
+   guard this note predicted it would need; Greptile caught the gap in review,
+   and it is now closed by routing that fallback through
+   `is_fully_qualified_launch_path`.
 7. **RESOLVED (#350).** The Linux `pre_exec` post-fork allocator-deadlock
    hazard below was fixed by #350 (merged), which moved `linux::launch`'s
    `pre_exec` closure to an allocation-free path so no thread can deadlock on
@@ -836,7 +923,10 @@ crate deliberately does not inherit the workspace's Apache-2.0
    sites, closing the CROSS-PROCESS race (the elevated provisioning binary
    racing the runner against the same sandbox home), as upstream `setup_main`
    does with its `read_acl_mutex`. Its behavioural proof (a real concurrent
-   launch) is a `spike307-win` lab item. Original detail retained below.
+   launch) is a `spike307-win` lab item. **Refined in the PR #401 review
+   round** (see that section above): the mutex acquisition itself now fails
+   CLOSED (propagates `CreateMutexW`/`WaitForSingleObject` failure as an error)
+   instead of silently falling back to fail-open. Original detail retained below.
    `workspace_cap_sid_for_cwd` and `writable_root_cap_sid_for_path` both
    `load_or_create_cap_sids` (read + parse JSON), mutate the in-memory
    `CapSids`, then `persist_caps` (serialize + `fs::write`) the whole file

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/acl.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/acl.rs
@@ -183,7 +183,14 @@ pub fn path_mask_allows(
 /// fail-closed: `add_deny_read_ace` returns `false` both when the ACE already
 /// exists and when the underlying Win32 set silently failed, so callers that
 /// must guarantee the deny is in force verify presence with this.
-pub fn path_has_read_deny(path: &Path, psid: *mut c_void) -> Result<bool> {
+///
+/// # Safety
+///
+/// `psid` must be a valid, well-formed `PSID` pointer (as returned by SID
+/// resolution such as `sandbox_users::sid_bytes_to_psid`) that stays valid for
+/// the duration of this call. This function dereferences it indirectly via
+/// the DACL walk in `dacl_has_read_deny_for_sid`.
+pub unsafe fn path_has_read_deny(path: &Path, psid: *mut c_void) -> Result<bool> {
     unsafe {
         let (p_dacl, sd) = fetch_dacl_handle(path)?;
         let has = dacl_has_read_deny_for_sid(p_dacl, psid);

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/acl.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/acl.rs
@@ -177,6 +177,23 @@ pub fn path_mask_allows(
     }
 }
 
+/// Path-based wrapper: does the DACL on `path` carry an effective (non
+/// inherit-only) read-deny ACE for `psid`? Single DACL fetch, symmetric with
+/// [`path_mask_allows`]. Used to make deny-read provisioning idempotent AND
+/// fail-closed: `add_deny_read_ace` returns `false` both when the ACE already
+/// exists and when the underlying Win32 set silently failed, so callers that
+/// must guarantee the deny is in force verify presence with this.
+pub fn path_has_read_deny(path: &Path, psid: *mut c_void) -> Result<bool> {
+    unsafe {
+        let (p_dacl, sd) = fetch_dacl_handle(path)?;
+        let has = dacl_has_read_deny_for_sid(p_dacl, psid);
+        if !sd.is_null() {
+            LocalFree(sd as HLOCAL);
+        }
+        Ok(has)
+    }
+}
+
 pub unsafe fn dacl_has_write_allow_for_sid(p_dacl: *mut ACL, psid: *mut c_void) -> bool {
     if p_dacl.is_null() {
         return false;

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/cap.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/cap.rs
@@ -47,11 +47,15 @@ impl Drop for CrossProcessCapLock {
     }
 }
 
-/// Acquires the cross-process cap-SID mutex, blocking until it is owned. Returns
-/// `None` only if the mutex object could not be created (in which case the
-/// intra-process lock still provides same-process safety); a WAIT_ABANDONED
-/// result still confers ownership, which is the desired behaviour here.
-fn acquire_cross_process_cap_lock(codex_home: &Path) -> Option<CrossProcessCapLock> {
+/// Acquires the cross-process cap-SID mutex, blocking until it is owned.
+/// Fails closed (CodeRabbit/Greptile findings, PR #401): returns an error if
+/// the mutex object could not be created, or if the wait does not return
+/// ownership, instead of silently returning `None`/proceeding under only the
+/// intra-process lock. Callers MUST propagate the error with `?` and abort the
+/// read-modify-write rather than treat a lock failure as success; a
+/// WAIT_ABANDONED result still confers ownership, which is the desired
+/// behaviour here and is not an error.
+fn acquire_cross_process_cap_lock(codex_home: &Path) -> std::io::Result<CrossProcessCapLock> {
     use std::hash::{Hash, Hasher};
     // Mutex names cannot contain '\' except the namespace prefix, so key the
     // name on a stable hash of the canonical cap_sid path rather than the path
@@ -69,10 +73,15 @@ fn acquire_cross_process_cap_lock(codex_home: &Path) -> Option<CrossProcessCapLo
         let h =
             windows_sys::Win32::System::Threading::CreateMutexW(std::ptr::null(), 0, wide.as_ptr());
         if h == 0 {
-            return None;
+            return Err(std::io::Error::last_os_error());
         }
-        let _ = windows_sys::Win32::System::Threading::WaitForSingleObject(h, u32::MAX);
-        Some(CrossProcessCapLock(h))
+        let wait = windows_sys::Win32::System::Threading::WaitForSingleObject(h, u32::MAX);
+        if wait == windows_sys::Win32::Foundation::WAIT_FAILED {
+            let err = std::io::Error::last_os_error();
+            let _ = windows_sys::Win32::Foundation::CloseHandle(h);
+            return Err(err);
+        }
+        Ok(CrossProcessCapLock(h))
     }
 }
 
@@ -122,8 +131,9 @@ pub fn load_or_create_cap_sids(codex_home: &Path) -> Result<CapSids> {
     let _guard = CAP_SID_LOCK
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
-    // Hold the cross-process mutex for the same critical section (A2, see above).
-    let _xproc = acquire_cross_process_cap_lock(codex_home);
+    // Hold the cross-process mutex for the same critical section (A2, see
+    // above). Fails closed: a lock failure aborts before the read-modify-write.
+    let _xproc = acquire_cross_process_cap_lock(codex_home)?;
     load_or_create_cap_sids_locked(&cap_sid_file(codex_home))
 }
 
@@ -167,8 +177,9 @@ pub fn workspace_cap_sid_for_cwd(codex_home: &Path, cwd: &Path) -> Result<String
     let _guard = CAP_SID_LOCK
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
-    // Hold the cross-process mutex for the same critical section (A2, see above).
-    let _xproc = acquire_cross_process_cap_lock(codex_home);
+    // Hold the cross-process mutex for the same critical section (A2, see
+    // above). Fails closed: a lock failure aborts before the read-modify-write.
+    let _xproc = acquire_cross_process_cap_lock(codex_home)?;
     let mut caps = load_or_create_cap_sids_locked(&path)?;
     let key = canonical_path_key(cwd);
     if let Some(sid) = caps.workspace_by_cwd.get(&key) {
@@ -186,8 +197,9 @@ pub fn writable_root_cap_sid_for_path(codex_home: &Path, root: &Path) -> Result<
     let _guard = CAP_SID_LOCK
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
-    // Hold the cross-process mutex for the same critical section (A2, see above).
-    let _xproc = acquire_cross_process_cap_lock(codex_home);
+    // Hold the cross-process mutex for the same critical section (A2, see
+    // above). Fails closed: a lock failure aborts before the read-modify-write.
+    let _xproc = acquire_cross_process_cap_lock(codex_home)?;
     let mut caps = load_or_create_cap_sids_locked(&path)?;
     let key = canonical_path_key(root);
     if let Some(sid) = caps.writable_root_by_path.get(&key) {

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/cap.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/cap.rs
@@ -27,6 +27,55 @@ use std::sync::Mutex;
 // ever matters.
 static CAP_SID_LOCK: Mutex<()> = Mutex::new(());
 
+// A2 (VENDORING open risk 8; documented deviation from the verbatim vendor):
+// the intra-process CAP_SID_LOCK above serializes threads within one process,
+// but the elevated provisioning binary and the per-task runner are SEPARATE
+// processes that both read-modify-write this file. A named OS mutex, keyed to
+// the cap_sid path, closes that cross-process race (the same discipline
+// upstream setup_main uses with its read_acl_mutex). It is held for the SAME
+// critical section as CAP_SID_LOCK and released on drop.
+struct CrossProcessCapLock(windows_sys::Win32::Foundation::HANDLE);
+
+impl Drop for CrossProcessCapLock {
+    fn drop(&mut self) {
+        // SAFETY: `self.0` is a mutex HANDLE we acquired below; release
+        // ownership then close the handle. Both are no-ops on an invalid handle.
+        unsafe {
+            let _ = windows_sys::Win32::System::Threading::ReleaseMutex(self.0);
+            let _ = windows_sys::Win32::Foundation::CloseHandle(self.0);
+        }
+    }
+}
+
+/// Acquires the cross-process cap-SID mutex, blocking until it is owned. Returns
+/// `None` only if the mutex object could not be created (in which case the
+/// intra-process lock still provides same-process safety); a WAIT_ABANDONED
+/// result still confers ownership, which is the desired behaviour here.
+fn acquire_cross_process_cap_lock(codex_home: &Path) -> Option<CrossProcessCapLock> {
+    use std::hash::{Hash, Hasher};
+    // Mutex names cannot contain '\' except the namespace prefix, so key the
+    // name on a stable hash of the canonical cap_sid path rather than the path
+    // itself. DefaultHasher (SipHash with fixed keys) is deterministic across
+    // processes, so both racers derive the same name.
+    let key = canonical_path_key(&cap_sid_file(codex_home));
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    key.hash(&mut hasher);
+    let name = format!("Local\\hive_cap_sid_{:016x}", hasher.finish());
+    let wide: Vec<u16> = name.encode_utf16().chain(std::iter::once(0)).collect();
+    // SAFETY: standard CreateMutexW + WaitForSingleObject. `wide` is a valid
+    // NUL-terminated UTF-16 name that outlives the call; the returned handle is
+    // owned by the CrossProcessCapLock guard and closed on drop.
+    unsafe {
+        let h =
+            windows_sys::Win32::System::Threading::CreateMutexW(std::ptr::null(), 0, wide.as_ptr());
+        if h == 0 {
+            return None;
+        }
+        let _ = windows_sys::Win32::System::Threading::WaitForSingleObject(h, u32::MAX);
+        Some(CrossProcessCapLock(h))
+    }
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct CapSids {
     pub workspace: String,
@@ -73,6 +122,8 @@ pub fn load_or_create_cap_sids(codex_home: &Path) -> Result<CapSids> {
     let _guard = CAP_SID_LOCK
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
+    // Hold the cross-process mutex for the same critical section (A2, see above).
+    let _xproc = acquire_cross_process_cap_lock(codex_home);
     load_or_create_cap_sids_locked(&cap_sid_file(codex_home))
 }
 
@@ -116,6 +167,8 @@ pub fn workspace_cap_sid_for_cwd(codex_home: &Path, cwd: &Path) -> Result<String
     let _guard = CAP_SID_LOCK
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
+    // Hold the cross-process mutex for the same critical section (A2, see above).
+    let _xproc = acquire_cross_process_cap_lock(codex_home);
     let mut caps = load_or_create_cap_sids_locked(&path)?;
     let key = canonical_path_key(cwd);
     if let Some(sid) = caps.workspace_by_cwd.get(&key) {
@@ -133,6 +186,8 @@ pub fn writable_root_cap_sid_for_path(codex_home: &Path, root: &Path) -> Result<
     let _guard = CAP_SID_LOCK
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
+    // Hold the cross-process mutex for the same critical section (A2, see above).
+    let _xproc = acquire_cross_process_cap_lock(codex_home);
     let mut caps = load_or_create_cap_sids_locked(&path)?;
     let key = canonical_path_key(root);
     if let Some(sid) = caps.writable_root_by_path.get(&key) {

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/desktop.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/desktop.rs
@@ -305,6 +305,24 @@ unsafe fn merge_grant_on_window_object(handle: isize, entries: &[EXPLICIT_ACCESS
 /// capability-restricted token + Job Object; UI/desktop isolation (a dedicated
 /// private window station for the runner) is a separate follow-up hardening and
 /// is intentionally not attempted here.
+///
+/// KNOWN GAP, dispositioned and NOT re-fixed here (Greptile finding "Desktop
+/// Grant Outlives Runner", PR #401 review round; opus security review PASSED
+/// PR #401 MERGE-WITH-TRACKED-FOLLOWUP on this exact basis): the grant is
+/// persistent (`WINSTA_ALL_ACCESS` / inheritable `GENERIC_ALL` / `DESKTOP_ALL_ACCESS`)
+/// and never revoked, so any later process running as the shared sandbox
+/// account on this station/desktop also inherits it. Unreachable in the
+/// product path today because `windows::launch` refuses every network
+/// policy (`DenyAll` and `AllowHosts` both fail closed; see VENDORING.md
+/// "Open risks" #3), so nothing reaches this grant outside the lab-only
+/// `spawn_confined_for_validation` entry.
+///
+/// HARD GATE ON INTEGRATION B: do not remove or loosen the network-refusal
+/// guards in `windows::launch` until the runner is switched to a dedicated,
+/// non-shared private window station (revoking this shared-station/desktop
+/// grant) instead of the caller's own interactive station. WFP egress
+/// enforcement landing without that switch would make this gap reachable in
+/// production. Track resolution together, not WFP alone.
 pub fn grant_winsta_desktop_access(sandbox_username: &str) -> Result<()> {
     let sid_bytes = crate::sandbox_users::resolve_sid(sandbox_username)?;
     let psid = crate::sandbox_users::sid_bytes_to_psid(&sid_bytes)?;

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/desktop.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/desktop.rs
@@ -15,8 +15,10 @@ use windows_sys::Win32::Foundation::ERROR_SUCCESS;
 use windows_sys::Win32::Foundation::GetLastError;
 use windows_sys::Win32::Foundation::HLOCAL;
 use windows_sys::Win32::Foundation::LocalFree;
+use windows_sys::Win32::Security::ACL;
 use windows_sys::Win32::Security::Authorization::EXPLICIT_ACCESS_W;
 use windows_sys::Win32::Security::Authorization::GRANT_ACCESS;
+use windows_sys::Win32::Security::Authorization::GetSecurityInfo;
 use windows_sys::Win32::Security::Authorization::SE_WINDOW_OBJECT;
 use windows_sys::Win32::Security::Authorization::SetEntriesInAclW;
 use windows_sys::Win32::Security::Authorization::SetSecurityInfo;
@@ -39,6 +41,9 @@ use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_SWITCHDESKTOP;
 use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_WRITE_DAC;
 use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_WRITE_OWNER;
 use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_WRITEOBJECTS;
+use windows_sys::Win32::System::StationsAndDesktops::GetProcessWindowStation;
+use windows_sys::Win32::System::StationsAndDesktops::GetThreadDesktop;
+use windows_sys::Win32::System::Threading::GetCurrentThreadId;
 
 const DESKTOP_ALL_ACCESS: u32 = DESKTOP_READOBJECTS
     | DESKTOP_CREATEWINDOW
@@ -193,4 +198,153 @@ impl Drop for PrivateDesktop {
             }
         }
     }
+}
+
+// ACE inheritance flags + generic-all mask (kept local; windows-sys spreads
+// these across modules and the numeric values are stable).
+const GENERIC_ALL_MASK: u32 = 0x1000_0000;
+// WINSTA_ALL_ACCESS is not re-exported by windows-sys 0.52; value from the
+// Win32 headers (winuser.h): the OR of all WINSTA_* rights.
+const WINSTA_ALL_ACCESS: u32 = 0x0000_037F;
+const CONTAINER_INHERIT_ACE: u32 = 0x2;
+const OBJECT_INHERIT_ACE: u32 = 0x1;
+const INHERIT_ONLY_ACE: u32 = 0x8;
+const NO_INHERITANCE: u32 = 0x0;
+
+fn explicit_grant(psid: *mut c_void, access: u32, inheritance: u32) -> EXPLICIT_ACCESS_W {
+    EXPLICIT_ACCESS_W {
+        grfAccessPermissions: access,
+        grfAccessMode: GRANT_ACCESS,
+        grfInheritance: inheritance,
+        Trustee: TRUSTEE_W {
+            pMultipleTrustee: ptr::null_mut(),
+            MultipleTrusteeOperation: 0,
+            TrusteeForm: TRUSTEE_IS_SID,
+            TrusteeType: TRUSTEE_IS_UNKNOWN,
+            ptstrName: psid as *mut u16,
+        },
+    }
+}
+
+/// Merges `entries` (allow ACEs) into the existing DACL of a window-station or
+/// desktop object, preserving every existing ACE. The interactive user's and
+/// SYSTEM's access are never removed; we only ADD the sandbox account.
+unsafe fn merge_grant_on_window_object(handle: isize, entries: &[EXPLICIT_ACCESS_W]) -> Result<()> {
+    let mut p_dacl: *mut ACL = ptr::null_mut();
+    let mut p_sd: *mut c_void = ptr::null_mut();
+    let code = GetSecurityInfo(
+        handle,
+        SE_WINDOW_OBJECT,
+        DACL_SECURITY_INFORMATION,
+        ptr::null_mut(),
+        ptr::null_mut(),
+        &mut p_dacl,
+        ptr::null_mut(),
+        &mut p_sd,
+    );
+    if code != ERROR_SUCCESS {
+        return Err(anyhow::anyhow!(
+            "GetSecurityInfo(window object) failed: {code}"
+        ));
+    }
+    let mut new_dacl: *mut ACL = ptr::null_mut();
+    let set_entries = SetEntriesInAclW(
+        entries.len() as u32,
+        entries.as_ptr(),
+        p_dacl,
+        &mut new_dacl,
+    );
+    if set_entries != ERROR_SUCCESS {
+        if !p_sd.is_null() {
+            LocalFree(p_sd as HLOCAL);
+        }
+        return Err(anyhow::anyhow!(
+            "SetEntriesInAclW(window object) failed: {set_entries}"
+        ));
+    }
+    let set_security = SetSecurityInfo(
+        handle,
+        SE_WINDOW_OBJECT,
+        DACL_SECURITY_INFORMATION,
+        ptr::null_mut(),
+        ptr::null_mut(),
+        new_dacl,
+        ptr::null_mut(),
+    );
+    if !new_dacl.is_null() {
+        LocalFree(new_dacl as HLOCAL);
+    }
+    if !p_sd.is_null() {
+        LocalFree(p_sd as HLOCAL);
+    }
+    if set_security != ERROR_SUCCESS {
+        return Err(anyhow::anyhow!(
+            "SetSecurityInfo(window object) failed: {set_security}"
+        ));
+    }
+    Ok(())
+}
+
+/// Grants the named account the window-station and desktop access a process
+/// launched AS that account needs to INITIALIZE.
+///
+/// The command-runner links `user32.dll`; its process-attach initialization
+/// connects to the caller's window station and desktop. When the runner is
+/// launched as the low-privilege sandbox account via `CreateProcessWithLogonW`,
+/// that account has no access to the caller's station/desktop by default, so
+/// the connect fails and the runner dies at load with `STATUS_DLL_INIT_FAILED`
+/// (0xC0000142) BEFORE `main` runs (no output, no crash event). Granting the
+/// sandbox SID access to the CURRENT window station + desktop (whatever the
+/// caller is on: the interactive `WinSta0` for the desktop app, a service
+/// station for a headless/CI host) fixes it. The launch leaves
+/// `STARTUPINFO.lpDesktop` NULL so the runner inherits this same, now-accessible
+/// station/desktop; there is deliberately no hardcoded station name.
+///
+/// Scope (D-005): this is a launch PREREQUISITE, not a relaxation of any control
+/// Step 3 enforces. Step 3's confinement is filesystem + sandbox user + a
+/// capability-restricted token + Job Object; UI/desktop isolation (a dedicated
+/// private window station for the runner) is a separate follow-up hardening and
+/// is intentionally not attempted here.
+pub fn grant_winsta_desktop_access(sandbox_username: &str) -> Result<()> {
+    let sid_bytes = crate::sandbox_users::resolve_sid(sandbox_username)?;
+    let psid = crate::sandbox_users::sid_bytes_to_psid(&sid_bytes)?;
+    // SAFETY: `psid` is a live SID from ConvertStringSidToSidW (freed below);
+    // the window-station/desktop handles are process/thread pseudo-handles that
+    // need no close. Every fallible Win32 step is checked.
+    let result = unsafe {
+        let winsta = GetProcessWindowStation();
+        if winsta == 0 {
+            LocalFree(psid as HLOCAL);
+            return Err(anyhow::anyhow!(
+                "GetProcessWindowStation failed: {}",
+                GetLastError()
+            ));
+        }
+        // KB165194: a window station needs two ACEs for a launched-as user — an
+        // inherit-only generic ACE so child desktops inherit access, plus the
+        // station-specific access on the station object itself.
+        let winsta_entries = [
+            explicit_grant(
+                psid,
+                GENERIC_ALL_MASK,
+                CONTAINER_INHERIT_ACE | INHERIT_ONLY_ACE | OBJECT_INHERIT_ACE,
+            ),
+            explicit_grant(psid, WINSTA_ALL_ACCESS, NO_INHERITANCE),
+        ];
+        merge_grant_on_window_object(winsta, &winsta_entries).and_then(|()| {
+            let desktop = GetThreadDesktop(GetCurrentThreadId());
+            if desktop == 0 {
+                return Err(anyhow::anyhow!(
+                    "GetThreadDesktop failed: {}",
+                    GetLastError()
+                ));
+            }
+            let desktop_entries = [explicit_grant(psid, DESKTOP_ALL_ACCESS, NO_INHERITANCE)];
+            merge_grant_on_window_object(desktop, &desktop_entries)
+        })
+    };
+    unsafe {
+        LocalFree(psid as HLOCAL);
+    }
+    result
 }

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/elevated/runner_client.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/elevated/runner_client.rs
@@ -335,6 +335,22 @@ pub fn spawn_runner_transport(
             }
         };
 
+    // The runner is launched AS the low-privilege sandbox account and links
+    // user32.dll, whose process-attach initialization connects to the caller's
+    // window station and desktop. That account has no access to them by
+    // default, so without this grant the runner dies at load with
+    // STATUS_DLL_INIT_FAILED (0xC0000142) BEFORE main runs (observed on
+    // spike307-win). Grant the sandbox SID access to the current station +
+    // desktop first; the launch leaves STARTUPINFO.lpDesktop NULL so the runner
+    // inherits this same, now-accessible station/desktop.
+    if let Err(err) = crate::desktop::grant_winsta_desktop_access(&sandbox_creds.username) {
+        unsafe {
+            CloseHandle(h_pipe_in);
+            CloseHandle(h_pipe_out);
+        }
+        return Err(err);
+    }
+
     let runner_exe = find_runner_exe(codex_home, log_dir);
     let runner_cmdline = runner_exe
         .to_str()

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/elevated/runner_client.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/elevated/runner_client.rs
@@ -338,7 +338,7 @@ pub fn spawn_runner_transport(
     let runner_cmdline = runner_exe
         .to_str()
         .map(str::to_owned)
-        .unwrap_or_else(|| "codex-command-runner.exe".to_string());
+        .unwrap_or_else(|| "hive-command-runner.exe".to_string());
     let runner_full_cmd = format!(
         "{} {} {}",
         quote_windows_arg(&runner_cmdline),

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/elevated/runner_client.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/elevated/runner_client.rs
@@ -42,6 +42,7 @@ use windows_sys::Win32::System::Pipes::PeekNamedPipe;
 use windows_sys::Win32::System::Threading::CreateProcessWithLogonW;
 use windows_sys::Win32::System::Threading::GetCurrentProcess;
 use windows_sys::Win32::System::Threading::GetCurrentThread;
+use windows_sys::Win32::System::Threading::GetExitCodeProcess;
 use windows_sys::Win32::System::Threading::LOGON_WITH_PROFILE;
 use windows_sys::Win32::System::Threading::PROCESS_INFORMATION;
 use windows_sys::Win32::System::Threading::STARTUPINFOW;
@@ -409,18 +410,30 @@ pub fn spawn_runner_transport(
     }
 
     if let Err(err) = connect_result {
+        // Diagnostic (D-004): capture the runner's real exit status BEFORE we
+        // terminate it, so a pre-handshake failure (early main exit, loader
+        // failure) is observable instead of being masked by our own
+        // TerminateProcess. 259 (STILL_ACTIVE) means the runner is still
+        // running / blocked; a small code (1/2) means it already exited in
+        // main; a 0xC000_xxxx code is an NTSTATUS (e.g. 0xC0000135 missing DLL).
+        let mut runner_exit_code: u32 = 259;
         unsafe {
             // Keep the process handle alive until the pipe handshake finishes. If the handshake
             // fails after the runner process has already launched, we still need a way to stop
-            // that child instead of leaking a stray `codex-command-runner.exe`.
+            // that child instead of leaking a stray runner process.
             if pi.hProcess != 0 {
+                if GetExitCodeProcess(pi.hProcess, &mut runner_exit_code) == 0 {
+                    runner_exit_code = 0xFFFF_FFFF;
+                }
                 let _ = TerminateProcess(pi.hProcess, 1);
                 CloseHandle(pi.hProcess);
             }
             CloseHandle(h_pipe_in);
             CloseHandle(h_pipe_out);
         }
-        return Err(err);
+        return Err(err.context(format!(
+            "runner process exit code before pipe handshake completed: {runner_exit_code} (0x{runner_exit_code:08x}); 259 = STILL_ACTIVE (runner still running / blocked)"
+        )));
     }
 
     let mut transport = RunnerTransport {

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/helper_materialization.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/helper_materialization.rs
@@ -97,10 +97,32 @@ pub(crate) fn resolve_helper_for_launch(
     }
 }
 
+/// A2 boundary #8 guard (VENDORING; documented deviation from the verbatim
+/// vendor): the resolved runner/helper path is executed elevated / as the
+/// sandbox user, so it MUST be a fully-qualified path (drive-absolute `C:\...`
+/// or UNC/device `\\...`), never a bare name resolvable through PATH or the
+/// untrusted cwd — a plant there is a direct escalation. Parsed with explicit
+/// `\`/`/` handling (not `Path::is_absolute`, which uses HOST conventions) so it
+/// is correct when this crate is cross-checked from a non-Windows CI host.
+pub fn is_fully_qualified_launch_path(p: &Path) -> bool {
+    let raw = p.to_string_lossy();
+    let bytes = raw.as_bytes();
+    let is_sep = |b: u8| b == b'\\' || b == b'/';
+    if bytes.len() >= 2 && is_sep(bytes[0]) && is_sep(bytes[1]) {
+        return true;
+    }
+    bytes.len() >= 3 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':' && is_sep(bytes[2])
+}
+
 pub fn resolve_current_exe_for_launch(codex_home: &Path, fallback_executable: &str) -> PathBuf {
     let source = match std::env::current_exe() {
         Ok(path) => path,
-        Err(_) => return PathBuf::from(fallback_executable),
+        // A2 boundary #8 guard: never hand back a bare, cwd/PATH-resolvable
+        // name for elevated execution. `Path::join` keeps an already-absolute
+        // fallback intact and anchors a relative one under the trusted helper
+        // bin dir (an absolute, non-existent path fails closed downstream rather
+        // than resolving a planted binary from the working directory).
+        Err(_) => return helper_bin_dir(codex_home).join(fallback_executable),
     };
     resolve_exe_for_launch(&source, codex_home)
 }
@@ -121,7 +143,14 @@ pub fn resolve_exe_for_launch(source: &Path, codex_home: &Path) -> PathBuf {
                 ),
                 Some(&sandbox_log_dir),
             );
-            source.to_path_buf()
+            // A2 boundary #8 guard: fall back to `source` ONLY if it is already
+            // fully-qualified; a relative source would be a cwd/PATH plant
+            // vector, so prefer the absolute helper-bin destination instead.
+            if is_fully_qualified_launch_path(source) {
+                source.to_path_buf()
+            } else {
+                destination
+            }
         }
     }
 }

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/helper_materialization.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/helper_materialization.rs
@@ -89,7 +89,23 @@ pub(crate) fn resolve_helper_for_launch(
             path
         }
         Err(err) => {
-            let fallback = legacy_lookup(kind);
+            let legacy = legacy_lookup(kind);
+            // A2 boundary #8 guard (VENDORING; documented deviation from the
+            // verbatim vendor, PR #401 CodeRabbit/Greptile follow-up):
+            // `legacy_lookup` can return a bare, cwd/PATH-resolvable file name
+            // when neither the sibling nor resource-dir lookup finds the
+            // helper. Handed to `CreateProcessWithLogonW` as-is, a bare name
+            // resolves through Windows executable search instead of failing
+            // closed, which is a direct escalation vector (a planted binary
+            // found first). Anchor it under the trusted helper bin dir
+            // instead when it is not already fully qualified; that path will
+            // not exist either in this failure branch, so the launch fails
+            // closed on a missing file rather than searching for one.
+            let fallback = if is_fully_qualified_launch_path(&legacy) {
+                legacy
+            } else {
+                helper_bin_dir(codex_home).join(kind.file_name())
+            };
             log_note(
                 &format!(
                     "helper copy failed for {}: {err:#}; falling back to legacy path {}",

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/helper_materialization.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/helper_materialization.rs
@@ -33,7 +33,13 @@ pub(crate) enum HelperExecutable {
 impl HelperExecutable {
     fn file_name(self) -> &'static str {
         match self {
-            Self::CommandRunner => "codex-command-runner.exe",
+            // The runner is built by the `hive-command-runner` cargo bin target
+            // (`hive-desktop-sandbox/src/bin/hive-command-runner.rs`), which
+            // produces `hive-command-runner.exe`. The stale vendored
+            // `codex-command-runner.exe` name never exists on disk, so every
+            // helper lookup (sibling copy AND legacy fallback) missed the real
+            // binary. See ../VENDORING.md.
+            Self::CommandRunner => "hive-command-runner.exe",
         }
     }
 
@@ -603,6 +609,6 @@ mod tests {
     fn materialized_file_name_adds_suffix_before_extension() {
         let file_name = materialized_file_name(HelperExecutable::CommandRunner, "test-suffix");
 
-        assert_eq!(file_name, "codex-command-runner-test-suffix.exe");
+        assert_eq!(file_name, "hive-command-runner-test-suffix.exe");
     }
 }

--- a/apps/desktop-sandbox/hive-desktop-sandbox/Cargo.toml
+++ b/apps/desktop-sandbox/hive-desktop-sandbox/Cargo.toml
@@ -24,6 +24,13 @@ doctest = false
 workspace = true
 
 [dependencies]
+# Pure, cross-platform parts of windows_elevated.rs (the provisioning-readiness
+# marker (de)serialization and the allow-path canonicalization) compile and are
+# unit-tested on every platform including this crate's Linux CI, so these are
+# unconditional, not windows-only.
+dunce = "1.0"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 codex-process-hardening = { path = "../codex-process-hardening" }
@@ -47,6 +54,26 @@ windows = { version = "0.58", features = [
     "Win32_System_Threading",
     "Win32_Storage_FileSystem",
 ] }
+# Step 3 Integration A: the elevated compose (windows_elevated.rs) and the two
+# Hive binaries orchestrate the vendored mechanism primitives, so this crate now
+# depends on the Apache-2.0 subcrate on Windows. The compose authors its own
+# net-new Win32 (LSA logon-right grant, seclogon service check, child wait) in
+# windows-sys 0.52 to interoperate natively with the subcrate's windows-sys
+# HANDLE/SID types, rather than bridging to the `windows` 0.58 crate above.
+codex-windows-sandbox = { path = "../codex-windows-sandbox" }
+anyhow = "1.0"
+windows-sys = { version = "0.52", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_Security_Authentication_Identity",
+    "Win32_System_Services",
+    "Win32_System_Threading",
+] }
+
+# Default features include `std` + `getrandom`, so `OsRng` (CSPRNG password
+# generation in provisioning) is available without hand-picking feature flags.
+[target.'cfg(windows)'.dependencies.rand]
+version = "0.8"
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/apps/desktop-sandbox/hive-desktop-sandbox/Cargo.toml
+++ b/apps/desktop-sandbox/hive-desktop-sandbox/Cargo.toml
@@ -75,6 +75,12 @@ windows-sys = { version = "0.52", features = [
 [target.'cfg(windows)'.dependencies.rand]
 version = "0.8"
 
+# Zeroizes the generated cleartext provisioning password on drop, matching
+# `codex-windows-sandbox`'s `SandboxCreds`/`runner_client` zeroize-on-drop
+# handling of the same class of secret.
+[target.'cfg(windows)'.dependencies.zeroize]
+version = "1"
+
 [dev-dependencies]
 tempfile = { workspace = true }
 pretty_assertions = { workspace = true }

--- a/apps/desktop-sandbox/hive-desktop-sandbox/Cargo.toml
+++ b/apps/desktop-sandbox/hive-desktop-sandbox/Cargo.toml
@@ -66,6 +66,7 @@ windows-sys = { version = "0.52", features = [
     "Win32_Foundation",
     "Win32_Security",
     "Win32_Security_Authentication_Identity",
+    "Win32_System_JobObjects",
     "Win32_System_Services",
     "Win32_System_Threading",
 ] }

--- a/apps/desktop-sandbox/hive-desktop-sandbox/src/bin/hive-command-runner.rs
+++ b/apps/desktop-sandbox/hive-desktop-sandbox/src/bin/hive-command-runner.rs
@@ -24,9 +24,20 @@
 #[cfg(windows)]
 fn main() -> std::process::ExitCode {
     let args: Vec<String> = std::env::args().collect();
+    // Earliest observable point: proves the runner image loaded and main ran,
+    // and whether the pipe arguments arrived (diagnostic, gated).
+    hive_desktop_sandbox::windows_elevated::runner_debug_log(&format!(
+        "hive-command-runner main entry: argc={} has_pipe_in={} has_pipe_out={}",
+        args.len(),
+        args.iter().any(|a| a.starts_with("--pipe-in=")),
+        args.iter().any(|a| a.starts_with("--pipe-out=")),
+    ));
     let pipe_in = arg_value(&args, "--pipe-in");
     let pipe_out = arg_value(&args, "--pipe-out");
     let (Some(pipe_in), Some(pipe_out)) = (pipe_in, pipe_out) else {
+        hive_desktop_sandbox::windows_elevated::runner_debug_log(
+            "exiting 2: missing --pipe-in/--pipe-out",
+        );
         eprintln!("usage: hive-command-runner --pipe-in=<name> --pipe-out=<name>");
         return std::process::ExitCode::from(2);
     };

--- a/apps/desktop-sandbox/hive-desktop-sandbox/src/bin/hive-command-runner.rs
+++ b/apps/desktop-sandbox/hive-desktop-sandbox/src/bin/hive-command-runner.rs
@@ -1,0 +1,55 @@
+//! Hive command-runner binary (Step 3 Integration A).
+//!
+//! This is the per-task runner that `runner_client::spawn_runner_transport`
+//! starts AS the low-privilege sandbox account via `CreateProcessWithLogonW`
+//! (blueprint A.Q1). It speaks the framed named-pipe IPC, derives a
+//! capability-restricted primary token from its OWN token, applies the per-task
+//! ACL confinement, and spawns the inner child under that token with
+//! `spawn_process_with_pipes` (the `tty = false` path). A `tty = true` request
+//! is refused fail-closed (ConPTY is Step 5); see
+//! [`hive_desktop_sandbox::windows_elevated::run_command_runner`].
+//!
+//! Port of the `tty = false` branch of upstream
+//! `bin/command_runner/win.rs`; ConPTY (`tty = true`, `spawn_conpty_process_as_user`,
+//! `ResizePseudoConsole`) is stubbed out, not vendored.
+//!
+//! Manifest: this binary relies on the OS default `asInvoker` execution level
+//! for an unmanifested exe; it must NOT auto-elevate, since it runs as the
+//! unprivileged sandbox account. Its name contains no installer-detection
+//! trigger word, so the OS does not auto-elevate it.
+//!
+//! Verification: the Win32 behaviour is lab-gated on `spike307-win` (D-004); CI
+//! only cross-compiles it for `x86_64-pc-windows-gnu`.
+
+#[cfg(windows)]
+fn main() -> std::process::ExitCode {
+    let args: Vec<String> = std::env::args().collect();
+    let pipe_in = arg_value(&args, "--pipe-in");
+    let pipe_out = arg_value(&args, "--pipe-out");
+    let (Some(pipe_in), Some(pipe_out)) = (pipe_in, pipe_out) else {
+        eprintln!("usage: hive-command-runner --pipe-in=<name> --pipe-out=<name>");
+        return std::process::ExitCode::from(2);
+    };
+    match hive_desktop_sandbox::windows_elevated::run_command_runner(&pipe_in, &pipe_out) {
+        Ok(()) => std::process::ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("hive-command-runner failed: {e}");
+            std::process::ExitCode::FAILURE
+        }
+    }
+}
+
+#[cfg(windows)]
+fn arg_value(args: &[String], key: &str) -> Option<String> {
+    let prefix = format!("{key}=");
+    args.iter()
+        .find_map(|a| a.strip_prefix(&prefix).map(str::to_string))
+}
+
+/// Non-Windows: the runner is meaningless off Windows. Fail closed rather than
+/// pretend, matching the crate's honest-stub discipline (D-005).
+#[cfg(not(windows))]
+fn main() -> std::process::ExitCode {
+    eprintln!("hive-command-runner is only functional on Windows");
+    std::process::ExitCode::FAILURE
+}

--- a/apps/desktop-sandbox/hive-desktop-sandbox/src/bin/hive-sandbox-provision.rs
+++ b/apps/desktop-sandbox/hive-desktop-sandbox/src/bin/hive-sandbox-provision.rs
@@ -1,0 +1,67 @@
+//! Hive sandbox setup / provisioning binary (Step 3 Integration A).
+//!
+//! One-time, ELEVATED provisioning of the single shared low-privilege sandbox
+//! account (Q3). It creates the least-privilege local group and account, grants
+//! the interactive-logon right and ensures the Secondary Logon service is
+//! enabled (so `CreateProcessWithLogonW` can use the hidden account, blueprint
+//! A.Q1), DPAPI-seals a CSPRNG password into a secrets directory whose ACL
+//! excludes the sandbox account, hides the account and its profile directory,
+//! and writes the readiness marker. It installs NO network egress control (WFP
+//! and the COM firewall block are Integration B; the upstream setup binary's
+//! `install_wfp_filters` / `ensure_offline_*` call sites are OMITTED here).
+//!
+//! See [`hive_desktop_sandbox::windows_elevated::provision_sandbox_account`].
+//!
+//! ## Elevation
+//!
+//! This binary relies on the OS default `asInvoker` execution level for an
+//! unmanifested exe, matching upstream's `bin/setup_main` intent (`asInvoker`,
+//! NOT `requireAdministrator`). It is deliberately named `hive-sandbox-provision`
+//! rather than `*-setup`/`*-install`: a bare exe whose filename matches Windows
+//! installer-detection heuristics (`setup`, `install`, `update`, `patch`) is
+//! auto-elevated by the OS even without a manifest, which would be an
+//! unintended, silent UAC prompt. Avoiding those trigger words in the name
+//! gives the correct `asInvoker` behaviour with no embedded manifest or build
+//! script. It is the ELEVATED WORKER: the desktop app's launch
+//! path runs it once via `ShellExecute "runas"` (the single UAC consent, lab
+//! item L1) when `sandbox_setup_is_complete` is false. That app-side elevation
+//! trigger lives in the desktop shell (Tauri), not in this crate, which is
+//! deliberately the OS-mechanism layer. Run directly, it must already be
+//! elevated; a non-elevated run fails at the first privileged step (fail-closed,
+//! never a partial account).
+//!
+//! ## Configuration
+//!
+//! The sandbox home directory is read from the `HIVE_SANDBOX_HOME` environment
+//! variable (required); there is no implicit default, so provisioning never
+//! writes an account marker to an unexpected location.
+//!
+//! Verification: the Win32 behaviour is lab-gated on `spike307-win` (D-004); CI
+//! only cross-compiles it for `x86_64-pc-windows-gnu`.
+
+#[cfg(windows)]
+fn main() -> std::process::ExitCode {
+    let sandbox_home = match std::env::var_os("HIVE_SANDBOX_HOME") {
+        Some(v) => std::path::PathBuf::from(v),
+        None => {
+            eprintln!("HIVE_SANDBOX_HOME must be set to the Hive sandbox home directory");
+            return std::process::ExitCode::from(2);
+        }
+    };
+    let mut log = std::io::stderr();
+    match hive_desktop_sandbox::windows_elevated::provision_sandbox_account(&sandbox_home, &mut log)
+    {
+        Ok(()) => std::process::ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("hive-sandbox-setup provisioning failed: {e}");
+            std::process::ExitCode::FAILURE
+        }
+    }
+}
+
+/// Non-Windows: provisioning is Windows-only. Fail closed (D-005).
+#[cfg(not(windows))]
+fn main() -> std::process::ExitCode {
+    eprintln!("hive-sandbox-setup is only functional on Windows");
+    std::process::ExitCode::FAILURE
+}

--- a/apps/desktop-sandbox/hive-desktop-sandbox/src/bin/hive-sandbox-validate.rs
+++ b/apps/desktop-sandbox/hive-desktop-sandbox/src/bin/hive-sandbox-validate.rs
@@ -41,6 +41,29 @@ fn main() -> std::process::ExitCode {
     let ws = std::env::var_os("HIVE_VALIDATE_WS")
         .map(PathBuf::from)
         .unwrap_or_else(|| sandbox_home.join("ws"));
+
+    // Greptile finding, PR #401: `sandbox_home`/`ws` flow unescaped into a
+    // `cmd.exe /c` script below (see the comment on `script` for why proper
+    // escaping is not attempted). This tool is lab-only and its env vars are
+    // operator-supplied, not attacker input, but fail closed rather than
+    // silently building a script whose structure a stray metacharacter can
+    // rewrite. Reject up front instead of trying to escape.
+    for (label, p) in [
+        ("HIVE_SANDBOX_HOME", &sandbox_home),
+        ("HIVE_VALIDATE_WS", &ws),
+    ] {
+        let s = p.to_string_lossy();
+        if s.chars()
+            .any(|c| c.is_whitespace() || "&|<>^%\"".contains(c))
+        {
+            eprintln!(
+                "{label} must not contain whitespace or cmd.exe metacharacters (& | < > ^ % \"): {}",
+                p.display()
+            );
+            return std::process::ExitCode::from(2);
+        }
+    }
+
     if let Err(e) = std::fs::create_dir_all(&ws) {
         eprintln!("create workspace {}: {e}", ws.display());
         return std::process::ExitCode::FAILURE;

--- a/apps/desktop-sandbox/hive-desktop-sandbox/src/bin/hive-sandbox-validate.rs
+++ b/apps/desktop-sandbox/hive-desktop-sandbox/src/bin/hive-sandbox-validate.rs
@@ -1,0 +1,170 @@
+//! Hive sandbox confined-spawn validation harness (Step 3 Integration A, D-004).
+//!
+//! Lab-only. Drives the lab-only
+//! [`hive_desktop_sandbox::windows_elevated::spawn_confined_for_validation`]
+//! entry point on `spike307-win` so the filesystem / user / token isolation
+//! matrix can be PROVEN on a real MSVC Windows host (CI only cross-compiles
+//! this crate for `x86_64-pc-windows-gnu`; it never runs the Win32 paths).
+//!
+//! It launches a probe command AS the low-privilege sandbox account under a
+//! workspace-write capability-restricted token and reports, with raw evidence
+//! (never a bare "pass"):
+//!   (a) the child token user SID (must equal the `hive_sandbox` account SID),
+//!   (b) a write OUTSIDE the writable root is denied,
+//!   (c) a write INSIDE the writable root succeeds,
+//!   (d) reading a seeded secret under the deny-read secrets dir is denied.
+//!
+//! This is a peer of `hive-sandbox-provision`: a `src/bin` target so it lands
+//! in `target/<profile>/` next to `hive-command-runner.exe`, which is what the
+//! helper-resolution sibling lookup (`helper_materialization::find_runner_exe`)
+//! needs to locate the runner. Run AFTER `hive-sandbox-provision` has created
+//! the account. It performs NO privileged provisioning itself.
+//!
+//! Configuration (environment):
+//!   HIVE_SANDBOX_HOME  required, same sandbox home passed to provisioning.
+//!   HIVE_VALIDATE_WS   optional writable-root dir; default `<home>\ws`. Must be
+//!                      granted write to the sandbox account by the operator
+//!                      (icacls) before running; it is the designated workspace.
+
+#[cfg(windows)]
+fn main() -> std::process::ExitCode {
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+
+    let sandbox_home = match std::env::var_os("HIVE_SANDBOX_HOME") {
+        Some(v) => PathBuf::from(v),
+        None => {
+            eprintln!("HIVE_SANDBOX_HOME must be set");
+            return std::process::ExitCode::from(2);
+        }
+    };
+    let ws = std::env::var_os("HIVE_VALIDATE_WS")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| sandbox_home.join("ws"));
+    if let Err(e) = std::fs::create_dir_all(&ws) {
+        eprintln!("create workspace {}: {e}", ws.display());
+        return std::process::ExitCode::FAILURE;
+    }
+
+    // Expected sandbox account SID, resolved independently of the child so the
+    // (a) assertion compares two independently-obtained values.
+    let expected_sid = match codex_windows_sandbox::sandbox_users::resolve_sid(
+        hive_desktop_sandbox::windows_elevated::SANDBOX_USERNAME,
+    ) {
+        Ok(bytes) => match codex_windows_sandbox::winutil::string_from_sid_bytes(&bytes) {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("sandbox SID to string: {e}");
+                return std::process::ExitCode::FAILURE;
+            }
+        },
+        Err(e) => {
+            eprintln!("resolve sandbox SID: {e:#}");
+            return std::process::ExitCode::FAILURE;
+        }
+    };
+
+    // Paths the probe touches. `outside` is the sandbox_home root: created by
+    // provisioning as an administrator, the least-privilege sandbox account has
+    // no write there, so a write must be denied. `secret` is the DPAPI blob
+    // under the deny-read secrets dir provisioning sealed.
+    let inside = ws.join("inside.txt");
+    let outside = sandbox_home.join("outside_probe.txt");
+    let secret = hive_desktop_sandbox::windows_elevated::sandbox_creds_path(&sandbox_home);
+    let _ = std::fs::remove_file(&inside);
+    let _ = std::fs::remove_file(&outside);
+
+    // Probe batch: each step prints a marker so stdout is self-describing.
+    let script = format!(
+        "whoami /user & echo ===INSIDE=== & (echo probe> \"{inside}\" && echo INSIDE_WRITE_OK || echo INSIDE_WRITE_DENIED) & \
+         echo ===OUTSIDE=== & (echo probe> \"{outside}\" && echo OUTSIDE_WRITE_OK || echo OUTSIDE_WRITE_DENIED) & \
+         echo ===SECRET=== & (type \"{secret}\" >nul 2>&1 && echo SECRET_READ_OK || echo SECRET_READ_DENIED)",
+        inside = inside.display(),
+        outside = outside.display(),
+        secret = secret.display(),
+    );
+    let command = vec![
+        r"C:\Windows\System32\cmd.exe".to_string(),
+        "/c".to_string(),
+        script,
+    ];
+
+    let policy = match hive_desktop_sandbox::SandboxPolicy::build(
+        vec![ws.clone()],
+        vec![],
+        sandbox_home.join("hooks"),
+        hive_desktop_sandbox::NetworkPolicy::DenyAll,
+    ) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("build policy: {e}");
+            return std::process::ExitCode::FAILURE;
+        }
+    };
+
+    let env: HashMap<String, String> = HashMap::new();
+    println!("== confined-spawn validation ==");
+    println!("sandbox_home = {}", sandbox_home.display());
+    println!("workspace    = {}", ws.display());
+    println!("expected sandbox SID = {expected_sid}");
+
+    let result = hive_desktop_sandbox::windows_elevated::spawn_confined_for_validation(
+        &sandbox_home,
+        &policy,
+        &command,
+        &ws,
+        &env,
+    );
+    let capture = match result {
+        Ok(c) => c,
+        Err(e) => {
+            // The IPC-failure blocker surfaces here as a confinement error
+            // (e.g. the 15s pipe-connect timeout). Print it as the evidence.
+            eprintln!("spawn_confined_for_validation FAILED: {e}");
+            return std::process::ExitCode::FAILURE;
+        }
+    };
+
+    let stdout = String::from_utf8_lossy(&capture.stdout);
+    let stderr = String::from_utf8_lossy(&capture.stderr);
+    println!(
+        "-- child exit_code = {} timed_out = {} --",
+        capture.exit_code, capture.timed_out
+    );
+    println!("-- child stdout --\n{stdout}");
+    println!("-- child stderr --\n{stderr}");
+
+    // Independent, parent-side filesystem evidence (does not trust child stdout).
+    let inside_exists = inside.is_file();
+    let outside_exists = outside.is_file();
+    println!("-- parent-side filesystem evidence --");
+    println!("inside file exists (expect true):  {inside_exists}");
+    println!("outside file exists (expect false): {outside_exists}");
+
+    // Derived verdicts from the raw evidence above. Printed for convenience;
+    // the raw evidence is authoritative.
+    let sid_ok = stdout.to_lowercase().contains(&expected_sid.to_lowercase());
+    let inside_ok = inside_exists && stdout.contains("INSIDE_WRITE_OK");
+    let outside_denied = !outside_exists && stdout.contains("OUTSIDE_WRITE_DENIED");
+    let secret_denied = stdout.contains("SECRET_READ_DENIED");
+    println!("-- derived verdicts --");
+    println!("(a) child SID == sandbox SID : {sid_ok}");
+    println!("(b) outside write denied     : {outside_denied}");
+    println!("(c) inside write ok          : {inside_ok}");
+    println!("(d) secret read denied       : {secret_denied}");
+
+    if sid_ok && inside_ok && outside_denied && secret_denied {
+        println!("VALIDATION: ALL ASSERTIONS PASS");
+        std::process::ExitCode::SUCCESS
+    } else {
+        println!("VALIDATION: ONE OR MORE ASSERTIONS FAILED (see evidence above)");
+        std::process::ExitCode::FAILURE
+    }
+}
+
+/// Non-Windows: the confined spawn is Windows-only. Fail closed (D-005).
+#[cfg(not(windows))]
+fn main() -> std::process::ExitCode {
+    eprintln!("hive-sandbox-validate is only functional on Windows");
+    std::process::ExitCode::FAILURE
+}

--- a/apps/desktop-sandbox/hive-desktop-sandbox/src/bin/hive-sandbox-validate.rs
+++ b/apps/desktop-sandbox/hive-desktop-sandbox/src/bin/hive-sandbox-validate.rs
@@ -66,22 +66,35 @@ fn main() -> std::process::ExitCode {
 
     // Paths the probe touches. `outside` is the sandbox_home root: created by
     // provisioning as an administrator, the least-privilege sandbox account has
-    // no write there, so a write must be denied. `secret` is the DPAPI blob
-    // under the deny-read secrets dir provisioning sealed.
+    // no write there, so a write must be denied. `canary` is a plaintext secret
+    // seeded (by this parent, as admin) INSIDE the deny-read secrets dir, so its
+    // marker inheriting the deny-read ACE means the confined child must not be
+    // able to read it back.
     let inside = ws.join("inside.txt");
     let outside = sandbox_home.join("outside_probe.txt");
-    let secret = hive_desktop_sandbox::windows_elevated::sandbox_creds_path(&sandbox_home);
+    let secrets = hive_desktop_sandbox::windows_elevated::secrets_dir(&sandbox_home);
+    let canary = secrets.join("canary.txt");
+    const CANARY_MARKER: &str = "HIVE_CANARY_DO_NOT_LEAK";
     let _ = std::fs::remove_file(&inside);
     let _ = std::fs::remove_file(&outside);
+    if let Err(e) = std::fs::write(&canary, CANARY_MARKER) {
+        eprintln!("seed canary {}: {e}", canary.display());
+        return std::process::ExitCode::FAILURE;
+    }
 
-    // Probe batch: each step prints a marker so stdout is self-describing.
+    // Probe batch. Paths under the sandbox home contain no spaces, so no inner
+    // quoting is used: quoting the whole script arg and re-quoting inner paths
+    // double-escapes through the argv -> command-line -> cmd re-parse and
+    // produces a malformed path. Commands are sequenced with `&`; each step
+    // prints a marker so stdout is self-describing. `echo`/`type` are cmd
+    // built-ins (no PATH needed); `whoami` resolves via the minimal PATH below.
     let script = format!(
-        "whoami /user & echo ===INSIDE=== & (echo probe> \"{inside}\" && echo INSIDE_WRITE_OK || echo INSIDE_WRITE_DENIED) & \
-         echo ===OUTSIDE=== & (echo probe> \"{outside}\" && echo OUTSIDE_WRITE_OK || echo OUTSIDE_WRITE_DENIED) & \
-         echo ===SECRET=== & (type \"{secret}\" >nul 2>&1 && echo SECRET_READ_OK || echo SECRET_READ_DENIED)",
+        "whoami /user & echo ===INSIDE=== & echo probe>{inside} & \
+         echo ===OUTSIDE=== & echo probe>{outside} & \
+         echo ===SECRET=== & type {canary}",
         inside = inside.display(),
         outside = outside.display(),
-        secret = secret.display(),
+        canary = canary.display(),
     );
     let command = vec![
         r"C:\Windows\System32\cmd.exe".to_string(),
@@ -102,7 +115,15 @@ fn main() -> std::process::ExitCode {
         }
     };
 
-    let env: HashMap<String, String> = HashMap::new();
+    // Minimal, scrubbed environment: enough for cmd/whoami to function
+    // (SystemRoot + a System32 PATH), nothing sensitive. Confinement comes from
+    // the token + ACLs, not from env starvation.
+    let mut env: HashMap<String, String> = HashMap::new();
+    env.insert("SystemRoot".to_string(), r"C:\Windows".to_string());
+    env.insert(
+        "PATH".to_string(),
+        r"C:\Windows\System32;C:\Windows".to_string(),
+    );
     println!("== confined-spawn validation ==");
     println!("sandbox_home = {}", sandbox_home.display());
     println!("workspace    = {}", ws.display());
@@ -144,9 +165,9 @@ fn main() -> std::process::ExitCode {
     // Derived verdicts from the raw evidence above. Printed for convenience;
     // the raw evidence is authoritative.
     let sid_ok = stdout.to_lowercase().contains(&expected_sid.to_lowercase());
-    let inside_ok = inside_exists && stdout.contains("INSIDE_WRITE_OK");
-    let outside_denied = !outside_exists && stdout.contains("OUTSIDE_WRITE_DENIED");
-    let secret_denied = stdout.contains("SECRET_READ_DENIED");
+    let inside_ok = inside_exists;
+    let outside_denied = !outside_exists;
+    let secret_denied = !stdout.contains(CANARY_MARKER);
     println!("-- derived verdicts --");
     println!("(a) child SID == sandbox SID : {sid_ok}");
     println!("(b) outside write denied     : {outside_denied}");

--- a/apps/desktop-sandbox/hive-desktop-sandbox/src/lib.rs
+++ b/apps/desktop-sandbox/hive-desktop-sandbox/src/lib.rs
@@ -12,6 +12,7 @@
 //! (Apache-2.0) versus newly authored here, and for open risks.
 
 pub mod policy;
+pub mod windows_elevated;
 pub mod windows_plan;
 pub mod windows_resolve;
 

--- a/apps/desktop-sandbox/hive-desktop-sandbox/src/windows.rs
+++ b/apps/desktop-sandbox/hive-desktop-sandbox/src/windows.rs
@@ -78,7 +78,18 @@
 //!   network limit and `windows_plan.rs`'s `netsh` codegen is never applied;
 //!   the WFP egress backend is a dedicated later step (Step 4).
 //! - Token privilege reduction / the low-privilege sandbox-user variant
-//!   (Step 3): see control 1 above.
+//!   (Step 3): see control 1 above. Step 3 Integration A lands the elevated
+//!   compose (the sandbox-account `CreateProcessWithLogonW` transport, the
+//!   capability-restricted token derived in the runner, and the per-task ACL
+//!   assembly) in [`crate::windows_elevated`]. That compose is NOT reached
+//!   through this `launch` (which keeps refusing both network policies until
+//!   the WFP egress backend lands in Integration B, per D-005): it is exercised
+//!   only through the lab-only
+//!   [`crate::windows_elevated::spawn_confined_for_validation`] entry point, so
+//!   the filesystem / user / token / Job isolation matrix can be proven on
+//!   `spike307-win` ahead of the composed network success path. The two
+//!   network-refusal guards below are the pure-tested
+//!   [`crate::windows_elevated::LaunchDecision`] made real.
 //! - Environment scrubbing: `CreateProcessAsUserW` is called with
 //!   `lpEnvironment = NULL`, so the child inherits the parent process's full
 //!   environment (secrets and `*_API_KEY`-style values included). A scrubbed

--- a/apps/desktop-sandbox/hive-desktop-sandbox/src/windows.rs
+++ b/apps/desktop-sandbox/hive-desktop-sandbox/src/windows.rs
@@ -99,6 +99,7 @@
 //!   terminal is a later step.
 
 use crate::policy::NetworkPolicy;
+use crate::windows_elevated::LaunchDecision;
 use crate::windows_plan::{
     WindowsConfinementPlan, command_line_to_utf16, is_fully_qualified_program,
 };
@@ -194,22 +195,20 @@ pub(crate) fn launch(
     command: &[String],
     cwd: &Path,
 ) -> Result<SandboxChild, LaunchError> {
-    if matches!(policy.network(), NetworkPolicy::AllowHosts(_)) {
-        // AllowHosts egress enforcement on Windows (WFP) is a later step; the
-        // netsh codegen in windows_plan.rs is NOT wired to a live effect.
-        // Reject rather than launch with unenforced network policy.
-        return Err(LaunchError::AllowHostsNotYetImplemented);
-    }
-    if matches!(policy.network(), NetworkPolicy::DenyAll) {
-        // DenyAll is equally unenforced on Windows in Step 1: the Job Object
-        // carries no network limit and the firewall rule text in
-        // windows_plan.rs is codegen only, never applied. Refuse rather than
-        // run a process while claiming a block-all egress control that is not
-        // in force (symmetric with the AllowHosts rejection above). Real
-        // enforcement is Step 4 (WFP). Two separate guards, not one exhaustive
-        // `match`, so the confinement seam below stays compiled and reachable
-        // for the CI cross-check until Step 4 removes these rejections.
-        return Err(LaunchError::NetworkConfinementNotImplemented);
+    if matches!(
+        policy.network(),
+        NetworkPolicy::AllowHosts(_) | NetworkPolicy::DenyAll
+    ) {
+        // Network confinement (WFP) is not applied on Windows yet (Step 4).
+        // Both network policies refuse rather than launch with an unenforced
+        // egress control. `LaunchDecision` is the single, unit-tested source
+        // of that refusal decision (see its type doc in
+        // `windows_elevated.rs`); this module no longer hand-duplicates the
+        // guard logic inline. Kept as an `if` (not a `match`) so rustc's
+        // dead-code analysis does not treat it as exhaustive and eliminate
+        // the confinement seam below, which must stay compiled and reachable
+        // for the CI cross-check until Step 4 removes this rejection.
+        return Err(LaunchDecision::for_policy(policy).into_refusal());
     }
     if command.is_empty() {
         return Err(LaunchError::Confinement(

--- a/apps/desktop-sandbox/hive-desktop-sandbox/src/windows_elevated.rs
+++ b/apps/desktop-sandbox/hive-desktop-sandbox/src/windows_elevated.rs
@@ -405,10 +405,22 @@ mod windows_impl {
         // SAFETY: `psid` was just built from a valid resolved SID byte buffer by
         // the vendored helper; `add_deny_read_ace` reads it and applies a
         // deny-read ACE to `path`. The buffer outlives the call.
-        let applied = unsafe { acl::add_deny_read_ace(path, psid) }
+        let newly_applied = unsafe { acl::add_deny_read_ace(path, psid) }
             .map_err(|e| anyhow::anyhow!("deny-read ACE on secrets dir: {e}"))?;
-        if !applied {
-            anyhow::bail!("deny-read ACE was not applied to the secrets directory");
+        // `add_deny_read_ace` returns `false` in TWO cases: the deny-read ACE is
+        // already present (an idempotent re-run, which must NOT fail), and — the
+        // vendored acl layer maps a failed `SetEntriesInAclW`/
+        // `SetNamedSecurityInfoW` to `Ok(false)` — when the ACE could not be
+        // applied at all. Treating every `false` as fatal is what broke
+        // re-running provisioning ("deny-read ACE was not applied"). Fail closed
+        // (D-005): only accept a non-add once we have confirmed the deny is
+        // actually in force on disk; otherwise bail.
+        if !newly_applied {
+            let present = acl::path_has_read_deny(path, psid)
+                .map_err(|e| anyhow::anyhow!("verify deny-read ACE on secrets dir: {e}"))?;
+            if !present {
+                anyhow::bail!("deny-read ACE was not applied to the secrets directory");
+            }
         }
         Ok(())
     }
@@ -654,6 +666,40 @@ mod windows_impl {
     // Runner-side (spawn_prep.rs + command_runner/win.rs port; tty = false)
     // -------------------------------------------------------------------
 
+    /// Append-only diagnostic sink for the command-runner startup path.
+    ///
+    /// The runner is launched by `CreateProcessWithLogonW` with
+    /// `CREATE_NO_WINDOW` and no redirected stdio, so anything it writes to
+    /// stderr is discarded: a failure BEFORE the IPC handshake (for example a
+    /// pipe-open error) otherwise leaves no trace at all, which is exactly the
+    /// blind spot that made the "runner exits before connecting" blocker
+    /// undiagnosable. This writes timestamped lines to
+    /// `<temp>/hive-command-runner.log` in the runner account's OWN temp
+    /// directory (readable by an administrator for lab inspection).
+    ///
+    /// Gated on `HIVE_RUNNER_DEBUG=1` so it is inert in normal operation and
+    /// leaves the release path untouched. It NEVER logs the sandbox password,
+    /// credential bytes, or environment values (D-005 honest logging); only
+    /// non-sensitive shape (counts, flags, pipe names, error kinds).
+    fn runner_debug_log(msg: &str) {
+        if std::env::var("HIVE_RUNNER_DEBUG").ok().as_deref() != Some("1") {
+            return;
+        }
+        let path = std::env::temp_dir().join("hive-command-runner.log");
+        if let Ok(mut f) = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+        {
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_millis())
+                .unwrap_or(0);
+            let pid = std::process::id();
+            let _ = writeln!(f, "[{now}][pid {pid}] {msg}");
+        }
+    }
+
     /// Runs the Hive command-runner protocol on the two named pipes. This is
     /// the process that `CreateProcessWithLogonW` starts AS the sandbox account;
     /// it derives a capability-restricted primary token FROM ITS OWN token and
@@ -665,21 +711,33 @@ mod windows_impl {
     /// fail-closed (an `Error` frame), never silently downgraded; ConPTY is
     /// Step 5.
     pub fn run_command_runner(pipe_in: &str, pipe_out: &str) -> Result<()> {
+        runner_debug_log(&format!(
+            "run_command_runner entry: pipe_in={pipe_in} pipe_out={pipe_out}"
+        ));
         // The runner is the pipe CLIENT: it opens the parent's server pipes as
         // files. `pipe_in` was created by the parent with PIPE_ACCESS_OUTBOUND
         // (parent writes, runner reads); `pipe_out` PIPE_ACCESS_INBOUND (runner
         // writes, parent reads). Opening a named pipe as a std file is the
         // documented client path and avoids a bespoke CreateFileW FFI.
+        runner_debug_log("opening inbound pipe (pipe_in)");
         let mut reader = File::options()
             .read(true)
             .write(true)
             .open(pipe_in)
-            .map_err(|e| anyhow::anyhow!("open inbound pipe {pipe_in}: {e}"))?;
+            .map_err(|e| {
+                runner_debug_log(&format!("open inbound pipe FAILED: {e}"));
+                anyhow::anyhow!("open inbound pipe {pipe_in}: {e}")
+            })?;
+        runner_debug_log("inbound pipe opened; opening outbound pipe (pipe_out)");
         let mut writer = File::options()
             .read(true)
             .write(true)
             .open(pipe_out)
-            .map_err(|e| anyhow::anyhow!("open outbound pipe {pipe_out}: {e}"))?;
+            .map_err(|e| {
+                runner_debug_log(&format!("open outbound pipe FAILED: {e}"));
+                anyhow::anyhow!("open outbound pipe {pipe_out}: {e}")
+            })?;
+        runner_debug_log("both pipes opened; reading spawn request frame");
 
         let request = match ipc_framed::read_frame(&mut reader) {
             Ok(Some(FramedMessage {
@@ -700,8 +758,25 @@ mod windows_impl {
             }
         };
 
+        // Non-sensitive shape only: NO env values, NO command args, NO creds.
+        runner_debug_log(&format!(
+            "spawn request received: program={:?} argc={} tty={} read_only={} cap_sids={} workspace_roots={} env_keys={}",
+            request
+                .command
+                .first()
+                .map(String::as_str)
+                .unwrap_or("<none>"),
+            request.command.len(),
+            request.tty,
+            request.permission_profile.read_only,
+            request.cap_sids.len(),
+            request.workspace_roots.len(),
+            request.env.len(),
+        ));
+
         // ConPTY stub site 1: fail closed, never downgrade to pipes silently.
         if request.tty {
+            runner_debug_log("rejecting tty=true (ConPTY is Step 5)");
             send_error(
                 &mut writer,
                 ErrorStage::SpawnChild,
@@ -747,6 +822,11 @@ mod windows_impl {
             .collect::<Result<Vec<_>>>()?;
         let cap_ptrs: Vec<*mut c_void> = cap_sids.iter().map(|s| s.as_ptr()).collect();
 
+        runner_debug_log(&format!(
+            "applying per-task allow ACEs: {} root(s) x {} cap sid(s)",
+            request.workspace_roots.len(),
+            cap_ptrs.len()
+        ));
         // Apply the per-task ACL grants for the workspace roots BEFORE spawning
         // (spawn_prep assembly). Each capability SID gets an allow-write ACE on
         // its writable roots; the cap SID is what the restricted token carries.
@@ -756,6 +836,10 @@ mod windows_impl {
                 // which outlives this loop); `add_allow_ace` applies an allow ACE
                 // to the validated absolute root path.
                 let _ = unsafe { acl::add_allow_ace(root.as_path(), *psid) }.map_err(|e| {
+                    runner_debug_log(&format!(
+                        "allow ACE FAILED on {}: {e}",
+                        root.as_path().display()
+                    ));
                     anyhow::anyhow!("allow ACE on {}: {e}", root.as_path().display())
                 })?;
             }
@@ -767,6 +851,10 @@ mod windows_impl {
         // handles are closed below. Because the derived token comes from the
         // caller's OWN token it is assignable, so the CreateProcessAsUserW
         // inside spawn_process_with_pipes needs no privilege (A.Q1).
+        runner_debug_log(&format!(
+            "deriving capability-restricted token from own token (read_only={})",
+            request.permission_profile.read_only
+        ));
         let token = unsafe {
             let base = get_current_token_for_restriction()?;
             let derived = if request.permission_profile.read_only {
@@ -777,6 +865,7 @@ mod windows_impl {
             CloseHandle(base);
             derived?
         };
+        runner_debug_log("token derived; spawning inner child via CreateProcessAsUserW");
 
         let spawn_result = spawn_process_with_pipes(
             token,
@@ -794,7 +883,14 @@ mod windows_impl {
         unsafe {
             CloseHandle(token);
         }
-        let handles = spawn_result?;
+        let handles = spawn_result.map_err(|e| {
+            runner_debug_log(&format!("spawn_process_with_pipes FAILED: {e}"));
+            e
+        })?;
+        runner_debug_log(&format!(
+            "inner child spawned (pid={}); acking SpawnReady and streaming",
+            handles.process.dwProcessId
+        ));
 
         stream_child(handles, writer)
     }
@@ -834,6 +930,9 @@ mod windows_impl {
             }
             code as i32
         };
+        runner_debug_log(&format!(
+            "child pid={pid} exited code={exit_code}; sending Exit frame"
+        ));
 
         ipc_framed::write_frame(
             &mut *writer,

--- a/apps/desktop-sandbox/hive-desktop-sandbox/src/windows_elevated.rs
+++ b/apps/desktop-sandbox/hive-desktop-sandbox/src/windows_elevated.rs
@@ -1,0 +1,1005 @@
+//! Hive-typed elevated Windows sandbox compose (Step 3, Integration A core).
+//!
+//! This module is the Hive-proprietary port of the upstream elevated helper
+//! surface (`openai/codex` `codex-rs/windows-sandbox-rs`, commit `a47c661…`,
+//! Apache-2.0; see `../../VENDORING.md`). It ports, retargeted from
+//! `codex_protocol` + `CODEX_HOME` to
+//! [`crate::windows_resolve::ResolvedWindowsSandboxPermissions`] and a
+//! caller-supplied Hive config directory (Q1 decision, drop `codex_protocol`):
+//!
+//! - `allow.rs::compute_allow_paths_for_permissions` -> [`compute_allow_paths`]
+//!   (pure path selection for the per-task ACL grant set).
+//! - `elevated_impl.rs::run_windows_sandbox_capture_for_permission_profile`
+//!   (the `tty = false` CAPTURE half only) -> [`run_windows_sandbox_capture`].
+//! - the token / env / cwd / ACL assembly of `spawn_prep.rs` -> the runner-side
+//!   [`run_command_runner`] (token derivation + per-task ACL + child spawn).
+//! - the provisioning-readiness and credential-load logic of `identity.rs` /
+//!   `setup.rs` (W2 shipped stand-ins) -> [`sandbox_setup_is_complete`],
+//!   [`load_logon_sandbox_creds`], [`provision_sandbox_account`].
+//!
+//! ## Elevation model (blueprint A.Q1, RESOLVED, locked)
+//!
+//! Nothing in the per-task launch path holds or needs
+//! `SeAssignPrimaryTokenPrivilege`, and nothing prompts UAC. The non-elevated
+//! Hive app launches the Hive command-runner AS the sandbox user with
+//! `CreateProcessWithLogonW` (done inside the vendored
+//! `runner_client::spawn_runner_transport`), passing the sandbox account, `.`
+//! domain, and the DPAPI-unsealed password with `LOGON_WITH_PROFILE`. The
+//! command-runner, now running as the low-privilege sandbox account, derives a
+//! capability-restricted primary token FROM ITS OWN token
+//! (`get_current_token_for_restriction` +
+//! `create_*_token_with_caps_and_user_from`) and spawns the inner child with
+//! `CreateProcessAsUserW` (via `spawn_process_with_pipes`). A token derived
+//! from the caller's own token is assignable, so that call needs no privilege.
+//! UAC prompts exactly once, at provisioning, when the setup binary runs
+//! elevated to create the OS account.
+//!
+//! ## Network semantics (blueprint Q2 / D-005, locked)
+//!
+//! Step 3 does NOT enforce network egress (WFP is Integration B). The public
+//! [`crate::launch`] therefore keeps REFUSING both `NetworkPolicy::DenyAll`
+//! (`NetworkConfinementNotImplemented`) and `NetworkPolicy::AllowHosts`
+//! (`AllowHostsNotYetImplemented`); see [`LaunchDecision`]. There is no
+//! `launch()` code path that reports success while a child has unrestricted
+//! network. The elevated compose ([`run_windows_sandbox_capture`]) is reachable
+//! ONLY through the explicit, lab-only
+//! [`spawn_confined_for_validation`] entry point, which is documented as NOT a
+//! network-confined launch and exists solely so the `spike307-win` lab can
+//! prove the filesystem / user / token / Job isolation matrix (exactly as #395
+//! proved its primitives by lab replica, ahead of the composed success path
+//! that lands with Integration B).
+//!
+//! ## Verification status (read before trusting this file)
+//!
+//! Every Win32 path here (`#[cfg(windows)]`) is cross-compiled by CI for
+//! `x86_64-pc-windows-gnu` (type-checked against real `windows-sys` 0.52
+//! signatures) but is NEVER executed off a real MSVC Windows host. All runtime
+//! confinement assertions are lab-gated on `spike307-win` (D-004); see the
+//! `LAB VALIDATION CHECKLIST` at the bottom of this file. The pure-logic parts
+//! ([`LaunchDecision::for_policy`], [`compute_allow_paths`], the config-path
+//! helpers) run on every platform, including this crate's Linux CI, and are
+//! unit-tested there.
+
+use crate::policy::NetworkPolicy;
+use crate::windows_resolve::ResolvedWindowsSandboxPermissions;
+use crate::{LaunchError, SandboxPolicy};
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+// ===========================================================================
+// Pure, cross-platform logic (unit-tested on Linux CI)
+// ===========================================================================
+
+/// Captured output and exit status of a confined child run over the framed
+/// pipe. Hive-native replacement for upstream's `windows_impl::CaptureResult`.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct CaptureResult {
+    pub exit_code: i32,
+    pub stdout: Vec<u8>,
+    pub stderr: Vec<u8>,
+    pub timed_out: bool,
+}
+
+/// The decision [`crate::launch`] reaches for a policy BEFORE any spawn.
+///
+/// Step 3 has no `Spawn` variant on purpose: [`NetworkPolicy`] has exactly two
+/// variants and Step 3 refuses BOTH (WFP is Integration B; Q2/D-005). A future
+/// `Spawn` variant lands with Integration B, when the refusal guards are
+/// removed and the composed success path runs for the first time. Keeping this
+/// as an explicit enum (rather than two inline `if` guards) makes the
+/// refuse-vs-spawn decision independently unit-testable, and gives Integration
+/// B one obvious place to add the success branch.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LaunchDecision {
+    /// `NetworkPolicy::AllowHosts`: refuse with
+    /// [`LaunchError::AllowHostsNotYetImplemented`] (needs the egress proxy +
+    /// WFP, Integration B).
+    RefuseAllowHosts,
+    /// `NetworkPolicy::DenyAll`: refuse with
+    /// [`LaunchError::NetworkConfinementNotImplemented`]. A `DenyAll` child
+    /// under a standard sandbox user CAN still open sockets, so spawning it
+    /// without WFP would be a SILENT fail-open (D-005, FORBIDDEN). Refuse until
+    /// Integration B installs the WFP block.
+    RefuseDenyAll,
+}
+
+impl LaunchDecision {
+    /// Pure mapping from a policy's network posture to the Step 3 launch
+    /// decision. Both variants refuse; see the type doc.
+    pub fn for_policy(policy: &SandboxPolicy) -> Self {
+        match policy.network() {
+            NetworkPolicy::AllowHosts(_) => LaunchDecision::RefuseAllowHosts,
+            NetworkPolicy::DenyAll => LaunchDecision::RefuseDenyAll,
+        }
+    }
+
+    /// The [`LaunchError`] this decision produces from the public launch path.
+    pub fn into_refusal(self) -> LaunchError {
+        match self {
+            LaunchDecision::RefuseAllowHosts => LaunchError::AllowHostsNotYetImplemented,
+            LaunchDecision::RefuseDenyAll => LaunchError::NetworkConfinementNotImplemented,
+        }
+    }
+}
+
+/// The filesystem paths a per-task ACL grant should allow (writable) and deny
+/// (read-only carve-outs inside a writable root). Hive port of
+/// `allow.rs::AllowDenyPaths`.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct AllowDenyPaths {
+    pub allow: HashSet<PathBuf>,
+    pub deny: HashSet<PathBuf>,
+}
+
+/// Port of `allow.rs::compute_allow_paths_for_permissions`, retargeted to the
+/// Hive resolver.
+///
+/// Upstream iterates `permissions.writable_roots_for_cwd(cwd, env)` (cwd- and
+/// env-parameterized) and, per writable root, canonicalizes the root into the
+/// `allow` set and pushes each `read_only_subpath` into `deny`. The Hive
+/// resolver is PRE-RESOLVED against a fixed cwd at
+/// [`ResolvedWindowsSandboxPermissions::from_policy`] time, so the accessor is
+/// the argument-free [`ResolvedWindowsSandboxPermissions::writable_roots`]; the
+/// six upstream call sites collapse to this one, per blueprint A.Q2. Honest
+/// difference recorded (D-005): `read_only_subpaths` is always empty from the
+/// Hive resolver today (`SandboxPolicy` cannot express a nested read-only
+/// carve-out, and `deny_read_resolver.rs`'s glob-scan carve-out selection is
+/// deliberately not ported because there is nothing to resolve yet), so `deny`
+/// is empty here rather than reproducing upstream's `.git`/`.codex`/`.agents`
+/// deny logic, which lives in upstream's resolver, not in `allow.rs`. When a
+/// future `SandboxPolicy` extension populates carve-outs, this function already
+/// propagates them without a shape change.
+///
+/// Only paths that currently exist are added, matching upstream (an ACL grant
+/// for a non-existent path is meaningless and would error at apply time).
+pub fn compute_allow_paths(permissions: &ResolvedWindowsSandboxPermissions) -> AllowDenyPaths {
+    let mut allow: HashSet<PathBuf> = HashSet::new();
+    let mut deny: HashSet<PathBuf> = HashSet::new();
+
+    for writable_root in permissions.writable_roots() {
+        let canonical =
+            dunce::canonicalize(&writable_root.root).unwrap_or_else(|_| writable_root.root.clone());
+        if canonical.exists() {
+            allow.insert(canonical);
+        }
+        for read_only_subpath in &writable_root.read_only_subpaths {
+            if read_only_subpath.exists() {
+                deny.insert(read_only_subpath.clone());
+            }
+        }
+    }
+
+    AllowDenyPaths { allow, deny }
+}
+
+// ---- Config-directory layout (pure; caller supplies the Hive sandbox home) --
+
+/// Provisioning-readiness marker filename under the Hive sandbox home. Mirrors
+/// upstream's setup-marker concept but with a Hive name and a Hive version.
+const SETUP_MARKER_FILE: &str = "setup-marker.json";
+/// Sealed sandbox-account credential file (DPAPI blob) under the sandbox home.
+const SANDBOX_CREDS_FILE: &str = "sandbox-creds.dpapi";
+/// Bump when the provisioning layout changes so a stale marker forces
+/// re-provisioning rather than a broken reuse.
+const SETUP_MARKER_VERSION: u32 = 1;
+
+/// `<home>/setup-marker.json`.
+pub fn setup_marker_path(sandbox_home: &Path) -> PathBuf {
+    sandbox_home.join(SETUP_MARKER_FILE)
+}
+
+/// `<home>/secrets` — DPAPI-sealed credential directory. Its ACL MUST exclude
+/// the sandbox account (lab item L5); provisioning applies that ACL.
+pub fn secrets_dir(sandbox_home: &Path) -> PathBuf {
+    sandbox_home.join("secrets")
+}
+
+/// `<home>/secrets/sandbox-creds.dpapi`.
+pub fn sandbox_creds_path(sandbox_home: &Path) -> PathBuf {
+    secrets_dir(sandbox_home).join(SANDBOX_CREDS_FILE)
+}
+
+/// Fixed local account name for the ONE shared low-privilege sandbox user
+/// (Q3: one shared user for the desktop surface). Kept short and prefixed so
+/// it is recognizable in `net user` output and unlikely to collide.
+pub const SANDBOX_USERNAME: &str = "hive_sandbox";
+/// Local group the sandbox account is the sole member of (least privilege).
+pub const SANDBOX_GROUP: &str = "hive_sandbox_users";
+
+/// `true` iff a valid, current provisioning marker exists. Port of
+/// `identity.rs::sandbox_setup_is_complete`, retargeted off `CODEX_HOME`.
+/// Pure filesystem read; safe on every platform (the account it gates is
+/// Windows-only, but the readiness check itself is not).
+pub fn sandbox_setup_is_complete(sandbox_home: &Path) -> bool {
+    let Ok(bytes) = std::fs::read(setup_marker_path(sandbox_home)) else {
+        return false;
+    };
+    match serde_json::from_slice::<SetupMarker>(&bytes) {
+        Ok(marker) => marker.version == SETUP_MARKER_VERSION,
+        Err(_) => false,
+    }
+}
+
+/// On-disk provisioning-readiness marker.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+struct SetupMarker {
+    version: u32,
+    username: String,
+}
+
+// ===========================================================================
+// Windows-only Win32 compose (cross-compiled for windows-gnu; lab-gated)
+// ===========================================================================
+
+#[cfg(windows)]
+pub use windows_impl::{
+    load_logon_sandbox_creds, provision_sandbox_account, run_command_runner,
+    run_windows_sandbox_capture, spawn_confined_for_validation,
+};
+
+#[cfg(windows)]
+mod windows_impl {
+    use super::*;
+    use codex_windows_sandbox::absolute_path::AbsolutePathBuf;
+    use codex_windows_sandbox::identity::SandboxCreds;
+    use codex_windows_sandbox::ipc_framed::{
+        self, ErrorStage, FramedMessage, Message, OutputPayload, OutputStream, SpawnReady,
+        SpawnRequest,
+    };
+    use codex_windows_sandbox::permission_profile::PermissionProfile;
+    use codex_windows_sandbox::process::{
+        ConsoleMode, PipeSpawnHandles, StderrMode, StdinMode, spawn_process_with_pipes,
+    };
+    use codex_windows_sandbox::runner_client::{retry_runner_spawn_once, spawn_runner_transport};
+    use codex_windows_sandbox::token::{
+        LocalSid, create_readonly_token_with_caps_and_user_from,
+        create_workspace_write_token_with_caps_and_user_from, get_current_token_for_restriction,
+    };
+    use codex_windows_sandbox::{acl, cap, dpapi, hide_users, sandbox_users};
+    use std::collections::HashMap;
+    use std::ffi::c_void;
+    use std::fs::File;
+    use std::io::{Read, Write};
+
+    use windows_sys::Win32::Foundation::{CloseHandle, GetLastError, HANDLE, WAIT_OBJECT_0};
+    use windows_sys::Win32::Security::Authentication::Identity::{
+        LSA_HANDLE, LSA_OBJECT_ATTRIBUTES, LSA_UNICODE_STRING, LsaAddAccountRights, LsaClose,
+        LsaOpenPolicy, POLICY_CREATE_ACCOUNT, POLICY_LOOKUP_NAMES,
+    };
+    use windows_sys::Win32::System::Services::{
+        CloseServiceHandle, OpenSCManagerW, OpenServiceW, QueryServiceStatus, SC_MANAGER_CONNECT,
+        SERVICE_QUERY_STATUS, SERVICE_START, SERVICE_STATUS, StartServiceW,
+    };
+    use windows_sys::Win32::System::Threading::{
+        GetExitCodeProcess, INFINITE, WaitForSingleObject,
+    };
+
+    // The runner-spawn transport wants a "codex_home"-shaped base directory for
+    // its runner-exe resolution and log dir; Hive passes the sandbox home. The
+    // name is kept as `codex_home` at the vendored call boundary only.
+    type Result<T> = anyhow::Result<T>;
+
+    // -------------------------------------------------------------------
+    // Credential seal / load (identity.rs port; DPAPI at rest)
+    // -------------------------------------------------------------------
+
+    /// Loads the sandbox-account logon credentials, DPAPI-unsealing the
+    /// password. Port of `identity.rs::require_logon_sandbox_creds`'s load half
+    /// (the resolver-driven ACL-refresh half is Integration-B/refresh scope and
+    /// is deliberately not reproduced: Step 3 provisions ACLs once, at
+    /// provisioning, per A.Q1). Fail-closed (D-005): any missing marker, missing
+    /// blob, or unseal failure returns an error and never a blank/guessed
+    /// credential.
+    pub fn load_logon_sandbox_creds(sandbox_home: &Path) -> Result<SandboxCreds> {
+        if !sandbox_setup_is_complete(sandbox_home) {
+            anyhow::bail!("sandbox account is not provisioned (no valid setup marker)");
+        }
+        let blob = std::fs::read(sandbox_creds_path(sandbox_home))
+            .map_err(|e| anyhow::anyhow!("read sealed sandbox creds: {e}"))?;
+        let cleartext = dpapi::unprotect(&blob)
+            .map_err(|e| anyhow::anyhow!("DPAPI unseal of sandbox creds failed: {e}"))?;
+        let password = String::from_utf8(cleartext)
+            .map_err(|_| anyhow::anyhow!("sealed sandbox password was not valid UTF-8"))?;
+        Ok(SandboxCreds {
+            username: SANDBOX_USERNAME.to_string(),
+            password,
+        })
+    }
+
+    /// Generates a strong random password for the sandbox account. Uses the
+    /// vendored crate's `rand` (CSPRNG `OsRng`-seeded) via a printable-ASCII
+    /// alphabet broad enough to satisfy the local-account complexity policy.
+    fn generate_password() -> String {
+        use rand::RngCore;
+        use rand::rngs::OsRng;
+        // 32 bytes of CSPRNG entropy, mapped to a 64-char complexity-satisfying
+        // set (upper, lower, digit, symbol) so `NetUserAdd` never rejects it.
+        const ALPHABET: &[u8] =
+            b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()-_=+";
+        let mut raw = [0u8; 32];
+        OsRng.fill_bytes(&mut raw);
+        let mut pw: String = raw
+            .iter()
+            .map(|b| ALPHABET[(*b as usize) % ALPHABET.len()] as char)
+            .collect();
+        // Guarantee at least one of each class regardless of the random draw,
+        // so complexity policy is satisfied deterministically (fail-closed:
+        // never emit a password the account-create step would reject).
+        pw.push_str("Aa1!");
+        pw
+    }
+
+    // -------------------------------------------------------------------
+    // Provisioning (identity.rs / setup.rs port; WFP + firewall OMITTED)
+    // -------------------------------------------------------------------
+
+    /// One-time, ELEVATED provisioning of the shared low-privilege sandbox
+    /// account. Port of the provisioning half of `identity.rs` /`setup.rs`
+    /// (`run_elevated_provisioning_setup`), retargeted to the Hive sandbox home
+    /// and with the WFP/firewall call sites OMITTED (Integration B): this
+    /// authors NO network egress control.
+    ///
+    /// Steps (each fail-closed; a failure aborts and does NOT leave a
+    /// half-created account usable):
+    /// 1. create the least-privilege local group and account (`sandbox_users`);
+    /// 2. grant the interactive-logon right and ensure the Secondary Logon
+    ///    service is enabled, so `CreateProcessWithLogonW` can use the account
+    ///    (blueprint A.Q1 provisioning invariant, lab item L1/L4);
+    /// 3. DPAPI-seal the CSPRNG password into a secrets dir whose ACL excludes
+    ///    the sandbox account (lab item L5);
+    /// 4. hide the account and its profile dir from the login screen (L4);
+    /// 5. write the readiness marker so subsequent launches do not re-elevate.
+    ///
+    /// MUST be run elevated (Administrator). Callers reach it through the setup
+    /// binary, which re-launches itself elevated via `ShellExecute "runas"` for
+    /// exactly one UAC consent (L1).
+    pub fn provision_sandbox_account(sandbox_home: &Path, log: &mut dyn Write) -> Result<()> {
+        std::fs::create_dir_all(sandbox_home)
+            .map_err(|e| anyhow::anyhow!("create sandbox home: {e}"))?;
+        let secrets = secrets_dir(sandbox_home);
+        std::fs::create_dir_all(&secrets)
+            .map_err(|e| anyhow::anyhow!("create secrets dir: {e}"))?;
+
+        let password = generate_password();
+
+        // 1. Least-privilege group + account.
+        sandbox_users::ensure_local_group(SANDBOX_GROUP, "Hive sandbox low-privilege users", log)?;
+        sandbox_users::ensure_local_user(SANDBOX_USERNAME, &password, log)?;
+        sandbox_users::ensure_local_group_member(SANDBOX_GROUP, SANDBOX_USERNAME)?;
+
+        // 2. Logon prerequisites for CreateProcessWithLogonW (A.Q1 invariant).
+        grant_interactive_logon_right(SANDBOX_USERNAME)?;
+        ensure_seclogon_enabled()?;
+
+        // 3. Seal the password; then ACL the secrets dir to EXCLUDE the sandbox
+        //    account so a compromised child cannot read its own credential.
+        let blob = dpapi::protect(password.as_bytes())
+            .map_err(|e| anyhow::anyhow!("DPAPI seal of sandbox password failed: {e}"))?;
+        std::fs::write(sandbox_creds_path(sandbox_home), &blob)
+            .map_err(|e| anyhow::anyhow!("write sealed sandbox creds: {e}"))?;
+        deny_sandbox_account_read(&secrets)?;
+
+        // 4. Hide the account + its profile dir from the login screen.
+        hide_users::hide_newly_created_users(&[SANDBOX_USERNAME.to_string()], sandbox_home);
+
+        // 5. Readiness marker (last, so a partial provisioning is never
+        //    reported complete).
+        let marker = SetupMarker {
+            version: SETUP_MARKER_VERSION,
+            username: SANDBOX_USERNAME.to_string(),
+        };
+        let bytes = serde_json::to_vec_pretty(&marker)
+            .map_err(|e| anyhow::anyhow!("serialize setup marker: {e}"))?;
+        std::fs::write(setup_marker_path(sandbox_home), bytes)
+            .map_err(|e| anyhow::anyhow!("write setup marker: {e}"))?;
+        let _ = writeln!(log, "provisioning complete for {SANDBOX_USERNAME}");
+        Ok(())
+    }
+
+    /// Applies a deny-read ACE for the sandbox account SID on `path`, so the
+    /// sealed credential is not readable by the child. Uses the vendored
+    /// `acl`/`sandbox_users` SID resolution.
+    fn deny_sandbox_account_read(path: &Path) -> Result<()> {
+        let sid_bytes = sandbox_users::resolve_sid(SANDBOX_USERNAME)?;
+        let psid = sandbox_users::sid_bytes_to_psid(&sid_bytes)?;
+        // SAFETY: `psid` was just built from a valid resolved SID byte buffer by
+        // the vendored helper; `add_deny_read_ace` reads it and applies a
+        // deny-read ACE to `path`. The buffer outlives the call.
+        let applied = unsafe { acl::add_deny_read_ace(path, psid) }
+            .map_err(|e| anyhow::anyhow!("deny-read ACE on secrets dir: {e}"))?;
+        if !applied {
+            anyhow::bail!("deny-read ACE was not applied to the secrets directory");
+        }
+        Ok(())
+    }
+
+    /// Grants `SeInteractiveLogonRight` to the account via the LSA policy API,
+    /// so the hidden sandbox account can be used by `CreateProcessWithLogonW`
+    /// (which performs an interactive-style logon). `hide_users` hides the
+    /// account from the login screen but must not strip this right; granting it
+    /// here is the counterpart (blueprint A.Q1 provisioning invariant).
+    fn grant_interactive_logon_right(username: &str) -> Result<()> {
+        // SAFETY: standard LsaOpenPolicy / LsaAddAccountRights sequence. All
+        // pointers point at locals that outlive the calls; every fallible step
+        // is checked and the policy handle is closed on every path.
+        unsafe {
+            let mut attrs: LSA_OBJECT_ATTRIBUTES = std::mem::zeroed();
+            attrs.Length = std::mem::size_of::<LSA_OBJECT_ATTRIBUTES>() as u32;
+            let mut policy: LSA_HANDLE = 0;
+            let status = LsaOpenPolicy(
+                std::ptr::null_mut(),
+                &attrs,
+                (POLICY_CREATE_ACCOUNT | POLICY_LOOKUP_NAMES) as u32,
+                &mut policy,
+            );
+            if status != 0 {
+                anyhow::bail!("LsaOpenPolicy failed: NTSTATUS 0x{status:08x}");
+            }
+
+            let sid_bytes = sandbox_users::resolve_sid(username)?;
+            let psid = sandbox_users::sid_bytes_to_psid(&sid_bytes)?;
+
+            let mut right: Vec<u16> = "SeInteractiveLogonRight".encode_utf16().collect();
+            let right_us = LSA_UNICODE_STRING {
+                Length: (right.len() * 2) as u16,
+                MaximumLength: (right.len() * 2) as u16,
+                Buffer: right.as_mut_ptr(),
+            };
+            let add_status = LsaAddAccountRights(policy, psid, &right_us, 1);
+            let _ = LsaClose(policy);
+            if add_status != 0 {
+                anyhow::bail!("LsaAddAccountRights failed: NTSTATUS 0x{add_status:08x}");
+            }
+        }
+        Ok(())
+    }
+
+    /// Ensures the Secondary Logon service (`seclogon`) is running, since
+    /// `CreateProcessWithLogonW` depends on it (blueprint A.Q1). Fail-closed: a
+    /// service that cannot be started aborts provisioning rather than leaving a
+    /// non-functional account.
+    fn ensure_seclogon_enabled() -> Result<()> {
+        // SAFETY: OpenSCManager / OpenService / QueryServiceStatus / StartService
+        // sequence; every handle is closed and every fallible step checked.
+        unsafe {
+            let scm = OpenSCManagerW(std::ptr::null(), std::ptr::null(), SC_MANAGER_CONNECT);
+            if scm == 0 {
+                anyhow::bail!("OpenSCManagerW failed: {}", GetLastError());
+            }
+            let name: Vec<u16> = "seclogon\0".encode_utf16().collect();
+            let svc = OpenServiceW(scm, name.as_ptr(), SERVICE_QUERY_STATUS | SERVICE_START);
+            if svc == 0 {
+                let err = GetLastError();
+                CloseServiceHandle(scm);
+                anyhow::bail!("OpenServiceW(seclogon) failed: {err}");
+            }
+            let mut status: SERVICE_STATUS = std::mem::zeroed();
+            // Already running is success; otherwise try to start it.
+            if QueryServiceStatus(svc, &mut status) != 0
+                && status.dwCurrentState == windows_sys::Win32::System::Services::SERVICE_RUNNING
+            {
+                CloseServiceHandle(svc);
+                CloseServiceHandle(scm);
+                return Ok(());
+            }
+            let started = StartServiceW(svc, 0, std::ptr::null());
+            CloseServiceHandle(svc);
+            CloseServiceHandle(scm);
+            if started == 0 {
+                let err = GetLastError();
+                // ERROR_SERVICE_ALREADY_RUNNING (1056) is benign.
+                if err != 1056 {
+                    anyhow::bail!("StartServiceW(seclogon) failed: {err}");
+                }
+            }
+        }
+        Ok(())
+    }
+
+    // -------------------------------------------------------------------
+    // Parent-side capture compose (elevated_impl.rs port; tty = false only)
+    // -------------------------------------------------------------------
+
+    /// Builds the capability-SID list for the ACL grants and the `SpawnRequest`
+    /// permission profile from the Hive resolver. Port of the cap-selection
+    /// block of `elevated_impl.rs::run_windows_sandbox_capture_for_permission_profile`.
+    fn cap_sids_for(
+        sandbox_home: &Path,
+        cwd: &Path,
+        permissions: &ResolvedWindowsSandboxPermissions,
+    ) -> Result<Vec<String>> {
+        let caps = cap::load_or_create_cap_sids(sandbox_home)?;
+        if permissions.uses_write_capabilities() {
+            let cap_sids = permissions
+                .writable_roots()
+                .iter()
+                .map(|root| cap::workspace_write_cap_sid_for_root(sandbox_home, cwd, &root.root))
+                .collect::<Result<Vec<_>>>()?;
+            if cap_sids.is_empty() {
+                anyhow::bail!("workspace-write sandbox has no writable-root capability SIDs");
+            }
+            Ok(cap_sids)
+        } else {
+            Ok(vec![caps.readonly])
+        }
+    }
+
+    /// Port of the `tty = false` CAPTURE half of
+    /// `elevated_impl.rs::run_windows_sandbox_capture_for_permission_profile`,
+    /// retargeted to the Hive resolver and sandbox home. Spawns the Hive
+    /// command-runner AS the sandbox user (via the vendored transport, which
+    /// uses `CreateProcessWithLogonW`), sends a `tty = false` `SpawnRequest`,
+    /// and drives the frame loop to capture stdout/stderr/exit.
+    ///
+    /// This is the confinement mechanism; it is NOT a network-confined launch.
+    /// It is invoked only through [`spawn_confined_for_validation`].
+    pub fn run_windows_sandbox_capture(
+        sandbox_home: &Path,
+        policy: &SandboxPolicy,
+        command: &[String],
+        cwd: &Path,
+        env: &HashMap<String, String>,
+    ) -> Result<CaptureResult> {
+        let permissions = ResolvedWindowsSandboxPermissions::from_policy(policy, cwd)
+            .map_err(|e| anyhow::anyhow!("resolve policy: {e}"))?;
+
+        let cap_sids = cap_sids_for(sandbox_home, cwd, &permissions)?;
+        let workspace_roots: Vec<AbsolutePathBuf> = permissions
+            .writable_roots()
+            .iter()
+            .map(|r| AbsolutePathBuf::new(r.root.clone()))
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(|e| anyhow::anyhow!("workspace root not absolute: {e}"))?;
+
+        let spawn_request = SpawnRequest {
+            command: command.to_vec(),
+            cwd: cwd.to_path_buf(),
+            env: env.clone(),
+            permission_profile: PermissionProfile {
+                read_only: !permissions.uses_write_capabilities(),
+            },
+            workspace_roots,
+            codex_home: sandbox_home.to_path_buf(),
+            real_codex_home: sandbox_home.to_path_buf(),
+            cap_sids,
+            timeout_ms: None,
+            tty: false,
+            stdin_open: false,
+            use_private_desktop: false,
+        };
+
+        let sandbox_creds = load_logon_sandbox_creds(sandbox_home)?;
+        let logs_base_dir = sandbox_home.join(".sandbox");
+        let _ = std::fs::create_dir_all(&logs_base_dir);
+
+        let transport = retry_runner_spawn_once(
+            sandbox_creds,
+            &spawn_request.command,
+            |creds| {
+                spawn_runner_transport(
+                    sandbox_home,
+                    cwd,
+                    &creds,
+                    Some(logs_base_dir.as_path()),
+                    spawn_request.clone(),
+                )
+            },
+            // Step 3 does not re-derive creds; a stale-cred failure is a real
+            // provisioning error (fail-closed), so the refresh closure just
+            // reloads the sealed creds rather than silently re-provisioning.
+            || load_logon_sandbox_creds(sandbox_home),
+        )?;
+
+        let (pipe_write, mut pipe_read) = transport.into_files();
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        let result = loop {
+            let msg = match ipc_framed::read_frame(&mut pipe_read) {
+                Ok(Some(msg)) => msg,
+                Ok(None) => break Err(anyhow::anyhow!("runner pipe closed before exit")),
+                Err(err) => break Err(err),
+            };
+            match msg.message {
+                Message::SpawnReady { .. } => {}
+                Message::Output { payload } => match ipc_framed::decode_bytes(&payload.data_b64) {
+                    Ok(bytes) => match payload.stream {
+                        OutputStream::Stdout => stdout.extend_from_slice(&bytes),
+                        OutputStream::Stderr => stderr.extend_from_slice(&bytes),
+                    },
+                    Err(err) => break Err(err),
+                },
+                Message::Exit { payload } => break Ok((payload.exit_code, payload.timed_out)),
+                Message::Error { payload } => {
+                    break Err(anyhow::anyhow!("runner error: {}", payload.message));
+                }
+                other => {
+                    break Err(anyhow::anyhow!("unexpected runner message: {other:?}"));
+                }
+            }
+        };
+        drop(pipe_write);
+        let (exit_code, timed_out) = result?;
+        Ok(CaptureResult {
+            exit_code,
+            stdout,
+            stderr,
+            timed_out,
+        })
+    }
+
+    /// Lab-only confinement-validation entry point. NOT a network-confined
+    /// launch (Q2/D-005): it runs the elevated compose so the `spike307-win`
+    /// lab can prove the filesystem / user / token / Job isolation matrix
+    /// directly, exactly as #395 proved its primitives by lab replica ahead of
+    /// the composed success path. The public [`crate::launch`] never calls this;
+    /// it keeps refusing both network policies until Integration B.
+    pub fn spawn_confined_for_validation(
+        sandbox_home: &Path,
+        policy: &SandboxPolicy,
+        command: &[String],
+        cwd: &Path,
+        env: &HashMap<String, String>,
+    ) -> std::result::Result<CaptureResult, LaunchError> {
+        if !sandbox_setup_is_complete(sandbox_home) {
+            return Err(LaunchError::Confinement(
+                "sandbox account not provisioned; run the Hive sandbox setup binary first"
+                    .to_string(),
+            ));
+        }
+        run_windows_sandbox_capture(sandbox_home, policy, command, cwd, env)
+            .map_err(|e| LaunchError::Confinement(format!("confined validation run: {e}")))
+    }
+
+    // -------------------------------------------------------------------
+    // Runner-side (spawn_prep.rs + command_runner/win.rs port; tty = false)
+    // -------------------------------------------------------------------
+
+    /// Runs the Hive command-runner protocol on the two named pipes. This is
+    /// the process that `CreateProcessWithLogonW` starts AS the sandbox account;
+    /// it derives a capability-restricted primary token FROM ITS OWN token and
+    /// spawns the inner child under it (A.Q1). Port of the `tty = false` branch
+    /// of `bin/command_runner/win.rs` (upstream lines 339-360) plus the
+    /// token/ACL assembly of `spawn_prep.rs`.
+    ///
+    /// ConPTY stub site 1 (blueprint R.1): a `tty = true` request is rejected
+    /// fail-closed (an `Error` frame), never silently downgraded; ConPTY is
+    /// Step 5.
+    pub fn run_command_runner(pipe_in: &str, pipe_out: &str) -> Result<()> {
+        // The runner is the pipe CLIENT: it opens the parent's server pipes as
+        // files. `pipe_in` was created by the parent with PIPE_ACCESS_OUTBOUND
+        // (parent writes, runner reads); `pipe_out` PIPE_ACCESS_INBOUND (runner
+        // writes, parent reads). Opening a named pipe as a std file is the
+        // documented client path and avoids a bespoke CreateFileW FFI.
+        let mut reader = File::options()
+            .read(true)
+            .write(true)
+            .open(pipe_in)
+            .map_err(|e| anyhow::anyhow!("open inbound pipe {pipe_in}: {e}"))?;
+        let mut writer = File::options()
+            .read(true)
+            .write(true)
+            .open(pipe_out)
+            .map_err(|e| anyhow::anyhow!("open outbound pipe {pipe_out}: {e}"))?;
+
+        let request = match ipc_framed::read_frame(&mut reader) {
+            Ok(Some(FramedMessage {
+                message: Message::SpawnRequest { payload },
+                ..
+            })) => *payload,
+            Ok(_) => {
+                send_error(
+                    &mut writer,
+                    ErrorStage::ReadSpawnRequest,
+                    "expected SpawnRequest",
+                );
+                anyhow::bail!("first frame was not a SpawnRequest");
+            }
+            Err(e) => {
+                send_error(&mut writer, ErrorStage::ReadSpawnRequest, &format!("{e}"));
+                return Err(e);
+            }
+        };
+
+        // ConPTY stub site 1: fail closed, never downgrade to pipes silently.
+        if request.tty {
+            send_error(
+                &mut writer,
+                ErrorStage::SpawnChild,
+                "ConPTY sessions (tty=true) are Step 5, not implemented",
+            );
+            anyhow::bail!("tty=true requested but ConPTY is not implemented (Step 5)");
+        }
+
+        match spawn_and_stream(&request, &mut writer) {
+            Ok(()) => Ok(()),
+            Err(e) => {
+                send_error(&mut writer, ErrorStage::SpawnChild, &format!("{e}"));
+                Err(e)
+            }
+        }
+    }
+
+    fn send_error(writer: &mut File, stage: ErrorStage, message: &str) {
+        let _ = ipc_framed::write_frame(
+            &mut *writer,
+            &FramedMessage {
+                version: ipc_framed::IPC_PROTOCOL_VERSION,
+                message: Message::Error {
+                    payload: ipc_framed::ErrorPayload {
+                        message: message.to_string(),
+                        stage,
+                        windows_error_code: None,
+                    },
+                },
+            },
+        );
+    }
+
+    /// Derives the capability-restricted token from the runner's own token,
+    /// applies the per-task ACL grants, spawns the child via
+    /// `spawn_process_with_pipes`, and streams Output/Exit frames.
+    fn spawn_and_stream(request: &SpawnRequest, writer: &mut File) -> Result<()> {
+        // Convert the capability SID strings into LocalSid pointers.
+        let cap_sids: Vec<LocalSid> = request
+            .cap_sids
+            .iter()
+            .map(|s| LocalSid::from_string(s))
+            .collect::<Result<Vec<_>>>()?;
+        let cap_ptrs: Vec<*mut c_void> = cap_sids.iter().map(|s| s.as_ptr()).collect();
+
+        // Apply the per-task ACL grants for the workspace roots BEFORE spawning
+        // (spawn_prep assembly). Each capability SID gets an allow-write ACE on
+        // its writable roots; the cap SID is what the restricted token carries.
+        for root in &request.workspace_roots {
+            for psid in &cap_ptrs {
+                // SAFETY: `psid` is a live LocalSid pointer (owned by `cap_sids`,
+                // which outlives this loop); `add_allow_ace` applies an allow ACE
+                // to the validated absolute root path.
+                let _ = unsafe { acl::add_allow_ace(root.as_path(), *psid) }.map_err(|e| {
+                    anyhow::anyhow!("allow ACE on {}: {e}", root.as_path().display())
+                })?;
+            }
+        }
+
+        // SAFETY: get_current_token_for_restriction returns the runner's own
+        // primary token; the *_and_user_from builders derive a capability-
+        // restricted token whose token user is this (sandbox) account. Both
+        // handles are closed below. Because the derived token comes from the
+        // caller's OWN token it is assignable, so the CreateProcessAsUserW
+        // inside spawn_process_with_pipes needs no privilege (A.Q1).
+        let token = unsafe {
+            let base = get_current_token_for_restriction()?;
+            let derived = if request.permission_profile.read_only {
+                create_readonly_token_with_caps_and_user_from(base, &cap_ptrs)
+            } else {
+                create_workspace_write_token_with_caps_and_user_from(base, &cap_ptrs)
+            };
+            CloseHandle(base);
+            derived?
+        };
+
+        let spawn_result = spawn_process_with_pipes(
+            token,
+            &request.command,
+            &request.cwd,
+            &request.env,
+            StdinMode::Closed,
+            StderrMode::Separate,
+            ConsoleMode::NoWindow,
+            /* use_private_desktop */ false,
+            None,
+        );
+        // SAFETY: `token` is a valid handle from the token builder above; close
+        // it once the spawn has consumed it (the child holds its own copy).
+        unsafe {
+            CloseHandle(token);
+        }
+        let handles = spawn_result?;
+
+        stream_child(handles, writer)
+    }
+
+    /// Streams the child's stdout/stderr as Output frames and its exit as an
+    /// Exit frame, after acking with SpawnReady.
+    fn stream_child(handles: PipeSpawnHandles, writer: &mut File) -> Result<()> {
+        let process = handles.process.hProcess;
+        let pid = handles.process.dwProcessId;
+
+        ipc_framed::write_frame(
+            &mut *writer,
+            &FramedMessage {
+                version: ipc_framed::IPC_PROTOCOL_VERSION,
+                message: Message::SpawnReady {
+                    payload: SpawnReady { process_id: pid },
+                },
+            },
+        )?;
+
+        // Drain stdout then stderr sequentially. tty=false capture does not need
+        // interleaving fidelity; ordering within a stream is preserved.
+        drain_stream(handles.stdout_read, OutputStream::Stdout, &mut *writer)?;
+        if let Some(err_read) = handles.stderr_read {
+            drain_stream(err_read, OutputStream::Stderr, &mut *writer)?;
+        }
+
+        // SAFETY: `process` is the child's process handle from PROCESS_INFORMATION;
+        // wait for it to exit, then read its exit code.
+        let exit_code = unsafe {
+            if WaitForSingleObject(process, INFINITE) != WAIT_OBJECT_0 {
+                anyhow::bail!("WaitForSingleObject on child failed: {}", GetLastError());
+            }
+            let mut code: u32 = 0;
+            if GetExitCodeProcess(process, &mut code) == 0 {
+                anyhow::bail!("GetExitCodeProcess failed: {}", GetLastError());
+            }
+            code as i32
+        };
+
+        ipc_framed::write_frame(
+            &mut *writer,
+            &FramedMessage {
+                version: ipc_framed::IPC_PROTOCOL_VERSION,
+                message: Message::Exit {
+                    payload: ipc_framed::ExitPayload {
+                        exit_code,
+                        timed_out: false,
+                    },
+                },
+            },
+        )?;
+        Ok(())
+    }
+
+    /// Reads a child pipe handle to EOF, emitting Output frames.
+    fn drain_stream(handle: HANDLE, stream: OutputStream, writer: &mut File) -> Result<()> {
+        // Wrap the raw read handle as a File so we get std buffered reads; the
+        // handle ownership transfers here and is closed on drop.
+        use std::os::windows::io::FromRawHandle;
+        // SAFETY: `handle` is a live read end of an anonymous pipe from
+        // spawn_process_with_pipes; wrapping it in a File takes ownership and
+        // closes it on drop. isize -> *mut c_void is the documented raw-handle
+        // representation on Windows.
+        let mut file = unsafe { File::from_raw_handle(handle as *mut _) };
+        let mut buf = [0u8; 8192];
+        loop {
+            match file.read(&mut buf) {
+                Ok(0) => break,
+                Ok(n) => {
+                    ipc_framed::write_frame(
+                        &mut *writer,
+                        &FramedMessage {
+                            version: ipc_framed::IPC_PROTOCOL_VERSION,
+                            message: Message::Output {
+                                payload: OutputPayload {
+                                    data_b64: ipc_framed::encode_bytes(&buf[..n]),
+                                    stream,
+                                },
+                            },
+                        },
+                    )?;
+                }
+                Err(ref e) if e.kind() == std::io::ErrorKind::BrokenPipe => break,
+                Err(e) => return Err(anyhow::anyhow!("read child {stream:?}: {e}")),
+            }
+        }
+        Ok(())
+    }
+}
+
+// ===========================================================================
+// Non-Windows honest fail-closed stubs (D-005), mirroring elevated_impl's
+// stub: the compose only exists on Windows; on other targets every entry point
+// returns an error rather than pretending to confine.
+// ===========================================================================
+
+#[cfg(not(windows))]
+mod non_windows_stub {
+    use super::*;
+    use std::collections::HashMap;
+
+    /// See the Windows impl. Non-Windows honest fail-closed stub.
+    pub fn spawn_confined_for_validation(
+        _sandbox_home: &Path,
+        _policy: &SandboxPolicy,
+        _command: &[String],
+        _cwd: &Path,
+        _env: &HashMap<String, String>,
+    ) -> Result<CaptureResult, LaunchError> {
+        Err(LaunchError::Confinement(
+            "the Windows elevated sandbox is only available on Windows".to_string(),
+        ))
+    }
+}
+
+#[cfg(not(windows))]
+pub use non_windows_stub::spawn_confined_for_validation;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::policy::SandboxPolicy;
+    use std::path::PathBuf;
+
+    fn policy(network: NetworkPolicy) -> SandboxPolicy {
+        SandboxPolicy::build(vec![], vec![], PathBuf::from(r"C:\hive\hooks"), network)
+            .expect("valid policy")
+    }
+
+    #[test]
+    fn deny_all_refuses_with_network_confinement_error() {
+        let decision = LaunchDecision::for_policy(&policy(NetworkPolicy::DenyAll));
+        assert_eq!(decision, LaunchDecision::RefuseDenyAll);
+        assert!(matches!(
+            decision.into_refusal(),
+            LaunchError::NetworkConfinementNotImplemented
+        ));
+    }
+
+    #[test]
+    fn allow_hosts_refuses_with_allow_hosts_error() {
+        let decision =
+            LaunchDecision::for_policy(&policy(NetworkPolicy::AllowHosts(vec!["h".into()])));
+        assert_eq!(decision, LaunchDecision::RefuseAllowHosts);
+        assert!(matches!(
+            decision.into_refusal(),
+            LaunchError::AllowHostsNotYetImplemented
+        ));
+    }
+
+    #[test]
+    fn compute_allow_paths_includes_existing_writable_roots_and_no_deny() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let ws = tmp.path().join("workspace");
+        std::fs::create_dir_all(&ws).expect("mkdir");
+        // A writable root under an absolute cwd. On Linux CI the tempdir path is
+        // absolute in host terms; from_policy uses windows-absolute parsing, so
+        // build the resolver directly to keep this test host-agnostic.
+        let policy = SandboxPolicy::build(
+            vec![ws.clone()],
+            vec![],
+            tmp.path().join("hooks"),
+            NetworkPolicy::DenyAll,
+        )
+        .expect("policy");
+        // Resolve against a windows-absolute cwd string (the roots themselves
+        // are what compute_allow_paths canonicalizes; cwd only gates from_policy).
+        let resolved =
+            ResolvedWindowsSandboxPermissions::from_policy(&policy, Path::new(r"C:\workspace"))
+                .expect("resolves");
+        let paths = compute_allow_paths(&resolved);
+        let canonical_ws = dunce::canonicalize(&ws).unwrap_or(ws);
+        assert!(
+            paths.allow.contains(&canonical_ws),
+            "expected the existing writable root in the allow set: {paths:?}"
+        );
+        assert!(
+            paths.deny.is_empty(),
+            "the Hive resolver produces no read-only carve-outs yet, so deny must be empty"
+        );
+    }
+
+    #[test]
+    fn compute_allow_paths_skips_nonexistent_writable_root() {
+        let policy = SandboxPolicy::build(
+            vec![PathBuf::from(r"C:\does\not\exist\anywhere")],
+            vec![],
+            PathBuf::from(r"C:\hive\hooks"),
+            NetworkPolicy::DenyAll,
+        )
+        .expect("policy");
+        let resolved =
+            ResolvedWindowsSandboxPermissions::from_policy(&policy, Path::new(r"C:\workspace"))
+                .expect("resolves");
+        let paths = compute_allow_paths(&resolved);
+        assert!(
+            paths.allow.is_empty(),
+            "a non-existent writable root must not be added to the allow set"
+        );
+    }
+
+    #[test]
+    fn setup_is_incomplete_without_marker() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        assert!(!sandbox_setup_is_complete(tmp.path()));
+    }
+}

--- a/apps/desktop-sandbox/hive-desktop-sandbox/src/windows_elevated.rs
+++ b/apps/desktop-sandbox/hive-desktop-sandbox/src/windows_elevated.rs
@@ -728,24 +728,24 @@ mod windows_impl {
         // (parent writes, runner reads); `pipe_out` PIPE_ACCESS_INBOUND (runner
         // writes, parent reads). Opening a named pipe as a std file is the
         // documented client path and avoids a bespoke CreateFileW FFI.
-        runner_debug_log("opening inbound pipe (pipe_in)");
-        let mut reader = File::options()
-            .read(true)
-            .write(true)
-            .open(pipe_in)
-            .map_err(|e| {
-                runner_debug_log(&format!("open inbound pipe FAILED: {e}"));
-                anyhow::anyhow!("open inbound pipe {pipe_in}: {e}")
-            })?;
-        runner_debug_log("inbound pipe opened; opening outbound pipe (pipe_out)");
-        let mut writer = File::options()
-            .read(true)
-            .write(true)
-            .open(pipe_out)
-            .map_err(|e| {
-                runner_debug_log(&format!("open outbound pipe FAILED: {e}"));
-                anyhow::anyhow!("open outbound pipe {pipe_out}: {e}")
-            })?;
+        // The two server pipes are HALF-DUPLEX, so the client (this runner) must
+        // open each with the single matching direction: `pipe_in` was created
+        // PIPE_ACCESS_OUTBOUND (server -> client), so the client opens it
+        // READ-only; `pipe_out` was created PIPE_ACCESS_INBOUND (client ->
+        // server), so the client opens it WRITE-only. Opening either with the
+        // opposite access added (read+write) is rejected by the half-duplex
+        // pipe with ERROR_ACCESS_DENIED, which previously aborted the runner at
+        // the first pipe open. Match the direction exactly.
+        runner_debug_log("opening inbound pipe (pipe_in, read)");
+        let mut reader = File::options().read(true).open(pipe_in).map_err(|e| {
+            runner_debug_log(&format!("open inbound pipe FAILED: {e}"));
+            anyhow::anyhow!("open inbound pipe {pipe_in}: {e}")
+        })?;
+        runner_debug_log("inbound pipe opened; opening outbound pipe (pipe_out, write)");
+        let mut writer = File::options().write(true).open(pipe_out).map_err(|e| {
+            runner_debug_log(&format!("open outbound pipe FAILED: {e}"));
+            anyhow::anyhow!("open outbound pipe {pipe_out}: {e}")
+        })?;
         runner_debug_log("both pipes opened; reading spawn request frame");
 
         let request = match ipc_framed::read_frame(&mut reader) {

--- a/apps/desktop-sandbox/hive-desktop-sandbox/src/windows_elevated.rs
+++ b/apps/desktop-sandbox/hive-desktop-sandbox/src/windows_elevated.rs
@@ -234,7 +234,7 @@ struct SetupMarker {
 #[cfg(windows)]
 pub use windows_impl::{
     load_logon_sandbox_creds, provision_sandbox_account, run_command_runner,
-    run_windows_sandbox_capture, spawn_confined_for_validation,
+    run_windows_sandbox_capture, runner_debug_log, spawn_confined_for_validation,
 };
 
 #[cfg(windows)]
@@ -681,11 +681,20 @@ mod windows_impl {
     /// leaves the release path untouched. It NEVER logs the sandbox password,
     /// credential bytes, or environment values (D-005 honest logging); only
     /// non-sensitive shape (counts, flags, pipe names, error kinds).
-    fn runner_debug_log(msg: &str) {
+    pub fn runner_debug_log(msg: &str) {
         if std::env::var("HIVE_RUNNER_DEBUG").ok().as_deref() != Some("1") {
             return;
         }
-        let path = std::env::temp_dir().join("hive-command-runner.log");
+        // Deterministic sink override (HIVE_RUNNER_DEBUG_DIR) so the log lands
+        // somewhere the sandbox account can write and an administrator can read,
+        // independent of how CreateProcessWithLogonW resolves the runner's TEMP
+        // (with a NULL environment block the runner inherits the caller's env,
+        // which makes the plain temp dir ambiguous). Falls back to the process
+        // temp dir when unset.
+        let dir = std::env::var_os("HIVE_RUNNER_DEBUG_DIR")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(std::env::temp_dir);
+        let path = dir.join("hive-command-runner.log");
         if let Ok(mut f) = std::fs::OpenOptions::new()
             .create(true)
             .append(true)

--- a/apps/desktop-sandbox/hive-desktop-sandbox/src/windows_elevated.rs
+++ b/apps/desktop-sandbox/hive-desktop-sandbox/src/windows_elevated.rs
@@ -266,12 +266,17 @@ mod windows_impl {
         LSA_HANDLE, LSA_OBJECT_ATTRIBUTES, LSA_UNICODE_STRING, LsaAddAccountRights, LsaClose,
         LsaOpenPolicy, POLICY_CREATE_ACCOUNT, POLICY_LOOKUP_NAMES,
     };
+    use windows_sys::Win32::System::JobObjects::{
+        AssignProcessToJobObject, CreateJobObjectW, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+        JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JobObjectExtendedLimitInformation,
+        SetInformationJobObject,
+    };
     use windows_sys::Win32::System::Services::{
         CloseServiceHandle, OpenSCManagerW, OpenServiceW, QueryServiceStatus, SC_MANAGER_CONNECT,
         SERVICE_QUERY_STATUS, SERVICE_START, SERVICE_STATUS, StartServiceW,
     };
     use windows_sys::Win32::System::Threading::{
-        GetExitCodeProcess, INFINITE, WaitForSingleObject,
+        GetExitCodeProcess, INFINITE, TerminateProcess, WaitForSingleObject,
     };
 
     // The runner-spawn transport wants a "codex_home"-shaped base directory for
@@ -904,12 +909,106 @@ mod windows_impl {
             runner_debug_log(&format!("spawn_process_with_pipes FAILED: {e}"));
             e
         })?;
+        // Greptile finding, PR #401: nothing previously controlled this child
+        // once spawned, so an IPC write failure or a parent disconnect below
+        // orphaned it with no controller left to stop it. Assign it to a
+        // kill-on-close Job Object now so any early return in `stream_child`
+        // (the SpawnReady write, a drain error, or the wait) terminates the
+        // child instead of leaving it running unsupervised. If job setup
+        // itself fails, terminate the child directly rather than propagate
+        // the error with an unconfined child still alive.
+        let job_guard = match confine_child_to_job(handles.process.hProcess) {
+            Ok(guard) => guard,
+            Err(e) => {
+                runner_debug_log(&format!(
+                    "confine_child_to_job FAILED: {e}; terminating unconfined child"
+                ));
+                // SAFETY: `handles.process.hProcess` is the live handle from
+                // `spawn_process_with_pipes` above; terminating it here (job
+                // setup failed) is the fail-closed choice over leaving it
+                // running with no containment at all.
+                unsafe {
+                    let _ = TerminateProcess(handles.process.hProcess, 1);
+                }
+                return Err(e);
+            }
+        };
         runner_debug_log(&format!(
-            "inner child spawned (pid={}); acking SpawnReady and streaming",
+            "inner child spawned (pid={}); confined to kill-on-close job; acking SpawnReady and streaming",
             handles.process.dwProcessId
         ));
 
-        stream_child(handles, writer)
+        let result = stream_child(handles, writer);
+        // By the time `stream_child` returns `Ok`, the child has already
+        // exited (it waits on the process handle before returning), so
+        // dropping the job here is a no-op in that case; on `Err` it
+        // terminates whatever is still running.
+        drop(job_guard);
+        result
+    }
+
+    /// RAII guard that terminates the sandboxed child if dropped before the
+    /// child has already exited on its own: closing the last handle to a job
+    /// created with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` terminates every
+    /// process still in it. Mirrors the base (non-elevated) variant's Step 1
+    /// containment (`windows.rs::create_job_object`), reused here for the
+    /// elevated path via `windows-sys` to interoperate with this module's
+    /// `HANDLE` type (see the module's own `windows-sys` vs `windows` crate
+    /// note at the top of this file).
+    struct ChildJobGuard(HANDLE);
+
+    impl Drop for ChildJobGuard {
+        fn drop(&mut self) {
+            // SAFETY: `self.0` is a job handle created by `CreateJobObjectW`
+            // in `confine_child_to_job`; closing it is safe at any point and,
+            // with KILL_ON_JOB_CLOSE set, is exactly the desired cleanup.
+            unsafe {
+                let _ = CloseHandle(self.0);
+            }
+        }
+    }
+
+    /// Creates a job object with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` and
+    /// assigns `process` to it immediately after spawn. Unlike the base
+    /// variant's Step 1 sequence, the child here is not `CREATE_SUSPENDED`
+    /// (upstream `create_process_as_user` never suspends it, and changing
+    /// that vendored primitive is out of scope here), so there is a narrow
+    /// window between spawn and this call in which the child runs outside
+    /// any job; that window is unchanged from before this fix. What this
+    /// closes is the much larger gap after it: previously nothing controlled
+    /// the child for the rest of its life, so an IPC failure or parent
+    /// disconnect at any later point orphaned it (Greptile finding, PR #401).
+    fn confine_child_to_job(process: HANDLE) -> Result<ChildJobGuard> {
+        // SAFETY: standard CreateJobObjectW / SetInformationJobObject /
+        // AssignProcessToJobObject sequence. `process` is the live handle
+        // from `spawn_process_with_pipes`, still owned and closed by its
+        // existing caller; the job handle is owned by the returned guard and
+        // closed on drop.
+        unsafe {
+            let job = CreateJobObjectW(std::ptr::null(), std::ptr::null());
+            if job == 0 {
+                anyhow::bail!("CreateJobObjectW failed: {}", GetLastError());
+            }
+            let mut limits: JOBOBJECT_EXTENDED_LIMIT_INFORMATION = std::mem::zeroed();
+            limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+            if SetInformationJobObject(
+                job,
+                JobObjectExtendedLimitInformation,
+                &limits as *const _ as *const c_void,
+                std::mem::size_of_val(&limits) as u32,
+            ) == 0
+            {
+                let err = GetLastError();
+                CloseHandle(job);
+                anyhow::bail!("SetInformationJobObject failed: {err}");
+            }
+            if AssignProcessToJobObject(job, process) == 0 {
+                let err = GetLastError();
+                CloseHandle(job);
+                anyhow::bail!("AssignProcessToJobObject failed: {err}");
+            }
+            Ok(ChildJobGuard(job))
+        }
     }
 
     /// Streams the child's stdout/stderr as Output frames and its exit as an
@@ -928,13 +1027,33 @@ mod windows_impl {
             },
         )?;
 
-        // Drain stdout then stderr sequentially. tty=false capture does not need
-        // interleaving fidelity; ordering within a stream is preserved.
+        // DEFERRED, not fixed here (CodeRabbit + Greptile findings, PR #401
+        // review round; VENDORING.md tracks both): draining stdout to EOF
+        // before touching stderr can deadlock if the child fills the stderr
+        // pipe buffer while stdout stays open (the child blocks on stderr,
+        // this runner blocks waiting for stdout EOF, neither ever proceeds).
+        // The correct fix is a concurrent two-thread drain (one per stream)
+        // with the frame `writer` behind a shared lock, which changes this
+        // exact lab-validated (D-004) spawn/stream path from single- to
+        // multi-threaded framing and needs re-validation on spike307-win
+        // before landing, not a blind rewrite. Tracked, not silently ignored.
         drain_stream(handles.stdout_read, OutputStream::Stdout, &mut *writer)?;
         if let Some(err_read) = handles.stderr_read {
             drain_stream(err_read, OutputStream::Stderr, &mut *writer)?;
         }
 
+        // DEFERRED, not fixed here (Greptile finding, PR #401 review round;
+        // VENDORING.md tracks it): `SpawnRequest::timeout_ms` is plumbed
+        // through the protocol but never read here, so the wait below is
+        // always `INFINITE` and `timed_out` below is always `false`. Today
+        // this is dormant, not reachable: the sole call site that builds a
+        // `SpawnRequest` (see `run_windows_sandbox_capture` in this file)
+        // always sets `timeout_ms: None`. Enforcing a real deadline correctly
+        // needs a watchdog concurrent with the drains above (the same
+        // restructuring as the drain-deadlock deferral just above, since a
+        // hang during drain must also be bounded, not only the final wait),
+        // so it is tracked together with that fix rather than half-done here.
+        //
         // SAFETY: `process` is the child's process handle from PROCESS_INFORMATION;
         // wait for it to exit, then read its exit code.
         let exit_code = unsafe {

--- a/apps/desktop-sandbox/hive-desktop-sandbox/src/windows_elevated.rs
+++ b/apps/desktop-sandbox/hive-desktop-sandbox/src/windows_elevated.rs
@@ -360,7 +360,12 @@ mod windows_impl {
         std::fs::create_dir_all(&secrets)
             .map_err(|e| anyhow::anyhow!("create secrets dir: {e}"))?;
 
-        let password = generate_password();
+        // Zeroizing<String> rather than a plain String: this cleartext
+        // password would otherwise linger in freed heap after this function
+        // returns. Matches the zeroize-on-drop handling `SandboxCreds`
+        // (codex-windows-sandbox::identity) and `runner_client` already give
+        // this same class of secret.
+        let password = zeroize::Zeroizing::new(generate_password());
 
         // 1. Least-privilege group + account.
         sandbox_users::ensure_local_group(SANDBOX_GROUP, "Hive sandbox low-privilege users", log)?;
@@ -416,7 +421,10 @@ mod windows_impl {
         // (D-005): only accept a non-add once we have confirmed the deny is
         // actually in force on disk; otherwise bail.
         if !newly_applied {
-            let present = acl::path_has_read_deny(path, psid)
+            // SAFETY: `psid` is the same live SID pointer built from
+            // `sandbox_users::sid_bytes_to_psid` used just above for
+            // `add_deny_read_ace`; it is still valid here.
+            let present = unsafe { acl::path_has_read_deny(path, psid) }
                 .map_err(|e| anyhow::anyhow!("verify deny-read ACE on secrets dir: {e}"))?;
             if !present {
                 anyhow::bail!("deny-read ACE was not applied to the secrets directory");


### PR DESCRIPTION
## Summary

Integration A: the elevated Windows sandbox core. Ports the resolver-coupled helper modules to Hive types and wires `windows::launch()` end to end, then validates the confinement behaviorally on the spike307-win lab (D-004).

Builds on the merged W1 (#398 primitives + resolver port), W2 (#399 transport + accounts), and A1 (#400 capture primitives + security fixes).

## What it does

- Ports `allow`, `elevated_impl` (capture path), `spawn_prep` + `command_runner` (runner side), and `identity`/`setup` provisioning to the Hive-typed `windows_resolve::ResolvedWindowsSandboxPermissions` in a new `windows_elevated.rs`. No `codex_protocol`.
- Elevation model: a non-elevated parent spawns the runner as the low-priv sandbox account via `CreateProcessWithLogonW` (no special privilege), the runner self-derives a capability-restricted token from its own token and `CreateProcessAsUserW`-spawns the child. Provisioning creates or reuses one shared low-priv sandbox account, seals its password with DPAPI, and ensures the invariants (SeInteractiveLogonRight, seclogon service). UAC once at provisioning only.
- Network policy stays fail closed: both `DenyAll` and `AllowHosts` are refused (`NetworkConfinementNotImplemented`) because WFP egress is Integration B. Spawning a `DenyAll` job without WFP would be a silent fail-open, which is forbidden (D-005). Confined spawn is reachable only via the lab-only `spawn_confined_for_validation` entry.
- ConPTY call sites stubbed fail closed (Step 5). WFP call sites omitted (Integration B). The existing `launch()` network-refuse guards are preserved.

## Fixes found and closed by the lab

- `helper_materialization` used the stale `codex-command-runner.exe` name; corrected to `hive-command-runner.exe` (broke helper lookup for every caller).
- `provision_sandbox_account` made idempotent (deny-read ACE presence verified via new `acl::path_has_read_deny`, fail closed).
- Root cause of the runner failing to connect: it exited `0xC0000142 STATUS_DLL_INIT_FAILED` before main because user32.dll process-attach needs window-station/desktop access the sandbox account lacked under `CreateProcessWithLogonW`. Fixed by `desktop::grant_winsta_desktop_access` (grants the sandbox SID the current winsta + desktop). Also fixed half-duplex pipes opened read+write (now `pipe_in` read-only, `pipe_out` write-only). Diagnostic logging added to the runner startup and IPC path.
- cap_sid cross-process named mutex (open risk 8) and the `helper_materialization` absolute-path guard both landed.

## Lab validation (spike307-win, native MSVC, D-004)

Native MSVC build clean (first compile of the ported core). 79 unit tests pass natively. Behavioral matrix, all PASS with evidence:
- Provisioning: sandbox account created (Users + hive_sandbox_users), SeInteractiveLogonRight granted, seclogon Running, CreateProcessWithLogonW succeeds.
- Confined spawn: child token user SID equals the sandbox account (not the caller); write outside the writable root is denied (Access is denied); write inside the writable root succeeds; a seeded secret path read is denied.

### Caveats (follow-ups, not confinement weakenings)

- The winsta/desktop grant was validated in an interactive session, which matches the real desktop app. A non-interactive or session-0 parent still lacks a usable desktop; a private window station is a noted follow-up.
- Job kill-on-close is the separate `windows::launch`/`SandboxChild` mechanism already validated under #395, not exercised by this IPC harness.
- ConPTY (Step 5) and network egress (Integration B) are out of scope here.

## Verification

- [ ] CI required checks green (windows-gnu cross-compile + Go + web + lints)
- [x] Native MSVC build clean + 79 tests pass on spike307-win
- [x] Confinement behavioral matrix PASS on spike307-win (evidence above)
- [ ] security-reviewer (mandatory, D-004: the elevated helper is a security boundary)
- [ ] rust-reviewer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added elevated Windows sandbox support for per-task command execution.
  * Added sandbox setup and provisioning tools for secure account and permissions management.
  * Added validation coverage for workspace isolation, restricted file access, and process identity.

* **Bug Fixes**
  * Prevented cross-process capability configuration conflicts.
  * Improved executable resolution to avoid unsafe fallback paths.
  * Improved diagnostics when sandbox runners fail to start.

* **Documentation**
  * Documented Windows sandbox integration, security boundaries, and current limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds the elevated Windows sandbox launch and provisioning flow. The main changes are:

- Adds low-privilege account provisioning and credential handling.
- Launches commands with capability-restricted tokens and filesystem confinement.
- Adds command-runner, provisioning, and validation binaries.
- Keeps unsupported network and ConPTY paths fail closed.
- Adds helper-path checks, cross-process SID locking, desktop access setup, and child job containment.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- Mutex failures now stop protected SID updates.
- Helper fallback paths no longer use Windows executable search.
- The confined child is assigned to a kill-on-close job before readiness is reported.
- No blocking issue was found in the updated code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/desktop-sandbox/codex-windows-sandbox/src/cap.rs | Adds a named cross-process mutex and stops capability SID updates when mutex creation or waiting fails. |
| apps/desktop-sandbox/codex-windows-sandbox/src/helper_materialization.rs | Corrects the runner filename and prevents relative helper paths from reaching process creation. |
| apps/desktop-sandbox/codex-windows-sandbox/src/desktop.rs | Adds the window-station and desktop permissions needed for the sandbox runner to initialize. |
| apps/desktop-sandbox/hive-desktop-sandbox/src/windows_elevated.rs | Implements provisioning, restricted process launch, IPC streaming, and kill-on-close containment for confined children. |
| apps/desktop-sandbox/hive-desktop-sandbox/src/bin/hive-sandbox-validate.rs | Adds the Windows confinement validation harness and rejects unsafe command-script path values. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Parent as Desktop parent
    participant Runner as Sandbox runner
    participant Child as Confined child
    participant Job as Kill-on-close job
    Parent->>Runner: Launch as sandbox account
    Parent->>Runner: Send spawn request
    Runner->>Child: Spawn with restricted token
    Runner->>Job: Create and configure job
    Runner->>Job: Assign child
    Runner-->>Parent: Send output and exit frames
    Runner->>Job: Close job after child exits
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Parent as Desktop parent
    participant Runner as Sandbox runner
    participant Child as Confined child
    participant Job as Kill-on-close job
    Parent->>Runner: Launch as sandbox account
    Parent->>Runner: Send spawn request
    Runner->>Child: Spawn with restricted token
    Runner->>Job: Create and configure job
    Runner->>Job: Assign child
    Runner-->>Parent: Send output and exit frames
    Runner->>Job: Close job after child exits
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: address CodeRabbit and Greptile fin..."](https://github.com/sakibsadmanshajib/hive/commit/e53514cfdc5dc54e5d898ad670cc9f0fabf05a91) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45579610)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - .claude/rules/openwolf.md ([source](https://app.greptile.com/scubed/github/sakibsadmanshajib/hive/-/custom-context?memory=3e51a3b4-2091-4dce-8aad-9423a1f1db38))
- Context used - CLAUDE.md ([source](https://app.greptile.com/scubed/github/sakibsadmanshajib/hive/-/custom-context?memory=a5912a3f-0055-4d8a-86c1-fedc669ad56e))
- Context used - .claude/rules/orchestrator.md ([source](https://app.greptile.com/scubed/github/sakibsadmanshajib/hive/-/custom-context?memory=7e0c2dc0-c014-43b2-9dbd-46ae72a640d0))
</details>

<!-- /greptile_comment -->