### PR TITLE
ci: report whether nightly metering retention is actually scheduled

### DIFF
--- a/.github/workflows/deploy-demo-box.yml
+++ b/.github/workflows/deploy-demo-box.yml
@@ -130,6 +130,27 @@ jobs:
           PGPASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
         run: scripts/apply-migrations.sh
 
+      - name: Report whether nightly metering retention is scheduled
+        # Issue #645. 20260729_02 sets the purge job up behind two guards that
+        # each degrade to a RAISE NOTICE, correctly, since nothing else in that
+        # migration needs pg_cron. The cost is that a host where the extension
+        # cannot be created silently gets no retention at all, evidenced only by
+        # a notice in a log nobody rereads after the run goes green.
+        #
+        # This step reports that state instead of leaving it buried. It is NOT a
+        # gate and never fails the job: on a host without pg_cron the extension
+        # genuinely cannot be created, and blocking every deploy for that is the
+        # mistake the guards already avoid. Absence surfaces as a ::warning::
+        # annotation on the run summary. The migration step above is unchanged
+        # and still fails the deploy on a real migration error.
+        env:
+          PGHOST: ${{ secrets.SUPABASE_DB_HOST }}
+          PGPORT: ${{ env.PG_POOL_PORT }}
+          PGUSER: ${{ secrets.SUPABASE_DB_USER }}
+          PGDATABASE: ${{ secrets.SUPABASE_DB_NAME }}
+          PGPASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+        run: scripts/check-retention-schedule.sh
+
   deploy:
     name: Pull + recreate stack on the demo box
     needs: migrate

--- a/scripts/check-retention-schedule.sh
+++ b/scripts/check-retention-schedule.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# check-retention-schedule.sh -- Report whether the nightly metering retention
+# job is actually scheduled. Reports, never blocks.
+#
+# Why this exists (issue #645)
+# ---------------------------
+# 20260729_02_metering_shadow_verdicts_retention.sql sets the purge job up in
+# two guarded blocks: one creates the pg_cron extension when
+# pg_available_extensions lists it, wrapped in an exception handler, and a later
+# one calls cron.schedule only when pg_extension shows pg_cron installed. Both
+# guards are correct, because nothing else in that migration depends on pg_cron
+# and aborting the deploy over it would be wrong.
+#
+# The problem is what those guards leave behind. Each degrades to a RAISE
+# NOTICE, so a host where the extension cannot be created gets no nightly
+# retention at all, and the only evidence is a line in a job log nobody reads
+# after the run goes green. metering_shadow_verdicts then grows without bound
+# and the first real symptom is disk pressure.
+#
+# That is the same defect class this repo spent a day removing: a guard that
+# correctly avoids aborting also converts a hard failure into an invisible one.
+# The fix is not to remove the guard, it is to make the absence visible. This
+# script is the "make it visible" half.
+#
+# Exit status
+# -----------
+# Always 0. Absence is reported, never fatal. On a host without pg_cron the
+# extension genuinely cannot be created, and blocking every deploy for that
+# would be the mistake the guards already avoid. The signal is a GitHub
+# ::warning:: annotation, which surfaces on the workflow run summary rather than
+# only in log text.
+#
+# This is deliberately NOT a gate. It does not weaken one either: the migration
+# step that runs before it still uses ON_ERROR_STOP=1 and still fails the deploy
+# on a real migration error.
+#
+# Connection settings come from libpq environment variables (PGHOST, PGPORT,
+# PGUSER, PGDATABASE, PGPASSWORD), same as apply-migrations.sh. No DSN is built
+# here, because DSN parameters are per driver and psql is a libpq client.
+
+set -euo pipefail
+
+JOB_NAME='metering-shadow-verdicts-purge'
+
+psql_q() { psql --no-psqlrc -qtAX -v ON_ERROR_STOP=1 "$@"; }
+
+# pg_extension has to be checked separately and first: when pg_cron is not
+# installed the cron schema does not exist either, and a single query
+# mentioning cron.job would fail to parse rather than returning a verdict,
+# no matter how the CASE is arranged.
+if ! extension_present="$(psql_q -c "SELECT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_cron')")"; then
+  echo "::warning::Could not determine whether nightly metering retention is scheduled: the pg_cron extension query failed. Retention status is UNKNOWN. Check public.metering_shadow_verdicts growth manually."
+  exit 0
+fi
+
+if [ "$extension_present" != "t" ]; then
+  echo "::warning::Nightly metering retention is NOT scheduled: the pg_cron extension is not installed on this database, so 20260729_02 skipped cron.schedule. public.metering_shadow_verdicts will grow without bound. Either install pg_cron (it must also be in shared_preload_libraries, see issue #615) or invoke CALL public.purge_metering_shadow_verdicts() from an external scheduler."
+  exit 0
+fi
+
+# Reached only when pg_cron is installed, so cron.job is guaranteed to resolve.
+# active is checked separately from existence because a disabled job looks
+# present in every naive check while scheduling exactly nothing.
+if ! state="$(psql_q -c "
+  SELECT CASE
+    WHEN count(*) = 0 THEN 'SCHEDULE_MISSING'
+    WHEN count(*) FILTER (WHERE active) = 0 THEN 'SCHEDULE_INACTIVE'
+    ELSE 'OK'
+  END
+  FROM cron.job
+  WHERE jobname = '$JOB_NAME'")"; then
+  echo "::warning::Could not determine whether nightly metering retention is scheduled: pg_cron is installed but the cron.job query failed. Retention status is UNKNOWN."
+  exit 0
+fi
+
+case "$state" in
+  SCHEDULE_MISSING)
+    echo "::warning::Nightly metering retention is NOT scheduled: pg_cron is installed but no cron job named '$JOB_NAME' exists. 20260729_02 either has not run on this database or its cron.schedule call did not take effect. public.metering_shadow_verdicts will grow without bound."
+    ;;
+  SCHEDULE_INACTIVE)
+    echo "::warning::Nightly metering retention is DISABLED: the cron job '$JOB_NAME' exists but is marked inactive, so it will never fire. public.metering_shadow_verdicts will grow without bound. Re-enable it with UPDATE cron.job SET active = true WHERE jobname = '$JOB_NAME'."
+    ;;
+  OK)
+    schedule="$(psql_q -c "SELECT schedule FROM cron.job WHERE jobname = '$JOB_NAME' AND active LIMIT 1")"
+    echo "::notice::Nightly metering retention is scheduled and active ('$JOB_NAME', $schedule)."
+    ;;
+  *)
+    echo "::warning::Unexpected retention schedule state '$state' for '$JOB_NAME'. Retention status is UNKNOWN."
+    ;;
+esac
+
+exit 0


### PR DESCRIPTION
Closes #645.

## The gap

`supabase/migrations/20260729_02_metering_shadow_verdicts_retention.sql` sets the metering purge job up behind two guards: a `DO $pg_cron_setup$` block that creates the `pg_cron` extension when `pg_available_extensions` lists it, now wrapped in an exception handler, and a later block that calls `cron.schedule` only when `pg_extension` shows pg_cron installed.

Both guards are correct. Nothing else in that migration depends on pg_cron, so aborting a deploy over it would be wrong.

The problem is what they leave behind. Each degrades to a `RAISE NOTICE`, so a host where the extension cannot be created gets no nightly retention at all, and the only evidence is a line in a job log nobody rereads once the run goes green. `metering_shadow_verdicts` then grows without bound and the first real symptom is disk pressure.

That is the same defect class this repo spent a day removing. **A guard that correctly avoids aborting also converts a hard failure into an invisible one.** The answer is not to remove the guard, it is to make the absence visible.

## Live state, checked read only before building anything

Queried over the pooler's transaction mode port so no session slot was taken, `SELECT 1` first:

| Check | Result |
| --- | --- |
| pg_cron available on disk | yes |
| pg_cron extension created | **yes** |
| `cron.job` entry | **`metering-shadow-verdicts-purge`, `0 21 * * *`, active** |
| purge procedure exists | yes |
| retention config table exists | yes |

**The demo box does currently have nightly retention.** The migrate run of `20260729_02` created it successfully. So this PR closes an observability gap rather than restoring a broken job.

## Approach, and why

A step in the `migrate` job, calling `scripts/check-retention-schedule.sh` after migrations apply.

Considered and rejected: folding it into `apply-migrations.sh` couples the applier to one migration's concern, and a control-plane startup check reports on a service boundary that has nothing to do with whether a scheduled job exists. The migrate job already holds the database credentials and already runs on every deploy, so it is the cheapest place that sees the truth. No new migration was needed, so none was added.

## Four states, not a boolean

A single boolean would hide which problem you have, and the three failure modes need different fixes:

| State | Meaning | Level |
| --- | --- | --- |
| extension absent | pg_cron is not installed, so `cron.schedule` was skipped | warning |
| schedule missing | pg_cron is installed but no job by that name exists | warning |
| schedule inactive | the job exists but is disabled, so it never fires | warning |
| ok | job exists and is active; its cron expression is reported | notice |

**Inactive is called out separately** because a disabled job looks present to every naive existence check while scheduling exactly nothing. A query failure is reported as a fourth, explicitly UNKNOWN outcome rather than being mistaken for absence.

## Absence reports, it does not abort

The script always exits 0. On a host without pg_cron the extension genuinely cannot be created, and blocking every deploy for that is precisely the mistake the guards already avoid. Absence surfaces as a GitHub `::warning::` annotation, which appears on the workflow run summary rather than only in log text.

I agree with the non-fatal call and am not arguing for the alternative. Fatal would mean any Enterprise or self-hosted target without pg_cron cannot deploy at all, which trades a silent gap for a hard block on a supported configuration. The migration itself already documents the external-scheduler fallback for exactly that case.

**No gate is weakened.** This step adds no `continue-on-error` and no swallowed exit code of its own, and the migration step before it is untouched: still `ON_ERROR_STOP=1` under `set -euo pipefail`, still failing the deploy on a real migration error, `deploy: needs: migrate` unchanged.

## Implementation note

The `pg_extension` check runs as its own query before the `cron.job` one. When pg_cron is absent the `cron` schema does not exist either, so a single statement mentioning `cron.job` fails to parse rather than returning a verdict, no matter how the `CASE` is arranged.

## Verification

All four states exercised end to end against real Postgres, each exiting 0:

- [x] **extension absent** — `pgvector/pgvector:pg17`, which ships no pg_cron. Emits the extension-absent warning.
- [x] **schedule missing** — `postgres:17` with `postgresql-17-cron` installed and `shared_preload_libraries=pg_cron`, extension created, no job scheduled. Emits the schedule-missing warning.
- [x] **ok** — same container after `cron.schedule('metering-shadow-verdicts-purge', '0 21 * * *', ...)`. Emits `::notice::` including the cron expression `0 21 * * *`.
- [x] **inactive** — same container after `UPDATE cron.job SET active = false`. Emits the disabled warning.
- [x] shellcheck clean; workflow YAML parses and the migrate job carries no `continue-on-error`.
- [ ] **Could not verify: the step running in CI.** The deploy workflow was not triggered, per instruction. The job name is created by `cron.schedule` in the test rather than by running `20260729_02` itself, which needs the full metering schema; the check only reads `cron.job`, so the two are equivalent for what it asserts.

Live state was read only throughout. Nothing was applied to the demo database.
