### PR TITLE
fix: serve Prometheus metrics on an internal-only listener

### DIFF
--- a/apps/control-plane/cmd/server/main.go
+++ b/apps/control-plane/cmd/server/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hibiken/asynq"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	goredis "github.com/redis/go-redis/v9"
 	"github.com/sakibsadmanshajib/hive/apps/agent-engine/engineapi"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/accounting"
@@ -73,6 +74,10 @@ import (
 	"github.com/sakibsadmanshajib/hive/packages/embedmodel"
 	"github.com/sakibsadmanshajib/hive/packages/storage"
 )
+
+// metricsListenAddr is the address of the telemetry-only listener that serves
+// /metrics, kept off the public listener so the Prometheus series stay internal.
+const metricsListenAddr = ":9101"
 
 // ledgerGrantAdapter wraps *ledger.Service to satisfy the paymentStub.LedgerGranter
 // interface (which returns only error, discarding the LedgerEntry return value).
@@ -740,8 +745,8 @@ func main() {
 		paymentsHandler = payments.NewHandler(paymentsSvc, &accountsResolverAdapter{svc: accountsSvc})
 	}
 
-	// Build Prometheus metrics registry before the router so /metrics and
-	// instrumentation middleware are wired in together.
+	// Build Prometheus metrics registry before the router so the instrumentation
+	// middleware and the telemetry listener share one registry.
 	metricsRegistry, promRegistry := metrics.NewRegistry()
 
 	// Create the mux upfront so filestore.RegisterRoutes (which requires *http.ServeMux)
@@ -870,7 +875,6 @@ func main() {
 		RoutingHandler:          routingHandler,
 		UsageHandler:            usageHandler,
 		MetricsRegistry:         metricsRegistry,
-		PrometheusRegistry:      promRegistry,
 		Mux:                     routerMux,
 		InternalToken:           cfg.InternalToken,
 		RoleSvc:                 roleSvc,
@@ -1140,6 +1144,26 @@ func main() {
 	_ = owuiClient
 	_ = auditLogger
 
+	// Telemetry listener. The Prometheus series carry provider names
+	// (hive_upstream_requests_total{provider=...}), payment-rail event counts,
+	// ledger posting counts, and the full /internal/* endpoint inventory, so
+	// /metrics is kept off the public listener: cfg.Port is published to the
+	// host and routed through the ingress tunnel, this port is neither.
+	// Prometheus scrapes it over the container network.
+	metricsMux := http.NewServeMux()
+	metricsMux.Handle("/metrics", promhttp.HandlerFor(promRegistry, promhttp.HandlerOpts{}))
+	metricsSrv := &http.Server{
+		Addr:              metricsListenAddr,
+		Handler:           metricsMux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	go func() {
+		log.Printf("control-plane metrics listening on %s", metricsListenAddr)
+		if err := metricsSrv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("metrics ListenAndServe: %v", err)
+		}
+	}()
+
 	addr := fmt.Sprintf(":%d", cfg.Port)
 	srv := &http.Server{
 		Addr:         addr,
@@ -1169,6 +1193,9 @@ func main() {
 
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer shutdownCancel()
+	if err := metricsSrv.Shutdown(shutdownCtx); err != nil {
+		log.Printf("metrics server shutdown error: %v", err)
+	}
 	if err := srv.Shutdown(shutdownCtx); err != nil {
 		log.Fatalf("server shutdown error: %v", err)
 	}

--- a/apps/control-plane/internal/platform/http/router.go
+++ b/apps/control-plane/internal/platform/http/router.go
@@ -4,9 +4,6 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
-
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/accounting"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/accounts"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/agenttask"
@@ -51,10 +48,6 @@ type RouterConfig struct {
 	// MetricsRegistry provides Prometheus counters/histograms for HTTP instrumentation.
 	// When non-nil, all requests are counted and timed via InstrumentHandler middleware.
 	MetricsRegistry *metrics.Registry
-
-	// PrometheusRegistry is the custom prometheus.Registry used to serve /metrics.
-	// When non-nil, the /metrics endpoint is registered on the mux.
-	PrometheusRegistry *prometheus.Registry
 
 	// BudgetsHandler handles budget threshold CRUD and alert dismissal endpoints.
 	BudgetsHandler *budgets.Handler
@@ -125,7 +118,11 @@ type RouterConfig struct {
 
 // NewRouter returns a configured http.Handler with all platform routes registered.
 // If MetricsRegistry is set, all requests are wrapped with Prometheus instrumentation.
-// If PrometheusRegistry is set, a /metrics endpoint is registered on the mux.
+// This router deliberately serves no /metrics endpoint: the Prometheus series
+// carry provider names, payment-rail counts, and the full internal endpoint
+// inventory, and this handler is the one exposed through the public ingress.
+// The scrape endpoint lives on the separate telemetry listener started in
+// cmd/server (metricsListenAddr), which is not published or routed publicly.
 //
 // IMPORTANT: The return type is http.Handler (not *http.ServeMux) so that the
 // instrumentation wrapper can be applied transparently. Plan 01 (Wave 2) depends
@@ -137,11 +134,6 @@ func NewRouter(cfg RouterConfig) http.Handler {
 	}
 
 	mux.HandleFunc("/health", handleHealth)
-
-	// Register /metrics endpoint using the custom prometheus registry (not DefaultRegistry).
-	if cfg.PrometheusRegistry != nil {
-		mux.Handle("/metrics", promhttp.HandlerFor(cfg.PrometheusRegistry, promhttp.HandlerOpts{}))
-	}
 
 	// internal wraps a service-to-service handler with the shared-secret guard.
 	internal := func(h http.Handler) http.Handler {

--- a/apps/control-plane/internal/platform/http/router_test.go
+++ b/apps/control-plane/internal/platform/http/router_test.go
@@ -1,0 +1,36 @@
+package http
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// NewRouter builds the handler served on the public port, which the demo and
+// cloud deployments publish through the ingress tunnel. The Prometheus series
+// name upstream providers, count payment-rail events, and enumerate every
+// /internal/* endpoint, so the scrape endpoint belongs on the separate
+// telemetry listener in cmd/server and must never be registered here.
+func TestNewRouterDoesNotServeMetrics(t *testing.T) {
+	h := NewRouter(RouterConfig{})
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("GET /metrics on the public router = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
+// Guards the test above against passing vacuously: an unwired router would 404
+// on everything.
+func TestNewRouterServesHealth(t *testing.T) {
+	h := NewRouter(RouterConfig{})
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /health = %d, want %d", rec.Code, http.StatusOK)
+	}
+}

--- a/apps/edge-api/cmd/server/main.go
+++ b/apps/edge-api/cmd/server/main.go
@@ -131,15 +131,9 @@ func main() {
 	// Create the main mux
 	mux := http.NewServeMux()
 
-	// Infrastructure routes (no unsupported middleware)
-	mux.HandleFunc("/health", handleHealth)
-
-	// Prometheus metrics endpoint — served from the custom registry (not DefaultRegistry).
-	mux.Handle("/metrics", proxy.MetricsHandler(promRegistry))
-
-	// Swagger docs (no unsupported middleware)
-	swaggerHandler := docs.SwaggerHandler(specPath)
-	mux.Handle("/docs/", swaggerHandler)
+	// Infrastructure routes (no unsupported middleware). /metrics is not among
+	// them; it is served on metricsListenAddr instead.
+	registerInfraRoutes(mux, specPath)
 
 	// Inference routes
 	routingClient := inference.NewRoutingClient(resolveControlPlaneBaseURL())
@@ -551,6 +545,23 @@ func main() {
 	// inner limit takes effect first. Chat keeps its own 4 MiB internal limit.
 	// MaxBytesHandler only bounds the inbound request body, so SSE streaming
 	// responses are unaffected.
+	// Telemetry listener. Prometheus scrapes this port over the container
+	// network; it is deliberately not published to the host and not routed
+	// through the public ingress.
+	metricsMux := http.NewServeMux()
+	metricsMux.Handle("/metrics", proxy.MetricsHandler(promRegistry))
+	go func() {
+		metricsSrv := &http.Server{
+			Addr:              metricsListenAddr,
+			Handler:           metricsMux,
+			ReadHeaderTimeout: 10 * time.Second,
+		}
+		log.Printf("edge-api metrics listening on %s", metricsListenAddr)
+		if err := metricsSrv.ListenAndServe(); err != nil {
+			log.Fatalf("metrics server failed: %v", err)
+		}
+	}()
+
 	srv := &http.Server{
 		Addr:    ":" + port,
 		Handler: http.MaxBytesHandler(handler, globalMaxBody),
@@ -584,6 +595,23 @@ func openOptionalDBPool(ctx context.Context) *pgxpool.Pool {
 		return nil
 	}
 	return pool
+}
+
+// metricsListenAddr is the address of the telemetry-only listener that serves
+// /metrics. It is separate from the public listener because the public port is
+// the one published to the host and routed through the ingress tunnel, so
+// anything mounted on it is internet-reachable. The edge-api series include
+// hive_upstream_requests_total{provider=...}, which names upstream providers
+// and must never reach a customer, plus the full endpoint inventory and traffic
+// volumes. Prometheus reaches this port over the container network only.
+const metricsListenAddr = ":9102"
+
+// registerInfraRoutes registers the unauthenticated infrastructure endpoints on
+// the public mux. /metrics is deliberately not registered here; see
+// metricsListenAddr.
+func registerInfraRoutes(mux *http.ServeMux, specPath string) {
+	mux.HandleFunc("/health", handleHealth)
+	mux.Handle("/docs/", docs.SwaggerHandler(specPath))
 }
 
 func handleHealth(w http.ResponseWriter, r *http.Request) {
@@ -902,7 +930,7 @@ func jwtAuditLogger() auth.AuditFailFunc {
 }
 
 // authSelectorMiddleware routes only Hive-versioned `/v1/*` traffic through
-// the auth Selector. Infrastructure endpoints (/health, /metrics, /docs/,
+// the auth Selector. Infrastructure endpoints (/health, /docs/,
 // /catalog/models) bypass authentication so probes and the Swagger UI keep
 // working. Within /v1, an OWUI body-metadata unwrap runs first so requests
 // arriving from Open WebUI (which sets the static shim key in Authorization

--- a/apps/edge-api/cmd/server/main_test.go
+++ b/apps/edge-api/cmd/server/main_test.go
@@ -272,6 +272,29 @@ func TestSharedStorageClientSatisfiesFilesStorageBackend(t *testing.T) {
 // apps/edge-api/internal/featuregate's own tests.
 func identityMiddleware(h http.Handler) http.Handler { return h }
 
+// The public mux is served on the port published through the ingress tunnel.
+// hive_upstream_requests_total labels every series with the upstream provider
+// name, which the provider-blind rule forbids exposing to customers, so
+// /metrics belongs on the telemetry listener (metricsListenAddr) and must not
+// be registered alongside the other unauthenticated infrastructure routes.
+func TestRegisterInfraRoutesDoesNotExposeMetrics(t *testing.T) {
+	mux := http.NewServeMux()
+	registerInfraRoutes(mux, "testdata/openapi.yaml")
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("GET /metrics on the public mux = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+
+	// Guards the assertion above against passing vacuously.
+	rec = httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /health = %d, want %d", rec.Code, http.StatusOK)
+	}
+}
+
 func TestRegisterMediaFileBatchRoutesRegistersAllPublicPaths(t *testing.T) {
 	mux := http.NewServeMux()
 	registerMediaFileBatchRoutes(

--- a/deploy/prometheus/prometheus.yml
+++ b/deploy/prometheus/prometheus.yml
@@ -11,14 +11,19 @@ alerting:
         - targets: ['alertmanager:9093']
 
 scrape_configs:
+  # Both services serve /metrics on a telemetry-only port, not on their public
+  # port (8081 / 8080). The public ports are published to the host and routed
+  # through the ingress tunnel, and the series carry provider names, payment
+  # rail counts, and the internal endpoint inventory. These ports are reachable
+  # over the container network only, which is where Prometheus runs.
   - job_name: 'control-plane'
     static_configs:
-      - targets: ['control-plane:8081']
+      - targets: ['control-plane:9101']
     metrics_path: /metrics
     scrape_interval: 10s
 
   - job_name: 'edge-api'
     static_configs:
-      - targets: ['edge-api:8080']
+      - targets: ['edge-api:9102']
     metrics_path: /metrics
     scrape_interval: 10s


### PR DESCRIPTION
## Problem

Both Go services mounted `/metrics` on their public listener. On the demo box that listener is published to the host and the Cloudflare Tunnel routes the public hostname straight at the container port, with no proxy in front of either service, so the scrape endpoint was reachable anonymously from the internet.

Live before this change:

```
control-hive /metrics -> HTTP 200, 51422 bytes
api-hive     /metrics -> HTTP 200, 6358 bytes
```

The control-plane body carried 530 series and enumerated the entire internal service-to-service surface along with its traffic volumes:

```
endpoint="/internal/accounting/reservations"
endpoint="/internal/apikeys/resolve"
endpoint="/internal/catalog/snapshot"
endpoint="/internal/providers"
endpoint="/internal/rag/ingest"
endpoint="/internal/routing/select"
endpoint="/internal/usage/attempts"
endpoint="/internal/usage/events"
```

The exposure is structural, not limited to what a single snapshot happened to contain. Prometheus emits a labelled series only after its first observation, so registered-but-idle series were absent from the capture above and would have published themselves as soon as normal traffic arrived:

- `hive_upstream_requests_total{provider,status}` labels every series with the upstream provider name. `CLAUDE.md` makes provider blindness non-negotiable: provider names never reach customers, and both boundaries are meant to sanitize them.
- `hive_payment_events_total{rail,status}` publishes per-rail payment event counts.
- `hive_ledger_postings_total{entry_type}` publishes ledger activity.

## Fix

Each service now serves `/metrics` from a second listener that Compose does not publish: control-plane on `:9101`, edge-api on `:9102`. Those ports are reachable over the container network only, which is where Prometheus already runs, so scraping is unaffected. The public routers no longer register the path at all.

This is fixed at the application boundary rather than with a blocklist in a proxy in front of it. A proxy rule would leave the endpoint publicly served and one ingress misconfiguration away from leaking again, and the tunnel ingress for these two hostnames is dashboard-managed and points at the container port directly, so there is no existing proxy layer to extend for either host.

`deploy/prometheus/prometheus.yml` follows the ports. No new environment variable and no new service: the listener address is a constant in each `cmd/server`, since it is an in-network address that no deployment needs to vary.

## Verification

Repo checks, run in the toolchain container against this branch:

```
go build ./apps/control-plane/... ./apps/edge-api/...                              # clean
go vet ./apps/control-plane/internal/platform/http/... ./apps/edge-api/cmd/...     # clean

=== RUN   TestNewRouterDoesNotServeMetrics
--- PASS: TestNewRouterDoesNotServeMetrics (0.00s)
=== RUN   TestNewRouterServesHealth
--- PASS: TestNewRouterServesHealth (0.00s)
=== RUN   TestRegisterInfraRoutesDoesNotExposeMetrics
--- PASS: TestRegisterInfraRoutesDoesNotExposeMetrics (0.00s)

ok  github.com/sakibsadmanshajib/hive/apps/control-plane/internal/platform/http
ok  github.com/sakibsadmanshajib/hive/apps/edge-api/cmd/server        (full package, -short)
```

No existing test asserted that `/metrics` was public, so nothing had to be relaxed. The two new tests assert each public handler answers 404 on `/metrics` while still answering 200 on `/health`, so the guard cannot pass vacuously against an unwired mux, and a future edit that re-registers the scrape endpoint on a public mux fails the build.

Live before and after proof against the running demo box is posted as a PR comment.

## Test plan

- [x] `go build` for both services
- [x] `go vet` for both changed packages
- [x] New regression tests pass and were confirmed to execute by name
- [x] Full `-short` package runs for both changed packages pass
- [ ] Live: public `/metrics` returns 404 on both hostnames after deploy
- [ ] Live: in-network scrape of both telemetry ports still returns a metrics body
