### PR TITLE
fix: give the streaming fallback release its own settlement deadline

### DIFF
--- a/apps/edge-api/internal/inference/accounting_client.go
+++ b/apps/edge-api/internal/inference/accounting_client.go
@@ -25,7 +25,12 @@ type AccountingClient struct {
 // box against Supabase us-east-1). The former 5s budget cut that call off
 // mid-flight: control-plane still committed the reservation while edge-api
 // saw a timeout, so /v1/audio/* answered 402 and the credit hold leaked.
-const accountingTimeout = 30 * time.Second
+//
+// A var, not a const, so tests can shrink it to exercise the
+// deadline-exhaustion path in milliseconds instead of real seconds. Same
+// reason the audio and images packages made their releaseTimeout a var in
+// PR #650.
+var accountingTimeout = 30 * time.Second
 
 // NewAccountingClient creates a new AccountingClient.
 func NewAccountingClient(baseURL string) *AccountingClient {

--- a/apps/edge-api/internal/inference/stream.go
+++ b/apps/edge-api/internal/inference/stream.go
@@ -402,9 +402,6 @@ func settlementCredits(hasUsage bool, totalTokens int64, prompt, content string)
 // or finalize. That must not also drop the usage telemetry for the request --
 // see the reservation.ID == "" branches below.
 func (o *Orchestrator) settleStream(reqCtx context.Context, snapshot authz.AuthSnapshot, attempt AttemptResult, reservation ReservationResult, requestID, endpoint, model string, acc *UsageAccumulator, promptBody, content string) bool {
-	ctx, cancel := context.WithTimeout(context.Background(), accountingTimeout)
-	defer cancel()
-
 	// Parse promptBody (the raw request bytes) down to just the message/input
 	// text before estimating -- see promptText in usage_clamp.go for why the
 	// raw bytes themselves must never be counted directly (issue #602).
@@ -415,16 +412,21 @@ func (o *Orchestrator) settleStream(reqCtx context.Context, snapshot authz.AuthS
 			reason, eventType = "client_disconnect", "interrupted"
 		}
 		if reservation.ID != "" {
-			if err := o.accounting.ReleaseReservation(ctx, ReleaseReservationInput{
+			releaseCtx, cancelRelease := freshSettlementCtx()
+			err := o.accounting.ReleaseReservation(releaseCtx, ReleaseReservationInput{
 				AccountID:     snapshot.AccountID,
 				ReservationID: reservation.ID,
 				Reason:        reason,
-			}); err != nil {
+			})
+			cancelRelease()
+			if err != nil {
 				log.Printf("inference: settle release failed request_id=%s reservation_id=%s: %v", requestID, reservation.ID, err)
 				return false
 			}
 		}
-		o.recordInterruptedEvent(ctx, snapshot, attempt, requestID, endpoint, model, acc, eventType)
+		eventCtx, cancelEvent := freshSettlementCtx()
+		defer cancelEvent()
+		o.recordInterruptedEvent(eventCtx, snapshot, attempt, requestID, endpoint, model, acc, eventType)
 		return true
 	}
 
@@ -432,35 +434,75 @@ func (o *Orchestrator) settleStream(reqCtx context.Context, snapshot authz.AuthS
 		// No reservation ever existed to finalize, but the request still
 		// delivered billable content -- record it so the telemetry isn't
 		// silently dropped just because CreateReservation failed earlier.
-		o.recordCompletedEvent(ctx, snapshot, attempt, requestID, endpoint, model, acc.ToUsageResponse())
+		eventCtx, cancelEvent := freshSettlementCtx()
+		defer cancelEvent()
+		o.recordCompletedEvent(eventCtx, snapshot, attempt, requestID, endpoint, model, acc.ToUsageResponse())
 		return true
 	}
 
-	if err := o.accounting.FinalizeReservation(ctx, FinalizeReservationInput{
+	finalizeCtx, cancelFinalize := freshSettlementCtx()
+	err := o.accounting.FinalizeReservation(finalizeCtx, FinalizeReservationInput{
 		AccountID:              snapshot.AccountID,
 		ReservationID:          reservation.ID,
 		ActualCredits:          credits,
 		TerminalUsageConfirmed: acc.HasUsage,
 		Status:                 "completed",
-	}); err != nil {
+	})
+	// Cancelled the moment finalize returns, never before: the call has
+	// already completed, so this can only release the timer, never abort a
+	// charge in flight. Nothing below reads finalizeCtx.
+	cancelFinalize()
+	if err != nil {
 		log.Printf("inference: settle finalize failed request_id=%s reservation_id=%s: %v", requestID, reservation.ID, err)
 		// A failed finalize must not leave the hold stranded: fall back to a
 		// full release so the customer's credits are freed rather than
 		// locked forever behind a charge that never landed.
-		if relErr := o.accounting.ReleaseReservation(ctx, ReleaseReservationInput{
+		releaseCtx, cancelRelease := freshSettlementCtx()
+		relErr := o.accounting.ReleaseReservation(releaseCtx, ReleaseReservationInput{
 			AccountID:     snapshot.AccountID,
 			ReservationID: reservation.ID,
 			Reason:        "finalize_failed",
-		}); relErr != nil {
+		})
+		cancelRelease()
+		if relErr != nil {
 			log.Printf("inference: settle finalize-fallback release failed request_id=%s reservation_id=%s: %v", requestID, reservation.ID, relErr)
 			return false
 		}
 		log.Printf("inference: settle finalize failed, released reservation instead request_id=%s reservation_id=%s", requestID, reservation.ID)
-		o.recordInterruptedEvent(ctx, snapshot, attempt, requestID, endpoint, model, acc, "finalize_failed")
+		eventCtx, cancelEvent := freshSettlementCtx()
+		defer cancelEvent()
+		o.recordInterruptedEvent(eventCtx, snapshot, attempt, requestID, endpoint, model, acc, "finalize_failed")
 		return true
 	}
-	o.recordCompletedEvent(ctx, snapshot, attempt, requestID, endpoint, model, acc.ToUsageResponse())
+	eventCtx, cancelEvent := freshSettlementCtx()
+	defer cancelEvent()
+	o.recordCompletedEvent(eventCtx, snapshot, attempt, requestID, endpoint, model, acc.ToUsageResponse())
 	return true
+}
+
+// freshSettlementCtx returns a new background context carrying a full
+// accountingTimeout budget, never the caller's request context: a client
+// disconnect is exactly what cancels that one.
+//
+// Every settlement call takes its own rather than sharing one across the
+// sequence. settleStream used to build a single context and reuse it for
+// finalize and for the fallback release that follows a failed finalize, so a
+// finalize that was merely SLOW rather than instantly failing consumed the
+// whole window and the release then ran on an already-expired context, never
+// left the gateway, and stranded the hold: #616's failure mode reintroduced
+// on the highest-traffic path (#657). The same starvation applied to the
+// usage events recorded after settlement, which would silently vanish.
+//
+// PR #650 established this shape for the audio and images settlement paths;
+// this is the same fix on the streaming path.
+//
+// The cost is that the worst case settlement window is now the sum of each
+// call's budget rather than one shared budget, so it roughly doubles on the
+// finalize-then-release path. That is the correct trade against stranding a
+// customer's credits, and it widens #649 for streaming in the same way #650
+// widened it for media.
+func freshSettlementCtx() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), accountingTimeout)
 }
 
 func (o *Orchestrator) recordInterruptedEvent(ctx context.Context, snapshot authz.AuthSnapshot, attempt AttemptResult, requestID, endpoint, model string, acc *UsageAccumulator, eventType string) {

--- a/apps/edge-api/internal/inference/stream_settle_context_test.go
+++ b/apps/edge-api/internal/inference/stream_settle_context_test.go
@@ -1,0 +1,139 @@
+package inference
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/authz"
+)
+
+// newAccountingMockSlowFinalize answers finalize with a 500 only after
+// sleeping, so finalize is SLOW rather than instantly failing, and answers
+// every other path 200 immediately.
+//
+// The slowness is the whole point. Every existing settlement mock fails
+// finalize instantly, which always leaves the fallback release plenty of
+// budget on a shared deadline, so none of them could ever catch a release
+// starved by the finalize that preceded it.
+func newAccountingMockSlowFinalize(rec *accountingRecorder, finalizeSleep time.Duration) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		rec.record(r.URL.Path, body)
+		if r.URL.Path == "/internal/accounting/reservations/finalize" {
+			time.Sleep(finalizeSleep)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+	}))
+}
+
+// TestSettleStream_ReleaseGetsFreshDeadlineAfterSlowFinalize is issue #657.
+//
+// settleStream built one background context and used it for both the finalize
+// call and the fallback release that follows a failed finalize. They shared a
+// single deadline, so a finalize that was merely SLOW consumed the whole
+// budget and the release then ran on an already-expired context, never left
+// the gateway, and stranded the hold. That is #616's failure mode on the
+// streaming path, which carries the most traffic.
+//
+// The assertion is on what the release context did to the release, not on a
+// call count: a shared context makes the release fail with context deadline
+// exceeded before it is ever sent, which surfaces both as the missing call at
+// the control plane and as the fallback-release failure log.
+//
+// accountingTimeout is shrunk so this proves the shared-versus-fresh property
+// in milliseconds rather than waiting out two real 30s budgets. It is read
+// when the accounting client is constructed as well as when each settlement
+// context is built, so it must be set before NewAccountingClient.
+func TestSettleStream_ReleaseGetsFreshDeadlineAfterSlowFinalize(t *testing.T) {
+	original := accountingTimeout
+	accountingTimeout = 200 * time.Millisecond
+	defer func() { accountingTimeout = original }()
+
+	rec := &accountingRecorder{}
+	// Finalize takes longer than its own full budget, so it exhausts whatever
+	// deadline it is given before failing.
+	acctSrv := newAccountingMockSlowFinalize(rec, 400*time.Millisecond)
+	defer acctSrv.Close()
+
+	orch := &Orchestrator{accounting: NewAccountingClient(acctSrv.URL)}
+	acc := &UsageAccumulator{TotalTokens: 25, HasUsage: true}
+
+	var settled bool
+	logs := captureLogs(t, func() {
+		settled = orch.settleStream(
+			context.Background(),
+			authz.AuthSnapshot{AccountID: "acct-test-1", KeyID: "key-test-1"},
+			AttemptResult{ID: "attempt-test-1"},
+			ReservationResult{ID: "res-test-1"},
+			"req-test-1", EndpointChatCompletions, "gpt-4o", acc, `{}`, "hello",
+		)
+	})
+
+	if !rec.has("/internal/accounting/reservations/finalize") {
+		t.Fatalf("expected FinalizeReservation to be attempted; calls seen: %+v", rec.calls)
+	}
+	if strings.Contains(logs, "finalize-fallback release failed") {
+		t.Fatalf("the fallback release ran on finalize's already-expired context instead of a fresh full budget (#657). logs: %q", logs)
+	}
+	if !rec.has("/internal/accounting/reservations/release") {
+		t.Fatalf("the fallback release never reached the control plane, so the hold is stranded (#657, the #616 failure mode). calls seen: %+v, logs: %q", rec.calls, logs)
+	}
+	if !settled {
+		t.Fatal("settleStream reported an unsettled reservation even though the release should have succeeded on its own budget")
+	}
+}
+
+// TestSettleStream_SlowButSuccessfulFinalize_NeverReleases guards the other
+// half of the invariant against this fix. Cancelling finalizeCtx explicitly,
+// which the fix does the moment finalize returns, must not create a path where
+// a finalize that SUCCEEDED is followed by a release that refunds a real
+// charge. The finalize here is slow enough to be interesting but answers 200,
+// so nothing may be released.
+func TestSettleStream_SlowButSuccessfulFinalize_NeverReleases(t *testing.T) {
+	original := accountingTimeout
+	accountingTimeout = 2 * time.Second
+	defer func() { accountingTimeout = original }()
+
+	rec := &accountingRecorder{}
+	acctSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		rec.record(r.URL.Path, body)
+		if r.URL.Path == "/internal/accounting/reservations/finalize" {
+			time.Sleep(100 * time.Millisecond)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer acctSrv.Close()
+
+	orch := &Orchestrator{accounting: NewAccountingClient(acctSrv.URL)}
+	acc := &UsageAccumulator{TotalTokens: 25, HasUsage: true}
+
+	settled := orch.settleStream(
+		context.Background(),
+		authz.AuthSnapshot{AccountID: "acct-test-1", KeyID: "key-test-1"},
+		AttemptResult{ID: "attempt-test-1"},
+		ReservationResult{ID: "res-test-1"},
+		"req-test-1", EndpointChatCompletions, "gpt-4o", acc, `{}`, "hello",
+	)
+
+	if !settled {
+		t.Fatal("expected a successful finalize to settle the reservation")
+	}
+	if !rec.has("/internal/accounting/reservations/finalize") {
+		t.Fatalf("expected FinalizeReservation to be attempted; calls seen: %+v", rec.calls)
+	}
+	if rec.has("/internal/accounting/reservations/release") {
+		t.Fatalf("a charged reservation must never also be released: that refunds a legitimate charge. calls seen: %+v", rec.calls)
+	}
+}


### PR DESCRIPTION
Closes #657. Follows the pattern established in #650.

`settleStream` built one background context and used it for both the finalize call and the fallback release that follows a failed finalize. They shared a single deadline, so a finalize that was merely slow rather than instantly failing consumed the whole window. The release then ran on an already expired context, never left the gateway, and stranded the hold. That is #616's failure mode on the streaming path, which carries the most traffic.

The uncomfortable part is that `settleStream` was the reference implementation the other sites were told to copy. It is right about using a background context instead of the cancelled request context. It was wrong about sharing that context between the two calls, and carried that defect the whole time.

## The fix

Exactly what #650 did for audio and images: build the release context only after finalize has already returned, so the release always starts on a full budget rather than the remainder.

```go
finalizeCtx, cancelFinalize := freshSettlementCtx()
err := o.accounting.FinalizeReservation(finalizeCtx, ...)
cancelFinalize()
if err != nil {
	releaseCtx, cancelRelease := freshSettlementCtx()
	relErr := o.accounting.ReleaseReservation(releaseCtx, ...)
	cancelRelease()
	...
}
```

`freshSettlementCtx` is a two line helper rather than a repeated `context.WithTimeout(context.Background(), accountingTimeout)`, because settleStream has seven such call sites and the reason they must not share is worth stating once where it cannot drift.

The usage events recorded after settlement get their own budget too. They sat on the same starved tail, so a slow finalize silently dropped the interrupted or completed event as well. Same root cause, same function, no extra risk.

## Why the test could not have caught this before

Every existing settlement mock fails finalize instantly, which always leaves the shared deadline with plenty left over. A release starved by the finalize before it was unreachable by construction.

`newAccountingMockSlowFinalize` sleeps before answering finalize with a 500, and `accountingTimeout` becomes a var so the test can shrink it to 200ms while the mock sleeps 400ms. Same approach as #650, which made the audio and images `releaseTimeout` a var for the same reason. No test in this package calls `t.Parallel()`, so mutating the package var is safe.

Failing first, against the shared context, with the release context's own error in the log:

```
=== RUN   TestSettleStream_ReleaseGetsFreshDeadlineAfterSlowFinalize
    stream_settle_context_test.go:85: the fallback release ran on finalize's already-expired context
    instead of a fresh full budget (#657). logs:
    "inference: settle finalize failed request_id=req-test-1 reservation_id=res-test-1: request failed:
      Post \"http://127.0.0.1:35357/internal/accounting/reservations/finalize\": context deadline exceeded
     inference: settle finalize-fallback release failed request_id=req-test-1 reservation_id=res-test-1:
      request failed: Post \"http://127.0.0.1:35357/internal/accounting/reservations/release\":
      context deadline exceeded\n"
--- FAIL: TestSettleStream_ReleaseGetsFreshDeadlineAfterSlowFinalize (0.43s)
```

The assertion is on what the release context did to the release, not on a call count. `context deadline exceeded` on the release is the defect stated in one line.

Green after:

```
--- PASS: TestSettleStream_ReleaseGetsFreshDeadlineAfterSlowFinalize (0.40s)
--- PASS: TestSettleStream_SlowButSuccessfulFinalize_NeverReleases (0.10s)
```

## Both invariants

**A reservation reaches a terminal state exactly once, charged or released, never both.** `cancelFinalize()` runs only after `FinalizeReservation` has already returned, so it can release the timer but can never abort a charge in flight, and nothing below reads `finalizeCtx`. The release still runs only when finalize returned an error. The residual case, a finalize that commits on the control plane but times out client side, is not created or widened by this change and is backstopped there: `accounting/service.go:415` refuses to release a finalized reservation, `:264` refuses to finalize a released one. Both verified present on current main.

`TestSettleStream_SlowButSuccessfulFinalize_NeverReleases` pins the new half specifically: a slow finalize that succeeds must not be followed by a release. `TestExecuteStreaming_NormalCompletion_ChargesConfirmedUsage_NoRegression` covers the fast path.

**A genuine finalize failure still releases the hold, or #616 returns.** `TestExecuteStreaming_FinalizeError_ReleasesReservationInstead` passes unchanged, and the new slow-finalize test is the same property under a deadline that has already been consumed.

Both, plus the surrounding disconnect suite, verified by name:

```
--- PASS: TestExecuteStreaming_ClientDisconnect_SettlesDeliveredTokensDespiteCancelledContext (0.11s)
--- PASS: TestExecuteStreaming_ClientDisconnect_NothingDelivered_ReleasesInFull (0.00s)
--- PASS: TestExecuteStreaming_NormalCompletion_ChargesConfirmedUsage_NoRegression (0.00s)
--- PASS: TestExecuteStreaming_FinalizeError_ReleasesReservationInstead (0.00s)
--- PASS: TestExecuteStreaming_ClientDisconnect_DuringDispatch_ReleasesReservation (2.00s)
```

## Consequence: the stall window doubles

Worst case settlement is now the sum of each call's budget rather than one shared budget, so the finalize then release path can take up to 2 x `accountingTimeout` (60s) instead of 30s. #650 accepted that trade for media and it is the same trade here: a doubled worst case stall beats stranding a customer's credits.

This widens #649 for the streaming path in the same way #650 widened it for media. Cross referenced there.

## Verification

Tested against the worktree `/tmp/streamctx` on `fix/stream-settle-context`, mounted directly (`docker run --rm -v /tmp/streamctx:/workspace hive-toolchain:latest`), not the shared checkout.

- `go test ./apps/edge-api/... -count=1 -short` passes with no `FAIL` and no `panic`
- `go vet ./apps/edge-api/...` clean
- `gofmt -l` clean for every file this PR touches (five unrelated files in the package carry pre-existing drift on main and were left alone)

No migration, no config change, no customer-visible surface touched.

## Not done here

The reservation reaper from #648 already backstops any hold this defect stranded in the past, so no cleanup is needed. The `recordCompletedEvent` call in `orchestrator.go` on the synchronous path still runs on the request context; changing that is #649's reordering work, not this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
