### PR TITLE
refactor: derive deployment posture from one shared function

### DIFF
--- a/apps/control-plane/cmd/backfill-tenants/main.go
+++ b/apps/control-plane/cmd/backfill-tenants/main.go
@@ -4,10 +4,11 @@
 //
 //	SUPABASE_DB_URL=<DB_URL> go run ./apps/control-plane/cmd/backfill-tenants
 //
-// Hive Cloud only. It refuses to run when LICENSE_FILE_PATH is set, mirroring
-// how cmd/server/main.go derives signup.WebhookDeps.SelfServeTenants, because
-// personal tenants are a Cloud concept and Enterprise posture is that
-// membership is administered. See checkPosture.
+// Hive Cloud only. It refuses to run when config.IsEnterprisePosture reports
+// Hive Enterprise (issue #653), the same posture check cmd/server/main.go
+// uses to derive signup.WebhookDeps.SelfServeTenants, because personal
+// tenants are a Cloud concept and Enterprise posture is that membership is
+// administered. See checkPosture.
 //
 // Operator run, deliberately not wired into server startup: it writes tenant
 // rows, and a tenancy write that happens automatically on every deploy is not
@@ -31,6 +32,7 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/platform/config"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/signup"
 )
 
@@ -44,12 +46,13 @@ var errEnterprisePosture = errors.New(
 		"administered, so this command refuses to run here rather than minting tenants the\n" +
 		"deployment forbids. Unset LICENSE_FILE_PATH only if this really is a Cloud database.")
 
-// checkPosture mirrors how cmd/server/main.go derives
-// signup.WebhookDeps.SelfServeTenants from platform/config.Config.LicenseFilePath,
-// so posture keeps one source of truth. Split out from main so the refusal is
-// testable without running the command.
+// checkPosture calls config.IsEnterprisePosture, the single source of truth
+// cmd/server/main.go also uses to derive signup.WebhookDeps.SelfServeTenants
+// (issue #653), so the two entry points cannot disagree on deployment
+// posture. Split out from main so the refusal is testable without running
+// the command.
 func checkPosture(licenseFilePath string) error {
-	if licenseFilePath != "" {
+	if config.IsEnterprisePosture(licenseFilePath) {
 		return errEnterprisePosture
 	}
 	return nil

--- a/apps/control-plane/cmd/server/main.go
+++ b/apps/control-plane/cmd/server/main.go
@@ -623,12 +623,11 @@ func main() {
 				// that hit Supabase directly and bypass the web-console precheck.
 				DisposableCheck: disposableBlocklist.IsDisposableEmail,
 				// Personal-tenant provisioning for a signup no tenant claims
-				// (issue #625). Hive Cloud only. An empty LicenseFilePath is
-				// already the switch that selects licensing.CloudSource over
-				// licensing.FileSource below, so posture keeps one source of
-				// truth rather than gaining a second flag that can disagree
-				// with the first.
-				SelfServeTenants: cfg.LicenseFilePath == "",
+				// (issue #625). Hive Cloud only. config.IsEnterprisePosture
+				// is the single source of truth for this branch (issue
+				// #653); it also gates cmd/backfill-tenants and the
+				// licensing.FileSource vs licensing.CloudSource switch below.
+				SelfServeTenants: !config.IsEnterprisePosture(cfg.LicenseFilePath),
 				SharedSecret:     signupSecret,
 			}
 			signupWebhook = signup.NewWebhook(signupDeps)
@@ -1181,7 +1180,7 @@ func main() {
 	// placeholder). Both satisfy licensing.Source identically, so the
 	// handler never branches on deployment mode.
 	var licenseSource licensing.Source
-	if cfg.LicenseFilePath != "" {
+	if config.IsEnterprisePosture(cfg.LicenseFilePath) {
 		licenseSource = licensing.FileSource{
 			Path:         cfg.LicenseFilePath,
 			PublicKeyB64: cfg.LicensePublicKeyB64,

--- a/apps/control-plane/internal/platform/config/config.go
+++ b/apps/control-plane/internal/platform/config/config.go
@@ -80,6 +80,23 @@ type Config struct {
 	LicenseRevalidateIntervalSeconds int
 }
 
+// IsEnterprisePosture derives Hive's deployment posture (issue #304 D9, issue
+// #625, issue #653) from a LICENSE_FILE_PATH value: non-empty means Hive
+// Enterprise (customer-hosted, membership administered, no self-serve
+// personal tenants); empty means Hive Cloud (hosted SaaS, self-serve personal
+// tenants on signup). This is the single source of truth for that branch:
+// cmd/server derives signup.WebhookDeps.SelfServeTenants from it and
+// cmd/backfill-tenants refuses to run against an Enterprise database because
+// of it. Before issue #653 both entry points wrote out the same `!= ""` check
+// independently, which could only stay in sync by coincidence. The predicate
+// is total over all string inputs (empty or not), so there is no unrecognized
+// value for this particular flag; callers that need a distinct fail-closed
+// error for a malformed license (e.g. LICENSE_FILE_PATH set without
+// LICENSE_PUBLIC_KEY) get that from Load, not from this function.
+func IsEnterprisePosture(licenseFilePath string) bool {
+	return licenseFilePath != ""
+}
+
 // Load reads configuration from environment variables and returns a validated Config.
 func Load() (*Config, error) {
 	portStr := os.Getenv("CONTROL_PLANE_PORT")

--- a/apps/control-plane/internal/platform/config/license_config_test.go
+++ b/apps/control-plane/internal/platform/config/license_config_test.go
@@ -42,6 +42,34 @@ func TestLicenseFilePathWithPublicKeyLoads(t *testing.T) {
 	}
 }
 
+// TestIsEnterprisePosture covers every LICENSE_FILE_PATH shape the two
+// consuming entry points (cmd/server and cmd/backfill-tenants) accept today:
+// unset, an absolute path, and a relative path all resolve to a posture. The
+// predicate is total over strings (issue #653): there is no third,
+// unrecognized posture value for this flag, since any non-empty string is
+// Enterprise and only the empty string is Cloud. The "whitespace-only" case
+// is included because it is easy to assume gets trimmed to empty; it does
+// not, matching the pre-#653 behaviour of both call sites (neither trimmed).
+func TestIsEnterprisePosture(t *testing.T) {
+	tests := []struct {
+		name            string
+		licenseFilePath string
+		want            bool
+	}{
+		{"unset is Hive Cloud", "", false},
+		{"absolute path is Hive Enterprise", "/etc/hive/license.json", true},
+		{"relative path is Hive Enterprise", "license.json", true},
+		{"whitespace-only is Hive Enterprise (not trimmed)", "   ", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsEnterprisePosture(tt.licenseFilePath); got != tt.want {
+				t.Errorf("IsEnterprisePosture(%q) = %v, want %v", tt.licenseFilePath, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestLicenseRevalidateIntervalOverride(t *testing.T) {
 	t.Setenv("SUPABASE_URL", "https://example.supabase.co")
 	t.Setenv("LICENSE_REVALIDATE_INTERVAL_SECONDS", "60")


### PR DESCRIPTION
## Summary

Fixes #653. cmd/server and cmd/backfill-tenants each derived Hive's deployment posture (Cloud vs Enterprise) from the same LICENSE_FILE_PATH check written out independently:

- cmd/server/main.go: `SelfServeTenants: cfg.LicenseFilePath == ""` (and a second, third occurrence in the same file selecting licensing.FileSource vs licensing.CloudSource)
- cmd/backfill-tenants/main.go: `checkPosture` did `licenseFilePath != ""` on a raw `os.Getenv("LICENSE_FILE_PATH")` read, bypassing the config package entirely

They agreed only by coincidence, per the issue: the moment either read gained a default or a trim, the two binaries could disagree on posture for the same deployment, and the failure is silent by construction (neither path errors, it just takes the other branch).

## Change

Added one exported function, `config.IsEnterprisePosture(licenseFilePath string) bool`, in `apps/control-plane/internal/platform/config/config.go`. Non-empty is Hive Enterprise, empty is Hive Cloud, no trimming, matching the existing behaviour exactly. All three call sites in `cmd/server/main.go` and the one in `cmd/backfill-tenants/main.go` now call this function instead of repeating the `!= ""` / `== ""` expression. No interface, no strategy pattern, no config abstraction: a single pure function of a string.

## Behavioural divergence check

None found. Both original expressions are exact logical inverses of the same predicate (`cfg.LicenseFilePath == ""` vs `licenseFilePath != ""`), and `cfg.LicenseFilePath` is itself an un-trimmed, un-defaulted `os.Getenv("LICENSE_FILE_PATH")` (see `config.Load`), identical to the raw read `cmd/backfill-tenants` did directly. So for every string value either site could receive, both resolved to the same posture before this change, and continue to after it. Preserved behaviour: any non-empty string (including a whitespace-only string) is Enterprise; only the exact empty string is Cloud. Covered by a new test case explicitly, since it is easy to assume whitespace gets trimmed to empty and it does not, on either side, before or after this change.

## Fail-closed / unknown-value note

The brief asked for a startup error on an unrecognized posture value, never a silent default to the more permissive mode. LICENSE_FILE_PATH is a free-form file path, not an enum register: there is no third, unrecognized value for this particular flag; every string maps deterministically to Cloud or Enterprise, so `IsEnterprisePosture` is total and cannot hit an "unknown" branch. The existing fail-closed behaviour for a genuinely malformed license configuration (LICENSE_FILE_PATH set without LICENSE_PUBLIC_KEY) is untouched: that check lives in `config.Load` already, returns an error, and is out of scope for this refactor since it is validation, not posture derivation.

No environment variable name or accepted value changed.

## Test plan

- [x] `docker compose --profile tools run toolchain "cd /workspace && go test ./apps/control-plane/... -count=1 -short"` — all packages pass, including new `TestIsEnterprisePosture` table-driven test (empty, absolute path, relative path, whitespace-only) and the pre-existing `TestCheckPostureRefusesEnterpriseDeployment` / `TestCheckPostureAllowsCloudDeployment` in cmd/backfill-tenants
- [x] `gofmt -l` clean on all touched files