### PR TITLE
feat: provision a personal tenant for self-serve signup

### DIFF
--- a/apps/control-plane/cmd/backfill-tenants/main.go
+++ b/apps/control-plane/cmd/backfill-tenants/main.go
@@ -35,6 +35,19 @@ func main() {
 		os.Exit(2)
 	}
 
+	// Deployment posture, read from the same env var
+	// platform/config.Config.LicenseFilePath reads. An operator pointing this
+	// at a Hive Enterprise database must not mint personal tenants there:
+	// Enterprise posture is that membership is administered. The sweep still
+	// runs, because retrying the billing mapping for an owner who already has
+	// a tenant is posture-neutral, but it creates nothing and reports the
+	// accounts it therefore cannot help.
+	selfServeTenants := os.Getenv("LICENSE_FILE_PATH") == ""
+	if !selfServeTenants {
+		fmt.Println("LICENSE_FILE_PATH is set, so this is a Hive Enterprise deployment:")
+		fmt.Println("no personal tenant will be created, mapping retries only.")
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
@@ -45,7 +58,7 @@ func main() {
 	}
 	defer pool.Close()
 
-	report, err := signup.BackfillPersonalTenants(ctx, pool)
+	report, err := signup.BackfillPersonalTenants(ctx, pool, selfServeTenants)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "backfill-tenants:", err)
 		os.Exit(1)

--- a/apps/control-plane/cmd/backfill-tenants/main.go
+++ b/apps/control-plane/cmd/backfill-tenants/main.go
@@ -1,0 +1,68 @@
+// Command backfill-tenants gives a tenant to every account that holds an
+// active API key but has no billing mapping, which is the state that answers
+// 403 account_not_provisioned on every request after PR #620. Issue #625.
+//
+//	SUPABASE_DB_URL=<DB_URL> go run ./apps/control-plane/cmd/backfill-tenants
+//
+// Operator run, deliberately not wired into server startup: it writes tenant
+// rows, and a tenancy write that happens automatically on every deploy is not
+// something anyone reviews. Idempotent, so re-running is safe and a second run
+// reports nothing newly provisioned.
+//
+// It calls signup.BackfillPersonalTenants, the same code path a live signup
+// runs, rather than a bespoke SQL predicate that could drift from it. Accounts
+// whose billing account is genuinely ambiguous are listed as skipped with a
+// reason and left alone: a wrong mapping is permanent and unrecoverable, and
+// is worse than a 403.
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/signup"
+)
+
+func main() {
+	dsn := os.Getenv("SUPABASE_DB_URL")
+	if dsn == "" {
+		fmt.Fprintln(os.Stderr, "backfill-tenants: SUPABASE_DB_URL is required")
+		os.Exit(2)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "backfill-tenants: connect:", err)
+		os.Exit(1)
+	}
+	defer pool.Close()
+
+	report, err := signup.BackfillPersonalTenants(ctx, pool)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "backfill-tenants:", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("provisioned %d account(s):\n", len(report.Provisioned))
+	for _, id := range report.Provisioned {
+		fmt.Printf("  %s\n", id)
+	}
+
+	skipped := make([]string, 0, len(report.Skipped))
+	for id, reason := range report.Skipped {
+		skipped = append(skipped, fmt.Sprintf("  %s  %s", id, reason))
+	}
+	sort.Strings(skipped)
+	fmt.Printf("skipped %d account(s), left unmapped on purpose:\n", len(skipped))
+	for _, line := range skipped {
+		fmt.Println(line)
+	}
+}

--- a/apps/control-plane/cmd/backfill-tenants/main.go
+++ b/apps/control-plane/cmd/backfill-tenants/main.go
@@ -4,6 +4,11 @@
 //
 //	SUPABASE_DB_URL=<DB_URL> go run ./apps/control-plane/cmd/backfill-tenants
 //
+// Hive Cloud only. It refuses to run when LICENSE_FILE_PATH is set, mirroring
+// how cmd/server/main.go derives signup.WebhookDeps.SelfServeTenants, because
+// personal tenants are a Cloud concept and Enterprise posture is that
+// membership is administered. See checkPosture.
+//
 // Operator run, deliberately not wired into server startup: it writes tenant
 // rows, and a tenancy write that happens automatically on every deploy is not
 // something anyone reviews. Idempotent, so re-running is safe and a second run
@@ -18,6 +23,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"sort"
@@ -28,6 +34,27 @@ import (
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/signup"
 )
 
+// errEnterprisePosture is returned when this command is pointed at a Hive
+// Enterprise deployment. Refusing loudly beats running a reduced sweep: an
+// operator who ran it in the wrong place needs to learn that, and a command
+// that half worked is the kind of thing nobody re-reads the output of.
+var errEnterprisePosture = errors.New(
+	"backfill-tenants: LICENSE_FILE_PATH is set, so this is a Hive Enterprise deployment.\n" +
+		"Personal tenants are a Hive Cloud concept: Enterprise posture is that membership is\n" +
+		"administered, so this command refuses to run here rather than minting tenants the\n" +
+		"deployment forbids. Unset LICENSE_FILE_PATH only if this really is a Cloud database.")
+
+// checkPosture mirrors how cmd/server/main.go derives
+// signup.WebhookDeps.SelfServeTenants from platform/config.Config.LicenseFilePath,
+// so posture keeps one source of truth. Split out from main so the refusal is
+// testable without running the command.
+func checkPosture(licenseFilePath string) error {
+	if licenseFilePath != "" {
+		return errEnterprisePosture
+	}
+	return nil
+}
+
 func main() {
 	dsn := os.Getenv("SUPABASE_DB_URL")
 	if dsn == "" {
@@ -35,17 +62,9 @@ func main() {
 		os.Exit(2)
 	}
 
-	// Deployment posture, read from the same env var
-	// platform/config.Config.LicenseFilePath reads. An operator pointing this
-	// at a Hive Enterprise database must not mint personal tenants there:
-	// Enterprise posture is that membership is administered. The sweep still
-	// runs, because retrying the billing mapping for an owner who already has
-	// a tenant is posture-neutral, but it creates nothing and reports the
-	// accounts it therefore cannot help.
-	selfServeTenants := os.Getenv("LICENSE_FILE_PATH") == ""
-	if !selfServeTenants {
-		fmt.Println("LICENSE_FILE_PATH is set, so this is a Hive Enterprise deployment:")
-		fmt.Println("no personal tenant will be created, mapping retries only.")
+	if err := checkPosture(os.Getenv("LICENSE_FILE_PATH")); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
@@ -58,7 +77,7 @@ func main() {
 	}
 	defer pool.Close()
 
-	report, err := signup.BackfillPersonalTenants(ctx, pool, selfServeTenants)
+	report, err := signup.BackfillPersonalTenants(ctx, pool, true)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "backfill-tenants:", err)
 		os.Exit(1)

--- a/apps/control-plane/cmd/backfill-tenants/main_test.go
+++ b/apps/control-plane/cmd/backfill-tenants/main_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// The command must refuse to run against a Hive Enterprise deployment. Without
+// this gate it reaches signup.ensurePersonalTenant, which writes
+// deployment = 'HIVE_CLOUD', so an operator pointing it at an Enterprise
+// database would mint tenants that Enterprise posture forbids and mislabel
+// them on the way in. Raised independently by two reviewers on PR #644.
+func TestCheckPostureRefusesEnterpriseDeployment(t *testing.T) {
+	err := checkPosture("/etc/hive/license.jwt")
+	if err == nil {
+		t.Fatal("expected a refusal when LICENSE_FILE_PATH is set")
+	}
+	// The operator has to learn WHY, otherwise a refusal is just a failure.
+	for _, want := range []string{"LICENSE_FILE_PATH", "Hive Enterprise", "refuses to run"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("refusal message must explain itself, missing %q in:\n%s", want, err)
+		}
+	}
+}
+
+// Cloud posture (no license file) must still run. Asserted so the fix above
+// cannot silently disable the backfill entirely, which would leave the
+// locked-out accounts from #625 unfixed while looking healthy.
+func TestCheckPostureAllowsCloudDeployment(t *testing.T) {
+	if err := checkPosture(""); err != nil {
+		t.Fatalf("Hive Cloud posture must run the backfill, got refusal: %v", err)
+	}
+}

--- a/apps/control-plane/cmd/server/main.go
+++ b/apps/control-plane/cmd/server/main.go
@@ -592,7 +592,14 @@ func main() {
 				// Disposable-domain backstop (issue #116) for scripted signups
 				// that hit Supabase directly and bypass the web-console precheck.
 				DisposableCheck: disposableBlocklist.IsDisposableEmail,
-				SharedSecret:    signupSecret,
+				// Personal-tenant provisioning for a signup no tenant claims
+				// (issue #625). Hive Cloud only. An empty LicenseFilePath is
+				// already the switch that selects licensing.CloudSource over
+				// licensing.FileSource below, so posture keeps one source of
+				// truth rather than gaining a second flag that can disagree
+				// with the first.
+				SelfServeTenants: cfg.LicenseFilePath == "",
+				SharedSecret:     signupSecret,
 			}
 			signupWebhook = signup.NewWebhook(signupDeps)
 			// Second entry point into the same provisioning implementation, for

--- a/apps/control-plane/internal/signup/personal_tenant.go
+++ b/apps/control-plane/internal/signup/personal_tenant.go
@@ -97,6 +97,13 @@ func (p *Provisioner) provisionSelfServeTenant(
 // A read that finds nothing after a conflict means the slug collided with a
 // tenant that is not this user's personal tenant. That cannot happen for a
 // uuid-derived slug, so it is reported as an error rather than papered over.
+//
+// deployment is hardcoded HIVE_CLOUD, and that is safe by construction rather
+// than by assumption: both callers are gated on the self-serve posture flag
+// (Reconcile on WebhookDeps.SelfServeTenants, BackfillPersonalTenants on its
+// selfServeTenants argument), which is only ever true on Hive Cloud. A
+// personal tenant is therefore never written to an ENTERPRISE_EDGE deployment,
+// so there is no posture for this column to get wrong.
 func ensurePersonalTenant(ctx context.Context, pool *pgxpool.Pool, userID uuid.UUID) (uuid.UUID, error) {
 	if pool == nil {
 		return uuid.Nil, errors.New("signup: nil pool")
@@ -198,7 +205,16 @@ type BackfillReport struct {
 //
 // Safe to re-run: an account that acquired a mapping is no longer a candidate,
 // and the partial unique index makes a repeat tenant insert a no-op.
-func BackfillPersonalTenants(ctx context.Context, pool *pgxpool.Pool) (BackfillReport, error) {
+// selfServeTenants carries the SAME deployment posture the live path reads
+// from WebhookDeps.SelfServeTenants. It must, or the backfill would become a
+// way to mint personal tenants on a Hive Enterprise database, where posture
+// says membership is administered, and to label them HIVE_CLOUD on top. When
+// it is false the sweep still runs, because retrying the mapping for an owner
+// who ALREADY has a tenant is posture-neutral and useful on every deployment
+// (EnsureTenantBillingAccount has never filtered on tenants.deployment); it
+// simply never creates a tenant, and reports the accounts it therefore cannot
+// help.
+func BackfillPersonalTenants(ctx context.Context, pool *pgxpool.Pool, selfServeTenants bool) (BackfillReport, error) {
 	report := BackfillReport{Skipped: map[uuid.UUID]string{}}
 	if pool == nil {
 		return report, errors.New("signup: nil pool")
@@ -241,9 +257,13 @@ func BackfillPersonalTenants(ctx context.Context, pool *pgxpool.Pool) (BackfillR
 			continue
 		}
 
-		tenantID, err := backfillTenantFor(ctx, pool, c.ownerID)
+		tenantID, err := backfillTenantFor(ctx, pool, c.ownerID, selfServeTenants)
 		if err != nil {
 			return report, fmt.Errorf("signup: resolve tenant for account %s: %w", c.accountID, err)
+		}
+		if tenantID == uuid.Nil {
+			report.Skipped[c.accountID] = "personal_tenant_disabled_for_deployment"
+			continue
 		}
 
 		mapped, reason, err := EnsureTenantBillingAccount(ctx, pool, tenantID)
@@ -290,7 +310,12 @@ func BackfillPersonalTenants(ctx context.Context, pool *pgxpool.Pool) (BackfillR
 // still not the same as choosing the mapping: EnsureTenantBillingAccount
 // applies its own conservative predicate to whatever tenant comes back, and
 // refuses if that tenant's members do not converge on a single account.
-func backfillTenantFor(ctx context.Context, pool *pgxpool.Pool, ownerID uuid.UUID) (uuid.UUID, error) {
+// Returns uuid.Nil with a nil error when the owner has no tenant and
+// selfServeTenants is false: on Hive Enterprise there is no tenant to give
+// them, and inventing one would violate the administered-membership posture.
+func backfillTenantFor(
+	ctx context.Context, pool *pgxpool.Pool, ownerID uuid.UUID, selfServeTenants bool,
+) (uuid.UUID, error) {
 	var tenantID uuid.UUID
 	err := pool.QueryRow(ctx, `
 		SELECT tu.tenant_id
@@ -307,6 +332,9 @@ func backfillTenantFor(ctx context.Context, pool *pgxpool.Pool, ownerID uuid.UUI
 	}
 	if !errors.Is(err, pgx.ErrNoRows) {
 		return uuid.Nil, fmt.Errorf("read existing tenant: %w", err)
+	}
+	if !selfServeTenants {
+		return uuid.Nil, nil
 	}
 
 	tenantID, err = ensurePersonalTenant(ctx, pool, ownerID)

--- a/apps/control-plane/internal/signup/personal_tenant.go
+++ b/apps/control-plane/internal/signup/personal_tenant.go
@@ -1,0 +1,320 @@
+package signup
+
+// Personal-tenant provisioning (issue #625).
+//
+// Reconcile's original invariant was that it never creates a tenant: it only
+// attaches a user to a tenant that already claims them, by unconsumed invite
+// token or by verified email domain. That invariant is deliberately relaxed
+// here, and only here, for one case: a Hive Cloud signup that no tenant
+// claims. Such a user used to reach OutcomeNoTenant and stay there forever,
+// which was merely "unentitled" until PR #620 made API-key tenant resolution
+// fail closed, at which point it became "every request 403s, permanently".
+//
+// The relaxation is narrow by construction:
+//
+//   - Resolution still runs FIRST. An invite token or a registered email
+//     domain still wins, so invite-based and domain-based attachment are
+//     byte-for-byte unchanged and a personal tenant is only ever minted when
+//     neither matched.
+//   - It is gated on WebhookDeps.SelfServeTenants, which is false for Hive
+//     Enterprise, whose posture is that membership is administered.
+//   - It creates a tenant of one, which "one org equals one tenant" (D-007)
+//     already covers. It is not a new tenancy concept.
+//
+// Billing mapping is deliberately NOT reimplemented here. The existing
+// two-call-site convergence (Provisioner.ensureTenantBillingAccount and
+// accounts.Service.provisionDefaultWorkspace, both calling the conservative
+// EnsureTenantBillingAccount) already maps whichever half of the
+// tenant_users/account_memberships pairing lands second, in either order. A
+// signup whose account does not exist yet is simply mapped later, by the
+// console visit that creates it.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/audit"
+)
+
+// personalTenantName is the display name every personal tenant carries. It is
+// deliberately not derived from the user's name or email: tenants.name is
+// readable wherever a tenant is listed, and an email local part there would
+// spread an identifier that belongs in auth.users alone.
+const personalTenantName = "Personal workspace"
+
+// provisionSelfServeTenant handles the Hive Cloud no-match case: mint the
+// user's personal tenant, then run the same provision() the invite and domain
+// paths run, so membership, billing mapping, audit events and Open WebUI group
+// wiring are identical no matter which path produced the tenant.
+//
+// Audit classification mirrors the rest of Reconcile: the event carries a
+// fixed stage and error string, never the raw database error, which may embed
+// SQL fragments or DSN substrings that auditor_ro must not read.
+func (p *Provisioner) provisionSelfServeTenant(
+	ctx context.Context, in ReconcileInput, emailToken, emailDomain string,
+) (Outcome, error) {
+	tenantID, err := ensurePersonalTenant(ctx, p.deps.Pool, in.UserID)
+	if err != nil {
+		log.Printf("signup: personal tenant provisioning failed user=%s: %v",
+			in.UserID, fmt.Errorf("personal_tenant_db: %w", err))
+		_ = p.deps.Audit.Log(ctx, audit.Event{
+			Actor:    audit.Actor{ID: in.UserID, Type: audit.ActorUser},
+			Action:   "AUTH_SIGNIN_FAILURE_NO_TENANT",
+			Severity: audit.SeverityError,
+			Before: map[string]string{"email_sha256": emailToken, "domain": emailDomain,
+				"stage": "personal_tenant", "error": "personal_tenant_db"},
+		})
+		return OutcomeNoTenant, fmt.Errorf("signup: provision personal tenant: %w", err)
+	}
+
+	if err := p.provision(ctx, tenantID, in, emailToken, emailDomain); err != nil {
+		log.Printf("signup: provision failed user=%s tenant=%s: %v",
+			in.UserID, tenantID, fmt.Errorf("provision_db: %w", err))
+		return OutcomeNoTenant, fmt.Errorf("signup: provision membership: %w", err)
+	}
+	return OutcomeProvisioned, nil
+}
+
+// ensurePersonalTenant is the single writer of a personal tenant, shared by
+// the live signup path and BackfillPersonalTenants so the two cannot drift.
+//
+// Concurrency is resolved by the DATABASE, not by a check-then-act here. The
+// slug is derived from userID, so concurrent callers for the same user collide
+// on tenants_slug_key, and the partial unique index
+// tenants_personal_owner_user_id_key (migration
+// 20260801_10_tenants_personal_owner.sql) independently rejects a second
+// personal tenant for that user. A bare ON CONFLICT DO NOTHING covers both
+// without having to guess which index Postgres checks first. The loser inserts
+// nothing, reads the winner's row, and returns the same id, so eight racing
+// callers produce exactly one tenant.
+//
+// A read that finds nothing after a conflict means the slug collided with a
+// tenant that is not this user's personal tenant. That cannot happen for a
+// uuid-derived slug, so it is reported as an error rather than papered over.
+func ensurePersonalTenant(ctx context.Context, pool *pgxpool.Pool, userID uuid.UUID) (uuid.UUID, error) {
+	if pool == nil {
+		return uuid.Nil, errors.New("signup: nil pool")
+	}
+	if userID == uuid.Nil {
+		return uuid.Nil, errors.New("signup: personal tenant requires a user id")
+	}
+
+	slug := "personal-" + userID.String()
+
+	var tenantID uuid.UUID
+	err := pool.QueryRow(ctx, `
+		INSERT INTO public.tenants (slug, name, deployment, personal_owner_user_id)
+		VALUES ($1, $2, 'HIVE_CLOUD', $3)
+		ON CONFLICT DO NOTHING
+		RETURNING id
+	`, slug, personalTenantName, userID).Scan(&tenantID)
+	if err == nil {
+		return tenantID, nil
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return uuid.Nil, fmt.Errorf("insert personal tenant: %w", err)
+	}
+
+	// Lost the race (or already provisioned on an earlier call). Read the
+	// winner's row.
+	err = pool.QueryRow(ctx, `
+		SELECT id FROM public.tenants WHERE personal_owner_user_id = $1
+	`, userID).Scan(&tenantID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return uuid.Nil, fmt.Errorf("personal tenant slug %q is taken by another tenant", slug)
+	}
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("read personal tenant: %w", err)
+	}
+	return tenantID, nil
+}
+
+// insertPersonalMembership attaches userID to tenantID.
+//
+// Role is MEMBER, matching (*Provisioner).provision, and that is deliberate
+// even though the user is the only member of their own tenant. OWNER would be
+// the intuitive choice, but public.custom_access_token_hook remaps an OWNER
+// role to owui_role ADMIN for Open WebUI's OAUTH_ROLES_CLAIM, so making every
+// self-serve signup an OWNER would silently make every self-serve signup an
+// Open WebUI administrator. Workspace-level authority already lives on
+// public.account_memberships, where the same user is 'owner' of their own
+// account, so nothing is lost by keeping the tenant role minimal.
+func insertPersonalMembership(ctx context.Context, pool *pgxpool.Pool, tenantID, userID uuid.UUID) error {
+	_, err := pool.Exec(ctx, `
+		INSERT INTO public.tenant_users(tenant_id, user_id, role, status)
+		VALUES ($1, $2, 'MEMBER', 'ACTIVE')
+		ON CONFLICT DO NOTHING
+	`, tenantID, userID)
+	if err != nil {
+		return fmt.Errorf("insert tenant_users: %w", err)
+	}
+	return nil
+}
+
+// BackfillReport records what a BackfillPersonalTenants sweep did, keyed by
+// account id. Skipped carries a reason per account precisely because those
+// accounts are the ones an operator has to look at: they stay locked out, and
+// a wrong mapping would be permanent and unrecoverable, so they are reported
+// rather than guessed.
+type BackfillReport struct {
+	// Provisioned lists accounts that resolve a tenant after the sweep, and
+	// therefore now pass PR #620's fail-closed API-key gate.
+	Provisioned []uuid.UUID
+	// Skipped maps an account left unmapped to the reason it was left alone.
+	Skipped map[uuid.UUID]string
+}
+
+// BackfillPersonalTenants gives a tenant to every account that holds an
+// active API key but has no billing mapping, which is the state that answers
+// 403 account_not_provisioned on every request after PR #620.
+//
+// It runs the SAME mechanism the live signup path runs (ensurePersonalTenant
+// then EnsureTenantBillingAccount) rather than a bespoke SQL predicate. That
+// is the point: PR #624's backfill migration refused to map accounts it could
+// not resolve unambiguously, and that guard was correct, so the fix is to make
+// a tenant exist rather than to widen the predicate that decides which tenant
+// an account belongs to.
+//
+// Two cases, both conservative:
+//
+//   - The owner already holds an ACTIVE tenant membership. No second tenant is
+//     minted. The sweep retries EnsureTenantBillingAccount against the tenant
+//     they already have, which is the same call both live call sites make, and
+//     which frequently succeeds now because the account side of the pairing
+//     has since landed.
+//   - The owner holds no tenant at all. A personal tenant is created for them,
+//     exactly as a fresh Hive Cloud signup would now get.
+//
+// In both cases the mapping itself is still decided by
+// EnsureTenantBillingAccount, so an owner whose accounts are genuinely
+// ambiguous (two active account memberships, no single billing answer) is left
+// UNMAPPED with a reason. A wrong mapping is worse than a 403.
+//
+// Safe to re-run: an account that acquired a mapping is no longer a candidate,
+// and the partial unique index makes a repeat tenant insert a no-op.
+func BackfillPersonalTenants(ctx context.Context, pool *pgxpool.Pool) (BackfillReport, error) {
+	report := BackfillReport{Skipped: map[uuid.UUID]string{}}
+	if pool == nil {
+		return report, errors.New("signup: nil pool")
+	}
+
+	type candidate struct{ accountID, ownerID uuid.UUID }
+
+	rows, err := pool.Query(ctx, `
+		SELECT DISTINCT a.id, a.owner_user_id
+		  FROM public.accounts a
+		  JOIN public.api_keys k
+		    ON k.account_id = a.id
+		   AND k.status = 'active'
+		 WHERE NOT EXISTS (
+		       SELECT 1 FROM public.tenant_billing_accounts tba
+		        WHERE tba.account_id = a.id
+		 )
+		 ORDER BY a.id
+	`)
+	if err != nil {
+		return report, fmt.Errorf("signup: list backfill candidates: %w", err)
+	}
+	var candidates []candidate
+	for rows.Next() {
+		var c candidate
+		if err := rows.Scan(&c.accountID, &c.ownerID); err != nil {
+			rows.Close()
+			return report, fmt.Errorf("signup: scan backfill candidate: %w", err)
+		}
+		candidates = append(candidates, c)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return report, fmt.Errorf("signup: read backfill candidates: %w", err)
+	}
+
+	for _, c := range candidates {
+		if c.ownerID == uuid.Nil {
+			report.Skipped[c.accountID] = "no_owner_identity"
+			continue
+		}
+
+		tenantID, err := backfillTenantFor(ctx, pool, c.ownerID)
+		if err != nil {
+			return report, fmt.Errorf("signup: resolve tenant for account %s: %w", c.accountID, err)
+		}
+
+		mapped, reason, err := EnsureTenantBillingAccount(ctx, pool, tenantID)
+		if err != nil {
+			return report, fmt.Errorf("signup: map billing account %s: %w", c.accountID, err)
+		}
+		if !mapped {
+			report.Skipped[c.accountID] = reason
+			continue
+		}
+		// The tenant is mapped, but confirm it is mapped to THIS account
+		// before reporting this account unblocked. A tenant whose owner has
+		// several accounts maps to one of them, and the others stay locked
+		// out and must be reported as such.
+		var mine bool
+		if err := pool.QueryRow(ctx, `
+			SELECT EXISTS (
+				SELECT 1 FROM public.tenant_billing_accounts
+				 WHERE tenant_id = $1 AND account_id = $2
+			)
+		`, tenantID, c.accountID).Scan(&mine); err != nil {
+			return report, fmt.Errorf("signup: confirm mapping for account %s: %w", c.accountID, err)
+		}
+		if !mine {
+			report.Skipped[c.accountID] = "tenant_already_billed_by_another_account"
+			continue
+		}
+		report.Provisioned = append(report.Provisioned, c.accountID)
+	}
+
+	return report, nil
+}
+
+// backfillTenantFor returns the tenant a backfill candidate's owner should
+// bill to: the ACTIVE tenant they already belong to if there is one, otherwise
+// a freshly provisioned personal tenant. Never mints a second tenant for an
+// owner who already has one.
+//
+// The ORDER BY is not an arbitrary tie-break. public.custom_access_token_hook
+// selects a multi-tenant user's default tenant with exactly this ordering
+// (joined_at ASC, tenant_id ASC), so the tenant chosen here is the one that
+// user's token already carries by default. Picking any other row would bill an
+// account to a tenant the user is not acting under. Choosing the tenant is
+// still not the same as choosing the mapping: EnsureTenantBillingAccount
+// applies its own conservative predicate to whatever tenant comes back, and
+// refuses if that tenant's members do not converge on a single account.
+func backfillTenantFor(ctx context.Context, pool *pgxpool.Pool, ownerID uuid.UUID) (uuid.UUID, error) {
+	var tenantID uuid.UUID
+	err := pool.QueryRow(ctx, `
+		SELECT tu.tenant_id
+		  FROM public.tenant_users tu
+		  JOIN public.tenants t ON t.id = tu.tenant_id
+		 WHERE tu.user_id     = $1
+		   AND tu.status      = 'ACTIVE'
+		   AND t.archived_at IS NULL
+		 ORDER BY tu.joined_at ASC, tu.tenant_id ASC
+		 LIMIT 1
+	`, ownerID).Scan(&tenantID)
+	if err == nil {
+		return tenantID, nil
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return uuid.Nil, fmt.Errorf("read existing tenant: %w", err)
+	}
+
+	tenantID, err = ensurePersonalTenant(ctx, pool, ownerID)
+	if err != nil {
+		return uuid.Nil, err
+	}
+	if err := insertPersonalMembership(ctx, pool, tenantID, ownerID); err != nil {
+		return uuid.Nil, err
+	}
+	return tenantID, nil
+}

--- a/apps/control-plane/internal/signup/personal_tenant_test.go
+++ b/apps/control-plane/internal/signup/personal_tenant_test.go
@@ -1,0 +1,549 @@
+package signup_test
+
+// Personal-tenant provisioning (issue #625).
+//
+// Every test here runs against the full migration chain via HIVE_TEST_DB_URL.
+// The DB-level guarantee under test is the partial unique index
+// tenants(personal_owner_user_id), so a fixture schema missing that index (or
+// missing the auth.users foreign keys the seeds depend on) would pass while
+// production fails, which is exactly the failure mode these tests exist to
+// prevent. PR #624 shipped a test that went green locally while violating
+// tenant_users_user_id_fkey, because the local container lacked the key.
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/apikeys"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/audit"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/signup"
+)
+
+// selfServeFixture is a Provisioner whose resolver never matches: no invite
+// token, no registered email domain. That is precisely the self-serve signup
+// #625 describes, the one that used to end at OutcomeNoTenant forever.
+type selfServeFixture struct {
+	prov   *signup.Provisioner
+	userID uuid.UUID
+	email  string
+}
+
+func newSelfServeFixture(t *testing.T, ctx context.Context, pool *pgxpool.Pool, selfServe bool) *selfServeFixture {
+	t.Helper()
+
+	email := "selfserve-" + uuid.NewString()[:8] + "@unclaimed.example"
+	userID := mustInsertAuthUser(t, ctx, pool, email)
+	ptCleanupUser(t, pool, userID)
+
+	noMatch := func(ctx context.Context, key string) (uuid.UUID, error) { return uuid.Nil, signup.ErrNoMatch }
+
+	return &selfServeFixture{
+		userID: userID,
+		email:  email,
+		prov: signup.NewProvisioner(signup.WebhookDeps{
+			Pool:     pool,
+			Resolver: signup.NewResolver(signup.ResolverDeps{InviteLookup: noMatch, DomainLookup: noMatch}),
+			Audit: audit.NewLogger(audit.LoggerDeps{
+				Sync: audit.NewSyncWriter(pool, audit.WriterConfig{DeploySHA: "s", Env: "test"}),
+				WAL:  &noopWAL{},
+			}),
+			EnsureGroup:      func(ctx context.Context, name string) (string, error) { return "grp-" + name, nil },
+			AddUser:          func(ctx context.Context, groupID, email string) error { return nil },
+			SelfServeTenants: selfServe,
+			SharedSecret:     "shh",
+		}),
+	}
+}
+
+// ptCleanupUser drops the personal tenant before the auth user, so the
+// tenants.personal_owner_user_id reference never blocks teardown.
+func ptCleanupUser(t *testing.T, pool *pgxpool.Pool, userID uuid.UUID) {
+	t.Helper()
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(),
+			`DELETE FROM public.tenants WHERE personal_owner_user_id = $1`, userID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM auth.users WHERE id = $1`, userID)
+	})
+}
+
+// ptAccount seeds an account owned by ownerID with ownerID as an ACTIVE
+// member, which is the shape accounts.Service.provisionDefaultWorkspace
+// produces and the shape EnsureTenantBillingAccount can resolve.
+func ptAccount(t *testing.T, ctx context.Context, pool *pgxpool.Pool, ownerID uuid.UUID) uuid.UUID {
+	t.Helper()
+	id := uuid.New()
+	_, err := pool.Exec(ctx,
+		`INSERT INTO public.accounts(id, slug, display_name, account_type, owner_user_id)
+		 VALUES ($1, $2, $2, 'personal', $3)`,
+		id, "pt-acct-"+uuid.NewString()[:8], ownerID)
+	require.NoError(t, err)
+	t.Cleanup(func() { _, _ = pool.Exec(context.Background(), `DELETE FROM public.accounts WHERE id = $1`, id) })
+
+	_, err = pool.Exec(ctx,
+		`INSERT INTO public.account_memberships(account_id, user_id, role, status)
+		 VALUES ($1, $2, 'owner', 'active')`, id, ownerID)
+	require.NoError(t, err)
+	return id
+}
+
+// ptAPIKey seeds an active, unrevoked key on accountID: the state that makes
+// an unmapped account a live 403 rather than a dormant row.
+func ptAPIKey(t *testing.T, ctx context.Context, pool *pgxpool.Pool, accountID, createdBy uuid.UUID) {
+	t.Helper()
+	sum := sha256.Sum256([]byte("pt-" + uuid.NewString()))
+	id := uuid.New()
+	_, err := pool.Exec(ctx,
+		`INSERT INTO public.api_keys(id, account_id, nickname, token_hash, redacted_suffix, status, created_by_user_id)
+		 VALUES ($1, $2, 'pt-key', $3, 'abcd', 'active', $4)`,
+		id, accountID, hex.EncodeToString(sum[:]), createdBy)
+	require.NoError(t, err)
+	t.Cleanup(func() { _, _ = pool.Exec(context.Background(), `DELETE FROM public.api_keys WHERE id = $1`, id) })
+}
+
+func ptPersonalTenants(t *testing.T, ctx context.Context, pool *pgxpool.Pool, userID uuid.UUID) int {
+	t.Helper()
+	var n int
+	require.NoError(t, pool.QueryRow(ctx,
+		`SELECT count(*) FROM public.tenants WHERE personal_owner_user_id = $1`, userID).Scan(&n))
+	return n
+}
+
+func ptTenantOf(t *testing.T, ctx context.Context, pool *pgxpool.Pool, userID uuid.UUID) (uuid.UUID, bool) {
+	t.Helper()
+	var id uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`SELECT id FROM public.tenants WHERE personal_owner_user_id = $1`, userID).Scan(&id); err != nil {
+		return uuid.Nil, false
+	}
+	return id, true
+}
+
+func ptMappedAccount(t *testing.T, ctx context.Context, pool *pgxpool.Pool, tenantID uuid.UUID) (uuid.UUID, bool) {
+	t.Helper()
+	var acct uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`SELECT account_id FROM public.tenant_billing_accounts WHERE tenant_id = $1`, tenantID).Scan(&acct); err != nil {
+		return uuid.Nil, false
+	}
+	return acct, true
+}
+
+// (a) A fresh self-serve signup ends with a tenant AND a billing mapping.
+// Before #625 this user reached OutcomeNoTenant and stayed there forever, so
+// every API key on their account answered 403 account_not_provisioned once
+// PR #620 made tenant resolution fail closed.
+func TestReconcileProvisionsPersonalTenantForSelfServeSignup(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	pool := newPool(t, ctx)
+	t.Cleanup(func() { pool.Close() })
+
+	fx := newSelfServeFixture(t, ctx, pool, true)
+	accountID := ptAccount(t, ctx, pool, fx.userID)
+
+	outcome, err := fx.prov.Reconcile(ctx, signup.ReconcileInput{UserID: fx.userID, Email: fx.email})
+	require.NoError(t, err)
+	require.Equal(t, signup.OutcomeProvisioned, outcome)
+
+	tenantID, ok := ptTenantOf(t, ctx, pool, fx.userID)
+	require.True(t, ok, "self-serve signup must end with a personal tenant")
+	require.Equal(t, 1, countMemberships(t, ctx, pool, fx.userID))
+	require.Equal(t, "ACTIVE", membershipStatus(t, ctx, pool, fx.userID, tenantID))
+
+	mapped, ok := ptMappedAccount(t, ctx, pool, tenantID)
+	require.True(t, ok, "the new tenant must be mapped to the owner's billing account")
+	require.Equal(t, accountID, mapped)
+}
+
+// (b) Running provisioning twice is a no-op, asserted on row counts rather
+// than on the returned outcome: a second tenant would be invisible to an
+// outcome-only assertion.
+func TestReconcilePersonalTenantIsIdempotent(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	pool := newPool(t, ctx)
+	t.Cleanup(func() { pool.Close() })
+
+	fx := newSelfServeFixture(t, ctx, pool, true)
+	ptAccount(t, ctx, pool, fx.userID)
+	in := signup.ReconcileInput{UserID: fx.userID, Email: fx.email}
+
+	for i := 0; i < 3; i++ {
+		outcome, err := fx.prov.Reconcile(ctx, in)
+		require.NoError(t, err)
+		require.Equal(t, signup.OutcomeProvisioned, outcome)
+	}
+
+	require.Equal(t, 1, ptPersonalTenants(t, ctx, pool, fx.userID))
+	require.Equal(t, 1, countMemberships(t, ctx, pool, fx.userID))
+}
+
+// (c) Two concurrent provisioning attempts produce exactly ONE tenant. This is
+// the test that proves the partial unique index on
+// tenants(personal_owner_user_id) rather than a check-then-act in Go: with
+// application-level checking only, both callers read "no tenant" and both
+// insert, and the loser of that race is a permanent duplicate tenant with its
+// own billing identity and its own entitlement surface.
+func TestReconcilePersonalTenantConcurrentCallsCreateExactlyOneTenant(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 40*time.Second)
+	defer cancel()
+	pool := newPool(t, ctx)
+	t.Cleanup(func() { pool.Close() })
+
+	fx := newSelfServeFixture(t, ctx, pool, true)
+	ptAccount(t, ctx, pool, fx.userID)
+	in := signup.ReconcileInput{UserID: fx.userID, Email: fx.email}
+
+	const racers = 8
+	var wg sync.WaitGroup
+	errs := make([]error, racers)
+	start := make(chan struct{})
+	for i := 0; i < racers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			_, errs[i] = fx.prov.Reconcile(ctx, in)
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i, err := range errs {
+		require.NoError(t, err, "racer %d", i)
+	}
+	require.Equal(t, 1, ptPersonalTenants(t, ctx, pool, fx.userID))
+	require.Equal(t, 1, countMemberships(t, ctx, pool, fx.userID))
+}
+
+// (d) An account with genuinely ambiguous ownership is left UNMAPPED rather
+// than guessed. The user is an ACTIVE member of two different accounts, so
+// there is no single answer to "which account bills this tenant". PR #624's
+// guard must survive: the tenant is still created (the user needs one to
+// authenticate at all) but no mapping is invented.
+func TestReconcilePersonalTenantLeavesAmbiguousOwnershipUnmapped(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	pool := newPool(t, ctx)
+	t.Cleanup(func() { pool.Close() })
+
+	fx := newSelfServeFixture(t, ctx, pool, true)
+	ptAccount(t, ctx, pool, fx.userID)
+	ptAccount(t, ctx, pool, fx.userID)
+
+	outcome, err := fx.prov.Reconcile(ctx, signup.ReconcileInput{UserID: fx.userID, Email: fx.email})
+	require.NoError(t, err)
+	require.Equal(t, signup.OutcomeProvisioned, outcome)
+
+	tenantID, ok := ptTenantOf(t, ctx, pool, fx.userID)
+	require.True(t, ok)
+	_, mapped := ptMappedAccount(t, ctx, pool, tenantID)
+	require.False(t, mapped, "two candidate accounts must never be resolved by guessing one")
+}
+
+// Enterprise posture: nothing fires. Membership on a customer-hosted
+// deployment is administered, so a self-serve signup with no invite and no
+// domain match must still end at OutcomeNoTenant with no tenant written.
+func TestReconcileDoesNotCreatePersonalTenantWhenSelfServeDisabled(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	pool := newPool(t, ctx)
+	t.Cleanup(func() { pool.Close() })
+
+	fx := newSelfServeFixture(t, ctx, pool, false)
+
+	outcome, err := fx.prov.Reconcile(ctx, signup.ReconcileInput{UserID: fx.userID, Email: fx.email})
+	require.NoError(t, err)
+	require.Equal(t, signup.OutcomeNoTenant, outcome)
+	require.Equal(t, 0, ptPersonalTenants(t, ctx, pool, fx.userID))
+	require.Equal(t, 0, countMemberships(t, ctx, pool, fx.userID))
+}
+
+// Invite and domain attachment behaviour is unchanged: a user whose email
+// domain IS registered still joins that existing tenant, and no personal
+// tenant is minted alongside it.
+func TestReconcileStillPrefersDomainMatchOverPersonalTenant(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	pool := newPool(t, ctx)
+	t.Cleanup(func() { pool.Close() })
+
+	fx := newReconcileFixture(t, ctx, pool)
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(),
+			`DELETE FROM public.tenants WHERE personal_owner_user_id = $1`, fx.userID)
+	})
+
+	outcome, err := fx.prov.Reconcile(ctx, signup.ReconcileInput{UserID: fx.userID, Email: fx.email})
+	require.NoError(t, err)
+	require.Equal(t, signup.OutcomeProvisioned, outcome)
+
+	require.Equal(t, 1, countMemberships(t, ctx, pool, fx.userID))
+	require.Equal(t, "ACTIVE", membershipStatus(t, ctx, pool, fx.userID, fx.tenantID))
+	require.Equal(t, 0, ptPersonalTenants(t, ctx, pool, fx.userID),
+		"a domain-matched user belongs to the org tenant, never to a personal one as well")
+}
+
+// ORG-MEMBERSHIP SEMANTICS, enforced rather than merely documented.
+//
+// The question #625 requires answering: what happens to an account whose
+// owning user is later added to a real organization tenant. The answer is
+// STAYS. The account keeps billing to its personal tenant permanently, and the
+// user simply gains a second tenant_users row for the org.
+//
+// Why "stays" and not "moves": public.tenant_billing_accounts is UNIQUE on
+// account_id and keyed on tenant_id, so an account can fund exactly one tenant
+// and "belongs to both" is not representable. Re-pointing the mapping would
+// retroactively re-attribute every credit and usage row already recorded under
+// the personal tenant into the organization, which is the exact leak of one
+// organization's usage into another that this design must prevent. Ledgers are
+// append only, so there is no correct way to move history.
+func TestPersonalTenantAndItsBillingMappingSurviveLaterOrgMembership(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	pool := newPool(t, ctx)
+	t.Cleanup(func() { pool.Close() })
+
+	fx := newSelfServeFixture(t, ctx, pool, true)
+	personalAccount := ptAccount(t, ctx, pool, fx.userID)
+
+	_, err := fx.prov.Reconcile(ctx, signup.ReconcileInput{UserID: fx.userID, Email: fx.email})
+	require.NoError(t, err)
+	personalTenant, ok := ptTenantOf(t, ctx, pool, fx.userID)
+	require.True(t, ok)
+	mapped, ok := ptMappedAccount(t, ctx, pool, personalTenant)
+	require.True(t, ok)
+	require.Equal(t, personalAccount, mapped)
+
+	// An administrator later adds this user to a real organization tenant.
+	orgTenant := mustInsertTenant(t, ctx, pool, "pt-org-"+uuid.NewString()[:8], "HIVE_CLOUD")
+	t.Cleanup(func() { _, _ = pool.Exec(context.Background(), `DELETE FROM public.tenants WHERE id = $1`, orgTenant) })
+	_, err = pool.Exec(ctx,
+		`INSERT INTO public.tenant_users(tenant_id, user_id, role, status) VALUES ($1, $2, 'MEMBER', 'ACTIVE')`,
+		orgTenant, fx.userID)
+	require.NoError(t, err)
+
+	// Reconcile runs again (console revisit, webhook redelivery). It must not
+	// move, duplicate, or re-point anything.
+	_, err = fx.prov.Reconcile(ctx, signup.ReconcileInput{UserID: fx.userID, Email: fx.email})
+	require.NoError(t, err)
+
+	stillMapped, ok := ptMappedAccount(t, ctx, pool, personalTenant)
+	require.True(t, ok, "the personal tenant keeps its billing mapping")
+	require.Equal(t, personalAccount, stillMapped, "the account must never be re-pointed at the org tenant")
+
+	_, orgClaimed := ptMappedAccount(t, ctx, pool, orgTenant)
+	require.False(t, orgClaimed,
+		"the org tenant must not acquire the user's personal account as its billing account")
+
+	require.Equal(t, 1, ptPersonalTenants(t, ctx, pool, fx.userID), "still exactly one personal tenant")
+	require.Equal(t, 2, countMemberships(t, ctx, pool, fx.userID),
+		"identity membership is many, billing attribution is one")
+}
+
+// (e) After the backfill, an API-key request from a previously locked-out
+// account resolves a tenant instead of failing closed. The assertion runs
+// through apikeys.Repository.GetTenantIDByAccountID, which is the exact lookup
+// PR #620 fails closed on (403 account_not_provisioned), so a pass here means
+// the real gate opens, not merely that a row exists somewhere.
+func TestBackfillPersonalTenantsUnblocksLockedOutAPIKeyAccount(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	pool := newPool(t, ctx)
+	t.Cleanup(func() { pool.Close() })
+
+	userID := mustInsertAuthUser(t, ctx, pool, "locked-"+uuid.NewString()[:8]+"@unclaimed.example")
+	ptCleanupUser(t, pool, userID)
+	accountID := ptAccount(t, ctx, pool, userID)
+	ptAPIKey(t, ctx, pool, accountID, userID)
+
+	repo := apikeys.NewPgxRepository(pool)
+	before, err := repo.GetTenantIDByAccountID(ctx, accountID)
+	require.NoError(t, err)
+	require.Equal(t, uuid.Nil, before, "precondition: the account is locked out (403 account_not_provisioned)")
+
+	report, err := signup.BackfillPersonalTenants(ctx, pool)
+	require.NoError(t, err)
+	require.Contains(t, report.Provisioned, accountID)
+
+	after, err := repo.GetTenantIDByAccountID(ctx, accountID)
+	require.NoError(t, err)
+	require.NotEqual(t, uuid.Nil, after, "backfilled account must now resolve a tenant")
+
+	tenantID, ok := ptTenantOf(t, ctx, pool, userID)
+	require.True(t, ok)
+	require.Equal(t, tenantID, after)
+}
+
+// The backfill reuses the live mapping mechanism rather than a bespoke rule.
+// An owner who ALREADY holds an active tenant membership must never be given a
+// second tenant; the backfill instead retries EnsureTenantBillingAccount on
+// the tenant they already have, which is the same call the live path makes.
+func TestBackfillPersonalTenantsMapsExistingTenantInsteadOfMintingSecond(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	pool := newPool(t, ctx)
+	t.Cleanup(func() { pool.Close() })
+
+	userID := mustInsertAuthUser(t, ctx, pool, "hastenant-"+uuid.NewString()[:8]+"@unclaimed.example")
+	ptCleanupUser(t, pool, userID)
+
+	orgTenant := mustInsertTenant(t, ctx, pool, "pt-has-"+uuid.NewString()[:8], "HIVE_CLOUD")
+	t.Cleanup(func() { _, _ = pool.Exec(context.Background(), `DELETE FROM public.tenants WHERE id = $1`, orgTenant) })
+	_, err := pool.Exec(ctx,
+		`INSERT INTO public.tenant_users(tenant_id, user_id, role, status) VALUES ($1, $2, 'MEMBER', 'ACTIVE')`,
+		orgTenant, userID)
+	require.NoError(t, err)
+
+	accountID := ptAccount(t, ctx, pool, userID)
+	ptAPIKey(t, ctx, pool, accountID, userID)
+
+	report, err := signup.BackfillPersonalTenants(ctx, pool)
+	require.NoError(t, err)
+	require.Contains(t, report.Provisioned, accountID)
+
+	require.Equal(t, 0, ptPersonalTenants(t, ctx, pool, userID),
+		"an owner who already has a tenant must not be given a second one")
+	mapped, ok := ptMappedAccount(t, ctx, pool, orgTenant)
+	require.True(t, ok, "the existing tenant is what gets mapped")
+	require.Equal(t, accountID, mapped)
+}
+
+// Ambiguity survives the backfill too. An owner with no tenant and TWO active
+// account memberships has no single billing answer, so the backfill leaves the
+// account unmapped and reports a reason rather than guessing. A wrong mapping
+// is permanent and is worse than a 403.
+func TestBackfillPersonalTenantsLeavesAmbiguousAccountUnmappedWithReason(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	pool := newPool(t, ctx)
+	t.Cleanup(func() { pool.Close() })
+
+	userID := mustInsertAuthUser(t, ctx, pool, "ambig-"+uuid.NewString()[:8]+"@unclaimed.example")
+	ptCleanupUser(t, pool, userID)
+	first := ptAccount(t, ctx, pool, userID)
+	second := ptAccount(t, ctx, pool, userID)
+	ptAPIKey(t, ctx, pool, first, userID)
+	ptAPIKey(t, ctx, pool, second, userID)
+
+	report, err := signup.BackfillPersonalTenants(ctx, pool)
+	require.NoError(t, err)
+
+	require.NotContains(t, report.Provisioned, first)
+	require.NotContains(t, report.Provisioned, second)
+	require.Contains(t, report.Skipped, first, "an ambiguous account is reported, never guessed")
+	require.NotEmpty(t, report.Skipped[first], "a skip must carry a reason an operator can act on")
+
+	tenantID, ok := ptTenantOf(t, ctx, pool, userID)
+	require.True(t, ok, "the user still gets a tenant so they can authenticate")
+	_, mapped := ptMappedAccount(t, ctx, pool, tenantID)
+	require.False(t, mapped, "but no billing mapping is invented")
+}
+
+// A second account owned by someone whose tenant is ALREADY billed by their
+// first account stays locked out and is reported, never silently counted as
+// provisioned. EnsureTenantBillingAccount answers "mapped" for that tenant
+// because a mapping exists, but it maps a DIFFERENT account, so the backfill
+// has to confirm the mapping is to the account it is currently sweeping.
+// Without that confirmation the sweep would report an account unblocked while
+// its every request still returns 403.
+func TestBackfillPersonalTenantsReportsAccountWhoseTenantIsBilledByAnother(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	pool := newPool(t, ctx)
+	t.Cleanup(func() { pool.Close() })
+
+	userID := mustInsertAuthUser(t, ctx, pool, "second-"+uuid.NewString()[:8]+"@unclaimed.example")
+	ptCleanupUser(t, pool, userID)
+
+	tenantID := mustInsertTenant(t, ctx, pool, "pt-billed-"+uuid.NewString()[:8], "HIVE_CLOUD")
+	t.Cleanup(func() { _, _ = pool.Exec(context.Background(), `DELETE FROM public.tenants WHERE id = $1`, tenantID) })
+	_, err := pool.Exec(ctx,
+		`INSERT INTO public.tenant_users(tenant_id, user_id, role, status) VALUES ($1, $2, 'MEMBER', 'ACTIVE')`,
+		tenantID, userID)
+	require.NoError(t, err)
+
+	billing := ptAccount(t, ctx, pool, userID)
+	_, err = pool.Exec(ctx,
+		`INSERT INTO public.tenant_billing_accounts(tenant_id, account_id) VALUES ($1, $2)`,
+		tenantID, billing)
+	require.NoError(t, err)
+
+	// A second account owned by the same user, key-bearing and unmapped.
+	secondAccount := ptAccount(t, ctx, pool, userID)
+	ptAPIKey(t, ctx, pool, secondAccount, userID)
+
+	report, err := signup.BackfillPersonalTenants(ctx, pool)
+	require.NoError(t, err)
+
+	require.NotContains(t, report.Provisioned, secondAccount,
+		"an account whose tenant is billed by a different account is not unblocked")
+	require.Contains(t, report.Skipped, secondAccount)
+	require.Equal(t, 0, ptPersonalTenants(t, ctx, pool, userID),
+		"the owner already has a tenant, so no personal tenant is minted")
+}
+
+// Re-running the backfill changes nothing: the same partial unique index that
+// makes the concurrent case safe makes the repeat case a no-op.
+func TestBackfillPersonalTenantsIsIdempotent(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	pool := newPool(t, ctx)
+	t.Cleanup(func() { pool.Close() })
+
+	userID := mustInsertAuthUser(t, ctx, pool, "twice-"+uuid.NewString()[:8]+"@unclaimed.example")
+	ptCleanupUser(t, pool, userID)
+	accountID := ptAccount(t, ctx, pool, userID)
+	ptAPIKey(t, ctx, pool, accountID, userID)
+
+	first, err := signup.BackfillPersonalTenants(ctx, pool)
+	require.NoError(t, err)
+	require.Contains(t, first.Provisioned, accountID)
+
+	second, err := signup.BackfillPersonalTenants(ctx, pool)
+	require.NoError(t, err)
+	require.NotContains(t, second.Provisioned, accountID)
+	require.Equal(t, 1, ptPersonalTenants(t, ctx, pool, userID))
+}
+
+// The partial unique index is the load-bearing constraint. Assert it directly,
+// so a migration that drops or widens it fails here rather than silently
+// re-opening the duplicate-tenant race the Go code relies on it to close.
+func TestTenantsPersonalOwnerUniqueIndexRejectsASecondPersonalTenant(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	pool := newPool(t, ctx)
+	t.Cleanup(func() { pool.Close() })
+
+	var isUnique bool
+	err := pool.QueryRow(ctx, `
+		SELECT i.indisunique
+		  FROM pg_index i
+		  JOIN pg_class c ON c.oid = i.indexrelid
+		 WHERE c.relname = 'tenants_personal_owner_user_id_key'
+	`).Scan(&isUnique)
+	require.NoError(t, err, "migration must create tenants_personal_owner_user_id_key")
+	require.True(t, isUnique)
+
+	userID := mustInsertAuthUser(t, ctx, pool, "dup-"+uuid.NewString()[:8]+"@unclaimed.example")
+	ptCleanupUser(t, pool, userID)
+
+	insert := func() error {
+		_, err := pool.Exec(ctx,
+			`INSERT INTO public.tenants(slug, name, deployment, personal_owner_user_id)
+			 VALUES ($1, $1, 'HIVE_CLOUD', $2)`, "dup-"+uuid.NewString()[:8], userID)
+		return err
+	}
+	require.NoError(t, insert())
+	err = insert()
+	require.Error(t, err, "a second personal tenant for one user must be rejected by the database")
+	require.Contains(t, err.Error(), "tenants_personal_owner_user_id_key")
+}

--- a/apps/control-plane/internal/signup/personal_tenant_test.go
+++ b/apps/control-plane/internal/signup/personal_tenant_test.go
@@ -370,7 +370,7 @@ func TestBackfillPersonalTenantsUnblocksLockedOutAPIKeyAccount(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, uuid.Nil, before, "precondition: the account is locked out (403 account_not_provisioned)")
 
-	report, err := signup.BackfillPersonalTenants(ctx, pool)
+	report, err := signup.BackfillPersonalTenants(ctx, pool, true)
 	require.NoError(t, err)
 	require.Contains(t, report.Provisioned, accountID)
 
@@ -406,7 +406,7 @@ func TestBackfillPersonalTenantsMapsExistingTenantInsteadOfMintingSecond(t *test
 	accountID := ptAccount(t, ctx, pool, userID)
 	ptAPIKey(t, ctx, pool, accountID, userID)
 
-	report, err := signup.BackfillPersonalTenants(ctx, pool)
+	report, err := signup.BackfillPersonalTenants(ctx, pool, true)
 	require.NoError(t, err)
 	require.Contains(t, report.Provisioned, accountID)
 
@@ -434,7 +434,7 @@ func TestBackfillPersonalTenantsLeavesAmbiguousAccountUnmappedWithReason(t *test
 	ptAPIKey(t, ctx, pool, first, userID)
 	ptAPIKey(t, ctx, pool, second, userID)
 
-	report, err := signup.BackfillPersonalTenants(ctx, pool)
+	report, err := signup.BackfillPersonalTenants(ctx, pool, true)
 	require.NoError(t, err)
 
 	require.NotContains(t, report.Provisioned, first)
@@ -481,7 +481,7 @@ func TestBackfillPersonalTenantsReportsAccountWhoseTenantIsBilledByAnother(t *te
 	secondAccount := ptAccount(t, ctx, pool, userID)
 	ptAPIKey(t, ctx, pool, secondAccount, userID)
 
-	report, err := signup.BackfillPersonalTenants(ctx, pool)
+	report, err := signup.BackfillPersonalTenants(ctx, pool, true)
 	require.NoError(t, err)
 
 	require.NotContains(t, report.Provisioned, secondAccount,
@@ -489,6 +489,65 @@ func TestBackfillPersonalTenantsReportsAccountWhoseTenantIsBilledByAnother(t *te
 	require.Contains(t, report.Skipped, secondAccount)
 	require.Equal(t, 0, ptPersonalTenants(t, ctx, pool, userID),
 		"the owner already has a tenant, so no personal tenant is minted")
+}
+
+// The backfill carries the same deployment posture gate the live path carries.
+// On Hive Enterprise it must not mint a personal tenant, because Enterprise
+// posture is that membership is administered, and a tenant created there would
+// also be mislabelled HIVE_CLOUD. The account is reported instead. Without this
+// the backfill would be a way around the gate Reconcile enforces.
+func TestBackfillPersonalTenantsCreatesNothingWhenSelfServeDisabled(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	pool := newPool(t, ctx)
+	t.Cleanup(func() { pool.Close() })
+
+	userID := mustInsertAuthUser(t, ctx, pool, "ent-"+uuid.NewString()[:8]+"@unclaimed.example")
+	ptCleanupUser(t, pool, userID)
+	accountID := ptAccount(t, ctx, pool, userID)
+	ptAPIKey(t, ctx, pool, accountID, userID)
+
+	report, err := signup.BackfillPersonalTenants(ctx, pool, false)
+	require.NoError(t, err)
+
+	require.NotContains(t, report.Provisioned, accountID)
+	require.Contains(t, report.Skipped, accountID)
+	require.Equal(t, "personal_tenant_disabled_for_deployment", report.Skipped[accountID])
+	require.Equal(t, 0, ptPersonalTenants(t, ctx, pool, userID),
+		"Enterprise posture must never gain a personal tenant via the backfill")
+	require.Equal(t, 0, countMemberships(t, ctx, pool, userID))
+}
+
+// With self-serve disabled the sweep is still useful: an owner who ALREADY has
+// a tenant gets their billing mapping retried, which is posture-neutral and
+// works on every deployment.
+func TestBackfillPersonalTenantsStillMapsExistingTenantWhenSelfServeDisabled(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	pool := newPool(t, ctx)
+	t.Cleanup(func() { pool.Close() })
+
+	userID := mustInsertAuthUser(t, ctx, pool, "entmap-"+uuid.NewString()[:8]+"@unclaimed.example")
+	ptCleanupUser(t, pool, userID)
+
+	tenantID := mustInsertTenant(t, ctx, pool, "pt-ent-"+uuid.NewString()[:8], "ENTERPRISE_EDGE")
+	t.Cleanup(func() { _, _ = pool.Exec(context.Background(), `DELETE FROM public.tenants WHERE id = $1`, tenantID) })
+	_, err := pool.Exec(ctx,
+		`INSERT INTO public.tenant_users(tenant_id, user_id, role, status) VALUES ($1, $2, 'MEMBER', 'ACTIVE')`,
+		tenantID, userID)
+	require.NoError(t, err)
+
+	accountID := ptAccount(t, ctx, pool, userID)
+	ptAPIKey(t, ctx, pool, accountID, userID)
+
+	report, err := signup.BackfillPersonalTenants(ctx, pool, false)
+	require.NoError(t, err)
+
+	require.Contains(t, report.Provisioned, accountID)
+	mapped, ok := ptMappedAccount(t, ctx, pool, tenantID)
+	require.True(t, ok)
+	require.Equal(t, accountID, mapped)
+	require.Equal(t, 0, ptPersonalTenants(t, ctx, pool, userID))
 }
 
 // Re-running the backfill changes nothing: the same partial unique index that
@@ -504,11 +563,11 @@ func TestBackfillPersonalTenantsIsIdempotent(t *testing.T) {
 	accountID := ptAccount(t, ctx, pool, userID)
 	ptAPIKey(t, ctx, pool, accountID, userID)
 
-	first, err := signup.BackfillPersonalTenants(ctx, pool)
+	first, err := signup.BackfillPersonalTenants(ctx, pool, true)
 	require.NoError(t, err)
 	require.Contains(t, first.Provisioned, accountID)
 
-	second, err := signup.BackfillPersonalTenants(ctx, pool)
+	second, err := signup.BackfillPersonalTenants(ctx, pool, true)
 	require.NoError(t, err)
 	require.NotContains(t, second.Provisioned, accountID)
 	require.Equal(t, 1, ptPersonalTenants(t, ctx, pool, userID))

--- a/apps/control-plane/internal/signup/reconcile.go
+++ b/apps/control-plane/internal/signup/reconcile.go
@@ -26,10 +26,13 @@ package signup
 //   - ViewerHandler (POST /api/v1/viewer/tenant-provision), which the console
 //     calls on the first authenticated request from a tenant-less user.
 //
-// Reconcile never creates a tenant. It only attaches a user to a tenant that
-// already claims them, by unconsumed invite token or by verified email domain,
-// which is the behaviour Resolver has always implemented. See the Reconcile
-// doc comment for why that is the right posture in both deployment modes.
+// Reconcile attaches a user to a tenant that already claims them, by
+// unconsumed invite token or by verified email domain, which is the behaviour
+// Resolver has always implemented. When neither matches AND the deployment is
+// Hive Cloud, it now also provisions a personal tenant for that user rather
+// than leaving them tenant-less forever (issue #625); see personal_tenant.go
+// for why that relaxation is narrow and where the concurrency guarantee comes
+// from. On Hive Enterprise nothing is created and the outcome is unchanged.
 
 import (
 	"context"
@@ -97,26 +100,26 @@ func NewProvisioner(deps WebhookDeps) *Provisioner { return &Provisioner{deps: d
 //  2. The disposable-domain backstop runs before any resolution or write.
 //  3. Resolver attaches to an existing tenant, or reports ErrNoMatch.
 //
-// Deployment posture. Reconcile does not auto-create a tenant in either mode,
-// so it needs no posture branch. That is not a simplification, it is the
-// existing behaviour of this package: Resolver has only ever performed
-// read-only lookups against tenant_invites and tenant_email_domains, and the
-// sole production writer of public.tenants is the operator-run
-// scripts/seed-demo-owner.py. Attaching only to a tenant that already claims
-// the user is the safe default in the customer-hosted posture, where
-// membership is administered, and it is unchanged from what Hive Cloud does
-// today. Should self-serve tenant creation ever be wanted in the hosted
-// posture only, the existing switch to branch on is
-// platform/config.Config.LicenseFilePath, which already selects
-// licensing.FileSource (Hive Enterprise) over licensing.CloudSource (Hive
-// Cloud); no new flag is needed for that either.
+// Deployment posture. WebhookDeps.SelfServeTenants branches step 3's
+// no-match case. On Hive Cloud a signup that no tenant claims is an org of
+// one and gets a personal tenant, because leaving it tenant-less is now a
+// permanent 403 rather than merely an absent entitlement (issue #625, and PR
+// #620 for the fail-closed gate that made it fatal). On Hive Enterprise,
+// whose posture is that membership is administered, nothing is created and
+// the outcome stays OutcomeNoTenant exactly as before. The flag is derived in
+// cmd/server/main.go from platform/config.Config.LicenseFilePath, the same
+// switch that already selects licensing.FileSource (Hive Enterprise) over
+// licensing.CloudSource (Hive Cloud), so posture has one source of truth.
 //
 // Concurrency. Two callers racing for the same user both fall through the
 // short-circuit, both resolve to the same tenant because resolution is a pure
 // function of the invite token and the email domain, and both insert. The
 // tenant_users primary key (tenant_id, user_id) plus ON CONFLICT DO NOTHING
 // makes the second insert a no-op, so the outcome is exactly one membership.
-// No tenant is created on either path, so no race can produce two tenants.
+// On the personal-tenant path the tenant itself is created too, and the race
+// there is settled by the database rather than by any check in Go: see
+// ensurePersonalTenant, which relies on the partial unique index
+// tenants_personal_owner_user_id_key.
 //
 // A nil error with OutcomeNoTenant is a successful determination, not a
 // failure. Only transient or unexpected faults return a non-nil error.
@@ -174,6 +177,13 @@ func (p *Provisioner) Reconcile(ctx context.Context, in ReconcileInput) (Outcome
 	tenantID, err := p.deps.Resolver.Resolve(ctx, Input{Email: in.Email, InviteToken: in.InviteToken})
 	if err != nil {
 		if errors.Is(err, ErrNoMatch) {
+			// No existing tenant claims this user. On Hive Cloud that is a
+			// self-serve signup and gets a personal tenant (issue #625);
+			// resolution above ran first, so an invite or a registered email
+			// domain still wins and this only ever fires when neither matched.
+			if p.deps.SelfServeTenants {
+				return p.provisionSelfServeTenant(ctx, in, emailToken, emailDomain)
+			}
 			_ = p.deps.Audit.Log(ctx, audit.Event{
 				Actor:    audit.Actor{ID: in.UserID, Type: audit.ActorUser},
 				Action:   "AUTH_SIGNIN_FAILURE_NO_TENANT",

--- a/apps/control-plane/internal/signup/webhook.go
+++ b/apps/control-plane/internal/signup/webhook.go
@@ -55,7 +55,16 @@ type WebhookDeps struct {
 	Audit       *audit.Logger
 	// DisposableCheck is an optional disposable-domain backstop (issue #116).
 	DisposableCheck DisposableCheckFunc
-	SharedSecret    string
+	// SelfServeTenants enables personal-tenant provisioning for a signup that
+	// no existing tenant claims (issue #625). True on Hive Cloud, where an
+	// account signing itself up is an org of one and must end up usable. False
+	// on Hive Enterprise, whose posture is that membership is administered, so
+	// an unclaimed signup stays at OutcomeNoTenant exactly as before. Wired in
+	// cmd/server/main.go from the same switch that already picks
+	// licensing.CloudSource over licensing.FileSource, so there is no second
+	// source of truth for deployment posture.
+	SelfServeTenants bool
+	SharedSecret     string
 }
 
 // Webhook implements http.Handler for POST /internal/auth/user-created.

--- a/supabase/migrations/20260801_10_tenants_personal_owner.sql
+++ b/supabase/migrations/20260801_10_tenants_personal_owner.sql
@@ -1,0 +1,78 @@
+-- supabase/migrations/20260801_10_tenants_personal_owner.sql
+--
+-- Issue #625: a self-serve signup with no unconsumed invite and no verified
+-- email domain match never got a tenant, permanently. Once PR #620 made
+-- API-key tenant resolution fail closed (403 account_not_provisioned), those
+-- accounts stopped being merely unentitled and became unusable. Measured live
+-- on 2026-07-31: eleven accounts holding active, unrevoked API keys had no
+-- tenant mapping, and one of them last transacted at the exact minute the
+-- credit ledger stopped recording.
+--
+-- The ruling on #625 is that self-serve signup provisions a PERSONAL tenant: a
+-- tenant of one, not a new tenancy concept, because "one org equals one
+-- tenant" (D-007) already covers a solo user as an org of one. This migration
+-- adds the one piece of schema that ruling needs, and nothing else.
+--
+-- personal_owner_user_id marks a tenant as the personal tenant of exactly one
+-- user, and the partial unique index is what makes provisioning safe under
+-- concurrency. Two simultaneous provisioning calls (a Supabase Database
+-- Webhook redelivery racing the console's own POST
+-- /api/v1/viewer/tenant-provision, or two browser tabs) both read "this user
+-- has no tenant" and both insert. A check-then-act in Go loses that race and
+-- leaves a permanent duplicate tenant, each with its own billing identity and
+-- its own entitlement surface. With this index the loser's INSERT ... ON
+-- CONFLICT DO NOTHING matches nothing and it re-reads the winner's row
+-- instead, so exactly one tenant exists no matter how many callers raced.
+-- PR #624 fixed one convergence bug of exactly this shape, so the risk is
+-- proven rather than theoretical.
+--
+-- The index is PARTIAL so it constrains only personal tenants. Every tenant
+-- created any other way (the operator script, an invite-based org tenant)
+-- keeps personal_owner_user_id NULL, and NULLs are unconstrained, so nothing
+-- about existing tenants changes.
+--
+-- Billing semantics this column encodes: public.tenant_billing_accounts is
+-- UNIQUE on account_id and keyed on tenant_id, so an account funds exactly one
+-- tenant. A user later added to a real organization tenant therefore keeps
+-- their personal tenant and their personal account's mapping unchanged, and
+-- simply gains a second public.tenant_users row. Re-pointing an existing
+-- mapping would retroactively re-attribute credit and usage history from the
+-- personal tenant into the organization, and the ledger is append only.
+--
+-- Deliberately NOT here:
+--   * No backfill of the existing locked-out accounts. That is done by
+--     apps/control-plane/internal/signup.BackfillPersonalTenants, so it runs
+--     the same conservative rule the live provisioning path runs rather than a
+--     second, bespoke SQL rule that can drift from it. See #624 for what
+--     happens when a mapping rule is guessed rather than proven.
+--   * No CREATE EXTENSION. It is not needed here, and on a project where the
+--     extension files are absent from the filesystem, CREATE EXTENSION IF NOT
+--     EXISTS raises and aborts the whole transaction.
+--   * No new GRANT. public.tenants is written today only by connections that
+--     bypass RLS (the live control-plane DSN authenticates as a role with
+--     rolbypassrls, which is also why the existing public.tenant_users writes
+--     in signup work with only a SELECT grant to hive_app). Adding an INSERT
+--     grant plus an RLS policy for a role that does not perform this write
+--     would be speculative surface, not protection.
+--
+-- Safely re-runnable: every statement is IF NOT EXISTS. The live migration
+-- tracker (supabase_migrations.schema_migrations) is known to be out of sync
+-- with what has actually been applied, so re-runnability is a requirement here
+-- rather than a nicety.
+--
+-- Depends on: 20260516_01_phase19_tenants.sql (public.tenants).
+
+BEGIN;
+
+ALTER TABLE public.tenants
+  ADD COLUMN IF NOT EXISTS personal_owner_user_id uuid
+  REFERENCES auth.users(id) ON DELETE SET NULL;
+
+COMMENT ON COLUMN public.tenants.personal_owner_user_id IS
+  'Non-null only on a personal (single-user) tenant created by self-serve signup, naming the user it belongs to. Unique among non-null values, so a user has at most one personal tenant. ON DELETE SET NULL rather than CASCADE: deleting an auth user must never cascade into a tenant that owns billing and usage history.';
+
+CREATE UNIQUE INDEX IF NOT EXISTS tenants_personal_owner_user_id_key
+  ON public.tenants(personal_owner_user_id)
+  WHERE personal_owner_user_id IS NOT NULL;
+
+COMMIT;


### PR DESCRIPTION
Closes #625. Builds on #620 (fail-closed API-key tenant gate) and #624 (mapping race fix).

## The problem

`signup.Provisioner.Reconcile` only ever attached a user to a tenant that already claimed them, by unconsumed invite token or by verified email domain. When neither matched it returned `OutcomeNoTenant`, permanently, and no other code path wrote `public.tenants`. That was survivable while a tenant-less account was merely unentitled. PR #620 made API-key tenant resolution fail closed with 403 `account_not_provisioned`, which turned it into "every request from that account fails, forever".

PR #624's backfill was right to leave these accounts alone. It refuses to map an account when there is no unambiguous tenant candidate, because a wrong mapping is permanent. The problem was never the predicate: there was no tenant to map to, because signup never created one.

## What this adds

**Provisioning lives in `Reconcile`**, at the `ErrNoMatch` branch, extracted into `provisionSelfServeTenant`. That is the single implementation both entry points already share (the Supabase webhook and the console's `POST /api/v1/viewer/tenant-provision`), so neither can drift. Resolution still runs first, so invite-based and domain-based attachment are unchanged and a personal tenant is only ever minted when neither matched.

The package doc previously stated "Reconcile never creates a tenant". That invariant is changed deliberately, and the doc is updated rather than left to lie.

**Deployment posture** is gated on `WebhookDeps.SelfServeTenants`, derived in `cmd/server/main.go` from `cfg.LicenseFilePath == ""`, the same switch that already selects `licensing.CloudSource` over `licensing.FileSource`. Posture keeps one source of truth. Hive Enterprise, whose posture is that membership is administered, creates nothing and still returns `OutcomeNoTenant`. This is the branch D-023 requires.

**A tenant of one, not a tenant per key.** D-007 already treats a solo user as an org of one, so a personal tenant is not a new tenancy concept.

**Billing mapping is not reimplemented.** The existing two-call-site convergence (`Provisioner.ensureTenantBillingAccount` and `accounts.Service.provisionDefaultWorkspace`, both calling the conservative `EnsureTenantBillingAccount` from #624) already maps whichever half of the `tenant_users` / `account_memberships` pairing lands second, in either order. A signup whose account does not exist yet is mapped later by the console visit that creates it.

## The database-level constraint

Migration `20260801_10_tenants_personal_owner.sql` adds `tenants.personal_owner_user_id` with a **partial unique index** `tenants_personal_owner_user_id_key ... WHERE personal_owner_user_id IS NOT NULL`. Partial, so it constrains only personal tenants and every existing tenant keeps a NULL there, unconstrained.

`ensurePersonalTenant` contains **no check-then-act**. It goes straight to `INSERT ... ON CONFLICT DO NOTHING RETURNING id`, and on conflict re-reads the winner's row. The slug is derived from the user id, so racing callers collide on `tenants_slug_key` as well; a bare `ON CONFLICT DO NOTHING` covers both without guessing which index Postgres checks first.

This was verified by removing it, not merely asserted. With both unique guards dropped, `TestReconcilePersonalTenantConcurrentCallsCreateExactlyOneTenant` fails with **6 tenants created from 8 concurrent callers**. With them restored it passes. The constraint is load-bearing.

## What happens when the owning user later joins a real organization tenant

**The account stays on its personal tenant. Permanently.**

- *Belongs to both* is not representable. `tenant_billing_accounts` is `UNIQUE (account_id)` and keyed on `tenant_id`, so an account funds exactly one tenant.
- *Moves* is wrong and is not implemented. Re-pointing the mapping would retroactively re-attribute every credit and usage row already recorded under the personal tenant into the organization, which is precisely the leak of one organization's usage into another that this design must prevent. The ledger is append only, so there is no correct way to move that history. `EnsureTenantBillingAccount` short-circuits on `alreadyMapped`, so no code path re-points an existing mapping.
- What *does* happen: the user gains an additional `tenant_users` row for the org. **Identity membership is many; billing attribution is one per account and immutable.** An organization that wants to pay for that user's work invites them to an organization-owned *account*, whose own mapping points at the organization's tenant.

One consequence worth stating explicitly: `custom_access_token_hook` orders memberships by `joined_at ASC, tenant_id ASC` and falls back to the first. A personal tenant is created at signup, so it has the earlier `joined_at` and remains the default tenant claim. The org tenant appears in the `tenants[]` claim and becomes active through the existing `selected_tenant_id` mechanism.

This is enforced, not just documented, by `TestPersonalTenantAndItsBillingMappingSurviveLaterOrgMembership`.

## Backfill

`signup.BackfillPersonalTenants` sweeps accounts that hold an active API key and have no billing mapping, running the same `ensurePersonalTenant` and `EnsureTenantBillingAccount` the live path runs, not a bespoke query. Operator-run via `apps/control-plane/cmd/backfill-tenants`, deliberately not wired into server startup: it writes tenancy rows, and a write that happens automatically on every deploy is not one anyone reviews. It is idempotent.

Where the owner already holds an active tenant, no second tenant is minted; the sweep retries the mapping against the tenant they already have. Where ownership is genuinely ambiguous the account is left **unmapped and reported with a reason**, because a wrong mapping is worse than a 403.

The sweep carries the **same posture gate as the live path**. Two reviewers independently flagged that without it the backfill would be a way around the gate `Reconcile` enforces, and would label an Enterprise tenant `HIVE_CLOUD`. Two layers now:

- The **command refuses to run** when `LICENSE_FILE_PATH` is set, exiting non-zero with a message that explains why. It reads that variable exactly as `cmd/server/main.go` derives `SelfServeTenants` from `platform/config.Config.LicenseFilePath`, so posture keeps one source of truth. Refusing beats a reduced sweep: a command that half worked is the kind of thing nobody re-reads the output of.
- `BackfillPersonalTenants` still takes `selfServeTenants` independently, so the library cannot mint a personal tenant on Enterprise even if some future caller skips the command.

That also makes the hardcoded `HIVE_CLOUD` in `ensurePersonalTenant` safe by construction rather than by assumption: every caller is gated, so a personal tenant is never written to an `ENTERPRISE_EDGE` deployment. Threading a deployment value through would advertise support for a posture the function must never run under.

### Measured against the live database, read only

The population is now **12** accounts, not 11 (one more has accumulated since the 2026-07-31 measurement, which is itself evidence that signup keeps minting unusable accounts).

| Outcome | Accounts | Why |
| --- | --- | --- |
| Resolve cleanly | **4** | Owner has no tenant at all. A personal tenant is created and maps to their single account. |
| Skipped, reported | 6 | Owner already has a tenant whose ACTIVE members span 2 or 4 distinct accounts. No single billing answer. |
| Skipped, reported | 2 | Owner's tenant still has a member with no active account membership, so it has not converged. |

Every account in #625's actual population, meaning those with no tenant at all, resolves. All 8 skipped accounts already have a tenant, so they are #624's ambiguity class rather than this issue's, and they are left alone by design.

### Honest note on the CI smoke key

I could not determine which key `secrets.HIVE_API_KEY` holds, and did not try to read the secret. Of the candidate keys currently unmapped and active:

- `ci-fixture-2026-07-28b`, on an account whose owner has no tenant, **is fixed by this PR**.
- The `live-smoke-*` keys, on `e2e-verified-workspace` and `e2e-verified-owner-s-workspace`, are **not**. Their owner already has a tenant whose members span several accounts, so the mapping is genuinely ambiguous and the sweep refuses it.

If `Live integration` uses a `live-smoke-*` key, this PR alone will not turn it green; that account needs an explicit operator decision about which account bills that tenant. Loosening the guard to make CI green is exactly the band-aid #624 exists to prevent.

## Tests

TDD, written before the implementation. First run failed to compile on `unknown field SelfServeTenants` and `undefined: signup.BackfillPersonalTenants`.

Covering the required cases: (a) fresh signup ends with tenant and mapping; (b) running twice is a no-op, asserted on row counts; (c) 8 concurrent attempts produce exactly one tenant, and fail without the DB constraint; (d) ambiguous ownership stays unmapped, preserving #624's guard; (e) a previously locked-out account resolves a tenant through `apikeys.Repository.GetTenantIDByAccountID`, the exact lookup #620 fails closed on. Plus Enterprise posture on the live path, the library backfill, and the command itself (`TestCheckPostureRefusesEnterpriseDeployment` asserts it refuses and that the message names the cause; `TestCheckPostureAllowsCloudDeployment` asserts Cloud posture still runs, so the gate cannot silently disable the backfill and leave #625's locked-out accounts unfixed while looking healthy). Plus unchanged domain-match behaviour, the org-membership semantics above, the backfill's skip and idempotency paths, and a direct assertion that the partial unique index exists and rejects a duplicate.

The operator command was also run end to end against a scratch database: it provisioned the seeded locked-out account, produced the expected rows (`slug=personal-<uuid>`, `name=Personal workspace`, `deployment=HIVE_CLOUD`, membership `MEMBER`/`ACTIVE`, one mapping row), and a second run reported `provisioned 0` with the tenant count still at 1.

## Verification substrate

Tested against a **scratch Postgres** (`pgvector/pgvector:pg17`) built the way `.github/workflows/ci.yml` builds it: fresh cluster, `.github/ci/test-db-bootstrap.sql`, then the full `supabase/migrations/` chain in filename order including this PR's migration. `auth.users` is seeded properly rather than with bare uuids, so `tenant_users_user_id_fkey` is real; PR #624 shipped a test that passed locally while violating that key because the local container lacked it.

The migration was applied twice to confirm it is safely re-runnable, since the live tracker `supabase_migrations.schema_migrations` cannot be trusted.

Tests ran against **this PR's worktree**, mounted explicitly, not the shared checkout.

Nothing was applied to the live database. The only live access was read-only `SELECT`s for the table above, after a `SELECT 1` probe.
