### PR TITLE
fix: forward HIVE_AGENT_ENGINE_* env vars into control-plane container

### DIFF
--- a/deploy/apptainer/README.md
+++ b/deploy/apptainer/README.md
@@ -68,7 +68,9 @@ placeholder tenant/user, `-dry-run`, its own placeholder `-sif` path ignoring
 
 Real agent-task sandbox launches run inside the `control-plane` process
 itself via `buildAgentEngine` (`apps/control-plane/cmd/server/main.go`), gated
-on five separate `HIVE_AGENT_ENGINE_*` env vars documented in `.env.example`.
+on five required `HIVE_AGENT_ENGINE_*` env vars (plus one optional,
+`HIVE_AGENT_ENGINE_SESSION_API_KEY`) documented in `.env.example`; six total
+are forwarded below.
 `docker-compose.yml` forwards these into the `control-plane` service, but
 setting them alone is not sufficient: `control-plane` here runs inside a
 `golang:1.24-alpine` dev container, which cannot exec the host's Apptainer

--- a/deploy/apptainer/README.md
+++ b/deploy/apptainer/README.md
@@ -59,6 +59,26 @@ HIVE_AGENT_SIF_PATH=/opt/hive/agent-engine.sif
 agent-engine refuses to start without it (`-sif` flag or `HIVE_AGENT_SIF_PATH`;
 see `apps/agent-engine/cmd/agent-engine/main.go`).
 
+**Note:** the steps above wire the standalone `agent-engine` compose service
+(`--profile agent`), which is a build/smoke-test container only (hardcoded
+placeholder tenant/user, `-dry-run`, its own placeholder `-sif` path ignoring
+`HIVE_AGENT_SIF_PATH`). It does not execute real per-task sandbox launches.
+
+## Real per-task execution (control-plane)
+
+Real agent-task sandbox launches run inside the `control-plane` process
+itself via `buildAgentEngine` (`apps/control-plane/cmd/server/main.go`), gated
+on five separate `HIVE_AGENT_ENGINE_*` env vars documented in `.env.example`.
+`docker-compose.yml` forwards these into the `control-plane` service, but
+setting them alone is not sufficient: `control-plane` here runs inside a
+`golang:1.24-alpine` dev container, which cannot exec the host's Apptainer
+directly (Apptainer's package build is glibc-linked with no musl loader in
+the container, no `/dev/fuse` device, and it would need real
+`CAP_SYS_ADMIN`-class privilege granted to the service that also holds
+Stripe/Supabase/payment secrets). Real sandbox launches need `control-plane`
+running as a bare host process on whatever box executes agent tasks, not
+this dev container. That deployment-topology decision is still open.
+
 ## Verifying a built image
 
 ```bash

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -310,6 +310,25 @@ services:
       LITELLM_CONTAINER_NAME: ${LITELLM_CONTAINER_NAME:-litellm}
       LITELLM_CONFIG_PATH: ${LITELLM_CONFIG_PATH:-/etc/litellm/config.yaml}
       LITELLM_MASTER_KEY: ${LITELLM_MASTER_KEY:-litellm-dev-key}
+      # Agent task execution (issue #305). See .env.example for the full
+      # explanation: buildAgentEngine (cmd/server/main.go) needs all five of
+      # these non-empty to launch real Apptainer sandboxes; any empty and
+      # tasks stay queued forever by design (agenttask.NotConfiguredEngine).
+      # These were previously documented in .env.example but never forwarded
+      # into this container's environment, so setting them in .env alone did
+      # nothing. Forwarding them here is necessary but not sufficient: this
+      # service still runs inside a golang:1.24-alpine dev container, which
+      # cannot exec the host's Apptainer directly (glibc-linked binary, no
+      # musl dynamic loader; no /dev/fuse; would need real CAP_SYS_ADMIN-class
+      # privilege on the service holding Stripe/Supabase/payment secrets).
+      # Real sandbox launches require control-plane to run as a bare host
+      # process on whatever box executes agent tasks, not this container.
+      HIVE_AGENT_ENGINE_SIF_PATH: ${HIVE_AGENT_ENGINE_SIF_PATH:-}
+      HIVE_AGENT_ENGINE_PACKS_DIR: ${HIVE_AGENT_ENGINE_PACKS_DIR:-}
+      HIVE_AGENT_ENGINE_WORKSPACE_ROOT: ${HIVE_AGENT_ENGINE_WORKSPACE_ROOT:-}
+      HIVE_AGENT_ENGINE_RUN_DIR: ${HIVE_AGENT_ENGINE_RUN_DIR:-}
+      HIVE_AGENT_ENGINE_PROFILE_ID: ${HIVE_AGENT_ENGINE_PROFILE_ID:-}
+      HIVE_AGENT_ENGINE_SESSION_API_KEY: ${HIVE_AGENT_ENGINE_SESSION_API_KEY:-}
     healthcheck:
       test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8081/health"]
       interval: 5s


### PR DESCRIPTION
## Summary

Apptainer is now installed and confirmed working on the demo box host (`apptainer exec agent-engine.sif echo ok` succeeds). Investigating why a queued coding-agent task still would not run surfaced a wiring gap distinct from the standalone `agent-engine` compose service:

- `control-plane`'s `buildAgentEngine` (`apps/control-plane/cmd/server/main.go`) gates real per-task Apptainer sandbox launches on five `HIVE_AGENT_ENGINE_*` env vars. `.env.example` documents all five, but `docker-compose.yml` never forwarded them into the `control-plane` service's `environment` block, so setting them in `.env` had zero effect.
- The standalone `agent-engine` compose service (`--profile agent`) is a build/smoke-test container only (hardcoded placeholder tenant/user, `-dry-run`, its own placeholder `-sif` path that ignores `HIVE_AGENT_SIF_PATH`). It never executed real per-task work and bringing it up does not move a queued task forward. `deploy/apptainer/README.md` read as if it did; clarified that.

## What this PR does

- Forwards the five `HIVE_AGENT_ENGINE_*` vars (`SIF_PATH`, `PACKS_DIR`, `WORKSPACE_ROOT`, `RUN_DIR`, `PROFILE_ID`, `SESSION_API_KEY`) into `control-plane`'s environment block in `deploy/docker/docker-compose.yml`, matching the existing `${VAR:-}` pattern used elsewhere in the file.
- Documents the still-open containerization question in `deploy/apptainer/README.md`: `control-plane` runs inside a `golang:1.24-alpine` dev container, which cannot exec the host's Apptainer directly. Confirmed on the box: the installed Apptainer binary is glibc-linked (`ldd` shows `libc.so.6`, `libseccomp.so.2`, `libselinux.so.1`, etc., interpreter `/lib64/ld-linux-x86-64.so.2`), while the control-plane image is Alpine/musl with no glibc loader present and no `/dev/fuse` device. Making this work would mean either bind-mounting a foreign-libc binary plus a handful of shared libraries into the container (fragile, breaks on any base-image bump) or rebuilding the image with glibc/fuse support, plus granting the container real `CAP_SYS_ADMIN`-class privilege (or the setuid-root Apptainer starter path) on the single most sensitive service in the stack, the one holding Stripe, Supabase service-role, bKash/SSLCommerz, and DB credentials.

## What this PR intentionally does not do

No container capability, mount, or Dockerfile changes. That path was evaluated and rejected for now: the security-surface increase on a secrets-holding service is disproportionate to a docker-compose plumbing fix, and the correct root-cause answer is more likely "control-plane needs to run as a bare host process on whatever box actually executes agent tasks" (matching the code comment in `buildAgentEngine`), a deployment-topology decision that needs explicit sign-off, not a fix folded into this diff. No security-reviewer pass was requested for this PR since no capability or privilege change is made, all six vars are additive with empty defaults and produce no behavior change until an operator sets real values.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('deploy/docker/docker-compose.yml'))"` confirms the compose file still parses and the six vars appear under `services.control-plane.environment`.
- [x] Confirmed no changes to `deploy/apptainer/**`, `vendor/openhands/**`, `apps/agent-engine/packs/**` since the last successful `agent-engine SIF` CI build (2026-07-17), so no fresh SIF build was needed; the CI artifact was downloaded and its sha256 verified identical on the demo box (`/home/sakib/hive-agent-sif/agent-engine.sif`).
- [ ] Once the containerization decision is made (bare-host control-plane, or an accepted capability-grant design with a dedicated security-reviewer pass), set the five vars for real and confirm a queued coding-agent task transitions out of QUEUED with `docker logs`/host logs as evidence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the agent-engine Compose profile performs build and smoke tests only, not real per-task sandbox launches.
  * Added guidance on configuring control-plane for actual sandbox execution and explained host deployment requirements and current topology considerations.

* **Configuration**
  * Forwarded agent-engine environment settings into the control-plane container.
  * Documented that leaving these settings empty keeps agent tasks queued.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->