### PR TITLE
feat: Windows WFP and firewall egress fence for desktop sandbox (Step 3 B2, inert)

### DIFF
--- a/apps/desktop-sandbox/VENDORING.md
+++ b/apps/desktop-sandbox/VENDORING.md
@@ -855,6 +855,47 @@ and should be diffed by hand, not overwritten.
   here. The Win32 FFI paths (real WFP install, firewall COM) are lab-deferred
   to `spike307-win` (D-004) and do not run in CI.
 
+### Integration B / D-004 activation blockers (must pass spike307-win lab before removing the network refusal)
+
+These are real correctness concerns raised in the PR #408 review that are
+UNREACHABLE today: this B2 PR is inert, `windows::launch` still refuses both
+network policies, so these firewall / WFP rules are never installed and no task
+ever runs under the fence. They become live only when the separate activation
+PR wires the fence into `launch()` and removes the refusal. Each must be
+resolved and validated on `spike307-win` (D-004) before that refusal is
+removed. The network refusal STAYS until every item below passes lab.
+
+The common root cause is the accepted single-shared-sandbox-account model
+(D-003: one human per machine; per-session isolation is an additive later
+step): all tasks run under one sandbox account SID, and the firewall / WFP
+rules use fixed names keyed on that one SID, so concurrent tasks share one rule
+set.
+
+1. Concurrent-task rule clobber and loopback-fence loss. Under the shared
+   account SID plus fixed rule names (`hive_sandbox_offline_*`), two concurrent
+   tasks last-writer-wins on the loopback allowlist / proxy port complement,
+   and a task calling `ensure_offline_proxy_allowlist(.., allow_local_binding =
+   true)` removes the loopback blocks another task still relies on. Activation
+   needs one of: per-task rule isolation (distinct rule names / a per-task
+   sublayer), refcounting of the shared rules, or an enforced single-active-task
+   invariant. Until then, activation must guarantee at most one active
+   sandboxed task.
+2. `INetFwRule` `RemotePorts = "*"` cleanup semantics (CodeRabbit,
+   `windows_firewall.rs` :427 region). Verify that reverting or removing the
+   narrowed TCP loopback block does not silently fall back to
+   `RemotePorts = "*"` in a way that opens all loopback ports on teardown.
+   Confirm the teardown order keeps the fence closed, never momentarily open.
+3. Firewall-COM rule ownership and cleanup guarantees (CodeRabbit,
+   `VENDORING.md` :783 region). Proxy-process teardown alone does not remove
+   the persisted firewall rules: a stale permitted proxy port can outlive the
+   proxy. Activation must define who owns rule cleanup (provision vs task end)
+   and prove no stale permitted port survives a task, a crash, or a reboot.
+4. Non-atomic `configure_rule` re-narrow (security-review LOW #1). When
+   re-narrowing an existing rule, `configure_rule` re-applies fields on a live
+   rule rather than swapping atomically, so a failure mid-update can leave the
+   rule broader than intended. Activation needs an atomic replace (or a
+   verified fail-closed intermediate) so a partial update never widens egress.
+
 ### Why not `codex-rs/windows-sandbox-rs` for the Windows backend (historical, #395 wave; superseded in part by Step 3 above)
 
 This section predates Step 3 and explains why the #395 wave (the base,

--- a/apps/desktop-sandbox/VENDORING.md
+++ b/apps/desktop-sandbox/VENDORING.md
@@ -766,6 +766,95 @@ of the Win32 compose, its behaviour is only lab-provable on `spike307-win`.
   provisioning binary is the elevated worker; `windows_elevated` only gates on
   `sandbox_setup_is_complete` and errors if unprovisioned.
 
+## Step 3 Integration B2 (Windows WFP + firewall egress fence, security boundary)
+
+Integration B2 implements the egress fence that A2 stubbed fail-closed above
+(`plan-b2-wfp-egress-2026-07-20.md`). It is a security boundary: per D-004 the
+ACTIVATION of this fence merges only after live `spike307-win` lab validation.
+This PR is the CI-buildable-now, INERT half: the WFP + firewall + proxy-port
+code is present, cross-compiled, and unit-tested, but `windows::launch` STILL
+refuses both network policies (the two refusal guards are untouched). Wiring
+the fence into `launch()` and removing the refusal is a separate lab-gated PR.
+
+CTO decisions applied (from the plan): Q1 keep the Codex two-layer model (WFP
+per-protocol SID blocks + firewall-COM block-all + loopback allowlist), not
+srt's pure-WFP; Q2 fixed Hive loopback proxy port range 62080-62089; Q3 TLS
+revocation stays on (loopback-CRL deferred); Q4 no per-task WFP rules (the
+per-task allowlist lives in the proxy, torn down by the B1 Job kill-on-close).
+
+Source: `openai/codex` at commit
+`a47c661ea9e226fe65e46cf9dbc5c5ed75c2c762` (Apache-2.0),
+`codex-rs/windows-sandbox-rs/`.
+
+### `codex-windows-sandbox/` (vendored WFP, Hive-owned identity)
+
+- `src/wfp.rs`: vendored from upstream `src/wfp.rs`. Deviations: the session /
+  provider / sublayer display names are renamed to a Hive identity; `PROVIDER_KEY`
+  and `SUBLAYER_KEY` are freshly minted Hive-owned GUIDs (never Codex's
+  `0x2e31d31c...` / `0xe65054fd...`, so a Hive install never shares a WFP
+  namespace with a Codex install on the same box, per the plan); and `to_wide`
+  is imported from `crate::winutil` (this crate keeps it there, not at the
+  crate root as upstream does). FFI body otherwise unchanged.
+- `src/wfp/filter_specs.rs`: vendored from upstream `src/wfp/filter_specs.rs`.
+  Deviations: every filter GUID is a freshly minted Hive-owned identity, and
+  every filter `name` renamed `codex_wfp_*` -> `hive_wfp_*`. The filter shape
+  (ALE_USER_ID + per-protocol ICMP/DNS-53/DoT-853/SMB-445/139 block at the
+  ALE_AUTH_CONNECT / ALE_RESOURCE_ASSIGNMENT layers) is unchanged.
+- `src/wfp_setup.rs`: PORTED, not verbatim, from upstream `src/wfp_setup.rs`.
+  The whole point of the port is the D-005 inversion: upstream's
+  `install_wfp_filters` treats a WFP-install failure (or panic) as NON-FATAL
+  (logs, emits a Statsig metric, and lets elevated setup continue). Hive
+  returns `Err` so provisioning ABORTS fail-closed. Upstream's OTEL / Statsig
+  metric machinery is dropped (this crate does not vendor `codex-otel`); the
+  caller gets a plain log callback and a `Result`.
+- `src/lib.rs`, `Cargo.toml`: `wfp` + `wfp_setup` module declarations and the
+  added windows-sys features (`Win32_NetworkManagement_WindowsFilteringPlatform`,
+  `Win32_Networking_WinSock`, `Win32_System_Rpc`).
+
+When re-vendoring `wfp.rs` / `filter_specs.rs` from a future upstream commit,
+re-apply the Hive-GUID and Hive-name renames; `wfp_setup.rs` is a Hive port
+and should be diffed by hand, not overwritten.
+
+### `hive-desktop-sandbox/` (firewall COM port + shared port math)
+
+- `src/windows_firewall.rs`: PORTED, Hive-authored, from upstream
+  `src/bin/setup_main/win/firewall.rs`. Deviations: rule-name constants
+  renamed `codex_sandbox_offline_*` -> `hive_sandbox_offline_*`; upstream's
+  `SetupErrorCode`/`SetupFailure` taxonomy replaced with plain `anyhow`
+  errors, preserving fail-closed behaviour (every COM failure and the
+  `LocalUserAuthorizedList` SID read-back mismatch still return `Err`); the
+  loopback-allowlist port complement is computed by the shared, Linux-testable
+  `crate::wfp_ports::blocked_loopback_tcp_remote_ports` instead of a private
+  copy; the `chrono` RFC3339 log timestamp is dropped. Present but INERT
+  (`#[allow(dead_code)]`, scoped to the module): nothing calls it until the
+  activation PR wires it into `launch()`.
+- `src/wfp_ports.rs`: newly authored (Hive-proprietary), platform-independent.
+  Holds the CTO-Q2 proxy port range (62080-62089), the loopback-TCP transport
+  seam (`bind_loopback_proxy`, binding a free in-range `127.0.0.1` port
+  directly, since Windows has no netns / bind-mount for the Linux
+  socket+shim path), and the loopback-allowlist complement math, all
+  unit-tested on the Linux CI job.
+- `src/windows_plan.rs`: RETIRED the broken `netsh` codegen
+  (`firewall_deny_outbound` / `firewall_allow_outbound_hosts` fields,
+  `RULE_NAME_PREFIX`, `allow_hosts_firewall_script`, `is_safe_firewall_host`,
+  and their tests). `netsh` evaluates block rules ahead of allow rules, so
+  that codegen could only ever express a strict deny-all, never AllowHosts,
+  and it was never wired to a live effect. Kept `command_line_to_utf16`,
+  `is_fully_qualified_program`, `parent_dir`, and the plan struct's ACL /
+  Job-Object fields.
+
+### Verification performed this pass (Integration B2)
+
+- `cargo check` and `cargo clippy --all-targets -- -D warnings` pass for both
+  `codex-windows-sandbox` and `hive-desktop-sandbox` on
+  `x86_64-pc-windows-gnu` AND `x86_64-pc-windows-msvc` (compile-only cross
+  checks; no Win32 execution).
+- `cargo test -p hive-desktop-sandbox` passes on the native Linux host: the
+  `wfp_ports` port-range / complement-math tests and the inert-boundary guard
+  (`launch()` still reports both network policies as not yet enforced) run
+  here. The Win32 FFI paths (real WFP install, firewall COM) are lab-deferred
+  to `spike307-win` (D-004) and do not run in CI.
+
 ### Why not `codex-rs/windows-sandbox-rs` for the Windows backend (historical, #395 wave; superseded in part by Step 3 above)
 
 This section predates Step 3 and explains why the #395 wave (the base,

--- a/apps/desktop-sandbox/codex-windows-sandbox/Cargo.toml
+++ b/apps/desktop-sandbox/codex-windows-sandbox/Cargo.toml
@@ -41,6 +41,11 @@ version = "0.52"
 features = [
     "Win32_Foundation",
     "Win32_NetworkManagement_NetManagement",
+    # WFP egress fence (Integration B2): FWPM_* / FWP_* structs and the
+    # Fwpm* engine/provider/sublayer/filter/transaction FFI live here.
+    "Win32_NetworkManagement_WindowsFilteringPlatform",
+    # IPPROTO_ICMP / IPPROTO_ICMPV6 constants used by the WFP filter specs.
+    "Win32_Networking_WinSock",
     "Win32_Security",
     "Win32_Security_Authorization",
     "Win32_Security_Cryptography",
@@ -51,6 +56,8 @@ features = [
     "Win32_System_IO",
     "Win32_System_Pipes",
     "Win32_System_Registry",
+    # RPC_C_AUTHN_DEFAULT passed to FwpmEngineOpen0.
+    "Win32_System_Rpc",
     "Win32_System_StationsAndDesktops",
     "Win32_System_Threading",
 ]

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/lib.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/lib.rs
@@ -82,6 +82,13 @@ pub mod sandbox_utils;
 pub mod setup_error;
 #[cfg(windows)]
 pub mod token;
+// Hive-owned WFP egress fence (Step 4 / Integration B2). Not upstream-verbatim:
+// Hive GUIDs + names in `wfp`, and `wfp_setup` inverts upstream's
+// log-and-continue to fail-closed. See `../VENDORING.md`.
+#[cfg(windows)]
+pub mod wfp;
+#[cfg(windows)]
+pub mod wfp_setup;
 #[cfg(windows)]
 pub mod winutil;
 #[cfg(windows)]

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/wfp.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/wfp.rs
@@ -1,0 +1,431 @@
+// Vendored from openai/codex codex-rs/windows-sandbox-rs/src/wfp.rs at commit
+// a47c661ea9e226fe65e46cf9dbc5c5ed75c2c762 (Apache-2.0). Deviations from
+// upstream (see ../VENDORING.md): the session / provider / sublayer display
+// names are renamed to a Hive identity; PROVIDER_KEY and SUBLAYER_KEY are
+// freshly minted Hive-owned GUIDs (never Codex's, so a Hive install and a
+// Codex install on the same box do not share a WFP namespace); and `to_wide`
+// is imported from `crate::winutil` (this crate keeps it there, not at the
+// crate root as upstream does). The FFI body is otherwise unchanged.
+mod filter_specs;
+
+use crate::winutil::to_wide;
+use anyhow::Result;
+use std::ffi::OsStr;
+use std::mem::zeroed;
+use std::ptr::null;
+use std::ptr::null_mut;
+use windows_sys::Win32::Foundation::FWP_E_ALREADY_EXISTS;
+use windows_sys::Win32::Foundation::FWP_E_FILTER_NOT_FOUND;
+use windows_sys::Win32::Foundation::FWP_E_NOT_FOUND;
+use windows_sys::Win32::Foundation::HANDLE;
+use windows_sys::Win32::Foundation::HLOCAL;
+use windows_sys::Win32::Foundation::LocalFree;
+use windows_sys::Win32::NetworkManagement::WindowsFilteringPlatform::FWP_ACTION_BLOCK;
+use windows_sys::Win32::NetworkManagement::WindowsFilteringPlatform::FWP_ACTRL_MATCH_FILTER;
+use windows_sys::Win32::NetworkManagement::WindowsFilteringPlatform::FWP_BYTE_BLOB;
+use windows_sys::Win32::NetworkManagement::WindowsFilteringPlatform::FWP_CONDITION_VALUE0;
+use windows_sys::Win32::NetworkManagement::WindowsFilteringPlatform::FWP_CONDITION_VALUE0_0;
+use windows_sys::Win32::NetworkManagement::WindowsFilteringPlatform::FWP_EMPTY;
+use windows_sys::Win32::NetworkManagement::WindowsFilteringPlatform::FWP_MATCH_EQUAL;
+use windows_sys::Win32::NetworkManagement::WindowsFilteringPlatform::FWP_SECURITY_DESCRIPTOR_TYPE;
+use windows_sys::Win32::NetworkManagement::WindowsFilteringPlatform::FWP_UINT8;
+use windows_sys::Win32::NetworkManagement::WindowsFilteringPlatform::FWP_UINT16;
+use windows_sys::Win32::NetworkManagement::WindowsFilteringPlatform::FWP_VALUE0;
+use windows_sys::Win32::NetworkManagement::WindowsFilteringPlatform::FWPM_ACTION0;
+use windows_sys::Win32::NetworkManagement::WindowsFilteringPlatform::FWPM_ACTION0_0;
+use windows_sys::Win32::NetworkManagement::WindowsFilteringPlatform::FWPM_CONDITION_ALE_USER_ID;
+use windows_sys::Win32::NetworkManagement::WindowsFilteringPlatform::FWPM_CONDITION_IP_PROTOCOL;
+use windows_sys::Win32::NetworkManagement::WindowsFilteringPlatform::FWPM_CONDITION_IP_REMOTE_PORT;
+use windows_sys::Win32::NetworkManagement::WindowsFilteringPlatform::FWPM_DISPLAY_DATA0;
+use windows_sys::Win32::NetworkManagement::WindowsFilteringPlatform::FWPM_FILTER_CONDITION0;
+use windows_sys::Win32::NetworkManagement::WindowsFilteringPlatform::FWPM_FILTER_FLAG_PERSISTENT;
+use windows_sys::Win32::NetworkManagement::WindowsFilteringPlatform::FWPM_FILTER0;
+use windows_sys::Win32::NetworkManagement::WindowsFilteringPlatform::FWPM_FILTER0_0;
+use windows_sys::Win32::NetworkManagement::WindowsFilteringPlatform::FWPM_PROVIDER_FLAG_PERSISTENT;
+use windows_sys::Win32::NetworkManagement::WindowsFilteringPlatform::FWPM_PROVIDER0;
+use windows_sys::Win32::NetworkManagement::WindowsFilteringPlatform::FWPM_SESSION0;
+use windows_sys::Win32::NetworkManagement::WindowsFilteringPlatform::FWPM_SUBLAYER_FLAG_PERSISTENT;
+use windows_sys::Win32::NetworkManagement::WindowsFilteringPlatform::FWPM_SUBLAYER0;
+use windows_sys::Win32::NetworkManagement::WindowsFilteringPlatform::FwpmEngineClose0;
+use windows_sys::Win32::NetworkManagement::WindowsFilteringPlatform::FwpmEngineOpen0;
+use windows_sys::Win32::NetworkManagement::WindowsFilteringPlatform::FwpmFilterAdd0;
+use windows_sys::Win32::NetworkManagement::WindowsFilteringPlatform::FwpmFilterDeleteByKey0;
+use windows_sys::Win32::NetworkManagement::WindowsFilteringPlatform::FwpmProviderAdd0;
+use windows_sys::Win32::NetworkManagement::WindowsFilteringPlatform::FwpmSubLayerAdd0;
+use windows_sys::Win32::NetworkManagement::WindowsFilteringPlatform::FwpmTransactionAbort0;
+use windows_sys::Win32::NetworkManagement::WindowsFilteringPlatform::FwpmTransactionBegin0;
+use windows_sys::Win32::NetworkManagement::WindowsFilteringPlatform::FwpmTransactionCommit0;
+use windows_sys::Win32::Security::Authorization::BuildExplicitAccessWithNameW;
+use windows_sys::Win32::Security::Authorization::BuildSecurityDescriptorW;
+use windows_sys::Win32::Security::Authorization::EXPLICIT_ACCESS_W;
+use windows_sys::Win32::Security::Authorization::GRANT_ACCESS;
+use windows_sys::Win32::Security::PSECURITY_DESCRIPTOR;
+use windows_sys::Win32::System::Rpc::RPC_C_AUTHN_DEFAULT;
+use windows_sys::Win32::System::Threading::INFINITE;
+use windows_sys::core::GUID;
+
+use filter_specs::ConditionSpec;
+use filter_specs::FILTER_SPECS;
+use filter_specs::FilterSpec;
+
+const SESSION_NAME: &str = "Hive Desktop Sandbox WFP";
+const PROVIDER_NAME: &str = "Hive Desktop Sandbox WFP";
+const PROVIDER_DESCRIPTION: &str = "Persistent WFP provider for Hive desktop sandbox filters";
+const SUBLAYER_NAME: &str = "Hive Desktop Sandbox WFP";
+const SUBLAYER_DESCRIPTION: &str = "Persistent WFP sublayer for Hive desktop sandbox filters";
+
+// WFP identifies persistent providers, sublayers, and filters by stable GUIDs.
+// These values are Hive-owned identities; do not regenerate them unless we
+// intentionally want to orphan old objects and create a new WFP namespace.
+const PROVIDER_KEY: GUID = GUID::from_u128(0x644854c2_dc9d_4d7f_9873_034169f826cf);
+const SUBLAYER_KEY: GUID = GUID::from_u128(0xab6cb1c9_5eb1_4b71_ad24_a9d87c1e0f58);
+
+/// Installs the persistent Hive WFP filters for `account`.
+///
+/// This is intended to run from the already-elevated setup/provision helper.
+/// Unlike upstream, the Hive caller ([`crate::wfp_setup::install_wfp_filters`])
+/// treats any returned error as FATAL to provisioning (fail-closed, D-005).
+pub fn install_wfp_filters_for_account(account: &str) -> Result<usize> {
+    let engine = Engine::open()?;
+    let mut transaction = engine.begin_transaction()?;
+    ensure_provider(engine.handle)?;
+    ensure_sublayer(engine.handle)?;
+
+    let user_condition = UserMatchCondition::for_account(account)?;
+    let mut installed_filter_count = 0;
+    for spec in FILTER_SPECS {
+        delete_filter_if_present(engine.handle, &spec.key)?;
+        add_filter(engine.handle, spec, &user_condition)?;
+        installed_filter_count += 1;
+    }
+
+    transaction.commit()?;
+    Ok(installed_filter_count)
+}
+
+/// Owns an open WFP engine handle and closes it on drop.
+struct Engine {
+    handle: HANDLE,
+}
+
+impl Engine {
+    fn open() -> Result<Self> {
+        let session_name = to_wide(OsStr::new(SESSION_NAME));
+        let mut session: FWPM_SESSION0 = unsafe { zeroed() };
+        session.displayData = FWPM_DISPLAY_DATA0 {
+            name: session_name.as_ptr() as *mut _,
+            description: null_mut(),
+        };
+        session.txnWaitTimeoutInMSec = INFINITE;
+
+        let mut handle = HANDLE::default();
+        let result = unsafe {
+            FwpmEngineOpen0(
+                null(),
+                RPC_C_AUTHN_DEFAULT as u32,
+                null(),
+                &session,
+                &mut handle,
+            )
+        };
+        ensure_success(result, "FwpmEngineOpen0")?;
+        Ok(Self { handle })
+    }
+
+    fn begin_transaction(&self) -> Result<Transaction<'_>> {
+        let result = unsafe { FwpmTransactionBegin0(self.handle, 0) };
+        ensure_success(result, "FwpmTransactionBegin0")?;
+        Ok(Transaction {
+            engine: self,
+            committed: false,
+        })
+    }
+}
+
+impl Drop for Engine {
+    fn drop(&mut self) {
+        unsafe {
+            FwpmEngineClose0(self.handle);
+        }
+    }
+}
+
+/// Aborts an open WFP transaction unless it was explicitly committed.
+struct Transaction<'a> {
+    engine: &'a Engine,
+    committed: bool,
+}
+
+impl Transaction<'_> {
+    fn commit(&mut self) -> Result<()> {
+        let result = unsafe { FwpmTransactionCommit0(self.engine.handle) };
+        ensure_success(result, "FwpmTransactionCommit0")?;
+        self.committed = true;
+        Ok(())
+    }
+}
+
+impl Drop for Transaction<'_> {
+    fn drop(&mut self) {
+        if !self.committed {
+            unsafe {
+                FwpmTransactionAbort0(self.engine.handle);
+            }
+        }
+    }
+}
+
+/// Builds the ALE_USER_ID condition blob that scopes filters to one account.
+struct UserMatchCondition {
+    security_descriptor: PSECURITY_DESCRIPTOR,
+    blob: FWP_BYTE_BLOB,
+}
+
+impl UserMatchCondition {
+    fn for_account(account: &str) -> Result<Self> {
+        let account_w = to_wide(OsStr::new(account));
+        let mut access: EXPLICIT_ACCESS_W = unsafe { zeroed() };
+        unsafe {
+            BuildExplicitAccessWithNameW(
+                &mut access,
+                account_w.as_ptr(),
+                FWP_ACTRL_MATCH_FILTER,
+                GRANT_ACCESS,
+                0,
+            );
+        }
+
+        let mut security_descriptor: PSECURITY_DESCRIPTOR = null_mut();
+        let mut security_descriptor_len = 0;
+        let result = unsafe {
+            BuildSecurityDescriptorW(
+                null(),
+                null(),
+                1,
+                &access,
+                0,
+                null(),
+                null_mut(),
+                &mut security_descriptor_len,
+                &mut security_descriptor,
+            )
+        };
+        ensure_success(result, "BuildSecurityDescriptorW")?;
+
+        Ok(Self {
+            security_descriptor,
+            blob: FWP_BYTE_BLOB {
+                size: security_descriptor_len,
+                data: security_descriptor as *mut u8,
+            },
+        })
+    }
+}
+
+impl Drop for UserMatchCondition {
+    fn drop(&mut self) {
+        if !self.security_descriptor.is_null() {
+            unsafe {
+                LocalFree(self.security_descriptor as HLOCAL);
+            }
+        }
+    }
+}
+
+/// Ensures the persistent Hive WFP provider exists.
+fn ensure_provider(engine: HANDLE) -> Result<()> {
+    let provider_name = to_wide(OsStr::new(PROVIDER_NAME));
+    let provider_description = to_wide(OsStr::new(PROVIDER_DESCRIPTION));
+    let provider = FWPM_PROVIDER0 {
+        providerKey: PROVIDER_KEY,
+        displayData: FWPM_DISPLAY_DATA0 {
+            name: provider_name.as_ptr() as *mut _,
+            description: provider_description.as_ptr() as *mut _,
+        },
+        flags: FWPM_PROVIDER_FLAG_PERSISTENT,
+        providerData: empty_blob(),
+        serviceName: null_mut(),
+    };
+
+    let result = unsafe { FwpmProviderAdd0(engine, &provider, null_mut()) };
+    ensure_success_or(result, "FwpmProviderAdd0", &[FWP_E_ALREADY_EXISTS as u32])
+}
+
+/// Ensures the persistent Hive sublayer exists under the Hive provider.
+fn ensure_sublayer(engine: HANDLE) -> Result<()> {
+    let sublayer_name = to_wide(OsStr::new(SUBLAYER_NAME));
+    let sublayer_description = to_wide(OsStr::new(SUBLAYER_DESCRIPTION));
+    let provider_key = PROVIDER_KEY;
+    let sublayer = FWPM_SUBLAYER0 {
+        subLayerKey: SUBLAYER_KEY,
+        displayData: FWPM_DISPLAY_DATA0 {
+            name: sublayer_name.as_ptr() as *mut _,
+            description: sublayer_description.as_ptr() as *mut _,
+        },
+        flags: FWPM_SUBLAYER_FLAG_PERSISTENT,
+        providerKey: &provider_key as *const _ as *mut _,
+        providerData: empty_blob(),
+        weight: 0x8000,
+    };
+
+    let result = unsafe { FwpmSubLayerAdd0(engine, &sublayer, null_mut()) };
+    ensure_success_or(result, "FwpmSubLayerAdd0", &[FWP_E_ALREADY_EXISTS as u32])
+}
+
+/// Adds one blocking WFP filter from the static filter spec list.
+fn add_filter(
+    engine: HANDLE,
+    spec: &FilterSpec,
+    user_condition: &UserMatchCondition,
+) -> Result<()> {
+    let filter_name = to_wide(OsStr::new(spec.name));
+    let filter_description = to_wide(OsStr::new(spec.description));
+    let mut filter_conditions = build_conditions(spec.conditions, user_condition);
+    let provider_key = PROVIDER_KEY;
+    let filter = FWPM_FILTER0 {
+        filterKey: spec.key,
+        displayData: FWPM_DISPLAY_DATA0 {
+            name: filter_name.as_ptr() as *mut _,
+            description: filter_description.as_ptr() as *mut _,
+        },
+        flags: FWPM_FILTER_FLAG_PERSISTENT,
+        providerKey: &provider_key as *const _ as *mut _,
+        providerData: empty_blob(),
+        layerKey: spec.layer_key,
+        subLayerKey: SUBLAYER_KEY,
+        weight: empty_value(),
+        numFilterConditions: filter_conditions.len() as u32,
+        filterCondition: filter_conditions.as_mut_ptr(),
+        action: FWPM_ACTION0 {
+            r#type: FWP_ACTION_BLOCK,
+            Anonymous: FWPM_ACTION0_0 {
+                filterType: zero_guid(),
+            },
+        },
+        Anonymous: FWPM_FILTER0_0 { rawContext: 0 },
+        reserved: null_mut(),
+        filterId: 0,
+        effectiveWeight: empty_value(),
+    };
+
+    let mut filter_id = 0_u64;
+    let result = unsafe { FwpmFilterAdd0(engine, &filter, null_mut(), &mut filter_id) };
+    ensure_success(result, &format!("FwpmFilterAdd0({})", spec.name))
+}
+
+/// Converts our compact condition specs into WFP filter conditions.
+fn build_conditions(
+    specs: &[ConditionSpec],
+    user_condition: &UserMatchCondition,
+) -> Vec<FWPM_FILTER_CONDITION0> {
+    specs
+        .iter()
+        .map(|spec| match spec {
+            ConditionSpec::User => FWPM_FILTER_CONDITION0 {
+                fieldKey: FWPM_CONDITION_ALE_USER_ID,
+                matchType: FWP_MATCH_EQUAL,
+                conditionValue: FWP_CONDITION_VALUE0 {
+                    r#type: FWP_SECURITY_DESCRIPTOR_TYPE,
+                    Anonymous: FWP_CONDITION_VALUE0_0 {
+                        sd: &user_condition.blob as *const _ as *mut _,
+                    },
+                },
+            },
+            ConditionSpec::Protocol(protocol) => FWPM_FILTER_CONDITION0 {
+                fieldKey: FWPM_CONDITION_IP_PROTOCOL,
+                matchType: FWP_MATCH_EQUAL,
+                conditionValue: FWP_CONDITION_VALUE0 {
+                    r#type: FWP_UINT8,
+                    Anonymous: FWP_CONDITION_VALUE0_0 { uint8: *protocol },
+                },
+            },
+            ConditionSpec::RemotePort(port) => FWPM_FILTER_CONDITION0 {
+                fieldKey: FWPM_CONDITION_IP_REMOTE_PORT,
+                matchType: FWP_MATCH_EQUAL,
+                conditionValue: FWP_CONDITION_VALUE0 {
+                    r#type: FWP_UINT16,
+                    Anonymous: FWP_CONDITION_VALUE0_0 { uint16: *port },
+                },
+            },
+        })
+        .collect()
+}
+
+/// Deletes an old copy of a filter before re-adding it.
+fn delete_filter_if_present(engine: HANDLE, key: &GUID) -> Result<()> {
+    let result = unsafe { FwpmFilterDeleteByKey0(engine, key) };
+    ensure_success_or(
+        result,
+        "FwpmFilterDeleteByKey0",
+        &[FWP_E_FILTER_NOT_FOUND as u32, FWP_E_NOT_FOUND as u32],
+    )
+}
+
+fn ensure_success(result: u32, operation: &str) -> Result<()> {
+    ensure_success_or(result, operation, &[])
+}
+
+fn ensure_success_or(result: u32, operation: &str, allowed: &[u32]) -> Result<()> {
+    if result == 0 || allowed.contains(&result) {
+        Ok(())
+    } else {
+        Err(anyhow::anyhow!(
+            "{operation} failed: {}",
+            format_error_code(result)
+        ))
+    }
+}
+
+fn format_error_code(result: u32) -> String {
+    format!("0x{result:08X}")
+}
+
+fn empty_blob() -> FWP_BYTE_BLOB {
+    FWP_BYTE_BLOB {
+        size: 0,
+        data: null_mut(),
+    }
+}
+
+fn empty_value() -> FWP_VALUE0 {
+    FWP_VALUE0 {
+        r#type: FWP_EMPTY,
+        Anonymous: unsafe { zeroed() },
+    }
+}
+
+fn zero_guid() -> GUID {
+    GUID::from_u128(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FILTER_SPECS;
+    use pretty_assertions::assert_eq;
+    use std::collections::BTreeSet;
+
+    #[test]
+    fn filter_keys_are_unique() {
+        let keys = FILTER_SPECS
+            .iter()
+            .map(|spec| {
+                (
+                    spec.key.data1,
+                    spec.key.data2,
+                    spec.key.data3,
+                    spec.key.data4,
+                )
+            })
+            .collect::<BTreeSet<_>>();
+        assert_eq!(keys.len(), FILTER_SPECS.len());
+    }
+
+    #[test]
+    fn filter_names_are_unique() {
+        let names = FILTER_SPECS
+            .iter()
+            .map(|spec| spec.name)
+            .collect::<BTreeSet<_>>();
+        assert_eq!(names.len(), FILTER_SPECS.len());
+    }
+}

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/wfp/filter_specs.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/wfp/filter_specs.rs
@@ -1,0 +1,133 @@
+// Vendored from openai/codex codex-rs/windows-sandbox-rs/src/wfp/filter_specs.rs
+// at commit a47c661ea9e226fe65e46cf9dbc5c5ed75c2c762 (Apache-2.0). Deviations
+// from upstream (see ../../VENDORING.md): every GUID is a freshly minted
+// Hive-owned identity (never Codex's, so a Hive install never shares a WFP
+// namespace with a Codex install on the same box), and every filter `name` is
+// renamed `codex_wfp_*` -> `hive_wfp_*`. The filter shape (ALE_USER_ID +
+// per-protocol block at the ALE_AUTH_CONNECT / ALE_RESOURCE_ASSIGNMENT layers)
+// is unchanged.
+use windows_sys::Win32::NetworkManagement::WindowsFilteringPlatform::FWPM_LAYER_ALE_AUTH_CONNECT_V4;
+use windows_sys::Win32::NetworkManagement::WindowsFilteringPlatform::FWPM_LAYER_ALE_AUTH_CONNECT_V6;
+use windows_sys::Win32::NetworkManagement::WindowsFilteringPlatform::FWPM_LAYER_ALE_RESOURCE_ASSIGNMENT_V4;
+use windows_sys::Win32::NetworkManagement::WindowsFilteringPlatform::FWPM_LAYER_ALE_RESOURCE_ASSIGNMENT_V6;
+use windows_sys::Win32::Networking::WinSock::IPPROTO_ICMP;
+use windows_sys::Win32::Networking::WinSock::IPPROTO_ICMPV6;
+use windows_sys::core::GUID;
+
+#[derive(Clone, Copy)]
+pub(super) enum ConditionSpec {
+    User,
+    Protocol(u8),
+    RemotePort(u16),
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct FilterSpec {
+    pub(super) key: GUID,
+    pub(super) name: &'static str,
+    pub(super) description: &'static str,
+    pub(super) layer_key: GUID,
+    pub(super) conditions: &'static [ConditionSpec],
+}
+
+pub(super) const FILTER_SPECS: &[FilterSpec] = &[
+    FilterSpec {
+        key: GUID::from_u128(0x7c8da4d6_ec2f_4225_8a11_3252affda1ef),
+        name: "hive_wfp_icmp_connect_v4",
+        description: "Block sandbox-account ICMP connect v4",
+        layer_key: FWPM_LAYER_ALE_AUTH_CONNECT_V4,
+        conditions: &[
+            ConditionSpec::User,
+            ConditionSpec::Protocol(IPPROTO_ICMP as u8),
+        ],
+    },
+    FilterSpec {
+        key: GUID::from_u128(0x10c896cc_7772_4c25_abf5_ed33d2fd61c3),
+        name: "hive_wfp_icmp_connect_v6",
+        description: "Block sandbox-account ICMP connect v6",
+        layer_key: FWPM_LAYER_ALE_AUTH_CONNECT_V6,
+        conditions: &[
+            ConditionSpec::User,
+            ConditionSpec::Protocol(IPPROTO_ICMPV6 as u8),
+        ],
+    },
+    FilterSpec {
+        key: GUID::from_u128(0x1513bc34_4515_4f60_83a0_e928d994b14c),
+        name: "hive_wfp_icmp_assign_v4",
+        description: "Block sandbox-account ICMP resource assignment v4",
+        layer_key: FWPM_LAYER_ALE_RESOURCE_ASSIGNMENT_V4,
+        conditions: &[
+            ConditionSpec::User,
+            ConditionSpec::Protocol(IPPROTO_ICMP as u8),
+        ],
+    },
+    FilterSpec {
+        key: GUID::from_u128(0x141ff07b_9e71_4099_8be9_b4c9decf8fc0),
+        name: "hive_wfp_icmp_assign_v6",
+        description: "Block sandbox-account ICMP resource assignment v6",
+        layer_key: FWPM_LAYER_ALE_RESOURCE_ASSIGNMENT_V6,
+        conditions: &[
+            ConditionSpec::User,
+            ConditionSpec::Protocol(IPPROTO_ICMPV6 as u8),
+        ],
+    },
+    // NAME_RESOLUTION_CACHE filters are intentionally omitted because ordinary
+    // static filter shapes returned FWP_E_OUT_OF_BOUNDS during upstream
+    // validation.
+    FilterSpec {
+        key: GUID::from_u128(0x4d93439a_6900_47e6_b42d_b4509696cf15),
+        name: "hive_wfp_dns_53_v4",
+        description: "Block sandbox-account DNS TCP or UDP port 53 v4",
+        layer_key: FWPM_LAYER_ALE_AUTH_CONNECT_V4,
+        conditions: &[ConditionSpec::User, ConditionSpec::RemotePort(53)],
+    },
+    FilterSpec {
+        key: GUID::from_u128(0xa069500a_60f9_4e22_9b6a_bf94916e4aaf),
+        name: "hive_wfp_dns_53_v6",
+        description: "Block sandbox-account DNS TCP or UDP port 53 v6",
+        layer_key: FWPM_LAYER_ALE_AUTH_CONNECT_V6,
+        conditions: &[ConditionSpec::User, ConditionSpec::RemotePort(53)],
+    },
+    FilterSpec {
+        key: GUID::from_u128(0xe9edcf72_649f_4d46_8477_52e760a48a1a),
+        name: "hive_wfp_dns_853_v4",
+        description: "Block sandbox-account DNS-over-TLS port 853 v4",
+        layer_key: FWPM_LAYER_ALE_AUTH_CONNECT_V4,
+        conditions: &[ConditionSpec::User, ConditionSpec::RemotePort(853)],
+    },
+    FilterSpec {
+        key: GUID::from_u128(0x78613308_bb1b_46d9_acaa_6340b1f1f550),
+        name: "hive_wfp_dns_853_v6",
+        description: "Block sandbox-account DNS-over-TLS port 853 v6",
+        layer_key: FWPM_LAYER_ALE_AUTH_CONNECT_V6,
+        conditions: &[ConditionSpec::User, ConditionSpec::RemotePort(853)],
+    },
+    FilterSpec {
+        key: GUID::from_u128(0x76805d3f_5ab5_4986_9687_ab5a17604b16),
+        name: "hive_wfp_smb_445_v4",
+        description: "Block sandbox-account SMB port 445 v4",
+        layer_key: FWPM_LAYER_ALE_AUTH_CONNECT_V4,
+        conditions: &[ConditionSpec::User, ConditionSpec::RemotePort(445)],
+    },
+    FilterSpec {
+        key: GUID::from_u128(0xf8f6080d_c477_471a_9104_8007d28ed672),
+        name: "hive_wfp_smb_445_v6",
+        description: "Block sandbox-account SMB port 445 v6",
+        layer_key: FWPM_LAYER_ALE_AUTH_CONNECT_V6,
+        conditions: &[ConditionSpec::User, ConditionSpec::RemotePort(445)],
+    },
+    FilterSpec {
+        key: GUID::from_u128(0x86cdc507_9476_45c3_8997_6188664eb02e),
+        name: "hive_wfp_smb_139_v4",
+        description: "Block sandbox-account SMB port 139 v4",
+        layer_key: FWPM_LAYER_ALE_AUTH_CONNECT_V4,
+        conditions: &[ConditionSpec::User, ConditionSpec::RemotePort(139)],
+    },
+    FilterSpec {
+        key: GUID::from_u128(0xbd7f5ac9_39dd_4a45_9370_3d55e3831ce6),
+        name: "hive_wfp_smb_139_v6",
+        description: "Block sandbox-account SMB port 139 v6",
+        layer_key: FWPM_LAYER_ALE_AUTH_CONNECT_V6,
+        conditions: &[ConditionSpec::User, ConditionSpec::RemotePort(139)],
+    },
+];

--- a/apps/desktop-sandbox/codex-windows-sandbox/src/wfp_setup.rs
+++ b/apps/desktop-sandbox/codex-windows-sandbox/src/wfp_setup.rs
@@ -1,0 +1,46 @@
+//! Fail-closed WFP install wrapper.
+//!
+//! Ported (not vendored verbatim) from openai/codex
+//! `codex-rs/windows-sandbox-rs/src/wfp_setup.rs` at commit
+//! a47c661ea9e226fe65e46cf9dbc5c5ed75c2c762 (Apache-2.0). See
+//! `../VENDORING.md`.
+//!
+//! Deviation from upstream, and the whole point of this wrapper: upstream's
+//! `install_wfp_filters` treats a WFP install failure (or panic) as
+//! NON-FATAL: it logs the error, emits a Statsig metric, and lets elevated
+//! setup continue anyway. Hive INVERTS that to fail-closed (D-005): a WFP
+//! install failure returns `Err`, and the elevated provisioning path aborts
+//! rather than leaving a sandbox account whose egress fence was never
+//! installed. The upstream OTEL / Statsig metric machinery is dropped (this
+//! crate does not vendor `codex-otel`); callers get a plain log callback and
+//! a `Result` instead.
+
+use crate::wfp::install_wfp_filters_for_account;
+use anyhow::Result;
+
+/// Installs the persistent Hive WFP egress filters for `account`, returning
+/// the number of filters installed on success.
+///
+/// Fail-closed: any error from the underlying WFP transaction is returned to
+/// the caller unchanged so provisioning aborts. `log` receives one human
+/// readable line describing the outcome (success count, or the failure and
+/// that provisioning is aborting).
+pub fn install_wfp_filters<F>(account: &str, mut log: F) -> Result<usize>
+where
+    F: FnMut(&str),
+{
+    match install_wfp_filters_for_account(account) {
+        Ok(installed_filter_count) => {
+            log(&format!(
+                "WFP setup installed {installed_filter_count} filters for {account}"
+            ));
+            Ok(installed_filter_count)
+        }
+        Err(err) => {
+            log(&format!(
+                "WFP setup FAILED for {account}: {err}; aborting provisioning (fail-closed, D-005)"
+            ));
+            Err(err)
+        }
+    }
+}

--- a/apps/desktop-sandbox/hive-desktop-sandbox/Cargo.toml
+++ b/apps/desktop-sandbox/hive-desktop-sandbox/Cargo.toml
@@ -43,13 +43,17 @@ libc = { workspace = true }
 tempfile = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
-# Restricted token + directory ACL + Job Object only. Windows Firewall
-# deny-outbound rule generation from the egress SSOT is blueprint Step 4.4's
-# scope, not this crate's; see `windows_plan.rs` and VENDORING.md.
+# Restricted token + directory ACL + Job Object, plus the Windows Firewall COM
+# half of the two-layer egress fence (Integration B2 / blueprint Step 4.4):
+# `windows_firewall.rs` drives INetFwPolicy2/INetFwRule3 to install the
+# block-all-outbound and loopback allowlist rules, SID-scoped to the sandbox
+# account. See `windows_firewall.rs` and VENDORING.md.
 windows = { version = "0.58", features = [
     "Win32_Foundation",
+    "Win32_NetworkManagement_WindowsFirewall",
     "Win32_Security",
     "Win32_Security_Authorization",
+    "Win32_System_Com",
     "Win32_System_JobObjects",
     "Win32_System_Threading",
     "Win32_Storage_FileSystem",

--- a/apps/desktop-sandbox/hive-desktop-sandbox/src/lib.rs
+++ b/apps/desktop-sandbox/hive-desktop-sandbox/src/lib.rs
@@ -15,6 +15,10 @@ pub mod policy;
 pub mod windows_elevated;
 pub mod windows_plan;
 pub mod windows_resolve;
+// Cross-platform (no Win32) pieces of the Windows WFP egress fence
+// (Integration B2): the loopback proxy port range and the loopback-allowlist
+// port complement math, unit-tested on this crate's Linux CI job.
+pub mod wfp_ports;
 
 #[cfg(target_os = "linux")]
 pub mod egress_proxy;
@@ -24,6 +28,15 @@ mod linux;
 pub mod shim;
 #[cfg(windows)]
 mod windows;
+// Windows Firewall COM half of the two-layer egress fence (Integration B2,
+// CTO Q1). Present and cross-compiled, but INERT: `launch` still refuses both
+// network policies, so nothing calls these entry points yet. `allow(dead_code)`
+// is deliberate and scoped to this module: the activation PR (separate,
+// lab-gated per D-004) wires `ensure_offline_outbound_block` /
+// `ensure_offline_proxy_allowlist` into the launch path and removes this allow.
+#[cfg(windows)]
+#[allow(dead_code)]
+mod windows_firewall;
 
 #[cfg(not(any(target_os = "linux", windows)))]
 compile_error!(
@@ -131,4 +144,30 @@ pub fn launch(
     cwd: &Path,
 ) -> Result<windows::SandboxChild, LaunchError> {
     windows::launch(policy, command, cwd)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Inert-boundary guard (Integration B2): the WFP + firewall egress code is
+    // present and cross-compiled, but `launch()` on Windows still REFUSES both
+    // network policies until the separate lab-gated activation PR (D-004). This
+    // Linux-runnable test asserts the two refusal variants still exist and
+    // still render as "not yet enforced", so an accidental early activation
+    // that dropped them would fail CI here as well as in the windows-gated
+    // `windows_elevated` decision tests.
+    #[test]
+    fn network_policies_still_report_as_not_yet_enforced() {
+        assert!(
+            LaunchError::AllowHostsNotYetImplemented
+                .to_string()
+                .contains("not yet enforced")
+        );
+        assert!(
+            LaunchError::NetworkConfinementNotImplemented
+                .to_string()
+                .contains("not yet enforced")
+        );
+    }
 }

--- a/apps/desktop-sandbox/hive-desktop-sandbox/src/wfp_ports.rs
+++ b/apps/desktop-sandbox/hive-desktop-sandbox/src/wfp_ports.rs
@@ -1,0 +1,168 @@
+//! Loopback proxy port range and the loopback-allowlist complement math for
+//! the Windows WFP egress fence (Integration B2).
+//!
+//! This module is deliberately platform-independent (no Win32): it holds the
+//! two pure pieces of the Windows egress boundary that this repository can
+//! actually unit-test on its Linux CI job, exactly like `windows_plan.rs`.
+//! The Win32 pieces that consume these (the firewall COM allowlist in
+//! `windows_firewall.rs`, keyed on the sandbox account SID) are compiled only
+//! `cfg(windows)` and lab-validated (`spike307-win`, D-004).
+//!
+//! CTO decision Q2 (`plan-b2-wfp-egress-2026-07-20.md`): the Hive loopback
+//! proxy binds a free port inside the fixed range **62080-62089**. The WFP /
+//! firewall PERMIT is scoped to loopback intersected with that range; the
+//! block complement (everything on loopback TCP except the bound proxy port)
+//! is computed by [`blocked_loopback_tcp_remote_ports`].
+
+use std::net::TcpListener;
+use std::ops::RangeInclusive;
+
+/// Lowest port the Hive loopback egress proxy may bind (CTO Q2).
+pub const PROXY_PORT_RANGE_LOW: u16 = 62080;
+/// Highest port the Hive loopback egress proxy may bind (CTO Q2).
+pub const PROXY_PORT_RANGE_HIGH: u16 = 62089;
+
+/// The fixed loopback proxy port range, `62080..=62089`.
+pub const PROXY_PORT_RANGE: RangeInclusive<u16> = PROXY_PORT_RANGE_LOW..=PROXY_PORT_RANGE_HIGH;
+
+/// Binds the Hive loopback egress proxy to the first free `127.0.0.1` port in
+/// [`PROXY_PORT_RANGE`], returning the listener and the bound port.
+///
+/// This is the Windows transport for the AllowlistProxy: unlike the Linux
+/// path (a Unix socket bind-mounted into the bwrap netns plus the
+/// `hive-egress-shim` TCP-to-unix bridge), Windows has no netns and no
+/// bind-mount, so the proxy binds a loopback TCP listener directly on a port
+/// inside the WFP/firewall permit range. Binding a specific in-range port
+/// (not `:0`) is required so the kernel PERMIT can be scoped to it. The proxy
+/// runs AS the launcher identity, not the blocked sandbox SID, so its own
+/// upstream egress is unaffected.
+///
+/// The listener is returned unaccepted so the caller can hand it to the
+/// AllowlistProxy body; this function performs no allowlist enforcement
+/// itself (that lives in `egress_proxy.rs`).
+pub fn bind_loopback_proxy() -> std::io::Result<(TcpListener, u16)> {
+    let mut last_err = None;
+    for port in PROXY_PORT_RANGE {
+        match TcpListener::bind(("127.0.0.1", port)) {
+            Ok(listener) => return Ok((listener, port)),
+            Err(err) => last_err = Some(err),
+        }
+    }
+    Err(last_err.unwrap_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::AddrInUse,
+            "no free loopback proxy port in range 62080-62089",
+        )
+    }))
+}
+
+/// Computes the loopback TCP remote-port ranges to BLOCK so that every port
+/// except the given `proxy_ports` is denied. Returns `None` when there is
+/// nothing to block (only possible if the entire `1..=65535` range is
+/// allowed, which never happens for a real single-port proxy).
+///
+/// This is the complement of the loopback allowlist: the firewall carries a
+/// broad loopback-TCP block and then narrows it to this port complement, so a
+/// child can reach only `127.0.0.1:<proxy_port>` and no other loopback
+/// listener. Port `0` is ignored (never a real bound port). Fail-closed: if
+/// this returns `None` because the caller passed no usable port, the broad
+/// loopback block installed before narrowing stays in force.
+pub fn blocked_loopback_tcp_remote_ports(proxy_ports: &[u16]) -> Option<String> {
+    let mut allowed_ports = proxy_ports
+        .iter()
+        .copied()
+        .filter(|port| *port != 0)
+        .collect::<Vec<_>>();
+    allowed_ports.sort_unstable();
+    allowed_ports.dedup();
+
+    let mut blocked_ranges = Vec::new();
+    let mut start = 1_u32;
+    for port in allowed_ports {
+        let port = u32::from(port);
+        if port < start {
+            continue;
+        }
+        if port > start {
+            blocked_ranges.push(port_range_string(start, port - 1));
+        }
+        start = port + 1;
+    }
+
+    if start <= u32::from(u16::MAX) {
+        blocked_ranges.push(port_range_string(start, u32::from(u16::MAX)));
+    }
+
+    if blocked_ranges.is_empty() {
+        None
+    } else {
+        Some(blocked_ranges.join(","))
+    }
+}
+
+fn port_range_string(start: u32, end: u32) -> String {
+    if start == end {
+        start.to_string()
+    } else {
+        format!("{start}-{end}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn proxy_port_range_is_the_locked_cto_q2_range() {
+        assert_eq!(PROXY_PORT_RANGE_LOW, 62080);
+        assert_eq!(PROXY_PORT_RANGE_HIGH, 62089);
+        assert_eq!(PROXY_PORT_RANGE.count(), 10);
+    }
+
+    #[test]
+    fn bind_loopback_proxy_returns_a_port_inside_the_range() {
+        let (listener, port) = bind_loopback_proxy().expect("a loopback port should be free");
+        assert!(
+            PROXY_PORT_RANGE.contains(&port),
+            "bound port {port} must be inside 62080-62089"
+        );
+        assert_eq!(listener.local_addr().unwrap().port(), port);
+    }
+
+    #[test]
+    fn complement_of_single_proxy_port_blocks_everything_else() {
+        // Allow only 62085: block 1..=62084 and 62086..=65535.
+        let blocked = blocked_loopback_tcp_remote_ports(&[62085])
+            .expect("a single-port allowlist must leave ports to block");
+        assert_eq!(blocked, "1-62084,62086-65535");
+    }
+
+    #[test]
+    fn complement_ignores_zero_and_dedups_and_sorts() {
+        let blocked = blocked_loopback_tcp_remote_ports(&[0, 62085, 62085, 62080])
+            .expect("still ports to block");
+        // Allowed {62080, 62085}: gaps are 1..=62079, 62081..=62084, 62086..=65535.
+        assert_eq!(blocked, "1-62079,62081-62084,62086-65535");
+    }
+
+    #[test]
+    fn complement_of_no_ports_blocks_the_whole_range() {
+        // Empty / all-zero allowlist => block everything (fail-closed).
+        assert_eq!(
+            blocked_loopback_tcp_remote_ports(&[]),
+            Some("1-65535".to_string())
+        );
+        assert_eq!(
+            blocked_loopback_tcp_remote_ports(&[0]),
+            Some("1-65535".to_string())
+        );
+    }
+
+    #[test]
+    fn complement_allowing_max_port_has_no_trailing_range() {
+        let blocked = blocked_loopback_tcp_remote_ports(&[u16::MAX])
+            .expect("everything below 65535 is still blocked");
+        assert_eq!(blocked, "1-65534");
+    }
+}

--- a/apps/desktop-sandbox/hive-desktop-sandbox/src/windows_firewall.rs
+++ b/apps/desktop-sandbox/hive-desktop-sandbox/src/windows_firewall.rs
@@ -17,7 +17,9 @@
 //!   Linux-testable [`crate::wfp_ports::blocked_loopback_tcp_remote_ports`]
 //!   rather than a private copy;
 //! - the `chrono` RFC3339 log timestamp is dropped (the caller's log sink owns
-//!   timestamps).
+//!   timestamps);
+//! - a defensive [`is_wellformed_sid_string`] guard rejects a malformed SID
+//!   before it is ever interpolated into the SDDL local-user spec.
 //!
 //! Applied only `cfg(windows)`. It is NOT wired into `launch()` in this
 //! (inert) B2 PR: `launch()` still refuses both network policies. Activation
@@ -77,6 +79,26 @@ struct BlockRuleSpec<'a> {
     remote_ports: Option<&'a str>,
 }
 
+/// True only for a well-formed SID string literal (`S-1-<authority>-<sub>...`,
+/// digits and `-` only). The sandbox SID is OS-generated today, but this is
+/// cheap insurance: it is interpolated into the SDDL local-user spec below, so
+/// anything carrying `)`, `;`, whitespace, or other SDDL metacharacters must
+/// never reach `format!`. Fail-closed: a malformed SID aborts rule install.
+fn is_wellformed_sid_string(sid: &str) -> bool {
+    let mut parts = sid.split('-');
+    if parts.next() != Some("S") || parts.next() != Some("1") {
+        return false;
+    }
+    let sub_authorities: Vec<&str> = parts.collect();
+    // A real SID has an identifier authority plus at least one sub-authority,
+    // and never more than 15 sub-authorities; every component is decimal.
+    !sub_authorities.is_empty()
+        && sub_authorities.len() <= 16
+        && sub_authorities.iter().all(|part| {
+            !part.is_empty() && part.len() <= 20 && part.bytes().all(|b| b.is_ascii_digit())
+        })
+}
+
 /// Installs / updates the loopback allowlist: blocks all loopback UDP and all
 /// loopback TCP except the `proxy_ports` (the bound proxy port), all scoped to
 /// the sandbox account SID. When `allow_local_binding` is true the loopback
@@ -88,18 +110,31 @@ pub fn ensure_offline_proxy_allowlist(
     allow_local_binding: bool,
     log: &mut dyn Write,
 ) -> Result<()> {
+    if !is_wellformed_sid_string(offline_sid) {
+        return Err(anyhow!(
+            "refusing to build firewall rule for malformed sandbox SID: {offline_sid:?}"
+        ));
+    }
     let local_user_spec = format!("O:LSD:(A;;CC;;;{offline_sid})");
 
+    // SAFETY: CoInitializeEx takes a null reserved pointer (`None`) and a valid
+    // COINIT flag; it is sound to call on any thread and is balanced by the
+    // CoUninitialize below on every return path.
     let hr = unsafe { CoInitializeEx(None, COINIT_APARTMENTTHREADED) };
     if hr.is_err() {
         return Err(anyhow!("CoInitializeEx failed: {hr:?}"));
     }
 
     let result = (|| -> Result<()> {
+        // SAFETY: CoCreateInstance is called after a successful CoInitializeEx
+        // on this thread with a valid CLSID/CLSCTX; the returned interface is
+        // checked via `map_err` before use.
         let policy: INetFwPolicy2 =
             unsafe { CoCreateInstance(&NetFwPolicy2, None, CLSCTX_INPROC_SERVER) }
                 .map_err(|err| anyhow!("CoCreateInstance NetFwPolicy2 failed: {err:?}"))?;
         ensure_local_policy_rules_take_effect(&policy)?;
+        // SAFETY: `policy` is a live, checked INetFwPolicy2; `Rules()` is a
+        // COM accessor with no additional pointer preconditions.
         let rules = unsafe { policy.Rules() }
             .map_err(|err| anyhow!("INetFwPolicy2::Rules failed: {err:?}"))?;
 
@@ -165,6 +200,8 @@ pub fn ensure_offline_proxy_allowlist(
         Ok(())
     })();
 
+    // SAFETY: balances the CoInitializeEx above; called exactly once on this
+    // thread regardless of the closure's outcome.
     unsafe {
         CoUninitialize();
     }
@@ -175,18 +212,28 @@ pub fn ensure_offline_proxy_allowlist(
 /// non-loopback address) scoped to the sandbox account SID. This is the
 /// block-all half of the two-layer fence.
 pub fn ensure_offline_outbound_block(offline_sid: &str, log: &mut dyn Write) -> Result<()> {
+    if !is_wellformed_sid_string(offline_sid) {
+        return Err(anyhow!(
+            "refusing to build firewall rule for malformed sandbox SID: {offline_sid:?}"
+        ));
+    }
     let local_user_spec = format!("O:LSD:(A;;CC;;;{offline_sid})");
 
+    // SAFETY: see `ensure_offline_proxy_allowlist`; null reserved pointer and a
+    // valid COINIT flag, balanced by the CoUninitialize below.
     let hr = unsafe { CoInitializeEx(None, COINIT_APARTMENTTHREADED) };
     if hr.is_err() {
         return Err(anyhow!("CoInitializeEx failed: {hr:?}"));
     }
 
     let result = (|| -> Result<()> {
+        // SAFETY: called after a successful CoInitializeEx with a valid
+        // CLSID/CLSCTX; the returned interface is checked before use.
         let policy: INetFwPolicy2 =
             unsafe { CoCreateInstance(&NetFwPolicy2, None, CLSCTX_INPROC_SERVER) }
                 .map_err(|err| anyhow!("CoCreateInstance NetFwPolicy2 failed: {err:?}"))?;
         ensure_local_policy_rules_take_effect(&policy)?;
+        // SAFETY: `policy` is a live, checked INetFwPolicy2 COM accessor.
         let rules = unsafe { policy.Rules() }
             .map_err(|err| anyhow!("INetFwPolicy2::Rules failed: {err:?}"))?;
 
@@ -206,6 +253,7 @@ pub fn ensure_offline_outbound_block(offline_sid: &str, log: &mut dyn Write) -> 
         Ok(())
     })();
 
+    // SAFETY: balances the CoInitializeEx above; called exactly once.
     unsafe {
         CoUninitialize();
     }
@@ -218,6 +266,9 @@ fn remove_rule_if_present(
     log: &mut dyn Write,
 ) -> Result<()> {
     let name = BSTR::from(internal_name);
+    // SAFETY: `rules` is a live INetFwRules; `Item`/`Remove` take a valid BSTR
+    // we own for the duration of the call. `Item` returning Err just means the
+    // rule is absent, so `Remove` only runs when the rule exists.
     if unsafe { rules.Item(&name) }.is_ok() {
         unsafe { rules.Remove(&name) }
             .map_err(|err| anyhow!("Rules::Remove failed for {internal_name}: {err:?}"))?;
@@ -228,6 +279,16 @@ fn remove_rule_if_present(
 
 fn ensure_local_policy_rules_take_effect(policy: &INetFwPolicy2) -> Result<()> {
     let mut modify_state = NET_FW_MODIFY_STATE::default();
+    // SAFETY: the generated safe `LocalPolicyModifyState` wrapper is
+    // deliberately bypassed here: it maps a non-`S_OK` success (`S_FALSE`, the
+    // "applies to only some active profiles" answer) to `Ok`, which would hide
+    // a partial-coverage result we MUST reject (fail-closed). Calling through
+    // the vtable returns the raw HRESULT so `validate_local_policy_modify_result`
+    // can distinguish `S_OK` from `S_FALSE`. This is ABI-correct against
+    // windows-0.58.0: `Interface::vtable(policy)` yields the interface's live
+    // vtable and `Interface::as_raw(policy)` its `this` pointer, both valid for
+    // the borrow of `policy`; `LocalPolicyModifyState(this, *out)` writes the
+    // out-param `modify_state`, which is a stack `NET_FW_MODIFY_STATE` we own.
     let result = unsafe {
         (Interface::vtable(policy).LocalPolicyModifyState)(
             Interface::as_raw(policy),
@@ -272,18 +333,26 @@ fn ensure_block_rule(
     log: &mut dyn Write,
 ) -> Result<()> {
     let name = BSTR::from(spec.internal_name);
+    // SAFETY: `rules` is a live INetFwRules; `Item` takes a BSTR we own. An Err
+    // just means the rule does not exist yet, handled by the `Err(_)` arm.
     let rule: INetFwRule3 = match unsafe { rules.Item(&name) } {
         Ok(existing) => existing
             .cast()
             .map_err(|err| anyhow!("cast existing firewall rule to INetFwRule3 failed: {err:?}"))?,
         Err(_) => {
+            // SAFETY: called after a successful CoInitializeEx on this thread
+            // with a valid CLSID/CLSCTX; the interface is checked before use.
             let new_rule: INetFwRule3 =
                 unsafe { CoCreateInstance(&NetFwRule, None, CLSCTX_INPROC_SERVER) }
                     .map_err(|err| anyhow!("CoCreateInstance NetFwRule failed: {err:?}"))?;
+            // SAFETY: `new_rule` is a live INetFwRule3; `SetName` takes a BSTR
+            // we own for the call.
             unsafe { new_rule.SetName(&name) }.map_err(|err| anyhow!("SetName failed: {err:?}"))?;
             // Set all properties before adding so we never leave a
             // half-configured rule.
             configure_rule(&new_rule, spec)?;
+            // SAFETY: `rules` is live and `new_rule` is a fully configured,
+            // live INetFwRule3 that `Add` takes by reference.
             unsafe { rules.Add(&new_rule) }.map_err(|err| anyhow!("Rules::Add failed: {err:?}"))?;
             new_rule
         }
@@ -305,6 +374,9 @@ fn ensure_block_rule(
 }
 
 fn configure_rule(rule: &INetFwRule3, spec: &BlockRuleSpec<'_>) -> Result<()> {
+    // SAFETY: `rule` is a live INetFwRule3. Every setter below is a COM property
+    // write taking either a Copy enum value or a BSTR we own for the duration of
+    // the call; each result is checked via `map_err`.
     unsafe {
         rule.SetDescription(&BSTR::from(spec.friendly_desc))
             .map_err(|err| anyhow!("SetDescription failed: {err:?}"))?;
@@ -323,6 +395,8 @@ fn configure_rule(rule: &INetFwRule3, spec: &BlockRuleSpec<'_>) -> Result<()> {
 
     // Read-back verification: fail-closed if we did not actually write the
     // expected SID scope, so a rule can never silently apply to every user.
+    // SAFETY: `rule` is a live INetFwRule3; `LocalUserAuthorizedList` reads back
+    // a COM-owned BSTR that `windows` frees.
     let actual = unsafe { rule.LocalUserAuthorizedList() }
         .map_err(|err| anyhow!("LocalUserAuthorizedList (read-back) failed: {err:?}"))?;
     let actual_str = actual.to_string();
@@ -336,6 +410,8 @@ fn configure_rule(rule: &INetFwRule3, spec: &BlockRuleSpec<'_>) -> Result<()> {
 }
 
 fn configure_rule_network_scope(rule: &INetFwRule3, spec: &BlockRuleSpec<'_>) -> Result<()> {
+    // SAFETY: `rule` is a live INetFwRule3. `SetProtocol` takes a Copy i32;
+    // `SetRemoteAddresses`/`SetRemotePorts` take BSTRs we own for each call.
     unsafe {
         rule.SetProtocol(spec.protocol)
             .map_err(|err| anyhow!("SetProtocol failed: {err:?}"))?;
@@ -376,5 +452,29 @@ mod tests {
     fn local_policy_modify_state_rejects_partial_profile_coverage() {
         validate_local_policy_modify_result(S_FALSE, NET_FW_MODIFY_STATE_OK)
             .expect_err("partial profile coverage should fail sandbox firewall setup");
+    }
+
+    #[test]
+    fn wellformed_sid_accepts_real_sids_and_rejects_injection() {
+        assert!(is_wellformed_sid_string("S-1-5-18"));
+        assert!(is_wellformed_sid_string(
+            "S-1-5-21-3623811015-3361044348-30300820-1013"
+        ));
+        // Not a SID / carries SDDL metacharacters that must never reach format!.
+        for bad in [
+            "",
+            "S-1",
+            "S-2-5-18",
+            "X-1-5-18",
+            "S-1-5-18)",
+            "S-1-5-18;DROP",
+            "S-1-5- 18",
+            "S-1-5-1a",
+        ] {
+            assert!(
+                !is_wellformed_sid_string(bad),
+                "{bad:?} must be rejected as a malformed SID"
+            );
+        }
     }
 }

--- a/apps/desktop-sandbox/hive-desktop-sandbox/src/windows_firewall.rs
+++ b/apps/desktop-sandbox/hive-desktop-sandbox/src/windows_firewall.rs
@@ -1,0 +1,380 @@
+//! Windows Firewall COM layer of the two-layer egress fence (Integration B2,
+//! CTO decision Q1: keep the Codex two-layer model, WFP per-protocol blocks
+//! plus this firewall block-all + loopback allowlist, both keyed on the
+//! sandbox account SID).
+//!
+//! Ported (Hive-authored, not vendored verbatim) from openai/codex
+//! `codex-rs/windows-sandbox-rs/src/bin/setup_main/win/firewall.rs` at commit
+//! a47c661ea9e226fe65e46cf9dbc5c5ed75c2c762 (Apache-2.0). See `../VENDORING.md`
+//! for the deviation record. Deviations from upstream:
+//! - rule name constants renamed `codex_sandbox_offline_*` ->
+//!   `hive_sandbox_offline_*`;
+//! - upstream's `SetupErrorCode`/`SetupFailure` taxonomy replaced with plain
+//!   `anyhow` errors (this is a Hive-authored port, not the Codex setup
+//!   binary), while preserving fail-closed behaviour: every COM failure and
+//!   the SID read-back mismatch still return `Err`;
+//! - the loopback-allowlist port complement is computed by the shared,
+//!   Linux-testable [`crate::wfp_ports::blocked_loopback_tcp_remote_ports`]
+//!   rather than a private copy;
+//! - the `chrono` RFC3339 log timestamp is dropped (the caller's log sink owns
+//!   timestamps).
+//!
+//! Applied only `cfg(windows)`. It is NOT wired into `launch()` in this
+//! (inert) B2 PR: `launch()` still refuses both network policies. Activation
+//! is a separate lab-gated PR (D-004).
+
+use crate::wfp_ports::blocked_loopback_tcp_remote_ports;
+use anyhow::Result;
+use anyhow::anyhow;
+use std::io::Write;
+
+use windows::Win32::Foundation::S_OK;
+use windows::Win32::Foundation::VARIANT_TRUE;
+use windows::Win32::NetworkManagement::WindowsFirewall::INetFwPolicy2;
+use windows::Win32::NetworkManagement::WindowsFirewall::INetFwRule3;
+use windows::Win32::NetworkManagement::WindowsFirewall::INetFwRules;
+use windows::Win32::NetworkManagement::WindowsFirewall::NET_FW_ACTION_BLOCK;
+use windows::Win32::NetworkManagement::WindowsFirewall::NET_FW_IP_PROTOCOL_ANY;
+use windows::Win32::NetworkManagement::WindowsFirewall::NET_FW_IP_PROTOCOL_TCP;
+use windows::Win32::NetworkManagement::WindowsFirewall::NET_FW_IP_PROTOCOL_UDP;
+use windows::Win32::NetworkManagement::WindowsFirewall::NET_FW_MODIFY_STATE;
+use windows::Win32::NetworkManagement::WindowsFirewall::NET_FW_MODIFY_STATE_OK;
+use windows::Win32::NetworkManagement::WindowsFirewall::NET_FW_PROFILE2_ALL;
+use windows::Win32::NetworkManagement::WindowsFirewall::NET_FW_RULE_DIR_OUT;
+use windows::Win32::NetworkManagement::WindowsFirewall::NetFwPolicy2;
+use windows::Win32::NetworkManagement::WindowsFirewall::NetFwRule;
+use windows::Win32::System::Com::CLSCTX_INPROC_SERVER;
+use windows::Win32::System::Com::COINIT_APARTMENTTHREADED;
+use windows::Win32::System::Com::CoCreateInstance;
+use windows::Win32::System::Com::CoInitializeEx;
+use windows::Win32::System::Com::CoUninitialize;
+use windows::core::BSTR;
+use windows::core::Interface;
+
+// Stable identifiers used to find/update rules idempotently. They intentionally
+// do not change between installs.
+const OFFLINE_BLOCK_RULE_NAME: &str = "hive_sandbox_offline_block_outbound";
+const OFFLINE_BLOCK_LOOPBACK_TCP_RULE_NAME: &str = "hive_sandbox_offline_block_loopback_tcp";
+const OFFLINE_BLOCK_LOOPBACK_UDP_RULE_NAME: &str = "hive_sandbox_offline_block_loopback_udp";
+const OFFLINE_PROXY_ALLOW_RULE_NAME: &str = "hive_sandbox_offline_allow_loopback_proxy";
+
+// Friendly text shown in the firewall UI.
+const OFFLINE_BLOCK_RULE_FRIENDLY: &str = "Hive Sandbox Offline - Block Non-Loopback Outbound";
+const OFFLINE_BLOCK_LOOPBACK_TCP_RULE_FRIENDLY: &str =
+    "Hive Sandbox Offline - Block Loopback TCP (Except Proxy)";
+const OFFLINE_BLOCK_LOOPBACK_UDP_RULE_FRIENDLY: &str = "Hive Sandbox Offline - Block Loopback UDP";
+
+const LOOPBACK_REMOTE_ADDRESSES: &str = "127.0.0.0/8,::/127";
+const NON_LOOPBACK_REMOTE_ADDRESSES: &str = "0.0.0.0-126.255.255.255,128.0.0.0-255.255.255.255,::,::2-ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff";
+
+struct BlockRuleSpec<'a> {
+    internal_name: &'a str,
+    friendly_desc: &'a str,
+    protocol: i32,
+    local_user_spec: &'a str,
+    offline_sid: &'a str,
+    remote_addresses: Option<&'a str>,
+    remote_ports: Option<&'a str>,
+}
+
+/// Installs / updates the loopback allowlist: blocks all loopback UDP and all
+/// loopback TCP except the `proxy_ports` (the bound proxy port), all scoped to
+/// the sandbox account SID. When `allow_local_binding` is true the loopback
+/// blocks are removed instead (DenyAll passes an empty `proxy_ports` with
+/// `allow_local_binding = false` to block loopback outright).
+pub fn ensure_offline_proxy_allowlist(
+    offline_sid: &str,
+    proxy_ports: &[u16],
+    allow_local_binding: bool,
+    log: &mut dyn Write,
+) -> Result<()> {
+    let local_user_spec = format!("O:LSD:(A;;CC;;;{offline_sid})");
+
+    let hr = unsafe { CoInitializeEx(None, COINIT_APARTMENTTHREADED) };
+    if hr.is_err() {
+        return Err(anyhow!("CoInitializeEx failed: {hr:?}"));
+    }
+
+    let result = (|| -> Result<()> {
+        let policy: INetFwPolicy2 =
+            unsafe { CoCreateInstance(&NetFwPolicy2, None, CLSCTX_INPROC_SERVER) }
+                .map_err(|err| anyhow!("CoCreateInstance NetFwPolicy2 failed: {err:?}"))?;
+        ensure_local_policy_rules_take_effect(&policy)?;
+        let rules = unsafe { policy.Rules() }
+            .map_err(|err| anyhow!("INetFwPolicy2::Rules failed: {err:?}"))?;
+
+        if allow_local_binding {
+            // Remove the loopback blocks so unrestricted local binding is
+            // possible again; drop the stale proxy exception too.
+            remove_rule_if_present(&rules, OFFLINE_PROXY_ALLOW_RULE_NAME, log)?;
+            remove_rule_if_present(&rules, OFFLINE_BLOCK_LOOPBACK_UDP_RULE_NAME, log)?;
+            remove_rule_if_present(&rules, OFFLINE_BLOCK_LOOPBACK_TCP_RULE_NAME, log)?;
+            return Ok(());
+        }
+
+        ensure_block_rule(
+            &rules,
+            &BlockRuleSpec {
+                internal_name: OFFLINE_BLOCK_LOOPBACK_UDP_RULE_NAME,
+                friendly_desc: OFFLINE_BLOCK_LOOPBACK_UDP_RULE_FRIENDLY,
+                protocol: NET_FW_IP_PROTOCOL_UDP.0,
+                local_user_spec: &local_user_spec,
+                offline_sid,
+                remote_addresses: Some(LOOPBACK_REMOTE_ADDRESSES),
+                remote_ports: None,
+            },
+            log,
+        )?;
+
+        // Install a broad TCP loopback block before narrowing it to the allowed
+        // proxy-port complement. If the narrowing update fails, the sandbox
+        // stays fail-closed (all loopback TCP blocked).
+        ensure_block_rule(
+            &rules,
+            &BlockRuleSpec {
+                internal_name: OFFLINE_BLOCK_LOOPBACK_TCP_RULE_NAME,
+                friendly_desc: OFFLINE_BLOCK_LOOPBACK_TCP_RULE_FRIENDLY,
+                protocol: NET_FW_IP_PROTOCOL_TCP.0,
+                local_user_spec: &local_user_spec,
+                offline_sid,
+                remote_addresses: Some(LOOPBACK_REMOTE_ADDRESSES),
+                remote_ports: None,
+            },
+            log,
+        )?;
+
+        // Remove the legacy overlapping allow rule only after the explicit
+        // block rules are in place so transitions do not fail open.
+        remove_rule_if_present(&rules, OFFLINE_PROXY_ALLOW_RULE_NAME, log)?;
+
+        if let Some(blocked_remote_ports) = blocked_loopback_tcp_remote_ports(proxy_ports) {
+            ensure_block_rule(
+                &rules,
+                &BlockRuleSpec {
+                    internal_name: OFFLINE_BLOCK_LOOPBACK_TCP_RULE_NAME,
+                    friendly_desc: OFFLINE_BLOCK_LOOPBACK_TCP_RULE_FRIENDLY,
+                    protocol: NET_FW_IP_PROTOCOL_TCP.0,
+                    local_user_spec: &local_user_spec,
+                    offline_sid,
+                    remote_addresses: Some(LOOPBACK_REMOTE_ADDRESSES),
+                    remote_ports: Some(&blocked_remote_ports),
+                },
+                log,
+            )?;
+        }
+        Ok(())
+    })();
+
+    unsafe {
+        CoUninitialize();
+    }
+    result
+}
+
+/// Installs the persistent block-all-outbound rule (all IP protocols to every
+/// non-loopback address) scoped to the sandbox account SID. This is the
+/// block-all half of the two-layer fence.
+pub fn ensure_offline_outbound_block(offline_sid: &str, log: &mut dyn Write) -> Result<()> {
+    let local_user_spec = format!("O:LSD:(A;;CC;;;{offline_sid})");
+
+    let hr = unsafe { CoInitializeEx(None, COINIT_APARTMENTTHREADED) };
+    if hr.is_err() {
+        return Err(anyhow!("CoInitializeEx failed: {hr:?}"));
+    }
+
+    let result = (|| -> Result<()> {
+        let policy: INetFwPolicy2 =
+            unsafe { CoCreateInstance(&NetFwPolicy2, None, CLSCTX_INPROC_SERVER) }
+                .map_err(|err| anyhow!("CoCreateInstance NetFwPolicy2 failed: {err:?}"))?;
+        ensure_local_policy_rules_take_effect(&policy)?;
+        let rules = unsafe { policy.Rules() }
+            .map_err(|err| anyhow!("INetFwPolicy2::Rules failed: {err:?}"))?;
+
+        ensure_block_rule(
+            &rules,
+            &BlockRuleSpec {
+                internal_name: OFFLINE_BLOCK_RULE_NAME,
+                friendly_desc: OFFLINE_BLOCK_RULE_FRIENDLY,
+                protocol: NET_FW_IP_PROTOCOL_ANY.0,
+                local_user_spec: &local_user_spec,
+                offline_sid,
+                remote_addresses: Some(NON_LOOPBACK_REMOTE_ADDRESSES),
+                remote_ports: None,
+            },
+            log,
+        )?;
+        Ok(())
+    })();
+
+    unsafe {
+        CoUninitialize();
+    }
+    result
+}
+
+fn remove_rule_if_present(
+    rules: &INetFwRules,
+    internal_name: &str,
+    log: &mut dyn Write,
+) -> Result<()> {
+    let name = BSTR::from(internal_name);
+    if unsafe { rules.Item(&name) }.is_ok() {
+        unsafe { rules.Remove(&name) }
+            .map_err(|err| anyhow!("Rules::Remove failed for {internal_name}: {err:?}"))?;
+        log_line(log, &format!("firewall rule removed name={internal_name}"))?;
+    }
+    Ok(())
+}
+
+fn ensure_local_policy_rules_take_effect(policy: &INetFwPolicy2) -> Result<()> {
+    let mut modify_state = NET_FW_MODIFY_STATE::default();
+    let result = unsafe {
+        (Interface::vtable(policy).LocalPolicyModifyState)(
+            Interface::as_raw(policy),
+            &mut modify_state,
+        )
+    };
+    validate_local_policy_modify_result(result, modify_state)
+}
+
+fn validate_local_policy_modify_result(
+    result: windows::core::HRESULT,
+    modify_state: NET_FW_MODIFY_STATE,
+) -> Result<()> {
+    if result.is_err() {
+        // The COM query itself failed, so Windows never gave us a policy answer.
+        return Err(anyhow!(
+            "INetFwPolicy2::LocalPolicyModifyState failed: {result:?}"
+        ));
+    }
+
+    if result != S_OK {
+        // S_FALSE means the answer only holds for some active profiles.
+        return Err(anyhow!(
+            "local firewall policy modifications do not apply to every current profile: LocalPolicyModifyState result={result:?}"
+        ));
+    }
+
+    if modify_state == NET_FW_MODIFY_STATE_OK {
+        return Ok(());
+    }
+
+    // Windows answered uniformly, and that answer says local rule edits are
+    // ineffective (e.g. a group-policy override).
+    Err(anyhow!(
+        "local firewall policy modifications will not take effect: LocalPolicyModifyState={modify_state:?}"
+    ))
+}
+
+fn ensure_block_rule(
+    rules: &INetFwRules,
+    spec: &BlockRuleSpec<'_>,
+    log: &mut dyn Write,
+) -> Result<()> {
+    let name = BSTR::from(spec.internal_name);
+    let rule: INetFwRule3 = match unsafe { rules.Item(&name) } {
+        Ok(existing) => existing
+            .cast()
+            .map_err(|err| anyhow!("cast existing firewall rule to INetFwRule3 failed: {err:?}"))?,
+        Err(_) => {
+            let new_rule: INetFwRule3 =
+                unsafe { CoCreateInstance(&NetFwRule, None, CLSCTX_INPROC_SERVER) }
+                    .map_err(|err| anyhow!("CoCreateInstance NetFwRule failed: {err:?}"))?;
+            unsafe { new_rule.SetName(&name) }.map_err(|err| anyhow!("SetName failed: {err:?}"))?;
+            // Set all properties before adding so we never leave a
+            // half-configured rule.
+            configure_rule(&new_rule, spec)?;
+            unsafe { rules.Add(&new_rule) }.map_err(|err| anyhow!("Rules::Add failed: {err:?}"))?;
+            new_rule
+        }
+    };
+
+    // Always re-apply fields to keep the setup idempotent.
+    configure_rule(&rule, spec)?;
+
+    let remote_addresses_log = spec.remote_addresses.unwrap_or("*");
+    let remote_ports_log = spec.remote_ports.unwrap_or("*");
+    log_line(
+        log,
+        &format!(
+            "firewall rule configured name={} protocol={} RemoteAddresses={remote_addresses_log} RemotePorts={remote_ports_log} LocalUserAuthorizedList={}",
+            spec.internal_name, spec.protocol, spec.local_user_spec
+        ),
+    )?;
+    Ok(())
+}
+
+fn configure_rule(rule: &INetFwRule3, spec: &BlockRuleSpec<'_>) -> Result<()> {
+    unsafe {
+        rule.SetDescription(&BSTR::from(spec.friendly_desc))
+            .map_err(|err| anyhow!("SetDescription failed: {err:?}"))?;
+        rule.SetDirection(NET_FW_RULE_DIR_OUT)
+            .map_err(|err| anyhow!("SetDirection failed: {err:?}"))?;
+        rule.SetAction(NET_FW_ACTION_BLOCK)
+            .map_err(|err| anyhow!("SetAction failed: {err:?}"))?;
+        rule.SetEnabled(VARIANT_TRUE)
+            .map_err(|err| anyhow!("SetEnabled failed: {err:?}"))?;
+        rule.SetProfiles(NET_FW_PROFILE2_ALL.0)
+            .map_err(|err| anyhow!("SetProfiles failed: {err:?}"))?;
+        configure_rule_network_scope(rule, spec)?;
+        rule.SetLocalUserAuthorizedList(&BSTR::from(spec.local_user_spec))
+            .map_err(|err| anyhow!("SetLocalUserAuthorizedList failed: {err:?}"))?;
+    }
+
+    // Read-back verification: fail-closed if we did not actually write the
+    // expected SID scope, so a rule can never silently apply to every user.
+    let actual = unsafe { rule.LocalUserAuthorizedList() }
+        .map_err(|err| anyhow!("LocalUserAuthorizedList (read-back) failed: {err:?}"))?;
+    let actual_str = actual.to_string();
+    if !actual_str.contains(spec.offline_sid) {
+        return Err(anyhow!(
+            "offline firewall rule user scope mismatch: expected SID {}, got {actual_str}",
+            spec.offline_sid
+        ));
+    }
+    Ok(())
+}
+
+fn configure_rule_network_scope(rule: &INetFwRule3, spec: &BlockRuleSpec<'_>) -> Result<()> {
+    unsafe {
+        rule.SetProtocol(spec.protocol)
+            .map_err(|err| anyhow!("SetProtocol failed: {err:?}"))?;
+        let remote_addresses = spec.remote_addresses.unwrap_or("*");
+        rule.SetRemoteAddresses(&BSTR::from(remote_addresses))
+            .map_err(|err| anyhow!("SetRemoteAddresses failed: {err:?}"))?;
+        if let Some(remote_ports) = spec.remote_ports {
+            rule.SetRemotePorts(&BSTR::from(remote_ports))
+                .map_err(|err| anyhow!("SetRemotePorts failed: {err:?}"))?;
+        }
+    }
+    Ok(())
+}
+
+fn log_line(log: &mut dyn Write, msg: &str) -> Result<()> {
+    writeln!(log, "{msg}")?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use windows::Win32::Foundation::S_FALSE;
+    use windows::Win32::NetworkManagement::WindowsFirewall::NET_FW_MODIFY_STATE_GP_OVERRIDE;
+
+    #[test]
+    fn local_policy_modify_state_accepts_effective_policy() {
+        assert!(validate_local_policy_modify_result(S_OK, NET_FW_MODIFY_STATE_OK).is_ok());
+    }
+
+    #[test]
+    fn local_policy_modify_state_rejects_ineffective_policy() {
+        validate_local_policy_modify_result(S_OK, NET_FW_MODIFY_STATE_GP_OVERRIDE)
+            .expect_err("group-policy override should fail sandbox firewall setup");
+    }
+
+    #[test]
+    fn local_policy_modify_state_rejects_partial_profile_coverage() {
+        validate_local_policy_modify_result(S_FALSE, NET_FW_MODIFY_STATE_OK)
+            .expect_err("partial profile coverage should fail sandbox firewall setup");
+    }
+}

--- a/apps/desktop-sandbox/hive-desktop-sandbox/src/windows_plan.rs
+++ b/apps/desktop-sandbox/hive-desktop-sandbox/src/windows_plan.rs
@@ -9,7 +9,6 @@
 //! validation.
 
 use crate::SandboxPolicy;
-use crate::policy::NetworkPolicy;
 use std::path::{Path, PathBuf};
 
 /// Windows-specific enforcement plan derived from a [`SandboxPolicy`].
@@ -36,117 +35,28 @@ pub struct WindowsConfinementPlan {
     /// closes is still required so no sandboxed process outlives its
     /// workspace/ACL lifetime.
     pub job_object_kill_on_close: bool,
-    /// `true` for both [`NetworkPolicy`] variants: a Windows Firewall
-    /// deny-outbound-by-default rule, with [`firewall_allow_outbound_hosts`]
-    /// carrying the per-host exceptions for `AllowHosts`. Blueprint Step
-    /// 4.4 (#308/#311) computes this plan and the rule text
-    /// ([`allow_hosts_firewall_script`]) but does not call the Firewall API
-    /// -- `windows::launch` never applies this firewall codegen (and rejects
-    /// `AllowHosts` outright with `AllowHostsNotYetImplemented`), so nothing
-    /// here is ever actually applied on a real Windows host today. Marked
-    /// explicitly untrusted:
-    /// this is codegen only, verified by pure unit tests on Linux CI, never
-    /// exercised against the real `netsh`/WFP surface.
-    ///
-    /// [`firewall_allow_outbound_hosts`]: WindowsConfinementPlan::firewall_allow_outbound_hosts
-    pub firewall_deny_outbound: bool,
-
-    /// Per-host outbound allow exceptions for [`NetworkPolicy::AllowHosts`],
-    /// layered on top of `firewall_deny_outbound`. Empty for
-    /// [`NetworkPolicy::DenyAll`] (nothing to allow).
-    pub firewall_allow_outbound_hosts: Vec<String>,
+    // Network egress is NOT represented in this plan. The old `netsh` codegen
+    // fields (`firewall_deny_outbound`, `firewall_allow_outbound_hosts`) were
+    // removed in Integration B2: `netsh` evaluates block rules ahead of allow
+    // rules, so that codegen could only ever express a strict deny-all, never
+    // the requested AllowHosts allowlist, and it was never wired to a live
+    // effect. Egress enforcement now lives in the WFP + Windows Firewall COM
+    // layer (`windows_firewall.rs` + `codex_windows_sandbox::wfp`), keyed on
+    // the sandbox account SID, applied at provision time.
 }
 
 impl WindowsConfinementPlan {
     pub fn for_policy(policy: &SandboxPolicy) -> Self {
-        let firewall_allow_outbound_hosts = match policy.network() {
-            NetworkPolicy::DenyAll => Vec::new(),
-            NetworkPolicy::AllowHosts(hosts) => hosts.clone(),
-        };
+        // `policy.network()` no longer feeds this plan: egress is enforced by
+        // the WFP + firewall COM layer at provision time, not by anything the
+        // plan carries. See the struct's network comment.
+        let _ = policy.network();
         Self {
             acl_deny_write_parent_dir: parent_dir(policy.hook_config_dir()),
             protect_dacl_from_inheritance: true,
             job_object_kill_on_close: true,
-            firewall_deny_outbound: true,
-            firewall_allow_outbound_hosts,
         }
     }
-}
-
-/// Rule-name prefix for every generated rule, so a caller (or a human
-/// reading `netsh advfirewall firewall show rule name=all`) can find and
-/// remove every rule this crate ever generated for one task by prefix.
-const RULE_NAME_PREFIX: &str = "Hive-Sandbox";
-
-/// Generates the `netsh advfirewall` command lines implementing `plan`,
-/// scoped to `program_path` (the sandboxed task's own executable) via
-/// `netsh`'s `program=` parameter so the rules only ever affect that one
-/// process, never the whole host. Pure text generation -- see the module
-/// doc and `firewall_deny_outbound`'s doc comment for why this is never
-/// applied by this crate. `task_id` scopes the rule *names* so concurrent
-/// sandboxed tasks (if this is ever wired to run more than one at a time)
-/// don't collide or shadow each other's rules.
-///
-/// Known incomplete design, not yet a working allowlist: Windows Firewall
-/// evaluates `Block` rules ahead of `Allow` rules regardless of
-/// specificity, so the single `action=block` rule below always wins over
-/// every per-host `action=allow` rule that follows it -- the net effect if
-/// this were ever applied is a strict deny-all, not the requested
-/// `AllowHosts`. `netsh` has no "allow overrides block" priority to ask
-/// for; a real allowlist needs either a single block rule built from an
-/// inverted (everything-except-the-allowed-hosts) IP range, or dropping
-/// `netsh` for the Windows Filtering Platform (WFP) directly. Tracked as a
-/// follow-up (see the crate's issue tracker); do not wire this to a real
-/// `netsh`/WFP call without fixing the precedence problem first, and note
-/// that `windows::launch` rejects `AllowHosts` outright
-/// (`AllowHostsNotYetImplemented`) and never calls this codegen, so nothing
-/// applies it for a live effect yet either way.
-pub fn allow_hosts_firewall_script(
-    plan: &WindowsConfinementPlan,
-    task_id: &str,
-    program_path: &str,
-) -> Vec<String> {
-    let mut lines = Vec::with_capacity(1 + plan.firewall_allow_outbound_hosts.len());
-    if plan.firewall_deny_outbound {
-        lines.push(format!(
-            "netsh advfirewall firewall add rule name=\"{RULE_NAME_PREFIX}-{task_id}-deny\" \
-             dir=out action=block program=\"{program_path}\" enable=yes"
-        ));
-    }
-    for host in &plan.firewall_allow_outbound_hosts {
-        // Issue #342 item 4: never interpolate a host into a command string
-        // that is not a safe literal. The egress SSOT
-        // (`apps/control-plane/internal/egress/service.go`'s `normalizeHosts`)
-        // already rejects whitespace and wildcards upstream, but this codegen
-        // must not depend on every future caller having sanitised its input.
-        // A host that is not a plain hostname/IP/CIDR literal gets no allow
-        // rule at all -- fail closed, so it stays denied by the block rule
-        // above rather than emitting an attacker-controlled `netsh` argument.
-        if !is_safe_firewall_host(host) {
-            continue;
-        }
-        lines.push(format!(
-            "netsh advfirewall firewall add rule name=\"{RULE_NAME_PREFIX}-{task_id}-allow-{host}\" \
-             dir=out action=allow program=\"{program_path}\" remoteip={host} enable=yes"
-        ));
-    }
-    lines
-}
-
-/// True only for a host string safe to interpolate verbatim into a `netsh`
-/// command line: a plain hostname, IPv4/IPv6 literal, or CIDR range. Rejects
-/// anything carrying quotes, whitespace, shell/`netsh` metacharacters, or
-/// wildcards, which is what makes the interpolation in
-/// [`allow_hosts_firewall_script`] injection-safe regardless of what a future
-/// caller passes. Deliberately a strict allowlist of characters rather than
-/// an attempt to escape: escaping `netsh`/`cmd` quoting correctly is subtle,
-/// and no legitimate egress host needs a character outside this set.
-fn is_safe_firewall_host(host: &str) -> bool {
-    !host.is_empty()
-        && host.len() <= 255
-        && host
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | ':' | '-' | '_' | '/'))
 }
 
 /// Computes the parent of a Windows-style path using explicit `\`/`/`
@@ -271,6 +181,7 @@ pub fn is_fully_qualified_program(program: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::policy::NetworkPolicy;
     use crate::policy::SandboxPolicy;
     use pretty_assertions::assert_eq;
 
@@ -313,90 +224,6 @@ mod tests {
     }
 
     #[test]
-    fn plan_requests_deny_outbound_firewall_for_deny_all_network() {
-        let policy = SandboxPolicy::build(
-            vec![],
-            vec![],
-            PathBuf::from(r"C:\Users\agent\AppData\Hive\hooks"),
-            NetworkPolicy::DenyAll,
-        )
-        .expect("valid policy");
-
-        let plan = WindowsConfinementPlan::for_policy(&policy);
-        assert!(plan.firewall_deny_outbound);
-        assert!(
-            plan.firewall_allow_outbound_hosts.is_empty(),
-            "DenyAll must not carry any allow exceptions"
-        );
-    }
-
-    #[test]
-    fn plan_requests_deny_outbound_and_per_host_exceptions_for_allow_hosts_network() {
-        let policy = SandboxPolicy::build(
-            vec![],
-            vec![],
-            PathBuf::from(r"C:\Users\agent\AppData\Hive\hooks"),
-            NetworkPolicy::AllowHosts(vec!["api.openrouter.ai".to_string()]),
-        )
-        .expect("valid policy");
-
-        let plan = WindowsConfinementPlan::for_policy(&policy);
-        // Blueprint Step 4.4 (#308/#311): deny-outbound-by-default now
-        // applies to AllowHosts too, not just DenyAll -- the exceptions
-        // below are what makes it an *allow*list rather than a full block.
-        assert!(plan.firewall_deny_outbound);
-        assert_eq!(
-            plan.firewall_allow_outbound_hosts,
-            vec!["api.openrouter.ai".to_string()]
-        );
-    }
-
-    #[test]
-    fn allow_hosts_firewall_script_orders_deny_rule_before_allow_exceptions() {
-        let policy = SandboxPolicy::build(
-            vec![],
-            vec![],
-            PathBuf::from(r"C:\Users\agent\AppData\Hive\hooks"),
-            NetworkPolicy::AllowHosts(vec![
-                "api.openrouter.ai".to_string(),
-                "example.com".to_string(),
-            ]),
-        )
-        .expect("valid policy");
-        let plan = WindowsConfinementPlan::for_policy(&policy);
-
-        let lines = allow_hosts_firewall_script(&plan, "task-123", r"C:\hive\sandboxed-task.exe");
-        assert_eq!(lines.len(), 3, "one deny rule plus one allow rule per host");
-        assert!(lines[0].contains("action=block"));
-        assert!(lines[0].contains("task-123"));
-        assert!(lines[1].contains("action=allow") && lines[1].contains("api.openrouter.ai"));
-        assert!(lines[2].contains("action=allow") && lines[2].contains("example.com"));
-        for line in &lines {
-            assert!(
-                line.contains(r#"program="C:\hive\sandboxed-task.exe""#),
-                "every rule must be scoped to the sandboxed task's own executable, not the whole host: {line}"
-            );
-        }
-    }
-
-    #[test]
-    fn allow_hosts_firewall_script_for_deny_all_is_just_the_deny_rule() {
-        let policy = SandboxPolicy::build(
-            vec![],
-            vec![],
-            PathBuf::from(r"C:\Users\agent\AppData\Hive\hooks"),
-            NetworkPolicy::DenyAll,
-        )
-        .expect("valid policy");
-        let plan = WindowsConfinementPlan::for_policy(&policy);
-
-        let lines = allow_hosts_firewall_script(&plan, "task-456", r"C:\hive\sandboxed-task.exe");
-        assert_eq!(lines.len(), 1);
-        assert!(lines[0].contains("action=block"));
-        assert!(lines[0].contains(r#"program="C:\hive\sandboxed-task.exe""#));
-    }
-
-    #[test]
     fn plan_for_hook_config_dir_at_drive_root_falls_back_to_itself() {
         let policy = SandboxPolicy::build(
             vec![],
@@ -424,57 +251,6 @@ mod tests {
         // Must be "C:\" (the drive root), not "C:" (Win32's "current
         // directory on drive C", a different and non-deterministic path).
         assert_eq!(plan.acl_deny_write_parent_dir, PathBuf::from(r"C:\"));
-    }
-
-    #[test]
-    fn allow_hosts_firewall_script_skips_unsafe_hosts() {
-        // Construct the plan directly so the injection guard is tested in
-        // isolation, even for hosts SandboxPolicy::build would itself reject:
-        // this codegen must be safe regardless of what a future caller passes.
-        let plan = WindowsConfinementPlan {
-            acl_deny_write_parent_dir: PathBuf::from(r"C:\Users\agent\AppData\Hive"),
-            protect_dacl_from_inheritance: true,
-            job_object_kill_on_close: true,
-            firewall_deny_outbound: true,
-            firewall_allow_outbound_hosts: vec![
-                "api.openrouter.ai".to_string(),
-                r#"evil.com" & calc.exe & echo "#.to_string(),
-                "with space.com".to_string(),
-                "*.wild.com".to_string(),
-            ],
-        };
-
-        let lines = allow_hosts_firewall_script(&plan, "task-1", r"C:\hive\task.exe");
-        // Deny rule plus exactly one allow rule: only the single safe host.
-        assert_eq!(
-            lines.len(),
-            2,
-            "unsafe hosts must not produce allow rules: {lines:?}"
-        );
-        assert!(lines[0].contains("action=block"));
-        assert!(lines[1].contains("action=allow") && lines[1].contains("api.openrouter.ai"));
-        for line in &lines {
-            assert!(
-                !line.contains("calc.exe"),
-                "no injected command must survive into a rule: {line}"
-            );
-        }
-    }
-
-    #[test]
-    fn is_safe_firewall_host_accepts_literals_and_rejects_metacharacters() {
-        for good in [
-            "api.openrouter.ai",
-            "10.0.0.1",
-            "2606:4700::1111",
-            "10.0.0.0/8",
-            "host-name_1",
-        ] {
-            assert!(is_safe_firewall_host(good), "{good} should be safe");
-        }
-        for bad in ["", "a b", "x\"y", "a&b", "a|b", "*.x.com", "a\nb", "a;b"] {
-            assert!(!is_safe_firewall_host(bad), "{bad} should be rejected");
-        }
     }
 
     /// Strips the trailing NUL and decodes the UTF-16 command line back to a

--- a/apps/desktop-sandbox/hive-desktop-sandbox/src/windows_plan.rs
+++ b/apps/desktop-sandbox/hive-desktop-sandbox/src/windows_plan.rs
@@ -47,10 +47,9 @@ pub struct WindowsConfinementPlan {
 
 impl WindowsConfinementPlan {
     pub fn for_policy(policy: &SandboxPolicy) -> Self {
-        // `policy.network()` no longer feeds this plan: egress is enforced by
-        // the WFP + firewall COM layer at provision time, not by anything the
-        // plan carries. See the struct's network comment.
-        let _ = policy.network();
+        // Network egress is not represented in this plan; it is enforced by the
+        // WFP + firewall COM layer at provision time (see the struct's network
+        // comment), so `policy.network()` is intentionally not read here.
         Self {
             acl_deny_write_parent_dir: parent_dir(policy.hook_config_dir()),
             protect_dacl_from_inheritance: true,


### PR DESCRIPTION
## Summary

Integration B2 implements the Windows network egress fence for the desktop
sandbox, following `plan-b2-wfp-egress-2026-07-20.md`. This is the
**CI-buildable, INERT half** of the security boundary: the WFP plus firewall
plus proxy-port code is present, cross-compiled, and unit-tested, but
`windows::launch` **still refuses both network policies**. Activation (wiring
the fence into `launch()` and removing the refusal) is a **separate lab-gated
PR** per D-004, because the boundary merges only after live `spike307-win`
validation.

## What is implemented

WFP layer, vendored into `codex-windows-sandbox` from `openai/codex` at
`a47c661ea9e226fe65e46cf9dbc5c5ed75c2c762` (Apache-2.0), keyed on the sandbox
account SID via `FWPM_CONDITION_ALE_USER_ID` (D-010 non-AppContainer):
- `wfp.rs`, `wfp/filter_specs.rs`: persistent provider plus sublayer and the
  per-protocol blocks (ICMP, DNS 53, DoT 853, SMB 445 and 139). Freshly minted
  Hive-owned GUIDs and `hive_wfp_*` names so a Hive install never shares a WFP
  namespace with a Codex install on the same box.
- `wfp_setup.rs`: ported and **inverted to fail-closed** (D-005). Upstream logs
  and continues on install failure; Hive returns `Err` so provisioning aborts.

Firewall COM layer, ported into `hive-desktop-sandbox` (CTO Q1: keep the Codex
two-layer model):
- `windows_firewall.rs`: block-all-outbound plus the loopback allowlist via
  `INetFwPolicy2` / `INetFwRule3`, SID-scoped, with a `LocalUserAuthorizedList`
  read-back verification that fails closed on mismatch. `hive_sandbox_offline_*`
  rule names, `anyhow` errors instead of the Codex `SetupFailure` taxonomy.

Shared and cleanup:
- `wfp_ports.rs`: cross-platform, Linux-tested. Fixed loopback proxy port range
  **62080 to 62089** (CTO Q2), the loopback-TCP transport seam (Windows has no
  netns or bind-mount, so the proxy binds a free in-range `127.0.0.1` port
  directly), and the loopback-allowlist complement math.
- `windows_plan.rs`: retired the broken `netsh` codegen. `netsh` evaluates
  block rules ahead of allow rules, so it could only ever express deny-all,
  never AllowHosts, and it was never wired to a live effect.

## CTO decisions applied

- **Q1**: kept the Codex two-layer model (WFP per-protocol SID blocks plus the
  firewall COM block-all and loopback allowlist), not srt pure-WFP.
- **Q2**: fixed Hive loopback proxy port range 62080 to 62089; the proxy binds
  a free port in range and the PERMIT is scoped to loopback intersected with
  that range.
- **Q3**: TLS revocation stays on (the loopback CRL distribution point is out
  of scope here).
- **Q4**: no per-task WFP rules; the per-task allowlist lives in the proxy
  process, torn down by the B1 Job kill-on-close.

## Inert and fail-closed

`windows::launch` still returns `AllowHostsNotYetImplemented` /
`NetworkConfinementNotImplemented` for both policies; the two refusal guards
are untouched. A Linux-runnable guard test asserts both refusals still render
as "not yet enforced", and the existing windows-gated decision tests still
assert the refusal mapping. The firewall module is `#[allow(dead_code)]`
scoped, since nothing calls it until activation.

## Deferred to the activation PR (lab-gated, D-004)

Wiring `ensure_offline_outbound_block` / `ensure_offline_proxy_allowlist` and
`install_wfp_filters` into the provision and launch path, removing the two
network refusals, the full AllowlistProxy Windows re-platform, and the section
5 lab validation matrix on `spike307-win`. No security behaviour changes at
runtime in this PR.

## Verification

- `cargo check` and `cargo clippy --all-targets -- -D warnings` pass for both
  crates on `x86_64-pc-windows-gnu` and `x86_64-pc-windows-msvc`.
- `cargo test -p hive-desktop-sandbox` passes on native Linux (port range,
  complement math, inert-boundary guard).
- Win32 FFI paths (real WFP install, firewall COM) are lab-deferred and do not
  run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Windows network security components for outbound traffic blocking and loopback proxy controls.
  * Added a fixed loopback proxy port range and utilities for calculating blocked ports.
  * Added validation and fail-closed behavior for Windows firewall configuration.

* **Documentation**
  * Documented the Windows network security design, configuration decisions, and current verification status.

* **Tests**
  * Added coverage for port allocation, filtering behavior, firewall validation, and deferred network-policy activation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds the inert Windows network egress fence for the desktop sandbox. The main changes are:

- Persistent, SID-scoped WFP filters for ICMP, DNS, DoT, and SMB traffic.
- Windows Firewall COM rules for outbound blocking and loopback proxy access.
- A fixed loopback proxy port range and tested port-complement logic.
- Fail-closed WFP setup and unchanged launch-time network policy refusals.
- Removal of the unused `netsh` firewall plan.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge in its current inert state.

- No blocking issue distinct from the existing firewall findings was found.
- Both network policies remain refused by the launch path.
- The new fence code is not reachable by sandbox tasks in this change.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/desktop-sandbox/hive-desktop-sandbox/src/windows_firewall.rs | Adds the inert Windows Firewall COM rule-management layer. |
| apps/desktop-sandbox/hive-desktop-sandbox/src/wfp_ports.rs | Adds loopback proxy port allocation and tested port-complement logic. |
| apps/desktop-sandbox/codex-windows-sandbox/src/wfp.rs | Adds transactional installation of persistent, SID-scoped WFP filters. |
| apps/desktop-sandbox/codex-windows-sandbox/src/wfp/filter_specs.rs | Defines the IPv4 and IPv6 WFP filter set with Hive-owned identities. |
| apps/desktop-sandbox/codex-windows-sandbox/src/wfp_setup.rs | Adds fail-closed error propagation for WFP setup. |
| apps/desktop-sandbox/hive-desktop-sandbox/src/windows_plan.rs | Removes the unused netsh-based firewall plan. |
| apps/desktop-sandbox/hive-desktop-sandbox/src/lib.rs | Registers the new modules and preserves the network policy refusal boundary. |

</details>

<sub>Reviews (3): Last reviewed commit: ["docs: record Integration B activation bl..."](https://github.com/sakibsadmanshajib/hive/commit/14163fb7b44bdcc293ffb4c2427b0b0a42540681) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45748432)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - .claude/rules/openwolf.md ([source](https://app.greptile.com/scubed/github/sakibsadmanshajib/hive/-/custom-context?memory=3e51a3b4-2091-4dce-8aad-9423a1f1db38))
- Context used - CLAUDE.md ([source](https://app.greptile.com/scubed/github/sakibsadmanshajib/hive/-/custom-context?memory=a5912a3f-0055-4d8a-86c1-fedc669ad56e))
- Context used - .claude/rules/orchestrator.md ([source](https://app.greptile.com/scubed/github/sakibsadmanshajib/hive/-/custom-context?memory=7e0c2dc0-c014-43b2-9dbd-46ae72a640d0))
</details>

<!-- /greptile_comment -->