### PR TITLE
fix: stop the session-mode pooler ceiling blocking deploys, purge and nightly

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,43 @@ SUPABASE_URL=https://<PROJECT_REF>.supabase.co
 SUPABASE_ANON_KEY=
 SUPABASE_SERVICE_ROLE_KEY=
 SUPABASE_DB_URL=
+#
+# SUPABASE_DB_POOL_URL is the same database reached through Supavisor's
+# TRANSACTION-mode port, 6543, instead of the SESSION-mode port, 5432. Optional:
+# leave it blank and every service falls back to SUPABASE_DB_URL, which is the
+# right thing for a local or enterprise stack talking to a direct Postgres.
+#
+# Set it for any deployment pointed at a hosted Supabase pooler, because session
+# mode is where the ceiling is. A session-mode client holds one server connection
+# for its whole session, so the number of clients that can connect at once equals
+# the project's pool_size, which is 15 on this project. Everything shares that
+# one number: the demo stack, every CI job that boots a stack, the CI purge job
+# and any one-off psql. Exceeding it returns
+# `FATAL: (EMAXCONNSESSION) max clients reached in session mode`, which has taken
+# the live chat surface down and has blocked deploys, the purge job and the OWUI
+# nightly. Transaction-mode clients are multiplexed over the same server
+# connections and are bounded instead by the far higher per-tier "max pooler
+# clients" limit, so they cost no session slot.
+#
+# Who uses which, and why it is not a free swap:
+#   * control-plane        session mode only. It holds a connection open for the
+#                          process lifetime on LISTEN tenant_settings_changed and
+#                          takes a session-scoped pg_advisory_lock across a whole
+#                          credit reservation. Transaction mode breaks both
+#                          silently, so platformdb.Open refuses port 6543.
+#   * edge-api             transaction mode. Only pg_advisory_xact_lock and
+#                          SET LOCAL, both transaction scoped.
+#   * open-webui pgvector  transaction mode. psycopg2, no server-side prepared
+#                          statements, no session state.
+#
+# Both DSNs should carry an explicit `pool_max_conns`. Without it pgxpool
+# defaults to max(4, NumCPU), so the session budget silently tracks the host's
+# core count and two Go services on an 8-core box can reserve 16 of the 15 slots
+# between them. Generate the pair with:
+#
+#   python3 scripts/derive-pooler-dsn.py --dsn "$SUPABASE_DB_URL"
+#
+SUPABASE_DB_POOL_URL=
 SUPABASE_JWT_ISSUER=https://<PROJECT_REF>.supabase.co/auth/v1
 SUPABASE_JWT_AUDIENCE=authenticated
 SUPABASE_JWKS_URL=https://<PROJECT_REF>.supabase.co/auth/v1/.well-known/jwks.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -689,12 +689,18 @@ jobs:
           SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
         run: |
           set -euo pipefail
-          # Password is stored in its raw decoded form — URL-encode it here so the
-          # resulting URL round-trips through pgx/pgconn URL parsing correctly.
-          ENC_PW=$(python3 -c 'import os,urllib.parse as u; print(u.quote(os.environ["SUPABASE_DB_PASSWORD"], safe=""))')
-          url="postgresql://${SUPABASE_DB_USER}:${ENC_PW}@${SUPABASE_DB_HOST}:${SUPABASE_DB_PORT}/${SUPABASE_DB_NAME}"
-          echo "SUPABASE_DB_URL=$url" >> "$GITHUB_ENV"
-          echo "reconstructed DB URL (host=${SUPABASE_DB_HOST}, port=${SUPABASE_DB_PORT}, user=${SUPABASE_DB_USER}, db=${SUPABASE_DB_NAME})"
+          # The script URL-encodes the password, which is stored in its raw
+          # decoded form, and emits both DSNs: a capped session-mode
+          # SUPABASE_DB_URL for control-plane, which needs session state, and a
+          # transaction-mode SUPABASE_DB_POOL_URL for edge-api and open-webui,
+          # which do not. Session-mode clients are capped at the project's
+          # pool_size of 15 and shared with the live demo stack, so a CI job that
+          # booted a stack on session mode alone could take chat-hive offline.
+          python3 scripts/derive-pooler-dsn.py --self-test
+          python3 scripts/derive-pooler-dsn.py \
+            --host "$SUPABASE_DB_HOST" --port "$SUPABASE_DB_PORT" \
+            --user "$SUPABASE_DB_USER" --dbname "$SUPABASE_DB_NAME" \
+            --password "$SUPABASE_DB_PASSWORD" >> "$GITHUB_ENV"
 
       - name: Pre-verify secrets reached runner env
         shell: bash
@@ -968,9 +974,16 @@ jobs:
           SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
         run: |
           set -euo pipefail
-          ENC_PW=$(python3 -c 'import os,urllib.parse as u; print(u.quote(os.environ["SUPABASE_DB_PASSWORD"], safe=""))')
-          url="postgresql://${SUPABASE_DB_USER}:${ENC_PW}@${SUPABASE_DB_HOST}:${SUPABASE_DB_PORT}/${SUPABASE_DB_NAME}"
-          echo "SUPABASE_DB_URL=$url" >> "$GITHUB_ENV"
+          # Emits a capped session-mode SUPABASE_DB_URL for control-plane and a
+          # transaction-mode SUPABASE_DB_POOL_URL for edge-api and open-webui.
+          # Session-mode clients are capped at the project's pool_size of 15 and
+          # shared with the live demo stack, so a CI job that booted a stack on
+          # session mode alone could take chat-hive offline.
+          python3 scripts/derive-pooler-dsn.py --self-test
+          python3 scripts/derive-pooler-dsn.py \
+            --host "$SUPABASE_DB_HOST" --port "$SUPABASE_DB_PORT" \
+            --user "$SUPABASE_DB_USER" --dbname "$SUPABASE_DB_NAME" \
+            --password "$SUPABASE_DB_PASSWORD" >> "$GITHUB_ENV"
 
       - name: Cache third-party images (redis, litellm)
         id: img-cache

--- a/.github/workflows/deploy-demo-box.yml
+++ b/.github/workflows/deploy-demo-box.yml
@@ -52,6 +52,36 @@ jobs:
           git fetch origin
           git pull --ff-only origin main
 
+      - name: Derive the pooler DSN split from the box's own .env
+        # The box's .env holds one SUPABASE_DB_URL, pointing at Supavisor's
+        # SESSION-mode port. Session-mode clients are 1:1 with server
+        # connections and capped at the project's pool_size of 15, shared by
+        # this stack, every CI job that boots a stack, the purge job and any
+        # one-off psql. That is why recreating open-webui here has been failing
+        # with EMAXCONNSESSION while the build itself succeeded.
+        #
+        # Derive both DSNs from that single value rather than adding a secret or
+        # editing the box's .env: a capped session DSN for control-plane, which
+        # needs session state, and a transaction-mode DSN for everyone who does
+        # not. Shell environment beats --env-file in compose interpolation, so
+        # exporting them here is enough for the compose file to pick them up.
+        working-directory: /home/sakib/hive
+        run: |
+          set -euo pipefail
+          existing=$(grep -E '^SUPABASE_DB_URL=' .env | head -1 | cut -d= -f2-)
+          # A hand-edited .env may quote the value; the DSN parser must not see
+          # the quotes.
+          existing="${existing%\"}"; existing="${existing#\"}"
+          existing="${existing%\'}"; existing="${existing#\'}"
+          if [ -z "$existing" ]; then
+            echo "::error::SUPABASE_DB_URL is missing or empty in the box's .env"
+            exit 1
+          fi
+          python3 scripts/derive-pooler-dsn.py --self-test
+          # stdout is the KEY=value pairs; the script logs a password-free
+          # host/port/params summary on stderr.
+          python3 scripts/derive-pooler-dsn.py --dsn "$existing" >> "$GITHUB_ENV"
+
       - name: Rebuild + recreate changed services
         # `--build` only rebuilds layers whose inputs changed (Docker build
         # cache), so this is cheap even though no service list is scoped out.

--- a/.github/workflows/owui-nightly.yml
+++ b/.github/workflows/owui-nightly.yml
@@ -49,12 +49,18 @@ jobs:
               exit 1
             fi
           done
-          # Password is stored in its raw decoded form — URL-encode it here so the
-          # resulting URL round-trips through pgx/pgconn URL parsing correctly.
-          ENC_PW=$(python3 -c 'import os,urllib.parse as u; print(u.quote(os.environ["SUPABASE_DB_PASSWORD"], safe=""))')
-          url="postgresql://${SUPABASE_DB_USER}:${ENC_PW}@${SUPABASE_DB_HOST}:${SUPABASE_DB_PORT}/${SUPABASE_DB_NAME}"
-          echo "SUPABASE_DB_URL=$url" >> "$GITHUB_ENV"
-          echo "reconstructed DB URL (host=${SUPABASE_DB_HOST}, port=${SUPABASE_DB_PORT}, user=${SUPABASE_DB_USER}, db=${SUPABASE_DB_NAME})"
+          # The script URL-encodes the password, which is stored in its raw
+          # decoded form, and emits both DSNs: a capped session-mode
+          # SUPABASE_DB_URL for control-plane, which needs session state, and a
+          # transaction-mode SUPABASE_DB_POOL_URL for edge-api and open-webui,
+          # which do not. This job booting its whole stack on session mode is
+          # what exhausted the 15-client pool and failed 12 consecutive nightly
+          # runs from 2026-07-26.
+          python3 scripts/derive-pooler-dsn.py --self-test
+          python3 scripts/derive-pooler-dsn.py \
+            --host "$SUPABASE_DB_HOST" --port "$SUPABASE_DB_PORT" \
+            --user "$SUPABASE_DB_USER" --dbname "$SUPABASE_DB_NAME" \
+            --password "$SUPABASE_DB_PASSWORD" >> "$GITHUB_ENV"
       - name: Seed OWUI e2e test user
         # Self-provisions the owui-e2e tenant, GoTrue user, membership, and a
         # real "hk_" Hive API key used as OWUI_SHIM_KEY (idempotent, password
@@ -136,6 +142,7 @@ jobs:
         run: |
           set -euo pipefail
           for v in SUPABASE_URL SUPABASE_ANON_KEY SUPABASE_SERVICE_ROLE_KEY SUPABASE_DB_URL \
+                   SUPABASE_DB_POOL_URL \
                    S3_ENDPOINT S3_ACCESS_KEY S3_SECRET_KEY S3_REGION \
                    OPENROUTER_API_KEY GROQ_API_KEY OWUI_SHIM_KEY; do
             val="${!v:-}"
@@ -149,6 +156,7 @@ jobs:
           SUPABASE_ANON_KEY=${SUPABASE_ANON_KEY}
           SUPABASE_SERVICE_ROLE_KEY=${SUPABASE_SERVICE_ROLE_KEY}
           SUPABASE_DB_URL=${SUPABASE_DB_URL}
+          SUPABASE_DB_POOL_URL=${SUPABASE_DB_POOL_URL}
           SUPABASE_JWT_ISSUER=${SUPABASE_URL}/auth/v1
           SUPABASE_JWT_AUDIENCE=authenticated
           SUPABASE_JWKS_URL=${SUPABASE_URL}/auth/v1/.well-known/jwks.json

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -26,12 +26,32 @@ jobs:
           sudo apt-get install -y -qq postgresql-client jq
           python3 -m pip install --quiet --upgrade awscli
 
+      - name: Pick the transaction-mode pooler port
+        # This job is short lived and needs no session state, so it has no
+        # business holding one of the project's 15 session-mode client slots.
+        # Those slots are shared with the live demo stack, and this job failing
+        # on EMAXCONNSESSION means CI fixture rows are never purged, which grows
+        # the shared-fixture surface and drives more contention: a closed loop.
+        # A direct Postgres serves every mode on its one port, so only a
+        # Supavisor pooler host gets the 6543 override.
+        env:
+          PGHOST: ${{ secrets.SUPABASE_DB_HOST }}
+          PGPORT: ${{ secrets.SUPABASE_DB_PORT }}
+        run: |
+          set -euo pipefail
+          port="$PGPORT"
+          case "$PGHOST" in
+            *.pooler.supabase.com) port=6543 ;;
+          esac
+          echo "PG_POOL_PORT=$port" >> "$GITHUB_ENV"
+          echo "psql will connect to $PGHOST:$port"
+
       - name: Resolve CI api_key_id + account_id
         id: keys
         env:
           HIVE_API_KEY: ${{ secrets.HIVE_API_KEY }}
           PGHOST: ${{ secrets.SUPABASE_DB_HOST }}
-          PGPORT: ${{ secrets.SUPABASE_DB_PORT }}
+          PGPORT: ${{ env.PG_POOL_PORT }}
           PGUSER: ${{ secrets.SUPABASE_DB_USER }}
           PGDATABASE: ${{ secrets.SUPABASE_DB_NAME }}
           PGPASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
@@ -70,7 +90,7 @@ jobs:
         id: paths
         env:
           PGHOST: ${{ secrets.SUPABASE_DB_HOST }}
-          PGPORT: ${{ secrets.SUPABASE_DB_PORT }}
+          PGPORT: ${{ env.PG_POOL_PORT }}
           PGUSER: ${{ secrets.SUPABASE_DB_USER }}
           PGDATABASE: ${{ secrets.SUPABASE_DB_NAME }}
           PGPASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
@@ -126,7 +146,7 @@ jobs:
         if: steps.keys.outputs.skip != '1'
         env:
           PGHOST: ${{ secrets.SUPABASE_DB_HOST }}
-          PGPORT: ${{ secrets.SUPABASE_DB_PORT }}
+          PGPORT: ${{ env.PG_POOL_PORT }}
           PGUSER: ${{ secrets.SUPABASE_DB_USER }}
           PGDATABASE: ${{ secrets.SUPABASE_DB_NAME }}
           PGPASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}

--- a/apps/control-plane/internal/platform/db/pool.go
+++ b/apps/control-plane/internal/platform/db/pool.go
@@ -7,14 +7,54 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
+// transactionPoolerPort is Supavisor's transaction-mode port. Session mode is
+// served on 5432 only (Supabase deprecated session mode on 6543 in February
+// 2025), so this port is unambiguous.
+const transactionPoolerPort = 6543
+
 // Open creates and validates a pgxpool connection using the provided database URL.
 // Returns an error if the URL is empty or the connection cannot be established.
+//
+// Pool size and query-exec mode come from the DSN (`pool_max_conns`,
+// `default_query_exec_mode`) rather than being set here, so a deployment can
+// budget its share of the shared Supavisor session-mode pool without a rebuild.
+// See scripts/derive-pooler-dsn.py for how those DSNs are produced and why the
+// budget matters.
 func Open(ctx context.Context, databaseURL string) (*pgxpool.Pool, error) {
 	if databaseURL == "" {
 		return nil, fmt.Errorf("database URL is empty; set SUPABASE_DB_URL")
 	}
 
-	pool, err := pgxpool.New(ctx, databaseURL)
+	cfg, err := pgxpool.ParseConfig(databaseURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse database URL: %w", err)
+	}
+
+	// Control-plane cannot run against a transaction-mode pooler, and the
+	// failure would be silent rather than loud: both users of session-scoped
+	// state keep working well enough to look healthy.
+	//
+	//   - settings.Resolver.StartListener holds one connection open for the
+	//     life of the process on `LISTEN tenant_settings_changed`. Transaction
+	//     mode returns the connection after each transaction, so notifications
+	//     stop arriving and every instance quietly serves stale tenant settings
+	//     from cache.
+	//   - accounting.PgxAccountLocker takes `pg_advisory_lock`, which is
+	//     session scoped, and holds it across a whole credit reservation. If the
+	//     connection can be handed to another client mid-reservation then the
+	//     lock serialises nothing, so two concurrent reservations against one
+	//     account can both proceed.
+	//
+	// Startup is the only place this is cheap to notice. edge-api has neither
+	// dependency and is expected to use transaction mode.
+	if cfg.ConnConfig.Port == transactionPoolerPort {
+		return nil, fmt.Errorf(
+			"database URL targets the transaction-mode pooler (port %d); control-plane requires session mode (port 5432) for LISTEN tenant_settings_changed and for session-scoped pg_advisory_lock",
+			transactionPoolerPort,
+		)
+	}
+
+	pool, err := pgxpool.NewWithConfig(ctx, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create db pool: %w", err)
 	}

--- a/apps/control-plane/internal/platform/db/pool_test.go
+++ b/apps/control-plane/internal/platform/db/pool_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/platform/db"
 )
 
@@ -51,6 +53,74 @@ func TestOpen_UnreachableHost(t *testing.T) {
 	if pool != nil {
 		pool.Close()
 		t.Fatal("expected nil pool when ping fails")
+	}
+}
+
+// TestOpen_RefusesTransactionModePooler pins the one mode control-plane cannot
+// run in. It holds a permanent connection on LISTEN tenant_settings_changed and
+// takes a session-scoped pg_advisory_lock across a whole credit reservation;
+// under transaction mode both keep looking healthy while silently doing nothing,
+// so refusing at startup is the only cheap signal. The DSN below is unreachable,
+// which is the point: the refusal must happen before any network call.
+func TestOpen_RefusesTransactionModePooler(t *testing.T) {
+	ctx := context.Background()
+	pool, err := db.Open(ctx, "postgresql://u:p@aws-1-us-east-1.pooler.supabase.com:6543/postgres")
+	if err == nil {
+		pool.Close()
+		t.Fatal("expected Open to refuse a transaction-mode DSN, got nil")
+	}
+	if pool != nil {
+		pool.Close()
+		t.Fatal("expected nil pool when the pooler mode is wrong")
+	}
+	// The message has to name the cause, or the next person sees only a
+	// connection error and starts debugging the network.
+	for _, want := range []string{"transaction-mode", "session mode", "LISTEN", "pg_advisory_lock"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error should name %q, got: %v", want, err)
+		}
+	}
+}
+
+// TestPoolerDSNCarriesBudgetAndExecMode asserts pgx honours the two DSN
+// parameters the pooler budget is expressed with. They live in the DSN rather
+// than in code so a deployment can resize without a rebuild, which only works
+// while pgx keeps parsing them. If a pgx upgrade dropped either one, both Go
+// services would silently revert to pgxpool's default of max(4, NumCPU)
+// connections each and re-exhaust the 15-client session-mode pooler.
+func TestPoolerDSNCarriesBudgetAndExecMode(t *testing.T) {
+	sessionDSN := "postgresql://u:p@aws-1-us-east-1.pooler.supabase.com:5432/postgres?pool_max_conns=6"
+	cfg, err := pgxpool.ParseConfig(sessionDSN)
+	if err != nil {
+		t.Fatalf("parse session DSN: %v", err)
+	}
+	if cfg.MaxConns != 6 {
+		t.Errorf("session MaxConns: want 6 got %d", cfg.MaxConns)
+	}
+	if cfg.ConnConfig.DefaultQueryExecMode != pgx.QueryExecModeCacheStatement {
+		t.Errorf("session exec mode: want the pgx default of cache statement, got %v",
+			cfg.ConnConfig.DefaultQueryExecMode)
+	}
+
+	transactionDSN := "postgresql://u:p@aws-1-us-east-1.pooler.supabase.com:6543/postgres?pool_max_conns=8&default_query_exec_mode=exec"
+	cfg, err = pgxpool.ParseConfig(transactionDSN)
+	if err != nil {
+		t.Fatalf("parse transaction DSN: %v", err)
+	}
+	if cfg.MaxConns != 8 {
+		t.Errorf("transaction MaxConns: want 8 got %d", cfg.MaxConns)
+	}
+	// Transaction mode cannot carry a prepared statement across the connection
+	// it was prepared on, so pgx has to stop caching them.
+	if cfg.ConnConfig.DefaultQueryExecMode != pgx.QueryExecModeExec {
+		t.Errorf("transaction exec mode: want exec got %v", cfg.ConnConfig.DefaultQueryExecMode)
+	}
+	// Neither may survive as a server runtime parameter, or every connection
+	// would fail with "unrecognized configuration parameter".
+	for _, unwanted := range []string{"pool_max_conns", "default_query_exec_mode"} {
+		if _, ok := cfg.ConnConfig.RuntimeParams[unwanted]; ok {
+			t.Errorf("%q leaked into server runtime params", unwanted)
+		}
 	}
 }
 

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -23,7 +23,16 @@ services:
       # SUPABASE_DB_URL: For the enterprise profile set this to the local DSN:
       #   postgres://postgres:<ENTERPRISE_DB_PASSWORD>@supabase-db:5432/postgres
       # For cloud/local profiles set this to the hosted Supabase DB URL.
-      SUPABASE_DB_URL: ${SUPABASE_DB_URL}
+      #
+      # edge-api prefers the TRANSACTION-mode pooler when one is configured.
+      # Session-mode clients are capped at the project's pool_size of 15 and
+      # every consumer shares that ceiling, so a service that does not need
+      # session state should not hold a slot. edge-api only ever takes
+      # pg_advisory_xact_lock and SET LOCAL, both transaction scoped, so it is
+      # safe here. control-plane is not; see its own SUPABASE_DB_URL below.
+      # Unset SUPABASE_DB_POOL_URL falls back to the session DSN, so an
+      # enterprise or local Postgres deployment behaves exactly as before.
+      SUPABASE_DB_URL: ${SUPABASE_DB_POOL_URL:-${SUPABASE_DB_URL}}
       S3_ENDPOINT: ${S3_ENDPOINT}
       S3_ACCESS_KEY: ${S3_ACCESS_KEY}
       S3_SECRET_KEY: ${S3_SECRET_KEY}
@@ -271,6 +280,14 @@ services:
       SUPABASE_SERVICE_ROLE_KEY: ${SUPABASE_SERVICE_ROLE_KEY}
       # Enterprise profile: set to local Postgres DSN:
       #   postgres://postgres:<ENTERPRISE_DB_PASSWORD>@supabase-db:5432/postgres
+      #
+      # Deliberately the SESSION-mode DSN, never SUPABASE_DB_POOL_URL.
+      # control-plane holds one connection open for the process lifetime on
+      # LISTEN tenant_settings_changed, and takes a session-scoped
+      # pg_advisory_lock that it holds across a whole credit reservation. Under
+      # a transaction-mode pooler both keep looking healthy while doing nothing.
+      # platformdb.Open refuses port 6543 outright so this cannot be changed by
+      # accident.
       SUPABASE_DB_URL: ${SUPABASE_DB_URL}
       REDIS_URL: ${REDIS_URL}
       # Enterprise profile: set to local Storage endpoint:
@@ -641,7 +658,18 @@ services:
       # authenticate at all (see scripts/seed-owui-e2e-user.py).
       RAG_EMBEDDING_MODEL: ${OWUI_RAG_EMBEDDING_ALIAS:-hive-embedding-default}
       VECTOR_DB: "pgvector"
-      PGVECTOR_DB_URL: ${SUPABASE_DB_URL:-}
+      # TRANSACTION-mode pooler when one is configured. This is the connection
+      # that has actually been failing: a recreated open-webui could not get a
+      # session-mode client (FATAL: (EMAXCONNSESSION) max clients reached in
+      # session mode, pool_size 15) because the Go services and CI had already
+      # taken the slots, so the container crash-looped and took chat-hive with
+      # it. Both users of this DSN are safe under transaction mode: SQLAlchemy
+      # here talks to pgvector through psycopg2, which uses no server-side
+      # prepared statements, and the #457 tenant-role patch
+      # (owui-patches/tenant_role_from_db.py) opens and closes its own psycopg2
+      # connection per login with no session state. Unset falls back to the
+      # session DSN, so local and enterprise stacks are unaffected.
+      PGVECTOR_DB_URL: ${SUPABASE_DB_POOL_URL:-${SUPABASE_DB_URL:-}}
       RAG_TOP_K: "5"
       ENABLE_RAG_HYBRID_SEARCH: "true"
       DATA_DIR: "/data"

--- a/scripts/derive-pooler-dsn.py
+++ b/scripts/derive-pooler-dsn.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Derive the session-mode and transaction-mode Supabase pooler DSNs from one input.
+
+Why this exists
+---------------
+`SUPABASE_DB_URL` points at Supavisor on port 5432, which is SESSION mode. In
+session mode a client holds one server connection for its whole session, so the
+number of clients that can connect at once equals the project's `pool_size`,
+which is 15. Every consumer shares that one ceiling: the demo stack
+(control-plane, edge-api, open-webui), every CI job that boots a stack, the
+`Purge CI test data` job, and any one-off `psql`. When the ceiling is hit the
+pooler answers `FATAL: (EMAXCONNSESSION) max clients reached in session mode`,
+which has taken down the live chat surface, `deploy-demo-box`, the purge job and
+the OWUI nightly.
+
+Port 6543 is TRANSACTION mode. There, clients are multiplexed over the same
+server connections and are instead bounded by the much higher per-tier
+"max pooler clients" limit, so a transaction-mode consumer costs no session
+slot at all. The catch is that transaction mode drops session-scoped features:
+prepared statements, `LISTEN`/`NOTIFY` and session-scoped advisory locks.
+
+So the split is by what a consumer actually needs, not by convenience:
+
+* control-plane MUST stay session mode. It holds one connection permanently for
+  `LISTEN tenant_settings_changed`, and `accounting.PgxAccountLocker` takes a
+  session-scoped `pg_advisory_lock` that it holds across a whole credit
+  reservation. Both break silently under transaction mode.
+* edge-api, open-webui's pgvector store, the purge job and one-off tooling need
+  none of that, so they belong on transaction mode. edge-api's DSN therefore
+  carries `default_query_exec_mode=exec`, which stops pgx using prepared
+  statements.
+
+Both DSNs also carry an explicit `pool_max_conns`. Without it pgxpool defaults to
+`max(4, NumCPU)`, so the session-mode budget silently tracks the host's core
+count: two Go services on an 8-core box would reserve 16 of the 15 slots between
+them and leave nothing for Open WebUI, which is exactly the observed failure.
+An explicit cap makes the budget a property of the deployment rather than of
+whatever hardware it lands on.
+
+Usage
+-----
+    derive-pooler-dsn.py --dsn "postgresql://user:pw@host:5432/postgres"
+    derive-pooler-dsn.py --host H --port 5432 --user U --dbname D --password P
+    derive-pooler-dsn.py --self-test
+
+Prints two `KEY=value` lines, ready to append to $GITHUB_ENV:
+
+    SUPABASE_DB_URL=...        session mode, capped
+    SUPABASE_DB_POOL_URL=...   transaction mode, capped, no prepared statements
+
+A host that is not a Supavisor pooler (a direct Postgres, as the enterprise
+profile uses) has no transaction-mode port, so its port is left alone and both
+values keep it. The cap still applies.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from urllib.parse import parse_qsl, quote, urlencode, urlsplit, urlunsplit
+
+# Supavisor's fixed port pair. Session mode is 5432 only: Supabase deprecated
+# session mode on 6543 in February 2025, so 6543 is unambiguously transaction
+# mode.
+SESSION_PORT = 5432
+TRANSACTION_PORT = 6543
+
+# Session slots are a hard 15 shared by everything, so control-plane gets a
+# budget rather than the whole pool. Six covers the permanent LISTEN connection
+# plus normal query traffic plus a held account advisory lock, and leaves room
+# for a second control-plane instance and any transient psql.
+SESSION_MAX_CONNS = 6
+
+# Transaction-mode clients are multiplexed, so this bound is only about not
+# stampeding the upstream server connections.
+TRANSACTION_MAX_CONNS = 8
+
+
+def is_pooler_host(host: str) -> bool:
+    """Report whether host is a Supavisor pooler, which is what has two ports."""
+    return host.lower().endswith(".pooler.supabase.com")
+
+
+def with_params(dsn: str, **params: str) -> str:
+    """Return dsn with params set, preserving any the caller already supplied."""
+    parts = urlsplit(dsn)
+    query = dict(parse_qsl(parts.query, keep_blank_values=True))
+    for key, value in params.items():
+        # An explicit value already in the DSN wins: the deployment knows
+        # something this script does not.
+        query.setdefault(key, value)
+    return urlunsplit(parts._replace(query=urlencode(query)))
+
+
+def with_port(dsn: str, port: int) -> str:
+    parts = urlsplit(dsn)
+    if parts.hostname is None:
+        raise ValueError(f"DSN has no host: {dsn!r}")
+    netloc = ""
+    if parts.username:
+        netloc += parts.username
+        if parts.password:
+            netloc += f":{parts.password}"
+        netloc += "@"
+    host = parts.hostname
+    if ":" in host:  # bare IPv6 literal
+        host = f"[{host}]"
+    netloc += f"{host}:{port}"
+    return urlunsplit(parts._replace(netloc=netloc))
+
+
+def derive(dsn: str) -> tuple[str, str]:
+    """Return (session_dsn, transaction_dsn) for one input DSN."""
+    parts = urlsplit(dsn)
+    host = parts.hostname
+    if not host:
+        raise ValueError(f"DSN has no host: {dsn!r}")
+
+    session = with_params(dsn, pool_max_conns=str(SESSION_MAX_CONNS))
+
+    if not is_pooler_host(host):
+        # A direct Postgres serves every mode on its one port. Capping is still
+        # right; moving the port would just break the connection.
+        return session, with_params(dsn, pool_max_conns=str(TRANSACTION_MAX_CONNS))
+
+    session = with_port(session, SESSION_PORT)
+    transaction = with_params(
+        with_port(dsn, TRANSACTION_PORT),
+        pool_max_conns=str(TRANSACTION_MAX_CONNS),
+        # Transaction mode cannot carry a prepared statement across the
+        # connection it was prepared on, and pgx caches prepared statements by
+        # default. `exec` sends each query unprepared using the extended
+        # protocol, which is what survives here.
+        default_query_exec_mode="exec",
+    )
+    return session, transaction
+
+
+def build_dsn(host: str, port: str, user: str, dbname: str, password: str) -> str:
+    return f"postgresql://{quote(user, safe='')}:{quote(password, safe='')}@{host}:{port}/{dbname}"
+
+
+def self_test() -> int:
+    pooler = "postgresql://postgres.abc:pw@aws-1-us-east-1.pooler.supabase.com:5432/postgres"
+    session, transaction = derive(pooler)
+
+    assert ":5432/" in session, session
+    assert "pool_max_conns=6" in session, session
+    # The session DSN must never disable prepared statements or otherwise
+    # advertise transaction-mode settings.
+    assert "default_query_exec_mode" not in session, session
+
+    assert ":6543/" in transaction, transaction
+    assert "pool_max_conns=8" in transaction, transaction
+    assert "default_query_exec_mode=exec" in transaction, transaction
+
+    # The credential must survive the port rewrite untouched.
+    assert "postgres.abc:pw@" in transaction, transaction
+
+    # An input already on the transaction port still yields a session DSN on
+    # 5432, so a mis-set port cannot silently strand control-plane.
+    session_from_6543, _ = derive(
+        "postgresql://u:p@aws-1-us-east-1.pooler.supabase.com:6543/postgres"
+    )
+    assert ":5432/" in session_from_6543, session_from_6543
+
+    # A direct Postgres keeps its port in both.
+    direct = "postgresql://postgres:pw@supabase-db:5432/postgres"
+    d_session, d_transaction = derive(direct)
+    assert ":5432/" in d_session and ":6543/" not in d_session, d_session
+    assert ":5432/" in d_transaction and ":6543/" not in d_transaction, d_transaction
+
+    # An explicit pool_max_conns in the input is the deployment's call, not ours.
+    pinned, _ = derive(pooler + "?pool_max_conns=2")
+    assert "pool_max_conns=2" in pinned, pinned
+    assert "pool_max_conns=6" not in pinned, pinned
+
+    # A password with URL-significant characters must not be mangled.
+    built = build_dsn("h.pooler.supabase.com", "5432", "u", "postgres", "p@ss/w:rd?")
+    assert "p%40ss%2Fw%3Ard%3F" in built, built
+    _, built_txn = derive(built)
+    assert "p%40ss%2Fw%3Ard%3F" in built_txn, built_txn
+
+    print("derive-pooler-dsn: self-test ok (9 assertions)")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--dsn")
+    ap.add_argument("--host")
+    ap.add_argument("--port", default=str(SESSION_PORT))
+    ap.add_argument("--user")
+    ap.add_argument("--dbname")
+    ap.add_argument("--password")
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args(argv)
+
+    if args.self_test:
+        return self_test()
+
+    dsn = args.dsn
+    if not dsn:
+        missing = [
+            name
+            for name in ("host", "user", "dbname", "password")
+            if not getattr(args, name)
+        ]
+        if missing:
+            ap.error(f"--dsn, or all of --host --user --dbname --password (missing: {', '.join(missing)})")
+        dsn = build_dsn(args.host, args.port, args.user, args.dbname, args.password)
+
+    session, transaction = derive(dsn)
+    print(f"SUPABASE_DB_URL={session}")
+    print(f"SUPABASE_DB_POOL_URL={transaction}")
+
+    # Summary on stderr so a caller can redirect stdout straight into
+    # $GITHUB_ENV and still get something readable in the log. Host, port and
+    # parameters only: the DSN carries the database password.
+    for name, value in (("SUPABASE_DB_URL", session), ("SUPABASE_DB_POOL_URL", transaction)):
+        parts = urlsplit(value)
+        print(
+            f"{name}: host={parts.hostname} port={parts.port} params={parts.query}",
+            file=sys.stderr,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## The ceiling, and why three unrelated things broke at once

`SUPABASE_DB_URL` points at Supavisor on port **5432**, which is **session mode**.
A session-mode client holds one server connection for its whole session, so the
number of clients that can connect simultaneously equals the project's
`pool_size`, which is **15**. Every consumer shares that single number: the demo
stack (control-plane, edge-api, open-webui), every CI job that boots a stack, the
`Purge CI test data` job, and any one-off `psql`. Past the ceiling the pooler
answers:

```text
FATAL: (EMAXCONNSESSION) max clients reached in session mode - max clients are limited to pool_size: 15
```

Observed consequences, all on 2026-07-28:

* `deploy-demo-box` fails at "Rebuild + recreate changed services" because a
  recreated `open-webui` cannot get a client. The build itself succeeds.
* `open-webui` crash-loops and `chat-hive.scubed.co` returns 502, so **a CI job
  can knock the live chat surface offline**.
* `Purge CI test data` fails, so CI fixture rows are never cleaned up, which
  grows the shared-fixture collision surface and drives more contention. A closed
  loop.
* `OWUI nightly e2e` failed 12 consecutive runs from 2026-07-26 on this alone.

Port **6543** is **transaction mode**: clients are multiplexed over the same
server connections and are bounded instead by the far higher per-tier "max pooler
clients" limit, so a transaction-mode consumer costs **no session slot at all**.

## Why this is not a port swap

Transaction mode drops session-scoped features, so each consumer is placed on
what it actually needs rather than on what is convenient.

| Consumer | Mode | Why |
|---|---|---|
| control-plane | **session** | Holds one connection for the process lifetime on `LISTEN tenant_settings_changed`; `accounting.PgxAccountLocker` takes a session-scoped `pg_advisory_lock` and holds it across a whole credit reservation. |
| edge-api | transaction | Only `pg_advisory_xact_lock` and `SET LOCAL`, both transaction scoped. |
| open-webui pgvector | transaction | psycopg2, no server-side prepared statements. The `#457` tenant-role patch opens and closes its own connection per login. |
| CI purge job | transaction | `psql`, short lived, no session state. |

**control-plane genuinely needs session mode, so it keeps it.** Both of its
dependencies fail *silently* under transaction mode rather than loudly: the
listener stops receiving notifications and every instance quietly serves stale
tenant settings from cache, and the advisory lock stops serialising anything, so
two concurrent reservations against one account can both proceed.
`platformdb.Open` therefore refuses port 6543 outright, naming both reasons, so a
later change cannot strand them by accident.

## The part that was invisible

Both DSNs now carry an explicit `pool_max_conns`. Without it `pgxpool` defaults
to `max(4, NumCPU)`, so the session-mode budget silently tracked the host's core
count. Two Go services on an 8-core box reserve **16 of the 15 slots** between
them and leave nothing for Open WebUI, which starts last. That is the observed
failure, and it means capping matters independently of the mode split: without a
cap the ceiling is a property of whatever hardware the stack lands on.

Sizing and exec mode live in the DSN rather than in code so a deployment can
rebudget without a rebuild. Because that only holds while pgx keeps parsing them,
`TestPoolerDSNCarriesBudgetAndExecMode` asserts pgx honours both parameters and
that neither leaks through as a server runtime parameter, which would fail every
connection with `unrecognized configuration parameter`.

## Plumbing

`scripts/derive-pooler-dsn.py` derives the pair from one input and carries the
reasoning plus a `--self-test` (9 assertions). The workflows call it instead of
assembling DSNs by hand.

The demo-box deploy derives both DSNs from the box's **existing** `.env`, so no
new secret is required and nothing on the box needs editing for this to take
effect. A host that is not a Supavisor pooler keeps its port in both values, so a
direct Postgres is untouched. An unset `SUPABASE_DB_POOL_URL` falls back to the
session DSN, so local and enterprise stacks behave exactly as before.

## Verification

Run locally against this branch:

* `python3 scripts/derive-pooler-dsn.py --self-test` passes (9 assertions),
  including that a quoted `.env` value and a password containing `@ / : ?` both
  survive.
* `go vet ./apps/control-plane/...` clean; `go test ./apps/control-plane/... -short`
  all pass, including the two new tests.
* `docker compose --profile local --profile chat config` renders the intended
  split with both vars set: control-plane `5432`, edge-api `6543`, open-webui
  pgvector `6543`. With only `SUPABASE_DB_URL` set, all three collapse back to it.
* All eight repo policy lints pass, and `lint-workflow-check-names.mjs` still
  reports 6 required contexts each published by exactly one job.
* `bash -n` clean on every new or changed workflow `run` block.

The real acceptance test is a green `deploy-demo-box`. That cannot run before
merge, because the job executes from the box's own clone of `main`, so the
derivation step does not exist there yet. `deploy-demo-box` triggers on push to
`main`, so the merge itself exercises it and I will confirm from that run.

## Sequencing note

Per the incident, never trigger a deploy or restart a service without first
confirming the pool has headroom: recreating a container into an exhausted pool
takes chat down and only resets the container's restart clock.