### PR TITLE
fix: enforce per-tenant quota and per-session cgroup limits on the real sandbox launch path

### DIFF
--- a/apps/agent-engine/cmd/agent-engine/main.go
+++ b/apps/agent-engine/cmd/agent-engine/main.go
@@ -144,6 +144,9 @@ func main() {
 		ProxySocketPath:  proxySocketPath,
 		ControlSocketDir: ctlDir,
 		MCPConfigPath:    mcpConfigPath,
+		MemoryLimit:      envOr("HIVE_SANDBOX_MEMORY_LIMIT", "4G"),
+		CPULimit:         envOr("HIVE_SANDBOX_CPU_LIMIT", "2"),
+		PidsLimit:        envInt("HIVE_SANDBOX_PIDS_LIMIT", 512),
 	}
 
 	argv, err := sandbox.BuildArgv(cfg)

--- a/apps/agent-engine/internal/engine/engine.go
+++ b/apps/agent-engine/internal/engine/engine.go
@@ -46,6 +46,7 @@ import (
 
 	"github.com/sakibsadmanshajib/hive/apps/agent-engine/internal/controlclient"
 	"github.com/sakibsadmanshajib/hive/apps/agent-engine/internal/egressproxy"
+	"github.com/sakibsadmanshajib/hive/apps/agent-engine/internal/quota"
 	"github.com/sakibsadmanshajib/hive/apps/agent-engine/internal/sandbox"
 )
 
@@ -109,11 +110,40 @@ type Config struct {
 	// ControlReadyTimeout bounds how long Launch waits for the in-SIF shim
 	// to create its control socket. Defaults to 30s.
 	ControlReadyTimeout time.Duration
+
+	// QuotaTenantConcurrency and QuotaUserConcurrency cap how many sessions
+	// one tenant and one user may run at once (issue #308). Non-positive
+	// values fall back to the defaults below.
+	QuotaTenantConcurrency int
+	QuotaUserConcurrency   int
+
+	// MemoryLimit, CPULimit and PidsLimit bound what each individual session
+	// may consume; see sandbox.LaunchConfig's fields of the same name.
+	MemoryLimit string
+	CPULimit    string
+	PidsLimit   int
 }
 
 func (c Config) withDefaults() Config {
 	if c.ControlReadyTimeout <= 0 {
 		c.ControlReadyTimeout = 30 * time.Second
+	}
+	if c.QuotaTenantConcurrency <= 0 {
+		c.QuotaTenantConcurrency = 4
+	}
+	if c.QuotaUserConcurrency <= 0 {
+		c.QuotaUserConcurrency = 2
+	}
+	// Sized for a coding-pack session: an arbitrary build plus the headless
+	// Chromium the browser tool drives.
+	if c.MemoryLimit == "" {
+		c.MemoryLimit = "4G"
+	}
+	if c.CPULimit == "" {
+		c.CPULimit = "2"
+	}
+	if c.PidsLimit <= 0 {
+		c.PidsLimit = 512
 	}
 	return c
 }
@@ -145,14 +175,27 @@ func realStart(argv []string) (process, error) {
 	return &osProcess{cmd: cmd}, nil
 }
 
+// terminalOutcome is a reaped session's final answer, replayed by Status
+// instead of dialling a control socket whose sandbox is already gone.
+type terminalOutcome struct {
+	status        Status
+	resultSummary string
+	errMessage    string
+}
+
 type session struct {
 	conversationID uuid.UUID
 	client         *controlclient.Client
 	proc           process
 	proxySrv       *http.Server
 	proxyListener  net.Listener
-	sessionDir     string // removed on Cancel; holds only Unix sockets
-	workingDir     string // removed on Cancel; the sandbox's /workspace bind mount
+	sessionDir     string // removed when reaped; holds only Unix sockets
+	workingDir     string // removed when reaped; the sandbox's /workspace bind mount
+	release        func() // frees this session's quota slot; safe to call repeatedly
+
+	// reaped and terminal are guarded by SandboxEngine.mu.
+	reaped   bool
+	terminal *terminalOutcome
 }
 
 // SandboxEngine launches, polls, and cancels agent-engine sandbox sessions.
@@ -160,16 +203,31 @@ type session struct {
 type SandboxEngine struct {
 	cfg   Config
 	start func(argv []string) (process, error)
+	q     *quota.Manager
 
-	mu       sync.Mutex
+	mu sync.Mutex
+	// ponytail: a reaped session keeps a small terminal record here instead
+	// of being deleted, so the map grows by one struct per completed task and
+	// only a process restart clears it. Add eviction if one process ever runs
+	// enough tasks for that to matter.
 	sessions map[string]*session
 }
 
 // New constructs a SandboxEngine from cfg.
 func New(cfg Config) *SandboxEngine {
+	cfg = cfg.withDefaults()
+	q, err := quota.New(quota.Limits{
+		TenantConcurrency: cfg.QuotaTenantConcurrency,
+		UserConcurrency:   cfg.QuotaUserConcurrency,
+	})
+	if err != nil {
+		// Unreachable: withDefaults replaces every non-positive limit.
+		panic(err)
+	}
 	return &SandboxEngine{
-		cfg:      cfg.withDefaults(),
+		cfg:      cfg,
 		start:    realStart,
+		q:        q,
 		sessions: make(map[string]*session),
 	}
 }
@@ -198,6 +256,19 @@ func (e *SandboxEngine) Launch(ctx context.Context, t Task) (sessionRef string, 
 		return "", fmt.Errorf("engine: Task.Pack is required")
 	}
 
+	release, err := e.q.Acquire(t.TenantID, t.UserID)
+	if err != nil {
+		return "", err
+	}
+	// succeeded flips true on the return at the very end of this function; it
+	// gates this cleanup and the resource cleanup registered further down.
+	succeeded := false
+	defer func() {
+		if !succeeded {
+			release()
+		}
+	}()
+
 	allowedHosts, err := e.cfg.ResolveEgressHosts(ctx, t.TenantID, t.UserID)
 	if err != nil {
 		return "", fmt.Errorf("engine: resolve egress policy, refusing to launch: %w", err)
@@ -217,13 +288,11 @@ func (e *SandboxEngine) Launch(ctx context.Context, t Task) (sessionRef string, 
 	workingDir := filepath.Join(e.cfg.WorkspaceRoot, t.ID.String())
 
 	// Single deferred cleanup for every failure branch below: closes
-	// whatever got started so far and removes both directories. succeeded
-	// flips true only on the return at the very end of this function.
+	// whatever got started so far and removes both directories.
 	var (
 		proxySrv *http.Server
 		proc     process
 	)
-	succeeded := false
 	defer func() {
 		if succeeded {
 			return
@@ -270,6 +339,9 @@ func (e *SandboxEngine) Launch(ctx context.Context, t Task) (sessionRef string, 
 		ProxySocketPath:  egressSocketPath,
 		ControlSocketDir: controlDir,
 		SessionAPIKey:    e.cfg.SessionAPIKey,
+		MemoryLimit:      e.cfg.MemoryLimit,
+		CPULimit:         e.cfg.CPULimit,
+		PidsLimit:        e.cfg.PidsLimit,
 	}
 
 	argv, err := sandbox.BuildArgv(lc)
@@ -317,6 +389,7 @@ func (e *SandboxEngine) Launch(ctx context.Context, t Task) (sessionRef string, 
 		proxyListener:  proxyListener,
 		sessionDir:     sessionDir,
 		workingDir:     workingDir,
+		release:        release,
 	}
 	e.mu.Lock()
 	e.sessions[convo.ID.String()] = sess
@@ -337,6 +410,13 @@ func (e *SandboxEngine) Status(ctx context.Context, sessionRef string) (status S
 		return "", "", "", err
 	}
 
+	e.mu.Lock()
+	replay := sess.terminal
+	e.mu.Unlock()
+	if replay != nil {
+		return replay.status, replay.resultSummary, replay.errMessage, nil
+	}
+
 	info, err := sess.client.GetConversation(ctx, id)
 	if err != nil {
 		return "", "", "", fmt.Errorf("engine: get conversation: %w", err)
@@ -348,19 +428,49 @@ func (e *SandboxEngine) Status(ctx context.Context, sessionRef string) (status S
 		if err != nil {
 			return "", "", "", fmt.Errorf("engine: get final response: %w", err)
 		}
-		return StatusSucceeded, summary, "", nil
+		status, resultSummary = StatusSucceeded, summary
 	case controlclient.StatusErrored, controlclient.StatusStuck:
-		return StatusFailed, "", fmt.Sprintf("agent-server execution_status=%s", info.ExecutionStatus), nil
+		status, errMessage = StatusFailed, fmt.Sprintf("agent-server execution_status=%s", info.ExecutionStatus)
 	case controlclient.StatusPaused, controlclient.StatusDeleting:
 		// paused only ever happens via this package's own Cancel today
 		// (ponytail: an externally-triggered pause would also read as
 		// cancelled here — no other component pauses a conversation yet).
-		return StatusCancelled, "", "", nil
+		status = StatusCancelled
 	case controlclient.StatusIdle:
 		return StatusQueued, "", "", nil
 	default: // running, waiting_for_confirmation, or a future value
 		return StatusRunning, "", "", nil
 	}
+
+	// Terminal. Nothing else ever frees this session: the agent-server is a
+	// server and keeps running after its conversation finishes, and
+	// apps/control-plane/internal/agenttask's poller only records the status,
+	// it never calls Cancel. Reaping here is what stops completed tasks from
+	// leaking their sandbox process, directories and quota slot.
+	_ = e.reap(sess, &terminalOutcome{status: status, resultSummary: resultSummary, errMessage: errMessage})
+	return status, resultSummary, errMessage, nil
+}
+
+// reap frees everything sess holds and records outcome for later Status
+// calls to replay. Idempotent: only the first call per session does the work.
+// The returned error is the sandbox process kill failure, which Cancel
+// surfaces to its caller and Status has nothing useful to do with.
+func (e *SandboxEngine) reap(sess *session, outcome *terminalOutcome) error {
+	e.mu.Lock()
+	if sess.reaped {
+		e.mu.Unlock()
+		return nil
+	}
+	sess.reaped = true
+	sess.terminal = outcome
+	e.mu.Unlock()
+
+	killErr := sess.proc.Kill()
+	_ = sess.proxySrv.Close()
+	_ = os.RemoveAll(sess.sessionDir)
+	_ = os.RemoveAll(sess.workingDir)
+	sess.release()
+	return killErr
 }
 
 // Cancel interrupts sessionRef's conversation and terminates its sandbox
@@ -372,14 +482,11 @@ func (e *SandboxEngine) Cancel(ctx context.Context, sessionRef string) error {
 	}
 
 	interruptErr := sess.client.Interrupt(ctx, id)
-	killErr := sess.proc.Kill()
-	_ = sess.proxySrv.Close()
-	_ = os.RemoveAll(sess.sessionDir)
-	_ = os.RemoveAll(sess.workingDir)
-
-	e.mu.Lock()
-	delete(e.sessions, sessionRef)
-	e.mu.Unlock()
+	// The session entry stays in the map holding its terminal outcome rather
+	// than being deleted: agenttask's poller retries Status whenever its own
+	// Transition call failed, and an unknown-session error there would leave
+	// the task active forever.
+	killErr := e.reap(sess, &terminalOutcome{status: StatusCancelled})
 
 	if interruptErr != nil {
 		return fmt.Errorf("engine: interrupt conversation: %w", interruptErr)

--- a/apps/agent-engine/internal/engine/engine_test.go
+++ b/apps/agent-engine/internal/engine/engine_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/sakibsadmanshajib/hive/apps/agent-engine/internal/controlclient"
+	"github.com/sakibsadmanshajib/hive/apps/agent-engine/internal/quota"
 	"github.com/sakibsadmanshajib/hive/apps/agent-engine/internal/sandbox"
 )
 
@@ -172,7 +173,15 @@ func shortTempDir(t *testing.T) string {
 
 func newTestEngine(t *testing.T, captured **fakeAgentServer) *SandboxEngine {
 	t.Helper()
+	return newTestEngineWithQuota(t, captured, 4, 2)
+}
+
+func newTestEngineWithQuota(t *testing.T, captured **fakeAgentServer, tenantConcurrency, userConcurrency int) *SandboxEngine {
+	t.Helper()
 	cfg := Config{
+		QuotaTenantConcurrency: tenantConcurrency,
+		QuotaUserConcurrency:   userConcurrency,
+
 		SIFPath:       "/fake/agent-server.sif",
 		PacksDir:      t.TempDir(),
 		WorkspaceRoot: t.TempDir(),
@@ -201,6 +210,92 @@ func newTestEngine(t *testing.T, captured **fakeAgentServer) *SandboxEngine {
 
 func testTask() Task {
 	return Task{ID: uuid.New(), TenantID: uuid.New(), UserID: uuid.New(), Pack: "coding-pack"}
+}
+
+// Issue #308: the quota package existed but nothing on the production launch
+// path ever acquired a slot, so one tenant could saturate the box.
+func TestSandboxEngine_Launch_EnforcesTenantQuota(t *testing.T) {
+	var fake *fakeAgentServer
+	e := newTestEngineWithQuota(t, &fake, 1, 1)
+
+	first := testTask()
+	if _, err := e.Launch(context.Background(), first); err != nil {
+		t.Fatalf("first Launch: %v", err)
+	}
+
+	// Same tenant, different user: isolates the tenant ceiling from the
+	// per-user one.
+	second := testTask()
+	second.TenantID = first.TenantID
+	if _, err := e.Launch(context.Background(), second); !errors.Is(err, quota.ErrTenantQuotaExceeded) {
+		t.Fatalf("expected ErrTenantQuotaExceeded, got %v", err)
+	}
+}
+
+func TestSandboxEngine_Launch_EnforcesUserQuota(t *testing.T) {
+	var fake *fakeAgentServer
+	e := newTestEngineWithQuota(t, &fake, 4, 1)
+
+	first := testTask()
+	if _, err := e.Launch(context.Background(), first); err != nil {
+		t.Fatalf("first Launch: %v", err)
+	}
+
+	second := testTask()
+	second.TenantID = first.TenantID
+	second.UserID = first.UserID
+	if _, err := e.Launch(context.Background(), second); !errors.Is(err, quota.ErrUserQuotaExceeded) {
+		t.Fatalf("expected ErrUserQuotaExceeded, got %v", err)
+	}
+}
+
+// The agent-server is a server: it keeps running after the conversation
+// finishes, and apps/control-plane/internal/agenttask's poller only records
+// the terminal status, it never calls Cancel. Without reaping here every
+// completed task leaked its sandbox process, its session directories and
+// (once quota is wired) its concurrency slot forever.
+func TestSandboxEngine_Status_TerminalReapsSandboxAndFreesQuota(t *testing.T) {
+	var fake *fakeAgentServer
+	e := newTestEngineWithQuota(t, &fake, 1, 1)
+
+	task := testTask()
+	sessionRef, err := e.Launch(context.Background(), task)
+	if err != nil {
+		t.Fatalf("Launch: %v", err)
+	}
+	first := fake
+
+	first.setFinalResponse("done")
+	first.setStatus(controlclient.StatusFinished)
+
+	status, summary, _, err := e.Status(context.Background(), sessionRef)
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if status != StatusSucceeded || summary != "done" {
+		t.Fatalf("expected succeeded/done, got %s/%q", status, summary)
+	}
+	if !first.wasKilled() {
+		t.Fatal("expected terminal Status to kill the sandbox process")
+	}
+
+	// The poller retries Status whenever its own Transition call failed, so a
+	// reaped session must keep answering instead of becoming unknown.
+	status, summary, _, err = e.Status(context.Background(), sessionRef)
+	if err != nil {
+		t.Fatalf("repeat Status after reap: %v", err)
+	}
+	if status != StatusSucceeded || summary != "done" {
+		t.Fatalf("expected repeat Status to still report succeeded/done, got %s/%q", status, summary)
+	}
+
+	// The freed slot is the point: the same tenant/user can launch again.
+	next := testTask()
+	next.TenantID = task.TenantID
+	next.UserID = task.UserID
+	if _, err := e.Launch(context.Background(), next); err != nil {
+		t.Fatalf("expected quota slot freed by the reap, got %v", err)
+	}
 }
 
 func TestSandboxEngine_Launch_StartsAndRunsConversation(t *testing.T) {
@@ -425,7 +520,14 @@ func TestSandboxEngine_Cancel_InterruptsAndKillsProcess(t *testing.T) {
 		t.Fatal("expected Cancel to kill the sandbox process")
 	}
 
-	if _, _, _, err := e.Status(context.Background(), sessionRef); !errors.Is(err, ErrUnknownSession) {
-		t.Fatalf("expected session to be forgotten after Cancel, got %v", err)
+	// A cancelled session keeps answering Status with its terminal outcome
+	// rather than becoming unknown: agenttask's poller retries Status whenever
+	// its own Transition failed, and an error there leaves the task active.
+	status, _, _, err := e.Status(context.Background(), sessionRef)
+	if err != nil {
+		t.Fatalf("Status after Cancel: %v", err)
+	}
+	if status != StatusCancelled {
+		t.Fatalf("expected cancelled after Cancel, got %s", status)
 	}
 }

--- a/apps/agent-engine/internal/sandbox/launcher.go
+++ b/apps/agent-engine/internal/sandbox/launcher.go
@@ -119,6 +119,20 @@ type LaunchConfig struct {
 	HostPort        int    // passed to the agent-server's own --host/--port; reachable from the host only via ControlSocketDir, see package doc
 	ProxySocketPath string // host path of the per-session egressproxy.Proxy's Unix socket listener
 
+	// MemoryLimit, CPULimit and PidsLimit bound what one session can take
+	// from the host, enforced by Apptainer's own cgroup flags (--memory,
+	// --cpus, --pids-limit). All three are required: the concurrency
+	// ceilings in apps/agent-engine/internal/quota cap how many sessions run
+	// at once but say nothing about what each one consumes, and a coding-pack
+	// session runs arbitrary builds plus headless Chromium. Rootless
+	// enforcement needs a cgroups v2 host with systemd delegation
+	// (https://apptainer.org/docs/user/main/cgroups.html); on a host without
+	// it Apptainer fails the launch, which is the correct outcome — issue
+	// #308 exists because unbounded sessions starve their neighbours.
+	MemoryLimit string // Apptainer --memory, e.g. "4G"
+	CPULimit    string // Apptainer --cpus, e.g. "2"
+	PidsLimit   int    // Apptainer --pids-limit
+
 	// ControlSocketDir is a host directory, created empty by the caller
 	// before launch, bind-mounted read-write into the sandbox at
 	// ControlSocketContainerDir. See the package doc and
@@ -155,6 +169,7 @@ var (
 	ErrMissingConfigDir        = errors.New("sandbox: Pack.ConfigDir is required")
 	ErrMissingWorkingDir       = errors.New("sandbox: Pack.WorkingDir is required")
 	ErrInvalidHostPort         = errors.New("sandbox: HostPort must be positive")
+	ErrMissingResourceLimit    = errors.New("sandbox: MemoryLimit, CPULimit and PidsLimit are required")
 	ErrNilTenant               = errors.New("sandbox: TenantID must not be uuid.Nil")
 	ErrNilUser                 = errors.New("sandbox: UserID must not be uuid.Nil")
 
@@ -182,6 +197,8 @@ func (c LaunchConfig) validate() error {
 		return ErrMissingWorkingDir
 	case c.HostPort <= 0:
 		return ErrInvalidHostPort
+	case c.MemoryLimit == "", c.CPULimit == "", c.PidsLimit <= 0:
+		return ErrMissingResourceLimit
 	}
 	return nil
 }
@@ -284,6 +301,9 @@ func BuildArgv(cfg LaunchConfig) (argv []string, err error) {
 		"--network", "none",
 		"--no-mount", "hostfs",
 		"--no-mount", "bind-paths",
+		"--memory", cfg.MemoryLimit,
+		"--cpus", cfg.CPULimit,
+		"--pids-limit", strconv.Itoa(cfg.PidsLimit),
 		"--env", "HTTP_PROXY=" + proxyURL,
 		"--env", "HTTPS_PROXY=" + proxyURL,
 		"--env", "NO_PROXY=127.0.0.1,localhost",

--- a/apps/agent-engine/internal/sandbox/launcher_test.go
+++ b/apps/agent-engine/internal/sandbox/launcher_test.go
@@ -24,6 +24,9 @@ func validConfig() sandbox.LaunchConfig {
 		HostPort:         38080,
 		ProxySocketPath:  "/srv/hive/run/t1/egress.sock",
 		ControlSocketDir: "/srv/hive/run/t1/control",
+		MemoryLimit:      "4G",
+		CPULimit:         "2",
+		PidsLimit:        512,
 	}
 }
 
@@ -49,6 +52,27 @@ func TestBuildArgv_AlwaysIsolatesNetwork(t *testing.T) {
 	joined := strings.Join(argv, " ")
 	if !strings.Contains(joined, "--net --network none") {
 		t.Fatalf("expected --net --network none present as an adjacent pair, got argv: %v", argv)
+	}
+}
+
+// Issue #308's other half: concurrency counting alone does not stop one
+// session's build plus headless Chromium from exhausting the host's RAM and
+// starving every other tenant on the box. These are Apptainer's own cgroup
+// flags, usable rootless on a cgroups v2 host with systemd delegation
+// (https://apptainer.org/docs/user/main/cgroups.html).
+func TestBuildArgv_AppliesResourceLimits(t *testing.T) {
+	argv, err := sandbox.BuildArgv(validConfig())
+	if err != nil {
+		t.Fatalf("BuildArgv: %v", err)
+	}
+	for _, want := range [][2]string{
+		{"--memory", "4G"},
+		{"--cpus", "2"},
+		{"--pids-limit", "512"},
+	} {
+		if !strings.Contains(strings.Join(argv, " "), want[0]+" "+want[1]) {
+			t.Fatalf("expected %s %s present as an adjacent pair, got argv: %v", want[0], want[1], argv)
+		}
 	}
 }
 
@@ -169,6 +193,9 @@ func TestBuildArgv_RejectsInvalidConfig(t *testing.T) {
 		{"empty pack working dir", func(c *sandbox.LaunchConfig) { c.Pack.WorkingDir = "" }, sandbox.ErrMissingWorkingDir},
 		{"zero host port", func(c *sandbox.LaunchConfig) { c.HostPort = 0 }, sandbox.ErrInvalidHostPort},
 		{"negative host port", func(c *sandbox.LaunchConfig) { c.HostPort = -1 }, sandbox.ErrInvalidHostPort},
+		{"empty memory limit", func(c *sandbox.LaunchConfig) { c.MemoryLimit = "" }, sandbox.ErrMissingResourceLimit},
+		{"empty cpu limit", func(c *sandbox.LaunchConfig) { c.CPULimit = "" }, sandbox.ErrMissingResourceLimit},
+		{"zero pids limit", func(c *sandbox.LaunchConfig) { c.PidsLimit = 0 }, sandbox.ErrMissingResourceLimit},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/apps/control-plane/cmd/server/main.go
+++ b/apps/control-plane/cmd/server/main.go
@@ -1475,6 +1475,14 @@ func buildAgentEngine(egressSvc *egress.Service) (agenttask.Engine, agenttask.St
 		},
 		AgentProfileID: profileID,
 		SessionAPIKey:  os.Getenv("HIVE_AGENT_ENGINE_SESSION_API_KEY"),
+		// Issue #308 noisy-neighbour controls: how many sessions a tenant or
+		// user may run at once, and what each one may consume. Zero values
+		// fall back to engineapi's own defaults.
+		QuotaTenantConcurrency: parseIntEnv("HIVE_QUOTA_TENANT_CONCURRENCY", 4),
+		QuotaUserConcurrency:   parseIntEnv("HIVE_QUOTA_USER_CONCURRENCY", 2),
+		MemoryLimit:            envOr("HIVE_SANDBOX_MEMORY_LIMIT", "4G"),
+		CPULimit:               envOr("HIVE_SANDBOX_CPU_LIMIT", "2"),
+		PidsLimit:              parseIntEnv("HIVE_SANDBOX_PIDS_LIMIT", 512),
 	})
 	real := agentengine.New(sandbox)
 	return real, real

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -121,6 +121,13 @@ services:
       HIVE_AGENT_SIF_PATH: ${HIVE_AGENT_SIF_PATH:-}
       HIVE_QUOTA_TENANT_CONCURRENCY: ${HIVE_QUOTA_TENANT_CONCURRENCY:-4}
       HIVE_QUOTA_USER_CONCURRENCY: ${HIVE_QUOTA_USER_CONCURRENCY:-2}
+      # Per-session cgroup ceilings (issue #308). Enforced by Apptainer's own
+      # --memory/--cpus/--pids-limit; rootless enforcement needs a cgroups v2
+      # host with systemd delegation, and Apptainer fails the launch loudly
+      # without it rather than running the session unbounded.
+      HIVE_SANDBOX_MEMORY_LIMIT: ${HIVE_SANDBOX_MEMORY_LIMIT:-4G}
+      HIVE_SANDBOX_CPU_LIMIT: ${HIVE_SANDBOX_CPU_LIMIT:-2}
+      HIVE_SANDBOX_PIDS_LIMIT: ${HIVE_SANDBOX_PIDS_LIMIT:-512}
     depends_on:
       control-plane:
         condition: service_healthy


### PR DESCRIPTION
## Decision context

This lands the implementable half of the server-side sandbox scalability decision for #308. The decision itself: **keep Apptainer rootless, do not move to Firecracker, gVisor or a hosted sandbox provider.** Reasoning, with sources:

- The existing launcher design (isolated netns via `--net --network none`, plus a Unix-socket egress relay bridged by socat, plus an allowlist proxy) is the same architecture Anthropic's own [sandbox-runtime](https://github.com/anthropic-experimental/sandbox-runtime) uses on Linux with bubblewrap. Independent convergent validation of what is already built.
- Every option with a stronger isolation ceiling needs host privileges a customer-hosted Enterprise box cannot be assumed to grant. Firecracker and Kata need `/dev/kvm` and nested virtualization ([Northflank comparison](https://northflank.com/blog/how-to-sandbox-ai-agents): Firecracker ~125ms, Kata ~200ms, both nested-virt gated). [gVisor rootless](https://gvisor.dev/docs/user_guide/rootless/) cannot use its netstack, so it forces `--network=none` anyway (the same design as today) while adding 10-30% I/O overhead on exactly the build and test path a coding pack runs.
- A SIF is a mounted squashfs: no daemon, no root socket, no per-session image unpack. Best fit for Compose single-box Enterprise with no Kubernetes.
- Cross-tenant hardware isolation comes from never co-scheduling two tenants on one worker VM, not from the sandbox layer. Single org equals single tenant, so an Enterprise deploy only ever needs user-versus-user isolation inside one already-trusted org.
- The WSL2 dev-box friction is not removable by any runtime choice: on that box `unshare -Ur --mount-proc` fails and there is no cgroups v2 at all, so rootless Apptainer, rootless gVisor and rootless Podman all fail identically. The fix is to make the physical Ubuntu box the sandbox validation host, not to change runtimes.

Residual risk worth recording: rootless Apptainer cannot apply a seccomp profile (`--security` needs a setuid-root install per the [Apptainer admin guide](https://apptainer.org/docs/admin/main/security.html)), so the host syscall surface stays full. That is precisely why the tenant boundary must be the VM boundary.

## What this PR fixes

Two defects found while reading the current path end to end. Neither was a design question; both were wiring gaps.

**1. Quota was dead code on the production path.** `quota.Manager` was only ever used by `cmd/agent-engine` (the standalone smoke-test binary). Real launches go control-plane `buildAgentEngine` to `engineapi` to `engine.SandboxEngine.Launch`, which never called `Acquire`. One tenant could saturate the box, the exact noisy-neighbour scenario #308 was filed for. `Launch` now acquires a slot before doing any work and releases it on every failure branch.

**2. No cgroup limits existed anywhere.** `grep` for `apply-cgroups`, `memory-limit` or `pids-limit` across `apps/agent-engine` returned nothing. Concurrency counting says how many sessions run, never what each consumes, and a coding-pack session runs arbitrary builds plus headless Chromium. `BuildArgv` now always emits Apptainer's `--memory`, `--cpus` and `--pids-limit`, and `LaunchConfig.validate` refuses to build an invocation missing any of them. Rootless enforcement requires cgroups v2 with systemd delegation ([Apptainer cgroups docs](https://apptainer.org/docs/user/main/cgroups.html)); on a host without it Apptainer fails the launch loudly, which is correct, since running unbounded is the bug.

**3. A session leak with the same root cause, exposed by wiring the quota.** The agent-server is a server: it keeps running after its conversation finishes, and `agenttask`'s poller only records the terminal status, it never calls `Cancel`. Every completed task therefore leaked its sandbox process, its session directories, and (once quota is wired) its concurrency slot, forever. `Status` now reaps the session the first time it observes a terminal state, which is the one place every terminal observation routes through. A reaped session keeps its terminal outcome in the map instead of being deleted, so the poller's `Status` retry after a failed `Transition` still gets an answer rather than an unknown-session error that would leave the task active forever. `Cancel` goes through the same reap path.

Limits are operator-tunable (`HIVE_QUOTA_TENANT_CONCURRENCY`, `HIVE_QUOTA_USER_CONCURRENCY`, `HIVE_SANDBOX_MEMORY_LIMIT`, `HIVE_SANDBOX_CPU_LIMIT`, `HIVE_SANDBOX_PIDS_LIMIT`), because an Enterprise single box and a cloud worker have very different budgets.

## Behaviour change to note in review

`Cancel` no longer deletes the session from the map, so `Status` after `Cancel` now returns `cancelled` instead of `ErrUnknownSession`. The existing Cancel test was updated to assert the new contract. This is deliberate: two different lifecycle rules for the same map is the kind of thing that gets decoded at 3am, and returning an error to the poller is what strands a task in the active list.

## Test plan

- [x] `go test ./apps/agent-engine/... -count=1` passes (all 10 packages with tests).
- [x] `go test ./apps/control-plane/... -count=1 -short` exits 0, 51 packages ok, no FAIL or panic.
- [x] `go vet` clean across both modules; `gofmt -l` clean on all touched files.
- [x] New tests: tenant ceiling denies a second launch, user ceiling denies a second launch, terminal `Status` kills the sandbox process and frees the slot for a re-launch, and a repeat `Status` after the reap still reports the terminal outcome.
- [x] New test asserts `--memory`, `--cpus` and `--pids-limit` are present as adjacent pairs in the built argv; three new rows cover the config rejection cases.
- [ ] **Live Apptainer validation not run here and cannot be**: WSL2 has no rootless user-namespace support and no cgroups v2 (`unshare -Ur --mount-proc` fails, `/sys/fs/cgroup/cgroup.controllers` absent). The cgroup flags are argv-verified only. Live launch plus the #307 adversarial isolation suite has to run on the physical Ubuntu box, and remains the gate before this path is trusted in production.

## Issues

- Closes the quota and per-session resource halves of #308. The per-user egress allowlist bullet is unaffected by this PR and needs a separate check that the desktop path consumes the same SSOT.
- Unblocks #307 Step 0.1 and 0.3, which need the physical box, not more code.
- Does not touch #384 or #305 scope.
- A follow-up issue is still needed for horizontal scale: promote agent-engine from an in-process embed to a worker service over its existing `engineapi` seam, with tenant-pinned placement. Not in this PR.

No visual proof artifact: this change touches no UI or UX surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable memory, CPU, and process limits for sandbox sessions.
  * Added per-tenant and per-user concurrency limits to prevent resource contention.
  * Sandbox sessions now clean up resources and release capacity after completion or cancellation.
  * Cancelled sessions retain their final status for reliable status checks.

* **Bug Fixes**
  * Improved sandbox cleanup and terminal session handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->