### PR TITLE
fix: fail closed when a credit reservation is refused

### DIFF
--- a/apps/edge-api/internal/inference/orchestrator.go
+++ b/apps/edge-api/internal/inference/orchestrator.go
@@ -161,15 +161,19 @@ func (o *Orchestrator) executeSync(
 		return
 	}
 
-	// Ensure reservation cleanup if we return without finalizing.
+	// Ensure reservation cleanup if we return without finalizing. Every exit
+	// path below settles through releaseReservationBackground, the same helper
+	// the streaming path uses: a fresh bounded background context, never the
+	// request context (a client disconnect is exactly what cancels that), and
+	// `finalized` gated on the release actually reaching the control plane
+	// rather than assumed. A failed attempt leaves `finalized` false so this
+	// defer gets one more shot before the request returns, which is what keeps
+	// a hold from being stranded (issue #616).
 	finalized := false
+	releaseReason := "interrupted"
 	defer func() {
 		if !finalized && reservation.ID != "" {
-			_ = o.accounting.ReleaseReservation(context.Background(), ReleaseReservationInput{
-				AccountID:     snapshot.AccountID,
-				ReservationID: reservation.ID,
-				Reason:        "interrupted",
-			})
+			o.releaseReservationBackground(snapshot, reservation.ID, requestID, releaseReason)
 		}
 	}()
 
@@ -177,12 +181,8 @@ func (o *Orchestrator) executeSync(
 	resp, err := dispatchWithRetry(ctx, route.LiteLLMModelName, body, dispatch)
 	if err != nil {
 		if reservation.ID != "" {
-			_ = o.accounting.ReleaseReservation(ctx, ReleaseReservationInput{
-				AccountID:     snapshot.AccountID,
-				ReservationID: reservation.ID,
-				Reason:        "upstream_error",
-			})
-			finalized = true
+			releaseReason = "upstream_error"
+			finalized = o.releaseReservationBackground(snapshot, reservation.ID, requestID, releaseReason)
 		}
 		apierrors.WriteProviderBlindUpstreamError(w, model, http.StatusBadGateway, err.Error())
 		return
@@ -192,12 +192,8 @@ func (o *Orchestrator) executeSync(
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		upstreamBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		if reservation.ID != "" {
-			_ = o.accounting.ReleaseReservation(ctx, ReleaseReservationInput{
-				AccountID:     snapshot.AccountID,
-				ReservationID: reservation.ID,
-				Reason:        "upstream_error",
-			})
-			finalized = true
+			releaseReason = "upstream_error"
+			finalized = o.releaseReservationBackground(snapshot, reservation.ID, requestID, releaseReason)
 		}
 		o.recordErrorEvent(ctx, snapshot, attempt, requestID, endpoint, model, resp.StatusCode, string(upstreamBody))
 		apierrors.WriteProviderBlindUpstreamError(w, model, resp.StatusCode, string(upstreamBody))
@@ -208,12 +204,8 @@ func (o *Orchestrator) executeSync(
 	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 10*1024*1024))
 	if err != nil {
 		if reservation.ID != "" {
-			_ = o.accounting.ReleaseReservation(ctx, ReleaseReservationInput{
-				AccountID:     snapshot.AccountID,
-				ReservationID: reservation.ID,
-				Reason:        "read_error",
-			})
-			finalized = true
+			releaseReason = "read_error"
+			finalized = o.releaseReservationBackground(snapshot, reservation.ID, requestID, releaseReason)
 		}
 		code := "upstream_error"
 		apierrors.WriteError(w, http.StatusBadGateway, "api_error", "Failed to read upstream response.", &code)
@@ -224,12 +216,8 @@ func (o *Orchestrator) executeSync(
 	normalized, usage, err := normalize(respBody, model)
 	if err != nil {
 		if reservation.ID != "" {
-			_ = o.accounting.ReleaseReservation(ctx, ReleaseReservationInput{
-				AccountID:     snapshot.AccountID,
-				ReservationID: reservation.ID,
-				Reason:        "normalize_error",
-			})
-			finalized = true
+			releaseReason = "normalize_error"
+			finalized = o.releaseReservationBackground(snapshot, reservation.ID, requestID, releaseReason)
 		}
 		code := "upstream_error"
 		apierrors.WriteError(w, http.StatusBadGateway, "api_error", "Failed to process upstream response.", &code)
@@ -242,14 +230,24 @@ func (o *Orchestrator) executeSync(
 		if usage != nil {
 			actualCredits = usage.TotalTokens
 		}
-		_ = o.accounting.FinalizeReservation(ctx, FinalizeReservationInput{
+		// Do not discard this error. A failed finalize used to set finalized
+		// anyway, which skipped the deferred release and so lost the charge and
+		// stranded the hold in the same step (issue #616). Leaving finalized
+		// false hands the reservation to the deferred release instead, so it
+		// still reaches a terminal state exactly once: charged here on success,
+		// released there on failure, never both.
+		if err := o.accounting.FinalizeReservation(ctx, FinalizeReservationInput{
 			AccountID:              snapshot.AccountID,
 			ReservationID:          reservation.ID,
 			ActualCredits:          actualCredits,
 			TerminalUsageConfirmed: true,
 			Status:                 "completed",
-		})
-		finalized = true
+		}); err != nil {
+			log.Printf("inference: finalize reservation failed, releasing hold instead request_id=%s reservation_id=%s: %v", requestID, reservation.ID, err)
+			releaseReason = "finalize_failed"
+		} else {
+			finalized = true
+		}
 	}
 
 	o.recordCompletedEvent(ctx, snapshot, attempt, requestID, endpoint, model, usage)
@@ -261,7 +259,11 @@ func (o *Orchestrator) executeSync(
 }
 
 func (o *Orchestrator) recordErrorEvent(ctx context.Context, snapshot authz.AuthSnapshot, attempt AttemptResult, requestID, endpoint, model string, statusCode int, errBody string) {
-	_ = o.accounting.RecordUsageEvent(ctx, RecordEventInput{
+	// Logged, not discarded: usage recording is best effort for the request
+	// itself, but a silent drop is how the streaming usage_events rows vanished
+	// unnoticed against an outdated CHECK constraint. Metering Step 2 shadow
+	// mode reads exactly this data.
+	if err := o.accounting.RecordUsageEvent(ctx, RecordEventInput{
 		AccountID:        snapshot.AccountID,
 		RequestAttemptID: attempt.ID,
 		APIKeyID:         snapshot.KeyID,
@@ -272,7 +274,9 @@ func (o *Orchestrator) recordErrorEvent(ctx context.Context, snapshot authz.Auth
 		Status:           fmt.Sprintf("upstream_%d", statusCode),
 		ErrorCode:        fmt.Sprintf("%d", statusCode),
 		ErrorType:        "upstream_error",
-	})
+	}); err != nil {
+		log.Printf("inference: record error event failed request_id=%s status=%d: %v", requestID, statusCode, err)
+	}
 }
 
 func (o *Orchestrator) recordCompletedEvent(ctx context.Context, snapshot authz.AuthSnapshot, attempt AttemptResult, requestID, endpoint, model string, usage *UsageResponse) {
@@ -294,5 +298,8 @@ func (o *Orchestrator) recordCompletedEvent(ctx context.Context, snapshot authz.
 		}
 		input.HiveCreditDelta = usage.TotalTokens
 	}
-	_ = o.accounting.RecordUsageEvent(ctx, input)
+	// Logged, not discarded, for the same reason as recordErrorEvent above.
+	if err := o.accounting.RecordUsageEvent(ctx, input); err != nil {
+		log.Printf("inference: record completed event failed request_id=%s: %v", requestID, err)
+	}
 }

--- a/apps/edge-api/internal/inference/orchestrator.go
+++ b/apps/edge-api/internal/inference/orchestrator.go
@@ -157,14 +157,8 @@ func (o *Orchestrator) executeSync(
 		EstimatedCredits: estimatedCredits,
 		PolicyMode:       "strict",
 	})
-	if err != nil {
-		if strings.Contains(err.Error(), "429") || strings.Contains(err.Error(), "budget") || strings.Contains(err.Error(), "insufficient") {
-			code := "insufficient_quota"
-			apierrors.WriteError(w, http.StatusTooManyRequests, "insufficient_quota",
-				"You exceeded your current quota, please check your plan and billing details.", &code)
-			return
-		}
-		log.Printf("inference: create reservation failed (non-fatal): %v", err)
+	if err != nil && refuseOnReservationFailure(w, endpoint, model, err) {
+		return
 	}
 
 	// Ensure reservation cleanup if we return without finalizing.

--- a/apps/edge-api/internal/inference/reservation_fail_closed_test.go
+++ b/apps/edge-api/internal/inference/reservation_fail_closed_test.go
@@ -1,0 +1,308 @@
+package inference
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	apierrors "github.com/sakibsadmanshajib/hive/apps/edge-api/internal/errors"
+)
+
+// --- fail-closed reservation harness ---
+//
+// A request must never reach a provider unless a credit reservation was
+// actually created, except for an enumerated set of infrastructure-transient
+// control-plane faults. These tests drive the real executeSync,
+// executeStreaming and executeResponsesStreaming lifecycles against a
+// control-plane stand-in that answers CreateReservation with a chosen status,
+// and count how many times the provider stand-in was reached.
+
+// newAccountingMockReservationStatus answers CreateReservation with the given
+// status code and raw body, and 200 for every other accounting/usage path, so
+// a test can pick exactly which reservation outcome the edge-api sees.
+func newAccountingMockReservationStatus(rec *accountingRecorder, status int, body string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var decoded map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&decoded)
+		rec.record(r.URL.Path, decoded)
+		if r.URL.Path == "/internal/accounting/reservations" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(status)
+			_, _ = w.Write([]byte(body))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		if r.URL.Path == "/internal/usage/attempts" {
+			_ = json.NewEncoder(w).Encode(AttemptResult{
+				ID: "attempt-test-1", RequestID: "req-test-1", Status: "accepted",
+			})
+		}
+	}))
+}
+
+// countingJSONServer stands in for the provider (via LiteLLM) on the
+// non-streaming path and counts how many times it was dispatched to.
+func countingJSONServer(hits *int64) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(hits, 1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(ChatCompletionResponse{
+			ID:     "chatcmpl-test-1",
+			Object: "chat.completion",
+			Model:  "route",
+			Usage:  &UsageResponse{PromptTokens: 20, CompletionTokens: 5, TotalTokens: 25},
+		})
+	}))
+}
+
+// countingSSEServer stands in for the provider on the streaming paths and
+// counts how many times it was dispatched to.
+func countingSSEServer(hits *int64) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(hits, 1)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher := w.(http.Flusher)
+		fmt.Fprintln(w, buildChunkLine("chunk-1", "route", "hello", nil))
+		flusher.Flush()
+		fmt.Fprintln(w, "data: [DONE]")
+		flusher.Flush()
+	}))
+}
+
+// deadAccountingURL returns the URL of an already-closed server, so calls to
+// it fail with a real connection-refused transport error rather than a
+// simulated one.
+func deadAccountingURL(t *testing.T) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	url := srv.URL
+	srv.Close()
+	return url
+}
+
+func callSync(orch *Orchestrator) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{}`))
+	req.Header.Set("Authorization", "Bearer test-token")
+	w := httptest.NewRecorder()
+	orch.executeSync(context.Background(), w, req, EndpointChatCompletions, []byte(`{}`), "gpt-4o",
+		NeedFlags{NeedChatCompletions: true}, 10000, orch.litellm.ChatCompletion, normalizeChatCompletion)
+	return w
+}
+
+func callStreaming(orch *Orchestrator) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{}`))
+	req.Header.Set("Authorization", "Bearer test-token")
+	w := httptest.NewRecorder()
+	_ = orch.executeStreaming(context.Background(), w, req, EndpointChatCompletions, []byte(`{}`), "gpt-4o", "gpt-4o",
+		NeedFlags{NeedChatCompletions: true, NeedStreaming: true}, 10000, false, nil, orch.litellm.ChatCompletion)
+	return w
+}
+
+func callResponsesStreaming(orch *Orchestrator) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{}`))
+	req.Header.Set("Authorization", "Bearer test-token")
+	w := httptest.NewRecorder()
+	orch.executeResponsesStreaming(context.Background(), w, req, []byte(`{}`),
+		ResponsesRequest{Model: "gpt-4o"}, "gpt-4o",
+		NeedFlags{NeedResponses: true, NeedStreaming: true}, 10000)
+	return w
+}
+
+// assertRefused checks the customer-facing refusal: the expected HTTP status,
+// no provider dispatch at all, no provider identity in the payload, and no
+// currency, FX or USD language of any kind (Bangladesh regulatory rule).
+func assertRefused(t *testing.T, w *httptest.ResponseRecorder, hits int64, wantStatus int) apierrors.OpenAIErrorBody {
+	t.Helper()
+	if hits != 0 {
+		t.Errorf("provider was dispatched %d time(s); a refused reservation must never reach a provider", hits)
+	}
+	if w.Code != wantStatus {
+		t.Errorf("status = %d, want %d (body: %s)", w.Code, wantStatus, w.Body.String())
+	}
+	var payload apierrors.OpenAIError
+	if err := json.Unmarshal(w.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("refusal body is not an OpenAI error envelope: %v (body: %s)", err, w.Body.String())
+	}
+	lower := strings.ToLower(w.Body.String())
+	for _, banned := range []string{"openrouter", "groq", "litellm", "$", "usd", "bdt", "taka", "exchange rate", "fx"} {
+		if strings.Contains(lower, banned) {
+			t.Errorf("refusal payload leaks %q: %s", banned, w.Body.String())
+		}
+	}
+	return payload.Error
+}
+
+// TestExecuteSync_ReservationRejected_RefusesWithoutDispatch is the primary
+// regression guard: control-plane answers 409 (credit policy rejected the
+// hold, so no credit_reservations row exists), and the request must be
+// refused instead of served for free.
+func TestExecuteSync_ReservationRejected_RefusesWithoutDispatch(t *testing.T) {
+	var hits int64
+	litellmSrv := countingJSONServer(&hits)
+	defer litellmSrv.Close()
+	routingSrv := newRoutingMock(litellmSrv.URL)
+	defer routingSrv.Close()
+	acctSrv := newAccountingMockReservationStatus(&accountingRecorder{}, http.StatusConflict,
+		`{"error":"accounting: reservation exceeds available credits"}`)
+	defer acctSrv.Close()
+
+	orch := newAuthorizedOrchestrator(acctSrv.URL, routingSrv.URL, litellmSrv.URL)
+	w := callSync(orch)
+
+	oerr := assertRefused(t, w, atomic.LoadInt64(&hits), http.StatusTooManyRequests)
+	if oerr.Code == nil || *oerr.Code != "insufficient_quota" {
+		t.Errorf("error.code = %v, want insufficient_quota", oerr.Code)
+	}
+}
+
+// TestExecuteSync_ReservationRateLimited_RefusesWithoutDispatch covers a 429
+// from the reservation call: also a refusal, never a free request.
+func TestExecuteSync_ReservationRateLimited_RefusesWithoutDispatch(t *testing.T) {
+	var hits int64
+	litellmSrv := countingJSONServer(&hits)
+	defer litellmSrv.Close()
+	routingSrv := newRoutingMock(litellmSrv.URL)
+	defer routingSrv.Close()
+	acctSrv := newAccountingMockReservationStatus(&accountingRecorder{}, http.StatusTooManyRequests,
+		`{"error":"too many reservation attempts"}`)
+	defer acctSrv.Close()
+
+	orch := newAuthorizedOrchestrator(acctSrv.URL, routingSrv.URL, litellmSrv.URL)
+	w := callSync(orch)
+
+	assertRefused(t, w, atomic.LoadInt64(&hits), http.StatusTooManyRequests)
+}
+
+// TestExecuteSync_ReservationUnrecognizedError_RefusesWithoutDispatch is the
+// regression guard for the whole bug class: an error nobody enumerated (here a
+// 400 validation rejection) must fail closed, not fall through to the provider.
+func TestExecuteSync_ReservationUnrecognizedError_RefusesWithoutDispatch(t *testing.T) {
+	var hits int64
+	litellmSrv := countingJSONServer(&hits)
+	defer litellmSrv.Close()
+	routingSrv := newRoutingMock(litellmSrv.URL)
+	defer routingSrv.Close()
+	acctSrv := newAccountingMockReservationStatus(&accountingRecorder{}, http.StatusBadRequest,
+		`{"error":"estimated_credits must be positive"}`)
+	defer acctSrv.Close()
+
+	orch := newAuthorizedOrchestrator(acctSrv.URL, routingSrv.URL, litellmSrv.URL)
+	w := callSync(orch)
+
+	assertRefused(t, w, atomic.LoadInt64(&hits), http.StatusServiceUnavailable)
+}
+
+// TestExecuteSync_ReservationControlPlane5xx_ProceedsUnreserved pins the
+// transient side of the classification: a control-plane 5xx is an
+// infrastructure fault, so paying traffic still flows rather than hard-failing
+// on a control-plane blip.
+func TestExecuteSync_ReservationControlPlane5xx_ProceedsUnreserved(t *testing.T) {
+	var hits int64
+	litellmSrv := countingJSONServer(&hits)
+	defer litellmSrv.Close()
+	routingSrv := newRoutingMock(litellmSrv.URL)
+	defer routingSrv.Close()
+	acctSrv := newAccountingMockReservationStatus(&accountingRecorder{}, http.StatusInternalServerError,
+		`{"error":"accounting: get balance: connection reset"}`)
+	defer acctSrv.Close()
+
+	orch := newAuthorizedOrchestrator(acctSrv.URL, routingSrv.URL, litellmSrv.URL)
+	w := callSync(orch)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200: a transient control-plane fault must not hard-fail the request (body: %s)", w.Code, w.Body.String())
+	}
+	if got := atomic.LoadInt64(&hits); got != 1 {
+		t.Errorf("provider dispatched %d time(s), want 1 on the transient path", got)
+	}
+}
+
+// TestExecuteSync_ReservationUnreachable_ProceedsUnreserved covers the other
+// transient condition: the control-plane is not answering at all
+// (connection refused), which must behave like the 5xx case.
+func TestExecuteSync_ReservationUnreachable_ProceedsUnreserved(t *testing.T) {
+	var hits int64
+	litellmSrv := countingJSONServer(&hits)
+	defer litellmSrv.Close()
+	routingSrv := newRoutingMock(litellmSrv.URL)
+	defer routingSrv.Close()
+
+	orch := newAuthorizedOrchestrator(deadAccountingURL(t), routingSrv.URL, litellmSrv.URL)
+	w := callSync(orch)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200: an unreachable control-plane must not hard-fail the request (body: %s)", w.Code, w.Body.String())
+	}
+	if got := atomic.LoadInt64(&hits); got != 1 {
+		t.Errorf("provider dispatched %d time(s), want 1 on the transient path", got)
+	}
+}
+
+// TestExecuteStreaming_ReservationRejected_RefusesWithoutDispatch asserts the
+// streaming path refuses identically to the non-streaming one; both were
+// broken by the same string-matching classification.
+func TestExecuteStreaming_ReservationRejected_RefusesWithoutDispatch(t *testing.T) {
+	var hits int64
+	litellmSrv := countingSSEServer(&hits)
+	defer litellmSrv.Close()
+	routingSrv := newRoutingMock(litellmSrv.URL)
+	defer routingSrv.Close()
+	acctSrv := newAccountingMockReservationStatus(&accountingRecorder{}, http.StatusConflict,
+		`{"error":"accounting: reservation exceeds available credits"}`)
+	defer acctSrv.Close()
+
+	orch := newAuthorizedOrchestrator(acctSrv.URL, routingSrv.URL, litellmSrv.URL)
+	w := callStreaming(orch)
+
+	oerr := assertRefused(t, w, atomic.LoadInt64(&hits), http.StatusTooManyRequests)
+	if oerr.Code == nil || *oerr.Code != "insufficient_quota" {
+		t.Errorf("error.code = %v, want insufficient_quota", oerr.Code)
+	}
+}
+
+// TestExecuteStreaming_ReservationUnrecognizedError_RefusesWithoutDispatch is
+// the streaming half of the bug-class guard.
+func TestExecuteStreaming_ReservationUnrecognizedError_RefusesWithoutDispatch(t *testing.T) {
+	var hits int64
+	litellmSrv := countingSSEServer(&hits)
+	defer litellmSrv.Close()
+	routingSrv := newRoutingMock(litellmSrv.URL)
+	defer routingSrv.Close()
+	acctSrv := newAccountingMockReservationStatus(&accountingRecorder{}, http.StatusBadRequest,
+		`{"error":"estimated_credits must be positive"}`)
+	defer acctSrv.Close()
+
+	orch := newAuthorizedOrchestrator(acctSrv.URL, routingSrv.URL, litellmSrv.URL)
+	w := callStreaming(orch)
+
+	assertRefused(t, w, atomic.LoadInt64(&hits), http.StatusServiceUnavailable)
+}
+
+// TestExecuteResponsesStreaming_ReservationRejected_RefusesWithoutDispatch
+// covers the third dispatch site, the Responses API streaming lifecycle.
+func TestExecuteResponsesStreaming_ReservationRejected_RefusesWithoutDispatch(t *testing.T) {
+	var hits int64
+	litellmSrv := countingSSEServer(&hits)
+	defer litellmSrv.Close()
+	routingSrv := newRoutingMock(litellmSrv.URL)
+	defer routingSrv.Close()
+	acctSrv := newAccountingMockReservationStatus(&accountingRecorder{}, http.StatusConflict,
+		`{"error":"accounting: reservation exceeds available credits"}`)
+	defer acctSrv.Close()
+
+	orch := newAuthorizedOrchestrator(acctSrv.URL, routingSrv.URL, litellmSrv.URL)
+	w := callResponsesStreaming(orch)
+
+	oerr := assertRefused(t, w, atomic.LoadInt64(&hits), http.StatusTooManyRequests)
+	if oerr.Code == nil || *oerr.Code != "insufficient_quota" {
+		t.Errorf("error.code = %v, want insufficient_quota", oerr.Code)
+	}
+}

--- a/apps/edge-api/internal/inference/reservation_guard.go
+++ b/apps/edge-api/internal/inference/reservation_guard.go
@@ -1,0 +1,81 @@
+package inference
+
+import (
+	"errors"
+	"log"
+	"net/http"
+	"net/url"
+
+	apierrors "github.com/sakibsadmanshajib/hive/apps/edge-api/internal/errors"
+)
+
+// refuseOnReservationFailure classifies a failed CreateReservation call. It
+// returns true when the request must not be dispatched to a provider, having
+// already written the customer-facing refusal, and false only when the failure
+// is an enumerated infrastructure-transient fault the request is allowed to
+// proceed through unreserved.
+//
+// Fail closed by default. A reservation failure means the request cannot be
+// accounted for, so serving it anyway gives away inference for free: that is
+// exactly what happened before this existed, because the three dispatch sites
+// classified the failure by string-matching the error text against "429",
+// "budget" and "insufficient". A control-plane credit rejection answers 409
+// with "reservation exceeds available credits", which matches none of those
+// three, so every insolvent account's traffic was logged as a non-fatal
+// warning and then served, unmetered.
+//
+// Classification is on the HTTP status the control-plane returned, never on
+// message text. The two failure directions point opposite ways -- serving free
+// is revenue loss, refusing a solvent customer is an outage -- so the
+// transient set below has to genuinely cover infrastructure faults, and
+// anything outside it has to refuse.
+func refuseOnReservationFailure(w http.ResponseWriter, endpoint, model string, err error) bool {
+	if reservationFailureTransient(err) {
+		log.Printf("inference: create reservation failed, proceeding unreserved (transient control-plane fault) endpoint=%s alias=%s: %v", endpoint, model, err)
+		return false
+	}
+
+	var statusErr *StatusError
+	if errors.As(err, &statusErr) && (statusErr.StatusCode == http.StatusConflict || statusErr.StatusCode == http.StatusTooManyRequests) {
+		// 409 is the control-plane's credit-policy rejection
+		// (accounting.PolicyError, see writeAccountingError); 429 is a rate
+		// limit on the reservation call itself. Both are quota verdicts, and
+		// both answer with the OpenAI-compatible insufficient_quota shape that
+		// SDKs already understand. Provider-blind and free of any currency,
+		// FX, USD or balance figure on purpose: this message reaches customers
+		// in Bangladesh, where exchange-rate language is not permitted.
+		code := "insufficient_quota"
+		apierrors.WriteError(w, http.StatusTooManyRequests, "insufficient_quota",
+			"You exceeded your current quota, please check your plan and billing details.", &code)
+		return true
+	}
+
+	// Anything unrecognized (a 4xx that is not a quota verdict, a malformed
+	// request, a decode failure) is fatal, never non-fatal: an error nobody
+	// enumerated is precisely the case that must not silently reach a provider.
+	log.Printf("inference: create reservation refused, unclassified failure endpoint=%s alias=%s: %v", endpoint, model, err)
+	code := "reservation_unavailable"
+	apierrors.WriteError(w, http.StatusServiceUnavailable, "api_error",
+		"Credit reservation is temporarily unavailable. Please retry.", &code)
+	return true
+}
+
+// reservationFailureTransient reports whether a reservation failure is an
+// infrastructure fault the gateway may ride out unreserved, rather than a
+// verdict about the account. The enumerated set is deliberately narrow:
+//
+//   - a control-plane 5xx: the accounting service itself failed, not the
+//     customer's credit position;
+//   - any transport-level failure, which net/http surfaces as *url.Error:
+//     connection refused, DNS failure, TLS failure, and request timeout or
+//     context deadline (the client's Timeout is accountingTimeout).
+//
+// Everything else, including a marshal or decode bug on our own side, is fatal.
+func reservationFailureTransient(err error) bool {
+	var statusErr *StatusError
+	if errors.As(err, &statusErr) {
+		return statusErr.StatusCode >= 500
+	}
+	var urlErr *url.Error
+	return errors.As(err, &urlErr)
+}

--- a/apps/edge-api/internal/inference/stream.go
+++ b/apps/edge-api/internal/inference/stream.go
@@ -189,14 +189,8 @@ func (o *Orchestrator) executeStreaming(
 		EstimatedCredits: estimatedCredits,
 		PolicyMode:       "strict",
 	})
-	if err != nil {
-		if strings.Contains(err.Error(), "429") || strings.Contains(err.Error(), "budget") || strings.Contains(err.Error(), "insufficient") {
-			code := "insufficient_quota"
-			apierrors.WriteError(w, http.StatusTooManyRequests, "insufficient_quota",
-				"You exceeded your current quota, please check your plan and billing details.", &code)
-			return nil
-		}
-		log.Printf("inference: create reservation failed (non-fatal): %v", err)
+	if err != nil && refuseOnReservationFailure(w, endpoint, model, err) {
+		return nil
 	}
 
 	// Set up defer for reservation settlement. This is the single settlement

--- a/apps/edge-api/internal/inference/stream_responses.go
+++ b/apps/edge-api/internal/inference/stream_responses.go
@@ -127,14 +127,8 @@ func (o *Orchestrator) executeResponsesStreaming(
 		EstimatedCredits: estimatedCredits,
 		PolicyMode:       "strict",
 	})
-	if err != nil {
-		if strings.Contains(err.Error(), "429") || strings.Contains(err.Error(), "budget") || strings.Contains(err.Error(), "insufficient") {
-			code := "insufficient_quota"
-			apierrors.WriteError(w, http.StatusTooManyRequests, "insufficient_quota",
-				"You exceeded your current quota, please check your plan and billing details.", &code)
-			return
-		}
-		log.Printf("inference: create reservation failed (non-fatal): %v", err)
+	if err != nil && refuseOnReservationFailure(w, EndpointResponses, model, err) {
+		return
 	}
 
 	// Set up defer for reservation settlement. This is the single settlement

--- a/apps/edge-api/internal/inference/sync_settlement_test.go
+++ b/apps/edge-api/internal/inference/sync_settlement_test.go
@@ -1,0 +1,200 @@
+package inference
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// --- synchronous settlement harness ---
+//
+// A reservation must reach a terminal state exactly once, either charged or
+// released, and a failure to charge must not leave it held. The streaming path
+// got that guarantee in PR #602; executeSync never did, which is how issue
+// #616 accumulated stranded active reservations.
+
+// newAccountingMockSyncFinalizeFails answers finalize with a 500 and every
+// other accounting or usage path with 200, and calls onFinalize (if set) before
+// answering, so a test can cancel the request context at exactly the moment
+// settlement begins.
+func newAccountingMockSyncFinalizeFails(rec *accountingRecorder, onFinalize func()) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		rec.record(r.URL.Path, body)
+		if r.URL.Path == "/internal/accounting/reservations/finalize" {
+			if onFinalize != nil {
+				onFinalize()
+			}
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		switch r.URL.Path {
+		case "/internal/accounting/reservations":
+			_ = json.NewEncoder(w).Encode(ReservationResult{
+				ID: "res-test-1", AccountID: "acct-test-1", Status: "active", EstimatedCredits: 10000,
+			})
+		case "/internal/usage/attempts":
+			_ = json.NewEncoder(w).Encode(AttemptResult{
+				ID: "attempt-test-1", RequestID: "req-test-1", Status: "accepted",
+			})
+		}
+	}))
+}
+
+func callSyncCtx(orch *Orchestrator, ctx context.Context) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{}`))
+	req.Header.Set("Authorization", "Bearer test-token")
+	w := httptest.NewRecorder()
+	orch.executeSync(ctx, w, req, EndpointChatCompletions, []byte(`{}`), "gpt-4o",
+		NeedFlags{NeedChatCompletions: true}, 10000, orch.litellm.ChatCompletion, normalizeChatCompletion)
+	return w
+}
+
+// captureLogs collects everything written to the standard logger while fn runs.
+func captureLogs(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf bytes.Buffer
+	prevOut, prevFlags := log.Writer(), log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	defer func() {
+		log.SetOutput(prevOut)
+		log.SetFlags(prevFlags)
+	}()
+	fn()
+	return buf.String()
+}
+
+// TestExecuteSync_FinalizeError_ReleasesReservationAndLogs is the issue #616
+// regression guard for the synchronous path: a finalize failure must not both
+// lose the charge and strand the hold, and it must not be swallowed silently.
+func TestExecuteSync_FinalizeError_ReleasesReservationAndLogs(t *testing.T) {
+	var hits int64
+	litellmSrv := countingJSONServer(&hits)
+	defer litellmSrv.Close()
+	routingSrv := newRoutingMock(litellmSrv.URL)
+	defer routingSrv.Close()
+	rec := &accountingRecorder{}
+	acctSrv := newAccountingMockSyncFinalizeFails(rec, nil)
+	defer acctSrv.Close()
+
+	orch := newAuthorizedOrchestrator(acctSrv.URL, routingSrv.URL, litellmSrv.URL)
+	logs := captureLogs(t, func() { callSyncCtx(orch, context.Background()) })
+
+	if !rec.has("/internal/accounting/reservations/finalize") {
+		t.Fatalf("expected FinalizeReservation to be attempted; calls seen: %+v", rec.calls)
+	}
+	body, ok := rec.find("/internal/accounting/reservations/release")
+	if !ok {
+		t.Fatalf("expected a fallback ReleaseReservation when finalize fails, or the hold is stranded; calls seen: %+v", rec.calls)
+	}
+	if body["reservation_id"] != "res-test-1" {
+		t.Errorf("reservation_id = %v, want res-test-1", body["reservation_id"])
+	}
+	if body["reason"] != "finalize_failed" {
+		t.Errorf("reason = %v, want finalize_failed", body["reason"])
+	}
+	if !strings.Contains(logs, "finalize") {
+		t.Errorf("finalize failure was swallowed: no finalize error in logs. logs: %q", logs)
+	}
+}
+
+// TestExecuteSync_FinalizeError_CancelledContext_StillReleases is the specific
+// trap PR #602 hit on the streaming side: the request context is already
+// cancelled by settlement time, so a release issued on that context is
+// silently swallowed and the hold survives.
+func TestExecuteSync_FinalizeError_CancelledContext_StillReleases(t *testing.T) {
+	var hits int64
+	litellmSrv := countingJSONServer(&hits)
+	defer litellmSrv.Close()
+	routingSrv := newRoutingMock(litellmSrv.URL)
+	defer routingSrv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	rec := &accountingRecorder{}
+	// The client hangs up exactly as settlement starts.
+	acctSrv := newAccountingMockSyncFinalizeFails(rec, cancel)
+	defer acctSrv.Close()
+
+	orch := newAuthorizedOrchestrator(acctSrv.URL, routingSrv.URL, litellmSrv.URL)
+	callSyncCtx(orch, ctx)
+
+	if ctx.Err() == nil {
+		t.Fatal("sanity check failed: context was not actually cancelled")
+	}
+	if _, ok := rec.find("/internal/accounting/reservations/release"); !ok {
+		t.Fatalf("expected ReleaseReservation to reach the control plane despite the cancelled request context; calls seen: %+v", rec.calls)
+	}
+}
+
+// TestExecuteSync_NormalCompletion_TerminatesExactlyOnce guards the other half
+// of the invariant: a successful charge must never also be released, which
+// would refund a legitimate charge.
+func TestExecuteSync_NormalCompletion_TerminatesExactlyOnce(t *testing.T) {
+	var hits int64
+	litellmSrv := countingJSONServer(&hits)
+	defer litellmSrv.Close()
+	routingSrv := newRoutingMock(litellmSrv.URL)
+	defer routingSrv.Close()
+	rec := &accountingRecorder{}
+	acctSrv := newAccountingMock(rec)
+	defer acctSrv.Close()
+
+	orch := newAuthorizedOrchestrator(acctSrv.URL, routingSrv.URL, litellmSrv.URL)
+	w := callSyncCtx(orch, context.Background())
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body: %s)", w.Code, w.Body.String())
+	}
+	body, ok := rec.find("/internal/accounting/reservations/finalize")
+	if !ok {
+		t.Fatalf("expected FinalizeReservation on a normal completion; calls seen: %+v", rec.calls)
+	}
+	if actual, _ := body["actual_credits"].(float64); int64(actual) != 25 {
+		t.Errorf("actual_credits = %v, want 25 (confirmed upstream usage)", body["actual_credits"])
+	}
+	if rec.has("/internal/accounting/reservations/release") {
+		t.Error("a charged reservation must never also be released: that refunds a legitimate charge")
+	}
+}
+
+// TestExecuteSync_UpstreamError_CancelledContext_StillReleases covers the
+// sibling release sites in executeSync (upstream error, read error, normalize
+// error), which had the same shape as the finalize path: released on the
+// request context, error discarded, finalized set unconditionally.
+func TestExecuteSync_UpstreamError_CancelledContext_StillReleases(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Upstream answers 500 and cancels the request context at the same moment.
+	litellmSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cancel()
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"upstream exploded"}`))
+	}))
+	defer litellmSrv.Close()
+	routingSrv := newRoutingMock(litellmSrv.URL)
+	defer routingSrv.Close()
+	rec := &accountingRecorder{}
+	acctSrv := newAccountingMock(rec)
+	defer acctSrv.Close()
+
+	orch := newAuthorizedOrchestrator(acctSrv.URL, routingSrv.URL, litellmSrv.URL)
+	callSyncCtx(orch, ctx)
+
+	if rec.has("/internal/accounting/reservations/finalize") {
+		t.Error("upstream failed: must not finalize a charge")
+	}
+	if _, ok := rec.find("/internal/accounting/reservations/release"); !ok {
+		t.Fatalf("expected ReleaseReservation despite the cancelled request context; calls seen: %+v", rec.calls)
+	}
+}


### PR DESCRIPTION
## The defect

The gateway served requests for free whenever a customer had insufficient credits.

`apps/control-plane/internal/accounting/service.go:87` runs `enforcePolicy` before the reservation insert at `:105`. On rejection it returns a `PolicyError`, which `apps/control-plane/internal/accounting/http.go:403` maps to HTTP 409. Because the rejection happens pre insert, no `credit_reservations` row is created at all.

The three edge-api dispatch sites then decided whether that failure was fatal by string matching the error text against `"429"`, `"budget"` and `"insufficient"`:

- `apps/edge-api/internal/inference/orchestrator.go:161`
- `apps/edge-api/internal/inference/stream.go:193`
- `apps/edge-api/internal/inference/stream_responses.go:131`

A 409 carrying "reservation exceeds available credits" matches none of the three, so the failure was logged as non fatal and the request proceeded to the provider: served, unmetered, and free. Every request on the demo box since 2026-07-28 08:10 took that path, because the account holds 563 credits against the flat 10000 credit estimate at `apps/edge-api/internal/inference/chat_completions.go:55`.

## The invariant now enforced

A request is never dispatched to a provider unless a credit reservation was successfully created, unless the failure is one of an explicitly enumerated set of infrastructure transient conditions. Fail closed by default. An unrecognized error is fatal, never non fatal.

## Classification

On HTTP status, never on error text. One shared helper, `refuseOnReservationFailure` in `apps/edge-api/internal/inference/reservation_guard.go`, is called by all three sites so a future edit cannot re diverge them.

| Reservation outcome | Verdict | Customer response |
| --- | --- | --- |
| 409 credit policy rejection | refuse | 429, `insufficient_quota` |
| 429 rate limited | refuse | 429, `insufficient_quota` |
| Control plane 5xx | transient, proceeds unreserved | request served normally |
| Transport failure: connection refused, DNS, TLS, timeout, context deadline (`*url.Error`) | transient, proceeds unreserved | request served normally |
| Anything else, including our own marshal or decode bugs | refuse | 503, `reservation_unavailable` |

The transient set is narrow on purpose, and it is narrow in the direction that matters: the two failure modes point opposite ways, since serving free is revenue loss while refusing a solvent customer is an outage. A control plane blip or an unreachable control plane is an infrastructure fault about us, not a verdict about the account, so paying traffic still flows there. Everything else refuses.

The refusal payload is provider blind and carries no currency, FX, USD or balance figure of any kind, and it reuses the existing `insufficient_quota` shape already used on the authorization path rather than inventing a new one.

## Tests

`apps/edge-api/internal/inference/reservation_fail_closed_test.go` drives the real `executeSync`, `executeStreaming` and `executeResponsesStreaming` lifecycles against an in process control plane stand in, and counts provider dispatches so a refusal that still burned provider spend cannot pass:

- 409 refuses and does not call the provider, on all three paths
- 429 refuses
- an unrecognized 400 refuses, the regression guard for the whole bug class
- a control plane 5xx still proceeds, the transient path
- an unreachable control plane (real connection refused against a closed listener) still proceeds

All five failed before the fix, on the three dispatch sites, with the provider dispatched once and a 200 returned.

## Verification

Run against this branch's own worktree, not the shared checkout:

```
docker run --rm -v /tmp/failclosed:/workspace hive-toolchain:latest \
  "cd /workspace && go test ./apps/edge-api/... -count=1 -short"
```

Every package in the `edge-api` module passes, `go vet` on the inference package is clean, and `lint:no-client-cost-fields` plus `lint:litellm-dispatch-requires-routing` pass.

## Out of scope

Issue #616 (32 stranded active reservations holding 154,000 credits, needs a reaper) and issue #617 (catalog prices too low) are untouched. No live UI surface changes, so no screenshot proof applies.

---

# Second half: a synchronous finalize failure stranded the hold (issue #616)

## The defect

`executeSync` called `FinalizeReservation` with the error discarded (`_ =`) and then set `finalized = true` regardless, which skipped the deferred release. A finalize failure therefore lost the charge and stranded the hold in the same step. That is the mechanism behind the stranded `active` reservations in issue #616. PR #602 gave the streaming path a fallback release on a fresh background context (`releaseReservationBackground`); the synchronous path never got the equivalent.

The three sibling release sites in the same function (upstream error, read error, normalize error) had the same shape: released on the request context, error discarded, `finalized` set unconditionally. A cancelled request context silently swallowed those releases too.

## The invariant now enforced

A reservation reaches a terminal state exactly once, either charged or released, and a failure to charge does not leave it held.

- Finalize succeeds: `finalized = true`, the deferred release does nothing. A legitimate charge is never also refunded.
- Finalize fails: the error is logged, `finalized` stays false, and the deferred release settles the hold with reason `finalize_failed`.
- Every release path now goes through `releaseReservationBackground`, so the release runs on a fresh bounded background context rather than the request context, and `finalized` reflects whether the release actually reached the control plane. A failed attempt leaves the deferred release one more chance rather than assuming success.

`RecordUsageEvent` errors in `recordErrorEvent` and `recordCompletedEvent` are now logged instead of silently discarded, matching `recordInterruptedEvent` on the streaming path. Usage recording stays best effort for the request itself.

## Tests

`apps/edge-api/internal/inference/sync_settlement_test.go`, all against the real `executeSync` lifecycle:

- a finalize failure releases the hold with reason `finalize_failed` and logs the error rather than swallowing it
- the release still reaches the control plane when the request context is already cancelled at settlement time, the specific trap #602 hit
- an upstream failure with an already cancelled request context still releases, covering the sibling sites
- a normal completion finalizes and never also releases, the double terminal guard

The first three failed before the fix ("expected a fallback ReleaseReservation when finalize fails, or the hold is stranded", with only attempt, reservation and finalize calls recorded). The double terminal guard passed before and after, which is the point of it.

## Out of scope, same shape, tracked in #616

Left alone deliberately: the media handlers `audio/handler.go:294,382,552` and `images/handler.go:266,445`, `batchstore/submitter.go:333`, the payments webhook (issue #628), and anything in `provider_routes` pricing. The media and batch sites carry the same discarded settlement shape and are tracked in #616.