### PR TITLE
fix: log the real cause of collapsed authz invalid_api_key denials

### DIFF
--- a/apps/edge-api/internal/authz/authorizer.go
+++ b/apps/edge-api/internal/authz/authorizer.go
@@ -90,7 +90,15 @@ func (a *Authorizer) Authorize(ctx context.Context, authHeader string, aliasID s
 
 	snapshot, err := a.client.Resolve(ctx, rawToken)
 	if err != nil {
-		// All resolution failures (not found, revoked, network error mapping) manifest as invalid key.
+		// All resolution failures (not found, revoked, control-plane/network
+		// error) manifest to the CALLER as the same generic invalid-key
+		// message, deliberately: distinguishing them client-side would let a
+		// caller enumerate which keys exist. Server-side, collapsing them the
+		// same way is a bug, not a feature -- log the real cause (err already
+		// carries the resolve-path outcome, e.g. control-plane status code
+		// for not-found/revoked vs a transport error) so an outage is
+		// diagnosable from logs instead of guesswork across reruns.
+		log.Printf("authz: key resolution failed err=%v", err)
 		code := "invalid_api_key"
 		return AuthSnapshot{}, nil, newErr(
 			"invalid_request_error",
@@ -103,6 +111,10 @@ func (a *Authorizer) Authorize(ctx context.Context, authHeader string, aliasID s
 	if !check.Allowed {
 		switch check.DenyCode {
 		case "invalid_api_key":
+			// check.DenyMsg already differentiates revoked/disabled/expired
+			// for the client message below; log it too so the same cause is
+			// visible server-side without grepping response bodies.
+			log.Printf("authz: access denied alias=%q reason=%q", aliasID, check.DenyMsg)
 			code := "invalid_api_key"
 			return AuthSnapshot{}, nil, newErr(
 				"invalid_request_error",

--- a/apps/edge-api/internal/authz/authorizer_test.go
+++ b/apps/edge-api/internal/authz/authorizer_test.go
@@ -1,10 +1,14 @@
 package authz
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log"
 	"strings"
 	"testing"
+
+	apierrors "github.com/sakibsadmanshajib/hive/apps/edge-api/internal/errors"
 )
 
 // #51: a Redis-backed limiter that cannot evaluate (transient outage,
@@ -85,6 +89,99 @@ func TestAuthorizeFailsOpenWhenExplicitlyEnabled(t *testing.T) {
 	if snapshot.KeyID != "key-1" {
 		t.Fatalf("expected resolved snapshot returned on fail-open, got %#v", snapshot)
 	}
+}
+
+// #566/#569 postmortem: a key-resolution failure (not found, revoked,
+// control-plane/network error) must reach the caller as the same generic
+// invalid_api_key message regardless of cause -- never let a caller
+// enumerate which keys exist -- but the real cause must still be visible
+// server-side, or an outage like this one is undiagnosable from logs alone.
+func TestAuthorizeLogsResolutionFailureCauseButKeepsClientMessageGeneric(t *testing.T) {
+	client := &Client{
+		ResolveOverride: func(_ context.Context, _ string) (AuthSnapshot, error) {
+			return AuthSnapshot{}, errors.New(`authz: status 404: {"error":"key not found"}`)
+		},
+	}
+
+	authorizer := NewAuthorizer(client, nil)
+
+	var logOutput string
+	var err *apierrors.OpenAIError
+	logOutput = captureAuthzLogs(t, func() {
+		_, _, err = authorizer.Authorize(context.Background(), "Bearer hk_test", "hive-default", 50, 100, 20)
+	})
+
+	// Client-facing half: byte-identical generic message, no hint of the
+	// underlying resolve-path outcome.
+	if err == nil {
+		t.Fatal("expected invalid_api_key error")
+	}
+	if err.Error.Type != "invalid_request_error" {
+		t.Fatalf("type = %q, want %q", err.Error.Type, "invalid_request_error")
+	}
+	if err.Error.Code == nil || *err.Error.Code != "invalid_api_key" {
+		t.Fatalf("code = %v, want %q", err.Error.Code, "invalid_api_key")
+	}
+	if err.Error.Message != "Incorrect API key provided." {
+		t.Fatalf("message = %q, want byte-identical generic message", err.Error.Message)
+	}
+
+	// Internal half: the distinguishable cause must be visible in logs.
+	if !strings.Contains(logOutput, "key not found") {
+		t.Fatalf("expected resolution failure cause in internal log, got %q", logOutput)
+	}
+}
+
+// Companion case for the CheckAccess deny path (key found but revoked):
+// check.DenyMsg already differentiates this from a not-found/network failure
+// in the client message (pre-existing behavior, unchanged by this test), and
+// that same cause must now also land in the internal log.
+func TestAuthorizeLogsDeniedReasonForRevokedKey(t *testing.T) {
+	client := &Client{
+		ResolveOverride: func(_ context.Context, _ string) (AuthSnapshot, error) {
+			return AuthSnapshot{
+				KeyID:     "key-1",
+				AccountID: "acc-1",
+				Status:    "revoked",
+			}, nil
+		},
+	}
+
+	authorizer := NewAuthorizer(client, nil)
+
+	var err *apierrors.OpenAIError
+	logOutput := captureAuthzLogs(t, func() {
+		_, _, err = authorizer.Authorize(context.Background(), "Bearer hk_test", "hive-default", 50, 100, 20)
+	})
+
+	if err == nil {
+		t.Fatal("expected invalid_api_key error")
+	}
+	if err.Error.Code == nil || *err.Error.Code != "invalid_api_key" {
+		t.Fatalf("code = %v, want %q", err.Error.Code, "invalid_api_key")
+	}
+	if err.Error.Message != "Incorrect API key provided: API key is revoked" {
+		t.Fatalf("message = %q, want unchanged revoked message", err.Error.Message)
+	}
+
+	if !strings.Contains(logOutput, "revoked") {
+		t.Fatalf("expected revoked reason in internal log, got %q", logOutput)
+	}
+}
+
+func captureAuthzLogs(t *testing.T, fn func()) string {
+	t.Helper()
+
+	var buf bytes.Buffer
+	originalWriter := log.Writer()
+	originalFlags := log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	defer log.SetOutput(originalWriter)
+	defer log.SetFlags(originalFlags)
+
+	fn()
+	return buf.String()
 }
 
 func containsAny(s string, subs ...string) bool {


### PR DESCRIPTION
## Summary

Diagnosed today's CI red (2026-07-28) alongside this fix: `Live integration` and `deploy-demo-box`/`OWUI nightly` failures in the same window turned out to be independent, not one root cause. See the diagnosis comment below. This PR is the one concrete fix that came out of it: a real observability defect in `authz.Authorize`.

`authz.Authorize` deliberately collapses every key-resolution failure (not found, revoked, control-plane/network error) into the same generic `invalid_api_key` message for the caller. That is correct and unchanged here: it stops a caller from enumerating which keys exist. The bug is that the same collapse was happening server-side too. Neither the `Resolve()` error nor the `CheckAccess` deny reason (revoked/disabled/expired) was ever logged, so when the shared CI fixture key stopped resolving today, there was nothing in the logs to say why, and it cost a full rerun just to confirm the failure wasn't a flake.

## Changes

- `apps/edge-api/internal/authz/authorizer.go`: log the real cause on both paths (the `err` from `Resolve()`, and `check.DenyMsg` from `CheckAccess`) without touching either return statement, so the client-facing response stays byte-identical.
- `apps/edge-api/internal/authz/authorizer_test.go`: two new tests, each asserting both halves: the unchanged client message/code, and the distinguishable internal log signal (using a local log-capture helper, same pattern as `provider_blind_test.go`).

## Test plan

- [x] `go build ./apps/edge-api/...`
- [x] `go vet ./apps/edge-api/internal/authz/...`
- [x] `go test ./apps/edge-api/internal/authz/... -v -count=1` — all pass, including the two new tests
- [x] `go test ./apps/edge-api/... -count=1 -short` — full edge-api suite green, no regressions
- [x] `gofmt -l` on both modified files — clean (pre-existing gofmt drift in unrelated files in this package was left untouched)

All commands run in the repo's Docker toolchain per `CLAUDE.md`.