### PR TITLE
fix: add restart policies so the demo box survives a reboot

### DIFF
--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -78,6 +78,7 @@ services:
       timeout: 3s
       retries: 5
       start_period: 120s
+    restart: unless-stopped
 
   agent-engine:
     image: hive-agent-engine:ci
@@ -196,6 +197,7 @@ services:
         fi
         exec litellm --config=/etc/litellm/config.yaml
     command: []
+    restart: unless-stopped
 
   sdk-tests-js:
     image: hive-sdk-tests-js:ci
@@ -384,6 +386,7 @@ services:
       timeout: 3s
       retries: 5
       start_period: 120s
+    restart: unless-stopped
 
   # ──────────────────────────────────────────────────────────────────────────
   # EnterpriseEdge: Self-hosted Supabase data plane (issue #231)
@@ -430,6 +433,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+    restart: unless-stopped
 
   web-console:
     image: hive-web-console:ci
@@ -445,6 +449,10 @@ services:
       NEXT_PUBLIC_SUPABASE_ANON_KEY: ${NEXT_PUBLIC_SUPABASE_ANON_KEY}
       NEXT_PUBLIC_APP_URL: ${NEXT_PUBLIC_APP_URL:-http://localhost:3000}
       CONTROL_PLANE_BASE_URL: http://control-plane:8081
+    # No profiles gate on this service: it always starts regardless of which
+    # --profile flags are active, so it is part of the running set on any box
+    # (including the demo box) exactly like the profiled services below.
+    restart: unless-stopped
 
   # Blueprint Step 3.1 (#311, #305) — standalone agent console sidecar.
   # Ratified 2026-07-16: extends nothing in Open WebUI; OWUI stays a pinned
@@ -477,6 +485,7 @@ services:
         condition: service_healthy
     environment:
       EDGE_API_INTERNAL_BASE_URL: http://edge-api:8080
+    restart: unless-stopped
 
   # Self-hosted production web-console (migration off Cloudflare Workers --
   # Workers was chosen originally only because Cloudflare Pages Functions
@@ -883,6 +892,7 @@ services:
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
       - '--storage.tsdb.retention.time=30d'
+    restart: unless-stopped
   grafana:
     image: grafana/grafana:latest
     profiles:
@@ -906,6 +916,7 @@ services:
       GF_AUTH_ANONYMOUS_ORG_ROLE: Viewer
     depends_on:
       - prometheus
+    restart: unless-stopped
 
   alertmanager:
     image: prom/alertmanager:latest
@@ -917,6 +928,7 @@ services:
       - ../../deploy/alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
     command:
       - '--config.file=/etc/alertmanager/alertmanager.yml'
+    restart: unless-stopped
 
 volumes:
   gomodcache:


### PR DESCRIPTION
## Summary

Live audit of the demo box (192.168.88.80) just before this PR:

- `docker.service`: enabled (reboot-safe).
- `cloudflared`: user-level systemd unit, enabled, `linger=yes` (reboot-safe).
- GitHub Actions runner (`actions.runner.sakibsadmanshajib-hive.hive-demo-box.service`): enabled and active (reboot-safe).
- Container restart policies as they stood: `unless-stopped` on `open-webui`, `web-console-prod`, `caddy-console`, `caddy-owui`, `caddy-artifacts`. Policy `no` (Docker's default when `restart:` is absent) on `edge-api`, `control-plane`, `litellm`, `redis`, `agent-console`, `web-console` (dev), `prometheus`, `grafana`, `alertmanager`.

Consequence: a reboot restores docker, the tunnel, and the runner, but the core Hive services stay down, so the whole public demo surface (api-hive, control-hive, chat-hive, console-hive) stays broken until someone runs compose by hand.

## Changes (`deploy/docker/docker-compose.yml`)

Added `restart: unless-stopped` (never `always`, so a deliberate manual `docker stop` is still respected) to every service that was missing a `restart:` key and is meant to run continuously:

- `edge-api`
- `control-plane`
- `litellm`
- `redis`
- `web-console` (dev, port 3000) — this service carries no `profiles:` key, so it always starts regardless of which `--profile` flags are passed and was confirmed live on the demo box; leaving it out would have kept one currently-running container reboot-unsafe while everything else got fixed.
- `agent-console`
- `prometheus`, `grafana`, `alertmanager` (monitoring profile) — judgment call: these are opt-in via `--profile monitoring`, so a reboot only restores them if an operator was already running that profile. The box has 10GB RAM total, but the combined footprint of these three is modest next to `open-webui`'s own 2G `mem_limit`, and `unless-stopped` still lets an operator free RAM with a manual stop without the policy fighting them. Once monitoring was deliberately turned on, losing it silently after a reboot (exactly when you most want visibility) seemed worse than the RAM cost.

## Deliberately left alone

- `agent-engine` — profile `agent`, not active on the demo box. Its `command` is a documented smoke-test invocation (see the in-file comment) that intentionally exits non-zero against a placeholder tenant/user; a restart policy here would crash-loop it forever.
- `toolchain`, `sdk-tests-js`, `sdk-tests-py`, `sdk-tests-java` — profile `tools`/`test`, one-shot CI/dev containers. A restart policy on a one-shot container makes it loop forever.
- `supabase-init` in `docker-compose.enterprise.yml` — one-shot bucket bootstrap, already explicitly `restart: "no"` with a comment explaining why.
- All other services in `docker-compose.enterprise.yml` (`supabase-db`, `supabase-auth`, `supabase-rest`, `supabase-storage`) already carry `restart: unless-stopped` from a prior change; nothing there needed fixing.

## Verification

`cd deploy/docker && docker compose --env-file ../../.env.example --profile local --profile chat config` — exit 0, resolved config confirmed via a small parse script that `agent-engine`/`toolchain`/`sdk-tests-*` still have no `restart` key.
Also re-ran with `--profile monitoring` added, and separately `-f docker-compose.yml -f docker-compose.enterprise.yml --profile enterprise config` — both exit 0.

## Deploy note

This causes `deploy-demo-box` to recreate the affected containers on its next run (new `restart` policy requires a container recreate to take effect). That is expected and is how the new policy actually gets applied to the running demo box. No manual deploy or SSH was performed as part of this PR.

## Test plan

- [x] `docker compose ... config` parses clean for `local+chat`, `local+chat+monitoring`, and the enterprise override, confirmed via CI on this PR
- [x] Confirmed via YAML parse that untouched one-shot services still have no `restart` key
- [ ] Next `deploy-demo-box` run recreates the changed containers and the demo box survives its next reboot with the full public surface back up unattended