### PR TITLE
fix: run finalize on a background context, not the request context (#637)

### DIFF
--- a/apps/edge-api/internal/audio/reservation.go
+++ b/apps/edge-api/internal/audio/reservation.go
@@ -21,18 +21,30 @@ const releaseTimeout = 30 * time.Second
 // failed finalize neither charged nor released the hold, stranding it
 // forever.
 //
-// The release runs on a fresh, bounded background context, never ctx. By
-// the time a request reaches this point the client may already have
-// disconnected, cancelling ctx, which would otherwise silently swallow the
-// release the same way it swallowed the original finalize: the exact bug
-// PR #602 fixed on the streaming inference path, reproduced here on the
-// media path.
+// Both finalize AND its fallback release run on a fresh, bounded background
+// context, never ctx (#637). By the time a request reaches this point the
+// client may already have disconnected, cancelling ctx: finalizing on ctx
+// then fails not because the ledger rejected the charge but because the
+// underlying HTTP call aborts on the cancelled context, which used to fall
+// through to the release-on-finalize-failure branch below and release a
+// hold for work that was genuinely delivered and should have been charged.
+// That's the exact bug PR #602 fixed on the streaming inference path
+// (settleStream), reproduced here on the media path: the client
+// disconnecting must not convert a chargeable request into a free one.
+// ctx itself is accepted only for call-site symmetry with the rest of the
+// handler and is otherwise unused -- settlement never depends on the
+// request context surviving to this point.
 //
 // Release is attempted only when finalize errors, so a reservation that
 // finalized successfully is never also released (which would refund a
 // legitimate charge).
 func (h *Handler) settleReservation(ctx context.Context, accountID, reservationID string, actualCredits int64, endpoint string) {
-	err := h.accounting.FinalizeReservation(ctx, FinalizeInput{
+	_ = ctx // intentionally unused -- see comment above (#637)
+
+	bgCtx, cancel := context.WithTimeout(context.Background(), releaseTimeout)
+	defer cancel()
+
+	err := h.accounting.FinalizeReservation(bgCtx, FinalizeInput{
 		AccountID:     accountID,
 		ReservationID: reservationID,
 		ActualCredits: actualCredits,
@@ -42,8 +54,6 @@ func (h *Handler) settleReservation(ctx context.Context, accountID, reservationI
 	}
 	log.Printf("audio: finalize reservation failed endpoint=%s reservation_id=%s: %v", endpoint, reservationID, err)
 
-	bgCtx, cancel := context.WithTimeout(context.Background(), releaseTimeout)
-	defer cancel()
 	if relErr := h.accounting.ReleaseReservation(bgCtx, accountID, reservationID, "finalize_failed"); relErr != nil {
 		log.Printf("audio: release reservation after finalize failure also failed endpoint=%s reservation_id=%s: %v", endpoint, reservationID, relErr)
 	}

--- a/apps/edge-api/internal/audio/reservation.go
+++ b/apps/edge-api/internal/audio/reservation.go
@@ -6,12 +6,14 @@ import (
 	"time"
 )
 
-// releaseTimeout bounds the background-context reservation release attempted
-// when FinalizeReservation fails. Mirrors the inference package's
+// releaseTimeout bounds each background-context accounting call in
+// settleReservation. Mirrors the inference package's
 // accountingTimeout/releaseReservationBackground pattern (PR #602) so a
 // finalize failure never strands the hold, even when the request context is
-// already cancelled by the time settleReservation runs.
-const releaseTimeout = 30 * time.Second
+// already cancelled by the time settleReservation runs. A var, not a const,
+// so tests can shrink it to exercise the deadline-exhaustion path in
+// milliseconds instead of real seconds.
+var releaseTimeout = 30 * time.Second
 
 // settleReservation finalizes a reservation and, only when finalize itself
 // fails, releases it instead, so a reservation always reaches a terminal
@@ -38,23 +40,34 @@ const releaseTimeout = 30 * time.Second
 // Release is attempted only when finalize errors, so a reservation that
 // finalized successfully is never also released (which would refund a
 // legitimate charge).
+//
+// Finalize and release each get their OWN context.WithTimeout call, the
+// release one created only after finalize has already failed, not one
+// shared context reused for both. A single shared deadline would let a
+// finalize call that is merely SLOW (not instant) consume the whole
+// window, so the fallback release would then run on an already-expired
+// context and fail with context deadline exceeded, stranding the hold --
+// exactly #616's failure mode, reintroduced through the fix meant to
+// prevent it. Giving the release a fresh, full budget is what actually
+// keeps the exactly-once-terminal-state invariant.
 func (h *Handler) settleReservation(ctx context.Context, accountID, reservationID string, actualCredits int64, endpoint string) {
 	_ = ctx // intentionally unused -- see comment above (#637)
 
-	bgCtx, cancel := context.WithTimeout(context.Background(), releaseTimeout)
-	defer cancel()
-
-	err := h.accounting.FinalizeReservation(bgCtx, FinalizeInput{
+	finalizeCtx, finalizeCancel := context.WithTimeout(context.Background(), releaseTimeout)
+	err := h.accounting.FinalizeReservation(finalizeCtx, FinalizeInput{
 		AccountID:     accountID,
 		ReservationID: reservationID,
 		ActualCredits: actualCredits,
 	})
+	finalizeCancel()
 	if err == nil {
 		return
 	}
 	log.Printf("audio: finalize reservation failed endpoint=%s reservation_id=%s: %v", endpoint, reservationID, err)
 
-	if relErr := h.accounting.ReleaseReservation(bgCtx, accountID, reservationID, "finalize_failed"); relErr != nil {
+	releaseCtx, releaseCancel := context.WithTimeout(context.Background(), releaseTimeout)
+	defer releaseCancel()
+	if relErr := h.accounting.ReleaseReservation(releaseCtx, accountID, reservationID, "finalize_failed"); relErr != nil {
 		log.Printf("audio: release reservation after finalize failure also failed endpoint=%s reservation_id=%s: %v", endpoint, reservationID, relErr)
 	}
 }

--- a/apps/edge-api/internal/audio/reservation_test.go
+++ b/apps/edge-api/internal/audio/reservation_test.go
@@ -19,14 +19,27 @@ type settleReservationMock struct {
 	// tests can prove the release ran on a live context even when the caller
 	// passed settleReservation an already-cancelled one.
 	releaseCtxErr error
+	// finalizeCtxErr captures ctx.Err() as observed by FinalizeReservation,
+	// so a test can prove finalize itself ran on a live context (#637) even
+	// when the caller passed settleReservation an already-cancelled one. A
+	// cancelled context here mimics what a real HTTP client does: it aborts
+	// immediately rather than making the call, which is exactly how #637
+	// converted a chargeable request into a released one.
+	finalizeCtxErr error
 }
 
 func (m *settleReservationMock) CreateReservation(context.Context, ReservationInput) (string, error) {
 	return "", nil
 }
 
-func (m *settleReservationMock) FinalizeReservation(context.Context, FinalizeInput) error {
+func (m *settleReservationMock) FinalizeReservation(ctx context.Context, _ FinalizeInput) error {
 	m.finalizeCalled = true
+	m.finalizeCtxErr = ctx.Err()
+	if ctx.Err() != nil {
+		// A real accounting HTTP client aborts immediately on an
+		// already-cancelled context rather than reaching the control plane.
+		return ctx.Err()
+	}
 	return m.finalizeErr
 }
 
@@ -89,5 +102,33 @@ func TestSettleReservationReleaseSurvivesCancelledRequestContext(t *testing.T) {
 	}
 	if m.releaseCtxErr != nil {
 		t.Fatalf("expected ReleaseReservation to receive a live (non-cancelled) context, got ctx.Err() = %v", m.releaseCtxErr)
+	}
+}
+
+// TestSettleReservationFinalizeSurvivesCancelledRequestContext is #637's
+// primary regression guard: a client that disconnects right before
+// settlement must still be CHARGED for delivered work, not have the hold
+// released. finalizeErr is nil here (finalize would succeed if it reached
+// the control plane on a live context), so if settleReservation still runs
+// FinalizeReservation on the caller's cancelled ctx, the mock's cancelled-
+// context short-circuit turns that success into a failure and this test
+// catches the resulting spurious release.
+func TestSettleReservationFinalizeSurvivesCancelledRequestContext(t *testing.T) {
+	m := &settleReservationMock{finalizeErr: nil}
+	h := &Handler{accounting: m}
+
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel() // simulate the client having already disconnected before settlement
+
+	h.settleReservation(cancelledCtx, "acct-1", "res-1", 500, "/v1/audio/speech")
+
+	if !m.finalizeCalled {
+		t.Fatal("expected FinalizeReservation to be attempted")
+	}
+	if m.finalizeCtxErr != nil {
+		t.Fatalf("expected FinalizeReservation to receive a live (non-cancelled) context despite the caller's ctx being cancelled, got ctx.Err() = %v", m.finalizeCtxErr)
+	}
+	if m.releaseCalled {
+		t.Fatal("expected delivered work to be CHARGED, not released, despite the client disconnecting before settlement (#637)")
 	}
 }

--- a/apps/edge-api/internal/audio/reservation_test.go
+++ b/apps/edge-api/internal/audio/reservation_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 )
 
 // settleReservationMock is a white-box double for AccountingInterface, used
@@ -26,6 +27,11 @@ type settleReservationMock struct {
 	// immediately rather than making the call, which is exactly how #637
 	// converted a chargeable request into a released one.
 	finalizeCtxErr error
+	// finalizeSleep, if set, is how long FinalizeReservation blocks before
+	// returning finalizeErr. Used to prove finalize and release do not share
+	// one context/deadline: a finalize that runs long enough to exhaust its
+	// own context must not leave the release with an already-expired one.
+	finalizeSleep time.Duration
 }
 
 func (m *settleReservationMock) CreateReservation(context.Context, ReservationInput) (string, error) {
@@ -34,10 +40,14 @@ func (m *settleReservationMock) CreateReservation(context.Context, ReservationIn
 
 func (m *settleReservationMock) FinalizeReservation(ctx context.Context, _ FinalizeInput) error {
 	m.finalizeCalled = true
+	if m.finalizeSleep > 0 {
+		time.Sleep(m.finalizeSleep)
+	}
 	m.finalizeCtxErr = ctx.Err()
 	if ctx.Err() != nil {
 		// A real accounting HTTP client aborts immediately on an
-		// already-cancelled context rather than reaching the control plane.
+		// already-cancelled or already-expired context rather than reaching
+		// the control plane.
 		return ctx.Err()
 	}
 	return m.finalizeErr
@@ -46,6 +56,9 @@ func (m *settleReservationMock) FinalizeReservation(ctx context.Context, _ Final
 func (m *settleReservationMock) ReleaseReservation(ctx context.Context, _, _, _ string) error {
 	m.releaseCalled = true
 	m.releaseCtxErr = ctx.Err()
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
 	return nil
 }
 
@@ -130,5 +143,38 @@ func TestSettleReservationFinalizeSurvivesCancelledRequestContext(t *testing.T) 
 	}
 	if m.releaseCalled {
 		t.Fatal("expected delivered work to be CHARGED, not released, despite the client disconnecting before settlement (#637)")
+	}
+}
+
+// TestSettleReservationReleaseGetsFreshDeadlineAfterSlowFinalize is the
+// review finding on #650: finalize and its fallback release must NOT share
+// one context/deadline. A finalize call that is merely SLOW (not instant)
+// can otherwise consume the whole background-context window, so the
+// release that follows a failed finalize would run on an already-expired
+// context and fail with context deadline exceeded, stranding the hold --
+// exactly #616's failure mode, reintroduced through the #637 fix meant to
+// prevent it. releaseTimeout is shrunk to a few milliseconds so this proves
+// the shared-vs-fresh-context property fast, without a real 30s wait.
+func TestSettleReservationReleaseGetsFreshDeadlineAfterSlowFinalize(t *testing.T) {
+	original := releaseTimeout
+	releaseTimeout = 20 * time.Millisecond
+	defer func() { releaseTimeout = original }()
+
+	m := &settleReservationMock{
+		finalizeErr:   errors.New("control-plane unreachable"),
+		finalizeSleep: 40 * time.Millisecond, // longer than releaseTimeout
+	}
+	h := &Handler{accounting: m}
+
+	h.settleReservation(context.Background(), "acct-1", "res-1", 500, "/v1/audio/speech")
+
+	if !m.finalizeCalled {
+		t.Fatal("expected FinalizeReservation to be attempted")
+	}
+	if !m.releaseCalled {
+		t.Fatal("expected ReleaseReservation to be attempted after finalize failure")
+	}
+	if m.releaseCtxErr != nil {
+		t.Fatalf("expected release to get a FRESH context with its own full deadline rather than finalize's already-expired one, got ctx.Err() = %v", m.releaseCtxErr)
 	}
 }

--- a/apps/edge-api/internal/images/reservation.go
+++ b/apps/edge-api/internal/images/reservation.go
@@ -6,12 +6,14 @@ import (
 	"time"
 )
 
-// releaseTimeout bounds the background-context reservation release attempted
-// when FinalizeReservation fails. Mirrors the inference package's
+// releaseTimeout bounds each background-context accounting call in
+// settleReservation. Mirrors the inference package's
 // accountingTimeout/releaseReservationBackground pattern (PR #602) so a
 // finalize failure never strands the hold, even when the request context is
-// already cancelled by the time settleReservation runs.
-const releaseTimeout = 30 * time.Second
+// already cancelled by the time settleReservation runs. A var, not a const,
+// so tests can shrink it to exercise the deadline-exhaustion path in
+// milliseconds instead of real seconds.
+var releaseTimeout = 30 * time.Second
 
 // settleReservation finalizes a reservation and, only when finalize itself
 // fails, releases it instead, so a reservation always reaches a terminal
@@ -38,23 +40,34 @@ const releaseTimeout = 30 * time.Second
 // Release is attempted only when finalize errors, so a reservation that
 // finalized successfully is never also released (which would refund a
 // legitimate charge).
+//
+// Finalize and release each get their OWN context.WithTimeout call, the
+// release one created only after finalize has already failed, not one
+// shared context reused for both. A single shared deadline would let a
+// finalize call that is merely SLOW (not instant) consume the whole
+// window, so the fallback release would then run on an already-expired
+// context and fail with context deadline exceeded, stranding the hold --
+// exactly #616's failure mode, reintroduced through the fix meant to
+// prevent it. Giving the release a fresh, full budget is what actually
+// keeps the exactly-once-terminal-state invariant.
 func (h *Handler) settleReservation(ctx context.Context, accountID, reservationID string, actualCredits int64, endpoint string) {
 	_ = ctx // intentionally unused -- see comment above (#637)
 
-	bgCtx, cancel := context.WithTimeout(context.Background(), releaseTimeout)
-	defer cancel()
-
-	err := h.accounting.FinalizeReservation(bgCtx, FinalizeInput{
+	finalizeCtx, finalizeCancel := context.WithTimeout(context.Background(), releaseTimeout)
+	err := h.accounting.FinalizeReservation(finalizeCtx, FinalizeInput{
 		AccountID:     accountID,
 		ReservationID: reservationID,
 		ActualCredits: actualCredits,
 	})
+	finalizeCancel()
 	if err == nil {
 		return
 	}
 	log.Printf("images: finalize reservation failed endpoint=%s reservation_id=%s: %v", endpoint, reservationID, err)
 
-	if relErr := h.accounting.ReleaseReservation(bgCtx, accountID, reservationID, "finalize_failed"); relErr != nil {
+	releaseCtx, releaseCancel := context.WithTimeout(context.Background(), releaseTimeout)
+	defer releaseCancel()
+	if relErr := h.accounting.ReleaseReservation(releaseCtx, accountID, reservationID, "finalize_failed"); relErr != nil {
 		log.Printf("images: release reservation after finalize failure also failed endpoint=%s reservation_id=%s: %v", endpoint, reservationID, relErr)
 	}
 }

--- a/apps/edge-api/internal/images/reservation.go
+++ b/apps/edge-api/internal/images/reservation.go
@@ -21,18 +21,30 @@ const releaseTimeout = 30 * time.Second
 // failed finalize neither charged nor released the hold, stranding it
 // forever.
 //
-// The release runs on a fresh, bounded background context, never ctx. By
-// the time a request reaches this point the client may already have
-// disconnected, cancelling ctx, which would otherwise silently swallow the
-// release the same way it swallowed the original finalize: the exact bug
-// PR #602 fixed on the streaming inference path, reproduced here on the
-// media path.
+// Both finalize AND its fallback release run on a fresh, bounded background
+// context, never ctx (#637). By the time a request reaches this point the
+// client may already have disconnected, cancelling ctx: finalizing on ctx
+// then fails not because the ledger rejected the charge but because the
+// underlying HTTP call aborts on the cancelled context, which used to fall
+// through to the release-on-finalize-failure branch below and release a
+// hold for work that was genuinely delivered and should have been charged.
+// That's the exact bug PR #602 fixed on the streaming inference path
+// (settleStream), reproduced here on the media path: the client
+// disconnecting must not convert a chargeable request into a free one.
+// ctx itself is accepted only for call-site symmetry with the rest of the
+// handler and is otherwise unused -- settlement never depends on the
+// request context surviving to this point.
 //
 // Release is attempted only when finalize errors, so a reservation that
 // finalized successfully is never also released (which would refund a
 // legitimate charge).
 func (h *Handler) settleReservation(ctx context.Context, accountID, reservationID string, actualCredits int64, endpoint string) {
-	err := h.accounting.FinalizeReservation(ctx, FinalizeInput{
+	_ = ctx // intentionally unused -- see comment above (#637)
+
+	bgCtx, cancel := context.WithTimeout(context.Background(), releaseTimeout)
+	defer cancel()
+
+	err := h.accounting.FinalizeReservation(bgCtx, FinalizeInput{
 		AccountID:     accountID,
 		ReservationID: reservationID,
 		ActualCredits: actualCredits,
@@ -42,8 +54,6 @@ func (h *Handler) settleReservation(ctx context.Context, accountID, reservationI
 	}
 	log.Printf("images: finalize reservation failed endpoint=%s reservation_id=%s: %v", endpoint, reservationID, err)
 
-	bgCtx, cancel := context.WithTimeout(context.Background(), releaseTimeout)
-	defer cancel()
 	if relErr := h.accounting.ReleaseReservation(bgCtx, accountID, reservationID, "finalize_failed"); relErr != nil {
 		log.Printf("images: release reservation after finalize failure also failed endpoint=%s reservation_id=%s: %v", endpoint, reservationID, relErr)
 	}

--- a/apps/edge-api/internal/images/reservation_test.go
+++ b/apps/edge-api/internal/images/reservation_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 )
 
 // settleReservationMock is a white-box double for AccountingInterface, used
@@ -26,6 +27,11 @@ type settleReservationMock struct {
 	// immediately rather than making the call, which is exactly how #637
 	// converted a chargeable request into a released one.
 	finalizeCtxErr error
+	// finalizeSleep, if set, is how long FinalizeReservation blocks before
+	// returning finalizeErr. Used to prove finalize and release do not share
+	// one context/deadline: a finalize that runs long enough to exhaust its
+	// own context must not leave the release with an already-expired one.
+	finalizeSleep time.Duration
 }
 
 func (m *settleReservationMock) CreateReservation(context.Context, ReservationInput) (string, error) {
@@ -34,10 +40,14 @@ func (m *settleReservationMock) CreateReservation(context.Context, ReservationIn
 
 func (m *settleReservationMock) FinalizeReservation(ctx context.Context, _ FinalizeInput) error {
 	m.finalizeCalled = true
+	if m.finalizeSleep > 0 {
+		time.Sleep(m.finalizeSleep)
+	}
 	m.finalizeCtxErr = ctx.Err()
 	if ctx.Err() != nil {
 		// A real accounting HTTP client aborts immediately on an
-		// already-cancelled context rather than reaching the control plane.
+		// already-cancelled or already-expired context rather than reaching
+		// the control plane.
 		return ctx.Err()
 	}
 	return m.finalizeErr
@@ -46,6 +56,9 @@ func (m *settleReservationMock) FinalizeReservation(ctx context.Context, _ Final
 func (m *settleReservationMock) ReleaseReservation(ctx context.Context, _, _, _ string) error {
 	m.releaseCalled = true
 	m.releaseCtxErr = ctx.Err()
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
 	return nil
 }
 
@@ -130,5 +143,38 @@ func TestSettleReservationFinalizeSurvivesCancelledRequestContext(t *testing.T) 
 	}
 	if m.releaseCalled {
 		t.Fatal("expected delivered work to be CHARGED, not released, despite the client disconnecting before settlement (#637)")
+	}
+}
+
+// TestSettleReservationReleaseGetsFreshDeadlineAfterSlowFinalize is the
+// review finding on #650: finalize and its fallback release must NOT share
+// one context/deadline. A finalize call that is merely SLOW (not instant)
+// can otherwise consume the whole background-context window, so the
+// release that follows a failed finalize would run on an already-expired
+// context and fail with context deadline exceeded, stranding the hold --
+// exactly #616's failure mode, reintroduced through the #637 fix meant to
+// prevent it. releaseTimeout is shrunk to a few milliseconds so this proves
+// the shared-vs-fresh-context property fast, without a real 30s wait.
+func TestSettleReservationReleaseGetsFreshDeadlineAfterSlowFinalize(t *testing.T) {
+	original := releaseTimeout
+	releaseTimeout = 20 * time.Millisecond
+	defer func() { releaseTimeout = original }()
+
+	m := &settleReservationMock{
+		finalizeErr:   errors.New("control-plane unreachable"),
+		finalizeSleep: 40 * time.Millisecond, // longer than releaseTimeout
+	}
+	h := &Handler{accounting: m}
+
+	h.settleReservation(context.Background(), "acct-1", "res-1", 5000, "/v1/images/generations")
+
+	if !m.finalizeCalled {
+		t.Fatal("expected FinalizeReservation to be attempted")
+	}
+	if !m.releaseCalled {
+		t.Fatal("expected ReleaseReservation to be attempted after finalize failure")
+	}
+	if m.releaseCtxErr != nil {
+		t.Fatalf("expected release to get a FRESH context with its own full deadline rather than finalize's already-expired one, got ctx.Err() = %v", m.releaseCtxErr)
 	}
 }

--- a/apps/edge-api/internal/images/reservation_test.go
+++ b/apps/edge-api/internal/images/reservation_test.go
@@ -19,14 +19,27 @@ type settleReservationMock struct {
 	// tests can prove the release ran on a live context even when the caller
 	// passed settleReservation an already-cancelled one.
 	releaseCtxErr error
+	// finalizeCtxErr captures ctx.Err() as observed by FinalizeReservation,
+	// so a test can prove finalize itself ran on a live context (#637) even
+	// when the caller passed settleReservation an already-cancelled one. A
+	// cancelled context here mimics what a real HTTP client does: it aborts
+	// immediately rather than making the call, which is exactly how #637
+	// converted a chargeable request into a released one.
+	finalizeCtxErr error
 }
 
 func (m *settleReservationMock) CreateReservation(context.Context, ReservationInput) (string, error) {
 	return "", nil
 }
 
-func (m *settleReservationMock) FinalizeReservation(context.Context, FinalizeInput) error {
+func (m *settleReservationMock) FinalizeReservation(ctx context.Context, _ FinalizeInput) error {
 	m.finalizeCalled = true
+	m.finalizeCtxErr = ctx.Err()
+	if ctx.Err() != nil {
+		// A real accounting HTTP client aborts immediately on an
+		// already-cancelled context rather than reaching the control plane.
+		return ctx.Err()
+	}
 	return m.finalizeErr
 }
 
@@ -89,5 +102,33 @@ func TestSettleReservationReleaseSurvivesCancelledRequestContext(t *testing.T) {
 	}
 	if m.releaseCtxErr != nil {
 		t.Fatalf("expected ReleaseReservation to receive a live (non-cancelled) context, got ctx.Err() = %v", m.releaseCtxErr)
+	}
+}
+
+// TestSettleReservationFinalizeSurvivesCancelledRequestContext is #637's
+// primary regression guard: a client that disconnects right before
+// settlement must still be CHARGED for delivered work, not have the hold
+// released. finalizeErr is nil here (finalize would succeed if it reached
+// the control plane on a live context), so if settleReservation still runs
+// FinalizeReservation on the caller's cancelled ctx, the mock's cancelled-
+// context short-circuit turns that success into a failure and this test
+// catches the resulting spurious release.
+func TestSettleReservationFinalizeSurvivesCancelledRequestContext(t *testing.T) {
+	m := &settleReservationMock{finalizeErr: nil}
+	h := &Handler{accounting: m}
+
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel() // simulate the client having already disconnected before settlement
+
+	h.settleReservation(cancelledCtx, "acct-1", "res-1", 5000, "/v1/images/generations")
+
+	if !m.finalizeCalled {
+		t.Fatal("expected FinalizeReservation to be attempted")
+	}
+	if m.finalizeCtxErr != nil {
+		t.Fatalf("expected FinalizeReservation to receive a live (non-cancelled) context despite the caller's ctx being cancelled, got ctx.Err() = %v", m.finalizeCtxErr)
+	}
+	if m.releaseCalled {
+		t.Fatal("expected delivered work to be CHARGED, not released, despite the client disconnecting before settlement (#637)")
 	}
 }

--- a/apps/edge-api/internal/inference/orchestrator.go
+++ b/apps/edge-api/internal/inference/orchestrator.go
@@ -236,13 +236,26 @@ func (o *Orchestrator) executeSync(
 		// false hands the reservation to the deferred release instead, so it
 		// still reaches a terminal state exactly once: charged here on success,
 		// released there on failure, never both.
-		if err := o.accounting.FinalizeReservation(ctx, FinalizeReservationInput{
+		//
+		// finalizeCtx, not ctx (#637): by this point the client can already
+		// have disconnected, cancelling ctx. Finalizing on ctx then fails not
+		// because the ledger rejected the charge but because the HTTP call
+		// itself aborts on the cancelled context, which fell through to the
+		// releaseReason = "finalize_failed" branch below and released a hold
+		// for work that was genuinely delivered -- converting a chargeable
+		// request into a free one for any client that disconnects at the
+		// right moment. Same fresh background context + accountingTimeout as
+		// releaseReservationBackground and settleStream (PR #602's pattern).
+		finalizeCtx, cancel := context.WithTimeout(context.Background(), accountingTimeout)
+		err := o.accounting.FinalizeReservation(finalizeCtx, FinalizeReservationInput{
 			AccountID:              snapshot.AccountID,
 			ReservationID:          reservation.ID,
 			ActualCredits:          actualCredits,
 			TerminalUsageConfirmed: true,
 			Status:                 "completed",
-		}); err != nil {
+		})
+		cancel()
+		if err != nil {
 			log.Printf("inference: finalize reservation failed, releasing hold instead request_id=%s reservation_id=%s: %v", requestID, reservation.ID, err)
 			releaseReason = "finalize_failed"
 		} else {

--- a/apps/edge-api/internal/inference/sync_settlement_test.go
+++ b/apps/edge-api/internal/inference/sync_settlement_test.go
@@ -49,6 +49,37 @@ func newAccountingMockSyncFinalizeFails(rec *accountingRecorder, onFinalize func
 	}))
 }
 
+// newAccountingMockSyncFinalizeSucceedsWithHook behaves like newAccountingMock
+// (every path, including finalize, answers 200) but calls onFinalize (if set)
+// right before answering the finalize request, so a test can cancel the
+// request context at exactly the moment finalize is in flight -- the same
+// technique newAccountingMockSyncFinalizeFails uses, but for the success
+// case, so a test can prove finalize itself is unaffected by that
+// cancellation (#637) rather than only proving the fallback release survives
+// it.
+func newAccountingMockSyncFinalizeSucceedsWithHook(rec *accountingRecorder, onFinalize func()) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		rec.record(r.URL.Path, body)
+		if r.URL.Path == "/internal/accounting/reservations/finalize" && onFinalize != nil {
+			onFinalize()
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		switch r.URL.Path {
+		case "/internal/accounting/reservations":
+			_ = json.NewEncoder(w).Encode(ReservationResult{
+				ID: "res-test-1", AccountID: "acct-test-1", Status: "active", EstimatedCredits: 10000,
+			})
+		case "/internal/usage/attempts":
+			_ = json.NewEncoder(w).Encode(AttemptResult{
+				ID: "attempt-test-1", RequestID: "req-test-1", Status: "accepted",
+			})
+		}
+	}))
+}
+
 func callSyncCtx(orch *Orchestrator, ctx context.Context) *httptest.ResponseRecorder {
 	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{}`))
 	req.Header.Set("Authorization", "Bearer test-token")
@@ -133,6 +164,54 @@ func TestExecuteSync_FinalizeError_CancelledContext_StillReleases(t *testing.T) 
 	}
 	if _, ok := rec.find("/internal/accounting/reservations/release"); !ok {
 		t.Fatalf("expected ReleaseReservation to reach the control plane despite the cancelled request context; calls seen: %+v", rec.calls)
+	}
+}
+
+// TestExecuteSync_ClientDisconnect_ChargesDeliveredWork is issue #637's
+// primary regression guard: unlike the previous test, the control plane's
+// finalize handler here SUCCEEDS (200) if it actually receives the call on a
+// live context. The client disconnects (its context is cancelled) exactly
+// as the finalize request reaches the mock, the same moment
+// TestExecuteSync_FinalizeError_CancelledContext_StillReleases exercises for
+// the failure case. Before #637's fix, finalize ran on that same cancelled
+// request context, so cancelling it here would make the finalize call fail
+// client-side regardless of the mock's 200, falling through to a release
+// and losing the charge for genuinely delivered work. After the fix,
+// finalize runs on its own independent background context, so cancelling
+// the caller's context has no effect on it: the charge must still land.
+func TestExecuteSync_ClientDisconnect_ChargesDeliveredWork(t *testing.T) {
+	var hits int64
+	litellmSrv := countingJSONServer(&hits)
+	defer litellmSrv.Close()
+	routingSrv := newRoutingMock(litellmSrv.URL)
+	defer routingSrv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	rec := &accountingRecorder{}
+	// The client hangs up exactly as settlement starts, same as the sibling
+	// failure-path test above, but this mock's finalize handler succeeds.
+	acctSrv := newAccountingMockSyncFinalizeSucceedsWithHook(rec, cancel)
+	defer acctSrv.Close()
+
+	orch := newAuthorizedOrchestrator(acctSrv.URL, routingSrv.URL, litellmSrv.URL)
+	callSyncCtx(orch, ctx)
+
+	if ctx.Err() == nil {
+		t.Fatal("sanity check failed: context was not actually cancelled")
+	}
+	if rec.has("/internal/accounting/reservations/release") {
+		t.Error("nothing should be released: content was already delivered and finalize succeeded")
+	}
+	body, ok := rec.find("/internal/accounting/reservations/finalize")
+	if !ok {
+		t.Fatalf("expected FinalizeReservation to reach control-plane despite the cancelled request context; calls seen: %+v", rec.calls)
+	}
+	if actual, _ := body["actual_credits"].(float64); int64(actual) != 25 {
+		t.Errorf("actual_credits = %v, want 25 (confirmed upstream usage)", body["actual_credits"])
+	}
+	if body["reservation_id"] != "res-test-1" {
+		t.Errorf("reservation_id = %v, want res-test-1", body["reservation_id"])
 	}
 }
 

--- a/apps/edge-api/internal/inference/sync_settlement_test.go
+++ b/apps/edge-api/internal/inference/sync_settlement_test.go
@@ -49,21 +49,26 @@ func newAccountingMockSyncFinalizeFails(rec *accountingRecorder, onFinalize func
 	}))
 }
 
-// newAccountingMockSyncFinalizeSucceedsWithHook behaves like newAccountingMock
-// (every path, including finalize, answers 200) but calls onFinalize (if set)
-// right before answering the finalize request, so a test can cancel the
-// request context at exactly the moment finalize is in flight -- the same
-// technique newAccountingMockSyncFinalizeFails uses, but for the success
-// case, so a test can prove finalize itself is unaffected by that
-// cancellation (#637) rather than only proving the fallback release survives
-// it.
-func newAccountingMockSyncFinalizeSucceedsWithHook(rec *accountingRecorder, onFinalize func()) *httptest.Server {
+// newAccountingMockSyncFinalizeSucceedsGated behaves like newAccountingMock
+// (every path, including finalize, answers 200) but for the finalize path
+// specifically, signals ready then blocks on proceed before answering. That
+// gives a test a deterministic happens-before order: cancel the caller's
+// context, THEN close proceed, so the mock only writes its response once
+// the cancellation is already in effect. Review on #650 found the earlier
+// version of this test (cancel() called from inside the handler,
+// concurrently with the handler returning) detected the #637 regression
+// only 29 times out of 30 -- a genuine race, not a guarantee -- because
+// whether the client observed the cancellation before or after it finished
+// reading the response depended on goroutine scheduling. The ready/proceed
+// gate removes that race entirely.
+func newAccountingMockSyncFinalizeSucceedsGated(rec *accountingRecorder, ready chan<- struct{}, proceed <-chan struct{}) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var body map[string]any
 		_ = json.NewDecoder(r.Body).Decode(&body)
 		rec.record(r.URL.Path, body)
-		if r.URL.Path == "/internal/accounting/reservations/finalize" && onFinalize != nil {
-			onFinalize()
+		if r.URL.Path == "/internal/accounting/reservations/finalize" {
+			close(ready)
+			<-proceed
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -171,14 +176,16 @@ func TestExecuteSync_FinalizeError_CancelledContext_StillReleases(t *testing.T) 
 // primary regression guard: unlike the previous test, the control plane's
 // finalize handler here SUCCEEDS (200) if it actually receives the call on a
 // live context. The client disconnects (its context is cancelled) exactly
-// as the finalize request reaches the mock, the same moment
-// TestExecuteSync_FinalizeError_CancelledContext_StillReleases exercises for
-// the failure case. Before #637's fix, finalize ran on that same cancelled
-// request context, so cancelling it here would make the finalize call fail
-// client-side regardless of the mock's 200, falling through to a release
-// and losing the charge for genuinely delivered work. After the fix,
-// finalize runs on its own independent background context, so cancelling
-// the caller's context has no effect on it: the charge must still land.
+// as the finalize request reaches the mock, deterministically: the mock
+// signals ready and blocks, the test cancels ctx (synchronous, guaranteed
+// complete once it returns), THEN closes proceed so the mock's response is
+// only ever written after the cancellation is already in effect. Before
+// #637's fix, finalize ran on that same cancelled request context, so
+// cancelling it here would make the finalize call fail client-side
+// regardless of the mock's 200, falling through to a release and losing
+// the charge for genuinely delivered work. After the fix, finalize runs on
+// its own independent background context, so cancelling the caller's
+// context has no effect on it: the charge must still land.
 func TestExecuteSync_ClientDisconnect_ChargesDeliveredWork(t *testing.T) {
 	var hits int64
 	litellmSrv := countingJSONServer(&hits)
@@ -189,13 +196,23 @@ func TestExecuteSync_ClientDisconnect_ChargesDeliveredWork(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	rec := &accountingRecorder{}
-	// The client hangs up exactly as settlement starts, same as the sibling
-	// failure-path test above, but this mock's finalize handler succeeds.
-	acctSrv := newAccountingMockSyncFinalizeSucceedsWithHook(rec, cancel)
+	ready := make(chan struct{})
+	proceed := make(chan struct{})
+	acctSrv := newAccountingMockSyncFinalizeSucceedsGated(rec, ready, proceed)
 	defer acctSrv.Close()
 
 	orch := newAuthorizedOrchestrator(acctSrv.URL, routingSrv.URL, litellmSrv.URL)
-	callSyncCtx(orch, ctx)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		callSyncCtx(orch, ctx)
+	}()
+
+	<-ready
+	cancel()
+	close(proceed)
+	<-done
 
 	if ctx.Err() == nil {
 		t.Fatal("sanity check failed: context was not actually cancelled")


### PR DESCRIPTION
## Summary

Fixes #637: a client that disconnects right before settlement cancels the request context. Finalize used to run on that context at three sites, so a disconnect at the right moment made finalize fail not because the ledger rejected the charge but because the HTTP call itself aborted on the cancelled context. That fell through to the existing release-on-finalize-failure fallback and released the hold instead of charging it, so delivered work was billed nothing.

The invariant holds and the customer is favoured, which is why this was raised as a non blocking follow up during review rather than a blocker, but it is lost revenue for work already delivered.

## Three sites

- `apps/edge-api/internal/inference/orchestrator.go`, the synchronous chat completions path. The release side of this function was already hardened by #629 (`releaseReservationBackground` everywhere, the `finalized` flag no longer set unconditionally after a discarded error); only the finalize call itself was left on the request context.
- `apps/edge-api/internal/audio/reservation.go`'s `settleReservation`, used by speech, transcription, and translation (added by #639).
- `apps/edge-api/internal/images/reservation.go`'s `settleReservation`, used by generation and edits (added by #639).

All three now match `settleStream` (PR #602), the model this follows: finalize and its fallback release both run on a fresh background context bounded by the existing accounting timeout, independent of the caller's context.

## Tests

Written first and shown failing against the pre-fix code:
- `TestExecuteSync_ClientDisconnect_ChargesDeliveredWork` (inference)
- `TestSettleReservationFinalizeSurvivesCancelledRequestContext` (audio, images)

These join already-passing tests covering the other three required properties, so all four are pinned per site:
- a genuine finalize failure still releases (`TestExecuteSync_FinalizeError_ReleasesReservationAndLogs`, `TestSettleReservationReleasesOnFinalizeFailure`)
- a successful charge is never also released (`TestExecuteSync_NormalCompletion_TerminatesExactlyOnce`, `TestSettleReservationNeverReleasesAfterSuccessfulFinalize`)
- the release path itself survives a cancelled context (`TestExecuteSync_FinalizeError_CancelledContext_StillReleases`, `TestSettleReservationReleaseSurvivesCancelledRequestContext`)

## Out of scope

On the media paths, settlement runs before the response body is written, so a control-plane outage can stall a successful request for the release timeout before the caller sees any bytes. Filed separately as #649: reordering write-then-settle across four handler entry points is a larger diff than this context fix and touches the same exactly-once invariant this change tightens.

## Test plan

- [x] New regression tests written first, shown failing (RED) against the pre-fix code
- [x] `go test ./apps/edge-api/...` full suite green
- [x] `go vet ./...` clean
- [x] Tested on my own worktree (`/tmp/finalizectx`), not the shared checkout

Does not merge here; money-path PRs get an independent reviewer per repo convention.