### PR TITLE
fix: Windows SandboxChild Killable + Send bound blocking desktop build

### DIFF
--- a/apps/desktop-sandbox/hive-desktop-sandbox/src/windows.rs
+++ b/apps/desktop-sandbox/hive-desktop-sandbox/src/windows.rs
@@ -163,6 +163,18 @@ impl Drop for SandboxChild {
     }
 }
 
+// SAFETY: `SandboxChild` exclusively owns `process` and `job` (transferred
+// out of `HandleGuard` via `into_raw` in `launch` below, never aliased), and
+// `pid` is a plain `u32`. Both handles are ordinary Win32 kernel-object
+// handles -- a process handle and a Job Object handle -- neither of which is
+// thread-affine: unlike a window or GDI handle, either can be waited on,
+// queried, or closed from any thread, not only the one that created it.
+// `windows::Win32::Foundation::HANDLE` is `!Send` only because it is a
+// newtype over a raw pointer, which is more conservative than the actual
+// Win32 contract for these two handle kinds. Moving a `SandboxChild` to
+// another thread (as the desktop app's `spawn_with_timeout` does) is sound.
+unsafe impl Send for SandboxChild {}
+
 /// RAII wrapper closing a Win32 handle on drop, so every fallible step below
 /// its acquisition cleans the handle up without an explicit `CloseHandle` on
 /// each error path. Ownership is transferred out with [`HandleGuard::into_raw`]

--- a/apps/desktop/src-tauri/src/local_tasks.rs
+++ b/apps/desktop/src-tauri/src/local_tasks.rs
@@ -105,6 +105,18 @@ impl Killable for std::process::Child {
     }
 }
 
+/// Windows-only: `hive_desktop_sandbox::launch` returns
+/// [`hive_desktop_sandbox::SandboxChild`] there instead of
+/// [`std::process::Child`] (it also owns the confining Job Object handle).
+/// Its `Drop` already kills the whole process tree -- closing the sole
+/// handle to the kill-on-close Job Object -- and `spawn_with_timeout` drops
+/// `child` immediately after calling `kill_best_effort`, so there is nothing
+/// additional to do here.
+#[cfg(windows)]
+impl Killable for hive_desktop_sandbox::SandboxChild {
+    fn kill_best_effort(&mut self) {}
+}
+
 /// Runs `spawn` (the actual OS-level launch attempt) on a dedicated thread
 /// and waits up to `timeout`. On timeout, returns an error immediately
 /// instead of blocking the caller -- a second, detached thread keeps

--- a/apps/desktop/src-tauri/src/local_tasks.rs
+++ b/apps/desktop/src-tauri/src/local_tasks.rs
@@ -133,7 +133,22 @@ where
     });
 
     match rx.recv_timeout(timeout) {
-        Ok(Ok(_child)) => Ok(()),
+        Ok(Ok(child)) => {
+            // `SandboxChild`'s own doc comment (windows.rs) requires the
+            // caller to "keep it alive for as long as the sandboxed task
+            // should run": its `Drop` closes the sole handle to a
+            // kill-on-close Job Object, which kills the whole process tree.
+            // This launcher has no completion tracking (see the module
+            // doc's "No completion tracking" note) -- there is no later
+            // point to hold `child` until -- so on the success path we
+            // forget it instead of letting it drop, which would otherwise
+            // kill the process this call just successfully launched. On
+            // Linux, `std::process::Child` here is spawned with inherited
+            // (not piped) stdio, so it owns no other resource forgetting
+            // would leak; this is a no-op there.
+            std::mem::forget(child);
+            Ok(())
+        }
         Ok(Err(e)) => Err(e),
         Err(_) => {
             thread::spawn(move || {
@@ -444,6 +459,11 @@ mod tests {
 
     struct FakeChild {
         killed: Arc<std::sync::atomic::AtomicBool>,
+        // Stands in for `SandboxChild`'s kill-on-drop Job Object: a real
+        // `Drop` side effect the success path must never trigger, since on
+        // Windows that side effect is "kill the process this call just
+        // launched" (see `spawn_with_timeout`'s success arm).
+        dropped: Option<Arc<std::sync::atomic::AtomicBool>>,
     }
 
     impl Killable for FakeChild {
@@ -452,14 +472,48 @@ mod tests {
         }
     }
 
+    impl Drop for FakeChild {
+        fn drop(&mut self) {
+            if let Some(dropped) = &self.dropped {
+                dropped.store(true, Ordering::SeqCst);
+            }
+        }
+    }
+
     #[test]
     fn spawn_with_timeout_returns_promptly_when_spawn_is_fast() {
         let result: Result<(), String> = spawn_with_timeout(Duration::from_secs(10), || {
             Ok(FakeChild {
                 killed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+                dropped: None,
             })
         });
         assert_eq!(result, Ok(()));
+    }
+
+    #[test]
+    fn spawn_with_timeout_does_not_drop_the_child_on_success() {
+        // Regression guard for the P1 finding on PR #412: the success arm
+        // used to bind and immediately drop the child. On Windows that
+        // drop kills the whole process tree the call just launched (see
+        // the `Killable for SandboxChild` doc comment above). A fake
+        // `Drop` side effect stands in for that here since `SandboxChild`
+        // itself only exists under `cfg(windows)`.
+        let dropped = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let dropped_for_spawn = Arc::clone(&dropped);
+
+        let result: Result<(), String> = spawn_with_timeout(Duration::from_secs(10), move || {
+            Ok(FakeChild {
+                killed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+                dropped: Some(dropped_for_spawn),
+            })
+        });
+
+        assert_eq!(result, Ok(()));
+        assert!(
+            !dropped.load(Ordering::SeqCst),
+            "success path must not drop the child"
+        );
     }
 
     #[test]
@@ -481,6 +535,7 @@ mod tests {
             thread::sleep(Duration::from_secs(2));
             Ok(FakeChild {
                 killed: killed_for_spawn,
+                dropped: None,
             })
         });
 


### PR DESCRIPTION
## Summary

The desktop app's `spawn_with_timeout` (`apps/desktop/src-tauri/src/local_tasks.rs`) requires its generic child type to implement `Killable + Send + 'static`. On Windows, `hive_desktop_sandbox::launch` returns `SandboxChild` (`apps/desktop-sandbox/hive-desktop-sandbox/src/windows.rs`) instead of `std::process::Child`, and `SandboxChild` satisfied neither bound:

- No `Killable` impl existed for it (only `std::process::Child` and a test `FakeChild` had one).
- Its two `windows::Win32::Foundation::HANDLE` fields make it `!Send` by default, since `HANDLE` is a newtype over a raw pointer.

This produced the two `E0277` errors that block `cargo build`/`cargo check` for the `hive-desktop` bin on the `x86_64-pc-windows-gnu` target.

## Fix

- `windows.rs`: `unsafe impl Send for SandboxChild {}` with a SAFETY comment. `SandboxChild` exclusively owns its `process` and `job` handles (transferred out of `HandleGuard::into_raw`, never aliased). Both are ordinary Win32 kernel-object handles (a process handle from `CreateProcessAsUserW`, a Job Object handle from `CreateJobObjectW`); neither is thread affine, unlike a window or GDI handle, so moving the struct to another thread is sound.
- `local_tasks.rs`: `#[cfg(windows)] impl Killable for hive_desktop_sandbox::SandboxChild` with `kill_best_effort` as a no-op. `SandboxChild::drop` already terminates the whole process tree by closing the last handle to the kill-on-close Job Object, and `spawn_with_timeout`'s only caller drops the child immediately after invoking `kill_best_effort`, so no additional work is needed there.

No changes to the vendored `codex-windows-sandbox` crate or to Windows sandbox behavior; this only touches our own `SandboxChild` wrapper and the desktop app's generic bound.

## Test plan

- [x] `cargo check --target x86_64-pc-windows-gnu -p hive-desktop-sandbox -p codex-windows-sandbox` (the exact CI command) — clean.
- [x] `cargo clippy --target x86_64-pc-windows-gnu -p hive-desktop-sandbox -p codex-windows-sandbox -- -D warnings` (the exact CI command) — clean.
- [x] `cargo check` for `hive-desktop-sandbox` on native Linux — clean, unaffected.
- [x] Standalone scratch crate reproducing `spawn_with_timeout`'s exact `Killable + Send + 'static` bound against `hive_desktop_sandbox::SandboxChild` on `x86_64-pc-windows-gnu` — clean.
- [ ] Full `hive-desktop` bin link on Windows: not verified locally (no mingw-w64/windres toolchain available in this environment, and CI does not cross-compile the full desktop bin either, only the two sandbox crates above). This gap pre-exists this change and is unrelated to it; the bin's own dependency graph (ring, rustls, tauri, wry, etc.) all check clean under `x86_64-pc-windows-gnu` up to the point where an unrelated resource-compiler (`windres`, for icon embedding) is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes the Windows sandbox child compatible with the desktop launch timeout helper. The main changes are:

- Marks `SandboxChild` as safe to move between threads.
- Adds a Windows `Killable` implementation that relies on job-handle cleanup.
- Uses the existing kill-on-close behavior for timeout cleanup.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The Windows success path terminates the sandbox process while reporting the task as started.

- `SandboxChild` is dropped in the helper's successful result branch.
- Its destructor closes the sole kill-on-close Job Object handle.
- The new process can therefore be killed before it performs its task.

apps/desktop/src-tauri/src/local_tasks.rs
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/desktop-sandbox/hive-desktop-sandbox/src/windows.rs | Adds `Send` for the exclusively owned process and Job Object handles; the ownership and handle types support moving the wrapper between threads. |
| apps/desktop/src-tauri/src/local_tasks.rs | Adds a no-op Windows kill method, but successful launches also drop the kill-on-close wrapper and terminate the new process. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant Helper as spawn_with_timeout
    participant Child as SandboxChild
    participant Job as Windows Job Object
    Caller->>Helper: launch sandbox process
    Helper->>Child: receive Ok(child)
    Helper->>Child: drop child on success
    Child->>Job: close sole job handle
    Job->>Job: kill process tree
    Helper-->>Caller: return Ok and record Started
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant Helper as spawn_with_timeout
    participant Child as SandboxChild
    participant Job as Windows Job Object
    Caller->>Helper: launch sandbox process
    Helper->>Child: receive Ok(child)
    Helper->>Child: drop child on success
    Child->>Job: close sole job handle
    Job->>Job: kill process tree
    Helper-->>Caller: return Ok and record Started
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fdesktop%2Fsrc-tauri%2Fsrc%2Flocal_tasks.rs%3A116-118%0A**Successful%20Launch%20Triggers%20Job%20Kill**%0A%0AOn%20Windows%2C%20the%20successful%20%60Ok%28Ok%28_child%29%29%60%20branch%20also%20drops%20%60SandboxChild%60%20before%20returning.%20Its%20destructor%20closes%20the%20sole%20Job%20Object%20handle%2C%20so%20%60JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE%60%20terminates%20the%20new%20process%20while%20the%20caller%20records%20the%20task%20as%20%60Started%60%3B%20the%20success%20path%20needs%20to%20retain%20or%20explicitly%20detach%20the%20child%20instead%20of%20using%20timeout%20cleanup%20semantics.%0A%0A&repo=sakibsadmanshajib%2Fhive&pr=412&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fdesktop%2Fsrc-tauri%2Fsrc%2Flocal_tasks.rs%3A116-118%0A**Successful%20Launch%20Triggers%20Job%20Kill**%0A%0AOn%20Windows%2C%20the%20successful%20%60Ok%28Ok%28_child%29%29%60%20branch%20also%20drops%20%60SandboxChild%60%20before%20returning.%20Its%20destructor%20closes%20the%20sole%20Job%20Object%20handle%2C%20so%20%60JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE%60%20terminates%20the%20new%20process%20while%20the%20caller%20records%20the%20task%20as%20%60Started%60%3B%20the%20success%20path%20needs%20to%20retain%20or%20explicitly%20detach%20the%20child%20instead%20of%20using%20timeout%20cleanup%20semantics.%0A%0A&pr=412&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22sakibsadmanshajib%2Fhive%22%20on%20the%20existing%20branch%20%22fix%2Fdesktop-windows-send-bound%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fdesktop-windows-send-bound%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fdesktop%2Fsrc-tauri%2Fsrc%2Flocal_tasks.rs%3A116-118%0A**Successful%20Launch%20Triggers%20Job%20Kill**%0A%0AOn%20Windows%2C%20the%20successful%20%60Ok%28Ok%28_child%29%29%60%20branch%20also%20drops%20%60SandboxChild%60%20before%20returning.%20Its%20destructor%20closes%20the%20sole%20Job%20Object%20handle%2C%20so%20%60JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE%60%20terminates%20the%20new%20process%20while%20the%20caller%20records%20the%20task%20as%20%60Started%60%3B%20the%20success%20path%20needs%20to%20retain%20or%20explicitly%20detach%20the%20child%20instead%20of%20using%20timeout%20cleanup%20semantics.%0A%0A&repo=sakibsadmanshajib%2Fhive&pr=412&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix: satisfy Killable + Send bound for W..."](https://github.com/sakibsadmanshajib/hive/commit/d08f6335b8d37d62507243d3df8c3f0f8f8468e5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46077194)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Context used - .claude/rules/openwolf.md ([source](https://app.greptile.com/scubed/github/sakibsadmanshajib/hive/-/custom-context?memory=3e51a3b4-2091-4dce-8aad-9423a1f1db38))
- Context used - CLAUDE.md ([source](https://app.greptile.com/scubed/github/sakibsadmanshajib/hive/-/custom-context?memory=a5912a3f-0055-4d8a-86c1-fedc669ad56e))
- Context used - .claude/rules/orchestrator.md ([source](https://app.greptile.com/scubed/github/sakibsadmanshajib/hive/-/custom-context?memory=7e0c2dc0-c014-43b2-9dbd-46ae72a640d0))
</details>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows process handling for sandboxed tasks.
  * Prevented successfully launched processes from being unintentionally terminated during cleanup.
  * Improved timeout behavior and validation for sandbox process lifecycle management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->