### PR TITLE
fix: sync minted OWUI_SHIM_KEY into Open WebUI's own persisted config

### DIFF
--- a/scripts/seed-owui-e2e-user.py
+++ b/scripts/seed-owui-e2e-user.py
@@ -21,7 +21,21 @@ allow_all_models=true -- listing is not billable, so there is no reason to
 depend on default-policy-group alias membership. Rotated every run the same
 way the GoTrue password is.
 
+Also pushes the minted SHIM_KEY straight into Open WebUI's own persisted
+OpenAI-connection config (POST /openai/config/update), not just .env and
+the container's OPENAI_API_KEY env var. OWUI only seeds that config from
+OPENAI_API_KEY on a volume's first boot -- every later container recreate
+on the same volume keeps the OLD key even after .env and the env var move
+on, and the chat UI silently shows "No models available" even though the
+new key works fine directly against edge-api. Confirmed live 2026-07-22.
+This sync step is best-effort: set OWUI_BASE_URL, OWUI_ADMIN_EMAIL, and
+OWUI_ADMIN_PASSWORD to enable it, or it logs a warning to stderr and
+skips (never fatal -- minting the Supabase-side credentials below is
+this script's real job).
+
 Required env: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY
+Optional env (OWUI config sync): OWUI_BASE_URL (default
+http://localhost:3003), OWUI_ADMIN_EMAIL, OWUI_ADMIN_PASSWORD
 
 Prints exactly three lines to stdout (and nothing else):
   EMAIL=<email>
@@ -103,6 +117,79 @@ def random_api_key() -> tuple[str, str, str]:
     raw_secret = "hk_" + encoded
     token_hash = hashlib.sha256(raw_secret.encode()).hexdigest()
     return raw_secret, token_hash, raw_secret[-6:]
+
+
+# Internal docker-network hostname edge-api resolves to inside the OWUI
+# container. Not host-reachable -- unlike OWUI_BASE_URL below, which this
+# script itself calls from the host, this is where OWUI's own backend
+# dials out to for chat completions once the config below is saved.
+OWUI_UPSTREAM_BASE_URL = "http://edge-api:8080/v1"
+
+
+def owui_config_body(raw_secret: str) -> dict:
+    """Body shape for OWUI's own POST /openai/config/update. Verified
+    live 2026-07-22 as the fix for the persisted-stale-key incident (see
+    module docstring)."""
+    return {
+        "ENABLE_OPENAI_API": True,
+        "OPENAI_API_BASE_URLS": [OWUI_UPSTREAM_BASE_URL],
+        "OPENAI_API_KEYS": [raw_secret],
+        "OPENAI_API_CONFIGS": {"0": {"enable": True}},
+    }
+
+
+def owui_request(base, headers, method, path, body=None):
+    """Same shape as request() above but never sys.exit on error --
+    sync_owui_config below is best-effort and must always fall through
+    to this script's real job (minting the Supabase-side credentials)."""
+    url = base + path
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(url, data=data, method=method, headers=dict(headers))
+    with urllib.request.urlopen(req, timeout=10) as resp:
+        raw = resp.read()
+        return resp.status, (json.loads(raw) if raw else None)
+
+
+def sync_owui_config(raw_secret: str) -> None:
+    """Best-effort: sign into OWUI as an admin and push raw_secret into
+    its own persisted OpenAI config, so it never drifts from the
+    SHIM_KEY this run just minted. Logs one line to stderr either way,
+    never raises, never sys.exit -- see module docstring for why."""
+    base = os.environ.get("OWUI_BASE_URL", "http://localhost:3003").rstrip("/")
+    email = os.environ.get("OWUI_ADMIN_EMAIL", "").strip()
+    password = os.environ.get("OWUI_ADMIN_PASSWORD", "").strip()
+    # No hardcoded credential defaults. Local/demo test account already
+    # documented above this script's own header comment (asdas@asdas.sda
+    # / asdas) if a caller wants to set these explicitly.
+    if not email or not password:
+        print(
+            "owui config sync skipped: OWUI_ADMIN_EMAIL/OWUI_ADMIN_PASSWORD not set",
+            file=sys.stderr,
+        )
+        return
+    try:
+        status, body = owui_request(
+            base, {"Content-Type": "application/json"}, "POST",
+            "/api/v1/auths/signin", {"email": email, "password": password},
+        )
+        token = (body or {}).get("token")
+        if status != 200 or not token:
+            print(f"owui config sync skipped: signin failed: {status} {body}", file=sys.stderr)
+            return
+        status, body = owui_request(
+            base,
+            {"Content-Type": "application/json", "Authorization": f"Bearer {token}"},
+            "POST", "/openai/config/update", owui_config_body(raw_secret),
+        )
+        if status != 200:
+            print(f"owui config sync skipped: config update failed: {status} {body}", file=sys.stderr)
+            return
+        print("owui config sync: ok", file=sys.stderr)
+    except urllib.error.HTTPError as e:
+        raw = e.read()
+        print(f"owui config sync skipped: {e.code} {raw[:300]!r}", file=sys.stderr)
+    except (urllib.error.URLError, OSError, json.JSONDecodeError) as e:
+        print(f"owui config sync skipped: {e}", file=sys.stderr)
 
 
 def main() -> None:
@@ -240,6 +327,11 @@ def main() -> None:
     if status not in (200, 201, 204):
         print(f"error: shim key policy create failed: {status} {body}", file=sys.stderr)
         sys.exit(1)
+
+    # 6. Best-effort: keep OWUI's own persisted config in sync with the
+    # key just minted above (see module docstring). Never touches the
+    # stdout contract below.
+    sync_owui_config(raw_secret)
 
     print(f"EMAIL={USER_EMAIL}")
     print(f"PASSWORD={password}")

--- a/scripts/seed-owui-e2e-user.py
+++ b/scripts/seed-owui-e2e-user.py
@@ -35,7 +35,9 @@ this script's real job).
 
 Required env: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY
 Optional env (OWUI config sync): OWUI_BASE_URL (default
-http://localhost:3003), OWUI_ADMIN_EMAIL, OWUI_ADMIN_PASSWORD
+http://localhost:3003), OWUI_ADMIN_EMAIL, OWUI_ADMIN_PASSWORD,
+EDGE_API_URL_FOR_OWUI (default http://edge-api:8080/v1 -- the docker-network
+hostname OWUI's own backend dials out to; override for a remote OWUI setup)
 
 Prints exactly three lines to stdout (and nothing else):
   EMAIL=<email>
@@ -126,15 +128,31 @@ def random_api_key() -> tuple[str, str, str]:
 OWUI_UPSTREAM_BASE_URL = "http://edge-api:8080/v1"
 
 
-def owui_config_body(raw_secret: str) -> dict:
-    """Body shape for OWUI's own POST /openai/config/update. Verified
-    live 2026-07-22 as the fix for the persisted-stale-key incident (see
-    module docstring)."""
+def merge_owui_config(existing: dict, upstream_url: str, raw_secret: str) -> dict:
+    """Merge raw_secret into an existing GET /openai/config response,
+    preserving every other configured connection untouched. OWUI's own
+    POST /openai/config/update REPLACES the whole collection -- it does
+    not merge server-side. Find-or-append here, or any other
+    OpenAI-compatible connection an admin configured by hand through
+    OWUI's own UI gets silently wiped by this script."""
+    base_urls = list(existing.get("OPENAI_API_BASE_URLS") or [])
+    api_keys = list(existing.get("OPENAI_API_KEYS") or [])
+    configs = dict(existing.get("OPENAI_API_CONFIGS") or {})
+    if upstream_url in base_urls:
+        idx = base_urls.index(upstream_url)
+        while len(api_keys) <= idx:  # defensive: OWUI keeps these aligned
+            api_keys.append("")
+        api_keys[idx] = raw_secret
+    else:
+        idx = len(base_urls)
+        base_urls.append(upstream_url)
+        api_keys.append(raw_secret)
+    configs[str(idx)] = {"enable": True}
     return {
         "ENABLE_OPENAI_API": True,
-        "OPENAI_API_BASE_URLS": [OWUI_UPSTREAM_BASE_URL],
-        "OPENAI_API_KEYS": [raw_secret],
-        "OPENAI_API_CONFIGS": {"0": {"enable": True}},
+        "OPENAI_API_BASE_URLS": base_urls,
+        "OPENAI_API_KEYS": api_keys,
+        "OPENAI_API_CONFIGS": configs,
     }
 
 
@@ -151,45 +169,73 @@ def owui_request(base, headers, method, path, body=None):
 
 
 def sync_owui_config(raw_secret: str) -> None:
-    """Best-effort: sign into OWUI as an admin and push raw_secret into
-    its own persisted OpenAI config, so it never drifts from the
-    SHIM_KEY this run just minted. Logs one line to stderr either way,
-    never raises, never sys.exit -- see module docstring for why."""
+    """Best-effort: sign into OWUI as an admin, fetch its existing
+    persisted OpenAI config, merge raw_secret into it (preserving any
+    other configured connection), and push the merged result back. Logs
+    to stderr either way, never raises, never sys.exit -- see module
+    docstring for why. By the time this runs the OLD key is already
+    deleted from Supabase (step 5 above), so a failure here leaves OWUI
+    pointed at a dead key -- the warn() below spells out manual recovery
+    so that never sits silent."""
     base = os.environ.get("OWUI_BASE_URL", "http://localhost:3003").rstrip("/")
     email = os.environ.get("OWUI_ADMIN_EMAIL", "").strip()
     password = os.environ.get("OWUI_ADMIN_PASSWORD", "").strip()
-    # No hardcoded credential defaults. Local/demo test account already
-    # documented above this script's own header comment (asdas@asdas.sda
-    # / asdas) if a caller wants to set these explicitly.
-    if not email or not password:
+    upstream_url = os.environ.get("EDGE_API_URL_FOR_OWUI", OWUI_UPSTREAM_BASE_URL).rstrip("/")
+
+    def warn(reason: str) -> None:
+        print(f"owui config sync skipped: {reason}", file=sys.stderr)
         print(
-            "owui config sync skipped: OWUI_ADMIN_EMAIL/OWUI_ADMIN_PASSWORD not set",
+            'owui config sync FAILED: chat UI will show "No models '
+            'available" until this is fixed by hand. Recover with:\n'
+            f"  TOKEN=$(curl -s -X POST {base}/api/v1/auths/signin "
+            '-H "Content-Type: application/json" '
+            '-d \'{"email":"<OWUI_ADMIN_EMAIL>","password":"<OWUI_ADMIN_PASSWORD>"}\' '
+            "| python3 -c \"import sys,json;print(json.load(sys.stdin)['token'])\")\n"
+            f"  curl -s -X POST {base}/openai/config/update "
+            '-H "Content-Type: application/json" -H "Authorization: Bearer $TOKEN" '
+            '-d \'{"ENABLE_OPENAI_API":true,"OPENAI_API_BASE_URLS":["' + upstream_url + '"],'
+            '"OPENAI_API_KEYS":["' + raw_secret + '"],"OPENAI_API_CONFIGS":{"0":{"enable":true}}}\'\n'
+            "  (the recipe above REPLACES OWUI's whole connection list -- fine for a "
+            "single-connection demo box, but check GET " + base + "/openai/config first "
+            "if other connections might exist)",
             file=sys.stderr,
         )
+
+    # No hardcoded credential defaults. Local/demo test account already
+    # documented in scripts/seed-demo-owner.py's header comment
+    # (asdas@asdas.sda / asdas) if a caller wants to set these explicitly.
+    if not email or not password:
+        print("owui config sync skipped: OWUI_ADMIN_EMAIL/OWUI_ADMIN_PASSWORD not set", file=sys.stderr)
         return
     try:
         status, body = owui_request(
             base, {"Content-Type": "application/json"}, "POST",
             "/api/v1/auths/signin", {"email": email, "password": password},
         )
-        token = (body or {}).get("token")
+        token = body.get("token") if isinstance(body, dict) else None
         if status != 200 or not token:
-            print(f"owui config sync skipped: signin failed: {status} {body}", file=sys.stderr)
+            warn(f"signin failed: {status} {body}")
             return
+
+        auth_headers = {"Content-Type": "application/json", "Authorization": f"Bearer {token}"}
+        status, existing = owui_request(base, auth_headers, "GET", "/openai/config")
+        if status != 200 or not isinstance(existing, dict):
+            warn(f"config fetch failed: {status} {existing}")
+            return
+
         status, body = owui_request(
-            base,
-            {"Content-Type": "application/json", "Authorization": f"Bearer {token}"},
-            "POST", "/openai/config/update", owui_config_body(raw_secret),
+            base, auth_headers, "POST", "/openai/config/update",
+            merge_owui_config(existing, upstream_url, raw_secret),
         )
         if status != 200:
-            print(f"owui config sync skipped: config update failed: {status} {body}", file=sys.stderr)
+            warn(f"config update failed: {status} {body}")
             return
         print("owui config sync: ok", file=sys.stderr)
     except urllib.error.HTTPError as e:
         raw = e.read()
-        print(f"owui config sync skipped: {e.code} {raw[:300]!r}", file=sys.stderr)
+        warn(f"{e.code} {raw[:300]!r}")
     except (urllib.error.URLError, OSError, json.JSONDecodeError) as e:
-        print(f"owui config sync skipped: {e}", file=sys.stderr)
+        warn(str(e))
 
 
 def main() -> None:

--- a/scripts/test_seed_owui_e2e_user.py
+++ b/scripts/test_seed_owui_e2e_user.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Self-check for sync_owui_config in seed-owui-e2e-user.py (fix for the
+live incident where OWUI's own persisted OpenAI config drifts from a
+freshly rotated SHIM_KEY -- see PR body). No framework, no network:
+mocks urllib.request.urlopen and exercises owui_config_body and
+sync_owui_config directly. Run: python3 scripts/test_seed_owui_e2e_user.py
+"""
+import importlib.util
+import json
+import os
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "seed_owui_e2e_user", Path(__file__).parent / "seed-owui-e2e-user.py"
+)
+seed_owui_e2e_user = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(seed_owui_e2e_user)
+
+
+class FakeResponse:
+    def __init__(self, status, body):
+        self.status = status
+        self._raw = json.dumps(body).encode()
+
+    def read(self):
+        return self._raw
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def test_body_shape() -> None:
+    body = seed_owui_e2e_user.owui_config_body("hk_secret123")
+    assert body["ENABLE_OPENAI_API"] is True
+    assert body["OPENAI_API_KEYS"] == ["hk_secret123"]
+    assert body["OPENAI_API_BASE_URLS"] == ["http://edge-api:8080/v1"]
+    assert body["OPENAI_API_CONFIGS"] == {"0": {"enable": True}}
+    print("ok: owui_config_body shape")
+
+
+def test_sync_posts_signin_then_config_update() -> None:
+    calls = []
+
+    def fake_urlopen(req, timeout=None):
+        calls.append(req)
+        if req.full_url.endswith("/api/v1/auths/signin"):
+            return FakeResponse(200, {"token": "fake-jwt"})
+        if req.full_url.endswith("/openai/config/update"):
+            return FakeResponse(200, {"status": True})
+        raise AssertionError(f"unexpected url: {req.full_url}")
+
+    original = urllib.request.urlopen
+    urllib.request.urlopen = fake_urlopen
+    try:
+        seed_owui_e2e_user.sync_owui_config("hk_secret123")
+    finally:
+        urllib.request.urlopen = original
+
+    assert len(calls) == 2
+    signin_body = json.loads(calls[0].data)
+    assert signin_body == {"email": "admin@example.com", "password": "pw"}
+    config_body = json.loads(calls[1].data)
+    assert config_body["OPENAI_API_KEYS"] == ["hk_secret123"]
+    assert calls[1].headers.get("Authorization") == "Bearer fake-jwt"
+    print("ok: sync_owui_config posts signin then config update with correct bodies")
+
+
+def test_sync_never_raises_on_failure() -> None:
+    def fake_urlopen(req, timeout=None):
+        raise urllib.error.URLError("connection refused")
+
+    original = urllib.request.urlopen
+    urllib.request.urlopen = fake_urlopen
+    try:
+        seed_owui_e2e_user.sync_owui_config("hk_secret123")  # must not raise
+    finally:
+        urllib.request.urlopen = original
+    print("ok: sync_owui_config does not raise when OWUI is unreachable")
+
+
+def test_sync_skips_without_admin_credentials() -> None:
+    calls = []
+
+    def fake_urlopen(req, timeout=None):
+        calls.append(req)
+        raise AssertionError("must not call network without admin credentials")
+
+    original = urllib.request.urlopen
+    urllib.request.urlopen = fake_urlopen
+    old_email = os.environ.pop("OWUI_ADMIN_EMAIL", None)
+    old_password = os.environ.pop("OWUI_ADMIN_PASSWORD", None)
+    try:
+        seed_owui_e2e_user.sync_owui_config("hk_secret123")
+    finally:
+        urllib.request.urlopen = original
+        if old_email is not None:
+            os.environ["OWUI_ADMIN_EMAIL"] = old_email
+        if old_password is not None:
+            os.environ["OWUI_ADMIN_PASSWORD"] = old_password
+
+    assert calls == []
+    print("ok: sync_owui_config skips the network call without admin credentials")
+
+
+def main() -> None:
+    os.environ["OWUI_ADMIN_EMAIL"] = "admin@example.com"
+    os.environ["OWUI_ADMIN_PASSWORD"] = "pw"
+    os.environ.setdefault("OWUI_BASE_URL", "http://localhost:3003")
+
+    test_body_shape()
+    test_sync_posts_signin_then_config_update()
+    test_sync_never_raises_on_failure()
+
+    del os.environ["OWUI_ADMIN_EMAIL"]
+    del os.environ["OWUI_ADMIN_PASSWORD"]
+    test_sync_skips_without_admin_credentials()
+
+    print("ok: seed-owui-e2e-user.py OWUI config sync")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_seed_owui_e2e_user.py
+++ b/scripts/test_seed_owui_e2e_user.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python3
-"""Self-check for sync_owui_config in seed-owui-e2e-user.py (fix for the
-live incident where OWUI's own persisted OpenAI config drifts from a
-freshly rotated SHIM_KEY -- see PR body). No framework, no network:
-mocks urllib.request.urlopen and exercises owui_config_body and
+"""Self-check for the OWUI config sync in seed-owui-e2e-user.py (fix for
+the live incident where OWUI's own persisted OpenAI config drifts from a
+freshly rotated SHIM_KEY -- see PR #423 body). No framework, no network:
+mocks urllib.request.urlopen and exercises merge_owui_config and
 sync_owui_config directly. Run: python3 scripts/test_seed_owui_e2e_user.py
 """
 import importlib.util
+import io
 import json
 import os
+import sys
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -34,53 +36,124 @@ class FakeResponse:
         return False
 
 
-def test_body_shape() -> None:
-    body = seed_owui_e2e_user.owui_config_body("hk_secret123")
-    assert body["ENABLE_OPENAI_API"] is True
-    assert body["OPENAI_API_KEYS"] == ["hk_secret123"]
-    assert body["OPENAI_API_BASE_URLS"] == ["http://edge-api:8080/v1"]
-    assert body["OPENAI_API_CONFIGS"] == {"0": {"enable": True}}
-    print("ok: owui_config_body shape")
+def patch_urlopen(fn):
+    original = urllib.request.urlopen
+    urllib.request.urlopen = fn
+    return original
 
 
-def test_sync_posts_signin_then_config_update() -> None:
+def restore_urlopen(original) -> None:
+    urllib.request.urlopen = original
+
+
+# --- merge_owui_config: pure function tests -------------------------------
+
+def test_merge_appends_when_no_existing_entry() -> None:
+    merged = seed_owui_e2e_user.merge_owui_config({}, "http://edge-api:8080/v1", "hk_new")
+    assert merged["OPENAI_API_BASE_URLS"] == ["http://edge-api:8080/v1"]
+    assert merged["OPENAI_API_KEYS"] == ["hk_new"]
+    assert merged["OPENAI_API_CONFIGS"] == {"0": {"enable": True}}
+    print("ok: merge_owui_config appends when there is no existing entry")
+
+
+def test_merge_preserves_other_entries_and_updates_matching_one() -> None:
+    existing = {
+        "ENABLE_OPENAI_API": True,
+        "OPENAI_API_BASE_URLS": ["https://api.openai.com/v1", "http://edge-api:8080/v1"],
+        "OPENAI_API_KEYS": ["sk-someone-elses-key", "hk_old_dead_key"],
+        "OPENAI_API_CONFIGS": {"0": {"enable": True}, "1": {"enable": True}},
+    }
+    merged = seed_owui_e2e_user.merge_owui_config(existing, "http://edge-api:8080/v1", "hk_new")
+    # the OTHER connection (index 0) must survive untouched
+    assert merged["OPENAI_API_BASE_URLS"][0] == "https://api.openai.com/v1"
+    assert merged["OPENAI_API_KEYS"][0] == "sk-someone-elses-key"
+    assert merged["OPENAI_API_CONFIGS"]["0"] == {"enable": True}
+    # our own connection (index 1) is updated in place, not appended again
+    assert merged["OPENAI_API_BASE_URLS"] == ["https://api.openai.com/v1", "http://edge-api:8080/v1"]
+    assert merged["OPENAI_API_KEYS"][1] == "hk_new"
+    print("ok: merge_owui_config preserves other connections and updates only its own")
+
+
+# --- sync_owui_config: full flow tests ------------------------------------
+
+def test_sync_full_flow_preserves_other_entries_in_final_post() -> None:
+    """The end-to-end regression the P1 review thread demanded: mock a
+    multi-entry existing config and assert the final POST body still
+    carries the other entry untouched."""
     calls = []
+    existing_config = {
+        "OPENAI_API_BASE_URLS": ["https://api.openai.com/v1"],
+        "OPENAI_API_KEYS": ["sk-someone-elses-key"],
+        "OPENAI_API_CONFIGS": {"0": {"enable": True}},
+    }
 
     def fake_urlopen(req, timeout=None):
         calls.append(req)
         if req.full_url.endswith("/api/v1/auths/signin"):
             return FakeResponse(200, {"token": "fake-jwt"})
+        if req.full_url.endswith("/openai/config") and req.get_method() == "GET":
+            return FakeResponse(200, existing_config)
         if req.full_url.endswith("/openai/config/update"):
             return FakeResponse(200, {"status": True})
-        raise AssertionError(f"unexpected url: {req.full_url}")
+        raise AssertionError(f"unexpected call: {req.get_method()} {req.full_url}")
 
-    original = urllib.request.urlopen
-    urllib.request.urlopen = fake_urlopen
+    original = patch_urlopen(fake_urlopen)
     try:
-        seed_owui_e2e_user.sync_owui_config("hk_secret123")
+        seed_owui_e2e_user.sync_owui_config("hk_new")
     finally:
-        urllib.request.urlopen = original
+        restore_urlopen(original)
 
-    assert len(calls) == 2
-    signin_body = json.loads(calls[0].data)
-    assert signin_body == {"email": "admin@example.com", "password": "pw"}
-    config_body = json.loads(calls[1].data)
-    assert config_body["OPENAI_API_KEYS"] == ["hk_secret123"]
-    assert calls[1].headers.get("Authorization") == "Bearer fake-jwt"
-    print("ok: sync_owui_config posts signin then config update with correct bodies")
+    assert len(calls) == 3
+    posted = json.loads(calls[2].data)
+    assert posted["OPENAI_API_BASE_URLS"] == ["https://api.openai.com/v1", "http://edge-api:8080/v1"]
+    assert posted["OPENAI_API_KEYS"] == ["sk-someone-elses-key", "hk_new"]
+    assert calls[2].headers.get("Authorization") == "Bearer fake-jwt"
+    print("ok: sync_owui_config's final POST preserves the other pre-existing connection")
 
 
-def test_sync_never_raises_on_failure() -> None:
+def test_sync_never_raises_on_unreachable_owui() -> None:
     def fake_urlopen(req, timeout=None):
         raise urllib.error.URLError("connection refused")
 
-    original = urllib.request.urlopen
-    urllib.request.urlopen = fake_urlopen
+    original = patch_urlopen(fake_urlopen)
     try:
         seed_owui_e2e_user.sync_owui_config("hk_secret123")  # must not raise
     finally:
-        urllib.request.urlopen = original
+        restore_urlopen(original)
     print("ok: sync_owui_config does not raise when OWUI is unreachable")
+
+
+def test_sync_signin_fails_no_token() -> None:
+    """A valid-JSON-but-non-dict signin response must not raise
+    AttributeError before the never-fatal contract kicks in -- P2 nit:
+    isinstance-guard body.get("token")."""
+    def fake_urlopen(req, timeout=None):
+        return FakeResponse(200, ["not", "a", "dict"])
+
+    original = patch_urlopen(fake_urlopen)
+    try:
+        seed_owui_e2e_user.sync_owui_config("hk_secret123")  # must not raise
+    finally:
+        restore_urlopen(original)
+    print("ok: sync_owui_config does not raise when signin body is not a dict")
+
+
+def test_sync_config_update_non_200() -> None:
+    def fake_urlopen(req, timeout=None):
+        if req.full_url.endswith("/api/v1/auths/signin"):
+            return FakeResponse(200, {"token": "fake-jwt"})
+        if req.full_url.endswith("/openai/config") and req.get_method() == "GET":
+            return FakeResponse(200, {})
+        if req.full_url.endswith("/openai/config/update"):
+            return FakeResponse(500, {"detail": "boom"})
+        raise AssertionError(f"unexpected call: {req.full_url}")
+
+    original = patch_urlopen(fake_urlopen)
+    try:
+        seed_owui_e2e_user.sync_owui_config("hk_secret123")  # must not raise
+    finally:
+        restore_urlopen(original)
+    print("ok: sync_owui_config does not raise on a non-200 config update")
 
 
 def test_sync_skips_without_admin_credentials() -> None:
@@ -90,14 +163,13 @@ def test_sync_skips_without_admin_credentials() -> None:
         calls.append(req)
         raise AssertionError("must not call network without admin credentials")
 
-    original = urllib.request.urlopen
-    urllib.request.urlopen = fake_urlopen
+    original = patch_urlopen(fake_urlopen)
     old_email = os.environ.pop("OWUI_ADMIN_EMAIL", None)
     old_password = os.environ.pop("OWUI_ADMIN_PASSWORD", None)
     try:
         seed_owui_e2e_user.sync_owui_config("hk_secret123")
     finally:
-        urllib.request.urlopen = original
+        restore_urlopen(original)
         if old_email is not None:
             os.environ["OWUI_ADMIN_EMAIL"] = old_email
         if old_password is not None:
@@ -107,14 +179,48 @@ def test_sync_skips_without_admin_credentials() -> None:
     print("ok: sync_owui_config skips the network call without admin credentials")
 
 
+def test_sync_never_writes_stdout() -> None:
+    """The invariant that matters most: whatever happens inside
+    sync_owui_config, the script's stdout contract (EMAIL=/PASSWORD=/
+    SHIM_KEY=, nothing else) must stay untouched. Runs the failure and
+    success paths with stdout captured and asserts it stayed empty."""
+    def unreachable(req, timeout=None):
+        raise urllib.error.URLError("down")
+
+    def server_error(req, timeout=None):
+        return FakeResponse(500, {"detail": "boom"})
+
+    def happy_path(req, timeout=None):
+        if req.full_url.endswith("signin"):
+            return FakeResponse(200, {"token": "fake-jwt"})
+        return FakeResponse(200, {})
+
+    for fake_urlopen in (unreachable, server_error, happy_path):
+        original = patch_urlopen(fake_urlopen)
+        captured = io.StringIO()
+        old_stdout = sys.stdout
+        sys.stdout = captured
+        try:
+            seed_owui_e2e_user.sync_owui_config("hk_secret123")
+        finally:
+            sys.stdout = old_stdout
+            restore_urlopen(original)
+        assert captured.getvalue() == "", f"sync_owui_config wrote to stdout: {captured.getvalue()!r}"
+    print("ok: sync_owui_config never writes to stdout, success or failure")
+
+
 def main() -> None:
     os.environ["OWUI_ADMIN_EMAIL"] = "admin@example.com"
     os.environ["OWUI_ADMIN_PASSWORD"] = "pw"
     os.environ.setdefault("OWUI_BASE_URL", "http://localhost:3003")
 
-    test_body_shape()
-    test_sync_posts_signin_then_config_update()
-    test_sync_never_raises_on_failure()
+    test_merge_appends_when_no_existing_entry()
+    test_merge_preserves_other_entries_and_updates_matching_one()
+    test_sync_full_flow_preserves_other_entries_in_final_post()
+    test_sync_never_raises_on_unreachable_owui()
+    test_sync_signin_fails_no_token()
+    test_sync_config_update_non_200()
+    test_sync_never_writes_stdout()
 
     del os.environ["OWUI_ADMIN_EMAIL"]
     del os.environ["OWUI_ADMIN_PASSWORD"]


### PR DESCRIPTION
## Summary

`scripts/seed-owui-e2e-user.py` mints a fresh `hk_`-prefixed shim key and prints it, expecting a human or CI step to copy it into `.env` and restart the `open-webui` container. It never touches Open WebUI's own persisted OpenAI-connection config.

Adds a best-effort sync step (step 6) that signs into OWUI as an admin and pushes the freshly minted key into OWUI's own config via `POST /openai/config/update`, so the two can never drift apart again.

## Why

Confirmed live against the running local demo stack, not theoretical. Open WebUI persists its own OpenAI-connection config (base URL and API key) in its own database, seeded from the `OPENAI_API_KEY` env var only on a container's first boot against a given volume. On every later container recreate that reuses the same volume, OWUI keeps its OLD persisted key even though `.env` and the container's own `OPENAI_API_KEY` env var now hold the new one.

Live symptom: the chat UI showed "No models available. Connect to an AI provider to start chatting." even though `curl .../v1/models` with the current key succeeded directly against `edge-api`. This was fixed live for the current session by manually POSTing to `/openai/config/update` with an authenticated OWUI session, but nothing in the codebase did this automatically, so the next key rotation or container recreate would silently break it again.

This has already caused at least one demo-blocking incident, and one misleading PR verification where a PR claimed "verified live" by curling `edge-api` directly, a check that does not exercise this failure mode at all (curling `edge-api` bypasses OWUI's own persisted config entirely).

## Changes

- `scripts/seed-owui-e2e-user.py`: adds `owui_config_body`, `owui_request`, and `sync_owui_config`. After minting the shim key (step 5), `main()` calls `sync_owui_config(raw_secret)` (step 6). Reads `OWUI_BASE_URL` (default `http://localhost:3003`, matching this repo's documented local/demo Caddy port), `OWUI_ADMIN_EMAIL`, and `OWUI_ADMIN_PASSWORD` from env, with no hardcoded credential defaults. If OWUI is unreachable or admin credentials are unset, prints a clear warning to stderr and continues; never calls `sys.exit`. The script's existing stdout contract (`EMAIL=`/`PASSWORD=`/`SHIM_KEY=`, nothing else) is unchanged.
- `scripts/test_seed_owui_e2e_user.py` (new): mocks `urllib.request.urlopen`, no real network or framework, mirrors the existing `test_seed_demo_owner.py` self-check style. Covers: correct `/openai/config/update` body shape, the signin-then-config-update call sequence with the right bodies and bearer token, non-fatal behavior when OWUI is unreachable, and skip-without-network-call when admin credentials are unset.

## Test plan

- [x] `python3 scripts/test_seed_owui_e2e_user.py` passes locally (4/4 checks, see commit).
- [x] `python3 scripts/test_seed_demo_owner.py` (sibling test) still passes, no regression from the shared import pattern.
- [x] `python3 -c "import ast; ast.parse(open('scripts/seed-owui-e2e-user.py').read())"` confirms no syntax errors.
- [ ] Live verification against the running Docker demo stack (rotate the key, confirm OWUI's `GET /openai/config` shows the new key and the chat UI lists models) is **not done in this PR**. This worktree has no Docker access, same posture as PR #416 and PR #422. Recommend a live smoke check before/alongside merge: run the script against a live `--profile chat` stack with `OWUI_ADMIN_EMAIL`/`OWUI_ADMIN_PASSWORD` set, then confirm the chat UI lists models without a manual `/openai/config/update` POST.

Branch: `fix/owui-shimkey-config-sync`. Not merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Newly created test users can now have their API key automatically synchronized with the configured Open WebUI connection.
  * Existing Open WebUI connections are preserved while the matching connection is updated or added.

* **Bug Fixes**
  * Synchronization failures no longer interrupt user provisioning.
  * Added recovery guidance for unavailable or incorrectly configured Open WebUI instances.

* **Tests**
  * Added comprehensive checks for configuration merging, failure handling, credential gating, and output behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR keeps Open WebUI’s persisted connection key aligned with newly minted shim keys. The main changes are:

- Authenticated fetch, merge, and update of the persisted OWUI configuration.
- Configurable OWUI address, credentials, and OWUI-visible edge API URL.
- Nonfatal sync handling with manual recovery instructions.
- Self-contained tests for merging, request flow, failures, and stdout isolation.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The recovery path should be fixed before merging.

- The automatic sync now preserves existing connections.
- The printed recovery command can remove unrelated connections from a multi-provider OWUI instance.

scripts/seed-owui-e2e-user.py
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/seed-owui-e2e-user.py | Adds persisted configuration synchronization and merge handling, but the failure recovery command can replace unrelated connections. |
| scripts/test_seed_owui_e2e_user.py | Adds coverage for configuration merging, request sequencing, nonfatal failures, missing credentials, and stdout behavior. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fseed-owui-e2e-user.py%3A196-197%0A**Recovery%20Replaces%20Other%20Connections**%0A%0AWhen%20automatic%20sync%20fails%2C%20this%20recovery%20command%20sends%20single-entry%20connection%20collections%20to%20%60%2Fopenai%2Fconfig%2Fupdate%60.%20On%20an%20OWUI%20instance%20with%20other%20configured%20providers%2C%20following%20the%20printed%20command%20removes%20those%20providers%20because%20the%20endpoint%20replaces%20the%20full%20collections.%20The%20recovery%20path%20should%20fetch%20and%20merge%20the%20current%20configuration%20just%20like%20the%20automatic%20path.%0A%0A&repo=sakibsadmanshajib%2Fhive&pr=423&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fseed-owui-e2e-user.py%3A196-197%0A**Recovery%20Replaces%20Other%20Connections**%0A%0AWhen%20automatic%20sync%20fails%2C%20this%20recovery%20command%20sends%20single-entry%20connection%20collections%20to%20%60%2Fopenai%2Fconfig%2Fupdate%60.%20On%20an%20OWUI%20instance%20with%20other%20configured%20providers%2C%20following%20the%20printed%20command%20removes%20those%20providers%20because%20the%20endpoint%20replaces%20the%20full%20collections.%20The%20recovery%20path%20should%20fetch%20and%20merge%20the%20current%20configuration%20just%20like%20the%20automatic%20path.%0A%0A&pr=423&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22sakibsadmanshajib%2Fhive%22%20on%20the%20existing%20branch%20%22fix%2Fowui-shimkey-config-sync%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fowui-shimkey-config-sync%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fseed-owui-e2e-user.py%3A196-197%0A**Recovery%20Replaces%20Other%20Connections**%0A%0AWhen%20automatic%20sync%20fails%2C%20this%20recovery%20command%20sends%20single-entry%20connection%20collections%20to%20%60%2Fopenai%2Fconfig%2Fupdate%60.%20On%20an%20OWUI%20instance%20with%20other%20configured%20providers%2C%20following%20the%20printed%20command%20removes%20those%20providers%20because%20the%20endpoint%20replaces%20the%20full%20collections.%20The%20recovery%20path%20should%20fetch%20and%20merge%20the%20current%20configuration%20just%20like%20the%20automatic%20path.%0A%0A&repo=sakibsadmanshajib%2Fhive&pr=423&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fix: merge-preserve OWUI config, actiona..."](https://github.com/sakibsadmanshajib/hive/commit/b6142de9af831de956046f333caab993bf3b5920) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46206902)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/scubed/github/sakibsadmanshajib/hive/-/custom-context?memory=a5912a3f-0055-4d8a-86c1-fedc669ad56e))
- Context used - .claude/rules/orchestrator.md ([source](https://app.greptile.com/scubed/github/sakibsadmanshajib/hive/-/custom-context?memory=7e0c2dc0-c014-43b2-9dbd-46ae72a640d0))
- Context used - .claude/rules/openwolf.md ([source](https://app.greptile.com/scubed/github/sakibsadmanshajib/hive/-/custom-context?memory=3e51a3b4-2091-4dce-8aad-9423a1f1db38))
</details>

<!-- /greptile_comment -->