### PR TITLE
fix: cross-surface demo owner account + featuregate 404

### DIFF
--- a/apps/edge-api/internal/middleware/unsupported_integration_test.go
+++ b/apps/edge-api/internal/middleware/unsupported_integration_test.go
@@ -69,6 +69,11 @@ func TestUnsupportedEndpointMiddleware_AgentSubsystemRoutesReachHandlers(t *test
 		{http.MethodPost, "/v1/artifacts"},
 		{http.MethodPost, "/v1/artifacts/" + id + "/versions"},
 		{http.MethodPost, "/v1/artifacts/" + id + "/share"},
+		// Feature-gate read (issue #293) — internal/featuregate/handler.go.
+		// Consumed by agent-console's isCoworkEnabled() and OWUI's gate
+		// Function; shipped registered on the mux (main.go) but missing from
+		// the matrix, so it 404-ed exactly like the routes above once did.
+		{http.MethodGet, "/v1/featuregate"},
 	}
 
 	for _, tc := range cases {

--- a/packages/openai-contract/matrix/support-matrix.json
+++ b/packages/openai-contract/matrix/support-matrix.json
@@ -1109,6 +1109,13 @@
       "notes": "Hive proprietary (agent subsystem): cancel an agent task."
     },
     {
+      "method": "GET",
+      "path": "/v1/featuregate",
+      "status": "supported_now",
+      "phase": null,
+      "notes": "Hive proprietary (agent subsystem, issue #293): per-tenant feature-gate read used by agent-console's Cowork gate and Open WebUI's gate Function."
+    },
+    {
       "method": "POST",
       "path": "/v1/artifacts",
       "status": "supported_now",

--- a/scripts/seed-demo-owner.py
+++ b/scripts/seed-demo-owner.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Idempotently provision the cross-surface Hive demo account.
+
+Solves the "3 auth systems, 0 shared admin account" gap for live demos: one
+Supabase GoTrue user that is simultaneously an OWNER of a real (non-e2e)
+tenant (unlocks agent-console's Cowork task console, gated on ENABLE_COWORK
+via apps/agent-console/lib/edge-api/gate.ts) and an owner + platform-admin of
+a web-console personal account (unlocks the owner-only billing pages AND the
+platform-admin-only panels -- feature gates, provider catalog, marketplace,
+credit grants -- all wrapped in apps/control-plane/internal/platform.
+RoleService.RequirePlatformAdmin, see internal/platform/http/router.go).
+
+Two independent role systems get written here, on purpose, same account:
+  - tenant_users.role = 'OWNER'   (Phase 19 tenant scope; uppercase enum)
+  - account_memberships.role = 'owner' + accounts.is_platform_admin = true
+    (Phase 2 billing-account scope; lowercase enum, separate schema)
+web-console reads the second system (lib/control-plane/client.ts getViewer);
+agent-console's tenant gate and the custom_access_token_hook JWT claims read
+the first. Neither table know about the other -- see
+apps/control-plane/internal/platform/role.go's Phase 14/18 module comment.
+
+OWUI is NOT covered by this script. docker-compose.yml wires OWUI's OIDC
+("Sign in with Hive") against SUPABASE_URL, but SUPABASE_OAUTH_CLIENT_ID /
+SUPABASE_OAUTH_CLIENT_SECRET are unset in .env, so the button is inert on
+this stack, and open-webui's OAUTH_ALLOWED_ROLES ("ADMIN,MEMBER,VIEWER")
+does not even include the OWNER role this script grants -- OWNER would fail
+that allow-list if OIDC were wired. OWUI identity stays separate; use the
+existing local OWUI test account (asdas@asdas.sda / asdas) for the chat
+surface demo.
+
+Required env: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY
+
+Prints exactly two lines to stdout (and nothing else):
+  EMAIL=<email>
+  PASSWORD=<password>
+Everything else (progress, ids, errors) goes to stderr.
+"""
+import json
+import os
+import secrets
+import string
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+TENANT_SLUG = "hive-demo"
+TENANT_NAME = "Hive Demo"
+TENANT_DEPLOYMENT = "HIVE_CLOUD"
+USER_EMAIL = "demo@hive-demo.invalid"  # .invalid: IANA-reserved TLD (RFC 2606)
+TENANT_ROLE = "OWNER"
+TENANT_STATUS = "ACTIVE"
+
+ACCOUNT_SLUG = "hive-demo-owner"
+ACCOUNT_NAME = "Hive Demo"
+
+# Demo-relevant tenant_settings feature gates. Excludes payment-rail toggles
+# (bkash/sslcommerz/stripe), audit sinks, and SSO -- none of those are on the
+# demo path and leaving them off keeps the tenant's gate surface legible.
+FEATURE_GATES = [
+    "ENABLE_ADMIN_CONSOLE",
+    "ENABLE_PROVIDER_CUSTOM",
+    "ENABLE_RAG",
+    "ENABLE_RAG_PERSONAL",
+    "ENABLE_RAG_SHARED_KB",
+    "ENABLE_VOICE",
+    "ENABLE_RELAY",
+    "ENABLE_COWORK",
+]
+
+
+def env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        print(f"error: {name} is not set", file=sys.stderr)
+        sys.exit(1)
+    return value
+
+
+def request(base, headers, method, path, body=None, params=None, prefer=None):
+    url = base + path
+    if params:
+        url += "?" + urllib.parse.urlencode(params)
+    data = json.dumps(body).encode() if body is not None else None
+    req_headers = dict(headers)
+    if prefer:
+        req_headers["Prefer"] = prefer
+    req = urllib.request.Request(url, data=data, method=method, headers=req_headers)
+    try:
+        with urllib.request.urlopen(req) as resp:
+            raw = resp.read()
+            return resp.status, (json.loads(raw) if raw else None)
+    except urllib.error.HTTPError as e:
+        raw = e.read()
+        try:
+            return e.code, json.loads(raw)
+        except json.JSONDecodeError:
+            print(f"error: {method} {path} -> {e.code}: {raw[:300]!r}", file=sys.stderr)
+            sys.exit(1)
+
+
+def random_password() -> str:
+    # Prefix guarantees upper/lower/digit/symbol classes regardless of the
+    # random draw; total length (28) clears any realistic GoTrue min-length
+    # policy with room to spare, well under bcrypt's 72-byte limit.
+    alphabet = string.ascii_letters + string.digits + "!@#$%^&*-_"
+    return "Aa1!" + "".join(secrets.choice(alphabet) for _ in range(24))
+
+
+def main() -> None:
+    supabase_url = env("SUPABASE_URL").rstrip("/")
+    service_key = env("SUPABASE_SERVICE_ROLE_KEY")
+    headers = {
+        "Authorization": f"Bearer {service_key}",
+        "apikey": service_key,
+        "Content-Type": "application/json",
+    }
+    rest = supabase_url + "/rest/v1"
+    gotrue = supabase_url + "/auth/v1"
+
+    # 1. Upsert the demo tenant.
+    status, body = request(
+        rest, headers, "POST", "/tenants",
+        body={"slug": TENANT_SLUG, "name": TENANT_NAME, "deployment": TENANT_DEPLOYMENT},
+        params={"on_conflict": "slug"},
+        prefer="resolution=merge-duplicates,return=representation",
+    )
+    if status not in (200, 201) or not body:
+        print(f"error: tenant upsert failed: {status} {body}", file=sys.stderr)
+        sys.exit(1)
+    tenant_id = body[0]["id"]
+    print(f"tenant_id={tenant_id}", file=sys.stderr)
+
+    # 2. Find-or-create the GoTrue user. `filter=<email>` does an exact
+    # server-side match (see scripts/seed-owui-e2e-user.py for the `email=`
+    # param 500 gotcha on this GoTrue version).
+    status, body = request(gotrue, headers, "GET", "/admin/users", params={"filter": USER_EMAIL})
+    if status != 200:
+        print(f"error: user lookup failed: {status} {body}", file=sys.stderr)
+        sys.exit(1)
+    existing = next(
+        (u for u in body.get("users", []) if u.get("email", "").lower() == USER_EMAIL.lower()),
+        None,
+    )
+
+    password = random_password()
+    user_metadata = {"selected_tenant_id": tenant_id}
+
+    if existing is None:
+        status, body = request(
+            gotrue, headers, "POST", "/admin/users",
+            body={
+                "email": USER_EMAIL,
+                "password": password,
+                "email_confirm": True,
+                "user_metadata": user_metadata,
+            },
+        )
+        if status not in (200, 201):
+            print(f"error: user create failed: {status} {body}", file=sys.stderr)
+            sys.exit(1)
+        user_id = body["id"]
+    else:
+        user_id = existing["id"]
+        # GoTrue admin updateUserById MERGES user_metadata, so this only
+        # ever adds/refreshes selected_tenant_id. Password rotates every run
+        # so no run reuses a prior credential.
+        status, body = request(
+            gotrue, headers, "PUT", f"/admin/users/{user_id}",
+            body={"password": password, "user_metadata": user_metadata},
+        )
+        if status != 200:
+            print(f"error: user update failed: {status} {body}", file=sys.stderr)
+            sys.exit(1)
+    print(f"user_id={user_id}", file=sys.stderr)
+
+    # 3. Upsert tenant membership: OWNER unlocks agent-console/edge-api's
+    # tenant-admin JWT-role claim (custom_access_token_hook) and is the top
+    # role in the tenant_users CHECK constraint.
+    status, body = request(
+        rest, headers, "POST", "/tenant_users",
+        body={
+            "tenant_id": tenant_id,
+            "user_id": user_id,
+            "role": TENANT_ROLE,
+            "status": TENANT_STATUS,
+        },
+        params={"on_conflict": "tenant_id,user_id"},
+        prefer="resolution=merge-duplicates",
+    )
+    if status not in (200, 201, 204):
+        print(f"error: tenant membership upsert failed: {status} {body}", file=sys.stderr)
+        sys.exit(1)
+
+    # 4. Upsert the web-console billing account. is_platform_admin=true here
+    # is what unlocks control-plane's RequirePlatformAdmin-gated admin panels
+    # (feature gates, provider catalog, marketplace, credit grants) -- tenant
+    # OWNER above does not imply this; they are unrelated schemas.
+    status, body = request(
+        rest, headers, "POST", "/accounts",
+        body={
+            "slug": ACCOUNT_SLUG,
+            "display_name": ACCOUNT_NAME,
+            "account_type": "business",
+            "owner_user_id": user_id,
+            "is_platform_admin": True,
+        },
+        params={"on_conflict": "slug"},
+        prefer="resolution=merge-duplicates,return=representation",
+    )
+    if status not in (200, 201) or not body:
+        print(f"error: account upsert failed: {status} {body}", file=sys.stderr)
+        sys.exit(1)
+    account_id = body[0]["id"]
+    print(f"account_id={account_id}", file=sys.stderr)
+
+    # 5. Upsert account_memberships (web-console's own owner-only page gate,
+    # e.g. app/console/billing/budget/page.tsx's `role === "owner"` check).
+    status, body = request(
+        rest, headers, "POST", "/account_memberships",
+        body={
+            "account_id": account_id,
+            "user_id": user_id,
+            "role": "owner",
+            "status": "active",
+        },
+        params={"on_conflict": "account_id,user_id"},
+        prefer="resolution=merge-duplicates",
+    )
+    if status not in (200, 201, 204):
+        print(f"error: account membership upsert failed: {status} {body}", file=sys.stderr)
+        sys.exit(1)
+
+    # 6. Upsert account_profiles with profile_setup_complete=true so the
+    # console's onboarding nudge does not stand between login and the demo.
+    status, body = request(
+        rest, headers, "POST", "/account_profiles",
+        body={
+            "account_id": account_id,
+            "owner_name": ACCOUNT_NAME,
+            "login_email": USER_EMAIL,
+            "profile_setup_complete": True,
+        },
+        params={"on_conflict": "account_id"},
+        prefer="resolution=merge-duplicates",
+    )
+    if status not in (200, 201, 204):
+        print(f"error: account profile upsert failed: {status} {body}", file=sys.stderr)
+        sys.exit(1)
+
+    # 7. Enable the demo-relevant tenant feature gates.
+    for key in FEATURE_GATES:
+        status, body = request(
+            rest, headers, "POST", "/tenant_settings",
+            body={
+                "tenant_id": tenant_id,
+                "key": key,
+                "enabled": True,
+                "updated_by": user_id,
+            },
+            params={"on_conflict": "tenant_id,key"},
+            prefer="resolution=merge-duplicates",
+        )
+        if status not in (200, 201, 204):
+            print(f"error: feature gate {key} upsert failed: {status} {body}", file=sys.stderr)
+            sys.exit(1)
+
+    print(f"EMAIL={USER_EMAIL}")
+    print(f"PASSWORD={password}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/seed-demo-owner.py
+++ b/scripts/seed-demo-owner.py
@@ -107,6 +107,51 @@ def random_password() -> str:
     return "Aa1!" + "".join(secrets.choice(alphabet) for _ in range(24))
 
 
+def find_by_slug(rest, headers, table, slug):
+    """Returns the row for slug in table, or None. Used by the tenant/account
+    collision guards below -- both tables are upserted by slug with the
+    service-role key (bypasses RLS), so a caller must know what it is about
+    to merge onto before doing so."""
+    status, body = request(
+        rest, headers, "GET", f"/{table}",
+        params={"select": "*", "slug": f"eq.{slug}"},
+    )
+    if status != 200:
+        print(f"error: {table} slug lookup failed: {status} {body}", file=sys.stderr)
+        sys.exit(1)
+    return body[0] if body else None
+
+
+def guard_tenant_slug(existing_tenant, foreign_members):
+    """Exits loud if existing_tenant (found by TENANT_SLUG) has members other
+    than our own demo user -- see the on_conflict=slug upsert comment below
+    for why merging onto it unchecked would be a privilege-escalation bug."""
+    if existing_tenant is not None and foreign_members:
+        print(
+            f"error: tenant slug {TENANT_SLUG!r} already belongs to tenant "
+            f"{existing_tenant['id']} with {len(foreign_members)} member(s) that are not "
+            "the demo user -- refusing to merge onto a tenant this script did not create. "
+            "Pick a different TENANT_SLUG for the demo.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+def guard_account_slug(existing_account, user_id):
+    """Exits loud if existing_account (found by ACCOUNT_SLUG) belongs to a
+    different user -- merging unchecked would silently grant that unrelated
+    account platform-admin (accounts.is_platform_admin)."""
+    if existing_account is not None and existing_account["owner_user_id"] != user_id:
+        print(
+            f"error: account slug {ACCOUNT_SLUG!r} already belongs to account "
+            f"{existing_account['id']} owned by a different user -- refusing to merge "
+            "(would silently grant that account is_platform_admin). Pick a different "
+            "ACCOUNT_SLUG for the demo.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
 def main() -> None:
     supabase_url = env("SUPABASE_URL").rstrip("/")
     service_key = env("SUPABASE_SERVICE_ROLE_KEY")
@@ -118,10 +163,81 @@ def main() -> None:
     rest = supabase_url + "/rest/v1"
     gotrue = supabase_url + "/auth/v1"
 
-    # 1. Upsert the demo tenant.
+    # 1. Find-or-create the GoTrue user first -- the tenant guard below needs
+    # user_id to tell "our own demo user" apart from an unrelated tenant's
+    # real members. user_metadata.selected_tenant_id is set once the tenant
+    # is resolved, further down. `filter=<email>` does an exact server-side
+    # match (see scripts/seed-owui-e2e-user.py for the `email=` param 500
+    # gotcha on this GoTrue version).
+    status, body = request(gotrue, headers, "GET", "/admin/users", params={"filter": USER_EMAIL})
+    if status != 200:
+        print(f"error: user lookup failed: {status} {body}", file=sys.stderr)
+        sys.exit(1)
+    existing_user = next(
+        (u for u in body.get("users", []) if u.get("email", "").lower() == USER_EMAIL.lower()),
+        None,
+    )
+
+    password = random_password()
+    if existing_user is None:
+        status, body = request(
+            gotrue, headers, "POST", "/admin/users",
+            body={"email": USER_EMAIL, "password": password, "email_confirm": True},
+        )
+        if status not in (200, 201):
+            print(f"error: user create failed: {status} {body}", file=sys.stderr)
+            sys.exit(1)
+        user_id = body["id"]
+    else:
+        user_id = existing_user["id"]
+        # Password rotates every run so no run reuses a prior credential.
+        status, body = request(
+            gotrue, headers, "PUT", f"/admin/users/{user_id}", body={"password": password},
+        )
+        if status != 200:
+            print(f"error: user update failed: {status} {body}", file=sys.stderr)
+            sys.exit(1)
+    print(f"user_id={user_id}", file=sys.stderr)
+
+    # 2. Guard + upsert the demo tenant. slug is user-chosen; an
+    # on_conflict=slug upsert with the service-role key would otherwise
+    # silently merge onto ANY pre-existing tenant with this slug -- adding
+    # our demo user as OWNER and flipping feature gates on for it, even if
+    # that tenant belongs to a real customer. Guard: if the slug already
+    # resolves to a tenant with members other than our own demo user, fail
+    # loud instead of touching it. A tenant with zero members, or whose only
+    # member is our own demo user (a prior run of this exact script), is
+    # safe to reuse. archived_at is force-reset to NULL on every run: this
+    # is a dedicated demo tenant this script owns outright, so reactivating
+    # it (rather than leaving a demo login unable to get a tenant claim) is
+    # the correct default -- see custom_access_token_hook's
+    # `t.archived_at IS NULL` filter.
+    existing_tenant = find_by_slug(rest, headers, "tenants", TENANT_SLUG)
+    if existing_tenant is not None:
+        status, members = request(
+            rest, headers, "GET", "/tenant_users",
+            params={"select": "user_id", "tenant_id": f"eq.{existing_tenant['id']}"},
+        )
+        if status != 200:
+            print(f"error: tenant membership lookup failed: {status} {members}", file=sys.stderr)
+            sys.exit(1)
+        foreign_members = [m for m in members if m["user_id"] != user_id]
+        guard_tenant_slug(existing_tenant, foreign_members)
+        if existing_tenant.get("archived_at"):
+            print(
+                f"tenant {existing_tenant['id']} was archived_at={existing_tenant['archived_at']}; "
+                "reactivating (dedicated demo tenant, safe to un-archive).",
+                file=sys.stderr,
+            )
+
     status, body = request(
         rest, headers, "POST", "/tenants",
-        body={"slug": TENANT_SLUG, "name": TENANT_NAME, "deployment": TENANT_DEPLOYMENT},
+        body={
+            "slug": TENANT_SLUG,
+            "name": TENANT_NAME,
+            "deployment": TENANT_DEPLOYMENT,
+            "archived_at": None,
+        },
         params={"on_conflict": "slug"},
         prefer="resolution=merge-duplicates,return=representation",
     )
@@ -131,48 +247,16 @@ def main() -> None:
     tenant_id = body[0]["id"]
     print(f"tenant_id={tenant_id}", file=sys.stderr)
 
-    # 2. Find-or-create the GoTrue user. `filter=<email>` does an exact
-    # server-side match (see scripts/seed-owui-e2e-user.py for the `email=`
-    # param 500 gotcha on this GoTrue version).
-    status, body = request(gotrue, headers, "GET", "/admin/users", params={"filter": USER_EMAIL})
-    if status != 200:
-        print(f"error: user lookup failed: {status} {body}", file=sys.stderr)
-        sys.exit(1)
-    existing = next(
-        (u for u in body.get("users", []) if u.get("email", "").lower() == USER_EMAIL.lower()),
-        None,
+    # Now that the tenant is resolved, point the user's selected tenant at
+    # it. GoTrue admin updateUserById MERGES user_metadata, so this only
+    # ever adds/refreshes selected_tenant_id.
+    status, body = request(
+        gotrue, headers, "PUT", f"/admin/users/{user_id}",
+        body={"user_metadata": {"selected_tenant_id": tenant_id}},
     )
-
-    password = random_password()
-    user_metadata = {"selected_tenant_id": tenant_id}
-
-    if existing is None:
-        status, body = request(
-            gotrue, headers, "POST", "/admin/users",
-            body={
-                "email": USER_EMAIL,
-                "password": password,
-                "email_confirm": True,
-                "user_metadata": user_metadata,
-            },
-        )
-        if status not in (200, 201):
-            print(f"error: user create failed: {status} {body}", file=sys.stderr)
-            sys.exit(1)
-        user_id = body["id"]
-    else:
-        user_id = existing["id"]
-        # GoTrue admin updateUserById MERGES user_metadata, so this only
-        # ever adds/refreshes selected_tenant_id. Password rotates every run
-        # so no run reuses a prior credential.
-        status, body = request(
-            gotrue, headers, "PUT", f"/admin/users/{user_id}",
-            body={"password": password, "user_metadata": user_metadata},
-        )
-        if status != 200:
-            print(f"error: user update failed: {status} {body}", file=sys.stderr)
-            sys.exit(1)
-    print(f"user_id={user_id}", file=sys.stderr)
+    if status != 200:
+        print(f"error: user metadata update failed: {status} {body}", file=sys.stderr)
+        sys.exit(1)
 
     # 3. Upsert tenant membership: OWNER unlocks agent-console/edge-api's
     # tenant-admin JWT-role claim (custom_access_token_hook) and is the top
@@ -192,10 +276,16 @@ def main() -> None:
         print(f"error: tenant membership upsert failed: {status} {body}", file=sys.stderr)
         sys.exit(1)
 
-    # 4. Upsert the web-console billing account. is_platform_admin=true here
-    # is what unlocks control-plane's RequirePlatformAdmin-gated admin panels
-    # (feature gates, provider catalog, marketplace, credit grants) -- tenant
-    # OWNER above does not imply this; they are unrelated schemas.
+    # 4. Guard + upsert the web-console billing account. is_platform_admin=
+    # true here is what unlocks control-plane's RequirePlatformAdmin-gated
+    # admin panels (feature gates, provider catalog, marketplace, credit
+    # grants) -- tenant OWNER above does not imply this; they are unrelated
+    # schemas. Same slug-collision risk as the tenant guard above: refuse to
+    # merge onto an existing account owned by a different user, since that
+    # would silently grant that unrelated account platform-admin.
+    existing_account = find_by_slug(rest, headers, "accounts", ACCOUNT_SLUG)
+    guard_account_slug(existing_account, user_id)
+
     status, body = request(
         rest, headers, "POST", "/accounts",
         body={

--- a/scripts/seed-demo-owner.py
+++ b/scripts/seed-demo-owner.py
@@ -137,16 +137,21 @@ def guard_tenant_slug(existing_tenant, foreign_members):
         sys.exit(1)
 
 
-def guard_account_slug(existing_account, user_id):
-    """Exits loud if existing_account (found by ACCOUNT_SLUG) belongs to a
-    different user -- merging unchecked would silently grant that unrelated
-    account platform-admin (accounts.is_platform_admin)."""
-    if existing_account is not None and existing_account["owner_user_id"] != user_id:
+def guard_account_slug(existing_account, foreign_owners):
+    """Exits loud if existing_account (found by ACCOUNT_SLUG) has an
+    account_memberships row with role='owner' belonging to someone other
+    than our demo user. control-plane's IsPlatformAdmin authorizes ANY
+    owner-role membership on an is_platform_admin account (see
+    apps/control-plane/internal/platform/role_pgx.go), not just
+    accounts.owner_user_id -- so that single column is not a sufficient
+    collision check. Merging unchecked here would silently grant every
+    such co-owner platform-admin too."""
+    if existing_account is not None and foreign_owners:
         print(
             f"error: account slug {ACCOUNT_SLUG!r} already belongs to account "
-            f"{existing_account['id']} owned by a different user -- refusing to merge "
-            "(would silently grant that account is_platform_admin). Pick a different "
-            "ACCOUNT_SLUG for the demo.",
+            f"{existing_account['id']} with {len(foreign_owners)} owner-role member(s) "
+            "that are not the demo user -- refusing to merge (would silently grant them "
+            "is_platform_admin too). Pick a different ACCOUNT_SLUG for the demo.",
             file=sys.stderr,
         )
         sys.exit(1)
@@ -281,10 +286,23 @@ def main() -> None:
     # admin panels (feature gates, provider catalog, marketplace, credit
     # grants) -- tenant OWNER above does not imply this; they are unrelated
     # schemas. Same slug-collision risk as the tenant guard above: refuse to
-    # merge onto an existing account owned by a different user, since that
-    # would silently grant that unrelated account platform-admin.
+    # merge onto an existing account that already has a different owner-role
+    # member, since that would silently grant them platform-admin too.
     existing_account = find_by_slug(rest, headers, "accounts", ACCOUNT_SLUG)
-    guard_account_slug(existing_account, user_id)
+    if existing_account is not None:
+        status, owners = request(
+            rest, headers, "GET", "/account_memberships",
+            params={
+                "select": "user_id",
+                "account_id": f"eq.{existing_account['id']}",
+                "role": "eq.owner",
+            },
+        )
+        if status != 200:
+            print(f"error: account membership lookup failed: {status} {owners}", file=sys.stderr)
+            sys.exit(1)
+        foreign_owners = [m for m in owners if m["user_id"] != user_id]
+        guard_account_slug(existing_account, foreign_owners)
 
     status, body = request(
         rest, headers, "POST", "/accounts",

--- a/scripts/test_seed_demo_owner.py
+++ b/scripts/test_seed_demo_owner.py
@@ -25,9 +25,9 @@ def exits(fn, *args) -> bool:
 
 
 def main() -> None:
-    # No existing row at all: never a collision, regardless of members/owner.
+    # No existing row at all: never a collision, regardless of members/owners.
     assert not exits(seed_demo_owner.guard_tenant_slug, None, [])
-    assert not exits(seed_demo_owner.guard_account_slug, None, "user-a")
+    assert not exits(seed_demo_owner.guard_account_slug, None, [])
 
     # Existing tenant whose only member is our own demo user: safe re-run.
     assert not exits(
@@ -41,18 +41,21 @@ def main() -> None:
         [{"user_id": "someone-else"}],
     )
 
-    # Existing account owned by our own demo user: safe re-run.
+    # Existing account whose only owner-role member is our own demo user:
+    # safe re-run (a co-owner with role='member' would not appear here at
+    # all -- only role='owner' rows are queried, matching IsPlatformAdmin).
     assert not exits(
-        seed_demo_owner.guard_account_slug,
-        {"id": "a1", "owner_user_id": "user-a"},
-        "user-a",
+        seed_demo_owner.guard_account_slug, {"id": "a1"}, []
     )
 
-    # Existing account owned by a different user: must fail, not merge.
+    # Existing account with a second owner-role member: control-plane's
+    # IsPlatformAdmin (role_pgx.go) authorizes ANY owner-role membership on
+    # an is_platform_admin account, so this second owner would silently
+    # gain platform-admin too -- must fail, not merge.
     assert exits(
         seed_demo_owner.guard_account_slug,
-        {"id": "a1", "owner_user_id": "someone-else"},
-        "user-a",
+        {"id": "a1"},
+        [{"user_id": "someone-else"}],
     )
 
     print("ok: seed-demo-owner.py slug-collision guards")

--- a/scripts/test_seed_demo_owner.py
+++ b/scripts/test_seed_demo_owner.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Self-check for the slug-collision guards in seed-demo-owner.py (P1 fix:
+Greptile review on PR #416 flagged that an unguarded on_conflict=slug upsert
+would silently elevate an unrelated pre-existing tenant/account to
+demo-owner privilege). No framework, no network: exercises the two pure
+guard functions directly. Run: python3 scripts/test_seed_demo_owner.py
+"""
+import importlib.util
+import sys
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "seed_demo_owner", Path(__file__).parent / "seed-demo-owner.py"
+)
+seed_demo_owner = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(seed_demo_owner)
+
+
+def exits(fn, *args) -> bool:
+    try:
+        fn(*args)
+    except SystemExit as e:
+        return e.code == 1
+    return False
+
+
+def main() -> None:
+    # No existing row at all: never a collision, regardless of members/owner.
+    assert not exits(seed_demo_owner.guard_tenant_slug, None, [])
+    assert not exits(seed_demo_owner.guard_account_slug, None, "user-a")
+
+    # Existing tenant whose only member is our own demo user: safe re-run.
+    assert not exits(
+        seed_demo_owner.guard_tenant_slug, {"id": "t1"}, []
+    )
+
+    # Existing tenant with a foreign member: real customer tenant, must fail.
+    assert exits(
+        seed_demo_owner.guard_tenant_slug,
+        {"id": "t1"},
+        [{"user_id": "someone-else"}],
+    )
+
+    # Existing account owned by our own demo user: safe re-run.
+    assert not exits(
+        seed_demo_owner.guard_account_slug,
+        {"id": "a1", "owner_user_id": "user-a"},
+        "user-a",
+    )
+
+    # Existing account owned by a different user: must fail, not merge.
+    assert exits(
+        seed_demo_owner.guard_account_slug,
+        {"id": "a1", "owner_user_id": "someone-else"},
+        "user-a",
+    )
+
+    print("ok: seed-demo-owner.py slug-collision guards")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds `scripts/seed-demo-owner.py`, an idempotent provisioning script (same pattern as `scripts/seed-owui-e2e-user.py`) that creates one Supabase-backed identity usable across web-console and agent-console: a real (non-throwaway) tenant membership with `tenant_users.role = OWNER`, plus a web-console personal account with `account_memberships.role = owner` and `accounts.is_platform_admin = true`. The demo tenant gets `ENABLE_COWORK`, `ENABLE_ADMIN_CONSOLE`, `ENABLE_PROVIDER_CUSTOM`, `ENABLE_RAG`, `ENABLE_RAG_PERSONAL`, `ENABLE_RAG_SHARED_KB`, `ENABLE_VOICE`, and `ENABLE_RELAY` enabled.
- Fixes a second, previously undiscovered bug found while verifying the above live: `GET /v1/featuregate` (added for issue #293, consumed by agent-console's `isCoworkEnabled()` and Open WebUI's gate Function) was never added to `packages/openai-contract/matrix/support-matrix.json`, so `UnsupportedEndpointMiddleware` 404-ed every call to it, for every caller, regardless of auth or tenant setup. This is the identical failure class `TestUnsupportedEndpointMiddleware_AgentSubsystemRoutesReachHandlers` was written to catch for the RAG/agent-task/artifacts routes; that test's case list just didn't include this one. Extends the guard and adds the matrix entry.

## Why

Live demo stack had three separate auth systems (OWUI local users, agent-console tenant auth, web-console account auth) and no account that worked across all three or held admin-equivalent access anywhere, blocking the Cowork task console and the web-console admin/provider/billing panels.

## Test plan
- [x] `go test ./apps/edge-api/internal/middleware/...` — RED confirmed with the matrix entry reverted (real 404), GREEN after the fix.
- [x] `go test ./apps/edge-api/internal/middleware/... ./apps/edge-api/internal/matrix/... ./apps/edge-api/internal/featuregate/...` all passing.
- [x] Ran `scripts/seed-demo-owner.py` against the live local stack's Supabase project.
- [x] Verified live: GoTrue password-grant login succeeds for the new account; issued JWT carries `tenant_id` + `role: OWNER`; `control-plane` `GET /api/v1/viewer` returns `current_account.role: owner`; `control-plane` `GET /api/v1/admin/feature-gates` (platform-admin gated) returns 200; `tenant_settings` confirmed `ENABLE_COWORK=true` for the demo tenant.
- [ ] Live stack's running `edge-api` container needs a rebuild (`docker compose build edge-api && up -d edge-api`) to pick up the matrix fix before the demo — the currently running container predates this fix and still 404s `/v1/featuregate`. Not done in this PR: no docker access to the main checkout's live stack from this sandboxed worktree.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR provisions a shared demo-owner identity and restores the feature-gate endpoint. The main changes are:

- Adds an idempotent Supabase demo-owner seed script.
- Grants tenant-owner and platform-admin access across the consoles.
- Enables the tenant feature gates needed by the demo.
- Adds `GET /v1/featuregate` to the endpoint support matrix.
- Extends middleware and seed-guard tests.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The remaining collision paths should be fixed before merging.

- The feature-gate matrix and middleware changes match the registered route.
- The account guard can overwrite a foreign recorded owner when no owner membership exists.
- The tenant guard can appropriate an unrelated tenant when it has no membership rows.

scripts/seed-demo-owner.py and scripts/test_seed_demo_owner.py
</details>

<details open><summary><h3>Security Review</h3></summary>

The collision guards still accept two unrelated existing records: an account with a foreign `owner_user_id` but no owner membership, and a tenant with no membership rows. The later upserts can overwrite or grant privileged access to those records.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/seed-demo-owner.py | Adds the provisioning workflow, but two pre-existing record shapes can still bypass its collision guards. |
| scripts/test_seed_demo_owner.py | Tests foreign membership collisions but does not cover a mismatched account owner or an unrelated memberless tenant. |
| packages/openai-contract/matrix/support-matrix.json | Marks the registered feature-gate endpoint as supported. |
| apps/edge-api/internal/middleware/unsupported_integration_test.go | Adds coverage that the feature-gate route reaches its handler. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ascripts%2Fseed-demo-owner.py%3A305%0A**Check%20the%20recorded%20owner**%0A%0AThis%20guard%20only%20rejects%20foreign%20%60owner%60%20membership%20rows.%20An%20existing%20account%20can%20have%20%60owner_user_id%60%20set%20to%20another%20user%20without%20a%20matching%20membership%20because%20the%20schema%20does%20not%20keep%20those%20fields%20synchronized.%20In%20that%20state%2C%20%60foreign_owners%60%20is%20empty%20and%20the%20upsert%20replaces%20the%20recorded%20owner%20while%20enabling%20platform-admin%20access%20on%20the%20account.%20Reject%20the%20collision%20when%20%60existing_account%5B'owner_user_id'%5D%60%20differs%20from%20the%20demo%20user%2C%20even%20if%20no%20owner%20memberships%20exist.%0A%0A%23%23%23%20Issue%202%20of%202%0Ascripts%2Fseed-demo-owner.py%3A230%0A**Reject%20unowned%20tenant%20collisions**%0A%0AAn%20existing%20tenant%20with%20no%20membership%20rows%20passes%20this%20guard%20even%20when%20it%20was%20not%20created%20by%20this%20script.%20The%20following%20upserts%20then%20rename%20and%20reactivate%20that%20tenant%2C%20add%20the%20demo%20user%20as%20%60OWNER%60%2C%20and%20enable%20the%20demo%20feature%20gates.%20Require%20evidence%20that%20the%20tenant%20belongs%20to%20a%20previous%20script%20run%2C%20or%20reject%20every%20pre-existing%20slug%20that%20cannot%20be%20tied%20to%20the%20demo%20identity.%0A%0A&repo=sakibsadmanshajib%2Fhive&pr=416&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ascripts%2Fseed-demo-owner.py%3A305%0A**Check%20the%20recorded%20owner**%0A%0AThis%20guard%20only%20rejects%20foreign%20%60owner%60%20membership%20rows.%20An%20existing%20account%20can%20have%20%60owner_user_id%60%20set%20to%20another%20user%20without%20a%20matching%20membership%20because%20the%20schema%20does%20not%20keep%20those%20fields%20synchronized.%20In%20that%20state%2C%20%60foreign_owners%60%20is%20empty%20and%20the%20upsert%20replaces%20the%20recorded%20owner%20while%20enabling%20platform-admin%20access%20on%20the%20account.%20Reject%20the%20collision%20when%20%60existing_account%5B'owner_user_id'%5D%60%20differs%20from%20the%20demo%20user%2C%20even%20if%20no%20owner%20memberships%20exist.%0A%0A%23%23%23%20Issue%202%20of%202%0Ascripts%2Fseed-demo-owner.py%3A230%0A**Reject%20unowned%20tenant%20collisions**%0A%0AAn%20existing%20tenant%20with%20no%20membership%20rows%20passes%20this%20guard%20even%20when%20it%20was%20not%20created%20by%20this%20script.%20The%20following%20upserts%20then%20rename%20and%20reactivate%20that%20tenant%2C%20add%20the%20demo%20user%20as%20%60OWNER%60%2C%20and%20enable%20the%20demo%20feature%20gates.%20Require%20evidence%20that%20the%20tenant%20belongs%20to%20a%20previous%20script%20run%2C%20or%20reject%20every%20pre-existing%20slug%20that%20cannot%20be%20tied%20to%20the%20demo%20identity.%0A%0A&pr=416&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22sakibsadmanshajib%2Fhive%22%20on%20the%20existing%20branch%20%22fix-demo-owner-account-featuregate-matrix%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix-demo-owner-account-featuregate-matrix%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ascripts%2Fseed-demo-owner.py%3A305%0A**Check%20the%20recorded%20owner**%0A%0AThis%20guard%20only%20rejects%20foreign%20%60owner%60%20membership%20rows.%20An%20existing%20account%20can%20have%20%60owner_user_id%60%20set%20to%20another%20user%20without%20a%20matching%20membership%20because%20the%20schema%20does%20not%20keep%20those%20fields%20synchronized.%20In%20that%20state%2C%20%60foreign_owners%60%20is%20empty%20and%20the%20upsert%20replaces%20the%20recorded%20owner%20while%20enabling%20platform-admin%20access%20on%20the%20account.%20Reject%20the%20collision%20when%20%60existing_account%5B'owner_user_id'%5D%60%20differs%20from%20the%20demo%20user%2C%20even%20if%20no%20owner%20memberships%20exist.%0A%0A%23%23%23%20Issue%202%20of%202%0Ascripts%2Fseed-demo-owner.py%3A230%0A**Reject%20unowned%20tenant%20collisions**%0A%0AAn%20existing%20tenant%20with%20no%20membership%20rows%20passes%20this%20guard%20even%20when%20it%20was%20not%20created%20by%20this%20script.%20The%20following%20upserts%20then%20rename%20and%20reactivate%20that%20tenant%2C%20add%20the%20demo%20user%20as%20%60OWNER%60%2C%20and%20enable%20the%20demo%20feature%20gates.%20Require%20evidence%20that%20the%20tenant%20belongs%20to%20a%20previous%20script%20run%2C%20or%20reject%20every%20pre-existing%20slug%20that%20cannot%20be%20tied%20to%20the%20demo%20identity.%0A%0A&repo=sakibsadmanshajib%2Fhive&pr=416&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["fix: guard\_account\_slug checks all owner..."](https://github.com/sakibsadmanshajib/hive/commit/afab2b3f6b31cfa75a0bd5cce3dafbe1c283c68a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46102975)</sub>

> Greptile also left **2 inline comments** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Context used - .claude/rules/openwolf.md ([source](https://app.greptile.com/scubed/github/sakibsadmanshajib/hive/-/custom-context?memory=3e51a3b4-2091-4dce-8aad-9423a1f1db38))
- Context used - CLAUDE.md ([source](https://app.greptile.com/scubed/github/sakibsadmanshajib/hive/-/custom-context?memory=a5912a3f-0055-4d8a-86c1-fedc669ad56e))
- Context used - .claude/rules/orchestrator.md ([source](https://app.greptile.com/scubed/github/sakibsadmanshajib/hive/-/custom-context?memory=7e0c2dc0-c014-43b2-9dbd-46ae72a640d0))
</details>

<!-- /greptile_comment -->