### PR TITLE
fix: platform admins get IsAdmin overlay in remaining hardcoded-false handlers

### DIFF
--- a/apps/control-plane/cmd/server/main.go
+++ b/apps/control-plane/cmd/server/main.go
@@ -441,6 +441,15 @@ func main() {
 			apikeysHandler = apikeysHandler.WithRoleService(roleSvc)
 		}
 
+		// Issue #424 — wire role service into the remaining handlers that
+		// independently build an Actor with a hardcoded isAdmin=false, so
+		// real platform admins are not silently denied profiles/billing,
+		// credit reservations, ledger, and usage analytics access.
+		profilesHandler = profilesHandler.WithRoleService(roleSvc)
+		accountingHandler = accountingHandler.WithRoleService(roleSvc)
+		ledgerHandler = ledgerHandler.WithRoleService(roleSvc)
+		usageHandler = usageHandler.WithRoleService(roleSvc)
+
 		grantsRepo := grants.NewPgxRepository(pool)
 		grantsSvc := grants.NewService(grantsRepo, roleSvc)
 		grantsHandler = grants.NewHandler(grantsSvc)

--- a/apps/control-plane/internal/accounting/http.go
+++ b/apps/control-plane/internal/accounting/http.go
@@ -3,6 +3,7 @@ package accounting
 import (
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"net/http"
 	"strings"
 
@@ -10,11 +11,13 @@ import (
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/accounts"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/auth"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/authz"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/platform"
 )
 
 type Handler struct {
 	svc         *Service
 	accountsSvc *accounts.Service
+	roleSvc     *platform.RoleService // optional — used to populate Actor.IsAdmin via IsPlatformAdmin
 	policy      authz.Policy
 }
 
@@ -48,6 +51,16 @@ type releaseReservationRequest struct {
 
 func NewHandler(svc *Service, accountsSvc *accounts.Service) *Handler {
 	return &Handler{svc: svc, accountsSvc: accountsSvc, policy: authz.NewPolicy()}
+}
+
+// WithRoleService returns a copy of the handler wired with the platform role
+// service so the admin overlay is enabled for Actor construction. Without it,
+// Actor.IsAdmin is always false and platform admins cannot manage credit
+// reservations via this handler unless also account-verified.
+func (h *Handler) WithRoleService(roleSvc *platform.RoleService) *Handler {
+	cloned := *h
+	cloned.roleSvc = roleSvc
+	return &cloned
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -347,12 +360,27 @@ func (h *Handler) resolveCurrentAccountID(w http.ResponseWriter, r *http.Request
 	}
 
 	// Phase 18: route authz through policy.Can — replaces bare EmailVerified check.
+	// isAdmin resolves the real platform-admin overlay when roleSvc is wired
+	// (see WithRoleService); without it, a real platform admin who is not
+	// account-verified is silently denied credit reservation access here.
+	isAdmin := false
+	if h.roleSvc != nil {
+		admin, err := h.roleSvc.IsPlatformAdmin(r.Context(), viewer.UserID)
+		if err != nil {
+			slog.ErrorContext(r.Context(), "accounting: platform-admin lookup failed",
+				slog.String("user_id", viewer.UserID.String()),
+				slog.String("err", err.Error()))
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "authorization unavailable"})
+			return uuid.Nil, false
+		}
+		isAdmin = admin
+	}
 	actor := accounts.ActorFor(viewer, accounts.Membership{
 		AccountID: viewerContext.CurrentAccount.ID,
 		UserID:    viewer.UserID,
 		Role:      viewerContext.CurrentAccount.Role,
 		Status:    "active",
-	}, false)
+	}, isAdmin)
 	if !h.policy.Can(actor, authz.PermAnalyticsView) {
 		writeJSON(w, http.StatusForbidden, map[string]string{
 			"error": "email must be verified before accessing credits",

--- a/apps/control-plane/internal/accounting/http_test.go
+++ b/apps/control-plane/internal/accounting/http_test.go
@@ -14,7 +14,22 @@ import (
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/auth"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/authz"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/ledger"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/platform"
 )
+
+// stubRoleStore is a minimal platform.RoleStore backing a real
+// *platform.RoleService for tests, keyed by userID -> is_platform_admin.
+type stubRoleStore struct {
+	adminUsers map[uuid.UUID]bool
+}
+
+func (s *stubRoleStore) GetMembershipRole(_ context.Context, _, _ uuid.UUID) (platform.MembershipRole, error) {
+	return "", nil
+}
+
+func (s *stubRoleStore) IsPlatformAdmin(_ context.Context, userID uuid.UUID) (bool, error) {
+	return s.adminUsers[userID], nil
+}
 
 type accountsRepoStub struct {
 	accountsMap map[uuid.UUID]*accounts.Account
@@ -472,5 +487,61 @@ func TestHandler_AuthzMatrix(t *testing.T) {
 				t.Errorf("want %d got %d: %s", tc.wantStatus, rr.Code, rr.Body.String())
 			}
 		})
+	}
+}
+
+// TestCreateReservation_PlatformAdminOverlayGrantsUnverifiedAccess is a
+// regression guard for issue #424: resolveCurrentAccountID hardcoded
+// isAdmin=false when building the Actor, so a real platform admin who is not
+// account-verified was silently denied credit-reservation access even though
+// the admin overlay should grant it. A hardcoded-false version returns 403
+// here; the fix must return 200.
+func TestCreateReservation_PlatformAdminOverlayGrantsUnverifiedAccess(t *testing.T) {
+	accountRepo := newAccountsRepoStub()
+	accountingRepo := newRepoStub()
+	ledgerSvc := &ledgerStub{balance: ledgerBalance(500)}
+	usageSvc := &usageStub{}
+
+	userID := uuid.New()
+	accountID := uuid.New()
+	accountRepo.accountsMap[accountID] = &accounts.Account{
+		ID:          accountID,
+		Slug:        "workspace-one",
+		DisplayName: "Workspace One",
+		AccountType: "business",
+		OwnerUserID: userID,
+	}
+	accountRepo.memberships = []accounts.Membership{
+		{ID: uuid.New(), AccountID: accountID, UserID: userID, Role: "member", Status: "active"},
+	}
+
+	roleSvc := platform.NewRoleService(&stubRoleStore{adminUsers: map[uuid.UUID]bool{userID: true}})
+	accountsSvc := accounts.NewService(accountRepo)
+	accountingSvc := NewService(accountingRepo, ledgerSvc, usageSvc)
+	handler := NewHandler(accountingSvc, accountsSvc).WithRoleService(roleSvc)
+
+	viewer := auth.Viewer{UserID: userID, Email: "admin@example.com", EmailVerified: false}
+
+	body, err := json.Marshal(map[string]any{
+		"request_id":        "req_platform_admin",
+		"attempt_number":    1,
+		"endpoint":          "/v1/responses",
+		"model_alias":       "hive-fast",
+		"estimated_credits": 120,
+		"policy_mode":       string(PolicyModeStrict),
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/accounts/current/credits/reservations", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(viewerCtx(viewer))
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 for platform admin overlay, got %d: %s", rr.Code, rr.Body.String())
 	}
 }

--- a/apps/control-plane/internal/accounts/http.go
+++ b/apps/control-plane/internal/accounts/http.go
@@ -2,6 +2,7 @@ package accounts
 
 import (
 	"encoding/json"
+	"log/slog"
 	"net/http"
 
 	"github.com/google/uuid"
@@ -12,8 +13,9 @@ import (
 
 // Handler handles all accounts-related HTTP routes.
 type Handler struct {
-	svc    *Service
-	policy authz.Policy
+	svc     *Service
+	roleSvc *platform.RoleService // optional — used by handleListMembers to populate Actor.IsAdmin
+	policy  authz.Policy
 }
 
 // NewHandler returns a new accounts Handler.
@@ -23,12 +25,13 @@ func NewHandler(svc *Service) *Handler {
 
 // WithRoleService returns a copy of the handler whose underlying Service is
 // wired with the platform role service, so GET /api/v1/viewer reports the
-// real platform-admin overlay in permissions[]. Mirrors the apikeys/budgets
-// handler idiom. Does not affect handleListMembers, which resolves its own
-// Actor directly (see comment there).
+// real platform-admin overlay in permissions[], and handleListMembers can
+// resolve the same overlay for its own independently-built Actor. Mirrors the
+// apikeys/budgets handler idiom.
 func (h *Handler) WithRoleService(roleSvc *platform.RoleService) *Handler {
 	cloned := *h
 	cloned.svc = h.svc.WithRoleService(roleSvc)
+	cloned.roleSvc = roleSvc
 	return &cloned
 }
 
@@ -84,19 +87,28 @@ func (h *Handler) handleListMembers(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Phase 18: route authz through policy.Can — replaces bare EmailVerified check.
-	// isAdmin hardcoded false here too: this Actor is built independently of
-	// EnsureViewerContext's own (now roleSvc-aware) actor, so a real platform
-	// admin who is not a workspace owner is still denied members.invite here.
-	// Known, separate gap from the reported bug (which is scoped to viewer
-	// permissions[] powering Feature Gates/Marketplace); not fixed in this
-	// change to keep the diff scoped. Fix path: give Handler its own roleSvc
-	// field via WithRoleService, same idiom as apikeys/budgets.
+	// isAdmin resolves the real platform-admin overlay when roleSvc is wired
+	// (see WithRoleService), so a real platform admin who is not a workspace
+	// owner is granted members.invite here too, matching the viewer
+	// permissions[] overlay fixed in EnsureViewerContext.
+	isAdmin := false
+	if h.roleSvc != nil {
+		admin, err := h.roleSvc.IsPlatformAdmin(r.Context(), viewer.UserID)
+		if err != nil {
+			slog.ErrorContext(r.Context(), "accounts: platform-admin lookup failed",
+				slog.String("user_id", viewer.UserID.String()),
+				slog.String("err", err.Error()))
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "authorization unavailable"})
+			return
+		}
+		isAdmin = admin
+	}
 	actor := ActorFor(viewer, Membership{
 		AccountID: vc.CurrentAccount.ID,
 		UserID:    viewer.UserID,
 		Role:      vc.CurrentAccount.Role,
 		Status:    "active",
-	}, false)
+	}, isAdmin)
 	if !h.policy.Can(actor, authz.PermMembersInvite) {
 		writeJSON(w, http.StatusForbidden, map[string]string{
 			"error": "email must be verified before accessing members",

--- a/apps/control-plane/internal/accounts/http_test.go
+++ b/apps/control-plane/internal/accounts/http_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/accounts"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/auth"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/platform"
 )
 
 // --- helpers ---
@@ -292,6 +293,51 @@ func TestMembersHandler_UnverifiedReturns403(t *testing.T) {
 
 	if rr.Code != http.StatusForbidden {
 		t.Fatalf("expected 403, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestMembersHandler_PlatformAdminOverlayGrantsAccess is a regression guard
+// for issue #424: handleListMembers hardcoded isAdmin=false when building its
+// own Actor (independent of EnsureViewerContext's roleSvc-aware actor), so a
+// real platform admin who is neither a workspace owner nor account-verified
+// was silently denied members.invite access. A hardcoded-false version
+// returns 403 here (see TestMembersHandler_UnverifiedReturns403); the fix
+// must return 200.
+func TestMembersHandler_PlatformAdminOverlayGrantsAccess(t *testing.T) {
+	repo := newStubRepo()
+
+	userID := uuid.New()
+	accountID := uuid.New()
+	repo.accountsMap[accountID] = &accounts.Account{
+		ID:          accountID,
+		Slug:        "restricted-workspace",
+		DisplayName: "Restricted Workspace",
+		AccountType: "personal",
+		OwnerUserID: uuid.New(),
+	}
+	repo.memberships = []accounts.Membership{
+		{ID: uuid.New(), AccountID: accountID, UserID: userID, Role: "member", Status: "active"},
+	}
+
+	store := &stubPlatformAdminStore{adminUsers: map[uuid.UUID]bool{userID: true}}
+	roleSvc := platform.NewRoleService(store)
+	svc := accounts.NewService(repo)
+	h := accounts.NewHandler(svc).WithRoleService(roleSvc)
+
+	viewer := auth.Viewer{
+		UserID:        userID,
+		Email:         "admin@example.com",
+		EmailVerified: false,
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/accounts/current/members", nil)
+	req = req.WithContext(viewerCtx(viewer))
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 for platform admin overlay, got %d: %s", rr.Code, rr.Body.String())
 	}
 }
 

--- a/apps/control-plane/internal/accounts/service.go
+++ b/apps/control-plane/internal/accounts/service.go
@@ -203,7 +203,19 @@ func (s *Service) CreateInvitation(ctx context.Context, accountID uuid.UUID, vie
 	}
 
 	// Phase 18: permission check via policy — replaces bare EmailVerified && role=="owner".
-	actor := ActorFor(viewer, chosen, false) // isAdmin=false: callers with admin overlay use middleware
+	// isAdmin resolves the real platform-admin overlay when roleSvc is wired
+	// (see WithRoleService), matching EnsureViewerContext's idiom: a real
+	// platform admin who is not a workspace owner is still granted
+	// members.invite via the overlay instead of being silently denied.
+	isAdmin := false
+	if s.roleSvc != nil {
+		admin, err := s.roleSvc.IsPlatformAdmin(ctx, viewer.UserID)
+		if err != nil {
+			return InvitationResult{}, fmt.Errorf("accounts: platform admin lookup: %w", err)
+		}
+		isAdmin = admin
+	}
+	actor := ActorFor(viewer, chosen, isAdmin)
 	if !s.policy.Can(actor, authz.PermMembersInvite) {
 		return InvitationResult{}, &GateError{
 			Code:    "permission_denied",

--- a/apps/control-plane/internal/accounts/service_platform_admin_test.go
+++ b/apps/control-plane/internal/accounts/service_platform_admin_test.go
@@ -107,3 +107,61 @@ func TestEnsureViewerContext_NoRoleService_DefaultsToNonAdmin(t *testing.T) {
 		}
 	}
 }
+
+// TestCreateInvitation_PlatformAdminOverlay is a regression guard for issue
+// #424: CreateInvitation hardcoded isAdmin=false when building its Actor, so
+// a real platform admin who is a non-owner member of the target account was
+// silently denied members.invite even though the admin overlay should grant
+// it. A hardcoded-false version returns permission_denied here; the fix must
+// succeed.
+func TestCreateInvitation_PlatformAdminOverlay(t *testing.T) {
+	cases := []struct {
+		name    string
+		isAdmin bool
+		wantErr bool
+	}{
+		{"platform admin non-owner member is granted members.invite", true, false},
+		{"non-admin non-owner member is denied members.invite", false, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := newStubRepo()
+			userID := uuid.New()
+			accountID := uuid.New()
+
+			repo.accountsMap[accountID] = &accounts.Account{
+				ID:          accountID,
+				Slug:        "ws",
+				DisplayName: "WS",
+				AccountType: "personal",
+				OwnerUserID: uuid.New(),
+			}
+			repo.memberships = []accounts.Membership{
+				{ID: uuid.New(), AccountID: accountID, UserID: userID, Role: "member", Status: "active"},
+			}
+
+			store := &stubPlatformAdminStore{adminUsers: map[uuid.UUID]bool{}}
+			if tc.isAdmin {
+				store.adminUsers[userID] = true
+			}
+			roleSvc := platform.NewRoleService(store)
+
+			svc := accounts.NewService(repo).WithRoleService(roleSvc)
+
+			viewer := auth.Viewer{
+				UserID:        userID,
+				Email:         "admin-check@example.com",
+				EmailVerified: false,
+			}
+
+			_, err := svc.CreateInvitation(context.Background(), accountID, viewer, "invitee@example.com")
+			if tc.wantErr && err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("expected no error, got: %v", err)
+			}
+		})
+	}
+}

--- a/apps/control-plane/internal/budgets/http.go
+++ b/apps/control-plane/internal/budgets/http.go
@@ -3,6 +3,7 @@ package budgets
 import (
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"math/big"
 	"net/http"
 	"strings"
@@ -148,12 +149,27 @@ func (h *Handler) resolveCurrentAccountID(w http.ResponseWriter, r *http.Request
 	}
 
 	// Phase 18: route authz through policy.Can — replaces bare EmailVerified check.
+	// isAdmin resolves the real platform-admin overlay when roleSvc is wired
+	// (see WithRoleService); without it, a real platform admin who is not
+	// account-verified is silently denied billing access here.
+	isAdmin := false
+	if h.roleSvc != nil {
+		admin, err := h.roleSvc.IsPlatformAdmin(r.Context(), viewer.UserID)
+		if err != nil {
+			slog.ErrorContext(r.Context(), "budgets: platform-admin lookup failed",
+				slog.String("user_id", viewer.UserID.String()),
+				slog.String("err", err.Error()))
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "authorization unavailable"})
+			return uuid.Nil, false
+		}
+		isAdmin = admin
+	}
 	actor := accounts.ActorFor(viewer, accounts.Membership{
 		AccountID: viewerContext.CurrentAccount.ID,
 		UserID:    viewer.UserID,
 		Role:      viewerContext.CurrentAccount.Role,
 		Status:    "active",
-	}, false)
+	}, isAdmin)
 	if !h.policy.Can(actor, authz.PermBillingView) {
 		writeJSON(w, http.StatusForbidden, map[string]string{
 			"error": "email must be verified before accessing billing",
@@ -201,13 +217,13 @@ func writeJSON(w http.ResponseWriter, status int, body any) {
 // only — no USD / FX fields. *big.Int values render as int64 (BDT subunits fit;
 // see types.go documentation).
 type budgetWireFormat struct {
-	WorkspaceID         uuid.UUID `json:"workspace_id"`
-	PeriodStart         time.Time `json:"period_start"`
-	SoftCapBDTSubunits  int64     `json:"soft_cap_bdt_subunits"`
-	HardCapBDTSubunits  int64     `json:"hard_cap_bdt_subunits"`
-	Currency            string    `json:"currency"`
-	CreatedAt           time.Time `json:"created_at"`
-	UpdatedAt           time.Time `json:"updated_at"`
+	WorkspaceID        uuid.UUID `json:"workspace_id"`
+	PeriodStart        time.Time `json:"period_start"`
+	SoftCapBDTSubunits int64     `json:"soft_cap_bdt_subunits"`
+	HardCapBDTSubunits int64     `json:"hard_cap_bdt_subunits"`
+	Currency           string    `json:"currency"`
+	CreatedAt          time.Time `json:"created_at"`
+	UpdatedAt          time.Time `json:"updated_at"`
 }
 
 type alertWireFormat struct {
@@ -516,12 +532,24 @@ func (h *Handler) requireWorkspaceOwner(w http.ResponseWriter, r *http.Request, 
 	if isOwner {
 		role = string(platform.RoleOwner)
 	}
+	// isAdmin resolves the real platform-admin overlay (h.roleSvc is already
+	// guaranteed non-nil by the nil check above); without it, a real platform
+	// admin who is not the workspace owner is silently denied this mutation,
+	// even though the overlay should grant it.
+	isAdmin, err := h.roleSvc.IsPlatformAdmin(r.Context(), userID)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "budgets: platform-admin lookup failed",
+			slog.String("user_id", userID.String()),
+			slog.String("err", err.Error()))
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "authorization unavailable"})
+		return false
+	}
 	actor := accounts.ActorFor(viewer, accounts.Membership{
 		AccountID: workspaceID,
 		UserID:    userID,
 		Role:      role,
 		Status:    "active",
-	}, false)
+	}, isAdmin)
 	if !h.policy.Can(actor, authz.PermBillingWrite) {
 		writeJSON(w, http.StatusForbidden, map[string]string{"error": "owner permission required"})
 		return false
@@ -550,12 +578,22 @@ func (h *Handler) requireWorkspaceMembership(r *http.Request, userID, workspaceI
 	if isOwner {
 		role = string(platform.RoleOwner)
 	}
+	// isAdmin resolves the real platform-admin overlay (h.roleSvc is already
+	// guaranteed non-nil by the nil check above); without it, a real platform
+	// admin who is not a workspace member is silently denied read access here.
+	isAdmin, err := h.roleSvc.IsPlatformAdmin(r.Context(), userID)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "budgets: platform-admin lookup failed",
+			slog.String("user_id", userID.String()),
+			slog.String("err", err.Error()))
+		return errors.New("authorization unavailable")
+	}
 	actor := accounts.ActorFor(viewer, accounts.Membership{
 		AccountID: workspaceID,
 		UserID:    userID,
 		Role:      role,
 		Status:    "active",
-	}, false)
+	}, isAdmin)
 	if !h.policy.Can(actor, authz.PermBillingWrite) {
 		return errors.New("not a member")
 	}
@@ -579,13 +617,13 @@ func parseWorkspacePathSuffix(path, prefix string) (uuid.UUID, bool) {
 
 func toBudgetWire(b *Budget) budgetWireFormat {
 	return budgetWireFormat{
-		WorkspaceID:         b.WorkspaceID,
-		PeriodStart:         b.PeriodStart,
-		SoftCapBDTSubunits:  b.SoftCap.Int64(),
-		HardCapBDTSubunits:  b.HardCap.Int64(),
-		Currency:            b.Currency,
-		CreatedAt:           b.CreatedAt,
-		UpdatedAt:           b.UpdatedAt,
+		WorkspaceID:        b.WorkspaceID,
+		PeriodStart:        b.PeriodStart,
+		SoftCapBDTSubunits: b.SoftCap.Int64(),
+		HardCapBDTSubunits: b.HardCap.Int64(),
+		Currency:           b.Currency,
+		CreatedAt:          b.CreatedAt,
+		UpdatedAt:          b.UpdatedAt,
 	}
 }
 

--- a/apps/control-plane/internal/budgets/http_test.go
+++ b/apps/control-plane/internal/budgets/http_test.go
@@ -1,7 +1,9 @@
 package budgets
 
 import (
+	"bytes"
 	"context"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -10,7 +12,76 @@ import (
 	"github.com/google/uuid"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/accounts"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/auth"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/platform"
 )
+
+// stubRoleStore is a minimal platform.RoleStore backing a real
+// *platform.RoleService for tests. adminUsers drives IsPlatformAdmin;
+// owners drives GetMembershipRole (and therefore IsWorkspaceOwner) — any
+// (userID, workspaceID) pair not present in owners resolves as a non-owner
+// member (never ErrWorkspaceNotFound).
+type stubRoleStore struct {
+	adminUsers map[uuid.UUID]bool
+	owners     map[uuid.UUID]uuid.UUID // workspaceID -> owner userID
+}
+
+func (s *stubRoleStore) GetMembershipRole(_ context.Context, userID, workspaceID uuid.UUID) (platform.MembershipRole, error) {
+	if ownerID, ok := s.owners[workspaceID]; ok && ownerID == userID {
+		return platform.RoleOwner, nil
+	}
+	return platform.RoleMember, nil
+}
+
+func (s *stubRoleStore) IsPlatformAdmin(_ context.Context, userID uuid.UUID) (bool, error) {
+	return s.adminUsers[userID], nil
+}
+
+// workspaceRepoStub is a minimal in-memory WorkspaceBudgetRepository —
+// only GetBudget/UpsertBudget are exercised by the platform-admin overlay
+// regression tests below.
+type workspaceRepoStub struct{}
+
+func (s *workspaceRepoStub) GetBudget(_ context.Context, _ uuid.UUID) (*Budget, error) {
+	return nil, nil
+}
+
+func (s *workspaceRepoStub) UpsertBudget(_ context.Context, in SetBudgetInput) (*Budget, error) {
+	return &Budget{
+		WorkspaceID: in.WorkspaceID,
+		PeriodStart: in.PeriodStart,
+		SoftCap:     in.SoftCap,
+		HardCap:     in.HardCap,
+		Currency:    "BDT",
+	}, nil
+}
+
+func (s *workspaceRepoStub) DeleteBudget(_ context.Context, _ uuid.UUID) error { return nil }
+
+func (s *workspaceRepoStub) ListAlerts(_ context.Context, _ uuid.UUID) ([]SpendAlert, error) {
+	return nil, nil
+}
+
+func (s *workspaceRepoStub) CreateAlert(_ context.Context, _ CreateAlertInput) (*SpendAlert, error) {
+	return nil, nil
+}
+
+func (s *workspaceRepoStub) UpdateAlert(_ context.Context, _ UpdateAlertInput) (*SpendAlert, error) {
+	return nil, nil
+}
+
+func (s *workspaceRepoStub) DeleteAlert(_ context.Context, _, _ uuid.UUID) error { return nil }
+
+func (s *workspaceRepoStub) ListWorkspacesWithBudget(_ context.Context) ([]uuid.UUID, error) {
+	return nil, nil
+}
+
+func (s *workspaceRepoStub) StampAlertFired(_ context.Context, _ uuid.UUID, _, _ time.Time) error {
+	return nil
+}
+
+func (s *workspaceRepoStub) MonthToDateSpendBDT(_ context.Context, _ uuid.UUID, _ time.Time) (*big.Int, error) {
+	return big.NewInt(0), nil
+}
 
 type httpRepoStub struct{}
 
@@ -187,5 +258,105 @@ func TestGetBudgetAllowsUnverifiedOwner(t *testing.T) {
 	// Phase 18: billing.view RequiresVerified=false → unverified owner gets 200.
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200 for unverified owner (billing.view requires no verification), got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestGetBudget_PlatformAdminOverlayGrantsAccess is a regression guard for
+// issue #424: resolveCurrentAccountID hardcoded isAdmin=false when building
+// the Actor, so a real platform admin who is a non-owner member was silently
+// denied billing.view access (PermBillingView is owner-only) even though the
+// admin overlay should grant it. A hardcoded-false version returns 403 here;
+// the fix must return 200.
+func TestGetBudget_PlatformAdminOverlayGrantsAccess(t *testing.T) {
+	accountRepo := newAccountsRepoStub()
+	userID := uuid.New()
+	accountID := uuid.New()
+
+	accountRepo.accountsMap[accountID] = &accounts.Account{
+		ID:          accountID,
+		Slug:        "ws",
+		DisplayName: "WS",
+		AccountType: "personal",
+		OwnerUserID: uuid.New(),
+	}
+	accountRepo.memberships = []accounts.Membership{
+		{ID: uuid.New(), AccountID: accountID, UserID: userID, Role: "member", Status: "active"},
+	}
+
+	roleSvc := platform.NewRoleService(&stubRoleStore{adminUsers: map[uuid.UUID]bool{userID: true}})
+	handler := NewHandler(NewService(&httpRepoStub{}, &notifierStub{}), accounts.NewService(accountRepo)).WithRoleService(roleSvc)
+
+	viewer := auth.Viewer{UserID: userID, Email: "admin@example.com", EmailVerified: true}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/accounts/current/budget", nil)
+	req = req.WithContext(viewerCtx(viewer))
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 for platform admin overlay, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestWorkspaceBudgetPUT_PlatformAdminOverlayGrantsAccess is a regression
+// guard for issue #424: requireWorkspaceOwner hardcoded isAdmin=false when
+// building the Actor, so a real platform admin who does not own the target
+// workspace was silently denied PUT /api/v1/budgets/{ws} even though the
+// admin overlay should grant it. A hardcoded-false version returns 403 here;
+// the fix must return 200.
+func TestWorkspaceBudgetPUT_PlatformAdminOverlayGrantsAccess(t *testing.T) {
+	userID := uuid.New()
+	workspaceID := uuid.New()
+
+	roleSvc := platform.NewRoleService(&stubRoleStore{
+		adminUsers: map[uuid.UUID]bool{userID: true},
+		owners:     map[uuid.UUID]uuid.UUID{}, // userID does not own workspaceID
+	})
+	svc := NewServiceWithWorkspace(&httpRepoStub{}, &notifierStub{}, &workspaceRepoStub{}, nil, nil)
+	handler := NewHandler(svc, accounts.NewService(newAccountsRepoStub())).WithRoleService(roleSvc)
+
+	viewer := auth.Viewer{UserID: userID, Email: "admin@example.com", EmailVerified: true}
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/budgets/"+workspaceID.String(),
+		bytes.NewBufferString(`{"soft_cap_bdt_subunits":1000,"hard_cap_bdt_subunits":2000}`))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(viewerCtx(viewer))
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 for platform admin overlay, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestWorkspaceBudgetGET_PlatformAdminOverlayGrantsAccess is a regression
+// guard for issue #424: requireWorkspaceMembership hardcoded isAdmin=false
+// when building the Actor, so a real platform admin who is not a member of
+// the target workspace was silently denied GET /api/v1/budgets/{ws} even
+// though the admin overlay should grant it. A hardcoded-false version
+// returns 403 here; the fix must return 200.
+func TestWorkspaceBudgetGET_PlatformAdminOverlayGrantsAccess(t *testing.T) {
+	userID := uuid.New()
+	workspaceID := uuid.New()
+
+	roleSvc := platform.NewRoleService(&stubRoleStore{
+		adminUsers: map[uuid.UUID]bool{userID: true},
+		owners:     map[uuid.UUID]uuid.UUID{}, // userID is not even a member of workspaceID
+	})
+	svc := NewServiceWithWorkspace(&httpRepoStub{}, &notifierStub{}, &workspaceRepoStub{}, nil, nil)
+	handler := NewHandler(svc, accounts.NewService(newAccountsRepoStub())).WithRoleService(roleSvc)
+
+	viewer := auth.Viewer{UserID: userID, Email: "admin@example.com", EmailVerified: true}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/budgets/"+workspaceID.String(), nil)
+	req = req.WithContext(viewerCtx(viewer))
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 for platform admin overlay, got %d: %s", rr.Code, rr.Body.String())
 	}
 }

--- a/apps/control-plane/internal/ledger/http.go
+++ b/apps/control-plane/internal/ledger/http.go
@@ -3,6 +3,7 @@ package ledger
 import (
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
@@ -11,16 +12,28 @@ import (
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/accounts"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/auth"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/authz"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/platform"
 )
 
 type Handler struct {
 	svc         *Service
 	accountsSvc *accounts.Service
+	roleSvc     *platform.RoleService // optional — used to populate Actor.IsAdmin via IsPlatformAdmin
 	policy      authz.Policy
 }
 
 func NewHandler(svc *Service, accountsSvc *accounts.Service) *Handler {
 	return &Handler{svc: svc, accountsSvc: accountsSvc, policy: authz.NewPolicy()}
+}
+
+// WithRoleService returns a copy of the handler wired with the platform role
+// service so the admin overlay is enabled for Actor construction. Without it,
+// Actor.IsAdmin is always false and platform admins cannot view the credit
+// ledger via this handler unless also account-verified.
+func (h *Handler) WithRoleService(roleSvc *platform.RoleService) *Handler {
+	cloned := *h
+	cloned.roleSvc = roleSvc
+	return &cloned
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -165,12 +178,27 @@ func (h *Handler) resolveCurrentAccountID(w http.ResponseWriter, r *http.Request
 	}
 
 	// Phase 18: route authz through policy.Can — replaces bare EmailVerified check.
+	// isAdmin resolves the real platform-admin overlay when roleSvc is wired
+	// (see WithRoleService); without it, a real platform admin who is not
+	// account-verified is silently denied ledger access here.
+	isAdmin := false
+	if h.roleSvc != nil {
+		admin, err := h.roleSvc.IsPlatformAdmin(r.Context(), viewer.UserID)
+		if err != nil {
+			slog.ErrorContext(r.Context(), "ledger: platform-admin lookup failed",
+				slog.String("user_id", viewer.UserID.String()),
+				slog.String("err", err.Error()))
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "authorization unavailable"})
+			return uuid.Nil, false
+		}
+		isAdmin = admin
+	}
 	actor := accounts.ActorFor(viewer, accounts.Membership{
 		AccountID: viewerContext.CurrentAccount.ID,
 		UserID:    viewer.UserID,
 		Role:      viewerContext.CurrentAccount.Role,
 		Status:    "active",
-	}, false)
+	}, isAdmin)
 	if !h.policy.Can(actor, authz.PermLedgerView) {
 		writeJSON(w, http.StatusForbidden, map[string]string{
 			"error": "email must be verified before accessing billing",

--- a/apps/control-plane/internal/ledger/http_test.go
+++ b/apps/control-plane/internal/ledger/http_test.go
@@ -10,7 +10,22 @@ import (
 	"github.com/google/uuid"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/accounts"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/auth"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/platform"
 )
+
+// stubRoleStore is a minimal platform.RoleStore backing a real
+// *platform.RoleService for tests, keyed by userID -> is_platform_admin.
+type stubRoleStore struct {
+	adminUsers map[uuid.UUID]bool
+}
+
+func (s *stubRoleStore) GetMembershipRole(_ context.Context, _, _ uuid.UUID) (platform.MembershipRole, error) {
+	return "", nil
+}
+
+func (s *stubRoleStore) IsPlatformAdmin(_ context.Context, userID uuid.UUID) (bool, error) {
+	return s.adminUsers[userID], nil
+}
 
 func viewerCtx(viewer auth.Viewer) context.Context {
 	return auth.WithViewer(context.Background(), viewer)
@@ -227,5 +242,44 @@ func TestHandler_LedgerAuthzMatrix(t *testing.T) {
 				t.Errorf("want %d got %d: %s", tc.wantStatus, rr.Code, rr.Body.String())
 			}
 		})
+	}
+}
+
+// TestGetBalance_PlatformAdminOverlayGrantsUnverifiedAccess is a regression
+// guard for issue #424: resolveCurrentAccountID hardcoded isAdmin=false when
+// building the Actor, so a real platform admin who is not account-verified
+// was silently denied ledger access even though the admin overlay should
+// grant it. A hardcoded-false version returns 403 here; the fix must return 200.
+func TestGetBalance_PlatformAdminOverlayGrantsUnverifiedAccess(t *testing.T) {
+	repo := newStubRepo()
+	userID := uuid.New()
+	accountID := uuid.New()
+
+	repo.accountsMap[accountID] = &accounts.Account{
+		ID:          accountID,
+		Slug:        "workspace-one",
+		DisplayName: "Workspace One",
+		AccountType: "business",
+		OwnerUserID: userID,
+	}
+	repo.memberships = []accounts.Membership{
+		{ID: uuid.New(), AccountID: accountID, UserID: userID, Role: "member", Status: "active"},
+	}
+
+	roleSvc := platform.NewRoleService(&stubRoleStore{adminUsers: map[uuid.UUID]bool{userID: true}})
+	ledgerSvc := NewService(repo)
+	accountsSvc := accounts.NewService(repo)
+	handler := NewHandler(ledgerSvc, accountsSvc).WithRoleService(roleSvc)
+
+	viewer := auth.Viewer{UserID: userID, Email: "admin@example.com", EmailVerified: false}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/accounts/current/credits/balance", nil)
+	req = req.WithContext(viewerCtx(viewer))
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 for platform admin overlay, got %d: %s", rr.Code, rr.Body.String())
 	}
 }

--- a/apps/control-plane/internal/profiles/http.go
+++ b/apps/control-plane/internal/profiles/http.go
@@ -3,24 +3,37 @@ package profiles
 import (
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"net/http"
 
 	"github.com/google/uuid"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/accounts"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/auth"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/authz"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/platform"
 )
 
 // Handler handles all profile-related HTTP routes.
 type Handler struct {
 	svc         *Service
 	accountsSvc *accounts.Service
+	roleSvc     *platform.RoleService // optional — used to populate Actor.IsAdmin via IsPlatformAdmin
 	policy      authz.Policy
 }
 
 // NewHandler returns a new profiles Handler.
 func NewHandler(svc *Service, accountsSvc *accounts.Service) *Handler {
 	return &Handler{svc: svc, accountsSvc: accountsSvc, policy: authz.NewPolicy()}
+}
+
+// WithRoleService returns a copy of the handler wired with the platform role
+// service so the admin overlay is enabled for Actor construction. Without it,
+// Actor.IsAdmin is always false and platform admins cannot manage billing
+// profiles via this handler unless they are also a verified workspace owner.
+func (h *Handler) WithRoleService(roleSvc *platform.RoleService) *Handler {
+	cloned := *h
+	cloned.roleSvc = roleSvc
+	return &cloned
 }
 
 // ServeHTTP dispatches requests to the appropriate sub-handler.
@@ -127,7 +140,22 @@ func (h *Handler) resolveVerifiedCurrentAccountID(w http.ResponseWriter, r *http
 	}
 
 	// Phase 18: route authz through policy.Can — replaces bare EmailVerified check.
-	// Actor is built from the already-resolved viewer context fields.
+	// Actor is built from the already-resolved viewer context fields. isAdmin
+	// resolves the real platform-admin overlay when roleSvc is wired (see
+	// WithRoleService); without it, a real platform admin who is not a
+	// verified workspace owner is silently denied billing access here.
+	isAdmin := false
+	if h.roleSvc != nil {
+		admin, err := h.roleSvc.IsPlatformAdmin(r.Context(), viewerContext.User.ID)
+		if err != nil {
+			slog.ErrorContext(r.Context(), "profiles: platform-admin lookup failed",
+				slog.String("user_id", viewerContext.User.ID.String()),
+				slog.String("err", err.Error()))
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "authorization unavailable"})
+			return uuid.Nil, false
+		}
+		isAdmin = admin
+	}
 	actor := accounts.ActorFor(
 		auth.Viewer{
 			UserID:        viewerContext.User.ID,
@@ -140,7 +168,7 @@ func (h *Handler) resolveVerifiedCurrentAccountID(w http.ResponseWriter, r *http
 			Role:      viewerContext.CurrentAccount.Role,
 			Status:    "active",
 		},
-		false,
+		isAdmin,
 	)
 	if !h.policy.Can(actor, authz.PermWorkspaceSettings) {
 		writeJSON(w, http.StatusForbidden, map[string]string{

--- a/apps/control-plane/internal/profiles/http_test.go
+++ b/apps/control-plane/internal/profiles/http_test.go
@@ -11,7 +11,22 @@ import (
 	"github.com/google/uuid"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/accounts"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/auth"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/platform"
 )
+
+// stubRoleStore is a minimal platform.RoleStore backing a real
+// *platform.RoleService for tests, keyed by userID -> is_platform_admin.
+type stubRoleStore struct {
+	adminUsers map[uuid.UUID]bool
+}
+
+func (s *stubRoleStore) GetMembershipRole(_ context.Context, _, _ uuid.UUID) (platform.MembershipRole, error) {
+	return "", nil
+}
+
+func (s *stubRoleStore) IsPlatformAdmin(_ context.Context, userID uuid.UUID) (bool, error) {
+	return s.adminUsers[userID], nil
+}
 
 func viewerCtx(viewer auth.Viewer) context.Context {
 	return auth.WithViewer(context.Background(), viewer)
@@ -406,5 +421,47 @@ func TestHandler_ProfilesAuthzMatrix(t *testing.T) {
 				t.Errorf("want %d got %d: %s", tc.wantStatus, rr.Code, rr.Body.String())
 			}
 		})
+	}
+}
+
+// TestBillingProfile_PlatformAdminOverlayGrantsAccess is a regression guard
+// for issue #424: resolveVerifiedCurrentAccountID hardcoded isAdmin=false
+// when building the Actor, so a real platform admin who is neither a
+// workspace owner nor account-verified was silently denied billing-profile
+// access even though the admin overlay should grant it. A hardcoded-false
+// version returns 403 (per TestHandler_ProfilesAuthzMatrix's "member
+// unverified" case); the fix must pass authz and reach the not-found path
+// (404, no profile stored), matching the "owner verified" case's behavior.
+func TestBillingProfile_PlatformAdminOverlayGrantsAccess(t *testing.T) {
+	repo := newStubRepo()
+	accountID := uuid.New()
+	userID := uuid.New()
+
+	repo.accountsMap[accountID] = &accounts.Account{
+		ID:          accountID,
+		Slug:        "ws",
+		DisplayName: "WS",
+		AccountType: "personal",
+		OwnerUserID: uuid.New(),
+	}
+	repo.memberships = []accounts.Membership{
+		{ID: uuid.New(), AccountID: accountID, UserID: userID, Role: "member", Status: "active"},
+	}
+
+	roleSvc := platform.NewRoleService(&stubRoleStore{adminUsers: map[uuid.UUID]bool{userID: true}})
+	profileSvc := NewService(repo)
+	accountsSvc := accounts.NewService(repo)
+	handler := NewHandler(profileSvc, accountsSvc).WithRoleService(roleSvc)
+
+	viewer := auth.Viewer{UserID: userID, Email: "admin@example.com", EmailVerified: false}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/accounts/current/billing-profile", nil)
+	req = req.WithContext(viewerCtx(viewer))
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 (authz passed, no profile stored) for platform admin overlay, got %d: %s", rr.Code, rr.Body.String())
 	}
 }

--- a/apps/control-plane/internal/usage/http.go
+++ b/apps/control-plane/internal/usage/http.go
@@ -3,6 +3,7 @@ package usage
 import (
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
@@ -12,16 +13,28 @@ import (
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/accounts"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/auth"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/authz"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/platform"
 )
 
 type Handler struct {
 	svc         *Service
 	accountsSvc *accounts.Service
+	roleSvc     *platform.RoleService // optional — used to populate Actor.IsAdmin via IsPlatformAdmin
 	policy      authz.Policy
 }
 
 func NewHandler(svc *Service, accountsSvc *accounts.Service) *Handler {
 	return &Handler{svc: svc, accountsSvc: accountsSvc, policy: authz.NewPolicy()}
+}
+
+// WithRoleService returns a copy of the handler wired with the platform role
+// service so the admin overlay is enabled for Actor construction. Without it,
+// Actor.IsAdmin is always false and platform admins cannot view usage
+// analytics via this handler unless also account-verified.
+func (h *Handler) WithRoleService(roleSvc *platform.RoleService) *Handler {
+	cloned := *h
+	cloned.roleSvc = roleSvc
+	return &cloned
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -393,12 +406,27 @@ func (h *Handler) resolveCurrentAccountID(w http.ResponseWriter, r *http.Request
 	}
 
 	// Phase 18: route authz through policy.Can — replaces bare EmailVerified check.
+	// isAdmin resolves the real platform-admin overlay when roleSvc is wired
+	// (see WithRoleService); without it, a real platform admin who is not
+	// account-verified is silently denied usage analytics access here.
+	isAdmin := false
+	if h.roleSvc != nil {
+		admin, err := h.roleSvc.IsPlatformAdmin(r.Context(), viewer.UserID)
+		if err != nil {
+			slog.ErrorContext(r.Context(), "usage: platform-admin lookup failed",
+				slog.String("user_id", viewer.UserID.String()),
+				slog.String("err", err.Error()))
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "authorization unavailable"})
+			return uuid.Nil, false
+		}
+		isAdmin = admin
+	}
 	actor := accounts.ActorFor(viewer, accounts.Membership{
 		AccountID: viewerContext.CurrentAccount.ID,
 		UserID:    viewer.UserID,
 		Role:      viewerContext.CurrentAccount.Role,
 		Status:    "active",
-	}, false)
+	}, isAdmin)
 	if !h.policy.Can(actor, authz.PermAnalyticsView) {
 		writeJSON(w, http.StatusForbidden, map[string]string{
 			"error": "email must be verified before accessing analytics",

--- a/apps/control-plane/internal/usage/http_test.go
+++ b/apps/control-plane/internal/usage/http_test.go
@@ -11,7 +11,22 @@ import (
 	"github.com/google/uuid"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/accounts"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/auth"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/platform"
 )
+
+// stubRoleStore is a minimal platform.RoleStore backing a real
+// *platform.RoleService for tests, keyed by userID -> is_platform_admin.
+type stubRoleStore struct {
+	adminUsers map[uuid.UUID]bool
+}
+
+func (s *stubRoleStore) GetMembershipRole(_ context.Context, _, _ uuid.UUID) (platform.MembershipRole, error) {
+	return "", nil
+}
+
+func (s *stubRoleStore) IsPlatformAdmin(_ context.Context, userID uuid.UUID) (bool, error) {
+	return s.adminUsers[userID], nil
+}
 
 func viewerCtx(viewer auth.Viewer) context.Context {
 	return auth.WithViewer(context.Background(), viewer)
@@ -417,5 +432,45 @@ func TestHandler_UsageAuthzMatrix(t *testing.T) {
 				t.Errorf("want %d got %d: %s", tc.wantStatus, rr.Code, rr.Body.String())
 			}
 		})
+	}
+}
+
+// TestListUsageEvents_PlatformAdminOverlayGrantsUnverifiedAccess is a
+// regression guard for issue #424: resolveCurrentAccountID hardcoded
+// isAdmin=false when building the Actor, so a real platform admin who is not
+// account-verified was silently denied usage analytics access even though the
+// admin overlay should grant it. A hardcoded-false version returns 403 here;
+// the fix must return 200.
+func TestListUsageEvents_PlatformAdminOverlayGrantsUnverifiedAccess(t *testing.T) {
+	repo := newStubRepo()
+	userID := uuid.New()
+	accountID := uuid.New()
+
+	repo.accountsMap[accountID] = &accounts.Account{
+		ID:          accountID,
+		Slug:        "workspace-one",
+		DisplayName: "Workspace One",
+		AccountType: "business",
+		OwnerUserID: userID,
+	}
+	repo.memberships = []accounts.Membership{
+		{ID: uuid.New(), AccountID: accountID, UserID: userID, Role: "member", Status: "active"},
+	}
+
+	roleSvc := platform.NewRoleService(&stubRoleStore{adminUsers: map[uuid.UUID]bool{userID: true}})
+	usageSvc := NewService(repo)
+	accountsSvc := accounts.NewService(repo)
+	handler := NewHandler(usageSvc, accountsSvc).WithRoleService(roleSvc)
+
+	viewer := auth.Viewer{UserID: userID, Email: "admin@example.com", EmailVerified: false}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/accounts/current/usage-events", nil)
+	req = req.WithContext(viewerCtx(viewer))
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 for platform admin overlay, got %d: %s", rr.Code, rr.Body.String())
 	}
 }


### PR DESCRIPTION
## Summary

PR #422 fixed `GET /api/v1/viewer` never surfacing `platform.admin` for real platform admins by wiring `roleSvc.IsPlatformAdmin(ctx, userID)` into `EnsureViewerContext`'s Actor construction. That review flagged several other call sites that independently build an `authz.Actor` with a hardcoded `isAdmin := false`, silently under-granting real platform admins who are not also a verified workspace owner/member on that specific surface. This PR closes all of them, using the exact same idiom (`Handler.roleSvc` field, nil-safe `WithRoleService`, `IsPlatformAdmin` lookup with `slog.ErrorContext` + 500 on error).

- `accounts.Handler.handleListMembers` — added a `Handler.roleSvc` field (separate from the `Service`'s own, already-fixed-in-#422 `roleSvc`) so the independently-built Actor there also resolves the overlay.
- `accounts.Service.CreateInvitation` — reuses the `Service.roleSvc` already wired for `EnsureViewerContext`, matching that function's own idiom (wrapped error return, no `writeJSON`, since it's a service method, not an HTTP handler).
- `profiles.Handler.resolveVerifiedCurrentAccountID` (billing-profile gate) — new `WithRoleService`.
- `accounting.Handler.resolveCurrentAccountID` (credit reservations gate) — new `WithRoleService`.
- `budgets.Handler` — `roleSvc` was already wired (used for `IsWorkspaceOwner`); fixed the 3 additional sites that hardcoded `isAdmin=false`: the legacy `resolveCurrentAccountID`, `requireWorkspaceOwner`, and `requireWorkspaceMembership`.
- `ledger.Handler.resolveCurrentAccountID` (credit ledger gate) — new `WithRoleService`.
- `usage.Handler.resolveCurrentAccountID` (usage analytics gate) — new `WithRoleService`.

`cmd/server/main.go` now calls `.WithRoleService(roleSvc)` on `profilesHandler`, `accountingHandler`, `ledgerHandler`, and `usageHandler`, next to the existing calls for `budgetsHandler`/`accountsHandler`/`apikeysHandler`.

Not a privilege-escalation risk: this is strictly closing an under-grant (real platform admins being denied access they should have), never widening access beyond what a genuine `is_platform_admin=true` row grants.

## Test plan

- [x] New regression test per call site proving a real platform admin (via a `platform.RoleService` backed by a stub `RoleStore`) is granted access that the prior hardcoded-`false` version would have denied:
  - `accounts`: `TestMembersHandler_PlatformAdminOverlayGrantsAccess`, `TestCreateInvitation_PlatformAdminOverlay` (table-driven, admin + non-admin cases)
  - `profiles`: `TestBillingProfile_PlatformAdminOverlayGrantsAccess`
  - `accounting`: `TestCreateReservation_PlatformAdminOverlayGrantsUnverifiedAccess`
  - `budgets`: `TestGetBudget_PlatformAdminOverlayGrantsAccess`, `TestWorkspaceBudgetPUT_PlatformAdminOverlayGrantsAccess`, `TestWorkspaceBudgetGET_PlatformAdminOverlayGrantsAccess`
  - `ledger`: `TestGetBalance_PlatformAdminOverlayGrantsUnverifiedAccess`
  - `usage`: `TestListUsageEvents_PlatformAdminOverlayGrantsUnverifiedAccess`
- [x] `gofmt -l` clean on all touched files
- [x] Full `go test ./apps/control-plane/... -count=1 -short` green (all ~50 packages, including all touched packages) via the Docker toolchain

Fixes #424

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR resolves the platform-admin overlay when constructing authorization actors in the remaining affected control-plane handlers.
- Wires the platform role service into accounts, profiles, accounting, budgets, ledger, and usage authorization paths.
- Returns an authorization error when platform-admin resolution fails instead of silently treating the user as a non-admin.
- Adds regression coverage for platform-admin access across every updated handler and service path.
- Repeats an already-completed platform-admin database lookup in several request paths, adding an avoidable failure point.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The duplicate platform-admin lookups should be removed before merging because a later transient database error can reject a request after the same authorization fact was already resolved successfully.

Several changed handlers call EnsureViewerContext, which queries IsPlatformAdmin, and then immediately query IsPlatformAdmin again for the same user; failure of the redundant second query turns an otherwise authorized request into a 500 response.

apps/control-plane/internal/accounts/http.go, apps/control-plane/internal/accounts/service.go, apps/control-plane/internal/accounting/http.go, apps/control-plane/internal/profiles/http.go, apps/control-plane/internal/budgets/http.go, apps/control-plane/internal/ledger/http.go, apps/control-plane/internal/usage/http.go
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/control-plane/cmd/server/main.go | Wires the shared role service into all newly role-aware handlers within the existing non-nil database initialization block. |
| apps/control-plane/internal/accounts/http.go | Adds platform-admin resolution to the member-list actor but repeats the lookup already performed by EnsureViewerContext. |
| apps/control-plane/internal/accounts/service.go | Applies the platform-admin overlay to invitation checks while introducing a second lookup after the handler resolves viewer context. |
| apps/control-plane/internal/budgets/http.go | Applies the overlay to billing gates, including a duplicate lookup on legacy current-account paths. |
| apps/control-plane/internal/accounting/http.go | Adds platform-admin resolution to credit reservation authorization but repeats the viewer-context lookup. |
| apps/control-plane/internal/profiles/http.go | Adds the platform-admin overlay to billing-profile authorization with a redundant role-store query. |
| apps/control-plane/internal/ledger/http.go | Adds the platform-admin overlay to ledger authorization with a redundant role-store query. |
| apps/control-plane/internal/usage/http.go | Adds the platform-admin overlay to usage authorization with a redundant role-store query. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Authenticated viewer] --> B[Resolve current account or workspace]
    B --> C[RoleService.IsPlatformAdmin]
    C -->|lookup error| D[Return authorization unavailable]
    C -->|admin| E[Build Actor with IsAdmin true]
    C -->|non-admin| F[Build Actor with membership role]
    E --> G[Policy.Can]
    F --> G
    G -->|allowed| H[Execute handler operation]
    G -->|denied| I[Return forbidden]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fcontrol-plane%2Finternal%2Faccounts%2Fhttp.go%3A96%0A**Duplicate%20admin%20lookup%20adds%20failures**%0A%0AAfter%20%60EnsureViewerContext%60%20has%20already%20resolved%20this%20user's%20platform-admin%20status%2C%20this%20second%20database%20lookup%20repeats%20the%20same%20authorization%20query.%20When%20the%20first%20lookup%20succeeds%20but%20this%20one%20encounters%20a%20transient%20database%20error%2C%20the%20request%20returns%20500%20despite%20already%20having%20enough%20information%20to%20authorize%20it%3B%20the%20same%20duplicate%20pattern%20was%20added%20to%20invitation%2C%20profiles%2C%20accounting%2C%20legacy%20budgets%2C%20ledger%2C%20and%20usage%20paths.%0A%0A&repo=sakibsadmanshajib%2Fhive&pr=427&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fcontrol-plane%2Finternal%2Faccounts%2Fhttp.go%3A96%0A**Duplicate%20admin%20lookup%20adds%20failures**%0A%0AAfter%20%60EnsureViewerContext%60%20has%20already%20resolved%20this%20user's%20platform-admin%20status%2C%20this%20second%20database%20lookup%20repeats%20the%20same%20authorization%20query.%20When%20the%20first%20lookup%20succeeds%20but%20this%20one%20encounters%20a%20transient%20database%20error%2C%20the%20request%20returns%20500%20despite%20already%20having%20enough%20information%20to%20authorize%20it%3B%20the%20same%20duplicate%20pattern%20was%20added%20to%20invitation%2C%20profiles%2C%20accounting%2C%20legacy%20budgets%2C%20ledger%2C%20and%20usage%20paths.%0A%0A&pr=427&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22sakibsadmanshajib%2Fhive%22%20on%20the%20existing%20branch%20%22fix%2F424-platform-admin-actor-remaining-handlers%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F424-platform-admin-actor-remaining-handlers%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fcontrol-plane%2Finternal%2Faccounts%2Fhttp.go%3A96%0A**Duplicate%20admin%20lookup%20adds%20failures**%0A%0AAfter%20%60EnsureViewerContext%60%20has%20already%20resolved%20this%20user's%20platform-admin%20status%2C%20this%20second%20database%20lookup%20repeats%20the%20same%20authorization%20query.%20When%20the%20first%20lookup%20succeeds%20but%20this%20one%20encounters%20a%20transient%20database%20error%2C%20the%20request%20returns%20500%20despite%20already%20having%20enough%20information%20to%20authorize%20it%3B%20the%20same%20duplicate%20pattern%20was%20added%20to%20invitation%2C%20profiles%2C%20accounting%2C%20legacy%20budgets%2C%20ledger%2C%20and%20usage%20paths.%0A%0A&repo=sakibsadmanshajib%2Fhive&pr=427&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix: platform admins get IsAdmin overlay..."](https://github.com/sakibsadmanshajib/hive/commit/41af8aa17752a38bba010c1767127bcffa4a11ad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46985141)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->