### PR TITLE
fix: never settle a missing usage block as confirmed usage on the sync path

### DIFF
--- a/apps/edge-api/internal/inference/orchestrator.go
+++ b/apps/edge-api/internal/inference/orchestrator.go
@@ -226,40 +226,79 @@ func (o *Orchestrator) executeSync(
 
 	// 8. Finalize reservation and record usage
 	if reservation.ID != "" {
-		actualCredits := estimatedCredits
-		if usage != nil {
-			actualCredits = usage.TotalTokens
-		}
-		// Do not discard this error. A failed finalize used to set finalized
-		// anyway, which skipped the deferred release and so lost the charge and
-		// stranded the hold in the same step (issue #616). Leaving finalized
-		// false hands the reservation to the deferred release instead, so it
-		// still reaches a terminal state exactly once: charged here on success,
-		// released there on failure, never both.
+		// What the provider actually reported, or an estimate from the bytes
+		// actually exchanged when it reported nothing -- never the flat
+		// reservation estimate (issue #636). estimatedCredits is a hold size,
+		// an authorization floor picked before the request ran; billing it as
+		// though it were a measurement charged a three-token reply 10000
+		// credits, and did so under TerminalUsageConfirmed = true, which tells
+		// control-plane the figure is a fact and so skips both the hold clamp
+		// and the reconciliation job that exist to correct estimates. Same
+		// settlementCredits helper the streaming path uses, so the two paths
+		// agree on what an absent usage block means.
 		//
-		// finalizeCtx, not ctx (#637): by this point the client can already
-		// have disconnected, cancelling ctx. Finalizing on ctx then fails not
-		// because the ledger rejected the charge but because the HTTP call
-		// itself aborts on the cancelled context, which fell through to the
-		// releaseReason = "finalize_failed" branch below and released a hold
-		// for work that was genuinely delivered -- converting a chargeable
-		// request into a free one for any client that disconnects at the
-		// right moment. Same fresh background context + accountingTimeout as
-		// releaseReservationBackground and settleStream (PR #602's pattern).
-		finalizeCtx, cancel := context.WithTimeout(context.Background(), accountingTimeout)
-		err := o.accounting.FinalizeReservation(finalizeCtx, FinalizeReservationInput{
-			AccountID:              snapshot.AccountID,
-			ReservationID:          reservation.ID,
-			ActualCredits:          actualCredits,
-			TerminalUsageConfirmed: true,
-			Status:                 "completed",
-		})
-		cancel()
-		if err != nil {
-			log.Printf("inference: finalize reservation failed, releasing hold instead request_id=%s reservation_id=%s: %v", requestID, reservation.ID, err)
-			releaseReason = "finalize_failed"
+		// The prompt and response text are extracted only when usage is
+		// missing: the normal path pays for neither parse.
+		hasUsage := usage != nil
+		var totalTokens int64
+		var prompt, content string
+		if hasUsage {
+			totalTokens = usage.TotalTokens
 		} else {
-			finalized = true
+			prompt, content = promptText(endpoint, body), responseText(endpoint, normalized)
+		}
+		actualCredits, billable := settlementCredits(hasUsage, totalTokens, prompt, content)
+		if !billable {
+			// Nothing measured and nothing produced: there is no quantity to
+			// charge, so leave finalized false and let the deferred release
+			// hand the hold back in full. That keeps the single-terminal-state
+			// invariant intact -- one release site, its own fresh background
+			// context -- rather than adding a second settlement call here.
+			releaseReason = "unmeasured_usage"
+			log.Printf("inference: settling unconfirmed with nothing billable, releasing hold request_id=%s reservation_id=%s endpoint=%s: upstream returned no usage and no output",
+				requestID, reservation.ID, endpoint)
+		} else {
+			if !hasUsage {
+				log.Printf("inference: settling unconfirmed usage estimate request_id=%s reservation_id=%s endpoint=%s estimated_credits=%d: upstream returned no usage block",
+					requestID, reservation.ID, endpoint, actualCredits)
+			}
+			// Do not discard this error. A failed finalize used to set finalized
+			// anyway, which skipped the deferred release and so lost the charge
+			// and stranded the hold in the same step (issue #616). Leaving
+			// finalized false hands the reservation to the deferred release
+			// instead, so it still reaches a terminal state exactly once:
+			// charged here on success, released there on failure, never both.
+			//
+			// finalizeCtx, not ctx (#637): by this point the client can already
+			// have disconnected, cancelling ctx. Finalizing on ctx then fails
+			// not because the ledger rejected the charge but because the HTTP
+			// call itself aborts on the cancelled context, which fell through
+			// to the releaseReason = "finalize_failed" branch below and
+			// released a hold for work that was genuinely delivered --
+			// converting a chargeable request into a free one for any client
+			// that disconnects at the right moment. Same fresh background
+			// context + accountingTimeout as releaseReservationBackground and
+			// settleStream (PR #602's pattern).
+			finalizeCtx, cancel := context.WithTimeout(context.Background(), accountingTimeout)
+			err := o.accounting.FinalizeReservation(finalizeCtx, FinalizeReservationInput{
+				AccountID:     snapshot.AccountID,
+				ReservationID: reservation.ID,
+				ActualCredits: actualCredits,
+				// hasUsage, never a bare true (issue #636): this flag is
+				// control-plane's instruction to treat the figure as measured
+				// truth, bill it in full even past the hold, and skip
+				// reconciliation entirely. Only the provider's own usage block
+				// earns it.
+				TerminalUsageConfirmed: hasUsage,
+				Status:                 "completed",
+			})
+			cancel()
+			if err != nil {
+				log.Printf("inference: finalize reservation failed, releasing hold instead request_id=%s reservation_id=%s: %v", requestID, reservation.ID, err)
+				releaseReason = "finalize_failed"
+			} else {
+				finalized = true
+			}
 		}
 	}
 

--- a/apps/edge-api/internal/inference/sync_unconfirmed_usage_test.go
+++ b/apps/edge-api/internal/inference/sync_unconfirmed_usage_test.go
@@ -1,0 +1,230 @@
+package inference
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// --- issue #636: a response with no usage block must never settle as a
+// confirmed charge ---
+//
+// The synchronous path used to fall back to the flat reservation estimate
+// (10000 credits for chat/completions/responses, 1000 for embeddings) whenever
+// the provider omitted the usage block, and sent that number with
+// TerminalUsageConfirmed = true. Confirmed means "the upstream reported this
+// figure", so the one guard that exists for estimates (the hold clamp plus the
+// reconciliation job in control-plane's finalizeLocked) was bypassed, and a
+// three-token reply could be billed 10000 credits permanently with nothing
+// left to correct it.
+
+// jsonProviderServer stands in for the provider (via LiteLLM) on the
+// non-streaming path, answering 200 with a caller-supplied raw body so a test
+// can serve a response whose usage block is absent rather than merely zeroed.
+func jsonProviderServer(body string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(body))
+	}))
+}
+
+// callSyncBody drives the real executeSync lifecycle with an explicit request
+// body, so the prompt half of the fallback estimate is exercised rather than
+// left empty by a `{}` body.
+func callSyncBody(orch *Orchestrator, reqBody string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(reqBody))
+	req.Header.Set("Authorization", "Bearer test-token")
+	w := httptest.NewRecorder()
+	orch.executeSync(context.Background(), w, req, EndpointChatCompletions, []byte(reqBody), "gpt-4o",
+		NeedFlags{NeedChatCompletions: true}, 10000, orch.litellm.ChatCompletion, normalizeChatCompletion)
+	return w
+}
+
+// syncRequestBody is an 11-character prompt: estimateCompletionTokens gives
+// ceil(11/4) = 3 tokens for the prompt half of the estimate.
+const syncRequestBody = `{"model":"gpt-4o","messages":[{"role":"user","content":"hello world"}]}`
+
+// noUsageResponseBody is a well-formed chat completion with 4000 characters of
+// assistant content and NO usage field at all: ceil(4000/4) = 1000 tokens for
+// the completion half. Thousands of tokens on purpose -- the 1-credit floor
+// makes a small-token assertion pass even when the arithmetic is wrong.
+func noUsageResponseBody(t *testing.T) string {
+	t.Helper()
+	content := strings.Repeat("x", 4000)
+	body, err := json.Marshal(map[string]any{
+		"id":      "chatcmpl-test-no-usage",
+		"object":  "chat.completion",
+		"created": 1700000000,
+		"model":   "route",
+		"choices": []map[string]any{{
+			"index":         0,
+			"message":       map[string]any{"role": "assistant", "content": content},
+			"finish_reason": "stop",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("marshal no-usage response: %v", err)
+	}
+	return string(body)
+}
+
+// TestExecuteSync_NoUsage_NeverConfirmsTheFlatEstimate is the issue #636 bound:
+// when the provider returns no usage, the settlement must not be marked
+// confirmed and must not charge the flat reservation estimate as though it had
+// been measured. It settles instead on a token estimate derived from the bytes
+// actually exchanged, flagged unconfirmed so control-plane clamps it to the
+// hold and opens a reconciliation job.
+func TestExecuteSync_NoUsage_NeverConfirmsTheFlatEstimate(t *testing.T) {
+	providerSrv := jsonProviderServer(noUsageResponseBody(t))
+	defer providerSrv.Close()
+	routingSrv := newRoutingMock(providerSrv.URL)
+	defer routingSrv.Close()
+	rec := &accountingRecorder{}
+	acctSrv := newAccountingMock(rec)
+	defer acctSrv.Close()
+
+	orch := newAuthorizedOrchestrator(acctSrv.URL, routingSrv.URL, providerSrv.URL)
+	var w *httptest.ResponseRecorder
+	logs := captureLogs(t, func() { w = callSyncBody(orch, syncRequestBody) })
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body: %s)", w.Code, w.Body.String())
+	}
+
+	body, ok := rec.find("/internal/accounting/reservations/finalize")
+	if !ok {
+		t.Fatalf("expected FinalizeReservation for a delivered response; calls seen: %+v", rec.calls)
+	}
+
+	confirmed, _ := body["terminal_usage_confirmed"].(bool)
+	actual, _ := body["actual_credits"].(float64)
+
+	if confirmed {
+		t.Errorf("terminal_usage_confirmed = true for a response that carried no usage block: an estimate must never be recorded as measured truth")
+	}
+	// The exact number the bound forbids: the flat estimate, confirmed.
+	if confirmed && int64(actual) == 10000 {
+		t.Errorf("the flat reservation estimate was billed as confirmed usage (issue #636)")
+	}
+	// 3 prompt tokens (11 chars) + 1000 completion tokens (4000 chars).
+	if int64(actual) != 1003 {
+		t.Errorf("actual_credits = %v, want 1003 (3 prompt + 1000 completion estimated tokens), never the flat 10000 estimate", body["actual_credits"])
+	}
+	if rec.has("/internal/accounting/reservations/release") {
+		t.Error("a charged reservation must never also be released: that refunds a legitimate charge")
+	}
+	if !strings.Contains(logs, "unconfirmed") {
+		t.Errorf("an unmeasured settlement must be loud, not silent; logs: %q", logs)
+	}
+}
+
+// TestExecuteSync_NoUsage_NoOutput_ReleasesInsteadOfCharging covers the other
+// half: nothing measured AND nothing produced means there is no billable
+// quantity at all, so the hold is released in full rather than charged at a
+// guessed figure. This matches settlementCredits' delivered=false contract on
+// the streaming path.
+func TestExecuteSync_NoUsage_NoOutput_ReleasesInsteadOfCharging(t *testing.T) {
+	providerSrv := jsonProviderServer(`{"id":"chatcmpl-empty","object":"chat.completion","model":"route","choices":[]}`)
+	defer providerSrv.Close()
+	routingSrv := newRoutingMock(providerSrv.URL)
+	defer routingSrv.Close()
+	rec := &accountingRecorder{}
+	acctSrv := newAccountingMock(rec)
+	defer acctSrv.Close()
+
+	orch := newAuthorizedOrchestrator(acctSrv.URL, routingSrv.URL, providerSrv.URL)
+	callSyncBody(orch, syncRequestBody)
+
+	if rec.has("/internal/accounting/reservations/finalize") {
+		t.Error("nothing was measured and nothing was produced: there is no quantity to charge")
+	}
+	body, ok := rec.find("/internal/accounting/reservations/release")
+	if !ok {
+		t.Fatalf("expected ReleaseReservation so the hold is not stranded; calls seen: %+v", rec.calls)
+	}
+	if body["reservation_id"] != "res-test-1" {
+		t.Errorf("reservation_id = %v, want res-test-1", body["reservation_id"])
+	}
+}
+
+// TestResponseText covers the completion half of the fallback estimate for
+// every endpoint that reaches executeSync. The Responses case matters most: its
+// normalized bytes are a ResponseObject, not a chat completion, so a chat-only
+// extractor would silently estimate 0 tokens for every unmeasured /v1/responses
+// call and settle it as free.
+func TestResponseText(t *testing.T) {
+	chatNormalized, _, err := normalizeChatCompletion([]byte(
+		`{"id":"c1","choices":[{"index":0,"message":{"role":"assistant","content":"chat reply"}}]}`), "alias")
+	if err != nil {
+		t.Fatalf("normalizeChatCompletion: %v", err)
+	}
+	completionNormalized, _, err := normalizeCompletion([]byte(
+		`{"id":"c2","choices":[{"index":0,"text":"legacy reply"}]}`), "alias")
+	if err != nil {
+		t.Fatalf("normalizeCompletion: %v", err)
+	}
+	responsesNormalized, _, err := normalizeResponsesSync([]byte(
+		`{"id":"c3","choices":[{"index":0,"message":{"role":"assistant","content":"responses reply"}}]}`),
+		"alias", ResponsesRequest{Model: "alias"})
+	if err != nil {
+		t.Fatalf("normalizeResponsesSync: %v", err)
+	}
+	embeddingsNormalized, _, err := normalizeEmbeddings([]byte(
+		`{"object":"list","data":[{"index":0,"embedding":[0.1,0.2]}]}`), "alias")
+	if err != nil {
+		t.Fatalf("normalizeEmbeddings: %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		endpoint   string
+		normalized []byte
+		want       string
+	}{
+		{"chat completions", EndpointChatCompletions, chatNormalized, "chat reply"},
+		{"legacy completions", EndpointCompletions, completionNormalized, "legacy reply"},
+		{"responses", EndpointResponses, responsesNormalized, "responses reply"},
+		{"embeddings carry no generated text", EndpointEmbeddings, embeddingsNormalized, ""},
+		{"unparseable body estimates nothing", EndpointChatCompletions, []byte(`not json`), ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := responseText(tt.endpoint, tt.normalized); got != tt.want {
+				t.Errorf("responseText(%s) = %q, want %q", tt.endpoint, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestExecuteSync_ConfirmedUsage_StaysConfirmed guards the direction this fix
+// must not break: a genuine upstream usage block is still billed in full and
+// still flagged confirmed, so control-plane bills it past the flat hold
+// instead of clamping a fact (the trap the PR #602 review caught).
+func TestExecuteSync_ConfirmedUsage_StaysConfirmed(t *testing.T) {
+	var hits int64
+	providerSrv := countingJSONServer(&hits)
+	defer providerSrv.Close()
+	routingSrv := newRoutingMock(providerSrv.URL)
+	defer routingSrv.Close()
+	rec := &accountingRecorder{}
+	acctSrv := newAccountingMock(rec)
+	defer acctSrv.Close()
+
+	orch := newAuthorizedOrchestrator(acctSrv.URL, routingSrv.URL, providerSrv.URL)
+	callSyncBody(orch, syncRequestBody)
+
+	body, ok := rec.find("/internal/accounting/reservations/finalize")
+	if !ok {
+		t.Fatalf("expected FinalizeReservation on a confirmed-usage completion; calls seen: %+v", rec.calls)
+	}
+	if confirmed, _ := body["terminal_usage_confirmed"].(bool); !confirmed {
+		t.Errorf("terminal_usage_confirmed = %v, want true: the upstream did report usage", body["terminal_usage_confirmed"])
+	}
+	if actual, _ := body["actual_credits"].(float64); int64(actual) != 25 {
+		t.Errorf("actual_credits = %v, want 25 (the upstream's own total_tokens)", body["actual_credits"])
+	}
+}

--- a/apps/edge-api/internal/inference/usage_clamp.go
+++ b/apps/edge-api/internal/inference/usage_clamp.go
@@ -103,6 +103,52 @@ func responsesOutputTexts(items []ResponseOutputItem) []string {
 	return out
 }
 
+// responseText pulls the generated text back out of an already-normalized
+// synchronous response, for the completion-side half of the settlement
+// estimate when the provider returned no usage block at all (issue #636).
+// It is the response-side mirror of promptText below.
+//
+// It re-parses the normalized bytes rather than having every normalizeFunc
+// return its output text, because it is only ever called on the anomaly path:
+// a response that did carry usage never reaches here, so the normal path pays
+// nothing for this.
+//
+// Embeddings return the empty string: an embeddings response carries vectors,
+// not generated text, so there is no completion quantity to estimate from.
+// Settlement therefore releases the hold in full for an embeddings response
+// with no usage block. That under-charges an anomaly whose hold is only 1000
+// credits, which is the customer-favouring direction and the correct one for a
+// quantity nobody measured.
+// ponytail: no embeddings-side input estimate, add one if providers turn out
+// to omit embeddings usage often enough to matter (it is logged when it
+// happens).
+func responseText(endpoint string, normalized []byte) string {
+	var texts []string
+	switch endpoint {
+	case EndpointChatCompletions:
+		var resp ChatCompletionResponse
+		if err := json.Unmarshal(normalized, &resp); err != nil {
+			return ""
+		}
+		texts = chatChoiceTexts(resp.Choices)
+	case EndpointCompletions:
+		var resp CompletionResponse
+		if err := json.Unmarshal(normalized, &resp); err != nil {
+			return ""
+		}
+		texts = completionChoiceTexts(resp.Choices)
+	case EndpointResponses:
+		var resp ResponseObject
+		if err := json.Unmarshal(normalized, &resp); err != nil {
+			return ""
+		}
+		texts = responsesOutputTexts(resp.Output)
+	default:
+		return ""
+	}
+	return strings.Join(texts, "")
+}
+
 // --- Prompt text extraction (issue #602) ---
 //
 // promptText pulls the human-authored text out of a raw OpenAI-compatible


### PR DESCRIPTION
## Summary

Fixes #636. On the synchronous inference path, a provider response that carried no usage block fell back to the flat reservation estimate (10000 credits for chat, completions and responses, 1000 for embeddings) and sent it to control-plane with `TerminalUsageConfirmed = true`.

That flag is not decorative. In `accounting.finalizeLocked` it is the instruction to treat the figure as measured truth: it skips the hold clamp (`!input.TerminalUsageConfirmed && actualCredits > heldCredits`), it sets the terminal status to `finalized` instead of `needs_reconciliation`, and it skips `CreateReconciliationJob` entirely. So a short reply that arrived without a usage block was billed the entire hold, recorded as a fact, and left with nothing in the system able to correct it. The streaming path had already dropped this fallback, so the two paths disagreed about what an absent usage block means.

## Behaviour chosen, and why

`executeSync` now settles through `settlementCredits`, the helper `settleStream` has used since PR #602. Three outcomes:

| Provider response | Charge | `terminal_usage_confirmed` |
|---|---|---|
| Usage block present | its own `total_tokens` | `true`, unchanged |
| No usage, output delivered | estimate from the prompt text and response text actually exchanged | `false` |
| No usage, no output | nothing, hold released in full | not finalized at all |

The middle row is the judgment call, and it deliberately does not charge zero. The argument against overcharging a customer for a response nobody measured is answered by four properties at once, not by refusing to bill:

1. **The number is derived from bytes that exist**, not from a hold size picked before the request ran. It is `ceil(len/4)` over the parsed prompt text plus the generated response text, the same conservative estimator the zero-completion clamp already uses. For the test case that means 1003 credits where the old code billed 10000.
2. **It is flagged unconfirmed**, so control-plane clamps it to the hold and can never exceed what was authorized, and it lands as `needs_reconciliation` with a `missing_terminal_usage` reconciliation job attached. The number is explicitly recorded as an estimate awaiting correction, which is the opposite of what the bug did.
3. **The estimator errs low.** Images and other non-text prompt parts are excluded outright (issue #602's rule), and multi-byte scripts count fewer tokens per byte than they consume, so the customer-favouring direction is the default direction of the error.
4. **Charging zero is the failure mode that took billing down for three days.** The gateway serving requests for free while every signal stayed quiet is a recorded incident, not a hypothetical, and "no usage block" is provider-controlled input: a provider that stops sending usage would silently turn into free inference at whatever scale it serves. Both unmeasured outcomes therefore log, and the unconfirmed one leaves a reconciliation row behind.

Where nothing at all was produced, there is no measured quantity in either direction and the tie goes to the customer: the hold is released and nothing is charged.

## Invariants honoured

- **One terminal state per reservation.** The no-output case does not add a second settlement call. It sets `releaseReason` and leaves `finalized` false, handing the reservation to the single existing deferred `releaseReservationBackground` site, which builds its own fresh bounded background context. No context or deadline is shared between the finalize and any release, which is the trap #657 reintroduced on the streaming path and #660 fixed.
- **No dropped settlement errors.** The finalize error still gates `finalized`, so a failed charge falls through to the deferred release rather than stranding the hold, and it is still logged.
- **No string matching on failures.** This change adds no error classification; the reservation path's `errors.As` on `StatusError.StatusCode` is untouched.
- **No new pricing arithmetic.** The live sync charge stays in today's unit, one credit per token, matching `priceEstimate`'s `legacy` figure in `internal/metering`. The per-million `math/big` model in that package is shadow mode and gated behind the unresolved credit-unit question, so wiring it into a live charge here would have changed what every request costs and is not this issue.
- **Root cause, not the reported symptom.** The guard is in `executeSync`, the single function all four synchronous endpoints route through, so chat completions, legacy completions, embeddings and the synchronous Responses path are fixed together rather than just the one the issue named.

`responseText` is the response-side mirror of `promptText` and reuses the three existing per-endpoint text extractors. It re-parses the normalized bytes instead of changing every `normalizeFunc` signature, and it only runs when the usage block is missing, so the normal path pays for no extra parsing.

## Behaviour delta worth naming in review

A response whose usage block is present but reports `total_tokens = 0` now releases the hold instead of finalizing a zero-credit charge. Both free the hold and both charge nothing; the terminal status changes from `finalized` to `released`, matching what the streaming path already does for the same input.

## Test plan

Red first, then green, in `apps/edge-api/internal/inference/sync_unconfirmed_usage_test.go`. All four drive the real `executeSync` lifecycle against in-process control-plane and provider stand-ins.

- `TestExecuteSync_NoUsage_NeverConfirmsTheFlatEstimate` is the explicit bound: a no-usage response must never produce a confirmed charge, and must not charge the flat estimate. Before the fix it reported `terminal_usage_confirmed = true` and `actual_credits = 10000`; after, `false` and `1003`. Deliberately sized in thousands of tokens (4000 characters of content) because the 1-credit floor lets a small-token assertion pass over broken arithmetic.
- `TestExecuteSync_NoUsage_NoOutput_ReleasesInsteadOfCharging`: no finalize at all, hold released.
- `TestExecuteSync_ConfirmedUsage_StaysConfirmed`: a genuine usage block is still billed in full and still confirmed, so control-plane keeps billing facts past the hold rather than clamping them.
- `TestResponseText`: per-endpoint output extraction, including the Responses round trip through `ResponseObject` (a chat-only extractor would have estimated zero for every unmeasured `/v1/responses` call) and the unparseable-body case.

```
cd deploy/docker && docker compose --profile tools run toolchain \
  "cd /workspace && go test ./apps/edge-api/... -count=1 -short"
```

Full `./apps/edge-api/...` suite green (25 packages). `gofmt` and `go vet` clean on all three changed files.

## Not in this PR

- The media settlement adapters (`internal/images`, `internal/audio`) also send `TerminalUsageConfirmed: true` with hardcoded per-request credit figures (5000, 1000, 500). That is a flat per-request price rather than a fallback for an unmeasured quantity, so it is a pricing question for the owner rather than the same defect, but it is the nearest sibling of this bug and worth a separate look.
- No `.wolf/buglog.jsonl` entry: `.wolf/` memory is main-agent territory per the orchestrator contract, and every branch that appends to that file serially conflicts on GitHub's server-side merge.

No customer-visible surface changes, so no visual proof applies: this is server-side settlement arithmetic with no UI.
