### PR TITLE
fix: provision tenant_users rows for e2e fixture accounts

### DIFF
--- a/supabase/functions/e2e-fixtures/index.ts
+++ b/supabase/functions/e2e-fixtures/index.ts
@@ -37,6 +37,17 @@ const FIXED = {
   invitedAccountId: "a45bec1f-e648-4811-9841-3ad28c7f34a9",
   unverifiedAccountId: "8ca58251-dfad-4e91-b2c8-b3649391871b",
   invitationId: "580df639-64b0-4a66-99f1-0cf3e293b78e",
+  // Phase 19 tenant-scope role system (public.tenants / public.tenant_users).
+  // custom_access_token_hook (20260516_07) raises `no_active_membership` and
+  // fails the whole password-grant login for any user with zero active
+  // tenant_users rows, independent of the account_memberships rows above --
+  // the two role systems don't know about each other (see
+  // scripts/seed-demo-owner.py's header comment for the same split).
+  // Only verifiedUser and unverifiedUser sign in through Playwright specs
+  // (inviterUser is only ever an invitation-sender in fixture data, never
+  // used in a signIn() flow), so only those two get a tenant.
+  verifiedTenantId: "6f1c9a2e-2b7a-4b1a-9a3e-4b2f6a1d7c01",
+  unverifiedTenantId: "d3a5f8e1-7c4b-4a9d-8e2f-1b6c9d3a7f02",
 };
 
 const DEFAULTS = {
@@ -79,8 +90,17 @@ async function ensureUser(
     fullName: string;
     appMetadata: Record<string, unknown>;
     accountIdHint: string;
+    // Phase 19 tenant claim custom_access_token_hook reads off
+    // auth.users.raw_user_meta_data->>'selected_tenant_id'. Optional: only
+    // verifiedUser/unverifiedUser pass this, inviterUser doesn't sign in.
+    selectedTenantId?: string;
   },
 ) {
+  const userMetadata: Record<string, unknown> = { full_name: opts.fullName };
+  if (opts.selectedTenantId) {
+    userMetadata.selected_tenant_id = opts.selectedTenantId;
+  }
+
   const { data: ownerRow } = await admin
     .from("accounts")
     .select("owner_user_id")
@@ -95,7 +115,7 @@ async function ensureUser(
         password: opts.password,
         email_confirm: opts.emailConfirm,
         app_metadata: opts.appMetadata,
-        user_metadata: { full_name: opts.fullName },
+        user_metadata: userMetadata,
       },
     );
     if (error) throw new Error(`updateUserById failed: ${error.message}`);
@@ -107,7 +127,7 @@ async function ensureUser(
     password: opts.password,
     email_confirm: opts.emailConfirm,
     app_metadata: opts.appMetadata,
-    user_metadata: { full_name: opts.fullName },
+    user_metadata: userMetadata,
   });
   if (error) {
     if (error.status === 422 || error.status === 400) {
@@ -126,7 +146,7 @@ async function ensureUser(
           password: opts.password,
           email_confirm: opts.emailConfirm,
           app_metadata: opts.appMetadata,
-          user_metadata: { full_name: opts.fullName },
+          user_metadata: userMetadata,
         });
       if (updErr) throw new Error(`updateUserById failed: ${updErr.message}`);
       return upd.user;
@@ -134,6 +154,55 @@ async function ensureUser(
     throw new Error(`createUser failed: ${error.message}`);
   }
   return data.user;
+}
+
+async function seedTenantsAndMemberships(
+  admin: any,
+  users: { verifiedUser: any; unverifiedUser: any },
+) {
+  const { verifiedUser, unverifiedUser } = users;
+
+  const { error: tenantErr } = await admin.from("tenants").upsert(
+    [
+      {
+        id: FIXED.verifiedTenantId,
+        slug: "e2e-verified-tenant",
+        name: "E2E Verified Tenant",
+        deployment: "HIVE_CLOUD",
+        archived_at: null,
+      },
+      {
+        id: FIXED.unverifiedTenantId,
+        slug: "e2e-unverified-tenant",
+        name: "E2E Unverified Tenant",
+        deployment: "HIVE_CLOUD",
+        archived_at: null,
+      },
+    ],
+    { onConflict: "id" },
+  );
+  if (tenantErr) throw new Error(`tenants upsert failed: ${tenantErr.message}`);
+
+  const { error: tenantUserErr } = await admin.from("tenant_users").upsert(
+    [
+      {
+        tenant_id: FIXED.verifiedTenantId,
+        user_id: verifiedUser.id,
+        role: "OWNER",
+        status: "ACTIVE",
+      },
+      {
+        tenant_id: FIXED.unverifiedTenantId,
+        user_id: unverifiedUser.id,
+        role: "OWNER",
+        status: "ACTIVE",
+      },
+    ],
+    { onConflict: "tenant_id,user_id" },
+  );
+  if (tenantUserErr) {
+    throw new Error(`tenant_users upsert failed: ${tenantUserErr.message}`);
+  }
 }
 
 async function seedAccountsAndMemberships(
@@ -464,6 +533,7 @@ Deno.serve(async (req) => {
         appMetadata: { hive_email_verified: true },
         fullName: "E2E Verified Owner",
         accountIdHint: FIXED.verifiedPrimaryAccountId,
+        selectedTenantId: FIXED.verifiedTenantId,
       }),
       ensureUser(admin, {
         email: unverifiedEmail,
@@ -472,6 +542,7 @@ Deno.serve(async (req) => {
         appMetadata: { hive_email_verified: false },
         fullName: "E2E Unverified Owner",
         accountIdHint: FIXED.unverifiedAccountId,
+        selectedTenantId: FIXED.unverifiedTenantId,
       }),
       ensureUser(admin, {
         email: FIXED.inviterEmail,
@@ -488,6 +559,7 @@ Deno.serve(async (req) => {
       unverifiedUser,
       inviterUser,
     });
+    await seedTenantsAndMemberships(admin, { verifiedUser, unverifiedUser });
     await resetProfilesAndInvitation(
       admin,
       { verifiedUser, unverifiedUser, inviterUser },


### PR DESCRIPTION
## Summary

Fixes #425.

`supabase/functions/e2e-fixtures/index.ts` provisioned `accounts` + `account_memberships` rows (the Phase 2 billing-scope role system) for the `e2e-verified@scubed.com.bd` and `e2e-unverified@scubed.com.bd` fixture accounts, but never touched `public.tenants` / `public.tenant_users` (the Phase 19 tenant-scope role system).

`public.custom_access_token_hook` (`supabase/migrations/20260516_07_phase19_custom_access_token_hook.sql`) only reads `tenant_users` when minting a JWT on login, and raises `RAISE EXCEPTION 'no_active_membership'` when a user has zero active `tenant_users` rows. Both fixture users had empty `tenant_users`, so GoTrue rejected the whole password-grant login for both, failing the `Web E2E (full stack)` CI check.

## Fix

Mirrors the working precedent in `scripts/seed-demo-owner.py`, which already solves this exact dual-role-system split for the demo owner account:

- Added a `seedTenantsAndMemberships` step that upserts two deterministic `public.tenants` rows (`e2e-verified-tenant`, `e2e-unverified-tenant`, fixed UUIDs, `onConflict: "id"`) and a `public.tenant_users` row per fixture user (`role: "OWNER"`, `status: "ACTIVE"`, `onConflict: "tenant_id,user_id"`).
- `ensureUser` now also sets `user_metadata.selected_tenant_id` for the two users that sign in, which `custom_access_token_hook` reads off `auth.users.raw_user_meta_data->>'selected_tenant_id'`.
- `inviterUser` is untouched: grepped `apps/web-console/tests/e2e` and confirmed it is never used in a `signIn()` flow, only as an invitation sender in seeded fixture data.
- All ids are fixed/deterministic, so repeated `POST /reset` calls stay idempotent (no duplicate tenants, no orphan `tenant_users` rows), matching the file's existing idempotency contract.

## #410 overlap

Issue #410 ("flaky: Web E2E signIn() fails intermittently on Supabase custom_access_token_hook (no_active_membership race)") describes the same `no_active_membership` exception from the same hook, hypothesized as a timing race. #425's live reproduction against the demo/CI Supabase project shows it is not a race: the fixture accounts had zero `tenant_users` rows outright, every time. This fix plausibly resolves #410 too, but that should be verified separately (watch the `Web E2E (full stack)` job across several runs post-merge) before closing #410 manually.

## Verification

Verified locally:
- `deno check index.ts` (via `denoland/deno:2.1.4` docker image) — passes clean, no type errors.
- `deno lint index.ts` — passes clean.
- Manually traced every `apps/web-console/tests/e2e` spec's usage of `inviterUser`/`inviterEmail` to confirm it is never used in a login flow.

Could NOT verify locally: the actual GoTrue token-issuance round-trip (this is a live Supabase-project-backed edge function; exercising it needs the edge function deployed against a real Supabase project + GoTrue, which this sandbox does not have). CI's `Web E2E (full stack)` job, run against the demo/staging Supabase project, is the first real exercise of this fix.

## Test plan

- [ ] CI `Web E2E (full stack)` job passes on this PR (exercises the fixture reset + `signIn()` for both verified and unverified fixture accounts)
- [ ] Manually confirm no duplicate `tenants`/`tenant_users` rows after repeated `POST /reset` calls against staging
- [ ] After merge, watch #410 across a few `Web E2E (full stack)` runs; close separately if it stops recurring

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * End-to-end test data setup now includes tenant records and user memberships.
  * Test users are associated with their selected tenants during setup.
  * Test environment resets now consistently restore tenant, membership, account, profile, and invitation data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds deterministic tenant provisioning for the verified and unverified E2E fixture users.
- Stores each fixture user’s selected tenant in auth metadata.
- Upserts matching tenants and active owner memberships.
- Runs tenant provisioning during fixture reset before profiles and invitations are reset.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with tenant metadata and active memberships consistently provisioned for both sign-in fixture users.

The new tenant and membership records satisfy the relevant schema constraints, align with the access-token hook’s lookup behavior, and preserve the fixture’s idempotent reset flow without affecting the service-role-only inviter.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| supabase/functions/e2e-fixtures/index.ts | Correctly provisions matching deterministic tenants, active memberships, and selected-tenant metadata for both fixture users that participate in sign-in flows. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Reset as E2E fixture reset
    participant Auth as Supabase Auth
    participant DB as Public tenant tables
    participant Hook as Access-token hook

    Reset->>Auth: Create/update fixture users with selected_tenant_id
    Reset->>DB: Upsert deterministic tenants
    Reset->>DB: Upsert ACTIVE OWNER tenant_users rows
    Reset-->>Reset: Reset profiles and invitation
    Note over Auth,DB: Fixture reset completes
    Auth->>Hook: Mint JWT during fixture-user sign-in
    Hook->>DB: Resolve selected active tenant membership
    DB-->>Hook: Tenant and OWNER role
    Hook-->>Auth: Add tenant claims
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: provision tenant\_users rows for e2e..."](https://github.com/sakibsadmanshajib/hive/commit/ec9fd74f315e9d3bf61bf105cdd1edd5052e1e63) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46983538)</sub>

<!-- /greptile_comment -->