### PR TITLE
docs: audit and dismiss account_billing_profiles delete window (#592)

### DIFF
--- a/apps/web-console/tests/e2e/support/e2e-fixture-seed.mjs
+++ b/apps/web-console/tests/e2e/support/e2e-fixture-seed.mjs
@@ -413,6 +413,21 @@ async function resetProfilesAndInvitation(
   );
   if (profErr) throw new Error(`profiles upsert failed: ${profErr.message}`);
 
+  // Audited for issue #592 (a plain delete with no paired upsert, unlike the
+  // account_memberships and account_invitations fixes above and below): left
+  // as a bare delete on purpose, not a bug needing a guard.
+  //
+  // control-plane's GetBillingProfile LEFT JOINs account_billing_profiles and
+  // COALESCEs every column, so a missing row after this delete reads back as
+  // blank fields, never ErrNotFound — there is nothing here for a concurrent
+  // read to observe as broken. And there is no concurrent read to begin with:
+  // the fixture CLI runs via execFileSync (fully synchronous — it blocks the
+  // calling test's beforeEach until the child process exits) from a single
+  // Playwright worker (playwright.config.ts pins workers: 1 for exactly this
+  // reason). No spec's page load can ever land inside this function's
+  // execution window, in this run or a concurrent one (account ids are
+  // namespaced per E2E_RUN_KEY, so two jobs never touch the same row). Revisit
+  // if workers ever goes above 1 or this CLI is invoked without blocking.
   const accountIds = [
     ids.verifiedPrimaryAccountId,
     ids.verifiedSecondaryAccountId,


### PR DESCRIPTION
## Summary

Closes #592.

The issue asked for an audit of `apps/web-console/tests/e2e/support` and
`supabase/functions/e2e-fixtures/index.ts` for any remaining un-paired
delete (the same shape of bug PR #583 fixed for `account_memberships` and
`account_invitations`), and a decision on whether the
`account_billing_profiles` delete in `resetProfilesAndInvitation` needs a
fix.

Audit result: it does not need a fix.

- `supabase/functions/e2e-fixtures/index.ts` no longer exists. Seeding
  moved in-process in PR #583, so there is nothing left to audit there.
- The only remaining un-paired delete in `apps/web-console/tests/e2e/support`
  is the `account_billing_profiles` loop. `GetBillingProfile`
  (`apps/control-plane/internal/profiles/repository.go`) LEFT JOINs both
  `account_profiles` and `account_billing_profiles` and COALESCEs every
  selected column, so a missing row after the delete reads back as blank
  fields, never `ErrNotFound`. There is nothing here for a read to observe
  as broken.
- There is also no concurrent reader of the window in the first place:
  every spec's `beforeEach` calls the fixture CLI through `execFileSync`
  (confirmed in `auth-shell.spec.ts`, `profile-completion.spec.ts`, and
  five other specs), which blocks the calling test synchronously until the
  child process exits, and `playwright.config.ts` pins `workers: 1`. No
  page load can land inside `resetProfilesAndInvitation`'s execution
  window, in this run or a concurrent one, and `buildIds(runKey)`
  namespaces every account id per `E2E_RUN_KEY` so two CI jobs never touch
  the same row anyway.

Change is a documentation-only PR: added an inline comment above the
delete loop recording this reasoning and referencing #592 directly, so it
does not get forgotten by living only in a PR body, and logged the same
conclusion to `.wolf/buglog.jsonl`. No functional code was touched.

An unrelated, separately real bug was found while reading this code during
the audit (`account_memberships.created_at` ties within a single bulk
upsert make `EnsureViewerContext`'s default-workspace pick vary from
reseed to reseed, since the Go-side tiebreak added by PR #583 sorts on a
fresh random `id` per run rather than the array's intended priority order).
That is a different bug class (a same-timestamp sort tie, not an un-paired
delete) and outside what #592 asked for, so it was deliberately left out
of this PR to keep the diff scoped to the confirmed defect, matching this
issue's own precedent. Flagging it for a follow-up issue rather than
bundling it here.

## Test plan

- [x] `node --check apps/web-console/tests/e2e/support/e2e-fixture-seed.mjs` passes.
- [x] Verified `GetBillingProfile`'s LEFT JOIN + COALESCE behavior by reading `apps/control-plane/internal/profiles/repository.go` directly.
- [x] Verified `playwright.config.ts` pins `workers: 1` and every credentialed spec's `beforeEach` calls the fixture CLI via `execFileSync`.
- [ ] Full E2E suite not run: no Hive core stack (control-plane/edge-api/Supabase) was up in this environment, and this repo shares one 15-client session-mode Supabase pool across CI, agents, and the live chat surface, so a stack was not started for a documentation-only change with no functional diff.