### PR TITLE
fix: proxy /v1/featuregate to edge-api in Caddyfile.owui

### DIFF
--- a/deploy/docker/Caddyfile.owui
+++ b/deploy/docker/Caddyfile.owui
@@ -81,7 +81,7 @@
   # origin and calls {origin}/v1/featuregate directly, so this one path needs
   # the same edge-api same-origin treatment as @agentApi above. Scoped to the
   # single path on purpose -- the rest of /v1/* stays off this host.
-  @featureGate path /v1/featuregate
+  @featureGate path /v1/featuregate /v1/featuregate/
   reverse_proxy @featureGate edge-api:8080 {
     header_up X-Forwarded-Proto {$HIVE_CHAT_EXTERNAL_SCHEME:http}
     transport http {

--- a/deploy/docker/Caddyfile.owui
+++ b/deploy/docker/Caddyfile.owui
@@ -77,6 +77,19 @@
     }
   }
 
+  # Desktop entitlement probe (#619). The desktop app derives its console
+  # origin and calls {origin}/v1/featuregate directly, so this one path needs
+  # the same edge-api same-origin treatment as @agentApi above. Scoped to the
+  # single path on purpose -- the rest of /v1/* stays off this host.
+  @featureGate path /v1/featuregate
+  reverse_proxy @featureGate edge-api:8080 {
+    header_up X-Forwarded-Proto {$HIVE_CHAT_EXTERNAL_SCHEME:http}
+    transport http {
+      response_header_timeout 60s
+      dial_timeout 5s
+    }
+  }
+
   reverse_proxy open-webui:8080 {
     header_up X-Forwarded-Proto {$HIVE_CHAT_EXTERNAL_SCHEME:http}
     transport http {


### PR DESCRIPTION
## Summary

Fixes #619. The desktop entitlement probe calls `{console origin}/v1/featuregate`. `deploy/docker/Caddyfile.owui` only proxied `/v1/agent/*` to edge-api, so the request fell through to the Open WebUI catch-all and got an HTML page back instead of the gateway's JSON.

Adds one narrowly scoped matcher, `@featureGate path /v1/featuregate`, reusing the exact `reverse_proxy` block already used for `@agentApi` (same edge-api upstream, same `X-Forwarded-Proto` header handling, same transport timeouts). Placed before the unmatched catch-all `reverse_proxy open-webui:8080` block so it is evaluated first, same ordering rationale already documented in this file for `@agentConsole`/`@agentApi`. No other block touched.

## Verification performed (local, static)

- `caddy validate --config /etc/caddy/Caddyfile.owui --adapter caddyfile` (caddy:2-alpine container, bind-mounted file, same mode `docker-compose.yml` uses for this file: `./Caddyfile.owui:/etc/caddy/Caddyfile:ro`, no envsubst/templating in front of it) -> `Valid configuration`. The pre-existing "Caddyfile input is not formatted" warning at line 15 is present on `origin/main` too (checked before this change), not introduced by this diff.
- Adapted the Caddyfile to JSON (`caddy adapt`) and enumerated the resulting route list: 6 top-level routes, each with a disjoint `path` matcher, in source order:
  1. `path_regexp` admin/signup block -> `static_response`
  2. admin-mutation method+path block -> `static_response`
  3. `path: [/agent-workspace, /agent-workspace/*]` -> `reverse_proxy` (agent-console)
  4. `path: [/v1/featuregate]` -> `reverse_proxy` (edge-api) **new**
  5. `path: [/v1/agent/*]` -> `reverse_proxy` (edge-api)
  6. no match (catch-all) -> `reverse_proxy` (open-webui)
- Confirmed the new route's `path` matcher (`/v1/featuregate`) does not overlap `/v1/agent/*`, `/agent-workspace*`, or any admin-block pattern, and sits ahead of the catch-all, so it cannot shadow and cannot be shadowed.
- `Caddyfile.console` (separate file, serves `console-hive`/web-console origin) is untouched; api-hive.scubed.co is not routed through this Caddyfile at all (routes straight to edge-api per existing infra), so it is unaffected by this change definitionally, not by test.

## Not verified

Live routing against a running stack is unverified. This is a static config validation + adapted-JSON route inspection only. Confirming `chat-hive.scubed.co` (Open WebUI) and the desktop probe's `/v1/featuregate` call both actually resolve correctly, and that `chat-hive`/`api-hive` still return 200, needs a deploy to the demo box or a local `docker compose` run with live containers, neither of which this change included.

## Test plan

- [ ] Deploy to demo box, confirm `chat-hive.scubed.co` still serves Open WebUI (200)
- [ ] Confirm `api-hive.scubed.co` still serves the gateway (200), unaffected (not routed through this file)
- [ ] Confirm `curl https://chat-hive.scubed.co/v1/featuregate` returns edge-api JSON, not OWUI HTML
- [ ] Run the desktop entitlement probe against the deployed stack and confirm it succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for desktop entitlement checks through the `/v1/featuregate` endpoint.
  * Preserves request scheme information and applies standard response and connection timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->