### PR TITLE
fix: stamp distinct created_at on seeded account_memberships to break EnsureViewerContext tie (#608)

### DIFF
--- a/apps/web-console/tests/e2e/support/e2e-fixture-seed.mjs
+++ b/apps/web-console/tests/e2e/support/e2e-fixture-seed.mjs
@@ -326,6 +326,36 @@ async function seedAccountsAndMemberships(admin, ids, users) {
     );
   }
 
+  // Fixes issue #608: account_memberships.created_at defaults to now(), and a
+  // single multi-row upsert statement stamps every inserted row with that one
+  // transaction timestamp: there is no wall-clock gap between them.
+  // ListMembershipsByUserID
+  // (apps/control-plane/internal/accounts/repository.go) orders by
+  // `created_at ASC, id ASC`, with id documented there as a tiebreaker "only
+  // for the pathological case of two memberships sharing one created_at". A
+  // bulk upsert is exactly that pathological case on every seed call, so
+  // verifiedUser's two memberships below (owner of the primary workspace,
+  // plain member of the shared one) tied on created_at and fell back to
+  // comparing each row's freshly random gen_random_uuid() id: a coin flip on
+  // every reseed, not a fixed order within one run. EnsureViewerContext takes
+  // memberships[0] as the signed-in user's default workspace whenever no
+  // `hive_account_id` cookie is set, which is every spec's first navigation
+  // after signIn(), so roughly half of all CI runs landed the verified spec
+  // user in the workspace they only have "member" role in. That is the
+  // confirmed cause of profile-completion.spec.ts's "billing settings save
+  // partial business profile" (an owner-only route) failing intermittently.
+  //
+  // Fixed at the source that produces the tie, not at the consumer that
+  // resolves it: the Go-side id tiebreak is correct general-purpose behavior
+  // (real production data can have two memberships insert in one statement
+  // too) and its own regression test already pins that shape, so it stays as
+  // a last-resort tiebreak rather than becoming the primary sort. Stamping
+  // created_at explicitly here, one millisecond apart in the intended
+  // priority order (verifiedUser's owned workspace before the one they only
+  // joined), means the seeded rows never reach that pathological case at all,
+  // on every seed call including reseeds of the same run key across
+  // Playwright retries.
+  const membershipSeedTime = Date.now();
   const { error: memErr } = await admin.from("account_memberships").upsert(
     [
       {
@@ -358,7 +388,10 @@ async function seedAccountsAndMemberships(admin, ids, users) {
         role: "owner",
         status: "active",
       },
-    ],
+    ].map((membership, index) => ({
+      ...membership,
+      created_at: new Date(membershipSeedTime + index).toISOString(),
+    })),
     { onConflict: "account_id,user_id" }
   );
   if (memErr) throw new Error(`memberships upsert failed: ${memErr.message}`);


### PR DESCRIPTION
## Summary

Fixes #608.

`seedAccountsAndMemberships` (`apps/web-console/tests/e2e/support/e2e-fixture-seed.mjs`) wrote verifiedUser's two memberships (owner of the primary workspace, plain member of the shared one) in a single multi-row upsert. `account_memberships.created_at` defaults to `now()`, and one INSERT statement stamps every inserted row with the same transaction timestamp, so the two rows tied on `created_at`.

`ListMembershipsByUserID` (`apps/control-plane/internal/accounts/repository.go`) orders `ORDER BY created_at ASC, id ASC`, with `id` documented there as a tiebreaker "only for the pathological case of two memberships sharing one created_at". The bulk seed hit exactly that case on every run, so which membership sorted first came down to comparing two freshly random `gen_random_uuid()` ids, a coin flip on every reseed. `EnsureViewerContext` takes `memberships[0]` as the default workspace on every spec's first navigation after `signIn()`, so roughly half of CI runs landed the verified spec user in the workspace they only have `member` role in, causing an owner-only route to 403 in `profile-completion.spec.ts`'s "billing settings save partial business profile" test.

## Fix shape

Chose to fix the seed data, not the Go selection logic. `ListMembershipsByUserID`'s `id` tiebreak is correct general-purpose behavior: real production data can legitimately produce two memberships in one statement too, and `TestListMembershipsByUserID_TiebreaksByID` already pins that shape as intentional. Changing the consumer's ordering to work around a test-fixture artifact would be the wrong root cause fix and would touch real production selection logic for a test-only problem.

Instead, `account_memberships.created_at` is now stamped explicitly, one millisecond apart per array index, in the seed's intended priority order (verifiedUser's owned workspace before the one they only joined). The seeded rows never reach the tie case at all, on every seed call including reseeds of the same run key across Playwright retries. The Go-side tiebreak stays untouched.

## Test plan

- [x] `node --check apps/web-console/tests/e2e/support/e2e-fixture-seed.mjs` passes.
- [x] Confirmed `ListMembershipsByUserID`'s ordering and its existing `TestListMembershipsByUserID_TiebreaksByID` regression test by reading `apps/control-plane/internal/accounts/repository.go` and `repository_membership_order_test.go` directly.
- [ ] `profile-completion.spec.ts` run repeatedly (10+ consecutive reseed-and-run cycles) to confirm the roughly 50% flake is gone: **not run in this environment**. No Hive core stack (control-plane/edge-api/Supabase) is up here, and this repo shares one 15-client session-mode Supabase pool across CI, agents, and the live chat surface; starting a fresh stack to hammer it with 10+ consecutive Playwright runs risks the same kind of pool exhaustion that previously 502'd the live chat host. Flagging this explicitly rather than claiming a run that did not happen. Recommend running this verification in CI or on a dedicated environment before merge.