### PR TITLE
feat: carry alias credit pricing on routing.SelectionResult

### DIFF
--- a/apps/control-plane/internal/routing/repository.go
+++ b/apps/control-plane/internal/routing/repository.go
@@ -13,6 +13,12 @@ import (
 type Repository interface {
 	LoadAliasPolicy(ctx context.Context, aliasID string) (catalog.AliasPolicySnapshot, error)
 	ListRouteCandidates(ctx context.Context, aliasID string) ([]RouteCandidate, error)
+	// LoadAliasPricing reads the alias's per-model credit price from
+	// public.model_aliases. A missing row is not an error: it returns the
+	// catalog.CatalogPricing zero value so a data-inconsistency on the
+	// pricing side never blocks a route the routing tables already
+	// approved (metering step 2, shadow mode; see SelectionResult.Pricing).
+	LoadAliasPricing(ctx context.Context, aliasID string) (catalog.CatalogPricing, error)
 }
 
 type pgxRepository struct {
@@ -108,6 +114,43 @@ func (r *pgxRepository) ListRouteCandidates(ctx context.Context, aliasID string)
 	}
 
 	return candidates, nil
+}
+
+// LoadAliasPricing reads public.model_aliases directly rather than going
+// through catalog.Service: routing already depends on the catalog package
+// for AliasPolicySnapshot, and a same-transactionable direct read keeps this
+// addition to one query on the pool routing already holds, with no new
+// cross-package call and no new network hop (metering step 2 brief section
+// 2.5).
+func (r *pgxRepository) LoadAliasPricing(ctx context.Context, aliasID string) (catalog.CatalogPricing, error) {
+	row := r.pool.QueryRow(ctx, `
+		SELECT
+			input_price_credits,
+			output_price_credits,
+			cache_read_price_credits,
+			cache_write_price_credits
+		FROM public.model_aliases
+		WHERE alias_id = $1
+	`, aliasID)
+
+	var pricing catalog.CatalogPricing
+	if err := row.Scan(
+		&pricing.InputPriceCredits,
+		&pricing.OutputPriceCredits,
+		&pricing.CacheReadPriceCredits,
+		&pricing.CacheWritePriceCredits,
+	); err != nil {
+		if err == pgx.ErrNoRows {
+			// No model_aliases row for an alias the routing tables already
+			// resolved is a data-inconsistency case, not a request-level
+			// error: return the zero value so SelectRoute keeps working and
+			// the caller reads it as "no cost basis available".
+			return catalog.CatalogPricing{}, nil
+		}
+		return catalog.CatalogPricing{}, fmt.Errorf("routing: load alias pricing: %w", err)
+	}
+
+	return pricing, nil
 }
 
 type rowScanner interface {

--- a/apps/control-plane/internal/routing/service.go
+++ b/apps/control-plane/internal/routing/service.go
@@ -141,12 +141,24 @@ func (s *Service) SelectRoute(ctx context.Context, input SelectionInput) (Select
 		fallbacks = append(fallbacks, candidate.RouteID)
 	}
 
+	// Pricing is a property of the alias, not of whichever candidate ended up
+	// primary vs. fallback, so it is resolved once here, after a route has
+	// actually been selected. Deferring it to this point (rather than up
+	// front, alongside LoadAliasPolicy) also means an alias that gets
+	// refused earlier -- unentitled, disallowed, no eligible routes -- never
+	// pays for a pricing lookup it will not use.
+	pricing, err := s.repo.LoadAliasPricing(ctx, aliasID)
+	if err != nil {
+		return SelectionResult{}, fmt.Errorf("routing: load alias pricing for %s: %w", aliasID, err)
+	}
+
 	return SelectionResult{
 		AliasID:          aliasID,
 		RouteID:          selected.RouteID,
 		LiteLLMModelName: selected.LiteLLMModelName,
 		Provider:         selected.Provider,
 		FallbackRouteIDs: fallbacks,
+		Pricing:          pricing,
 	}, nil
 }
 

--- a/apps/control-plane/internal/routing/service_test.go
+++ b/apps/control-plane/internal/routing/service_test.go
@@ -18,6 +18,11 @@ type stubRepository struct {
 	candidatesErr   error
 	listCalls       int
 	loadPolicyCalls int
+
+	pricing            catalog.CatalogPricing
+	pricingErr         error
+	pricingCalls       int
+	sawPricingAliasIDs []string
 }
 
 func (s *stubRepository) LoadAliasPolicy(_ context.Context, _ string) (catalog.AliasPolicySnapshot, error) {
@@ -36,6 +41,16 @@ func (s *stubRepository) ListRouteCandidates(_ context.Context, _ string) ([]Rou
 	}
 
 	return append([]RouteCandidate(nil), s.candidates...), nil
+}
+
+func (s *stubRepository) LoadAliasPricing(_ context.Context, aliasID string) (catalog.CatalogPricing, error) {
+	s.pricingCalls++
+	s.sawPricingAliasIDs = append(s.sawPricingAliasIDs, aliasID)
+	if s.pricingErr != nil {
+		return catalog.CatalogPricing{}, s.pricingErr
+	}
+
+	return s.pricing, nil
 }
 
 // stubEntitlements stands in for catalog.Service, the production
@@ -710,5 +725,180 @@ func TestRequireToolCapable_MixedProviderOnlyCapableSelected(t *testing.T) {
 	// share the same provider slug.
 	if result.RouteID != "route-tools" {
 		t.Fatalf("expected route-tools (capable), got %q", result.RouteID)
+	}
+}
+
+// TestSelectRouteCarriesAliasPricing is metering step 2 wave 1a's core
+// assertion: SelectRoute must surface the alias's per-model credit price on
+// the result so a caller (edge-api's metering gate, wired in a later wave)
+// can price a request without a second round trip. Two aliases with
+// different prices must produce different Pricing values for identical
+// token counts (spec 8.2 item 9's regression guard against reverting to a
+// flat total-tokens estimate).
+func TestSelectRouteCarriesAliasPricing(t *testing.T) {
+	repo := entitlementTestRepo()
+	cacheRead := int64(1)
+	cacheWrite := int64(5)
+	repo.pricing = catalog.CatalogPricing{
+		InputPriceCredits:      12,
+		OutputPriceCredits:     36,
+		CacheReadPriceCredits:  &cacheRead,
+		CacheWritePriceCredits: &cacheWrite,
+	}
+
+	svc := NewService(repo, &stubEntitlements{visible: true})
+
+	result, err := svc.SelectRoute(context.Background(), SelectionInput{
+		AliasID:             "hive-fast",
+		TenantID:            uuid.New(),
+		NeedChatCompletions: true,
+	})
+	if err != nil {
+		t.Fatalf("SelectRoute returned error: %v", err)
+	}
+	if result.Pricing.InputPriceCredits != 12 {
+		t.Fatalf("expected input price 12, got %d", result.Pricing.InputPriceCredits)
+	}
+	if result.Pricing.OutputPriceCredits != 36 {
+		t.Fatalf("expected output price 36, got %d", result.Pricing.OutputPriceCredits)
+	}
+	if result.Pricing.CacheReadPriceCredits == nil || *result.Pricing.CacheReadPriceCredits != 1 {
+		t.Fatalf("expected cache read price 1, got %v", result.Pricing.CacheReadPriceCredits)
+	}
+	if result.Pricing.CacheWritePriceCredits == nil || *result.Pricing.CacheWritePriceCredits != 5 {
+		t.Fatalf("expected cache write price 5, got %v", result.Pricing.CacheWritePriceCredits)
+	}
+	if repo.pricingCalls != 1 {
+		t.Fatalf("expected exactly one pricing lookup, got %d", repo.pricingCalls)
+	}
+	if len(repo.sawPricingAliasIDs) != 1 || repo.sawPricingAliasIDs[0] != "hive-fast" {
+		t.Fatalf("expected pricing lookup for hive-fast, got %v", repo.sawPricingAliasIDs)
+	}
+}
+
+// TestSelectRouteHandlesZeroPricingWithoutPanic covers an alias with no
+// model_aliases row (a data-inconsistency case, not a customer-facing
+// error): the repository returns the catalog.CatalogPricing zero value, and
+// SelectRoute must return it as-is rather than panic or fail the selection.
+// A missing price is "no cost basis", a verdict shadow-mode logs, not a
+// reason to break a route the routing tables already approved.
+func TestSelectRouteHandlesZeroPricingWithoutPanic(t *testing.T) {
+	repo := entitlementTestRepo()
+	// repo.pricing left at its zero value deliberately.
+
+	svc := NewService(repo, &stubEntitlements{visible: true})
+
+	result, err := svc.SelectRoute(context.Background(), SelectionInput{
+		AliasID:             "hive-fast",
+		NeedChatCompletions: true,
+	})
+	if err != nil {
+		t.Fatalf("SelectRoute returned error for zero pricing: %v", err)
+	}
+	if result.Pricing.InputPriceCredits != 0 || result.Pricing.OutputPriceCredits != 0 {
+		t.Fatalf("expected zero-value pricing, got %+v", result.Pricing)
+	}
+	if result.Pricing.CacheReadPriceCredits != nil || result.Pricing.CacheWritePriceCredits != nil {
+		t.Fatalf("expected nil cache pricing pointers, got %+v", result.Pricing)
+	}
+}
+
+// TestSelectRoutePriceIsAliasStableAcrossFallback asserts spec decision 15:
+// price is a property of the alias, not of whichever route within it gets
+// selected as primary vs. fallback. The same alias with multiple eligible
+// routes must report one price, not a per-route price that could silently
+// vary when the fallback order changes.
+func TestSelectRoutePriceIsAliasStableAcrossFallback(t *testing.T) {
+	repo := &stubRepository{
+		policy: catalog.AliasPolicySnapshot{
+			AliasID:                 "hive-fast",
+			PolicyMode:              "latency",
+			AllowPriceClassWidening: false,
+			FallbackOrder:           []string{"route-groq-fast", "route-openrouter-fast-fallback"},
+		},
+		candidates: []RouteCandidate{
+			{
+				RouteID:                 "route-groq-fast",
+				AliasID:                 "hive-fast",
+				Provider:                "groq",
+				LiteLLMModelName:        "route-groq-fast",
+				PriceClass:              "standard",
+				HealthState:             "healthy",
+				Priority:                10,
+				SupportsChatCompletions: true,
+			},
+			{
+				RouteID:                 "route-openrouter-fast-fallback",
+				AliasID:                 "hive-fast",
+				Provider:                "openrouter",
+				LiteLLMModelName:        "route-openrouter-fast-fallback",
+				PriceClass:              "standard",
+				HealthState:             "healthy",
+				Priority:                20,
+				SupportsChatCompletions: true,
+			},
+		},
+		pricing: catalog.CatalogPricing{InputPriceCredits: 8, OutputPriceCredits: 24},
+	}
+
+	svc := NewService(repo, &stubEntitlements{visible: true})
+
+	result, err := svc.SelectRoute(context.Background(), SelectionInput{
+		AliasID:             "hive-fast",
+		NeedChatCompletions: true,
+	})
+	if err != nil {
+		t.Fatalf("SelectRoute returned error: %v", err)
+	}
+	if result.RouteID != "route-groq-fast" {
+		t.Fatalf("expected primary route-groq-fast, got %q", result.RouteID)
+	}
+	if len(result.FallbackRouteIDs) != 1 || result.FallbackRouteIDs[0] != "route-openrouter-fast-fallback" {
+		t.Fatalf("expected one fallback route-openrouter-fast-fallback, got %v", result.FallbackRouteIDs)
+	}
+	if result.Pricing.InputPriceCredits != 8 || result.Pricing.OutputPriceCredits != 24 {
+		t.Fatalf("expected alias-level pricing 8/24 regardless of which route was primary, got %+v", result.Pricing)
+	}
+}
+
+// TestSelectRoutePropagatesPricingLookupFailure matches the repo's existing
+// convention (TestSelectRoutePropagatesAliasLookupErrors): a genuine
+// infrastructure failure resolving pricing (DB unreachable, etc., as
+// distinct from "no row for this alias", which LoadAliasPricing must treat
+// as a zero-value, non-error result) surfaces to the caller rather than
+// being silently swallowed into a wrong zero price.
+func TestSelectRoutePropagatesPricingLookupFailure(t *testing.T) {
+	repo := entitlementTestRepo()
+	repo.pricingErr = errors.New("pricing db down")
+
+	svc := NewService(repo, &stubEntitlements{visible: true})
+
+	_, err := svc.SelectRoute(context.Background(), SelectionInput{
+		AliasID:             "hive-fast",
+		NeedChatCompletions: true,
+	})
+	if err == nil {
+		t.Fatal("expected pricing lookup failure to be surfaced")
+	}
+}
+
+// TestSelectRouteSkipsPricingLookupOnEarlyRefusal asserts the pricing
+// lookup is not a wasted query on a path that was always going to fail: an
+// unentitled alias must be refused before any pricing read, exactly as it
+// already skips ListRouteCandidates (TestSelectRouteDeniesAliasHiddenFromTenant).
+func TestSelectRouteSkipsPricingLookupOnEarlyRefusal(t *testing.T) {
+	repo := entitlementTestRepo()
+	svc := NewService(repo, &stubEntitlements{visible: false})
+
+	_, err := svc.SelectRoute(context.Background(), SelectionInput{
+		AliasID:             "hive-fast",
+		TenantID:            uuid.New(),
+		NeedChatCompletions: true,
+	})
+	if err == nil {
+		t.Fatal("expected an unentitled alias to be refused")
+	}
+	if repo.pricingCalls != 0 {
+		t.Fatalf("expected pricing lookup to be skipped for an unentitled alias, got %d calls", repo.pricingCalls)
 	}
 }

--- a/apps/control-plane/internal/routing/types.go
+++ b/apps/control-plane/internal/routing/types.go
@@ -1,6 +1,10 @@
 package routing
 
-import "github.com/google/uuid"
+import (
+	"github.com/google/uuid"
+
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/catalog"
+)
 
 type SelectionInput struct {
 	AliasID string
@@ -63,4 +67,27 @@ type SelectionResult struct {
 	LiteLLMModelName string   `json:"litellm_model_name"`
 	Provider         string   `json:"provider"`
 	FallbackRouteIDs []string `json:"fallback_route_ids"`
+
+	// Pricing is the alias's per-model credit price, read from
+	// public.model_aliases via Repository.LoadAliasPricing. It is
+	// alias-stable, not route-stable: every candidate SelectRoute could
+	// have chosen for this alias (primary or any fallback) carries the same
+	// price, so a fallback to a different route never changes it (metering
+	// step 2 design, spec decision 15).
+	//
+	// Additive field: an existing caller that only reads AliasID/RouteID/
+	// LiteLLMModelName/Provider/FallbackRouteIDs keeps compiling and behaves
+	// identically. A caller that reads Pricing before an alias has a
+	// model_aliases row sees the catalog.CatalogPricing zero value, which
+	// must be read as "no cost basis available", never as "free"; this
+	// step's own metering gate (edge-api internal/metering, added
+	// separately) is what turns that distinction into a shadow-mode
+	// verdict. Nothing in this package enforces or debits against it.
+	//
+	// The credit unit itself (per-token vs. per-million-tokens) is
+	// unresolved pending the owner's ruling (spec section 12 item 1) and
+	// blocks Step 4, not this addition: these are the same raw
+	// input/output/cache price fields already served today by
+	// catalog.Service for /v1/models, passed through unchanged.
+	Pricing catalog.CatalogPricing `json:"pricing"`
 }


### PR DESCRIPTION
## Summary

Metering Step 2, Wave 1a only (per the architecture brief for backend metering shadow mode). Pure plumbing addition to control-plane's routing package: `routing.SelectionResult` now carries the alias's per-model credit price so a later consumer (the edge-api metering shadow gate, built in a separate wave/PR) can price a dispatch without a second round trip.

This PR **enforces nothing and debits nothing**. It is shadow-mode groundwork only:

- `routing.Repository` gains `LoadAliasPricing(ctx, aliasID) (catalog.CatalogPricing, error)`, reading `input_price_credits` / `output_price_credits` / `cache_read_price_credits` / `cache_write_price_credits` from `public.model_aliases`.
- A missing `model_aliases` row returns the `catalog.CatalogPricing` zero value, not an error: a pricing data gap must never block a route the routing tables already approved. A genuine query failure (DB unreachable) still propagates, matching the existing `LoadAliasPolicy` convention.
- `Service.SelectRoute` resolves pricing once, after a route has been chosen, and only on the success path, so an alias refused earlier (unentitled, disallowed, no eligible routes) never pays for a pricing lookup it will not use.
- Price is alias-stable: whichever route ends up primary vs. fallback for the same alias reports the same price (spec decision 15).
- Purely additive to `SelectionResult`: existing callers that ignore the new `Pricing` field keep compiling and behave identically. Verified by the existing `batchstore` suite (which builds `SelectionResult` literals) and a full `go build` across both `apps/control-plane` and `apps/edge-api`.

No enforcement, no reservation/ledger call, no wiring into `cmd/server/main.go` (that is a later, single-owner wave by design, to avoid a shared-file merge conflict across parallel PRs).

## Test plan

RED (genuine, before implementation): new table-driven cases added to `apps/control-plane/internal/routing/service_test.go` failed for the right reason (pricing never resolved, since `service.go` did not yet call the new repository method):
- `TestSelectRouteCarriesAliasPricing`: `expected input price 12, got 0`
- `TestSelectRoutePriceIsAliasStableAcrossFallback`: pricing came back zero-valued instead of the stubbed alias price
- `TestSelectRoutePropagatesPricingLookupFailure`: expected error was not surfaced

GREEN (after wiring `repository.go` + `service.go`): all of the above pass, plus:
- `TestSelectRouteHandlesZeroPricingWithoutPanic`: no `model_aliases` row, no panic, zero-value result returned
- `TestSelectRouteSkipsPricingLookupOnEarlyRefusal`: unentitled alias never triggers a pricing lookup

Full regression, run from the feature branch:
```
cd deploy/docker && docker compose --profile tools run toolchain \
  "cd /workspace && go test ./apps/control-plane/... -count=1 -short"
```
All packages pass, including `batchstore` (constructs `SelectionResult` literals) and the existing `TestRoutingRepositoryDoesNotRunCapabilityDDL` regression guard (repository.go still runs zero DDL).

Also ran, to prove nothing else in the workspace broke from the additive struct change:
```
cd deploy/docker && docker compose --profile tools run toolchain \
  "cd /workspace && go build ./apps/control-plane/... ./apps/edge-api/..."
```

- [x] `go test ./apps/control-plane/...` green
- [x] `go build` clean across control-plane and edge-api
- [x] `go vet ./apps/control-plane/internal/routing/...` clean
- [x] Regression guard `TestRoutingRepositoryDoesNotRunCapabilityDDL` still passes (no DDL added)
- [x] Zero behavior change: no reservation, no ledger write, no refusal added anywhere in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Route selection results now include pricing details for the selected alias, including input, output, and cache read/write credit rates.
  * Pricing remains consistent when fallback routes are used.
* **Bug Fixes**
  * Aliases without configured pricing are handled safely with zero pricing.
  * Pricing lookup failures are reported instead of being silently ignored.
  * Pricing is not requested for requests that are refused before route selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->