### PR TITLE
fix: release stranded reservation holds and bind tenant on media routing

### DIFF
--- a/apps/edge-api/internal/audio/authz_adapter.go
+++ b/apps/edge-api/internal/audio/authz_adapter.go
@@ -26,5 +26,6 @@ func (a *AuthorizerAdapter) AuthorizeRequest(r *http.Request) (AuthResult, error
 	return AuthResult{
 		AccountID: snapshot.AccountID,
 		APIKeyID:  snapshot.KeyID,
+		TenantID:  snapshot.TenantID,
 	}, nil
 }

--- a/apps/edge-api/internal/audio/handler.go
+++ b/apps/edge-api/internal/audio/handler.go
@@ -38,6 +38,11 @@ type Authorizer interface {
 type AuthResult struct {
 	AccountID string
 	APIKeyID  string
+	// TenantID is resolved control-plane-side from AccountID (D-030, via
+	// public.tenant_billing_accounts). Empty means the account has no
+	// resolvable tenant; RoutingAdapter fails the request closed on that
+	// rather than skipping the tenant-scoped entitlement check (#623).
+	TenantID string
 }
 
 // RoutingInterface selects a provider route for a given model alias.
@@ -48,8 +53,12 @@ type RoutingInterface interface {
 // RouteInput specifies the alias and capability requirements for route selection.
 type RouteInput struct {
 	AliasID string
-	NeedTTS bool
-	NeedSTT bool
+	// TenantID is the requesting API key's resolved tenant (AuthResult.TenantID).
+	// RoutingAdapter binds it onto ctx before calling the routing client and
+	// fails closed if it is missing or unparseable (#623).
+	TenantID string
+	NeedTTS  bool
+	NeedSTT  bool
 }
 
 // RouteResult contains the selected route details.
@@ -202,8 +211,9 @@ func (h *Handler) handleSpeech(w http.ResponseWriter, r *http.Request) {
 
 	// Select route based on model alias and TTS capability.
 	route, err := h.routing.SelectRoute(ctx, RouteInput{
-		AliasID: speechReq.Model,
-		NeedTTS: true,
+		AliasID:  speechReq.Model,
+		TenantID: auth.TenantID,
+		NeedTTS:  true,
 	})
 	if err != nil {
 		code := "model_not_found"
@@ -290,12 +300,9 @@ func (h *Handler) handleSpeech(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Finalize reservation on success.
-	_ = h.accounting.FinalizeReservation(ctx, FinalizeInput{
-		AccountID:     auth.AccountID,
-		ReservationID: reservationID,
-		ActualCredits: 1000,
-	})
+	// Finalize reservation on success; falls back to releasing the hold if
+	// finalize itself fails, so it never strands (#616).
+	h.settleReservation(ctx, auth.AccountID, reservationID, 1000, "/v1/audio/speech")
 
 	// Binary relay: copy Content-Type exactly from upstream.
 	if lastCT != "" {
@@ -379,11 +386,7 @@ func (h *Handler) handleTranscription(w http.ResponseWriter, r *http.Request) {
 	h.stt.Transcribe(rec, r)
 
 	if rec.status >= 200 && rec.status < 300 {
-		_ = h.accounting.FinalizeReservation(ctx, FinalizeInput{
-			AccountID:     auth.AccountID,
-			ReservationID: reservationID,
-			ActualCredits: 500,
-		})
+		h.settleReservation(ctx, auth.AccountID, reservationID, 500, "/v1/audio/transcriptions")
 	} else {
 		_ = h.accounting.ReleaseReservation(ctx, auth.AccountID, reservationID, "upstream_error")
 	}
@@ -439,8 +442,9 @@ func (h *Handler) handleMultipartAudio(w http.ResponseWriter, r *http.Request, l
 
 	// Select route based on model alias and STT capability.
 	route, err := h.routing.SelectRoute(ctx, RouteInput{
-		AliasID: modelAlias,
-		NeedSTT: true,
+		AliasID:  modelAlias,
+		TenantID: auth.TenantID,
+		NeedSTT:  true,
 	})
 	if err != nil {
 		code := "model_not_found"
@@ -548,12 +552,9 @@ func (h *Handler) handleMultipartAudio(w http.ResponseWriter, r *http.Request, l
 		return
 	}
 
-	// Finalize reservation on success.
-	_ = h.accounting.FinalizeReservation(ctx, FinalizeInput{
-		AccountID:     auth.AccountID,
-		ReservationID: reservationID,
-		ActualCredits: 500,
-	})
+	// Finalize reservation on success; falls back to releasing the hold if
+	// finalize itself fails, so it never strands (#616).
+	h.settleReservation(ctx, auth.AccountID, reservationID, 500, accountingEndpoint)
 
 	// Extract duration for metering (best-effort).
 	var durResp struct {

--- a/apps/edge-api/internal/audio/handler_test.go
+++ b/apps/edge-api/internal/audio/handler_test.go
@@ -52,18 +52,27 @@ func (m *mockLiteLLMAudio) Close() { m.server.Close() }
 type mockAudioAuthorizer struct {
 	accountID string
 	apiKeyID  string
+	tenantID  string
 }
 
 func (a *mockAudioAuthorizer) AuthorizeRequest(_ *http.Request) (audio.AuthResult, error) {
-	return audio.AuthResult{AccountID: a.accountID, APIKeyID: a.apiKeyID}, nil
+	return audio.AuthResult{AccountID: a.accountID, APIKeyID: a.apiKeyID, TenantID: a.tenantID}, nil
 }
 
-// mockAudioRouting is a stub that echoes the alias as the LiteLLM model name.
+// mockAudioRouting is a stub that echoes the alias as the LiteLLM model name
+// and records the last TenantID it was called with, so tests can prove the
+// handler threads AuthResult.TenantID through to RouteInput (#623).
 type mockAudioRouting struct {
-	litellmModel string
+	litellmModel   string
+	lastTenantID   string
+	selectRouteErr error
 }
 
 func (r *mockAudioRouting) SelectRoute(_ context.Context, input audio.RouteInput) (audio.RouteResult, error) {
+	r.lastTenantID = input.TenantID
+	if r.selectRouteErr != nil {
+		return audio.RouteResult{}, r.selectRouteErr
+	}
 	litellm := r.litellmModel
 	if litellm == "" {
 		litellm = input.AliasID
@@ -75,6 +84,7 @@ func (r *mockAudioRouting) SelectRoute(_ context.Context, input audio.RouteInput
 type mockAudioAccounting struct {
 	reservationID  string
 	createErr      error
+	finalizeErr    error
 	finalizeCalled bool
 	releaseCalled  bool
 }
@@ -88,7 +98,7 @@ func (a *mockAudioAccounting) CreateReservation(_ context.Context, _ audio.Reser
 
 func (a *mockAudioAccounting) FinalizeReservation(_ context.Context, _ audio.FinalizeInput) error {
 	a.finalizeCalled = true
-	return nil
+	return a.finalizeErr
 }
 
 func (a *mockAudioAccounting) ReleaseReservation(_ context.Context, _, _, _ string) error {
@@ -805,5 +815,156 @@ func TestTranscriptionReservationQuotaRefusalReturns402(t *testing.T) {
 
 	if w.Code != http.StatusPaymentRequired {
 		t.Fatalf("expected 402, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// --- #616: finalize failure must release, never strand, the hold ---
+
+// TestSpeechFinalizeFailureReleasesReservation covers handleSpeech's finalize
+// site (handler.go, the /v1/audio/speech success path). A finalize failure
+// must not leave the reservation stranded: it must be released.
+func TestSpeechFinalizeFailureReleasesReservation(t *testing.T) {
+	mock := newMockLiteLLMAudio([]byte{0xFF, 0xFB}, 200, "audio/mpeg")
+	defer mock.Close()
+
+	acc := &mockAudioAccounting{reservationID: "res-speech-finalize-fail", finalizeErr: fmt.Errorf("control-plane unreachable")}
+	w := postSpeech(t, buildAudioHandlerWithAccounting(mock.server.URL, acc))
+
+	// The client already received a correct response; finalize bookkeeping
+	// failing afterward must not turn into a client-visible error.
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 (finalize bookkeeping failure must stay invisible to the caller), got %d: %s", w.Code, w.Body.String())
+	}
+	if !acc.finalizeCalled {
+		t.Fatal("expected FinalizeReservation to be attempted")
+	}
+	if !acc.releaseCalled {
+		t.Fatal("expected ReleaseReservation to be called after finalize failure: the hold would otherwise strand (#616)")
+	}
+}
+
+// TestTranscriptionSTTFinalizeFailureReleasesReservation covers
+// handleTranscription's finalize site on the local-STT path
+// (handler.go:382 before the fix).
+func TestTranscriptionSTTFinalizeFailureReleasesReservation(t *testing.T) {
+	sttBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"text":"ok"}`)) //nolint:errcheck
+	}))
+	defer sttBackend.Close()
+
+	auth := &mockAudioAuthorizer{accountID: "acct-test", apiKeyID: "key-test"}
+	routing := &mockAudioRouting{}
+	acc := &mockAudioAccounting{reservationID: "res-stt-finalize-fail", finalizeErr: fmt.Errorf("control-plane unreachable")}
+	h := audio.NewHandler(auth, routing, acc, "http://unused-litellm.example.com", "test-key")
+	h.WithSTT(stt.NewTieredClient(stt.Config{
+		ParakeetBaseURL:      sttBackend.URL,
+		FasterWhisperBaseURL: sttBackend.URL,
+	}))
+
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	_ = mw.WriteField("model", "whisper-1")
+	fw, _ := mw.CreateFormFile("file", "audio.wav")
+	fw.Write([]byte("audio")) //nolint:errcheck
+	mw.Close()
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/audio/transcriptions", &buf)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	req.Header.Set("Authorization", "Bearer test-key")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if !acc.releaseCalled {
+		t.Fatal("expected ReleaseReservation to be called after finalize failure: the hold would otherwise strand (#616)")
+	}
+}
+
+// TestTranslationFinalizeFailureReleasesReservation covers
+// handleMultipartAudio's shared finalize site (handler.go:552 before the
+// fix), reached via /v1/audio/translations.
+func TestTranslationFinalizeFailureReleasesReservation(t *testing.T) {
+	mock := newMockLiteLLMAudio([]byte(`{"text":"bonjour","duration":3.1}`), 200, "application/json")
+	defer mock.Close()
+
+	auth := &mockAudioAuthorizer{accountID: "acct-test", apiKeyID: "key-test"}
+	routing := &mockAudioRouting{}
+	acc := &mockAudioAccounting{reservationID: "res-translation-finalize-fail", finalizeErr: fmt.Errorf("control-plane unreachable")}
+	h := audio.NewHandler(auth, routing, acc, mock.server.URL, "test-key")
+
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	_ = mw.WriteField("model", "whisper-1")
+	fw, _ := mw.CreateFormFile("file", "audio.mp3")
+	fw.Write([]byte("fake-audio-bytes")) //nolint:errcheck
+	mw.Close()
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/audio/translations", &buf)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	req.Header.Set("Authorization", "Bearer test-key")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if !acc.releaseCalled {
+		t.Fatal("expected ReleaseReservation to be called after finalize failure: the hold would otherwise strand (#616)")
+	}
+}
+
+// --- #623: tenant must thread from AuthResult to RouteInput ---
+
+// TestSpeechThreadsTenantIDToRouting proves the handler passes the
+// authenticated caller's resolved tenant through to RouteInput, which is
+// what lets RoutingAdapter bind it for the control-plane entitlement check.
+func TestSpeechThreadsTenantIDToRouting(t *testing.T) {
+	mock := newMockLiteLLMAudio([]byte{0xFF, 0xFB}, 200, "audio/mpeg")
+	defer mock.Close()
+
+	tenantID := "22222222-2222-2222-2222-222222222222"
+	auth := &mockAudioAuthorizer{accountID: "acct-test", apiKeyID: "key-test", tenantID: tenantID}
+	routing := &mockAudioRouting{}
+	acc := &mockAudioAccounting{reservationID: "res-tenant-thread"}
+	h := audio.NewHandler(auth, routing, acc, mock.server.URL, "test-key")
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/audio/speech",
+		strings.NewReader(`{"model":"hive-tts","input":"hello","voice":"alloy"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer test-key")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if routing.lastTenantID != tenantID {
+		t.Fatalf("expected RouteInput.TenantID %q, got %q", tenantID, routing.lastTenantID)
+	}
+}
+
+// TestSpeechTenantRestrictedAliasRefused is the #623 regression guard at the
+// handler level: when route selection refuses an alias (the shape a
+// tenant-restricted alias produces via RoutingAdapter, once bound), the
+// caller must be refused, not served.
+func TestSpeechTenantRestrictedAliasRefused(t *testing.T) {
+	auth := &mockAudioAuthorizer{accountID: "acct-test", apiKeyID: "key-test", tenantID: "33333333-3333-3333-3333-333333333333"}
+	routing := &mockAudioRouting{selectRouteErr: fmt.Errorf("audio: select route: %w", audio.ErrAccountNotProvisioned)}
+	acc := &mockAudioAccounting{reservationID: "res-restricted"}
+	h := audio.NewHandler(auth, routing, acc, "http://unused.example.com", "test-key")
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/audio/speech",
+		strings.NewReader(`{"model":"hive-restricted","input":"hello","voice":"alloy"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer test-key")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code == http.StatusOK {
+		t.Fatal("expected a refusal, not a 200, for a route-selection failure")
 	}
 }

--- a/apps/edge-api/internal/audio/reservation.go
+++ b/apps/edge-api/internal/audio/reservation.go
@@ -1,0 +1,50 @@
+package audio
+
+import (
+	"context"
+	"log"
+	"time"
+)
+
+// releaseTimeout bounds the background-context reservation release attempted
+// when FinalizeReservation fails. Mirrors the inference package's
+// accountingTimeout/releaseReservationBackground pattern (PR #602) so a
+// finalize failure never strands the hold, even when the request context is
+// already cancelled by the time settleReservation runs.
+const releaseTimeout = 30 * time.Second
+
+// settleReservation finalizes a reservation and, only when finalize itself
+// fails, releases it instead, so a reservation always reaches a terminal
+// state exactly once (charged or released), and a failed charge never
+// leaves the hold stranded (#616). This used to be a bare
+// `_ = h.accounting.FinalizeReservation(...)`, whose error was discarded: a
+// failed finalize neither charged nor released the hold, stranding it
+// forever.
+//
+// The release runs on a fresh, bounded background context, never ctx. By
+// the time a request reaches this point the client may already have
+// disconnected, cancelling ctx, which would otherwise silently swallow the
+// release the same way it swallowed the original finalize: the exact bug
+// PR #602 fixed on the streaming inference path, reproduced here on the
+// media path.
+//
+// Release is attempted only when finalize errors, so a reservation that
+// finalized successfully is never also released (which would refund a
+// legitimate charge).
+func (h *Handler) settleReservation(ctx context.Context, accountID, reservationID string, actualCredits int64, endpoint string) {
+	err := h.accounting.FinalizeReservation(ctx, FinalizeInput{
+		AccountID:     accountID,
+		ReservationID: reservationID,
+		ActualCredits: actualCredits,
+	})
+	if err == nil {
+		return
+	}
+	log.Printf("audio: finalize reservation failed endpoint=%s reservation_id=%s: %v", endpoint, reservationID, err)
+
+	bgCtx, cancel := context.WithTimeout(context.Background(), releaseTimeout)
+	defer cancel()
+	if relErr := h.accounting.ReleaseReservation(bgCtx, accountID, reservationID, "finalize_failed"); relErr != nil {
+		log.Printf("audio: release reservation after finalize failure also failed endpoint=%s reservation_id=%s: %v", endpoint, reservationID, relErr)
+	}
+}

--- a/apps/edge-api/internal/audio/reservation_test.go
+++ b/apps/edge-api/internal/audio/reservation_test.go
@@ -1,0 +1,93 @@
+package audio
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// settleReservationMock is a white-box double for AccountingInterface, used
+// only by this file's tests (package audio, not audio_test) so
+// settleReservation (an unexported method) can be exercised directly
+// without racing real HTTP dispatch to force a finalize failure.
+type settleReservationMock struct {
+	finalizeErr error
+
+	finalizeCalled bool
+	releaseCalled  bool
+	// releaseCtxErr captures ctx.Err() as observed by ReleaseReservation, so
+	// tests can prove the release ran on a live context even when the caller
+	// passed settleReservation an already-cancelled one.
+	releaseCtxErr error
+}
+
+func (m *settleReservationMock) CreateReservation(context.Context, ReservationInput) (string, error) {
+	return "", nil
+}
+
+func (m *settleReservationMock) FinalizeReservation(context.Context, FinalizeInput) error {
+	m.finalizeCalled = true
+	return m.finalizeErr
+}
+
+func (m *settleReservationMock) ReleaseReservation(ctx context.Context, _, _, _ string) error {
+	m.releaseCalled = true
+	m.releaseCtxErr = ctx.Err()
+	return nil
+}
+
+// TestSettleReservationReleasesOnFinalizeFailure is the #616 regression guard:
+// a failed finalize must release the hold rather than stranding it.
+func TestSettleReservationReleasesOnFinalizeFailure(t *testing.T) {
+	m := &settleReservationMock{finalizeErr: errors.New("control-plane unreachable")}
+	h := &Handler{accounting: m}
+
+	h.settleReservation(context.Background(), "acct-1", "res-1", 500, "/v1/audio/speech")
+
+	if !m.finalizeCalled {
+		t.Fatal("expected FinalizeReservation to be attempted")
+	}
+	if !m.releaseCalled {
+		t.Fatal("expected ReleaseReservation to be called after finalize failure: the hold would otherwise strand")
+	}
+}
+
+// TestSettleReservationNeverReleasesAfterSuccessfulFinalize is the
+// exactly-once-terminal-state guard: a reservation that finalized (charged)
+// successfully must never also be released, which would refund a
+// legitimate charge.
+func TestSettleReservationNeverReleasesAfterSuccessfulFinalize(t *testing.T) {
+	m := &settleReservationMock{finalizeErr: nil}
+	h := &Handler{accounting: m}
+
+	h.settleReservation(context.Background(), "acct-1", "res-1", 500, "/v1/audio/speech")
+
+	if !m.finalizeCalled {
+		t.Fatal("expected FinalizeReservation to be attempted")
+	}
+	if m.releaseCalled {
+		t.Fatal("expected ReleaseReservation NOT to be called after a successful finalize: would double-settle the reservation")
+	}
+}
+
+// TestSettleReservationReleaseSurvivesCancelledRequestContext is the #602
+// trap reproduced on the media path: by the time settleReservation runs the
+// client may already have disconnected, cancelling the request context. The
+// release must run on a fresh background context, not the cancelled one, or
+// it silently fails the same way the original finalize call used to.
+func TestSettleReservationReleaseSurvivesCancelledRequestContext(t *testing.T) {
+	m := &settleReservationMock{finalizeErr: errors.New("upstream write failed: client disconnected")}
+	h := &Handler{accounting: m}
+
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel() // simulate the client having already disconnected
+
+	h.settleReservation(cancelledCtx, "acct-1", "res-1", 500, "/v1/audio/speech")
+
+	if !m.releaseCalled {
+		t.Fatal("expected ReleaseReservation to be called despite the cancelled request context")
+	}
+	if m.releaseCtxErr != nil {
+		t.Fatalf("expected ReleaseReservation to receive a live (non-cancelled) context, got ctx.Err() = %v", m.releaseCtxErr)
+	}
+}

--- a/apps/edge-api/internal/audio/routing_adapter.go
+++ b/apps/edge-api/internal/audio/routing_adapter.go
@@ -2,10 +2,23 @@ package audio
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
+	"github.com/google/uuid"
+	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/auth"
 	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/inference"
 )
+
+// ErrAccountNotProvisioned reports an API-key principal whose account has no
+// resolvable tenant (AuthResult.TenantID, sourced from
+// authz.AuthSnapshot.TenantID, is empty or unparseable). SelectRoute fails
+// closed on this before ever calling the routing client, the same way
+// inference.Orchestrator.selectRoute does for chat/completions (D-030,
+// PR #620): without a tenant the tenant-scoped entitlement check inside
+// control-plane's routing.Service.SelectRoute cannot run at all, so admitting
+// the request would silently reopen the gap that check exists to close.
+var ErrAccountNotProvisioned = errors.New("audio: account has no tenant")
 
 // RoutingAdapter adapts *inference.RoutingClient to the audio.RoutingInterface.
 type RoutingAdapter struct {
@@ -18,7 +31,24 @@ func NewRoutingAdapter(inner *inference.RoutingClient) *RoutingAdapter {
 }
 
 // SelectRoute calls the routing client with audio-specific capability flags.
+//
+// input.TenantID is bound onto ctx here (via auth.WithUser, the same
+// context key inference.RoutingClient.SelectRoute already reads first via
+// auth.TenantID) before delegating to the routing client. Without this, the
+// audio endpoints never put a tenant on ctx at all, so RoutingClient.SelectRoute
+// sent an empty tenant_id, which control-plane parsed as uuid.Nil and treated
+// as "skip the tenant-scoped entitlement gate", making a tenant-restricted
+// alias reachable through /v1/audio/* by any API key even though the same
+// alias is correctly refused on chat (#623). A key whose account has no
+// resolvable tenant fails closed here, before the routing client is ever
+// called, rather than falling back to unfiltered access.
 func (a *RoutingAdapter) SelectRoute(ctx context.Context, input RouteInput) (RouteResult, error) {
+	tenantID, err := uuid.Parse(input.TenantID)
+	if err != nil || tenantID == uuid.Nil {
+		return RouteResult{}, fmt.Errorf("audio: select route: %w", ErrAccountNotProvisioned)
+	}
+	ctx = auth.WithUser(ctx, &auth.User{TenantID: tenantID})
+
 	result, err := a.inner.SelectRoute(ctx, inference.SelectRouteInput{
 		AliasID: input.AliasID,
 		NeedTTS: input.NeedTTS,

--- a/apps/edge-api/internal/audio/routing_adapter_test.go
+++ b/apps/edge-api/internal/audio/routing_adapter_test.go
@@ -1,0 +1,149 @@
+package audio_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/audio"
+	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/inference"
+)
+
+// fakeRoutingServer stands in for control-plane's /internal/routing/select.
+// It records whether it was ever called, and the tenant_id it received, so
+// tests can tell "the adapter refused locally" apart from "the adapter asked
+// control-plane and got refused" without depending on any real
+// routing.Service code.
+type fakeRoutingServer struct {
+	called    bool
+	tenantID  string
+	status    int
+	aliasID   string
+	litellmID string
+}
+
+func newFakeRoutingServer(status int) (*fakeRoutingServer, *httptest.Server) {
+	f := &fakeRoutingServer{status: status, aliasID: "hive-restricted", litellmID: "route-groq-restricted"}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		f.called = true
+		var decoded map[string]any
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &decoded)
+		if tid, ok := decoded["tenant_id"]; ok {
+			f.tenantID, _ = tid.(string)
+		}
+		if f.status != http.StatusOK {
+			w.WriteHeader(f.status)
+			_, _ = w.Write([]byte(`{"error":"routing: model not entitled for tenant"}`))
+			return
+		}
+		_ = json.NewEncoder(w).Encode(inference.SelectRouteResult{
+			AliasID:          f.aliasID,
+			LiteLLMModelName: f.litellmID,
+		})
+	}))
+	return f, srv
+}
+
+// TestRoutingAdapterFailsClosedWithNoTenant is the #623 regression guard: an
+// API key with no resolvable tenant must never reach control-plane's routing
+// endpoint at all: reaching it with an empty tenant_id is exactly the shape
+// that let control-plane parse it as uuid.Nil and skip the entitlement gate.
+func TestRoutingAdapterFailsClosedWithNoTenant(t *testing.T) {
+	fake, srv := newFakeRoutingServer(http.StatusOK)
+	defer srv.Close()
+
+	adapter := audio.NewRoutingAdapter(inference.NewRoutingClient(srv.URL))
+
+	_, err := adapter.SelectRoute(context.Background(), audio.RouteInput{
+		AliasID:  "hive-restricted",
+		TenantID: "", // no resolvable tenant
+		NeedTTS:  true,
+	})
+	if err == nil {
+		t.Fatal("expected SelectRoute to fail closed for a missing tenant")
+	}
+	if !errors.Is(err, audio.ErrAccountNotProvisioned) {
+		t.Fatalf("expected ErrAccountNotProvisioned, got %v", err)
+	}
+	if fake.called {
+		t.Fatal("expected the routing server to never be contacted: fail-closed must happen locally, before any request goes out")
+	}
+}
+
+// TestRoutingAdapterFailsClosedWithUnparseableTenant covers a malformed
+// tenant string the same way as an empty one: both mean "no resolvable
+// tenant" and must fail closed identically.
+func TestRoutingAdapterFailsClosedWithUnparseableTenant(t *testing.T) {
+	fake, srv := newFakeRoutingServer(http.StatusOK)
+	defer srv.Close()
+
+	adapter := audio.NewRoutingAdapter(inference.NewRoutingClient(srv.URL))
+
+	_, err := adapter.SelectRoute(context.Background(), audio.RouteInput{
+		AliasID:  "hive-restricted",
+		TenantID: "not-a-uuid",
+		NeedTTS:  true,
+	})
+	if err == nil {
+		t.Fatal("expected SelectRoute to fail closed for an unparseable tenant")
+	}
+	if fake.called {
+		t.Fatal("expected the routing server to never be contacted for an unparseable tenant")
+	}
+}
+
+// TestRoutingAdapterBindsTenantOntoWire proves the core #623 fix: a resolved
+// tenant now actually reaches control-plane on the wire. Before the fix, the
+// audio RoutingAdapter never put a tenant on ctx at all, so
+// inference.RoutingClient.SelectRoute always sent an empty tenant_id.
+func TestRoutingAdapterBindsTenantOntoWire(t *testing.T) {
+	fake, srv := newFakeRoutingServer(http.StatusOK)
+	defer srv.Close()
+
+	adapter := audio.NewRoutingAdapter(inference.NewRoutingClient(srv.URL))
+
+	tenantID := uuid.New()
+	result, err := adapter.SelectRoute(context.Background(), audio.RouteInput{
+		AliasID:  "hive-restricted",
+		TenantID: tenantID.String(),
+		NeedTTS:  true,
+	})
+	if err != nil {
+		t.Fatalf("SelectRoute returned error: %v", err)
+	}
+	if !fake.called {
+		t.Fatal("expected the routing server to be contacted for a resolvable tenant")
+	}
+	if fake.tenantID != tenantID.String() {
+		t.Fatalf("expected tenant_id %q on the wire, got %q", tenantID.String(), fake.tenantID)
+	}
+	if result.AliasID != "hive-restricted" {
+		t.Fatalf("expected a permitted alias to still route successfully, got alias=%q", result.AliasID)
+	}
+}
+
+// TestRoutingAdapterRefusesEntitlementDenial proves the #623 regression end
+// to end: a tenant that control-plane's routing.Service refuses (the
+// restricted-alias gate at routing/service.go) must surface as a SelectRoute
+// error the handler treats as "model not available", not a silent success.
+func TestRoutingAdapterRefusesEntitlementDenial(t *testing.T) {
+	_, srv := newFakeRoutingServer(http.StatusForbidden)
+	defer srv.Close()
+
+	adapter := audio.NewRoutingAdapter(inference.NewRoutingClient(srv.URL))
+
+	_, err := adapter.SelectRoute(context.Background(), audio.RouteInput{
+		AliasID:  "hive-restricted",
+		TenantID: uuid.New().String(),
+		NeedTTS:  true,
+	})
+	if err == nil {
+		t.Fatal("expected SelectRoute to refuse a tenant-restricted alias")
+	}
+}

--- a/apps/edge-api/internal/images/authz_adapter.go
+++ b/apps/edge-api/internal/images/authz_adapter.go
@@ -26,5 +26,6 @@ func (a *AuthorizerAdapter) AuthorizeRequest(r *http.Request) (AuthResult, error
 	return AuthResult{
 		AccountID: snapshot.AccountID,
 		APIKeyID:  snapshot.KeyID,
+		TenantID:  snapshot.TenantID,
 	}, nil
 }

--- a/apps/edge-api/internal/images/handler.go
+++ b/apps/edge-api/internal/images/handler.go
@@ -11,9 +11,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/authz"
 	apierrors "github.com/sakibsadmanshajib/hive/apps/edge-api/internal/errors"
-	"github.com/google/uuid"
 )
 
 // Capability flags used when this handler calls the routing layer.
@@ -34,6 +34,11 @@ type Authorizer interface {
 type AuthResult struct {
 	AccountID string
 	APIKeyID  string
+	// TenantID is resolved control-plane-side from AccountID (D-030, via
+	// public.tenant_billing_accounts). Empty means the account has no
+	// resolvable tenant; RoutingAdapter fails the request closed on that
+	// rather than skipping the tenant-scoped entitlement check (#623).
+	TenantID string
 }
 
 // RoutingInterface selects a provider route for a given model alias.
@@ -43,7 +48,11 @@ type RoutingInterface interface {
 
 // RouteInput specifies the alias and capability requirements for route selection.
 type RouteInput struct {
-	AliasID             string
+	AliasID string
+	// TenantID is the requesting API key's resolved tenant (AuthResult.TenantID).
+	// RoutingAdapter binds it onto ctx before calling the routing client and
+	// fails closed if it is missing or unparseable (#623).
+	TenantID            string
 	NeedImageGeneration bool
 	NeedImageEdit       bool
 }
@@ -183,6 +192,7 @@ func (h *Handler) handleGeneration(w http.ResponseWriter, r *http.Request) {
 	// Select route based on model alias and capability.
 	route, err := h.routing.SelectRoute(ctx, RouteInput{
 		AliasID:             req.Model,
+		TenantID:            auth.TenantID,
 		NeedImageGeneration: true,
 	})
 	if err != nil {
@@ -262,12 +272,9 @@ func (h *Handler) handleGeneration(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Finalize reservation on success.
-	_ = h.accounting.FinalizeReservation(ctx, FinalizeInput{
-		AccountID:     auth.AccountID,
-		ReservationID: reservationID,
-		ActualCredits: 5000,
-	})
+	// Finalize reservation on success; falls back to releasing the hold if
+	// finalize itself fails, so it never strands (#616).
+	h.settleReservation(ctx, auth.AccountID, reservationID, 5000, "/v1/images/generations")
 
 	// Normalize: for URL mode, upload each image to S3 and replace with presigned URL.
 	if responseFormat == "url" {
@@ -325,6 +332,7 @@ func (h *Handler) handleEdit(w http.ResponseWriter, r *http.Request) {
 	// Select route based on model alias and capability.
 	route, err := h.routing.SelectRoute(ctx, RouteInput{
 		AliasID:       modelAlias,
+		TenantID:      auth.TenantID,
 		NeedImageEdit: true,
 	})
 	if err != nil {
@@ -441,12 +449,9 @@ func (h *Handler) handleEdit(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Finalize reservation on success.
-	_ = h.accounting.FinalizeReservation(ctx, FinalizeInput{
-		AccountID:     auth.AccountID,
-		ReservationID: reservationID,
-		ActualCredits: 5000,
-	})
+	// Finalize reservation on success; falls back to releasing the hold if
+	// finalize itself fails, so it never strands (#616).
+	h.settleReservation(ctx, auth.AccountID, reservationID, 5000, "/v1/images/edits")
 
 	// Normalize: for URL mode, upload each image to S3 and replace with presigned URL.
 	if responseFormat == "url" {

--- a/apps/edge-api/internal/images/handler_test.go
+++ b/apps/edge-api/internal/images/handler_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -72,18 +73,27 @@ func (ms *mockStorage) PresignedURL(_ context.Context, _, _ string, _ time.Durat
 type mockAuthorizer struct {
 	accountID string
 	apiKeyID  string
+	tenantID  string
 }
 
 func (a *mockAuthorizer) AuthorizeRequest(_ *http.Request) (images.AuthResult, error) {
-	return images.AuthResult{AccountID: a.accountID, APIKeyID: a.apiKeyID}, nil
+	return images.AuthResult{AccountID: a.accountID, APIKeyID: a.apiKeyID, TenantID: a.tenantID}, nil
 }
 
-// mockRouting is a stub that echoes the alias as the LiteLLM model name.
+// mockRouting is a stub that echoes the alias as the LiteLLM model name and
+// records the last TenantID it was called with, so tests can prove the
+// handler threads AuthResult.TenantID through to RouteInput (#623).
 type mockRouting struct {
-	litellmModel string
+	litellmModel   string
+	lastTenantID   string
+	selectRouteErr error
 }
 
 func (r *mockRouting) SelectRoute(_ context.Context, input images.RouteInput) (images.RouteResult, error) {
+	r.lastTenantID = input.TenantID
+	if r.selectRouteErr != nil {
+		return images.RouteResult{}, r.selectRouteErr
+	}
 	litellm := r.litellmModel
 	if litellm == "" {
 		litellm = input.AliasID
@@ -94,6 +104,7 @@ func (r *mockRouting) SelectRoute(_ context.Context, input images.RouteInput) (i
 // mockAccounting is a stub that tracks reservation calls.
 type mockAccounting struct {
 	reservationID  string
+	finalizeErr    error
 	finalizeCalled bool
 	releaseCalled  bool
 }
@@ -104,7 +115,7 @@ func (a *mockAccounting) CreateReservation(_ context.Context, _ images.Reservati
 
 func (a *mockAccounting) FinalizeReservation(_ context.Context, _ images.FinalizeInput) error {
 	a.finalizeCalled = true
-	return nil
+	return a.finalizeErr
 }
 
 func (a *mockAccounting) ReleaseReservation(_ context.Context, _, _, _ string) error {
@@ -337,5 +348,126 @@ func TestImageUnknownPathReturns404(t *testing.T) {
 
 	if w.Code != http.StatusNotFound {
 		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+// --- #616: finalize failure must release, never strand, the hold ---
+
+// TestImageGenerationFinalizeFailureReleasesReservation covers
+// handleGeneration's finalize site (handler.go:266 before the fix).
+func TestImageGenerationFinalizeFailureReleasesReservation(t *testing.T) {
+	respBody := `{"created":1700000000,"data":[{"b64_json":"abc123"}]}`
+	mock := newMockLiteLLM([]byte(respBody), 200, "application/json")
+	defer mock.Close()
+
+	auth := &mockAuthorizer{accountID: "acct-test", apiKeyID: "key-test"}
+	routing := &mockRouting{}
+	acc := &mockAccounting{reservationID: "res-gen-finalize-fail", finalizeErr: fmt.Errorf("control-plane unreachable")}
+	h := images.NewHandler(auth, routing, acc, mock.server.URL, "test-key", &mockStorage{}, "hive-images")
+
+	// b64_json avoids the S3 upload branch, keeping this test focused on
+	// reservation settlement.
+	body := `{"model":"dall-e-3","prompt":"a cat","response_format":"b64_json"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/images/generations", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer test-key")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 (finalize bookkeeping failure must stay invisible to the caller), got %d: %s", w.Code, w.Body.String())
+	}
+	if !acc.finalizeCalled {
+		t.Fatal("expected FinalizeReservation to be attempted")
+	}
+	if !acc.releaseCalled {
+		t.Fatal("expected ReleaseReservation to be called after finalize failure: the hold would otherwise strand (#616)")
+	}
+}
+
+// TestImageEditFinalizeFailureReleasesReservation covers handleEdit's
+// finalize site (handler.go:445 before the fix).
+func TestImageEditFinalizeFailureReleasesReservation(t *testing.T) {
+	respBody := `{"created":1700000000,"data":[{"b64_json":"abc123"}]}`
+	mock := newMockLiteLLM([]byte(respBody), 200, "application/json")
+	defer mock.Close()
+
+	auth := &mockAuthorizer{accountID: "acct-test", apiKeyID: "key-test"}
+	routing := &mockRouting{}
+	acc := &mockAccounting{reservationID: "res-edit-finalize-fail", finalizeErr: fmt.Errorf("control-plane unreachable")}
+	h := images.NewHandler(auth, routing, acc, mock.server.URL, "test-key", &mockStorage{}, "hive-images")
+
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	_ = mw.WriteField("model", "dall-e-2")
+	_ = mw.WriteField("prompt", "make it blue")
+	fw, _ := mw.CreateFormFile("image", "input.png")
+	fw.Write([]byte("fake-image-bytes"))
+	mw.Close()
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/images/edits", &buf)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	req.Header.Set("Authorization", "Bearer test-key")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if !acc.releaseCalled {
+		t.Fatal("expected ReleaseReservation to be called after finalize failure: the hold would otherwise strand (#616)")
+	}
+}
+
+// --- #623: tenant must thread from AuthResult to RouteInput ---
+
+// TestImageGenerationThreadsTenantIDToRouting proves the handler passes the
+// authenticated caller's resolved tenant through to RouteInput, which is
+// what lets RoutingAdapter bind it for the control-plane entitlement check.
+func TestImageGenerationThreadsTenantIDToRouting(t *testing.T) {
+	respBody := `{"created":1700000000,"data":[{"b64_json":"abc123"}]}`
+	mock := newMockLiteLLM([]byte(respBody), 200, "application/json")
+	defer mock.Close()
+
+	tenantID := "44444444-4444-4444-4444-444444444444"
+	auth := &mockAuthorizer{accountID: "acct-test", apiKeyID: "key-test", tenantID: tenantID}
+	routing := &mockRouting{}
+	acc := &mockAccounting{reservationID: "res-tenant-thread"}
+	h := images.NewHandler(auth, routing, acc, mock.server.URL, "test-key", &mockStorage{}, "hive-images")
+
+	body := `{"model":"dall-e-3","prompt":"a cat","response_format":"b64_json"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/images/generations", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer test-key")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if routing.lastTenantID != tenantID {
+		t.Fatalf("expected RouteInput.TenantID %q, got %q", tenantID, routing.lastTenantID)
+	}
+}
+
+// TestImageGenerationTenantRestrictedAliasRefused is the #623 regression
+// guard at the handler level: when route selection refuses an alias (the
+// shape a tenant-restricted alias produces via RoutingAdapter, once bound),
+// the caller must be refused, not served.
+func TestImageGenerationTenantRestrictedAliasRefused(t *testing.T) {
+	auth := &mockAuthorizer{accountID: "acct-test", apiKeyID: "key-test", tenantID: "55555555-5555-5555-5555-555555555555"}
+	routing := &mockRouting{selectRouteErr: fmt.Errorf("images: select route: %w", images.ErrAccountNotProvisioned)}
+	acc := &mockAccounting{reservationID: "res-restricted"}
+	h := images.NewHandler(auth, routing, acc, "http://unused.example.com", "test-key", &mockStorage{}, "hive-images")
+
+	body := `{"model":"dall-e-restricted","prompt":"a cat","response_format":"b64_json"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/images/generations", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer test-key")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code == http.StatusOK {
+		t.Fatal("expected a refusal, not a 200, for a route-selection failure")
 	}
 }

--- a/apps/edge-api/internal/images/reservation.go
+++ b/apps/edge-api/internal/images/reservation.go
@@ -1,0 +1,50 @@
+package images
+
+import (
+	"context"
+	"log"
+	"time"
+)
+
+// releaseTimeout bounds the background-context reservation release attempted
+// when FinalizeReservation fails. Mirrors the inference package's
+// accountingTimeout/releaseReservationBackground pattern (PR #602) so a
+// finalize failure never strands the hold, even when the request context is
+// already cancelled by the time settleReservation runs.
+const releaseTimeout = 30 * time.Second
+
+// settleReservation finalizes a reservation and, only when finalize itself
+// fails, releases it instead, so a reservation always reaches a terminal
+// state exactly once (charged or released), and a failed charge never
+// leaves the hold stranded (#616). This used to be a bare
+// `_ = h.accounting.FinalizeReservation(...)`, whose error was discarded: a
+// failed finalize neither charged nor released the hold, stranding it
+// forever.
+//
+// The release runs on a fresh, bounded background context, never ctx. By
+// the time a request reaches this point the client may already have
+// disconnected, cancelling ctx, which would otherwise silently swallow the
+// release the same way it swallowed the original finalize: the exact bug
+// PR #602 fixed on the streaming inference path, reproduced here on the
+// media path.
+//
+// Release is attempted only when finalize errors, so a reservation that
+// finalized successfully is never also released (which would refund a
+// legitimate charge).
+func (h *Handler) settleReservation(ctx context.Context, accountID, reservationID string, actualCredits int64, endpoint string) {
+	err := h.accounting.FinalizeReservation(ctx, FinalizeInput{
+		AccountID:     accountID,
+		ReservationID: reservationID,
+		ActualCredits: actualCredits,
+	})
+	if err == nil {
+		return
+	}
+	log.Printf("images: finalize reservation failed endpoint=%s reservation_id=%s: %v", endpoint, reservationID, err)
+
+	bgCtx, cancel := context.WithTimeout(context.Background(), releaseTimeout)
+	defer cancel()
+	if relErr := h.accounting.ReleaseReservation(bgCtx, accountID, reservationID, "finalize_failed"); relErr != nil {
+		log.Printf("images: release reservation after finalize failure also failed endpoint=%s reservation_id=%s: %v", endpoint, reservationID, relErr)
+	}
+}

--- a/apps/edge-api/internal/images/reservation_test.go
+++ b/apps/edge-api/internal/images/reservation_test.go
@@ -1,0 +1,93 @@
+package images
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// settleReservationMock is a white-box double for AccountingInterface, used
+// only by this file's tests (package images, not images_test) so
+// settleReservation (an unexported method) can be exercised directly
+// without racing real HTTP dispatch to force a finalize failure.
+type settleReservationMock struct {
+	finalizeErr error
+
+	finalizeCalled bool
+	releaseCalled  bool
+	// releaseCtxErr captures ctx.Err() as observed by ReleaseReservation, so
+	// tests can prove the release ran on a live context even when the caller
+	// passed settleReservation an already-cancelled one.
+	releaseCtxErr error
+}
+
+func (m *settleReservationMock) CreateReservation(context.Context, ReservationInput) (string, error) {
+	return "", nil
+}
+
+func (m *settleReservationMock) FinalizeReservation(context.Context, FinalizeInput) error {
+	m.finalizeCalled = true
+	return m.finalizeErr
+}
+
+func (m *settleReservationMock) ReleaseReservation(ctx context.Context, _, _, _ string) error {
+	m.releaseCalled = true
+	m.releaseCtxErr = ctx.Err()
+	return nil
+}
+
+// TestSettleReservationReleasesOnFinalizeFailure is the #616 regression guard:
+// a failed finalize must release the hold rather than stranding it.
+func TestSettleReservationReleasesOnFinalizeFailure(t *testing.T) {
+	m := &settleReservationMock{finalizeErr: errors.New("control-plane unreachable")}
+	h := &Handler{accounting: m}
+
+	h.settleReservation(context.Background(), "acct-1", "res-1", 5000, "/v1/images/generations")
+
+	if !m.finalizeCalled {
+		t.Fatal("expected FinalizeReservation to be attempted")
+	}
+	if !m.releaseCalled {
+		t.Fatal("expected ReleaseReservation to be called after finalize failure: the hold would otherwise strand")
+	}
+}
+
+// TestSettleReservationNeverReleasesAfterSuccessfulFinalize is the
+// exactly-once-terminal-state guard: a reservation that finalized (charged)
+// successfully must never also be released, which would refund a
+// legitimate charge.
+func TestSettleReservationNeverReleasesAfterSuccessfulFinalize(t *testing.T) {
+	m := &settleReservationMock{finalizeErr: nil}
+	h := &Handler{accounting: m}
+
+	h.settleReservation(context.Background(), "acct-1", "res-1", 5000, "/v1/images/generations")
+
+	if !m.finalizeCalled {
+		t.Fatal("expected FinalizeReservation to be attempted")
+	}
+	if m.releaseCalled {
+		t.Fatal("expected ReleaseReservation NOT to be called after a successful finalize: would double-settle the reservation")
+	}
+}
+
+// TestSettleReservationReleaseSurvivesCancelledRequestContext is the #602
+// trap reproduced on the media path: by the time settleReservation runs the
+// client may already have disconnected, cancelling the request context. The
+// release must run on a fresh background context, not the cancelled one, or
+// it silently fails the same way the original finalize call used to.
+func TestSettleReservationReleaseSurvivesCancelledRequestContext(t *testing.T) {
+	m := &settleReservationMock{finalizeErr: errors.New("upstream write failed: client disconnected")}
+	h := &Handler{accounting: m}
+
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel() // simulate the client having already disconnected
+
+	h.settleReservation(cancelledCtx, "acct-1", "res-1", 5000, "/v1/images/generations")
+
+	if !m.releaseCalled {
+		t.Fatal("expected ReleaseReservation to be called despite the cancelled request context")
+	}
+	if m.releaseCtxErr != nil {
+		t.Fatalf("expected ReleaseReservation to receive a live (non-cancelled) context, got ctx.Err() = %v", m.releaseCtxErr)
+	}
+}

--- a/apps/edge-api/internal/images/routing_adapter.go
+++ b/apps/edge-api/internal/images/routing_adapter.go
@@ -2,10 +2,23 @@ package images
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
+	"github.com/google/uuid"
+	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/auth"
 	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/inference"
 )
+
+// ErrAccountNotProvisioned reports an API-key principal whose account has no
+// resolvable tenant (AuthResult.TenantID, sourced from
+// authz.AuthSnapshot.TenantID, is empty or unparseable). SelectRoute fails
+// closed on this before ever calling the routing client, the same way
+// inference.Orchestrator.selectRoute does for chat/completions (D-030,
+// PR #620): without a tenant the tenant-scoped entitlement check inside
+// control-plane's routing.Service.SelectRoute cannot run at all, so admitting
+// the request would silently reopen the gap that check exists to close.
+var ErrAccountNotProvisioned = errors.New("images: account has no tenant")
 
 // RoutingAdapter adapts *inference.RoutingClient to the images.RoutingInterface.
 type RoutingAdapter struct {
@@ -18,7 +31,24 @@ func NewRoutingAdapter(inner *inference.RoutingClient) *RoutingAdapter {
 }
 
 // SelectRoute calls the routing client with image-specific capability flags.
+//
+// input.TenantID is bound onto ctx here (via auth.WithUser, the same
+// context key inference.RoutingClient.SelectRoute already reads first via
+// auth.TenantID) before delegating to the routing client. Without this, the
+// images endpoints never put a tenant on ctx at all, so RoutingClient.SelectRoute
+// sent an empty tenant_id, which control-plane parsed as uuid.Nil and treated
+// as "skip the tenant-scoped entitlement gate", making a tenant-restricted
+// alias reachable through /v1/images/* by any API key even though the same
+// alias is correctly refused on chat (#623). A key whose account has no
+// resolvable tenant fails closed here, before the routing client is ever
+// called, rather than falling back to unfiltered access.
 func (a *RoutingAdapter) SelectRoute(ctx context.Context, input RouteInput) (RouteResult, error) {
+	tenantID, err := uuid.Parse(input.TenantID)
+	if err != nil || tenantID == uuid.Nil {
+		return RouteResult{}, fmt.Errorf("images: select route: %w", ErrAccountNotProvisioned)
+	}
+	ctx = auth.WithUser(ctx, &auth.User{TenantID: tenantID})
+
 	result, err := a.inner.SelectRoute(ctx, inference.SelectRouteInput{
 		AliasID:             input.AliasID,
 		NeedImageGeneration: input.NeedImageGeneration,

--- a/apps/edge-api/internal/images/routing_adapter_test.go
+++ b/apps/edge-api/internal/images/routing_adapter_test.go
@@ -1,0 +1,149 @@
+package images_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/images"
+	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/inference"
+)
+
+// fakeRoutingServer stands in for control-plane's /internal/routing/select.
+// It records whether it was ever called, and the tenant_id it received, so
+// tests can tell "the adapter refused locally" apart from "the adapter asked
+// control-plane and got refused" without depending on any real
+// routing.Service code.
+type fakeRoutingServer struct {
+	called    bool
+	tenantID  string
+	status    int
+	aliasID   string
+	litellmID string
+}
+
+func newFakeRoutingServer(status int) (*fakeRoutingServer, *httptest.Server) {
+	f := &fakeRoutingServer{status: status, aliasID: "hive-restricted-image", litellmID: "route-groq-restricted-image"}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		f.called = true
+		var decoded map[string]any
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &decoded)
+		if tid, ok := decoded["tenant_id"]; ok {
+			f.tenantID, _ = tid.(string)
+		}
+		if f.status != http.StatusOK {
+			w.WriteHeader(f.status)
+			_, _ = w.Write([]byte(`{"error":"routing: model not entitled for tenant"}`))
+			return
+		}
+		_ = json.NewEncoder(w).Encode(inference.SelectRouteResult{
+			AliasID:          f.aliasID,
+			LiteLLMModelName: f.litellmID,
+		})
+	}))
+	return f, srv
+}
+
+// TestRoutingAdapterFailsClosedWithNoTenant is the #623 regression guard: an
+// API key with no resolvable tenant must never reach control-plane's routing
+// endpoint at all: reaching it with an empty tenant_id is exactly the shape
+// that let control-plane parse it as uuid.Nil and skip the entitlement gate.
+func TestRoutingAdapterFailsClosedWithNoTenant(t *testing.T) {
+	fake, srv := newFakeRoutingServer(http.StatusOK)
+	defer srv.Close()
+
+	adapter := images.NewRoutingAdapter(inference.NewRoutingClient(srv.URL))
+
+	_, err := adapter.SelectRoute(context.Background(), images.RouteInput{
+		AliasID:             "hive-restricted-image",
+		TenantID:            "", // no resolvable tenant
+		NeedImageGeneration: true,
+	})
+	if err == nil {
+		t.Fatal("expected SelectRoute to fail closed for a missing tenant")
+	}
+	if !errors.Is(err, images.ErrAccountNotProvisioned) {
+		t.Fatalf("expected ErrAccountNotProvisioned, got %v", err)
+	}
+	if fake.called {
+		t.Fatal("expected the routing server to never be contacted: fail-closed must happen locally, before any request goes out")
+	}
+}
+
+// TestRoutingAdapterFailsClosedWithUnparseableTenant covers a malformed
+// tenant string the same way as an empty one: both mean "no resolvable
+// tenant" and must fail closed identically.
+func TestRoutingAdapterFailsClosedWithUnparseableTenant(t *testing.T) {
+	fake, srv := newFakeRoutingServer(http.StatusOK)
+	defer srv.Close()
+
+	adapter := images.NewRoutingAdapter(inference.NewRoutingClient(srv.URL))
+
+	_, err := adapter.SelectRoute(context.Background(), images.RouteInput{
+		AliasID:             "hive-restricted-image",
+		TenantID:            "not-a-uuid",
+		NeedImageGeneration: true,
+	})
+	if err == nil {
+		t.Fatal("expected SelectRoute to fail closed for an unparseable tenant")
+	}
+	if fake.called {
+		t.Fatal("expected the routing server to never be contacted for an unparseable tenant")
+	}
+}
+
+// TestRoutingAdapterBindsTenantOntoWire proves the core #623 fix: a resolved
+// tenant now actually reaches control-plane on the wire. Before the fix, the
+// images RoutingAdapter never put a tenant on ctx at all, so
+// inference.RoutingClient.SelectRoute always sent an empty tenant_id.
+func TestRoutingAdapterBindsTenantOntoWire(t *testing.T) {
+	fake, srv := newFakeRoutingServer(http.StatusOK)
+	defer srv.Close()
+
+	adapter := images.NewRoutingAdapter(inference.NewRoutingClient(srv.URL))
+
+	tenantID := uuid.New()
+	result, err := adapter.SelectRoute(context.Background(), images.RouteInput{
+		AliasID:             "hive-restricted-image",
+		TenantID:            tenantID.String(),
+		NeedImageGeneration: true,
+	})
+	if err != nil {
+		t.Fatalf("SelectRoute returned error: %v", err)
+	}
+	if !fake.called {
+		t.Fatal("expected the routing server to be contacted for a resolvable tenant")
+	}
+	if fake.tenantID != tenantID.String() {
+		t.Fatalf("expected tenant_id %q on the wire, got %q", tenantID.String(), fake.tenantID)
+	}
+	if result.AliasID != "hive-restricted-image" {
+		t.Fatalf("expected a permitted alias to still route successfully, got alias=%q", result.AliasID)
+	}
+}
+
+// TestRoutingAdapterRefusesEntitlementDenial proves the #623 regression end
+// to end: a tenant that control-plane's routing.Service refuses (the
+// restricted-alias gate at routing/service.go) must surface as a SelectRoute
+// error the handler treats as "model not available", not a silent success.
+func TestRoutingAdapterRefusesEntitlementDenial(t *testing.T) {
+	_, srv := newFakeRoutingServer(http.StatusForbidden)
+	defer srv.Close()
+
+	adapter := images.NewRoutingAdapter(inference.NewRoutingClient(srv.URL))
+
+	_, err := adapter.SelectRoute(context.Background(), images.RouteInput{
+		AliasID:             "hive-restricted-image",
+		TenantID:            uuid.New().String(),
+		NeedImageGeneration: true,
+	})
+	if err == nil {
+		t.Fatal("expected SelectRoute to refuse a tenant-restricted alias")
+	}
+}


### PR DESCRIPTION
## Summary

Two related defects in the audio and images handlers, fixed together in one PR because they live in the same files.

**Stranded reservation holds (fixes #616).** `handleSpeech`, `handleTranscription` (local-STT path), and `handleMultipartAudio` (shared by transcription-fallback and translation) all discarded the return value of `FinalizeReservation`. A failed finalize neither charged nor released the hold, stranding it forever. 32 reservations are currently stranded holding 154000 credits.

The invariant enforced here: a reservation must reach a terminal state exactly once, either charged or released, and a failure to charge must never leave it held.

`settleReservation` (new, one per package) finalizes and, only when finalize itself fails, releases the hold instead. The release runs on a fresh bounded background context (`context.WithTimeout(context.Background(), 30*time.Second)`), never the request context, mirroring the pattern PR #602 established for the streaming inference path: by the time this runs the client may already have disconnected, cancelling the request context, which would otherwise silently swallow the release the same way it swallowed the original finalize. Release is attempted only when finalize errors, so a reservation is never both charged and released (tested explicitly).

**Tenant not bound on media routing (fixes #623).** `audio.RoutingAdapter.SelectRoute` and `images.RoutingAdapter.SelectRoute` called `inference.RoutingClient.SelectRoute` without ever binding a tenant onto the request context. `RoutingClient.SelectRoute` then sent an empty `tenant_id`, which control-plane parsed as `uuid.Nil`, and the tenant-scoped entitlement gate in `routing.Service.SelectRoute` treats `uuid.Nil` as "skip this check" (the batch executor's intentional untenanted case). That made the restricted-alias refusal unreachable for API-key callers on `/v1/audio/*` and `/v1/images/*`.

**Security consequence:** a tenant-restricted model alias was reachable through the audio and images endpoints by any API key, while being correctly refused on chat. This is a tenant isolation gap, not a cosmetic inconsistency.

The fix threads the caller's resolved tenant end to end: `AuthResult.TenantID` (populated from `authz.AuthSnapshot.TenantID`) flows into `RouteInput.TenantID`, and `RoutingAdapter.SelectRoute` binds it onto the context via `auth.WithUser` before calling the routing client, exactly the context key `RoutingClient.SelectRoute` already reads first via `auth.TenantID`. A missing or unparseable tenant fails closed: `RoutingAdapter.SelectRoute` returns an error before the routing client is ever called, so no partially-scoped request reaches control-plane.

This follows the D-030 / PR #620 pattern from `inference.Orchestrator.selectRoute` (parse tenant, fail closed, bind before calling `SelectRoute`). The private `withAPIKeyTenant` helper that PR uses lives in `apps/edge-api/internal/inference/`, which was off limits for this change (another PR has concurrent edits in flight there), so this reuses the public `auth.WithUser`/`auth.TenantID` binding instead, the same one JWT sessions use and that `RoutingClient.SelectRoute` already checks first. Deduplicating the two binding mechanisms (`withAPIKeyTenant` vs. `auth.WithUser`) is a natural follow-up once the inference package is free.

## Out of scope (left untouched, noted for follow-up)

- `apps/edge-api/internal/batchstore/submitter.go:333` has the same finalize-discard shape; left alone per the brief (batch executor's `uuid.Nil` tenant is intentional and separate).
- Payments webhook (#628), reservation classification (#626), pricing (#617), and audio billing using flat literals instead of the catalog (#627) are real but separate issues, not touched here.
- The pre-existing `_ = h.accounting.ReleaseReservation(ctx, ...)` calls on the various upstream/request-error abort paths in these same handlers discard their return value too and use the request context, the same exposure class as the bug this PR fixes on the success path. Out of scope for this PR (the brief scoped this fix to the 5 finalize call sites specifically), flagging as a candidate follow-up.

## Test plan

TDD: tests were written first and confirmed to fail (compile failure, `settleReservation` undefined) before the implementation existed.

- [x] `TestSettleReservation*` (audio, images): finalize failure releases the hold; a successful finalize never also releases (exactly-once terminal state); release survives an already-cancelled request context (the #602 trap), verified by asserting the context `ReleaseReservation` receives is not cancelled even though the caller's context was.
- [x] `TestSpeechFinalizeFailureReleasesReservation`, `TestTranscriptionSTTFinalizeFailureReleasesReservation`, `TestTranslationFinalizeFailureReleasesReservation` (audio): each of the 3 audio finalize sites releases on failure, end to end through `ServeHTTP`, response still 200 (bookkeeping failure stays invisible to the caller).
- [x] `TestImageGenerationFinalizeFailureReleasesReservation`, `TestImageEditFinalizeFailureReleasesReservation` (images): same, for both image finalize sites.
- [x] `TestRoutingAdapterFailsClosedWithNoTenant`, `TestRoutingAdapterFailsClosedWithUnparseableTenant` (audio, images): a missing/malformed tenant refuses locally; the fake routing server is never even contacted.
- [x] `TestRoutingAdapterBindsTenantOntoWire` (audio, images): a resolvable tenant reaches control-plane on the wire, and a permitted alias still routes successfully (no lockout of legitimate traffic).
- [x] `TestRoutingAdapterRefusesEntitlementDenial` (audio, images): a control-plane 403 (tenant not entitled) surfaces as a `SelectRoute` error.
- [x] `TestSpeechThreadsTenantIDToRouting` / `TestImageGenerationThreadsTenantIDToRouting`: handler passes `AuthResult.TenantID` through to `RouteInput.TenantID`.
- [x] `TestSpeechTenantRestrictedAliasRefused` / `TestImageGenerationTenantRestrictedAliasRefused`: a route-selection refusal is surfaced to the caller as a refusal, not served.
- [x] Full `go build ./apps/edge-api/... ./apps/control-plane/...` and `go vet ./apps/edge-api/...` clean.
- [x] Full `go test ./apps/edge-api/... -count=1 -short` green (no regressions across the module).
- [x] `go test ./apps/edge-api/internal/audio/... ./apps/edge-api/internal/images/... -count=1 -v` all green.
- [x] `gofmt -l` clean.
- [x] `node tools/lint-no-direct-tenant-id.mjs` and `lint-no-direct-tenant-setting.mjs` both pass.

Tested tree: `/tmp/mediafix2` (worktree on this branch), via `docker run --rm -v /tmp/mediafix2:/workspace ... hive-toolchain:latest`.

## Bug log

Entries for `.wolf/buglog.jsonl` (not appended in this PR per merge-conflict avoidance policy; carried by the coordinating agent):

1. Stranded reservation holds: audio/images `FinalizeReservation` error discarded on the success path, so a failed finalize neither charged nor released the hold. Root cause: bare `_ = h.accounting.FinalizeReservation(...)`. Fix: `settleReservation` releases on finalize failure, on a fresh background context (mirrors PR #602's `releaseReservationBackground` pattern) so a cancelled request context cannot swallow the release.
2. Tenant not bound on media routing: `audio.RoutingAdapter`/`images.RoutingAdapter` called `inference.RoutingClient.SelectRoute` without binding a tenant, so control-plane's `routing.Service.SelectRoute` parsed the empty `tenant_id` as `uuid.Nil` and skipped its tenant-scoped entitlement gate, making tenant-restricted aliases reachable via `/v1/audio/*` and `/v1/images/*`. Fix: thread `AuthResult.TenantID` through `RouteInput`, bind via `auth.WithUser` in `RoutingAdapter.SelectRoute`, fail closed when missing/unparseable, following the D-030/PR #620 pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)