### PR TITLE
feat: reap credit holds whose request never reached a terminal state

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -442,6 +442,22 @@ AUDIT_COLD_ARCHIVE_BUCKET=hive-audit-cold
 # Default 24h. Set to a shorter value in dev/staging to test without waiting a day.
 AUDIT_COLD_ARCHIVE_CRON_INTERVAL=24h
 
+# Stranded-hold reaper (issue #616). Releases credit holds whose request never
+# reached a terminal state, so abandoned reservations stop permanently reducing
+# an account's available balance.
+# HIVE_RESERVATION_REAPER_ENABLED: set to false to stop the reaper entirely.
+# Any other value, including unset, leaves it running.
+HIVE_RESERVATION_REAPER_ENABLED=true
+# HIVE_RESERVATION_REAPER_TTL: how long a hold must sit unsettled before it is
+# treated as abandoned rather than in flight (Go duration). Default 1h. Do not
+# lower this below the longest a request can legitimately still be running:
+# releasing a live request's hold revokes the authorization for work in
+# progress, which then bills against nothing.
+HIVE_RESERVATION_REAPER_TTL=1h
+# HIVE_RESERVATION_REAPER_INTERVAL: how often the reaper scans (Go duration).
+# Default 15m. A pass also runs eagerly at startup.
+HIVE_RESERVATION_REAPER_INTERVAL=15m
+
 # Grafana admin credentials (required when running --profile monitoring).
 # The previous baked-in admin/admin default was a hardcoded-credential
 # regression and is no longer tolerated — the service refuses to start

--- a/apps/control-plane/cmd/server/main.go
+++ b/apps/control-plane/cmd/server/main.go
@@ -387,6 +387,36 @@ func main() {
 			WithAccountLocker(accounting.NewPgxAccountLocker(pool))
 		accountingHandler = accounting.NewHandler(accountingSvc, accountsSvc)
 
+		// Issue #616 — stranded-hold reaper. A finalize that fails loses its
+		// charge and strands the hold in the same step, and reserved credits
+		// are subtracted from available balance until something releases them,
+		// so an account can end up refused service it has already paid for.
+		//
+		// This runs in process rather than as a pg_cron job for two reasons.
+		// The release has to go through the accounting service to take the
+		// per-account lock, post a real reservation_release entry under an
+		// idempotency key, write the reservation event and unwind the API key
+		// delta; a SQL job would have to reimplement all of that against an
+		// append-only ledger. And a pg_cron schedule that silently fails to
+		// exist looks exactly like a system with no leak, which is the failure
+		// mode that let this sit unnoticed for days. A missing runner here is
+		// visible in the startup log below.
+		reaperEnabled := !strings.EqualFold(strings.TrimSpace(os.Getenv("HIVE_RESERVATION_REAPER_ENABLED")), "false")
+		reaperTTL := parseDurationEnv("HIVE_RESERVATION_REAPER_TTL", accounting.ReaperDefaultTTL)
+		reaperInterval := parseDurationEnv("HIVE_RESERVATION_REAPER_INTERVAL", 15*time.Minute)
+		if reaperEnabled {
+			reservationReaper := accounting.NewReaper(accountingRepo, accountingSvc, accounting.ReaperConfig{
+				TTL:      reaperTTL,
+				Interval: reaperInterval,
+				Logger:   slog.Default(),
+			})
+			reservationReaper.Start(runCtx)
+			defer reservationReaper.Stop()
+			log.Printf("reservation reaper started (ttl=%s, interval=%s)", reaperTTL, reaperInterval)
+		} else {
+			log.Println("reservation reaper DISABLED by HIVE_RESERVATION_REAPER_ENABLED=false; stranded credit holds will not be released")
+		}
+
 		budgetsRepo := budgets.NewPgxRepository(pool)
 		workspaceBudgetsRepo := budgets.NewWorkspacePgxRepository(pool)
 		emailNotifier := budgets.NewLogNotifier(slog.Default())

--- a/apps/control-plane/internal/accounting/reaper.go
+++ b/apps/control-plane/internal/accounting/reaper.go
@@ -1,0 +1,259 @@
+package accounting
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// ReaperReleaseReason is stamped on every hold the reaper retires. It lands in
+// credit_reservation_events.reason and in the release ledger entry metadata, so
+// a pass is auditable long after the log line has rotated away.
+const ReaperReleaseReason = "stranded_hold_reaper"
+
+// ReaperDefaultTTL is how long a hold must sit in a non-terminal state before
+// the reaper treats its request as abandoned rather than in flight.
+//
+// Releasing a hold for a request that is still running would revoke the
+// authorization for work being performed, which then bills against nothing, so
+// the TTL is set from the longest a request can legitimately still be running
+// rather than from how quickly stranded credits should come back:
+//
+//   - every inference call, streaming included, is bounded at 120s by the
+//     LiteLLM client (apps/edge-api/internal/inference/litellm_client.go);
+//     http.Client.Timeout covers reading the response body, so an SSE stream
+//     cannot outlive it
+//   - the chat sidecar dispatch client is bounded at 5 minutes
+//     (apps/edge-api/internal/chat/dispatch.go)
+//   - a single control-plane accounting call is bounded at 30s
+//     (accountingTimeout in apps/edge-api/internal/inference)
+//
+// One hour is twelve times the largest of those. Batches, the one path that can
+// legitimately hold credits for a whole 24h completion window, are excluded
+// structurally by ListStaleReservations rather than by inflating this value.
+const ReaperDefaultTTL = time.Hour
+
+const (
+	reaperDefaultInterval   = 15 * time.Minute
+	reaperDefaultBatchLimit = 200
+)
+
+// staleReservationLister is the candidate source the reaper reads. It matches
+// Repository.ListStaleReservations so the production repository drops in
+// directly. Declared here per Go's interface-where-used convention.
+type staleReservationLister interface {
+	ListStaleReservations(ctx context.Context, olderThan time.Time, limit int) ([]Reservation, error)
+}
+
+// reservationReleaser is the settlement surface the reaper drives. It matches
+// Service.ReleaseReservation: releases go through the accounting service so
+// they take the per-account lock, post a real reservation_release ledger entry
+// under an idempotency key, write the reservation event, and unwind the API key
+// reservation delta. The reaper never writes to the ledger itself.
+type reservationReleaser interface {
+	ReleaseReservation(ctx context.Context, input ReleaseReservationInput) (Reservation, error)
+}
+
+// ReapResult is one pass worth of work, recorded so a continuing leak shows up
+// as a rising released count instead of staying silent.
+type ReapResult struct {
+	Scanned  int
+	Released int
+	Credits  int64
+	Failed   int
+}
+
+// ReaperConfig controls Reaper behaviour. Zero values take defaults.
+type ReaperConfig struct {
+	TTL        time.Duration
+	Interval   time.Duration
+	BatchLimit int
+	Logger     *slog.Logger
+	Now        func() time.Time
+}
+
+// Reaper releases credit holds whose request never reached a terminal state.
+//
+// It exists because a finalize that fails loses its charge and strands the
+// hold in the same step, and reserved credits are subtracted from available
+// balance forever after (issue #616). Without it, an account can be refused
+// service it has paid for by its own abandoned holds.
+type Reaper struct {
+	repo     staleReservationLister
+	releaser reservationReleaser
+	ttl      time.Duration
+	interval time.Duration
+	limit    int
+	logger   *slog.Logger
+	now      func() time.Time
+
+	mu      sync.Mutex
+	cancel  context.CancelFunc
+	doneCh  chan struct{}
+	started bool
+}
+
+// NewReaper builds a Reaper. Both dependencies must be non-nil.
+func NewReaper(repo staleReservationLister, releaser reservationReleaser, cfg ReaperConfig) *Reaper {
+	if repo == nil || releaser == nil {
+		panic("accounting: nil reaper dependency")
+	}
+	ttl := cfg.TTL
+	if ttl <= 0 {
+		ttl = ReaperDefaultTTL
+	}
+	interval := cfg.Interval
+	if interval <= 0 {
+		interval = reaperDefaultInterval
+	}
+	limit := cfg.BatchLimit
+	if limit <= 0 {
+		limit = reaperDefaultBatchLimit
+	}
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	now := cfg.Now
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	return &Reaper{
+		repo:     repo,
+		releaser: releaser,
+		ttl:      ttl,
+		interval: interval,
+		limit:    limit,
+		logger:   logger,
+		now:      now,
+	}
+}
+
+// RunOnce performs exactly one reaping pass synchronously. It is the unit of
+// work the loop schedules and the unit tests exercise.
+//
+// Two passes may overlap without releasing a hold twice. That is enforced by
+// the database, not by a check here: the release carries the fixed idempotency
+// key reservation:<id>:release, and the credit_idempotency_keys primary key
+// turns the second write into a no-op that returns the first entry, so the
+// second pass posts no ledger row. The per-account advisory lock and the
+// service backstops that refuse to release a finalized reservation and to
+// finalize a released one close the remaining orderings.
+func (r *Reaper) RunOnce(ctx context.Context) (ReapResult, error) {
+	cutoff := r.now().Add(-r.ttl)
+
+	stale, err := r.repo.ListStaleReservations(ctx, cutoff, r.limit)
+	if err != nil {
+		r.logger.WarnContext(ctx, "accounting: reaper candidate scan failed",
+			"error", err, "cutoff", cutoff.Format(time.RFC3339))
+		return ReapResult{}, fmt.Errorf("accounting: reaper scan: %w", err)
+	}
+
+	result := ReapResult{Scanned: len(stale)}
+	for _, reservation := range stale {
+		if ctx.Err() != nil {
+			break
+		}
+
+		held := remainingHeldCredits(reservation)
+		if _, err := r.releaser.ReleaseReservation(ctx, ReleaseReservationInput{
+			AccountID:     reservation.AccountID,
+			ReservationID: reservation.ID,
+			Reason:        ReaperReleaseReason,
+		}); err != nil {
+			// A refused release is not fatal to the pass: one reservation that
+			// settled underneath us must not strand the rest of the batch.
+			result.Failed++
+			r.logger.WarnContext(ctx, "accounting: reaper could not release a stranded hold",
+				"reservation_id", reservation.ID.String(),
+				"account_id", reservation.AccountID.String(),
+				"error", err)
+			continue
+		}
+
+		result.Released++
+		// ponytail: credits are counted from the candidate snapshot, so two
+		// overlapping passes can each count the same hold in their own totals.
+		// The ledger cannot double count it, per the idempotency key above, and
+		// the durable per-hold record is the credit_reservation_events row.
+		result.Credits += held
+	}
+
+	if result.Released > 0 || result.Failed > 0 {
+		r.logger.InfoContext(ctx, "accounting: reaper released stranded holds",
+			"scanned", result.Scanned,
+			"released", result.Released,
+			"credits", result.Credits,
+			"failed", result.Failed,
+			"ttl", r.ttl.String(),
+			"cutoff", cutoff.Format(time.RFC3339))
+	}
+
+	return result, nil
+}
+
+// Start launches the reaping loop on a background goroutine. Subsequent Start
+// calls are no-ops until Stop is called. The supplied parent context controls
+// loop cancellation in addition to Stop.
+func (r *Reaper) Start(parent context.Context) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.started {
+		return
+	}
+	ctx, cancel := context.WithCancel(parent)
+	doneCh := make(chan struct{})
+	r.cancel = cancel
+	r.doneCh = doneCh
+	r.started = true
+
+	go r.loop(ctx, doneCh)
+}
+
+// Stop signals the loop to exit and waits for the in-flight pass to finish.
+// Safe to call multiple times.
+func (r *Reaper) Stop() {
+	r.mu.Lock()
+	if !r.started {
+		r.mu.Unlock()
+		return
+	}
+	cancel := r.cancel
+	doneCh := r.doneCh
+	r.started = false
+	r.cancel = nil
+	r.doneCh = nil
+	r.mu.Unlock()
+
+	cancel()
+	<-doneCh
+}
+
+func (r *Reaper) loop(ctx context.Context, doneCh chan<- struct{}) {
+	defer close(doneCh)
+
+	// Eager first pass. Holds already stranded before this process started are
+	// the reason the reaper exists, and waiting a full interval to return them
+	// keeps an account locked out of an API it has paid for.
+	if _, err := r.RunOnce(ctx); err != nil {
+		// already logged
+		_ = err
+	}
+
+	ticker := time.NewTicker(r.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if _, err := r.RunOnce(ctx); err != nil {
+				// already logged
+				_ = err
+			}
+		}
+	}
+}

--- a/apps/control-plane/internal/accounting/reaper_test.go
+++ b/apps/control-plane/internal/accounting/reaper_test.go
@@ -1,0 +1,304 @@
+package accounting
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/ledger"
+)
+
+// reaperLedger models the parts of the real ledger the reaper depends on:
+// an append-only entry log deduplicated by idempotency key (the production
+// guard is the credit_idempotency_keys primary key plus ON CONFLICT DO
+// NOTHING in ledger/repository.go), and a balance derived from those entries.
+// Tests assert on the entry log rather than on return values, because a
+// duplicate release returns the existing entry and is indistinguishable from a
+// fresh one at the call site.
+type reaperLedger struct {
+	mu       sync.Mutex
+	posted   int64
+	held     int64
+	released int64
+	seenKeys map[string]bool
+	entries  []ledger.LedgerEntry
+}
+
+func newReaperLedger(grant int64) *reaperLedger {
+	return &reaperLedger{posted: grant, seenKeys: make(map[string]bool)}
+}
+
+// post applies an entry unless its (entry type, idempotency key) pair has
+// already been written, mirroring the production ON CONFLICT DO NOTHING path.
+func (l *reaperLedger) post(entryType ledger.EntryType, key string, delta int64, apply func()) ledger.LedgerEntry {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	dedupeKey := string(entryType) + "|" + key
+	if l.seenKeys[dedupeKey] {
+		for _, existing := range l.entries {
+			if existing.EntryType == entryType && existing.IdempotencyKey == key {
+				return existing
+			}
+		}
+	}
+	l.seenKeys[dedupeKey] = true
+	apply()
+	entry := ledger.LedgerEntry{ID: uuid.New(), EntryType: entryType, CreditsDelta: delta, IdempotencyKey: key}
+	l.entries = append(l.entries, entry)
+	return entry
+}
+
+func (l *reaperLedger) GetBalance(_ context.Context, _ uuid.UUID) (ledger.BalanceSummary, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	reserved := l.held - l.released
+	return ledger.BalanceSummary{
+		PostedCredits:    l.posted,
+		ReservedCredits:  reserved,
+		AvailableCredits: l.posted - reserved,
+	}, nil
+}
+
+func (l *reaperLedger) ReserveCredits(_ context.Context, _ uuid.UUID, _ string, _, _ *uuid.UUID, key string, credits int64, _ map[string]any) (ledger.LedgerEntry, error) {
+	return l.post(ledger.EntryTypeReservationHold, key, -credits, func() { l.held += credits }), nil
+}
+
+func (l *reaperLedger) ReleaseReservedCredits(_ context.Context, _ uuid.UUID, _ string, _, _ *uuid.UUID, key string, credits int64, _ map[string]any) (ledger.LedgerEntry, error) {
+	return l.post(ledger.EntryTypeReservationRelease, key, credits, func() { l.released += credits }), nil
+}
+
+func (l *reaperLedger) ChargeUsage(_ context.Context, _ uuid.UUID, _ string, _, _ *uuid.UUID, key string, credits int64, _ map[string]any) (ledger.LedgerEntry, error) {
+	return l.post(ledger.EntryTypeUsageCharge, key, -credits, func() { l.posted -= credits }), nil
+}
+
+func (l *reaperLedger) RefundCredits(_ context.Context, _ uuid.UUID, _ string, _, _ *uuid.UUID, key string, credits int64, _ map[string]any) (ledger.LedgerEntry, error) {
+	return l.post(ledger.EntryTypeRefund, key, credits, func() { l.posted += credits }), nil
+}
+
+// entryCount counts the ledger rows of a given type, which is the exactly-once
+// assertion surface.
+func (l *reaperLedger) entryCount(entryType ledger.EntryType) int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	count := 0
+	for _, entry := range l.entries {
+		if entry.EntryType == entryType {
+			count++
+		}
+	}
+	return count
+}
+
+// seedReservation inserts a reservation directly with an explicit age, standing
+// in for a hold whose request died before reaching a terminal state.
+func seedReservation(repo *repoStub, accountID uuid.UUID, credits int64, status ReservationStatus, age time.Duration) Reservation {
+	at := time.Now().UTC().Add(-age)
+	reservation := Reservation{
+		ID:               uuid.New(),
+		AccountID:        accountID,
+		RequestAttemptID: uuid.New(),
+		ReservationKey:   buildReservationKey(accountID, uuid.NewString(), 1),
+		RequestID:        uuid.NewString(),
+		AttemptNumber:    1,
+		Endpoint:         "/v1/chat/completions",
+		ModelAlias:       "hive-fast",
+		PolicyMode:       PolicyModeStrict,
+		Status:           status,
+		ReservedCredits:  credits,
+		CreatedAt:        at,
+		UpdatedAt:        at,
+	}
+	repo.reservations[reservation.ID] = reservation
+	return reservation
+}
+
+func newReaperFixture(t *testing.T, grant int64) (*Reaper, *repoStub, *reaperLedger) {
+	t.Helper()
+	repo := newRepoStub()
+	ledgerSvc := newReaperLedger(grant)
+	svc := NewService(repo, ledgerSvc, concurrentUsage{})
+	reaper := NewReaper(repo, svc, ReaperConfig{TTL: ReaperDefaultTTL})
+	return reaper, repo, ledgerSvc
+}
+
+// (a) A hold whose request never reached a terminal state, older than the TTL,
+// is released, and (e) the credits return to the account balance.
+func TestReaperReleasesStrandedHoldPastTTL(t *testing.T) {
+	reaper, repo, ledgerSvc := newReaperFixture(t, 300000)
+	accountID := uuid.New()
+	reservation := seedReservation(repo, accountID, 10000, ReservationStatusActive, 6*time.Hour)
+
+	// Post the original hold so the balance reflects the stranded reservation.
+	if _, err := ledgerSvc.ReserveCredits(context.Background(), accountID, reservation.RequestID, nil, &reservation.ID, "reservation:"+reservation.ID.String()+":reserve", 10000, nil); err != nil {
+		t.Fatalf("seed hold: %v", err)
+	}
+	before, _ := ledgerSvc.GetBalance(context.Background(), accountID)
+	if before.AvailableCredits != 290000 {
+		t.Fatalf("fixture wrong: available before reap = %d, want 290000", before.AvailableCredits)
+	}
+
+	result, err := reaper.RunOnce(context.Background())
+	if err != nil {
+		t.Fatalf("RunOnce returned error: %v", err)
+	}
+	if result.Released != 1 {
+		t.Fatalf("expected 1 stranded hold released, got %d", result.Released)
+	}
+	if result.Credits != 10000 {
+		t.Fatalf("expected 10000 credits released, got %d", result.Credits)
+	}
+
+	stored, err := repo.GetReservation(context.Background(), accountID, reservation.ID)
+	if err != nil {
+		t.Fatalf("reload reservation: %v", err)
+	}
+	if stored.Status != ReservationStatusReleased {
+		t.Fatalf("expected reservation status released, got %q", stored.Status)
+	}
+
+	after, _ := ledgerSvc.GetBalance(context.Background(), accountID)
+	if after.AvailableCredits != 300000 {
+		t.Fatalf("released credits did not return to the balance: available = %d, want 300000", after.AvailableCredits)
+	}
+	if after.ReservedCredits != 0 {
+		t.Fatalf("expected reserved credits to return to zero, got %d", after.ReservedCredits)
+	}
+}
+
+// (b) The invariant guard: a hold for a request that is still in flight is not
+// released. In flight is defined as younger than the TTL, because a stuck
+// attempt row is exactly what makes a hold stranded, so attempt status alone
+// cannot distinguish the two.
+func TestReaperLeavesInFlightHoldAlone(t *testing.T) {
+	reaper, repo, ledgerSvc := newReaperFixture(t, 300000)
+	accountID := uuid.New()
+	reservation := seedReservation(repo, accountID, 10000, ReservationStatusActive, 30*time.Second)
+
+	result, err := reaper.RunOnce(context.Background())
+	if err != nil {
+		t.Fatalf("RunOnce returned error: %v", err)
+	}
+	if result.Released != 0 {
+		t.Fatalf("reaper released an in-flight hold: released = %d", result.Released)
+	}
+	if got := ledgerSvc.entryCount(ledger.EntryTypeReservationRelease); got != 0 {
+		t.Fatalf("reaper posted %d release entries for an in-flight hold, want 0", got)
+	}
+
+	stored, err := repo.GetReservation(context.Background(), accountID, reservation.ID)
+	if err != nil {
+		t.Fatalf("reload reservation: %v", err)
+	}
+	if stored.Status != ReservationStatusActive {
+		t.Fatalf("expected in-flight reservation to stay active, got %q", stored.Status)
+	}
+
+	// Positive control: the same fixture is reapable, so the assertions above
+	// prove the TTL held it back rather than that nothing was reapable at all.
+	// Without this a broken reaper that releases nothing would pass the test.
+	eager := NewReaper(repo, NewService(repo, ledgerSvc, concurrentUsage{}), ReaperConfig{TTL: time.Nanosecond})
+	control, err := eager.RunOnce(context.Background())
+	if err != nil {
+		t.Fatalf("control RunOnce returned error: %v", err)
+	}
+	if control.Released != 1 {
+		t.Fatalf("control: the same hold should be reapable with a zero TTL, released = %d", control.Released)
+	}
+}
+
+// (c) A hold that already reached a terminal state is not released, twice over:
+// the candidate query excludes it, and if one ever slipped through, the service
+// backstop at service.go refuses to release a finalized reservation.
+func TestReaperLeavesFinalizedHoldAlone(t *testing.T) {
+	t.Run("excluded from candidates", func(t *testing.T) {
+		reaper, repo, ledgerSvc := newReaperFixture(t, 300000)
+		accountID := uuid.New()
+		seedReservation(repo, accountID, 10000, ReservationStatusFinalized, 6*time.Hour)
+		seedReservation(repo, accountID, 10000, ReservationStatusReleased, 6*time.Hour)
+
+		result, err := reaper.RunOnce(context.Background())
+		if err != nil {
+			t.Fatalf("RunOnce returned error: %v", err)
+		}
+		if result.Scanned != 0 {
+			t.Fatalf("terminal reservations were scanned as candidates: %d", result.Scanned)
+		}
+		if got := ledgerSvc.entryCount(ledger.EntryTypeReservationRelease); got != 0 {
+			t.Fatalf("reaper posted %d release entries for terminal holds, want 0", got)
+		}
+	})
+
+	t.Run("service backstop refuses a finalized hold", func(t *testing.T) {
+		repo := newRepoStub()
+		ledgerSvc := newReaperLedger(300000)
+		svc := NewService(repo, ledgerSvc, concurrentUsage{})
+		accountID := uuid.New()
+		finalized := seedReservation(repo, accountID, 10000, ReservationStatusFinalized, 6*time.Hour)
+
+		// A lister that hands the reaper a finalized reservation anyway, which is
+		// what a widened query or a race with a concurrent finalize would do.
+		reaper := NewReaper(staleListerFunc(func(context.Context, time.Time, int) ([]Reservation, error) {
+			return []Reservation{finalized}, nil
+		}), svc, ReaperConfig{TTL: ReaperDefaultTTL})
+
+		result, err := reaper.RunOnce(context.Background())
+		if err != nil {
+			t.Fatalf("RunOnce returned error: %v", err)
+		}
+		if result.Released != 0 {
+			t.Fatalf("reaper released a finalized hold: released = %d", result.Released)
+		}
+		if result.Failed != 1 {
+			t.Fatalf("expected the refused release to be counted as a failure, got %d", result.Failed)
+		}
+		if got := ledgerSvc.entryCount(ledger.EntryTypeReservationRelease); got != 0 {
+			t.Fatalf("reaper posted %d release entries for a finalized hold, want 0", got)
+		}
+	})
+}
+
+// (d) Two overlapping passes must retire the hold exactly once. The assertion is
+// on ledger rows, not on the two return values, because the second pass gets the
+// first pass's entry back and cannot tell it apart from its own.
+func TestConcurrentReaperRunsReleaseExactlyOnce(t *testing.T) {
+	repo := newRepoStub()
+	ledgerSvc := newReaperLedger(300000)
+	svc := NewService(repo, ledgerSvc, concurrentUsage{})
+	accountID := uuid.New()
+	reservation := seedReservation(repo, accountID, 10000, ReservationStatusActive, 6*time.Hour)
+	if _, err := ledgerSvc.ReserveCredits(context.Background(), accountID, reservation.RequestID, nil, &reservation.ID, "reservation:"+reservation.ID.String()+":reserve", 10000, nil); err != nil {
+		t.Fatalf("seed hold: %v", err)
+	}
+
+	first := NewReaper(repo, svc, ReaperConfig{TTL: ReaperDefaultTTL})
+	second := NewReaper(repo, svc, ReaperConfig{TTL: ReaperDefaultTTL})
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	for _, reaper := range []*Reaper{first, second} {
+		go func(r *Reaper) {
+			defer wg.Done()
+			if _, err := r.RunOnce(context.Background()); err != nil {
+				t.Errorf("concurrent RunOnce returned error: %v", err)
+			}
+		}(reaper)
+	}
+	wg.Wait()
+
+	if got := ledgerSvc.entryCount(ledger.EntryTypeReservationRelease); got != 1 {
+		t.Fatalf("expected exactly 1 release ledger entry from two concurrent passes, got %d", got)
+	}
+	balance, _ := ledgerSvc.GetBalance(context.Background(), accountID)
+	if balance.AvailableCredits != 300000 {
+		t.Fatalf("double release corrupted the balance: available = %d, want 300000", balance.AvailableCredits)
+	}
+}
+
+// staleListerFunc adapts a function to the reaper's candidate source.
+type staleListerFunc func(ctx context.Context, olderThan time.Time, limit int) ([]Reservation, error)
+
+func (f staleListerFunc) ListStaleReservations(ctx context.Context, olderThan time.Time, limit int) ([]Reservation, error) {
+	return f(ctx, olderThan, limit)
+}

--- a/apps/control-plane/internal/accounting/repository.go
+++ b/apps/control-plane/internal/accounting/repository.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -18,6 +19,7 @@ type Repository interface {
 	FinalizeReservation(ctx context.Context, accountID, reservationID uuid.UUID, consumedCredits, releasedCredits int64, terminalUsageConfirmed bool, status ReservationStatus, reason string) (Reservation, error)
 	ReleaseReservation(ctx context.Context, accountID, reservationID uuid.UUID, releasedCredits int64, reason string) (Reservation, error)
 	CreateReconciliationJob(ctx context.Context, reservationID, requestAttemptID uuid.UUID, reason string) error
+	ListStaleReservations(ctx context.Context, olderThan time.Time, limit int) ([]Reservation, error)
 }
 
 type pgxRepository struct {
@@ -258,6 +260,55 @@ func (r *pgxRepository) CreateReconciliationJob(ctx context.Context, reservation
 	}
 
 	return nil
+}
+
+// ListStaleReservations returns holds still sitting in a non-terminal state
+// whose reservation has not been touched since olderThan, which is how a
+// request that died before settlement looks from the database (issue #616).
+//
+// Two predicates keep an in-flight request out of the result. Both created_at
+// and updated_at must precede the cutoff, so a long request that expanded its
+// hold recently is not treated as abandoned. And a reservation still attached
+// to a running batch is excluded outright: a batch legitimately holds credits
+// for its whole completion window, 24h by default, which is far longer than
+// any inference request can run, so the batch row is the authoritative
+// in-flight signal on that path rather than elapsed time.
+func (r *pgxRepository) ListStaleReservations(ctx context.Context, olderThan time.Time, limit int) ([]Reservation, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+
+	rows, err := r.pool.Query(ctx, reservationSelect+`
+		WHERE cr.status IN ('active', 'expanded')
+		  AND cr.created_at < $1
+		  AND cr.updated_at < $1
+		  AND NOT EXISTS (
+			SELECT 1
+			FROM public.batches b
+			WHERE b.reservation_id = cr.id::text
+			  AND b.status NOT IN ('completed', 'failed', 'cancelled', 'expired')
+		  )
+		ORDER BY cr.created_at
+		LIMIT $2
+	`, olderThan, limit)
+	if err != nil {
+		return nil, fmt.Errorf("accounting: list stale reservations: %w", err)
+	}
+	defer rows.Close()
+
+	var stale []Reservation
+	for rows.Next() {
+		reservation, err := scanReservation(rows)
+		if err != nil {
+			return nil, err
+		}
+		stale = append(stale, reservation)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("accounting: iterate stale reservations: %w", err)
+	}
+
+	return stale, nil
 }
 
 const reservationSelect = `

--- a/apps/control-plane/internal/accounting/service_concurrency_test.go
+++ b/apps/control-plane/internal/accounting/service_concurrency_test.go
@@ -78,6 +78,9 @@ func (r *concurrentRepo) ReleaseReservation(context.Context, uuid.UUID, uuid.UUI
 func (r *concurrentRepo) CreateReconciliationJob(context.Context, uuid.UUID, uuid.UUID, string) error {
 	return nil
 }
+func (r *concurrentRepo) ListStaleReservations(context.Context, time.Time, int) ([]Reservation, error) {
+	return nil, nil
+}
 
 // concurrentUsage is a goroutine-safe usage stub.
 type concurrentUsage struct{}

--- a/apps/control-plane/internal/accounting/service_test.go
+++ b/apps/control-plane/internal/accounting/service_test.go
@@ -3,6 +3,7 @@ package accounting
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -211,7 +212,10 @@ type reconciliationJob struct {
 	reason           string
 }
 
+// repoStub is guarded by a mutex so the concurrent reaper test can drive two
+// passes at once without racing on the maps.
 type repoStub struct {
+	mu                 sync.Mutex
 	reservations       map[uuid.UUID]Reservation
 	reconciliationJobs []reconciliationJob
 	releaseEventCounts map[uuid.UUID]int
@@ -225,6 +229,8 @@ func newRepoStub() *repoStub {
 }
 
 func (r *repoStub) CreateReservation(_ context.Context, reservation Reservation, reason string) (Reservation, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	now := time.Now().UTC()
 	reservation.CreatedAt = now
 	reservation.UpdatedAt = now
@@ -233,6 +239,12 @@ func (r *repoStub) CreateReservation(_ context.Context, reservation Reservation,
 }
 
 func (r *repoStub) GetReservation(_ context.Context, accountID, reservationID uuid.UUID) (Reservation, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.getLocked(accountID, reservationID)
+}
+
+func (r *repoStub) getLocked(accountID, reservationID uuid.UUID) (Reservation, error) {
 	reservation, ok := r.reservations[reservationID]
 	if !ok || reservation.AccountID != accountID {
 		return Reservation{}, ErrNotFound
@@ -240,8 +252,31 @@ func (r *repoStub) GetReservation(_ context.Context, accountID, reservationID uu
 	return reservation, nil
 }
 
+// ListStaleReservations mirrors the production predicates: non-terminal status,
+// and untouched since the cutoff on both timestamps.
+func (r *repoStub) ListStaleReservations(_ context.Context, olderThan time.Time, limit int) ([]Reservation, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var stale []Reservation
+	for _, reservation := range r.reservations {
+		if reservation.Status != ReservationStatusActive && reservation.Status != ReservationStatusExpanded {
+			continue
+		}
+		if !reservation.CreatedAt.Before(olderThan) || !reservation.UpdatedAt.Before(olderThan) {
+			continue
+		}
+		stale = append(stale, reservation)
+		if limit > 0 && len(stale) == limit {
+			break
+		}
+	}
+	return stale, nil
+}
+
 func (r *repoStub) ExpandReservation(_ context.Context, accountID, reservationID uuid.UUID, additionalCredits int64, reason string) (Reservation, error) {
-	reservation, err := r.GetReservation(context.Background(), accountID, reservationID)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	reservation, err := r.getLocked(accountID, reservationID)
 	if err != nil {
 		return Reservation{}, err
 	}
@@ -254,7 +289,9 @@ func (r *repoStub) ExpandReservation(_ context.Context, accountID, reservationID
 }
 
 func (r *repoStub) FinalizeReservation(_ context.Context, accountID, reservationID uuid.UUID, consumedCredits, releasedCredits int64, terminalUsageConfirmed bool, status ReservationStatus, reason string) (Reservation, error) {
-	reservation, err := r.GetReservation(context.Background(), accountID, reservationID)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	reservation, err := r.getLocked(accountID, reservationID)
 	if err != nil {
 		return Reservation{}, err
 	}
@@ -269,7 +306,9 @@ func (r *repoStub) FinalizeReservation(_ context.Context, accountID, reservation
 }
 
 func (r *repoStub) ReleaseReservation(_ context.Context, accountID, reservationID uuid.UUID, releasedCredits int64, reason string) (Reservation, error) {
-	reservation, err := r.GetReservation(context.Background(), accountID, reservationID)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	reservation, err := r.getLocked(accountID, reservationID)
 	if err != nil {
 		return Reservation{}, err
 	}
@@ -286,6 +325,8 @@ func (r *repoStub) ReleaseReservation(_ context.Context, accountID, reservationI
 }
 
 func (r *repoStub) CreateReconciliationJob(_ context.Context, reservationID, requestAttemptID uuid.UUID, reason string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	r.reconciliationJobs = append(r.reconciliationJobs, reconciliationJob{
 		reservationID:    reservationID,
 		requestAttemptID: requestAttemptID,

--- a/supabase/migrations/20260801_02_credit_reservations_stale_hold_index.sql
+++ b/supabase/migrations/20260801_02_credit_reservations_stale_hold_index.sql
@@ -1,0 +1,17 @@
+-- Issue #616: serve the stranded-hold reaper's candidate scan.
+--
+-- The reaper looks for reservations still sitting in a non-terminal state past
+-- a TTL. The existing index on (account_id, updated_at desc) cannot serve that
+-- scan because the reaper has no account predicate to lead with.
+--
+-- The index is partial, so it only ever holds unsettled reservations and a row
+-- leaves it as soon as the request settles. On a healthy system that is a
+-- handful of rows regardless of how large the table grows.
+--
+-- Re-runnable: guarded per statement, and no data is written.
+create index if not exists idx_credit_reservations_stale_holds
+  on public.credit_reservations (created_at)
+  where status in ('active', 'expanded');
+
+comment on index public.idx_credit_reservations_stale_holds is
+  'Serves the stranded-hold reaper candidate scan (issue #616).';


### PR DESCRIPTION
Closes #616.

A reaper that releases credit reservation holds whose request never reached a terminal state.

The leak itself is already fixed (#629 for the sync path, #639 for audio and images), so new holds should no longer strand. This is the other half of that issue: the holds already stranded need releasing, and nothing exists to release them. On the demo box that is 32 rows in `active` state stranding 154000 credits, enough to drive the demo account below the flat 10000 credit reservation estimate, after which the gateway correctly refuses every request.

## The TTL, and why one hour

The dangerous failure mode is releasing too eagerly: revoking the authorization for work currently being performed, which then bills against nothing. So the TTL is set from the longest a request can legitimately still be running, not from how quickly stranded credits should come back.

| Bound | Value | Source |
| --- | --- | --- |
| Any inference call, streaming included | 120s | `apps/edge-api/internal/inference/litellm_client.go:26`. `http.Client.Timeout` covers reading the response body, so an SSE stream cannot outlive it. |
| Chat sidecar dispatch | 5 min | `apps/edge-api/internal/chat/dispatch.go:42` |
| One control-plane accounting call | 30s | `accountingTimeout`, `apps/edge-api/internal/inference/accounting_client.go:28` |

One hour is twelve times the largest of those.

Batches are the one path that legitimately holds credits far longer: `public.batches.completion_window` defaults to 24h. Rather than inflate the TTL to 26h and leave every stranded hold sitting for a day, the candidate query excludes any reservation still attached to a batch in a non-terminal state. The batch row is the authoritative in-flight signal on that path; elapsed time is not. Verified below.

The TTL is overridable via `HIVE_RESERVATION_REAPER_TTL`, with the reasoning restated in `.env.example` so it cannot be lowered casually.

## Why an in-process ticker rather than pg_cron

Two reasons.

The release has to go through the accounting service. It takes the per-account advisory lock, posts a real `reservation_release` ledger entry under an idempotency key, writes the `credit_reservation_events` row and unwinds the API key reservation delta. A SQL job would have to reimplement all of that against an append-only ledger whose invariants live in the service, which is exactly the hand-written `UPDATE` the issue rules out.

And `pg_cron` has a silent failure mode here. `20260729_02` creates the extension behind an exception handler and nothing asserts the schedule actually exists afterward, so a job that was never scheduled is indistinguishable from a system with no leak. That absence of signal is what let this sit for days. A runner that is not running is visible in the control-plane startup log, which prints either the active TTL and interval or an explicit disabled line.

The runner follows the existing `spendalerts.Runner` shape already wired in `main.go`: `Start` / `Stop` / `RunOnce`, bound to `runCtx`, with an eager first pass at startup so a restart does not wait a full interval before returning credits.

## Exactly once, enforced by the database

Not by a check then act in Go:

- The release carries the fixed idempotency key `reservation:<id>:release`. `credit_idempotency_keys` has a primary key on `(account_id, operation_type, idempotency_key)` and `ledger/repository.go` inserts `ON CONFLICT DO NOTHING`, then returns the existing entry. A second concurrent release posts no second ledger row.
- `repo.ReleaseReservation` updates `WHERE status <> 'released'`, so the row lock serializes the two writers and the loser affects zero rows.
- The per-account Postgres advisory lock serializes the two passes for a given account across processes.

Layered on top, the service backstops confirmed still in place at `accounting/service.go:414` (refuses to release a finalized reservation) and `:263` (refuses to finalize a released one). The reaper leans on those rather than reimplementing the check. A refused release is counted as a failure and logged, and does not abort the rest of the pass.

## What a run records

- One structured log line per pass whenever anything was released or failed: scanned, released, credits, failed, ttl, cutoff.
- Durably, per hold: every release writes a `credit_reservation_events` row with `reason = 'stranded_hold_reaper'`, and the same reason lands in the release ledger entry metadata. So a future leak stays countable long after the log rotates:

```sql
SELECT date_trunc('day', created_at) AS day, count(*), sum(credits_delta)
FROM public.credit_reservation_events
WHERE reason = 'stranded_hold_reaper'
GROUP BY 1 ORDER BY 1 DESC;
```

A rising daily count means the leak is back. It should show one spike for the backlog and then nothing.

## Releasing the 32 holds already stranded

By running this mechanism over them, not a one-off script. They are all older than the TTL, in `active` state, and not attached to any batch, so they are exactly the candidate set. On the next control-plane deploy the eager startup pass releases all 32 and logs one line with the total. No separate step, and the cleanup is itself the proof the mechanism works.

To hold it back until you choose, set `HIVE_RESERVATION_REAPER_ENABLED=false` before the deploy. The startup log then says so explicitly rather than going quiet.

After the pass, expected state:

```sql
SELECT status, count(*), sum(reserved_credits - consumed_credits - released_credits) AS still_held
FROM public.credit_reservations GROUP BY status;
```

`active` should hold nothing, and the demo account's available credits should rise by 154000.

## Verification

Tested against the worktree `/tmp/reaper` on `feat/reservation-reaper`, mounted directly (`docker run --rm -v /tmp/reaper:/workspace hive-toolchain:latest`), not the shared checkout.

Tests written first and confirmed failing before the implementation existed:

```
=== RUN   TestReaperReleasesStrandedHoldPastTTL
    reaper_test.go:147: expected 1 stranded hold released, got 0
--- FAIL: TestReaperReleasesStrandedHoldPastTTL (0.00s)
=== RUN   TestReaperLeavesFinalizedHoldAlone/service_backstop_refuses_a_finalized_hold
    reaper_test.go:242: expected the refused release to be counted as a failure, got 0
--- FAIL: TestReaperLeavesFinalizedHoldAlone (0.00s)
=== RUN   TestConcurrentReaperRunsReleaseExactlyOnce
    reaper_test.go:279: expected exactly 1 release ledger entry from two concurrent passes, got 0
--- FAIL: TestConcurrentReaperRunsReleaseExactlyOnce (0.00s)
FAIL	github.com/sakibsadmanshajib/hive/apps/control-plane/internal/accounting	0.031s
```

Green after:

```
--- PASS: TestReaperReleasesStrandedHoldPastTTL (0.00s)
--- PASS: TestReaperLeavesInFlightHoldAlone (0.00s)
--- PASS: TestReaperLeavesFinalizedHoldAlone (0.00s)
    --- PASS: TestReaperLeavesFinalizedHoldAlone/excluded_from_candidates (0.00s)
    --- PASS: TestReaperLeavesFinalizedHoldAlone/service_backstop_refuses_a_finalized_hold (0.00s)
--- PASS: TestConcurrentReaperRunsReleaseExactlyOnce (0.00s)
ok  	github.com/sakibsadmanshajib/hive/apps/control-plane/internal/accounting	0.006s
```

Full `go test ./apps/control-plane/... -count=1 -short` passes with no `FAIL` and no `panic`. The race detector could not be used: the toolchain image has no gcc, so `-race` fails to build. The shared state the concurrent test touches is mutex guarded instead.

The in-flight test carries a positive control: the same fixture is reaped when the TTL is set to a nanosecond, so a reaper that released nothing at all could not pass it.

The exactly-once test asserts on ledger rows rather than on the two return values, because the second pass gets the first pass's entry back and cannot tell it apart from its own.

Migration checked on a scratch `pgvector/pgvector:pg17` with the full 80 file chain applied in order after `.github/ci/test-db-bootstrap.sql`, the same recipe CI uses. It applied clean, and re-applying the new file twice more is a no-op (`IF NOT EXISTS`, no data statements, so no `ON CONFLICT` is needed). The candidate query planned against that schema uses the new partial index:

```
->  Hash Right Anti Join
      Hash Cond: (b.reservation_id = (cr.id)::text)
      ->  Seq Scan on batches b
            Filter: (status <> ALL ('{completed,failed,cancelled,expired}'::text[]))
      ->  Index Scan using idx_credit_reservations_stale_holds on credit_reservations cr
            Index Cond: (created_at < (now() - '01:00:00'::interval))
            Filter: (updated_at < (now() - '01:00:00'::interval))
```

The predicates were then exercised with real rows under real constraints. Four holds: one stranded six hours, one created 30 seconds ago, one finalized, one attached to an `in_progress` batch.

```
   reaped
------------
 k:stranded
(1 row)
```

Then, after flipping only the batch to `completed`:

```
 reaped_after_batch_completes
------------------------------
 k:batch
 k:stranded
(2 rows)
```

So the batch hold is protected exactly while its batch runs, and becomes reapable the moment it does not.

The migration uses prefix `20260801_02` because `20260801_01` is already taken by the payment webhook deliveries migration on main.

## Not done here

The reaper does not touch `request_attempts` rows stuck in `dispatching` or `streaming`, noted in the issue as the upstream cause. Those are a reporting artifact once the hold is released, and cleaning them is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
