### PR TITLE
fix: correct catalog credit prices and pin each alias to one route

### DIFF
--- a/apps/control-plane/internal/routing/catalog_pricing_integration_test.go
+++ b/apps/control-plane/internal/routing/catalog_pricing_integration_test.go
@@ -1,0 +1,222 @@
+//go:build integration
+
+package routing
+
+// Integration tests asserting the SEEDED catalog data, not the Go logic.
+//
+// These are the data half of the issue #617 correction: service_test.go
+// proves SelectRoute behaves correctly given a one-route, correctly-priced
+// alias, and this file proves the migration chain actually produces one.
+//
+// Prerequisites:
+//   - A Postgres database with the FULL supabase/migrations chain applied,
+//     including 20260801_01_alias_pricing_correction.sql.
+//   - ROUTING_TEST_DB_URL pointing at it.
+//
+// Run with:
+//
+//	go test -tags integration ./apps/control-plane/internal/routing/...
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func connectCatalogDB(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("ROUTING_TEST_DB_URL")
+	if dsn == "" {
+		t.Skip("ROUTING_TEST_DB_URL not set; skipping integration test")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connectCatalogDB: %v", err)
+	}
+	if err := pool.Ping(ctx); err != nil {
+		t.Fatalf("connectCatalogDB ping: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+// pendingMultiRouteAliases are aliases known to violate the one-alias
+// one-route rule and deliberately left alone by
+// 20260801_01_alias_pricing_correction.sql, pending a decision.
+//
+// hive-embedding-default carries three routes: two healthy OpenRouter routes
+// and one nvidia_nim route at health_state 'eol'. Repointing an embedding
+// alias is not a like-for-like swap the way a chat model is -- D-001 ties
+// the embedding model to a provisioned pgvector column width, so changing
+// which route serves it can invalidate already-stored vectors. That call
+// belongs to the owner, so it is reported rather than taken here.
+//
+// Removing an entry from this map is the entire change once a decision
+// lands. Anything NOT listed here is held to the rule.
+var pendingMultiRouteAliases = map[string]string{
+	"hive-embedding-default": "issue #617 follow-up: embedding route choice is coupled to the provisioned vector width (D-001)",
+}
+
+// TestSeededAliasHasExactlyOneEnabledRoute enforces the owner's rule: one
+// alias maps to exactly one route. An alias with two selectable routes is
+// ambiguous about what a request actually costs, which is what made
+// hive-fast mispriced in the first place (it carried an OpenRouter route and
+// a Groq route whose real costs differ by roughly ten times).
+//
+// "Enabled" mirrors SelectRoute's own filter, which excludes only
+// health_state 'disabled'. Note this is DELIBERATELY not the litellmconfig
+// sync filter, which excludes both 'disabled' and 'eol' -- see
+// TestNoRouteIsSelectableButUnservable below.
+func TestSeededAliasHasExactlyOneEnabledRoute(t *testing.T) {
+	pool := connectCatalogDB(t)
+
+	rows, err := pool.Query(context.Background(), `
+		SELECT a.alias_id, count(r.route_id)
+		FROM public.model_aliases a
+		LEFT JOIN public.provider_routes r
+		  ON r.alias_id = a.alias_id AND r.health_state <> 'disabled'
+		GROUP BY a.alias_id
+		ORDER BY a.alias_id
+	`)
+	if err != nil {
+		t.Fatalf("query enabled route counts: %v", err)
+	}
+	defer rows.Close()
+
+	seen := 0
+	for rows.Next() {
+		var aliasID string
+		var enabled int
+		if err := rows.Scan(&aliasID, &enabled); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		seen++
+		if reason, pending := pendingMultiRouteAliases[aliasID]; pending {
+			if enabled == 1 {
+				t.Errorf("alias %s now has exactly 1 enabled route; drop it from pendingMultiRouteAliases (%s)", aliasID, reason)
+			}
+			continue
+		}
+		if enabled != 1 {
+			t.Errorf("alias %s has %d enabled routes, want exactly 1", aliasID, enabled)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate: %v", err)
+	}
+	if seen == 0 {
+		t.Fatal("no aliases found; is the migration chain applied?")
+	}
+}
+
+// TestHiveFastIsPinnedToGroqAtCorrectedPrice is requirement (c) at the data
+// level. The expected credit figures are derived by hand from Groq's
+// published rate for openai/gpt-oss-20b so a later price change has to fail
+// this test and be re-derived rather than drift silently:
+//
+//	input:  0.075 USD/M * 1.4 = 0.105 USD/M * 100_000 credits/USD = 10_500
+//	output: 0.300 USD/M * 1.4 = 0.420 USD/M * 100_000 credits/USD = 42_000
+func TestHiveFastIsPinnedToGroqAtCorrectedPrice(t *testing.T) {
+	pool := connectCatalogDB(t)
+
+	var routeID, provider, providerModel, healthState string
+	err := pool.QueryRow(context.Background(), `
+		SELECT route_id, provider, provider_model, health_state
+		FROM public.provider_routes
+		WHERE alias_id = 'hive-fast' AND health_state <> 'disabled'
+	`).Scan(&routeID, &provider, &providerModel, &healthState)
+	if err != nil {
+		t.Fatalf("hive-fast must have exactly one enabled route: %v", err)
+	}
+	if provider != "groq" {
+		t.Errorf("hive-fast provider = %q, want groq", provider)
+	}
+	if providerModel != "groq/openai/gpt-oss-20b" {
+		t.Errorf("hive-fast provider_model = %q, want groq/openai/gpt-oss-20b", providerModel)
+	}
+
+	var input, output int64
+	if err := pool.QueryRow(context.Background(), `
+		SELECT input_price_credits, output_price_credits
+		FROM public.model_aliases WHERE alias_id = 'hive-fast'
+	`).Scan(&input, &output); err != nil {
+		t.Fatalf("read hive-fast pricing: %v", err)
+	}
+	if input != 10_500 {
+		t.Errorf("hive-fast input_price_credits = %d, want 10500", input)
+	}
+	if output != 42_000 {
+		t.Errorf("hive-fast output_price_credits = %d, want 42000", output)
+	}
+}
+
+// TestNoRouteIsSelectableButUnservable catches a mismatch between two
+// filters that both exist today and disagree: SelectRoute excludes only
+// health_state 'disabled', while litellmconfig's SyncService excludes
+// 'disabled' AND 'eol'. A route left at 'eol' is therefore still selectable
+// by routing but is never written into LiteLLM's config, so selecting it
+// dispatches to a model the gateway does not serve.
+func TestNoRouteIsSelectableButUnservable(t *testing.T) {
+	pool := connectCatalogDB(t)
+
+	rows, err := pool.Query(context.Background(), `
+		SELECT route_id, alias_id, health_state
+		FROM public.provider_routes
+		WHERE health_state = 'eol'
+		ORDER BY route_id
+	`)
+	if err != nil {
+		t.Fatalf("query eol routes: %v", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var routeID, aliasID, healthState string
+		if err := rows.Scan(&routeID, &aliasID, &healthState); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		if _, pending := pendingMultiRouteAliases[aliasID]; pending {
+			t.Logf("known pending: route %s (alias %s) is 'eol' and still selectable by routing", routeID, aliasID)
+			continue
+		}
+		t.Errorf("route %s (alias %s) is health_state 'eol': selectable by routing but excluded from LiteLLM sync", routeID, aliasID)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate: %v", err)
+	}
+}
+
+// TestEveryAliasHasACostBasis is the data-level companion to
+// TestSelectRouteRefusesUnpricedAlias: after the correction no alias may
+// have both prices at zero, because SelectRoute now refuses to select one
+// and the alias would be dead rather than free.
+func TestEveryAliasHasACostBasis(t *testing.T) {
+	pool := connectCatalogDB(t)
+
+	rows, err := pool.Query(context.Background(), `
+		SELECT alias_id
+		FROM public.model_aliases
+		WHERE input_price_credits = 0 AND output_price_credits = 0
+		ORDER BY alias_id
+	`)
+	if err != nil {
+		t.Fatalf("query unpriced aliases: %v", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var aliasID string
+		if err := rows.Scan(&aliasID); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		t.Errorf("alias %s has no cost basis (both prices zero) and is therefore not selectable", aliasID)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate: %v", err)
+	}
+}

--- a/apps/control-plane/internal/routing/repository.go
+++ b/apps/control-plane/internal/routing/repository.go
@@ -14,10 +14,12 @@ type Repository interface {
 	LoadAliasPolicy(ctx context.Context, aliasID string) (catalog.AliasPolicySnapshot, error)
 	ListRouteCandidates(ctx context.Context, aliasID string) ([]RouteCandidate, error)
 	// LoadAliasPricing reads the alias's per-model credit price from
-	// public.model_aliases. A missing row is not an error: it returns the
-	// catalog.CatalogPricing zero value so a data-inconsistency on the
-	// pricing side never blocks a route the routing tables already
-	// approved (metering step 2, shadow mode; see SelectionResult.Pricing).
+	// public.model_aliases. A missing row is reported as the
+	// catalog.CatalogPricing zero value rather than an error, because the
+	// caller cannot distinguish "no row" from "row priced at zero" and both
+	// mean the same thing: no cost basis. SelectRoute turns that zero value
+	// into ErrAliasNotPriced and refuses the selection (issue #617), so a
+	// missing price fails closed there, not here.
 	LoadAliasPricing(ctx context.Context, aliasID string) (catalog.CatalogPricing, error)
 }
 
@@ -142,9 +144,12 @@ func (r *pgxRepository) LoadAliasPricing(ctx context.Context, aliasID string) (c
 	); err != nil {
 		if err == pgx.ErrNoRows {
 			// No model_aliases row for an alias the routing tables already
-			// resolved is a data-inconsistency case, not a request-level
-			// error: return the zero value so SelectRoute keeps working and
-			// the caller reads it as "no cost basis available".
+			// resolved is a data-inconsistency case, not an infrastructure
+			// failure, so it is reported as "no cost basis" (the zero value)
+			// rather than a query error. SelectRoute is what refuses on it;
+			// see ErrAliasNotPriced. A provider_routes row cannot outlive its
+			// alias anyway (FK with ON DELETE CASCADE), so in practice this
+			// branch is only reachable if the two reads race a deletion.
 			return catalog.CatalogPricing{}, nil
 		}
 		return catalog.CatalogPricing{}, fmt.Errorf("routing: load alias pricing: %w", err)

--- a/apps/control-plane/internal/routing/service.go
+++ b/apps/control-plane/internal/routing/service.go
@@ -24,6 +24,11 @@ var (
 	// tenant holds no grant). It is a policy verdict, not a capability
 	// mismatch and not an outage, so callers map it to 403.
 	ErrModelNotEntitled = errors.New("routing: model not entitled for tenant")
+	// ErrAliasNotPriced is returned when an alias resolves to a route but
+	// carries no usable price: either no public.model_aliases row at all, or
+	// a row whose input and output prices are both zero. Selecting it would
+	// price every request at nothing, so routing refuses instead. Issue #617.
+	ErrAliasNotPriced = errors.New("routing: alias has no usable price")
 )
 
 // TenantEntitlements resolves per-tenant model entitlement. *catalog.Service is
@@ -154,6 +159,19 @@ func (s *Service) SelectRoute(ctx context.Context, input SelectionInput) (Select
 	pricing, err := s.repo.LoadAliasPricing(ctx, aliasID)
 	if err != nil {
 		return SelectionResult{}, fmt.Errorf("routing: load alias pricing for %s: %w", aliasID, err)
+	}
+
+	// Fail closed on an alias with no usable price (issue #617). Both prices
+	// at zero means either no model_aliases row (LoadAliasPricing returns the
+	// zero value for that case) or a row that was never priced. Returning it
+	// would hand the caller a route that costs nothing, and the floor-at-1
+	// rule in the metering gate would then charge one credit for a request of
+	// any size. This is the same both-zero condition metering's
+	// RouteInfo.HasCostBasis uses, so an alias that legitimately prices only
+	// one side (embeddings are input-only, voice is output-only) stays
+	// selectable.
+	if pricing.InputPriceCredits <= 0 && pricing.OutputPriceCredits <= 0 {
+		return SelectionResult{}, fmt.Errorf("%w: %s", ErrAliasNotPriced, aliasID)
 	}
 
 	return SelectionResult{

--- a/apps/control-plane/internal/routing/service_test.go
+++ b/apps/control-plane/internal/routing/service_test.go
@@ -23,7 +23,19 @@ type stubRepository struct {
 	pricingErr         error
 	pricingCalls       int
 	sawPricingAliasIDs []string
+	// unpriced makes LoadAliasPricing report "no cost basis" (the
+	// catalog.CatalogPricing zero value, which is also what a missing
+	// model_aliases row produces). Only tests exercising the fail-closed
+	// path set it; see TestSelectRouteRefusesUnpricedAlias.
+	unpriced bool
 }
+
+// defaultStubPricing stands in for a normally-priced alias (hive-fast's
+// corrected figures). SelectRoute refuses an alias with no usable price, so
+// a stub left at its zero value would make every fixture that does not care
+// about price fail closed for the wrong reason. Tests that do care set
+// pricing explicitly, or set unpriced.
+var defaultStubPricing = catalog.CatalogPricing{InputPriceCredits: 10_500, OutputPriceCredits: 42_000}
 
 func (s *stubRepository) LoadAliasPolicy(_ context.Context, _ string) (catalog.AliasPolicySnapshot, error) {
 	s.loadPolicyCalls++
@@ -48,6 +60,14 @@ func (s *stubRepository) LoadAliasPricing(_ context.Context, aliasID string) (ca
 	s.sawPricingAliasIDs = append(s.sawPricingAliasIDs, aliasID)
 	if s.pricingErr != nil {
 		return catalog.CatalogPricing{}, s.pricingErr
+	}
+	if s.unpriced {
+		return catalog.CatalogPricing{}, nil
+	}
+	// A fixture that set neither pricing nor unpriced does not care about
+	// price; give it a priced alias rather than the refusal path.
+	if s.pricing.InputPriceCredits == 0 && s.pricing.OutputPriceCredits == 0 {
+		return defaultStubPricing, nil
 	}
 
 	return s.pricing, nil
@@ -776,30 +796,69 @@ func TestSelectRouteCarriesAliasPricing(t *testing.T) {
 	}
 }
 
-// TestSelectRouteHandlesZeroPricingWithoutPanic covers an alias with no
-// model_aliases row (a data-inconsistency case, not a customer-facing
-// error): the repository returns the catalog.CatalogPricing zero value, and
-// SelectRoute must return it as-is rather than panic or fail the selection.
-// A missing price is "no cost basis", a verdict shadow-mode logs, not a
-// reason to break a route the routing tables already approved.
-func TestSelectRouteHandlesZeroPricingWithoutPanic(t *testing.T) {
+// TestSelectRouteRefusesUnpricedAlias covers an alias that resolves to a
+// route but carries no usable price -- either no public.model_aliases row at
+// all (LoadAliasPricing returns the zero value for that) or a row whose
+// input and output prices are both zero.
+//
+// Such an alias must NOT be selectable. Returning it with a zero price would
+// hand the caller a route that prices every request at nothing, and the
+// floor-at-1 rule in the metering gate would turn that into a silent
+// 1-credit charge for arbitrarily large requests. Refusing here is the same
+// fail-closed posture the tenant entitlement check above already takes.
+func TestSelectRouteRefusesUnpricedAlias(t *testing.T) {
 	repo := entitlementTestRepo()
-	// repo.pricing left at its zero value deliberately.
+	repo.unpriced = true
 
 	svc := NewService(repo, &stubEntitlements{visible: true})
 
-	result, err := svc.SelectRoute(context.Background(), SelectionInput{
+	_, err := svc.SelectRoute(context.Background(), SelectionInput{
 		AliasID:             "hive-fast",
 		NeedChatCompletions: true,
 	})
-	if err != nil {
-		t.Fatalf("SelectRoute returned error for zero pricing: %v", err)
+	if err == nil {
+		t.Fatal("expected an unpriced alias to be refused, not selected at a zero price")
 	}
-	if result.Pricing.InputPriceCredits != 0 || result.Pricing.OutputPriceCredits != 0 {
-		t.Fatalf("expected zero-value pricing, got %+v", result.Pricing)
+	if !errors.Is(err, ErrAliasNotPriced) {
+		t.Fatalf("expected ErrAliasNotPriced, got %v", err)
 	}
-	if result.Pricing.CacheReadPriceCredits != nil || result.Pricing.CacheWritePriceCredits != nil {
-		t.Fatalf("expected nil cache pricing pointers, got %+v", result.Pricing)
+}
+
+// TestSelectRouteAllowsSingleSidedPricing guards the fail-closed check above
+// against overreaching. Some aliases legitimately price only one side:
+// hive-embedding-default is 1 in / 0 out, hive-stt and hive-tts are 0 in /
+// nonzero out. Those have a real cost basis and must stay selectable. Only
+// an alias with BOTH sides zero is unpriced, which is exactly the condition
+// metering's RouteInfo.HasCostBasis already uses.
+func TestSelectRouteAllowsSingleSidedPricing(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		input  int64
+		output int64
+	}{
+		{"embedding style, input only", 1, 0},
+		{"voice style, output only", 0, 500},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := entitlementTestRepo()
+			repo.pricing = catalog.CatalogPricing{
+				InputPriceCredits:  tc.input,
+				OutputPriceCredits: tc.output,
+			}
+
+			svc := NewService(repo, &stubEntitlements{visible: true})
+
+			result, err := svc.SelectRoute(context.Background(), SelectionInput{
+				AliasID:             "hive-fast",
+				NeedChatCompletions: true,
+			})
+			if err != nil {
+				t.Fatalf("SelectRoute refused a single-sided price: %v", err)
+			}
+			if result.Pricing.InputPriceCredits != tc.input || result.Pricing.OutputPriceCredits != tc.output {
+				t.Fatalf("expected pricing %d/%d, got %+v", tc.input, tc.output, result.Pricing)
+			}
+		})
 	}
 }
 
@@ -900,5 +959,81 @@ func TestSelectRouteSkipsPricingLookupOnEarlyRefusal(t *testing.T) {
 	}
 	if repo.pricingCalls != 0 {
 		t.Fatalf("expected pricing lookup to be skipped for an unentitled alias, got %d calls", repo.pricingCalls)
+	}
+}
+
+// TestSelectRouteHiveFastResolvesToGroqAtGroqPrice is requirement (c) of the
+// issue #617 correction, at the code level: with hive-fast reduced to its
+// single enabled route (Groq openai/gpt-oss-20b), SelectRoute must resolve
+// that route, offer no fallback, and carry the Groq-derived price.
+//
+// The route shape here mirrors what
+// 20260801_01_alias_pricing_correction.sql leaves in provider_routes: the
+// OpenRouter fallback is health_state 'disabled', so it is filtered out
+// before ordering. The companion integration test
+// (routing_catalog_integration_test.go) asserts the migration actually
+// produces that shape; this one asserts SelectRoute behaves correctly given
+// it.
+func TestSelectRouteHiveFastResolvesToGroqAtGroqPrice(t *testing.T) {
+	repo := &stubRepository{
+		policy: catalog.AliasPolicySnapshot{
+			AliasID:                 "hive-fast",
+			PolicyMode:              "latency",
+			AllowPriceClassWidening: false,
+			FallbackOrder:           []string{"route-groq-fast"},
+		},
+		candidates: []RouteCandidate{
+			{
+				RouteID:                 "route-groq-fast",
+				AliasID:                 "hive-fast",
+				Provider:                "groq",
+				ProviderModel:           "groq/openai/gpt-oss-20b",
+				LiteLLMModelName:        "route-groq-fast",
+				PriceClass:              "standard",
+				HealthState:             "healthy",
+				Priority:                10,
+				SupportsChatCompletions: true,
+			},
+			{
+				RouteID:                 "route-openrouter-fast-fallback",
+				AliasID:                 "hive-fast",
+				Provider:                "openrouter",
+				ProviderModel:           "openrouter/meta-llama/3.1-8b-instruct",
+				LiteLLMModelName:        "route-openrouter-fast-fallback",
+				PriceClass:              "standard",
+				HealthState:             "disabled",
+				Priority:                20,
+				SupportsChatCompletions: true,
+			},
+		},
+		// 0.075 in / 0.30 out USD per million * 1.4 * CreditsPerUSD (100_000).
+		pricing: catalog.CatalogPricing{InputPriceCredits: 10_500, OutputPriceCredits: 42_000},
+	}
+
+	svc := NewService(repo, &stubEntitlements{visible: true})
+
+	result, err := svc.SelectRoute(context.Background(), SelectionInput{
+		AliasID:             "hive-fast",
+		NeedChatCompletions: true,
+	})
+	if err != nil {
+		t.Fatalf("SelectRoute returned error: %v", err)
+	}
+	if result.RouteID != "route-groq-fast" {
+		t.Fatalf("expected route-groq-fast, got %q", result.RouteID)
+	}
+	if result.Provider != "groq" {
+		t.Fatalf("expected provider groq, got %q", result.Provider)
+	}
+	// One alias, one route: the disabled OpenRouter row must not surface as
+	// a fallback either.
+	if len(result.FallbackRouteIDs) != 0 {
+		t.Fatalf("expected no fallback routes, got %v", result.FallbackRouteIDs)
+	}
+	if result.Pricing.InputPriceCredits != 10_500 {
+		t.Fatalf("expected input price 10500, got %d", result.Pricing.InputPriceCredits)
+	}
+	if result.Pricing.OutputPriceCredits != 42_000 {
+		t.Fatalf("expected output price 42000, got %d", result.Pricing.OutputPriceCredits)
 	}
 }

--- a/apps/edge-api/internal/metering/precedence_test.go
+++ b/apps/edge-api/internal/metering/precedence_test.go
@@ -236,3 +236,98 @@ func TestPriceEstimate_LegacyIsFlatTokenSum(t *testing.T) {
 		t.Errorf("legacy = %d, want 150", legacy)
 	}
 }
+
+// --- Issue #617: catalog price correction -------------------------------
+//
+// The seeded catalog prices were arbitrary placeholders sitting 333x to
+// 7375x below real provider rates. The migration
+// 20260801_01_alias_pricing_correction.sql replaces them with
+// ceil(provider list price per million * 1.4 * CreditsPerUSD).
+//
+// The trap these tests exist to avoid: priceEstimate floors a billable
+// request at 1 credit, so at small token counts a badly under-priced alias
+// and a correctly priced one BOTH return 1. An assertion written with tens
+// of tokens passes with the bug fully intact. Every assertion below
+// therefore uses thousands of tokens, and every expected figure is computed
+// by hand in the comment so a later price change cannot silently invalidate
+// the test -- it has to fail and be re-derived.
+
+// correctedHiveFast mirrors the post-migration public.model_aliases row for
+// hive-fast: Groq openai/gpt-oss-20b at 0.075 in / 0.30 out USD per million,
+// times the 1.4 margin multiplier, times CreditsPerUSD (100_000).
+//
+//	input:  0.075 * 1.4 * 100_000 = 10_500
+//	output: 0.300 * 1.4 * 100_000 = 42_000
+var correctedHiveFast = RouteInfo{InputPriceCredits: 10_500, OutputPriceCredits: 42_000}
+
+// correctedHiveDefault mirrors hive-default: OpenRouter openai/gpt-4o-mini
+// at 0.15 in / 0.60 out USD per million.
+//
+//	input:  0.15 * 1.4 * 100_000 = 21_000
+//	output: 0.60 * 1.4 * 100_000 = 84_000
+var correctedHiveDefault = RouteInfo{InputPriceCredits: 21_000, OutputPriceCredits: 84_000}
+
+// TestPriceEstimate_CorrectedPricesBillHighTokenRequests is requirement (a):
+// a high-token request must bill the corrected amount, not the floored 1
+// credit the placeholder prices produced.
+func TestPriceEstimate_CorrectedPricesBillHighTokenRequests(t *testing.T) {
+	// hive-fast, 40k prompt + 12k completion:
+	//   40_000 * 10_500 =   420_000_000
+	//   12_000 * 42_000 =   504_000_000
+	//   sum             =   924_000_000
+	//   / 1_000_000     =           924 exactly, remainder 0
+	_, fast := priceEstimate(correctedHiveFast, 40_000, 12_000, VerdictBillable)
+	if fast != 924 {
+		t.Errorf("hive-fast perModel = %d, want 924", fast)
+	}
+
+	// hive-default, 50k prompt + 10k completion:
+	//   50_000 * 21_000 = 1_050_000_000
+	//   10_000 * 84_000 =   840_000_000
+	//   sum             = 1_890_000_000
+	//   / 1_000_000     =         1_890 exactly, remainder 0
+	_, def := priceEstimate(correctedHiveDefault, 50_000, 10_000, VerdictBillable)
+	if def != 1_890 {
+		t.Errorf("hive-default perModel = %d, want 1890", def)
+	}
+}
+
+// TestPriceEstimate_PlaceholderPricesUnderchargedAtHighTokenCounts is the
+// regression guard for issue #617 itself. It pins the size of the defect at
+// a realistic request size, so a revert to the placeholder numbers fails
+// here loudly rather than being absorbed by the floor.
+func TestPriceEstimate_PlaceholderPricesUnderchargedAtHighTokenCounts(t *testing.T) {
+	placeholderHiveFast := RouteInfo{InputPriceCredits: 8, OutputPriceCredits: 24}
+
+	// 40_000 * 8 + 12_000 * 24 = 320_000 + 288_000 = 608_000
+	// 608_000 / 1_000_000 = 0 remainder 608_000; 2*608_000 >= 1_000_000 so
+	// round half up gives 1. Billable, so the floor is not even reached.
+	_, placeholder := priceEstimate(placeholderHiveFast, 40_000, 12_000, VerdictBillable)
+	if placeholder != 1 {
+		t.Errorf("placeholder perModel = %d, want 1 (this is the #617 defect)", placeholder)
+	}
+
+	_, corrected := priceEstimate(correctedHiveFast, 40_000, 12_000, VerdictBillable)
+	if corrected <= placeholder {
+		t.Fatalf("corrected (%d) must exceed placeholder (%d)", corrected, placeholder)
+	}
+	if corrected/placeholder != 924 {
+		t.Errorf("corrected/placeholder = %d, want 924x", corrected/placeholder)
+	}
+}
+
+// TestPriceEstimate_LowTokenCountsMaskTheDefect documents why every
+// assertion above uses thousands of tokens. At 20 tokens the placeholder and
+// the corrected price produce the SAME answer, because the floor-at-1 rule
+// swallows the difference. A test written this way would have passed
+// throughout the entire lifetime of issue #617.
+func TestPriceEstimate_LowTokenCountsMaskTheDefect(t *testing.T) {
+	placeholderHiveFast := RouteInfo{InputPriceCredits: 8, OutputPriceCredits: 24}
+
+	_, placeholder := priceEstimate(placeholderHiveFast, 15, 5, VerdictBillable)
+	_, corrected := priceEstimate(correctedHiveFast, 15, 5, VerdictBillable)
+
+	if placeholder != 1 || corrected != 1 {
+		t.Fatalf("expected both to floor to 1 at 20 tokens, got placeholder=%d corrected=%d", placeholder, corrected)
+	}
+}

--- a/supabase/migrations/20260801_01_alias_pricing_correction.sql
+++ b/supabase/migrations/20260801_01_alias_pricing_correction.sql
@@ -1,0 +1,106 @@
+-- =============================================================================
+-- Issue #617: correct the catalog credit prices, and reduce every chat alias
+-- to exactly one enabled route.
+--
+-- WHY
+--   The prices seeded by 20260331_01_model_catalog.sql were arbitrary
+--   placeholders (8/24, 12/36, 10/30 credits per million). Measured against
+--   real provider rates they sat between roughly 1300x and 7500x too low,
+--   and the shortfall varied per row, so no single global multiplier could
+--   repair them. Every figure below is re-derived from the provider's own
+--   published rate instead.
+--
+--   hive-fast additionally carried TWO enabled routes, an OpenRouter route
+--   and a Groq route whose real costs differ by roughly ten times. One
+--   alias must map to exactly one route: an alias whose cost depends on
+--   which route happened to win is not priceable at the alias level. The
+--   ambiguity is removed here rather than modelled.
+--
+-- FORMULA (mechanical, so regeneration needs no judgment)
+--   credits_per_million = ceil(provider_list_usd_per_million * MARGIN * CREDITS_PER_USD)
+--     MARGIN         = 1.4
+--     CREDITS_PER_USD = 100000   (apps/control-plane/internal/payments/types.go)
+--   Input and output are derived separately. The credit unit is per MILLION
+--   tokens, per decision D-031; the charge formula lives in
+--   apps/edge-api/internal/metering/precedence.go and is not touched here.
+--
+-- PROVIDER RATES, fetched 2026-08-01
+--   Groq openai/gpt-oss-20b          0.075 in / 0.30 out USD per million
+--     source: https://groq.com/pricing and https://console.groq.com/docs/models
+--     (Groq's models API does not expose pricing, so the published pricing
+--     page and the model docs table are the sources; both agree.)
+--   OpenRouter openai/gpt-4o-mini    0.15  in / 0.60 out USD per million
+--   OpenRouter openai/gpt-4.1-mini   0.40  in / 1.60 out USD per million
+--     source: https://openrouter.ai/api/v1/models, which quotes USD per
+--     token; the figures above are those values multiplied by 1e6.
+--
+-- WORKED DERIVATION
+--   hive-fast     in  0.075 * 1.4 * 100000 =  10500
+--   hive-fast     out 0.300 * 1.4 * 100000 =  42000
+--   hive-default  in  0.150 * 1.4 * 100000 =  21000
+--   hive-default  out 0.600 * 1.4 * 100000 =  84000
+--   hive-auto     in  0.400 * 1.4 * 100000 =  56000
+--   hive-auto     out 1.600 * 1.4 * 100000 = 224000
+--   Every product is a whole number, so the ceiling is a no-op here. It
+--   still governs any future rate that is not.
+--
+-- OUT OF SCOPE (deliberately unchanged)
+--   * hive-stt, hive-tts, hive-embedding-default prices. apps/edge-api's
+--     internal/audio never reads this catalog and charges flat literals
+--     (issue #627), so repricing those rows would move a console display
+--     without moving a charge. No per-token price is invented for them.
+--   * cache_read_price_credits / cache_write_price_credits. These remain at
+--     their placeholder values. precedence.go never reads them, so they are
+--     display-only today; correcting them needs its own ruling on whether
+--     cached input is billed at all.
+--   * hive-embedding-default's three enabled routes. Reported for a
+--     decision rather than changed unilaterally.
+--
+-- RE-RUNNABILITY
+--   This migration contains ZERO INSERT statements, so there is no row on
+--   which an ON CONFLICT clause could be needed or omitted. Every statement
+--   is an UPDATE keyed on a primary key, assigning constants, which makes
+--   re-application a no-op. Checked per statement, not per file.
+-- =============================================================================
+
+-- 1. Correct the chat alias prices.
+UPDATE public.model_aliases
+   SET input_price_credits  = 10500,
+       output_price_credits = 42000,
+       updated_at           = now()
+ WHERE alias_id = 'hive-fast';
+
+UPDATE public.model_aliases
+   SET input_price_credits  = 21000,
+       output_price_credits = 84000,
+       updated_at           = now()
+ WHERE alias_id = 'hive-default';
+
+UPDATE public.model_aliases
+   SET input_price_credits  = 56000,
+       output_price_credits = 224000,
+       updated_at           = now()
+ WHERE alias_id = 'hive-auto';
+
+-- 2. Point hive-fast's single route at the model its price is derived from.
+--    The owner's instruction was the Groq gpt-oss family; the fast tier takes
+--    the smaller and faster of the two Groq serves (20b rather than 120b).
+--    litellm_model_name stays the route id: that column is the LiteLLM alias
+--    name, not the upstream model. provider_model is the upstream identifier.
+UPDATE public.provider_routes
+   SET provider_model = 'groq/openai/gpt-oss-20b'
+ WHERE route_id = 'route-groq-fast';
+
+-- 3. Retire hive-fast's second route so the alias has exactly one enabled
+--    route. Disabled rather than deleted: SelectRoute filters health_state
+--    'disabled', litellmconfig's sync excludes it from the gateway config,
+--    and keeping the row preserves the history and stays reversible.
+UPDATE public.provider_routes
+   SET health_state = 'disabled'
+ WHERE route_id = 'route-openrouter-fast-fallback';
+
+-- 4. Drop the retired route from hive-fast's fallback order so the policy
+--    row cannot name a route that is no longer selectable.
+UPDATE public.alias_route_policies
+   SET fallback_order = '["route-groq-fast"]'::jsonb
+ WHERE alias_id = 'hive-fast';


### PR DESCRIPTION
## Summary

Corrects the catalog credit prices, which were arbitrary placeholders sitting roughly 1300x to 7500x below real provider rates, and reduces every chat alias to exactly one enabled route.

Fixes #617. Supersedes #643, which modelled the price ambiguity by moving pricing onto `provider_routes`. The owner's ruling is that the ambiguity should be removed rather than modelled: one model, one price. Price therefore stays on `model_aliases`, and `hive-fast` is pinned to a single route.

Please close #643 in favour of this branch.

## What changed

**Prices.** Derived mechanically as `ceil(provider_list_usd_per_million * 1.4 * CreditsPerUSD)`, with `CreditsPerUSD = 100000`. Input and output derived separately. The multiplier, the source of each rate, and the fetch date are all recorded in the migration header so regeneration needs no judgment.

| alias | route | provider rate per million | corrected credits |
|---|---|---|---|
| `hive-fast` | Groq `openai/gpt-oss-20b` | 0.075 in / 0.30 out | 10500 in / 42000 out (was 8 / 24) |
| `hive-default` | OpenRouter `openai/gpt-4o-mini` | 0.15 in / 0.60 out | 21000 in / 84000 out (was 12 / 36) |
| `hive-auto` | OpenRouter `openai/gpt-4.1-mini` | 0.40 in / 1.60 out | 56000 in / 224000 out (was 10 / 30) |

Rates fetched 2026-08-01. OpenRouter figures come from `https://openrouter.ai/api/v1/models`, which quotes per token; the table shows those values multiplied by 1e6. Groq does not expose pricing through its models API, so the Groq figures come from its published pricing page and the model table in its docs, which agree with each other.

**One alias, one route.** `hive-fast` carried two enabled routes, a Groq route and an OpenRouter route, whose real costs differ by roughly ten times. An alias whose cost depends on which route happened to win is not priceable at the alias level. `route-groq-fast` is repointed to `openai/gpt-oss-20b` and `route-openrouter-fast-fallback` is set to `health_state = 'disabled'` rather than deleted, so the row keeps its history and the change is reversible. `alias_route_policies.fallback_order` for `hive-fast` is trimmed to match, so no policy row names a route that is no longer selectable.

**Fail closed.** `SelectRoute` now returns `ErrAliasNotPriced` for an alias whose input and output prices are both zero, instead of returning it at a zero price. This matters because of an interaction that is easy to miss: `precedence.go` floors any billable request at one credit, so an unpriced alias would not bill zero, it would bill exactly one credit for a request of any size. The condition is the same both-sides-zero test that `metering.RouteInfo.HasCostBasis` already uses, so an alias that legitimately prices only one side stays selectable, which covers embeddings (input only) and voice (output only).

## What deliberately did not change

- `provider_routes` gains no price columns and no `pricing_unit` column.
- `precedence.go` is untouched. Its round-half-up `math/big` arithmetic is correct and matches D-031.
- TTS, STT, and embeddings prices are out of scope. `internal/audio` never reads this catalog and charges flat literals (#627), so repricing those rows would move a console display without moving a charge. No per-token price is invented for them and no unit label is stamped on them.
- `cache_read_price_credits` and `cache_write_price_credits` remain at their placeholder values. `precedence.go` never reads them, so they are display-only today. Correcting them needs its own ruling on whether cached input is billed at all.

## Tests

Written failing first. The trap they are built around: the floor-at-one-credit rule masks under-pricing at low token counts, so an assertion using tens of tokens passes with the bug fully intact. Every billing assertion uses thousands of tokens, and every expected figure is computed by hand in the test so a future price change has to fail the test and be re-derived rather than drift silently.

- `TestPriceEstimate_CorrectedPricesBillHighTokenRequests` — 40k prompt plus 12k completion on `hive-fast` bills 924 credits, derived by hand in the comment.
- `TestPriceEstimate_PlaceholderPricesUnderchargedAtHighTokenCounts` — pins the size of the defect: the same request under the placeholder prices bills 1 credit, a 924x shortfall.
- `TestPriceEstimate_LowTokenCountsMaskTheDefect` — documents the trap by showing that at 20 tokens the placeholder and the corrected price return the same answer.
- `TestSelectRouteRefusesUnpricedAlias` — an unpriced alias is refused, not billed at zero.
- `TestSelectRouteAllowsSingleSidedPricing` — guards that refusal against overreaching into embeddings and voice.
- `TestSelectRouteHiveFastResolvesToGroqAtGroqPrice` — `hive-fast` resolves to the Groq route, offers no fallback, and carries the Groq price.
- `catalog_pricing_integration_test.go` — the data half, run against a database with the full migration chain applied: every alias has exactly one enabled route, `hive-fast` is pinned to `groq/openai/gpt-oss-20b` at 10500/42000, and no alias is left without a cost basis.

## Migration safety

`20260801_01_alias_pricing_correction.sql` contains zero INSERT statements, so there is no row on which an `ON CONFLICT` clause could be needed or omitted. Checked per statement, not per file. Every statement is an UPDATE keyed on a primary key assigning constants, so re-application is a no-op. Verified by applying it twice to a scratch database carrying the full migration chain and confirming identical results. Nothing was applied to the live database; the live reads used to audit the current state were read-only against the transaction-mode pooler port.

## Reported, not changed

Two findings from the per-alias audit are left alone because they are decisions rather than defects, and both are recorded as a documented exception in the integration test so they fail loudly the moment they are resolved:

1. `hive-embedding-default` has three enabled routes, so it also violates the one-alias-one-route rule. Repointing an embedding alias is not a like-for-like swap the way a chat model is, because D-001 ties the embedding model to a provisioned pgvector column width, so changing which route serves it can invalidate already-stored vectors.
2. `route-nvidia-embedding` sits at `health_state = 'eol'`. `SelectRoute` filters only `'disabled'`, while `litellmconfig`'s sync excludes both `'disabled'` and `'eol'`. That route is therefore selectable by routing but is never written into the gateway config, so selecting it would dispatch to a model the gateway does not serve.

Separately, `litellmconfig.SyncService.Sync` selects `pr.model_id`, and no such column exists on `provider_routes` in any migration. That query cannot succeed against the real schema. It is pre-existing and outside this change, so it is flagged rather than fixed here.
