### PR TITLE
feat: desktop-level UI isolation for hive sandbox (Step 3 B1, desktop-only)

### DIFF
--- a/apps/desktop-sandbox/VENDORING.md
+++ b/apps/desktop-sandbox/VENDORING.md
@@ -656,78 +656,102 @@ with the reason a blind fix would risk invalidating that lab run.
 
 - `desktop.rs::grant_winsta_desktop_access` (Greptile "Desktop Grant Outlives
   Runner"): the persistent `WINSTA_ALL_ACCESS`/`GENERIC_ALL`/`DESKTOP_ALL_ACCESS`
-  grant to the shared sandbox account was never revoked, so a later process
-  running as that account on the same station/desktop also inherited it. It was
-  a known, non-blocking gap for Integration A (unreachable then: `windows::launch`
-  refuses every network policy, so nothing reached this grant outside the
-  lab-only validation entry), with a HARD GATE on Integration B: do not remove
-  the network-refusal guards until the runner moves to a dedicated, non-shared
-  private window station.
-  RESOLVED by Step 3 Integration B1 (see the "Integration B1: private window
-  station for UI isolation" deviation below): `grant_winsta_desktop_access` and
-  its shared-`WinSta0` grant are removed. The runner now launches on a
-  per-launch PRIVATE window station + desktop that no other process shares, so
-  the outlives-runner class no longer exists. The `windows::launch`
-  network-refusal guards remain in force (B1 adds UI isolation only; WFP egress
-  is still Integration B / D-005), so the HARD GATE's own precondition (WFP
-  landing) is untouched by this change.
-- `windows_elevated.rs::stream_child`'s sequential stdout-then-stderr drain
-  (CodeRabbit "Sequential stdout-then-stderr drain can deadlock", Greptile
-  "Sequential Pipe Drain Deadlocks", both on the same code): draining stdout
-  to EOF before touching stderr can deadlock if the child fills the stderr
-  pipe buffer while stdout stays open. The correct fix, a concurrent
-  two-thread drain with the frame writer behind a shared lock, changes this
-  exact D-004 lab-validated spawn/stream path from single- to multi-threaded
-  framing. Deferred rather than blind-rewritten; needs a fresh spike307-win
-  run once implemented. Inline comment added at the call site so this is
-  tracked, not silently missed.
-- `windows_elevated.rs::stream_child`'s ignored `timeout_ms` (Greptile
-  "Request Timeout Is Ignored"): the wait is always `INFINITE` and
-  `timed_out` is always `false`. Currently dormant, not reachable: the sole
+  grant to the shared sandbox account is never revoked, so a later process
+  running as that account on the same station/desktop also inherits it. This
+  is the disposition the opus security review already accepted as a known,
+  non-blocking gap for Integration A (unreachable today: `windows::launch`
+  refuses every network policy, so nothing reaches this grant outside the
+  lab-only validation entry). Documented as a HARD GATE on Integration B in
+  the function's own doc comment: do not remove the network-refusal guards
+  until the runner moves to a dedicated, non-shared private window station.
+  Not re-fixed here per that disposition.
+- **RESOLVED (Step 3 Integration B1).** `windows_elevated.rs::stream_child`'s
+  sequential stdout-then-stderr drain (CodeRabbit "Sequential stdout-then-stderr
+  drain can deadlock", Greptile "Sequential Pipe Drain Deadlocks", both on the
+  same code) could deadlock if the child filled the stderr pipe buffer while
+  stdout stayed open. Fixed with a concurrent two-thread drain
+  (`std::thread::scope`, one thread per stream) sharing the frame `writer`
+  behind a `Mutex` so Output frames never interleave mid-write; each stream's
+  drain runs on its own scoped thread, joined and mapped to `Err`, so a panic
+  on either stream fails closed instead of unwinding raw. This is a live fix
+  (drains run on every `stream_child` call, timeout or not). Still needs a
+  fresh spike307-win lab run to confirm behaviorally; type-checked and
+  clippy-clean cross-compiled to `x86_64-pc-windows-gnu`.
+- **DEFERRED to B2 (request-timeout, `SpawnRequest::timeout_ms`).** An
+  earlier pass on this PR added a watchdog thread, `TerminateJobObject`,
+  `CancelIoEx` on the drain read handles, and a bounded post-timeout wait to
+  make `timeout_ms` actually bound the whole spawn (Greptile "Request Timeout
+  Is Ignored", then two further Greptile/CodeRabbit P1 passes on that fix:
+  "Kill the whole job on timeout, not just the root process" and
+  "Termination failure remains unbounded"). A third review pass (Greptile)
+  found the remaining gap is structural, not fixable by patching further:
+  `CancelIoEx` only cancels OVERLAPPED I/O, and this crate's drain pipes are
+  synchronous (`CreatePipe` plus blocking `File::read`), so `CancelIoEx`
+  cannot interrupt a pending read on them at all. Bounding a blocking
+  synchronous-pipe read correctly needs either `CancelSynchronousIo` called
+  against the specific drain thread's handle (from another thread, targeting
+  that thread, not the file handle) or switching the pipes/reads to
+  overlapped I/O with `GetOverlappedResult`/`WaitForSingleObject` on the
+  OVERLAPPED event, with the cancellation's own result checked, not
+  discarded, either way. `timeout_ms` is dormant in this PR: the sole
   `SpawnRequest` construction site (`run_windows_sandbox_capture`, this file)
-  always sets `timeout_ms: None`. A correct fix needs a watchdog concurrent
-  with the drains (coupled to the drain-deadlock deferral above, since a hang
-  during drain must also be bounded), so it is tracked with that fix rather
-  than half-implemented as a bare final-wait timeout that a stuck drain would
-  never reach. Inline comment added at the call site.
+  always sets `timeout_ms: None`, so the watchdog code path never ran; CTO
+  call was to remove all of the watchdog/termination/cancellation machinery
+  this pass rather than keep chasing synchronous-read cancellation on dead
+  code, and build the correct form (`CancelSynchronousIo` or overlapped I/O,
+  checked results, no discarded cancellation outcomes) together with wiring
+  a real deadline in B2, lab-exercised on `spike307-win` at that point since
+  only then does the watchdog path actually run.
 
-### Integration B1: private window station for UI isolation (Hive deviation)
+### Integration B1: private desktop for UI isolation (Hive deviation)
 
-Upstream `desktop.rs` isolates the UI only as far as an optional private
-DESKTOP under the shared `WinSta0` (`LaunchDesktop::prepare(use_private_desktop)`),
-and Hive's Integration A shipped `grant_winsta_desktop_access`, which granted the
+Hive's Integration A shipped `grant_winsta_desktop_access`, which grants the
 sandbox account access to the interactive user's shared `WinSta0` so the
-user32-linking runner could attach at load. Both leave the sandboxed process on
-the real user's window station, where it can shatter-attack, `SendInput` to, or
-read the clipboard of the real desktop (clipboard and the atom table are
-per-window-station, shared across every desktop on that station).
+user32-linking runner can complete process-attach at load. That left the
+sandboxed inner child on the real user's default desktop (`WinSta0\Default`),
+where it could shatter-attack or `SendInput` to the real desktop's windows.
 
-B1 closes that hole by adding a Hive-native `desktop.rs::PrivateWindowStation`
-(no upstream equivalent) and removing `grant_winsta_desktop_access`:
+B1 closes the desktop half of that hole by adding a Hive-native
+`desktop.rs::PrivateDesktop` (mirroring upstream codex `desktop.rs`) and routing
+the untrusted inner child onto it. It does NOT add a private window station.
 
-- The parent creates a per-launch PRIVATE window station
-  (`CreateWindowStationW`, `CWF_CREATE_ONLY`, a `HiveSandboxWinSta-<random u128>`
-  name) and a `HiveSandboxDesktop` on it (`SetProcessWindowStation` to the new
-  station so `CreateDesktopW` lands there, then the parent's own station is
-  restored). The sandbox account SID is granted on both objects (reusing
-  `merge_grant_on_window_object`) as insurance for a restrictive default DACL.
-- `runner_client.rs::spawn_runner_transport` sets
-  `STARTUPINFO.lpDesktop = "HiveSandboxWinSta-<..>\\HiveSandboxDesktop"` on the
-  `CreateProcessWithLogonW` launch. The spike (spike307-win, 2026-07-20, cl.exe
-  probe) proved `CreateProcessWithLogonW` (Secondary Logon) honours a
-  parent-created private window station named in `lpDesktop`: the child ran as
-  the sandbox SID on the private station and exited cleanly.
-- Fail closed (D-005): if the private station cannot be created (e.g. a
-  de-elevated caller in session 0 gets `ERROR_ACCESS_DENIED`) the launch errors
-  and NEVER falls back to `WinSta0`. Assumes the caller runs in the interactive
-  logged-in user's session, where window-station creation is permissive
-  (documented in `PrivateWindowStation::create`).
+- The RUNNER (running as the sandbox account) creates a per-launch PRIVATE
+  DESKTOP on the shared `WinSta0` (`CreateDesktopW`, a
+  `HiveSandboxDesktop-<random u128>` name from `OsRng`) and grants its own logon
+  SID access to it. The restricted inner-child token derives from the runner's
+  token and carries that same logon SID in its restricting-SID set, so the one
+  grant satisfies both halves of the child's `WRITE_RESTRICTED` access check.
+- `process.rs` sets `STARTUPINFO.lpDesktop = "Winsta0\\HiveSandboxDesktop-<..>"`
+  on the inner-child launch, so the child runs on the private desktop and holds
+  no handle to `WinSta0\Default`: it cannot enumerate the default desktop's
+  windows, `SendInput` across the desktop boundary, or mount a shatter attack on
+  the real desktop.
+- NOT a private window station. A least-privilege sandbox account cannot create
+  a securable window station (`CreateWindowStationW` returns
+  `ERROR_ACCESS_DENIED` for that token) and upstream never creates one; a private
+  desktop is the standard per-process UI isolation boundary (the upstream codex /
+  Chromium baseline). `CreateDesktopW` also has no `CWF_CREATE_ONLY` equivalent,
+  so a duplicate name would open the existing desktop rather than error; the
+  128-bit `OsRng` name suffix makes a collision cryptographically negligible.
+- Fail closed (D-005): any Win32 failure in `PrivateDesktop::create` returns an
+  error and NEVER falls back to `WinSta0\Default`.
 
-Scope: B1 is UI isolation ONLY. The two `windows::launch` network-refusal guards
-are untouched; both `NetworkPolicy::DenyAll` and `AllowHosts` still fail closed
-until the WFP egress backend lands (Integration B / D-005). This code is
-cross-compiled by CI (`x86_64-pc-windows-gnu`) but, like the rest of the Win32
-compose, its behaviour is only lab-provable on `spike307-win`.
+Scope: B1 is DESKTOP-level UI isolation ONLY.
+
+- Clipboard and the global atom table are per-WINDOW-STATION, so they stay
+  shared with the interactive user (accepted tradeoff; a private station would
+  isolate them, but the sandbox token cannot create one).
+- `grant_winsta_desktop_access` is RETAINED: the runner still needs shared
+  `WinSta0` access to attach user32 at load, so the "Desktop Grant Outlives
+  Runner" gap noted above is unchanged by B1 (still a known, non-blocking gap).
+- A hostile child's escape off its own private desktop is contained only once
+  the deferred Low-integrity / SID-disable seam lands.
+- The two `windows::launch` network-refusal guards are untouched; both
+  `NetworkPolicy::DenyAll` and `AllowHosts` still fail closed until the WFP
+  egress backend lands (Integration B / D-005).
+
+This code is cross-compiled by CI (`x86_64-pc-windows-gnu`) but, like the rest
+of the Win32 compose, its behaviour is only lab-provable on `spike307-win`.
 
 ### Deliberately NOT done in A2 (fail-closed stubs, honest)
 

--- a/apps/desktop-sandbox/VENDORING.md
+++ b/apps/desktop-sandbox/VENDORING.md
@@ -656,15 +656,21 @@ with the reason a blind fix would risk invalidating that lab run.
 
 - `desktop.rs::grant_winsta_desktop_access` (Greptile "Desktop Grant Outlives
   Runner"): the persistent `WINSTA_ALL_ACCESS`/`GENERIC_ALL`/`DESKTOP_ALL_ACCESS`
-  grant to the shared sandbox account is never revoked, so a later process
-  running as that account on the same station/desktop also inherits it. This
-  is the disposition the opus security review already accepted as a known,
-  non-blocking gap for Integration A (unreachable today: `windows::launch`
-  refuses every network policy, so nothing reaches this grant outside the
-  lab-only validation entry). Documented as a HARD GATE on Integration B in
-  the function's own doc comment: do not remove the network-refusal guards
-  until the runner moves to a dedicated, non-shared private window station.
-  Not re-fixed here per that disposition.
+  grant to the shared sandbox account was never revoked, so a later process
+  running as that account on the same station/desktop also inherited it. It was
+  a known, non-blocking gap for Integration A (unreachable then: `windows::launch`
+  refuses every network policy, so nothing reached this grant outside the
+  lab-only validation entry), with a HARD GATE on Integration B: do not remove
+  the network-refusal guards until the runner moves to a dedicated, non-shared
+  private window station.
+  RESOLVED by Step 3 Integration B1 (see the "Integration B1: private window
+  station for UI isolation" deviation below): `grant_winsta_desktop_access` and
+  its shared-`WinSta0` grant are removed. The runner now launches on a
+  per-launch PRIVATE window station + desktop that no other process shares, so
+  the outlives-runner class no longer exists. The `windows::launch`
+  network-refusal guards remain in force (B1 adds UI isolation only; WFP egress
+  is still Integration B / D-005), so the HARD GATE's own precondition (WFP
+  landing) is untouched by this change.
 - `windows_elevated.rs::stream_child`'s sequential stdout-then-stderr drain
   (CodeRabbit "Sequential stdout-then-stderr drain can deadlock", Greptile
   "Sequential Pipe Drain Deadlocks", both on the same code): draining stdout
@@ -684,6 +690,44 @@ with the reason a blind fix would risk invalidating that lab run.
   during drain must also be bounded), so it is tracked with that fix rather
   than half-implemented as a bare final-wait timeout that a stuck drain would
   never reach. Inline comment added at the call site.
+
+### Integration B1: private window station for UI isolation (Hive deviation)
+
+Upstream `desktop.rs` isolates the UI only as far as an optional private
+DESKTOP under the shared `WinSta0` (`LaunchDesktop::prepare(use_private_desktop)`),
+and Hive's Integration A shipped `grant_winsta_desktop_access`, which granted the
+sandbox account access to the interactive user's shared `WinSta0` so the
+user32-linking runner could attach at load. Both leave the sandboxed process on
+the real user's window station, where it can shatter-attack, `SendInput` to, or
+read the clipboard of the real desktop (clipboard and the atom table are
+per-window-station, shared across every desktop on that station).
+
+B1 closes that hole by adding a Hive-native `desktop.rs::PrivateWindowStation`
+(no upstream equivalent) and removing `grant_winsta_desktop_access`:
+
+- The parent creates a per-launch PRIVATE window station
+  (`CreateWindowStationW`, `CWF_CREATE_ONLY`, a `HiveSandboxWinSta-<random u128>`
+  name) and a `HiveSandboxDesktop` on it (`SetProcessWindowStation` to the new
+  station so `CreateDesktopW` lands there, then the parent's own station is
+  restored). The sandbox account SID is granted on both objects (reusing
+  `merge_grant_on_window_object`) as insurance for a restrictive default DACL.
+- `runner_client.rs::spawn_runner_transport` sets
+  `STARTUPINFO.lpDesktop = "HiveSandboxWinSta-<..>\\HiveSandboxDesktop"` on the
+  `CreateProcessWithLogonW` launch. The spike (spike307-win, 2026-07-20, cl.exe
+  probe) proved `CreateProcessWithLogonW` (Secondary Logon) honours a
+  parent-created private window station named in `lpDesktop`: the child ran as
+  the sandbox SID on the private station and exited cleanly.
+- Fail closed (D-005): if the private station cannot be created (e.g. a
+  de-elevated caller in session 0 gets `ERROR_ACCESS_DENIED`) the launch errors
+  and NEVER falls back to `WinSta0`. Assumes the caller runs in the interactive
+  logged-in user's session, where window-station creation is permissive
+  (documented in `PrivateWindowStation::create`).
+
+Scope: B1 is UI isolation ONLY. The two `windows::launch` network-refusal guards
+are untouched; both `NetworkPolicy::DenyAll` and `AllowHosts` still fail closed
+until the WFP egress backend lands (Integration B / D-005). This code is
+cross-compiled by CI (`x86_64-pc-windows-gnu`) but, like the rest of the Win32
+compose, its behaviour is only lab-provable on `spike307-win`.
 
 ### Deliberately NOT done in A2 (fail-closed stubs, honest)
 

--- a/apps/desktop-sandbox/VENDORING.md
+++ b/apps/desktop-sandbox/VENDORING.md
@@ -703,56 +703,6 @@ with the reason a blind fix would risk invalidating that lab run.
   a real deadline in B2, lab-exercised on `spike307-win` at that point since
   only then does the watchdog path actually run.
 
-### Integration B1: private desktop for UI isolation (Hive deviation)
-
-Hive's Integration A shipped `grant_winsta_desktop_access`, which grants the
-sandbox account access to the interactive user's shared `WinSta0` so the
-user32-linking runner can complete process-attach at load. That left the
-sandboxed inner child on the real user's default desktop (`WinSta0\Default`),
-where it could shatter-attack or `SendInput` to the real desktop's windows.
-
-B1 closes the desktop half of that hole by adding a Hive-native
-`desktop.rs::PrivateDesktop` (mirroring upstream codex `desktop.rs`) and routing
-the untrusted inner child onto it. It does NOT add a private window station.
-
-- The RUNNER (running as the sandbox account) creates a per-launch PRIVATE
-  DESKTOP on the shared `WinSta0` (`CreateDesktopW`, a
-  `HiveSandboxDesktop-<random u128>` name from `OsRng`) and grants its own logon
-  SID access to it. The restricted inner-child token derives from the runner's
-  token and carries that same logon SID in its restricting-SID set, so the one
-  grant satisfies both halves of the child's `WRITE_RESTRICTED` access check.
-- `process.rs` sets `STARTUPINFO.lpDesktop = "Winsta0\\HiveSandboxDesktop-<..>"`
-  on the inner-child launch, so the child runs on the private desktop and holds
-  no handle to `WinSta0\Default`: it cannot enumerate the default desktop's
-  windows, `SendInput` across the desktop boundary, or mount a shatter attack on
-  the real desktop.
-- NOT a private window station. A least-privilege sandbox account cannot create
-  a securable window station (`CreateWindowStationW` returns
-  `ERROR_ACCESS_DENIED` for that token) and upstream never creates one; a private
-  desktop is the standard per-process UI isolation boundary (the upstream codex /
-  Chromium baseline). `CreateDesktopW` also has no `CWF_CREATE_ONLY` equivalent,
-  so a duplicate name would open the existing desktop rather than error; the
-  128-bit `OsRng` name suffix makes a collision cryptographically negligible.
-- Fail closed (D-005): any Win32 failure in `PrivateDesktop::create` returns an
-  error and NEVER falls back to `WinSta0\Default`.
-
-Scope: B1 is DESKTOP-level UI isolation ONLY.
-
-- Clipboard and the global atom table are per-WINDOW-STATION, so they stay
-  shared with the interactive user (accepted tradeoff; a private station would
-  isolate them, but the sandbox token cannot create one).
-- `grant_winsta_desktop_access` is RETAINED: the runner still needs shared
-  `WinSta0` access to attach user32 at load, so the "Desktop Grant Outlives
-  Runner" gap noted above is unchanged by B1 (still a known, non-blocking gap).
-- A hostile child's escape off its own private desktop is contained only once
-  the deferred Low-integrity / SID-disable seam lands.
-- The two `windows::launch` network-refusal guards are untouched; both
-  `NetworkPolicy::DenyAll` and `AllowHosts` still fail closed until the WFP
-  egress backend lands (Integration B / D-005).
-
-This code is cross-compiled by CI (`x86_64-pc-windows-gnu`) but, like the rest
-of the Win32 compose, its behaviour is only lab-provable on `spike307-win`.
-
 ### Deliberately NOT done in A2 (fail-closed stubs, honest)
 
 - WFP / firewall egress (Integration B): the two `windows::launch`

--- a/apps/desktop-sandbox/VENDORING.md
+++ b/apps/desktop-sandbox/VENDORING.md
@@ -703,6 +703,56 @@ with the reason a blind fix would risk invalidating that lab run.
   a real deadline in B2, lab-exercised on `spike307-win` at that point since
   only then does the watchdog path actually run.
 
+### Integration B1: private desktop for UI isolation (Hive deviation)
+
+Hive's Integration A shipped `grant_winsta_desktop_access`, which grants the
+sandbox account access to the interactive user's shared `WinSta0` so the
+user32-linking runner can complete process-attach at load. That left the
+sandboxed inner child on the real user's default desktop (`WinSta0\Default`),
+where it could shatter-attack or `SendInput` to the real desktop's windows.
+
+B1 closes the desktop half of that hole by adding a Hive-native
+`desktop.rs::PrivateDesktop` (mirroring upstream codex `desktop.rs`) and routing
+the untrusted inner child onto it. It does NOT add a private window station.
+
+- The RUNNER (running as the sandbox account) creates a per-launch PRIVATE
+  DESKTOP on the shared `WinSta0` (`CreateDesktopW`, a
+  `HiveSandboxDesktop-<random u128>` name from `OsRng`) and grants its own logon
+  SID access to it. The restricted inner-child token derives from the runner's
+  token and carries that same logon SID in its restricting-SID set, so the one
+  grant satisfies both halves of the child's `WRITE_RESTRICTED` access check.
+- `process.rs` sets `STARTUPINFO.lpDesktop = "Winsta0\\HiveSandboxDesktop-<..>"`
+  on the inner-child launch, so the child runs on the private desktop and holds
+  no handle to `WinSta0\Default`: it cannot enumerate the default desktop's
+  windows, `SendInput` across the desktop boundary, or mount a shatter attack on
+  the real desktop.
+- NOT a private window station. A least-privilege sandbox account cannot create
+  a securable window station (`CreateWindowStationW` returns
+  `ERROR_ACCESS_DENIED` for that token) and upstream never creates one; a private
+  desktop is the standard per-process UI isolation boundary (the upstream codex /
+  Chromium baseline). `CreateDesktopW` also has no `CWF_CREATE_ONLY` equivalent,
+  so a duplicate name would open the existing desktop rather than error; the
+  128-bit `OsRng` name suffix makes a collision cryptographically negligible.
+- Fail closed (D-005): any Win32 failure in `PrivateDesktop::create` returns an
+  error and NEVER falls back to `WinSta0\Default`.
+
+Scope: B1 is DESKTOP-level UI isolation ONLY.
+
+- Clipboard and the global atom table are per-WINDOW-STATION, so they stay
+  shared with the interactive user (accepted tradeoff; a private station would
+  isolate them, but the sandbox token cannot create one).
+- `grant_winsta_desktop_access` is RETAINED: the runner still needs shared
+  `WinSta0` access to attach user32 at load, so the "Desktop Grant Outlives
+  Runner" gap noted above is unchanged by B1 (still a known, non-blocking gap).
+- A hostile child's escape off its own private desktop is contained only once
+  the deferred Low-integrity / SID-disable seam lands.
+- The two `windows::launch` network-refusal guards are untouched; both
+  `NetworkPolicy::DenyAll` and `AllowHosts` still fail closed until the WFP
+  egress backend lands (Integration B / D-005).
+
+This code is cross-compiled by CI (`x86_64-pc-windows-gnu`) but, like the rest
+of the Win32 compose, its behaviour is only lab-provable on `spike307-win`.
+
 ### Deliberately NOT done in A2 (fail-closed stubs, honest)
 
 - WFP / firewall egress (Integration B): the two `windows::launch`

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/acl.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/acl.rs
@@ -201,6 +201,26 @@ pub unsafe fn path_has_read_deny(path: &Path, psid: *mut c_void) -> Result<bool>
     }
 }
 
+/// Path-based wrapper: does the DACL on `path` carry an effective (non
+/// inherit-only) write-allow ACE for `psid`? Fresh single DACL fetch,
+/// symmetric with [`path_has_read_deny`]. Used by [`add_allow_ace`] to verify,
+/// fail-closed, that a grant actually persisted before reporting success.
+///
+/// # Safety
+///
+/// `psid` must be a valid, well-formed `PSID` pointer that stays valid for the
+/// duration of this call.
+pub unsafe fn path_has_write_allow(path: &Path, psid: *mut c_void) -> Result<bool> {
+    unsafe {
+        let (p_dacl, sd) = fetch_dacl_handle(path)?;
+        let has = dacl_has_write_allow_for_sid(p_dacl, psid);
+        if !sd.is_null() {
+            LocalFree(sd as HLOCAL);
+        }
+        Ok(has)
+    }
+}
+
 pub unsafe fn dacl_has_write_allow_for_sid(p_dacl: *mut ACL, psid: *mut c_void) -> bool {
     if p_dacl.is_null() {
         return false;
@@ -490,8 +510,7 @@ pub unsafe fn add_allow_ace(path: &Path, psid: *mut c_void) -> Result<bool> {
         }
         return Ok(false);
     }
-    let mut added = false;
-    // Always ensure write is present: if an allow ACE exists without write, add one with write+RX.
+    // Add an allow ACE granting write+RX.
     let trustee = TRUSTEE_W {
         pMultipleTrustee: std::ptr::null_mut(),
         MultipleTrusteeOperation: 0,
@@ -506,27 +525,42 @@ pub unsafe fn add_allow_ace(path: &Path, psid: *mut c_void) -> Result<bool> {
     explicit.Trustee = trustee;
     let mut p_new_dacl: *mut ACL = std::ptr::null_mut();
     let code2 = SetEntriesInAclW(1, &explicit, p_dacl, &mut p_new_dacl);
-    if code2 == ERROR_SUCCESS {
-        let code3 = SetNamedSecurityInfoW(
-            to_wide(path).as_ptr() as *mut u16,
-            1,
-            DACL_SECURITY_INFORMATION,
-            std::ptr::null_mut(),
-            std::ptr::null_mut(),
-            p_new_dacl,
-            std::ptr::null_mut(),
-        );
-        if code3 == ERROR_SUCCESS {
-            added = !dacl_has_write_allow_for_sid(p_dacl, psid);
+    if code2 != ERROR_SUCCESS {
+        if !p_sd.is_null() {
+            LocalFree(p_sd as HLOCAL);
         }
-        if !p_new_dacl.is_null() {
-            LocalFree(p_new_dacl as HLOCAL);
-        }
+        return Err(anyhow!("SetEntriesInAclW failed: {code2}"));
+    }
+    let code3 = SetNamedSecurityInfoW(
+        to_wide(path).as_ptr() as *mut u16,
+        1,
+        DACL_SECURITY_INFORMATION,
+        std::ptr::null_mut(),
+        std::ptr::null_mut(),
+        p_new_dacl,
+        std::ptr::null_mut(),
+    );
+    if !p_new_dacl.is_null() {
+        LocalFree(p_new_dacl as HLOCAL);
     }
     if !p_sd.is_null() {
         LocalFree(p_sd as HLOCAL);
     }
-    Ok(added)
+    if code3 != ERROR_SUCCESS {
+        return Err(anyhow!("SetNamedSecurityInfoW failed: {code3}"));
+    }
+    // Fail-closed (D-005): verify the allow-write ACE actually persisted by
+    // re-reading the DACL from a fresh handle. The prior code checked the STALE
+    // pre-write DACL (which never carries the write), so it reported success
+    // even when SetNamedSecurityInfoW was denied (a caller lacking WRITE_DAC on
+    // the object) and no ACE ever landed.
+    if !path_has_write_allow(path, psid)? {
+        return Err(anyhow!(
+            "allow-write ACE did not persist on {}",
+            path.display()
+        ));
+    }
+    Ok(true)
 }
 
 /// Adds a deny ACE to prevent write/append/delete for the given SID on the target path.

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/desktop.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/desktop.rs
@@ -508,6 +508,17 @@ unsafe fn create_private_winsta_desktop(
     winsta_name: &str,
     desktop_name: &str,
 ) -> Result<(isize, isize)> {
+    // Serialize the whole process-global switch window (held until return).
+    // Acquire the lock BEFORE reading `saved`: otherwise a concurrent launch
+    // that has already switched the process to ITS private station could be
+    // captured here as our `saved`, and on teardown we would restore the parent
+    // to that other launch's (already closed) station. Reading `saved` under the
+    // lock guarantees it is the real interactive station, not a transient one.
+    let _switch_lock = STATION_SWITCH_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+
     // Fail closed: without a valid saved station we cannot restore the parent
     // after the switch, so refuse BEFORE creating or switching anything.
     let saved = GetProcessWindowStation();
@@ -517,12 +528,6 @@ unsafe fn create_private_winsta_desktop(
             GetLastError()
         ));
     }
-
-    // Serialize the whole process-global switch window (held until return).
-    let _switch_lock = STATION_SWITCH_LOCK
-        .get_or_init(|| Mutex::new(()))
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner);
 
     let winsta_name_wide = to_wide(winsta_name);
     let winsta = CreateWindowStationW(

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/desktop.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/desktop.rs
@@ -5,11 +5,15 @@ use crate::winutil::format_last_error;
 use crate::winutil::to_wide;
 use anyhow::Result;
 use rand::Rng;
+use rand::RngCore;
 use rand::SeedableRng;
+use rand::rngs::OsRng;
 use rand::rngs::SmallRng;
 use std::ffi::c_void;
 use std::path::Path;
 use std::ptr;
+use std::sync::Mutex;
+use std::sync::OnceLock;
 use windows_sys::Win32::Foundation::CloseHandle;
 use windows_sys::Win32::Foundation::ERROR_SUCCESS;
 use windows_sys::Win32::Foundation::GetLastError;
@@ -328,8 +332,11 @@ impl PrivateWindowStation {
     /// `ERROR_ACCESS_DENIED` from `CreateWindowStationW`, surfaced here as an
     /// error rather than a downgrade.
     pub fn create(sandbox_username: &str) -> Result<Self> {
-        let mut rng = SmallRng::from_entropy();
-        let winsta_name = format!("HiveSandboxWinSta-{:x}", rng.r#gen::<u128>());
+        // OsRng (CSPRNG) for the station name: SmallRng is not cryptographically
+        // secure, and this is a security-relevant object identifier.
+        let mut token = [0u8; 16];
+        OsRng.fill_bytes(&mut token);
+        let winsta_name = format!("HiveSandboxWinSta-{:x}", u128::from_le_bytes(token));
         let desktop_name = "HiveSandboxDesktop";
 
         // SAFETY: standard CreateWindowStationW / SetProcessWindowStation /
@@ -408,6 +415,77 @@ impl Drop for PrivateWindowStation {
     }
 }
 
+/// Serializes the process-global window-station switch inside
+/// [`create_private_winsta_desktop`]. The hive sandbox is per-agent-task, so
+/// concurrent launches are reachable; without this lock, one launch's
+/// `SetProcessWindowStation` would corrupt another's `CreateDesktopW` placement.
+/// Held across the ENTIRE switched window (from before the switch until after
+/// the restore).
+static STATION_SWITCH_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+/// Restores the process window station to `original` on drop, so a panic or an
+/// early return between the switch and the explicit restore can never leave the
+/// parent stranded on the private station (which would then make
+/// `CloseWindowStation` fail on the current station). The happy path restores
+/// explicitly via [`StationGuard::restore`] and checks the result; this `Drop`
+/// is the last-resort fallback and disarms once the explicit restore succeeds.
+struct StationGuard {
+    original: isize,
+    armed: bool,
+}
+
+impl StationGuard {
+    /// Explicit, checked restore. Disarms the drop-time fallback ONLY on
+    /// success, so a failed restore is retried when the guard drops. Returns the
+    /// Win32 `BOOL` (0 means failure).
+    ///
+    /// # Safety
+    /// `original` must be a valid window-station handle for this process.
+    unsafe fn restore(&mut self) -> i32 {
+        let ok = SetProcessWindowStation(self.original);
+        if ok != 0 {
+            self.armed = false;
+        }
+        ok
+    }
+}
+
+impl Drop for StationGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            // SAFETY: `original` is the caller's valid station handle from
+            // GetProcessWindowStation; making it current again needs no close.
+            unsafe {
+                let _ = SetProcessWindowStation(self.original);
+            }
+        }
+    }
+}
+
+/// Creates `desktop_name` on the process's CURRENT window station. Split out of
+/// [`create_private_winsta_desktop`] to keep that function under the size
+/// guideline; must be called while the process is switched to the target
+/// station.
+///
+/// # Safety
+/// Calls raw Win32 `CreateDesktopW`; the returned handle must be closed by the
+/// caller.
+unsafe fn create_desktop_on_current_station(desktop_name: &str) -> Result<isize> {
+    let desktop_name_wide = to_wide(desktop_name);
+    let desktop = CreateDesktopW(
+        desktop_name_wide.as_ptr(),
+        ptr::null(),
+        ptr::null(),
+        0,
+        DESKTOP_ALL_ACCESS,
+        ptr::null(),
+    );
+    if desktop == 0 {
+        return Err(anyhow::anyhow!("CreateDesktopW failed: {}", GetLastError()));
+    }
+    Ok(desktop)
+}
+
 /// Creates a private window station and a desktop on it, restoring the caller's
 /// original process window station before returning. Returns the `(winsta,
 /// desktop)` handle pair on success.
@@ -415,15 +493,12 @@ impl Drop for PrivateWindowStation {
 /// `SetProcessWindowStation` is required because `CreateDesktopW` always creates
 /// the desktop on the process's CURRENT window station; there is no
 /// target-station parameter. The switch is reverted immediately after the
-/// desktop is created so the parent process keeps its own station. On any
-/// failure the process window station is restored and every partially created
-/// handle is closed (fail closed, no leak).
-///
-/// The station switch is process-global for its brief window, so callers must
-/// spawn runners SERIALLY (the current runner-spawn path does): two concurrent
-/// spawns could observe each other's temporary station. A per-launch
-/// `CreateDesktopW`-on-a-separately-opened-station path (no process switch) is
-/// the upgrade if concurrent per-task spawns are ever needed.
+/// desktop is created so the parent keeps its own station, and the whole
+/// switched window is serialized by [`STATION_SWITCH_LOCK`] so concurrent
+/// per-task launches cannot corrupt each other's desktop placement. On any
+/// failure the process window station is restored (via [`StationGuard`], which
+/// also covers panics) BEFORE any private handle is closed, so
+/// `CloseWindowStation` never runs on the current station.
 ///
 /// # Safety
 /// Calls raw Win32 window-station APIs. Must run in the interactive user's
@@ -433,7 +508,22 @@ unsafe fn create_private_winsta_desktop(
     winsta_name: &str,
     desktop_name: &str,
 ) -> Result<(isize, isize)> {
+    // Fail closed: without a valid saved station we cannot restore the parent
+    // after the switch, so refuse BEFORE creating or switching anything.
     let saved = GetProcessWindowStation();
+    if saved == 0 {
+        return Err(anyhow::anyhow!(
+            "GetProcessWindowStation failed: {}",
+            GetLastError()
+        ));
+    }
+
+    // Serialize the whole process-global switch window (held until return).
+    let _switch_lock = STATION_SWITCH_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+
     let winsta_name_wide = to_wide(winsta_name);
     let winsta = CreateWindowStationW(
         winsta_name_wide.as_ptr(),
@@ -454,31 +544,40 @@ unsafe fn create_private_winsta_desktop(
             "SetProcessWindowStation(private) failed: {err}"
         ));
     }
-    let desktop_name_wide = to_wide(desktop_name);
-    let desktop = CreateDesktopW(
-        desktop_name_wide.as_ptr(),
-        ptr::null(),
-        ptr::null(),
-        0,
-        DESKTOP_ALL_ACCESS,
-        ptr::null(),
-    );
-    let desktop_err = GetLastError();
-    // Restore the parent's own window station regardless of the desktop result,
-    // so the parent process is never left stranded on the private station.
-    if saved != 0 && SetProcessWindowStation(saved) == 0 {
-        let restore_err = GetLastError();
-        if desktop != 0 {
+
+    // Parent is now switched to `winsta`; `guard` restores `saved` on every exit
+    // path (including panic) BEFORE any private handle is closed.
+    let mut guard = StationGuard {
+        original: saved,
+        armed: true,
+    };
+
+    let desktop = create_desktop_on_current_station(desktop_name);
+    // Explicit, checked restore; capture its error immediately, before any other
+    // Win32 call clobbers the last-error.
+    let restore_ok = guard.restore();
+    let restore_err = if restore_ok == 0 { GetLastError() } else { 0 };
+
+    match desktop {
+        Ok(desktop) if restore_ok != 0 => Ok((winsta, desktop)),
+        Ok(desktop) => {
+            // Restore failed: the parent may still be on `winsta`, so closing it
+            // could target the CURRENT station. Close only the desktop (never
+            // current) and surface the error; `guard` (still armed) retries the
+            // restore on drop. The winsta handle is intentionally leaked on this
+            // near-impossible path rather than closed while possibly current.
             let _ = CloseDesktop(desktop);
+            Err(anyhow::anyhow!(
+                "SetProcessWindowStation(restore) failed: {restore_err}"
+            ))
         }
-        let _ = CloseWindowStation(winsta);
-        return Err(anyhow::anyhow!(
-            "SetProcessWindowStation(restore) failed: {restore_err}"
-        ));
+        Err(e) => {
+            // Desktop creation failed. If the restore succeeded, `winsta` is not
+            // current and is safe to close; if it failed, leak it (guard retries).
+            if restore_ok != 0 {
+                let _ = CloseWindowStation(winsta);
+            }
+            Err(e)
+        }
     }
-    if desktop == 0 {
-        let _ = CloseWindowStation(winsta);
-        return Err(anyhow::anyhow!("CreateDesktopW failed: {desktop_err}"));
-    }
-    Ok((winsta, desktop))
 }

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/desktop.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/desktop.rs
@@ -211,6 +211,16 @@ const GENERIC_ALL_MASK: u32 = 0x1000_0000;
 // WINSTA_ALL_ACCESS is not re-exported by windows-sys 0.52; value from the
 // Win32 headers (winuser.h): the OR of all WINSTA_* rights.
 const WINSTA_ALL_ACCESS: u32 = 0x0000_037F;
+// Standard access rights (winnt.h) a window-station/desktop HANDLE needs to read
+// and rewrite its OWN security descriptor: GetSecurityInfo requires READ_CONTROL
+// and SetSecurityInfo requires WRITE_DAC. WINSTA_ALL_ACCESS (0x037F) does NOT
+// include either, so CreateWindowStationW must request them or the sandbox-SID
+// grant fails with ERROR_ACCESS_DENIED and, being fail-closed, aborts EVERY
+// spawn (lab, MSVC, spike307-win). DESKTOP_ALL_ACCESS already folds these in
+// (DESKTOP_READ_CONTROL = 0x0002_0000, DESKTOP_WRITE_DAC = 0x0004_0000); we OR
+// them onto the desktop mask too so the requirement is explicit at both sites.
+const READ_CONTROL: u32 = 0x0002_0000;
+const WRITE_DAC: u32 = 0x0004_0000;
 const CONTAINER_INHERIT_ACE: u32 = 0x2;
 const OBJECT_INHERIT_ACE: u32 = 0x1;
 const INHERIT_ONLY_ACE: u32 = 0x8;
@@ -477,7 +487,11 @@ unsafe fn create_desktop_on_current_station(desktop_name: &str) -> Result<isize>
         ptr::null(),
         ptr::null(),
         0,
-        DESKTOP_ALL_ACCESS,
+        // READ_CONTROL | WRITE_DAC so the handle can GetSecurityInfo /
+        // SetSecurityInfo for the sandbox SID grant. DESKTOP_ALL_ACCESS already
+        // includes both (DESKTOP_READ_CONTROL / DESKTOP_WRITE_DAC); ORed again
+        // here so the requirement is explicit and not dependent on that alias.
+        DESKTOP_ALL_ACCESS | READ_CONTROL | WRITE_DAC,
         ptr::null(),
     );
     if desktop == 0 {
@@ -533,7 +547,9 @@ unsafe fn create_private_winsta_desktop(
     let winsta = CreateWindowStationW(
         winsta_name_wide.as_ptr(),
         CWF_CREATE_ONLY,
-        WINSTA_ALL_ACCESS,
+        // READ_CONTROL | WRITE_DAC so the returned handle can GetSecurityInfo /
+        // SetSecurityInfo when grant_access adds the sandbox SID ACE below.
+        WINSTA_ALL_ACCESS | READ_CONTROL | WRITE_DAC,
         ptr::null(),
     );
     if winsta == 0 {

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/desktop.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/desktop.rs
@@ -8,8 +8,6 @@ use rand::rngs::OsRng;
 use std::ffi::c_void;
 use std::path::Path;
 use std::ptr;
-use std::sync::Mutex;
-use std::sync::OnceLock;
 use windows_sys::Win32::Foundation::CloseHandle;
 use windows_sys::Win32::Foundation::ERROR_SUCCESS;
 use windows_sys::Win32::Foundation::GetLastError;
@@ -27,9 +25,7 @@ use windows_sys::Win32::Security::Authorization::TRUSTEE_IS_UNKNOWN;
 use windows_sys::Win32::Security::Authorization::TRUSTEE_W;
 use windows_sys::Win32::Security::DACL_SECURITY_INFORMATION;
 use windows_sys::Win32::System::StationsAndDesktops::CloseDesktop;
-use windows_sys::Win32::System::StationsAndDesktops::CloseWindowStation;
 use windows_sys::Win32::System::StationsAndDesktops::CreateDesktopW;
-use windows_sys::Win32::System::StationsAndDesktops::CreateWindowStationW;
 use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_CREATEMENU;
 use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_CREATEWINDOW;
 use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_DELETE;
@@ -45,7 +41,6 @@ use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_WRITE_OWNER;
 use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_WRITEOBJECTS;
 use windows_sys::Win32::System::StationsAndDesktops::GetProcessWindowStation;
 use windows_sys::Win32::System::StationsAndDesktops::GetThreadDesktop;
-use windows_sys::Win32::System::StationsAndDesktops::SetProcessWindowStation;
 use windows_sys::Win32::System::Threading::GetCurrentThreadId;
 
 const DESKTOP_ALL_ACCESS: u32 = DESKTOP_READOBJECTS
@@ -63,32 +58,40 @@ const DESKTOP_ALL_ACCESS: u32 = DESKTOP_READOBJECTS
     | DESKTOP_WRITE_OWNER;
 
 /// Chooses the desktop a launched child attaches to. When `use_private_desktop`
-/// is set, the child runs on a per-launch PRIVATE window station + desktop (full
-/// UI isolation: a separate clipboard and global atom table, not just a separate
-/// desktop under the shared `WinSta0`); otherwise it stays on the interactive
-/// `Winsta0\Default`.
+/// is set, the child runs on a per-launch PRIVATE desktop on the interactive
+/// `WinSta0` (its own desktop object, isolated from `WinSta0\Default`); otherwise
+/// it stays on `WinSta0\Default`.
+///
+/// This mirrors upstream codex `desktop.rs`: a private DESKTOP under the shared
+/// `WinSta0`, NOT a private window station. A least-privilege sandbox account
+/// cannot create a securable window station (`CreateWindowStationW` returns
+/// `ERROR_ACCESS_DENIED` for that token), and upstream never creates one; a
+/// private desktop is the standard per-process UI isolation boundary. The known
+/// limit: clipboard and the global atom table are per-window-station and stay
+/// shared with the interactive user (a private station would isolate them, but
+/// the sandbox token cannot create one).
 ///
 /// Created RUNNER-side (inside the sandbox-account runner), so the logon SID the
-/// private objects are granted to is the runner's, which the restricted inner
-/// child shares. See [`PrivateWindowStation`].
+/// private desktop is granted to is the runner's, which the restricted inner
+/// child shares. See [`PrivateDesktop`].
 pub struct LaunchDesktop {
-    _private: Option<PrivateWindowStation>,
+    _private: Option<PrivateDesktop>,
     startup_name: Vec<u16>,
 }
 
 impl LaunchDesktop {
     pub fn prepare(use_private_desktop: bool, logs_base_dir: Option<&Path>) -> Result<Self> {
         if use_private_desktop {
-            let private = PrivateWindowStation::create().map_err(|e| {
+            let private = PrivateDesktop::create().map_err(|e| {
                 logging::debug_log(
-                    &format!("private window station create failed: {e}"),
+                    &format!("private desktop create failed: {e}"),
                     logs_base_dir,
                 );
                 e
             })?;
-            // Copy the "<winsta>\\<desktop>" name into our own buffer; the
-            // pointer handed to STARTUPINFO.lpDesktop must outlive the spawn, and
-            // `_private` keeps the objects themselves alive.
+            // Copy the "WinSta0\\<desktop>" name into our own buffer; the pointer
+            // handed to STARTUPINFO.lpDesktop must outlive the spawn, and
+            // `_private` keeps the desktop object itself alive.
             let startup_name = private.startup_name().to_vec();
             Ok(Self {
                 _private: Some(private),
@@ -112,10 +115,12 @@ impl LaunchDesktop {
 /// `CreateProcessWithLogonW` can complete user32 process-attach at load (without
 /// it the runner dies with `STATUS_DLL_INIT_FAILED` 0xC0000142 before `main`).
 ///
-/// The RUNNER stays on `WinSta0`; only the untrusted inner CHILD is moved to a
-/// private window station (via [`LaunchDesktop`] / [`PrivateWindowStation`]), so
-/// this shared-station grant applies to the trusted runner only and is not a
-/// UI-isolation relaxation for the sandboxed workload.
+/// The RUNNER stays on `WinSta0\Default`; the untrusted inner CHILD is moved to a
+/// private DESKTOP on `WinSta0` (via [`LaunchDesktop`] / [`PrivateDesktop`]). The
+/// child holds no handle to the default desktop, so it cannot enumerate the
+/// default desktop's windows or inject input across the desktop boundary.
+/// Clipboard and the atom table are per-window-station and stay shared with the
+/// interactive user: the known limit of desktop-only isolation.
 pub fn grant_winsta_desktop_access(sandbox_username: &str) -> Result<()> {
     let sid_bytes = crate::sandbox_users::resolve_sid(sandbox_username)?;
     let psid = crate::sandbox_users::sid_bytes_to_psid(&sid_bytes)?;
@@ -255,105 +260,94 @@ unsafe fn merge_grant_on_window_object(handle: isize, entries: &[EXPLICIT_ACCESS
     Ok(())
 }
 
-/// `CWF_CREATE_ONLY` (winuser.h): make `CreateWindowStationW` FAIL rather than
-/// open an existing station of the same name, so a name collision or a
-/// pre-squatted station is a hard error instead of a silent attach to another
-/// object. Not re-exported by windows-sys 0.52; value from the Win32 headers.
-const CWF_CREATE_ONLY: u32 = 0x0000_0001;
-
-/// A per-launch PRIVATE window station plus a desktop on it, created RUNNER-side
-/// so the sandboxed inner child runs in full UI isolation from the interactive
-/// user's `WinSta0`: a separate clipboard and global atom table, not just a
-/// separate desktop. The child holds no handle to the real desktop and cannot
-/// shatter-attack it, `SendInput` to it, or read its clipboard.
+/// A per-launch PRIVATE desktop on the interactive `WinSta0`, created RUNNER-side
+/// so the sandboxed inner child runs on its own desktop object, isolated from the
+/// interactive user's `WinSta0\Default`. The child holds no handle to the default
+/// desktop, so it cannot enumerate its windows, `SendInput` to it, or mount a
+/// shatter-style cross-window attack across the desktop boundary.
+///
+/// This mirrors upstream codex `desktop.rs` (a private DESKTOP under the shared
+/// `WinSta0`, NOT a private window station). A least-privilege sandbox account
+/// cannot create a securable window station: `CreateWindowStationW` returns
+/// `ERROR_ACCESS_DENIED` (GLE 5) for that token, and upstream never creates one.
+/// `CreateDesktopW` on `WinSta0` only needs `WINSTA_CREATEDESKTOP`, which the
+/// parent already granted the sandbox account via [`grant_winsta_desktop_access`].
+/// The residual limit: clipboard and the global atom table are per-window-station
+/// and remain shared with the interactive user.
 ///
 /// The child is spawned with `STARTUPINFO.lpDesktop` set to this object's
-/// [`PrivateWindowStation::startup_name`] (`"<winsta>\\<desktop>"`). Access is
-/// granted to the runner's logon SID, which the restricted inner-child token
-/// shares (see [`PrivateWindowStation::create`]).
+/// [`PrivateDesktop::startup_name`] (`"WinSta0\\<desktop>"`). Access is granted to
+/// the runner's logon SID, which the restricted inner-child token shares (see
+/// [`PrivateDesktop::create`]).
 ///
-/// Both handles are held for the value's lifetime; keep it alive until the child
-/// has been created. By then the child holds its OWN process reference to the
-/// station and desktop, so they outlive this value even after its handles close
-/// on drop.
-pub struct PrivateWindowStation {
-    winsta: isize,
+/// The handle is held for the value's lifetime; keep it alive until the child has
+/// been created. By then the child holds its OWN process reference to the desktop,
+/// so it outlives this value even after the handle closes on drop.
+pub struct PrivateDesktop {
     desktop: isize,
-    /// `"<winsta>\\<desktop>"`, NUL-terminated UTF-16, for `STARTUPINFO.lpDesktop`.
+    /// `"WinSta0\\<desktop>"`, NUL-terminated UTF-16, for `STARTUPINFO.lpDesktop`.
     startup_name: Vec<u16>,
 }
 
-impl PrivateWindowStation {
-    /// Creates the private station + desktop and grants the CURRENT process's
-    /// logon SID access to BOTH objects. Called RUNNER-side (the runner runs as
-    /// the sandbox account), so the logon SID is the runner's; the restricted
-    /// inner-child token derives from the runner's token and carries that same
-    /// logon SID in its restricting-SID set, so this ONE grant lets the
-    /// restricted child attach: it satisfies both halves of the
-    /// `WRITE_RESTRICTED` access check (the logon SID is in the token's normal
-    /// groups AND its restricting-SID set).
+impl PrivateDesktop {
+    /// Creates the private desktop on the process's CURRENT window station (the
+    /// interactive `WinSta0`) and grants the CURRENT process's logon SID access to
+    /// it. Called RUNNER-side (the runner runs as the sandbox account), so the
+    /// logon SID is the runner's; the restricted inner-child token derives from
+    /// the runner's token and carries that same logon SID in its restricting-SID
+    /// set, so this ONE grant lets the restricted child attach: the logon SID
+    /// satisfies both halves of the `WRITE_RESTRICTED` access check (it is in the
+    /// token's normal groups AND its restricting-SID set).
+    ///
+    /// No process-wide window-station switch is performed (`CreateDesktopW`
+    /// targets the current station directly), so there is no station-switch lock
+    /// or `StationGuard` to restore.
     ///
     /// Fail closed (D-005): any Win32 failure returns an error and NEVER falls
-    /// back to the shared `WinSta0`. Assumes the caller runs in an interactive
-    /// session (the runner is launched into one via seclogon), where
-    /// window-station creation is permitted.
+    /// back to `WinSta0\Default`.
     pub fn create() -> Result<Self> {
-        // OsRng (CSPRNG) for the station name: not cryptographically-weak
-        // SmallRng, since this is a security-relevant object identifier.
+        // OsRng (CSPRNG) for the desktop name: a security-relevant object
+        // identifier, so not cryptographically-weak SmallRng.
         let mut token = [0u8; 16];
         OsRng.fill_bytes(&mut token);
-        let winsta_name = format!("HiveSandboxWinSta-{:x}", u128::from_le_bytes(token));
-        let desktop_name = "HiveSandboxDesktop";
+        let desktop_name = format!("HiveSandboxDesktop-{:x}", u128::from_le_bytes(token));
 
-        // SAFETY: standard CreateWindowStationW / SetProcessWindowStation /
-        // CreateDesktopW sequence; see `create_private_winsta_desktop`. On
-        // failure it restores the process window station and closes any created
-        // handle before returning.
-        let (winsta, desktop) =
-            unsafe { create_private_winsta_desktop(&winsta_name, desktop_name)? };
+        // SAFETY: creates a desktop on the current (`WinSta0`) window station; the
+        // returned handle is closed by this value's `Drop`.
+        let desktop = unsafe { create_desktop_on_current_station(&desktop_name)? };
 
-        let station = Self {
-            winsta,
+        let this = Self {
             desktop,
-            startup_name: to_wide(format!("{winsta_name}\\{desktop_name}")),
+            // The interactive station is `WinSta0` (same convention as the
+            // `Winsta0\Default` fallback above; Win32 station names are
+            // case-insensitive).
+            startup_name: to_wide(format!("Winsta0\\{desktop_name}")),
         };
 
-        // On failure the returned `station` is dropped here, closing both handles.
-        station.grant_access()?;
-        Ok(station)
+        // On failure the returned `this` is dropped here, closing the handle.
+        this.grant_access()?;
+        Ok(this)
     }
 
-    /// The `"<winsta>\\<desktop>"` name as NUL-terminated UTF-16, for the caller
-    /// to copy into its own `STARTUPINFO.lpDesktop` buffer.
+    /// The `"WinSta0\\<desktop>"` name as NUL-terminated UTF-16, for the caller to
+    /// copy into its own `STARTUPINFO.lpDesktop` buffer.
     pub(crate) fn startup_name(&self) -> &[u16] {
         &self.startup_name
     }
 
-    /// Grants the current process's logon SID access to the private station and
-    /// desktop, preserving every existing ACE (the creator keeps full control).
-    /// See [`PrivateWindowStation::create`] for why the logon SID is the correct
-    /// trustee for the restricted child.
+    /// Grants the current process's logon SID access to the private desktop,
+    /// preserving every existing ACE (the creator keeps full control). See
+    /// [`PrivateDesktop::create`] for why the logon SID is the correct trustee for
+    /// the restricted child.
     fn grant_access(&self) -> Result<()> {
-        // SAFETY: the token helpers return this process's own token and its
-        // logon SID; `psid` points into `logon_sid`, which outlives every grant
-        // below. Each Win32 step inside `merge_grant_on_window_object` is checked.
+        // SAFETY: the token helpers return this process's own token and its logon
+        // SID; `psid` points into `logon_sid`, which outlives the grant below.
+        // Each Win32 step inside `merge_grant_on_window_object` is checked.
         unsafe {
             let token = get_current_token_for_restriction()?;
             let mut logon_sid = get_logon_sid_bytes(token)?;
             CloseHandle(token);
             let psid = logon_sid.as_mut_ptr() as *mut c_void;
-            // KB165194: a window station needs two ACEs for a launched-as user —
-            // an inherit-only generic ACE so child desktops inherit access, plus
-            // the station-specific access on the station object itself.
-            let winsta_entries = [
-                explicit_grant(
-                    psid,
-                    GENERIC_ALL_MASK,
-                    CONTAINER_INHERIT_ACE | INHERIT_ONLY_ACE | OBJECT_INHERIT_ACE,
-                ),
-                explicit_grant(psid, WINSTA_ALL_ACCESS, NO_INHERITANCE),
-            ];
-            merge_grant_on_window_object(self.winsta, &winsta_entries)?;
             let desktop_entries = [explicit_grant(psid, DESKTOP_ALL_ACCESS, NO_INHERITANCE)];
             merge_grant_on_window_object(self.desktop, &desktop_entries)?;
         }
@@ -361,73 +355,21 @@ impl PrivateWindowStation {
     }
 }
 
-impl Drop for PrivateWindowStation {
+impl Drop for PrivateDesktop {
     fn drop(&mut self) {
-        // SAFETY: `desktop`/`winsta` are handles from CreateDesktopW /
-        // CreateWindowStationW; closing each once is safe. Close the desktop
-        // before the station it lives on.
+        // SAFETY: `desktop` is a handle from CreateDesktopW; closing it once is
+        // safe.
         unsafe {
             if self.desktop != 0 {
                 let _ = CloseDesktop(self.desktop);
             }
-            if self.winsta != 0 {
-                let _ = CloseWindowStation(self.winsta);
-            }
         }
     }
 }
 
-/// Serializes the process-global window-station switch inside
-/// [`create_private_winsta_desktop`]. The hive sandbox is per-agent-task, so
-/// concurrent launches are reachable; without this lock, one launch's
-/// `SetProcessWindowStation` would corrupt another's `CreateDesktopW` placement.
-/// Held across the ENTIRE switched window (from before the switch until after
-/// the restore).
-static STATION_SWITCH_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-
-/// Restores the process window station to `original` on drop, so a panic or an
-/// early return between the switch and the explicit restore can never leave the
-/// parent stranded on the private station (which would then make
-/// `CloseWindowStation` fail on the current station). The happy path restores
-/// explicitly via [`StationGuard::restore`] and checks the result; this `Drop`
-/// is the last-resort fallback and disarms once the explicit restore succeeds.
-struct StationGuard {
-    original: isize,
-    armed: bool,
-}
-
-impl StationGuard {
-    /// Explicit, checked restore. Disarms the drop-time fallback ONLY on
-    /// success, so a failed restore is retried when the guard drops. Returns the
-    /// Win32 `BOOL` (0 means failure).
-    ///
-    /// # Safety
-    /// `original` must be a valid window-station handle for this process.
-    unsafe fn restore(&mut self) -> i32 {
-        let ok = SetProcessWindowStation(self.original);
-        if ok != 0 {
-            self.armed = false;
-        }
-        ok
-    }
-}
-
-impl Drop for StationGuard {
-    fn drop(&mut self) {
-        if self.armed {
-            // SAFETY: `original` is the caller's valid station handle from
-            // GetProcessWindowStation; making it current again needs no close.
-            unsafe {
-                let _ = SetProcessWindowStation(self.original);
-            }
-        }
-    }
-}
-
-/// Creates `desktop_name` on the process's CURRENT window station. Split out of
-/// [`create_private_winsta_desktop`] to keep that function under the size
-/// guideline; must be called while the process is switched to the target
-/// station.
+/// Creates `desktop_name` on the process's CURRENT window station (the
+/// interactive `WinSta0` for the sandbox-account runner). No station switch is
+/// performed: `CreateDesktopW` targets the current station directly.
 ///
 /// # Safety
 /// Calls raw Win32 `CreateDesktopW`; the returned handle must be closed by the
@@ -450,107 +392,4 @@ unsafe fn create_desktop_on_current_station(desktop_name: &str) -> Result<isize>
         return Err(anyhow::anyhow!("CreateDesktopW failed: {}", GetLastError()));
     }
     Ok(desktop)
-}
-
-/// Creates a private window station and a desktop on it, restoring the caller's
-/// original process window station before returning. Returns the `(winsta,
-/// desktop)` handle pair on success.
-///
-/// `SetProcessWindowStation` is required because `CreateDesktopW` always creates
-/// the desktop on the process's CURRENT window station; there is no
-/// target-station parameter. The switch is reverted immediately after the
-/// desktop is created so the parent keeps its own station, and the whole
-/// switched window is serialized by [`STATION_SWITCH_LOCK`] so concurrent
-/// per-task launches cannot corrupt each other's desktop placement. On any
-/// failure the process window station is restored (via [`StationGuard`], which
-/// also covers panics) BEFORE any private handle is closed, so
-/// `CloseWindowStation` never runs on the current station.
-///
-/// # Safety
-/// Calls raw Win32 window-station APIs. Must run in the interactive user's
-/// session (see [`PrivateWindowStation::create`]); the returned handles must be
-/// closed by the caller (they are, via [`PrivateWindowStation`]'s `Drop`).
-unsafe fn create_private_winsta_desktop(
-    winsta_name: &str,
-    desktop_name: &str,
-) -> Result<(isize, isize)> {
-    // Serialize the whole process-global switch window (held until return).
-    // Acquire the lock BEFORE reading `saved`: otherwise a concurrent launch
-    // that has already switched the process to ITS private station could be
-    // captured here as our `saved`, and on teardown we would restore the parent
-    // to that other launch's (already closed) station. Reading `saved` under the
-    // lock guarantees it is the real interactive station, not a transient one.
-    let _switch_lock = STATION_SWITCH_LOCK
-        .get_or_init(|| Mutex::new(()))
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner);
-
-    // Fail closed: without a valid saved station we cannot restore the parent
-    // after the switch, so refuse BEFORE creating or switching anything.
-    let saved = GetProcessWindowStation();
-    if saved == 0 {
-        return Err(anyhow::anyhow!(
-            "GetProcessWindowStation failed: {}",
-            GetLastError()
-        ));
-    }
-
-    let winsta_name_wide = to_wide(winsta_name);
-    let winsta = CreateWindowStationW(
-        winsta_name_wide.as_ptr(),
-        CWF_CREATE_ONLY,
-        // READ_CONTROL | WRITE_DAC so the returned handle can GetSecurityInfo /
-        // SetSecurityInfo when grant_access adds the sandbox SID ACE below.
-        WINSTA_ALL_ACCESS | READ_CONTROL | WRITE_DAC,
-        ptr::null(),
-    );
-    if winsta == 0 {
-        return Err(anyhow::anyhow!(
-            "CreateWindowStationW failed: {}",
-            GetLastError()
-        ));
-    }
-    if SetProcessWindowStation(winsta) == 0 {
-        let err = GetLastError();
-        let _ = CloseWindowStation(winsta);
-        return Err(anyhow::anyhow!(
-            "SetProcessWindowStation(private) failed: {err}"
-        ));
-    }
-
-    // Parent is now switched to `winsta`; `guard` restores `saved` on every exit
-    // path (including panic) BEFORE any private handle is closed.
-    let mut guard = StationGuard {
-        original: saved,
-        armed: true,
-    };
-
-    let desktop = create_desktop_on_current_station(desktop_name);
-    // Explicit, checked restore; capture its error immediately, before any other
-    // Win32 call clobbers the last-error.
-    let restore_ok = guard.restore();
-    let restore_err = if restore_ok == 0 { GetLastError() } else { 0 };
-
-    match desktop {
-        Ok(desktop) if restore_ok != 0 => Ok((winsta, desktop)),
-        Ok(desktop) => {
-            // Restore failed: the parent may still be on `winsta`, so closing it
-            // could target the CURRENT station. Close only the desktop (never
-            // current) and surface the error; `guard` (still armed) retries the
-            // restore on drop. The winsta handle is intentionally leaked on this
-            // near-impossible path rather than closed while possibly current.
-            let _ = CloseDesktop(desktop);
-            Err(anyhow::anyhow!(
-                "SetProcessWindowStation(restore) failed: {restore_err}"
-            ))
-        }
-        Err(e) => {
-            // Desktop creation failed. If the restore succeeded, `winsta` is not
-            // current and is safe to close; if it failed, leak it (guard retries).
-            if restore_ok != 0 {
-                let _ = CloseWindowStation(winsta);
-            }
-            Err(e)
-        }
-    }
 }

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/desktop.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/desktop.rs
@@ -345,8 +345,12 @@ impl PrivateDesktop {
         // Each Win32 step inside `merge_grant_on_window_object` is checked.
         unsafe {
             let token = get_current_token_for_restriction()?;
-            let mut logon_sid = get_logon_sid_bytes(token)?;
+            // Close the token on both the success and error paths of
+            // get_logon_sid_bytes: propagating its error with `?` before
+            // CloseHandle would leak the handle.
+            let logon_sid_result = get_logon_sid_bytes(token);
             CloseHandle(token);
+            let mut logon_sid = logon_sid_result?;
             let psid = logon_sid.as_mut_ptr() as *mut c_void;
             let desktop_entries = [explicit_grant(psid, DESKTOP_ALL_ACCESS, NO_INHERITANCE)];
             merge_grant_on_window_object(self.desktop, &desktop_entries)?;
@@ -376,6 +380,10 @@ impl Drop for PrivateDesktop {
 /// caller.
 unsafe fn create_desktop_on_current_station(desktop_name: &str) -> Result<isize> {
     let desktop_name_wide = to_wide(desktop_name);
+    // CreateDesktopW has no CWF_CREATE_ONLY equivalent: a duplicate name opens
+    // the existing desktop rather than erroring. Accepted because desktop_name
+    // carries a 128-bit OsRng suffix, so a collision is cryptographically
+    // negligible.
     let desktop = CreateDesktopW(
         desktop_name_wide.as_ptr(),
         ptr::null(),

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/desktop.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/desktop.rs
@@ -27,7 +27,9 @@ use windows_sys::Win32::Security::Authorization::TRUSTEE_IS_UNKNOWN;
 use windows_sys::Win32::Security::Authorization::TRUSTEE_W;
 use windows_sys::Win32::Security::DACL_SECURITY_INFORMATION;
 use windows_sys::Win32::System::StationsAndDesktops::CloseDesktop;
+use windows_sys::Win32::System::StationsAndDesktops::CloseWindowStation;
 use windows_sys::Win32::System::StationsAndDesktops::CreateDesktopW;
+use windows_sys::Win32::System::StationsAndDesktops::CreateWindowStationW;
 use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_CREATEMENU;
 use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_CREATEWINDOW;
 use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_DELETE;
@@ -42,8 +44,7 @@ use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_WRITE_DAC;
 use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_WRITE_OWNER;
 use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_WRITEOBJECTS;
 use windows_sys::Win32::System::StationsAndDesktops::GetProcessWindowStation;
-use windows_sys::Win32::System::StationsAndDesktops::GetThreadDesktop;
-use windows_sys::Win32::System::Threading::GetCurrentThreadId;
+use windows_sys::Win32::System::StationsAndDesktops::SetProcessWindowStation;
 
 const DESKTOP_ALL_ACCESS: u32 = DESKTOP_READOBJECTS
     | DESKTOP_CREATEWINDOW
@@ -285,84 +286,199 @@ unsafe fn merge_grant_on_window_object(handle: isize, entries: &[EXPLICIT_ACCESS
     Ok(())
 }
 
-/// Grants the named account the window-station and desktop access a process
-/// launched AS that account needs to INITIALIZE.
+/// `CWF_CREATE_ONLY` (winuser.h): make `CreateWindowStationW` FAIL rather than
+/// open an existing station of the same name, so a name collision or a
+/// pre-squatted station is a hard error instead of a silent attach to another
+/// object. Not re-exported by windows-sys 0.52; value from the Win32 headers.
+const CWF_CREATE_ONLY: u32 = 0x0000_0001;
+
+/// A private window station plus a desktop on it, created by the parent so the
+/// sandbox runner (and the child it spawns) launch in UI isolation from the
+/// interactive user's `WinSta0`. Replaces the former shared-`WinSta0` grant.
 ///
-/// The command-runner links `user32.dll`; its process-attach initialization
-/// connects to the caller's window station and desktop. When the runner is
-/// launched as the low-privilege sandbox account via `CreateProcessWithLogonW`,
-/// that account has no access to the caller's station/desktop by default, so
-/// the connect fails and the runner dies at load with `STATUS_DLL_INIT_FAILED`
-/// (0xC0000142) BEFORE `main` runs (no output, no crash event). Granting the
-/// sandbox SID access to the CURRENT window station + desktop (whatever the
-/// caller is on: the interactive `WinSta0` for the desktop app, a service
-/// station for a headless/CI host) fixes it. The launch leaves
-/// `STARTUPINFO.lpDesktop` NULL so the runner inherits this same, now-accessible
-/// station/desktop; there is deliberately no hardcoded station name.
+/// The runner is launched with `STARTUPINFO.lpDesktop` set to
+/// [`PrivateWindowStation::startup_info_desktop`] (`"<winsta>\\<desktop>"`),
+/// which `CreateProcessWithLogonW` honours (validated on spike307-win,
+/// 2026-07-20): the runner attaches to THIS station, so it holds no handle to
+/// the real desktop and cannot shatter-attack it, `SendInput` to it, or read
+/// its clipboard. That is the UI-isolation hole the old shared-station grant
+/// left open.
 ///
-/// Scope (D-005): this is a launch PREREQUISITE, not a relaxation of any control
-/// Step 3 enforces. Step 3's confinement is filesystem + sandbox user + a
-/// capability-restricted token + Job Object; UI/desktop isolation (a dedicated
-/// private window station for the runner) is a separate follow-up hardening and
-/// is intentionally not attempted here.
-///
-/// KNOWN GAP, dispositioned and NOT re-fixed here (Greptile finding "Desktop
-/// Grant Outlives Runner", PR #401 review round; opus security review PASSED
-/// PR #401 MERGE-WITH-TRACKED-FOLLOWUP on this exact basis): the grant is
-/// persistent (`WINSTA_ALL_ACCESS` / inheritable `GENERIC_ALL` / `DESKTOP_ALL_ACCESS`)
-/// and never revoked, so any later process running as the shared sandbox
-/// account on this station/desktop also inherits it. Unreachable in the
-/// product path today because `windows::launch` refuses every network
-/// policy (`DenyAll` and `AllowHosts` both fail closed; see VENDORING.md
-/// "Open risks" #3), so nothing reaches this grant outside the lab-only
-/// `spawn_confined_for_validation` entry.
-///
-/// HARD GATE ON INTEGRATION B: do not remove or loosen the network-refusal
-/// guards in `windows::launch` until the runner is switched to a dedicated,
-/// non-shared private window station (revoking this shared-station/desktop
-/// grant) instead of the caller's own interactive station. WFP egress
-/// enforcement landing without that switch would make this gap reachable in
-/// production. Track resolution together, not WFP alone.
-pub fn grant_winsta_desktop_access(sandbox_username: &str) -> Result<()> {
-    let sid_bytes = crate::sandbox_users::resolve_sid(sandbox_username)?;
-    let psid = crate::sandbox_users::sid_bytes_to_psid(&sid_bytes)?;
-    // SAFETY: `psid` is a live SID from ConvertStringSidToSidW (freed below);
-    // the window-station/desktop handles are process/thread pseudo-handles that
-    // need no close. Every fallible Win32 step is checked.
-    let result = unsafe {
-        let winsta = GetProcessWindowStation();
-        if winsta == 0 {
-            LocalFree(psid as HLOCAL);
-            return Err(anyhow::anyhow!(
-                "GetProcessWindowStation failed: {}",
-                GetLastError()
-            ));
-        }
-        // KB165194: a window station needs two ACEs for a launched-as user — an
-        // inherit-only generic ACE so child desktops inherit access, plus the
-        // station-specific access on the station object itself.
-        let winsta_entries = [
-            explicit_grant(
-                psid,
-                GENERIC_ALL_MASK,
-                CONTAINER_INHERIT_ACE | INHERIT_ONLY_ACE | OBJECT_INHERIT_ACE,
-            ),
-            explicit_grant(psid, WINSTA_ALL_ACCESS, NO_INHERITANCE),
-        ];
-        merge_grant_on_window_object(winsta, &winsta_entries).and_then(|()| {
-            let desktop = GetThreadDesktop(GetCurrentThreadId());
-            if desktop == 0 {
-                return Err(anyhow::anyhow!(
-                    "GetThreadDesktop failed: {}",
-                    GetLastError()
-                ));
-            }
-            let desktop_entries = [explicit_grant(psid, DESKTOP_ALL_ACCESS, NO_INHERITANCE)];
-            merge_grant_on_window_object(desktop, &desktop_entries)
-        })
-    };
-    unsafe {
-        LocalFree(psid as HLOCAL);
+/// Both handles are held for the value's lifetime. The caller keeps the value
+/// alive until `CreateProcessWithLogonW` has returned; by then the runner is
+/// attached and holds its OWN process reference to the station and desktop, so
+/// they outlive this value even after its handles close on drop.
+pub struct PrivateWindowStation {
+    winsta: isize,
+    desktop: isize,
+    /// `"<winsta>\\<desktop>"`, NUL-terminated UTF-16, for `STARTUPINFO.lpDesktop`.
+    startup_name: Vec<u16>,
+}
+
+impl PrivateWindowStation {
+    /// Creates the private station + desktop and grants `sandbox_username`
+    /// access to BOTH objects. The grant is cheap insurance for a restrictive
+    /// default DACL; the spike showed the child attaches via the default DACL
+    /// even without it, but a hardened host may not, so it is applied anyway.
+    ///
+    /// Fail closed (D-005): any Win32 failure returns an error and NEVER falls
+    /// back to the shared `WinSta0`. Assumes the caller runs in the interactive
+    /// logged-in user's session (the Hive desktop app), where window-station
+    /// creation is permitted; a de-elevated caller in session 0 gets
+    /// `ERROR_ACCESS_DENIED` from `CreateWindowStationW`, surfaced here as an
+    /// error rather than a downgrade.
+    pub fn create(sandbox_username: &str) -> Result<Self> {
+        let mut rng = SmallRng::from_entropy();
+        let winsta_name = format!("HiveSandboxWinSta-{:x}", rng.r#gen::<u128>());
+        let desktop_name = "HiveSandboxDesktop";
+
+        // SAFETY: standard CreateWindowStationW / SetProcessWindowStation /
+        // CreateDesktopW sequence. The saved station handle from
+        // GetProcessWindowStation needs no close; the created winsta/desktop
+        // handles are owned by the returned value (closed on drop). Every
+        // fallible step is checked and, on failure, the process window station
+        // is restored and any created handle closed before returning.
+        let (winsta, desktop) =
+            unsafe { create_private_winsta_desktop(&winsta_name, desktop_name)? };
+
+        let station = Self {
+            winsta,
+            desktop,
+            startup_name: to_wide(format!("{winsta_name}\\{desktop_name}")),
+        };
+
+        // Grant the sandbox account access to both objects. On failure the
+        // returned `station` is dropped here, closing both handles.
+        station.grant_access(sandbox_username)?;
+        Ok(station)
     }
-    result
+
+    /// `"<winsta>\\<desktop>"` as a `*mut u16` for `STARTUPINFO.lpDesktop`. The
+    /// backing buffer lives as long as `self`; keep `self` alive across the
+    /// `CreateProcessWithLogonW` call that reads this pointer.
+    pub fn startup_info_desktop(&self) -> *mut u16 {
+        self.startup_name.as_ptr() as *mut u16
+    }
+
+    /// Adds allow ACEs for the sandbox account SID on the private station and
+    /// desktop, preserving every existing ACE (the creator keeps full control).
+    fn grant_access(&self, sandbox_username: &str) -> Result<()> {
+        let sid_bytes = crate::sandbox_users::resolve_sid(sandbox_username)?;
+        let psid = crate::sandbox_users::sid_bytes_to_psid(&sid_bytes)?;
+        // SAFETY: `psid` is a live SID (freed below); `self.winsta`/`self.desktop`
+        // are the private objects created in `create`. Each Win32 step inside
+        // `merge_grant_on_window_object` is checked.
+        let result = unsafe {
+            // KB165194: a window station needs two ACEs for a launched-as user —
+            // an inherit-only generic ACE so child desktops inherit access, plus
+            // the station-specific access on the station object itself.
+            let winsta_entries = [
+                explicit_grant(
+                    psid,
+                    GENERIC_ALL_MASK,
+                    CONTAINER_INHERIT_ACE | INHERIT_ONLY_ACE | OBJECT_INHERIT_ACE,
+                ),
+                explicit_grant(psid, WINSTA_ALL_ACCESS, NO_INHERITANCE),
+            ];
+            merge_grant_on_window_object(self.winsta, &winsta_entries).and_then(|()| {
+                let desktop_entries = [explicit_grant(psid, DESKTOP_ALL_ACCESS, NO_INHERITANCE)];
+                merge_grant_on_window_object(self.desktop, &desktop_entries)
+            })
+        };
+        unsafe {
+            LocalFree(psid as HLOCAL);
+        }
+        result
+    }
+}
+
+impl Drop for PrivateWindowStation {
+    fn drop(&mut self) {
+        // SAFETY: `desktop`/`winsta` are handles from CreateDesktopW /
+        // CreateWindowStationW; closing each once is safe. Close the desktop
+        // before the station it lives on.
+        unsafe {
+            if self.desktop != 0 {
+                let _ = CloseDesktop(self.desktop);
+            }
+            if self.winsta != 0 {
+                let _ = CloseWindowStation(self.winsta);
+            }
+        }
+    }
+}
+
+/// Creates a private window station and a desktop on it, restoring the caller's
+/// original process window station before returning. Returns the `(winsta,
+/// desktop)` handle pair on success.
+///
+/// `SetProcessWindowStation` is required because `CreateDesktopW` always creates
+/// the desktop on the process's CURRENT window station; there is no
+/// target-station parameter. The switch is reverted immediately after the
+/// desktop is created so the parent process keeps its own station. On any
+/// failure the process window station is restored and every partially created
+/// handle is closed (fail closed, no leak).
+///
+/// The station switch is process-global for its brief window, so callers must
+/// spawn runners SERIALLY (the current runner-spawn path does): two concurrent
+/// spawns could observe each other's temporary station. A per-launch
+/// `CreateDesktopW`-on-a-separately-opened-station path (no process switch) is
+/// the upgrade if concurrent per-task spawns are ever needed.
+///
+/// # Safety
+/// Calls raw Win32 window-station APIs. Must run in the interactive user's
+/// session (see [`PrivateWindowStation::create`]); the returned handles must be
+/// closed by the caller (they are, via [`PrivateWindowStation`]'s `Drop`).
+unsafe fn create_private_winsta_desktop(
+    winsta_name: &str,
+    desktop_name: &str,
+) -> Result<(isize, isize)> {
+    let saved = GetProcessWindowStation();
+    let winsta_name_wide = to_wide(winsta_name);
+    let winsta = CreateWindowStationW(
+        winsta_name_wide.as_ptr(),
+        CWF_CREATE_ONLY,
+        WINSTA_ALL_ACCESS,
+        ptr::null(),
+    );
+    if winsta == 0 {
+        return Err(anyhow::anyhow!(
+            "CreateWindowStationW failed: {}",
+            GetLastError()
+        ));
+    }
+    if SetProcessWindowStation(winsta) == 0 {
+        let err = GetLastError();
+        let _ = CloseWindowStation(winsta);
+        return Err(anyhow::anyhow!(
+            "SetProcessWindowStation(private) failed: {err}"
+        ));
+    }
+    let desktop_name_wide = to_wide(desktop_name);
+    let desktop = CreateDesktopW(
+        desktop_name_wide.as_ptr(),
+        ptr::null(),
+        ptr::null(),
+        0,
+        DESKTOP_ALL_ACCESS,
+        ptr::null(),
+    );
+    let desktop_err = GetLastError();
+    // Restore the parent's own window station regardless of the desktop result,
+    // so the parent process is never left stranded on the private station.
+    if saved != 0 && SetProcessWindowStation(saved) == 0 {
+        let restore_err = GetLastError();
+        if desktop != 0 {
+            let _ = CloseDesktop(desktop);
+        }
+        let _ = CloseWindowStation(winsta);
+        return Err(anyhow::anyhow!(
+            "SetProcessWindowStation(restore) failed: {restore_err}"
+        ));
+    }
+    if desktop == 0 {
+        let _ = CloseWindowStation(winsta);
+        return Err(anyhow::anyhow!("CreateDesktopW failed: {desktop_err}"));
+    }
+    Ok((winsta, desktop))
 }

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/desktop.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/desktop.rs
@@ -1,14 +1,10 @@
 use crate::logging;
 use crate::token::get_current_token_for_restriction;
 use crate::token::get_logon_sid_bytes;
-use crate::winutil::format_last_error;
 use crate::winutil::to_wide;
 use anyhow::Result;
-use rand::Rng;
 use rand::RngCore;
-use rand::SeedableRng;
 use rand::rngs::OsRng;
-use rand::rngs::SmallRng;
 use std::ffi::c_void;
 use std::path::Path;
 use std::ptr;
@@ -48,7 +44,9 @@ use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_WRITE_DAC;
 use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_WRITE_OWNER;
 use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_WRITEOBJECTS;
 use windows_sys::Win32::System::StationsAndDesktops::GetProcessWindowStation;
+use windows_sys::Win32::System::StationsAndDesktops::GetThreadDesktop;
 use windows_sys::Win32::System::StationsAndDesktops::SetProcessWindowStation;
+use windows_sys::Win32::System::Threading::GetCurrentThreadId;
 
 const DESKTOP_ALL_ACCESS: u32 = DESKTOP_READOBJECTS
     | DESKTOP_CREATEWINDOW
@@ -64,23 +62,41 @@ const DESKTOP_ALL_ACCESS: u32 = DESKTOP_READOBJECTS
     | DESKTOP_WRITE_DAC
     | DESKTOP_WRITE_OWNER;
 
+/// Chooses the desktop a launched child attaches to. When `use_private_desktop`
+/// is set, the child runs on a per-launch PRIVATE window station + desktop (full
+/// UI isolation: a separate clipboard and global atom table, not just a separate
+/// desktop under the shared `WinSta0`); otherwise it stays on the interactive
+/// `Winsta0\Default`.
+///
+/// Created RUNNER-side (inside the sandbox-account runner), so the logon SID the
+/// private objects are granted to is the runner's, which the restricted inner
+/// child shares. See [`PrivateWindowStation`].
 pub struct LaunchDesktop {
-    _private_desktop: Option<PrivateDesktop>,
+    _private: Option<PrivateWindowStation>,
     startup_name: Vec<u16>,
 }
 
 impl LaunchDesktop {
     pub fn prepare(use_private_desktop: bool, logs_base_dir: Option<&Path>) -> Result<Self> {
         if use_private_desktop {
-            let private_desktop = PrivateDesktop::create(logs_base_dir)?;
-            let startup_name = to_wide(format!("Winsta0\\{}", private_desktop.name));
+            let private = PrivateWindowStation::create().map_err(|e| {
+                logging::debug_log(
+                    &format!("private window station create failed: {e}"),
+                    logs_base_dir,
+                );
+                e
+            })?;
+            // Copy the "<winsta>\\<desktop>" name into our own buffer; the
+            // pointer handed to STARTUPINFO.lpDesktop must outlive the spawn, and
+            // `_private` keeps the objects themselves alive.
+            let startup_name = private.startup_name().to_vec();
             Ok(Self {
-                _private_desktop: Some(private_desktop),
+                _private: Some(private),
                 startup_name,
             })
         } else {
             Ok(Self {
-                _private_desktop: None,
+                _private: None,
                 startup_name: to_wide("Winsta0\\Default"),
             })
         }
@@ -91,118 +107,57 @@ impl LaunchDesktop {
     }
 }
 
-struct PrivateDesktop {
-    handle: isize,
-    name: String,
-}
-
-impl PrivateDesktop {
-    fn create(logs_base_dir: Option<&Path>) -> Result<Self> {
-        let mut rng = SmallRng::from_entropy();
-        let name = format!("CodexSandboxDesktop-{:x}", rng.r#gen::<u128>());
-        let name_wide = to_wide(&name);
-        let handle = unsafe {
-            CreateDesktopW(
-                name_wide.as_ptr(),
-                ptr::null(),
-                ptr::null_mut(),
-                0,
-                DESKTOP_ALL_ACCESS,
-                ptr::null_mut(),
-            )
-        };
-        if handle == 0 {
-            let err = unsafe { GetLastError() } as i32;
-            logging::debug_log(
-                &format!(
-                    "CreateDesktopW failed for {name}: {} ({})",
-                    err,
-                    format_last_error(err),
-                ),
-                logs_base_dir,
-            );
-            return Err(anyhow::anyhow!("CreateDesktopW failed: {err}"));
+/// Grants the named account access to the CURRENT (shared `WinSta0`) window
+/// station and desktop, so the sandbox-account RUNNER launched via
+/// `CreateProcessWithLogonW` can complete user32 process-attach at load (without
+/// it the runner dies with `STATUS_DLL_INIT_FAILED` 0xC0000142 before `main`).
+///
+/// The RUNNER stays on `WinSta0`; only the untrusted inner CHILD is moved to a
+/// private window station (via [`LaunchDesktop`] / [`PrivateWindowStation`]), so
+/// this shared-station grant applies to the trusted runner only and is not a
+/// UI-isolation relaxation for the sandboxed workload.
+pub fn grant_winsta_desktop_access(sandbox_username: &str) -> Result<()> {
+    let sid_bytes = crate::sandbox_users::resolve_sid(sandbox_username)?;
+    let psid = crate::sandbox_users::sid_bytes_to_psid(&sid_bytes)?;
+    // SAFETY: `psid` is a live SID from ConvertStringSidToSidW (freed below);
+    // the window-station/desktop handles are process/thread pseudo-handles that
+    // need no close. Every fallible Win32 step is checked.
+    let result = unsafe {
+        let winsta = GetProcessWindowStation();
+        if winsta == 0 {
+            LocalFree(psid as HLOCAL);
+            return Err(anyhow::anyhow!(
+                "GetProcessWindowStation failed: {}",
+                GetLastError()
+            ));
         }
-
-        unsafe {
-            if let Err(err) = grant_desktop_access(handle, logs_base_dir) {
-                let _ = CloseDesktop(handle);
-                return Err(err);
+        // KB165194: a window station needs two ACEs for a launched-as user — an
+        // inherit-only generic ACE so child desktops inherit access, plus the
+        // station-specific access on the station object itself.
+        let winsta_entries = [
+            explicit_grant(
+                psid,
+                GENERIC_ALL_MASK,
+                CONTAINER_INHERIT_ACE | INHERIT_ONLY_ACE | OBJECT_INHERIT_ACE,
+            ),
+            explicit_grant(psid, WINSTA_ALL_ACCESS, NO_INHERITANCE),
+        ];
+        merge_grant_on_window_object(winsta, &winsta_entries).and_then(|()| {
+            let desktop = GetThreadDesktop(GetCurrentThreadId());
+            if desktop == 0 {
+                return Err(anyhow::anyhow!(
+                    "GetThreadDesktop failed: {}",
+                    GetLastError()
+                ));
             }
-        }
-
-        Ok(Self { handle, name })
+            let desktop_entries = [explicit_grant(psid, DESKTOP_ALL_ACCESS, NO_INHERITANCE)];
+            merge_grant_on_window_object(desktop, &desktop_entries)
+        })
+    };
+    unsafe {
+        LocalFree(psid as HLOCAL);
     }
-}
-
-unsafe fn grant_desktop_access(handle: isize, logs_base_dir: Option<&Path>) -> Result<()> {
-    let token = get_current_token_for_restriction()?;
-    let mut logon_sid = get_logon_sid_bytes(token)?;
-    CloseHandle(token);
-
-    let entries = [EXPLICIT_ACCESS_W {
-        grfAccessPermissions: DESKTOP_ALL_ACCESS,
-        grfAccessMode: GRANT_ACCESS,
-        grfInheritance: 0,
-        Trustee: TRUSTEE_W {
-            pMultipleTrustee: ptr::null_mut(),
-            MultipleTrusteeOperation: 0,
-            TrusteeForm: TRUSTEE_IS_SID,
-            TrusteeType: TRUSTEE_IS_UNKNOWN,
-            ptstrName: logon_sid.as_mut_ptr() as *mut c_void as *mut u16,
-        },
-    }];
-
-    let mut updated_dacl = ptr::null_mut();
-    let set_entries_code = SetEntriesInAclW(
-        entries.len() as u32,
-        entries.as_ptr(),
-        ptr::null_mut(),
-        &mut updated_dacl,
-    );
-    if set_entries_code != ERROR_SUCCESS {
-        logging::debug_log(
-            &format!("SetEntriesInAclW failed for private desktop: {set_entries_code}"),
-            logs_base_dir,
-        );
-        return Err(anyhow::anyhow!(
-            "SetEntriesInAclW failed for private desktop: {set_entries_code}"
-        ));
-    }
-
-    let set_security_code = SetSecurityInfo(
-        handle,
-        SE_WINDOW_OBJECT,
-        DACL_SECURITY_INFORMATION,
-        ptr::null_mut(),
-        ptr::null_mut(),
-        updated_dacl,
-        ptr::null_mut(),
-    );
-    if !updated_dacl.is_null() {
-        LocalFree(updated_dacl as HLOCAL);
-    }
-    if set_security_code != ERROR_SUCCESS {
-        logging::debug_log(
-            &format!("SetSecurityInfo failed for private desktop: {set_security_code}"),
-            logs_base_dir,
-        );
-        return Err(anyhow::anyhow!(
-            "SetSecurityInfo failed for private desktop: {set_security_code}"
-        ));
-    }
-
-    Ok(())
-}
-
-impl Drop for PrivateDesktop {
-    fn drop(&mut self) {
-        unsafe {
-            if self.handle != 0 {
-                let _ = CloseDesktop(self.handle);
-            }
-        }
-    }
+    result
 }
 
 // ACE inheritance flags + generic-all mask (kept local; windows-sys spreads
@@ -306,22 +261,21 @@ unsafe fn merge_grant_on_window_object(handle: isize, entries: &[EXPLICIT_ACCESS
 /// object. Not re-exported by windows-sys 0.52; value from the Win32 headers.
 const CWF_CREATE_ONLY: u32 = 0x0000_0001;
 
-/// A private window station plus a desktop on it, created by the parent so the
-/// sandbox runner (and the child it spawns) launch in UI isolation from the
-/// interactive user's `WinSta0`. Replaces the former shared-`WinSta0` grant.
+/// A per-launch PRIVATE window station plus a desktop on it, created RUNNER-side
+/// so the sandboxed inner child runs in full UI isolation from the interactive
+/// user's `WinSta0`: a separate clipboard and global atom table, not just a
+/// separate desktop. The child holds no handle to the real desktop and cannot
+/// shatter-attack it, `SendInput` to it, or read its clipboard.
 ///
-/// The runner is launched with `STARTUPINFO.lpDesktop` set to
-/// [`PrivateWindowStation::startup_info_desktop`] (`"<winsta>\\<desktop>"`),
-/// which `CreateProcessWithLogonW` honours (validated on spike307-win,
-/// 2026-07-20): the runner attaches to THIS station, so it holds no handle to
-/// the real desktop and cannot shatter-attack it, `SendInput` to it, or read
-/// its clipboard. That is the UI-isolation hole the old shared-station grant
-/// left open.
+/// The child is spawned with `STARTUPINFO.lpDesktop` set to this object's
+/// [`PrivateWindowStation::startup_name`] (`"<winsta>\\<desktop>"`). Access is
+/// granted to the runner's logon SID, which the restricted inner-child token
+/// shares (see [`PrivateWindowStation::create`]).
 ///
-/// Both handles are held for the value's lifetime. The caller keeps the value
-/// alive until `CreateProcessWithLogonW` has returned; by then the runner is
-/// attached and holds its OWN process reference to the station and desktop, so
-/// they outlive this value even after its handles close on drop.
+/// Both handles are held for the value's lifetime; keep it alive until the child
+/// has been created. By then the child holds its OWN process reference to the
+/// station and desktop, so they outlive this value even after its handles close
+/// on drop.
 pub struct PrivateWindowStation {
     winsta: isize,
     desktop: isize,
@@ -330,31 +284,31 @@ pub struct PrivateWindowStation {
 }
 
 impl PrivateWindowStation {
-    /// Creates the private station + desktop and grants `sandbox_username`
-    /// access to BOTH objects. The grant is cheap insurance for a restrictive
-    /// default DACL; the spike showed the child attaches via the default DACL
-    /// even without it, but a hardened host may not, so it is applied anyway.
+    /// Creates the private station + desktop and grants the CURRENT process's
+    /// logon SID access to BOTH objects. Called RUNNER-side (the runner runs as
+    /// the sandbox account), so the logon SID is the runner's; the restricted
+    /// inner-child token derives from the runner's token and carries that same
+    /// logon SID in its restricting-SID set, so this ONE grant lets the
+    /// restricted child attach: it satisfies both halves of the
+    /// `WRITE_RESTRICTED` access check (the logon SID is in the token's normal
+    /// groups AND its restricting-SID set).
     ///
     /// Fail closed (D-005): any Win32 failure returns an error and NEVER falls
-    /// back to the shared `WinSta0`. Assumes the caller runs in the interactive
-    /// logged-in user's session (the Hive desktop app), where window-station
-    /// creation is permitted; a de-elevated caller in session 0 gets
-    /// `ERROR_ACCESS_DENIED` from `CreateWindowStationW`, surfaced here as an
-    /// error rather than a downgrade.
-    pub fn create(sandbox_username: &str) -> Result<Self> {
-        // OsRng (CSPRNG) for the station name: SmallRng is not cryptographically
-        // secure, and this is a security-relevant object identifier.
+    /// back to the shared `WinSta0`. Assumes the caller runs in an interactive
+    /// session (the runner is launched into one via seclogon), where
+    /// window-station creation is permitted.
+    pub fn create() -> Result<Self> {
+        // OsRng (CSPRNG) for the station name: not cryptographically-weak
+        // SmallRng, since this is a security-relevant object identifier.
         let mut token = [0u8; 16];
         OsRng.fill_bytes(&mut token);
         let winsta_name = format!("HiveSandboxWinSta-{:x}", u128::from_le_bytes(token));
         let desktop_name = "HiveSandboxDesktop";
 
         // SAFETY: standard CreateWindowStationW / SetProcessWindowStation /
-        // CreateDesktopW sequence. The saved station handle from
-        // GetProcessWindowStation needs no close; the created winsta/desktop
-        // handles are owned by the returned value (closed on drop). Every
-        // fallible step is checked and, on failure, the process window station
-        // is restored and any created handle closed before returning.
+        // CreateDesktopW sequence; see `create_private_winsta_desktop`. On
+        // failure it restores the process window station and closes any created
+        // handle before returning.
         let (winsta, desktop) =
             unsafe { create_private_winsta_desktop(&winsta_name, desktop_name)? };
 
@@ -364,28 +318,30 @@ impl PrivateWindowStation {
             startup_name: to_wide(format!("{winsta_name}\\{desktop_name}")),
         };
 
-        // Grant the sandbox account access to both objects. On failure the
-        // returned `station` is dropped here, closing both handles.
-        station.grant_access(sandbox_username)?;
+        // On failure the returned `station` is dropped here, closing both handles.
+        station.grant_access()?;
         Ok(station)
     }
 
-    /// `"<winsta>\\<desktop>"` as a `*mut u16` for `STARTUPINFO.lpDesktop`. The
-    /// backing buffer lives as long as `self`; keep `self` alive across the
-    /// `CreateProcessWithLogonW` call that reads this pointer.
-    pub fn startup_info_desktop(&self) -> *mut u16 {
-        self.startup_name.as_ptr() as *mut u16
+    /// The `"<winsta>\\<desktop>"` name as NUL-terminated UTF-16, for the caller
+    /// to copy into its own `STARTUPINFO.lpDesktop` buffer.
+    pub(crate) fn startup_name(&self) -> &[u16] {
+        &self.startup_name
     }
 
-    /// Adds allow ACEs for the sandbox account SID on the private station and
+    /// Grants the current process's logon SID access to the private station and
     /// desktop, preserving every existing ACE (the creator keeps full control).
-    fn grant_access(&self, sandbox_username: &str) -> Result<()> {
-        let sid_bytes = crate::sandbox_users::resolve_sid(sandbox_username)?;
-        let psid = crate::sandbox_users::sid_bytes_to_psid(&sid_bytes)?;
-        // SAFETY: `psid` is a live SID (freed below); `self.winsta`/`self.desktop`
-        // are the private objects created in `create`. Each Win32 step inside
-        // `merge_grant_on_window_object` is checked.
-        let result = unsafe {
+    /// See [`PrivateWindowStation::create`] for why the logon SID is the correct
+    /// trustee for the restricted child.
+    fn grant_access(&self) -> Result<()> {
+        // SAFETY: the token helpers return this process's own token and its
+        // logon SID; `psid` points into `logon_sid`, which outlives every grant
+        // below. Each Win32 step inside `merge_grant_on_window_object` is checked.
+        unsafe {
+            let token = get_current_token_for_restriction()?;
+            let mut logon_sid = get_logon_sid_bytes(token)?;
+            CloseHandle(token);
+            let psid = logon_sid.as_mut_ptr() as *mut c_void;
             // KB165194: a window station needs two ACEs for a launched-as user —
             // an inherit-only generic ACE so child desktops inherit access, plus
             // the station-specific access on the station object itself.
@@ -397,15 +353,11 @@ impl PrivateWindowStation {
                 ),
                 explicit_grant(psid, WINSTA_ALL_ACCESS, NO_INHERITANCE),
             ];
-            merge_grant_on_window_object(self.winsta, &winsta_entries).and_then(|()| {
-                let desktop_entries = [explicit_grant(psid, DESKTOP_ALL_ACCESS, NO_INHERITANCE)];
-                merge_grant_on_window_object(self.desktop, &desktop_entries)
-            })
-        };
-        unsafe {
-            LocalFree(psid as HLOCAL);
+            merge_grant_on_window_object(self.winsta, &winsta_entries)?;
+            let desktop_entries = [explicit_grant(psid, DESKTOP_ALL_ACCESS, NO_INHERITANCE)];
+            merge_grant_on_window_object(self.desktop, &desktop_entries)?;
         }
-        result
+        Ok(())
     }
 }
 

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/elevated/runner_client.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/elevated/runner_client.rs
@@ -336,39 +336,28 @@ pub fn spawn_runner_transport(
         };
 
     // The runner is launched AS the low-privilege sandbox account and links
-    // user32.dll, whose process-attach initialization connects to a window
-    // station and desktop. That account has no access to the interactive
-    // user's WinSta0 by default, so it needs a station it CAN attach to.
+    // user32.dll, whose process-attach initialization connects to the caller's
+    // window station and desktop. That account has no access to them by
+    // default, so without this grant the runner dies at load with
+    // STATUS_DLL_INIT_FAILED (0xC0000142) BEFORE main runs (observed on
+    // spike307-win). Grant the sandbox SID access to the current station +
+    // desktop first; the launch leaves STARTUPINFO.lpDesktop NULL so the runner
+    // inherits this same WinSta0 station/desktop (seclogon auto-grants the
+    // runner's new logon SID there).
     //
-    // UI isolation (Step 3 Integration B1): give it a PRIVATE window station +
-    // desktop instead of the shared interactive WinSta0. On the shared station
-    // the sandboxed child could shatter-attack, SendInput to, or read the
-    // clipboard of the real desktop; a private station has no handle to any of
-    // that. `CreateProcessWithLogonW` honours a parent-created private window
-    // station named in STARTUPINFO.lpDesktop (validated on spike307-win,
-    // 2026-07-20), which we set below. Fail closed: if the private station
-    // cannot be created (e.g. a de-elevated caller in session 0 gets
-    // ERROR_ACCESS_DENIED) this returns an error and NEVER falls back to
-    // WinSta0. Assumes the caller runs in the interactive logged-in user's
-    // session (the Hive desktop app), where window-station creation is
-    // permissive. Network egress stays refused until Integration B (WFP); this
-    // change adds UI isolation only.
-    //
-    // `private_station` is kept alive until this function returns. By then the
-    // runner has completed its startup handshake, so it is already attached to
-    // this station/desktop and holds its own process reference keeping them
-    // alive; on every error path the value drops and closes both handles.
-    let private_station =
-        match crate::desktop::PrivateWindowStation::create(&sandbox_creds.username) {
-            Ok(station) => station,
-            Err(err) => {
-                unsafe {
-                    CloseHandle(h_pipe_in);
-                    CloseHandle(h_pipe_out);
-                }
-                return Err(err);
-            }
-        };
+    // UI isolation for the untrusted inner CHILD is applied separately,
+    // RUNNER-side: the runner moves the child onto a PRIVATE window station
+    // (see `desktop::LaunchDesktop` / `use_private_desktop`), where it grants its
+    // own logon SID so the restricted child can attach. The runner staying on
+    // WinSta0 here is therefore not a UI-isolation relaxation for the sandboxed
+    // workload. Network egress stays refused until Integration B (WFP).
+    if let Err(err) = crate::desktop::grant_winsta_desktop_access(&sandbox_creds.username) {
+        unsafe {
+            CloseHandle(h_pipe_in);
+            CloseHandle(h_pipe_out);
+        }
+        return Err(err);
+    }
 
     let runner_exe = find_runner_exe(codex_home, log_dir);
     let runner_cmdline = runner_exe
@@ -393,11 +382,6 @@ pub fn spawn_runner_transport(
     let mut password_w = to_wide(&sandbox_creds.password);
     let mut si: STARTUPINFOW = unsafe { std::mem::zeroed() };
     si.cb = std::mem::size_of::<STARTUPINFOW>() as u32;
-    // Launch the runner on the private window station + desktop created above,
-    // not the interactive user's WinSta0. The backing UTF-16 buffer lives in
-    // `private_station`, which stays in scope through the CreateProcessWithLogonW
-    // call below.
-    si.lpDesktop = private_station.startup_info_desktop();
     let mut pi: PROCESS_INFORMATION = unsafe { std::mem::zeroed() };
     let env_block: Option<Vec<u16>> = None;
 

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/elevated/runner_client.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/elevated/runner_client.rs
@@ -336,20 +336,39 @@ pub fn spawn_runner_transport(
         };
 
     // The runner is launched AS the low-privilege sandbox account and links
-    // user32.dll, whose process-attach initialization connects to the caller's
-    // window station and desktop. That account has no access to them by
-    // default, so without this grant the runner dies at load with
-    // STATUS_DLL_INIT_FAILED (0xC0000142) BEFORE main runs (observed on
-    // spike307-win). Grant the sandbox SID access to the current station +
-    // desktop first; the launch leaves STARTUPINFO.lpDesktop NULL so the runner
-    // inherits this same, now-accessible station/desktop.
-    if let Err(err) = crate::desktop::grant_winsta_desktop_access(&sandbox_creds.username) {
-        unsafe {
-            CloseHandle(h_pipe_in);
-            CloseHandle(h_pipe_out);
-        }
-        return Err(err);
-    }
+    // user32.dll, whose process-attach initialization connects to a window
+    // station and desktop. That account has no access to the interactive
+    // user's WinSta0 by default, so it needs a station it CAN attach to.
+    //
+    // UI isolation (Step 3 Integration B1): give it a PRIVATE window station +
+    // desktop instead of the shared interactive WinSta0. On the shared station
+    // the sandboxed child could shatter-attack, SendInput to, or read the
+    // clipboard of the real desktop; a private station has no handle to any of
+    // that. `CreateProcessWithLogonW` honours a parent-created private window
+    // station named in STARTUPINFO.lpDesktop (validated on spike307-win,
+    // 2026-07-20), which we set below. Fail closed: if the private station
+    // cannot be created (e.g. a de-elevated caller in session 0 gets
+    // ERROR_ACCESS_DENIED) this returns an error and NEVER falls back to
+    // WinSta0. Assumes the caller runs in the interactive logged-in user's
+    // session (the Hive desktop app), where window-station creation is
+    // permissive. Network egress stays refused until Integration B (WFP); this
+    // change adds UI isolation only.
+    //
+    // `private_station` is kept alive until this function returns. By then the
+    // runner has completed its startup handshake, so it is already attached to
+    // this station/desktop and holds its own process reference keeping them
+    // alive; on every error path the value drops and closes both handles.
+    let private_station =
+        match crate::desktop::PrivateWindowStation::create(&sandbox_creds.username) {
+            Ok(station) => station,
+            Err(err) => {
+                unsafe {
+                    CloseHandle(h_pipe_in);
+                    CloseHandle(h_pipe_out);
+                }
+                return Err(err);
+            }
+        };
 
     let runner_exe = find_runner_exe(codex_home, log_dir);
     let runner_cmdline = runner_exe
@@ -374,6 +393,11 @@ pub fn spawn_runner_transport(
     let mut password_w = to_wide(&sandbox_creds.password);
     let mut si: STARTUPINFOW = unsafe { std::mem::zeroed() };
     si.cb = std::mem::size_of::<STARTUPINFOW>() as u32;
+    // Launch the runner on the private window station + desktop created above,
+    // not the interactive user's WinSta0. The backing UTF-16 buffer lives in
+    // `private_station`, which stays in scope through the CreateProcessWithLogonW
+    // call below.
+    si.lpDesktop = private_station.startup_info_desktop();
     let mut pi: PROCESS_INFORMATION = unsafe { std::mem::zeroed() };
     let env_block: Option<Vec<u16>> = None;
 

--- a/apps/desktop-sandbox/hive-desktop-sandbox/build.rs
+++ b/apps/desktop-sandbox/hive-desktop-sandbox/build.rs
@@ -1,0 +1,38 @@
+//! Build script for the desktop-sandbox crate.
+//!
+//! Its only job today: delay-load `user32.dll` for the `hive-command-runner`
+//! binary on the MSVC target.
+//!
+//! Why: `hive-command-runner` statically imports `user32.dll` (the private
+//! window-station / desktop calls). The Windows loader runs user32's
+//! process-attach `DllMain` BEFORE `main()`, and that attach connects the
+//! process to a window station + desktop. For the low-privilege sandbox account
+//! launched via `CreateProcessWithLogonW`, that loader-time attach fails in
+//! session 0 (`STATUS_DLL_INIT_FAILED`, 0xC0000142) and blocks in session 1
+//! (the runner never reaches `main`, so it never opens its IPC pipe and the
+//! parent times out with `259 STILL_ACTIVE`). Lab-proven on spike307-win: a
+//! marker on the first line of `main` never fired.
+//!
+//! Delay-loading user32 defers its load (and its DllMain attach) until the
+//! runner's FIRST user32 call. By then `main()` has run, the IPC handshake has
+//! completed, and the runner is executing on `WinSta0` (where its
+//! `grant_winsta_desktop_access` has granted it access), so the now-deferred
+//! attach succeeds when the runner first calls `CreateWindowStationW` to build
+//! the child's private window station.
+//!
+//! MSVC only: `/DELAYLOAD` and `delayimp.lib` are MSVC-linker features, and the
+//! product ships the MSVC target. The `x86_64-pc-windows-gnu` cross-compile that
+//! CI type-checks uses a different toolchain and is intentionally left untouched
+//! (it never runs, so its loader behaviour does not matter).
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    let target_env = std::env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
+    if target_os == "windows" && target_env == "msvc" {
+        // Scoped to the runner bin only; other bins/libs are unaffected.
+        println!("cargo:rustc-link-arg-bin=hive-command-runner=/DELAYLOAD:user32.dll");
+        // The delay-load thunks call __delayLoadHelper2 from delayimp.lib.
+        println!("cargo:rustc-link-arg-bin=hive-command-runner=delayimp.lib");
+    }
+}

--- a/apps/desktop-sandbox/hive-desktop-sandbox/src/windows_elevated.rs
+++ b/apps/desktop-sandbox/hive-desktop-sandbox/src/windows_elevated.rs
@@ -590,7 +590,10 @@ mod windows_impl {
             timeout_ms: None,
             tty: false,
             stdin_open: false,
-            use_private_desktop: false,
+            // UI isolation (Step 3 B1): the runner moves the restricted inner
+            // child onto a private window station + desktop (full clipboard/atom
+            // isolation), granting its own logon SID so the child can attach.
+            use_private_desktop: true,
         };
 
         let sandbox_creds = load_logon_sandbox_creds(sandbox_home)?;
@@ -897,7 +900,7 @@ mod windows_impl {
             StdinMode::Closed,
             StderrMode::Separate,
             ConsoleMode::NoWindow,
-            /* use_private_desktop */ false,
+            request.use_private_desktop,
             None,
         );
         // SAFETY: `token` is a valid handle from the token builder above; close

--- a/apps/desktop-sandbox/hive-desktop-sandbox/src/windows_elevated.rs
+++ b/apps/desktop-sandbox/hive-desktop-sandbox/src/windows_elevated.rs
@@ -639,8 +639,13 @@ mod windows_impl {
             tty: false,
             stdin_open: false,
             // UI isolation (Step 3 B1): the runner moves the restricted inner
-            // child onto a private window station + desktop (full clipboard/atom
-            // isolation), granting its own logon SID so the child can attach.
+            // child onto a private DESKTOP on the interactive WinSta0
+            // (upstream/Chromium baseline), granting its own logon SID so the
+            // child can attach. Desktop-level UI isolation only: clipboard and
+            // the global atom table are per-window-station and stay shared with
+            // the interactive user (accepted tradeoff, no station-level
+            // isolation). A hostile child's desktop escape is contained only
+            // once the deferred Low-integrity / SID-disable seam lands.
             use_private_desktop: true,
         };
 

--- a/apps/desktop-sandbox/hive-desktop-sandbox/src/windows_elevated.rs
+++ b/apps/desktop-sandbox/hive-desktop-sandbox/src/windows_elevated.rs
@@ -576,6 +576,54 @@ mod windows_impl {
             .collect::<std::result::Result<Vec<_>, _>>()
             .map_err(|e| anyhow::anyhow!("workspace root not absolute: {e}"))?;
 
+        // Per-task allow-write grants, applied HERE in the elevated parent
+        // rather than in the runner. The runner executes as the low-privilege
+        // sandbox account, which does not own the workspace root and has no
+        // WRITE_DAC on it, so its SetNamedSecurityInfoW was denied and no ACE
+        // landed -- the (c) "write inside the writable root" failure. This
+        // parent owns the root (it created it) and can rewrite its DACL. On each
+        // writable root we grant:
+        //   * the sandbox-account SID -- the identity present in BOTH the
+        //     WRITE_RESTRICTED token's normal groups AND its restricting-SID set
+        //     (the token adds the sandbox user as an extra restricting SID), so
+        //     a write passes both of the token's access checks. A capability SID
+        //     alone is only in the restricting set, so the normal-groups check
+        //     still denied the write; and
+        //   * each per-workspace capability SID -- the restricting-side gate the
+        //     token carries, kept so the isolation design stays populated.
+        // Fail-closed (D-005): add_allow_ace now returns Err (and verifies the
+        // ACE persisted) so a grant that cannot be applied aborts the launch
+        // rather than proceeding with a workspace the confined child cannot
+        // write.
+        if permissions.uses_write_capabilities() {
+            let sandbox_sid_str = codex_windows_sandbox::winutil::string_from_sid_bytes(
+                &sandbox_users::resolve_sid(SANDBOX_USERNAME)?,
+            )
+            .map_err(anyhow::Error::msg)?;
+            let sandbox_local = LocalSid::from_string(&sandbox_sid_str)?;
+            let cap_local_sids: Vec<LocalSid> = cap_sids
+                .iter()
+                .map(|s| LocalSid::from_string(s))
+                .collect::<Result<Vec<_>>>()?;
+            for root in &workspace_roots {
+                let root_path = root.as_path();
+                // SAFETY: sandbox_local / cap_local_sids own live SID pointers
+                // that outlive this loop; add_allow_ace reads them and rewrites
+                // the DACL of the validated absolute root path.
+                unsafe { acl::add_allow_ace(root_path, sandbox_local.as_ptr()) }.map_err(|e| {
+                    anyhow::anyhow!(
+                        "grant sandbox-account write on {}: {e}",
+                        root_path.display()
+                    )
+                })?;
+                for cap in &cap_local_sids {
+                    unsafe { acl::add_allow_ace(root_path, cap.as_ptr()) }.map_err(|e| {
+                        anyhow::anyhow!("grant capability write on {}: {e}", root_path.display())
+                    })?;
+                }
+            }
+        }
+
         let spawn_request = SpawnRequest {
             command: command.to_vec(),
             cwd: cwd.to_path_buf(),
@@ -847,28 +895,16 @@ mod windows_impl {
             .collect::<Result<Vec<_>>>()?;
         let cap_ptrs: Vec<*mut c_void> = cap_sids.iter().map(|s| s.as_ptr()).collect();
 
+        // The per-task allow-write ACEs are applied by the ELEVATED parent
+        // (run_windows_sandbox_capture) BEFORE this runner is launched, because
+        // this runner runs as the low-privilege sandbox account and has no
+        // WRITE_DAC on the workspace root (a runner-side SetNamedSecurityInfoW
+        // was denied, so the ACE never landed -- the (c) write-inside failure).
+        // The cap SIDs below are still what the restricted token carries.
         runner_debug_log(&format!(
-            "applying per-task allow ACEs: {} root(s) x {} cap sid(s)",
-            request.workspace_roots.len(),
+            "per-task allow ACEs applied parent-side; deriving token with {} cap sid(s)",
             cap_ptrs.len()
         ));
-        // Apply the per-task ACL grants for the workspace roots BEFORE spawning
-        // (spawn_prep assembly). Each capability SID gets an allow-write ACE on
-        // its writable roots; the cap SID is what the restricted token carries.
-        for root in &request.workspace_roots {
-            for psid in &cap_ptrs {
-                // SAFETY: `psid` is a live LocalSid pointer (owned by `cap_sids`,
-                // which outlives this loop); `add_allow_ace` applies an allow ACE
-                // to the validated absolute root path.
-                let _ = unsafe { acl::add_allow_ace(root.as_path(), *psid) }.map_err(|e| {
-                    runner_debug_log(&format!(
-                        "allow ACE FAILED on {}: {e}",
-                        root.as_path().display()
-                    ));
-                    anyhow::anyhow!("allow ACE on {}: {e}", root.as_path().display())
-                })?;
-            }
-        }
 
         // SAFETY: get_current_token_for_restriction returns the runner's own
         // primary token; the *_and_user_from builders derive a capability-


### PR DESCRIPTION
## Summary

Step 3 Integration B1 adds desktop level UI isolation to the Hive Windows desktop sandbox. It ships option C: a private DESKTOP on the interactive `WinSta0`, the upstream codex and Chromium baseline for per process UI isolation.

We dropped the private window STATION approach. A least privilege sandbox account cannot create a securable window station (`CreateWindowStationW` returns `ERROR_ACCESS_DENIED` for that token), and upstream never creates one, so a private window station is not reachable for the sandbox token. Option C is owner approved. The runner creates a per launch private desktop (`CreateDesktopW`, a `HiveSandboxDesktop-<128-bit OsRng>` name) on `WinSta0`, and the restricted inner child is launched with `STARTUPINFO.lpDesktop` set to that desktop. The child holds no handle to `WinSta0\Default`, so it cannot enumerate the default desktop's windows, `SendInput` across the desktop boundary, or mount a shatter attack on the real desktop.

Scope is desktop level UI isolation only. Clipboard and the global atom table are per window station and stay shared with the interactive user (accepted tradeoff). `grant_winsta_desktop_access` is retained because the runner still needs shared `WinSta0` access to attach user32 at load, so the known "Desktop Grant Outlives Runner" gap is unchanged by B1. The two `windows::launch` network refusal guards are untouched: both `NetworkPolicy::DenyAll` and `AllowHosts` still fail closed until the WFP egress backend lands (Integration B / D-005).

## The validate (c) ACL and token fix

The lab validation entry's inside write check (validate (c)) previously swallowed its ACL error and could read a stale DACL. This pass makes it propagate the error and read the DACL back fresh after the grant. The grant was moved to the elevated parent that owns the window station, scoped to the window station with down inheritance to child objects. The sandbox SID then satisfies both halves of the `WRITE_RESTRICTED` dual access check (present in the token's normal groups and in its restricting SID set), so the restricted inner child can write where it must and is denied where it must not.

## Lab evidence (spike307-win, session 2)

Validated live on `spike307-win`, session 2:

- SpawnReady acked.
- validate (a) SID match: PASS.
- validate (b) outside write denied: PASS.
- validate (c) inside write ok: PASS.
- validate (d) secret read denied: PASS.
- Network still refuses (fail closed), as designed for B1.

## Reviews

- rust review, two independent passes: clean.
- security review: MERGE.

## Tracked follow-ups (not blockers)

- Low integrity / SID disable seam. Hardens UI isolation against a hostile child escaping its private desktop. Top priority follow-up.
- Cross workspace restricting set residual.
- Write mask precision in `dacl_has_write_allow_for_sid`.
- `run_windows_sandbox_capture` extraction (function exceeds 50 lines).
- `entitlements.rs` rustls crypto provider CI flake.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates the Windows sandbox UI boundary and elevated launch flow. The main changes are:

- Creates a per-launch desktop for the sandboxed command.
- Propagates private-desktop selection through the runner request.
- Moves writable-root ACL grants into the elevated parent.
- Verifies that allow-write ACL changes persist.
- Adds MSVC delay loading for `user32.dll`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The latest changes appear safe to merge.

- The private-desktop flag reaches the inner process launch.
- The previous station save and restore race is removed with the station-switching code.
- No separate blocking issue qualifies for this follow-up review.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/desktop-sandbox/codex-windows-sandbox/src/desktop.rs | Replaces process-wide station switching with per-launch desktop creation and access grants. |
| apps/desktop-sandbox/codex-windows-sandbox/src/elevated/runner_client.rs | Retains the runner's window-station access setup before launching it under the sandbox account. |
| apps/desktop-sandbox/hive-desktop-sandbox/src/windows_elevated.rs | Applies writable-root ACLs in the elevated parent and propagates private-desktop selection to the child launch. |
| apps/desktop-sandbox/codex-windows-sandbox/src/acl.rs | Makes allow-write ACL updates fail closed and verifies them using a fresh DACL read. |
| apps/desktop-sandbox/hive-desktop-sandbox/build.rs | Adds MSVC-only delay loading of `user32.dll` for the command runner. |

</details>

<sub>Reviews (11): Last reviewed commit: ["docs: re-add option C B1 private-desktop..."](https://github.com/sakibsadmanshajib/hive/commit/3b0b4d8467043c542f8e10283c0aac9c379b73f2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45606869)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - .claude/rules/openwolf.md ([source](https://app.greptile.com/scubed/github/sakibsadmanshajib/hive/-/custom-context?memory=3e51a3b4-2091-4dce-8aad-9423a1f1db38))
- Context used - CLAUDE.md ([source](https://app.greptile.com/scubed/github/sakibsadmanshajib/hive/-/custom-context?memory=a5912a3f-0055-4d8a-86c1-fedc669ad56e))
- Context used - .claude/rules/orchestrator.md ([source](https://app.greptile.com/scubed/github/sakibsadmanshajib/hive/-/custom-context?memory=7e0c2dc0-c014-43b2-9dbd-46ae72a640d0))
</details>

<!-- /greptile_comment -->