### PR TITLE
fix: apply missing rag_embedding_config migration, fix invalid OWUI demo key

### DIFF
--- a/apps/control-plane/internal/rag/migration_schema_test.go
+++ b/apps/control-plane/internal/rag/migration_schema_test.go
@@ -1,0 +1,97 @@
+package rag
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestRagEmbeddingConfigMigrationExists guards against the exact demo-blocking
+// regression found 2026-07-21: the rag_embedding_config migration shipped in
+// the repo but was never applied to a live Supabase project, and both
+// provision.go (here) and edge-api/internal/rag/config.go query the table by
+// this literal name. If a future migration renames or drops the table
+// without updating both consumers, this test catches the drift statically
+// (no live DB needed), the same way repository_schema_test.go guards
+// provider_capabilities.
+func TestRagEmbeddingConfigMigrationExists(t *testing.T) {
+	migration := findRagEmbeddingConfigMigration(t)
+
+	for _, want := range []string{
+		"CREATE TABLE IF NOT EXISTS public.rag_embedding_config",
+		"id             SMALLINT    PRIMARY KEY DEFAULT 1",
+		"ON CONFLICT (id) DO NOTHING",
+	} {
+		if !strings.Contains(migration, want) {
+			t.Fatalf("rag_embedding_config migration must contain %q (idempotent singleton config table)", want)
+		}
+	}
+}
+
+// TestProvisionQueriesRagEmbeddingConfigByLiteralName pins the table name
+// this package's query uses to the same literal the migration creates, so a
+// rename on one side without the other fails fast in CI instead of only
+// surfacing as a silent "relation does not exist" warning at boot.
+func TestProvisionQueriesRagEmbeddingConfigByLiteralName(t *testing.T) {
+	source := readRagRepoFile(t, "apps/control-plane/internal/rag/provision.go")
+
+	if !strings.Contains(source, "FROM public.rag_embedding_config WHERE id = 1") {
+		t.Fatal("provision.go must read the singleton row from public.rag_embedding_config WHERE id = 1")
+	}
+}
+
+func findRagEmbeddingConfigMigration(t *testing.T) string {
+	t.Helper()
+
+	root := ragRepoRoot(t)
+	matches, err := filepath.Glob(filepath.Join(root, "supabase/migrations/*.sql"))
+	if err != nil {
+		t.Fatalf("glob supabase migrations: %v", err)
+	}
+	if len(matches) == 0 {
+		t.Fatal("expected at least one Supabase migration")
+	}
+
+	for _, path := range matches {
+		body, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read migration %s: %v", path, err)
+		}
+		text := string(body)
+		if strings.Contains(text, "CREATE TABLE IF NOT EXISTS public.rag_embedding_config") {
+			return text
+		}
+	}
+
+	t.Fatal("expected a migration creating public.rag_embedding_config")
+	return ""
+}
+
+func readRagRepoFile(t *testing.T, relativePath string) string {
+	t.Helper()
+
+	body, err := os.ReadFile(filepath.Join(ragRepoRoot(t), filepath.FromSlash(relativePath)))
+	if err != nil {
+		t.Fatalf("read %s: %v", relativePath, err)
+	}
+	return string(body)
+}
+
+func ragRepoRoot(t *testing.T) string {
+	t.Helper()
+
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get working directory: %v", err)
+	}
+
+	for dir := wd; ; dir = filepath.Dir(dir) {
+		if _, err := os.Stat(filepath.Join(dir, "go.work")); err == nil {
+			return dir
+		}
+		if parent := filepath.Dir(dir); parent == dir {
+			t.Fatalf("could not find repository root from %s", wd)
+		}
+	}
+}

--- a/apps/control-plane/internal/rag/migration_schema_test.go
+++ b/apps/control-plane/internal/rag/migration_schema_test.go
@@ -30,14 +30,21 @@ func TestRagEmbeddingConfigMigrationExists(t *testing.T) {
 }
 
 // TestProvisionQueriesRagEmbeddingConfigByLiteralName pins the table name
-// this package's query uses to the same literal the migration creates, so a
-// rename on one side without the other fails fast in CI instead of only
-// surfacing as a silent "relation does not exist" warning at boot.
+// both independent consumers of the singleton row query by, to the same
+// literal the migration creates. edge-api/internal/rag/config.go queries this
+// table independently of control-plane's provision.go (control-plane writes,
+// edge-api only reads) -- a rename on one side without the other fails fast
+// in CI here instead of only surfacing as a silent "relation does not exist"
+// warning at boot.
 func TestProvisionQueriesRagEmbeddingConfigByLiteralName(t *testing.T) {
-	source := readRagRepoFile(t, "apps/control-plane/internal/rag/provision.go")
-
-	if !strings.Contains(source, "FROM public.rag_embedding_config WHERE id = 1") {
-		t.Fatal("provision.go must read the singleton row from public.rag_embedding_config WHERE id = 1")
+	for _, path := range []string{
+		"apps/control-plane/internal/rag/provision.go",
+		"apps/edge-api/internal/rag/config.go",
+	} {
+		source := readRagRepoFile(t, path)
+		if !strings.Contains(source, "FROM public.rag_embedding_config WHERE id = 1") {
+			t.Fatalf("%s must read the singleton row from public.rag_embedding_config WHERE id = 1", path)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Two real bugs were blocking the local chat demo stack.

1. **Missing migration.** `supabase/migrations/20260719_01_rag_embedding_config.sql` (shipped with #394/#397) was never applied to the Supabase project backing this local `.env`. control-plane and edge-api both logged `relation "public.rag_embedding_config" does not exist` on every boot. Applied the migration directly (idempotent: `CREATE TABLE IF NOT EXISTS` + `ON CONFLICT DO NOTHING`); warning is gone from both services' logs.

2. **"No models available" in Open WebUI was not a provider-seeding gap.** `custom_providers`, `provider_routes`, `model_aliases`, and `provider_capabilities` were already fully seeded (OpenRouter + Groq routes, `hive-default`/`hive-fast`/etc. all present and healthy) and `edge-api` already served real chat completions when queried directly. The actual cause: local `.env`'s `OWUI_SHIM_KEY` held a placeholder value that was never registered in `api_keys`, so Open WebUI's own bodyless model-listing probe 401ed silently against edge-api. Fixed by minting a real key with the existing `scripts/seed-owui-e2e-user.py` (the same script the OWUI nightly Playwright workflow already uses to produce `OWUI_SHIM_KEY`) and setting it locally. No source change needed for this half; it was a local `.env` value.

## Changes in this PR

- `apps/control-plane/internal/rag/migration_schema_test.go`: static, DB-less regression test (same convention as `TestRoutingRepositoryDoesNotRunCapabilityDDL` in `routing/repository_schema_test.go`) that pins the migration's `CREATE TABLE public.rag_embedding_config` shape and the literal table name `provision.go` queries, so a future rename/drop on either side fails in CI instead of only surfacing as a silent boot warning.

## Verification (live local stack)

- Applied migration directly against the demo Supabase project; `to_regclass('public.rag_embedding_config')` now resolves.
- `control-plane` and `edge-api` restarted; `WARNING: could not read rag_embedding_config` no longer appears in either log.
- Regenerated `OWUI_SHIM_KEY` via `scripts/seed-owui-e2e-user.py`; recreated `open-webui` container.
- `curl -H "Authorization: Bearer <OWUI_SHIM_KEY>" http://localhost:8080/v1/models` returns `200` with 6 real models (`hive-default`, `hive-fast`, `hive-auto`, `hive-embedding-default`, `hive-stt`, `hive-tts`).
- `curl ... /v1/chat/completions -d '{"model":"hive-fast", ...}'` returns a real assistant completion from the live Groq-backed route.
- `go test ./apps/control-plane/internal/rag/...` passes, including the two new tests.

## Test plan

- [x] New regression tests pass locally via the toolchain container
- [x] Full `rag` package test suite passes (no regressions)
- [x] Live local stack verified end-to-end (migration applied, real model list, real chat completion)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds tests for the `rag_embedding_config` migration and its consumers. The main changes are:

- Checks the singleton table migration shape and idempotent seed behavior.
- Checks that control-plane and edge-api query the same table and row.
- Adds repository-root and source-file helpers for these static checks.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- The updated test covers both control-plane and edge-api consumers.
- No blocking issue was found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/control-plane/internal/rag/migration_schema_test.go | Adds static checks for the migration shape and matching table references in both services. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test: also pin edge-api&#39;s rag\_embedding\_..."](https://github.com/sakibsadmanshajib/hive/commit/5314e6665c0384ea39c0bbb3f997f1e3fd816bce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46102966)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - .claude/rules/openwolf.md ([source](https://app.greptile.com/scubed/github/sakibsadmanshajib/hive/-/custom-context?memory=3e51a3b4-2091-4dce-8aad-9423a1f1db38))
- Context used - CLAUDE.md ([source](https://app.greptile.com/scubed/github/sakibsadmanshajib/hive/-/custom-context?memory=a5912a3f-0055-4d8a-86c1-fedc669ad56e))
- Context used - .claude/rules/orchestrator.md ([source](https://app.greptile.com/scubed/github/sakibsadmanshajib/hive/-/custom-context?memory=7e0c2dc0-c014-43b2-9dbd-46ae72a640d0))
</details>

<!-- /greptile_comment -->