### PR TITLE
test: cover OIDC sign-in against the deployed origin

### DIFF
--- a/apps/web-console/e2e/phase-19/owui/deployed-login.spec.ts
+++ b/apps/web-console/e2e/phase-19/owui/deployed-login.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from "@playwright/test";
+
+// Deployed-origin OIDC sign-in smoke. owui.setup.ts already covers this
+// journey, but it also installs the hive_jwt_forward Function and writes
+// storageState, and both of those mutate whatever they point at. Neither is
+// acceptable against a live deployment, so this spec logs in and asserts,
+// nothing else.
+//
+// It exists because the consent page is served from Supabase's site_url,
+// which is a different origin from the chat surface (chat-hive.scubed.co ->
+// console-hive.scubed.co -> back). The nightly exercises that hop with the
+// chat surface on localhost; this one exercises it with both sides deployed,
+// which is the only configuration a real user ever sees.
+const OWUI_URL = process.env.OWUI_URL ?? "";
+
+test("OIDC sign-in completes against the deployed origin", async ({ page }) => {
+  const isDeployed =
+    new URL(OWUI_URL || "http://localhost").hostname !== "localhost";
+  if (!isDeployed) {
+    test.skip(true, "OWUI_URL is not a deployed origin");
+    return;
+  }
+
+  const email = process.env.OWUI_E2E_EMAIL;
+  const password = process.env.OWUI_E2E_PASSWORD;
+  if (!email || !password) {
+    test.skip(true, "OWUI_E2E_EMAIL/OWUI_E2E_PASSWORD not set");
+    return;
+  }
+
+  const owuiOrigin = new URL(OWUI_URL).origin;
+  await page.goto("/auth");
+
+  const hiveButton = page.getByRole("button", { name: /continue with hive/i });
+  await expect(hiveButton).toBeVisible({ timeout: 30_000 });
+  // The login page animates continuously, so Playwright's click-stability
+  // check never settles and force-click still requires the element in the
+  // viewport. dispatchEvent fires the handler regardless of geometry.
+  await hiveButton.dispatchEvent("click");
+
+  const emailBox = page.getByRole("textbox", { name: /email/i });
+  const passwordBox = page.getByRole("textbox", { name: /password/i });
+  const approveButton = page.getByRole("button", { name: /approve/i });
+  const newChatButton = page.getByRole("button", { name: /new chat/i });
+
+  // Consent renders first and only then bounces to sign-in once its
+  // client-side session check comes back empty, so a URL check can observe
+  // the transient consent pathname and wrongly conclude we are past login.
+  // Wait on the DOM instead.
+  await expect(emailBox.or(approveButton)).toBeVisible({ timeout: 45_000 });
+
+  if (await emailBox.isVisible()) {
+    await emailBox.fill(email);
+    await passwordBox.fill(password);
+    await page.getByRole("button", { name: /continue/i }).click();
+  }
+
+  // Supabase auto-approves a client the user has already granted, so consent
+  // shows at most once per user and client. Both outcomes are valid.
+  await expect(approveButton.or(newChatButton)).toBeVisible({ timeout: 45_000 });
+  if (await approveButton.isVisible()) {
+    await approveButton.click();
+  }
+
+  await page.waitForURL((u) => u.origin === owuiOrigin, { timeout: 45_000 });
+  await expect(newChatButton).toBeVisible({ timeout: 60_000 });
+});

--- a/apps/web-console/e2e/phase-19/owui/playwright.owui.config.ts
+++ b/apps/web-console/e2e/phase-19/owui/playwright.owui.config.ts
@@ -6,9 +6,11 @@ import { defineConfig, devices } from "@playwright/test";
 // storageState file. SUPABASE_OAUTH_CLIENT_ID/SECRET gate the OAuth-backed
 // "Continue with Hive" journey the same way OWUI_E2E_EMAIL/PASSWORD gate the
 // seeded test user -- both must mirror owui.setup.ts's own skip condition.
+const hasUserCreds = Boolean(
+  process.env.OWUI_E2E_EMAIL && process.env.OWUI_E2E_PASSWORD,
+);
 const hasCreds = Boolean(
-  process.env.OWUI_E2E_EMAIL &&
-    process.env.OWUI_E2E_PASSWORD &&
+  hasUserCreds &&
     process.env.SUPABASE_OAUTH_CLIENT_ID &&
     process.env.SUPABASE_OAUTH_CLIENT_SECRET,
 );
@@ -46,6 +48,20 @@ export default defineConfig({
       name: "owui-perf",
       testMatch: hasCreds ? /performance\/.*\.spec\.ts$/ : [],
       dependencies: ["owui-setup"],
+      use: { ...devices["Desktop Chrome"] },
+    },
+    {
+      // Logs in from scratch against a deployed OWUI_URL, so it takes no
+      // storageState and depends on no setup project. The spec skips itself
+      // when OWUI_URL is localhost, which leaves the nightly unaffected.
+      // Gated on the user credentials only, not on SUPABASE_OAUTH_CLIENT_*:
+      // for a deployed target the OAuth client is configured on that
+      // deployment, not in whatever environment runs this spec.
+      name: "owui-deployed-login",
+      testMatch: hasUserCreds ? /deployed-login\.spec\.ts$/ : [],
+      // The journey crosses two origins over the public internet and ends on
+      // a full SPA load, so it needs more than the 60s default above.
+      timeout: 180_000,
       use: { ...devices["Desktop Chrome"] },
     },
   ],


### PR DESCRIPTION
## Why

The OAuth consent page is served from Supabase's `site_url`, so signing in to Hive Chat is a cross-origin journey: `chat-hive.scubed.co` to `console-hive.scubed.co` and back. Nothing in CI exercised that with both sides deployed. `owui.setup.ts` covers the same journey, but with the chat surface on `localhost:3003`, which is not a configuration any real user ever hits.

That gap is what allowed the consent-origin break fixed for #271 to reach a live deployment while the nightly stayed green.

## Why this is a separate spec rather than a reuse of owui.setup.ts

`owui.setup.ts` cannot simply be repointed at a deployment. Past the login itself it does two things that write to the target:

1. `installHiveJwtForwardFilter` creates and toggles the `hive_jwt_forward` Function through Open WebUI's admin API.
2. It writes `storageState` for the dependent projects to consume.

Running that against the live box would mutate the box's Open WebUI configuration as a side effect of a smoke test. This spec logs in and asserts, and does nothing else.

## What it does

Drives the real journey through the public hostnames: loads `/auth`, clicks "Continue with Hive", signs in on the consent origin, approves if a consent screen is shown, then asserts the browser is back on the deployed chat origin with the UI loaded.

Two behaviours worth calling out, both learned from the existing suite rather than guessed:

- Consent renders first and only bounces to sign-in once its client-side session check returns empty, so the wait is on the DOM rather than on a URL. A URL check can observe the transient consent pathname and wrongly conclude login is done.
- Supabase auto-approves a client the user has already granted, so the consent screen appears at most once per user and client. Both outcomes have to be accepted or the spec passes for the wrong reason on every run after the first.

## Gating

The new `owui-deployed-login` project takes no `storageState` and depends on no setup project, because it logs in from scratch. It is gated on `OWUI_E2E_EMAIL` and `OWUI_E2E_PASSWORD` only, deliberately not on `SUPABASE_OAUTH_CLIENT_ID` and `SUPABASE_OAUTH_CLIENT_SECRET` the way the other projects are: for a deployed target the OAuth client is configured on that deployment, not in whatever environment runs the spec. The existing `hasCreds` gate is unchanged and still guards the other three projects.

The spec skips itself when `OWUI_URL` is localhost, so the nightly is unaffected.

The 180s project timeout replaces the config's 60s default for this project only. The journey crosses two origins over the public internet and ends on a full SPA load, and 60s is not enough for that.

## Verification

Run live against the demo box:

```
$ OWUI_URL=https://chat-hive.scubed.co npx playwright test \
    --config=e2e/phase-19/owui/playwright.owui.config.ts --project=owui-deployed-login

  ✓  1 [owui-deployed-login] › deployed-login.spec.ts:16:5 › OIDC sign-in completes against the deployed origin (15.7s)
  1 passed (18.5s)
```

No-regression check against the nightly's own shape, confirmed rather than assumed:

| Environment | Result |
| --- | --- |
| `OWUI_URL=https://chat-hive.scubed.co` plus credentials | 1 passed |
| `OWUI_URL=http://localhost:3003` plus credentials (nightly shape) | 1 skipped |
| No credentials | 0 tests in 0 files, project deselected |

The spec was also confirmed to fail correctly rather than pass vacuously: an earlier run caught the demo box mid-recreate and failed on a Cloudflare 502 with the failure screenshot showing the gateway error page, which is the intended behaviour when the deployment is down.

`tsc --noEmit` does not cover these files. `apps/web-console/tsconfig.json` excludes `e2e/phase-19/**`, which applies to the whole existing suite, not just this addition. Playwright's own transform compiles the spec on every run.

## Screenshots

Test-only change, so there is no UI diff to show. The user-visible surface this protects was captured while fixing #271: the consent screen and the resulting signed-in chat session, both through the deployed origins.

## Test plan

- [x] Passes against the deployed origin
- [x] Skips on localhost, so the nightly is unchanged
- [x] Deselected entirely when credentials are absent
- [x] Fails on a real outage rather than passing vacuously
- [x] Mutates nothing on the target, unlike `owui.setup.ts`
