### PR TITLE
fix: cap the unauthenticated payment webhook body

### DIFF
--- a/apps/control-plane/internal/payments/http.go
+++ b/apps/control-plane/internal/payments/http.go
@@ -287,15 +287,42 @@ func (h *Handler) handleGetCheckoutIntent(w http.ResponseWriter, r *http.Request
 // handleWebhook — POST /webhooks/{provider} (unauthenticated, signature-verified)
 // ---------------------------------------------------------------------------
 
+// maxWebhookBodyBytes caps the unauthenticated webhook body (issue #640).
+//
+// 1 MiB matches the limit the other control-plane JSON handlers already use
+// (internal/egress, internal/marketplace). It sits far above what the rails
+// actually send: a real signed Stripe checkout.session.completed event measures
+// about 1.5 KB, which TestWebhook_RealStripeEventIsFarBelowCap asserts, leaving
+// roughly a 670x margin. That margin is deliberate, because a cap that rejected
+// a legitimate provider event would break settlement, which is far worse than
+// the storage abuse being closed here.
+const maxWebhookBodyBytes = 1 << 20
+
 func (h *Handler) handleWebhook(w http.ResponseWriter, r *http.Request, rail Rail) {
 	if r.Method != http.MethodPost {
 		writePaymentJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
 		return
 	}
 
+	// This route is unauthenticated by design, and since #638 the delivery row
+	// carrying the full raw body is written before signature verification. The
+	// cap belongs here, ahead of that write, so an oversized payload is refused
+	// before it can be persisted. Capping any later would accomplish nothing:
+	// the oversized row would already exist (issue #640).
+	r.Body = http.MaxBytesReader(w, r.Body, maxWebhookBodyBytes)
+
 	// MUST read raw body first, before any JSON parsing.
 	rawBody, err := io.ReadAll(r.Body)
 	if err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			// Not transient and not worth a redelivery: the same oversized body
+			// would be refused every time. Nothing is lost by declining, because
+			// no provider legitimately sends anything near this size.
+			log.Printf("payments webhook: rejected oversized body (rail=%s, limit=%d)", rail, maxWebhookBodyBytes)
+			writePaymentJSON(w, http.StatusRequestEntityTooLarge, map[string]string{"status": "error"})
+			return
+		}
 		log.Printf("payments webhook: read body error: %v", err)
 		// A truncated read is transient: ask for a redelivery rather than
 		// claiming a payload we never saw was handled (issue #628).

--- a/apps/control-plane/internal/payments/http_body_cap_signature_test.go
+++ b/apps/control-plane/internal/payments/http_body_cap_signature_test.go
@@ -1,0 +1,327 @@
+package payments_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	stripego "github.com/stripe/stripe-go/v84"
+	"github.com/stripe/stripe-go/v84/webhook"
+
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/ledger"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/payments"
+	stripeRail "github.com/sakibsadmanshajib/hive/apps/control-plane/internal/payments/stripe"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/profiles"
+)
+
+// Issue #640, third acceptance point: the body cap must be an extra gate in
+// front of signature verification, never a replacement for it or a way around
+// it. These tests drive the REAL Stripe rail, so verification runs for real.
+//
+// The signing secret below is an obvious fake and the signatures are generated
+// with stripe-go's own test helper. Nothing here weakens, bypasses or
+// conditionally skips verification.
+const testWebhookSecret = "whsec_testvalidwebhooksecret12345"
+
+// ---------------------------------------------------------------------------
+// Minimal Repository stub. Only the webhook settlement path is exercised.
+// ---------------------------------------------------------------------------
+
+type capRepo struct {
+	mu         sync.Mutex
+	intents    map[uuid.UUID]payments.PaymentIntent
+	byProv     map[string]uuid.UUID
+	deliveries []payments.WebhookDelivery
+}
+
+func newCapRepo() *capRepo {
+	return &capRepo{
+		intents: make(map[uuid.UUID]payments.PaymentIntent),
+		byProv:  make(map[string]uuid.UUID),
+	}
+}
+
+func (r *capRepo) InsertPaymentIntent(_ context.Context, intent payments.PaymentIntent) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.intents[intent.ID] = intent
+	r.byProv[intent.ProviderIntentID] = intent.ID
+	return nil
+}
+
+func (r *capRepo) GetPaymentIntent(_ context.Context, id uuid.UUID) (payments.PaymentIntent, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	i, ok := r.intents[id]
+	if !ok {
+		return payments.PaymentIntent{}, payments.ErrIntentNotFound
+	}
+	return i, nil
+}
+
+func (r *capRepo) GetPaymentIntentByProviderID(_ context.Context, providerID string) (payments.PaymentIntent, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	id, ok := r.byProv[providerID]
+	if !ok {
+		return payments.PaymentIntent{}, payments.ErrIntentNotFound
+	}
+	return r.intents[id], nil
+}
+
+func (r *capRepo) CompareAndSetStatus(_ context.Context, id uuid.UUID, from, to payments.IntentStatus) (bool, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	i, ok := r.intents[id]
+	if !ok {
+		return false, payments.ErrIntentNotFound
+	}
+	if i.Status != from {
+		return false, nil
+	}
+	i.Status = to
+	r.intents[id] = i
+	return true, nil
+}
+
+func (r *capRepo) UpdateProviderDetails(_ context.Context, _ uuid.UUID, _, _ string, _ *time.Time) error {
+	return nil
+}
+func (r *capRepo) SetConfirmingAt(_ context.Context, _ uuid.UUID, _ time.Time) error { return nil }
+func (r *capRepo) ListConfirmingIntents(_ context.Context, _ time.Time) ([]payments.PaymentIntent, error) {
+	return nil, nil
+}
+func (r *capRepo) InsertPaymentEvent(_ context.Context, _ payments.PaymentEvent) error { return nil }
+
+func (r *capRepo) InsertWebhookDelivery(_ context.Context, delivery payments.WebhookDelivery) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.deliveries = append(r.deliveries, delivery)
+	return nil
+}
+
+func (r *capRepo) UpdateWebhookDelivery(_ context.Context, id uuid.UUID, status payments.DeliveryStatus, _ *uuid.UUID, _, errorDetail string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for i := range r.deliveries {
+		if r.deliveries[i].ID == id {
+			r.deliveries[i].Status = status
+			r.deliveries[i].ErrorDetail = errorDetail
+			return nil
+		}
+	}
+	return nil
+}
+
+func (r *capRepo) deliveryCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.deliveries)
+}
+
+func (r *capRepo) InsertFXSnapshot(_ context.Context, _ payments.FXSnapshot) error { return nil }
+func (r *capRepo) GetFXSnapshot(_ context.Context, _ uuid.UUID) (payments.FXSnapshot, error) {
+	return payments.FXSnapshot{}, payments.ErrIntentNotFound
+}
+
+// ---------------------------------------------------------------------------
+// Remaining dependencies
+// ---------------------------------------------------------------------------
+
+type capLedger struct{}
+
+func (capLedger) GrantCredits(_ context.Context, _ uuid.UUID, _ string, _ int64, _ map[string]any) (ledger.LedgerEntry, error) {
+	return ledger.LedgerEntry{}, nil
+}
+
+type capProfiles struct{}
+
+func (capProfiles) GetBillingProfile(_ context.Context, _ uuid.UUID) (profiles.BillingProfile, error) {
+	return profiles.BillingProfile{BillingContactName: "Jane", CountryCode: "US"}, nil
+}
+func (capProfiles) GetAccountProfile(_ context.Context, _ uuid.UUID) (profiles.AccountProfile, error) {
+	return profiles.AccountProfile{CountryCode: "US"}, nil
+}
+
+type capFX struct{}
+
+func (capFX) CreateSnapshot(_ context.Context, _ payments.Repository, _ uuid.UUID) (payments.FXSnapshot, error) {
+	return payments.FXSnapshot{}, nil
+}
+
+type capResolver struct{}
+
+func (capResolver) EnsureViewerContext(_ context.Context) (uuid.UUID, error) { return uuid.Nil, nil }
+
+// ---------------------------------------------------------------------------
+// Fixture driving the real Stripe rail
+// ---------------------------------------------------------------------------
+
+type signatureFixture struct {
+	handler *payments.Handler
+	repo    *capRepo
+}
+
+func newSignatureFixture(t *testing.T) *signatureFixture {
+	t.Helper()
+
+	repo := newCapRepo()
+	_ = repo.InsertPaymentIntent(t.Context(), payments.PaymentIntent{
+		ID:               uuid.New(),
+		AccountID:        uuid.New(),
+		Rail:             payments.RailStripe,
+		Status:           payments.IntentStatusPendingRedirect,
+		Credits:          100_000,
+		ProviderIntentID: "cs_test_640",
+		Metadata:         map[string]any{},
+	})
+
+	rail := stripeRail.NewRail("sk_test_key", testWebhookSecret)
+	svc := payments.NewService(repo, capLedger{}, capProfiles{}, capFX{},
+		map[payments.Rail]payments.PaymentRail{payments.RailStripe: rail})
+
+	return &signatureFixture{handler: payments.NewHandler(svc, capResolver{}), repo: repo}
+}
+
+// signedEvent builds a genuinely signed Stripe event using stripe-go's test
+// helper. padTo inflates the payload with a real event field so the signature
+// stays valid at any size.
+//
+// The Checkout Session is this rail's unit of payment; payment_intent.* events
+// are deliberately not settled (see stripe/rail.go), so the event has to be a
+// paid checkout.session.completed to reach the settlement path at all.
+func signedEvent(t *testing.T, sessionID string, padTo int) ([]byte, string) {
+	t.Helper()
+
+	sess := &stripego.CheckoutSession{
+		ID:            sessionID,
+		PaymentStatus: stripego.CheckoutSessionPaymentStatusPaid,
+	}
+	rawObj, err := json.Marshal(sess)
+	if err != nil {
+		t.Fatalf("marshal checkout session: %v", err)
+	}
+
+	event := struct {
+		Object     string              `json:"object"`
+		Type       stripego.EventType  `json:"type"`
+		APIVersion string              `json:"api_version"`
+		Data       *stripego.EventData `json:"data"`
+		Padding    string              `json:"padding,omitempty"`
+	}{
+		Object:     "event",
+		Type:       stripego.EventType("checkout.session.completed"),
+		APIVersion: stripego.APIVersion,
+		Data:       &stripego.EventData{Raw: json.RawMessage(rawObj)},
+	}
+
+	rawEvent, err := json.Marshal(event)
+	if err != nil {
+		t.Fatalf("marshal event: %v", err)
+	}
+	if padTo > len(rawEvent) {
+		event.Padding = strings.Repeat("X", padTo-len(rawEvent))
+		if rawEvent, err = json.Marshal(event); err != nil {
+			t.Fatalf("marshal padded event: %v", err)
+		}
+	}
+
+	signed := webhook.GenerateTestSignedPayload(&webhook.UnsignedPayload{
+		Payload:   rawEvent,
+		Secret:    testWebhookSecret,
+		Timestamp: time.Now(),
+	})
+	return rawEvent, signed.Header
+}
+
+func (f *signatureFixture) post(body []byte, signature string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/stripe", bytes.NewReader(body))
+	if signature != "" {
+		req.Header.Set("Stripe-Signature", signature)
+	}
+	rr := httptest.NewRecorder()
+	f.handler.ServeHTTP(rr, req)
+	return rr
+}
+
+// TestWebhook_OversizedBodyRejectedEvenWithValidSignature proves the cap is not
+// something an authenticated-looking caller can talk its way past. A correctly
+// signed but oversized payload is still refused, and still writes no row.
+func TestWebhook_OversizedBodyRejectedEvenWithValidSignature(t *testing.T) {
+	f := newSignatureFixture(t)
+
+	body, sig := signedEvent(t, "cs_test_640", 2<<20)
+	rr := f.post(body, sig)
+
+	if rr.Code != http.StatusRequestEntityTooLarge {
+		t.Errorf("expected 413 for an oversized body even with a valid signature, got %d", rr.Code)
+	}
+	if got := f.repo.deliveryCount(); got != 0 {
+		t.Errorf("expected 0 delivery rows, got %d", got)
+	}
+}
+
+// TestWebhook_InvalidSignatureStillRejected is the regression guard on the
+// security property itself. If the cap had been added by loosening or
+// short-circuiting verification, this would start passing bad signatures.
+func TestWebhook_InvalidSignatureStillRejected(t *testing.T) {
+	f := newSignatureFixture(t)
+
+	body, _ := signedEvent(t, "cs_test_640", 0)
+
+	for _, tc := range []struct {
+		name string
+		sig  string
+	}{
+		{"absent", ""},
+		{"garbage", "t=1,v1=deadbeef"},
+		{"wrong key", func() string {
+			signed := webhook.GenerateTestSignedPayload(&webhook.UnsignedPayload{
+				Payload:   body,
+				Secret:    "whsec_testwrongsecret000000000000",
+				Timestamp: time.Now(),
+			})
+			return signed.Header
+		}()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rr := f.post(body, tc.sig)
+			if rr.Code/100 == 2 {
+				t.Fatalf("an unverifiable payload was accepted with %d", rr.Code)
+			}
+		})
+	}
+}
+
+// TestWebhook_ValidSignatureUnderCapStillSettles confirms the cap did not break
+// the normal path: a real signed event under the limit still settles, and its
+// delivery row is still written.
+func TestWebhook_ValidSignatureUnderCapStillSettles(t *testing.T) {
+	f := newSignatureFixture(t)
+
+	body, sig := signedEvent(t, "cs_test_640", 0)
+	if rr := f.post(body, sig); rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 for a valid signed event, got %d body=%s", rr.Code, rr.Body.String())
+	}
+	if got := f.repo.deliveryCount(); got != 1 {
+		t.Errorf("expected 1 delivery row, got %d", got)
+	}
+}
+
+// TestWebhook_RealStripeEventIsFarBelowCap is the evidence that the chosen limit
+// cannot drop a legitimate provider event. A real signed payment_intent event is
+// a few hundred bytes; the cap is 1 MiB.
+func TestWebhook_RealStripeEventIsFarBelowCap(t *testing.T) {
+	body, _ := signedEvent(t, "cs_test_640", 0)
+	t.Logf("real signed Stripe checkout.session.completed event: %d bytes (cap is %d bytes)", len(body), 1<<20)
+	if len(body) > (1<<20)/10 {
+		t.Errorf("a routine provider event is %d bytes, uncomfortably close to the cap", len(body))
+	}
+}

--- a/apps/control-plane/internal/payments/http_body_cap_test.go
+++ b/apps/control-plane/internal/payments/http_body_cap_test.go
@@ -1,0 +1,178 @@
+package payments
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/profiles"
+)
+
+// Issue #640: handleWebhook is unauthenticated by design and read the body with
+// no size limit. Since #638 the delivery row carrying the full raw_body is
+// written BEFORE signature verification, so any unauthenticated caller could
+// write an arbitrarily large row on every request, and providers retry on every
+// non 2xx including 400, so a rejected payload wrote a fresh row per redelivery.
+//
+// The record-before-verify ordering is deliberate and stays. The fix is the cap.
+
+// bodyCapFixture wires the real Service and Handler over the in-memory stub
+// repository so delivery rows can actually be counted.
+type bodyCapFixture struct {
+	handler *Handler
+	repo    *stubRepository
+	rail    *stubRail
+}
+
+func newBodyCapFixture(t *testing.T) *bodyCapFixture {
+	t.Helper()
+
+	repo := newStubRepository()
+	stubbedRail := newStubRail(RailStripe)
+
+	intentID := uuid.New()
+	providerIntentID := "prov_stripe_640"
+	intent := PaymentIntent{
+		ID:               intentID,
+		AccountID:        uuid.New(),
+		Rail:             RailStripe,
+		Status:           IntentStatusPendingRedirect,
+		Credits:          100_000,
+		AmountUSD:        100,
+		IdempotencyKey:   "idem-640",
+		ProviderIntentID: providerIntentID,
+		Metadata:         map[string]any{},
+		CreatedAt:        time.Now(),
+		UpdatedAt:        time.Now(),
+	}
+	_ = repo.InsertPaymentIntent(t.Context(), intent)
+	repo.byProv[providerIntentID] = intentID
+
+	stubbedRail.eventResult = RailEvent{
+		ProviderIntentID: providerIntentID,
+		EventType:        "payment.succeeded",
+		RawPayload:       []byte(`{}`),
+	}
+
+	prof := &stubProfiles{
+		accountProfile: profiles.AccountProfile{CountryCode: "US"},
+		billingProfile: profiles.BillingProfile{BillingContactName: "Jane", CountryCode: "US"},
+	}
+	svc := NewService(repo, &stubLedger{}, prof, &stubFXProvider{}, map[Rail]PaymentRail{RailStripe: stubbedRail})
+
+	return &bodyCapFixture{
+		handler: NewHandler(svc, &stubBodyCapResolver{}),
+		repo:    repo,
+		rail:    stubbedRail,
+	}
+}
+
+// stubBodyCapResolver satisfies AccountResolver. The webhook route is
+// unauthenticated, so this is never consulted on the paths under test.
+type stubBodyCapResolver struct{}
+
+func (s *stubBodyCapResolver) EnsureViewerContext(_ context.Context) (uuid.UUID, error) {
+	return uuid.Nil, nil
+}
+
+func (f *bodyCapFixture) post(body []byte) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/stripe", bytes.NewReader(body))
+	rr := httptest.NewRecorder()
+	f.handler.ServeHTTP(rr, req)
+	return rr
+}
+
+// TestWebhook_OversizedBody_RejectedWithoutPersistingDelivery is the core of
+// #640. The cap has to sit ahead of the delivery insert, otherwise capping the
+// read accomplishes nothing: the oversized row would already be written.
+func TestWebhook_OversizedBody_RejectedWithoutPersistingDelivery(t *testing.T) {
+	f := newBodyCapFixture(t)
+
+	oversized := []byte(`{"padding":"` + strings.Repeat("A", maxWebhookBodyBytes+1024) + `"}`)
+	rr := f.post(oversized)
+
+	if rr.Code == http.StatusOK {
+		t.Fatalf("an oversized unauthenticated body was accepted (%d)", rr.Code)
+	}
+	if rr.Code != http.StatusRequestEntityTooLarge {
+		t.Errorf("expected 413, got %d", rr.Code)
+	}
+
+	if got := len(f.repo.deliveryList()); got != 0 {
+		t.Errorf("expected 0 delivery rows for an oversized body, got %d: an unauthenticated caller can still write arbitrarily large rows", got)
+	}
+}
+
+// TestWebhook_OversizedBody_RepeatedDeliveriesPersistNothing covers the
+// compounding case the issue calls out: providers retry on every non 2xx,
+// including 400, so an uncapped reject wrote a fresh row per redelivery.
+func TestWebhook_OversizedBody_RepeatedDeliveriesPersistNothing(t *testing.T) {
+	f := newBodyCapFixture(t)
+
+	oversized := []byte(`{"padding":"` + strings.Repeat("B", maxWebhookBodyBytes+1024) + `"}`)
+	for i := 0; i < 5; i++ {
+		if code := f.post(oversized).Code; code == http.StatusOK {
+			t.Fatalf("redelivery %d accepted an oversized body", i+1)
+		}
+	}
+
+	if got := len(f.repo.deliveryList()); got != 0 {
+		t.Errorf("expected 0 delivery rows after 5 oversized redeliveries, got %d", got)
+	}
+}
+
+// TestWebhook_NormalPayload_SucceedsAndPersistsDelivery is the guard against
+// fixing #640 by breaking settlement. A cap set below a legitimate provider
+// payload would be far worse than the problem it solves.
+func TestWebhook_NormalPayload_SucceedsAndPersistsDelivery(t *testing.T) {
+	f := newBodyCapFixture(t)
+
+	rr := f.post([]byte(`{"type":"payment_intent.succeeded","data":{"object":{"id":"pi_abc"}}}`))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 for a normal payload, got %d body=%s", rr.Code, rr.Body.String())
+	}
+
+	records := f.repo.deliveryList()
+	if len(records) != 1 {
+		t.Fatalf("expected 1 delivery row, got %d", len(records))
+	}
+	if records[0].Status != DeliveryStatusProcessed {
+		t.Errorf("expected the delivery marked processed, got %s", records[0].Status)
+	}
+}
+
+// TestWebhook_PayloadAtCap_StillAccepted pins the boundary so a later tightening
+// of the limit cannot silently start dropping legitimate provider events.
+func TestWebhook_PayloadAtCap_StillAccepted(t *testing.T) {
+	f := newBodyCapFixture(t)
+
+	// Exactly at the limit. MaxBytesReader rejects only what exceeds it.
+	prefix := `{"padding":"`
+	suffix := `"}`
+	padding := maxWebhookBodyBytes - len(prefix) - len(suffix)
+	atCap := []byte(prefix + strings.Repeat("C", padding) + suffix)
+	if len(atCap) != maxWebhookBodyBytes {
+		t.Fatalf("test built a %d byte body, expected %d", len(atCap), maxWebhookBodyBytes)
+	}
+
+	if rr := f.post(atCap); rr.Code != http.StatusOK {
+		t.Fatalf("a payload exactly at the cap was rejected with %d", rr.Code)
+	}
+	if got := len(f.repo.deliveryList()); got != 1 {
+		t.Errorf("expected 1 delivery row, got %d", got)
+	}
+}
+
+// TestWebhook_CapIsAtLeastOneMiB documents the floor. Provider events are a few
+// kilobytes in practice; the margin is what keeps an unusually large but
+// legitimate event from being dropped.
+func TestWebhook_CapIsAtLeastOneMiB(t *testing.T) {
+	if maxWebhookBodyBytes < 1<<20 {
+		t.Fatalf("cap %d is below 1 MiB and risks rejecting legitimate provider events", maxWebhookBodyBytes)
+	}
+}


### PR DESCRIPTION
Fixes #640.

## The problem

`handleWebhook` is unauthenticated by design and read the request body with `io.ReadAll` and no size limit. Since #638 the delivery row carrying the full `raw_body` is written **before** signature verification, so any unauthenticated caller could write an arbitrarily large row on every request.

It compounds with retry behaviour. Providers retry on every non 2xx, including 400, so a rejected payload wrote a fresh row on each redelivery.

This is availability and storage rather than money loss, which is why it did not block #638.

## The fix

`http.MaxBytesReader` at the top of the handler, matching the pattern already used in `internal/rag`, `internal/agenttask`, `internal/egress`, `internal/marketplace` and `internal/signupguard`.

Response mapping stays deliberate:

| Case | Status | Why |
|---|---|---|
| Oversized body | 413 | Not transient. The same body would be refused every time, so a redelivery is pointless. |
| Truncated read | 500 | Genuinely transient, keeps its existing behaviour from #628 so the provider redelivers. |

## The ordering is unchanged

Recording the delivery before verification is deliberate and is the dead letter #628 required. This change does not touch it. `service.go` is not modified.

The cap sits ahead of the delivery insert on purpose. Capping any later would accomplish nothing, because the oversized row would already exist.

## Why 1 MiB

It matches `internal/egress` and `internal/marketplace`. The other limits in the repo are 64 KiB (`agenttask`), 4 KiB (`signupguard`), 4 MiB (`edge-api/anthropic`) and 10 MiB (`rag` ingest), so 1 MiB is the established default for a control-plane JSON endpoint.

Evidence it cannot drop a legitimate event: a real signed Stripe `checkout.session.completed` event measures **1,565 bytes** against a **1,048,576 byte** cap, a roughly 670x margin. `TestWebhook_RealStripeEventIsFarBelowCap` measures this and fails if a routine event ever creeps within 10% of the limit. A cap that rejected a legitimate provider event would break settlement, which would be far worse than the abuse being closed here.

## Signature verification is untouched

Nothing was weakened, bypassed, or conditionally skipped. The new tests in `http_body_cap_signature_test.go` drive the **real Stripe rail** and prove it:

- a missing, malformed, or wrong key signature is still rejected
- an oversized body is refused with 413 **even when its signature is valid**, so the cap is an extra gate rather than something a caller can talk its way past
- a valid signed event under the cap still settles and still writes its delivery row

Signatures are generated with stripe-go's own `GenerateTestSignedPayload` against an obviously fake secret. No real or real-looking credentials.

## Tests

Failing first, on behaviour rather than compile errors:

```
--- FAIL: TestWebhook_OversizedBody_RejectedWithoutPersistingDelivery
    http_body_cap_test.go:100: an oversized unauthenticated body was accepted (200)
--- FAIL: TestWebhook_OversizedBody_RepeatedDeliveriesPersistNothing
    http_body_cap_test.go:120: redelivery 1 accepted an oversized body
--- FAIL: TestWebhook_OversizedBodyRejectedEvenWithValidSignature
    http_body_cap_signature_test.go:257: expected 413 for an oversized body even with a valid signature, got 400
    http_body_cap_signature_test.go:260: expected 0 delivery rows, got 1
```

Coverage added:

- oversized body rejected with **zero** delivery rows persisted, asserted on row count
- five oversized redeliveries persist zero rows, covering the compounding case
- a normal payload still succeeds end to end and still persists its row, marked processed
- a payload exactly at the cap is still accepted, pinning the boundary
- the cap cannot regress below 1 MiB

## Verification

Run against **this branch's worktree** (`/tmp/bodycap`, `447a5c4d`), not the shared checkout:

```
docker run --rm -v /tmp/bodycap:/workspace hive-toolchain:latest \
  "cd /workspace && go build ./apps/control-plane/... && go vet ./apps/control-plane/internal/payments/... && go test ./apps/control-plane/... -count=1 -short"
```

Build clean, vet clean, full control-plane suite green, all payments subpackages green.

No migration. No customer-facing surface changed. Error bodies carry no provider name, no FX rate, and no USD amount.