### PR TITLE
feat: enable duckduckgo web search in Open WebUI chat

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -251,6 +251,14 @@ SUPABASE_WEBHOOK_SECRET=
 OWUI_BASE_URL=http://open-webui:8080
 OWUI_ADMIN_TOKEN=
 OWUI_E2E_MODE=false
+# Open WebUI web search. Off by default -- this env var is shared with the
+# enterprise profile, which must not silently make live outbound search
+# calls. Set ENABLE_WEB_SEARCH=true + WEB_SEARCH_ENGINE=duckduckgo for a
+# local/demo instance (duckduckgo needs no API key).
+ENABLE_WEB_SEARCH=false
+WEB_SEARCH_ENGINE=
+BYPASS_WEB_SEARCH_WEB_LOADER=false
+BYPASS_WEB_SEARCH_EMBEDDING_AND_RETRIEVAL=false
 # Shared shim key Open WebUI sets in `Authorization: Bearer <OWUI_SHIM_KEY>`
 # for every upstream call. edge-api recognizes this exact value and unwraps
 # the real per-user JWT from `body.__metadata.upstream_auth` (written by the

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -449,17 +449,19 @@ services:
       ENABLE_COMMUNITY_SHARING: "false"
       ENABLE_MODEL_FILTER: "true"
       ENABLE_EVALUATION_ARENA_MODELS: "false"
-      # Web search (demo). duckduckgo is the only OWUI-supported engine that
-      # needs zero API key/account signup (backend/open_webui/routers/
-      # retrieval.py engine=='duckduckgo' branch), so it is the fastest safe
-      # path with no time to provision a paid search API or stand up SearXNG.
-      # Both bypass flags skip full-page fetch and RAG-embedding retrieval
-      # for search results (snippet-only), which keeps this feature working
-      # independently of the separate model-routing/embedding path.
-      ENABLE_WEB_SEARCH: "true"
-      WEB_SEARCH_ENGINE: "duckduckgo"
-      BYPASS_WEB_SEARCH_WEB_LOADER: "true"
-      BYPASS_WEB_SEARCH_EMBEDDING_AND_RETRIEVAL: "true"
+      # Web search. Opt-in via .env, default off (same pattern as
+      # OWUI_E2E_MODE below) -- this service block is shared with the
+      # enterprise profile, which must not silently inherit live outbound
+      # search calls. When enabled, duckduckgo is the only OWUI-supported
+      # engine needing zero API key/account signup (backend/open_webui/
+      # routers/retrieval.py engine=='duckduckgo' branch). Both bypass flags
+      # skip full-page fetch and RAG-embedding retrieval for search results
+      # (snippet-only), keeping this feature independent of the separate
+      # model-routing/embedding path.
+      ENABLE_WEB_SEARCH: ${ENABLE_WEB_SEARCH:-false}
+      WEB_SEARCH_ENGINE: ${WEB_SEARCH_ENGINE:-}
+      BYPASS_WEB_SEARCH_WEB_LOADER: ${BYPASS_WEB_SEARCH_WEB_LOADER:-false}
+      BYPASS_WEB_SEARCH_EMBEDDING_AND_RETRIEVAL: ${BYPASS_WEB_SEARCH_EMBEDDING_AND_RETRIEVAL:-false}
       # Hive product branding. LICENSE-DECISION.md: latest Open WebUI image with
       # WEBUI_NAME and visible surfaces overridden to "Hive"; upstream Open WebUI
       # branding-preservation license risk is accepted by the project owner.

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -449,6 +449,17 @@ services:
       ENABLE_COMMUNITY_SHARING: "false"
       ENABLE_MODEL_FILTER: "true"
       ENABLE_EVALUATION_ARENA_MODELS: "false"
+      # Web search (demo). duckduckgo is the only OWUI-supported engine that
+      # needs zero API key/account signup (backend/open_webui/routers/
+      # retrieval.py engine=='duckduckgo' branch), so it is the fastest safe
+      # path with no time to provision a paid search API or stand up SearXNG.
+      # Both bypass flags skip full-page fetch and RAG-embedding retrieval
+      # for search results (snippet-only), which keeps this feature working
+      # independently of the separate model-routing/embedding path.
+      ENABLE_WEB_SEARCH: "true"
+      WEB_SEARCH_ENGINE: "duckduckgo"
+      BYPASS_WEB_SEARCH_WEB_LOADER: "true"
+      BYPASS_WEB_SEARCH_EMBEDDING_AND_RETRIEVAL: "true"
       # Hive product branding. LICENSE-DECISION.md: latest Open WebUI image with
       # WEBUI_NAME and visible surfaces overridden to "Hive"; upstream Open WebUI
       # branding-preservation license risk is accepted by the project owner.


### PR DESCRIPTION
## Summary
- Owner confirmed the open-webui service had zero web-search env vars wired (not disabled, just absent). Owner wants web search working in chat for a demo tonight.
- Adds ENABLE_WEB_SEARCH=true, WEB_SEARCH_ENGINE=duckduckgo, BYPASS_WEB_SEARCH_WEB_LOADER=true, BYPASS_WEB_SEARCH_EMBEDDING_AND_RETRIEVAL=true to deploy/docker/docker-compose.yml (open-webui service). No docker-compose.staging.yml change needed; it does not override the open-webui service.
- duckduckgo chosen because it is the only OWUI-supported engine (backend/open_webui/routers/retrieval.py, `engine == 'duckduckgo'` branch) requiring zero API key or account signup, confirmed against the current upstream `main` branch (package.json version 0.10.2), matching the pinned image `ghcr.io/open-webui/open-webui:main@sha256:74093dadc9c6...`.
- Both bypass flags return search-result snippets directly (skip full-page fetch and RAG-embedding retrieval), which decouples this feature from the RAG embedding path that runs through the same model-provider stack as chat completions.

## Verification (live, against the running local stack)
- Rebuilt and restarted the open-webui container; confirmed all four env vars present inside the container and the container reports healthy.
- `GET /api/v1/retrieval/config` (authenticated) confirms the running instance reports `ENABLE_WEB_SEARCH=true`, `WEB_SEARCH_ENGINE=duckduckgo`, and both bypass flags true — this is the same config the chat UI reads to decide whether to render the web-search toggle.
- `POST /api/v1/retrieval/process/web/search` (authenticated) with a live query returned real, current DuckDuckGo results (page snippets referencing "Jul 22, 2026", i.e. genuinely current, not cached/stale) end to end, with zero API key configured.
- Full chat completion end-to-end (send message, toggle web search, get an assistant reply with cited sources) is currently blocked by a separate, parallel bug: `GET /api/models` on this instance returns an empty list (no working provider/model wired yet). That is being fixed by another agent and is not part of this change. The web-search wiring itself is independently confirmed working via the retrieval API above.

## Test plan
- [x] Env vars present inside the running open-webui container
- [x] Retrieval config API reflects the new settings
- [x] Direct web-search retrieval API call returns live, current results with the duckduckgo engine
- [ ] Full in-chat toggle + cited-source reply (blocked on the separate model-routing/provider bug; re-verify once that lands)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds opt-in DuckDuckGo search to Open WebUI chat. The main changes are:

- Adds web-search settings to `.env.example` with disabled defaults.
- Passes the settings into the Open WebUI container.
- Enables snippet-only search when operators turn on both bypass options.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- The previous default-on behavior is removed.
- Enterprise deployments resolve web search to disabled unless an operator explicitly enables it.
- No blocking issues remain in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .env.example | Documents the Open WebUI search variables with safe disabled defaults. |
| deploy/docker/docker-compose.yml | Passes operator-controlled web-search settings to Open WebUI and defaults outbound search to off. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: make Open WebUI web search opt-in, ..."](https://github.com/sakibsadmanshajib/hive/commit/208b075e6dbc9b915a7054a49b60fe753b8f2bc8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46101174)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - .claude/rules/openwolf.md ([source](https://app.greptile.com/scubed/github/sakibsadmanshajib/hive/-/custom-context?memory=3e51a3b4-2091-4dce-8aad-9423a1f1db38))
- Context used - CLAUDE.md ([source](https://app.greptile.com/scubed/github/sakibsadmanshajib/hive/-/custom-context?memory=a5912a3f-0055-4d8a-86c1-fedc669ad56e))
- Context used - .claude/rules/orchestrator.md ([source](https://app.greptile.com/scubed/github/sakibsadmanshajib/hive/-/custom-context?memory=7e0c2dc0-c014-43b2-9dbd-46ae72a640d0))
</details>

<!-- /greptile_comment -->