### PR TITLE
fix: block OWUI native functions/models admin API to match control-plane governance

### DIFF
--- a/deploy/docker/Caddyfile.owui
+++ b/deploy/docker/Caddyfile.owui
@@ -31,7 +31,7 @@
   # admin panel under a non-blocked path, mutation verbs are dropped.
   @adminMutation {
     method PUT POST PATCH DELETE
-    path /api/v*/configs* /api/v*/admin* /api/v*/users/* /api/v*/groups* /api/v*/roles*
+    path /api/v*/configs* /api/v*/admin* /api/v*/users/* /api/v*/groups* /api/v*/roles* /api/v*/functions* /api/v*/models*
   }
   respond @adminMutation 404
 


### PR DESCRIPTION
## Summary

The OWUI Caddy proxy drops admin mutation verbs (PUT, POST, PATCH, DELETE) on admin adjacent API paths, but the matcher list was missing `/api/v*/functions*` and `/api/v*/models*`. Open WebUI's own model and connection configuration API was therefore still mutable through the proxy, even though the control plane already owns model visibility (PRs #205 and #206) and feature gates.

This backs decision D-014: web-console plus control-plane is the sole source of truth for model visibility, feature gates, RBAC, billing, and API keys in Hive Enterprise. Open WebUI's native admin surface stays disabled, and the proxy blocks the API paths that would let it be reached anyway.

## Test plan

Caddy path matcher config change only, no test suite covers it. Verified locally that the adapted config is still valid:

```
docker run --rm -v "$PWD/Caddyfile.owui:/etc/caddy/Caddyfile:ro" -e HIVE_CHAT_EXTERNAL_SCHEME=http \
  caddy:2-alpine caddy validate --adapter caddyfile --config /etc/caddy/Caddyfile
# -> Valid configuration
```

Before merge, verify live against a running OWUI plus Caddy stack:

- [ ] `curl -i -X POST http://localhost:8090/api/v1/models/create` returns 404 from the proxy.
- [ ] `curl -i -X POST http://localhost:8090/api/v1/functions/create` returns 404 from the proxy.
- [ ] `curl -i http://localhost:8090/api/v1/models` (GET) still succeeds, so the chat model picker keeps working.