### PR TITLE
fix: real platform admins get platform.admin in viewer permissions

### DIFF
--- a/apps/control-plane/cmd/server/main.go
+++ b/apps/control-plane/cmd/server/main.go
@@ -427,6 +427,13 @@ func main() {
 		// returns 503 "role service unavailable" on every mutating request.
 		budgetsHandler = budgetsHandler.WithRoleService(roleSvc)
 
+		// Wire role service into the accounts handler so GET /api/v1/viewer
+		// reports the real platform-admin overlay in permissions[]. Without
+		// this, platform admins never see platform.admin there and the
+		// web-console Feature Gates/Marketplace pages refuse to render even
+		// though the underlying admin-gated routes already allow them.
+		accountsHandler = accountsHandler.WithRoleService(roleSvc)
+
 		// Phase 18 — wire role service into the apikeys handler so the admin
 		// overlay is reflected in Actor.IsAdmin during PermAPIKeysWrite checks.
 		// Without it, platform admins are silently denied by policy.Can.

--- a/apps/control-plane/internal/accounts/http.go
+++ b/apps/control-plane/internal/accounts/http.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/auth"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/authz"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/platform"
 )
 
 // Handler handles all accounts-related HTTP routes.
@@ -18,6 +19,17 @@ type Handler struct {
 // NewHandler returns a new accounts Handler.
 func NewHandler(svc *Service) *Handler {
 	return &Handler{svc: svc, policy: authz.NewPolicy()}
+}
+
+// WithRoleService returns a copy of the handler whose underlying Service is
+// wired with the platform role service, so GET /api/v1/viewer reports the
+// real platform-admin overlay in permissions[]. Mirrors the apikeys/budgets
+// handler idiom. Does not affect handleListMembers, which resolves its own
+// Actor directly (see comment there).
+func (h *Handler) WithRoleService(roleSvc *platform.RoleService) *Handler {
+	cloned := *h
+	cloned.svc = h.svc.WithRoleService(roleSvc)
+	return &cloned
 }
 
 // ServeHTTP dispatches requests to the appropriate sub-handler.
@@ -72,6 +84,13 @@ func (h *Handler) handleListMembers(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Phase 18: route authz through policy.Can — replaces bare EmailVerified check.
+	// isAdmin hardcoded false here too: this Actor is built independently of
+	// EnsureViewerContext's own (now roleSvc-aware) actor, so a real platform
+	// admin who is not a workspace owner is still denied members.invite here.
+	// Known, separate gap from the reported bug (which is scoped to viewer
+	// permissions[] powering Feature Gates/Marketplace); not fixed in this
+	// change to keep the diff scoped. Fix path: give Handler its own roleSvc
+	// field via WithRoleService, same idiom as apikeys/budgets.
 	actor := ActorFor(viewer, Membership{
 		AccountID: vc.CurrentAccount.ID,
 		UserID:    viewer.UserID,

--- a/apps/control-plane/internal/accounts/service.go
+++ b/apps/control-plane/internal/accounts/service.go
@@ -18,13 +18,27 @@ import (
 
 // Service encapsulates all accounts business logic.
 type Service struct {
-	repo   Repository
-	policy authz.Policy
+	repo    Repository
+	policy  authz.Policy
+	roleSvc *platform.RoleService // optional — see WithRoleService
 }
 
 // NewService returns a new accounts Service.
 func NewService(repo Repository) *Service {
 	return &Service{repo: repo, policy: authz.NewPolicy()}
+}
+
+// WithRoleService returns a copy of the Service wired with the platform role
+// service so EnsureViewerContext can resolve the real platform-admin overlay
+// for the viewer's Permissions[]. Without it, isAdmin is always false and a
+// real platform admin never sees platform.admin in permissions[], even though
+// admin-gated routes (which resolve their own Actor via roleSvc directly)
+// correctly allow them. That mismatch is what made Feature Gates and
+// Marketplace in web-console refuse to render for real admins.
+func (s *Service) WithRoleService(roleSvc *platform.RoleService) *Service {
+	cloned := *s
+	cloned.roleSvc = roleSvc
+	return &cloned
 }
 
 // EnsureViewerContext returns the full viewer context for the given viewer.
@@ -81,7 +95,18 @@ func (s *Service) EnsureViewerContext(ctx context.Context, viewer auth.Viewer, r
 
 	// Phase 18 Plan 04: emit permissions[] — the full granted-permission set for
 	// the chosen workspace actor. Gates fields removed from response wire shape.
-	chosenActor := ActorFor(viewer, chosen, false) // isAdmin=false: workspace-scoped
+	// isAdmin resolves the real platform_admin overlay when roleSvc is wired
+	// (see WithRoleService); nil roleSvc (most unit tests, and any caller that
+	// has not wired it) keeps the prior workspace-scoped false behaviour.
+	isAdmin := false
+	if s.roleSvc != nil {
+		admin, err := s.roleSvc.IsPlatformAdmin(ctx, viewer.UserID)
+		if err != nil {
+			return ViewerContext{}, fmt.Errorf("accounts: platform admin lookup: %w", err)
+		}
+		isAdmin = admin
+	}
+	chosenActor := ActorFor(viewer, chosen, isAdmin)
 	permissions := s.policy.AllGranted(chosenActor)
 	if permissions == nil {
 		permissions = []string{}

--- a/apps/control-plane/internal/accounts/service_platform_admin_test.go
+++ b/apps/control-plane/internal/accounts/service_platform_admin_test.go
@@ -1,0 +1,109 @@
+package accounts_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/accounts"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/auth"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/platform"
+)
+
+// stubPlatformAdminStore is a minimal platform.RoleStore backing a real
+// *platform.RoleService for tests, keyed by userID -> is_platform_admin.
+type stubPlatformAdminStore struct {
+	adminUsers map[uuid.UUID]bool
+}
+
+func (s *stubPlatformAdminStore) GetMembershipRole(_ context.Context, _, _ uuid.UUID) (platform.MembershipRole, error) {
+	return "", nil
+}
+
+func (s *stubPlatformAdminStore) IsPlatformAdmin(_ context.Context, userID uuid.UUID) (bool, error) {
+	return s.adminUsers[userID], nil
+}
+
+// TestEnsureViewerContext_PlatformAdminOverlay is a regression guard for the
+// live bug where GET /api/v1/viewer never included "platform.admin" in
+// permissions[] for a real platform admin, because EnsureViewerContext
+// hardcoded isAdmin=false regardless of accounts.is_platform_admin. That
+// mismatch made the web-console Feature Gates and Marketplace pages (which
+// gate purely on permissions[] containing "platform.admin") refuse to render
+// for real admins, even though admin-gated backend routes already allowed
+// them via a separately-resolved Actor.
+func TestEnsureViewerContext_PlatformAdminOverlay(t *testing.T) {
+	cases := []struct {
+		name        string
+		isAdmin     bool
+		wantPresent bool
+	}{
+		{"platform admin gets platform.admin in permissions", true, true},
+		{"non admin does not get platform.admin in permissions", false, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := newStubRepo()
+			userID := uuid.New()
+
+			store := &stubPlatformAdminStore{adminUsers: map[uuid.UUID]bool{}}
+			if tc.isAdmin {
+				store.adminUsers[userID] = true
+			}
+			roleSvc := platform.NewRoleService(store)
+
+			svc := accounts.NewService(repo).WithRoleService(roleSvc)
+
+			viewer := auth.Viewer{
+				UserID:        userID,
+				Email:         "admin-check@example.com",
+				EmailVerified: true,
+				FullName:      "Admin Check",
+			}
+
+			vc, err := svc.EnsureViewerContext(context.Background(), viewer, uuid.Nil)
+			if err != nil {
+				t.Fatalf("EnsureViewerContext error: %v", err)
+			}
+
+			present := false
+			for _, p := range vc.Permissions {
+				if p == "platform.admin" {
+					present = true
+					break
+				}
+			}
+			if present != tc.wantPresent {
+				t.Errorf("platform.admin present: want %v got %v (permissions=%v)", tc.wantPresent, present, vc.Permissions)
+			}
+		})
+	}
+}
+
+// TestEnsureViewerContext_NoRoleService_DefaultsToNonAdmin confirms the
+// pre-existing behaviour is preserved when WithRoleService is never called
+// (nil roleSvc): isAdmin stays false, matching every existing caller/test
+// that constructs a Service via NewService alone.
+func TestEnsureViewerContext_NoRoleService_DefaultsToNonAdmin(t *testing.T) {
+	repo := newStubRepo()
+	svc := accounts.NewService(repo)
+
+	viewer := auth.Viewer{
+		UserID:        uuid.New(),
+		Email:         "no-role-svc@example.com",
+		EmailVerified: true,
+		FullName:      "No Role Svc",
+	}
+
+	vc, err := svc.EnsureViewerContext(context.Background(), viewer, uuid.Nil)
+	if err != nil {
+		t.Fatalf("EnsureViewerContext error: %v", err)
+	}
+
+	for _, p := range vc.Permissions {
+		if p == "platform.admin" {
+			t.Error("expected platform.admin absent when roleSvc is not wired")
+		}
+	}
+}


### PR DESCRIPTION
## Summary

GET /api/v1/viewer never included platform.admin in permissions[] for a real platform admin, because accounts.Service.EnsureViewerContext hardcoded isAdmin=false when building the actor used to compute the permissions array. This is separate from the admin-gated backend routes (for example GET /api/v1/admin/feature-gates), which resolve their own Actor through platform.RoleService and correctly return 200 with data for the same account.

## Why

Live-reproduced bug, confirmed against the running local docker stack: a real platform-admin demo account logs into web-console, and control-plane's own admin-gated endpoint correctly returns 200 with data for this account (verified by curl with a real JWT), but the web-console Feature Gates and Marketplace pages both render "Admin access required" and refuse to show anything. This blocks the live demo's admin-panel walkthrough.

Root cause: apps/control-plane/internal/accounts/service.go, EnsureViewerContext, called `ActorFor(viewer, chosen, false)` unconditionally. authz.Policy.Can only grants platform.admin when actor.IsAdmin is true, so the permissions[] array returned by GET /api/v1/viewer never carried platform.admin no matter what accounts.is_platform_admin said in the database. The web-console frontend (apps/web-console/app/console/feature-gates/page.tsx and .../marketplace/page.tsx) gates purely on that array, so it always denied real admins.

## Fix

accounts.Service and accounts.Handler each gain an optional WithRoleService method, mirroring the existing apikeys/budgets handler idiom already in this codebase. EnsureViewerContext now resolves the real platform_admin overlay via roleSvc.IsPlatformAdmin when roleSvc is wired, and keeps the prior false behaviour when it is not (nil roleSvc), so no existing caller or test needed changes. main.go wires accountsHandler.WithRoleService(roleSvc) next to the existing budgets/apikeys wiring, in the same place and in the same style.

handleListMembers in accounts/http.go builds its own Actor independently and still hardcodes isAdmin=false. That is a separate, narrower gap (a platform admin who is not a workspace owner would still be denied members.invite there) and is left untouched with a comment explaining why, to keep this diff focused on the reported bug.

## Test plan

- Added apps/control-plane/internal/accounts/service_platform_admin_test.go: a table-driven regression test asserting that a viewer with a true platform-admin overlay gets platform.admin in EnsureViewerContext's returned permissions[], and a non-admin does not. Verified RED first (git stash of the three implementation files with the test kept in place produced a compile failure referencing the not-yet-existing WithRoleService, since the capability did not exist yet), then GREEN after restoring the fix.
- Also added a regression test confirming the pre-existing behaviour is preserved when WithRoleService is never called (isAdmin stays false), matching every existing caller.
- Full suite: `go vet ./apps/control-plane/...` and `go test ./apps/control-plane/... -count=1 -short` via the documented Docker toolchain, all packages pass, no failures.
- Live verification against the running local demo stack at localhost:3000 (confirming the Feature Gates and Marketplace pages actually render for the real platform-admin demo account after this fix) is being done separately by the orchestrating session, not by this PR's author, since this worktree has no docker access to the running demo stack. This mirrors the same pattern already used in PR #416's body for the same reason.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds the platform-admin overlay to viewer permissions. The main changes are:

- Wires the platform role service into the accounts handler.
- Resolves platform-admin status when building viewer permissions.
- Preserves the previous behavior when no role service is configured.
- Adds tests for admin, non-admin, and unwired service cases.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.
- Handler wiring occurs before route registration.
- Role lookup errors follow the endpoint's existing database error behavior.
- The unwired service path keeps its previous permissions behavior.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/control-plane/cmd/server/main.go | Wires the role service into the accounts handler before router construction. |
| apps/control-plane/internal/accounts/http.go | Adds immutable role-service wiring for the handler while leaving existing account routes unchanged. |
| apps/control-plane/internal/accounts/service.go | Uses the platform-admin lookup when computing viewer permissions and preserves the unwired fallback. |
| apps/control-plane/internal/accounts/service_platform_admin_test.go | Tests admin, non-admin, and missing-role-service behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: real platform admins get platform.a..."](https://github.com/sakibsadmanshajib/hive/commit/57113935bd17b1bf7f5d05d25edaf35d84a6ee6b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46205556)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/scubed/github/sakibsadmanshajib/hive/-/custom-context?memory=a5912a3f-0055-4d8a-86c1-fedc669ad56e))
- Context used - .claude/rules/orchestrator.md ([source](https://app.greptile.com/scubed/github/sakibsadmanshajib/hive/-/custom-context?memory=7e0c2dc0-c014-43b2-9dbd-46ae72a640d0))
- Context used - .claude/rules/openwolf.md ([source](https://app.greptile.com/scubed/github/sakibsadmanshajib/hive/-/custom-context?memory=3e51a3b4-2091-4dce-8aad-9423a1f1db38))
</details>

<!-- /greptile_comment -->