### PR TITLE
chore: guard against dangling LiteLLM fallback references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -480,6 +480,8 @@ jobs:
         run: npm run lint:proof-tokens
       - if: needs.changes.outputs.run != 'false'
         run: npm run lint:litellm-routing
+      - if: needs.changes.outputs.run != 'false'
+        run: npm run lint:litellm-config
 
   agent-console-unit:
     name: Agent console (type + unit + build)

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint:request-url-origin": "node tools/lint-no-request-url-origin.mjs",
     "lint:model-visibility": "node tools/lint-tenant-model-visibility-single-source.mjs",
     "lint:litellm-routing": "node tools/lint-litellm-dispatch-requires-routing.mjs",
+    "lint:litellm-config": "node tools/lint-litellm-config-fallbacks.mjs",
     "lint:proof-tokens": "node tools/lint-no-token-in-proof-captures.mjs",
     "soc2:report": "node tools/soc2-coverage-report.mjs",
     "soc2:check": "node tools/soc2-coverage-report.mjs --check",

--- a/tools/lint-litellm-config-fallbacks.mjs
+++ b/tools/lint-litellm-config-fallbacks.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+// Structural guard: every LiteLLM fallback target must be a real route.
+//
+// deploy/litellm/config.yaml's litellm_settings.fallbacks list reroutes a
+// failing model group to another one, e.g.
+//   - route-openrouter-embedding: [route-openrouter-embedding-fallback]
+// Both the source key and every name in its target array are model_name
+// values that must exist in model_list. A typo or a removed model_list entry
+// leaves a fallback pointing at nothing: LiteLLM only discovers this at
+// request time ("No fallback model group found for original
+// model_group=..."), after the primary route has already failed, which is
+// the worst possible moment to learn the safety net is missing.
+//
+// This does not flag a group with no fallback of its own (the last entry in
+// a cascade, e.g. route-openrouter-embedding-fallback today) -- that is a
+// deliberate terminal node, not a dangling reference. It only flags a
+// fallback list that NAMES a model_name absent from model_list.
+//
+// Mirrors the shape of the other tools/lint-*.mjs scanners: self-test first
+// so a broken detector fails loudly instead of turning this into a lint that
+// always passes.
+
+import { readFileSync } from "node:fs";
+import { parse } from "yaml";
+import assert from "node:assert/strict";
+
+const CONFIG_PATH = "deploy/litellm/config.yaml";
+
+// Returns the list of {source, target} pairs this config's fallbacks
+// declare, and the set of model_name values model_list actually defines.
+function extractFallbackRefs(doc) {
+  const modelNames = new Set(
+    (doc.model_list ?? []).map((entry) => entry.model_name),
+  );
+  const pairs = [];
+  for (const entry of doc.litellm_settings?.fallbacks ?? []) {
+    for (const [source, targets] of Object.entries(entry)) {
+      for (const target of targets) {
+        pairs.push({ source, target });
+      }
+    }
+  }
+  return { modelNames, pairs };
+}
+
+function findDanglingRefs(source) {
+  const doc = parse(source);
+  const { modelNames, pairs } = extractFallbackRefs(doc);
+  const dangling = [];
+  for (const { source: from, target: to } of pairs) {
+    if (!modelNames.has(from)) dangling.push(`fallback source '${from}' is not a model_list model_name`);
+    if (!modelNames.has(to)) dangling.push(`fallback target '${to}' (from '${from}') is not a model_list model_name`);
+  }
+  return dangling;
+}
+
+function selfTest() {
+  const valid = `
+model_list:
+  - model_name: route-a
+    litellm_params: {model: x}
+  - model_name: route-b
+    litellm_params: {model: y}
+litellm_settings:
+  fallbacks:
+    - route-a: [route-b]
+`;
+  assert.deepEqual(
+    findDanglingRefs(valid),
+    [],
+    "detector flags a fallback chain where every name resolves",
+  );
+
+  const danglingTarget = `
+model_list:
+  - model_name: route-a
+    litellm_params: {model: x}
+litellm_settings:
+  fallbacks:
+    - route-a: [route-a-fallback]
+`;
+  assert.equal(
+    findDanglingRefs(danglingTarget).length,
+    1,
+    "detector misses a fallback target absent from model_list",
+  );
+
+  const danglingSource = `
+model_list:
+  - model_name: route-b
+    litellm_params: {model: y}
+litellm_settings:
+  fallbacks:
+    - route-a: [route-b]
+`;
+  assert.equal(
+    findDanglingRefs(danglingSource).length,
+    1,
+    "detector misses a fallback source absent from model_list",
+  );
+
+  const terminalNodeIsFine = `
+model_list:
+  - model_name: route-a
+    litellm_params: {model: x}
+  - model_name: route-b
+    litellm_params: {model: y}
+litellm_settings:
+  fallbacks:
+    - route-a: [route-b]
+`;
+  // route-b has no fallback of its own -- a deliberate terminal node, not a
+  // defect, and must not be flagged.
+  assert.deepEqual(
+    findDanglingRefs(terminalNodeIsFine),
+    [],
+    "detector wrongly flags a terminal fallback node (one with no fallback of its own)",
+  );
+}
+
+selfTest();
+if (process.argv.includes("--self-test")) {
+  console.log("lint-litellm-config-fallbacks: SELF-TEST PASS");
+  process.exit(0);
+}
+
+const dangling = findDanglingRefs(readFileSync(CONFIG_PATH, "utf8"));
+if (dangling.length > 0) {
+  console.error(`${CONFIG_PATH}: dangling LiteLLM fallback reference(s):`);
+  for (const msg of dangling) console.error(`  - ${msg}`);
+  console.error(
+    "\n  Every fallback source and target must be a model_name defined in model_list.\n" +
+      "  Fix the typo, or add/restore the missing model_list entry.",
+  );
+  process.exit(1);
+}
+console.log("lint-litellm-config-fallbacks: PASS");


### PR DESCRIPTION
## Summary

Investigated a production error found in the demo box's live LiteLLM logs (not filed as an issue, not in any PR):

```
litellm.UnsupportedParamsError: Setting dimensions is not supported for OpenAI
`text-embedding-3` and later models. To drop it from the call, set litellm.drop_params = True.
No fallback model group found for original model_group=route-openrouter-embedding-fallback.
```

**RAG embedding is not currently broken on the demo box.** Both log lines trace to a single, already-fixed, historical cause, not two live defects.

## What actually happened

All 112 occurrences of this error cluster in a roughly one-minute window on 2026-07-26 13:37 to 13:38, immediately followed by a successful `POST /embeddings 200 OK` at 13:39:42, and zero recurrences in the two days since (confirmed with successful embeddings later that same day and no further errors of any kind through the present).

Root cause: the demo box was mid-rollout of the commit (`c7b967f3`, merged 2026-07-26 12:56, ~41 minutes before the error burst) that stopped `apps/edge-api/internal/rag/embed.go` and `apps/control-plane/internal/rag/ingest.go` from sending a `dimensions` field to LiteLLM's embedding routes. Per decision D-001, the embedding model and its dimension are admin-selectable and any MRL reduction happens client-side (`reduceEmbedding`), never via LiteLLM's `dimensions` request parameter, specifically because LiteLLM's generic `openai/` adapter (how every OpenRouter embedding route is declared) rejects `dimensions` outright for anything it doesn't recognize as `text-embedding-3`-or-later, ignoring `drop_params`.

The stale pre-fix binary was still serving requests for about a minute during rollout, so it sent `dimensions` on every embedding call. That single cause cascaded through the whole fallback chain (`route-openrouter-embedding` to `route-openrouter-embedding-fallback`), and when the terminal node in that chain also failed, LiteLLM logs "No fallback model group found" because a terminal node deliberately has no fallback of its own, that message is not evidence of a second, independent defect.

Confirmed `route-openrouter-embedding-fallback` IS a real, defined `model_name` in `deploy/litellm/config.yaml`'s `model_list`, so there is no actual dangling reference in the current config. Grepped the RAG and embedmodel packages: no code path constructs a `dimensions` field anywhere outside test files that assert it is absent.

## What this PR ships

Since there's no live bug to fix, this ships the hardening asked for: a guard so a *real* dangling fallback reference (the class of defect this looked like at first) cannot ship silently in the future.

- `tools/lint-litellm-config-fallbacks.mjs`: parses `deploy/litellm/config.yaml` and fails if any `litellm_settings.fallbacks` source or target name is not a `model_name` defined in `model_list`. Does not flag a terminal node (a group with no fallback of its own), only a name that resolves to nothing.
- Wired into the same `repo-policy-lints` CI job as the existing `lint:litellm-routing` check (added by #573), via the same `npm run lint:*` pattern, rather than a new mechanism.
- Self-test embedded in the script (same shape as the other `tools/lint-*.mjs` scanners): proves the detector catches a dangling source, a dangling target, and does not false-positive on a valid terminal node.

## Test plan

- [x] `node tools/lint-litellm-config-fallbacks.mjs --self-test` passes
- [x] `node tools/lint-litellm-config-fallbacks.mjs` passes clean against the real `deploy/litellm/config.yaml`
- [x] Manually mutated a copy of the real config to introduce a dangling target and confirmed the detector fires
- [x] Confirmed via `docker logs --timestamps litellm` on the demo box that the error has not recurred since 2026-07-26 13:38, with successful embedding calls both immediately after and later the same day