### PR TITLE
fix: prefer new-format Supabase secret key for e2e-fixtures admin client

### DIFF
--- a/supabase/functions/e2e-fixtures/index.ts
+++ b/supabase/functions/e2e-fixtures/index.ts
@@ -7,6 +7,16 @@
 // the service-role key out of CI runners entirely — Playwright only
 // needs the edge function's shared `E2E_FIXTURE_SECRET`.
 //
+// Admin client key precedence: projects with asymmetric JWT signing keys
+// (ES256) enabled reject the legacy auto-injected `SUPABASE_SERVICE_ROLE_KEY`
+// on GoTrue's admin API (`unrecognized JWT kid`). Supabase auto-injects a
+// parallel `SUPABASE_SECRET_KEYS` (JSON, keyed by name, e.g. `{"default":
+// "sb_secret_..."}`) alongside it; that new-format key is preferred when
+// present, with `SUPABASE_SERVICE_ROLE_KEY` kept as the fallback for
+// self-hosted/local projects still on the legacy scheme. See
+// https://supabase.com/docs/guides/getting-started/migrating-to-new-api-keys
+// and https://supabase.com/docs/guides/functions/secrets.
+//
 // Deploy:
 //   supabase functions deploy e2e-fixtures \
 //     --project-ref <ref> --no-verify-jwt
@@ -57,6 +67,23 @@ const DEFAULTS = {
   unverifiedPassword: "E2eFixture-Unverified#2026",
   invitationToken: "e2e-invitation-token-2026-fixture",
 };
+
+// Prefers the new-format secret key (SUPABASE_SECRET_KEYS, JSON-encoded,
+// keyed by name) over the legacy SUPABASE_SERVICE_ROLE_KEY. Falls back to
+// the legacy key on parse failure or when the new var is absent (local /
+// self-hosted projects without signing-key migration).
+function resolveServiceKey(): string | undefined {
+  const raw = Deno.env.get("SUPABASE_SECRET_KEYS");
+  if (raw) {
+    try {
+      const parsed = JSON.parse(raw);
+      if (parsed?.default) return parsed.default;
+    } catch {
+      // fall through to legacy
+    }
+  }
+  return Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+}
 
 function jsonResponse(body: unknown, status = 200) {
   return new Response(JSON.stringify(body), {
@@ -408,14 +435,16 @@ Deno.serve(async (req) => {
     return jsonResponse({ error: "method not allowed" }, 405);
   }
 
-  // Auth: accept EITHER the dedicated E2E_FIXTURE_SECRET (when set) OR the
-  // auto-injected SUPABASE_SERVICE_ROLE_KEY. The service role key is what
-  // every caller in CI / local already has, so accepting it removes the
-  // separate secret-setup step while keeping the endpoint locked to the same
-  // blast radius (root DB access).
+  // Auth: accept the dedicated E2E_FIXTURE_SECRET (when set), the legacy
+  // auto-injected SUPABASE_SERVICE_ROLE_KEY, or the new-format resolved
+  // service key (SUPABASE_SECRET_KEYS). Every caller in CI / local already
+  // has one of these, so accepting them removes the separate secret-setup
+  // step while keeping the endpoint locked to the same blast radius (root
+  // DB access). Additive only — neither existing fallback is removed.
   const acceptedSecrets = [
     Deno.env.get("E2E_FIXTURE_SECRET"),
     Deno.env.get("SUPABASE_SERVICE_ROLE_KEY"),
+    resolveServiceKey(),
   ].filter((v): v is string => !!v);
   if (acceptedSecrets.length === 0) {
     return jsonResponse(
@@ -440,7 +469,7 @@ Deno.serve(async (req) => {
   }
 
   const supabaseUrl = Deno.env.get("SUPABASE_URL");
-  const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  const serviceRoleKey = resolveServiceKey();
   if (!supabaseUrl || !serviceRoleKey) {
     return jsonResponse(
       { error: "SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY missing" },


### PR DESCRIPTION
## Summary

Fixes #429.

Root cause (confirmed via official Supabase docs and GoTrue source, not re-derived here): the project has JWT signing keys (ES256 asymmetric) enabled. GoTrue's admin API validates incoming Authorization tokens by kid-lookup first, falling back to the legacy HS256 shared secret only when the token's `alg` header is literally `HS256` (see GoTrue's `parseJWTClaims`, https://github.com/supabase/auth/blob/master/internal/api/auth.go). `supabase/functions/e2e-fixtures/index.ts` built its admin client with the legacy auto-injected `SUPABASE_SERVICE_ROLE_KEY`, which GoTrue's admin API (`admin.auth.admin.updateUserById`/`createUser`) rejects with `invalid JWT: unrecognized JWT kid <nil> for algorithm ES256`.

## Fix

Per Supabase's own docs:
- https://supabase.com/docs/guides/getting-started/migrating-to-new-api-keys
- https://supabase.com/docs/guides/functions/secrets

Supabase auto-injects a parallel `SUPABASE_SECRET_KEYS` env var into every Edge Function (JSON-encoded, keyed by name, e.g. `{"default": "sb_secret_..."}`). That new-format key is a drop-in replacement for `SUPABASE_SERVICE_ROLE_KEY` as the second argument to `createClient()`.

- Added `resolveServiceKey()`: prefers `SUPABASE_SECRET_KEYS.default`, falls back to `SUPABASE_SERVICE_ROLE_KEY` on parse failure or absence (self-hosted/local projects without the signing-key migration).
- Admin client (`createClient(supabaseUrl, serviceRoleKey, ...)`) now uses the resolved key.
- `X-E2E-Secret` accepted-secrets check (`acceptedSecrets`) keeps both existing fallbacks (`E2E_FIXTURE_SECRET`, legacy `SUPABASE_SERVICE_ROLE_KEY`) unchanged, and additionally accepts the resolved new-format key. Additive only, no existing contract removed.
- Updated the file's header comment to document the new key precedence.

## Verification

Verified locally:
- `deno check index.ts` (via `denoland/deno:2.1.4` docker image, same command used to verify #425) — passes clean, no type errors.
- `deno lint index.ts` — passes clean.

Could NOT verify locally: the actual GoTrue admin-API round-trip. This is a live Supabase-project-backed edge function; exercising it needs deployment against the real project. Same limitation noted in #425/#426. Real end-to-end verification will happen via a live redeploy + CI rerun after merge (not done in this PR).

## Test plan

- [ ] Redeploy `e2e-fixtures` to the demo/staging Supabase project
- [ ] CI `Web E2E (full stack)` job passes (exercises `ensureUser`'s `updateUserById`/`createUser` admin calls)
- [ ] Confirm auth service logs show no further `unrecognized JWT kid` 403s on `/admin/users/{id}`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates the E2E fixture Edge Function’s privileged credential handling.
- Adds resolution of the new-format `SUPABASE_SECRET_KEYS.default` credential with legacy service-role fallback.
- Uses the resolved credential for the Supabase admin client.
- Accepts the resolved credential as an additional `X-E2E-Secret` value.
- Documents credential precedence and asymmetric JWT compatibility.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete changed-code failure identified.

The new credential path preserves the existing dedicated and legacy credentials while preferring the new-format service credential needed by asymmetric-signing deployments.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| supabase/functions/e2e-fixtures/index.ts | Adds new-format Supabase secret-key resolution and applies it consistently to fixture authorization and admin-client initialization without removing legacy fallbacks. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Read SUPABASE_SECRET_KEYS] --> B{Valid JSON with default key?}
    B -- Yes --> C[Use new-format secret]
    B -- No --> D[Use SUPABASE_SERVICE_ROLE_KEY]
    C --> E[Create Supabase admin client]
    D --> E
    C --> F[Add to accepted fixture secrets]
    D --> F
    G[E2E_FIXTURE_SECRET] --> F
    H[Legacy service-role key] --> F
    F --> I{X-E2E-Secret accepted?}
    I -- Yes --> J[Execute fixture action]
    I -- No --> K[Return 401]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: prefer new-format Supabase secret k..."](https://github.com/sakibsadmanshajib/hive/commit/a6d954f2870f1bb9cdf4c3e2d89fdccfe939b078) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47018543)</sub>

<!-- /greptile_comment -->