### PR TITLE
fix: mount and load deploy/prometheus/alerts/ rule files

### DIFF
--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -707,6 +707,7 @@ services:
     volumes:
       - ../../deploy/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - ../../deploy/prometheus/alerts.yml:/etc/prometheus/alerts.yml:ro
+      - ../../deploy/prometheus/alerts:/etc/prometheus/alerts:ro
       - prometheus-data:/prometheus
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'

--- a/deploy/prometheus/prometheus.yml
+++ b/deploy/prometheus/prometheus.yml
@@ -4,6 +4,11 @@ global:
 
 rule_files:
   - "/etc/prometheus/alerts.yml"
+  # deploy/prometheus/alerts/*.yml (e.g. rate-limit.yml, added in #133) ship in
+  # the repo but were never mounted into the Prometheus container, so those
+  # rule groups silently never loaded in any profile (local/cloud/enterprise
+  # all share this file). Glob picks up the whole directory automatically.
+  - "/etc/prometheus/alerts/*.yml"
 
 alerting:
   alertmanagers:


### PR DESCRIPTION
## Summary
- Prometheus's rule_files only referenced /etc/prometheus/alerts.yml (single
  file). deploy/prometheus/alerts/rate-limit.yml (rate-limit alert group,
  added in #133) was never mounted into the container and never loaded by
  any profile (local, cloud, enterprise all share this compose file).
- Mount the alerts/ directory read-only and glob it into rule_files so this
  and any future rule file in that directory loads without further compose
  edits.

## Verified live
Brought up the monitoring profile on the demo box, confirmed both rule
groups now load via Prometheus's /api/v1/rules (hive-critical plus
hive_rate_limit), and confirmed `docker compose config` still validates.

Note: the rate-limit rule group's expressions reference
`rate_limit_exceeded_total`, a metric that is not currently emitted anywhere
in edge-api or control-plane (only recorded as an error-response code, not a
Prometheus counter). Wiring this fix makes the rule group load correctly;
instrumenting the counter itself is separate follow-up work, not part of
this config fix.

## Test plan
- [x] `docker compose config -q` validates
- [x] Verified live on the demo box: `/api/v1/rules` now returns both
      `hive-critical` and `hive_rate_limit` groups
- [ ] CI green