### PR TITLE
fix: unify the release idempotency key shape

### DIFF
--- a/apps/control-plane/internal/accounting/release_idempotency_test.go
+++ b/apps/control-plane/internal/accounting/release_idempotency_test.go
@@ -1,0 +1,179 @@
+package accounting
+
+import (
+	"context"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/ledger"
+)
+
+// TestReleaseIdempotencyKeyShapeIsUnified is issue #652's static regression
+// guard: finalizeLocked's partial release (charge some, release the
+// remainder) and releaseLocked's full release must build the release
+// idempotency key the same way. A key that varies with the released amount
+// cannot deduplicate two release attempts of DIFFERING amounts for the same
+// reservation, which is precisely the case worth catching -- so
+// service.go must not contain the old amount-varying shape anywhere.
+func TestReleaseIdempotencyKeyShapeIsUnified(t *testing.T) {
+	source := readAccountingServiceSource(t)
+
+	if strings.Contains(source, `"release-%d"`) {
+		t.Fatal(`service.go must not build a release idempotency key that varies with the credit amount; use the flat "release" key everywhere, matching releaseLocked`)
+	}
+	if matches := regexp.MustCompile(`idempotencyKey\(reservation\.ID,\s*"release"\)`).FindAllString(source, -1); len(matches) < 2 {
+		t.Fatalf(`expected both finalizeLocked's partial release and releaseLocked's full release to call idempotencyKey(reservation.ID, "release"); found %d occurrences, want at least 2`, len(matches))
+	}
+}
+
+func readAccountingServiceSource(t *testing.T) string {
+	t.Helper()
+	body, err := os.ReadFile("service.go")
+	if err != nil {
+		t.Fatalf("read service.go: %v", err)
+	}
+	return string(body)
+}
+
+// --- live ledger dedup proof ---
+//
+// The static test above proves the two call sites now compute the same key
+// string. This proves what that buys: the underlying ledger dedup mechanism
+// (credit_idempotency_keys' primary key, ON CONFLICT DO NOTHING) actually
+// stops a second release for the same reservation from posting, even when
+// the two attempts disagree on how many credits to release -- exactly the
+// case a key that varied by amount could never catch. Gated on
+// HIVE_TEST_DB_URL, same convention as internal/payments/settlement_live_db_test.go.
+
+func newAccountingTestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("HIVE_TEST_DB_URL")
+	if dsn == "" {
+		t.Skip("HIVE_TEST_DB_URL not set")
+	}
+	if !strings.Contains(strings.ToLower(dsn), "test") {
+		t.Fatalf("refusing to run: HIVE_TEST_DB_URL must point at a test database (DSN missing 'test' marker)")
+	}
+	pool, err := pgxpool.New(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+// seedReleaseIdempotencyAccount inserts the auth.users row and the account a
+// ledger entry's account_id must reference, and registers cleanup. Mirrors
+// internal/payments/settlement_live_db_test.go's seedPaymentsAccount.
+func seedReleaseIdempotencyAccount(t *testing.T, pool *pgxpool.Pool) uuid.UUID {
+	t.Helper()
+	ctx := context.Background()
+
+	var userID uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO auth.users (id, email, raw_user_meta_data)
+		 VALUES (gen_random_uuid(), $1, '{}'::jsonb) RETURNING id`,
+		"release-idempotency-"+uuid.NewString()+"@test.local",
+	).Scan(&userID); err != nil {
+		t.Skipf("seed auth.users failed (is this a migrated test DB?): %v", err)
+	}
+
+	var accountID uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO public.accounts (id, slug, display_name, account_type, owner_user_id)
+		 VALUES (gen_random_uuid(), $1, 'release idempotency test', 'personal', $2) RETURNING id`,
+		"release-idempotency-"+uuid.NewString(), userID,
+	).Scan(&accountID); err != nil {
+		t.Fatalf("seed account: %v", err)
+	}
+
+	t.Cleanup(func() {
+		cleanupCtx := context.Background()
+		_, _ = pool.Exec(cleanupCtx, `DELETE FROM public.accounts WHERE id = $1`, accountID)
+		_, _ = pool.Exec(cleanupCtx, `DELETE FROM auth.users WHERE id = $1`, userID)
+	})
+	return accountID
+}
+
+// TestReleaseIdempotency_DifferingAmountsForSameReservationDedupeToFirst is
+// (a), (b), and (c) together: two release attempts for the SAME reservation,
+// using the unified key both finalizeLocked and releaseLocked now build
+// (so it stands in for either code path, edge-api's normal settlement
+// fallback or the #648 reaper), computing DIFFERENT credit amounts -- the
+// exact case a key that varied by amount could never catch. Only the first
+// amount may land: asserted on the ledger's own entries and balance, not on
+// either call's return value.
+func TestReleaseIdempotency_DifferingAmountsForSameReservationDedupeToFirst(t *testing.T) {
+	pool := newAccountingTestPool(t)
+	accountID := seedReleaseIdempotencyAccount(t, pool)
+	ctx := context.Background()
+
+	ledgerSvc := ledger.NewService(ledger.NewPgxRepository(pool))
+	if _, err := ledgerSvc.GrantCredits(ctx, accountID, uuid.NewString(), 10000, map[string]any{"reason": "test grant"}); err != nil {
+		t.Fatalf("grant initial credits: %v", err)
+	}
+
+	reservationID := uuid.New()
+	requestID := uuid.NewString()
+
+	// A real hold precedes any release: 1500 credits reserved, available
+	// drops by 1500. Captured AFTER the hold, so "moved" below isolates what
+	// the releases themselves do.
+	if _, err := ledgerSvc.ReserveCredits(ctx, accountID, requestID, nil, &reservationID, "reservation:"+reservationID.String()+":reserve", 1500, map[string]any{"path": "hold"}); err != nil {
+		t.Fatalf("reserve credits: %v", err)
+	}
+	before, err := ledgerSvc.GetBalance(ctx, accountID)
+	if err != nil {
+		t.Fatalf("get balance after hold, before release: %v", err)
+	}
+
+	svc := &Service{} // only idempotencyKey is used; no repo/lock dependency needed for it
+	key := svc.idempotencyKey(reservationID, "release")
+
+	// First attempt: the full hold released, the amount finalizeLocked's
+	// (or releaseLocked's) own computation would produce for this
+	// reservation.
+	if _, err := ledgerSvc.ReleaseReservedCredits(ctx, accountID, requestID, nil, &reservationID, key, 1500, map[string]any{"path": "finalize-or-settlement-release"}); err != nil {
+		t.Fatalf("first release: %v", err)
+	}
+
+	// Second attempt: a DIFFERENT amount, the shape of a reaper release
+	// recomputing remaining held credits independently and landing on a
+	// different number (state drift, a retry after a partial failure,
+	// etc). Same key, so this must be a no-op against the ledger, not a
+	// second entry -- exactly the case a key that varied by amount could
+	// never catch.
+	if _, err := ledgerSvc.ReleaseReservedCredits(ctx, accountID, requestID, nil, &reservationID, key, 1600, map[string]any{"path": "reaper-release"}); err != nil {
+		t.Fatalf("second release: %v", err)
+	}
+
+	var entryCount int
+	var totalDelta int64
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*), COALESCE(sum(credits_delta), 0)
+		 FROM public.credit_ledger_entries
+		 WHERE account_id = $1 AND reservation_id = $2 AND entry_type = 'reservation_release'`,
+		accountID, reservationID,
+	).Scan(&entryCount, &totalDelta); err != nil {
+		t.Fatalf("query ledger entries: %v", err)
+	}
+	if entryCount != 1 {
+		t.Fatalf("expected exactly one reservation_release ledger entry, got %d", entryCount)
+	}
+	if totalDelta != 1500 {
+		t.Fatalf("expected the ledger to reflect only the FIRST release amount (1500), got total credits_delta=%d", totalDelta)
+	}
+
+	after, err := ledgerSvc.GetBalance(ctx, accountID)
+	if err != nil {
+		t.Fatalf("get balance after releases: %v", err)
+	}
+	moved := after.AvailableCredits - before.AvailableCredits
+	if moved != 1500 {
+		t.Fatalf("expected available balance to move by exactly 1500 (the first release only, hold fully returned), moved by %d", moved)
+	}
+}

--- a/apps/control-plane/internal/accounting/service.go
+++ b/apps/control-plane/internal/accounting/service.go
@@ -303,7 +303,13 @@ func (s *Service) finalizeLocked(ctx context.Context, input FinalizeReservationI
 	}
 
 	if releaseCredits > 0 {
-		if _, err := s.ledgerSvc.ReleaseReservedCredits(ctx, reservation.AccountID, reservation.RequestID, &reservation.RequestAttemptID, &reservation.ID, s.idempotencyKey(reservation.ID, fmt.Sprintf("release-%d", releaseCredits)), releaseCredits, map[string]any{
+		// Idempotency key is "release", not "release-<credits>" (issue #652):
+		// releaseLocked below already keys its full release the same way, and a
+		// key that varies with the amount cannot deduplicate two release
+		// attempts of DIFFERING amounts for the same reservation, which is
+		// exactly the case worth catching. One reservation, one release key,
+		// regardless of which path or how much it releases.
+		if _, err := s.ledgerSvc.ReleaseReservedCredits(ctx, reservation.AccountID, reservation.RequestID, &reservation.RequestAttemptID, &reservation.ID, s.idempotencyKey(reservation.ID, "release"), releaseCredits, map[string]any{
 			"endpoint":           reservation.Endpoint,
 			"model_alias":        reservation.ModelAlias,
 			"terminal_confirmed": input.TerminalUsageConfirmed,
@@ -417,6 +423,9 @@ func (s *Service) releaseLocked(ctx context.Context, input ReleaseReservationInp
 
 	releaseCredits := remainingHeldCredits(reservation)
 	if releaseCredits > 0 {
+		// Same "release" key finalizeLocked's own partial release uses above
+		// (issue #652): one reservation, one release key, whichever caller
+		// (edge-api settlement fallback or the reaper) reaches it first.
 		if _, err := s.ledgerSvc.ReleaseReservedCredits(ctx, reservation.AccountID, reservation.RequestID, &reservation.RequestAttemptID, &reservation.ID, s.idempotencyKey(reservation.ID, "release"), releaseCredits, map[string]any{
 			"endpoint":    reservation.Endpoint,
 			"model_alias": reservation.ModelAlias,

--- a/supabase/migrations/20260801_11_normalize_release_idempotency_keys.sql
+++ b/supabase/migrations/20260801_11_normalize_release_idempotency_keys.sql
@@ -1,0 +1,42 @@
+-- Issue #652: reservation release idempotency keys used two different shapes.
+-- finalizeLocked's partial release (charge some, release the remainder) keyed
+-- on "reservation:<id>:release-<credits>"; releaseLocked's full release
+-- (edge-api's settlement fallback, and the #648 reaper) already keyed on the
+-- flat "reservation:<id>:release". A key that varies with the amount cannot
+-- deduplicate two release attempts of DIFFERING amounts for the same
+-- reservation, which is exactly the case worth catching, so the code fix
+-- (same commit) makes finalizeLocked use the flat shape too.
+--
+-- Transition safety: a reservation already fully settled (status finalized,
+-- or remaining held credits already zero) can never attempt a second release
+-- regardless of key shape -- releaseLocked refuses a finalized reservation
+-- outright, and remainingHeldCredits() gates the ledger call itself once the
+-- prior charge+release already accounts for the whole hold. The one gap the
+-- code fix alone would leave open: a reservation whose FIRST release was
+-- already posted under the OLD shape before this migration runs would not be
+-- protected by the new flat key, so a later differing-amount release attempt
+-- (the reaper, most plausibly) would not collide with it and could post a
+-- second entry. This migration closes that gap by normalizing every existing
+-- old-shape row to the new flat key, so a historical reservation is covered
+-- by the same guard a freshly-created one gets.
+--
+-- Checked live before writing this (read only, transaction-mode pooler):
+-- 291 rows in the old release-<credits> shape, 44 already in the flat
+-- shape, zero reservations carrying both -- so this UPDATE cannot violate
+-- the (account_id, operation_type, idempotency_key) primary key today. The
+-- WHERE NOT EXISTS guard is kept anyway so a row landing in both shapes
+-- between the check above and this migration actually running is skipped
+-- rather than erroring, and so the statement is safely re-runnable: the
+-- second run finds no more old-shape rows to match.
+
+update public.credit_idempotency_keys old
+set idempotency_key = regexp_replace(old.idempotency_key, '^(reservation:[0-9a-f-]+:release)-[0-9]+$', '\1')
+where old.operation_type = 'reservation_release'
+  and old.idempotency_key ~ '^reservation:[0-9a-f-]+:release-[0-9]+$'
+  and not exists (
+    select 1
+    from public.credit_idempotency_keys flat
+    where flat.account_id = old.account_id
+      and flat.operation_type = old.operation_type
+      and flat.idempotency_key = regexp_replace(old.idempotency_key, '^(reservation:[0-9a-f-]+:release)-[0-9]+$', '\1')
+  );


### PR DESCRIPTION
## Summary

Fixes #652. Credit reservation release paths disagreed on the idempotency key they write. `finalizeLocked`'s partial release (charge some, release the remainder) keyed on `reservation:<id>:release-<credits>`. `releaseLocked`'s full release, used by both edge-api's settlement fallback and the #648 reaper, already keyed on the flat `reservation:<id>:release`.

A key that varies with the released amount cannot deduplicate two release attempts of DIFFERING amounts for the same reservation, which is precisely the case worth catching. `finalizeLocked` now uses the same flat `"release"` key `releaseLocked` already did. One reservation, one release key, whichever path or amount reaches it.

## Which shapes exist live today

Checked read only against the transaction-mode pooler before deciding: **291 rows** in the old `release-<credits>` shape, **44 rows** already in the flat `release` shape, **zero** reservations carrying both.

## Transition safety

A reservation already fully settled cannot attempt a second release regardless of key shape: `releaseLocked` refuses a finalized reservation outright, and `remainingHeldCredits()` gates the ledger call itself once a prior charge and release already account for the whole hold.

The one gap the code fix alone would leave open: a reservation whose first release was already posted under the OLD shape before this migration runs would not be protected by the new flat key, so a later differing-amount release attempt (the reaper, most plausibly) would not collide with it and could post a second entry. The included migration (`20260801_11_normalize_release_idempotency_keys.sql`) closes that gap by normalizing every existing old-shape row to the new flat key, guarded by `WHERE NOT EXISTS` so it cannot violate the `(account_id, operation_type, idempotency_key)` primary key and is safely re-runnable.

## Tests

Written first and shown failing against the pre-fix code:
- `TestReleaseIdempotencyKeyShapeIsUnified`: static regression guard asserting both call sites build the release key the same way.
- `TestReleaseIdempotency_DifferingAmountsForSameReservationDedupeToFirst`: live Postgres test proving two release attempts for the same reservation with DIFFERING amounts (modeling the finalize path vs. the reaper path, which now share the same key) collapse to exactly one ledger entry, and the account balance moves exactly once, asserted on `credit_ledger_entries` and `GetBalance` rather than on either call's return value.

## Test plan

- [x] `go test ./apps/control-plane/internal/accounting/...` green, both with and without `HIVE_TEST_DB_URL`
- [x] Full `go test ./apps/control-plane/...` green
- [x] `go vet ./...` clean
- [x] Full 83-file migration chain (including the new migration) applied cleanly to a scratch Postgres
- [x] Tested on my own worktree (`/tmp/relkey`), never the shared checkout

Does not merge here; money-path PRs get an independent reviewer per repo convention.