### PR TITLE
fix: retry Groq TTS on silent-audio responses proxied through LiteLLM

### DIFF
--- a/apps/edge-api/internal/audio/handler.go
+++ b/apps/edge-api/internal/audio/handler.go
@@ -5,17 +5,19 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"log"
 	"mime/multipart"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/authz"
 	apierrors "github.com/sakibsadmanshajib/hive/apps/edge-api/internal/errors"
 	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/stt"
-	"github.com/google/uuid"
 )
 
 // Capability flags used when this handler calls the routing layer.
@@ -241,29 +243,50 @@ func (h *Handler) handleSpeech(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Dispatch to LiteLLM.
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, h.litellmBaseURL+"/audio/speech", bytes.NewReader(rewrittenBody))
-	if err != nil {
+	// Dispatch to LiteLLM, retrying up to maxSpeechAttempts times if the
+	// upstream TTS backend returns a 200 with silent (all-zero) WAV sample
+	// data instead of the requested speech. This is a confirmed live defect
+	// in Groq's Orpheus TTS backend -- reproduced identically calling Groq
+	// directly and through LiteLLM's route-groq-tts, so it is not fixable by
+	// swapping providers or LiteLLM versions -- that occurs on a meaningful
+	// fraction of requests (see live_voice_integration_test.go). Retrying
+	// almost always recovers a correct clip.
+	var (
+		lastStatus int
+		lastCT     string
+		lastBody   []byte
+		success    bool
+	)
+	for attempt := 1; attempt <= maxSpeechAttempts; attempt++ {
+		statusCode, ct, respBody, err := h.fetchSpeechOnce(ctx, rewrittenBody)
+		if err != nil {
+			_ = h.accounting.ReleaseReservation(ctx, auth.AccountID, reservationID, "upstream_error")
+			apierrors.WriteProviderBlindUpstreamError(w, speechReq.Model, http.StatusBadGateway, err.Error())
+			return
+		}
+		lastStatus, lastCT, lastBody = statusCode, ct, respBody
+
+		if statusCode < 200 || statusCode >= 300 {
+			break
+		}
+		if data, ok := wavDataChunk(respBody); ok && isDegenerateSilence(data) {
+			log.Printf("audio: speech synthesis attempt %d/%d for alias=%s returned silent WAV, retrying", attempt, maxSpeechAttempts, route.AliasID)
+			continue
+		}
+		success = true
+		break
+	}
+
+	if lastStatus < 200 || lastStatus >= 300 {
+		_ = h.accounting.ReleaseReservation(ctx, auth.AccountID, reservationID, "upstream_error")
+		apierrors.WriteProviderBlindUpstreamError(w, speechReq.Model, lastStatus, string(lastBody))
+		return
+	}
+	if !success {
+		// Every attempt came back silent.
 		_ = h.accounting.ReleaseReservation(ctx, auth.AccountID, reservationID, "upstream_error")
 		code := "upstream_error"
-		apierrors.WriteError(w, http.StatusBadGateway, "api_error", "Failed to build upstream request.", &code)
-		return
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+h.masterKey)
-
-	resp, err := h.httpClient.Do(req)
-	if err != nil {
-		_ = h.accounting.ReleaseReservation(ctx, auth.AccountID, reservationID, "upstream_error")
-		apierrors.WriteProviderBlindUpstreamError(w, speechReq.Model, http.StatusBadGateway, err.Error())
-		return
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		upstreamBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		_ = h.accounting.ReleaseReservation(ctx, auth.AccountID, reservationID, "upstream_error")
-		apierrors.WriteProviderBlindUpstreamError(w, speechReq.Model, resp.StatusCode, string(upstreamBody))
+		apierrors.WriteError(w, http.StatusServiceUnavailable, "api_error", "Speech synthesis is temporarily unavailable. Please retry.", &code)
 		return
 	}
 
@@ -274,16 +297,47 @@ func (h *Handler) handleSpeech(w http.ResponseWriter, r *http.Request) {
 		ActualCredits: 1000,
 	})
 
-	// Binary relay: copy Content-Type exactly from upstream, pipe body directly.
-	ct := resp.Header.Get("Content-Type")
-	if ct != "" {
-		w.Header().Set("Content-Type", ct)
+	// Binary relay: copy Content-Type exactly from upstream.
+	if lastCT != "" {
+		w.Header().Set("Content-Type", lastCT)
 	}
-	if cl := resp.Header.Get("Content-Length"); cl != "" {
-		w.Header().Set("Content-Length", cl)
-	}
+	w.Header().Set("Content-Length", strconv.Itoa(len(lastBody)))
 	w.WriteHeader(http.StatusOK)
-	io.Copy(w, resp.Body) //nolint:errcheck
+	w.Write(lastBody) //nolint:errcheck
+}
+
+// maxSpeechAttempts bounds retries against the silent-WAV defect described
+// above handleSpeech's dispatch loop.
+const maxSpeechAttempts = 3
+
+// maxSpeechResponseBytes bounds how much of the upstream speech response
+// this handler buffers in memory to inspect before relaying to the client.
+// TTS clips for realistic request sizes are well under this.
+const maxSpeechResponseBytes = 25 << 20
+
+// fetchSpeechOnce makes one dispatch attempt to LiteLLM's /audio/speech and
+// returns the upstream status, Content-Type, and buffered body. err is set
+// only for request-construction or transport/read failures; a non-2xx
+// upstream status is returned as a normal (status, body) pair, not an error.
+func (h *Handler) fetchSpeechOnce(ctx context.Context, rewrittenBody []byte) (statusCode int, contentType string, body []byte, err error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, h.litellmBaseURL+"/audio/speech", bytes.NewReader(rewrittenBody))
+	if err != nil {
+		return 0, "", nil, fmt.Errorf("build upstream speech request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+h.masterKey)
+
+	resp, err := h.httpClient.Do(req)
+	if err != nil {
+		return 0, "", nil, err
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxSpeechResponseBytes))
+	if err != nil {
+		return 0, "", nil, fmt.Errorf("read upstream speech response: %w", err)
+	}
+	return resp.StatusCode, resp.Header.Get("Content-Type"), respBody, nil
 }
 
 // handleTranscription processes POST /v1/audio/transcriptions.

--- a/apps/edge-api/internal/audio/live_voice_integration_test.go
+++ b/apps/edge-api/internal/audio/live_voice_integration_test.go
@@ -13,22 +13,31 @@ package audio_test
 // three are already covered exhaustively in handler_test.go against a fake
 // upstream, so restubbing them here would add nothing).
 //
-// IMPORTANT — why this test points at Groq directly instead of through
-// LiteLLM, unlike Hive's real deployment: while writing this test, live
-// verification found that LiteLLM v1.77.7-stable and main-stable both proxy
-// /audio/speech and /audio/transcriptions to Groq without erroring, but
-// silently corrupt the binary audio payload in both directions (200 OK,
-// correct byte length, but PCM samples come back all-zero on the way out and
-// Whisper transcribes garbage — " you" — on the way in), while an identical
-// request straight to Groq's own API works perfectly. That is a real,
-// separate infrastructure defect (outside Hive's own Go code, in the pinned
-// LiteLLM proxy layer) and is reported alongside this change rather than
-// fixed here — fixing it is out of scope for a test-coverage pass. Pointing
-// this test at LiteLLM would make it fail for that reason instead of
-// verifying what it is meant to verify: that audio.Handler's own dispatch,
-// multipart handling, and response passthrough are correct end to end
-// against a real provider. Hive's provider-agnostic design means the handler
-// code under test here is identical either way; only the base URL changes.
+// IMPORTANT — this test points at Groq directly rather than through
+// LiteLLM, unlike Hive's real deployment, to isolate audio.Handler's own
+// dispatch, multipart handling, and response passthrough from anything
+// upstream of it. Hive's provider-agnostic design means the handler code
+// under test here is identical either way; only the base URL changes.
+// TestLiveVoiceRoundTripThroughLiteLLM below is this test's production
+// twin, run against a real LiteLLM proxy instead.
+//
+// Follow-up finding (resolved): while writing this test, live verification
+// first appeared to show LiteLLM-specific corruption -- audio round-tripped
+// through LiteLLM's route-groq-tts / route-groq-stt intermittently came back
+// as HTTP 200 with a correctly-shaped WAV file that was entirely silent
+// (all-zero PCM samples), which Whisper then (correctly) transcribed as
+// near-garbage (" you") on the STT leg. Wider live testing traced this to
+// Groq's Orpheus TTS backend itself, not LiteLLM or Hive's own code: calling
+// Groq's API directly, with no LiteLLM or Hive code in between, reproduces
+// the exact same intermittent silent-WAV response (confirmed via repeated
+// live curl requests against api.groq.com, same request, same ~1-in-4 to
+// ~1-in-5 failure rate, byte-identical corrupted payload each time it
+// occurred). The STT leg was never independently broken; it was always
+// correctly transcribing whatever audio the TTS leg actually produced.
+// handleSpeech (handler.go) now retries internally when it detects a
+// silent-WAV response and only returns 200 once it has verified non-silent
+// audio, so this is fixed at the point Hive controls even though the root
+// cause is upstream and outside Hive's (or LiteLLM's) control.
 //
 // Prerequisites:
 //   - A real GROQ_API_KEY (voice-groq-stt-tts routes: deploy/litellm/config.yaml).
@@ -192,6 +201,144 @@ func TestLiveVoiceRoundTrip(t *testing.T) {
 	for _, word := range []string{"quick", "brown", "fox", "lazy", "dog"} {
 		if !strings.Contains(gotLower, word) {
 			t.Errorf("transcription %q missing expected word %q from spoken sentence %q", got.Text, word, sentence)
+		}
+	}
+}
+
+// liveAudioHandlerLiteLLM builds the same production audio.Handler as
+// liveAudioHandler above, but points litellmBaseURL at a real LiteLLM proxy
+// instance instead of straight at Groq. This is the production topology
+// (deploy/litellm/config.yaml's route-groq-tts / route-groq-stt), unlike
+// TestLiveVoiceRoundTrip above which bypasses LiteLLM entirely.
+func liveAudioHandlerLiteLLM(t *testing.T, litellmModelName string) *audio.Handler {
+	t.Helper()
+	base := os.Getenv("LITELLM_TEST_BASE_URL")
+	if base == "" {
+		base = "http://localhost:4000"
+	}
+	masterKey := os.Getenv("LITELLM_TEST_MASTER_KEY")
+	if masterKey == "" {
+		masterKey = "litellm-dev-key"
+	}
+	return audio.NewHandler(liveAuthStub{}, liveRoutingStub{providerModel: litellmModelName}, liveAccountingStub{}, base, masterKey)
+}
+
+// TestLiveVoiceRoundTripThroughLiteLLM is TestLiveVoiceRoundTrip's production
+// twin: it speaks the same known sentence through the real Handler pointed at
+// a real LiteLLM proxy (deploy/litellm/config.yaml's route-groq-tts /
+// route-groq-stt, which both forward to Groq), instead of hitting Groq
+// directly. This is the actual topology every real Hive voice request goes
+// through, so a pass here (and not just in TestLiveVoiceRoundTrip) is the
+// only live proof that production /v1/audio traffic is not corrupted.
+//
+// Prerequisites:
+//   - A running LiteLLM proxy with route-groq-tts / route-groq-stt configured
+//     and a real GROQ_API_KEY behind them (see deploy/litellm/config.yaml).
+//   - LITELLM_TEST_BASE_URL pointed at that proxy (default http://localhost:4000).
+//   - LITELLM_TEST_MASTER_KEY matching its LITELLM_MASTER_KEY (default
+//     litellm-dev-key, matching deploy/docker/docker-compose.yml's dev default).
+//   - HIVE_AUDIO_LITELLM_LIVE_TEST=1 to opt in.
+func TestLiveVoiceRoundTripThroughLiteLLM(t *testing.T) {
+	if os.Getenv("HIVE_AUDIO_LITELLM_LIVE_TEST") != "1" {
+		t.Skip("HIVE_AUDIO_LITELLM_LIVE_TEST not set; skipping live voice round trip through LiteLLM")
+	}
+
+	const sentence = "The quick brown fox jumps over the lazy dog"
+
+	// Leg 1: text to speech via the real Handler, through LiteLLM's
+	// route-groq-tts, to Groq's Orpheus TTS backend.
+	speechHandler := liveAudioHandlerLiteLLM(t, "route-groq-tts")
+	speechBody, err := json.Marshal(map[string]string{
+		"model":           "hive-tts",
+		"input":           sentence,
+		"voice":           "troy",
+		"response_format": "wav",
+	})
+	if err != nil {
+		t.Fatalf("marshal speech request: %v", err)
+	}
+	speechReq := httptest.NewRequest(http.MethodPost, "/v1/audio/speech", bytes.NewReader(speechBody))
+	speechReq.Header.Set("Content-Type", "application/json")
+	speechRec := httptest.NewRecorder()
+	speechHandler.ServeHTTP(speechRec, speechReq)
+
+	if speechRec.Code != http.StatusOK {
+		t.Fatalf("speech synthesis through LiteLLM failed: status=%d body=%s", speechRec.Code, speechRec.Body.String())
+	}
+	audioBytes := speechRec.Body.Bytes()
+	if len(audioBytes) == 0 {
+		t.Fatal("speech synthesis through LiteLLM returned an empty body")
+	}
+
+	// PCM content check, not just byte count: a WAV file with a correct
+	// header and length but all-zero sample data is exactly the confirmed
+	// live defect this test guards against (see handleSpeech's silent-WAV
+	// retry loop in handler.go) -- Groq's Orpheus TTS backend intermittently
+	// returns HTTP 200 with silence instead of the requested speech, on a
+	// meaningful fraction of requests, reproduced identically calling Groq
+	// directly and through LiteLLM. handleSpeech retries internally and
+	// only returns 200 once it has verified non-silent audio (or gives up
+	// with a 503 after exhausting retries), so this assertion should never
+	// fail in practice; it stays here as a regression guard against that
+	// retry logic being weakened or removed.
+	sampleData := audioBytes
+	if len(sampleData) > 44 {
+		sampleData = sampleData[44:]
+	}
+	allZero := true
+	for _, b := range sampleData {
+		if b != 0 {
+			allZero = false
+			break
+		}
+	}
+	if allZero {
+		t.Fatal("speech synthesis through LiteLLM returned WAV sample data that is entirely zero (silence) — audio corrupted in transit")
+	}
+
+	// Leg 2: feed the synthesized audio into the real Handler, through
+	// LiteLLM's route-groq-stt, to Groq's Whisper backend.
+	transcribeHandler := liveAudioHandlerLiteLLM(t, "route-groq-stt")
+	var multipartBody bytes.Buffer
+	mw := multipart.NewWriter(&multipartBody)
+	if err := mw.WriteField("model", "hive-stt"); err != nil {
+		t.Fatalf("write model field: %v", err)
+	}
+	if err := mw.WriteField("language", "en"); err != nil {
+		t.Fatalf("write language field: %v", err)
+	}
+	fw, err := mw.CreateFormFile("file", "speech.wav")
+	if err != nil {
+		t.Fatalf("create form file: %v", err)
+	}
+	if _, err := fw.Write(audioBytes); err != nil {
+		t.Fatalf("write audio to multipart: %v", err)
+	}
+	if err := mw.Close(); err != nil {
+		t.Fatalf("close multipart writer: %v", err)
+	}
+
+	transcribeReq := httptest.NewRequest(http.MethodPost, "/v1/audio/transcriptions", &multipartBody)
+	transcribeReq.Header.Set("Content-Type", mw.FormDataContentType())
+	transcribeRec := httptest.NewRecorder()
+	transcribeHandler.ServeHTTP(transcribeRec, transcribeReq)
+
+	if transcribeRec.Code != http.StatusOK {
+		t.Fatalf("transcription through LiteLLM failed: status=%d body=%s", transcribeRec.Code, transcribeRec.Body.String())
+	}
+
+	var got audio.TranscriptionResponse
+	if err := json.Unmarshal(transcribeRec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("transcription response through LiteLLM is not valid JSON matching the OpenAI contract: %v (body=%s)", err, transcribeRec.Body.String())
+	}
+	if strings.TrimSpace(got.Text) == "" {
+		t.Fatal("transcription response through LiteLLM has an empty text field")
+	}
+
+	gotLower := strings.ToLower(got.Text)
+	for _, word := range []string{"quick", "brown", "fox", "lazy", "dog"} {
+		if !strings.Contains(gotLower, word) {
+			t.Errorf("transcription through LiteLLM %q missing expected word %q from spoken sentence %q", got.Text, word, sentence)
 		}
 	}
 }

--- a/apps/edge-api/internal/audio/speech_silence_retry_test.go
+++ b/apps/edge-api/internal/audio/speech_silence_retry_test.go
@@ -1,0 +1,145 @@
+package audio_test
+
+import (
+	"encoding/binary"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// buildTestWAV constructs a minimal canonical 44-byte-header PCM WAV file
+// wrapping the given sample bytes, matching the shape Groq's Orpheus TTS
+// backend returns for response_format=wav.
+func buildTestWAV(samples []byte) []byte {
+	dataLen := len(samples)
+	buf := make([]byte, 44+dataLen)
+	copy(buf[0:4], "RIFF")
+	binary.LittleEndian.PutUint32(buf[4:8], uint32(36+dataLen)) //nolint:gosec
+	copy(buf[8:12], "WAVE")
+	copy(buf[12:16], "fmt ")
+	binary.LittleEndian.PutUint32(buf[16:20], 16)
+	binary.LittleEndian.PutUint16(buf[20:22], 1)     // PCM
+	binary.LittleEndian.PutUint16(buf[22:24], 1)     // mono
+	binary.LittleEndian.PutUint32(buf[24:28], 24000) // sample rate
+	binary.LittleEndian.PutUint32(buf[28:32], 48000) // byte rate
+	binary.LittleEndian.PutUint16(buf[32:34], 2)     // block align
+	binary.LittleEndian.PutUint16(buf[34:36], 16)    //nolint:gosec // bits per sample
+	copy(buf[36:40], "data")
+	binary.LittleEndian.PutUint32(buf[40:44], uint32(dataLen)) //nolint:gosec
+	copy(buf[44:], samples)
+	return buf
+}
+
+func silentTestWAV(n int) []byte {
+	return buildTestWAV(make([]byte, n))
+}
+
+func speechTestWAV(n int) []byte {
+	samples := make([]byte, n)
+	for i := range samples {
+		samples[i] = byte(i%200 + 1) // any non-zero pattern
+	}
+	return buildTestWAV(samples)
+}
+
+// sequencedSpeechServer serves one response body per call in order, from
+// responses, repeating the last entry once exhausted. It counts calls.
+type sequencedSpeechServer struct {
+	server    *httptest.Server
+	responses [][]byte
+	calls     atomic.Int32
+}
+
+func newSequencedSpeechServer(responses [][]byte) *sequencedSpeechServer {
+	s := &sequencedSpeechServer{responses: responses}
+	s.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := int(s.calls.Add(1)) - 1
+		body := s.responses[len(s.responses)-1]
+		if n < len(s.responses) {
+			body = s.responses[n]
+		}
+		w.Header().Set("Content-Type", "audio/wav")
+		w.WriteHeader(http.StatusOK)
+		w.Write(body) //nolint:errcheck
+	}))
+	return s
+}
+
+func (s *sequencedSpeechServer) Close() { s.server.Close() }
+
+func TestSpeechRetriesOnSilentWAVThenSucceeds(t *testing.T) {
+	good := speechTestWAV(2000)
+	mock := newSequencedSpeechServer([][]byte{silentTestWAV(2000), good})
+	defer mock.Close()
+
+	h := buildAudioHandler(mock.server.URL)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/audio/speech", strings.NewReader(`{"model":"hive-tts","input":"hello","voice":"alloy","response_format":"wav"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer test-key")
+	w := httptest.NewRecorder()
+
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if w.Body.Len() != len(good) {
+		t.Fatalf("expected the good (second attempt) WAV of length %d, got %d bytes", len(good), w.Body.Len())
+	}
+	if got := mock.calls.Load(); got != 2 {
+		t.Errorf("expected exactly 2 upstream calls (silent then good), got %d", got)
+	}
+}
+
+func TestSpeechFailsAfterAllAttemptsSilent(t *testing.T) {
+	silent := silentTestWAV(2000)
+	mock := newSequencedSpeechServer([][]byte{silent, silent, silent})
+	defer mock.Close()
+
+	h := buildAudioHandler(mock.server.URL)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/audio/speech", strings.NewReader(`{"model":"hive-tts","input":"hello","voice":"alloy","response_format":"wav"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer test-key")
+	w := httptest.NewRecorder()
+
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 once every retry attempt comes back silent, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := mock.calls.Load(); got != 3 {
+		t.Errorf("expected exactly 3 upstream attempts (maxSpeechAttempts), got %d", got)
+	}
+}
+
+func TestSpeechNonWAVResponseIsNeverRetried(t *testing.T) {
+	// A non-WAV format (e.g. mp3) can't be validated for silence by this
+	// package, so it must be relayed on the first attempt regardless of
+	// content, even if the bytes happen to be all zero.
+	allZeroMP3 := make([]byte, 500)
+	mock := newSequencedSpeechServer([][]byte{allZeroMP3, speechTestWAV(2000)})
+	defer mock.Close()
+
+	h := buildAudioHandler(mock.server.URL)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/audio/speech", strings.NewReader(`{"model":"hive-tts","input":"hello","voice":"alloy","response_format":"mp3"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer test-key")
+	w := httptest.NewRecorder()
+
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if w.Body.Len() != len(allZeroMP3) {
+		t.Fatalf("expected the first (only) attempt's body relayed unchanged, got %d bytes", w.Body.Len())
+	}
+	if got := mock.calls.Load(); got != 1 {
+		t.Errorf("expected exactly 1 upstream call (non-WAV responses are never retried), got %d", got)
+	}
+}

--- a/apps/edge-api/internal/audio/wav_silence.go
+++ b/apps/edge-api/internal/audio/wav_silence.go
@@ -1,0 +1,56 @@
+package audio
+
+import "encoding/binary"
+
+// wavDataChunk locates and returns the sample data ("data" subchunk) of a
+// RIFF/WAVE file. It returns ok=false for anything that isn't a WAVE file
+// (including compressed formats such as mp3/opus/aac, which this package
+// never attempts to silence-check) so callers can skip validation entirely
+// for non-WAV responses.
+func wavDataChunk(b []byte) (data []byte, ok bool) {
+	if len(b) < 12 || string(b[0:4]) != "RIFF" || string(b[8:12]) != "WAVE" {
+		return nil, false
+	}
+	pos := 12
+	for pos+8 <= len(b) {
+		chunkID := string(b[pos : pos+4])
+		chunkSize := int(binary.LittleEndian.Uint32(b[pos+4 : pos+8]))
+		dataStart := pos + 8
+		if chunkID == "data" {
+			end := dataStart + chunkSize
+			if end > len(b) || chunkSize < 0 {
+				end = len(b)
+			}
+			if dataStart > end {
+				return nil, false
+			}
+			return b[dataStart:end], true
+		}
+		pos = dataStart + chunkSize
+		if chunkSize%2 == 1 { // RIFF subchunks are word-aligned
+			pos++
+		}
+	}
+	return nil, false
+}
+
+// isDegenerateSilence reports whether WAV sample data is silence rather than
+// real audio content. Confirmed live defect: Groq's Orpheus TTS backend
+// (reached directly or through LiteLLM's route-groq-tts -- both were tested
+// live and behave identically) intermittently returns HTTP 200 with a
+// correctly-shaped WAV file whose PCM sample data is entirely zero, instead
+// of the requested speech. A real spoken sentence is never anywhere close to
+// all-zero at the byte level, so a strict threshold has no false positives
+// against genuine (even quiet) audio.
+func isDegenerateSilence(data []byte) bool {
+	if len(data) == 0 {
+		return true
+	}
+	nonZero := 0
+	for _, v := range data {
+		if v != 0 {
+			nonZero++
+		}
+	}
+	return float64(nonZero)/float64(len(data)) < 0.001
+}


### PR DESCRIPTION
## Summary

PR #460 documented, without fixing, a suspected LiteLLM-side defect: audio round-tripped through LiteLLM's Groq TTS/STT routes appeared to come back corrupted in both directions. This PR traces the defect precisely and fixes it at the point Hive controls.

- **Root cause is Groq's own Orpheus TTS backend, not LiteLLM and not Hive's existing code.** Groq's TTS endpoint intermittently returns HTTP 200 with a correctly-shaped WAV file whose PCM sample data is entirely silent, instead of the requested speech. This reproduces identically calling Groq directly (no LiteLLM or Hive code involved), through a locally pinned LiteLLM v1.77.7-stable (the currently deployed version), through the newest available LiteLLM v1.83.14-stable, and live against the actual production demo box's LiteLLM instance.
- **The STT leg was never independently broken.** It always correctly transcribed whatever audio the TTS leg actually produced; feeding it silence correctly yields near-garbage ("you"), which is what PR #460 observed and attributed to a second defect.
- **Upgrading the pinned LiteLLM image does not help.** v1.83.14-stable (the newest available `-stable` Docker tag) reproduces the same defect at a similar rate, confirming this is not a LiteLLM regression with an upstream fix to adopt.
- **Bypassing LiteLLM for these routes was considered and rejected.** Since the defect reproduces identically calling Groq directly, bypassing LiteLLM would fix nothing while adding a raw provider key and Groq-specific request handling into edge-api, undermining Hive's provider-blind design.

## Fix

`handleSpeech` (`apps/edge-api/internal/audio/handler.go`) now buffers and inspects the upstream `/audio/speech` response and retries up to three times when it detects a silent WAV (`wav_silence.go`), returning a clear retryable 503 only if every attempt comes back silent. It never relays audio already known to be broken to the client.

## Test plan

- [x] `go vet` and `gofmt` clean on the touched package
- [x] Full `apps/edge-api` unit test suite passes (`go test ./apps/edge-api/...`)
- [x] New deterministic unit coverage (`speech_silence_retry_test.go`): retry-then-succeed, exhausted-retries-returns-503, and non-WAV-format-is-never-retried
- [x] New live test (`TestLiveVoiceRoundTripThroughLiteLLM` in `live_voice_integration_test.go`), the production-topology twin of PR #460's live test, going through a real LiteLLM proxy instead of hitting Groq directly (gated behind `HIVE_AUDIO_LITELLM_LIVE_TEST=1`, never runs in CI)
- [x] Confirmed live: 8 sequential raw curl requests to a locally pinned LiteLLM v1.77.7-stable reproduced the silent-WAV defect (~25-35% of requests), byte-identical corrupted payload every time it occurred, also reproduced identically hitting Groq directly and through v1.83.14-stable
- [x] Confirmed the fix recovers correct audio and correct transcription across repeated runs against both a locally pinned LiteLLM instance and the real production demo box's LiteLLM
- [x] Confirmed live on the production demo box today: 5 of 8 raw `/audio/speech` requests through the box's real LiteLLM instance came back silent (worse than the local rate); a direct run of this fix's `TestLiveVoiceRoundTripThroughLiteLLM` against that same live production LiteLLM instance (no code deployed to the box) passed 3/3 times, recovering the correct spoken sentence each time after 1-2 internal retries

🤖 Generated with [Claude Code](https://claude.com/claude-code)