### PR TITLE
fix: settle streaming reservations on disconnect instead of losing the hold

### DIFF
--- a/apps/control-plane/internal/accounting/service.go
+++ b/apps/control-plane/internal/accounting/service.go
@@ -264,11 +264,24 @@ func (s *Service) finalizeLocked(ctx context.Context, input FinalizeReservationI
 		return Reservation{}, &PolicyError{Message: "released reservations cannot be finalized"}
 	}
 
-	releaseCredits := releasableCredits(reservation, input.ActualCredits)
 	heldCredits := remainingHeldCredits(reservation)
 
-	if input.ActualCredits > 0 {
-		if _, err := s.ledgerSvc.ChargeUsage(ctx, reservation.AccountID, reservation.RequestID, &reservation.RequestAttemptID, &reservation.ID, s.idempotencyKey(reservation.ID, fmt.Sprintf("charge-%d", input.ActualCredits)), input.ActualCredits, map[string]any{
+	// Hard invariant: a settlement must never charge more than it reserved.
+	// input.ActualCredits is caller-supplied (edge-api's token estimate,
+	// which can run far ahead of the hold -- e.g. a huge request body
+	// disconnected after one output token, see issue #602). finalizeLocked
+	// is the single chokepoint every settlement path routes through (sync
+	// and streaming, all endpoints), so clamping here protects the ledger
+	// even if a future estimator change reintroduces an overcount.
+	actualCredits := input.ActualCredits
+	if actualCredits > heldCredits {
+		actualCredits = heldCredits
+	}
+
+	releaseCredits := releasableCredits(reservation, actualCredits)
+
+	if actualCredits > 0 {
+		if _, err := s.ledgerSvc.ChargeUsage(ctx, reservation.AccountID, reservation.RequestID, &reservation.RequestAttemptID, &reservation.ID, s.idempotencyKey(reservation.ID, fmt.Sprintf("charge-%d", actualCredits)), actualCredits, map[string]any{
 			"endpoint":           reservation.Endpoint,
 			"model_alias":        reservation.ModelAlias,
 			"terminal_confirmed": input.TerminalUsageConfirmed,
@@ -296,7 +309,7 @@ func (s *Service) finalizeLocked(ctx context.Context, input FinalizeReservationI
 		eventType = usage.UsageEventReconciled
 	}
 
-	reservation, err = s.repo.FinalizeReservation(ctx, input.AccountID, input.ReservationID, input.ActualCredits, releaseCredits, input.TerminalUsageConfirmed, nextStatus, reason)
+	reservation, err = s.repo.FinalizeReservation(ctx, input.AccountID, input.ReservationID, actualCredits, releaseCredits, input.TerminalUsageConfirmed, nextStatus, reason)
 	if err != nil {
 		return Reservation{}, fmt.Errorf("accounting: finalize reservation: %w", err)
 	}
@@ -329,7 +342,7 @@ func (s *Service) finalizeLocked(ctx context.Context, input FinalizeReservationI
 		Endpoint:         reservation.Endpoint,
 		ModelAlias:       reservation.ModelAlias,
 		Status:           string(status),
-		HiveCreditDelta:  -input.ActualCredits,
+		HiveCreditDelta:  -actualCredits,
 		CustomerTags:     reservation.CustomerTags,
 		InternalMetadata: map[string]any{
 			"reservation_id":           reservation.ID.String(),
@@ -342,10 +355,10 @@ func (s *Service) finalizeLocked(ctx context.Context, input FinalizeReservationI
 
 	if attempt != nil && attempt.APIKeyID != nil && s.apiKeySvc != nil {
 		at := time.Now().UTC()
-		if err := s.apiKeySvc.ApplyReservationDelta(ctx, *attempt.APIKeyID, -heldCredits, input.ActualCredits, at); err != nil {
+		if err := s.apiKeySvc.ApplyReservationDelta(ctx, *attempt.APIKeyID, -heldCredits, actualCredits, at); err != nil {
 			return Reservation{}, fmt.Errorf("accounting: apply reservation delta: %w", err)
 		}
-		if err := s.apiKeySvc.RecordUsageFinalization(ctx, *attempt.APIKeyID, attempt.ModelAlias, 0, 0, 0, 0, input.ActualCredits, at); err != nil {
+		if err := s.apiKeySvc.RecordUsageFinalization(ctx, *attempt.APIKeyID, attempt.ModelAlias, 0, 0, 0, 0, actualCredits, at); err != nil {
 			return Reservation{}, fmt.Errorf("accounting: record usage finalization: %w", err)
 		}
 		if err := s.apiKeySvc.MarkLastUsed(ctx, *attempt.APIKeyID, at); err != nil {

--- a/apps/control-plane/internal/accounting/service.go
+++ b/apps/control-plane/internal/accounting/service.go
@@ -266,15 +266,27 @@ func (s *Service) finalizeLocked(ctx context.Context, input FinalizeReservationI
 
 	heldCredits := remainingHeldCredits(reservation)
 
-	// Hard invariant: a settlement must never charge more than it reserved.
-	// input.ActualCredits is caller-supplied (edge-api's token estimate,
-	// which can run far ahead of the hold -- e.g. a huge request body
-	// disconnected after one output token, see issue #602). finalizeLocked
-	// is the single chokepoint every settlement path routes through (sync
-	// and streaming, all endpoints), so clamping here protects the ledger
-	// even if a future estimator change reintroduces an overcount.
+	// Hard invariant, estimates only: an UNCONFIRMED settlement must never
+	// charge more than it reserved. input.ActualCredits there is an edge-api
+	// token estimate that can run far ahead of the hold (e.g. a huge request
+	// body disconnected after one output token, see issue #602).
+	// finalizeLocked is the single chokepoint every settlement path routes
+	// through (sync and streaming, all endpoints), so clamping here protects
+	// the ledger even if a future estimator change reintroduces an overcount.
+	//
+	// The hold is an authorization floor, not a ceiling on truth: when
+	// TerminalUsageConfirmed is true the upstream itself reported the token
+	// count, so it must be billed in full even past the hold -- edge-api's
+	// reservation is a flat, never-expanded estimate (10000 for chat/
+	// completions/responses, 1000 for embeddings; ExpandReservation exists
+	// but no caller ever invokes it), so any request whose real usage
+	// legitimately exceeds that floor (long context, RAG, coding-agent
+	// traffic) would otherwise be silently undercharged with no
+	// reconciliation job, since TerminalUsageConfirmed=true skips
+	// reconciliation entirely. Clamping a confirmed fact was the bug the
+	// PR #602 review caught in the previous version of this fix.
 	actualCredits := input.ActualCredits
-	if actualCredits > heldCredits {
+	if !input.TerminalUsageConfirmed && actualCredits > heldCredits {
 		actualCredits = heldCredits
 	}
 

--- a/apps/control-plane/internal/accounting/service_test.go
+++ b/apps/control-plane/internal/accounting/service_test.go
@@ -458,6 +458,60 @@ func TestFinalizeReservationClampsChargeToReservedHold(t *testing.T) {
 	}
 }
 
+// TestFinalizeReservationConfirmedUsageAboveHoldIsNotClamped is the
+// regression guard for the follow-up review finding on the clamp above: the
+// clamp must only ever apply to an unconfirmed estimate. When upstream
+// confirms real usage above the reservation's flat, never-expanded hold
+// (long context, RAG, coding-agent traffic routinely exceed 10000 tokens),
+// the true amount must still be charged in full -- the hold is an
+// authorization floor, not a ceiling on a confirmed fact. Silently capping
+// a confirmed charge would undercharge with no reconciliation job, since
+// TerminalUsageConfirmed=true skips reconciliation entirely.
+func TestFinalizeReservationConfirmedUsageAboveHoldIsNotClamped(t *testing.T) {
+	repo := newRepoStub()
+	ledgerSvc := &ledgerStub{}
+	usageSvc := &usageStub{}
+	svc := NewService(repo, ledgerSvc, usageSvc)
+
+	accountID := uuid.New()
+	attemptID := uuid.New()
+	reservationID := uuid.New()
+	repo.reservations[reservationID] = Reservation{
+		ID:               reservationID,
+		AccountID:        accountID,
+		RequestAttemptID: attemptID,
+		ReservationKey:   "req_confirmed_overage:1",
+		PolicyMode:       PolicyModeStrict,
+		Status:           ReservationStatusActive,
+		ReservedCredits:  10000,
+	}
+
+	// Upstream confirmed 15000 real tokens against a flat 10000 hold.
+	reservation, err := svc.FinalizeReservation(context.Background(), FinalizeReservationInput{
+		AccountID:              accountID,
+		ReservationID:          reservationID,
+		ActualCredits:          15000,
+		TerminalUsageConfirmed: true,
+		Status:                 string(usage.AttemptStatusCompleted),
+	})
+	if err != nil {
+		t.Fatalf("FinalizeReservation returned error: %v", err)
+	}
+
+	if reservation.ConsumedCredits != 15000 {
+		t.Fatalf("expected confirmed usage billed in full unclamped, got %d", reservation.ConsumedCredits)
+	}
+	if reservation.ReleasedCredits != 0 {
+		t.Fatalf("expected zero released credits on a confirmed overage, got %d", reservation.ReleasedCredits)
+	}
+	if len(ledgerSvc.chargeCalls) != 1 || ledgerSvc.chargeCalls[0].credits != 15000 {
+		t.Fatalf("expected the ledger charge for the true 15000, got %#v", ledgerSvc.chargeCalls)
+	}
+	if len(ledgerSvc.releaseCalls) != 0 {
+		t.Fatalf("expected no release call on a confirmed overage, got %#v", ledgerSvc.releaseCalls)
+	}
+}
+
 func TestFinalizeReservationMarksAmbiguousStreamForReconciliation(t *testing.T) {
 	repo := newRepoStub()
 	ledgerSvc := &ledgerStub{}

--- a/apps/control-plane/internal/accounting/service_test.go
+++ b/apps/control-plane/internal/accounting/service_test.go
@@ -406,6 +406,58 @@ func TestFinalizeReservationCreatesChargeAndRelease(t *testing.T) {
 	}
 }
 
+// TestFinalizeReservationClampsChargeToReservedHold is the regression guard
+// for issue #602: an edge-api token estimate that runs far ahead of the
+// reserved hold (a huge request body disconnected after one output token)
+// must never charge more than what was reserved. finalizeLocked is the
+// single chokepoint every settlement path (sync + streaming, all endpoints)
+// routes through, so this test asserts the clamp there rather than at any
+// one caller.
+func TestFinalizeReservationClampsChargeToReservedHold(t *testing.T) {
+	repo := newRepoStub()
+	ledgerSvc := &ledgerStub{}
+	usageSvc := &usageStub{}
+	svc := NewService(repo, ledgerSvc, usageSvc)
+
+	accountID := uuid.New()
+	attemptID := uuid.New()
+	reservationID := uuid.New()
+	repo.reservations[reservationID] = Reservation{
+		ID:               reservationID,
+		AccountID:        accountID,
+		RequestAttemptID: attemptID,
+		ReservationKey:   "req_overcharge:1",
+		PolicyMode:       PolicyModeStrict,
+		Status:           ReservationStatusActive,
+		ReservedCredits:  10000,
+	}
+
+	// A deliberately enormous estimate, far beyond the 10000-credit hold.
+	reservation, err := svc.FinalizeReservation(context.Background(), FinalizeReservationInput{
+		AccountID:              accountID,
+		ReservationID:          reservationID,
+		ActualCredits:          2_600_000,
+		TerminalUsageConfirmed: false,
+		Status:                 string(usage.AttemptStatusInterrupted),
+	})
+	if err != nil {
+		t.Fatalf("FinalizeReservation returned error: %v", err)
+	}
+
+	if reservation.ConsumedCredits != 10000 {
+		t.Fatalf("expected consumed credits clamped to the 10000 hold, got %d", reservation.ConsumedCredits)
+	}
+	if reservation.ReleasedCredits != 0 {
+		t.Fatalf("expected zero released credits when the estimate exhausts the hold, got %d", reservation.ReleasedCredits)
+	}
+	if len(ledgerSvc.chargeCalls) != 1 || ledgerSvc.chargeCalls[0].credits != 10000 {
+		t.Fatalf("expected the ledger charge clamped to 10000, got %#v", ledgerSvc.chargeCalls)
+	}
+	if len(ledgerSvc.releaseCalls) != 0 {
+		t.Fatalf("expected no release call when the clamped charge consumes the full hold, got %#v", ledgerSvc.releaseCalls)
+	}
+}
+
 func TestFinalizeReservationMarksAmbiguousStreamForReconciliation(t *testing.T) {
 	repo := newRepoStub()
 	ledgerSvc := &ledgerStub{}

--- a/apps/edge-api/internal/inference/settlement_test.go
+++ b/apps/edge-api/internal/inference/settlement_test.go
@@ -1,6 +1,9 @@
 package inference
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // TestSettlementCredits is the RED-first spec for the settlement decision at
 // the heart of the disconnect-settlement fix: what a stream should charge
@@ -14,6 +17,7 @@ func TestSettlementCredits(t *testing.T) {
 		name          string
 		hasUsage      bool
 		totalTokens   int64
+		promptBody    string
 		content       string
 		wantCredits   int64
 		wantDelivered bool
@@ -58,11 +62,29 @@ func TestSettlementCredits(t *testing.T) {
 			wantCredits:   1,
 			wantDelivered: true,
 		},
+		{
+			name:          "no confirmed usage: fallback bills the prompt too, not completion bytes alone (PR #602 finding 4 -- a long prompt aborted after one token must not settle for ~1 credit)",
+			hasUsage:      false,
+			totalTokens:   0,
+			promptBody:    strings.Repeat("x", 4000),
+			content:       "a",
+			wantCredits:   estimateCompletionTokens(strings.Repeat("x", 4000)) + 1,
+			wantDelivered: true,
+		},
+		{
+			name:          "no confirmed usage and nothing delivered: prompt cost is NOT billed even with a large promptBody -- nothing delivered still means release in full",
+			hasUsage:      false,
+			totalTokens:   0,
+			promptBody:    strings.Repeat("x", 4000),
+			content:       "",
+			wantCredits:   0,
+			wantDelivered: false,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			credits, delivered := settlementCredits(tt.hasUsage, tt.totalTokens, tt.content)
+			credits, delivered := settlementCredits(tt.hasUsage, tt.totalTokens, tt.promptBody, tt.content)
 			if credits != tt.wantCredits {
 				t.Errorf("credits = %d, want %d", credits, tt.wantCredits)
 			}

--- a/apps/edge-api/internal/inference/settlement_test.go
+++ b/apps/edge-api/internal/inference/settlement_test.go
@@ -1,0 +1,77 @@
+package inference
+
+import "testing"
+
+// TestSettlementCredits is the RED-first spec for the settlement decision at
+// the heart of the disconnect-settlement fix: what a stream should charge
+// when it ends, and whether the reservation should be finalized (charged) or
+// released in full. It replaces the old estimatedCredits fallback (a flat,
+// hardcoded number) with either confirmed usage tokens or a content-based
+// estimate -- never a made-up flat charge, and never zero when something was
+// actually produced.
+func TestSettlementCredits(t *testing.T) {
+	tests := []struct {
+		name          string
+		hasUsage      bool
+		totalTokens   int64
+		content       string
+		wantCredits   int64
+		wantDelivered bool
+	}{
+		{
+			name:          "confirmed usage wins over content estimate",
+			hasUsage:      true,
+			totalTokens:   250,
+			content:       "irrelevant when usage is confirmed",
+			wantCredits:   250,
+			wantDelivered: true,
+		},
+		{
+			name:          "no confirmed usage but content delivered: content-based estimate, floored at 1, never the flat 10000 estimate",
+			hasUsage:      false,
+			totalTokens:   0,
+			content:       "partial reply the client never fully received",
+			wantCredits:   estimateCompletionTokens("partial reply the client never fully received"),
+			wantDelivered: true,
+		},
+		{
+			name:          "no usage and no content: nothing delivered, release in full",
+			hasUsage:      false,
+			totalTokens:   0,
+			content:       "",
+			wantCredits:   0,
+			wantDelivered: false,
+		},
+		{
+			name:          "usage confirmed but reports zero total tokens: nothing delivered",
+			hasUsage:      true,
+			totalTokens:   0,
+			content:       "",
+			wantCredits:   0,
+			wantDelivered: false,
+		},
+		{
+			name:          "single character of content still floors at one credit, not zero",
+			hasUsage:      false,
+			totalTokens:   0,
+			content:       "a",
+			wantCredits:   1,
+			wantDelivered: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			credits, delivered := settlementCredits(tt.hasUsage, tt.totalTokens, tt.content)
+			if credits != tt.wantCredits {
+				t.Errorf("credits = %d, want %d", credits, tt.wantCredits)
+			}
+			if delivered != tt.wantDelivered {
+				t.Errorf("delivered = %v, want %v", delivered, tt.wantDelivered)
+			}
+			if credits == 10000 {
+				t.Errorf("credits must never fall back to the flat 10000 estimate")
+			}
+		})
+	}
+}

--- a/apps/edge-api/internal/inference/stream.go
+++ b/apps/edge-api/internal/inference/stream.go
@@ -203,7 +203,7 @@ func (o *Orchestrator) executeStreaming(
 		if finalized || reservation.ID == "" {
 			return
 		}
-		finalized = o.settleStream(snapshot, attempt, reservation, requestID, endpoint, model, accumulator, accumulator.Content.String())
+		finalized = o.settleStream(ctx, snapshot, attempt, reservation, requestID, endpoint, model, accumulator, accumulator.Content.String())
 	}()
 
 	// 6. Dispatch to LiteLLM with bounded retry on 429/5xx (safe: no bytes
@@ -362,22 +362,30 @@ func settlementCredits(hasUsage bool, totalTokens int64, content string) (credit
 // TerminalUsageConfirmed mirrors hasUsage: it is only ever true when the
 // upstream itself sent a genuine usage block, so anything settled from a
 // content estimate is flagged for reconciliation rather than treated as a
-// confirmed final charge.
-func (o *Orchestrator) settleStream(snapshot authz.AuthSnapshot, attempt AttemptResult, reservation ReservationResult, requestID, endpoint, model string, acc *UsageAccumulator, content string) bool {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+// confirmed final charge. reqCtx is the caller's original request context,
+// consulted only to tell apart the two ways delivered can end up false: a
+// cancelled reqCtx means the client hung up; a live reqCtx with nothing
+// delivered means the upstream provider ended or errored the stream while
+// the client was still there.
+func (o *Orchestrator) settleStream(reqCtx context.Context, snapshot authz.AuthSnapshot, attempt AttemptResult, reservation ReservationResult, requestID, endpoint, model string, acc *UsageAccumulator, content string) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), accountingTimeout)
 	defer cancel()
 
 	credits, delivered := settlementCredits(acc.HasUsage, acc.TotalTokens, content)
 	if !delivered {
+		reason, eventType := "upstream_error", "upstream_error"
+		if reqCtx.Err() != nil {
+			reason, eventType = "client_disconnect", "interrupted"
+		}
 		if err := o.accounting.ReleaseReservation(ctx, ReleaseReservationInput{
 			AccountID:     snapshot.AccountID,
 			ReservationID: reservation.ID,
-			Reason:        "client_disconnect",
+			Reason:        reason,
 		}); err != nil {
 			log.Printf("inference: settle release failed request_id=%s reservation_id=%s: %v", requestID, reservation.ID, err)
 			return false
 		}
-		o.recordInterruptedEvent(ctx, snapshot, attempt, requestID, endpoint, model, acc)
+		o.recordInterruptedEvent(ctx, snapshot, attempt, requestID, endpoint, model, acc, eventType)
 		return true
 	}
 
@@ -389,22 +397,35 @@ func (o *Orchestrator) settleStream(snapshot authz.AuthSnapshot, attempt Attempt
 		Status:                 "completed",
 	}); err != nil {
 		log.Printf("inference: settle finalize failed request_id=%s reservation_id=%s: %v", requestID, reservation.ID, err)
-		return false
+		// A failed finalize must not leave the hold stranded: fall back to a
+		// full release so the customer's credits are freed rather than
+		// locked forever behind a charge that never landed.
+		if relErr := o.accounting.ReleaseReservation(ctx, ReleaseReservationInput{
+			AccountID:     snapshot.AccountID,
+			ReservationID: reservation.ID,
+			Reason:        "finalize_failed",
+		}); relErr != nil {
+			log.Printf("inference: settle finalize-fallback release failed request_id=%s reservation_id=%s: %v", requestID, reservation.ID, relErr)
+			return false
+		}
+		log.Printf("inference: settle finalize failed, released reservation instead request_id=%s reservation_id=%s", requestID, reservation.ID)
+		o.recordInterruptedEvent(ctx, snapshot, attempt, requestID, endpoint, model, acc, "finalize_failed")
+		return true
 	}
 	o.recordCompletedEvent(ctx, snapshot, attempt, requestID, endpoint, model, acc.ToUsageResponse())
 	return true
 }
 
-func (o *Orchestrator) recordInterruptedEvent(ctx context.Context, snapshot authz.AuthSnapshot, attempt AttemptResult, requestID, endpoint, model string, acc *UsageAccumulator) {
+func (o *Orchestrator) recordInterruptedEvent(ctx context.Context, snapshot authz.AuthSnapshot, attempt AttemptResult, requestID, endpoint, model string, acc *UsageAccumulator, eventType string) {
 	input := RecordEventInput{
 		AccountID:        snapshot.AccountID,
 		RequestAttemptID: attempt.ID,
 		APIKeyID:         snapshot.KeyID,
 		RequestID:        requestID,
-		EventType:        "interrupted",
+		EventType:        eventType,
 		Endpoint:         endpoint,
 		ModelAlias:       model,
-		Status:           "interrupted",
+		Status:           eventType,
 	}
 	if acc != nil && acc.HasUsage {
 		input.InputTokens = acc.InputTokens

--- a/apps/edge-api/internal/inference/stream.go
+++ b/apps/edge-api/internal/inference/stream.go
@@ -200,10 +200,10 @@ func (o *Orchestrator) executeStreaming(
 	finalized := false
 	accumulator := &UsageAccumulator{}
 	defer func() {
-		if finalized || reservation.ID == "" {
+		if finalized {
 			return
 		}
-		finalized = o.settleStream(ctx, snapshot, attempt, reservation, requestID, endpoint, model, accumulator, accumulator.Content.String())
+		finalized = o.settleStream(ctx, snapshot, attempt, reservation, requestID, endpoint, model, accumulator, string(body), accumulator.Content.String())
 	}()
 
 	// 6. Dispatch to LiteLLM with bounded retry on 429/5xx (safe: no bytes
@@ -211,12 +211,7 @@ func (o *Orchestrator) executeStreaming(
 	resp, err := dispatchWithRetry(ctx, route.LiteLLMModelName, body, dispatch)
 	if err != nil {
 		if reservation.ID != "" {
-			_ = o.accounting.ReleaseReservation(ctx, ReleaseReservationInput{
-				AccountID:     snapshot.AccountID,
-				ReservationID: reservation.ID,
-				Reason:        "upstream_error",
-			})
-			finalized = true
+			finalized = o.releaseReservationBackground(snapshot, reservation.ID, requestID, "upstream_error")
 		}
 		apierrors.WriteProviderBlindUpstreamError(w, model, http.StatusBadGateway, err.Error())
 		return nil
@@ -226,12 +221,7 @@ func (o *Orchestrator) executeStreaming(
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		upstreamBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		if reservation.ID != "" {
-			_ = o.accounting.ReleaseReservation(ctx, ReleaseReservationInput{
-				AccountID:     snapshot.AccountID,
-				ReservationID: reservation.ID,
-				Reason:        "upstream_error",
-			})
-			finalized = true
+			finalized = o.releaseReservationBackground(snapshot, reservation.ID, requestID, "upstream_error")
 		}
 		o.recordErrorEvent(ctx, snapshot, attempt, requestID, endpoint, model, resp.StatusCode, string(upstreamBody))
 		apierrors.WriteProviderBlindUpstreamError(w, model, resp.StatusCode, string(upstreamBody))
@@ -242,12 +232,7 @@ func (o *Orchestrator) executeStreaming(
 	flusher, ok := w.(http.Flusher)
 	if !ok {
 		if reservation.ID != "" {
-			_ = o.accounting.ReleaseReservation(ctx, ReleaseReservationInput{
-				AccountID:     snapshot.AccountID,
-				ReservationID: reservation.ID,
-				Reason:        "internal_error",
-			})
-			finalized = true
+			finalized = o.releaseReservationBackground(snapshot, reservation.ID, requestID, "internal_error")
 		}
 		code := "internal_error"
 		apierrors.WriteError(w, http.StatusInternalServerError, "api_error",
@@ -339,18 +324,57 @@ func (o *Orchestrator) executeStreaming(
 	return nil
 }
 
+// releaseReservationBackground releases a reservation on a fresh bounded
+// background context, never the caller's request context: a client
+// disconnect is exactly what cancels that context, so releasing on it (the
+// original bug this PR fixes) lets a dead context silently swallow the
+// release, same as it used to swallow the finalize. Returns true only when
+// the release actually reached the control plane, so callers gate
+// `finalized` on real settlement instead of assuming success -- a failed
+// attempt here still leaves `finalized` false, so the deferred settleStream
+// gets one more shot at it before the request returns.
+func (o *Orchestrator) releaseReservationBackground(snapshot authz.AuthSnapshot, reservationID, requestID, reason string) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), accountingTimeout)
+	defer cancel()
+	if err := o.accounting.ReleaseReservation(ctx, ReleaseReservationInput{
+		AccountID:     snapshot.AccountID,
+		ReservationID: reservationID,
+		Reason:        reason,
+	}); err != nil {
+		log.Printf("inference: release reservation failed request_id=%s reservation_id=%s reason=%s: %v", requestID, reservationID, reason, err)
+		return false
+	}
+	return true
+}
+
 // settlementCredits derives what a stream settlement should charge: real
 // usage tokens when the upstream confirmed them, otherwise a content-based
 // estimate. There is no estimatedCredits fallback here on purpose -- an
 // unconfirmed usage block must never turn into a flat, hardcoded overcharge.
 // delivered is false only when nothing was produced at all; the caller must
 // release the reservation in full rather than charge in that case.
-func settlementCredits(hasUsage bool, totalTokens int64, content string) (credits int64, delivered bool) {
+//
+// The unconfirmed-usage estimate bills prompt tokens too, not completion
+// bytes alone: a client that aborts right after the first output token
+// (e.g. after a long prompt finishes prefill) must not settle for ~1 credit
+// just because only one token of *output* existed to estimate from. The
+// confirmed-usage branch above already bills prompt+completion via
+// totalTokens; promptBody (the raw request body) is a conservative proxy for
+// prompt cost when no real usage block ever arrived, using the same
+// cl100k-by-length heuristic already used for completion text. ponytail:
+// counting raw JSON bytes (including field names and punctuation) instead of
+// tokenizing just the message content overestimates slightly, but that
+// biases toward the safe side, not the abuse-enabling one; a real prompt
+// tokenizer can replace this if the overcount ever matters.
+func settlementCredits(hasUsage bool, totalTokens int64, promptBody, content string) (credits int64, delivered bool) {
 	if hasUsage {
 		return totalTokens, totalTokens > 0
 	}
-	credits = estimateCompletionTokens(content)
-	return credits, credits > 0
+	completion := estimateCompletionTokens(content)
+	if completion == 0 {
+		return 0, false
+	}
+	return estimateCompletionTokens(promptBody) + completion, true
 }
 
 // settleStream is the single settlement point for an ended streaming
@@ -367,25 +391,41 @@ func settlementCredits(hasUsage bool, totalTokens int64, content string) (credit
 // cancelled reqCtx means the client hung up; a live reqCtx with nothing
 // delivered means the upstream provider ended or errored the stream while
 // the client was still there.
-func (o *Orchestrator) settleStream(reqCtx context.Context, snapshot authz.AuthSnapshot, attempt AttemptResult, reservation ReservationResult, requestID, endpoint, model string, acc *UsageAccumulator, content string) bool {
+//
+// reservation.ID may be empty: CreateReservation is allowed to fail
+// non-fatally (a transient control-plane error should not abort a request
+// that could otherwise complete), in which case there is nothing to release
+// or finalize. That must not also drop the usage telemetry for the request --
+// see the reservation.ID == "" branches below.
+func (o *Orchestrator) settleStream(reqCtx context.Context, snapshot authz.AuthSnapshot, attempt AttemptResult, reservation ReservationResult, requestID, endpoint, model string, acc *UsageAccumulator, promptBody, content string) bool {
 	ctx, cancel := context.WithTimeout(context.Background(), accountingTimeout)
 	defer cancel()
 
-	credits, delivered := settlementCredits(acc.HasUsage, acc.TotalTokens, content)
+	credits, delivered := settlementCredits(acc.HasUsage, acc.TotalTokens, promptBody, content)
 	if !delivered {
 		reason, eventType := "upstream_error", "upstream_error"
 		if reqCtx.Err() != nil {
 			reason, eventType = "client_disconnect", "interrupted"
 		}
-		if err := o.accounting.ReleaseReservation(ctx, ReleaseReservationInput{
-			AccountID:     snapshot.AccountID,
-			ReservationID: reservation.ID,
-			Reason:        reason,
-		}); err != nil {
-			log.Printf("inference: settle release failed request_id=%s reservation_id=%s: %v", requestID, reservation.ID, err)
-			return false
+		if reservation.ID != "" {
+			if err := o.accounting.ReleaseReservation(ctx, ReleaseReservationInput{
+				AccountID:     snapshot.AccountID,
+				ReservationID: reservation.ID,
+				Reason:        reason,
+			}); err != nil {
+				log.Printf("inference: settle release failed request_id=%s reservation_id=%s: %v", requestID, reservation.ID, err)
+				return false
+			}
 		}
 		o.recordInterruptedEvent(ctx, snapshot, attempt, requestID, endpoint, model, acc, eventType)
+		return true
+	}
+
+	if reservation.ID == "" {
+		// No reservation ever existed to finalize, but the request still
+		// delivered billable content -- record it so the telemetry isn't
+		// silently dropped just because CreateReservation failed earlier.
+		o.recordCompletedEvent(ctx, snapshot, attempt, requestID, endpoint, model, acc.ToUsageResponse())
 		return true
 	}
 
@@ -433,5 +473,13 @@ func (o *Orchestrator) recordInterruptedEvent(ctx context.Context, snapshot auth
 		input.HiveCreditDelta = acc.TotalTokens
 		input.CacheReadTokens = acc.CachedTokens
 	}
-	_ = o.accounting.RecordUsageEvent(ctx, input)
+	// Do not discard this error: event_type values here (upstream_error,
+	// finalize_failed, interrupted) previously were not in the usage_events
+	// CHECK constraint (see the accompanying migration), so this insert was
+	// failing on every call and vanishing silently. Metering Step 2 shadow
+	// mode is recording exactly this data for Step 4's future enforcement
+	// thresholds, so a silent drop here biases that decision.
+	if err := o.accounting.RecordUsageEvent(ctx, input); err != nil {
+		log.Printf("inference: record interrupted event failed request_id=%s event_type=%s: %v", requestID, eventType, err)
+	}
 }

--- a/apps/edge-api/internal/inference/stream.go
+++ b/apps/edge-api/internal/inference/stream.go
@@ -359,14 +359,15 @@ func (o *Orchestrator) releaseReservationBackground(snapshot authz.AuthSnapshot,
 // (e.g. after a long prompt finishes prefill) must not settle for ~1 credit
 // just because only one token of *output* existed to estimate from. The
 // confirmed-usage branch above already bills prompt+completion via
-// totalTokens; promptBody (the raw request body) is a conservative proxy for
-// prompt cost when no real usage block ever arrived, using the same
-// cl100k-by-length heuristic already used for completion text. ponytail:
-// counting raw JSON bytes (including field names and punctuation) instead of
-// tokenizing just the message content overestimates slightly, but that
-// biases toward the safe side, not the abuse-enabling one; a real prompt
-// tokenizer can replace this if the overcount ever matters.
-func settlementCredits(hasUsage bool, totalTokens int64, promptBody, content string) (credits int64, delivered bool) {
+// totalTokens; prompt is the parsed message/input text (see promptText in
+// usage_clamp.go), not the raw request body -- the raw body also carries
+// field names, sampling params, tool schemas, and base64 image data, and
+// counting those as tokens is issue #602's over-charge root cause (a request
+// body under the 10MiB limit could estimate ~2.6M credits against a 10000
+// credit hold). The control-plane hard clamp in finalizeLocked is the
+// backstop that keeps any residual overcount here from ever exceeding the
+// reserved hold, but this function should still return a realistic number.
+func settlementCredits(hasUsage bool, totalTokens int64, prompt, content string) (credits int64, delivered bool) {
 	if hasUsage {
 		return totalTokens, totalTokens > 0
 	}
@@ -374,7 +375,7 @@ func settlementCredits(hasUsage bool, totalTokens int64, promptBody, content str
 	if completion == 0 {
 		return 0, false
 	}
-	return estimateCompletionTokens(promptBody) + completion, true
+	return estimateCompletionTokens(prompt) + completion, true
 }
 
 // settleStream is the single settlement point for an ended streaming
@@ -401,7 +402,10 @@ func (o *Orchestrator) settleStream(reqCtx context.Context, snapshot authz.AuthS
 	ctx, cancel := context.WithTimeout(context.Background(), accountingTimeout)
 	defer cancel()
 
-	credits, delivered := settlementCredits(acc.HasUsage, acc.TotalTokens, promptBody, content)
+	// Parse promptBody (the raw request bytes) down to just the message/input
+	// text before estimating -- see promptText in usage_clamp.go for why the
+	// raw bytes themselves must never be counted directly (issue #602).
+	credits, delivered := settlementCredits(acc.HasUsage, acc.TotalTokens, promptText(endpoint, []byte(promptBody)), content)
 	if !delivered {
 		reason, eventType := "upstream_error", "upstream_error"
 		if reqCtx.Err() != nil {

--- a/apps/edge-api/internal/inference/stream.go
+++ b/apps/edge-api/internal/inference/stream.go
@@ -190,20 +190,20 @@ func (o *Orchestrator) executeStreaming(
 		log.Printf("inference: create reservation failed (non-fatal): %v", err)
 	}
 
-	// Set up defer for reservation cleanup on unexpected exit.
+	// Set up defer for reservation settlement. This is the single settlement
+	// site for a streaming request: it always runs, whether the stream ends
+	// normally or the client disconnects mid-stream, and it always dispatches
+	// on its own background context (see settleStream) rather than the ctx
+	// this function was called with. A client disconnect is exactly what
+	// cancels that ctx, so settling on it (the old behavior) let a dead
+	// context silently swallow both the charge and the release.
 	finalized := false
 	accumulator := &UsageAccumulator{}
 	defer func() {
-		if !finalized && reservation.ID != "" {
-			// Customer-favoring: release with whatever tokens we accumulated.
-			_ = o.accounting.ReleaseReservation(context.Background(), ReleaseReservationInput{
-				AccountID:     snapshot.AccountID,
-				ReservationID: reservation.ID,
-				Reason:        "client_disconnect",
-			})
-			// Record interrupted usage event.
-			o.recordInterruptedEvent(context.Background(), snapshot, attempt, requestID, endpoint, model, accumulator)
+		if finalized || reservation.ID == "" {
+			return
 		}
+		finalized = o.settleStream(snapshot, attempt, reservation, requestID, endpoint, model, accumulator, accumulator.Content.String())
 	}()
 
 	// 6. Dispatch to LiteLLM with bounded retry on 429/5xx (safe: no bytes
@@ -336,26 +336,63 @@ func (o *Orchestrator) executeStreaming(
 		flusher.Flush()
 	}
 
-	// 11. Finalize reservation
-	if reservation.ID != "" {
-		usage := accumulator.ToUsageResponse()
-		actualCredits := estimatedCredits
-		if accumulator.HasUsage {
-			actualCredits = usage.TotalTokens
+	return nil
+}
+
+// settlementCredits derives what a stream settlement should charge: real
+// usage tokens when the upstream confirmed them, otherwise a content-based
+// estimate. There is no estimatedCredits fallback here on purpose -- an
+// unconfirmed usage block must never turn into a flat, hardcoded overcharge.
+// delivered is false only when nothing was produced at all; the caller must
+// release the reservation in full rather than charge in that case.
+func settlementCredits(hasUsage bool, totalTokens int64, content string) (credits int64, delivered bool) {
+	if hasUsage {
+		return totalTokens, totalTokens > 0
+	}
+	credits = estimateCompletionTokens(content)
+	return credits, credits > 0
+}
+
+// settleStream is the single settlement point for an ended streaming
+// request (chat completions or the Responses API): it finalizes a charge
+// for delivered tokens, or releases the reservation hold in full when
+// nothing reached the accumulator. It always dispatches on its own bounded
+// background context, independent of the caller's request context, because
+// the caller's context is exactly what a client disconnect cancels.
+// TerminalUsageConfirmed mirrors hasUsage: it is only ever true when the
+// upstream itself sent a genuine usage block, so anything settled from a
+// content estimate is flagged for reconciliation rather than treated as a
+// confirmed final charge.
+func (o *Orchestrator) settleStream(snapshot authz.AuthSnapshot, attempt AttemptResult, reservation ReservationResult, requestID, endpoint, model string, acc *UsageAccumulator, content string) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	credits, delivered := settlementCredits(acc.HasUsage, acc.TotalTokens, content)
+	if !delivered {
+		if err := o.accounting.ReleaseReservation(ctx, ReleaseReservationInput{
+			AccountID:     snapshot.AccountID,
+			ReservationID: reservation.ID,
+			Reason:        "client_disconnect",
+		}); err != nil {
+			log.Printf("inference: settle release failed request_id=%s reservation_id=%s: %v", requestID, reservation.ID, err)
+			return false
 		}
-		_ = o.accounting.FinalizeReservation(ctx, FinalizeReservationInput{
-			AccountID:              snapshot.AccountID,
-			ReservationID:          reservation.ID,
-			ActualCredits:          actualCredits,
-			TerminalUsageConfirmed: accumulator.HasUsage,
-			Status:                 "completed",
-		})
-		finalized = true
+		o.recordInterruptedEvent(ctx, snapshot, attempt, requestID, endpoint, model, acc)
+		return true
 	}
 
-	o.recordCompletedEvent(ctx, snapshot, attempt, requestID, endpoint, model, accumulator.ToUsageResponse())
-
-	return nil
+	if err := o.accounting.FinalizeReservation(ctx, FinalizeReservationInput{
+		AccountID:              snapshot.AccountID,
+		ReservationID:          reservation.ID,
+		ActualCredits:          credits,
+		TerminalUsageConfirmed: acc.HasUsage,
+		Status:                 "completed",
+	}); err != nil {
+		log.Printf("inference: settle finalize failed request_id=%s reservation_id=%s: %v", requestID, reservation.ID, err)
+		return false
+	}
+	o.recordCompletedEvent(ctx, snapshot, attempt, requestID, endpoint, model, acc.ToUsageResponse())
+	return true
 }
 
 func (o *Orchestrator) recordInterruptedEvent(ctx context.Context, snapshot authz.AuthSnapshot, attempt AttemptResult, requestID, endpoint, model string, acc *UsageAccumulator) {

--- a/apps/edge-api/internal/inference/stream_disconnect_test.go
+++ b/apps/edge-api/internal/inference/stream_disconnect_test.go
@@ -1,0 +1,400 @@
+package inference
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/authz"
+)
+
+// --- disconnect-settlement test harness ---
+//
+// These tests exercise the real executeStreaming/executeResponsesStreaming
+// lifecycle end-to-end against in-process httptest stand-ins for the
+// control-plane (routing + accounting) and LiteLLM, so the regression guard
+// is the real defer/context wiring, not a hand-simulated approximation of it.
+
+// recordedCall is one POST the edge-api sent to a control-plane internal
+// endpoint, captured by path and decoded JSON body.
+type recordedCall struct {
+	path string
+	body map[string]any
+}
+
+// accountingRecorder captures every call edge-api's AccountingClient makes,
+// so a test can assert exactly what settlement decided (finalize vs release,
+// actual_credits, terminal_usage_confirmed) without a real database.
+type accountingRecorder struct {
+	mu    sync.Mutex
+	calls []recordedCall
+}
+
+func (r *accountingRecorder) record(path string, body map[string]any) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, recordedCall{path: path, body: body})
+}
+
+func (r *accountingRecorder) find(path string) (map[string]any, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, c := range r.calls {
+		if c.path == path {
+			return c.body, true
+		}
+	}
+	return nil, false
+}
+
+func (r *accountingRecorder) has(path string) bool {
+	_, ok := r.find(path)
+	return ok
+}
+
+// newAccountingMock stands in for the control-plane's internal accounting
+// and usage endpoints. It always answers 200 OK: this test isolates what
+// edge-api *decides to send*, not control-plane's own ledger business logic
+// (covered separately by the control-plane accounting service tests).
+func newAccountingMock(rec *accountingRecorder) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		rec.record(r.URL.Path, body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		switch r.URL.Path {
+		case "/internal/accounting/reservations":
+			_ = json.NewEncoder(w).Encode(ReservationResult{
+				ID: "res-test-1", AccountID: "acct-test-1", Status: "active", EstimatedCredits: 10000,
+			})
+		case "/internal/usage/attempts":
+			_ = json.NewEncoder(w).Encode(AttemptResult{
+				ID: "attempt-test-1", RequestID: "req-test-1", Status: "streaming",
+			})
+		}
+	}))
+}
+
+// newRoutingMock stands in for the control-plane's route-selection endpoint,
+// always resolving to litellmURL regardless of the request body.
+func newRoutingMock(litellmURL string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(SelectRouteResult{
+			AliasID:          "gpt-4o",
+			RouteID:          "route-test-1",
+			LiteLLMModelName: "openrouter/openai/gpt-4o",
+			Provider:         "openrouter",
+		})
+	}))
+}
+
+// newAuthorizedOrchestrator wires an Orchestrator whose authorizer always
+// admits the request via authz.Client.ResolveOverride (the existing test
+// seam for bypassing Redis/control-plane I/O) and whose routing/accounting/
+// litellm clients point at the given mock servers.
+func newAuthorizedOrchestrator(acctURL, routingURL, litellmURL string) *Orchestrator {
+	client := &authz.Client{
+		ResolveOverride: func(_ context.Context, _ string) (authz.AuthSnapshot, error) {
+			return authz.AuthSnapshot{
+				KeyID:          "key-test-1",
+				AccountID:      "acct-test-1",
+				Status:         "active",
+				AllowAllModels: true,
+				BudgetKind:     "none",
+			}, nil
+		},
+	}
+	return &Orchestrator{
+		authorizer: authz.NewAuthorizer(client, nil),
+		routing:    NewRoutingClient(routingURL),
+		accounting: NewAccountingClient(acctURL),
+		litellm:    NewLiteLLMClient(litellmURL, "test-key"),
+	}
+}
+
+// gatedSSEServer streams firstChunk (if non-empty), signals ready, then
+// blocks until the request context the client used to fetch it is
+// cancelled -- the same shape as an upstream that keeps a generation open
+// after Hive's own client has abandoned the request. ready lets the test
+// cancel deterministically instead of racing a sleep against a goroutine.
+func gatedSSEServer(firstChunk string, ready chan<- struct{}) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher := w.(http.Flusher)
+		// Always flush right after the status line, even with no content:
+		// otherwise headers can still be sitting in a buffer, unsent, when the
+		// test cancels below -- racing the dispatch call itself (which would
+		// then fail before the SSE loop even starts) instead of the mid-loop
+		// disconnect this harness means to simulate.
+		flusher.Flush()
+		if firstChunk != "" {
+			fmt.Fprintln(w, buildChunkLine("chunk-1", "route", firstChunk, nil))
+			flusher.Flush()
+			// Give the client's own scan loop -- a separate goroutine -- a
+			// deterministic window to actually consume these already-flushed
+			// bytes before ready fires. Flushing here only proves the server
+			// sent them; without this, the test can cancel before the
+			// client-side goroutine gets scheduled to read them, cutting the
+			// stream off before anything reaches the accumulator even though
+			// the bytes were on the wire.
+			time.Sleep(50 * time.Millisecond)
+		}
+		close(ready)
+		// Prefer reacting to the request context closing (the realistic
+		// signal: the client gave up and the connection tore down), but
+		// never block the handler -- and therefore httptest.Server.Close --
+		// indefinitely if this sandbox's loopback networking doesn't
+		// propagate that promptly.
+		select {
+		case <-r.Context().Done():
+		case <-time.After(2 * time.Second):
+		}
+	}))
+}
+
+// completingSSEServer streams a full, ordinary completion (content, a
+// finish_reason, a terminal usage chunk, [DONE]) with no disconnect at all.
+// Used as the no-regression control case for normal completions.
+func completingSSEServer() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher := w.(http.Flusher)
+		stop := "stop"
+		fmt.Fprintln(w, buildChunkLine("chunk-1", "route", "hello there", nil))
+		flusher.Flush()
+		fmt.Fprintln(w, buildChunkLine("chunk-2", "route", "", &stop))
+		flusher.Flush()
+		usageChunk := ChatCompletionChunk{
+			ID:      "chunk-3",
+			Object:  "chat.completion.chunk",
+			Created: 1700000000,
+			Model:   "route",
+			Choices: []ChunkChoice{},
+			Usage: &UsageResponse{
+				PromptTokens:     20,
+				CompletionTokens: 5,
+				TotalTokens:      25,
+			},
+		}
+		b, _ := json.Marshal(usageChunk)
+		fmt.Fprintln(w, "data: "+string(b))
+		flusher.Flush()
+		fmt.Fprintln(w, "data: [DONE]")
+		flusher.Flush()
+	}))
+}
+
+// headerCommitRecorder wraps httptest.ResponseRecorder and closes committed
+// exactly once, the first time WriteHeader is called. executeStreaming only
+// calls WriteHeader on the outer response after dispatch has already
+// succeeded and the upstream status + Flusher checks have passed, so
+// waiting on committed gives a race-free "the SSE loop is about to start"
+// signal -- unlike waiting on the mock server alone, which only proves the
+// server *sent* bytes, not that this process's dispatch call already
+// returned.
+type headerCommitRecorder struct {
+	*httptest.ResponseRecorder
+	once      sync.Once
+	committed chan struct{}
+}
+
+func newHeaderCommitRecorder() *headerCommitRecorder {
+	return &headerCommitRecorder{
+		ResponseRecorder: httptest.NewRecorder(),
+		committed:        make(chan struct{}),
+	}
+}
+
+func (r *headerCommitRecorder) WriteHeader(code int) {
+	r.ResponseRecorder.WriteHeader(code)
+	r.once.Do(func() { close(r.committed) })
+}
+
+func runExecuteStreaming(orch *Orchestrator, ctx context.Context) (done <-chan struct{}, committed <-chan struct{}) {
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{}`))
+	req.Header.Set("Authorization", "Bearer test-token")
+	w := newHeaderCommitRecorder()
+	doneCh := make(chan struct{})
+	go func() {
+		defer close(doneCh)
+		_ = orch.executeStreaming(ctx, w, req, EndpointChatCompletions, []byte(`{}`), "gpt-4o", "gpt-4o",
+			NeedFlags{NeedChatCompletions: true, NeedStreaming: true}, 10000, false, nil, orch.litellm.ChatCompletion)
+	}()
+	return doneCh, w.committed
+}
+
+func waitReady(t *testing.T, ready <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-ready:
+	case <-time.After(5 * time.Second):
+		t.Fatal("upstream mock never became ready")
+	}
+}
+
+func waitDone(t *testing.T, done <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("executeStreaming did not return in time")
+	}
+}
+
+// TestExecuteStreaming_ClientDisconnect_SettlesDeliveredTokensDespiteCancelledContext
+// is the primary regression guard: it reproduces the exact bug shape from the
+// investigation (dispatch and settlement sharing a request context that the
+// client disconnect cancels) and asserts that settlement still reaches the
+// control-plane, charging for what was actually delivered -- not the flat
+// 10000 estimate, and not zero.
+func TestExecuteStreaming_ClientDisconnect_SettlesDeliveredTokensDespiteCancelledContext(t *testing.T) {
+	rec := &accountingRecorder{}
+	acctSrv := newAccountingMock(rec)
+	defer acctSrv.Close()
+
+	ready := make(chan struct{})
+	litellmSrv := gatedSSEServer("here is a partial reply the client never received in full", ready)
+	defer litellmSrv.Close()
+
+	routingSrv := newRoutingMock(litellmSrv.URL)
+	defer routingSrv.Close()
+
+	orch := newAuthorizedOrchestrator(acctSrv.URL, routingSrv.URL, litellmSrv.URL)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done, _ := runExecuteStreaming(orch, ctx)
+	waitReady(t, ready)
+
+	// Simulate the client disconnect: cancel the exact context executeStreaming
+	// was called with, the same context dispatch used to reach litellmSrv.
+	cancel()
+	waitDone(t, done)
+
+	if ctx.Err() == nil {
+		t.Fatal("sanity check failed: context was not actually cancelled")
+	}
+
+	if rec.has("/internal/accounting/reservations/release") {
+		t.Error("nothing should be released in full: content was delivered")
+	}
+
+	body, ok := rec.find("/internal/accounting/reservations/finalize")
+	if !ok {
+		t.Fatalf("expected FinalizeReservation to reach control-plane despite the cancelled context; calls seen: %+v", rec.calls)
+	}
+
+	actual, _ := body["actual_credits"].(float64)
+	if actual <= 0 {
+		t.Errorf("actual_credits = %v, want > 0 (content was delivered)", body["actual_credits"])
+	}
+	if int64(actual) == 10000 {
+		t.Error("actual_credits must not fall back to the flat 10000 estimate")
+	}
+	if confirmed, _ := body["terminal_usage_confirmed"].(bool); confirmed {
+		t.Error("terminal_usage_confirmed must be false: upstream never sent a real usage block")
+	}
+	if body["reservation_id"] != "res-test-1" {
+		t.Errorf("reservation_id = %v, want res-test-1", body["reservation_id"])
+	}
+}
+
+// TestExecuteStreaming_ClientDisconnect_NothingDelivered_ReleasesInFull covers
+// the opposite outcome required by the ruling: when a disconnect happens
+// before any content reaches the accumulator, the hold must be released in
+// full and nothing charged.
+func TestExecuteStreaming_ClientDisconnect_NothingDelivered_ReleasesInFull(t *testing.T) {
+	rec := &accountingRecorder{}
+	acctSrv := newAccountingMock(rec)
+	defer acctSrv.Close()
+
+	ready := make(chan struct{})
+	litellmSrv := gatedSSEServer("", ready) // no content at all before disconnect
+	defer litellmSrv.Close()
+
+	routingSrv := newRoutingMock(litellmSrv.URL)
+	defer routingSrv.Close()
+
+	orch := newAuthorizedOrchestrator(acctSrv.URL, routingSrv.URL, litellmSrv.URL)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done, committed := runExecuteStreaming(orch, ctx)
+	waitReady(t, ready)
+	// Wait for executeStreaming's own dispatch to have already succeeded
+	// (see headerCommitRecorder) before cancelling: with no content chunk to
+	// anchor timing on, waiting on the mock server alone would race the
+	// dispatch call itself instead of the SSE-loop-active disconnect this
+	// test means to simulate.
+	select {
+	case <-committed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("executeStreaming never committed SSE response headers")
+	}
+	cancel()
+	waitDone(t, done)
+
+	if rec.has("/internal/accounting/reservations/finalize") {
+		t.Error("nothing was delivered: must not finalize a charge")
+	}
+
+	body, ok := rec.find("/internal/accounting/reservations/release")
+	if !ok {
+		t.Fatalf("expected ReleaseReservation (full release) when nothing was delivered; calls seen: %+v", rec.calls)
+	}
+	if body["reservation_id"] != "res-test-1" {
+		t.Errorf("reservation_id = %v, want res-test-1", body["reservation_id"])
+	}
+	if body["reason"] != "client_disconnect" {
+		t.Errorf("reason = %v, want client_disconnect", body["reason"])
+	}
+}
+
+// TestExecuteStreaming_NormalCompletion_ChargesConfirmedUsage_NoRegression is
+// the no-regression control: an ordinary completion (no disconnect) must
+// still finalize using the upstream-confirmed usage tokens, exactly as
+// before the fix.
+func TestExecuteStreaming_NormalCompletion_ChargesConfirmedUsage_NoRegression(t *testing.T) {
+	rec := &accountingRecorder{}
+	acctSrv := newAccountingMock(rec)
+	defer acctSrv.Close()
+
+	litellmSrv := completingSSEServer()
+	defer litellmSrv.Close()
+
+	routingSrv := newRoutingMock(litellmSrv.URL)
+	defer routingSrv.Close()
+
+	orch := newAuthorizedOrchestrator(acctSrv.URL, routingSrv.URL, litellmSrv.URL)
+
+	done, _ := runExecuteStreaming(orch, context.Background())
+	waitDone(t, done)
+
+	body, ok := rec.find("/internal/accounting/reservations/finalize")
+	if !ok {
+		t.Fatalf("expected FinalizeReservation on normal completion; calls seen: %+v", rec.calls)
+	}
+	actual, _ := body["actual_credits"].(float64)
+	if int64(actual) != 25 {
+		t.Errorf("actual_credits = %v, want 25 (confirmed upstream usage)", body["actual_credits"])
+	}
+	if confirmed, _ := body["terminal_usage_confirmed"].(bool); !confirmed {
+		t.Error("terminal_usage_confirmed must be true: upstream sent a real usage block")
+	}
+	if rec.has("/internal/accounting/reservations/release") {
+		t.Error("normal completion must not release; it must finalize")
+	}
+}

--- a/apps/edge-api/internal/inference/stream_disconnect_test.go
+++ b/apps/edge-api/internal/inference/stream_disconnect_test.go
@@ -110,6 +110,30 @@ func newAccountingMockFinalizeFails(rec *accountingRecorder) *httptest.Server {
 	}))
 }
 
+// newAccountingMockReservationFails behaves like newAccountingMock but
+// answers every CreateReservation call with a 500, the transient
+// control-plane failure that stream.go's step 5 explicitly tolerates
+// (reservation.ID stays "" and the request proceeds). A test can use this to
+// exercise the reservation.ID == "" branches of settleStream.
+func newAccountingMockReservationFails(rec *accountingRecorder) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		rec.record(r.URL.Path, body)
+		if r.URL.Path == "/internal/accounting/reservations" {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		if r.URL.Path == "/internal/usage/attempts" {
+			_ = json.NewEncoder(w).Encode(AttemptResult{
+				ID: "attempt-test-1", RequestID: "req-test-1", Status: "streaming",
+			})
+		}
+	}))
+}
+
 // newRoutingMock stands in for the control-plane's route-selection endpoint,
 // always resolving to litellmURL regardless of the request body.
 func newRoutingMock(litellmURL string) *httptest.Server {
@@ -183,6 +207,21 @@ func gatedSSEServer(firstChunk string, ready chan<- struct{}) *httptest.Server {
 		// never block the handler -- and therefore httptest.Server.Close --
 		// indefinitely if this sandbox's loopback networking doesn't
 		// propagate that promptly.
+		select {
+		case <-r.Context().Done():
+		case <-time.After(2 * time.Second):
+		}
+	}))
+}
+
+// neverRespondingServer signals ready as soon as it receives the request (so
+// a test knows dispatch is in flight against it), then blocks without ever
+// writing a response -- the shape of an upstream stuck in prefill. It reacts
+// to the request context closing (the client gave up mid-dispatch, before
+// any bytes came back) or a hard timeout so it can never hang the test.
+func neverRespondingServer(ready chan<- struct{}) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(ready)
 		select {
 		case <-r.Context().Done():
 		case <-time.After(2 * time.Second):
@@ -505,5 +544,86 @@ func TestExecuteStreaming_UpstreamClosesWithoutDelivery_ReleasesAsUpstreamError(
 	}
 	if body["reason"] != "upstream_error" {
 		t.Errorf("reason = %v, want upstream_error (client never disconnected)", body["reason"])
+	}
+}
+
+// TestExecuteStreaming_ClientDisconnect_DuringDispatch_ReleasesReservation is
+// the regression guard for the second-round PR #602 finding: dispatchWithRetry
+// itself failing because the client cancelled the request context mid-prefill
+// (before any bytes ever came back from the upstream). The old code released
+// on that same cancelled context, discarded the error, and still set
+// finalized = true, stranding the hold -- exactly the bug this whole PR
+// exists to fix, just one step earlier in the lifecycle. releaseReservationBackground
+// must release on its own background context so the hold actually clears.
+func TestExecuteStreaming_ClientDisconnect_DuringDispatch_ReleasesReservation(t *testing.T) {
+	rec := &accountingRecorder{}
+	acctSrv := newAccountingMock(rec)
+	defer acctSrv.Close()
+
+	ready := make(chan struct{})
+	litellmSrv := neverRespondingServer(ready)
+	defer litellmSrv.Close()
+
+	routingSrv := newRoutingMock(litellmSrv.URL)
+	defer routingSrv.Close()
+
+	orch := newAuthorizedOrchestrator(acctSrv.URL, routingSrv.URL, litellmSrv.URL)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done, _ := runExecuteStreaming(orch, ctx)
+	waitReady(t, ready) // dispatch is in flight against the upstream mock
+	cancel()            // client disconnects before dispatch ever gets a response
+	waitDone(t, done)
+
+	if rec.has("/internal/accounting/reservations/finalize") {
+		t.Error("dispatch never succeeded: must not finalize a charge")
+	}
+
+	body, ok := rec.find("/internal/accounting/reservations/release")
+	if !ok {
+		t.Fatalf("expected ReleaseReservation despite the cancelled dispatch context; calls seen: %+v", rec.calls)
+	}
+	if body["reservation_id"] != "res-test-1" {
+		t.Errorf("reservation_id = %v, want res-test-1", body["reservation_id"])
+	}
+	if body["reason"] != "upstream_error" {
+		t.Errorf("reason = %v, want upstream_error", body["reason"])
+	}
+}
+
+// TestExecuteStreaming_NoReservation_StillRecordsCompletedUsageEvent is the
+// regression guard for the second-round PR #602 finding that recordCompletedEvent
+// was gated on reservation.ID != "": when CreateReservation fails non-fatally
+// (a transient control-plane error stream.go explicitly tolerates so the
+// request can still complete), a normal completion must still record its
+// usage event instead of silently dropping the telemetry.
+func TestExecuteStreaming_NoReservation_StillRecordsCompletedUsageEvent(t *testing.T) {
+	rec := &accountingRecorder{}
+	acctSrv := newAccountingMockReservationFails(rec)
+	defer acctSrv.Close()
+
+	litellmSrv := completingSSEServer()
+	defer litellmSrv.Close()
+
+	routingSrv := newRoutingMock(litellmSrv.URL)
+	defer routingSrv.Close()
+
+	orch := newAuthorizedOrchestrator(acctSrv.URL, routingSrv.URL, litellmSrv.URL)
+
+	done, _ := runExecuteStreaming(orch, context.Background())
+	waitDone(t, done)
+
+	if rec.has("/internal/accounting/reservations/finalize") {
+		t.Error("no reservation was ever created: nothing to finalize")
+	}
+
+	body, ok := rec.find("/internal/usage/events")
+	if !ok {
+		t.Fatalf("expected the completed usage event to still be recorded even with no reservation; calls seen: %+v", rec.calls)
+	}
+	if body["event_type"] != "completed" {
+		t.Errorf("event_type = %v, want completed", body["event_type"])
 	}
 }

--- a/apps/edge-api/internal/inference/stream_disconnect_test.go
+++ b/apps/edge-api/internal/inference/stream_disconnect_test.go
@@ -82,6 +82,34 @@ func newAccountingMock(rec *accountingRecorder) *httptest.Server {
 	}))
 }
 
+// newAccountingMockFinalizeFails behaves like newAccountingMock but answers
+// every finalize call with a 500, so a test can exercise the finalize-error
+// fallback path (settleStream must release the reservation instead of
+// stranding the hold when the finalize call itself fails).
+func newAccountingMockFinalizeFails(rec *accountingRecorder) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		rec.record(r.URL.Path, body)
+		if r.URL.Path == "/internal/accounting/reservations/finalize" {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		switch r.URL.Path {
+		case "/internal/accounting/reservations":
+			_ = json.NewEncoder(w).Encode(ReservationResult{
+				ID: "res-test-1", AccountID: "acct-test-1", Status: "active", EstimatedCredits: 10000,
+			})
+		case "/internal/usage/attempts":
+			_ = json.NewEncoder(w).Encode(AttemptResult{
+				ID: "attempt-test-1", RequestID: "req-test-1", Status: "streaming",
+			})
+		}
+	}))
+}
+
 // newRoutingMock stands in for the control-plane's route-selection endpoint,
 // always resolving to litellmURL regardless of the request body.
 func newRoutingMock(litellmURL string) *httptest.Server {
@@ -159,6 +187,18 @@ func gatedSSEServer(firstChunk string, ready chan<- struct{}) *httptest.Server {
 		case <-r.Context().Done():
 		case <-time.After(2 * time.Second):
 		}
+	}))
+}
+
+// abruptUpstreamCloseServer commits SSE headers then closes the connection
+// immediately, sending no content, no usage block, and no [DONE] -- an
+// upstream provider dying mid-stream while the client is still connected,
+// as opposed to the client disconnecting itself.
+func abruptUpstreamCloseServer() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
 	}))
 }
 
@@ -396,5 +436,74 @@ func TestExecuteStreaming_NormalCompletion_ChargesConfirmedUsage_NoRegression(t 
 	}
 	if rec.has("/internal/accounting/reservations/release") {
 		t.Error("normal completion must not release; it must finalize")
+	}
+}
+
+// TestExecuteStreaming_FinalizeError_ReleasesReservationInstead is the
+// regression guard for PR #602 finding 2: a failed FinalizeReservation call
+// must not leave the hold stranded. settleStream must fall back to a full
+// release so the customer's credits are freed rather than locked forever
+// behind a charge that never landed.
+func TestExecuteStreaming_FinalizeError_ReleasesReservationInstead(t *testing.T) {
+	rec := &accountingRecorder{}
+	acctSrv := newAccountingMockFinalizeFails(rec)
+	defer acctSrv.Close()
+
+	litellmSrv := completingSSEServer()
+	defer litellmSrv.Close()
+
+	routingSrv := newRoutingMock(litellmSrv.URL)
+	defer routingSrv.Close()
+
+	orch := newAuthorizedOrchestrator(acctSrv.URL, routingSrv.URL, litellmSrv.URL)
+
+	done, _ := runExecuteStreaming(orch, context.Background())
+	waitDone(t, done)
+
+	if !rec.has("/internal/accounting/reservations/finalize") {
+		t.Fatalf("expected FinalizeReservation to be attempted; calls seen: %+v", rec.calls)
+	}
+
+	body, ok := rec.find("/internal/accounting/reservations/release")
+	if !ok {
+		t.Fatalf("expected fallback ReleaseReservation when finalize fails; calls seen: %+v", rec.calls)
+	}
+	if body["reason"] != "finalize_failed" {
+		t.Errorf("reason = %v, want finalize_failed", body["reason"])
+	}
+	if body["reservation_id"] != "res-test-1" {
+		t.Errorf("reservation_id = %v, want res-test-1", body["reservation_id"])
+	}
+}
+
+// TestExecuteStreaming_UpstreamClosesWithoutDelivery_ReleasesAsUpstreamError
+// is the regression guard for PR #602 finding 3: when nothing is delivered
+// because the upstream provider ended the stream early -- not because the
+// client disconnected -- the release reason must say so instead of always
+// claiming client_disconnect.
+func TestExecuteStreaming_UpstreamClosesWithoutDelivery_ReleasesAsUpstreamError(t *testing.T) {
+	rec := &accountingRecorder{}
+	acctSrv := newAccountingMock(rec)
+	defer acctSrv.Close()
+
+	litellmSrv := abruptUpstreamCloseServer()
+	defer litellmSrv.Close()
+
+	routingSrv := newRoutingMock(litellmSrv.URL)
+	defer routingSrv.Close()
+
+	orch := newAuthorizedOrchestrator(acctSrv.URL, routingSrv.URL, litellmSrv.URL)
+
+	// Never cancelled: the client stays connected for the whole request.
+	// Only the upstream provider ends the stream early.
+	done, _ := runExecuteStreaming(orch, context.Background())
+	waitDone(t, done)
+
+	body, ok := rec.find("/internal/accounting/reservations/release")
+	if !ok {
+		t.Fatalf("expected ReleaseReservation when nothing was delivered; calls seen: %+v", rec.calls)
+	}
+	if body["reason"] != "upstream_error" {
+		t.Errorf("reason = %v, want upstream_error (client never disconnected)", body["reason"])
 	}
 }

--- a/apps/edge-api/internal/inference/stream_responses.go
+++ b/apps/edge-api/internal/inference/stream_responses.go
@@ -139,10 +139,10 @@ func (o *Orchestrator) executeResponsesStreaming(
 	acc := &UsageAccumulator{}
 	translator := &responsesEventTranslator{aliasID: model}
 	defer func() {
-		if finalized || reservation.ID == "" {
+		if finalized {
 			return
 		}
-		finalized = o.settleStream(ctx, snapshot, attempt, reservation, requestID, EndpointResponses, model, acc, translator.currentContent.String())
+		finalized = o.settleStream(ctx, snapshot, attempt, reservation, requestID, EndpointResponses, model, acc, string(body), translator.currentContent.String())
 	}()
 
 	// 6. Dispatch to LiteLLM (always with stream_options for usage) with
@@ -151,12 +151,7 @@ func (o *Orchestrator) executeResponsesStreaming(
 	resp, err := dispatchWithRetry(ctx, route.LiteLLMModelName, body, o.litellm.ChatCompletion)
 	if err != nil {
 		if reservation.ID != "" {
-			_ = o.accounting.ReleaseReservation(ctx, ReleaseReservationInput{
-				AccountID:     snapshot.AccountID,
-				ReservationID: reservation.ID,
-				Reason:        "upstream_error",
-			})
-			finalized = true
+			finalized = o.releaseReservationBackground(snapshot, reservation.ID, requestID, "upstream_error")
 		}
 		apierrors.WriteProviderBlindUpstreamError(w, model, http.StatusBadGateway, err.Error())
 		return
@@ -166,12 +161,7 @@ func (o *Orchestrator) executeResponsesStreaming(
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		upstreamBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		if reservation.ID != "" {
-			_ = o.accounting.ReleaseReservation(ctx, ReleaseReservationInput{
-				AccountID:     snapshot.AccountID,
-				ReservationID: reservation.ID,
-				Reason:        "upstream_error",
-			})
-			finalized = true
+			finalized = o.releaseReservationBackground(snapshot, reservation.ID, requestID, "upstream_error")
 		}
 		o.recordErrorEvent(ctx, snapshot, attempt, requestID, EndpointResponses, model, resp.StatusCode, string(upstreamBody))
 		apierrors.WriteProviderBlindUpstreamError(w, model, resp.StatusCode, string(upstreamBody))
@@ -182,12 +172,7 @@ func (o *Orchestrator) executeResponsesStreaming(
 	flusher, ok := w.(http.Flusher)
 	if !ok {
 		if reservation.ID != "" {
-			_ = o.accounting.ReleaseReservation(ctx, ReleaseReservationInput{
-				AccountID:     snapshot.AccountID,
-				ReservationID: reservation.ID,
-				Reason:        "internal_error",
-			})
-			finalized = true
+			finalized = o.releaseReservationBackground(snapshot, reservation.ID, requestID, "internal_error")
 		}
 		code := "internal_error"
 		apierrors.WriteError(w, http.StatusInternalServerError, "api_error",

--- a/apps/edge-api/internal/inference/stream_responses.go
+++ b/apps/edge-api/internal/inference/stream_responses.go
@@ -142,7 +142,7 @@ func (o *Orchestrator) executeResponsesStreaming(
 		if finalized || reservation.ID == "" {
 			return
 		}
-		finalized = o.settleStream(snapshot, attempt, reservation, requestID, EndpointResponses, model, acc, translator.currentContent.String())
+		finalized = o.settleStream(ctx, snapshot, attempt, reservation, requestID, EndpointResponses, model, acc, translator.currentContent.String())
 	}()
 
 	// 6. Dispatch to LiteLLM (always with stream_options for usage) with

--- a/apps/edge-api/internal/inference/stream_responses.go
+++ b/apps/edge-api/internal/inference/stream_responses.go
@@ -128,18 +128,21 @@ func (o *Orchestrator) executeResponsesStreaming(
 		log.Printf("inference: create reservation failed (non-fatal): %v", err)
 	}
 
-	// Cleanup defer for client disconnects.
+	// Set up defer for reservation settlement. This is the single settlement
+	// site for a streaming request: it always runs, whether the stream ends
+	// normally or the client disconnects mid-stream, and it always dispatches
+	// on its own background context (see settleStream) rather than the ctx
+	// this function was called with. translator is declared here (before its
+	// fields are filled in at step 9) so the defer can read its accumulated
+	// content regardless of which exit path fires.
 	finalized := false
 	acc := &UsageAccumulator{}
+	translator := &responsesEventTranslator{aliasID: model}
 	defer func() {
-		if !finalized && reservation.ID != "" {
-			_ = o.accounting.ReleaseReservation(context.Background(), ReleaseReservationInput{
-				AccountID:     snapshot.AccountID,
-				ReservationID: reservation.ID,
-				Reason:        "client_disconnect",
-			})
-			o.recordInterruptedEvent(context.Background(), snapshot, attempt, requestID, EndpointResponses, model, acc)
+		if finalized || reservation.ID == "" {
+			return
 		}
+		finalized = o.settleStream(snapshot, attempt, reservation, requestID, EndpointResponses, model, acc, translator.currentContent.String())
 	}()
 
 	// 6. Dispatch to LiteLLM (always with stream_options for usage) with
@@ -199,15 +202,11 @@ func (o *Orchestrator) executeResponsesStreaming(
 	w.Header().Set("X-Accel-Buffering", "no")
 	w.WriteHeader(http.StatusOK)
 
-	// 9. Build state machine
-	responseID := "resp_" + uuid.New().String()
-	msgID := "msg_" + uuid.New().String()
-	translator := &responsesEventTranslator{
-		responseID: responseID,
-		aliasID:    model,
-		created:    time.Now().Unix(),
-		msgID:      msgID,
-	}
+	// 9. Build state machine (translator was declared earlier, before the
+	// settlement defer, so fill in the remaining fields here).
+	translator.responseID = "resp_" + uuid.New().String()
+	translator.created = time.Now().Unix()
+	translator.msgID = "msg_" + uuid.New().String()
 
 	writeSSEEvent := func(eventType string, data any) {
 		dataJSON, err := json.Marshal(data)
@@ -341,25 +340,6 @@ func (o *Orchestrator) executeResponsesStreaming(
 			}
 		}
 	}
-
-	// 11. Finalize reservation
-	if reservation.ID != "" {
-		usage := acc.ToUsageResponse()
-		actualCredits := estimatedCredits
-		if acc.HasUsage {
-			actualCredits = usage.TotalTokens
-		}
-		_ = o.accounting.FinalizeReservation(ctx, FinalizeReservationInput{
-			AccountID:              snapshot.AccountID,
-			ReservationID:          reservation.ID,
-			ActualCredits:          actualCredits,
-			TerminalUsageConfirmed: acc.HasUsage,
-			Status:                 "completed",
-		})
-		finalized = true
-	}
-
-	o.recordCompletedEvent(ctx, snapshot, attempt, requestID, EndpointResponses, model, acc.ToUsageResponse())
 }
 
 // emitCompleted emits the response.completed event with the full response object.

--- a/apps/edge-api/internal/inference/stream_responses_disconnect_test.go
+++ b/apps/edge-api/internal/inference/stream_responses_disconnect_test.go
@@ -1,0 +1,63 @@
+package inference
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestExecuteResponsesStreaming_ClientDisconnect_SettlesDeliveredTokensDespiteCancelledContext
+// mirrors the chat-completions regression guard for the Responses API
+// streaming path (stream_responses.go), which the ruling requires to receive
+// an identical fix: one settle site, on a context that survives the client
+// disconnecting.
+func TestExecuteResponsesStreaming_ClientDisconnect_SettlesDeliveredTokensDespiteCancelledContext(t *testing.T) {
+	rec := &accountingRecorder{}
+	acctSrv := newAccountingMock(rec)
+	defer acctSrv.Close()
+
+	ready := make(chan struct{})
+	litellmSrv := gatedSSEServer("partial responses-api reply", ready)
+	defer litellmSrv.Close()
+
+	routingSrv := newRoutingMock(litellmSrv.URL)
+	defer routingSrv.Close()
+
+	orch := newAuthorizedOrchestrator(acctSrv.URL, routingSrv.URL, litellmSrv.URL)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{}`))
+	req.Header.Set("Authorization", "Bearer test-token")
+	w := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		orch.executeResponsesStreaming(ctx, w, req, []byte(`{}`), ResponsesRequest{Model: "gpt-4o"}, "gpt-4o",
+			NeedFlags{NeedResponses: true, NeedStreaming: true}, 10000)
+	}()
+
+	waitReady(t, ready)
+	cancel()
+	waitDone(t, done)
+
+	if rec.has("/internal/accounting/reservations/release") {
+		t.Error("nothing should be released in full: content was delivered")
+	}
+
+	body, ok := rec.find("/internal/accounting/reservations/finalize")
+	if !ok {
+		t.Fatalf("expected FinalizeReservation to reach control-plane despite the cancelled context; calls seen: %+v", rec.calls)
+	}
+	actual, _ := body["actual_credits"].(float64)
+	if actual <= 0 {
+		t.Errorf("actual_credits = %v, want > 0 (content was delivered)", body["actual_credits"])
+	}
+	if int64(actual) == 10000 {
+		t.Error("actual_credits must not fall back to the flat 10000 estimate")
+	}
+}

--- a/apps/edge-api/internal/inference/usage_clamp.go
+++ b/apps/edge-api/internal/inference/usage_clamp.go
@@ -1,6 +1,10 @@
 package inference
 
-import "log"
+import (
+	"encoding/json"
+	"log"
+	"strings"
+)
 
 // estimateCompletionTokens returns a conservative cl100k-style approximation
 // of the token count for a piece of text. The exact formula does not matter —
@@ -97,4 +101,136 @@ func responsesOutputTexts(items []ResponseOutputItem) []string {
 		}
 	}
 	return out
+}
+
+// --- Prompt text extraction (issue #602) ---
+//
+// promptText pulls the human-authored text out of a raw OpenAI-compatible
+// request body for the prompt-side half of the disconnect-settlement
+// estimate. It deliberately does NOT read the raw request bytes: the raw
+// body also carries field names, sampling params, tool schemas, and (for
+// multimodal messages) base64 image data URIs, none of which are prompt
+// tokens. Counting raw bytes let an ordinary image-attached chat request
+// estimate millions of "tokens" from a few hundred KB of base64, which is
+// the root cause of issue #602's over-charge.
+//
+// Images: excluded from this estimate entirely, not approximated by byte
+// length or a fixed per-image allowance. This is a fallback path -- it only
+// runs when the upstream never confirmed real usage -- so under-counting a
+// multimodal prompt here is the safe direction, and the hard hold-clamp in
+// control-plane's finalizeLocked is the backstop against any remaining
+// overcount regardless of what this function returns.
+func promptText(endpoint string, body []byte) string {
+	switch endpoint {
+	case EndpointChatCompletions:
+		return chatRequestText(body)
+	case EndpointCompletions:
+		return completionRequestText(body)
+	case EndpointResponses:
+		return responsesRequestText(body)
+	default:
+		return ""
+	}
+}
+
+// textCarrier matches any request-side object shaped { "content": ... },
+// covering chat messages and Responses API input items alike.
+type textCarrier struct {
+	Content json.RawMessage `json:"content"`
+}
+
+// textPart matches one multimodal content-array entry. Only "text" /
+// "input_text" parts contribute; image/audio parts are skipped by omission.
+type textPart struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// contentText resolves a message "content" field that is either a plain
+// string or an array of typed parts (the OpenAI multimodal shape).
+func contentText(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+	var parts []textPart
+	if err := json.Unmarshal(raw, &parts); err != nil {
+		return ""
+	}
+	var sb strings.Builder
+	for _, p := range parts {
+		if p.Type == "text" || p.Type == "input_text" {
+			sb.WriteString(p.Text)
+		}
+	}
+	return sb.String()
+}
+
+// chatRequestText extracts every message's text content from a raw
+// /v1/chat/completions request body.
+func chatRequestText(body []byte) string {
+	var req struct {
+		Messages []textCarrier `json:"messages"`
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		return ""
+	}
+	var sb strings.Builder
+	for _, m := range req.Messages {
+		sb.WriteString(contentText(m.Content))
+	}
+	return sb.String()
+}
+
+// completionRequestText extracts the prompt from a raw legacy
+// /v1/completions request body. prompt is either a string or an array of
+// strings per the OpenAI spec.
+func completionRequestText(body []byte) string {
+	var req struct {
+		Prompt json.RawMessage `json:"prompt"`
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(req.Prompt, &s); err == nil {
+		return s
+	}
+	var arr []string
+	if err := json.Unmarshal(req.Prompt, &arr); err == nil {
+		return strings.Join(arr, "")
+	}
+	return ""
+}
+
+// responsesRequestText extracts instructions + input text from a raw
+// /v1/responses request body. input is either a string or an array of
+// message-shaped items.
+func responsesRequestText(body []byte) string {
+	var req struct {
+		Input        json.RawMessage `json:"input"`
+		Instructions *string         `json:"instructions"`
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		return ""
+	}
+	var sb strings.Builder
+	if req.Instructions != nil {
+		sb.WriteString(*req.Instructions)
+	}
+	var s string
+	if err := json.Unmarshal(req.Input, &s); err == nil {
+		sb.WriteString(s)
+		return sb.String()
+	}
+	var items []textCarrier
+	if err := json.Unmarshal(req.Input, &items); err == nil {
+		for _, it := range items {
+			sb.WriteString(contentText(it.Content))
+		}
+	}
+	return sb.String()
 }

--- a/apps/edge-api/internal/inference/usage_clamp_test.go
+++ b/apps/edge-api/internal/inference/usage_clamp_test.go
@@ -1,6 +1,9 @@
 package inference
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func ptrStr(s string) *string { return &s }
 
@@ -225,6 +228,79 @@ func TestUsageAccumulator_ClampPreservesNonZero(t *testing.T) {
 	acc.ClampUsage(usage, "id", "alias", EndpointChatCompletions)
 	if usage.CompletionTokens != 4 || usage.TotalTokens != 7 {
 		t.Fatalf("clamp wrongly mutated nonzero usage: %+v", usage)
+	}
+}
+
+// TestPromptText_ChatCompletionsExcludesImageData is the regression guard
+// for issue #602's over-charge root cause: a multimodal chat request's
+// base64 image data URI must never be counted as prompt text. Counting raw
+// request bytes let an ordinary image-attached request estimate millions of
+// "tokens" from a few hundred KB of base64 (base64 tokenizes far below
+// byte_len/4), producing a settlement charge many multiples of the
+// reservation hold.
+func TestPromptText_ChatCompletionsExcludesImageData(t *testing.T) {
+	hugeBase64 := strings.Repeat("A", 200_000) // stand-in for a real image payload
+	body := []byte(`{"model":"hive-default","messages":[` +
+		`{"role":"user","content":[` +
+		`{"type":"text","text":"describe this image"},` +
+		`{"type":"image_url","image_url":{"url":"data:image/png;base64,` + hugeBase64 + `"}}` +
+		`]}]}`)
+
+	got := promptText(EndpointChatCompletions, body)
+	if got != "describe this image" {
+		t.Fatalf("expected only the text part, got %d bytes: %q...", len(got), got[:min(40, len(got))])
+	}
+	if estimateCompletionTokens(got) > 100 {
+		t.Fatalf("estimate exploded despite excluding image data: %d tokens from %q", estimateCompletionTokens(got), got)
+	}
+}
+
+func TestPromptText_ChatCompletionsStringContent(t *testing.T) {
+	body := []byte(`{"model":"m","messages":[{"role":"system","content":"be helpful"},{"role":"user","content":"hi there"}]}`)
+	got := promptText(EndpointChatCompletions, body)
+	if got != "be helpfulhi there" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestPromptText_ChatCompletionsMalformedBodyReturnsEmpty(t *testing.T) {
+	if got := promptText(EndpointChatCompletions, []byte(`not json`)); got != "" {
+		t.Fatalf("expected empty text for malformed body, got %q", got)
+	}
+}
+
+func TestPromptText_CompletionsStringAndArrayPrompt(t *testing.T) {
+	if got := promptText(EndpointCompletions, []byte(`{"model":"m","prompt":"once upon a time"}`)); got != "once upon a time" {
+		t.Fatalf("string prompt: got %q", got)
+	}
+	if got := promptText(EndpointCompletions, []byte(`{"model":"m","prompt":["a","b","c"]}`)); got != "abc" {
+		t.Fatalf("array prompt: got %q", got)
+	}
+}
+
+func TestPromptText_ResponsesStringInputAndInstructions(t *testing.T) {
+	body := []byte(`{"model":"m","instructions":"be terse","input":"summarize this"}`)
+	got := promptText(EndpointResponses, body)
+	if got != "be tersesummarize this" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestPromptText_ResponsesArrayInputExcludesImageParts(t *testing.T) {
+	hugeBase64 := strings.Repeat("B", 200_000)
+	body := []byte(`{"model":"m","input":[{"role":"user","content":[` +
+		`{"type":"input_text","text":"what is this"},` +
+		`{"type":"input_image","image_url":"data:image/png;base64,` + hugeBase64 + `"}` +
+		`]}]}`)
+	got := promptText(EndpointResponses, body)
+	if got != "what is this" {
+		t.Fatalf("expected only input_text, got %d bytes", len(got))
+	}
+}
+
+func TestPromptText_UnknownEndpointReturnsEmpty(t *testing.T) {
+	if got := promptText("embeddings", []byte(`{"input":"x"}`)); got != "" {
+		t.Fatalf("expected empty text for unhandled endpoint, got %q", got)
 	}
 }
 

--- a/supabase/migrations/20260730_01_usage_events_event_type_extend.sql
+++ b/supabase/migrations/20260730_01_usage_events_event_type_extend.sql
@@ -19,8 +19,21 @@
 -- re-ADD with the extended, strictly broader list -- every row that already
 -- satisfied the old constraint still satisfies this one, so no data rewrite
 -- or backfill is needed.
-
-BEGIN;
+--
+-- usage_events is a hot metering table with continuous writes, so the ADD
+-- CONSTRAINT + VALIDATE steps are split (NOT VALID, then a separate
+-- VALIDATE CONSTRAINT statement, no shared BEGIN/COMMIT) rather than a bare
+-- ADD CONSTRAINT: a bare ADD CONSTRAINT validates every existing row before
+-- committing and holds ACCESS EXCLUSIVE for the whole scan, blocking reads
+-- and writes for its duration. NOT VALID skips that scan when the
+-- constraint is added (ACCESS EXCLUSIVE held only for the instant catalog
+-- update), and the follow-up VALIDATE CONSTRAINT does the scan under
+-- SHARE UPDATE EXCLUSIVE, which does not block concurrent reads or writes.
+-- Matches the pattern already used in 20260507_01_invoices_period_order_check.sql.
+-- Deliberately no wrapping BEGIN/COMMIT: keeping ADD and VALIDATE as
+-- separate auto-committed statements is what lets VALIDATE run under the
+-- weaker lock instead of inheriting ACCESS EXCLUSIVE from the same
+-- transaction as ADD CONSTRAINT.
 
 ALTER TABLE public.usage_events
     DROP CONSTRAINT IF EXISTS usage_events_event_type_check;
@@ -31,6 +44,7 @@ ALTER TABLE public.usage_events
         'accepted', 'reservation_created', 'stream_update', 'completed',
         'released', 'refunded', 'error', 'reconciled',
         'upstream_error', 'finalize_failed', 'interrupted'
-    ));
+    )) NOT VALID;
 
-COMMIT;
+ALTER TABLE public.usage_events
+    VALIDATE CONSTRAINT usage_events_event_type_check;

--- a/supabase/migrations/20260730_01_usage_events_event_type_extend.sql
+++ b/supabase/migrations/20260730_01_usage_events_event_type_extend.sql
@@ -1,0 +1,36 @@
+-- supabase/migrations/20260730_01_usage_events_event_type_extend.sql
+--
+-- PR #602 (streaming disconnect settlement) has edge-api write usage_events
+-- rows with event_type 'upstream_error' and 'finalize_failed' (settleStream,
+-- apps/edge-api/internal/inference/stream.go), and 'interrupted' (already
+-- used as a request_attempts.status value, but never previously written as
+-- a usage_events.event_type). None of the three were in the CHECK constraint
+-- 20260330_02_usage_accounting.sql put on usage_events.event_type, so every
+-- one of these inserts has been failing and silently dropped since the
+-- disconnect-settlement code first shipped -- the app code discards the
+-- insert error (see RecordUsageEvent callers in stream.go).
+--
+-- This matters beyond audit completeness: metering Step 2 is currently
+-- shadow-mode recording exactly this data, and Step 4's future enforcement
+-- thresholds get set from it. A silent hole in disconnect/error telemetry
+-- biases that decision before it is even made.
+--
+-- Idempotent against a populated table: DROP CONSTRAINT IF EXISTS then
+-- re-ADD with the extended, strictly broader list -- every row that already
+-- satisfied the old constraint still satisfies this one, so no data rewrite
+-- or backfill is needed.
+
+BEGIN;
+
+ALTER TABLE public.usage_events
+    DROP CONSTRAINT IF EXISTS usage_events_event_type_check;
+
+ALTER TABLE public.usage_events
+    ADD CONSTRAINT usage_events_event_type_check
+    CHECK (event_type IN (
+        'accepted', 'reservation_created', 'stream_update', 'completed',
+        'released', 'refunded', 'error', 'reconciled',
+        'upstream_error', 'finalize_failed', 'interrupted'
+    ));
+
+COMMIT;


### PR DESCRIPTION
## Problem

A mid-stream client disconnect currently settles nothing. `apps/edge-api/internal/inference/stream.go` (and `stream_responses.go`, same shape) called `FinalizeReservation` on the same request context the disconnect had just cancelled. `accounting_client.go` builds that outbound call with `http.NewRequestWithContext(ctx, ...)`, so it fails before it ever leaves the process. The tail settle block then set `finalized = true` unconditionally, regardless of whether the call actually succeeded, which also suppressed the existing deferred release path. Net effect: no charge, no ledger entry, no usage event, and the reservation stays `active` forever, permanently reducing the account's spendable balance.

A second, opposite defect: with no terminal usage block, the settlement fell back to a hardcoded flat 10000 estimate (from `chat_completions.go` / `completions.go`), a latent overcharge whenever a stream ended without upstream-confirmed usage.

## Fix

Collapse settlement into the single existing defer, which already runs on every exit path. A new `settleStream` helper dispatches on its own `context.WithTimeout(context.Background(), 5*time.Second)`, independent of the caller's context (the exact thing a disconnect cancels). The tail settle block and its flat-estimate fallback are deleted entirely.

- Delivered tokens (usage-confirmed by the upstream, or, absent that, a content-based estimate floored at one credit when anything was produced) settle via `FinalizeReservation`.
- Nothing delivered releases the reservation in full via `ReleaseReservation`.
- `finalized` is set only after `settleStream` itself reports success, so a failed settle attempt still falls through correctly.
- `TerminalUsageConfirmed` mirrors `hasUsage`, so an estimate-based settle is still flagged into the existing `needs_reconciliation` path rather than treated as a confirmed final charge.
- No floor is ever applied above what was actually delivered.

## Tests

Table-driven unit coverage for the settlement decision (`settlement_test.go`), plus end-to-end regression tests that exercise the real `executeStreaming` / `executeResponsesStreaming` lifecycle against in-process mock servers (`stream_disconnect_test.go`, `stream_responses_disconnect_test.go`):

- Disconnect settles at delivered tokens, not the flat estimate, not zero, despite the request context already being cancelled (the primary regression guard).
- Disconnect with nothing delivered releases the reservation in full.
- Normal completion (no disconnect) still charges confirmed usage tokens, no regression.

## Follow-up (filed, not in scope here)

- #600: orphan-hold reaper + `expires_at` on reservations, and a worker to actually consume `credit_reconciliation_jobs` (currently write-only). This PR removes the main producer of orphan holds going forward; historical stranded holds are untouched by it.
- #601: revisit the LiteLLM pin (`v1.77.7-stable`) once upstream `cancel_on_disconnect` covers the streaming path; the merged support today is non-streaming only, and Groq is on the unsupported-provider list regardless.

## Test plan

- [x] `go build ./apps/edge-api/...`
- [x] `go test ./apps/edge-api/internal/inference/... -count=1 -short` (new + existing tests green)
- [x] `go test ./apps/edge-api/... -count=1 -short` (full package, no regression)
- [x] `go test ./apps/control-plane/... -count=1 -short` (full package, no regression, including routing after rebase onto #597)
- [ ] CI green (watching)