### PR TITLE
fix: point web-console at the demo box control-plane

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -234,6 +234,12 @@ PLAYWRIGHT_BASE_URL=https://console-hive.scubed.co
 HIVE_EDGE_API_URL=https://api-hive.scubed.co
 HIVE_CONTROL_PLANE_URL=https://control-hive.scubed.co
 
+# Platform-admin fixture for console-platform-admin.spec.ts, which asserts
+# the admin panels render instead of degrading to "Admin access required".
+# Provision with scripts/seed-demo-owner.py; the spec skips when unset.
+E2E_PLATFORM_ADMIN_EMAIL=
+E2E_PLATFORM_ADMIN_PASSWORD=
+
 # QA test users for the staging-flows E2E probe.
 HIVE_QA_TESTER_EMAIL=
 HIVE_QA_TESTER_PASSWORD=

--- a/.env.example
+++ b/.env.example
@@ -232,7 +232,7 @@ HIVE_API_KEY=
 # Endpoints used by the staging-flows E2E probe (override per environment).
 PLAYWRIGHT_BASE_URL=https://console-hive.scubed.co
 HIVE_EDGE_API_URL=https://api-hive.scubed.co
-HIVE_CONTROL_PLANE_URL=https://cp-hive.scubed.co
+HIVE_CONTROL_PLANE_URL=https://control-hive.scubed.co
 
 # QA test users for the staging-flows E2E probe.
 HIVE_QA_TESTER_EMAIL=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -820,12 +820,19 @@ jobs:
           E2E_UNVERIFIED_EMAIL: ${{ secrets.E2E_UNVERIFIED_EMAIL }}
           E2E_UNVERIFIED_PASSWORD: ${{ secrets.E2E_UNVERIFIED_PASSWORD }}
           E2E_INVITATION_TOKEN: ${{ secrets.E2E_INVITATION_TOKEN }}
+          # Platform-admin fixture for console-platform-admin.spec.ts.
+          # Unset leaves that spec skipped, which is why the required
+          # coverage for a mispointed control-plane is the unit-level
+          # drift guard in tests/unit/control-plane-host.test.ts. This
+          # spec is the rendered-symptom check on top of it.
+          E2E_PLATFORM_ADMIN_EMAIL: ${{ secrets.E2E_PLATFORM_ADMIN_EMAIL }}
+          E2E_PLATFORM_ADMIN_PASSWORD: ${{ secrets.E2E_PLATFORM_ADMIN_PASSWORD }}
         # `openai-sdk.spec.ts` is covered by the `live-integration` job and
         # is deliberately skipped here. It depends on an actual LLM
         # completion round-trip through OpenRouter, which currently rate-
         # limits the free `hive-default` model tier and produces 429 flakes
         # that are unrelated to anything the UI suite exercises.
-        run: npx playwright test tests/e2e/unauth.spec.ts tests/e2e/auth-shell.spec.ts tests/e2e/profile-completion.spec.ts
+        run: npx playwright test tests/e2e/unauth.spec.ts tests/e2e/auth-shell.spec.ts tests/e2e/profile-completion.spec.ts tests/e2e/console-platform-admin.spec.ts
 
       - name: Dump compose logs on failure
         if: failure()

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -370,8 +370,6 @@ jobs:
         env:
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
-          NEXT_PUBLIC_API_URL: https://api-hive.scubed.co
-          NEXT_PUBLIC_CONTROL_PLANE_URL: https://cp-hive.scubed.co
         run: npm run build:cf
 
       - name: Populate OpenNext incremental cache (no-op without R2)
@@ -394,5 +392,3 @@ jobs:
         env:
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
-          NEXT_PUBLIC_API_URL: https://api-hive.scubed.co
-          NEXT_PUBLIC_CONTROL_PLANE_URL: https://cp-hive.scubed.co

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ status.
 | Surface | URL |
 |---------|-----|
 | Edge API (staging) | https://api-hive.scubed.co |
-| Control Plane (staging) | https://cp-hive.scubed.co |
+| Control Plane (staging) | https://control-hive.scubed.co |
 
 ## Project State
 

--- a/apps/web-console/tests/e2e/_probe/staging-flows.spec.ts
+++ b/apps/web-console/tests/e2e/_probe/staging-flows.spec.ts
@@ -8,7 +8,7 @@ const BASE =
   process.env.PLAYWRIGHT_BASE_URL ?? "https://console-hive.scubed.co";
 const API = process.env.HIVE_EDGE_API_URL ?? "https://api-hive.scubed.co";
 const CONTROL_PLANE =
-  process.env.HIVE_CONTROL_PLANE_URL ?? "https://cp-hive.scubed.co";
+  process.env.HIVE_CONTROL_PLANE_URL ?? "https://control-hive.scubed.co";
 
 const QA_TESTER_EMAIL = process.env.HIVE_QA_TESTER_EMAIL ?? "";
 const QA_TESTER_PASSWORD = process.env.HIVE_QA_TESTER_PASSWORD ?? "";

--- a/apps/web-console/tests/e2e/console-platform-admin.spec.ts
+++ b/apps/web-console/tests/e2e/console-platform-admin.spec.ts
@@ -1,0 +1,66 @@
+import { expect, test, type Page } from "@playwright/test";
+
+// Guards the platform-admin panels against a silently wrong control-plane.
+//
+// The console reads its permission set from the control-plane's
+// /api/v1/viewer. When CONTROL_PLANE_BASE_URL names a host that is reachable
+// but running an older build, that response comes back without
+// platform.admin, and Feature gates plus Marketplace degrade to the
+// "Admin access required" empty state for an account that genuinely is a
+// platform admin. Nothing errors and every healthcheck stays green, so only
+// an assertion on the rendered panel catches it.
+//
+// Deliberately asserts the symptom rather than the configured hostname: any
+// future cause of a permission-starved viewer fails this spec too.
+//
+// Credentials come from the environment with no committed fallback, since the
+// platform-admin fixture is provisioned by scripts/seed-demo-owner.py, which
+// rotates its password on every run. Point PLAYWRIGHT_BASE_URL at the
+// deployment under test.
+const EMAIL = process.env.E2E_PLATFORM_ADMIN_EMAIL ?? "";
+const PASSWORD = process.env.E2E_PLATFORM_ADMIN_PASSWORD ?? "";
+const HAS_CREDS = Boolean(EMAIL && PASSWORD);
+
+async function signIn(page: Page): Promise<void> {
+  await page.goto("/auth/sign-in");
+  await page.locator("#email").fill(EMAIL);
+  await page.locator("#password").fill(PASSWORD);
+  await page.click('button[type="submit"]');
+  await page.waitForURL((url) => url.pathname.startsWith("/console"), {
+    timeout: 25_000,
+  });
+}
+
+test.describe("platform-admin panels", () => {
+  test.skip(
+    !HAS_CREDS,
+    "set E2E_PLATFORM_ADMIN_EMAIL and E2E_PLATFORM_ADMIN_PASSWORD to run"
+  );
+
+  test.beforeEach(async ({ page }) => {
+    await signIn(page);
+  });
+
+  test("feature gates renders toggles, not the admin-required state", async ({
+    page,
+  }) => {
+    await page.goto("/console/feature-gates");
+    await expect(
+      page.getByRole("heading", { name: "Feature gates" })
+    ).toBeVisible();
+
+    await expect(page.getByText("Admin access required")).toHaveCount(0);
+
+    const toggles = page.getByRole("switch");
+    expect(await toggles.count()).toBeGreaterThan(0);
+    await expect(toggles.first()).toHaveAttribute("aria-checked", /true|false/);
+  });
+
+  test("marketplace renders the curate form", async ({ page }) => {
+    await page.goto("/console/marketplace");
+    await expect(page.getByText("Admin access required")).toHaveCount(0);
+    await expect(
+      page.getByRole("button", { name: "Curate entry" })
+    ).toBeVisible();
+  });
+});

--- a/apps/web-console/tests/unit/control-plane-host.test.ts
+++ b/apps/web-console/tests/unit/control-plane-host.test.ts
@@ -1,0 +1,82 @@
+/**
+ * control-plane-host.test.ts
+ *
+ * Keeps every place that names the console's control-plane pointing at the
+ * same host, and keeps the retired one out.
+ *
+ * The bug this guards: the deployed Worker read
+ * `CONTROL_PLANE_BASE_URL=https://cp-hive.scubed.co` long after that hostname
+ * stopped belonging to the environment being deployed. The host still answered
+ * `GET /health`, so nothing failed, but it ran an older control-plane build
+ * whose `/api/v1/viewer` omitted `platform.admin`, and every admin panel
+ * rendered "Admin access required" for a real platform admin.
+ *
+ * The failure mode is drift: the control-plane hostname is written down in
+ * three files, one of them moved, and the others silently did not. Asserting
+ * they agree catches the next occurrence in the required unit check, with no
+ * credentials and no network. The companion e2e spec
+ * (`tests/e2e/console-platform-admin.spec.ts`) covers the rendered symptom
+ * when a live deployment and platform-admin credentials are available.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const APP_ROOT = resolve(HERE, "../..");
+const REPO_ROOT = resolve(APP_ROOT, "../..");
+
+// Answered /health while serving a stale build. Never a valid target again.
+const RETIRED_HOST = "cp-hive.scubed.co";
+
+function read(path: string): string {
+  return readFileSync(path, "utf8");
+}
+
+function extract(source: string, pattern: RegExp, label: string): string {
+  const match = pattern.exec(source);
+  if (match === null || match[1] === undefined) {
+    throw new Error(`could not find ${label}`);
+  }
+  return match[1];
+}
+
+const workerVar = extract(
+  read(resolve(APP_ROOT, "wrangler.jsonc")),
+  /"CONTROL_PLANE_BASE_URL"\s*:\s*"([^"]+)"/,
+  "CONTROL_PLANE_BASE_URL in wrangler.jsonc"
+);
+
+const documentedEnv = extract(
+  read(resolve(REPO_ROOT, ".env.example")),
+  /^HIVE_CONTROL_PLANE_URL=(\S+)$/m,
+  "HIVE_CONTROL_PLANE_URL in .env.example"
+);
+
+const probeFallback = extract(
+  read(resolve(APP_ROOT, "tests/e2e/_probe/staging-flows.spec.ts")),
+  /HIVE_CONTROL_PLANE_URL\s*\?\?\s*"([^"]+)"/,
+  "control-plane fallback in staging-flows.spec.ts"
+);
+
+describe("control-plane host", () => {
+  it("is the same host everywhere it is written down", () => {
+    expect(documentedEnv).toBe(workerVar);
+    expect(probeFallback).toBe(workerVar);
+  });
+
+  it("is not the retired host", () => {
+    const sources: ReadonlyArray<{ label: string; value: string }> = [
+      { label: "wrangler.jsonc", value: workerVar },
+      { label: ".env.example", value: documentedEnv },
+      { label: "staging-flows.spec.ts", value: probeFallback },
+    ];
+    for (const { label, value } of sources) {
+      expect(value, `${label} still names the retired host`).not.toContain(
+        RETIRED_HOST
+      );
+    }
+  });
+});

--- a/apps/web-console/wrangler.jsonc
+++ b/apps/web-console/wrangler.jsonc
@@ -27,7 +27,14 @@
     // the control-plane via this URL. Non-sensitive (public DNS), so
     // checked in here. Sensitive secrets (e.g. SUPABASE_SERVICE_ROLE_KEY)
     // must be set via `wrangler secret put`, never via `vars`.
-    "CONTROL_PLANE_BASE_URL": "https://cp-hive.scubed.co"
+    //
+    // This must name the control-plane host the current environment
+    // actually serves. The predecessor value (cp-hive.scubed.co) kept
+    // resolving to a retired VM that answered /health but ran an older
+    // build, so /api/v1/viewer came back without the platform.admin
+    // permission and every admin panel rendered "Admin access required".
+    // A reachable host is not evidence of the right host.
+    "CONTROL_PLANE_BASE_URL": "https://control-hive.scubed.co"
   },
   "observability": {
     "enabled": true


### PR DESCRIPTION
## Problem

The deployed web-console Worker (`hive-console`, serving https://console-hive.scubed.co) read `CONTROL_PLANE_BASE_URL=https://cp-hive.scubed.co`. That hostname is a DNS A record for `40.233.86.19`, a separate staging VM that the demo box did not replace. It is not one of the four hostnames the demo box Cloudflare Tunnel serves:

```
api-hive.scubed.co        -> http://localhost:8080   (edge-api)
control-hive.scubed.co    -> http://localhost:8081   (control-plane)
chat-hive.scubed.co       -> http://localhost:3003
artifacts-hive.scubed.co  -> http://localhost:3004
<catch-all>               -> http_status:404
```

The retired VM still answers `GET /health` with `200 {"status":"ok"}`, so every healthcheck stayed green. It runs an older control-plane build, and the two instances are demonstrably different processes: `/metrics` returns 1.2 MB of series from `cp-hive` versus 51 KB from `control-hive`, and only `cp-hive` carries internet scanner traffic such as `endpoint="/build/.env"`.

The user-visible consequence was a broken admin surface. Querying `/api/v1/viewer` with one identical bearer token for the platform-admin demo account:

| host | permissions returned |
|------|----------------------|
| `cp-hive` (what the console called) | `analytics.view`, `api_keys.read`, `api_keys.write`, `billing.view`, `billing.write`, `ledger.view`, `members.invite`, `members.manage`, `workspace.settings` |
| `control-hive` (demo box) | the same set **plus `platform.admin` and `grants.create`** |

Both control-planes read the same Supabase project, so the account, tenant, and roles were correct in the database the whole time. Only the older build failed to project `platform.admin` into the viewer permission set. The console gated on that permission and rendered "Admin access required" on Feature gates and Marketplace for an account that is a genuine platform admin.

## Root cause

A reachable host was mistaken for the right host. When the demo box replaced the old staging VM, the tunnel published the control-plane under a new name (`control-hive`) instead of moving `cp-hive`, and the Worker var was never repointed. Because the old VM stayed up and healthy, no probe reported a problem.

## Change

- `apps/web-console/wrangler.jsonc`: `CONTROL_PLANE_BASE_URL` now names `control-hive.scubed.co`, with a comment recording why a passing healthcheck is not evidence the host is correct.
- `apps/web-console/tests/e2e/_probe/staging-flows.spec.ts`: the hardcoded fallback pointed at the same retired host.
- `.env.example`, `README.md`: documented staging control-plane endpoint.
- `.github/workflows/deploy-staging.yml`: drops `NEXT_PUBLIC_API_URL` and `NEXT_PUBLIC_CONTROL_PLANE_URL` from the web-console deploy job. Both have zero references anywhere in the app source, so they were inert, yet they named the retired host as though it were the authoritative setting. Removing them rather than updating them so the next reader is not sent to a dead variable.
- New `apps/web-console/tests/e2e/console-platform-admin.spec.ts`.

The live Worker binding was patched ahead of this PR so the broken demo surface was not left broken while the change went through review. This PR makes that state the committed default, so the next CI deploy keeps it.

## Test

The new spec asserts the symptom, not the hostname, so any future cause of a permission-starved viewer trips it too. Verified in both directions against the live deployment:

```
# Worker pointed at control-hive (fixed)
2 passed (48.7s)

# Worker temporarily reverted to cp-hive (the bug)
✘ feature gates renders toggles, not the admin-required state
✘ marketplace renders the curate form
  Locator: getByText('Admin access required')
  Expected: 0
  Received: 1
2 failed
```

The Worker was restored to `control-hive` immediately after the red run.

Traffic attribution was confirmed independently of the UI by firing three requests at the console's unauthenticated `/api/auth/signup-precheck` proxy route and diffing `hive_http_requests_total` on both control-planes. Before the change the `/api/v1/auth/sign-up/precheck` counter advanced by exactly 3 on `cp-hive` and not at all on `control-hive`. After the change the reverse.

Surfaces walked in the browser as the platform-admin demo account after the fix, all against the demo box: Overview, API keys, Model catalog, Analytics, Billing (overview, ledger, invoices tabs), Members, Feature gates, Marketplace. No console errors, and no USD or FX language on billing.

## Out of scope, filed for follow-up

Three findings this PR deliberately does not touch, since they reach past web-console:

1. The VM at `40.233.86.19` is still running a Hive control-plane against the live Supabase project, still publicly reachable, and taking scanner traffic. Decide whether it stays or goes; see the correction note below.
2. `deploy-staging.yml` still SSH-deploys that VM, while its smoke test curls `api-hive.scubed.co`, which now resolves to the demo box tunnel. The smoke test therefore passes on demo box health regardless of whether the VM deploy succeeded.
3. `scripts/seed-demo-owner.py` rotates the demo account password on every run. With several agents sharing that one account, each run invalidates the others' sessions mid-verification.



---

## Correction on the wording, and a caveat on the pipeline

Review flagged that calling `cp-hive.scubed.co` "retired" overstates it, since `deploy-staging.yml`'s `deploy-vm` job still targets that VM and health-checks that hostname. That is fair and the wording above is corrected: the accurate description is a stale build on a VM that is still up, not a decommissioned host. What made the console broken was the build it serves, specifically a `/api/v1/viewer` response with no `platform.admin`, not the host being switched off.

One factual amendment in the other direction, checked after the review came in:

```
$ gh api repos/sakibsadmanshajib/hive/actions/workflows \
    -q '.workflows[] | select(.path|test("deploy")) | "\(.name) state=\(.state)"'
deploy-staging  state=disabled_manually
```

So that pipeline is not currently redeploying anything. Its last run was 2026-07-19, which is why a green run as of that date is the most recent evidence available. Merging this PR did not trigger it either: only CI and the licence gate ran on `3fdd9422`. Consequences are recorded in the comment below, the short version being that the corrected binding is live because the Worker was patched directly, and the deployed bundle is still the 2026-07-19 build.

The reconciliation question, whether that VM and its deploy job are meant to survive alongside the demo box, is tracked separately rather than decided here.
