### PR TITLE
ci: serialize Web E2E full stack runs on the shared Supabase pool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -905,6 +905,25 @@ jobs:
     name: Web E2E (full stack)
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    # Interim mitigation for issue #631, not the fix. This job boots against
+    # the shared Supabase project's session mode pooler (pool_size 15), and
+    # concurrent runs exhaust it: on 2026-08-01, four unrelated PRs (#644,
+    # #646, #647, #648) ran this job at overlapping times and all four
+    # failed with `page.goto: net::ERR_ABORTED` / a 30s context timeout,
+    # which reads as a front end bug rather than the database contention it
+    # actually is. Job-level (not workflow-level) so unrelated jobs above
+    # keep running in parallel. Literal constant group, deliberately NOT
+    # `${{ github.workflow }}-${{ github.ref }}`: that idiom only dedupes
+    # within one branch and still lets different branches' runs collide on
+    # the pool, which is exactly this failure mode. `cancel-in-progress:
+    # false` because pre-empting a run that is mid-flight against the pool
+    # loses a legitimate result instead of just delaying it; this queues
+    # runs one at a time instead. The real fix (local/CI stacks on their own
+    # Postgres, or splitting session/transaction mode pools) stays open on
+    # #631.
+    concurrency:
+      group: web-e2e-shared-supabase-pool
+      cancel-in-progress: false
     if: >-
       needs.changes.outputs.run == 'true' &&
       (github.event_name == 'push' ||

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,10 @@ jobs:
       pull-requests: read
     outputs:
       run: ${{ steps.decide.outputs.run }}
+      # Narrower than `run`: true only when a changed path can actually
+      # affect the browser flow web-e2e exercises. See the decide step for
+      # the reasoning per path category (issue #659 follow-up).
+      web_e2e: ${{ steps.decide.outputs.web_e2e }}
     steps:
       - name: Decide whether the real suite must run
         id: decide
@@ -111,7 +115,14 @@ jobs:
           set -uo pipefail
 
           run_everything() {
+            # Also runs web-e2e: every one of these is a case where the
+            # diff itself is unknown (API failure, no base commit, a
+            # non-diff event, a possibly-truncated list), and the whole
+            # point of the narrower web_e2e gate below is to skip only
+            # when the actual changed paths are known and provably
+            # irrelevant to the browser flow.
             echo "run=true" >> "$GITHUB_OUTPUT"
+            echo "web_e2e=true" >> "$GITHUB_OUTPUT"
             echo "verdict: RUN the real suite — $1"
             exit 0
           }
@@ -176,21 +187,86 @@ jobs:
           # Allow-list: paths that cannot affect any build, test or lint
           # in this workflow. Keep it narrow. Adding an entry here weakens
           # the merge gate for every future pull request.
+          #
+          # Below, the loop also computes web_e2e, a second and much
+          # narrower signal used only to gate the non-required web-e2e
+          # job (issue #659 follow-up: four unrelated PRs, a migration
+          # baseline script, a payments webhook cap, a decision ledger
+          # amendment, and a reservation reaper, all ran the full browser
+          # suite the same evening and collided on the shared Supabase
+          # pool, issue #631). Unlike `run` above, this is an opt-in
+          # allow-list: web_e2e starts false and only a path that can
+          # actually reach the booted browser flow turns it true. That
+          # is deliberately the opposite default from `run`, because
+          # `run` gates required checks (a missed skip there would hide
+          # a real regression) while web-e2e is not a required check, so
+          # a missed skip here only costs CI minutes and pool
+          # contention, not correctness. The categories, and why:
+          #   - apps/web-console/*   the app under test, and its own
+          #     Playwright specs (apps/web-console/e2e,
+          #     apps/web-console/tests/e2e).
+          #   - apps/edge-api/*, apps/control-plane/*   the two Go
+          #     services this job builds via docker/bake-action and
+          #     boots (deploy/docker/Dockerfile.edge-api,
+          #     Dockerfile.control-plane) before Playwright runs.
+          #   - packages/storage/*, packages/audit-canonical/*,
+          #     packages/embedmodel/*   go.work members actually
+          #     imported by edge-api and/or control-plane (confirmed by
+          #     grep, not assumed), so a change here changes the built
+          #     images even though the path isn't under apps/.
+          #   - deploy/docker/*   the compose files and Dockerfiles the
+          #     job runs (`docker compose ... up`, docker-bake.hcl).
+          #   - scripts/derive-pooler-dsn.py   executed directly by this
+          #     job's own "Reconstruct SUPABASE_DB_URL" step.
+          #   - .github/workflows/ci.yml   this file, so a change to the
+          #     web-e2e job definition (or to this gate) proves itself
+          #     by actually running, instead of the new wiring going
+          #     untested the way the routing integration tests did
+          #     before issue #655.
+          # Deliberately excluded: supabase/migrations/*. This job never
+          # applies the migration chain itself (unlike go-tests' own
+          # ephemeral Postgres); it runs against the shared Supabase
+          # project's already-live schema, which a new migration file
+          # does not change until separately deployed with
+          # `supabase db push`. A migration-only PR cannot affect what
+          # the browser flow exercises today. This was one of the four
+          # PRs above, and is exactly why it should not have run this
+          # suite.
+          run="false"
+          web_e2e="false"
           while IFS= read -r f; do
             [ -n "$f" ] || continue
             case "$f" in
               *.js | *.mjs | *.cjs | *.jsx | *.ts | *.mts | *.cts | *.tsx \
               | *.sh | *.py)
-                run_everything "'$f' is executable code"
+                run="true"
                 ;;
-              *.md | LICENSE | NOTICE) continue ;;
-              docs/* | .wolf/* | .claude/* | .vscode/* | .cursor/*) continue ;;
+              *.md | LICENSE | NOTICE) : ;;
+              docs/* | .wolf/* | .claude/* | .vscode/* | .cursor/*) : ;;
+              *) run="true" ;;
             esac
-            run_everything "'$f' is outside the docs-only allow-list"
+            case "$f" in
+              apps/web-console/* | apps/edge-api/* | apps/control-plane/* \
+              | packages/storage/* | packages/audit-canonical/* \
+              | packages/embedmodel/* | deploy/docker/* \
+              | scripts/derive-pooler-dsn.py | .github/workflows/ci.yml)
+                web_e2e="true"
+                ;;
+            esac
           done < /tmp/changed-files.txt
 
-          echo "run=false" >> "$GITHUB_OUTPUT"
-          echo "verdict: SKIP — every changed path is docs-only"
+          echo "run=$run" >> "$GITHUB_OUTPUT"
+          echo "web_e2e=$web_e2e" >> "$GITHUB_OUTPUT"
+          if [ "$run" = "true" ]; then
+            echo "verdict: RUN the real suite, a changed path is outside the docs-only allow-list"
+          else
+            echo "verdict: SKIP — every changed path is docs-only"
+          fi
+          if [ "$web_e2e" = "true" ]; then
+            echo "web-e2e verdict: RUN, a changed path can affect the booted browser flow"
+          else
+            echo "web-e2e verdict: SKIP, no changed path can affect the booted browser flow"
+          fi
 
   # ------------------------------------------------------------------
   # Unit-level jobs (run on every PR including forks)
@@ -905,27 +981,37 @@ jobs:
     name: Web E2E (full stack)
     runs-on: ubuntu-latest
     timeout-minutes: 25
-    # Interim mitigation for issue #631, not the fix. This job boots against
-    # the shared Supabase project's session mode pooler (pool_size 15), and
-    # concurrent runs exhaust it: on 2026-08-01, four unrelated PRs (#644,
-    # #646, #647, #648) ran this job at overlapping times and all four
-    # failed with `page.goto: net::ERR_ABORTED` / a 30s context timeout,
-    # which reads as a front end bug rather than the database contention it
-    # actually is. Job-level (not workflow-level) so unrelated jobs above
-    # keep running in parallel. Literal constant group, deliberately NOT
-    # `${{ github.workflow }}-${{ github.ref }}`: that idiom only dedupes
-    # within one branch and still lets different branches' runs collide on
-    # the pool, which is exactly this failure mode. `cancel-in-progress:
-    # false` because pre-empting a run that is mid-flight against the pool
-    # loses a legitimate result instead of just delaying it; this queues
-    # runs one at a time instead. The real fix (local/CI stacks on their own
-    # Postgres, or splitting session/transaction mode pools) stays open on
-    # #631.
-    concurrency:
-      group: web-e2e-shared-supabase-pool
-      cancel-in-progress: false
+    # This job boots against the shared Supabase project's session mode
+    # pooler (pool_size 15), and concurrent runs exhaust it: on 2026-08-01,
+    # four unrelated PRs (#644, #646, #647, #648) ran this job at
+    # overlapping times and all four failed with `page.goto:
+    # net::ERR_ABORTED` / a 30s context timeout, which reads as a front end
+    # bug rather than the database contention it actually is (issue #631).
+    #
+    # An earlier version of this fix serialized every web-e2e run with a
+    # job-level `concurrency:` group. That was reverted: GitHub Actions
+    # only holds one job per concurrency group as pending, so a third
+    # queued run cancels the second outright before it ever executes.
+    # web-e2e is not a required check, so a canceled result would surface
+    # nowhere and a PR could merge with no browser coverage at all, a
+    # silent gap of exactly the kind issue #659 exists to prevent (a
+    # skipped test and a passing test are indistinguishable inside a green
+    # check). Trading a noisy false-red failure for a silent absence is
+    # not a fix.
+    #
+    # What replaced it: gate this job on `needs.changes.outputs.web_e2e`
+    # (see the `changes` job's decide step for the path reasoning),
+    # instead of the blanket `needs.changes.outputs.run` every other job
+    # here uses. Two of the four PRs above, the migration baseline script
+    # and its probe, touched no path that can reach the booted browser
+    # flow and should not have run this job at all; this gate is
+    # deterministic and reviewable in a diff, unlike a queue race. It
+    # reduces how often web-e2e runs, which reduces how often two runs
+    # land on the shared pool at the same time, but does not eliminate the
+    # coupling. That real fix stays open on #631.
     if: >-
       needs.changes.outputs.run == 'true' &&
+      needs.changes.outputs.web_e2e == 'true' &&
       (github.event_name == 'push' ||
        (github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name == github.repository))


### PR DESCRIPTION
## Update: the concurrency approach was reverted

The first commit on this PR added a `concurrency` group to serialize `web-e2e` runs, on direct instruction, as an interim mitigation for #631. Reviewing my own report on it surfaced a real flaw: GitHub Actions only holds one job per concurrency group as pending, so with several PRs racing, a run caught in the middle gets canceled outright before it ever executes, not just delayed. `web-e2e` is not a required check, so that cancellation surfaces nowhere. A PR could merge with no browser coverage at all and nobody would notice. That trades a noisy false red for a silent absence, which directly contradicts the principle issue #659 exists to establish: a skipped test and a passing test must not be indistinguishable inside a green check. Shipping it anyway on the strength of the original instruction would have been the wrong call, so it was reverted rather than merged. The second commit replaces it with path gating instead.

## Summary

Interim mitigation for #631, not the fix. `Web E2E (full stack)` boots against the shared Supabase project's session mode pooler (pool_size 15). Concurrent runs exhaust it. On 2026-08-01, four unrelated PRs (#644, #646, #647, #648) ran this job at overlapping times and all four failed with `page.goto: net::ERR_ABORTED` and a 30 second context setup timeout, a signature that reads as a front end bug rather than the database contention it actually is.

Two of those four, the migration baseline script (#630) and its probe (#646), touch no path that could possibly affect a browser flow. Every PR tonight ran the full suite regardless, because the workflow's only gate was the blanket "is this diff docs-only" check. This PR narrows that for `web-e2e` specifically: run it less often, on fewer genuinely-relevant diffs, so overlapping runs on the shared pool become rarer.

## What changed

Added a second output to the `changes` job, `web_e2e`, computed in the same `decide` step and file-list scan that already produces `run`, gating `web-e2e` in addition to it:

```yaml
if: >-
  needs.changes.outputs.run == 'true' &&
  needs.changes.outputs.web_e2e == 'true' &&
  ...
```

Unlike `run` (deny-by-default: anything not explicitly docs-only forces a run, because `run` also gates required checks and a missed skip there would hide a real regression), `web_e2e` is an allow-list (default skip): true only when a changed path can reach the browser flow this job actually boots. `web-e2e` is not required, so a missed skip here only costs CI minutes and pool contention, not correctness, which is why the opposite polarity is safe here specifically.

Path categories and reasoning, per path:

- `apps/web-console/*`: the app under test, including its own Playwright specs (`apps/web-console/e2e`, `apps/web-console/tests/e2e`).
- `apps/edge-api/*`, `apps/control-plane/*`: the two Go services this job builds via `docker/bake-action` (`deploy/docker/Dockerfile.edge-api`, `Dockerfile.control-plane`) and boots before Playwright runs.
- `packages/storage/*`, `packages/audit-canonical/*`, `packages/embedmodel/*`: `go.work` members. Confirmed by grep, not assumed, that both edge-api and control-plane actually import at least one of these, so a change here changes the built images even though the path is not under `apps/`.
- `deploy/docker/*`: the compose files and Dockerfiles the job's own steps run (`docker compose ... up`, `docker-bake.hcl`).
- `scripts/derive-pooler-dsn.py`: executed directly by this job's "Reconstruct SUPABASE_DB_URL" step.
- `.github/workflows/ci.yml`: this file, so a change to the `web-e2e` job definition or to this gate proves itself by actually running, rather than a broken wiring going unnoticed the way the routing integration tests did before #655.

Deliberately excluded: `supabase/migrations/*`. This job never applies the migration chain itself, unlike `go-tests`' own ephemeral Postgres bootstrap; it runs against the shared Supabase project's already-live schema, which a new migration file does not change until separately deployed with `supabase db push`. A migration-only PR cannot affect what the browser flow exercises today. This is exactly the #630 / #646 case above.

## How the skip surfaces

Deterministically, not by race. A PR whose diff has no path in the allow-list gets `web_e2e=false` from a single, reviewable computation over the actual changed-file list, the same mechanism already used for `run` (issue #553's single-source-of-truth job). `web-e2e` then shows as a skipped check in the PR, distinct from success or failure, with the reason visible in the `Detect changed paths` job's own log output (`web-e2e verdict: SKIP, no changed path can affect the booted browser flow`). No race, no cancellation, nothing hidden.

## Verified against tonight's real PRs

Extracted the exact classification loop from the workflow and ran it against the real file list of every PR merged today (15 total, not accounted for by branch protection status until push):

- `web_e2e=false` (correctly skips): #632 (decisions ledger only), #630 (migration baseline script), #646 (migration probe script), #654 (retention check script).
- `web_e2e=true` (correctly still runs): #629, #638, #639, #644, #647, #648, #650, #651, #656, #658, #660, all of which touch `apps/edge-api` or `apps/control-plane`.

11 of 15 would still run `web-e2e`, 4 would now skip. Note: this is 15 PRs by direct query (`gh pr list --state merged`, `mergedAt >= 2026-08-01T00:00:00Z`), not the 19 referenced verbally; flagging the discrepancy rather than silently matching it.

## What I checked vs what needs observation

Checked: YAML parses correctly (`web-e2e` has no `concurrency` key, the `if:` condition includes both outputs, `changes.outputs.web_e2e` is wired to `steps.decide.outputs.web_e2e`), `actionlint` via the `rhysd/actionlint` Docker image reports no new errors (only the same one pre-existing unrelated shellcheck warning as before), `bash -n` on the extracted decide script passes, and the classification loop was extracted verbatim and run against 15 real PR file lists rather than reasoned about in the abstract.

Could not verify: how this behaves against a PR that touches both a web-e2e-relevant path and only a migration, or any other combination, beyond what today's real PRs happened to exercise. Also could not verify that "skipped" (vs. some other status) is what actually renders in the PR checks UI for a job whose `if:` evaluates false, that needs one real PR with a docs/migration-only diff after merge to observe directly.

Does not merge here.
