### PR TITLE
fix: eliminate desktop entitlements test flakes (accept race + rustls provider)

### DIFF
--- a/apps/desktop/src-tauri/src/entitlements.rs
+++ b/apps/desktop/src-tauri/src/entitlements.rs
@@ -439,23 +439,25 @@ mod tests {
 
     // -- crypto provider (BLOCKER fix regression) ------------------------------
 
-    /// Mirrors main.rs's startup call. rustls 0.23 panics on the first TLS
-    /// handshake if more than one crypto provider is linked (both ring and
-    /// aws-lc-rs are, via Cargo feature unification -- see Cargo.toml) and
-    /// none was installed as the process default. cargo test runs every
-    /// test in this file in one process, so this may run after another test
-    /// already installed one; install_default's Err in that case is exactly
-    /// as fine as it is in main.rs, hence the same `let _ =`.
+    /// Goes through `ensure_crypto_provider()` -- the same helper
+    /// `mock_server()` and `unreachable_origin()` call -- rather than
+    /// installing the provider itself, so a regression in the helper (guard
+    /// logic removed, wrong provider, no-op closure) fails this test instead
+    /// of hiding behind a redundant direct install. `cargo test` runs every
+    /// test in this file in one process in an unspecified order, so this may
+    /// run after another test already drove the `Once`; that's fine, since
+    /// `ensure_crypto_provider()` only needs to guarantee a default provider
+    /// is installed by the time it returns, not that it was the one to
+    /// install it -- the assertions below hold either way.
     ///
     /// A full HTTPS round-trip against a local TLS test server (the
     /// reviewer's stronger option) is deliberately skipped: it needs a
     /// self-signed cert plus a cert-generation dependency neither this
     /// crate nor its dev-dependencies carry today, disproportionate for a
-    /// gap already closed by the single explicit install_default() call
-    /// this test exercises directly.
+    /// gap already closed by exercising the real installation path here.
     #[test]
     fn crypto_provider_installs_and_client_builds_deterministically() {
-        let _ = rustls::crypto::ring::default_provider().install_default();
+        ensure_crypto_provider();
         assert!(rustls::crypto::CryptoProvider::get_default().is_some());
         assert!(build_client().is_ok());
     }

--- a/apps/desktop/src-tauri/src/entitlements.rs
+++ b/apps/desktop/src-tauri/src/entitlements.rs
@@ -232,6 +232,23 @@ mod tests {
     use super::*;
     use std::io::{Read, Write};
     use std::net::TcpListener;
+    use std::sync::Once;
+
+    /// Installs rustls's process-wide default crypto provider exactly once.
+    /// `build_client()` (via reqwest's `rustls-no-provider` feature, see
+    /// Cargo.toml) panics on its first call unless a provider was already
+    /// installed -- `main.rs` does this at real startup, but `cargo test`
+    /// never runs `main()`, and it runs every test below in one process, in
+    /// parallel, in an unspecified order. Guarded by `Once` so concurrent
+    /// tests race on the flag, not on rustls's own (fallible-if-repeated)
+    /// install call.
+    static CRYPTO_PROVIDER_INIT: Once = Once::new();
+
+    fn ensure_crypto_provider() {
+        CRYPTO_PROVIDER_INIT.call_once(|| {
+            let _ = rustls::crypto::ring::default_provider().install_default();
+        });
+    }
 
     /// Spawns a one-shot HTTP server on an ephemeral port that writes a
     /// response with the given status line and body (Content-Length
@@ -241,7 +258,15 @@ mod tests {
     /// formatted before spawning so the thread only ever owns a `String`,
     /// letting callers (e.g. the oversized-body test) pass a borrowed,
     /// dynamically built body instead of a `&'static str` literal.
+    ///
+    /// Accepts in a loop rather than taking only the first `Result`: under
+    /// CI load a transient accept error (e.g. `ECONNABORTED`) previously
+    /// left the listener thread give up silently, so the client's request
+    /// ran out the clock against `FETCH_TIMEOUT` instead of getting a
+    /// response. Looping retries past a transient error instead of treating
+    /// it as "no client is coming".
     fn mock_server(status_line: &str, body: &str) -> String {
+        ensure_crypto_provider();
         let response = format!(
             "{status_line}\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n{body}",
             body.len()
@@ -249,10 +274,15 @@ mod tests {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let addr = listener.local_addr().unwrap();
         std::thread::spawn(move || {
-            if let Ok((mut stream, _)) = listener.accept() {
+            for conn in listener.incoming() {
+                let mut stream = match conn {
+                    Ok(stream) => stream,
+                    Err(_) => continue,
+                };
                 let mut buf = [0u8; 1024];
                 let _ = stream.read(&mut buf);
                 let _ = stream.write_all(response.as_bytes());
+                break;
             }
         });
         format!("http://{addr}")
@@ -261,6 +291,7 @@ mod tests {
     /// Binds an ephemeral port, then immediately drops the listener so the
     /// port is guaranteed to refuse the next connection.
     fn unreachable_origin() -> String {
+        ensure_crypto_provider();
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let addr = listener.local_addr().unwrap();
         drop(listener);


### PR DESCRIPTION
## Summary

Fixes two independent, unrelated causes of intermittent `cargo test` failures in `apps/desktop/src-tauri` (entitlements module):

- **Accept race**: `mock_server`'s listener thread called `TcpListener::accept()` exactly once. Under CI load a transient accept error (e.g. `ECONNABORTED`) left the thread give up silently instead of handling the real client connection, so the client request ran out the clock against `FETCH_TIMEOUT` instead of getting a response. Now loops over `listener.incoming()`, retrying past transient errors and breaking only once a connection is actually handled.
- **rustls crypto provider**: `reqwest` is built with the `rustls-no-provider` feature (see `Cargo.toml`), so the first TLS-capable client build panics unless a process-wide `rustls::crypto::CryptoProvider` was installed first. `main.rs` installs one once at real startup, but `cargo test` never runs `main()`, and runs every test in this file in one process, in parallel, in an unspecified order. Added an `Once`-guarded `ensure_crypto_provider()` (mirrors `main.rs`'s own `rustls::crypto::ring::default_provider().install_default()` call), invoked from both `mock_server` and `unreachable_origin`, plus a direct regression test for the install path.

No source changes outside `entitlements.rs`'s test module. `Cargo.lock` is untouched (an unrelated `codex-windows-sandbox` path-dependency resolution churn appeared transiently from running `cargo test`/`clippy` locally and was reverted before committing, kept out of this diff).

## Test plan

- [x] `cargo test` inside the CI-equivalent GTK/WebKit/dbus toolchain (`deploy/docker/Dockerfile.desktop-linux`, matching `.github/workflows/ci.yml`'s `desktop-tests` job): 45/45 passing, run **3 consecutive times**, 0 failures each time.
- [x] `cargo fmt --check`: clean.
- [x] `cargo clippy --all-targets -- -D warnings`: clean, 0 warnings.
- [x] `.wolf/buglog.jsonl` updated with root cause, fix, and tags for both defects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test reliability and consistency in concurrent CI environments.
  * Made network-related test setup more deterministic.
  * Enhanced mock server handling to better tolerate transient connection errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->