### PR TITLE
fix: strip OpenAI product name from web-console meta description

### DIFF
--- a/apps/web-console/app/layout.tsx
+++ b/apps/web-console/app/layout.tsx
@@ -31,7 +31,7 @@ const fraunces = Fraunces({
 export const metadata: Metadata = {
   title: "Hive Console",
   description:
-    "OpenAI-compatible inference, prepaid credits, and observability for builders in Bangladesh.",
+    "Hive inference API, prepaid credits, and observability for builders in Bangladesh.",
   icons: { icon: "/favicon.ico" },
 };
 


### PR DESCRIPTION
## Summary

Owner directive: no third-party product branding anywhere user-facing, Hive only. Audited every user-facing surface for visible third-party product names/logos/attribution.

- `apps/web-console/app/layout.tsx`: root metadata description said "OpenAI-compatible inference..." (renders in browser tab tooltip, search results, social link previews). Reworded to "Hive inference API..." with no third-party name.

## What was audited and left unchanged (internal-only, does not render to a user)

- `apps/web-console`, `apps/agent-console` middleware/test/comment references to "Open WebUI", "OpenHands", "Next.js" are all module-doc comments explaining upstream behavior for engineers; none render in any UI.
- `apps/desktop` (Tauri): window title, `index.html` title/body, `tauri.conf.json` `productName` are all already "Hive" only. No third-party name found anywhere in the desktop UI.
- `deploy/docker/Caddyfile.artifacts` and `Caddyfile.owui`: no branded error pages, no vendor names in served content (comments only). `open-webui` service env vars in `docker-compose.yml` intentionally untouched, per instruction, being handled by a separate branding fix in progress.
- `website/` marketing sites: no leftover generator/template branding found.

## Test plan

- [x] Grepped `apps/web-console`, `apps/agent-console`, `apps/desktop` for `open.?webui|openhands|next\.js|vercel|powered by|built with` and separately for `OpenAI|Anthropic|Groq|OpenRouter` in `.tsx` UI files; only the one real hit fixed here.
- [x] Built `apps/web-console` from `deploy/docker/Dockerfile.web-console` in isolation, ran it, fetched the rendered `<title>` and `<meta name="description">` from the live dev server: confirms "Hive Console" / "Hive inference API..." with zero occurrences of "OpenAI" in the response body.
- [ ] agent-console and desktop had no diffs, so no rebuild needed; confirmed via static grep only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the web console’s page description to highlight Hive’s inference API, prepaid credits, and observability features for builders in Bangladesh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes third-party branding from the web console metadata.

- Rewords the root description as the Hive inference API.
- Leaves metadata structure and runtime behavior unchanged.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web-console/app/layout.tsx | Rewords the root metadata description without changing its type, structure, or rendering path. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: strip OpenAI product name from web-..."](https://github.com/sakibsadmanshajib/hive/commit/b8b14f74b937c1cb4372e78550b69391ce81d756) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46100326)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - .claude/rules/openwolf.md ([source](https://app.greptile.com/scubed/github/sakibsadmanshajib/hive/-/custom-context?memory=3e51a3b4-2091-4dce-8aad-9423a1f1db38))
- Context used - CLAUDE.md ([source](https://app.greptile.com/scubed/github/sakibsadmanshajib/hive/-/custom-context?memory=a5912a3f-0055-4d8a-86c1-fedc669ad56e))
- Context used - .claude/rules/orchestrator.md ([source](https://app.greptile.com/scubed/github/sakibsadmanshajib/hive/-/custom-context?memory=7e0c2dc0-c014-43b2-9dbd-46ae72a640d0))
</details>

<!-- /greptile_comment -->