### PR TITLE
fix: keep pgx-only pool_max_conns off the psycopg2 DSNs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,14 +44,23 @@ SUPABASE_DB_URL=
 #   * open-webui pgvector  transaction mode. psycopg2, no server-side prepared
 #                          statements, no session state.
 #
-# Both DSNs should carry an explicit `pool_max_conns`. Without it pgxpool
+# Both pgx DSNs should carry an explicit `pool_max_conns`. Without it pgxpool
 # defaults to max(4, NumCPU), so the session budget silently tracks the host's
 # core count and two Go services on an 8-core box can reserve 16 of the 15 slots
-# between them. Generate the pair with:
+# between them.
+#
+# SUPABASE_DB_POOL_URL_LIBPQ is that same transaction-mode DSN with the pgx-only
+# parameters removed, for the consumers that do not speak pgx: psycopg2 in Open
+# WebUI and psql in the purge job. libpq has no `pool_max_conns` connection
+# option and fails the whole connection on an unknown one, so the pgx flavour
+# reaches it as `invalid dsn: invalid connection option "pool_max_conns"`.
+#
+# Generate all three with:
 #
 #   python3 scripts/derive-pooler-dsn.py --dsn "$SUPABASE_DB_URL"
 #
 SUPABASE_DB_POOL_URL=
+SUPABASE_DB_POOL_URL_LIBPQ=
 SUPABASE_JWT_ISSUER=https://<PROJECT_REF>.supabase.co/auth/v1
 SUPABASE_JWT_AUDIENCE=authenticated
 SUPABASE_JWKS_URL=https://<PROJECT_REF>.supabase.co/auth/v1/.well-known/jwks.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -480,6 +480,8 @@ jobs:
         run: npm run lint:proof-tokens
       - if: needs.changes.outputs.run != 'false'
         run: npm run lint:litellm-routing
+      - if: needs.changes.outputs.run != 'false'
+        run: npm run lint:pgx-dsn
 
   agent-console-unit:
     name: Agent console (type + unit + build)

--- a/.github/workflows/owui-nightly.yml
+++ b/.github/workflows/owui-nightly.yml
@@ -142,7 +142,7 @@ jobs:
         run: |
           set -euo pipefail
           for v in SUPABASE_URL SUPABASE_ANON_KEY SUPABASE_SERVICE_ROLE_KEY SUPABASE_DB_URL \
-                   SUPABASE_DB_POOL_URL \
+                   SUPABASE_DB_POOL_URL SUPABASE_DB_POOL_URL_LIBPQ \
                    S3_ENDPOINT S3_ACCESS_KEY S3_SECRET_KEY S3_REGION \
                    OPENROUTER_API_KEY GROQ_API_KEY OWUI_SHIM_KEY; do
             val="${!v:-}"
@@ -157,6 +157,7 @@ jobs:
           SUPABASE_SERVICE_ROLE_KEY=${SUPABASE_SERVICE_ROLE_KEY}
           SUPABASE_DB_URL=${SUPABASE_DB_URL}
           SUPABASE_DB_POOL_URL=${SUPABASE_DB_POOL_URL}
+          SUPABASE_DB_POOL_URL_LIBPQ=${SUPABASE_DB_POOL_URL_LIBPQ}
           SUPABASE_JWT_ISSUER=${SUPABASE_URL}/auth/v1
           SUPABASE_JWT_AUDIENCE=authenticated
           SUPABASE_JWKS_URL=${SUPABASE_URL}/auth/v1/.well-known/jwks.json

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -669,7 +669,14 @@ services:
       # (owui-patches/tenant_role_from_db.py) opens and closes its own psycopg2
       # connection per login with no session state. Unset falls back to the
       # session DSN, so local and enterprise stacks are unaffected.
-      PGVECTOR_DB_URL: ${SUPABASE_DB_POOL_URL:-${SUPABASE_DB_URL:-}}
+      #
+      # The _LIBPQ flavour, never SUPABASE_DB_POOL_URL itself. `pool_max_conns`
+      # and `default_query_exec_mode` are pgx DSN parameters; libpq has no such
+      # connection options and rejects the entire DSN on an unknown one. Handing
+      # psycopg2 the pgx flavour produced
+      # `invalid dsn: invalid connection option "pool_max_conns"`, which
+      # crash-looped this container and returned 502 on chat-hive.scubed.co.
+      PGVECTOR_DB_URL: ${SUPABASE_DB_POOL_URL_LIBPQ:-${SUPABASE_DB_URL:-}}
       RAG_TOP_K: "5"
       ENABLE_RAG_HYBRID_SEARCH: "true"
       DATA_DIR: "/data"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lint:model-visibility": "node tools/lint-tenant-model-visibility-single-source.mjs",
     "lint:litellm-routing": "node tools/lint-litellm-dispatch-requires-routing.mjs",
     "lint:proof-tokens": "node tools/lint-no-token-in-proof-captures.mjs",
+    "lint:pgx-dsn": "node tools/lint-no-pgx-dsn-for-libpq.mjs",
     "soc2:report": "node tools/soc2-coverage-report.mjs",
     "soc2:check": "node tools/soc2-coverage-report.mjs --check",
     "cloudflare:check": "node deploy/cloudflare/reconcile-tunnel-dns.mjs",

--- a/scripts/derive-pooler-dsn.py
+++ b/scripts/derive-pooler-dsn.py
@@ -94,6 +94,18 @@ def is_pooler_host(host: str) -> bool:
     return host.lower().endswith(".pooler.supabase.com")
 
 
+def encode_query(pairs: list[tuple[str, str]] | dict[str, str]) -> str:
+    """Re-encode query pairs the way a Postgres connection URI expects.
+
+    `parse_qsl` decodes `%20` to a space, and `urlencode` defaults to form
+    encoding, which would emit that space as `+`. A Postgres URI is percent
+    encoded, not form encoded: libpq passes `+` through as a literal plus, so
+    `options=-c%20statement_timeout%3D3000` would round-trip into an options
+    string the server cannot parse. `quote` keeps it as `%20`.
+    """
+    return urlencode(pairs, quote_via=quote)
+
+
 def with_params(dsn: str, **params: str) -> str:
     """Return dsn with params set, preserving any the caller already supplied."""
     parts = urlsplit(dsn)
@@ -102,14 +114,14 @@ def with_params(dsn: str, **params: str) -> str:
         # An explicit value already in the DSN wins: the deployment knows
         # something this script does not.
         query.setdefault(key, value)
-    return urlunsplit(parts._replace(query=urlencode(query)))
+    return urlunsplit(parts._replace(query=encode_query(query)))
 
 
 def without_params(dsn: str, *keys: str) -> str:
     """Return dsn with keys removed, including any the input already carried."""
     parts = urlsplit(dsn)
     query = [(k, v) for k, v in parse_qsl(parts.query, keep_blank_values=True) if k not in keys]
-    return urlunsplit(parts._replace(query=urlencode(query)))
+    return urlunsplit(parts._replace(query=encode_query(query)))
 
 
 def with_port(dsn: str, port: int) -> str:
@@ -220,7 +232,17 @@ def self_test() -> int:
     assert "p%40ss%2Fw%3Ard%3F" in built_txn, built_txn
     assert "p%40ss%2Fw%3Ard%3F" in built_libpq, built_libpq
 
-    print("derive-pooler-dsn: self-test ok (18 assertions)")
+    # A percent-encoded parameter the deployment set must survive both the add
+    # and the strip as percent encoding. Form encoding would emit the space in
+    # `options` as `+`, which libpq passes through literally and the server then
+    # cannot parse.
+    encoded = pooler + "?options=-c%20statement_timeout%3D3000"
+    enc_session, enc_transaction, enc_libpq = derive(encoded)
+    for flavour in (enc_session, enc_transaction, enc_libpq):
+        assert "options=-c%20statement_timeout%3D3000" in flavour, flavour
+        assert "+" not in urlsplit(flavour).query, flavour
+
+    print("derive-pooler-dsn: self-test ok (27 assertions)")
     return 0
 
 

--- a/scripts/derive-pooler-dsn.py
+++ b/scripts/derive-pooler-dsn.py
@@ -43,10 +43,18 @@ Usage
     derive-pooler-dsn.py --host H --port 5432 --user U --dbname D --password P
     derive-pooler-dsn.py --self-test
 
-Prints two `KEY=value` lines, ready to append to $GITHUB_ENV:
+Prints three `KEY=value` lines, ready to append to $GITHUB_ENV:
 
-    SUPABASE_DB_URL=...        session mode, capped
-    SUPABASE_DB_POOL_URL=...   transaction mode, capped, no prepared statements
+    SUPABASE_DB_URL=...              session mode, capped
+    SUPABASE_DB_POOL_URL=...         transaction mode, capped, no prepared statements
+    SUPABASE_DB_POOL_URL_LIBPQ=...   transaction mode, no pgx-only parameters
+
+`pool_max_conns` and `default_query_exec_mode` are pgx's own DSN parameters, not
+libpq connection options. libpq rejects the whole DSN on an unknown option, so
+psycopg2 and psql get their own flavour of the transaction DSN with those two
+stripped. Handing the pgx flavour to Open WebUI is what produced
+`invalid dsn: invalid connection option "pool_max_conns"`, which crash-looped the
+container and returned 502 on the live chat surface.
 
 A host that is not a Supavisor pooler (a direct Postgres, as the enterprise
 profile uses) has no transaction-mode port, so its port is left alone and both
@@ -75,6 +83,11 @@ SESSION_MAX_CONNS = 6
 # stampeding the upstream server connections.
 TRANSACTION_MAX_CONNS = 8
 
+# pgx reads these out of the DSN itself. libpq has no such connection options and
+# fails the whole connection on an unknown one, so every non-pgx consumer
+# (psycopg2 in Open WebUI, psql in the purge job) needs them removed.
+PGX_ONLY_PARAMS = ("pool_max_conns", "default_query_exec_mode")
+
 
 def is_pooler_host(host: str) -> bool:
     """Report whether host is a Supavisor pooler, which is what has two ports."""
@@ -89,6 +102,13 @@ def with_params(dsn: str, **params: str) -> str:
         # An explicit value already in the DSN wins: the deployment knows
         # something this script does not.
         query.setdefault(key, value)
+    return urlunsplit(parts._replace(query=urlencode(query)))
+
+
+def without_params(dsn: str, *keys: str) -> str:
+    """Return dsn with keys removed, including any the input already carried."""
+    parts = urlsplit(dsn)
+    query = [(k, v) for k, v in parse_qsl(parts.query, keep_blank_values=True) if k not in keys]
     return urlunsplit(parts._replace(query=urlencode(query)))
 
 
@@ -109,8 +129,12 @@ def with_port(dsn: str, port: int) -> str:
     return urlunsplit(parts._replace(netloc=netloc))
 
 
-def derive(dsn: str) -> tuple[str, str]:
-    """Return (session_dsn, transaction_dsn) for one input DSN."""
+def derive(dsn: str) -> tuple[str, str, str]:
+    """Return (session_dsn, transaction_dsn, transaction_libpq_dsn) for one DSN.
+
+    The third value is the transaction DSN as libpq will accept it: same host,
+    port and credential, with pgx's own parameters stripped.
+    """
     parts = urlsplit(dsn)
     host = parts.hostname
     if not host:
@@ -121,7 +145,8 @@ def derive(dsn: str) -> tuple[str, str]:
     if not is_pooler_host(host):
         # A direct Postgres serves every mode on its one port. Capping is still
         # right; moving the port would just break the connection.
-        return session, with_params(dsn, pool_max_conns=str(TRANSACTION_MAX_CONNS))
+        transaction = with_params(dsn, pool_max_conns=str(TRANSACTION_MAX_CONNS))
+        return session, transaction, without_params(transaction, *PGX_ONLY_PARAMS)
 
     session = with_port(session, SESSION_PORT)
     transaction = with_params(
@@ -133,7 +158,7 @@ def derive(dsn: str) -> tuple[str, str]:
         # protocol, which is what survives here.
         default_query_exec_mode="exec",
     )
-    return session, transaction
+    return session, transaction, without_params(transaction, *PGX_ONLY_PARAMS)
 
 
 def build_dsn(host: str, port: str, user: str, dbname: str, password: str) -> str:
@@ -142,7 +167,7 @@ def build_dsn(host: str, port: str, user: str, dbname: str, password: str) -> st
 
 def self_test() -> int:
     pooler = "postgresql://postgres.abc:pw@aws-1-us-east-1.pooler.supabase.com:5432/postgres"
-    session, transaction = derive(pooler)
+    session, transaction, libpq = derive(pooler)
 
     assert ":5432/" in session, session
     assert "pool_max_conns=6" in session, session
@@ -157,31 +182,45 @@ def self_test() -> int:
     # The credential must survive the port rewrite untouched.
     assert "postgres.abc:pw@" in transaction, transaction
 
+    # libpq rejects a DSN outright on an unknown connection option, so the
+    # psycopg2/psql flavour reaches the same port with neither pgx parameter.
+    # Open WebUI got the pgx flavour once and answered
+    # `invalid dsn: invalid connection option "pool_max_conns"`, crash-looped,
+    # and took chat-hive.scubed.co to 502 with it.
+    assert ":6543/" in libpq, libpq
+    assert "postgres.abc:pw@" in libpq, libpq
+    for pgx_only in PGX_ONLY_PARAMS:
+        assert pgx_only not in libpq, libpq
+
     # An input already on the transaction port still yields a session DSN on
     # 5432, so a mis-set port cannot silently strand control-plane.
-    session_from_6543, _ = derive(
+    session_from_6543, _, _ = derive(
         "postgresql://u:p@aws-1-us-east-1.pooler.supabase.com:6543/postgres"
     )
     assert ":5432/" in session_from_6543, session_from_6543
 
-    # A direct Postgres keeps its port in both.
+    # A direct Postgres keeps its port in all three.
     direct = "postgresql://postgres:pw@supabase-db:5432/postgres"
-    d_session, d_transaction = derive(direct)
+    d_session, d_transaction, d_libpq = derive(direct)
     assert ":5432/" in d_session and ":6543/" not in d_session, d_session
     assert ":5432/" in d_transaction and ":6543/" not in d_transaction, d_transaction
+    assert ":5432/" in d_libpq and "pool_max_conns" not in d_libpq, d_libpq
 
     # An explicit pool_max_conns in the input is the deployment's call, not ours.
-    pinned, _ = derive(pooler + "?pool_max_conns=2")
+    pinned, _, pinned_libpq = derive(pooler + "?pool_max_conns=2")
     assert "pool_max_conns=2" in pinned, pinned
     assert "pool_max_conns=6" not in pinned, pinned
+    # ...but libpq still cannot parse it, so the strip has to win over the pin.
+    assert "pool_max_conns" not in pinned_libpq, pinned_libpq
 
     # A password with URL-significant characters must not be mangled.
     built = build_dsn("h.pooler.supabase.com", "5432", "u", "postgres", "p@ss/w:rd?")
     assert "p%40ss%2Fw%3Ard%3F" in built, built
-    _, built_txn = derive(built)
+    _, built_txn, built_libpq = derive(built)
     assert "p%40ss%2Fw%3Ard%3F" in built_txn, built_txn
+    assert "p%40ss%2Fw%3Ard%3F" in built_libpq, built_libpq
 
-    print("derive-pooler-dsn: self-test ok (9 assertions)")
+    print("derive-pooler-dsn: self-test ok (18 assertions)")
     return 0
 
 
@@ -210,14 +249,19 @@ def main(argv: list[str]) -> int:
             ap.error(f"--dsn, or all of --host --user --dbname --password (missing: {', '.join(missing)})")
         dsn = build_dsn(args.host, args.port, args.user, args.dbname, args.password)
 
-    session, transaction = derive(dsn)
+    session, transaction, libpq = derive(dsn)
     print(f"SUPABASE_DB_URL={session}")
     print(f"SUPABASE_DB_POOL_URL={transaction}")
+    print(f"SUPABASE_DB_POOL_URL_LIBPQ={libpq}")
 
     # Summary on stderr so a caller can redirect stdout straight into
     # $GITHUB_ENV and still get something readable in the log. Host, port and
     # parameters only: the DSN carries the database password.
-    for name, value in (("SUPABASE_DB_URL", session), ("SUPABASE_DB_POOL_URL", transaction)):
+    for name, value in (
+        ("SUPABASE_DB_URL", session),
+        ("SUPABASE_DB_POOL_URL", transaction),
+        ("SUPABASE_DB_POOL_URL_LIBPQ", libpq),
+    ):
         parts = urlsplit(value)
         print(
             f"{name}: host={parts.hostname} port={parts.port} params={parts.query}",

--- a/tools/lint-no-pgx-dsn-for-libpq.mjs
+++ b/tools/lint-no-pgx-dsn-for-libpq.mjs
@@ -35,7 +35,7 @@
 // scanner with a MUST_CATCH / MUST_ALLOW self-test that runs as a preflight on
 // every invocation.
 
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import { dirname, resolve, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import assert from "node:assert/strict";
@@ -43,8 +43,19 @@ import YAML from "yaml";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(HERE, "..");
-const COMPOSE_FILE = join(REPO_ROOT, "deploy", "docker", "docker-compose.yml");
+const COMPOSE_DIR = join(REPO_ROOT, "deploy", "docker");
 const DERIVE_SCRIPT = join(REPO_ROOT, "scripts", "derive-pooler-dsn.py");
+
+// Every compose file, not just the base one. An overlay (enterprise, staging,
+// relay, override) can set the same env key on the same service, and the last
+// file on the command line wins, so a pgx-flavoured DSN reintroduced in an
+// overlay would be just as fatal and twice as easy to miss.
+function composeFiles() {
+  return readdirSync(COMPOSE_DIR)
+    .filter((f) => /^docker-compose.*\.ya?ml$/.test(f))
+    .sort()
+    .map((f) => join(COMPOSE_DIR, f));
+}
 
 // Services whose database driver is pgx, and which may therefore be handed a
 // DSN carrying pgx's own parameters. Both are Go services on pgxpool. Every
@@ -194,7 +205,6 @@ function main() {
   const deriveSource = readFileSync(DERIVE_SCRIPT, "utf8");
   const pgxOnlyParams = parsePgxOnlyParams(deriveSource);
   const emittedVars = new Set(parseEmittedVars(deriveSource));
-  const compose = YAML.parse(readFileSync(COMPOSE_FILE, "utf8"));
 
   let failed = false;
   const fail = (msg) => {
@@ -214,37 +224,42 @@ function main() {
   }
 
   let checked = 0;
-  for (const [service, spec] of Object.entries(compose.services ?? {})) {
-    const env = spec?.environment;
-    if (!env || Array.isArray(env)) continue;
-    for (const [key, raw] of Object.entries(env)) {
-      if (typeof raw !== "string") continue;
-      const referenced = referencedVars(raw);
-      const isPoolerDsn = referenced.some((n) => n.startsWith("SUPABASE_DB_"));
-      if (!isPoolerDsn && !pgxOnlyParams.some((p) => raw.includes(`${p}=`))) continue;
-      checked += 1;
+  const files = composeFiles();
+  for (const file of files) {
+    const where = file.slice(REPO_ROOT.length + 1);
+    const compose = YAML.parse(readFileSync(file, "utf8"));
+    for (const [service, spec] of Object.entries(compose?.services ?? {})) {
+      const env = spec?.environment;
+      if (!env || Array.isArray(env)) continue;
+      for (const [key, raw] of Object.entries(env)) {
+        if (typeof raw !== "string") continue;
+        const referenced = referencedVars(raw);
+        const isPoolerDsn = referenced.some((n) => n.startsWith("SUPABASE_DB_"));
+        if (!isPoolerDsn && !pgxOnlyParams.some((p) => raw.includes(`${p}=`))) continue;
+        checked += 1;
 
-      // A. Only a declared pgx service may read a pgx-flavoured DSN.
-      if (!PGX_SERVICES.has(service)) {
-        for (const offence of findOffenders(raw, pgxOnlyParams)) {
-          fail(
-            `deploy/docker/docker-compose.yml: service \`${service}\` env \`${key}\` ${offence}. ` +
-              `\`${service}\` is not declared as a pgx consumer, so its DSN is parsed by libpq, ` +
-              "which fails the whole connection on an unknown option. Use " +
-              "$SUPABASE_DB_POOL_URL_LIBPQ, or add the service to PGX_SERVICES in this lint if it " +
-              "really does speak pgx.",
-          );
+        // A. Only a declared pgx service may read a pgx-flavoured DSN.
+        if (!PGX_SERVICES.has(service)) {
+          for (const offence of findOffenders(raw, pgxOnlyParams)) {
+            fail(
+              `${where}: service \`${service}\` env \`${key}\` ${offence}. ` +
+                `\`${service}\` is not declared as a pgx consumer, so its DSN is parsed by libpq, ` +
+                "which fails the whole connection on an unknown option. Use " +
+                "$SUPABASE_DB_POOL_URL_LIBPQ, or add the service to PGX_SERVICES in this lint if " +
+                "it really does speak pgx.",
+            );
+          }
         }
-      }
 
-      // B. No reference to a pooler variable the derivation script never emits.
-      for (const name of referenced) {
-        if (name.startsWith("SUPABASE_DB_") && !emittedVars.has(name)) {
-          fail(
-            `deploy/docker/docker-compose.yml: service \`${service}\` env \`${key}\` reads ` +
-              `$${name}, which scripts/derive-pooler-dsn.py does not emit. The interpolation ` +
-              "would silently fall through to its default instead of failing.",
-          );
+        // B. No reference to a pooler variable the derivation script never emits.
+        for (const name of referenced) {
+          if (name.startsWith("SUPABASE_DB_") && !emittedVars.has(name)) {
+            fail(
+              `${where}: service \`${service}\` env \`${key}\` reads $${name}, which ` +
+                "scripts/derive-pooler-dsn.py does not emit. The interpolation would silently " +
+                "fall through to its default instead of failing.",
+            );
+          }
         }
       }
     }
@@ -260,8 +275,8 @@ function main() {
   }
 
   console.log(
-    `lint-no-pgx-dsn-for-libpq: ok (${checked} DSN-bearing compose env values checked, ` +
-      `pgx-only params: ${pgxOnlyParams.join(", ")})`,
+    `lint-no-pgx-dsn-for-libpq: ok (${checked} DSN-bearing env values across ${files.length} ` +
+      `compose files, pgx-only params: ${pgxOnlyParams.join(", ")})`,
   );
   process.exit(0);
 }

--- a/tools/lint-no-pgx-dsn-for-libpq.mjs
+++ b/tools/lint-no-pgx-dsn-for-libpq.mjs
@@ -1,0 +1,271 @@
+#!/usr/bin/env node
+// Structural guard against handing a pgx-flavoured DSN to a libpq consumer.
+//
+// PR #593 split the Supabase pooler DSNs and stamped `pool_max_conns` and
+// `default_query_exec_mode` onto them. Those are pgx's own connection-string
+// parameters, read by pgxpool before it ever talks to Postgres. libpq has no
+// such connection options and rejects the entire DSN the moment it meets an
+// unknown one, so Open WebUI's psycopg2 answered:
+//
+//   sqlalchemy.exc.ProgrammingError: (psycopg2.ProgrammingError) invalid dsn:
+//   invalid connection option "pool_max_conns"
+//
+// The container never became healthy, the deploy failed on `dependency failed
+// to start: container hive-open-webui-1 is unhealthy`, and chat-hive.scubed.co
+// returned 502 for the better part of an hour. control-plane and edge-api, both
+// pgx, parsed the same DSNs without complaint in the same run, which is exactly
+// why nothing caught it: the asymmetry is invisible unless something checks for
+// it.
+//
+// Three checks, all cheap and all structural:
+//
+//   A. Default-deny by service. Only the services listed in PGX_SERVICES may
+//      reference a pgx-only DSN variable. A new service added to compose is a
+//      libpq consumer until someone declares otherwise, so the failure mode is
+//      a lint error rather than a crash-looping container.
+//   B. No dangling reference. A pooler DSN variable a libpq consumer reads must
+//      actually be emitted by scripts/derive-pooler-dsn.py. Renaming the
+//      variable in one place and not the other would otherwise fall through to
+//      the compose default silently.
+//   C. No unstripped parameter. Every parameter the derivation script stamps
+//      onto a DSN must appear in its own PGX_ONLY_PARAMS strip list, so adding
+//      a fourth pgx parameter later cannot leak into the libpq flavour.
+//
+// Mirrors the pattern of tools/lint-no-token-in-proof-captures.mjs: a small
+// scanner with a MUST_CATCH / MUST_ALLOW self-test that runs as a preflight on
+// every invocation.
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import assert from "node:assert/strict";
+import YAML from "yaml";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(HERE, "..");
+const COMPOSE_FILE = join(REPO_ROOT, "deploy", "docker", "docker-compose.yml");
+const DERIVE_SCRIPT = join(REPO_ROOT, "scripts", "derive-pooler-dsn.py");
+
+// Services whose database driver is pgx, and which may therefore be handed a
+// DSN carrying pgx's own parameters. Both are Go services on pgxpool. Every
+// other service in compose is treated as a libpq consumer by default: Open
+// WebUI reaches pgvector through psycopg2, and anything shelling out to psql
+// parses its DSN through the same libpq.
+const PGX_SERVICES = new Set(["edge-api", "control-plane"]);
+
+// The environment variables the derivation script emits with pgx parameters
+// stamped on. `SUPABASE_DB_URL` is deliberately NOT here: it is the fallback
+// every profile without a Supavisor pooler depends on (local, enterprise, a
+// direct Postgres), where it is a plain DSN with no parameters at all. In the
+// environments where the derivation script does stamp it, that same script
+// always emits the libpq flavour alongside it, so the fallback is never the
+// value that actually reaches a libpq consumer.
+const PGX_ONLY_VARS = new Set(["SUPABASE_DB_POOL_URL"]);
+
+// A compose interpolation, braced or bare, at any nesting depth:
+// `${A:-${B:-}}` yields ["A", "B"].
+const VAR_RE = /\$\{?([A-Za-z_][A-Za-z0-9_]*)/g;
+
+export function referencedVars(value) {
+  const found = [];
+  VAR_RE.lastIndex = 0;
+  let match = VAR_RE.exec(value);
+  while (match !== null) {
+    found.push(match[1]);
+    match = VAR_RE.exec(value);
+  }
+  return found;
+}
+
+// Reads the strip list out of the derivation script rather than restating it,
+// so the two cannot drift apart.
+export function parsePgxOnlyParams(source) {
+  const block = source.match(/PGX_ONLY_PARAMS\s*=\s*\(([^)]*)\)/);
+  assert.ok(block, "derive-pooler-dsn.py: PGX_ONLY_PARAMS tuple not found");
+  return [...block[1].matchAll(/["']([^"']+)["']/g)].map((m) => m[1]);
+}
+
+// Every parameter the script stamps onto a DSN, from its with_params() calls.
+// Balanced-paren scan rather than a regex, so a multi-line call and a nested
+// `str(...)` argument both read correctly.
+export function parseStampedParams(source) {
+  const params = new Set();
+  const NEEDLE = "with_params(";
+  for (let idx = source.indexOf(NEEDLE); idx !== -1; idx = source.indexOf(NEEDLE, idx + 1)) {
+    let depth = 1;
+    let i = idx + NEEDLE.length;
+    const start = i;
+    while (i < source.length && depth > 0) {
+      if (source[i] === "(") depth += 1;
+      else if (source[i] === ")") depth -= 1;
+      i += 1;
+    }
+    // Drop nested groups so a call's own arguments cannot be read as ours.
+    let flat = source.slice(start, i - 1);
+    for (let prev = null; prev !== flat; ) {
+      prev = flat;
+      flat = flat.replace(/\([^()]*\)/g, "");
+    }
+    for (const kw of flat.matchAll(/([A-Za-z_][A-Za-z0-9_]*)\s*=/g)) params.add(kw[1]);
+  }
+  return [...params];
+}
+
+// The name every emitted variable is printed under, from the script's own
+// `print(f"NAME={...}")` lines.
+export function parseEmittedVars(source) {
+  return [...source.matchAll(/print\(f["']([A-Z_][A-Z0-9_]*)=\{/g)].map((m) => m[1]);
+}
+
+// One compose env value, checked against the two ways a libpq consumer can be
+// handed something it cannot parse: a reference to a pgx-flavoured variable, or
+// a literal DSN with the parameter written out.
+export function findOffenders(value, pgxOnlyParams) {
+  const offenders = [];
+  for (const name of referencedVars(value)) {
+    if (PGX_ONLY_VARS.has(name)) {
+      offenders.push(`references the pgx-flavoured $${name}`);
+    }
+  }
+  for (const param of pgxOnlyParams) {
+    if (value.includes(`${param}=`)) {
+      offenders.push(`carries the pgx-only parameter \`${param}\``);
+    }
+  }
+  return offenders;
+}
+
+const SELF_TEST_PARAMS = ["pool_max_conns", "default_query_exec_mode"];
+
+const MUST_CATCH = [
+  // The exact line PR #593 shipped, which took chat-hive.scubed.co to 502.
+  ["the #593 regression verbatim", "${SUPABASE_DB_POOL_URL:-${SUPABASE_DB_URL:-}}"],
+  ["bare reference", "${SUPABASE_DB_POOL_URL}"],
+  ["unbraced reference", "$SUPABASE_DB_POOL_URL"],
+  ["buried in a fallback chain", "${SOMETHING_ELSE:-${SUPABASE_DB_POOL_URL}}"],
+  ["literal pgx parameter", "postgresql://u:p@pooler:6543/postgres?pool_max_conns=8"],
+  ["literal exec-mode parameter", "postgresql://u:p@pooler:6543/postgres?default_query_exec_mode=exec"],
+];
+
+const MUST_ALLOW = [
+  // The libpq flavour shares a prefix with the banned name; matching on the
+  // prefix alone would reject the fix itself.
+  ["the libpq flavour with its fallback", "${SUPABASE_DB_POOL_URL_LIBPQ:-${SUPABASE_DB_URL:-}}"],
+  ["the libpq flavour alone", "${SUPABASE_DB_POOL_URL_LIBPQ}"],
+  ["the session DSN, which every poolerless profile falls back to", "${SUPABASE_DB_URL}"],
+  ["a plain literal DSN", "postgresql://postgres:pw@supabase-db:5432/postgres"],
+  ["an unrelated value", "pgvector"],
+];
+
+function selfTest() {
+  for (const [name, value] of MUST_CATCH) {
+    assert.ok(
+      findOffenders(value, SELF_TEST_PARAMS).length > 0,
+      `self-test: NOT caught -> ${name}: ${value}`,
+    );
+  }
+  for (const [name, value] of MUST_ALLOW) {
+    const offenders = findOffenders(value, SELF_TEST_PARAMS);
+    assert.equal(
+      offenders.length,
+      0,
+      `self-test: false positive -> ${name}: ${JSON.stringify(offenders)}`,
+    );
+  }
+  assert.deepEqual(
+    referencedVars("${A:-${B:-}}"),
+    ["A", "B"],
+    "self-test: nested interpolation not extracted",
+  );
+  return MUST_CATCH.length + MUST_ALLOW.length + 1;
+}
+
+function main() {
+  let assertions;
+  try {
+    assertions = selfTest();
+  } catch (err) {
+    console.error(`lint-no-pgx-dsn-for-libpq: SELF-TEST FAILED\n${err.message}`);
+    process.exit(2);
+  }
+  console.log(`lint-no-pgx-dsn-for-libpq: self-test ok (${assertions} assertions)`);
+  if (process.argv.includes("--self-test")) process.exit(0);
+
+  const deriveSource = readFileSync(DERIVE_SCRIPT, "utf8");
+  const pgxOnlyParams = parsePgxOnlyParams(deriveSource);
+  const emittedVars = new Set(parseEmittedVars(deriveSource));
+  const compose = YAML.parse(readFileSync(COMPOSE_FILE, "utf8"));
+
+  let failed = false;
+  const fail = (msg) => {
+    console.error(msg);
+    failed = true;
+  };
+
+  // C. Every parameter the script stamps must also be stripped for libpq.
+  for (const param of parseStampedParams(deriveSource)) {
+    if (!pgxOnlyParams.includes(param)) {
+      fail(
+        `scripts/derive-pooler-dsn.py: \`${param}\` is stamped onto a DSN but is not in ` +
+          "PGX_ONLY_PARAMS, so it survives into the libpq flavour and libpq will reject the " +
+          "whole connection string.",
+      );
+    }
+  }
+
+  let checked = 0;
+  for (const [service, spec] of Object.entries(compose.services ?? {})) {
+    const env = spec?.environment;
+    if (!env || Array.isArray(env)) continue;
+    for (const [key, raw] of Object.entries(env)) {
+      if (typeof raw !== "string") continue;
+      const referenced = referencedVars(raw);
+      const isPoolerDsn = referenced.some((n) => n.startsWith("SUPABASE_DB_"));
+      if (!isPoolerDsn && !pgxOnlyParams.some((p) => raw.includes(`${p}=`))) continue;
+      checked += 1;
+
+      // A. Only a declared pgx service may read a pgx-flavoured DSN.
+      if (!PGX_SERVICES.has(service)) {
+        for (const offence of findOffenders(raw, pgxOnlyParams)) {
+          fail(
+            `deploy/docker/docker-compose.yml: service \`${service}\` env \`${key}\` ${offence}. ` +
+              `\`${service}\` is not declared as a pgx consumer, so its DSN is parsed by libpq, ` +
+              "which fails the whole connection on an unknown option. Use " +
+              "$SUPABASE_DB_POOL_URL_LIBPQ, or add the service to PGX_SERVICES in this lint if it " +
+              "really does speak pgx.",
+          );
+        }
+      }
+
+      // B. No reference to a pooler variable the derivation script never emits.
+      for (const name of referenced) {
+        if (name.startsWith("SUPABASE_DB_") && !emittedVars.has(name)) {
+          fail(
+            `deploy/docker/docker-compose.yml: service \`${service}\` env \`${key}\` reads ` +
+              `$${name}, which scripts/derive-pooler-dsn.py does not emit. The interpolation ` +
+              "would silently fall through to its default instead of failing.",
+          );
+        }
+      }
+    }
+  }
+
+  if (failed) {
+    console.error(
+      "\nlint-no-pgx-dsn-for-libpq: a DSN destined for a libpq consumer carries a pgx-only " +
+        "option. psycopg2 and psql both parse through libpq, which rejects the entire " +
+        "connection string on an unknown connection option rather than ignoring it.",
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `lint-no-pgx-dsn-for-libpq: ok (${checked} DSN-bearing compose env values checked, ` +
+      `pgx-only params: ${pgxOnlyParams.join(", ")})`,
+  );
+  process.exit(0);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}


### PR DESCRIPTION
## The outage

PR #593 split the Supabase pooler DSNs and pointed Open WebUI's `PGVECTOR_DB_URL` at the transaction-mode DSN. That DSN carries `pool_max_conns` and `default_query_exec_mode`, which are **pgx** DSN parameters. libpq has no such connection options and rejects the entire DSN when it meets an unknown one, so psycopg2 inside Open WebUI answered:

```text
sqlalchemy.exc.ProgrammingError: (psycopg2.ProgrammingError) invalid dsn: invalid connection option "pool_max_conns"
```

The container never became healthy, `deploy-demo-box` run 30383939147 failed at "Rebuild + recreate changed services" with `dependency failed to start: container hive-open-webui-1 is unhealthy`, and `chat-hive.scubed.co` has been returning 502 since 17:42 UTC on 2026-07-28.

`pool_max_conns` is read by pgxpool out of the connection string before it ever talks to Postgres; it is not a Postgres or libpq concept. pgx ignores nothing and libpq forgives nothing, so the same string is valid for one driver and fatal for the other. control-plane and edge-api, both pgx, went Healthy in that same run against DSNs carrying the same parameters. That asymmetry is why only chat was down while `control-hive.scubed.co/health` and `api-hive.scubed.co/health` stayed 200, and it is why nothing caught this before it reached the box.

The mode split itself was right. One shared environment variable feeding two different drivers was not.

## The fix

`scripts/derive-pooler-dsn.py` now emits a third line, `SUPABASE_DB_POOL_URL_LIBPQ`: the same transaction-mode host, port and credential with both pgx-only parameters stripped, including any the input DSN already pinned (a pin libpq cannot parse is still unparseable). Consumers are placed on the flavour their driver speaks:

| Consumer | Driver | Value |
|---|---|---|
| control-plane | pgx | `SUPABASE_DB_URL` (session mode, unchanged) |
| edge-api | pgx | `SUPABASE_DB_POOL_URL` (transaction mode, unchanged) |
| open-webui pgvector | psycopg2 | `SUPABASE_DB_POOL_URL_LIBPQ` (new) |

`owui-nightly.yml` materializes the new value into `.env.ci`. Without it the nightly's Open WebUI would fall back to the session DSN and walk straight back into the 15-client ceiling that #593 exists to avoid. `ci.yml` and `deploy-demo-box.yml` redirect the script's stdout into `$GITHUB_ENV`, so they pick the new value up with no change.

Unset behaviour is unchanged: a local or enterprise stack with no pooler falls back to `SUPABASE_DB_URL` exactly as before.

`platformdb.Open` still refuses port 6543. control-plane genuinely needs session mode, for `settings.Resolver.StartListener` holding `LISTEN tenant_settings_changed` and for `accounting.PgxAccountLocker` holding a session-scoped `pg_advisory_lock` across a reservation. Both fail silently under transaction mode. Only the option placement changed here, never the mode split.

## Every other libpq consumer #593 touched

Audited, not assumed:

* **Open WebUI pgvector store** (`PGVECTOR_DB_URL`, SQLAlchemy + psycopg2). Broken, fixed above.
* **The #457 tenant-role patch** (`deploy/docker/owui-patches/tenant_role_from_db.py`, its own psycopg2 connection per login). Reads the same `PGVECTOR_DB_URL`, so it was broken by the same value and is fixed by the same change.
* **The CI purge job** (`.github/workflows/pr-cleanup.yml`, `psql`). Connects through `PGHOST`/`PGPORT`/`PGUSER`/`PGDATABASE`/`PGPASSWORD`, never a DSN, so no pgx parameter can reach it. Unaffected. Its separate session-mode ceiling problem is #591 and is out of scope here.
* **Open WebUI's own application database.** Not set in compose, so it stays on the bundled SQLite under `DATA_DIR` and never sees a pooler DSN at all.

No pool sizing was added for Open WebUI. Transaction-mode pooling returns the connection per transaction rather than holding it for the session, which is the ceiling problem this DSN split exists to solve, and the pinned image (`open-webui:v0.10.2`) could not be inspected from here to confirm the name of a pgvector pool-sizing variable. Adding an unverified environment variable would be guesswork, so nothing was added.

## Regression guard

`tools/lint-no-pgx-dsn-for-libpq.mjs`, wired into the required **Repo policy lints** job in `ci.yml` next to `lint:proof-tokens`, as `npm run lint:pgx-dsn`. Three structural checks:

1. **Default-deny by service.** Only `edge-api` and `control-plane` are declared pgx consumers. Any other compose service referencing the pgx-flavoured `SUPABASE_DB_POOL_URL`, or carrying a pgx-only parameter in a literal DSN, fails. A service added to compose later is treated as a libpq consumer until someone declares otherwise, so the failure mode is a lint error instead of a crash-looping container.
2. **No dangling reference.** A `SUPABASE_DB_*` variable a service reads must actually be emitted by `derive-pooler-dsn.py`. Renaming it in one file and not the other would otherwise fall through to the compose default in silence.
3. **No unstripped parameter.** Every parameter the derivation script stamps on via `with_params` must appear in its own `PGX_ONLY_PARAMS` strip list, so a fourth pgx parameter added later cannot leak into the libpq flavour. The lint reads both lists out of the Python source rather than restating them, so they cannot drift.

`SUPABASE_DB_URL` is deliberately not on the banned list: it is the fallback every poolerless profile depends on, where it is a plain DSN with no parameters, and the derivation script never stamps it without emitting the libpq flavour alongside.

The lint walks every `deploy/docker/docker-compose*.yml`, not just the base file. An overlay can set the same env key on the same service and the last file on the command line wins, so a pgx-flavoured DSN reintroduced in the enterprise or staging overlay would be just as fatal and harder to spot.

## Query encoding, found in review

`parse_qsl` decodes `%20` to a space and `urlencode` then form-encodes it back as `+`. A Postgres connection URI is percent encoded, not form encoded, so libpq passes that plus through literally: an input DSN carrying `options=-c%20statement_timeout%3D3000` came back out as `options=-c+statement_timeout%3D3000`, which the server cannot parse. Both `with_params` and `without_params` now encode through one `encode_query` helper using `quote_via=quote`. `with_params` predates this PR and had the same flaw, so the fix is in the shared helper rather than only on the new line. Latent rather than live: the box's DSN carries no query parameters, so nothing had hit it.

## Test plan

- [x] `python3 scripts/derive-pooler-dsn.py --self-test` passes, now 27 assertions. New coverage: the libpq flavour keeps port 6543 and the credential, carries neither pgx parameter, strips a `pool_max_conns` the input had pinned, and round-trips a percent-encoded `options=` parameter byte-identically in all three flavours with no `+` in any query.
- [x] `npm run lint:pgx-dsn` passes on this branch (12 self-test assertions, 3 DSN-bearing env values across 5 compose files) and **fails on the pre-fix line**, reproduced by restoring `PGVECTOR_DB_URL: ${SUPABASE_DB_POOL_URL:-...}`:
  ```text
  docker-compose.yml: service `open-webui` env `PGVECTOR_DB_URL` references the pgx-flavoured
  $SUPABASE_DB_POOL_URL. `open-webui` is not declared as a pgx consumer, so its DSN is parsed by
  libpq, which fails the whole connection on an unknown option.
  ```
  Checks 2 and 3 were each verified to fail by mutation as well: renaming the variable in compose, and adding an unstripped `statement_cache_capacity` to the derivation script. Overlay coverage was verified the same way, by injecting `PGVECTOR_DB_URL: ${SUPABASE_DB_POOL_URL}` into `docker-compose.enterprise.yml`.
- [x] `docker-compose.yml`, `ci.yml` and `owui-nightly.yml` parse as YAML; `npm run lint:pgx-dsn` is present as a step in the `repo-policy-lints` job.
- [ ] Post-merge `deploy-demo-box` reaches "Smoke test public hostnames" and `chat-hive.scubed.co` returns 200. This is the real acceptance test: the derivation only runs on the box, from the box's own `.env`, so it cannot be exercised before merge.
