### PR TITLE
feat: per-route credit pricing (D-032)

### DIFF
--- a/apps/control-plane/internal/routing/repository.go
+++ b/apps/control-plane/internal/routing/repository.go
@@ -13,12 +13,18 @@ import (
 type Repository interface {
 	LoadAliasPolicy(ctx context.Context, aliasID string) (catalog.AliasPolicySnapshot, error)
 	ListRouteCandidates(ctx context.Context, aliasID string) ([]RouteCandidate, error)
-	// LoadAliasPricing reads the alias's per-model credit price from
-	// public.model_aliases. A missing row is not an error: it returns the
-	// catalog.CatalogPricing zero value so a data-inconsistency on the
-	// pricing side never blocks a route the routing tables already
-	// approved (metering step 2, shadow mode; see SelectionResult.Pricing).
-	LoadAliasPricing(ctx context.Context, aliasID string) (catalog.CatalogPricing, error)
+	// LoadRoutePricing reads the SELECTED route's per-route credit price
+	// from public.provider_routes (D-032: price lives on the route, not the
+	// alias, because one alias can carry routes to providers at very
+	// different real cost -- see SelectionResult.Pricing). A missing row IS
+	// an error: fail closed, the same posture as the tenant entitlement
+	// check above. provider_routes.input_price_credits/output_price_credits
+	// are NOT NULL for every route seeded today, so this is only reachable
+	// via a genuine data or infrastructure fault, never a silent free ride.
+	// Cache read/write pricing is not carried per-route: precedence.go's
+	// billing formula never reads it, so CacheReadPriceCredits/
+	// CacheWritePriceCredits are always nil on the returned value.
+	LoadRoutePricing(ctx context.Context, routeID string) (catalog.CatalogPricing, error)
 }
 
 type pgxRepository struct {
@@ -116,38 +122,39 @@ func (r *pgxRepository) ListRouteCandidates(ctx context.Context, aliasID string)
 	return candidates, nil
 }
 
-// LoadAliasPricing reads public.model_aliases directly rather than going
+// LoadRoutePricing reads public.provider_routes directly rather than going
 // through catalog.Service: routing already depends on the catalog package
 // for AliasPolicySnapshot, and a same-transactionable direct read keeps this
 // addition to one query on the pool routing already holds, with no new
-// cross-package call and no new network hop (metering step 2 brief section
-// 2.5).
-func (r *pgxRepository) LoadAliasPricing(ctx context.Context, aliasID string) (catalog.CatalogPricing, error) {
+// cross-package call and no new network hop (D-032, following the same
+// convention the alias-keyed version used).
+//
+// WHERE pricing_unit = 'tokens' is D-032's pricing-unit contract: this
+// routing package only ever meters tokens (chat completions), so a route
+// whose pricing_unit is anything else must be rejected rather than
+// mispriced. That row simply does not match this query, so it falls through
+// the existing pgx.ErrNoRows fail-closed branch below with no separate
+// mismatch check needed.
+func (r *pgxRepository) LoadRoutePricing(ctx context.Context, routeID string) (catalog.CatalogPricing, error) {
 	row := r.pool.QueryRow(ctx, `
 		SELECT
 			input_price_credits,
-			output_price_credits,
-			cache_read_price_credits,
-			cache_write_price_credits
-		FROM public.model_aliases
-		WHERE alias_id = $1
-	`, aliasID)
+			output_price_credits
+		FROM public.provider_routes
+		WHERE route_id = $1 AND pricing_unit = 'tokens'
+	`, routeID)
 
 	var pricing catalog.CatalogPricing
 	if err := row.Scan(
 		&pricing.InputPriceCredits,
 		&pricing.OutputPriceCredits,
-		&pricing.CacheReadPriceCredits,
-		&pricing.CacheWritePriceCredits,
 	); err != nil {
-		if err == pgx.ErrNoRows {
-			// No model_aliases row for an alias the routing tables already
-			// resolved is a data-inconsistency case, not a request-level
-			// error: return the zero value so SelectRoute keeps working and
-			// the caller reads it as "no cost basis available".
-			return catalog.CatalogPricing{}, nil
-		}
-		return catalog.CatalogPricing{}, fmt.Errorf("routing: load alias pricing: %w", err)
+		// Fail closed (D-032): unlike the old alias-keyed lookup, a missing
+		// or unreadable price row is a real error, not a zero-value success.
+		// A route the routing tables already resolved but that carries no
+		// price is a data-inconsistency serious enough to refuse the whole
+		// selection rather than silently bill it as free.
+		return catalog.CatalogPricing{}, fmt.Errorf("routing: load route pricing for %s: %w", routeID, err)
 	}
 
 	return pricing, nil

--- a/apps/control-plane/internal/routing/repository_schema_test.go
+++ b/apps/control-plane/internal/routing/repository_schema_test.go
@@ -72,6 +72,69 @@ func TestListRouteCandidatesSelectsMediaColumns(t *testing.T) {
 	}
 }
 
+// TestProviderRoutePricingMigrationAddsPricingUnitColumn is D-032's amended
+// requirement (per CodeRabbit thread 2 on PR #632, ruled valid): a price row
+// with no unit dimension guarantees a second migration once D-033's
+// non-token modalities need pricing. The column must exist, be NOT NULL, and
+// be constrained to 'tokens' for every route this migration prices, so a
+// future non-'tokens' insert needs its own explicit constraint change rather
+// than sliding in silently.
+func TestProviderRoutePricingMigrationAddsPricingUnitColumn(t *testing.T) {
+	migration := providerRoutePricingMigration(t)
+	lower := strings.ToLower(migration)
+
+	if !strings.Contains(migration, "pricing_unit") {
+		t.Fatal("provider_routes pricing migration must add a pricing_unit column")
+	}
+	if !strings.Contains(lower, "pricing_unit") || !strings.Contains(lower, "not null") {
+		t.Fatal("pricing_unit must be NOT NULL: a route with no unit is unselectable, matching the no-price fail-closed rule")
+	}
+	if !regexp.MustCompile(`(?is)check\s*\(\s*pricing_unit\s*=\s*'tokens'\s*\)`).MatchString(migration) {
+		t.Fatal("pricing_unit must be constrained to 'tokens' for every currently priced route (check (pricing_unit = 'tokens'))")
+	}
+}
+
+// TestLoadRoutePricingRejectsPricingUnitMismatch guards D-032's pricing-unit
+// contract: a route whose pricing_unit does not match what its handler
+// meters must be REJECTED, not silently mispriced. This routing package
+// only ever meters tokens (chat completions), so LoadRoutePricing's query
+// must filter on pricing_unit = 'tokens' -- a route with any other unit then
+// falls through the existing ErrNoRows fail-closed path with no new branch.
+func TestLoadRoutePricingRejectsPricingUnitMismatch(t *testing.T) {
+	source := readRepoFile(t, "apps/control-plane/internal/routing/repository.go")
+
+	if !regexp.MustCompile(`(?is)LoadRoutePricing.*pricing_unit\s*=\s*'tokens'`).MatchString(source) {
+		t.Fatal("LoadRoutePricing must filter WHERE pricing_unit = 'tokens' so a unit mismatch fails closed instead of mispricing")
+	}
+}
+
+func providerRoutePricingMigration(t *testing.T) string {
+	t.Helper()
+
+	root := repoRoot(t)
+	matches, err := filepath.Glob(filepath.Join(root, "supabase/migrations/*.sql"))
+	if err != nil {
+		t.Fatalf("glob supabase migrations: %v", err)
+	}
+
+	for _, path := range matches {
+		body, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read migration %s: %v", path, err)
+		}
+
+		text := string(body)
+		lower := strings.ToLower(text)
+		if strings.Contains(lower, "alter table public.provider_routes") &&
+			strings.Contains(text, "input_price_credits") {
+			return text
+		}
+	}
+
+	t.Fatal("expected a migration altering public.provider_routes to add input_price_credits/output_price_credits")
+	return ""
+}
+
 func providerCapabilitiesMediaMigration(t *testing.T) string {
 	t.Helper()
 

--- a/apps/control-plane/internal/routing/service.go
+++ b/apps/control-plane/internal/routing/service.go
@@ -145,15 +145,18 @@ func (s *Service) SelectRoute(ctx context.Context, input SelectionInput) (Select
 		fallbacks = append(fallbacks, candidate.RouteID)
 	}
 
-	// Pricing is a property of the alias, not of whichever candidate ended up
-	// primary vs. fallback, so it is resolved once here, after a route has
-	// actually been selected. Deferring it to this point (rather than up
-	// front, alongside LoadAliasPolicy) also means an alias that gets
-	// refused earlier -- unentitled, disallowed, no eligible routes -- never
-	// pays for a pricing lookup it will not use.
-	pricing, err := s.repo.LoadAliasPricing(ctx, aliasID)
+	// Pricing is a property of the SELECTED ROUTE (D-032), not of the alias:
+	// one alias can carry routes to providers at very different real cost
+	// (hive-fast's OpenRouter vs. Groq routes), so it is resolved once here,
+	// by selected.RouteID, after a route has actually been selected.
+	// Deferring it to this point (rather than up front, alongside
+	// LoadAliasPolicy) also means an alias that gets refused earlier --
+	// unentitled, disallowed, no eligible routes -- never pays for a
+	// pricing lookup it will not use. A route with no price fails the
+	// whole selection closed rather than falling back to a free route.
+	pricing, err := s.repo.LoadRoutePricing(ctx, selected.RouteID)
 	if err != nil {
-		return SelectionResult{}, fmt.Errorf("routing: load alias pricing for %s: %w", aliasID, err)
+		return SelectionResult{}, fmt.Errorf("routing: load route pricing for %s: %w", selected.RouteID, err)
 	}
 
 	return SelectionResult{

--- a/apps/control-plane/internal/routing/service_test.go
+++ b/apps/control-plane/internal/routing/service_test.go
@@ -20,9 +20,10 @@ type stubRepository struct {
 	loadPolicyCalls int
 
 	pricing            catalog.CatalogPricing
+	pricingByRoute     map[string]catalog.CatalogPricing
 	pricingErr         error
 	pricingCalls       int
-	sawPricingAliasIDs []string
+	sawPricingRouteIDs []string
 }
 
 func (s *stubRepository) LoadAliasPolicy(_ context.Context, _ string) (catalog.AliasPolicySnapshot, error) {
@@ -43,11 +44,14 @@ func (s *stubRepository) ListRouteCandidates(_ context.Context, _ string) ([]Rou
 	return append([]RouteCandidate(nil), s.candidates...), nil
 }
 
-func (s *stubRepository) LoadAliasPricing(_ context.Context, aliasID string) (catalog.CatalogPricing, error) {
+func (s *stubRepository) LoadRoutePricing(_ context.Context, routeID string) (catalog.CatalogPricing, error) {
 	s.pricingCalls++
-	s.sawPricingAliasIDs = append(s.sawPricingAliasIDs, aliasID)
+	s.sawPricingRouteIDs = append(s.sawPricingRouteIDs, routeID)
 	if s.pricingErr != nil {
 		return catalog.CatalogPricing{}, s.pricingErr
+	}
+	if p, ok := s.pricingByRoute[routeID]; ok {
+		return p, nil
 	}
 
 	return s.pricing, nil
@@ -728,14 +732,12 @@ func TestRequireToolCapable_MixedProviderOnlyCapableSelected(t *testing.T) {
 	}
 }
 
-// TestSelectRouteCarriesAliasPricing is metering step 2 wave 1a's core
-// assertion: SelectRoute must surface the alias's per-model credit price on
-// the result so a caller (edge-api's metering gate, wired in a later wave)
-// can price a request without a second round trip. Two aliases with
-// different prices must produce different Pricing values for identical
-// token counts (spec 8.2 item 9's regression guard against reverting to a
-// flat total-tokens estimate).
-func TestSelectRouteCarriesAliasPricing(t *testing.T) {
+// TestSelectRouteCarriesRoutePricing is D-032's core assertion: SelectRoute
+// must surface the SELECTED ROUTE's per-route credit price (from
+// public.provider_routes, not public.model_aliases) on the result, keyed by
+// route_id, so a caller (edge-api's metering gate) can price a request
+// without a second round trip.
+func TestSelectRouteCarriesRoutePricing(t *testing.T) {
 	repo := entitlementTestRepo()
 	cacheRead := int64(1)
 	cacheWrite := int64(5)
@@ -771,20 +773,23 @@ func TestSelectRouteCarriesAliasPricing(t *testing.T) {
 	if repo.pricingCalls != 1 {
 		t.Fatalf("expected exactly one pricing lookup, got %d", repo.pricingCalls)
 	}
-	if len(repo.sawPricingAliasIDs) != 1 || repo.sawPricingAliasIDs[0] != "hive-fast" {
-		t.Fatalf("expected pricing lookup for hive-fast, got %v", repo.sawPricingAliasIDs)
+	if len(repo.sawPricingRouteIDs) != 1 || repo.sawPricingRouteIDs[0] != "route-groq-fast" {
+		t.Fatalf("expected pricing lookup keyed by route_id route-groq-fast, got %v", repo.sawPricingRouteIDs)
 	}
 }
 
-// TestSelectRouteHandlesZeroPricingWithoutPanic covers an alias with no
-// model_aliases row (a data-inconsistency case, not a customer-facing
-// error): the repository returns the catalog.CatalogPricing zero value, and
-// SelectRoute must return it as-is rather than panic or fail the selection.
-// A missing price is "no cost basis", a verdict shadow-mode logs, not a
-// reason to break a route the routing tables already approved.
-func TestSelectRouteHandlesZeroPricingWithoutPanic(t *testing.T) {
+// TestSelectRouteFailsClosedForRouteWithNoPrice is D-032's fail-closed
+// requirement: a route with no price row is not selectable. Under the OLD
+// alias-keyed pricing this case (a missing model_aliases row) was swallowed
+// into a successful zero-value price, silently billing zero. provider_routes
+// price columns are NOT NULL for every route seeded today, so this is only
+// reachable via a repository/query failure (a future route inserted without
+// a price, a bad route_id) -- and that failure must refuse the selection,
+// the same posture as the tenant entitlement check above, not fall through
+// to a free route.
+func TestSelectRouteFailsClosedForRouteWithNoPrice(t *testing.T) {
 	repo := entitlementTestRepo()
-	// repo.pricing left at its zero value deliberately.
+	repo.pricingErr = errors.New("no price row for route")
 
 	svc := NewService(repo, &stubEntitlements{visible: true})
 
@@ -792,23 +797,54 @@ func TestSelectRouteHandlesZeroPricingWithoutPanic(t *testing.T) {
 		AliasID:             "hive-fast",
 		NeedChatCompletions: true,
 	})
-	if err != nil {
-		t.Fatalf("SelectRoute returned error for zero pricing: %v", err)
+	if err == nil {
+		t.Fatalf("expected a route with no price to refuse selection, got result %+v", result)
 	}
-	if result.Pricing.InputPriceCredits != 0 || result.Pricing.OutputPriceCredits != 0 {
-		t.Fatalf("expected zero-value pricing, got %+v", result.Pricing)
-	}
-	if result.Pricing.CacheReadPriceCredits != nil || result.Pricing.CacheWritePriceCredits != nil {
-		t.Fatalf("expected nil cache pricing pointers, got %+v", result.Pricing)
+	if !reflect.DeepEqual(result, SelectionResult{}) {
+		t.Fatalf("expected zero-value SelectionResult on failure, got %+v", result)
 	}
 }
 
-// TestSelectRoutePriceIsAliasStableAcrossFallback asserts spec decision 15:
-// price is a property of the alias, not of whichever route within it gets
-// selected as primary vs. fallback. The same alias with multiple eligible
-// routes must report one price, not a per-route price that could silently
-// vary when the fallback order changes.
-func TestSelectRoutePriceIsAliasStableAcrossFallback(t *testing.T) {
+// TestSelectRoutePriceIsRouteStableAcrossFallback is D-032's motivating case:
+// hive-fast routes to both OpenRouter llama-3.1-8b ($0.05/$0.08 per M) and
+// Groq llama-3.3-70b ($0.59/$0.79 per M) under one alias. Pricing must now
+// be a property of whichever ROUTE was actually selected, not a single
+// alias-wide number: whichever route becomes primary must bill its OWN
+// price, and swapping priority (so the other route becomes primary) must
+// change which price comes back. This replaces the old
+// TestSelectRoutePriceIsAliasStableAcrossFallback, which asserted the
+// opposite (one shared alias price regardless of route) -- that was the bug
+// D-032 fixes, not a behavior to preserve.
+func TestSelectRoutePriceIsRouteStableAcrossFallback(t *testing.T) {
+	candidates := []RouteCandidate{
+		{
+			RouteID:                 "route-groq-fast",
+			AliasID:                 "hive-fast",
+			Provider:                "groq",
+			LiteLLMModelName:        "route-groq-fast",
+			PriceClass:              "standard",
+			HealthState:             "healthy",
+			Priority:                10,
+			SupportsChatCompletions: true,
+		},
+		{
+			RouteID:                 "route-openrouter-fast-fallback",
+			AliasID:                 "hive-fast",
+			Provider:                "openrouter",
+			LiteLLMModelName:        "route-openrouter-fast-fallback",
+			PriceClass:              "standard",
+			HealthState:             "healthy",
+			Priority:                20,
+			SupportsChatCompletions: true,
+		},
+	}
+	pricingByRoute := map[string]catalog.CatalogPricing{
+		"route-groq-fast":               {InputPriceCredits: 82600, OutputPriceCredits: 110600},
+		"route-openrouter-fast-fallback": {InputPriceCredits: 7000, OutputPriceCredits: 11200},
+	}
+
+	// Groq primary (lower priority number wins): result must carry Groq's
+	// own price, not OpenRouter's and not a blended/shared number.
 	repo := &stubRepository{
 		policy: catalog.AliasPolicySnapshot{
 			AliasID:                 "hive-fast",
@@ -816,31 +852,9 @@ func TestSelectRoutePriceIsAliasStableAcrossFallback(t *testing.T) {
 			AllowPriceClassWidening: false,
 			FallbackOrder:           []string{"route-groq-fast", "route-openrouter-fast-fallback"},
 		},
-		candidates: []RouteCandidate{
-			{
-				RouteID:                 "route-groq-fast",
-				AliasID:                 "hive-fast",
-				Provider:                "groq",
-				LiteLLMModelName:        "route-groq-fast",
-				PriceClass:              "standard",
-				HealthState:             "healthy",
-				Priority:                10,
-				SupportsChatCompletions: true,
-			},
-			{
-				RouteID:                 "route-openrouter-fast-fallback",
-				AliasID:                 "hive-fast",
-				Provider:                "openrouter",
-				LiteLLMModelName:        "route-openrouter-fast-fallback",
-				PriceClass:              "standard",
-				HealthState:             "healthy",
-				Priority:                20,
-				SupportsChatCompletions: true,
-			},
-		},
-		pricing: catalog.CatalogPricing{InputPriceCredits: 8, OutputPriceCredits: 24},
+		candidates:     candidates,
+		pricingByRoute: pricingByRoute,
 	}
-
 	svc := NewService(repo, &stubEntitlements{visible: true})
 
 	result, err := svc.SelectRoute(context.Background(), SelectionInput{
@@ -853,20 +867,46 @@ func TestSelectRoutePriceIsAliasStableAcrossFallback(t *testing.T) {
 	if result.RouteID != "route-groq-fast" {
 		t.Fatalf("expected primary route-groq-fast, got %q", result.RouteID)
 	}
-	if len(result.FallbackRouteIDs) != 1 || result.FallbackRouteIDs[0] != "route-openrouter-fast-fallback" {
-		t.Fatalf("expected one fallback route-openrouter-fast-fallback, got %v", result.FallbackRouteIDs)
+	if result.Pricing.InputPriceCredits != 82600 || result.Pricing.OutputPriceCredits != 110600 {
+		t.Fatalf("expected Groq's own price 82600/110600, got %+v", result.Pricing)
 	}
-	if result.Pricing.InputPriceCredits != 8 || result.Pricing.OutputPriceCredits != 24 {
-		t.Fatalf("expected alias-level pricing 8/24 regardless of which route was primary, got %+v", result.Pricing)
+
+	// Reverse the policy's fallback order so OpenRouter becomes primary: the
+	// returned price must change to OpenRouter's, proving it is route-keyed,
+	// not cached once per alias.
+	repo2 := &stubRepository{
+		policy: catalog.AliasPolicySnapshot{
+			AliasID:                 "hive-fast",
+			PolicyMode:              "latency",
+			AllowPriceClassWidening: false,
+			FallbackOrder:           []string{"route-openrouter-fast-fallback", "route-groq-fast"},
+		},
+		candidates:     candidates,
+		pricingByRoute: pricingByRoute,
+	}
+	svc2 := NewService(repo2, &stubEntitlements{visible: true})
+
+	result2, err := svc2.SelectRoute(context.Background(), SelectionInput{
+		AliasID:             "hive-fast",
+		NeedChatCompletions: true,
+	})
+	if err != nil {
+		t.Fatalf("SelectRoute returned error on swapped priority: %v", err)
+	}
+	if result2.RouteID != "route-openrouter-fast-fallback" {
+		t.Fatalf("expected primary route-openrouter-fast-fallback, got %q", result2.RouteID)
+	}
+	if result2.Pricing.InputPriceCredits != 7000 || result2.Pricing.OutputPriceCredits != 11200 {
+		t.Fatalf("expected OpenRouter's own price 7000/11200 after priority swap, got %+v", result2.Pricing)
 	}
 }
 
 // TestSelectRoutePropagatesPricingLookupFailure matches the repo's existing
 // convention (TestSelectRoutePropagatesAliasLookupErrors): a genuine
-// infrastructure failure resolving pricing (DB unreachable, etc., as
-// distinct from "no row for this alias", which LoadAliasPricing must treat
-// as a zero-value, non-error result) surfaces to the caller rather than
-// being silently swallowed into a wrong zero price.
+// infrastructure failure resolving a route's price (DB unreachable, etc.)
+// surfaces to the caller rather than being silently swallowed into a wrong
+// zero price. Complements TestSelectRouteFailsClosedForRouteWithNoPrice,
+// which covers the missing-price-row case specifically.
 func TestSelectRoutePropagatesPricingLookupFailure(t *testing.T) {
 	repo := entitlementTestRepo()
 	repo.pricingErr = errors.New("pricing db down")

--- a/apps/control-plane/internal/routing/types.go
+++ b/apps/control-plane/internal/routing/types.go
@@ -73,21 +73,22 @@ type SelectionResult struct {
 	Provider         string   `json:"provider"`
 	FallbackRouteIDs []string `json:"fallback_route_ids"`
 
-	// Pricing is the alias's per-model credit price, read from
-	// public.model_aliases via Repository.LoadAliasPricing. It is
-	// alias-stable, not route-stable: every candidate SelectRoute could
-	// have chosen for this alias (primary or any fallback) carries the same
-	// price, so a fallback to a different route never changes it (metering
-	// step 2 design, spec decision 15).
+	// Pricing is the SELECTED ROUTE's per-route credit price (D-032), read
+	// from public.provider_routes via Repository.LoadRoutePricing. It is
+	// route-stable, not alias-stable: this is keyed by RouteID above, so a
+	// fallback to a different route under the same alias carries that
+	// route's own price, not a shared alias-wide number. This replaced the
+	// original alias-stable design (metering step 2, spec decision 15) once
+	// #617 showed one alias can route to providers whose real cost differs
+	// by an order of magnitude (hive-fast: OpenRouter vs. Groq), so no
+	// single alias-wide price could be correct for both.
 	//
 	// Additive field: an existing caller that only reads AliasID/RouteID/
 	// LiteLLMModelName/Provider/FallbackRouteIDs keeps compiling and behaves
-	// identically. A caller that reads Pricing before an alias has a
-	// model_aliases row sees the catalog.CatalogPricing zero value, which
-	// must be read as "no cost basis available", never as "free"; this
-	// step's own metering gate (edge-api internal/metering, added
-	// separately) is what turns that distinction into a shadow-mode
-	// verdict. Nothing in this package enforces or debits against it.
+	// identically. A route with no price row fails the whole SelectRoute
+	// call closed (see LoadRoutePricing) rather than returning a usable
+	// result with a zero-value Pricing, so a caller that reaches this field
+	// at all can trust it reflects a real, non-null price.
 	//
 	// The credit unit is per million tokens: charges compute as
 	// (prompt_tokens * input_price + completion_tokens * output_price) / 1_000_000
@@ -97,8 +98,12 @@ type SelectionResult struct {
 	// Per-token integer pricing misprices 347 of 365 models by 1000x or more;
 	// per-million fits all real rates and avoids repricing existing grants/invoices.
 	// Decision D-031: vault decision-2026-07-31-credit-unit-per-million.md.
-	// Issue #617 tracks catalog price correction (seeded prices are ~6 orders of magnitude too low).
-	// These are the same raw input/output/cache price fields already served today by
-	// catalog.Service for /v1/models, passed through unchanged.
+	// Issue #617 found the seeded prices themselves ~333x-7,375x too low
+	// (non-uniform, ruling out a scale-factor bug); D-032 is the resulting
+	// decision to reprice per-route. CacheReadPriceCredits/
+	// CacheWritePriceCredits are always nil here: precedence.go's billing
+	// formula never reads them, and provider_routes does not carry them.
+	// catalog.Service's own /v1/models listing is unaffected by this change
+	// and keeps serving model_aliases' cache price fields for display.
 	Pricing catalog.CatalogPricing `json:"pricing"`
 }

--- a/apps/edge-api/internal/metering/precedence_test.go
+++ b/apps/edge-api/internal/metering/precedence_test.go
@@ -236,3 +236,29 @@ func TestPriceEstimate_LegacyIsFlatTokenSum(t *testing.T) {
 		t.Errorf("legacy = %d, want 150", legacy)
 	}
 }
+
+// TestPriceEstimate_HighTokenRequestBillsCorrectedRoutePrice is #617/D-032's
+// sanity check, done right: the ~90-token sample in #617's own writeup
+// rounds to the same 1-credit floor whether priced at the old broken 8/24
+// or a corrected route price, because the floor-at-1 rule swallows the
+// whole error at that volume. A high-token request is what actually proves
+// repricing worked. Uses hive-fast's Groq route (llama-3.3-70b-versatile,
+// $0.59/$0.79 per million tokens, live 2026-07-31) at the ruled 1.4x margin:
+// 82,600 input / 110,600 output credits per million (D-032).
+func TestPriceEstimate_HighTokenRequestBillsCorrectedRoutePrice(t *testing.T) {
+	route := RouteInfo{InputPriceCredits: 82600, OutputPriceCredits: 110600}
+
+	// Hand-computed, not derived from the code under test:
+	//   (50,000*82,600 + 10,000*110,600) / 1,000,000
+	// = (4,130,000,000 + 1,106,000,000) / 1,000,000
+	// = 5,236,000,000 / 1,000,000 = 5236 exactly (no rounding).
+	// The OLD stored price (8/24) on this same request:
+	//   (50,000*8 + 10,000*24) / 1,000,000 = 640,000/1,000,000 -> floors to 1.
+	// So the pre-repricing catalog would have billed 1 credit for a request
+	// that should cost 5,236 -- the under-pricing #617 describes, visible
+	// only because this request is large enough to clear the floor.
+	_, perModel := priceEstimate(route, 50_000, 10_000, VerdictBillable)
+	if perModel != 5236 {
+		t.Fatalf("expected corrected charge 5236 credits, got %d", perModel)
+	}
+}

--- a/supabase/migrations/20260731_02_provider_route_pricing.sql
+++ b/supabase/migrations/20260731_02_provider_route_pricing.sql
@@ -1,0 +1,112 @@
+-- D-032: per-route pricing (bigint credits per million tokens), replacing
+-- alias-level model_aliases.input_price_credits/output_price_credits as
+-- billing's source of truth. Issue #617 found the seeded model_aliases
+-- values were placeholders 333x-7,375x too low against real provider rates
+-- (non-uniform ratio, ruling out a single scale-factor bug), and one alias
+-- (hive-fast) routes to providers whose real cost differs by an order of
+-- magnitude, so no single alias-wide price could ever be correct for both
+-- routes at once. model_aliases columns are left in place unchanged:
+-- catalog.Service still reads them for the customer-facing /v1/models
+-- listing, which is out of scope for this migration.
+--
+-- Margin: 1.4x provider list cost (owner ruling, D-032), applied uniformly,
+-- no per-row exceptions. All four repriced routes land on whole credit
+-- values with no rounding needed. Live prices fetched 2026-07-31:
+--   OpenRouter: GET https://openrouter.ai/api/v1/models (public, no auth),
+--   pricing.prompt / pricing.completion, USD per token.
+--   Groq: https://groq.com/pricing, USD per million tokens.
+-- CreditsPerUSD = 100,000 (apps/control-plane/internal/payments/types.go:37-38).
+--
+-- OUT OF SCOPE for this repricing (filed as a separate follow-up to #617):
+-- hive-stt, hive-tts, and hive-embedding-default's three routes.
+--   - apps/edge-api/internal/audio/handler.go bills TTS/STT with hardcoded
+--     flat credit literals (1000 / 500 per request) and never reads this
+--     column at all, so repricing these rows would change only the console
+--     catalog display, not any actual charge -- a different, larger fix.
+--   - hive-embedding-default's two OpenRouter-routed candidates have no
+--     discoverable live price: OpenRouter's public /v1/models endpoint does
+--     not cover the generic openai/ adapter path embeddings ride (see
+--     deploy/litellm/config.yaml's comments on this).
+-- Their existing model_aliases values are carried forward unchanged below so
+-- the NOT NULL constraint is satisfiable without inventing a number for a
+-- row this ruling explicitly excluded.
+--
+-- Re-verified live 2026-08-01 against the same two sources: OpenRouter's
+-- gpt-4.1-mini, gpt-4o-mini, and llama-3.1-8b-instruct prices, and Groq's
+-- llama-3.3-70b-versatile price, are unchanged from the 2026-07-31 figures
+-- below.
+--
+-- pricing_unit (D-032 as amended, CodeRabbit thread 2 on PR #632): every
+-- price row carries an explicit unit so a row can be rejected on a unit
+-- mismatch instead of silently mispriced. Every route this migration prices
+-- is a chat-completions route, hence 'tokens' for all of them, including the
+-- carried-forward STT/TTS/embedding rows above -- their real unit (D-033:
+-- characters, audio duration) is a separate migration for when #627 actually
+-- wires per-request pricing for those handlers, not invented here.
+
+alter table public.provider_routes
+    add column input_price_credits bigint,
+    add column output_price_credits bigint,
+    add column pricing_unit text;
+
+-- hive-auto: OpenRouter openai/gpt-4.1-mini, $0.40 / $1.60 per M tokens ->
+-- 40,000 / 160,000 credits per M at cost, x1.4 margin.
+update public.provider_routes set
+    input_price_credits = 56000,
+    output_price_credits = 224000
+where route_id = 'route-openrouter-auto';
+
+-- hive-default: OpenRouter openai/gpt-4o-mini, $0.15 / $0.60 per M -> 15,000
+-- / 60,000 at cost, x1.4.
+update public.provider_routes set
+    input_price_credits = 21000,
+    output_price_credits = 84000
+where route_id = 'route-openrouter-default';
+
+-- hive-fast, OpenRouter route: meta-llama/3.1-8b-instruct, $0.05 / $0.08 per
+-- M -> 5,000 / 8,000 at cost, x1.4. The cheaper of hive-fast's two routes --
+-- see the Groq route immediately below for why one alias-wide price could
+-- never cover both (this pair is D-032's motivating case).
+update public.provider_routes set
+    input_price_credits = 7000,
+    output_price_credits = 11200
+where route_id = 'route-openrouter-fast-fallback';
+
+-- hive-fast, Groq route: llama-3.3-70b-versatile, $0.59 / $0.79 per M ->
+-- 59,000 / 79,000 at cost, x1.4. Roughly 8x-12x the OpenRouter route's
+-- per-token cost under the same alias.
+update public.provider_routes set
+    input_price_credits = 82600,
+    output_price_credits = 110600
+where route_id = 'route-groq-fast';
+
+-- Out of scope (see header comment): carried forward unchanged from
+-- model_aliases so no route is left without a price.
+update public.provider_routes r set
+    input_price_credits = m.input_price_credits,
+    output_price_credits = m.output_price_credits
+from public.model_aliases m
+where r.alias_id = m.alias_id
+  and r.route_id in (
+    'route-groq-stt',
+    'route-groq-tts',
+    'route-nvidia-embedding',
+    'route-openrouter-embedding',
+    'route-openrouter-embedding-fallback'
+  );
+
+-- Every route this migration prices meters tokens.
+update public.provider_routes set pricing_unit = 'tokens';
+
+-- Fail-closed (D-032): every route seeded to date now carries a real price
+-- and a real unit, so this makes "a route with no price" and "a route with
+-- no unit" both unreachable for current data rather than merely
+-- discouraged. A future route inserted without a price or unit fails at
+-- insert time instead of silently billing as free or under the wrong unit.
+-- pricing_unit is constrained to 'tokens' only: D-033 widens this check when
+-- a non-token modality actually gets real per-request pricing, not before.
+alter table public.provider_routes
+    alter column input_price_credits set not null,
+    alter column output_price_credits set not null,
+    alter column pricing_unit set not null,
+    add constraint provider_routes_pricing_unit_check check (pricing_unit = 'tokens');


### PR DESCRIPTION
## Summary

Implements D-032 as ruled and merged in `.wolf/decisions.md` and the vault (`decision-2026-07-31-per-route-pricing.md`), closing #617.

- Credit price moves from `model_aliases` to `provider_routes`, per route, as bigint credits per million tokens with separate input and output columns.
- Adds an explicit `pricing_unit` column, `NOT NULL`, constrained to `tokens` for every currently priced route (D-033's non-token units extend this column later rather than forcing a second schema change).
- `hive-fast` carries two routes at real costs differing by roughly ten times (OpenRouter llama-3.1-8b at $0.05/$0.08 per million, Groq llama-3.3-70b at $0.59/$0.79 per million; both re-verified live 2026-08-01, unchanged from the 2026-07-31 figures). One alias-wide price could never be correct for both.
- Stored price is provider list cost times 1.4, rounded up to a whole credit per million. This rounding is authoring-time only and does not compete with D-031's round-half-up settlement in `internal/routing/precedence.go` (untouched).
- Fail-closed: every route seeded to date is backfilled with a real price and `pricing_unit` before the columns become `NOT NULL`. A future route with no price, or whose `pricing_unit` does not match what its handler meters, is rejected rather than silently mispriced.
- `Repository.LoadAliasPricing` (alias-keyed) is removed. `LoadRoutePricing` (route-keyed) filters `WHERE route_id = $1 AND pricing_unit = 'tokens'`, so a unit mismatch falls through the existing `ErrNoRows` fail-closed path with no new branch.

## Out of scope

TTS, STT, and embeddings (tracked separately, #627). `internal/audio` never reads this catalog at all; it charges flat literals (1000 credits speech, 500 transcription), so repricing those three rows would only change a console display, not any real charge. Embedding pricing has no discoverable live source since OpenRouter's public listing excludes embedding models. Their existing `model_aliases` values are carried forward unchanged in the migration so the `NOT NULL` constraint is satisfiable without inventing a number.

## Test plan

- [x] New tests written first and shown failing (RED) before implementation: `TestProviderRoutePricingMigrationAddsPricingUnitColumn`, `TestLoadRoutePricingRejectsPricingUnitMismatch`
- [x] `hive-fast`'s two routes each bill their own price (`TestSelectRoutePriceIsRouteStableAcrossFallback`)
- [x] A route with no price is not selectable (`TestSelectRouteFailsClosedForRouteWithNoPrice`)
- [x] A high-token request bills the corrected amount, hand-computed (`TestPriceEstimate_HighTokenRequestBillsCorrectedRoutePrice`, avoids the floor-at-1-credit trap that masks under-pricing at low token counts)
- [x] `go test ./apps/control-plane/...` and `./apps/edge-api/...` full suites, green
- [x] `go vet ./...` clean on both modules
- [x] Full `supabase/migrations/*.sql` chain (79 files) applied cleanly to a scratch Postgres with every production constraint present
- [x] Live negative test against that scratch DB: an insert with `pricing_unit = 'characters'` is rejected by the CHECK constraint; an insert with a `NULL` price is rejected by `NOT NULL`

Does not merge here; money-path PRs get an independent reviewer per repo convention.