### PR TITLE
fix: stop seed-demo-owner.py rotating an existing account's password

### DIFF
--- a/scripts/seed-demo-owner.py
+++ b/scripts/seed-demo-owner.py
@@ -29,10 +29,20 @@ existing local OWUI test account (asdas@asdas.sda / asdas) for the chat
 surface demo.
 
 Required env: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY
+Optional env: HIVE_DEMO_PASSWORD -- set the account's password to this value.
 
-Prints exactly two lines to stdout (and nothing else):
+Prints to stdout (and nothing else):
   EMAIL=<email>
-  PASSWORD=<password>
+  PASSWORD=<password>   only when this run actually set a password
+
+A PASSWORD line appears when the account was created by this run, or when
+HIVE_DEMO_PASSWORD was provided. For an account that already exists and no
+HIVE_DEMO_PASSWORD, the password is left untouched and no PASSWORD line is
+printed, because this run does not know it. See password_to_set for why the
+default is no longer to rotate. Callers that need a credential must either pass
+HIVE_DEMO_PASSWORD or already hold one; a caller that reads PASSWORD
+unconditionally will see the line disappear rather than receive a stale value.
+
 Everything else (progress, ids, errors) goes to stderr.
 """
 import json
@@ -105,6 +115,28 @@ def random_password() -> str:
     # policy with room to spare, well under bcrypt's 72-byte limit.
     alphabet = string.ascii_letters + string.digits + "!@#$%^&*-_"
     return "Aa1!" + "".join(secrets.choice(alphabet) for _ in range(24))
+
+
+def password_to_set(user_exists: bool, env_password: str) -> str | None:
+    """The password this run should write, or None to leave it untouched.
+
+    This script used to rotate unconditionally so that no run reused a prior
+    credential. That was correct while a single operator ran it. Several agents
+    now share this account concurrently, and because the control-plane resolves
+    every bearer against GoTrue on each request, a rotation revokes their live
+    sessions mid-task. It happened repeatedly in one session.
+
+    So the default is now to leave an existing account alone, and a caller that
+    genuinely wants to set the password says so through HIVE_DEMO_PASSWORD.
+    A brand-new account still gets a fresh random password, since there is no
+    session to break and no credential to preserve.
+    """
+    env_password = env_password.strip()
+    if env_password:
+        return env_password
+    if not user_exists:
+        return random_password()
+    return None
 
 
 def find_by_slug(rest, headers, table, slug):
@@ -203,7 +235,7 @@ def main() -> None:
         None,
     )
 
-    password = random_password()
+    password = password_to_set(existing_user is not None, os.environ.get("HIVE_DEMO_PASSWORD", ""))
     if existing_user is None:
         status, body = request(
             gotrue, headers, "POST", "/admin/users",
@@ -215,13 +247,19 @@ def main() -> None:
         user_id = body["id"]
     else:
         user_id = existing_user["id"]
-        # Password rotates every run so no run reuses a prior credential.
-        status, body = request(
-            gotrue, headers, "PUT", f"/admin/users/{user_id}", body={"password": password},
-        )
-        if status != 200:
-            print(f"error: user update failed: {status} {body}", file=sys.stderr)
-            sys.exit(1)
+        if password is None:
+            print(
+                "password left unchanged (set HIVE_DEMO_PASSWORD to change it); "
+                "existing sessions stay valid",
+                file=sys.stderr,
+            )
+        else:
+            status, body = request(
+                gotrue, headers, "PUT", f"/admin/users/{user_id}", body={"password": password},
+            )
+            if status != 200:
+                print(f"error: user update failed: {status} {body}", file=sys.stderr)
+                sys.exit(1)
     print(f"user_id={user_id}", file=sys.stderr)
 
     # 2. Guard + upsert the demo tenant. slug is user-chosen; an
@@ -398,7 +436,8 @@ def main() -> None:
             sys.exit(1)
 
     print(f"EMAIL={USER_EMAIL}")
-    print(f"PASSWORD={password}")
+    if password is not None:
+        print(f"PASSWORD={password}")
 
 
 if __name__ == "__main__":

--- a/scripts/seed-demo-owner.py
+++ b/scripts/seed-demo-owner.py
@@ -36,9 +36,9 @@ Prints to stdout (and nothing else):
   PASSWORD=<password>   only when this run actually set a password
 
 A PASSWORD line appears when the account was created by this run, or when
-HIVE_DEMO_PASSWORD was provided. For an account that already exists and no
-HIVE_DEMO_PASSWORD, the password is left untouched and no PASSWORD line is
-printed, because this run does not know it. See password_to_set for why the
+HIVE_DEMO_PASSWORD contains a non-whitespace value. For an account that already
+exists with no such value, the password is left untouched and no PASSWORD line
+is printed, because this run does not know it. See password_to_set for why the
 default is no longer to rotate. Callers that need a credential must either pass
 HIVE_DEMO_PASSWORD or already hold one; a caller that reads PASSWORD
 unconditionally will see the line disappear rather than receive a stale value.
@@ -117,7 +117,7 @@ def random_password() -> str:
     return "Aa1!" + "".join(secrets.choice(alphabet) for _ in range(24))
 
 
-def password_to_set(user_exists: bool, env_password: str) -> str | None:
+def password_to_set(user_exists: bool, env_password: str, new_user_password: str) -> str | None:
     """The password this run should write, or None to leave it untouched.
 
     This script used to rotate unconditionally so that no run reused a prior
@@ -128,14 +128,15 @@ def password_to_set(user_exists: bool, env_password: str) -> str | None:
 
     So the default is now to leave an existing account alone, and a caller that
     genuinely wants to set the password says so through HIVE_DEMO_PASSWORD.
-    A brand-new account still gets a fresh random password, since there is no
-    session to break and no credential to preserve.
+    A brand-new account still gets new_user_password, since there is no session
+    to break and no credential to preserve. Generation stays in the caller so
+    this selector is pure and directly assertable.
     """
     env_password = env_password.strip()
     if env_password:
         return env_password
     if not user_exists:
-        return random_password()
+        return new_user_password
     return None
 
 
@@ -235,7 +236,11 @@ def main() -> None:
         None,
     )
 
-    password = password_to_set(existing_user is not None, os.environ.get("HIVE_DEMO_PASSWORD", ""))
+    password = password_to_set(
+        existing_user is not None,
+        os.environ.get("HIVE_DEMO_PASSWORD", ""),
+        random_password(),
+    )
     if existing_user is None:
         status, body = request(
             gotrue, headers, "POST", "/admin/users",

--- a/scripts/test_seed_demo_owner.py
+++ b/scripts/test_seed_demo_owner.py
@@ -92,16 +92,20 @@ def main() -> None:
     # password_to_set: an account that already exists keeps its password unless
     # the caller explicitly supplies one. Rotating it revokes every live session
     # for the shared demo account, which broke concurrent agents repeatedly.
-    assert seed_demo_owner.password_to_set(True, "") is None
-    assert seed_demo_owner.password_to_set(True, "  ") is None
-    assert seed_demo_owner.password_to_set(True, "explicit-pw") == "explicit-pw"
-    assert seed_demo_owner.password_to_set(False, "explicit-pw") == "explicit-pw"
+    assert seed_demo_owner.password_to_set(True, "", "generated-pw") is None
+    assert seed_demo_owner.password_to_set(True, "  ", "generated-pw") is None
+    assert seed_demo_owner.password_to_set(True, "explicit-pw", "generated-pw") == "explicit-pw"
+    assert seed_demo_owner.password_to_set(False, "explicit-pw", "generated-pw") == "explicit-pw"
 
     # A brand-new account has no session to break and no credential to keep, so
-    # it still gets a fresh random password.
-    generated = seed_demo_owner.password_to_set(False, "")
-    assert generated is not None and len(generated) == 28
-    assert generated != seed_demo_owner.password_to_set(False, "")
+    # it still gets the freshly generated password the caller passed in.
+    assert seed_demo_owner.password_to_set(False, "", "generated-pw") == "generated-pw"
+
+    # random_password itself: length clears GoTrue minimums, prefix guarantees
+    # all four character classes, and consecutive draws differ.
+    generated = seed_demo_owner.random_password()
+    assert len(generated) == 28 and generated.startswith("Aa1!")
+    assert generated != seed_demo_owner.random_password()
 
     print("ok: seed-demo-owner.py slug-collision guards + password_to_set")
 

--- a/scripts/test_seed_demo_owner.py
+++ b/scripts/test_seed_demo_owner.py
@@ -89,7 +89,21 @@ def main() -> None:
         "demo-user",
     )
 
-    print("ok: seed-demo-owner.py slug-collision guards")
+    # password_to_set: an account that already exists keeps its password unless
+    # the caller explicitly supplies one. Rotating it revokes every live session
+    # for the shared demo account, which broke concurrent agents repeatedly.
+    assert seed_demo_owner.password_to_set(True, "") is None
+    assert seed_demo_owner.password_to_set(True, "  ") is None
+    assert seed_demo_owner.password_to_set(True, "explicit-pw") == "explicit-pw"
+    assert seed_demo_owner.password_to_set(False, "explicit-pw") == "explicit-pw"
+
+    # A brand-new account has no session to break and no credential to keep, so
+    # it still gets a fresh random password.
+    generated = seed_demo_owner.password_to_set(False, "")
+    assert generated is not None and len(generated) == 28
+    assert generated != seed_demo_owner.password_to_set(False, "")
+
+    print("ok: seed-demo-owner.py slug-collision guards + password_to_set")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes the root cause of the repeated `demo@hive-demo.invalid` lockouts during today's multi-agent session.

## Problem

`scripts/seed-demo-owner.py` rotated the account's password on every run, by design: "Password rotates every run so no run reuses a prior credential." That is the right call for a script one operator runs.

Several agents now share this account concurrently, and `apps/control-plane/internal/auth/client.go` resolves every bearer token by calling GoTrue `GET /auth/v1/user` on each request. So a rotation does not just invalidate the old password, it revokes the live sessions of every other agent mid-task. That happened twice in one session: once from this script, and once from a verification script that had copied the same pattern.

## Change

An account that already exists keeps its password unless the caller explicitly asks for a change through `HIVE_DEMO_PASSWORD`. A brand-new account still gets a fresh random password, since there is no session to break and no credential to preserve.

The decision is one pure function so it is testable without a network:

```python
def password_to_set(user_exists: bool, env_password: str) -> str | None:
    env_password = env_password.strip()
    if env_password:
        return env_password
    if not user_exists:
        return random_password()
    return None
```

The stdout contract changes with it: `PASSWORD` is printed only when this run actually set a password. A caller that reads it unconditionally now sees the line disappear rather than receive a stale value, which is the failure mode I want. The module docstring spells this out.

## Live proof

Ran the patched script against the demo box with no `HIVE_DEMO_PASSWORD`, then checked the existing credential still authenticates.

```
--- run with no HIVE_DEMO_PASSWORD ---
password left unchanged (set HIVE_DEMO_PASSWORD to change it); existing sessions stay valid
user_id=df41abee-1fa2-47df-ae2d-a3146595ff8a
error: tenant slug 'hive-demo' already belongs to tenant 7d9cec95-... that this script cannot confirm it created -- 1 member(s) that are not the demo user ...
exit=1

stable password still valid after seed run -> 200
```

The password step runs before the tenant guard, so the guard exit does not mask the result: the run reached the password decision, skipped the write, and the pre-existing credential still signs in. Before this change the same run would have rotated the password and returned a new one.

Separately, that guard failure is correct and unrelated: another agent's fixture user is currently a second OWNER of the shared `hive-demo` tenant, so the anti-privilege-escalation guard refuses to merge onto it. Not addressed here.

## Tests

`scripts/test_seed_demo_owner.py` gains the `password_to_set` truth table, in the existing no-framework style:

- existing account, no env var, and whitespace-only env var, both leave the password untouched
- explicit env var wins whether or not the account exists
- new account with no env var still generates, and two calls do not generate the same password

```
python3 scripts/test_seed_demo_owner.py
ok: seed-demo-owner.py slug-collision guards + password_to_set
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented demo account passwords from being rotated when no new password is provided.
  * Preserved existing sessions by skipping password updates for existing accounts unless an update is explicitly configured.
  * Password credentials are now printed only when a password is set or updated.

* **Tests**
  * Added assertions for password-preservation and update behavior for both existing and newly created demo accounts.
  * Strengthened coverage for generated password format and variability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->