### PR TITLE
THROWAWAY 553 harness: docs-only (do not merge)

### DIFF
--- a/docs/verification/ci-553-harness.md
+++ b/docs/verification/ci-553-harness.md
@@ -1,0 +1,5 @@
+# Issue 553 harness case: documentation only
+
+Throwaway file. The pull request that carries it changes nothing but this file,
+so the verbatim `changes` job must report `run=false` and the required-shaped
+job must conclude success having executed no real steps.


### PR DESCRIPTION
Harness case: documentation only, verbatim changes job. Do not merge.

@coderabbitai ignore