### PR TITLE
ci: harden baseline regeneration and check in the probe that generates it

### DIFF
--- a/scripts/migration-baseline.conf
+++ b/scripts/migration-baseline.conf
@@ -69,6 +69,20 @@
 #     are stripped before parsing. Such files fall to unprovable and stay
 #     pending, which is the safe direction.
 #
+# RE-RUN HAZARD SCANNING, and a false positive worth not re-deriving. Whether a
+# pending file is safe to re-run turns on per-statement guards, not per-file
+# ones. A file-level "does this file contain ON CONFLICT" scan is wrong in both
+# directions:
+#   * False negative. 20260717_02 carried an ON CONFLICT on one insert while
+#     four others were bare, so a file-level scan cleared it and a replay against
+#     a clone of live then aborted on model_aliases_pkey. Those four are guarded
+#     now.
+#   * False positive. 20260423_01 was reported in review as carrying a bare
+#     INSERT INTO public.model_aliases. It does not. It has carried
+#     `on conflict (alias_id) do nothing` at line 40 since before that review,
+#     and all four of its inserts are guarded. Recorded here so the claim is not
+#     re-derived from a coarser scan later.
+#
 # SUPERSESSION. A later migration may legitimately drop something an earlier one
 # created, in which case the earlier migration did run and its object is simply
 # gone. The probe accounts for this by ignoring any object that a later file
@@ -76,13 +90,21 @@
 # drops its audit_outbox_undelivered index, and the earlier file would be
 # re-run, aborting on the objects that do still exist.
 #
-# SHELF LIFE. This list is a snapshot, and the demo database is being changed
-# out of band while this work is in flight: between two runs of the probe on
-# 2026-08-01 the applied count moved from 54 to 60, because another operator
-# applied migrations by hand mid-session. Re-run the probe and compare before
-# merging. A baseline that under-reports what is applied re-runs a
-# non-idempotent migration and aborts the deploy loudly, which is recoverable
-# but is still a blocked deploy.
+# WHEN THIS FILE ACTUALLY MATTERS. Only when public.hive_schema_migrations is
+# EMPTY. apply-migrations.sh seeds from this list on that run alone; from then
+# on the ledger is the authority and this file is inert. As of 2026-08-01 the
+# ledger is populated and matches the repository exactly, so a stale entry here
+# changes nothing today. It matters again only if the ledger is ever rebuilt,
+# for example on a new environment or after a restore, and that is precisely
+# when nobody would be watching for a bad baseline.
+#
+# SHELF LIFE. This list is a snapshot and can go stale whenever migrations are
+# applied out of band. It already did: between two probe runs on 2026-08-01 the
+# applied count moved from 54 to 60, from the deploy running plus one table
+# applied by hand. So regenerate this file from the probe rather than trusting
+# it. If it is ever used while under-reporting what is applied, the first run
+# re-runs a non-idempotent migration and aborts loudly, which is visible and
+# recoverable, but it does block that deploy.
 #
 # Result: 60 provably applied (listed below), 0 provably unapplied, 0 partially
 # applied, 18 unprovable. All 18 non-applied files are pending, each with its

--- a/scripts/migration-baseline.conf
+++ b/scripts/migration-baseline.conf
@@ -24,9 +24,11 @@
 # PROVENANCE. Read this before trusting or editing the list, and re-verify
 # rather than assuming if the database may have changed since.
 #
-# Established on 2026-08-01 by an exhaustive object-by-object probe of all 78
-# files against the live demo database, read only, over the pooler's
-# TRANSACTION mode port (6543). Transaction mode is used so the probe consumes
+# Established on 2026-08-01 by scripts/probe-applied-migrations.py, an
+# exhaustive object-by-object probe of all 78 files against the live demo
+# database, read only, over the pooler's TRANSACTION mode port (6543). The
+# probe is checked in, so this list is reproducible rather than asserted: run
+# `scripts/probe-applied-migrations.py --emit-baseline` to regenerate it. Transaction mode is used so the probe consumes
 # no session-mode slot: those are capped at pool_size 15 and shared with CI,
 # agents and the live chat surface. A read only probe needs none of what
 # transaction mode drops (prepared statements, LISTEN and NOTIFY, advisory
@@ -67,11 +69,27 @@
 #     are stripped before parsing. Such files fall to unprovable and stay
 #     pending, which is the safe direction.
 #
-# Result: 54 provably applied (listed below), 6 provably unapplied, 1 partially
-# applied, 17 unprovable. All 24 non-applied files are pending. The full
-# verdict table, including why each non-applied file is not listed, is in the
-# pull request body, and every non-applied file is listed by verdict at the
-# bottom of this file.
+# SUPERSESSION. A later migration may legitimately drop something an earlier one
+# created, in which case the earlier migration did run and its object is simply
+# gone. The probe accounts for this by ignoring any object that a later file
+# drops. Without it, 20260516_05 reads as partially applied because 20260518_01
+# drops its audit_outbox_undelivered index, and the earlier file would be
+# re-run, aborting on the objects that do still exist.
+#
+# SHELF LIFE. This list is a snapshot, and the demo database is being changed
+# out of band while this work is in flight: between two runs of the probe on
+# 2026-08-01 the applied count moved from 54 to 60, because another operator
+# applied migrations by hand mid-session. Re-run the probe and compare before
+# merging. A baseline that under-reports what is applied re-runs a
+# non-idempotent migration and aborts the deploy loudly, which is recoverable
+# but is still a blocked deploy.
+#
+# Result: 60 provably applied (listed below), 0 provably unapplied, 0 partially
+# applied, 18 unprovable. All 18 non-applied files are pending, each with its
+# reason recorded below. Every one of those 18 was executed successfully against
+# a throwaway clone of the live schema plus provider catalog, so they are known
+# re-runnable rather than assumed.
+
 
 applied = 20260328_01_identity_foundation.sql
 applied = 20260328_02_billing_identity_profiles.sql
@@ -91,6 +109,7 @@ applied = 20260414_01_provider_capabilities_media_columns.sql
 applied = 20260414_02_filestore_tables.sql
 applied = 20260420_01_batch_accounting_attribution.sql
 applied = 20260425_01_api_key_rate_limits.sql
+applied = 20260427_01_batch_local_executor.sql
 applied = 20260428_01_budgets_alerts_invoices_grants.sql
 applied = 20260507_01_invoices_period_order_check.sql
 applied = 20260516_01_phase19_tenants.sql
@@ -99,7 +118,11 @@ applied = 20260516_03_phase19_tenant_users.sql
 applied = 20260516_04_phase19_audit_log.sql
 applied = 20260516_05_phase19_audit_outbox.sql
 applied = 20260516_06_phase19_llm_traces.sql
+applied = 20260516_08_phase19_tenant_invites.sql
+applied = 20260516_09_phase19_tenant_email_domains.sql
+applied = 20260518_01_phase19_audit_outbox_claim.sql
 applied = 20260518_03_phase19_audit_partitions_default.sql
+applied = 20260518_04_phase19_audit_rls_and_indexes.sql
 applied = 20260611_01_provider_catalog_schema.sql
 applied = 20260625_01_enable_pgvector.sql
 applied = 20260625_02_add_audit_sink_sentry_setting.sql
@@ -126,30 +149,43 @@ applied = 20260728_01_tenant_billing_account.sql
 applied = 20260728_02_tenant_setting_key_enable_usage_metering.sql
 applied = 20260728_04_metering_shadow_verdicts.sql
 applied = 20260729_01_metering_shadow_verdicts_created_at_index.sql
+applied = 20260729_02_metering_shadow_verdicts_retention.sql
 applied = 20260730_01_usage_events_event_type_extend.sql
 
 # NOT listed above, therefore pending. Kept here as a record of why.
 #   UNPROVABLE  20260423_01_embedding_alias.sql
+#     reason: data only, and row data is never probed
 #   UNPROVABLE  20260424_01_api_key_policies_embedding_alias.sql
-#   UNAPPLIED   20260424_02_embedding_fallback_route.sql
+#     reason: data only, and row data is never probed
+#   UNPROVABLE  20260424_02_embedding_fallback_route.sql
+#     reason: data only, and row data is never probed; drops only, whose absence proves nothing
 #   UNPROVABLE  20260424_03_embedding_alias_groups.sql
+#     reason: data only, and row data is never probed
 #   UNPROVABLE  20260424_04_embedding_nvidia_primary.sql
-#   UNAPPLIED   20260427_01_batch_local_executor.sql
+#     reason: data only, and row data is never probed
 #   UNPROVABLE  20260516_07_phase19_custom_access_token_hook.sql
-#   UNAPPLIED   20260516_08_phase19_tenant_invites.sql
-#   UNAPPLIED   20260516_09_phase19_tenant_email_domains.sql
-#   UNAPPLIED   20260518_01_phase19_audit_outbox_claim.sql
+#     reason: CREATE OR REPLACE function or procedure only, which is weak evidence; DDL built inside a dollar quoted block, invisible to the parser; grants only, which are not probed
 #   UNPROVABLE  20260518_02_phase19_embedding_openrouter_primary.sql
-#   PARTIAL     20260518_04_phase19_audit_rls_and_indexes.sql
+#     reason: DDL built inside a dollar quoted block, invisible to the parser; data only, and row data is never probed
 #   UNPROVABLE  20260529_01_rls_tenant_tables.sql
+#     reason: DDL built inside a dollar quoted block, invisible to the parser
 #   UNPROVABLE  20260612_01_seed_tools_supported.sql
+#     reason: data only, and row data is never probed
 #   UNPROVABLE  20260717_01_default_group_hive_auto.sql
+#     reason: data only, and row data is never probed
 #   UNPROVABLE  20260717_02_voice_groq_stt_tts.sql
+#     reason: data only, and row data is never probed
 #   UNPROVABLE  20260717_03_rag_embedding_dim_drop_check.sql
+#     reason: drops only, whose absence proves nothing; comments only, which are not probed
 #   UNPROVABLE  20260719_01_rename_carl_feature_category.sql
+#     reason: data only, and row data is never probed
 #   UNPROVABLE  20260726_01_owui_role_claim.sql
+#     reason: CREATE OR REPLACE function or procedure only, which is weak evidence; DDL built inside a dollar quoted block, invisible to the parser; grants only, which are not probed
 #   UNPROVABLE  20260726_01_tenant_users_hive_app_grant.sql
+#     reason: DDL built inside a dollar quoted block, invisible to the parser; grants only, which are not probed
 #   UNPROVABLE  20260727_01_token_hook_membershipless_no_raise.sql
+#     reason: CREATE OR REPLACE function or procedure only, which is weak evidence; DDL built inside a dollar quoted block, invisible to the parser; grants only, which are not probed
 #   UNPROVABLE  20260728_03_tenant_billing_account_backfill.sql
-#   UNAPPLIED   20260729_02_metering_shadow_verdicts_retention.sql
+#     reason: data only, and row data is never probed
 #   UNPROVABLE  20260731_01_tenant_billing_account_backfill_v2.sql
+#     reason: DDL built inside a dollar quoted block, invisible to the parser; data only, and row data is never probed

--- a/scripts/migration-baseline.conf
+++ b/scripts/migration-baseline.conf
@@ -25,7 +25,7 @@
 # rather than assuming if the database may have changed since.
 #
 # Established on 2026-08-01 by scripts/probe-applied-migrations.py, an
-# exhaustive object-by-object probe of all 78 files against the live demo
+# exhaustive object-by-object probe of all 79 files against the live demo
 # database, read only, over the pooler's TRANSACTION mode port (6543). The
 # probe is checked in, so this list is reproducible rather than asserted: run
 # `scripts/probe-applied-migrations.py --emit-baseline` to regenerate it. Transaction mode is used so the probe consumes
@@ -106,11 +106,12 @@
 # re-runs a non-idempotent migration and aborts loudly, which is visible and
 # recoverable, but it does block that deploy.
 #
-# Result: 60 provably applied (listed below), 0 provably unapplied, 0 partially
+# Result: 61 provably applied (listed below), 0 provably unapplied, 0 partially
 # applied, 18 unprovable. All 18 non-applied files are pending, each with its
 # reason recorded below. Every one of those 18 was executed successfully against
 # a throwaway clone of the live schema plus provider catalog, so they are known
 # re-runnable rather than assumed.
+
 
 
 applied = 20260328_01_identity_foundation.sql
@@ -173,6 +174,7 @@ applied = 20260728_04_metering_shadow_verdicts.sql
 applied = 20260729_01_metering_shadow_verdicts_created_at_index.sql
 applied = 20260729_02_metering_shadow_verdicts_retention.sql
 applied = 20260730_01_usage_events_event_type_extend.sql
+applied = 20260801_01_payment_webhook_deliveries.sql
 
 # NOT listed above, therefore pending. Kept here as a record of why.
 #   UNPROVABLE  20260423_01_embedding_alias.sql

--- a/scripts/probe-applied-migrations.py
+++ b/scripts/probe-applied-migrations.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Decide which supabase/migrations files are already applied to a database.
+
+Why this exists
+---------------
+scripts/migration-baseline.conf tells scripts/apply-migrations.sh which
+migrations ran before the ledger existed. That list has to come from evidence,
+not from filenames: the drift on the demo database is interleaved, not a
+prefix. 20260516_01 through _07 are applied while _08 and _09 are not, and
+20260518_02 is applied while _01 and _04 are not.
+
+An earlier version of the baseline was written from a spot check and asserted
+in a comment that it had been probed exhaustively. That claim was false and a
+review caught it. This script exists so the claim is reproducible: anyone can
+re-run it and get the same verdicts, instead of trusting a comment.
+
+Usage
+-----
+    scripts/probe-applied-migrations.py                  print the verdict table
+    scripts/probe-applied-migrations.py --emit-baseline  print baseline conf body
+
+Connection settings come from libpq environment variables (PGHOST, PGPORT,
+PGUSER, PGDATABASE, PGPASSWORD), the same as scripts/apply-migrations.sh. Point
+PGPORT at the pooler's TRANSACTION mode port (6543), never session mode: this
+runs a batch of catalog queries and session-mode clients are capped at
+pool_size 15, shared with CI, agents and the live chat surface. A read only
+probe needs nothing transaction mode drops.
+
+Every query it runs is read only. It never writes.
+
+What counts as evidence
+-----------------------
+For each file the SQL is parsed with comments and dollar quoted bodies removed,
+so that commented out DDL and DDL built dynamically inside a DO block are not
+mistaken for real DDL, and every STRONG object the file creates is extracted:
+tables, indexes, policies, types, triggers, added columns, added constraints,
+extensions, enum values and views. A file is APPLIED only if every one of those
+is present.
+
+CREATE OR REPLACE functions and procedures are WEAK evidence and never prove a
+file applied, because a later migration replacing the same function would
+otherwise vouch for an earlier one.
+
+Verdicts: APPLIED, UNAPPLIED (has strong objects, none present), PARTIAL (some
+present, some not), UNPROVABLE (nothing checkable). Only APPLIED is treated as
+applied. Everything else stays pending, because unknown must never resolve to
+applied: a wrongly applied mark is a permanent silent skip, a wrongly unapplied
+mark is a loud abort you can see and fix.
+
+Known limits, which is why the verdict is evidence and not proof: existence is
+checked, definition is not, so an object that exists with a different type,
+default, predicate or column set still counts. Grants, ownership, column
+defaults, comments, storage parameters and RLS enable flags are not checked,
+and row data is never checked.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+MIGRATIONS_DIR = os.path.join(REPO_ROOT, "supabase", "migrations")
+
+
+def psql(sql: str) -> list[str]:
+    """Run one read-only query and return its rows. Fails loudly."""
+    out = subprocess.run(
+        ["psql", "--no-psqlrc", "-qtAX", "-v", "ON_ERROR_STOP=1", "-c", sql],
+        capture_output=True, text=True,
+    )
+    if out.returncode != 0:
+        sys.exit(f"psql failed: {out.stderr.strip()}")
+    return [line for line in out.stdout.splitlines() if line]
+
+
+def load_catalog() -> dict[str, set[str]]:
+    """One batch of catalog reads, rather than a query per migration."""
+    psql("SELECT 1")
+    return {
+        "table": set(psql(
+            "SELECT lower(c.relname) FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace "
+            "WHERE n.nspname='public' AND c.relkind IN ('r','p','v','m','f')")),
+        "index": set(psql("SELECT lower(indexname) FROM pg_indexes WHERE schemaname='public'")),
+        "policy": set(psql("SELECT lower(policyname) FROM pg_policies WHERE schemaname='public'")),
+        "type": set(psql(
+            "SELECT lower(t.typname) FROM pg_type t JOIN pg_namespace n ON n.oid=t.typnamespace "
+            "WHERE n.nspname='public'")),
+        "trigger": set(psql("SELECT lower(tgname) FROM pg_trigger WHERE NOT tgisinternal")),
+        "constraint": set(psql(
+            "SELECT lower(conname) FROM pg_constraint c JOIN pg_namespace n ON n.oid=c.connamespace "
+            "WHERE n.nspname='public'")),
+        "extension": set(psql("SELECT lower(extname) FROM pg_extension")),
+        "column": set(psql(
+            "SELECT lower(table_name)||'.'||lower(column_name) FROM information_schema.columns "
+            "WHERE table_schema='public'")),
+        "enum": set(psql(
+            "SELECT lower(t.typname)||':'||e.enumlabel FROM pg_enum e "
+            "JOIN pg_type t ON t.oid=e.enumtypid")),
+    }
+
+
+def strip_sql(text: str) -> str:
+    text = re.sub(r"/\*.*?\*/", " ", text, flags=re.S)
+    text = re.sub(r"--[^\n]*", " ", text)
+    # Dollar quoted bodies are removed so dynamically built DDL inside DO blocks
+    # is not read as real DDL. Files whose only DDL lives there fall to
+    # UNPROVABLE and stay pending, which is the safe direction.
+    return re.sub(r"\$([A-Za-z_]*)\$.*?\$\1\$", " ", text, flags=re.S)
+
+
+IN = r"(?:IF\s+NOT\s+EXISTS\s+)?"
+NAME = r'([A-Za-z0-9_."]+)'
+STRONG = [
+    ("table", re.compile(rf"CREATE\s+(?:UNLOGGED\s+)?TABLE\s+{IN}{NAME}", re.I)),
+    ("index", re.compile(rf"CREATE\s+(?:UNIQUE\s+)?INDEX\s+(?:CONCURRENTLY\s+)?{IN}{NAME}\s+ON", re.I)),
+    ("policy", re.compile(rf"CREATE\s+POLICY\s+{NAME}\s+ON", re.I)),
+    ("type", re.compile(rf"CREATE\s+TYPE\s+{NAME}", re.I)),
+    ("trigger", re.compile(rf"CREATE\s+(?:OR\s+REPLACE\s+)?(?:CONSTRAINT\s+)?TRIGGER\s+{NAME}", re.I)),
+    ("column", re.compile(rf"ALTER\s+TABLE\s+{IN}{NAME}\s+ADD\s+COLUMN\s+{IN}{NAME}", re.I)),
+    ("constraint", re.compile(rf"ADD\s+CONSTRAINT\s+{NAME}", re.I)),
+    ("extension", re.compile(rf"CREATE\s+EXTENSION\s+{IN}{NAME}", re.I)),
+    ("enum", re.compile(rf"ALTER\s+TYPE\s+{NAME}\s+ADD\s+VALUE\s+{IN}'([^']+)'", re.I)),
+    ("view", re.compile(rf"CREATE\s+(?:OR\s+REPLACE\s+)?(?:MATERIALIZED\s+)?VIEW\s+{IN}{NAME}", re.I)),
+]
+WEAK_FUNC = re.compile(rf"CREATE\s+(?:OR\s+REPLACE\s+)?(?:FUNCTION|PROCEDURE)\s+{NAME}", re.I)
+
+# A later migration may legitimately drop something an earlier one created, in
+# which case the earlier migration DID run and its object is simply gone. Without
+# this, existence probing reports a false PARTIAL and the earlier file would be
+# re-run, aborting on the objects that do still exist. Real case: 20260516_05
+# creates index audit_outbox_undelivered and 20260518_01 drops it.
+DROPPED = re.compile(
+    r"DROP\s+(?:TABLE|INDEX|POLICY|TYPE|TRIGGER|VIEW|CONSTRAINT|EXTENSION)\s+"
+    rf"(?:CONCURRENTLY\s+)?(?:IF\s+EXISTS\s+)?{NAME}", re.I)
+
+
+def unqualify(name: str) -> str:
+    return name.replace('"', "").split(".")[-1].lower()
+
+
+def unprovable_reason(sql: str, raw: str) -> str:
+    """Why a file had nothing checkable. This is what decides whether
+    re-running it is safe, so it is recorded per entry rather than left as a
+    bare label."""
+    bits = []
+    if WEAK_FUNC.search(sql):
+        bits.append("CREATE OR REPLACE function or procedure only, which is weak evidence")
+    if re.search(r"\$([A-Za-z_]*)\$", raw):
+        bits.append("DDL built inside a dollar quoted block, invisible to the parser")
+    if re.search(r"^\s*(INSERT|UPDATE|DELETE)\b", sql, re.I | re.M):
+        bits.append("data only, and row data is never probed")
+    if re.search(r"\b(GRANT|REVOKE)\b", sql, re.I):
+        bits.append("grants only, which are not probed")
+    if re.search(r"\bDROP\s+(CONSTRAINT|POLICY|INDEX|TRIGGER)\b", sql, re.I):
+        bits.append("drops only, whose absence proves nothing")
+    if re.search(r"\bALTER\s+TABLE\b.*\b(ENABLE|FORCE)\s+ROW\s+LEVEL\s+SECURITY", sql, re.I | re.S):
+        bits.append("RLS enable or force flags only, which are not probed")
+    if re.search(r"\bCOMMENT\s+ON\b", sql, re.I):
+        bits.append("comments only, which are not probed")
+    return "; ".join(bits) if bits else "no checkable statements found"
+
+
+def classify(catalog: dict[str, set[str]]) -> list[tuple[str, str, str]]:
+    files = sorted(f for f in os.listdir(MIGRATIONS_DIR) if f.endswith(".sql"))
+    sources = {
+        f: strip_sql(open(os.path.join(MIGRATIONS_DIR, f), encoding="utf-8").read())
+        for f in files
+    }
+    # Names dropped by each file, so a later drop can excuse an earlier create.
+    drops = {
+        f: {unqualify(m.group(1)) for m in DROPPED.finditer(sources[f])} for f in files
+    }
+
+    results = []
+    for position, name in enumerate(files):
+        raw = open(os.path.join(MIGRATIONS_DIR, name), encoding="utf-8").read()
+        sql = sources[name]
+        dropped_later: set[str] = set()
+        for later in files[position + 1:]:
+            dropped_later |= drops[later]
+        objects = []
+        for kind, pattern in STRONG:
+            for m in pattern.finditer(sql):
+                if kind == "column":
+                    key = f"{unqualify(m.group(1))}.{unqualify(m.group(2))}"
+                elif kind == "enum":
+                    key = f"{unqualify(m.group(1))}:{m.group(2)}"
+                else:
+                    key = unqualify(m.group(1))
+                if key in dropped_later or key.split(".")[-1] in dropped_later:
+                    continue
+                lookup = catalog["table"] if kind == "view" else catalog[kind]
+                objects.append((kind, key, key in lookup))
+
+        if not objects:
+            results.append((name, "UNPROVABLE", unprovable_reason(sql, raw)))
+            continue
+        missing = [o for o in objects if not o[2]]
+        if not missing:
+            results.append((name, "APPLIED", f"all {len(objects)} strong objects present"))
+        elif len(missing) == len(objects):
+            results.append((name, "UNAPPLIED",
+                            f"0 of {len(objects)} present, first missing {missing[0][0]}:{missing[0][1]}"))
+        else:
+            detail = ", ".join(f"{k}:{n}" for k, n, _ in missing[:6])
+            results.append((name, "PARTIAL",
+                            f"{len(objects) - len(missing)} of {len(objects)} present, missing {detail}"))
+    return results
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--emit-baseline", action="store_true",
+                        help="print the applied= lines and the pending record block")
+    args = parser.parse_args()
+
+    results = classify(load_catalog())
+
+    if args.emit_baseline:
+        for name, verdict, _ in results:
+            if verdict == "APPLIED":
+                print(f"applied = {name}")
+        print("\n# NOT listed above, therefore pending. Kept here as a record of why.")
+        for name, verdict, reason in results:
+            if verdict != "APPLIED":
+                print(f"#   {verdict:<11} {name}")
+                print(f"#     reason: {reason}")
+        return
+
+    for name, verdict, reason in results:
+        print(f"{verdict:<11} {name}  [{reason}]")
+    counts = {v: sum(1 for _, x, _ in results if x == v)
+              for v in ("APPLIED", "UNAPPLIED", "PARTIAL", "UNPROVABLE")}
+    print("\n" + ", ".join(f"{k}={v}" for k, v in counts.items()) + f", TOTAL={len(results)}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Follow-up to #630. **This hardens baseline REGENERATION. It does not fix a live abort.** An earlier revision of this description claimed a pending deploy failure; that claim was wrong and is corrected below.

## Correcting the earlier claim

I previously argued that main's baseline listing 54 applied against a live count of 60 meant the next `migrate` run would abort. It does not, and the reasoning error is worth stating because it is the same class of mistake this PR guards against.

`scripts/migration-baseline.conf` seeds `public.hive_schema_migrations` **only when that ledger is empty**. Once the first `migrate` run populated it, the ledger became the authority and the conf went inert. My probe re-derives state from object existence, which is a different question from what the ledger records, and I treated the two as interchangeable.

Verified since: the post-merge deploy succeeded, reporting "applied 25 migration(s)", including `20260801_01_payment_webhook_deliveries.sql` which logged `relation "payment_webhook_deliveries" already exists, skipping` and still completed, so idempotency held on live and not only on a clone. The ledger holds 79 rows, the repo carries 79 migration files, and diffing both directions shows nothing unrecorded and nothing recorded that is absent from the repo. Nothing is pending.

## Why this still matters

The baseline governs what happens when the ledger is **rebuilt**: a new environment, a restore, or any bootstrap from empty. That is exactly the moment nobody is watching for a bad baseline, and a wrong one there is silent. The file now says plainly when it applies and when it is inert.

## What is in this PR

**1. The probe is checked in.** Closes #642. #630 asserted an exhaustive probe whose artifact did not exist in the repository, so the claim could not be re-run or reviewed. `scripts/probe-applied-migrations.py` now generates the baseline:

```
scripts/probe-applied-migrations.py                  # verdict table
scripts/probe-applied-migrations.py --emit-baseline  # regenerate the conf body
```

It reaches Postgres through `psql` and libpq environment variables, so it adds no dependency, and every query is read only. Point `PGPORT` at the pooler's transaction mode port: it issues a batch of catalog queries, and session mode clients are capped at `pool_size` 15 shared with CI, agents and the live chat surface.

**2. Per-entry reasons for pending files.** Previously a bare `UNPROVABLE` label. Each now records why nothing was checkable, generated rather than hand written: data only, grants only, drops only, `CREATE OR REPLACE` function only, DDL inside a dollar quoted block, RLS enable or force flags only, comments only. That distinction is what decides whether re-running a file is safe.

**3. The supersession fix.** A later migration may legitimately drop something an earlier one created, in which case the earlier migration did run and its object is simply gone. Existence probing alone marked `20260516_05_phase19_audit_outbox` partial because `20260518_01` drops its `audit_outbox_undelivered` index. Unfixed, a regenerated baseline would call a file full of bare `CREATE TABLE` statements pending and abort the rebuild. The probe now ignores any object a later file drops, fixing the class rather than the instance. As a side effect `20260424_02` correctly falls to unprovable, since its only strong object is dropped later.

**4. A review false positive, recorded so it is not re-derived.** `20260423_01_embedding_alias.sql` was reported as carrying a bare `INSERT INTO public.model_aliases`. It does not, and did not: `on conflict (alias_id) do nothing` sits at line 40 and all four of its inserts are guarded. The underlying lesson is recorded with it: re-run hazard scanning has to be **per statement, not per file**, and a file-level scan errs in both directions. It cleared `20260717_02` because one of its five inserts was guarded, which a clone replay then caught aborting on `model_aliases_pkey`, and the same coarseness produced this false positive.

## Shelf life, which is the real lesson

The baseline is a snapshot and goes stale whenever migrations are applied out of band. It already did during this work: the applied count moved from 54 to 60 between two probe runs on the same day, from the deploy running plus one table applied by hand before #638. So regenerate it from the probe rather than trusting it. With the probe checked in that is one command.

That risk is now **bounded**, because the ledger is populated and authoritative. A stale entry here changes nothing until the ledger is rebuilt.

This PR is rebased onto current main and the baseline was regenerated against the 79 file tree rather than hand edited, since shipping a baseline that omits a file would demonstrate the exact staleness it warns about.

## Verification

- [x] `scripts/apply-migrations.sh --check` reports `applied=61 pending=18 migrations=79`
- [x] Baseline regenerated by the checked-in probe, run read only against live over port 6543: 61 applied, 0 unapplied, 0 partial, 18 unprovable
- [x] All 18 pending files were executed successfully against a throwaway clone of the live schema plus provider catalog during #630, and a second run there was a no op
- [x] shellcheck clean, probe parses
- [ ] **Could not verify: a ledger rebuild end to end.** The path this PR protects is bootstrap from an empty ledger, which was exercised on the clone during #630 but not on any live environment, and deliberately so.
- [ ] The baseline can go stale again at any time. Re-run the probe and compare before merging.

The gate is untouched: `ON_ERROR_STOP=1` under `set -euo pipefail`, `deploy: needs: migrate`, no `|| true`, no `continue-on-error`.
