### PR TITLE
fix: default agent-console to same-origin edge-api calls

### DIFF
--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -391,10 +391,26 @@ services:
       # NEXT_PUBLIC_* are baked into the client bundle by `next build`
       # (Dockerfile.agent-console runs a production build, not `next dev`),
       # so they must travel as build args, not runtime `environment:`.
+      #
+      # NEXT_PUBLIC_EDGE_API_BASE_URL default is empty (same-origin), not an
+      # absolute host:port. apps/agent-console/lib/edge-api/tasks.ts builds
+      # its task list/create/cancel calls as `${baseUrl}/v1/agent/tasks`
+      # from the BROWSER, not from this container, so a baked-in
+      # http://localhost:8080 resolves against whatever machine the browser
+      # is running on. That only happens to work when the browser and this
+      # docker host are the same machine. It breaks for the desktop app,
+      # whose webview runs on a different host (e.g. Windows) than the
+      # docker engine (e.g. WSL2): localhost:8080 there points at the
+      # browser's own host, which has nothing listening, and task calls
+      # fail silently. Empty string makes the fetch same-origin relative
+      # (/v1/agent/tasks), which Caddyfile.owui already reverse-proxies to
+      # edge-api on the same origin the browser loaded /agent-workspace
+      # from. Override in .env only if edge-api is reachable at a different
+      # absolute origin than the one serving /agent-workspace.
       args:
         NEXT_PUBLIC_SUPABASE_URL: ${NEXT_PUBLIC_SUPABASE_URL}
         NEXT_PUBLIC_SUPABASE_ANON_KEY: ${NEXT_PUBLIC_SUPABASE_ANON_KEY}
-        NEXT_PUBLIC_EDGE_API_BASE_URL: ${NEXT_PUBLIC_EDGE_API_BASE_URL:-http://localhost:8080}
+        NEXT_PUBLIC_EDGE_API_BASE_URL: ${NEXT_PUBLIC_EDGE_API_BASE_URL:-}
     profiles:
       - chat
       - enterprise


### PR DESCRIPTION
## Summary

- `NEXT_PUBLIC_EDGE_API_BASE_URL` defaulted to `http://localhost:8080` in `deploy/docker/docker-compose.yml`. That value is baked into the `agent-console` client bundle at build time (`next build`, not `next dev`), so it cannot be changed at runtime by an operator without a rebuild.
- `apps/agent-console/lib/edge-api/tasks.ts` reads that value in the browser and calls `${baseUrl}/v1/agent/tasks` directly from the client for task list, create, and cancel. A baked-in `http://localhost:8080` only resolves correctly when the browser and the docker host are the same machine.
- That assumption breaks for the desktop app: its webview runs on a different host (for example Windows) than the docker engine (for example WSL2). `http://localhost:8080` in that webview resolves against the webview's own host, which has nothing listening on that port, so task calls fail even though `/agent-workspace` itself loads fine and looks healthy.
- Default changed to an empty string, so the client fetch becomes same-origin relative (`/v1/agent/tasks`). `Caddyfile.owui` already reverse-proxies `/v1/*` to edge-api on the same origin that serves `/agent-workspace`, so this works for both the single-host local case and the cross-host desktop case with no other change. An explicit `NEXT_PUBLIC_EDGE_API_BASE_URL` in `.env` still overrides the default.

Found while standing up a demo deployment for the Windows desktop app: the workaround was applied locally in `.env` first, this PR moves the fix into the compose default so it ships for anyone who brings the stack up, not just this box.

## Test plan

- [x] Brought up the minimal service set (`redis`, `control-plane`, `edge-api`, `litellm`, `open-webui`, `caddy-owui`, `agent-console`) with this default and confirmed `GET /agent-workspace` returns 200 HTML and `GET /v1/featuregate` returns a real edge-api response through Caddy.
- [x] Confirmed from an actual cross-host Windows client (WSL interop) that both endpoints are reachable at the WSL2 box's origin.
- [ ] Confirm task list/create/cancel calls succeed from the desktop webview against this default (not yet exercised end to end, since the demo's agent-engine runtime is not wired up on this box).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default API connection behavior to use same-origin relative paths, improving compatibility in deployed environments.
  * Prevented the application from incorrectly targeting a fixed localhost address by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR changes agent-console task calls to use the serving origin by default. The main changes are:

- Replaces the baked-in localhost edge-api URL with an empty build argument.
- Documents how browser-side URL resolution affects cross-host desktop deployments.
- Keeps explicit edge-api origins configurable through the environment.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The default agent task path is broken until same-origin `/v1/agent/tasks` requests are routed to edge-api.

- The empty build argument correctly produces a relative task URL.
- The serving Caddy sends that URL to Open WebUI instead of edge-api.
- Task list, create, and cancel calls therefore fail under the new default.

deploy/docker/docker-compose.yml and deploy/docker/Caddyfile.owui
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| deploy/docker/docker-compose.yml | Changes the browser-facing edge-api default to same-origin, but the resulting task path is not routed to edge-api by the current Caddy configuration. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Browser at /agent-workspace] -->|fetch /v1/agent/tasks| B[Caddy]
    B -->|current catch-all| C[Open WebUI]
    C --> D[Task request fails]
    B -. required route .-> E[edge-api]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart LR
    A[Browser at /agent-workspace] -->|fetch /v1/agent/tasks| B[Caddy]
    B -->|current catch-all| C[Open WebUI]
    C --> D[Task request fails]
    B -. required route .-> E[edge-api]
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adeploy%2Fdocker%2Fdocker-compose.yml%3A413%0A**Same-Origin%20Route%20Targets%20Open%20WebUI**%0A%0AWith%20the%20empty%20default%2C%20task%20list%2C%20create%2C%20and%20cancel%20calls%20resolve%20to%20%60%2Fv1%2Fagent%2Ftasks%60%20on%20Caddy's%20port.%20%60Caddyfile.owui%60%20only%20sends%20%60%2Fagent-workspace%60%20to%20agent-console%20and%20sends%20this%20%60%2Fv1%60%20path%20through%20its%20Open%20WebUI%20catch-all%2C%20so%20the%20default%20task%20workflow%20receives%20a%20404%20or%20non-task%20response%20instead%20of%20reaching%20edge-api.%0A%0A&repo=sakibsadmanshajib%2Fhive&pr=411&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adeploy%2Fdocker%2Fdocker-compose.yml%3A413%0A**Same-Origin%20Route%20Targets%20Open%20WebUI**%0A%0AWith%20the%20empty%20default%2C%20task%20list%2C%20create%2C%20and%20cancel%20calls%20resolve%20to%20%60%2Fv1%2Fagent%2Ftasks%60%20on%20Caddy's%20port.%20%60Caddyfile.owui%60%20only%20sends%20%60%2Fagent-workspace%60%20to%20agent-console%20and%20sends%20this%20%60%2Fv1%60%20path%20through%20its%20Open%20WebUI%20catch-all%2C%20so%20the%20default%20task%20workflow%20receives%20a%20404%20or%20non-task%20response%20instead%20of%20reaching%20edge-api.%0A%0A&pr=411&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22sakibsadmanshajib%2Fhive%22%20on%20the%20existing%20branch%20%22fix%2Fagent-console-same-origin-edge-api%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fagent-console-same-origin-edge-api%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adeploy%2Fdocker%2Fdocker-compose.yml%3A413%0A**Same-Origin%20Route%20Targets%20Open%20WebUI**%0A%0AWith%20the%20empty%20default%2C%20task%20list%2C%20create%2C%20and%20cancel%20calls%20resolve%20to%20%60%2Fv1%2Fagent%2Ftasks%60%20on%20Caddy's%20port.%20%60Caddyfile.owui%60%20only%20sends%20%60%2Fagent-workspace%60%20to%20agent-console%20and%20sends%20this%20%60%2Fv1%60%20path%20through%20its%20Open%20WebUI%20catch-all%2C%20so%20the%20default%20task%20workflow%20receives%20a%20404%20or%20non-task%20response%20instead%20of%20reaching%20edge-api.%0A%0A&repo=sakibsadmanshajib%2Fhive&pr=411&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix: default agent-console to same-origi..."](https://github.com/sakibsadmanshajib/hive/commit/6d0750bf4f9168806d0e36e984fa35e0fab4fb83) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46065084)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Context used - .claude/rules/openwolf.md ([source](https://app.greptile.com/scubed/github/sakibsadmanshajib/hive/-/custom-context?memory=3e51a3b4-2091-4dce-8aad-9423a1f1db38))
- Context used - CLAUDE.md ([source](https://app.greptile.com/scubed/github/sakibsadmanshajib/hive/-/custom-context?memory=a5912a3f-0055-4d8a-86c1-fedc669ad56e))
- Context used - .claude/rules/orchestrator.md ([source](https://app.greptile.com/scubed/github/sakibsadmanshajib/hive/-/custom-context?memory=7e0c2dc0-c014-43b2-9dbd-46ae72a640d0))
</details>

<!-- /greptile_comment -->