### PR TITLE
fix: unbreak the RAG embedding pipeline end to end

### DIFF
--- a/DEMO.md
+++ b/DEMO.md
@@ -54,6 +54,21 @@ Set `HIVE_AGENT_SIF_PATH` in `.env` to the resulting `.sif` path.
 | Caddy (OWUI proxy) | http://localhost:8090 | loads |
 | Artifacts | via caddy-artifacts | static served |
 
+RAG needs more than a health check, because its failure modes are silent
+(a document lands with `status=error`, or search answers 503, while every
+service still reports healthy). Prove the whole path instead:
+
+```bash
+export EDGE_API_URL=http://localhost:8080   # or the deployed edge origin
+python3 scripts/verify-rag-roundtrip.py     # needs the SUPABASE_* vars from .env
+```
+
+It uploads a document with a unique marker, waits for embedding, then requires
+the marker back out of vector search and out of the grounded answer. Prints
+PASS or the first step that could not be proven. Note that the serverless
+embedding route is slow and uneven, so the script retries each step a few
+times and prints every attempt.
+
 Do not present until all are green.
 
 ## Demo walkthrough (per surface)

--- a/apps/control-plane/internal/rag/embed_test.go
+++ b/apps/control-plane/internal/rag/embed_test.go
@@ -3,6 +3,7 @@ package rag
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"math"
 	"net/http"
 	"net/http/httptest"
@@ -45,10 +46,16 @@ func TestReduceEmbeddingNoop(t *testing.T) {
 
 // TestHTTPEmbedClientTruncates drives a fake 4096-dim backend through
 // HTTPEmbedClient with reduceTo=1024 and expects a 1024-dim result per item.
+// It also guards against reintroducing the `dimensions` request parameter:
+// LiteLLM's generic openai adapter rejects it for any model name without
+// "text-embedding-3" and ignores drop_params, which failed every ingest.
 func TestHTTPEmbedClientTruncates(t *testing.T) {
+	var gotBody map[string]any
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req embedRequest
-		_ = json.NewDecoder(r.Body).Decode(&req)
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &req)
+		_ = json.Unmarshal(raw, &gotBody)
 		vec := make([]float32, 4096)
 		for i := range vec {
 			vec[i] = 0.01
@@ -70,6 +77,9 @@ func TestHTTPEmbedClientTruncates(t *testing.T) {
 	}
 	if len(vecs) != 2 {
 		t.Fatalf("len(vecs) = %d, want 2", len(vecs))
+	}
+	if _, present := gotBody["dimensions"]; present {
+		t.Error("request body carried a dimensions field; LiteLLM's openai adapter 400s on it")
 	}
 	for i, v := range vecs {
 		if len(v) != EmbeddingDimension {

--- a/apps/control-plane/internal/rag/ingest.go
+++ b/apps/control-plane/internal/rag/ingest.go
@@ -31,8 +31,8 @@ type HTTPEmbedClient struct {
 	// chosen dim is below its native width, else 0. Not an independent operator
 	// knob (the old EMBEDDING_TRUNCATE_TO): a non-MRL model at a non-native dim
 	// is rejected at config time, so reduceTo is only set where the reduction
-	// is legitimate. It doubles as the `dimensions` value requested from the
-	// endpoint; the client-side reduce is a no-op when the endpoint honors it.
+	// is legitimate. The reduction is always applied client-side; see
+	// embedRequest for why the `dimensions` request parameter is not sent.
 	// 0 means require the native width exactly.
 	reduceTo int
 	// apiKey authenticates to the backend (LiteLLM requires it; a local
@@ -45,8 +45,8 @@ type HTTPEmbedClient struct {
 // model must be the alias returning EmbeddingDimension vectors, e.g. "bge-m3".
 // reduceTo: 0 requires the backend already return EmbeddingDimension; otherwise
 // the MRL reduction target (== EmbeddingDimension) derived from
-// embedmodel.Resolve, sent as `dimensions` and applied client-side only if the
-// endpoint ignores it.
+// embedmodel.Resolve, applied client-side to the native-width vector the
+// backend returns.
 // apiKey is sent as a Bearer token when non-empty (LiteLLM's LITELLM_MASTER_KEY);
 // leave empty for backends that require no auth.
 func NewHTTPEmbedClient(baseURL, model string, reduceTo int, apiKey string) *HTTPEmbedClient {
@@ -83,13 +83,18 @@ func reduceEmbedding(vec []float32, target int) []float32 {
 	return out
 }
 
+// embedRequest deliberately carries no `dimensions` field. LiteLLM's generic
+// `openai/` adapter, which is how every OpenRouter embedding route is declared
+// (deploy/litellm/config.yaml), rejects `dimensions` outright for any model
+// whose name does not contain "text-embedding-3" and raises
+// UnsupportedParamsError with HTTP 400. That check ignores `drop_params`, so no
+// LiteLLM setting can make the parameter safe to send, and ingestion failed for
+// every document rather than degrading. Requesting the narrower width from the
+// endpoint bought nothing anyway: reduceEmbedding performs the identical MRL
+// truncate-and-renormalize on the native-width vector.
 type embedRequest struct {
 	Model string   `json:"model"`
 	Input []string `json:"input"`
-	// Dimensions requests a native N-wide vector from an MRL-capable endpoint
-	// (Qwen3 supports it). Omitted when 0; the reduceEmbedding fallback covers
-	// an endpoint that ignores it.
-	Dimensions int `json:"dimensions,omitempty"`
 }
 
 type embedResponse struct {
@@ -102,7 +107,7 @@ type embedResponse struct {
 // Errors are wrapped with a provider-blind message — callers must not
 // expose the raw error to customers.
 func (c *HTTPEmbedClient) Embed(ctx context.Context, inputs []string) ([][]float32, error) {
-	body, err := json.Marshal(embedRequest{Model: c.model, Input: inputs, Dimensions: c.reduceTo})
+	body, err := json.Marshal(embedRequest{Model: c.model, Input: inputs})
 	if err != nil {
 		return nil, fmt.Errorf("rag.embed: marshal: %w", err)
 	}

--- a/apps/control-plane/internal/rag/ingest.go
+++ b/apps/control-plane/internal/rag/ingest.go
@@ -10,6 +10,10 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/sakibsadmanshajib/hive/packages/embedmodel"
 )
 
 // EmbedClient calls the local embedding service (bge-m3 via Ollama/LiteLLM).
@@ -158,9 +162,19 @@ func (c *HTTPEmbedClient) Embed(ctx context.Context, inputs []string) ([][]float
 	return out, nil
 }
 
+// ingestRepo is the slice of *Repo the Ingester needs. It exists so the
+// ingest tests drive the real Ingest method against a fake store; while the
+// dependency was the concrete *Repo the tests had to re-implement Ingest, and
+// a provenance bug in the real code passed a green suite.
+type ingestRepo interface {
+	UpdateDocumentStatus(ctx context.Context, tenantID, docID uuid.UUID, status, errMsg string) error
+	InsertChunks(ctx context.Context, tenantID, docID uuid.UUID, chunks []Chunk, embeddings [][]float32) error
+	SetEmbeddedProvenance(ctx context.Context, tenantID, docID uuid.UUID, model string, dim int) error
+}
+
 // Ingester chunks a document, embeds each chunk, and stores results.
 type Ingester struct {
-	repo  *Repo
+	repo  ingestRepo
 	embed EmbedClient
 	// batchSize controls how many chunks are embedded in one HTTP call.
 	// ponytail: global constant, tune if embed service has payload limits.
@@ -175,7 +189,7 @@ type Ingester struct {
 // is stamped onto every document as provenance (paired with the current
 // EmbeddingDimension) so a later model swap can find which documents still
 // need re-embedding.
-func NewIngester(repo *Repo, embed EmbedClient, batchSize int, embedModel string) *Ingester {
+func NewIngester(repo ingestRepo, embed EmbedClient, batchSize int, embedModel string) *Ingester {
 	if batchSize <= 0 {
 		batchSize = 32
 	}
@@ -215,8 +229,13 @@ func (ing *Ingester) Ingest(ctx context.Context, tenantID, docID interface{ Stri
 	}
 	embeddings, err := embedInBatches(ctx, ing.embed, texts, ing.batchSize)
 	if err != nil {
+		// The document-facing status message stays provider-blind; the wrapped
+		// cause is for the server-side log only (the ingest HTTP boundary logs
+		// it and returns a generic body). Swallowing it here left every embed
+		// failure, from an unsupported request field to a width mismatch,
+		// indistinguishable in the logs.
 		_ = ing.repo.UpdateDocumentStatus(ctx, tid, did, StatusError, "embedding service unavailable")
-		return fmt.Errorf("rag.ingest: embed batch: embedding service unavailable")
+		return fmt.Errorf("rag.ingest: embed batch: %w", err)
 	}
 
 	if err := ing.repo.InsertChunks(ctx, tid, did, chunks, embeddings); err != nil {
@@ -224,5 +243,11 @@ func (ing *Ingester) Ingest(ctx context.Context, tenantID, docID interface{ Stri
 		return fmt.Errorf("rag.ingest: store chunks: %w", err)
 	}
 
-	return ing.repo.SetEmbeddedProvenance(ctx, tid, did, ing.embedModel, EmbeddingDimension)
+	// Canonicalize exactly as reembed.go does. EMBEDDING_MODEL is usually a
+	// LiteLLM route alias, while the re-embed worker selects and stamps the
+	// canonical registry id, so stamping the raw alias here made every fresh
+	// document look stale to the catch-up worker (needless paid re-embedding on
+	// the next boot) and made edge-api's consistency guard fail search and chat
+	// closed for a corpus that was in fact consistent.
+	return ing.repo.SetEmbeddedProvenance(ctx, tid, did, embedmodel.Canonical(ing.embedModel), EmbeddingDimension)
 }

--- a/apps/control-plane/internal/rag/ingest.go
+++ b/apps/control-plane/internal/rag/ingest.go
@@ -55,9 +55,13 @@ type HTTPEmbedClient struct {
 // leave empty for backends that require no auth.
 func NewHTTPEmbedClient(baseURL, model string, reduceTo int, apiKey string) *HTTPEmbedClient {
 	return &HTTPEmbedClient{
-		baseURL:  strings.TrimRight(baseURL, "/"),
-		model:    model,
-		client:   &http.Client{Timeout: 30 * time.Second},
+		baseURL: strings.TrimRight(baseURL, "/"),
+		model:   model,
+		// 60s for the same reason as edge-api's query-side embedder: LiteLLM's
+		// request_timeout is 45s and a single Qwen3 8B embedding through
+		// OpenRouter measured 35 to 40 seconds, so a 30s client budget aborted
+		// batches the upstream would have answered.
+		client:   &http.Client{Timeout: 60 * time.Second},
 		reduceTo: reduceTo,
 		apiKey:   apiKey,
 	}

--- a/apps/control-plane/internal/rag/ingest_test.go
+++ b/apps/control-plane/internal/rag/ingest_test.go
@@ -12,9 +12,9 @@ import (
 // fakeEmbedClient returns a fixed 1024-dim vector for every input.
 // Structurally valid: slice of the correct length, no unsafe casts.
 type fakeEmbedClient struct {
-	calls   int
-	failOn  int // if > 0, return error on this call index (1-based)
-	lastIn  []string
+	calls  int
+	failOn int // if > 0, return error on this call index (1-based)
+	lastIn []string
 }
 
 func (f *fakeEmbedClient) Embed(_ context.Context, inputs []string) ([][]float32, error) {
@@ -34,13 +34,23 @@ func (f *fakeEmbedClient) Embed(_ context.Context, inputs []string) ([][]float32
 	return out, nil
 }
 
-// fakeRepo records calls without a real DB.
+// fakeRepo records calls without a real DB. It satisfies ingestRepo, so the
+// tests below drive the real Ingester.Ingest rather than a copy of it.
 type fakeRepo struct {
-	inserted      []Document
-	statusUpdates []string
-	chunks        []Chunk
-	embeddings    [][]float32
-	getErr        error
+	inserted        []Document
+	statusUpdates   []string
+	chunks          []Chunk
+	embeddings      [][]float32
+	getErr          error
+	provenanceModel string
+	provenanceDim   int
+}
+
+func (f *fakeRepo) SetEmbeddedProvenance(_ context.Context, _, _ uuid.UUID, model string, dim int) error {
+	f.statusUpdates = append(f.statusUpdates, StatusEmbedded)
+	f.provenanceModel = model
+	f.provenanceDim = dim
+	return nil
 }
 
 func (f *fakeRepo) InsertDocument(_ context.Context, d Document) (uuid.UUID, error) {
@@ -59,26 +69,18 @@ func (f *fakeRepo) InsertChunks(_ context.Context, _, _ uuid.UUID, chunks []Chun
 	return nil
 }
 
-// ingestableRepo adapts fakeRepo to the Ingester's Repo dependency.
-// Ingester calls repo.UpdateDocumentStatus and repo.InsertChunks via the real *Repo type.
-// We test the Ingester logic independently by calling the unexported helpers through
-// a thin wrapper that satisfies the same method signatures.
-
 // TestIngester_HappyPath verifies chunking + embedding + storage flow.
 func TestIngester_HappyPath(t *testing.T) {
 	embed := &fakeEmbedClient{}
 	repo := &fakeRepo{}
 
-	// Build a real Repo-shaped struct indirectly via the exported Ingester
-	// by providing a thin test harness that exposes the needed methods.
-	// Since Ingester holds *Repo (concrete), we test via ingesterHarness.
-	harness := newIngesterHarness(repo, embed)
+	ing := NewIngester(repo, embed, 0, "route-openrouter-embedding-fallback")
 
 	tenantID := uuid.New()
 	docID := uuid.New()
 	text := strings.Repeat("The quick brown fox jumps over the lazy dog. ", 60)
 
-	err := harness.Ingest(context.Background(), tenantID, docID, text)
+	err := ing.Ingest(context.Background(), tenantID, docID, text)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -112,13 +114,37 @@ func TestIngester_HappyPath(t *testing.T) {
 	}
 }
 
+// TestIngester_StampsCanonicalProvenance pins the provenance spelling.
+// EMBEDDING_MODEL is normally a LiteLLM route alias, while the re-embed worker
+// selects and stamps the canonical registry id. Stamping the raw alias made
+// every fresh document look stale to the catch-up worker and tripped edge-api's
+// consistency guard, which failed RAG search and chat closed for a corpus that
+// was embedded under exactly the configured model.
+func TestIngester_StampsCanonicalProvenance(t *testing.T) {
+	embed := &fakeEmbedClient{}
+	repo := &fakeRepo{}
+	ing := NewIngester(repo, embed, 0, "route-openrouter-embedding-fallback")
+
+	if err := ing.Ingest(context.Background(), uuid.New(), uuid.New(),
+		strings.Repeat("Grounding content. ", 50)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if want := "qwen3-embedding-8b"; repo.provenanceModel != want {
+		t.Errorf("provenance model = %q, want canonical %q", repo.provenanceModel, want)
+	}
+	if repo.provenanceDim != EmbeddingDimension {
+		t.Errorf("provenance dim = %d, want %d", repo.provenanceDim, EmbeddingDimension)
+	}
+}
+
 // TestIngester_EmbedFailure verifies provider-blind error propagation and status=error.
 func TestIngester_EmbedFailure(t *testing.T) {
 	embed := &fakeEmbedClient{failOn: 1}
 	repo := &fakeRepo{}
-	harness := newIngesterHarness(repo, embed)
+	ing := NewIngester(repo, embed, 0, "route-openrouter-embedding-fallback")
 
-	err := harness.Ingest(context.Background(), uuid.New(), uuid.New(),
+	err := ing.Ingest(context.Background(), uuid.New(), uuid.New(),
 		strings.Repeat("Some content. ", 50))
 	if err == nil {
 		t.Fatal("expected error from embed failure")
@@ -143,9 +169,9 @@ func TestIngester_EmbedFailure(t *testing.T) {
 func TestIngester_EmptyText(t *testing.T) {
 	embed := &fakeEmbedClient{}
 	repo := &fakeRepo{}
-	harness := newIngesterHarness(repo, embed)
+	ing := NewIngester(repo, embed, 0, "route-openrouter-embedding-fallback")
 
-	err := harness.Ingest(context.Background(), uuid.New(), uuid.New(), "")
+	err := ing.Ingest(context.Background(), uuid.New(), uuid.New(), "")
 	if err == nil {
 		t.Fatal("expected error for empty text")
 	}
@@ -156,70 +182,16 @@ func TestIngester_BatchBoundary(t *testing.T) {
 	embed := &fakeEmbedClient{}
 	repo := &fakeRepo{}
 	// batchSize=1 forces one embed call per chunk; we need >= 3 chunks.
-	harness := newIngesterHarnessWithBatch(repo, embed, 1)
+	ing := NewIngester(repo, embed, 1, "route-openrouter-embedding-fallback")
 
 	// Build text long enough to produce multiple chunks at DefaultChunkTokens.
 	// DefaultChunkTokens=512 => ~2048 chars per chunk. 20000 chars => ~10 chunks.
 	text := strings.Repeat("The quick brown fox jumps over the lazy dog. ", 450)
-	err := harness.Ingest(context.Background(), uuid.New(), uuid.New(), text)
+	err := ing.Ingest(context.Background(), uuid.New(), uuid.New(), text)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if embed.calls < 2 {
 		t.Errorf("expected >= 2 embed calls for batchSize=1, got %d", embed.calls)
 	}
-}
-
-// --- thin ingester harness so we can inject fakeRepo without a real pgxpool ---
-
-type ingesterHarness struct {
-	repo  *fakeRepo
-	embed EmbedClient
-	batch int
-}
-
-func newIngesterHarness(r *fakeRepo, e EmbedClient) *ingesterHarness {
-	return &ingesterHarness{repo: r, embed: e, batch: 32}
-}
-
-func newIngesterHarnessWithBatch(r *fakeRepo, e EmbedClient, batch int) *ingesterHarness {
-	return &ingesterHarness{repo: r, embed: e, batch: batch}
-}
-
-func (h *ingesterHarness) Ingest(ctx context.Context, tenantID, docID uuid.UUID, text string) error {
-	if err := h.repo.UpdateDocumentStatus(ctx, tenantID, docID, StatusProcessing, ""); err != nil {
-		return err
-	}
-
-	chunks := ChunkText(text, DefaultChunkTokens, DefaultOverlapTokens)
-	if len(chunks) == 0 {
-		_ = h.repo.UpdateDocumentStatus(ctx, tenantID, docID, StatusError, "document produced no text chunks")
-		return errors.New("rag.ingest: document produced no text chunks")
-	}
-
-	embeddings := make([][]float32, 0, len(chunks))
-	for start := 0; start < len(chunks); start += h.batch {
-		end := start + h.batch
-		if end > len(chunks) {
-			end = len(chunks)
-		}
-		batch := chunks[start:end]
-		texts := make([]string, len(batch))
-		for i, c := range batch {
-			texts[i] = c.Content
-		}
-		vecs, err := h.embed.Embed(ctx, texts)
-		if err != nil {
-			_ = h.repo.UpdateDocumentStatus(ctx, tenantID, docID, StatusError, "embedding service unavailable")
-			return errors.New("rag.ingest: embed batch: embedding service unavailable")
-		}
-		embeddings = append(embeddings, vecs...)
-	}
-
-	if err := h.repo.InsertChunks(ctx, tenantID, docID, chunks, embeddings); err != nil {
-		_ = h.repo.UpdateDocumentStatus(ctx, tenantID, docID, StatusError, "chunk storage failed")
-		return err
-	}
-
-	return h.repo.UpdateDocumentStatus(ctx, tenantID, docID, StatusEmbedded, "")
 }

--- a/apps/edge-api/internal/rag/embed.go
+++ b/apps/edge-api/internal/rag/embed.go
@@ -29,10 +29,9 @@ type HTTPEmbedder struct {
 	// chosen dim is below its native width, else 0. It is NOT an independent
 	// operator knob (the old EMBEDDING_TRUNCATE_TO): a non-MRL model at a
 	// non-native dim is rejected at config time, so reduceTo is only ever set
-	// for a model where the reduction is legitimate. It doubles as the
-	// `dimensions` value requested from the endpoint (preferred over client
-	// slicing); when the endpoint honors it and returns a dim-wide vector, the
-	// client-side reduce is a no-op. 0 means require the native width exactly.
+	// for a model where the reduction is legitimate. The reduction is always
+	// applied client-side; see embedReq for why the `dimensions` request
+	// parameter is not sent. 0 means require the native width exactly.
 	reduceTo int
 	// apiKey authenticates to the backend (LiteLLM requires it; a local
 	// bge-m3/Ollama endpoint does not). Empty means send no Authorization header.
@@ -45,8 +44,8 @@ type HTTPEmbedder struct {
 // reduceTo: 0 to require the backend already return EmbeddingDimension;
 //
 //	otherwise the MRL reduction target (== EmbeddingDimension), derived from
-//	embedmodel.Resolve, sent to the endpoint as `dimensions` and applied
-//	client-side only if the endpoint ignores it.
+//	embedmodel.Resolve and applied client-side to the native-width vector the
+//	backend returns.
 //
 // apiKey is sent as a Bearer token when non-empty (LiteLLM's LITELLM_MASTER_KEY);
 // leave empty for backends that require no auth.
@@ -84,14 +83,18 @@ func reduceEmbedding(vec []float32, target int) []float32 {
 	return out
 }
 
+// embedReq deliberately carries no `dimensions` field. LiteLLM's generic
+// `openai/` adapter, which is how every OpenRouter embedding route is declared
+// (deploy/litellm/config.yaml), rejects `dimensions` outright for any model
+// whose name does not contain "text-embedding-3" and raises
+// UnsupportedParamsError with HTTP 400. That check ignores `drop_params`, so no
+// LiteLLM setting can make the parameter safe to send, and the whole embedding
+// route fails rather than degrading. Requesting the narrower width from the
+// endpoint bought nothing anyway: reduceEmbedding performs the identical MRL
+// truncate-and-renormalize on the native-width vector.
 type embedReq struct {
 	Model string   `json:"model"`
 	Input []string `json:"input"`
-	// Dimensions requests a native N-wide vector from an MRL-capable endpoint
-	// (Qwen3 supports it). Omitted when 0 so non-MRL native-width models are
-	// unaffected. Preferred over client-side slicing; the reduceEmbedding
-	// fallback covers an endpoint that silently ignores the parameter.
-	Dimensions int `json:"dimensions,omitempty"`
 }
 
 type embedResp struct {
@@ -103,7 +106,7 @@ type embedResp struct {
 // Embed embeds a single text string and returns an EmbeddingDimension-wide vector.
 // Errors are provider-blind: no backend URL, model name, or upstream message.
 func (e *HTTPEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
-	body, err := json.Marshal(embedReq{Model: e.model, Input: []string{text}, Dimensions: e.reduceTo})
+	body, err := json.Marshal(embedReq{Model: e.model, Input: []string{text}})
 	if err != nil {
 		return nil, fmt.Errorf("rag.embed: marshal: %w", err)
 	}
@@ -139,8 +142,8 @@ func (e *HTTPEmbedder) Embed(ctx context.Context, text string) ([]float32, error
 	}
 	vec := result.Data[0].Embedding
 	if e.reduceTo > 0 {
-		// No-op when the endpoint already honored `dimensions` and returned a
-		// reduceTo-wide vector; a legitimate MRL slice otherwise.
+		// Legitimate MRL slice; a no-op for a backend that already serves the
+		// model at reduceTo width.
 		vec = reduceEmbedding(vec, e.reduceTo)
 	}
 	if len(vec) != EmbeddingDimension {

--- a/apps/edge-api/internal/rag/embed.go
+++ b/apps/edge-api/internal/rag/embed.go
@@ -51,9 +51,15 @@ type HTTPEmbedder struct {
 // leave empty for backends that require no auth.
 func NewHTTPEmbedder(baseURL, model string, reduceTo int, apiKey string) *HTTPEmbedder {
 	return &HTTPEmbedder{
-		baseURL:  strings.TrimRight(baseURL, "/"),
-		model:    model,
-		client:   &http.Client{Timeout: 30 * time.Second},
+		baseURL: strings.TrimRight(baseURL, "/"),
+		model:   model,
+		// 60s, not 30s: LiteLLM's own request_timeout is 45s
+		// (deploy/litellm/config.yaml), so a 30s client budget gave up before
+		// the upstream it is waiting on had. A single Qwen3 8B embedding
+		// through OpenRouter measured 35 to 40 seconds on the demo stack, so
+		// every query-side embed timed out and RAG search and chat answered
+		// 503 while ingestion of the same corpus succeeded.
+		client:   &http.Client{Timeout: 60 * time.Second},
 		reduceTo: reduceTo,
 		apiKey:   apiKey,
 	}

--- a/apps/edge-api/internal/rag/embed_test.go
+++ b/apps/edge-api/internal/rag/embed_test.go
@@ -55,17 +55,16 @@ func TestReduceEmbeddingNoop(t *testing.T) {
 	}
 }
 
-// TestHTTPEmbedderReducesWhenEndpointIgnoresDimensions drives a fake backend
-// that ignores `dimensions` and returns 4096-dim; the client-side MRL reduce
-// fallback must bring it to EmbeddingDimension. It also asserts the client
-// asked for the narrower width via `dimensions` (preferred endpoint-native).
-func TestHTTPEmbedderReducesWhenEndpointIgnoresDimensions(t *testing.T) {
-	var gotDims int
+// TestHTTPEmbedderNeverRequestsDimensions is the regression guard for the
+// LiteLLM 400: its generic openai adapter rejects `dimensions` for any model
+// name without "text-embedding-3" and ignores drop_params, so sending the
+// parameter failed every embedding call. The narrower width must be reached by
+// reducing the native-width response client-side instead.
+func TestHTTPEmbedderNeverRequestsDimensions(t *testing.T) {
+	var gotBody map[string]any
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var req embedReq
-		_ = json.NewDecoder(r.Body).Decode(&req)
-		gotDims = req.Dimensions
-		vec := make([]float32, 4096) // endpoint ignores dimensions, returns native
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		vec := make([]float32, 4096) // native width, as the provider serves it
 		for i := range vec {
 			vec[i] = 0.01
 		}
@@ -82,22 +81,21 @@ func TestHTTPEmbedderReducesWhenEndpointIgnoresDimensions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Embed() error = %v", err)
 	}
-	if gotDims != 1024 {
-		t.Errorf("requested dimensions = %d, want 1024 (endpoint-native preferred)", gotDims)
+	if _, present := gotBody["dimensions"]; present {
+		t.Error("request body carried a dimensions field; LiteLLM's openai adapter 400s on it")
 	}
 	if len(vec) != EmbeddingDimension {
 		t.Errorf("len = %d, want %d", len(vec), EmbeddingDimension)
 	}
 }
 
-// TestHTTPEmbedderEndpointHonorsDimensions covers the preferred path: the
-// endpoint honors `dimensions` and returns EmbeddingDimension natively, so the
-// client-side reduce is a no-op and the strict width check passes.
-func TestHTTPEmbedderEndpointHonorsDimensions(t *testing.T) {
+// TestHTTPEmbedderAcceptsBackendAtTargetWidth covers a backend that already
+// serves the model at the configured width (a local bge-m3 endpoint, or a
+// provider serving Qwen3 reduced): the client-side reduce is a no-op and the
+// strict width check passes.
+func TestHTTPEmbedderAcceptsBackendAtTargetWidth(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var req embedReq
-		_ = json.NewDecoder(r.Body).Decode(&req)
-		vec := make([]float32, req.Dimensions) // honor the requested width
+		vec := make([]float32, EmbeddingDimension)
 		for i := range vec {
 			vec[i] = 0.02
 		}

--- a/apps/edge-api/internal/rag/repository.go
+++ b/apps/edge-api/internal/rag/repository.go
@@ -172,6 +172,12 @@ func (r *Repo) DeleteDocument(ctx context.Context, tenantID, docID uuid.UUID) (b
 // against those chunks would silently mix two incompatible vector spaces.
 // The handler uses this to fail RAG search closed instead (WithEmbeddingGuard);
 // this package does not re-embed anything (PR2).
+//
+// model is canonicalized before the comparison, the same way the control-plane
+// ingest and re-embed paths canonicalize before stamping provenance. Without it
+// a process configured with the LiteLLM route alias compared alias against the
+// canonical id every stored row holds and failed every request closed for a
+// corpus that was in fact embedded under exactly this model.
 func (r *Repo) EmbeddingMismatch(ctx context.Context, tenantID uuid.UUID, model string, dim int) (bool, error) {
 	var mismatch bool
 	err := r.withTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
@@ -180,7 +186,7 @@ func (r *Repo) EmbeddingMismatch(ctx context.Context, tenantID uuid.UUID, model 
 				SELECT 1 FROM public.rag_documents
 				WHERE status = 'embedded' AND (embedding_model != $1 OR embedding_dim != $2)
 			)`,
-			model, dim,
+			embedmodel.Canonical(model), dim,
 		).Scan(&mismatch)
 	})
 	if err != nil {

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -485,7 +485,14 @@ services:
       RAG_EMBEDDING_ENGINE: "openai"
       RAG_OPENAI_API_BASE_URL: "http://edge-api:8080/v1"
       RAG_OPENAI_API_KEY: ${OWUI_SHIM_KEY:-}
-      RAG_EMBEDDING_MODEL: "text-embedding-3-small"
+      # OWUI's own document RAG embeds through the Hive gateway, so this must
+      # name a Hive catalog alias (public.model_aliases), not an OpenAI model
+      # id. "text-embedding-3-small" is not in the catalog and every document
+      # upload failed alias resolution. OWUI's own embedding calls carry no
+      # request body metadata, so they cannot be unwrapped to a per-user JWT:
+      # OWUI_SHIM_KEY must be a real minted "hk_" Hive API key for this path to
+      # authenticate at all (see scripts/seed-owui-e2e-user.py).
+      RAG_EMBEDDING_MODEL: ${OWUI_RAG_EMBEDDING_ALIAS:-hive-embedding-default}
       VECTOR_DB: "pgvector"
       PGVECTOR_DB_URL: ${SUPABASE_DB_URL:-}
       RAG_TOP_K: "5"

--- a/deploy/litellm/config.yaml
+++ b/deploy/litellm/config.yaml
@@ -148,8 +148,13 @@ model_list:
 # Covers 429/5xx automatically. `fallbacks:` kicks in only after retries
 # exhaust. `cooldown_time` prevents hammering a model that just failed.
 # `drop_params: true` silently drops provider-unsupported request fields
-# (e.g. some OpenRouter free embedding providers reject `encoding_format`
-# or `dimensions`) instead of returning a hard 400 to the client.
+# (e.g. some OpenRouter free embedding providers reject `encoding_format`)
+# instead of returning a hard 400 to the client. It does NOT cover
+# `dimensions` on the embedding routes below: LiteLLM's generic openai adapter
+# raises UnsupportedParamsError for any model name without "text-embedding-3"
+# before consulting drop_params, so callers must not send that field at all
+# (see apps/edge-api/internal/rag/embed.go and
+# apps/control-plane/internal/rag/ingest.go, which reduce client-side instead).
 litellm_settings:
   # Sovereign edge: disable all LiteLLM telemetry so no call metadata is
   # sent to LiteLLM's hosted services. Must be set to False (string form)

--- a/scripts/verify-rag-roundtrip.py
+++ b/scripts/verify-rag-roundtrip.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""End-to-end check of the Hive RAG pipeline against a running stack.
+
+Uploads a document carrying a unique marker phrase, waits for control-plane to
+chunk and embed it, then proves the marker comes back out of pgvector through
+POST /v1/rag/search and through the grounded POST /v1/rag/chat answer. Exits
+non-zero on the first step that cannot be proven, so it works as a demo
+readiness gate and as a post-deploy smoke check.
+
+Why a script and not a CI test: the path needs a real embedding provider and a
+real Supabase project. CI has neither, and that blind spot is exactly how a
+broken embedding request field shipped (LiteLLM rejected `dimensions` for every
+document while the unit suite stayed green). Run this against the demo box, or
+any live stack, after touching the RAG or embedding code.
+
+Idempotent: the throwaway tenant, its member user, and the ENABLE_RAG gate are
+upserted, and the user's password is rotated every run, mirroring
+scripts/seed-owui-e2e-user.py. It writes nothing outside its own tenant.
+
+Retries: the serverless embedding route is slow and uneven (measured between
+one and over a hundred seconds per call on the demo stack), so ingest and query
+steps are each attempted a few times before the run is called a failure. A
+retry here is about upstream weather, not about masking a defect. Every attempt
+is printed, so a run that only passes on the third try is visible rather than
+silently green.
+
+Required env: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, SUPABASE_ANON_KEY
+Optional env: EDGE_API_URL (default http://localhost:8080),
+              RAG_CHAT_MODEL (default hive-fast)
+"""
+import json
+import os
+import secrets
+import string
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+TENANT_SLUG = "rag-verify-e2e"
+TENANT_NAME = "RAG Verify E2E"
+TENANT_DEPLOYMENT = "ENTERPRISE_EDGE"
+# .invalid is IANA-reserved for exactly this (RFC 2606).
+USER_EMAIL = "rag-verify-e2e@hive-e2e.invalid"
+MEMBER_ROLE = "MEMBER"
+MEMBER_STATUS = "ACTIVE"
+RAG_GATE = "ENABLE_RAG"
+
+INGEST_ATTEMPTS = 3
+QUERY_ATTEMPTS = 3
+INGEST_POLL_SECONDS = 180
+
+
+def env(name: str, default: str = "") -> str:
+    value = os.environ.get(name, "").strip() or default
+    if not value:
+        print(f"error: {name} is not set", file=sys.stderr)
+        sys.exit(1)
+    return value
+
+
+def request(base, headers, method, path, body=None, params=None, prefer=None, timeout=120):
+    url = base + path
+    if params:
+        url += "?" + urllib.parse.urlencode(params)
+    data = json.dumps(body).encode() if body is not None else None
+    req_headers = dict(headers)
+    if data is not None:
+        req_headers.setdefault("Content-Type", "application/json")
+    if prefer:
+        req_headers["Prefer"] = prefer
+    req = urllib.request.Request(url, data=data, method=method, headers=req_headers)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read()
+            return resp.status, (json.loads(raw) if raw else None)
+    except urllib.error.HTTPError as e:
+        raw = e.read()
+        try:
+            return e.code, json.loads(raw)
+        except json.JSONDecodeError:
+            return e.code, {"raw": raw[:300].decode(errors="replace")}
+    except (urllib.error.URLError, TimeoutError) as e:
+        return 0, {"transport_error": str(e)}
+
+
+def random_password() -> str:
+    alphabet = string.ascii_letters + string.digits + "!@#$%^&*-_"
+    return "Aa1!" + "".join(secrets.choice(alphabet) for _ in range(24))
+
+
+def fail(message: str) -> None:
+    print(f"FAIL: {message}")
+    sys.exit(1)
+
+
+def provision(supabase_url: str, service_key: str) -> tuple[str, str]:
+    """Upsert the throwaway tenant, member user, and RAG gate. Returns
+    (tenant_id, password)."""
+    headers = {"Authorization": f"Bearer {service_key}", "apikey": service_key}
+    rest = supabase_url + "/rest/v1"
+    gotrue = supabase_url + "/auth/v1"
+
+    status, body = request(
+        rest, headers, "POST", "/tenants",
+        body={"slug": TENANT_SLUG, "name": TENANT_NAME, "deployment": TENANT_DEPLOYMENT},
+        params={"on_conflict": "slug"},
+        prefer="resolution=merge-duplicates,return=representation",
+    )
+    if status not in (200, 201) or not body:
+        fail(f"tenant upsert: {status} {body}")
+    tenant_id = body[0]["id"]
+
+    # `filter=` is the exact-match param this GoTrue version supports.
+    status, body = request(gotrue, headers, "GET", "/admin/users", params={"filter": USER_EMAIL})
+    if status != 200:
+        fail(f"user lookup: {status} {body}")
+    existing = next(
+        (u for u in body.get("users", []) if u.get("email", "").lower() == USER_EMAIL.lower()),
+        None,
+    )
+
+    password = random_password()
+    metadata = {"selected_tenant_id": tenant_id}
+    if existing is None:
+        status, body = request(
+            gotrue, headers, "POST", "/admin/users",
+            body={"email": USER_EMAIL, "password": password,
+                  "email_confirm": True, "user_metadata": metadata},
+        )
+        if status not in (200, 201):
+            fail(f"user create: {status} {body}")
+        user_id = body["id"]
+    else:
+        user_id = existing["id"]
+        status, body = request(
+            gotrue, headers, "PUT", f"/admin/users/{user_id}",
+            body={"password": password, "user_metadata": metadata},
+        )
+        if status != 200:
+            fail(f"user password rotate: {status} {body}")
+
+    status, body = request(
+        rest, headers, "POST", "/tenant_users",
+        body={"tenant_id": tenant_id, "user_id": user_id,
+              "role": MEMBER_ROLE, "status": MEMBER_STATUS},
+        params={"on_conflict": "tenant_id,user_id"},
+        prefer="resolution=merge-duplicates",
+    )
+    if status not in (200, 201, 204):
+        fail(f"membership upsert: {status} {body}")
+
+    status, body = request(
+        rest, headers, "POST", "/tenant_settings",
+        body={"tenant_id": tenant_id, "key": RAG_GATE, "enabled": True, "updated_by": user_id},
+        params={"on_conflict": "tenant_id,key"},
+        prefer="resolution=merge-duplicates",
+    )
+    if status not in (200, 201, 204):
+        fail(f"{RAG_GATE} gate upsert: {status} {body}")
+
+    print(f"provisioned tenant {TENANT_SLUG} with {RAG_GATE} enabled")
+    return tenant_id, password
+
+
+def sign_in(supabase_url: str, anon_key: str, password: str) -> str:
+    status, body = request(
+        supabase_url + "/auth/v1", {"apikey": anon_key}, "POST",
+        "/token?grant_type=password", body={"email": USER_EMAIL, "password": password},
+    )
+    token = (body or {}).get("access_token", "")
+    if status != 200 or not token:
+        fail(f"sign in: {status} {body}")
+    print("signed in, tenant-scoped JWT acquired")
+    return token
+
+
+def ingest(edge: str, auth: dict, marker: str) -> str:
+    """Upload a marked document and wait for status=embedded. Returns doc id."""
+    content = (
+        "Hive RAG round-trip fixture. "
+        f"The pilot codename recorded in this note is {marker}. "
+        "No other document in this tenant carries that codename."
+    )
+    for attempt in range(1, INGEST_ATTEMPTS + 1):
+        status, body = request(
+            edge, auth, "POST", "/v1/rag/documents",
+            body={"name": f"rag-roundtrip-{marker}.txt", "content": content},
+        )
+        if status != 202:
+            print(f"  upload attempt {attempt}: http {status} {body}")
+            continue
+        doc_id = body["id"]
+        deadline = time.time() + INGEST_POLL_SECONDS
+        state = "pending"
+        while time.time() < deadline:
+            status, doc = request(edge, auth, "GET", f"/v1/rag/documents/{doc_id}")
+            state = (doc or {}).get("status", "")
+            if state in ("embedded", "error"):
+                break
+            time.sleep(2)
+        print(f"  ingest attempt {attempt}: status={state} {(doc or {}).get('error_msg') or ''}")
+        if state == "embedded":
+            return doc_id
+    fail(f"document never reached status=embedded after {INGEST_ATTEMPTS} attempts")
+
+
+def search(edge: str, auth: dict, marker: str) -> None:
+    for attempt in range(1, QUERY_ATTEMPTS + 1):
+        status, body = request(
+            edge, auth, "POST", "/v1/rag/search",
+            body={"query": "What is the pilot codename recorded in the note?", "top_k": 3},
+        )
+        if status != 200:
+            print(f"  search attempt {attempt}: http {status} {body}")
+            continue
+        hits = (body or {}).get("results", [])
+        if any(marker in h.get("content", "") for h in hits):
+            top = hits[0].get("score")
+            print(f"  search attempt {attempt}: {len(hits)} hits, marker retrieved, top score {top}")
+            return
+        print(f"  search attempt {attempt}: {len(hits)} hits but no marker")
+    fail("vector search never returned the marked chunk")
+
+
+def grounded_chat(edge: str, auth: dict, marker: str, model: str) -> None:
+    for attempt in range(1, QUERY_ATTEMPTS + 1):
+        status, body = request(
+            edge, auth, "POST", "/v1/rag/chat",
+            body={
+                "model": model,
+                "messages": [{"role": "user", "content":
+                              "What pilot codename is recorded in the note? "
+                              "Answer only from the provided context."}],
+                "top_k": 3,
+            },
+        )
+        if status != 200:
+            print(f"  chat attempt {attempt}: http {status} {body}")
+            continue
+        try:
+            answer = body["choices"][0]["message"]["content"]
+        except (KeyError, IndexError, TypeError):
+            print(f"  chat attempt {attempt}: unexpected response shape {str(body)[:200]}")
+            continue
+        citations = (body or {}).get("citations") or []
+        print(f"  chat attempt {attempt}: {answer.strip()[:200]}")
+        if marker not in answer.upper():
+            print(f"  chat attempt {attempt}: answer is not grounded in the document")
+            continue
+        if not citations:
+            fail("grounded answer carried no citations")
+        print(f"  chat attempt {attempt}: grounded, {len(citations)} citations")
+        return
+    fail("grounded chat never answered from the document")
+
+
+def main() -> None:
+    supabase_url = env("SUPABASE_URL").rstrip("/")
+    service_key = env("SUPABASE_SERVICE_ROLE_KEY")
+    anon_key = env("SUPABASE_ANON_KEY")
+    edge = env("EDGE_API_URL", "http://localhost:8080").rstrip("/")
+    model = env("RAG_CHAT_MODEL", "hive-fast")
+
+    # Uppercase so the answer check is case-insensitive without weakening it.
+    marker = "PLUM" + secrets.token_hex(3).upper()
+
+    _, password = provision(supabase_url, service_key)
+    auth = {"Authorization": f"Bearer {sign_in(supabase_url, anon_key, password)}"}
+
+    print(f"ingesting document marked {marker}")
+    doc_id = ingest(edge, auth, marker)
+    print(f"searching for the marker (document {doc_id})")
+    search(edge, auth, marker)
+    print(f"asking {model} to answer from the document")
+    grounded_chat(edge, auth, marker, model)
+
+    print("PASS: upload, embed, vector search, and grounded answer all verified")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Problem

RAG was dead end to end on the demo stack, in three separate places, and the unit suite was green through all of it.

1. **Every document upload failed.** LiteLLM answered each embed call with HTTP 400 `UnsupportedParamsError`, the ingester recorded `status=error` with the provider blind "embedding service unavailable", and no chunk was ever stored. Both embedders sent `dimensions` as the MRL reduction target, and LiteLLM's generic `openai/` adapter, which is how every OpenRouter embedding route is declared, rejects that field for any model whose name does not contain `text-embedding-3`. The check runs before `drop_params` is consulted, so the globally enabled `drop_params` could not save the call and the route had no further fallback to try.

2. **With ingestion unblocked, every search and grounded chat answered 503** with "embedding model changed, re-embed required". The corpus was consistent; the comparison was not. The re-embed worker canonicalizes provenance through `embedmodel.Canonical` and stores `qwen3-embedding-8b`, while the ingest path stored the raw `EMBEDDING_MODEL` value, normally the route alias `route-openrouter-embedding-fallback`. Both name the same model. edge-api's consistency guard string compared alias against canonical id and failed closed, and the boot time catch-up worker saw every freshly ingested document as stale and re-embedded it again, paying for the same vectors on each restart.

3. **The query side then timed out.** The embedding HTTP client allowed 30 seconds while LiteLLM's own `request_timeout` is 45, so the client always abandoned requests the upstream was still answering. A single Qwen3 Embedding 8B call through OpenRouter measured 35 to 40 seconds on this stack.

Two supporting problems made all of this hard to see. The ingester replaced the real embed error with a fixed string before returning, so an unsupported request field, a transport timeout, and a width mismatch were one indistinguishable log line. And the ingest tests drove a copy of `Ingest` that lived in the test file, so neither the provenance bug nor the swallowed error could ever fail them.

## Changes

- Neither embedder sends `dimensions`. `reduceEmbedding` already performs the identical MRL truncate and renormalize on the native width vector, and the strict width check after it still guards against a backend serving an unexpected dimension.
- Ingest stamps the canonical model id, like the re-embed worker already did, and the guard canonicalizes its configured model before comparing. Rows written under the old behaviour heal on the next catch-up pass, so no data migration is needed.
- Embedding client budget raised to 60 seconds, above the upstream it waits on.
- Ingest wraps the real embed error into the returned error. The document facing status message stays provider blind.
- `Ingester` depends on a narrow `ingestRepo` interface, the duplicated test harness is deleted, and the ingest tests now exercise the real method. Net fewer lines.
- Open WebUI's own document RAG points at a real Hive catalog alias. `RAG_EMBEDDING_MODEL` was hardcoded to `text-embedding-3-small`, which is not in `public.model_aliases`, so OWUI native uploads could never resolve a route even with valid credentials.
- The LiteLLM config comment no longer claims `drop_params` covers `dimensions`.
- `scripts/verify-rag-roundtrip.py` proves the whole path against a running stack, and the demo guide's verify section uses it.

## Test plan

- [x] `go test ./apps/edge-api/internal/rag/... ./apps/control-plane/internal/rag/... -count=1 -short` green, `go vet` clean, `gofmt` clean.
- [x] New regression guards: both embedders assert the request body carries no `dimensions` field, and the ingester asserts canonical provenance.
- [x] Live round trip against the demo box: upload, embed, vector search, grounded answer with citations. Transcript in the first comment.
- [x] Confirmed against the running stack that the embedding route answers HTTP 200 with a 4096 wide Qwen3 vector when `dimensions` is omitted and HTTP 400 when it is present.

## Known follow up, not fixed here

The serverless embedding route is slow and uneven: five sequential probes on the demo box measured 0.9s, a timeout past 120s, 102s, 75s, and 33s. The pipeline is correct now and passes, but a demo query can still miss the 60 second budget. The durable fix is a posture change rather than a code change, running bge-m3 locally, which is native 1024 dim and therefore an exact match for the already provisioned `vector(1024)` column and needs no re-provisioning. Raised separately.

Separately, RAG audit writes are being dropped on this stack: `rag audit write failed: ERROR: no partition of relation "audit_log" found for row`. Not caused by this branch and not in its scope, raised separately.
