### PR TITLE
test: let the platform-admin gate assertions auto-wait

### DIFF
--- a/apps/web-console/tests/e2e/console-platform-admin.spec.ts
+++ b/apps/web-console/tests/e2e/console-platform-admin.spec.ts
@@ -52,15 +52,15 @@ test.describe("platform-admin panels", () => {
     await expect(page.getByText("Admin access required")).toHaveCount(0);
 
     const toggles = page.getByRole("switch");
-    expect(await toggles.count()).toBeGreaterThan(0);
+    await expect(toggles).not.toHaveCount(0);
     await expect(toggles.first()).toHaveAttribute("aria-checked", /true|false/);
   });
 
   test("marketplace renders the curate form", async ({ page }) => {
     await page.goto("/console/marketplace");
-    await expect(page.getByText("Admin access required")).toHaveCount(0);
     await expect(
       page.getByRole("button", { name: "Curate entry" })
     ).toBeVisible();
+    await expect(page.getByText("Admin access required")).toHaveCount(0);
   });
 });


### PR DESCRIPTION
Follow-up to #440, addressing review feedback that arrived after that PR merged.

## The flake

```js
const toggles = page.getByRole("switch");
expect(await toggles.count()).toBeGreaterThan(0);
```

`await toggles.count()` resolves once and hands a plain number to `expect`, so the assertion sits outside Playwright's retry loop. On a slow first paint the count reads zero and the test fails before the switches mount. The following line did auto-wait, but it never ran, because this one had already failed.

Replaced with `await expect(toggles).not.toHaveCount(0)`, which retries the count until the timeout.

## Assertion ordering on the marketplace test

Same class of defect, one test lower. The marketplace case led with `expect(page.getByText("Admin access required")).toHaveCount(0)`. An absence assertion is satisfied by a page that rendered nothing at all, so on its own it cannot tell "no admin gate" apart from "nothing loaded yet". Reordered so the Curate entry button is asserted visible first, matching how the feature-gates test was already written.

Both tests still needed both assertions to pass, so this was never a false green in practice. It is a clearer failure message when something does break.

## Test

Ran against the live deployment with the platform-admin fixture:

```
✓ platform-admin panels › feature gates renders toggles, not the admin-required state (19.4s)
✓ platform-admin panels › marketplace renders the curate form (15.6s)
2 passed (37.8s)
```

Worth recording: the first run of this failed on both tests, and it was not the code change. The shared `demo@hive-demo.invalid` password had been rotated by another process between runs, so sign-in 400'd. Re-set the password and both passed unchanged. That fixture is contended and any red run against it should be checked for a live credential before the diff is blamed.
