### PR TITLE
fix: close owner_user_id desync + zero-membership tenant gaps in seed-demo-owner guards

### DIFF
--- a/scripts/seed-demo-owner.py
+++ b/scripts/seed-demo-owner.py
@@ -122,36 +122,56 @@ def find_by_slug(rest, headers, table, slug):
     return body[0] if body else None
 
 
-def guard_tenant_slug(existing_tenant, foreign_members):
-    """Exits loud if existing_tenant (found by TENANT_SLUG) has members other
-    than our own demo user -- see the on_conflict=slug upsert comment below
-    for why merging onto it unchecked would be a privilege-escalation bug."""
-    if existing_tenant is not None and foreign_members:
+def guard_tenant_slug(existing_tenant, foreign_members, own_member):
+    """Exits loud unless existing_tenant (found by TENANT_SLUG) is provably
+    ours: our own demo user must already be a member (own_member), proof a
+    prior run of this exact script created it, AND no other member may be
+    present (foreign_members empty) -- see the on_conflict=slug upsert
+    comment below for why merging onto it unchecked would be a
+    privilege-escalation bug. A tenant with zero members at all is NOT safe
+    to reuse just because it has no foreign members: it may be a
+    pre-existing tenant this script never touched (never seeded, or fully
+    cleaned up), so own_member must be true, not merely foreign_members
+    empty (issue #420)."""
+    if existing_tenant is not None and (foreign_members or not own_member):
         print(
             f"error: tenant slug {TENANT_SLUG!r} already belongs to tenant "
-            f"{existing_tenant['id']} with {len(foreign_members)} member(s) that are not "
-            "the demo user -- refusing to merge onto a tenant this script did not create. "
-            "Pick a different TENANT_SLUG for the demo.",
+            f"{existing_tenant['id']} that this script cannot confirm it created -- "
+            f"{len(foreign_members)} member(s) that are not the demo user and/or no "
+            "membership row proving the demo user already belongs to it. Refusing to "
+            "merge onto a tenant this script did not create. Pick a different "
+            "TENANT_SLUG for the demo.",
             file=sys.stderr,
         )
         sys.exit(1)
 
 
-def guard_account_slug(existing_account, foreign_owners):
-    """Exits loud if existing_account (found by ACCOUNT_SLUG) has an
-    account_memberships row with role='owner' belonging to someone other
-    than our demo user. control-plane's IsPlatformAdmin authorizes ANY
+def guard_account_slug(existing_account, foreign_owners, user_id):
+    """Exits loud unless existing_account (found by ACCOUNT_SLUG) is provably
+    ours: accounts.owner_user_id must already equal our own demo user AND no
+    account_memberships row with role='owner' may belong to anyone else
+    (foreign_owners empty). control-plane's IsPlatformAdmin authorizes ANY
     owner-role membership on an is_platform_admin account (see
     apps/control-plane/internal/platform/role_pgx.go), not just
     accounts.owner_user_id -- so that single column is not a sufficient
-    collision check. Merging unchecked here would silently grant every
-    such co-owner platform-admin too."""
-    if existing_account is not None and foreign_owners:
+    collision check on its own. The reverse gap is also real (issue #420):
+    accounts.owner_user_id is not schema-enforced to match any membership
+    row, so an existing account could point owner_user_id at a different
+    user with zero owner-role membership rows at all -- foreign_owners
+    would be empty and the old guard let that through, then the upsert
+    silently replaced owner_user_id and enabled is_platform_admin. Checking
+    owner_user_id against our own user_id directly closes that gap."""
+    if existing_account is not None and (
+        foreign_owners or existing_account.get("owner_user_id") != user_id
+    ):
         print(
             f"error: account slug {ACCOUNT_SLUG!r} already belongs to account "
-            f"{existing_account['id']} with {len(foreign_owners)} owner-role member(s) "
-            "that are not the demo user -- refusing to merge (would silently grant them "
-            "is_platform_admin too). Pick a different ACCOUNT_SLUG for the demo.",
+            f"{existing_account['id']} that this script cannot confirm it owns -- "
+            f"{len(foreign_owners)} owner-role member(s) that are not the demo user "
+            f"and/or owner_user_id={existing_account.get('owner_user_id')!r} does not "
+            "match the demo user. Refusing to merge (would silently grant unrelated "
+            "user(s) is_platform_admin too, or adopt an account we do not own). Pick a "
+            "different ACCOUNT_SLUG for the demo.",
             file=sys.stderr,
         )
         sys.exit(1)
@@ -208,14 +228,14 @@ def main() -> None:
     # on_conflict=slug upsert with the service-role key would otherwise
     # silently merge onto ANY pre-existing tenant with this slug -- adding
     # our demo user as OWNER and flipping feature gates on for it, even if
-    # that tenant belongs to a real customer. Guard: if the slug already
-    # resolves to a tenant with members other than our own demo user, fail
-    # loud instead of touching it. A tenant with zero members, or whose only
-    # member is our own demo user (a prior run of this exact script), is
-    # safe to reuse. archived_at is force-reset to NULL on every run: this
-    # is a dedicated demo tenant this script owns outright, so reactivating
-    # it (rather than leaving a demo login unable to get a tenant claim) is
-    # the correct default -- see custom_access_token_hook's
+    # that tenant belongs to a real customer. Guard: only a tenant whose
+    # only member is our own demo user (proof: a prior run of this exact
+    # script) is safe to reuse -- a tenant with zero members is NOT
+    # automatically safe, since it may be a pre-existing tenant this script
+    # never touched (issue #420). archived_at is force-reset to NULL on
+    # every run: this is a dedicated demo tenant this script owns outright,
+    # so reactivating it (rather than leaving a demo login unable to get a
+    # tenant claim) is the correct default -- see custom_access_token_hook's
     # `t.archived_at IS NULL` filter.
     existing_tenant = find_by_slug(rest, headers, "tenants", TENANT_SLUG)
     if existing_tenant is not None:
@@ -227,7 +247,8 @@ def main() -> None:
             print(f"error: tenant membership lookup failed: {status} {members}", file=sys.stderr)
             sys.exit(1)
         foreign_members = [m for m in members if m["user_id"] != user_id]
-        guard_tenant_slug(existing_tenant, foreign_members)
+        own_member = any(m["user_id"] == user_id for m in members)
+        guard_tenant_slug(existing_tenant, foreign_members, own_member)
         if existing_tenant.get("archived_at"):
             print(
                 f"tenant {existing_tenant['id']} was archived_at={existing_tenant['archived_at']}; "
@@ -286,8 +307,11 @@ def main() -> None:
     # admin panels (feature gates, provider catalog, marketplace, credit
     # grants) -- tenant OWNER above does not imply this; they are unrelated
     # schemas. Same slug-collision risk as the tenant guard above: refuse to
-    # merge onto an existing account that already has a different owner-role
-    # member, since that would silently grant them platform-admin too.
+    # merge onto an existing account unless owner_user_id already matches
+    # our demo user AND no other owner-role member exists -- owner_user_id
+    # is not schema-enforced to match any membership row, so checking it
+    # directly closes the desync gap the membership-only check missed
+    # (issue #420).
     existing_account = find_by_slug(rest, headers, "accounts", ACCOUNT_SLUG)
     if existing_account is not None:
         status, owners = request(
@@ -302,7 +326,7 @@ def main() -> None:
             print(f"error: account membership lookup failed: {status} {owners}", file=sys.stderr)
             sys.exit(1)
         foreign_owners = [m for m in owners if m["user_id"] != user_id]
-        guard_account_slug(existing_account, foreign_owners)
+        guard_account_slug(existing_account, foreign_owners, user_id)
 
     status, body = request(
         rest, headers, "POST", "/accounts",

--- a/scripts/test_seed_demo_owner.py
+++ b/scripts/test_seed_demo_owner.py
@@ -2,8 +2,10 @@
 """Self-check for the slug-collision guards in seed-demo-owner.py (P1 fix:
 Greptile review on PR #416 flagged that an unguarded on_conflict=slug upsert
 would silently elevate an unrelated pre-existing tenant/account to
-demo-owner privilege). No framework, no network: exercises the two pure
-guard functions directly. Run: python3 scripts/test_seed_demo_owner.py
+demo-owner privilege; issue #420 is the fast-follow closing the two edge
+cases PR #416's review left open: owner_user_id desync and zero-membership
+tenant collision). No framework, no network: exercises the two pure guard
+functions directly. Run: python3 scripts/test_seed_demo_owner.py
 """
 import importlib.util
 import sys
@@ -26,26 +28,44 @@ def exits(fn, *args) -> bool:
 
 def main() -> None:
     # No existing row at all: never a collision, regardless of members/owners.
-    assert not exits(seed_demo_owner.guard_tenant_slug, None, [])
-    assert not exits(seed_demo_owner.guard_account_slug, None, [])
+    assert not exits(seed_demo_owner.guard_tenant_slug, None, [], False)
+    assert not exits(seed_demo_owner.guard_account_slug, None, [], "demo-user")
 
-    # Existing tenant whose only member is our own demo user: safe re-run.
+    # (c) Legitimate case: existing tenant whose only member is our own demo
+    # user (own_member=True, no foreign members) -- a prior run of this
+    # exact script created it. Safe re-run, idempotency must not regress.
     assert not exits(
-        seed_demo_owner.guard_tenant_slug, {"id": "t1"}, []
+        seed_demo_owner.guard_tenant_slug, {"id": "t1"}, [], True
     )
 
-    # Existing tenant with a foreign member: real customer tenant, must fail.
+    # Existing tenant with a foreign member: real customer tenant, must fail
+    # regardless of own_member.
     assert exits(
         seed_demo_owner.guard_tenant_slug,
         {"id": "t1"},
         [{"user_id": "someone-else"}],
+        True,
     )
 
-    # Existing account whose only owner-role member is our own demo user:
-    # safe re-run (a co-owner with role='member' would not appear here at
-    # all -- only role='owner' rows are queried, matching IsPlatformAdmin).
+    # (b) issue #420 gap 2: a pre-existing tenant with ZERO memberships at
+    # all (never seeded by this script, or fully cleaned up) has no foreign
+    # members either -- own_member=False must still refuse it, not adopt it.
+    assert exits(
+        seed_demo_owner.guard_tenant_slug,
+        {"id": "t1"},
+        [],
+        False,
+    )
+
+    # (c) Legitimate case: existing account whose owner_user_id already
+    # matches our demo user and no other owner-role member exists -- safe
+    # re-run (a co-owner with role='member' would not appear here at all --
+    # only role='owner' rows are queried, matching IsPlatformAdmin).
     assert not exits(
-        seed_demo_owner.guard_account_slug, {"id": "a1"}, []
+        seed_demo_owner.guard_account_slug,
+        {"id": "a1", "owner_user_id": "demo-user"},
+        [],
+        "demo-user",
     )
 
     # Existing account with a second owner-role member: control-plane's
@@ -54,8 +74,19 @@ def main() -> None:
     # gain platform-admin too -- must fail, not merge.
     assert exits(
         seed_demo_owner.guard_account_slug,
-        {"id": "a1"},
+        {"id": "a1", "owner_user_id": "demo-user"},
         [{"user_id": "someone-else"}],
+        "demo-user",
+    )
+
+    # (a) issue #420 gap 1: owner_user_id points at a different user with NO
+    # matching owner-role membership row at all (foreign_owners empty) --
+    # must now be refused instead of silently adopted and overwritten.
+    assert exits(
+        seed_demo_owner.guard_account_slug,
+        {"id": "a1", "owner_user_id": "someone-else-entirely"},
+        [],
+        "demo-user",
     )
 
     print("ok: seed-demo-owner.py slug-collision guards")


### PR DESCRIPTION
## Summary

Fixes #420, the fast-follow from PR #416's Greptile review. Two remaining slug-collision edge cases in `scripts/seed-demo-owner.py`:

1. **owner_user_id desync**: `guard_account_slug` only rejected foreign `account_memberships` rows with `role='owner'`. `accounts.owner_user_id` is not schema-enforced to match any membership row, so an existing account could have `owner_user_id` pointing at a different user with zero owner-role membership rows at all. That state passed the guard, then the upsert silently replaced `owner_user_id` and enabled `is_platform_admin`.
2. **Zero-membership tenant collision**: `guard_tenant_slug` only rejected tenants with foreign `tenant_users` rows. A pre-existing tenant with zero memberships (never seeded, or fully cleaned up) passed the guard even though it was never created by this script, then got renamed, reactivated, and granted the demo user as OWNER.

## Approach

Adopted fix direction (b) from the issue: both guards now require positive proof of provenance instead of only checking for the absence of foreign rows.

- `guard_tenant_slug(existing_tenant, foreign_members, own_member)`: refuses unless the demo user already has a `tenant_users` membership row on the existing tenant (`own_member`), in addition to the existing foreign-member check. A tenant with zero members at all no longer passes by default.
- `guard_account_slug(existing_account, foreign_owners, user_id)`: refuses unless `accounts.owner_user_id` already equals the demo user, in addition to the existing foreign-owner check. A desynced `owner_user_id` with no matching membership row no longer passes by default.

No new schema/marker column needed: after a legitimate first run, the script's own upserts (tenant membership, `owner_user_id`) already leave exactly this provenance signal behind, so the second run of the same script still reuses its own rows correctly (idempotency preserved).

## Test plan

- [x] Extended `scripts/test_seed_demo_owner.py` (no framework, pure function assertions, same pattern as the existing file): proves (a) an account with mismatched `owner_user_id` and no matching membership is now refused, (b) a zero-membership foreign tenant is now refused, (c) the legitimate reuse case (own membership / matching `owner_user_id`) still passes.
- [x] Ran `python3 scripts/test_seed_demo_owner.py` locally: exit 0, `ok: seed-demo-owner.py slug-collision guards`.
- [x] Ran both `scripts/test_seed_demo_owner.py` and `scripts/test_seed_owui_e2e_user.py` inside the repo's Docker toolchain container (`deploy/docker`, `--profile tools run toolchain`): both exit 0.

Backend/script-only change, no UI surface touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved demo setup safeguards to prevent tenant or account data from being incorrectly merged when slug conflicts occur.
  * Added validation for tenant membership and account ownership, including cases with missing or mismatched ownership records.

* **Tests**
  * Expanded coverage for empty tenants, foreign memberships, ownership mismatches, and safe repeat setup scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR tightens privileged demo-seed slug-collision checks.
- Existing tenants now require a demo-user membership and no foreign memberships before reuse.
- Existing accounts now require a matching owner_user_id and no foreign owner memberships.
- Pure-function assertions cover the newly rejected collision states and legitimate reruns.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

This PR should not merge until the tenant-seeding flow can safely recover after interruption between the tenant and membership upserts.

The new guard correctly blocks unrelated zero-membership tenants, but the script creates the same state itself when the separate membership request fails, after which every rerun exits before it can repair the missing membership.

scripts/seed-demo-owner.py
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/seed-demo-owner.py | Adds positive provenance checks for tenant and account reuse, but the tenant check prevents recovery when execution stops between tenant and membership upserts. |
| scripts/test_seed_demo_owner.py | Updates pure guard tests for the stricter checks, but does not exercise the partial first-run lifecycle that exposes the recovery failure. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Find existing tenant by slug] --> B{Tenant exists?}
    B -- No --> C[Upsert tenant]
    B -- Yes --> D[Read tenant memberships]
    D --> E{Demo membership exists and no foreign members?}
    E -- No --> F[Exit]
    E -- Yes --> C
    C --> G[Upsert demo membership]
    G -- Failure or interruption --> H[Tenant remains with zero memberships]
    H --> A
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fseed-demo-owner.py%3A136%0A**Partial%20tenant%20state%20becomes%20unrecoverable**%0A%0AWhen%20the%20tenant%20upsert%20succeeds%20but%20execution%20fails%20before%20the%20separate%20membership%20upsert%2C%20the%20next%20run%20finds%20a%20zero-membership%20tenant%20and%20this%20guard%20rejects%20it%2C%20causing%20every%20subsequent%20seed%20attempt%20to%20exit%20before%20it%20can%20create%20the%20missing%20membership.%0A%0A&repo=sakibsadmanshajib%2Fhive&pr=430&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fseed-demo-owner.py%3A136%0A**Partial%20tenant%20state%20becomes%20unrecoverable**%0A%0AWhen%20the%20tenant%20upsert%20succeeds%20but%20execution%20fails%20before%20the%20separate%20membership%20upsert%2C%20the%20next%20run%20finds%20a%20zero-membership%20tenant%20and%20this%20guard%20rejects%20it%2C%20causing%20every%20subsequent%20seed%20attempt%20to%20exit%20before%20it%20can%20create%20the%20missing%20membership.%0A%0A&pr=430&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22sakibsadmanshajib%2Fhive%22%20on%20the%20existing%20branch%20%22fix%2F420-seed-demo-owner-provenance-guard%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F420-seed-demo-owner-provenance-guard%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fseed-demo-owner.py%3A136%0A**Partial%20tenant%20state%20becomes%20unrecoverable**%0A%0AWhen%20the%20tenant%20upsert%20succeeds%20but%20execution%20fails%20before%20the%20separate%20membership%20upsert%2C%20the%20next%20run%20finds%20a%20zero-membership%20tenant%20and%20this%20guard%20rejects%20it%2C%20causing%20every%20subsequent%20seed%20attempt%20to%20exit%20before%20it%20can%20create%20the%20missing%20membership.%0A%0A&repo=sakibsadmanshajib%2Fhive&pr=430&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix: close owner\_user\_id desync + zero-m..."](https://github.com/sakibsadmanshajib/hive/commit/ca7770c7680eee2d76d017ad95b437912d79f12a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47007000)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->