### PR TITLE
ci: gate the pricing correction integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,6 +287,13 @@ jobs:
             psql "$dsn" -v ON_ERROR_STOP=1 -f "$f"
           done
           echo "HIVE_TEST_DB_URL=$dsn" >> "$GITHUB_ENV"
+          # Same ephemeral database, same full migration chain (including
+          # 20260801_01_alias_pricing_correction.sql), read via the routing
+          # package's own env var name (issue #655). Separate name from
+          # HIVE_TEST_DB_URL because the integration test predates this
+          # wiring and was never plumbed into any workflow; no reason to
+          # rename it now that it is.
+          echo "ROUTING_TEST_DB_URL=$dsn" >> "$GITHUB_ENV"
 
       - name: go test — RLS suites against live Postgres (control-plane, edge-api only)
         if: >-
@@ -296,7 +303,11 @@ jobs:
         run: |
           set -euo pipefail
           if [ "${{ matrix.module }}" = "control-plane" ]; then
-            go test -count=1 -v ./internal/accounts/... ./internal/agenttask/... ./internal/egress/... ./internal/payments/... ./internal/profiles/... ./internal/rag/... ./internal/tenants/... ./internal/signup/...
+            # -tags integration additionally compiles in
+            # routing/catalog_pricing_integration_test.go (issue #655), which
+            # carries a //go:build integration constraint the other packages
+            # below do not use; passing the tag is a no-op for them.
+            go test -tags integration -count=1 -v ./internal/accounts/... ./internal/agenttask/... ./internal/egress/... ./internal/payments/... ./internal/profiles/... ./internal/rag/... ./internal/tenants/... ./internal/signup/... ./internal/routing/...
           else
             go test -count=1 -v ./internal/artifacts/... ./internal/rag/...
           fi

--- a/apps/control-plane/internal/routing/catalog_pricing_integration_test.go
+++ b/apps/control-plane/internal/routing/catalog_pricing_integration_test.go
@@ -30,7 +30,15 @@ func connectCatalogDB(t *testing.T) *pgxpool.Pool {
 	t.Helper()
 	dsn := os.Getenv("ROUTING_TEST_DB_URL")
 	if dsn == "" {
-		t.Skip("ROUTING_TEST_DB_URL not set; skipping integration test")
+		// A skipped test and a passing test are indistinguishable inside a
+		// green check (issue #655). This suite guards the corrected catalog
+		// prices from #617/#651, so in CI a missing DSN is a wiring defect,
+		// not a reason to quietly pass. Gated on CI rather than the
+		// variable itself so a local developer run can still skip.
+		if os.Getenv("CI") != "" {
+			t.Fatal("ROUTING_TEST_DB_URL not set in CI: this suite guards the corrected catalog prices (#617) and must not silently pass as skipped")
+		}
+		t.Skip("ROUTING_TEST_DB_URL not set; skipping integration test (set CI=true to make this fail instead of skip)")
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()


### PR DESCRIPTION
## Summary

Fixes #655. `catalog_pricing_integration_test.go` sat behind the `integration` build tag and required `ROUTING_TEST_DB_URL`, which no workflow ever set, so its assertions never executed in CI. The data half of the #617/#651 pricing correction (corrected credit prices, one route per alias, `hive-fast` pinned to Groq) was unguarded against regression: wrong prices are silent, nothing errors, and that is exactly how the original placeholders survived 1312x-7467x below real provider rates.

## What changed

- Wired the routing package's integration tests into the existing `go-tests` job's control-plane leg, reusing the same ephemeral `pgvector/pgvector:pg17` service and `.github/ci/test-db-bootstrap.sql` already used for the signup package's live-DB suites, rather than a second CI mechanism.
- `ROUTING_TEST_DB_URL` points at the same database as `HIVE_TEST_DB_URL` once the full migration chain is applied to it.
- `-tags integration` added to the one combined `go test` invocation. It has no effect on the other packages in that list (accounts, agenttask, egress, payments, profiles, rag, tenants, signup), which carry no build constraint.
- `connectCatalogDB` now fails (`t.Fatal`) when `ROUTING_TEST_DB_URL` is unset AND `CI` is set, instead of skipping, so a broken wiring shows up as a red check rather than a green one that ran nothing. Gated on `CI` rather than the variable itself so a local developer run without the variable still skips.

## Proof the tests actually run, not skip

- `CI=true go test -tags integration ./apps/control-plane/internal/routing/...` with no DB configured: **fails** with `ROUTING_TEST_DB_URL not set in CI: this suite guards the corrected catalog prices (#617) and must not silently pass as skipped`.
- Same command with `CI` unset: **skips** as before (local developer path preserved).
- A fresh scratch Postgres, bootstrapped and fully migrated (82 migrations) exactly as the workflow does, then the exact combined `go test` command from the workflow run once: every package passes, including `routing`'s four integration tests (`TestSeededAliasHasExactlyOneEnabledRoute`, `TestHiveFastIsPinnedToGroqAtCorrectedPrice`, `TestNoRouteIsSelectableButUnservable`, `TestEveryAliasHasACostBasis`).

## Other suites found skipping silently (not fixed here, listed for separate triage)

Own env var name, never wired into any workflow at all (same class of problem as this issue):
- `apps/control-plane/internal/providers/integration_test.go`: `PROVIDERS_TEST_DB_URL`
- `apps/control-plane/internal/catalog/catalog_integration_test.go`: `CATALOG_TEST_DB_URL`
- `apps/control-plane/internal/litellmconfig/sync_integration_test.go`: `LITELLM_TEST_DB_URL`
- `apps/agent-engine/internal/sandbox/launcher_test.go` and `apptainer_integration_test.go`: `HIVE_APPTAINER_TEST` (needs a real apptainer runtime, not just a DB)
- `apps/edge-api/internal/audio/live_voice_integration_test.go`: `GROQ_API_KEY` (needs a real provider key, different risk profile than a DB var)

Use the shared `HIVE_TEST_DB_URL` name (so the ephemeral DB exists and the variable is exported in CI) but the package is not in the explicit `go test` package list in ci.yml, so it never actually runs there either:
- control-plane: `auditarchive`, `audit` (`log_test.go`, `wal_test.go`), `auditverifier`, `platform` (`role_rls_test.go`), `marketplace`, `tenant/settings`, `auditworker`, `licensing`, `usage`, `tests/compliance` (`audit_chain_integrity_test.go`, `audit_coverage_test.go`)
- edge-api: `auth` (`tenant_fallback_test.go`), `chat` (`dispatch_test.go`)

## Test plan

- [x] `go vet ./...` and `go vet -tags integration ./...` clean
- [x] YAML syntax validated
- [x] RED/GREEN proven for the CI-vs-local skip/fail behavior
- [x] Full combined CI command proven to pass on a genuinely fresh migrated database
- [x] Tested on my own worktree (`/tmp/pricegate`), never the shared checkout

Does not merge here.