### PR TITLE
fix: point PR-cleanup purge job at the transaction-mode pooler

### DIFF
--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -31,7 +31,16 @@ jobs:
         env:
           HIVE_API_KEY: ${{ secrets.HIVE_API_KEY }}
           PGHOST: ${{ secrets.SUPABASE_DB_HOST }}
-          PGPORT: ${{ secrets.SUPABASE_DB_PORT }}
+          # 6543, not secrets.SUPABASE_DB_PORT (5432, session mode). This job
+          # only ever runs single ad-hoc statements or short BEGIN/COMMIT
+          # blocks, never a long-lived session, so it fits Supavisor's
+          # transaction-mode pooler exactly: the server connection returns to
+          # the pool after each transaction instead of being held for the
+          # job's whole 10-minute timeout window. Session mode's pool is a
+          # shared 15-client ceiling with every other job hitting this same
+          # project; this job failing with EMAXCONNSESSION under load is what
+          # sent it here in the first place, see issue tracking the pool.
+          PGPORT: 6543
           PGUSER: ${{ secrets.SUPABASE_DB_USER }}
           PGDATABASE: ${{ secrets.SUPABASE_DB_NAME }}
           PGPASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
@@ -70,7 +79,7 @@ jobs:
         id: paths
         env:
           PGHOST: ${{ secrets.SUPABASE_DB_HOST }}
-          PGPORT: ${{ secrets.SUPABASE_DB_PORT }}
+          PGPORT: 6543
           PGUSER: ${{ secrets.SUPABASE_DB_USER }}
           PGDATABASE: ${{ secrets.SUPABASE_DB_NAME }}
           PGPASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
@@ -126,7 +135,7 @@ jobs:
         if: steps.keys.outputs.skip != '1'
         env:
           PGHOST: ${{ secrets.SUPABASE_DB_HOST }}
-          PGPORT: ${{ secrets.SUPABASE_DB_PORT }}
+          PGPORT: 6543
           PGUSER: ${{ secrets.SUPABASE_DB_USER }}
           PGDATABASE: ${{ secrets.SUPABASE_DB_NAME }}
           PGPASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}


### PR DESCRIPTION
## Summary

The "Purge CI test data + branch" job (`pr-cleanup.yml`) connects on port 5432, Supavisor's session-mode pooler, shared across every CI job and capped at `pool_size: 15`. Confirmed failing under load:

```
FATAL: (EMAXCONNSESSION) max clients reached in session mode - max clients are limited to pool_size: 15
```

This job never holds a session across statements: each step is a handful of ad hoc `psql -c` queries or a single explicit `BEGIN; ... COMMIT;` block. It never needed session mode, and failing under exactly the load conditions that make cleanup most necessary meant CI test data accumulated instead of being purged, growing the collision surface for `Web E2E` fixture rows.

## Fix

`PGPORT: 6543` (transaction mode) instead of `${{ secrets.SUPABASE_DB_PORT }}` (5432, session mode), in all three steps that connect. The pooled connection is returned after each statement or transaction instead of held for the job's run, so it stops competing for the same 15-client ceiling every other job shares.

No other behavior change. The job's SQL has no prepared statements, no `LISTEN`/`NOTIFY`, no advisory locks held across statements, nothing that requires a persistent session, so transaction-mode pooling is a strict fit, not a compromise.

Scoped to this one workflow only. `secrets.SUPABASE_DB_PORT` (session mode) is untouched everywhere else it is used; apps with their own connection pools (control-plane, edge-api) have different requirements and are out of scope here.

## Test plan
- [ ] Next merged/closed PR's `Purge CI test data + branch` job connects and completes without `EMAXCONNSESSION`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized the database connection port used during automated cleanup tasks.
  * Continued cleanup of temporary CI-related database records and storage data after pull requests are closed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->