### PR TITLE
fix: make control-plane admin provider and egress-policy surfaces reachable

### DIFF
--- a/apps/control-plane/cmd/server/main.go
+++ b/apps/control-plane/cmd/server/main.go
@@ -796,14 +796,16 @@ func main() {
 	}
 
 	// Issue #308 — egress policy single source of truth. Admin CRUD is
-	// owner-gated via roleSvc.IsWorkspaceOwner (constructed above, in scope
-	// whenever pool != nil). Neither the server-side OpenHands allowed_hosts
+	// owner-gated via tenantRoleSvc.IsTenantOwner: egress_policies is keyed by
+	// tenant_id, so authority comes from public.tenant_users, not from the
+	// account-scoped roleSvc. Neither the server-side OpenHands allowed_hosts
 	// consumer nor the desktop firewall rule generator is wired here.
 	var egressPolicyHandler *egress.Handler
 	var egressSvc *egress.Service
-	if pool != nil && roleSvc != nil {
+	if pool != nil {
 		egressRepo := egress.NewPgxRepository(pool)
-		egressSvc = egress.NewService(egressRepo, roleSvc)
+		tenantRoleSvc := platform.NewTenantRoleService(platform.NewPgxTenantRoleStore(pool))
+		egressSvc = egress.NewService(egressRepo, tenantRoleSvc)
 		egressPolicyHandler = egress.NewHandler(egressSvc)
 	}
 

--- a/apps/control-plane/internal/egress/owner_port_test.go
+++ b/apps/control-plane/internal/egress/owner_port_test.go
@@ -1,0 +1,75 @@
+package egress_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/egress"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/platform"
+)
+
+// public.egress_policies is keyed by tenant_id, so the write gate has to read
+// authority from public.tenant_users. It was wired to the account-scoped
+// platform.RoleService instead, whose IsWorkspaceOwner resolves its id against
+// public.accounts: a tenant id never exists there, the store returned
+// ErrWorkspaceNotFound, and every /api/v1/egress-policy/ request answered 500.
+// The mistake compiled cleanly because both predicates took two bare UUIDs.
+//
+// These two assertions are the guard. The first pins the correct type to the
+// port; the second fails if the port is ever widened back to a shape the
+// account-scoped service also satisfies.
+
+var _ egress.OwnerChecker = (*platform.TenantRoleService)(nil)
+
+func TestAccountScopedRoleServiceDoesNotSatisfyOwnerChecker(t *testing.T) {
+	var accountScoped any = (*platform.RoleService)(nil)
+	if _, ok := accountScoped.(egress.OwnerChecker); ok {
+		t.Fatal("platform.RoleService satisfies egress.OwnerChecker: the egress write gate is " +
+			"account-scoped again and cannot authorize a tenant id")
+	}
+}
+
+// stubTenantRoleStore returns a fixed tenant_users role.
+type stubTenantRoleStore struct {
+	role platform.TenantRole
+	err  error
+}
+
+func (s stubTenantRoleStore) GetTenantRole(context.Context, uuid.UUID, uuid.UUID) (platform.TenantRole, error) {
+	return s.role, s.err
+}
+
+func TestTenantRoleServiceIsTenantOwner(t *testing.T) {
+	cases := []struct {
+		name string
+		role platform.TenantRole
+		want bool
+	}{
+		{"owner", platform.TenantRoleOwner, true},
+		{"admin is not owner", platform.TenantRoleAdmin, false},
+		{"member is not owner", platform.TenantRole("MEMBER"), false},
+		{"no membership", platform.TenantRole(""), false},
+		{"lowercase account-scoped value is not owner", platform.TenantRole("owner"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := platform.NewTenantRoleService(stubTenantRoleStore{role: tc.role})
+			got, err := svc.IsTenantOwner(context.Background(), uuid.New(), uuid.New())
+			if err != nil {
+				t.Fatalf("IsTenantOwner: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("role %q: got %v, want %v", tc.role, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTenantRoleServicePropagatesStoreError(t *testing.T) {
+	svc := platform.NewTenantRoleService(stubTenantRoleStore{err: context.DeadlineExceeded})
+	if _, err := svc.IsTenantOwner(context.Background(), uuid.New(), uuid.New()); err == nil {
+		t.Fatal("expected the store error to propagate, got nil")
+	}
+}

--- a/apps/control-plane/internal/egress/service.go
+++ b/apps/control-plane/internal/egress/service.go
@@ -16,12 +16,18 @@ import (
 var hostCharPattern = regexp.MustCompile(`^[a-zA-Z0-9.:-]+$`)
 
 // OwnerChecker is the narrow port the service uses to verify the caller owns
-// the workspace being configured. *platform.RoleService satisfies this
+// the tenant being configured. *platform.TenantRoleService satisfies this
 // interface structurally — accepting the interface here (rather than the
 // concrete type) avoids a package dependency and keeps unit tests DB-free
 // (mirrors internal/grants/service.go's AdminChecker).
+//
+// This port is tenant-scoped, not account-scoped: public.egress_policies is
+// keyed by tenant_id and its RLS predicate reads app.current_tenant_id, so the
+// caller's authority has to be read from public.tenant_users. The
+// account-scoped platform.RoleService.IsWorkspaceOwner resolves its id against
+// public.accounts and can never authorize a tenant id.
 type OwnerChecker interface {
-	IsWorkspaceOwner(ctx context.Context, userID, workspaceID uuid.UUID) (bool, error)
+	IsTenantOwner(ctx context.Context, userID, tenantID uuid.UUID) (bool, error)
 }
 
 // Service holds the egress-policy business logic: host-list validation, the
@@ -123,7 +129,7 @@ func (s *Service) DeleteUserOverride(ctx context.Context, callerID, tenantID, ta
 }
 
 func (s *Service) requireOwner(ctx context.Context, callerID, tenantID uuid.UUID) error {
-	isOwner, err := s.owner.IsWorkspaceOwner(ctx, callerID, tenantID)
+	isOwner, err := s.owner.IsTenantOwner(ctx, callerID, tenantID)
 	if err != nil {
 		return err
 	}

--- a/apps/control-plane/internal/egress/service_test.go
+++ b/apps/control-plane/internal/egress/service_test.go
@@ -62,7 +62,7 @@ type fakeOwner struct {
 	err     error
 }
 
-func (f *fakeOwner) IsWorkspaceOwner(_ context.Context, _, _ uuid.UUID) (bool, error) {
+func (f *fakeOwner) IsTenantOwner(_ context.Context, _, _ uuid.UUID) (bool, error) {
 	return f.isOwner, f.err
 }
 

--- a/apps/control-plane/internal/platform/http/router.go
+++ b/apps/control-plane/internal/platform/http/router.go
@@ -70,12 +70,15 @@ type RouterConfig struct {
 	// X-Internal-Token header.
 	InternalToken string
 
-	// ProvidersRouter exposes an InternalMux() for CRUD over custom_providers.
-	// Mounted under /internal/providers (shared-secret) and
-	// /api/v1/admin/providers (platform admin JWT).
+	// ProvidersRouter exposes the two CRUD surfaces over custom_providers:
+	// InternalMux() is mounted under /internal/providers (shared-secret) and
+	// AdminMux() under /api/v1/admin/providers (platform admin JWT). The two
+	// are separate handlers because a ServeMux matches on the whole request
+	// path, so one mux cannot serve both prefixes.
 	// Using a narrow interface avoids an import cycle between platform/http and providers.
 	ProvidersRouter interface {
 		InternalMux() http.Handler
+		AdminMux() http.Handler
 	}
 
 	// RoleSvc is required to gate the /api/v1/admin/providers routes
@@ -274,7 +277,7 @@ func NewRouter(cfg RouterConfig) http.Handler {
 
 		if cfg.RoleSvc != nil && cfg.AuthMiddleware != nil {
 			adminProviders := cfg.AuthMiddleware.Require(
-				cfg.RoleSvc.RequirePlatformAdmin(cfg.ProvidersRouter.InternalMux()),
+				cfg.RoleSvc.RequirePlatformAdmin(cfg.ProvidersRouter.AdminMux()),
 			)
 			mux.Handle("/api/v1/admin/providers", adminProviders)
 			mux.Handle("/api/v1/admin/providers/", adminProviders)

--- a/apps/control-plane/internal/platform/http/router_providers_test.go
+++ b/apps/control-plane/internal/platform/http/router_providers_test.go
@@ -1,0 +1,117 @@
+package http
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/auth"
+)
+
+// The admin provider surface was mounted with the providers handler's
+// InternalMux(), whose ServeMux patterns are absolute /internal/providers paths,
+// so every /api/v1/admin/providers request fell through to the default 404.
+// Testing the handler's AdminMux() in isolation does not catch that: the bug
+// lives in this package's wiring, not in the handler. Reverting the one-line
+// mount here still passed the handler's own tests, so this asserts dispatch
+// through NewRouter itself.
+
+// fakeProvidersRouter returns handlers that name which surface was reached.
+type fakeProvidersRouter struct{}
+
+func (fakeProvidersRouter) InternalMux() http.Handler { return namedHandler("internal-mux") }
+func (fakeProvidersRouter) AdminMux() http.Handler    { return namedHandler("admin-mux") }
+
+func namedHandler(name string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(name))
+	})
+}
+
+// passThroughRoleSvc stands in for platform.RoleService. The platform-admin
+// decision is covered by that package's own tests; this one is about routing, so
+// the gate is a pass-through and every request here counts as an admin.
+type passThroughRoleSvc struct{}
+
+func (passThroughRoleSvc) RequirePlatformAdmin(next http.Handler) http.Handler { return next }
+
+// authMiddlewareAcceptingAnyToken points a real auth.Middleware at a stub GoTrue
+// so Require admits the request without a network call, keeping the real
+// middleware in the chain rather than stubbing it out.
+func authMiddlewareAcceptingAnyToken(t *testing.T) *auth.Middleware {
+	t.Helper()
+	gotrue := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/auth/v1/user" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id": "3f1d5f9c-0b1e-4f0a-9c3d-8a2b7c6d5e4f",
+			"email": "admin@example.invalid",
+			"email_confirmed_at": "2026-01-01T00:00:00Z",
+			"user_metadata": {"selected_tenant_id": "7c9e6679-7425-40de-944b-e07fc1f90ae7"}
+		}`))
+	}))
+	t.Cleanup(gotrue.Close)
+	return auth.NewMiddleware(auth.NewClient(gotrue.URL, "anon-key"))
+}
+
+func routerWithProviders(t *testing.T) http.Handler {
+	t.Helper()
+	return NewRouter(RouterConfig{
+		AuthMiddleware:  authMiddlewareAcceptingAnyToken(t),
+		ProvidersRouter: fakeProvidersRouter{},
+		RoleSvc:         passThroughRoleSvc{},
+		InternalToken:   "s3cret",
+	})
+}
+
+func TestNewRouterDispatchesAdminProvidersToAdminMux(t *testing.T) {
+	router := routerWithProviders(t)
+
+	for _, path := range []string{
+		"/api/v1/admin/providers",
+		"/api/v1/admin/providers/3bf18e5c-2ddd-4114-9205-61fb1184acc0",
+	} {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		req.Header.Set("Authorization", "Bearer any-token")
+		rr := httptest.NewRecorder()
+		router.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Fatalf("GET %s: got %d, want 200; body: %q", path, rr.Code, rr.Body.String())
+		}
+		if got := rr.Body.String(); got != "admin-mux" {
+			t.Fatalf("GET %s: reached %q, want the admin mux", path, got)
+		}
+	}
+}
+
+func TestNewRouterDispatchesInternalProvidersToInternalMux(t *testing.T) {
+	router := routerWithProviders(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/internal/providers", nil)
+	req.Header.Set(InternalTokenHeader, "s3cret")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if got := rr.Body.String(); got != "internal-mux" {
+		t.Fatalf("GET /internal/providers: reached %q, want the internal mux", got)
+	}
+}
+
+func TestNewRouterAdminProvidersRequiresAuth(t *testing.T) {
+	router := routerWithProviders(t)
+
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/v1/admin/providers", nil))
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated admin request: got %d, want 401", rr.Code)
+	}
+	if rr.Body.String() == "admin-mux" {
+		t.Fatal("unauthenticated request reached the admin mux")
+	}
+}

--- a/apps/control-plane/internal/platform/role.go
+++ b/apps/control-plane/internal/platform/role.go
@@ -58,6 +58,65 @@ type RoleStore interface {
 	IsPlatformAdmin(ctx context.Context, userID uuid.UUID) (bool, error)
 }
 
+// TenantRole captures the role string stored in public.tenant_users.role.
+//
+// Deliberately distinct from MembershipRole. These are two independent role
+// systems over two independent id spaces: tenant_users is the Phase 19 tenant
+// scope (uppercase enum, keyed by tenant_id) while account_memberships is the
+// Phase 2 billing-account scope (lowercase enum, keyed by account_id). A
+// tenant_id never resolves in public.accounts and vice versa, so a caller
+// holding a tenant id must use the tenant-scoped predicates below rather than
+// IsWorkspaceOwner.
+type TenantRole string
+
+const (
+	TenantRoleOwner TenantRole = "OWNER"
+	TenantRoleAdmin TenantRole = "ADMIN"
+)
+
+// TenantRoleStore is the narrow data-access interface behind the tenant-scoped
+// role predicates. Kept separate from RoleStore because the two read different
+// tables in different id spaces.
+//
+// Defined here (where it is used) per Go interface-placement convention.
+type TenantRoleStore interface {
+	// GetTenantRole returns the role userID holds on tenantID, considering
+	// only ACTIVE memberships. Returns ("", nil) when there is no such
+	// membership, which callers treat as not-a-member.
+	GetTenantRole(ctx context.Context, userID, tenantID uuid.UUID) (TenantRole, error)
+}
+
+// TenantRoleService wraps a TenantRoleStore behind the tenant-scoped
+// predicates. Construct via NewTenantRoleService and inject into HTTP wiring,
+// mirroring RoleService.
+type TenantRoleService struct {
+	store TenantRoleStore
+}
+
+// NewTenantRoleService returns a TenantRoleService backed by the given store.
+func NewTenantRoleService(store TenantRoleStore) *TenantRoleService {
+	return &TenantRoleService{store: store}
+}
+
+// IsTenantOwner reports whether userID holds an ACTIVE role='OWNER' membership
+// on tenantID.
+//
+// Returns:
+//   - (true,  nil) — active owner membership exists
+//   - (false, nil) — non-owner membership, inactive membership, or no membership
+//   - (false, err) — propagated store error
+//
+// A tenant that does not exist yields (false, nil): no membership row can
+// reference it, so the caller fails closed with a permission error rather than
+// distinguishing "no such tenant" for an unauthorized caller.
+func (s *TenantRoleService) IsTenantOwner(ctx context.Context, userID, tenantID uuid.UUID) (bool, error) {
+	role, err := s.store.GetTenantRole(ctx, userID, tenantID)
+	if err != nil {
+		return false, err
+	}
+	return role == TenantRoleOwner, nil
+}
+
 // RoleService wraps a RoleStore behind the public predicates. Construct via
 // NewRoleService and inject into HTTP wiring.
 type RoleService struct {

--- a/apps/control-plane/internal/platform/role_pgx.go
+++ b/apps/control-plane/internal/platform/role_pgx.go
@@ -25,6 +25,13 @@ func NewPgxRoleStore(pool *pgxpool.Pool) RoleStore {
 	return &pgxRoleStore{pool: pool}
 }
 
+// NewPgxTenantRoleStore returns a TenantRoleStore backed by the given pgx pool.
+// It queries `public.tenant_users`, the tenant-scoped role table, which is a
+// different id space from the account tables NewPgxRoleStore reads.
+func NewPgxTenantRoleStore(pool *pgxpool.Pool) TenantRoleStore {
+	return &pgxRoleStore{pool: pool}
+}
+
 // GetMembershipRole returns the role for (userID, workspaceID).
 //
 // Returns:
@@ -60,6 +67,25 @@ func (s *pgxRoleStore) GetMembershipRole(ctx context.Context, userID, workspaceI
 		return "", fmt.Errorf("platform: get membership role: %w", err)
 	}
 	return MembershipRole(role), nil
+}
+
+// GetTenantRole returns the ACTIVE tenant_users role for (userID, tenantID),
+// or ("", nil) when no active membership exists.
+func (s *pgxRoleStore) GetTenantRole(ctx context.Context, userID, tenantID uuid.UUID) (TenantRole, error) {
+	var role string
+	err := s.pool.QueryRow(ctx, `
+		SELECT role
+		FROM public.tenant_users
+		WHERE tenant_id = $1 AND user_id = $2 AND status = 'ACTIVE'
+		LIMIT 1
+	`, tenantID, userID).Scan(&role)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return "", nil
+		}
+		return "", fmt.Errorf("platform: get tenant role: %w", err)
+	}
+	return TenantRole(role), nil
 }
 
 // IsPlatformAdmin returns whether userID owns at least one account row

--- a/apps/control-plane/internal/platform/role_pgx.go
+++ b/apps/control-plane/internal/platform/role_pgx.go
@@ -10,7 +10,11 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-// pgxRoleStore is the concrete pgxpool-backed implementation of RoleStore.
+// pgxRoleStore is the concrete pgxpool-backed implementation of both RoleStore
+// (account-scoped, public.accounts + public.account_memberships) and
+// TenantRoleStore (tenant-scoped, public.tenant_users). One struct because both
+// need nothing but the pool; the two constructors below return the narrow
+// interface each caller wants.
 // Phase 14 seeds this so main.go can wire RoleService for the owner-gated
 // endpoints. Phase 18 may swap the backing query without changing the
 // interface (RBAC contract stub locked).
@@ -71,9 +75,28 @@ func (s *pgxRoleStore) GetMembershipRole(ctx context.Context, userID, workspaceI
 
 // GetTenantRole returns the ACTIVE tenant_users role for (userID, tenantID),
 // or ("", nil) when no active membership exists.
+//
+// Runs inside an explicit transaction with app.current_tenant_id set LOCAL,
+// because hive_app is NOT BYPASSRLS and the tenant_users policy this query
+// relies on is keyed on that setting
+// (20260726_01_tenant_users_hive_app_grant.sql). LOCAL scope inside an explicit
+// transaction is required, not incidental: see the withTenantTx comment in
+// apps/control-plane/internal/egress/repository.go for the two ways this was
+// gotten wrong before, one of which leaked the setting across tenants on a
+// pooled connection.
 func (s *pgxRoleStore) GetTenantRole(ctx context.Context, userID, tenantID uuid.UUID) (TenantRole, error) {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return "", fmt.Errorf("platform: begin tenant role tx: %w", err)
+	}
+	defer tx.Rollback(ctx) // no-op once Commit has succeeded
+
+	if _, err := tx.Exec(ctx, "SELECT set_config('app.current_tenant_id', $1, true)", tenantID.String()); err != nil {
+		return "", fmt.Errorf("platform: set tenant scope: %w", err)
+	}
+
 	var role string
-	err := s.pool.QueryRow(ctx, `
+	err = tx.QueryRow(ctx, `
 		SELECT role
 		FROM public.tenant_users
 		WHERE tenant_id = $1 AND user_id = $2 AND status = 'ACTIVE'
@@ -84,6 +107,9 @@ func (s *pgxRoleStore) GetTenantRole(ctx context.Context, userID, tenantID uuid.
 			return "", nil
 		}
 		return "", fmt.Errorf("platform: get tenant role: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return "", fmt.Errorf("platform: commit tenant role tx: %w", err)
 	}
 	return TenantRole(role), nil
 }

--- a/apps/control-plane/internal/platform/role_rls_test.go
+++ b/apps/control-plane/internal/platform/role_rls_test.go
@@ -1,0 +1,179 @@
+package platform_test
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/platform"
+)
+
+// The unit tests for IsTenantOwner stub TenantRoleStore, so they say nothing
+// about whether the production DB role can read public.tenant_users at all.
+// That table was created for the PostgREST path only: it granted TO
+// authenticated and its policies evaluate auth.jwt(), which is NULL outside a
+// PostgREST request. hive_app was never granted anything on it, so before
+// 20260726_01_tenant_users_hive_app_grant.sql this query permission-failed or
+// returned zero rows in production while passing on a superuser dev connection,
+// which would have left the egress-policy admin surface 403 for every real
+// tenant owner.
+//
+// These tests connect as hive_app specifically, mirroring
+// apps/control-plane/internal/egress/repository_test.go, so that class of gap
+// fails here instead of in production.
+
+// newRLSTestPool connects as hive_app, which is NOT BYPASSRLS in production, so
+// the tenant_users policy is exercised rather than bypassed by whatever
+// superuser role HIVE_TEST_DB_URL otherwise connects as. MaxConns is pinned to 1
+// so every Acquire returns the same physical connection the SET ROLE was issued
+// on, and the pool is closed at test end so the role change never leaks.
+func newRLSTestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("HIVE_TEST_DB_URL")
+	if dsn == "" {
+		t.Skip("HIVE_TEST_DB_URL not set")
+	}
+	if !strings.Contains(strings.ToLower(dsn), "test") {
+		t.Fatalf("refusing to run: HIVE_TEST_DB_URL must point at a test database (DSN missing 'test' marker)")
+	}
+
+	cfg, err := pgxpool.ParseConfig(dsn)
+	if err != nil {
+		t.Fatalf("parse HIVE_TEST_DB_URL: %v", err)
+	}
+	cfg.MaxConns = 1
+
+	ctx := context.Background()
+	pool, err := pgxpool.NewWithConfig(ctx, cfg)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	if _, err := pool.Exec(ctx, "SET ROLE hive_app"); err != nil {
+		pool.Close()
+		t.Skipf("SET ROLE hive_app failed (is hive_app provisioned + migrations applied on this test DB?): %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+// seedMembership inserts a tenant and one tenant_users row over an unscoped
+// connection. hive_app has SELECT only on tenant_users, and no policy at all on
+// tenants, so fixture setup is deliberately not done through the role under test.
+func seedMembership(t *testing.T, tenantID, userID uuid.UUID, role, status string) {
+	t.Helper()
+	dsn := os.Getenv("HIVE_TEST_DB_URL")
+	ctx := context.Background()
+	setup, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("seed pool: %v", err)
+	}
+	defer setup.Close()
+
+	if _, err := setup.Exec(ctx,
+		`INSERT INTO public.tenants (id, slug, name, deployment)
+		 VALUES ($1, $2, 'tenant role test', 'HIVE_CLOUD')
+		 ON CONFLICT (id) DO NOTHING`,
+		tenantID, "role-test-"+tenantID.String()); err != nil {
+		t.Fatalf("seed tenant: %v", err)
+	}
+	// tenant_users.user_id is an FK onto auth.users, so the membership row needs
+	// a real user behind it.
+	if _, err := setup.Exec(ctx,
+		`INSERT INTO auth.users (id, email)
+		 VALUES ($1, $2)
+		 ON CONFLICT (id) DO NOTHING`,
+		userID, "role-test-"+userID.String()+"@hive-test.invalid"); err != nil {
+		t.Fatalf("seed auth user: %v", err)
+	}
+	if _, err := setup.Exec(ctx,
+		`INSERT INTO public.tenant_users (tenant_id, user_id, role, status)
+		 VALUES ($1, $2, $3, $4)
+		 ON CONFLICT (tenant_id, user_id) DO UPDATE SET role = EXCLUDED.role, status = EXCLUDED.status`,
+		tenantID, userID, role, status); err != nil {
+		t.Fatalf("seed membership: %v", err)
+	}
+	t.Cleanup(func() {
+		cleanup, err := pgxpool.New(context.Background(), dsn)
+		if err != nil {
+			return
+		}
+		defer cleanup.Close()
+		_, _ = cleanup.Exec(context.Background(), `DELETE FROM auth.users WHERE id = $1`, userID)
+	})
+	t.Cleanup(func() {
+		cleanup, err := pgxpool.New(context.Background(), dsn)
+		if err != nil {
+			return
+		}
+		defer cleanup.Close()
+		_, _ = cleanup.Exec(context.Background(), `DELETE FROM public.tenants WHERE id = $1`, tenantID)
+	})
+}
+
+func TestIsTenantOwner_RLS_ReadsOwnerMembershipAsHiveApp(t *testing.T) {
+	pool := newRLSTestPool(t)
+	tenantID, userID := uuid.New(), uuid.New()
+	seedMembership(t, tenantID, userID, "OWNER", "ACTIVE")
+
+	svc := platform.NewTenantRoleService(platform.NewPgxTenantRoleStore(pool))
+	isOwner, err := svc.IsTenantOwner(context.Background(), userID, tenantID)
+	if err != nil {
+		t.Fatalf("IsTenantOwner: %v (hive_app cannot read public.tenant_users, is the grant migration applied?)", err)
+	}
+	if !isOwner {
+		t.Fatal("expected the seeded ACTIVE OWNER to be recognized as tenant owner under hive_app")
+	}
+}
+
+func TestIsTenantOwner_RLS_NonOwnerAndInactiveAreNotOwners(t *testing.T) {
+	pool := newRLSTestPool(t)
+	svc := platform.NewTenantRoleService(platform.NewPgxTenantRoleStore(pool))
+	ctx := context.Background()
+
+	for _, tc := range []struct {
+		name   string
+		role   string
+		status string
+	}{
+		{"member is not owner", "MEMBER", "ACTIVE"},
+		{"admin is not owner", "ADMIN", "ACTIVE"},
+		{"suspended owner is not owner", "OWNER", "SUSPENDED"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tenantID, userID := uuid.New(), uuid.New()
+			seedMembership(t, tenantID, userID, tc.role, tc.status)
+
+			isOwner, err := svc.IsTenantOwner(ctx, userID, tenantID)
+			if err != nil {
+				t.Fatalf("IsTenantOwner: %v", err)
+			}
+			if isOwner {
+				t.Fatalf("role=%s status=%s must not count as tenant owner", tc.role, tc.status)
+			}
+		})
+	}
+}
+
+// The tenant_users policy for hive_app is keyed on app.current_tenant_id, which
+// GetTenantRole sets per call. A membership in another tenant must therefore
+// stay invisible even though the row exists.
+func TestIsTenantOwner_RLS_ForeignTenantMembershipIsInvisible(t *testing.T) {
+	pool := newRLSTestPool(t)
+	tenantA, tenantB := uuid.New(), uuid.New()
+	userID := uuid.New()
+	seedMembership(t, tenantA, userID, "OWNER", "ACTIVE")
+	seedMembership(t, tenantB, uuid.New(), "OWNER", "ACTIVE")
+
+	svc := platform.NewTenantRoleService(platform.NewPgxTenantRoleStore(pool))
+	isOwner, err := svc.IsTenantOwner(context.Background(), userID, tenantB)
+	if err != nil {
+		t.Fatalf("IsTenantOwner: %v", err)
+	}
+	if isOwner {
+		t.Fatal("a user owning tenant A must not be reported as owner of tenant B")
+	}
+}

--- a/apps/control-plane/internal/providers/admin_mux_test.go
+++ b/apps/control-plane/internal/providers/admin_mux_test.go
@@ -1,0 +1,105 @@
+package providers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// The admin surface used to be mounted with InternalMux(), whose ServeMux
+// patterns are absolute ("/internal/providers"). A ServeMux matches on the
+// whole request path, so no /api/v1/admin/providers request could ever match a
+// pattern and every one fell through to the default 404 — the platform-admin
+// provider surface was unreachable in production while the internal one worked.
+// These tests pin each prefix to its own mux.
+
+func seededAdminRepo() (*stubRepo, uuid.UUID) {
+	id := uuid.New()
+	return &stubRepo{
+		providers: []Provider{{
+			ID:            id,
+			Slug:          "openrouter",
+			DisplayName:   "OpenRouter",
+			BaseURL:       "https://openrouter.ai/api/v1",
+			APIKeyEnv:     "OPENROUTER_API_KEY",
+			LiteLLMPrefix: "openrouter/",
+			Enabled:       true,
+		}},
+	}, id
+}
+
+func TestAdminMuxRoutesAdminPrefix(t *testing.T) {
+	repo, seeded := seededAdminRepo()
+	mux := NewHandler(NewService(repo)).AdminMux()
+
+	cases := []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{"list collection", http.MethodGet, "/api/v1/admin/providers"},
+		{"get item", http.MethodGet, "/api/v1/admin/providers/" + seeded.String()},
+		{"delete item", http.MethodDelete, "/api/v1/admin/providers/" + seeded.String()},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			mux.ServeHTTP(rr, httptest.NewRequest(tc.method, tc.path, nil))
+			if rr.Code == http.StatusNotFound {
+				t.Fatalf("%s %s: got 404, the admin prefix is not routed; body: %s",
+					tc.method, tc.path, rr.Body.String())
+			}
+		})
+	}
+}
+
+func TestAdminMuxUnknownIDReturns404(t *testing.T) {
+	repo, _ := seededAdminRepo()
+	mux := NewHandler(NewService(repo)).AdminMux()
+
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/v1/admin/providers/"+uuid.New().String(), nil))
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("unknown provider id: got %d, want 404", rr.Code)
+	}
+}
+
+// extractID reads the last path segment, so a well-formed id has to resolve
+// identically under either prefix.
+func TestAdminAndInternalMuxResolveSameProvider(t *testing.T) {
+	repo, seeded := seededAdminRepo()
+	h := NewHandler(NewService(repo))
+
+	for _, tc := range []struct {
+		name string
+		mux  http.Handler
+		path string
+	}{
+		{"admin", h.AdminMux(), "/api/v1/admin/providers/" + seeded.String()},
+		{"internal", h.InternalMux(), "/internal/providers/" + seeded.String()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			tc.mux.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, tc.path, nil))
+			if rr.Code != http.StatusOK {
+				t.Fatalf("GET %s: got %d, want 200; body: %s", tc.path, rr.Code, rr.Body.String())
+			}
+			if got := decodeProvider(t, rr.Body).ID; got != seeded {
+				t.Fatalf("GET %s: got id %s, want %s", tc.path, got, seeded)
+			}
+		})
+	}
+}
+
+func TestInternalMuxDoesNotRouteAdminPrefix(t *testing.T) {
+	repo, _ := seededAdminRepo()
+	mux := NewHandler(NewService(repo)).InternalMux()
+
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/v1/admin/providers", nil))
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("internal mux must not route the admin prefix: got %d", rr.Code)
+	}
+}

--- a/apps/control-plane/internal/providers/http.go
+++ b/apps/control-plane/internal/providers/http.go
@@ -19,8 +19,12 @@ func NewHandler(svc *Service) *Handler {
 	return &Handler{svc: svc}
 }
 
-// InternalMux returns an http.Handler that routes the five CRUD endpoints.
-// Callers should wrap this with RequireInternalToken before mounting.
+const internalPrefix = "/internal/providers"
+const adminPrefix = "/api/v1/admin/providers"
+
+// InternalMux returns an http.Handler that routes the five CRUD endpoints on
+// the service-to-service surface. Callers should wrap this with
+// RequireInternalToken before mounting.
 //
 //	POST   /internal/providers
 //	GET    /internal/providers
@@ -28,9 +32,30 @@ func NewHandler(svc *Service) *Handler {
 //	PUT    /internal/providers/{id}
 //	DELETE /internal/providers/{id}
 func (h *Handler) InternalMux() http.Handler {
+	return h.muxFor(internalPrefix)
+}
+
+// AdminMux returns the same five CRUD endpoints on the platform-admin surface.
+// Callers should wrap this with the auth middleware plus RequirePlatformAdmin
+// before mounting.
+//
+//	POST   /api/v1/admin/providers
+//	GET    /api/v1/admin/providers
+//	GET    /api/v1/admin/providers/{id}
+//	PUT    /api/v1/admin/providers/{id}
+//	DELETE /api/v1/admin/providers/{id}
+//
+// A ServeMux matches on the whole request path, so the internal mux cannot be
+// reused for this mount: its patterns would never match an /api/v1 path and
+// every request would fall through to the default 404.
+func (h *Handler) AdminMux() http.Handler {
+	return h.muxFor(adminPrefix)
+}
+
+func (h *Handler) muxFor(prefix string) http.Handler {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/internal/providers", h.handleCollection)
-	mux.HandleFunc("/internal/providers/", h.handleItem)
+	mux.HandleFunc(prefix, h.handleCollection)
+	mux.HandleFunc(prefix+"/", h.handleItem)
 	return mux
 }
 

--- a/scripts/verify-control-plane.py
+++ b/scripts/verify-control-plane.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Assert every control-plane surface answers correctly on a running stack.
+
+CI cannot cover this: the control-plane's auth middleware resolves each bearer
+against live Supabase GoTrue, and most reads need real rows. So the surfaces
+below are only ever exercised against a deployed stack, which is how two routes
+shipped structurally broken (an admin mux mounted under a prefix its ServeMux
+patterns could never match, and a tenant id handed to an account-scoped
+ownership predicate). Both answered every request with 404 and 500 respectively
+while every unit test passed. This script is the check that fails on that class.
+
+It asserts status codes rather than printing them, and exits non-zero on the
+first surface that answers unexpectedly.
+
+Usage (from the repo root, on a host that can reach the stack):
+
+    set -a; . .env; set +a
+    python3 scripts/verify-control-plane.py
+
+Required env: SUPABASE_URL, SUPABASE_ANON_KEY, SUPABASE_SERVICE_ROLE_KEY,
+CONTROL_PLANE_INTERNAL_TOKEN.
+
+Optional env:
+    HIVE_CONTROL_PLANE_URL   default http://localhost:8081
+    HIVE_EDGE_API_URL        default http://localhost:8080
+    HIVE_VERIFY_EMAIL        default demo@hive-demo.invalid
+    HIVE_VERIFY_TENANT_SLUG  default hive-demo
+
+The caller identified by HIVE_VERIFY_EMAIL must already exist and be both a
+platform admin and an OWNER of the tenant; scripts/seed-demo-owner.py
+provisions exactly that. Its password is rotated through the GoTrue admin API
+on each run, so no credential is ever passed on the command line or printed.
+"""
+import hashlib
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+CP = os.environ.get("HIVE_CONTROL_PLANE_URL", "http://localhost:8081").rstrip("/")
+EDGE = os.environ.get("HIVE_EDGE_API_URL", "http://localhost:8080").rstrip("/")
+EMAIL = os.environ.get("HIVE_VERIFY_EMAIL", "demo@hive-demo.invalid")
+TENANT_SLUG = os.environ.get("HIVE_VERIFY_TENANT_SLUG", "hive-demo")
+
+failures: list[str] = []
+
+
+def env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        sys.exit(f"error: {name} is not set")
+    return value
+
+
+def http(method, url, headers=None, body=None, timeout=120):
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(url, data=data, method=method, headers=headers or {})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            return r.status, r.read().decode(errors="replace")
+    except urllib.error.HTTPError as e:
+        return e.code, e.read().decode(errors="replace")
+    except Exception as e:  # noqa: BLE001 — a transport failure is a result too
+        return 0, f"<transport error: {type(e).__name__}: {e}>"
+
+
+def check(method, path, headers, want, body=None, base=None):
+    """Assert one request's status is in `want`. Returns the response body."""
+    base = base or CP
+    status, raw = http(method, base + path, headers, body)
+    flat = " ".join(raw.split())
+    ok = status in want
+    print(f"  [{'PASS' if ok else 'FAIL'}] {method:6} {path:56} -> {status} (want {'/'.join(map(str, want))})")
+    if not ok:
+        print(f"           body: {flat[:300]}")
+        failures.append(f"{method} {path} -> {status}, want {want}")
+    return raw
+
+
+def main() -> None:
+    supabase = env("SUPABASE_URL").rstrip("/")
+    anon = env("SUPABASE_ANON_KEY")
+    service = env("SUPABASE_SERVICE_ROLE_KEY")
+    internal_token = env("CONTROL_PLANE_INTERNAL_TOKEN")
+    svc_h = {"Authorization": f"Bearer {service}", "apikey": service, "Content-Type": "application/json"}
+
+    print(f"control-plane {CP} | edge-api {EDGE} | caller {EMAIL}")
+
+    print("\n== liveness ==")
+    check("GET", "/health", {}, (200,))
+
+    # Resolve the caller and mint a session. The password is rotated rather than
+    # supplied so this script never needs a stored credential.
+    status, raw = http(
+        "GET", f"{supabase}/auth/v1/admin/users?" + urllib.parse.urlencode({"filter": EMAIL}), svc_h
+    )
+    if status != 200:
+        sys.exit(f"error: user lookup failed: {status} {raw[:200]}")
+    user = next((u for u in json.loads(raw).get("users", []) if u.get("email", "").lower() == EMAIL.lower()), None)
+    if user is None:
+        sys.exit(f"error: {EMAIL} does not exist; run scripts/seed-demo-owner.py first")
+
+    password = "Verify-" + os.urandom(12).hex() + "-aA1!"
+    status, raw = http("PUT", f"{supabase}/auth/v1/admin/users/{user['id']}", svc_h, {"password": password})
+    if status != 200:
+        sys.exit(f"error: password rotate failed: {status} {raw[:200]}")
+    status, raw = http(
+        "POST", f"{supabase}/auth/v1/token?grant_type=password",
+        {"apikey": anon, "Content-Type": "application/json"},
+        {"email": EMAIL, "password": password},
+    )
+    if status != 200:
+        sys.exit(f"error: sign-in failed: {status} {raw[:200]}")
+    auth = {"Authorization": f"Bearer {json.loads(raw)['access_token']}", "Content-Type": "application/json"}
+    internal = {"X-Internal-Token": internal_token, "Content-Type": "application/json"}
+
+    status, raw = http(
+        "GET", f"{supabase}/rest/v1/tenants?select=id&slug=eq.{urllib.parse.quote(TENANT_SLUG)}", svc_h
+    )
+    rows = json.loads(raw) if status == 200 else []
+    if not rows:
+        sys.exit(f"error: tenant slug {TENANT_SLUG!r} not found")
+    tenant = rows[0]["id"]
+    print(f"caller resolved, tenant {tenant}")
+
+    print("\n== account, profile and billing reads (session JWT) ==")
+    for path in (
+        "/api/v1/viewer",
+        "/api/v1/accounts/current/members",
+        "/api/v1/accounts/current/profile",
+        "/api/v1/accounts/current/billing-profile",
+        "/api/v1/accounts/current/credits/balance",
+        "/api/v1/accounts/current/credits/ledger",
+        "/api/v1/accounts/current/invoices",
+        "/api/v1/accounts/current/budget",
+        "/api/v1/accounts/current/analytics/usage",
+        "/api/v1/accounts/current/analytics/spend",
+        "/api/v1/accounts/current/analytics/errors",
+        "/api/v1/accounts/current/request-attempts",
+        "/api/v1/accounts/current/usage-events",
+        "/api/v1/accounts/current/checkout/rails",
+    ):
+        check("GET", path, auth, (200,))
+
+    print("\n== catalog ==")
+    check("GET", "/api/v1/catalog/models", auth, (200,))
+    check("GET", "/api/v1/catalog/models", {}, (200,))
+
+    print("\n== platform-admin surfaces ==")
+    # A prefix mismatch here answers with Go's default "404 page not found",
+    # which is exactly what these assertions exist to catch.
+    check("GET", "/api/v1/admin/feature-gates", auth, (200,))
+    check("GET", "/api/v1/admin/providers", auth, (200,))
+    check("GET", "/api/v1/admin/marketplace", auth, (200,))
+
+    print("\n== tenant-owner surfaces ==")
+    # 404 means routed and authorized with nothing stored yet; 500 means the
+    # ownership predicate could not resolve the tenant id at all.
+    check("GET", f"/api/v1/egress-policy/{tenant}", auth, (200, 404))
+
+    print("\n== api-key lifecycle and the full key auth chain ==")
+    raw = check("POST", "/api/v1/accounts/current/api-keys", auth, (201,), {"nickname": "verify-control-plane"})
+    key_id = secret = ""
+    try:
+        created = json.loads(raw)
+        key_id, secret = created.get("id", ""), created.get("secret", "")
+    except json.JSONDecodeError:
+        failures.append("api-key create response was not JSON")
+
+    check("GET", "/api/v1/accounts/current/api-keys", auth, (200,))
+    if key_id:
+        check("GET", f"/api/v1/accounts/current/api-keys/{key_id}", auth, (200,))
+        check("GET", f"/api/v1/accounts/current/api-keys/{key_id}/limits", auth, (200,))
+    if secret:
+        check("POST", "/internal/apikeys/resolve", internal, (200,),
+              {"token_hash": hashlib.sha256(secret.encode()).hexdigest()})
+        key_auth = {"Authorization": f"Bearer {secret}", "Content-Type": "application/json"}
+        check("GET", "/v1/models", key_auth, (200,), base=EDGE)
+        check("POST", "/v1/chat/completions", key_auth, (200,),
+              {"model": "hive-default", "messages": [{"role": "user", "content": "say pong"}],
+               "max_tokens": 16}, base=EDGE)
+    else:
+        failures.append("api-key create returned no secret, key auth chain not exercised")
+
+    print("\n== internal service-to-service surfaces ==")
+    check("GET", "/internal/catalog/snapshot", internal, (200,))
+    check("GET", f"/internal/featuregate/{tenant}", internal, (200,))
+    check("GET", "/internal/providers", internal, (200,))
+    check("GET", f"/internal/marketplace/{tenant}/mcp-servers", internal, (200,))
+    check("GET", f"/internal/egress-policy/{tenant}", internal, (200,))
+
+    print("\n== negative auth cases ==")
+    check("GET", "/internal/catalog/snapshot", {"X-Internal-Token": "wrong-token"}, (401,))
+    check("GET", "/internal/catalog/snapshot", {}, (401,))
+    check("GET", "/api/v1/accounts/current/credits/balance", {"Authorization": "Bearer not-a-jwt"}, (401,))
+    check("GET", "/api/v1/accounts/current/credits/balance", {}, (401,))
+    check("GET", "/api/v1/admin/providers", {}, (401,))
+    check("GET", f"/api/v1/egress-policy/{tenant}", {}, (401,))
+
+    print("\n== cleanup ==")
+    if key_id:
+        check("POST", f"/api/v1/accounts/current/api-keys/{key_id}/revoke", auth, (200, 204), {})
+
+    print()
+    if failures:
+        print(f"FAILED: {len(failures)} surface(s) answered unexpectedly")
+        for f in failures:
+            print(f"  - {f}")
+        sys.exit(1)
+    print("PASSED: every control-plane surface answered as expected")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/verify-control-plane.py
+++ b/scripts/verify-control-plane.py
@@ -17,8 +17,8 @@ Usage (from the repo root, on a host that can reach the stack):
     set -a; . .env; set +a
     python3 scripts/verify-control-plane.py
 
-Required env: SUPABASE_URL, SUPABASE_ANON_KEY, SUPABASE_SERVICE_ROLE_KEY,
-CONTROL_PLANE_INTERNAL_TOKEN.
+Required env: SUPABASE_URL, SUPABASE_ANON_KEY, CONTROL_PLANE_INTERNAL_TOKEN,
+and HIVE_VERIFY_PASSWORD for the caller below.
 
 Optional env:
     HIVE_CONTROL_PLANE_URL   default http://localhost:8081
@@ -28,9 +28,14 @@ Optional env:
 
 The caller identified by HIVE_VERIFY_EMAIL must already exist and be both a
 platform admin and an OWNER of the tenant; scripts/seed-demo-owner.py
-provisions exactly that. Its password is rotated through the GoTrue admin API
-on each run, so no credential is ever passed on the command line or printed.
+provisions exactly that.
+
+This script signs in with an existing password and never rotates it. Rotating
+would revoke every live session for that account, and the control-plane
+resolves each bearer against GoTrue on every request, so a rotation here knocks
+out anyone else testing concurrently with the same account.
 """
+import base64
 import hashlib
 import json
 import os
@@ -82,30 +87,14 @@ def check(method, path, headers, want, body=None, base=None):
 def main() -> None:
     supabase = env("SUPABASE_URL").rstrip("/")
     anon = env("SUPABASE_ANON_KEY")
-    service = env("SUPABASE_SERVICE_ROLE_KEY")
     internal_token = env("CONTROL_PLANE_INTERNAL_TOKEN")
-    svc_h = {"Authorization": f"Bearer {service}", "apikey": service, "Content-Type": "application/json"}
+    password = env("HIVE_VERIFY_PASSWORD")
 
     print(f"control-plane {CP} | edge-api {EDGE} | caller {EMAIL}")
 
     print("\n== liveness ==")
     check("GET", "/health", {}, (200,))
 
-    # Resolve the caller and mint a session. The password is rotated rather than
-    # supplied so this script never needs a stored credential.
-    status, raw = http(
-        "GET", f"{supabase}/auth/v1/admin/users?" + urllib.parse.urlencode({"filter": EMAIL}), svc_h
-    )
-    if status != 200:
-        sys.exit(f"error: user lookup failed: {status} {raw[:200]}")
-    user = next((u for u in json.loads(raw).get("users", []) if u.get("email", "").lower() == EMAIL.lower()), None)
-    if user is None:
-        sys.exit(f"error: {EMAIL} does not exist; run scripts/seed-demo-owner.py first")
-
-    password = "Verify-" + os.urandom(12).hex() + "-aA1!"
-    status, raw = http("PUT", f"{supabase}/auth/v1/admin/users/{user['id']}", svc_h, {"password": password})
-    if status != 200:
-        sys.exit(f"error: password rotate failed: {status} {raw[:200]}")
     status, raw = http(
         "POST", f"{supabase}/auth/v1/token?grant_type=password",
         {"apikey": anon, "Content-Type": "application/json"},
@@ -113,16 +102,19 @@ def main() -> None:
     )
     if status != 200:
         sys.exit(f"error: sign-in failed: {status} {raw[:200]}")
-    auth = {"Authorization": f"Bearer {json.loads(raw)['access_token']}", "Content-Type": "application/json"}
+    token = json.loads(raw)["access_token"]
+    auth = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
     internal = {"X-Internal-Token": internal_token, "Content-Type": "application/json"}
 
-    status, raw = http(
-        "GET", f"{supabase}/rest/v1/tenants?select=id&slug=eq.{urllib.parse.quote(TENANT_SLUG)}", svc_h
-    )
-    rows = json.loads(raw) if status == 200 else []
-    if not rows:
-        sys.exit(f"error: tenant slug {TENANT_SLUG!r} not found")
-    tenant = rows[0]["id"]
+    # custom_access_token_hook stamps tenant_id on every token it mints and
+    # refuses to mint one at all without an ACTIVE membership, so the claim is
+    # the tenant. Reading it here keeps this a caller-scoped check with no
+    # service-role key.
+    payload = token.split(".")[1]
+    claims = json.loads(base64.urlsafe_b64decode(payload + "=" * (-len(payload) % 4)))
+    tenant = claims.get("tenant_id") or ""
+    if not tenant:
+        sys.exit("error: token carried no tenant_id claim; is the caller an ACTIVE tenant member?")
     print(f"caller resolved, tenant {tenant}")
 
     print("\n== account, profile and billing reads (session JWT) ==")

--- a/supabase/migrations/20260726_01_tenant_users_hive_app_grant.sql
+++ b/supabase/migrations/20260726_01_tenant_users_hive_app_grant.sql
@@ -1,0 +1,60 @@
+-- supabase/migrations/20260726_01_tenant_users_hive_app_grant.sql
+--
+-- Let the control-plane read tenant-scoped roles under the production DB role.
+--
+-- public.tenant_users was created for the PostgREST path only: 20260516_03_
+-- phase19_tenant_users.sql grants SELECT/INSERT/UPDATE/DELETE TO authenticated
+-- and 20260518_04_phase19_audit_rls_and_indexes.sql adds RLS policies keyed on
+-- auth.jwt(). Nothing ever granted hive_app anything on it, and every policy on
+-- it is unqualified (so PUBLIC, which includes hive_app) and evaluates
+-- auth.jwt(), which is NULL outside a PostgREST request. hive_app is NOT
+-- BYPASSRLS, so a control-plane query against this table permission-fails or
+-- returns zero rows in production.
+--
+-- That went unnoticed because every other Phase-19+ table the control-plane
+-- reads got an explicit hive_app grant plus an app.current_tenant_id policy
+-- (public.egress_policies in 20260715_03_egress_policy_ssot.sql,
+-- public.marketplace_tenant_entries in 20260716_01_marketplace_catalog.sql,
+-- public.agent_tasks in 20260716_03_agent_tasks.sql), and because a superuser
+-- connection string masks the gap entirely.
+--
+-- platform.TenantRoleService.IsTenantOwner is the first control-plane reader of
+-- this table, and it gates the /api/v1/egress-policy/ admin surface. Without
+-- this migration that surface answers 403 or 500 for every legitimate tenant
+-- owner in production while passing on a superuser dev connection.
+--
+-- Depends on: 20260516_03_phase19_tenant_users.sql (public.tenant_users)
+
+BEGIN;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public' AND tablename = 'tenant_users'
+          AND policyname = 'tenant_users_hive_app_tenant_isolation'
+    ) THEN
+        -- PERMISSIVE, so this ORs with the existing auth.jwt()-keyed policies
+        -- rather than replacing them: the PostgREST path keeps working
+        -- unchanged and hive_app gains its own scoped read.
+        --
+        -- SELECT only. The control-plane reads roles here; membership writes
+        -- stay with the PostgREST/service-role path that owns them today.
+        --
+        -- NULLIF(..., '') guards the Postgres GUC placeholder quirk documented
+        -- at length in 20260715_03_egress_policy_ssot.sql: once a session has
+        -- called set_config('app.current_tenant_id', ..., true), later
+        -- current_setting(name, true) calls on that pooled connection return ''
+        -- rather than NULL, and ''::uuid raises invalid input syntax instead of
+        -- filtering. Folding '' to NULL first makes the comparison NULL, which
+        -- Postgres treats as false, so an unscoped query fails closed with zero
+        -- rows instead of erroring.
+        CREATE POLICY tenant_users_hive_app_tenant_isolation
+            ON public.tenant_users AS PERMISSIVE FOR SELECT TO hive_app
+            USING (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::uuid);
+    END IF;
+END$$;
+
+GRANT SELECT ON public.tenant_users TO hive_app;
+
+COMMIT;


### PR DESCRIPTION
## Problem

Live verification of the control-plane against the demo box found two admin surfaces that are registered in the router but can never succeed. Both fail closed, so neither is a privilege leak, but neither has ever worked in production.

### 1. `/api/v1/admin/providers` always returned 404

The mount reused `providers.Handler.InternalMux()`, whose `ServeMux` patterns are the absolute paths `/internal/providers` and `/internal/providers/`. A `ServeMux` matches on the whole request path, so no `/api/v1/...` request could match a pattern and every one fell through to the default handler. The response was Go's built-in `404 page not found`, not the handler's own JSON error, which is the tell.

### 2. `/api/v1/egress-policy/` always returned 500

The write gate called `platform.RoleService.IsWorkspaceOwner` with a tenant id. That predicate resolves its id against `public.accounts`, and a tenant id never exists there, so the store returned `ErrWorkspaceNotFound`, which `writePolicyError` maps through its default branch to a 500. `public.egress_policies` is keyed by `tenant_id` and its RLS predicate reads `app.current_tenant_id`, so the caller's authority has to come from `public.tenant_users`.

The two role systems are separate id spaces by design (`tenant_users.role` uppercase, tenant-keyed; `account_memberships.role` lowercase, account-keyed), and the mistake compiled cleanly because both predicates take two bare UUIDs.

## Change

`providers.Handler` now exposes `AdminMux()` beside `InternalMux()`, each building its own mux over its own prefix, and the router mounts the admin one behind the existing platform-admin gate. `extractID` already reads the last path segment, so ids resolve identically under either prefix.

The platform package gains the tenant-scoped counterpart to its account-scoped primitives: `TenantRole`, `TenantRoleStore`, `TenantRoleService.IsTenantOwner`, and a pgx store reading `public.tenant_users` for ACTIVE memberships. The egress service's `OwnerChecker` port switches to `IsTenantOwner` and `main.go` wires the new service. The shape is additive, so all eight existing `RoleStore` implementations are untouched.

## Live proof

Built from this branch on the demo box and run as a throwaway container on port 8091, with the existing stack left running on 8081. Same request, same credential, both ports. Caller is the seeded demo owner (platform admin plus tenant OWNER).

```
--- GET /api/v1/admin/providers
      8081 main   (before) -> 404  404 page not found
      8091 fix    (after)  -> 200  [{"id":"3bf18e5c-...","slug":"openrouter","display_name":"OpenRouter",...

--- GET /api/v1/egress-policy/7d9cec95-85ac-49bc-bd0b-9b60c7ba3afa
      8081 main   (before) -> 500  {"error":"egress policy request failed"}
      8091 fix    (after)  -> 404  {"error":"egress policy not found"}

--- PUT /api/v1/egress-policy/7d9cec95-85ac-49bc-bd0b-9b60c7ba3afa
      8081 main   (before) -> 500  {"error":"egress policy request failed"}
      8091 fix    (after)  -> 200  {"tenant_id":"7d9cec95-...","allowed_hosts":["api.github.com"],"updated_at":"2026-07-26T13:09:16.661145Z"}
```

The `404 egress policy not found` on GET is correct: the tenant had no stored policy until the PUT below it wrote one.

Internal service-to-service surfaces unchanged:

```
  GET /internal/providers                      8081 main -> 200   8091 fix -> 200
  GET /internal/egress-policy/{tenant}         8081 main -> 200   8091 fix -> 200
```

Unauthenticated requests still rejected:

```
  GET /api/v1/admin/providers        no creds -> 401  {"error":"missing authorization header"}
  GET /api/v1/egress-policy/{tenant} no creds -> 401  {"error":"missing authorization header"}
  GET /internal/providers            no creds -> 401  {"error":"unauthorized"}
```

Authorization negative case, a MEMBER-role (non-owner) user on the same tenant against the fixed build:

```
  GET    -> 403  {"error":"workspace owner permission required"}
  PUT    -> 403  {"error":"workspace owner permission required"}
  DELETE -> 403  {"error":"workspace owner permission required"}

  confirm the non-owner PUT did not write:
  egress_policies rows for demo tenant: [{"user_id":null,"allowed_hosts":["api.github.com"]}]   (the owner's row only)
```

A tenant-less user cannot reach the gate at all: `custom_access_token_hook` refuses to mint a token without an ACTIVE membership (`P0001 no_active_membership`), so MEMBER is the real non-owner case.

All test data was removed afterwards. The `egress_policies` row this test wrote was deleted, restoring the demo tenant to no stored policy, and the probe user and its membership were deleted.

## Tests

Added, and they fail against the pre-fix code by construction:

- `providers/admin_mux_test.go` pins each prefix to its own mux, asserts the admin prefix routes for collection and item requests, asserts both muxes resolve the same provider id, and asserts the internal mux does not serve the admin prefix.
- `egress/owner_port_test.go` asserts `*platform.TenantRoleService` satisfies `egress.OwnerChecker` and that the account-scoped `*platform.RoleService` does not. That second assertion is the guard for the exact substitution that compiled before and broke the surface at runtime. Plus a truth table for `IsTenantOwner` over OWNER, ADMIN, MEMBER, absent, and the lowercase account-scoped value, and store-error propagation.

```
go build ./apps/control-plane/...                  BUILD_OK
go vet ./apps/control-plane/...                    clean
go test ./apps/control-plane/... -count=1 -short   all packages ok, no failures
```
