### PR TITLE
fix: voice endpoints failed with a false insufficient credits error

### DIFF
--- a/apps/edge-api/internal/audio/accounting_adapter.go
+++ b/apps/edge-api/internal/audio/accounting_adapter.go
@@ -2,7 +2,9 @@ package audio
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 
 	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/inference"
 )
@@ -30,6 +32,13 @@ func (a *AccountingAdapter) CreateReservation(ctx context.Context, input Reserva
 		PolicyMode:       "strict",
 	})
 	if err != nil {
+		// Control-plane answers 409 when the credit policy rejects the hold
+		// (accounting.PolicyError). Every other failure is an infrastructure
+		// fault and must not be billed to the caller as a quota problem.
+		var statusErr *inference.StatusError
+		if errors.As(err, &statusErr) && statusErr.StatusCode == http.StatusConflict {
+			return "", fmt.Errorf("audio: create reservation: %w: %w", ErrInsufficientCredits, err)
+		}
 		return "", fmt.Errorf("audio: create reservation: %w", err)
 	}
 	return result.ID, nil

--- a/apps/edge-api/internal/audio/accounting_adapter_test.go
+++ b/apps/edge-api/internal/audio/accounting_adapter_test.go
@@ -3,6 +3,7 @@ package audio
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -63,5 +64,46 @@ func TestAccountingAdapterCreateReservationUsesStrictPolicy(t *testing.T) {
 	}
 	if got.EstimatedCredits != 1000 {
 		t.Fatalf("CreateReservation() estimated_credits = %d, want %d", got.EstimatedCredits, 1000)
+	}
+}
+
+// Control-plane answers 409 (accounting.PolicyError) when the credit policy
+// refuses a hold, and 5xx or a timeout when it simply cannot answer. Only the
+// former may surface as insufficient credits.
+func TestAccountingAdapterClassifiesReservationFailures(t *testing.T) {
+	tests := []struct {
+		name      string
+		status    int
+		wantQuota bool
+	}{
+		{name: "policy refusal", status: http.StatusConflict, wantQuota: true},
+		{name: "control plane error", status: http.StatusInternalServerError, wantQuota: false},
+		{name: "internal auth rejected", status: http.StatusUnauthorized, wantQuota: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(`{"error":"reservation exceeds available credits"}`))
+			}))
+			defer server.Close()
+
+			adapter := NewAccountingAdapter(inference.NewAccountingClient(server.URL))
+			_, err := adapter.CreateReservation(context.Background(), ReservationInput{
+				AccountID:        "account-1",
+				APIKeyID:         "11111111-1111-1111-1111-111111111111",
+				RequestID:        "req-1",
+				Endpoint:         "/v1/audio/speech",
+				ModelAlias:       "hive-tts",
+				EstimatedCredits: 1000,
+			})
+			if err == nil {
+				t.Fatal("CreateReservation() error = nil, want failure")
+			}
+			if got := errors.Is(err, ErrInsufficientCredits); got != tc.wantQuota {
+				t.Fatalf("errors.Is(err, ErrInsufficientCredits) = %v, want %v (err = %v)", got, tc.wantQuota, err)
+			}
+		})
 	}
 }

--- a/apps/edge-api/internal/audio/handler.go
+++ b/apps/edge-api/internal/audio/handler.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -55,6 +56,13 @@ type RouteResult struct {
 	AliasID          string
 	LiteLLMModelName string
 }
+
+// ErrInsufficientCredits reports that the accounting layer refused the
+// reservation because the account lacks credits. CreateReservation
+// implementations must wrap it for that case only, so a reservation that
+// could not be reached at all is never reported to the caller as a
+// billing problem.
+var ErrInsufficientCredits = errors.New("audio: insufficient credits")
 
 // AccountingInterface manages credit reservations for audio requests.
 type AccountingInterface interface {
@@ -113,6 +121,21 @@ func NewHandler(
 // instead of LiteLLM. Call before serving requests.
 func (h *Handler) WithSTT(c *stt.TieredClient) {
 	h.stt = c
+}
+
+// writeReservationFailure answers a failed credit reservation. Only a real
+// credit refusal is a 402; a reservation that timed out or errored is an
+// infrastructure fault, logged and reported as retryable so operators are
+// not chasing a phantom billing problem.
+func writeReservationFailure(w http.ResponseWriter, endpoint, alias string, err error) {
+	if errors.Is(err, ErrInsufficientCredits) {
+		code := "insufficient_quota"
+		apierrors.WriteError(w, http.StatusPaymentRequired, "invalid_request_error", "Insufficient credits to complete this request.", &code)
+		return
+	}
+	log.Printf("audio: create reservation failed for endpoint=%s alias=%s: %v", endpoint, alias, err)
+	code := "upstream_error"
+	apierrors.WriteError(w, http.StatusServiceUnavailable, "api_error", "Credit reservation is temporarily unavailable. Please retry.", &code)
 }
 
 // authorize validates the request API key and writes a 401 on failure.
@@ -198,8 +221,7 @@ func (h *Handler) handleSpeech(w http.ResponseWriter, r *http.Request) {
 		EstimatedCredits: 1000,
 	})
 	if err != nil {
-		code := "insufficient_quota"
-		apierrors.WriteError(w, http.StatusPaymentRequired, "invalid_request_error", "Insufficient credits to complete this request.", &code)
+		writeReservationFailure(w, "/v1/audio/speech", route.AliasID, err)
 		return
 	}
 
@@ -296,8 +318,7 @@ func (h *Handler) handleTranscription(w http.ResponseWriter, r *http.Request) {
 		EstimatedCredits: 500,
 	})
 	if err != nil {
-		code := "insufficient_quota"
-		apierrors.WriteError(w, http.StatusPaymentRequired, "invalid_request_error", "Insufficient credits to complete this request.", &code)
+		writeReservationFailure(w, "/v1/audio/transcriptions", "stt", err)
 		return
 	}
 
@@ -385,9 +406,7 @@ func (h *Handler) handleMultipartAudio(w http.ResponseWriter, r *http.Request, l
 		EstimatedCredits: 500,
 	})
 	if err != nil {
-		log.Printf("audio: create reservation failed for endpoint=%s alias=%s: %v", accountingEndpoint, route.AliasID, err)
-		code := "insufficient_quota"
-		apierrors.WriteError(w, http.StatusPaymentRequired, "invalid_request_error", "Insufficient credits to complete this request.", &code)
+		writeReservationFailure(w, accountingEndpoint, route.AliasID, err)
 		return
 	}
 

--- a/apps/edge-api/internal/audio/handler_test.go
+++ b/apps/edge-api/internal/audio/handler_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -73,11 +74,15 @@ func (r *mockAudioRouting) SelectRoute(_ context.Context, input audio.RouteInput
 // mockAudioAccounting is a stub that tracks reservation calls.
 type mockAudioAccounting struct {
 	reservationID  string
+	createErr      error
 	finalizeCalled bool
 	releaseCalled  bool
 }
 
 func (a *mockAudioAccounting) CreateReservation(_ context.Context, _ audio.ReservationInput) (string, error) {
+	if a.createErr != nil {
+		return "", a.createErr
+	}
 	return a.reservationID, nil
 }
 
@@ -700,5 +705,105 @@ func TestParakeetAPIKeyAbsentWhenNotConfigured(t *testing.T) {
 	}
 	if receivedAuth != "" {
 		t.Errorf("expected no Authorization header forwarded when key not configured, got %q", receivedAuth)
+	}
+}
+
+// --- Reservation failure classification tests ---
+
+// buildAudioHandlerWithAccounting wires the handler to a caller-supplied
+// accounting double so reservation failures can be simulated.
+func buildAudioHandlerWithAccounting(litellmBaseURL string, acc *mockAudioAccounting) *audio.Handler {
+	auth := &mockAudioAuthorizer{accountID: "acct-test", apiKeyID: "key-test"}
+	routing := &mockAudioRouting{}
+	return audio.NewHandler(auth, routing, acc, litellmBaseURL, "test-key")
+}
+
+func postSpeech(t *testing.T, h *audio.Handler) *httptest.ResponseRecorder {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/audio/speech",
+		strings.NewReader(`{"model":"hive-tts","input":"hello","voice":"troy"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer test-key")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	return w
+}
+
+func postTranscription(t *testing.T, h *audio.Handler) *httptest.ResponseRecorder {
+	t.Helper()
+
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	_ = mw.WriteField("model", "hive-stt")
+	fw, _ := mw.CreateFormFile("file", "audio.wav")
+	fw.Write([]byte("audio")) //nolint:errcheck
+	mw.Close()
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/audio/transcriptions", &buf)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	req.Header.Set("Authorization", "Bearer test-key")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	return w
+}
+
+// A reservation that could not be reached (the live failure: control-plane
+// took longer than the client timeout) must not tell the caller they are out
+// of credits.
+func TestSpeechReservationTransportFailureIsNotQuota(t *testing.T) {
+	mock := newMockLiteLLMAudio([]byte("unused"), 200, "audio/mpeg")
+	defer mock.Close()
+
+	acc := &mockAudioAccounting{createErr: fmt.Errorf("create reservation: %w", context.DeadlineExceeded)}
+	w := postSpeech(t, buildAudioHandlerWithAccounting(mock.server.URL, acc))
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d: %s", w.Code, w.Body.String())
+	}
+	if strings.Contains(w.Body.String(), "insufficient_quota") {
+		t.Errorf("transport failure reported as a quota problem: %s", w.Body.String())
+	}
+}
+
+func TestSpeechReservationQuotaRefusalReturns402(t *testing.T) {
+	mock := newMockLiteLLMAudio([]byte("unused"), 200, "audio/mpeg")
+	defer mock.Close()
+
+	acc := &mockAudioAccounting{createErr: fmt.Errorf("create reservation: %w", audio.ErrInsufficientCredits)}
+	w := postSpeech(t, buildAudioHandlerWithAccounting(mock.server.URL, acc))
+
+	if w.Code != http.StatusPaymentRequired {
+		t.Fatalf("expected 402, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "insufficient_quota") {
+		t.Errorf("expected insufficient_quota code, got %s", w.Body.String())
+	}
+}
+
+func TestTranscriptionReservationTransportFailureIsNotQuota(t *testing.T) {
+	mock := newMockLiteLLMAudio([]byte(`{"text":"unused"}`), 200, "application/json")
+	defer mock.Close()
+
+	acc := &mockAudioAccounting{createErr: fmt.Errorf("create reservation: %w", context.DeadlineExceeded)}
+	w := postTranscription(t, buildAudioHandlerWithAccounting(mock.server.URL, acc))
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d: %s", w.Code, w.Body.String())
+	}
+	if strings.Contains(w.Body.String(), "insufficient_quota") {
+		t.Errorf("transport failure reported as a quota problem: %s", w.Body.String())
+	}
+}
+
+func TestTranscriptionReservationQuotaRefusalReturns402(t *testing.T) {
+	mock := newMockLiteLLMAudio([]byte(`{"text":"unused"}`), 200, "application/json")
+	defer mock.Close()
+
+	acc := &mockAudioAccounting{createErr: fmt.Errorf("create reservation: %w", audio.ErrInsufficientCredits)}
+	w := postTranscription(t, buildAudioHandlerWithAccounting(mock.server.URL, acc))
+
+	if w.Code != http.StatusPaymentRequired {
+		t.Fatalf("expected 402, got %d: %s", w.Code, w.Body.String())
 	}
 }

--- a/apps/edge-api/internal/inference/accounting_client.go
+++ b/apps/edge-api/internal/inference/accounting_client.go
@@ -19,12 +19,32 @@ type AccountingClient struct {
 	httpClient *http.Client
 }
 
+// accountingTimeout bounds a single control-plane accounting call. A
+// reservation is six sequential round trips to Postgres, so it takes 4-8s
+// when the database is a region away from the gateway (measured on the demo
+// box against Supabase us-east-1). The former 5s budget cut that call off
+// mid-flight: control-plane still committed the reservation while edge-api
+// saw a timeout, so /v1/audio/* answered 402 and the credit hold leaked.
+const accountingTimeout = 30 * time.Second
+
 // NewAccountingClient creates a new AccountingClient.
 func NewAccountingClient(baseURL string) *AccountingClient {
 	return &AccountingClient{
 		baseURL:    strings.TrimRight(baseURL, "/"),
-		httpClient: &http.Client{Timeout: 5 * time.Second},
+		httpClient: &http.Client{Timeout: accountingTimeout},
 	}
+}
+
+// StatusError reports a non-2xx response from a control-plane accounting or
+// usage call. Callers match on StatusCode to tell a business rejection (409,
+// credit policy) from an infrastructure fault (5xx, timeout, auth).
+type StatusError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *StatusError) Error() string {
+	return fmt.Sprintf("status %d: %s", e.StatusCode, e.Body)
 }
 
 // --- Reservation types ---
@@ -168,7 +188,7 @@ func (c *AccountingClient) post(ctx context.Context, path string, input any, out
 	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("status %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+		return &StatusError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(respBody))}
 	}
 
 	if output != nil {


### PR DESCRIPTION
## Problem

Every voice call on the demo box returned 402 `insufficient_quota`, on an account holding 100,000 credits:

```
$ curl https://api-hive.scubed.co/v1/audio/transcriptions -H "Authorization: Bearer hk_***" \
    -F model=hive-stt -F file=@sample.wav
{"error":{"message":"Insufficient credits to complete this request.","type":"invalid_request_error","code":"insufficient_quota"}}
HTTP 402   openai-processing-ms: 7230
```

edge-api's own log gave away the real cause:

```
audio: create reservation failed for endpoint=/v1/audio/transcriptions alias=hive-stt:
  audio: create reservation: accounting: create reservation: request failed:
  Post "http://control-plane:8081/internal/accounting/reservations":
  context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```

Two defects combined.

1. **The accounting client's 5 second budget is below the real cost of a reservation.** Creating one is six sequential round trips to Postgres. Measured from inside the demo box against Supabase us-east-1, a single reservation takes 4 to 8 seconds and a single-query control-plane endpoint takes 0.5 to 1.7 seconds:

   ```
   POST /internal/accounting/reservations  200  7.10s
   POST /internal/accounting/reservations  200  4.11s
   POST /internal/apikeys/resolve          200  1.73s
   GET  /health                            200  0.0006s
   ```

   So control-plane always answered correctly, just too late. Worse, it had already committed the reservation, so each failed voice call left an orphaned hold on the account:

   ```
   status | reserved | endpoint                   | model_alias
   active |     1000 | /v1/audio/speech           | hive-tts
   active |      500 | /v1/audio/transcriptions   | hive-stt
   ```

2. **The audio handler mapped every reservation error to 402** and two of its three reservation sites logged nothing, so an infrastructure fault was indistinguishable from a customer who is out of credits.

## Change

- `accountingTimeout` is 30 seconds, above the measured worst case, with the measurement recorded in a comment so the number is not mistaken for arbitrary.
- `inference.StatusError` carries the upstream status code so callers can tell a business rejection from a transport fault.
- Control-plane returns 409 for a credit policy refusal (`accounting.PolicyError`). The audio adapter marks only that case with the new `audio.ErrInsufficientCredits` sentinel.
- One `writeReservationFailure` helper serves all three audio reservation sites: 402 for a real refusal, otherwise a logged, retryable 503.

## Live verification

Patched image built and run as a side-car container on the demo box (`hive-edge-api:voicefix-prod`, port 8099), same network and env as the live service.

Text to speech through the gateway:

```
$ curl http://127.0.0.1:8099/v1/audio/speech -H "Authorization: Bearer hk_***" \
    -d '{"model":"hive-tts","input":"Hive gateway voice proof, twenty sixth of July.","voice":"troy","response_format":"wav"}' \
    -o edge-tts.wav
TTS HTTP 200 size=199750 ct=audio/mpeg t=21.10

$ file edge-tts.wav
edge-tts.wav: RIFF (little-endian) data, WAVE audio, Microsoft PCM, 16 bit, mono 24000 Hz
```

That same audio fed back into transcription through the gateway:

```
$ curl http://127.0.0.1:8099/v1/audio/transcriptions -H "Authorization: Bearer hk_***" \
    -F model=hive-stt -F file=@edge-tts.wav
{"text":" Hive Gateway Voice Proof, 26th of July."}
STT HTTP 200 t=22.37
```

Both reservations settled instead of leaking:

```
status    | reserved | consumed | endpoint                 | model_alias
finalized |      500 |      500 | /v1/audio/transcriptions | hive-stt
finalized |     1000 |     1000 | /v1/audio/speech         | hive-tts
```

Provider path was confirmed independently first: LiteLLM `route-groq-tts` returned a 145,990 byte WAV and `route-groq-stt` transcribed it back to the exact input sentence, so the catalog and LiteLLM config from the voice migration are correct.

## Tests

New cases in `apps/edge-api/internal/audio`:

- `TestAccountingAdapterClassifiesReservationFailures` — 409 maps to `ErrInsufficientCredits`, 500 and 401 do not.
- `TestSpeechReservationTransportFailureIsNotQuota` and the transcription equivalent — a timed-out reservation returns 503 and never mentions `insufficient_quota`.
- `TestSpeechReservationQuotaRefusalReturns402` and the transcription equivalent — a genuine refusal still returns 402 with the OpenAI-compatible code.

```
ok  github.com/sakibsadmanshajib/hive/apps/edge-api/internal/audio      0.120s
ok  github.com/sakibsadmanshajib/hive/apps/edge-api/internal/inference  0.093s
```

## Follow-ups, deliberately not in this PR

- `/v1/images/*` and `/v1/batches` reserve credits through the same client and still map any reservation error to 402. They inherit the timeout fix, not the error classification.
- Nothing sweeps orphaned `active` reservations. `credit_reconciliation_jobs` exists but no runner is wired, so holds already leaked by this bug stay until cleaned by hand.
- A reservation costing six serial round trips is the deeper problem. Collapsing it into one transactional call would cut voice latency from roughly 21 seconds to a few.