### PR TITLE
feat: lint blocking cost/USD/provider fields from customer responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint:litellm-config": "node tools/lint-litellm-config-fallbacks.mjs",
     "lint:proof-tokens": "node tools/lint-no-token-in-proof-captures.mjs",
     "lint:pgx-dsn": "node tools/lint-no-pgx-dsn-for-libpq.mjs",
+    "lint:no-client-cost-fields": "node tools/lint-no-client-cost-fields.mjs",
     "soc2:report": "node tools/soc2-coverage-report.mjs",
     "soc2:check": "node tools/soc2-coverage-report.mjs --check",
     "cloudflare:check": "node deploy/cloudflare/reconcile-tunnel-dns.mjs",

--- a/tools/lint-no-client-cost-fields.mjs
+++ b/tools/lint-no-client-cost-fields.mjs
@@ -1,0 +1,218 @@
+#!/usr/bin/env node
+// Structural guard: no cost, USD/FX, or provider-identity field may reach a
+// customer-bound Go struct.
+//
+// Two hard product rules this backs, per CLAUDE.md:
+//   * Provider-blind errors: provider names never leak to customers. Errors
+//     and responses are sanitized at both the control-plane and edge-api
+//     boundaries.
+//   * Regulatory: BD customers must never see FX rates, currency-exchange
+//     language, or USD amounts. `amount_usd` was stripped from every
+//     customer-bound surface by PR #137 (2026-05-09); the dedicated FX guard
+//     that followed it was deleted by owner decision on 2026-07-19, and its
+//     USD-absence assertions now live inside the broader billing functional
+//     tests. This lint is the cheap structural guard, scoped to what a lint
+//     can actually prove (a field name reaching a JSON struct tag) -- it does
+//     not replace those functional tests.
+//
+// False-positive shape this lint must not repeat (the deleted FX guard was
+// over-eager and got disabled): a JSON tag exactly named "provider" is
+// forbidden, but a field that merely CONTAINS "provider" as a substring
+// (provider_intent_id, provider_event_id -- payment-gateway ids, a different
+// concept) is not. Likewise "cost_credits" (Hive's internal cost basis) is
+// forbidden, but "price_credits" (input_price_credits/output_price_credits,
+// what the customer is shown and expected to see) is not -- "cost" is what
+// Hive pays upstream, "price" is what the customer pays, and conflating them
+// would flag the catalog response on every run.
+//
+// Some JSON-tagged Go structs carrying these exact field names are
+// deliberately internal: service-to-service payloads over an
+// internal-token-gated endpoint, an Asynq job-queue message, or (once Wave 1b
+// of this spec lands) a log-only shadow-mode verdict row. None of those are
+// ever marshaled into an HTTP response a customer receives, so they are
+// allowlisted by path below, each with its own justification, the same shape
+// tools/lint-no-direct-tenant-id.mjs already uses for its own internal
+// service-to-service exceptions.
+//
+// Not yet wired into CI (see .github/workflows/*): Wave 4 of this spec owns
+// that wiring. Runnable standalone today via `npm run lint:no-client-cost-fields`.
+
+import { readFileSync } from "node:fs";
+import { execSync } from "node:child_process";
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+
+// Exact JSON struct-tag names that must never reach a customer response.
+// Matched against the literal tag value (optionally with ",omitempty"), not
+// as a substring -- see the false-positive note above.
+const FORBIDDEN_FIELDS = [
+  {
+    tag: "provider",
+    re: /json:"provider(,omitempty)?"/,
+    why: "names the upstream provider (OpenRouter, Groq, ...); provider identity must never leak to a customer",
+  },
+  {
+    tag: "provider_name",
+    re: /json:"provider_name(,omitempty)?"/,
+    why: "same as provider: names the upstream provider",
+  },
+  {
+    tag: "upstream_provider",
+    re: /json:"upstream_provider(,omitempty)?"/,
+    why: "same as provider: names the upstream provider",
+  },
+  {
+    tag: "cost_credits",
+    re: /json:"cost_credits(,omitempty)?"/,
+    why: "Hive's internal cost basis (what Hive pays), distinct from the customer-facing input_price_credits/output_price_credits fields",
+  },
+  {
+    tag: "cost_usd",
+    re: /json:"cost_usd(,omitempty)?"/,
+    why: "internal cost basis denominated in USD; must never reach a customer response",
+  },
+  {
+    tag: "upstream_cost",
+    re: /json:"upstream_cost(,omitempty)?"/,
+    why: "internal cost basis; must never reach a customer response",
+  },
+  {
+    tag: "amount_usd",
+    re: /json:"amount_usd(,omitempty)?"/,
+    why: "the exact field PR #137 stripped from every BD-customer-bound surface; regulatory bar on FX/USD language for BD customers",
+  },
+  {
+    tag: "usd",
+    re: /json:"usd(,omitempty)?"/,
+    why: "a bare USD amount; regulatory bar on FX/USD language for BD customers",
+  },
+  {
+    tag: "fx_rate",
+    re: /json:"fx_rate(,omitempty)?"/,
+    why: "an FX rate; regulatory bar on currency-exchange language for BD customers",
+  },
+  {
+    tag: "exchange_rate",
+    re: /json:"exchange_rate(,omitempty)?"/,
+    why: "an FX rate; regulatory bar on currency-exchange language for BD customers",
+  },
+];
+
+// Paths allowed to carry these exact field names because the struct they sit
+// on is never marshaled into a customer-bound HTTP response. A directory
+// entry (trailing "/") matches by prefix; anything else matches the exact
+// file.
+const ALLOWLIST = [
+  // Internal service-to-service payload for the /internal/routing/select
+  // endpoint, gated by a shared internal token (not a customer-facing
+  // route). tools/lint-no-direct-tenant-id.mjs already grants this same
+  // directory the same posture for the same reason.
+  "apps/control-plane/internal/routing/",
+  // Client-side counterpart of that same internal endpoint.
+  "apps/edge-api/internal/inference/routing_client.go",
+  // Asynq internal job-queue payload (TypeBatchPoll/TypeBatchExecute);
+  // serialized for the queue, never marshaled into an HTTP response.
+  "apps/control-plane/internal/batchstore/",
+  // Wave 1b of this spec's shadow-mode verdict logger (not yet merged as of
+  // this PR). metering_shadow_verdicts is a log-only, service-role-only
+  // table (spec section 3.3/4): deliberately internal, never read by any
+  // customer-facing path.
+  "apps/edge-api/internal/metering/",
+  "tools/lint-no-client-cost-fields.mjs",
+  "tools/lint-no-client-cost-fields.test.mjs",
+];
+
+export function isAllowlistedPath(filePath) {
+  return ALLOWLIST.some((entry) =>
+    entry.endsWith("/") ? filePath.startsWith(entry) : filePath === entry,
+  );
+}
+
+export function findClientCostFieldViolations(filePath, source) {
+  if (isAllowlistedPath(filePath)) return [];
+  const violations = [];
+  const lines = source.split("\n");
+  lines.forEach((line, index) => {
+    for (const field of FORBIDDEN_FIELDS) {
+      if (field.re.test(line)) {
+        violations.push({
+          file: filePath,
+          lineNumber: index + 1,
+          tag: field.tag,
+          why: field.why,
+          line: line.trim(),
+        });
+      }
+    }
+  });
+  return violations;
+}
+
+function selfTest() {
+  const offending = `
+    type ChatCompletionResponse struct {
+      Model    string \`json:"model"\`
+      Provider string \`json:"provider"\`
+    }
+  `;
+  assert.equal(
+    findClientCostFieldViolations("apps/edge-api/internal/chat/response.go", offending).length,
+    1,
+    "detector no longer recognises a provider field on a customer-bound struct; this lint would be vacuous",
+  );
+
+  const clean = `
+    type ChatCompletionResponse struct {
+      Model string \`json:"model"\`
+      Usage Usage  \`json:"usage"\`
+    }
+  `;
+  assert.equal(
+    findClientCostFieldViolations("apps/edge-api/internal/chat/response.go", clean).length,
+    0,
+    "detector flags a clean customer-facing struct",
+  );
+
+  assert.equal(
+    isAllowlistedPath("apps/control-plane/internal/routing/types.go"),
+    true,
+    "internal routing service-to-service payload is no longer allowlisted",
+  );
+}
+
+selfTest();
+if (process.argv.includes("--self-test")) {
+  console.log("lint-no-client-cost-fields: SELF-TEST PASS");
+  process.exit(0);
+}
+
+// The repo-wide scan (and its process.exit) only runs when this file is
+// invoked directly, so tools/lint-no-client-cost-fields.test.mjs can import
+// the functions above without triggering a full scan as a side effect.
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+if (isMain) {
+  const files = execSync("git ls-files", { encoding: "utf8" })
+    .split("\n")
+    .filter(Boolean)
+    .filter((f) => f.startsWith("apps/") && f.endsWith(".go") && !f.endsWith("_test.go"));
+
+  if (files.length === 0) {
+    console.error("no Go files found under apps/; the lint is scanning the wrong tree");
+    process.exit(1);
+  }
+
+  let violations = 0;
+  for (const file of files) {
+    const source = readFileSync(file, "utf8");
+    for (const v of findClientCostFieldViolations(file, source)) {
+      violations++;
+      console.error(`${file}:${v.lineNumber}: forbidden client-visible ${v.tag} field -- ${v.why}\n  ${v.line}`);
+    }
+  }
+
+  if (violations > 0) {
+    console.error(`\n${violations} client-visible cost/provider-field violation(s).`);
+    process.exit(1);
+  }
+  console.log("lint-no-client-cost-fields: PASS");
+}

--- a/tools/lint-no-client-cost-fields.test.mjs
+++ b/tools/lint-no-client-cost-fields.test.mjs
@@ -1,0 +1,160 @@
+// tools/lint-no-client-cost-fields.test.mjs
+// Fixture tests for tools/lint-no-client-cost-fields.mjs, written before the
+// lint module existed (TDD RED first). Dependency-free, node:assert only,
+// matching the style every tools/lint-*.mjs script already uses for its own
+// inline selfTest(). Kept as its own file because the task requires a
+// separate test file rather than folding these cases into the lint script's
+// existing selfTest() convention.
+//
+// Run: node tools/lint-no-client-cost-fields.test.mjs
+
+import assert from "node:assert/strict";
+import {
+  findClientCostFieldViolations,
+  isAllowlistedPath,
+} from "./lint-no-client-cost-fields.mjs";
+
+// A path the lint has no reason to treat as internal-only.
+const CUSTOMER_PATH = "apps/edge-api/internal/chat/response.go";
+
+// --- Case 1: a fixture that DOES expose a provider field in a customer-bound
+// struct must be flagged. ---
+{
+  const offendingProvider = `
+    package chat
+
+    type ChatCompletionResponse struct {
+      ID       string \`json:"id"\`
+      Model    string \`json:"model"\`
+      Provider string \`json:"provider"\`
+    }
+  `;
+  const violations = findClientCostFieldViolations(CUSTOMER_PATH, offendingProvider);
+  assert.equal(
+    violations.length,
+    1,
+    "a customer-bound struct with a provider field must be flagged exactly once",
+  );
+  assert.equal(violations[0].tag, "provider");
+}
+
+// --- Case 2: a fixture that DOES expose a USD field in a customer-bound
+// struct must be flagged (the exact regression PR #137 fixed). ---
+{
+  const offendingUsd = `
+    package chat
+
+    type ChatCompletionResponse struct {
+      ID        string \`json:"id"\`
+      AmountUsd float64 \`json:"amount_usd"\`
+    }
+  `;
+  const violations = findClientCostFieldViolations(CUSTOMER_PATH, offendingUsd);
+  assert.equal(violations.length, 1, "a customer-bound struct with amount_usd must be flagged");
+  assert.equal(violations[0].tag, "amount_usd");
+}
+
+// --- Case 3: a clean fixture must not be flagged. Includes the customer-
+// facing price_credits fields deliberately, since these are the fields a
+// customer IS supposed to see (what they pay, in credits, no FX) and must
+// never be confused with the forbidden cost/provider/USD fields (what Hive
+// pays, or which upstream delivered it). This is the false-positive guard:
+// a lint that cannot tell "price to customer" from "Hive's cost" would cry
+// wolf on every catalog response and get disabled, same fate as the FX guard
+// deleted 2026-07-19. ---
+{
+  const clean = `
+    package chat
+
+    type ChatCompletionResponse struct {
+      ID                 string \`json:"id"\`
+      Model              string \`json:"model"\`
+      Usage              Usage  \`json:"usage"\`
+    }
+
+    type ModelPricing struct {
+      InputPriceCredits  int64 \`json:"input_price_credits"\`
+      OutputPriceCredits int64 \`json:"output_price_credits"\`
+    }
+  `;
+  const violations = findClientCostFieldViolations(CUSTOMER_PATH, clean);
+  assert.equal(violations.length, 0, "a clean customer-facing fixture must not be flagged");
+}
+
+// --- Case 4: an internal-only path (the shadow-mode verdict records this
+// step's brief describes, section 3.3/4: metering_shadow_verdicts is a
+// log-only table, never read by any customer-facing path) must not be
+// flagged even though the same field names appear. ---
+{
+  const shadowVerdictLogger = `
+    package metering
+
+    // verdictRow mirrors public.metering_shadow_verdicts. Never marshaled to
+    // an HTTP response; written once, post-response, for grading only.
+    type verdictRow struct {
+      RequestID                string \`json:"request_id"\`
+      Provider                 string \`json:"provider"\`
+      EstimatedCreditsPerModel int64  \`json:"estimated_credits_per_model"\`
+      WouldRefuseCode          string \`json:"would_refuse_code,omitempty"\`
+    }
+  `;
+  const shadowPath = "apps/edge-api/internal/metering/verdictlog.go";
+  assert.equal(isAllowlistedPath(shadowPath), true, "the metering package must be allowlisted");
+  const violations = findClientCostFieldViolations(shadowPath, shadowVerdictLogger);
+  assert.equal(
+    violations.length,
+    0,
+    "the internal-only shadow-mode verdict logger must not be flagged",
+  );
+}
+
+// --- Case 5: the real internal-only shape that exists on main today
+// (routing.SelectionResult / SelectRouteResult): a service-to-service
+// payload between control-plane and edge-api over the internal
+// /internal/routing/select endpoint, gated by a shared secret, never a
+// customer response. Regression guard using the actual field shape at
+// apps/control-plane/internal/routing/types.go:64 as of commit 573151d7. ---
+{
+  const routingSelectionResult = `
+    package routing
+
+    type SelectionResult struct {
+      AliasID          string   \`json:"alias_id"\`
+      RouteID          string   \`json:"route_id"\`
+      LiteLLMModelName string   \`json:"litellm_model_name"\`
+      Provider         string   \`json:"provider"\`
+      FallbackRouteIDs []string \`json:"fallback_route_ids"\`
+    }
+  `;
+  const routingPath = "apps/control-plane/internal/routing/types.go";
+  assert.equal(isAllowlistedPath(routingPath), true, "the routing package must be allowlisted");
+  const violations = findClientCostFieldViolations(routingPath, routingSelectionResult);
+  assert.equal(violations.length, 0, "the internal routing service-to-service payload must not be flagged");
+}
+
+// --- Case 6 (false-positive guard): fields that merely CONTAIN "provider" or
+// "cost" as a substring, with a different exact json tag, must not be
+// flagged. These are real fields on main today (payments/types.go,
+// usage/types.go) naming a payment-gateway provider id, not an LLM upstream
+// provider identity -- a different concept the literal task wording ("cost
+// or provider field") does not intend to catch. A substring match here would
+// have made this lint fire on main from day one, which is exactly the
+// "cries wolf, gets disabled" failure mode the brief warns about. ---
+{
+  const paymentProviderIds = `
+    package payments
+
+    type PaymentIntentResponse struct {
+      ProviderIntentID string \`json:"provider_intent_id"\`
+      ProviderEventID  string \`json:"provider_event_id"\`
+    }
+  `;
+  const violations = findClientCostFieldViolations(CUSTOMER_PATH, paymentProviderIds);
+  assert.equal(
+    violations.length,
+    0,
+    "provider_intent_id/provider_event_id (payment-gateway ids) must not be confused with the LLM upstream provider field",
+  );
+}
+
+console.log("lint-no-client-cost-fields.test: PASS");


### PR DESCRIPTION
## Summary

Metering Step 2, Wave 2c only (per the vault brief spec-2026-07-28-backend-metering.md section 9.2, `.wolf/decisions.md` D-027). Adds one new repo lint: `tools/lint-no-client-cost-fields.mjs`, plus its own test file `tools/lint-no-client-cost-fields.test.mjs`, plus a `package.json` script entry. No other file touched.

## The rule being guarded

Two hard product rules, both already stated in `CLAUDE.md`:

- Provider-blind errors: provider names never leak to customers. Sanitized at both the control-plane and edge-api boundaries.
- Regulatory: BD customers must never see FX rates, currency-exchange language, or USD amounts. `amount_usd` was stripped from every customer-bound surface by PR #137. The dedicated FX guard that followed was deleted by owner decision on 2026-07-19; its USD-absence assertions now live inside the broader billing functional tests. This lint is the cheap structural guard, scoped to what a lint can actually prove (a forbidden JSON tag on a Go struct), and does not replace those functional tests.

The lint fails when an exact JSON struct tag (`provider`, `provider_name`, `upstream_provider`, `cost_credits`, `cost_usd`, `upstream_cost`, `amount_usd`, `usd`, `fx_rate`, `exchange_rate`) appears on a Go struct outside a small, individually justified allowlist of paths that are never marshaled into a customer-bound HTTP response:

- `apps/control-plane/internal/routing/` and its edge-api client counterpart `apps/edge-api/internal/inference/routing_client.go`: an internal service-to-service payload over the `/internal/routing/select` endpoint, gated by a shared internal token, not a customer-facing route. Same posture `tools/lint-no-direct-tenant-id.mjs` already grants this exact directory.
- `apps/control-plane/internal/batchstore/`: an Asynq internal job-queue payload, never marshaled into an HTTP response.
- `apps/edge-api/internal/metering/`: Wave 1b's shadow-mode verdict logger (not yet merged as of this PR). `metering_shadow_verdicts` is a log-only, service-role-only table; deliberately internal, never read by any customer-facing path.

Modeled on `tools/lint-no-direct-tenant-id.mjs`: exact JSON-tag matching (not substring), a per-entry justified allowlist, `git ls-files`-driven scan restricted to `apps/**/*.go` (excluding `_test.go`), same PASS/violation output shape and exit-code convention (0 clean, 1 on any violation).

## False-positive reasoning

The real failure mode here is a lint that cries wolf and gets disabled, exactly what happened to the FX guard deleted 2026-07-19. Two confusions were checked against the actual repo and locked in as test cases:

1. **Substring vs exact tag.** `payments/types.go` and `usage/types.go` carry `ProviderIntentID`, `ProviderEventID`, `ProviderRequestID` (payment-gateway ids, e.g. Stripe/bKash/SSLCommerz), whose JSON tags contain "provider" as a substring but are not the exact tag `provider`. A substring match would have fired on `main` from day one. The lint matches the exact tag value only.
2. **Cost vs price.** `input_price_credits`/`output_price_credits` (`catalog/types.go`) are the customer-facing price fields the console is supposed to show; `cost_credits` (Hive's internal cost basis, written only to the tag-less `TraceRow` in `chat/trace.go`, which has no JSON tags at all and so is naturally excluded) is not. The lint distinguishes these by exact tag name, never by a "contains cost" heuristic.

Both are asserted directly against real field shapes from `apps/control-plane/internal/payments/types.go` and `apps/control-plane/internal/catalog/types.go` in the test file, not just described in prose.

## Not yet wired into CI

No `.github/workflows/*` file is touched by this PR. Wave 4 of the same spec owns CI wiring (it also renames the sibling `tools/lint-litellm-dispatch-requires-routing.mjs` guard and adds the `METERING_GATE` predicate to it). Until Wave 4 lands, this lint is runnable standalone via `npm run lint:no-client-cost-fields` but not yet enforced on any PR.

## Evidence it exits zero on current `main`

```
$ node tools/lint-no-client-cost-fields.mjs
lint-no-client-cost-fields: PASS
$ echo $?
0
```

A targeted grep across every `apps/**/*.go` file for the exact forbidden tags before writing the allowlist found precisely three real hits, all in the paths above (`routing_client.go:59`, `routing/types.go:64`, `batchstore/types.go:19`), each genuinely internal-only per the code's own comments (e.g. `chat/dispatch.go`: "Provider name is internal only -- never written to audit_log.after_json").

## TDD evidence

RED (module did not exist yet):

```
$ node tools/lint-no-client-cost-fields.test.mjs
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../tools/lint-no-client-cost-fields.mjs'
```

GREEN (after implementation):

```
$ node tools/lint-no-client-cost-fields.test.mjs
lint-no-client-cost-fields.test: PASS
$ node tools/lint-no-client-cost-fields.mjs --self-test
lint-no-client-cost-fields: SELF-TEST PASS
$ node tools/lint-no-client-cost-fields.mjs
lint-no-client-cost-fields: PASS
```

Test file covers: a provider-field fixture and a USD-field fixture (must flag), a clean fixture including customer-facing price_credits fields (must not flag), the shadow-mode-verdict-logger internal-only fixture from the brief (must not flag), the real `routing.SelectionResult` shape from `main` (must not flag), and the payment-gateway-provider-id false-positive guard (must not flag).

## Test plan

- [x] `node tools/lint-no-client-cost-fields.test.mjs` passes
- [x] `node tools/lint-no-client-cost-fields.mjs --self-test` passes
- [x] `node tools/lint-no-client-cost-fields.mjs` exits 0 on current `main`
- [x] `npm run lint:no-client-cost-fields` runs the lint via the new script entry
- [x] `git diff --stat` against `main` touches only `package.json`, `tools/lint-no-client-cost-fields.mjs`, `tools/lint-no-client-cost-fields.test.mjs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a lint command to detect restricted cost-related fields in customer-facing responses.
  * Added automated checks covering prohibited fields, allowed internal paths, and false-positive scenarios.

* **Chores**
  * Added a standalone validation tool with clear pass/fail reporting for development workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->