### PR TITLE
chore: broaden .dockerignore to other build-irrelevant artifact classes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -20,6 +20,18 @@
 # node_modules it installs for itself.
 **/node_modules
 **/.next
+
+# None of the below are ever COPYed by any Dockerfile in this repo; excluding
+# them shrinks every build context and removes other paths that could hit
+# the same class of stray-local-artifact collision as node_modules above.
 .git
 .pnpm-store
 **/.pnpm-store
+**/playwright-report*
+**/test-results
+.wolf
+
+# Built on a different host (linux/amd64 apptainer), never present in a
+# Docker build context on purpose, but if one is ever built locally it would
+# be several GB; excluded so a future build never accidentally ships it.
+**/*.sif


### PR DESCRIPTION
## Summary

Follow-up to #584 (merged). Broadens the root `.dockerignore` beyond the four exclusions needed to fix the chronic `deploy-demo-box` build failure, to cover other paths no Dockerfile in this repo ever needs.

## Changes

Adds to `.dockerignore`:
- `**/playwright-report*`, `**/test-results`: web-console/agent-console test output, never `COPY`ed by any Dockerfile.
- `.wolf`: agent bookkeeping, never `COPY`ed.
- `**/*.sif`: agent-engine's Apptainer image, built on a separate linux/amd64 host and several GB when present. Not currently on the demo box, excluded pre-emptively so a future local build never ships one by accident.

## Verification

Reproduced directly on the demo box via SSH: full `docker compose build` of every service (edge-api, control-plane, web-console, web-console-prod, agent-console, open-webui) still succeeds with these additions on top of #584's baseline four exclusions. No Dockerfile needs any of these paths, so this is a pure size/hygiene win with no behavior change to any image.

## Test plan

- [x] Full rebuild of all six services on the demo box succeeds with the broadened file