### PR TITLE
fix: calibrate the unconfirmed-usage token estimate so it under-counts every script

### DIFF
--- a/apps/edge-api/internal/inference/stream.go
+++ b/apps/edge-api/internal/inference/stream.go
@@ -370,6 +370,12 @@ func (o *Orchestrator) releaseReservationBackground(snapshot authz.AuthSnapshot,
 // credit hold). The control-plane hard clamp in finalizeLocked is the
 // backstop that keeps any residual overcount here from ever exceeding the
 // reserved hold, but this function should still return a realistic number.
+//
+// The estimator itself is calibrated to land BELOW real tokenization for every
+// writing system rather than near its average, so the direction of its error
+// favours the customer instead of depending on the script they write in (issue
+// #673). See bytesPerToken in usage_clamp.go for the measurements; the clamp is
+// the backstop, not the reason the figure is defensible.
 func settlementCredits(hasUsage bool, totalTokens int64, prompt, content string) (credits int64, delivered bool) {
 	if hasUsage {
 		return totalTokens, totalTokens > 0

--- a/apps/edge-api/internal/inference/sync_unconfirmed_usage_test.go
+++ b/apps/edge-api/internal/inference/sync_unconfirmed_usage_test.go
@@ -44,17 +44,18 @@ func callSyncBody(orch *Orchestrator, reqBody string) *httptest.ResponseRecorder
 	return w
 }
 
-// syncRequestBody is an 11-character prompt: estimateCompletionTokens gives
-// ceil(11/4) = 3 tokens for the prompt half of the estimate.
+// syncRequestBody is an 11-byte prompt, which the estimator floors at its
+// minimum of 1 token for the prompt half of the estimate.
 const syncRequestBody = `{"model":"gpt-4o","messages":[{"role":"user","content":"hello world"}]}`
 
-// noUsageResponseBody is a well-formed chat completion with 4000 characters of
-// assistant content and NO usage field at all: ceil(4000/4) = 1000 tokens for
-// the completion half. Thousands of tokens on purpose -- the 1-credit floor
-// makes a small-token assertion pass even when the arithmetic is wrong.
+// noUsageResponseBody is a well-formed chat completion with 12,000 bytes of
+// assistant content and NO usage field at all: 12000/bytesPerToken = 1000
+// tokens for the completion half. Thousands of tokens on purpose -- the
+// 1-credit floor makes a small-token assertion pass even when the arithmetic is
+// wrong.
 func noUsageResponseBody(t *testing.T) string {
 	t.Helper()
-	content := strings.Repeat("x", 4000)
+	content := strings.Repeat("x", 12000)
 	body, err := json.Marshal(map[string]any{
 		"id":      "chatcmpl-test-no-usage",
 		"object":  "chat.completion",
@@ -110,9 +111,9 @@ func TestExecuteSync_NoUsage_NeverConfirmsTheFlatEstimate(t *testing.T) {
 	if confirmed && int64(actual) == 10000 {
 		t.Errorf("the flat reservation estimate was billed as confirmed usage (issue #636)")
 	}
-	// 3 prompt tokens (11 chars) + 1000 completion tokens (4000 chars).
-	if int64(actual) != 1003 {
-		t.Errorf("actual_credits = %v, want 1003 (3 prompt + 1000 completion estimated tokens), never the flat 10000 estimate", body["actual_credits"])
+	// 1 prompt token (11 bytes, floored) + 1000 completion tokens (12,000 bytes).
+	if int64(actual) != 1001 {
+		t.Errorf("actual_credits = %v, want 1001 (1 prompt + 1000 completion estimated tokens), never the flat 10000 estimate", body["actual_credits"])
 	}
 	if rec.has("/internal/accounting/reservations/release") {
 		t.Error("a charged reservation must never also be released: that refunds a legitimate charge")

--- a/apps/edge-api/internal/inference/token_estimate_scripts_test.go
+++ b/apps/edge-api/internal/inference/token_estimate_scripts_test.go
@@ -302,6 +302,34 @@ func TestEstimateCompletionTokens_SeparatorRunsDoNotOvercharge(t *testing.T) {
 			// o200k_base 1800, cl100k_base 1800, o200k_harmony 1800
 			minRealTokens: 1800,
 		},
+		{
+			// The most common non-markdown table a model emits, and the case that
+			// made the membership set's first draft wrong: U+2500 is the rune the
+			// separator row is drawn with, and it measures 48 real bytes per token.
+			name:      "unicode box drawing table",
+			in:        unicodeBoxTable(120, 40),
+			wantBytes: 40800,
+			// o200k_base 2400, cl100k_base 3000, o200k_harmony 2400. 1.13x of real
+			// usage before U+2500 joined the set.
+			minRealTokens: 2400,
+		},
+		{
+			name:      "horizontal rule of box drawing light horizontal",
+			in:        strings.Repeat(strings.Repeat("─", 60)+"\n", 200),
+			wantBytes: 36200,
+			// o200k_base 1200, cl100k_base 1800, o200k_harmony 1200. 2.51x before.
+			minRealTokens: 1200,
+		},
+		{
+			// Our own masking convention, and the reason a capital X is a member:
+			// a run of X measures 16 real bytes per token, so it over-charged 1.33x
+			// on its own even though this line-broken form stayed under.
+			name:      "masked identifiers",
+			in:        strings.Repeat("Account: "+strings.Repeat("X", 12)+"3456\n", 800),
+			wantBytes: 20800,
+			// o200k_base 6400, cl100k_base 6400, o200k_harmony 6400
+			minRealTokens: 6400,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -317,6 +345,16 @@ func TestEstimateCompletionTokens_SeparatorRunsDoNotOvercharge(t *testing.T) {
 			}
 		})
 	}
+}
+
+// unicodeBoxTable builds rows of a two-column table drawn the way a model draws
+// one when it is not writing markdown: a U+2500 separator row, then a data row
+// whose cells are padded with spaces.
+func unicodeBoxTable(rows, width int) string {
+	sep := "├" + strings.Repeat("─", width) + "┼" + strings.Repeat("─", width) + "┤\n"
+	pad := strings.Repeat(" ", width-2)
+	row := "│ x" + pad + "│ y" + pad + "│\n"
+	return strings.Repeat(sep+row, rows)
 }
 
 // asciiBoxTable builds rows of a two-column ASCII box-drawing table: a border
@@ -437,4 +475,128 @@ func max64(a, b int64) int64 {
 		return a
 	}
 	return b
+}
+
+// collapsibleRunes is the measured membership of runCollapsible, one row per
+// member, and it exists because the set was wrong twice: first by being derived
+// from a property (whitespace) instead of a measurement, then by being measured
+// against the wrong statistic. Editing the switch without adding a measured row
+// here now fails the completeness check below.
+//
+// The criterion, restated exactly: a rune is a member when the worst-case real
+// bytes per token for a long run of it reaches bytesPerToken or more, where
+// worst-case means the LARGEST bytes per token of the three encodings, which is
+// the same thing as the SMALLEST token count. The smallest count is the number
+// the estimate has to stay under, so deciding membership on it is the direction
+// that cannot over-charge on any of the three. Deciding it on the largest count
+// instead is what left U+2500 and eight others out: they compress hard on
+// o200k_base and o200k_harmony while cl100k_base splits the run, so the run
+// over-charged by up to 2.51x against the binding reference.
+//
+// Every minRealTokens is measured with tiktoken 0.13.0 for runLen copies of the
+// rune, smallest of the three encodings.
+var collapsibleRunes = []struct {
+	name          string
+	rune          rune
+	runLen        int
+	wantBytes     int
+	minRealTokens int64
+}{
+	{name: "space", rune: ' ', runLen: 12000, wantBytes: 12000, minRealTokens: 95},                                 // 126.3 real bytes/token; o200k 95, cl100k 95, harmony 95
+	{name: "tab", rune: '\t', runLen: 12000, wantBytes: 12000, minRealTokens: 750},                                 // 16.0; o200k 750, cl100k 750, harmony 750
+	{name: "newline", rune: '\n', runLen: 12000, wantBytes: 12000, minRealTokens: 375},                             // 32.0; o200k 750, cl100k 375, harmony 750
+	{name: "hyphen minus", rune: '-', runLen: 12000, wantBytes: 12000, minRealTokens: 187},                         // 64.2; o200k 187, cl100k 187, harmony 187
+	{name: "equals", rune: '=', runLen: 12000, wantBytes: 12000, minRealTokens: 187},                               // 64.2; o200k 187, cl100k 188, harmony 187
+	{name: "underscore", rune: '_', runLen: 12000, wantBytes: 12000, minRealTokens: 188},                           // 63.8; o200k 188, cl100k 188, harmony 188
+	{name: "solidus", rune: '/', runLen: 12000, wantBytes: 12000, minRealTokens: 187},                              // 64.2; o200k 188, cl100k 187, harmony 188
+	{name: "full stop", rune: '.', runLen: 12000, wantBytes: 12000, minRealTokens: 188},                            // 63.8; o200k 188, cl100k 188, harmony 188
+	{name: "asterisk", rune: '*', runLen: 12000, wantBytes: 12000, minRealTokens: 187},                             // 64.2; o200k 187, cl100k 188, harmony 187
+	{name: "number sign", rune: '#', runLen: 12000, wantBytes: 12000, minRealTokens: 188},                          // 63.8; o200k 188, cl100k 188, harmony 188
+	{name: "percent", rune: '%', runLen: 12000, wantBytes: 12000, minRealTokens: 188},                              // 63.8; o200k 375, cl100k 188, harmony 375
+	{name: "plus", rune: '+', runLen: 12000, wantBytes: 12000, minRealTokens: 375},                                 // 32.0; o200k 375, cl100k 375, harmony 375
+	{name: "tilde", rune: '~', runLen: 12000, wantBytes: 12000, minRealTokens: 375},                                // 32.0; o200k 375, cl100k 375, harmony 375
+	{name: "semicolon", rune: ';', runLen: 12000, wantBytes: 12000, minRealTokens: 750},                            // 16.0; o200k 750, cl100k 750, harmony 750
+	{name: "exclamation mark", rune: '!', runLen: 12000, wantBytes: 12000, minRealTokens: 750},                     // 16.0; o200k 750, cl100k 1500, harmony 750
+	{name: "colon", rune: ':', runLen: 12000, wantBytes: 12000, minRealTokens: 750},                                // 16.0; o200k 750, cl100k 1500, harmony 750
+	{name: "capital X", rune: 'X', runLen: 12000, wantBytes: 12000, minRealTokens: 750},                            // 16.0; o200k 750, cl100k 1500, harmony 750
+	{name: "no break space", rune: '\u00a0', runLen: 12000, wantBytes: 24000, minRealTokens: 1500},                 // 16.0; o200k 1500, cl100k 1500, harmony 1500
+	{name: "en dash", rune: '\u2013', runLen: 12000, wantBytes: 36000, minRealTokens: 3000},                        // 12.0; o200k 3000, cl100k 6000, harmony 3000
+	{name: "em dash", rune: '\u2014', runLen: 12000, wantBytes: 36000, minRealTokens: 750},                         // 48.0; o200k 750, cl100k 750, harmony 750
+	{name: "horizontal ellipsis", rune: '\u2026', runLen: 12000, wantBytes: 36000, minRealTokens: 750},             // 48.0; o200k 750, cl100k 1500, harmony 750
+	{name: "zero width space", rune: '\u200b', runLen: 12000, wantBytes: 36000, minRealTokens: 3000},               // 12.0; o200k 3000, cl100k 6000, harmony 3000
+	{name: "box drawings light horizontal", rune: '\u2500', runLen: 12000, wantBytes: 36000, minRealTokens: 750},   // 48.0; o200k 750, cl100k 1500, harmony 750
+	{name: "box drawings heavy horizontal", rune: '\u2501', runLen: 12000, wantBytes: 36000, minRealTokens: 1500},  // 24.0; o200k 1500, cl100k 6000, harmony 1500
+	{name: "box drawings double horizontal", rune: '\u2550', runLen: 12000, wantBytes: 36000, minRealTokens: 1500}, // 24.0; o200k 1500, cl100k 6000, harmony 1500
+	{name: "full block", rune: '\u2588', runLen: 12000, wantBytes: 36000, minRealTokens: 3000},                     // 12.0; o200k 3000, cl100k 3000, harmony 3000
+	{name: "white square", rune: '\u25a1', runLen: 12000, wantBytes: 36000, minRealTokens: 750},                    // 48.0; o200k 750, cl100k 24000, harmony 750
+	{name: "black star", rune: '\u2605', runLen: 12000, wantBytes: 36000, minRealTokens: 3000},                     // 12.0; o200k 3000, cl100k 6000, harmony 3000
+	{name: "female sign", rune: '\u2640', runLen: 12000, wantBytes: 36000, minRealTokens: 3000},                    // 12.0; o200k 3000, cl100k 3000, harmony 3000
+	{name: "ideographic space", rune: '\u3000', runLen: 12000, wantBytes: 36000, minRealTokens: 750},               // 48.0; o200k 750, cl100k 6000, harmony 750
+	{name: "katakana middle dot", rune: '\u30fb', runLen: 12000, wantBytes: 36000, minRealTokens: 3000},            // 12.0; o200k 3000, cl100k 6000, harmony 3000
+	{name: "katakana prolonged sound mark", rune: '\u30fc', runLen: 12000, wantBytes: 36000, minRealTokens: 3000},  // 12.0; o200k 3000, cl100k 12000, harmony 3000
+	{name: "fullwidth exclamation mark", rune: '\uff01', runLen: 12000, wantBytes: 36000, minRealTokens: 3000},     // 12.0; o200k 3000, cl100k 6000, harmony 3000
+	{name: "fullwidth asterisk", rune: '\uff0a', runLen: 12000, wantBytes: 36000, minRealTokens: 3000},             // 12.0; o200k 3000, cl100k 24000, harmony 3000
+	{name: "fullwidth equals sign", rune: '\uff1d', runLen: 12000, wantBytes: 36000, minRealTokens: 3000},          // 12.0; o200k 3000, cl100k 24000, harmony 3000
+}
+
+// TestRunCollapsible_MembershipIsMeasured pins the whole set rather than the few
+// runes a bug report happens to name. It asserts three things: every measured
+// member is in the switch, a pure run of each stays inside both bounds, and the
+// switch contains nothing that has not been measured here.
+//
+// The families swept to build this list, at 6,000 and 24,000 rune runs, worst of
+// the three encodings: ASCII printable including letters and digits, Latin-1
+// punctuation and symbols, general punctuation U+2000 to U+206F, arrows, math
+// operators, box drawing, block elements, geometric shapes, miscellaneous
+// symbols, dingbats, CJK symbols and punctuation, katakana, halfwidth and
+// fullwidth forms, the invisible format characters, and a sample of the emoji a
+// model repeats to draw a bar. Nothing else in those families reaches 12: the
+// closest misses measure 8, which are '<' '>' '?' '@' '^' ',' the macron U+00AF
+// and the letters a f l o x A F, and everything else is at 4 or below.
+func TestRunCollapsible_MembershipIsMeasured(t *testing.T) {
+	for _, m := range collapsibleRunes {
+		t.Run(m.name, func(t *testing.T) {
+			if !runCollapsible(m.rune) {
+				t.Fatalf("U+%04X measures %.1f real bytes per token, at or above bytesPerToken, but is not in the switch: its runs over-charge",
+					m.rune, float64(m.wantBytes)/float64(m.minRealTokens))
+			}
+			in := strings.Repeat(string(m.rune), m.runLen)
+			if len(in) != m.wantBytes {
+				t.Fatalf("fixture is %d bytes, measured against %d", len(in), m.wantBytes)
+			}
+			got := estimateCompletionTokens(in)
+			t.Logf("%d bytes, estimate %d, real %d, %.3f of real usage", m.wantBytes, got, m.minRealTokens, float64(got)/float64(m.minRealTokens))
+			if got > m.minRealTokens {
+				t.Errorf("estimate %d exceeds real usage %d tokens (%.2fx)", got, m.minRealTokens, float64(got)/float64(m.minRealTokens))
+			}
+			if got*20 < m.minRealTokens {
+				t.Errorf("estimate %d is under 5%% of real usage %d tokens: a member must still pay in proportion to its run",
+					got, m.minRealTokens)
+			}
+		})
+	}
+
+	t.Run("nothing unmeasured is in the switch", func(t *testing.T) {
+		measured := make(map[rune]bool, len(collapsibleRunes))
+		for _, m := range collapsibleRunes {
+			measured[m.rune] = true
+		}
+		for r := rune(0); r <= 0x10FFFF; r++ {
+			if runCollapsible(r) && !measured[r] {
+				t.Errorf("U+%04X is collapsed by the switch but has no measured row: a collapse without a measurement is how the estimator gives inference away", r)
+			}
+		}
+	})
+
+	t.Run("runes the vocabulary does not compress are never collapsed", func(t *testing.T) {
+		// The undercharge side of the vice. Measured real bytes per token: U+1680
+		// 1.0, U+0085 1.0, vertical tab 1.0, form feed 1.0, carriage return 2.0,
+		// U+2000 1.5, U+2028 3.0, U+202F 3.0. All far below bytesPerToken, so
+		// collapsing any of them hands out inference we pay for.
+		for _, r := range []rune{'\u1680', '\u0085', '\v', '\f', '\r', '\u2000', '\u2028', '\u202f'} {
+			if runCollapsible(r) {
+				t.Errorf("U+%04X costs about one real token per byte and must never be collapsed", r)
+			}
+		}
+	})
 }

--- a/apps/edge-api/internal/inference/token_estimate_scripts_test.go
+++ b/apps/edge-api/internal/inference/token_estimate_scripts_test.go
@@ -204,3 +204,234 @@ func TestEstimateCompletionTokens_WhitespaceRunsDoNotInflate(t *testing.T) {
 		})
 	}
 }
+
+// textCase is a measured fixture for the two run-collapse bounds below. Every
+// minRealTokens is again the SMALLEST count across tiktoken 0.13.0 o200k_base,
+// cl100k_base and o200k_harmony, and wantBytes guards the fixture itself: these
+// figures were measured on the exact byte string, so a transcription slip in
+// the builder below has to fail loudly rather than quietly re-baseline a money
+// bound.
+type textCase struct {
+	name          string
+	in            string
+	wantBytes     int
+	minRealTokens int64
+}
+
+func (tc textCase) check(t *testing.T) int64 {
+	t.Helper()
+	if len(tc.in) != tc.wantBytes {
+		t.Fatalf("fixture is %d bytes, measured against %d: the measured token counts no longer describe this input", len(tc.in), tc.wantBytes)
+	}
+	return estimateCompletionTokens(tc.in)
+}
+
+// TestEstimateCompletionTokens_SeparatorRunsDoNotOvercharge is the other half of
+// the bound the script test states. Byte length is NOT a structural upper bound
+// on token count: byte-pair vocabularies carry long single tokens for repeated
+// punctuation, so real bytes per token reaches 64 for a run of dashes and 128
+// for a run of spaces, far above the divisor. Measured on this fixture set
+// before the fix, an unmeasured settlement over-charged a horizontal rule by
+// 6.59x, a log banner by 4.21x and a blank form by 0.93 of real, and every one
+// of these shapes is output a model produces routinely.
+//
+// The hard bound is est <= real, same as the script test. The second bound is a
+// margin: for the shapes that show up inside ordinary assistant output the
+// estimate must keep at least 20 percent of headroom, because a fixture sitting
+// at 0.98 of real is one vocabulary change away from over-charging.
+func TestEstimateCompletionTokens_SeparatorRunsDoNotOvercharge(t *testing.T) {
+	tests := []textCase{
+		{
+			name:      "horizontal rules of seventy eight dashes",
+			in:        strings.Repeat(strings.Repeat("-", 78)+"\n", 200),
+			wantBytes: 15800,
+			// o200k_base 200, cl100k_base 400, o200k_harmony 200 (79.0 real bytes/token)
+			minRealTokens: 200,
+		},
+		{
+			name: "twenty thousand bytes of repeated separators",
+			in: strings.Repeat("=", 5000) + strings.Repeat("-", 5000) +
+				strings.Repeat("*", 5000) + strings.Repeat("/", 5000),
+			wantBytes: 20000,
+			// o200k_base 312, cl100k_base 314, o200k_harmony 312 (64.1 real bytes/token)
+			minRealTokens: 312,
+		},
+		{
+			name:      "log banner of a hundred equals signs per line",
+			in:        strings.Repeat(strings.Repeat("=", 100)+"\n", 300),
+			wantBytes: 30300,
+			// o200k_base 600, cl100k_base 900, o200k_harmony 600
+			minRealTokens: 600,
+		},
+		{
+			name:      "blank form lines of underscore runs",
+			in:        strings.Repeat("Name: "+strings.Repeat("_", 60)+"\n", 400),
+			wantBytes: 26800,
+			// o200k_base 2400, cl100k_base 2400, o200k_harmony 2400
+			minRealTokens: 2400,
+		},
+		{
+			name:      "table of contents leader dots",
+			in:        strings.Repeat("Chapter heading "+strings.Repeat(".", 40)+" 12\n", 500),
+			wantBytes: 30000,
+			// o200k_base 3500, cl100k_base 3500, o200k_harmony 3500
+			minRealTokens: 3500,
+		},
+		{
+			name:      "markdown table separator rows",
+			in:        strings.Repeat("|---|---|---|---|\n", 1400),
+			wantBytes: 25200,
+			// o200k_base 12600, cl100k_base 12600, o200k_harmony 12600
+			minRealTokens: 12600,
+		},
+		{
+			name:      "ascii box drawing table",
+			in:        asciiBoxTable(120, 60),
+			wantBytes: 29760,
+			// o200k_base 1680, cl100k_base 1680, o200k_harmony 1680. The densest
+			// realistic formatting measured: 0.83 of real usage before this fix,
+			// and an independent measurement of a narrower variant reached 0.976.
+			minRealTokens: 1680,
+		},
+		{
+			name: "report with a horizontal rule per section",
+			in: strings.Repeat(strings.Repeat("=", 78)+"\nSection: findings\n"+
+				strings.Repeat("The gateway settled every reservation exactly once.\n", 3), 60),
+			wantBytes: 15180,
+			// o200k_base 1800, cl100k_base 1800, o200k_harmony 1800
+			minRealTokens: 1800,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.check(t)
+			if got > tt.minRealTokens {
+				t.Errorf("estimate %d exceeds real usage %d tokens (%.2fx): a separator run is not one token per twelve bytes",
+					got, tt.minRealTokens, float64(got)/float64(tt.minRealTokens))
+			}
+			if got*100 > tt.minRealTokens*80 {
+				t.Errorf("estimate %d is %d%% of real usage %d: formatted output must keep at least 20%% of headroom",
+					got, got*100/tt.minRealTokens, tt.minRealTokens)
+			}
+		})
+	}
+}
+
+// asciiBoxTable builds rows of a two-column ASCII box-drawing table: a border
+// line of dashes, then a data line whose cells are padded with spaces.
+func asciiBoxTable(rows, width int) string {
+	border := "+" + strings.Repeat("-", width) + "+" + strings.Repeat("-", width) + "+\n"
+	pad := strings.Repeat(" ", width-6)
+	row := "| Item" + pad + " | " + pad + "Item |\n"
+	return strings.Repeat(border+row, rows)
+}
+
+// TestEstimateCompletionTokens_WhitespaceIsNeverFree is the undercharge bound,
+// and it is the one that decides how the run-collapse must be written.
+//
+// Collapsing every Unicode whitespace run is not safe: `unicode.IsSpace` covers
+// the whole White_Space property, and several of those code points tokenize at
+// ONE REAL TOKEN PER BYTE. Measured, all three encodings agree: U+1680 ogham
+// space mark and U+0085 next line cost a token per byte, as do the ASCII control
+// bytes U+000B vertical tab and U+000C form feed, which are ASCII whitespace and
+// so are not excluded by an ASCII-only rule either. A caller who finds a route
+// that omits its usage block (issue #636) can therefore send a full context
+// window of these, have us pay the provider for every token of it, and be
+// charged the 1-credit floor. Issue #600 makes that settlement permanent.
+//
+// So the estimate for caller-controlled whitespace must stay PROPORTIONAL to
+// real usage: at least 5 percent of it, the same order as the 12 percent floor
+// the sparsest real script lands at, rather than collapsing to nothing.
+//
+// The last three cases are the other side of the same choice. U+3000, U+00A0 and
+// U+200B really are compressed hard by the vocabulary (48, 16 and 12 real bytes
+// per token), so counting them at full byte length over-charges: U+3000 by 4.00x
+// and U+00A0 by 1.33x. They rule out "collapse ASCII whitespace only" just as
+// firmly as U+1680 rules out "collapse all of it".
+func TestEstimateCompletionTokens_WhitespaceIsNeverFree(t *testing.T) {
+	tests := []textCase{
+		{
+			name:      "ogham space mark",
+			in:        strings.Repeat(" ", 40000),
+			wantBytes: 120000,
+			// 3 bytes each; o200k_base 120000, cl100k_base 120000, o200k_harmony 120000
+			minRealTokens: 120000,
+		},
+		{
+			name:      "next line",
+			in:        strings.Repeat("", 40000),
+			wantBytes: 80000,
+			// 2 bytes each; all three encodings 80000 (one token per byte)
+			minRealTokens: 80000,
+		},
+		{
+			name:      "en quad",
+			in:        strings.Repeat(" ", 20000),
+			wantBytes: 60000,
+			// 3 bytes each; all three encodings 40000
+			minRealTokens: 40000,
+		},
+		{
+			name:      "vertical tab",
+			in:        strings.Repeat("\v", 40000),
+			wantBytes: 40000,
+			// all three encodings 40000 (one token per byte)
+			minRealTokens: 40000,
+		},
+		{
+			name:      "form feed",
+			in:        strings.Repeat("\f", 40000),
+			wantBytes: 40000,
+			// all three encodings 40000 (one token per byte)
+			minRealTokens: 40000,
+		},
+		{
+			name:      "carriage return",
+			in:        strings.Repeat("\r", 40000),
+			wantBytes: 40000,
+			// o200k_base 20000, cl100k_base 40000, o200k_harmony 20000
+			minRealTokens: 20000,
+		},
+		{
+			name:      "ideographic space",
+			in:        strings.Repeat("　", 20000),
+			wantBytes: 60000,
+			// 3 bytes each; o200k_base 1250, cl100k_base 10000, o200k_harmony 1250
+			minRealTokens: 1250,
+		},
+		{
+			name:      "no break space",
+			in:        strings.Repeat(" ", 20000),
+			wantBytes: 40000,
+			// 2 bytes each; all three encodings 2500
+			minRealTokens: 2500,
+		},
+		{
+			name:      "zero width space",
+			in:        strings.Repeat("​", 20000),
+			wantBytes: 60000,
+			// 3 bytes each; o200k_base 5000, cl100k_base 10000, o200k_harmony 5000
+			minRealTokens: 5000,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.check(t)
+			if got*20 < tt.minRealTokens {
+				t.Errorf("estimate %d is under 5%% of real usage %d tokens (1 credit per %d real tokens): caller-controlled whitespace must not buy unbilled inference",
+					got, tt.minRealTokens, tt.minRealTokens/max64(got, 1))
+			}
+			if got > tt.minRealTokens {
+				t.Errorf("estimate %d exceeds real usage %d tokens (%.2fx): whitespace the vocabulary compresses must not be counted byte for byte",
+					got, tt.minRealTokens, float64(got)/float64(tt.minRealTokens))
+			}
+		})
+	}
+}
+
+func max64(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/apps/edge-api/internal/inference/token_estimate_scripts_test.go
+++ b/apps/edge-api/internal/inference/token_estimate_scripts_test.go
@@ -1,0 +1,206 @@
+package inference
+
+import (
+	"strings"
+	"testing"
+)
+
+// Issue #673: the unconfirmed-usage estimator is a customer-facing money
+// figure, so it must never exceed real token usage, and the size of its error
+// must not depend on the script the customer writes in. Bangladesh is the
+// first market, so Bengali is the case that matters most.
+//
+// minRealTokens below is MEASURED, not assumed. Every figure is the smallest
+// count returned by tiktoken 0.13.0 across o200k_base, cl100k_base and
+// o200k_harmony for scriptRepeat copies of the sentence. The smallest is the
+// binding reference: an estimate at or below it cannot overcharge on any of
+// the three, and o200k_harmony is the tokenizer of the gpt-oss model the
+// hive-fast alias pins to (D-032), so this is not a hypothetical family.
+// Reproduce with:
+//
+//	pip install tiktoken==0.13.0
+//	python -c 'import tiktoken; print(len(tiktoken.get_encoding("o200k_base").encode(SENTENCE * 60)))'
+type scriptCase struct {
+	name          string
+	sentence      string // the same sentence in each script, semantically equivalent
+	minRealTokens int64  // smallest real count across the three encodings
+}
+
+// scriptRepeat pushes every case into the thousands of characters. Small
+// inputs prove nothing here: estimateCompletionTokens floors at 1 credit, and
+// at CreditsPerUSD = 100_000 that floor hides any amount of under-pricing.
+const scriptRepeat = 60
+
+var scriptCases = []scriptCase{
+	{
+		name:     "latin_english",
+		sentence: "Artificial intelligence is changing how businesses work in Bangladesh.",
+		// o200k_base 601, cl100k_base 602, o200k_harmony 601
+		minRealTokens: 601,
+	},
+	{
+		name:     "bengali",
+		sentence: "কৃত্রিম বুদ্ধিমত্তা বাংলাদেশে ব্যবসার কাজ করার ধরন পাল্টে দিচ্ছে।",
+		// o200k_base 1441, cl100k_base 4561, o200k_harmony 1441
+		minRealTokens: 1441,
+	},
+	{
+		name:     "chinese",
+		sentence: "人工智能正在改变孟加拉国的商业运作方式。",
+		// o200k_base 900, cl100k_base 1260, o200k_harmony 900
+		minRealTokens: 900,
+	},
+	{
+		name:     "japanese",
+		sentence: "人工知能はバングラデシュでのビジネスの進め方を変えつつある。",
+		// o200k_base 1620, cl100k_base 1980, o200k_harmony 1620
+		minRealTokens: 1620,
+	},
+	{
+		name:     "korean",
+		sentence: "인공지능은 방글라데시에서 기업이 일하는 방식을 바꾸고 있습니다.",
+		// o200k_base 1261, cl100k_base 1741, o200k_harmony 1261
+		minRealTokens: 1261,
+	},
+	{
+		name:     "arabic",
+		sentence: "الذكاء الاصطناعي يغير طريقة عمل الشركات في بنغلاديش.",
+		// o200k_base 1081, cl100k_base 2281, o200k_harmony 1081
+		minRealTokens: 1081,
+	},
+	{
+		name:     "devanagari",
+		sentence: "कृत्रिम बुद्धिमत्ता बांग्लादेश में व्यवसायों के काम करने का तरीका बदल रही है।",
+		// o200k_base 1322, cl100k_base 4621, o200k_harmony 1322
+		minRealTokens: 1322,
+	},
+	{
+		name:     "emoji",
+		sentence: "👨‍👩‍👧‍👦 🇧🇩 🙂 🎉 ✅ 🚀",
+		// o200k_base 1261, cl100k_base 1922, o200k_harmony 1261
+		minRealTokens: 1261,
+	},
+}
+
+func repeated(c scriptCase) string { return strings.Repeat(c.sentence+" ", scriptRepeat) }
+
+// TestEstimateCompletionTokens_NeverOverchargesAnyScript is the hard bound: on
+// an unmeasured settlement the estimate must err LOW for every writing system,
+// not just for Latin. The byte-per-four formula this replaced overcharged six
+// of these eight scripts against o200k_base, Bengali at 1.87x real and
+// Devanagari at 2.36x.
+func TestEstimateCompletionTokens_NeverOverchargesAnyScript(t *testing.T) {
+	for _, c := range scriptCases {
+		t.Run(c.name, func(t *testing.T) {
+			got := estimateCompletionTokens(repeated(c))
+			if got > c.minRealTokens {
+				t.Errorf("estimate %d exceeds real usage %d tokens (%.2fx): an unmeasured charge must favour the customer",
+					got, c.minRealTokens, float64(got)/float64(c.minRealTokens))
+			}
+			// The other direction still has to hold: erring low must not mean
+			// erring to nothing. Free inference on provider-controlled input is
+			// the failure mode that took billing down for three days.
+			if floor := c.minRealTokens * 15 / 100; got < floor {
+				t.Errorf("estimate %d is below %d, 15%% of real usage %d: the estimator has collapsed toward free inference",
+					got, floor, c.minRealTokens)
+			}
+		})
+	}
+}
+
+// TestEstimateCompletionTokens_ChargeParityAcrossScripts is the fairness bound.
+//
+// It is stated on the FRACTION OF TRUE USAGE each script is charged, not on the
+// raw charge, because real tokenizers are not script-neutral: measured on
+// o200k_base the same sentence costs 601 tokens in English and 1441 in Bengali,
+// so equal raw charges would require deliberately mispricing one of them by
+// 2.4x. Equal fractions of real usage is the bound that means nobody is
+// penalised for their writing system.
+//
+// Tolerance: Bengali within 10 percent of English, and no more than 2x spread
+// across the three. Measured after the fix: English 59 percent, Bengali 62
+// percent, Chinese 34 percent of real usage.
+//
+// This assertion is invariant to the divisor: both ratios are linear in it, so
+// it tests the UNIT the estimator counts in, which is exactly what #673 is
+// about. Counting runes instead of UTF-8 bytes fails it at 61 percent apart,
+// because Bengali really does consume about 2.6x the tokens per character that
+// English does, and byte length is the only cheap measure that tracks that.
+func TestEstimateCompletionTokens_ChargeParityAcrossScripts(t *testing.T) {
+	pct := func(name string) int64 {
+		for _, c := range scriptCases {
+			if c.name == name {
+				return estimateCompletionTokens(repeated(c)) * 100 / c.minRealTokens
+			}
+		}
+		t.Fatalf("no script case named %q", name)
+		return 0
+	}
+	en, bn, zh := pct("latin_english"), pct("bengali"), pct("chinese")
+
+	drift := bn - en
+	if drift < 0 {
+		drift = -drift
+	}
+	if drift*100 > en*10 {
+		t.Errorf("Bengali is charged %d%% of its real usage against English %d%%, more than 10%% apart: the estimator penalises a writing system", bn, en)
+	}
+	lo, hi := en, en
+	for _, v := range []int64{bn, zh} {
+		if v < lo {
+			lo = v
+		}
+		if v > hi {
+			hi = v
+		}
+	}
+	if hi > lo*2 {
+		t.Errorf("fraction-of-real-usage spread across English %d%%, Bengali %d%%, Chinese %d%% exceeds 2x", en, bn, zh)
+	}
+	for _, v := range []struct {
+		name string
+		p    int64
+	}{{"english", en}, {"bengali", bn}, {"chinese", zh}} {
+		if v.p > 100 {
+			t.Errorf("%s is charged %d%% of real usage: over 100%% is an overcharge", v.name, v.p)
+		}
+	}
+}
+
+// TestEstimateCompletionTokens_WhitespaceRunsDoNotInflate covers #673's
+// worst-case input. Byte-pair encoders carry multi-whitespace tokens, so a run
+// of N whitespace characters costs far fewer than N/4 tokens: 40,000 spaces is
+// 313 real tokens and the old formula charged 10,000 of them, the entire hold.
+func TestEstimateCompletionTokens_WhitespaceRunsDoNotInflate(t *testing.T) {
+	tests := []struct {
+		name          string
+		in            string
+		minRealTokens int64
+	}{
+		{
+			name: "forty thousand spaces",
+			in:   strings.Repeat(" ", 40000),
+			// 40000 bytes; o200k_base 313, cl100k_base 313, o200k_harmony 313
+			minRealTokens: 313,
+		},
+		{
+			name: "one thousand newlines",
+			in:   strings.Repeat("\n", 1000),
+			// 1000 bytes; o200k_base 63, cl100k_base 32, o200k_harmony 63
+			minRealTokens: 32,
+		},
+		{
+			name: "words padded with fifty spaces each",
+			in:   strings.Repeat("word"+strings.Repeat(" ", 50), 200),
+			// 10800 bytes; o200k_base 400, cl100k_base 400, o200k_harmony 400
+			minRealTokens: 400,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := estimateCompletionTokens(tt.in); got > tt.minRealTokens {
+				t.Errorf("estimate %d exceeds real usage %d tokens: a whitespace run is not tokens", got, tt.minRealTokens)
+			}
+		})
+	}
+}

--- a/apps/edge-api/internal/inference/token_estimate_scripts_test.go
+++ b/apps/edge-api/internal/inference/token_estimate_scripts_test.go
@@ -93,6 +93,7 @@ func TestEstimateCompletionTokens_NeverOverchargesAnyScript(t *testing.T) {
 	for _, c := range scriptCases {
 		t.Run(c.name, func(t *testing.T) {
 			got := estimateCompletionTokens(repeated(c))
+			t.Logf("estimate %d, real %d, %.3f of real usage", got, c.minRealTokens, float64(got)/float64(c.minRealTokens))
 			if got > c.minRealTokens {
 				t.Errorf("estimate %d exceeds real usage %d tokens (%.2fx): an unmeasured charge must favour the customer",
 					got, c.minRealTokens, float64(got)/float64(c.minRealTokens))
@@ -305,6 +306,7 @@ func TestEstimateCompletionTokens_SeparatorRunsDoNotOvercharge(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.check(t)
+			t.Logf("%d bytes, estimate %d, real %d, %.3f of real usage", tt.wantBytes, got, tt.minRealTokens, float64(got)/float64(tt.minRealTokens))
 			if got > tt.minRealTokens {
 				t.Errorf("estimate %d exceeds real usage %d tokens (%.2fx): a separator run is not one token per twelve bytes",
 					got, tt.minRealTokens, float64(got)/float64(tt.minRealTokens))
@@ -352,21 +354,21 @@ func TestEstimateCompletionTokens_WhitespaceIsNeverFree(t *testing.T) {
 	tests := []textCase{
 		{
 			name:      "ogham space mark",
-			in:        strings.Repeat(" ", 40000),
+			in:        strings.Repeat("\u1680", 40000),
 			wantBytes: 120000,
 			// 3 bytes each; o200k_base 120000, cl100k_base 120000, o200k_harmony 120000
 			minRealTokens: 120000,
 		},
 		{
 			name:      "next line",
-			in:        strings.Repeat("", 40000),
+			in:        strings.Repeat("\u0085", 40000),
 			wantBytes: 80000,
 			// 2 bytes each; all three encodings 80000 (one token per byte)
 			minRealTokens: 80000,
 		},
 		{
 			name:      "en quad",
-			in:        strings.Repeat(" ", 20000),
+			in:        strings.Repeat("\u2000", 20000),
 			wantBytes: 60000,
 			// 3 bytes each; all three encodings 40000
 			minRealTokens: 40000,
@@ -394,21 +396,21 @@ func TestEstimateCompletionTokens_WhitespaceIsNeverFree(t *testing.T) {
 		},
 		{
 			name:      "ideographic space",
-			in:        strings.Repeat("　", 20000),
+			in:        strings.Repeat("\u3000", 20000),
 			wantBytes: 60000,
 			// 3 bytes each; o200k_base 1250, cl100k_base 10000, o200k_harmony 1250
 			minRealTokens: 1250,
 		},
 		{
 			name:      "no break space",
-			in:        strings.Repeat(" ", 20000),
+			in:        strings.Repeat("\u00a0", 20000),
 			wantBytes: 40000,
 			// 2 bytes each; all three encodings 2500
 			minRealTokens: 2500,
 		},
 		{
 			name:      "zero width space",
-			in:        strings.Repeat("​", 20000),
+			in:        strings.Repeat("\u200b", 20000),
 			wantBytes: 60000,
 			// 3 bytes each; o200k_base 5000, cl100k_base 10000, o200k_harmony 5000
 			minRealTokens: 5000,
@@ -417,6 +419,7 @@ func TestEstimateCompletionTokens_WhitespaceIsNeverFree(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.check(t)
+			t.Logf("%d bytes, estimate %d, real %d, %.3f of real usage", tt.wantBytes, got, tt.minRealTokens, float64(got)/float64(tt.minRealTokens))
 			if got*20 < tt.minRealTokens {
 				t.Errorf("estimate %d is under 5%% of real usage %d tokens (1 credit per %d real tokens): caller-controlled whitespace must not buy unbilled inference",
 					got, tt.minRealTokens, tt.minRealTokens/max64(got, 1))

--- a/apps/edge-api/internal/inference/usage_clamp.go
+++ b/apps/edge-api/internal/inference/usage_clamp.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"log"
 	"strings"
-	"unicode"
 	"unicode/utf8"
 )
 
@@ -15,23 +14,33 @@ import (
 // Unit: UTF-8 bytes, not characters. Every tokenizer our providers serve is a
 // byte-level BPE, so a token is always at least one byte ("the token sequence
 // is shorter than the bytes corresponding to the original text", tiktoken
-// README, github.com/openai/tiktoken), which makes byte length a structural
-// upper bound on the token count and character count no bound at all: measured
-// emoji cost 1.17 tokens per character, so a rune count can sit below the truth
-// by any margin. Byte length also tracks real tokenization far more evenly
-// across scripts than character count does, because a script the vocabulary
-// covers poorly degrades toward one token per byte. Measured on the eight
-// scripts in token_estimate_scripts_test.go, bytes per token spans 2.6 to 9.4
-// (3.6x) while characters per token spans 0.9 to 7.1 (7.9x). Calibrating a rune
-// divisor the same way this one is calibrated (9, clearing the sparsest script)
-// would charge English 79 percent of its real usage and Japanese 13 percent of
-// theirs, so the customer's writing system would decide their discount.
+// README, github.com/openai/tiktoken), while character count is no bound in
+// either direction: measured emoji cost 1.17 tokens per character, so a rune
+// count can sit below the truth by any margin. Byte length also tracks real
+// tokenization far more evenly across scripts than character count does,
+// because a script the vocabulary covers poorly degrades toward one token per
+// byte. Measured on the eight scripts in token_estimate_scripts_test.go, bytes
+// per token spans 2.6 to 9.0 (3.5x) while characters per token spans 0.9 to 7.1
+// (7.9x). Calibrating a rune divisor the same way this one is calibrated (9,
+// clearing the sparsest script) would charge English 79 percent of its real
+// usage and Japanese 13 percent of theirs, so the customer's writing system
+// would decide their discount.
+//
+// What byte length does NOT give is a free pass for the divisor. The structural
+// bound is only one token per byte; nothing makes real text cost a token per 12
+// bytes. Repeated punctuation blows straight through it, because the vocabulary
+// carries long single tokens for it: measured worst case across o200k_base,
+// cl100k_base and o200k_harmony, a run of spaces reaches 128 real bytes per
+// token and a run of dashes 64, so counting those runs byte for byte
+// over-charged a plain horizontal rule by 6.58x. That is what runCollapsible
+// below is for, and the calibration of 12 holds only for text once those runs
+// are collapsed.
 //
 // Value: 12, from measurement, not from a rule of thumb. Real bytes per token
 // for representative prose (tiktoken 0.13.0, o200k_base) is 7.1 for English,
 // 7.5 for Bengali, 5.4 for Arabic, 4.1 for Chinese, 3.4 for Japanese, 2.6 for
-// emoji and 9.4 for Devanagari, the sparsest of the eight. 12 clears that
-// sparsest case by about 25 percent, so the estimate lands at 21 to 79 percent
+// emoji and 9.0 for Devanagari, the sparsest of the eight. 12 clears that
+// sparsest case by about 33 percent, so the estimate lands at 21 to 79 percent
 // of real usage across all eight rather than above it.
 //
 // The 4 this replaced was the average byte-per-token ratio the tiktoken README
@@ -56,17 +65,20 @@ const bytesPerToken = 12
 // measured margins, and the tests in token_estimate_scripts_test.go for the
 // bound this must keep holding.
 //
-// Whitespace runs collapse to one byte each before counting. BPE vocabularies
-// carry multi-whitespace tokens, so 40,000 spaces is 313 real tokens, not
-// 10,000: the old formula billed a whitespace-padded prompt the entire 10,000
-// credit hold. Collapsing is the cheap way to stop a run of anything the
-// tokenizer compresses hard from dominating the estimate.
+// Runs of a character the vocabulary compresses hard are counted at one byte
+// per bytesPerToken bytes rather than byte for byte, so a run stays
+// proportional to its real cost instead of either dominating the estimate or
+// vanishing from it. See runCollapsible for the measured membership and both
+// failure modes it is pinned between.
 //
 // The result is not a lower bound for every conceivable input: BPE can compress
-// a long repeated word into one 17-byte token, so pathological text can still
-// estimate above its true count. The hold clamp in control-plane's
-// finalizeLocked (accounting/service.go) remains the backstop that keeps an
-// unconfirmed charge inside the authorization the customer already granted.
+// a long repeated word into one 17-byte token, and an alternating pair of
+// separators the vocabulary pairs up (measured: 20,000 repetitions of "-=" cost
+// 16 real bytes per token, estimated at 1.33x) is not a run, so pathological
+// text can still estimate above its true count. The hold clamp in
+// control-plane's finalizeLocked (accounting/service.go) remains the backstop
+// that keeps an unconfirmed charge inside the authorization the customer
+// already granted.
 func estimateCompletionTokens(text string) int64 {
 	if text == "" {
 		return 0
@@ -78,27 +90,88 @@ func estimateCompletionTokens(text string) int64 {
 	return n
 }
 
-// collapsedByteLen is the UTF-8 byte length of text with every run of
-// whitespace counted as a single byte. It allocates nothing, because the text
-// it is handed can be megabytes of prompt.
+// runCollapsible reports whether a run of r repeated is compressed hard enough
+// by real tokenizers that counting the run at full byte length would
+// over-charge. Membership is measured, never intuited: it is exactly the runes
+// whose worst-case real bytes per token for a long run reaches bytesPerToken or
+// more (tiktoken 0.13.0, worst of o200k_base, cl100k_base and o200k_harmony,
+// runs from 1e3 to 2e5 bytes, where the ratio saturates):
+//
+//	' ' 128 | '-' '=' '_' '/' '.' '*' '#' 64 | U+3000 48 | '\n' 32
+//	'%' '+' '~' 32 | '\t' ';' U+00A0 16 | U+200B 12
+//
+// Everything else is counted at full byte length, because it already costs a
+// token per 12 bytes or fewer and the plain estimate therefore under-counts it:
+// ':' '!' '<' '>' at 8, '|' ',' '(' ')' '$' '\\' '?' '@' '^' at 4, '{' '}' '['
+// ']' '&' and both quotes at 2, U+2000 U+205F U+2029 at 1.5, and every ASCII
+// control byte plus U+0085 next line and U+1680 ogham space mark at one real
+// token per byte.
+//
+// That last group is why this is not the simpler test it looks like it should
+// be. Collapsing whitespace by the Unicode White_Space property gives away real
+// inference: U+1680 and U+0085 cost a provider token per byte while collapsing
+// to nothing, and restricting the collapse to ASCII whitespace does not fix it,
+// because U+000B vertical tab and U+000C form feed are ASCII whitespace and also
+// cost a token per byte. Testing for non-alphanumeric instead over-collapses in
+// the same way. Membership has to follow the measured compression ratio, and
+// nothing else: the two directions are a vice, and a rule that is not measured
+// escapes it on one side or the other. Letters and digits are absent because
+// they are measured too: the longest same-byte run of one costs 8 real bytes per
+// token or fewer, so they need no collapse.
+//
+// ponytail: a fixed measured set, re-measure it (not just the divisor) if we
+// onboard a tokenizer outside the o200k and cl100k families. Deriving the set at
+// runtime would mean shipping a tokenizer into the settlement path, which is
+// several orders more machinery than a fallback estimate deserves.
+func runCollapsible(r rune) bool {
+	switch r {
+	case ' ', '\t', '\n',
+		'-', '=', '_', '/', '.', '*', '#', '%', '+', '~', ';',
+		'\u00a0', '\u200b', '\u3000': // NBSP, zero width space, ideographic space
+		return true
+	}
+	return false
+}
+
+// collapsedByteLen is the UTF-8 byte length of text, except that every run of a
+// repeated runCollapsible rune contributes one byte per bytesPerToken bytes of
+// the run instead of its full length. It allocates nothing, because the text it
+// is handed can be megabytes of prompt.
+//
+// One byte per bytesPerToken bytes is the calibration, not a round number: it
+// makes a pure run cost bytesPerToken squared, 144 bytes per estimated token,
+// which clears the sparsest measured run (128 real bytes per token, for spaces)
+// with about 12 percent of headroom. Dividing by less would over-charge a
+// space-padded prompt; collapsing a run to a single byte the way this used to
+// makes the charge independent of the run's length, which is the shape that
+// hands out unbilled inference.
+//
+// A run is one repeated rune, not any stretch of collapsible ones. A mixed
+// stretch can be an adversarial alternation the vocabulary does not compress at
+// all ("~;" repeated costs one real token per byte), so collapsing mixed
+// stretches would reopen the give-up this closes.
 func collapsedByteLen(text string) int {
 	n := 0
-	inSpace := true // leading whitespace contributes nothing
 	for i := 0; i < len(text); {
 		// DecodeRuneInString rather than range plus utf8.RuneLen: RuneLen
 		// reports 3 for the replacement rune a malformed byte decodes to, which
 		// would count invalid input as larger than it is.
 		r, size := utf8.DecodeRuneInString(text[i:])
 		i += size
-		if unicode.IsSpace(r) {
-			if !inSpace {
-				n++
-				inSpace = true
-			}
+		if !runCollapsible(r) {
+			n += size
 			continue
 		}
-		inSpace = false
-		n += size
+		runBytes := size
+		for i < len(text) {
+			next, nextSize := utf8.DecodeRuneInString(text[i:])
+			if next != r {
+				break
+			}
+			runBytes += nextSize
+			i += nextSize
+		}
+		n += (runBytes + bytesPerToken - 1) / bytesPerToken
 	}
 	return n
 }

--- a/apps/edge-api/internal/inference/usage_clamp.go
+++ b/apps/edge-api/internal/inference/usage_clamp.go
@@ -73,9 +73,12 @@ const bytesPerToken = 12
 //
 // The result is not a lower bound for every conceivable input: BPE can compress
 // a long repeated word into one 17-byte token, and an alternating pair of
-// separators the vocabulary pairs up (measured: 20,000 repetitions of "-=" cost
-// 16 real bytes per token, estimated at 1.33x) is not a run, so pathological
-// text can still estimate above its true count. The hold clamp in
+// separators the vocabulary pairs up is not a run, so pathological text can
+// still estimate above its true count. That alternation case has a measured
+// ceiling: sweeping every two-rune alternation over the collapsible members plus
+// '|' at 8,000 repetitions, the worst is "=-" and "+-" at 16 real bytes per
+// token, estimated at 1.33x, and completing the member set did not move it
+// because an alternation is never collapsed either way. The hold clamp in
 // control-plane's finalizeLocked (accounting/service.go) remains the backstop
 // that keeps an unconfirmed charge inside the authorization the customer
 // already granted.
@@ -93,19 +96,31 @@ func estimateCompletionTokens(text string) int64 {
 // runCollapsible reports whether a run of r repeated is compressed hard enough
 // by real tokenizers that counting the run at full byte length would
 // over-charge. Membership is measured, never intuited: it is exactly the runes
-// whose worst-case real bytes per token for a long run reaches bytesPerToken or
-// more (tiktoken 0.13.0, worst of o200k_base, cl100k_base and o200k_harmony,
-// runs from 1e3 to 2e5 bytes, where the ratio saturates):
+// whose real bytes per token for a long run reaches bytesPerToken or more
+// (tiktoken 0.13.0, runs from 6e3 to 2.4e4 runes, where the ratio saturates).
 //
-//	' ' 128 | '-' '=' '_' '/' '.' '*' '#' 64 | U+3000 48 | '\n' 32
-//	'%' '+' '~' 32 | '\t' ';' U+00A0 16 | U+200B 12
+// The statistic is the LARGEST bytes per token of o200k_base, cl100k_base and
+// o200k_harmony, which is the same as the SMALLEST token count. That choice is
+// the whole correctness argument: the smallest count is the number the charge is
+// compared against, so a member cannot over-charge on any of the three. Using
+// the smallest bytes per token instead only collapses a run when every encoding
+// compresses it, which is what first left nine over-charging runes out of this
+// switch, U+2500 among them.
+//
+// Measured members, with the ratio that earns each one:
+//
+//	' ' 128 | '-' '=' '_' '/' '.' '*' '#' '%' 64
+//	U+2014 U+2026 U+2500 U+25A1 U+3000 48 | U+2501 U+2550 24
+//	'\n' '+' '~' 32 | '\t' ';' '!' ':' 'X' U+00A0 16
+//	U+2013 U+200B U+2588 U+2605 U+2640 U+30FB U+30FC U+FF01 U+FF0A U+FF1D 12
 //
 // Everything else is counted at full byte length, because it already costs a
-// token per 12 bytes or fewer and the plain estimate therefore under-counts it:
-// ':' '!' '<' '>' at 8, '|' ',' '(' ')' '$' '\\' '?' '@' '^' at 4, '{' '}' '['
-// ']' '&' and both quotes at 2, U+2000 U+205F U+2029 at 1.5, and every ASCII
-// control byte plus U+0085 next line and U+1680 ogham space mark at one real
-// token per byte.
+// token per 12 bytes or fewer and the plain estimate therefore under-counts it.
+// The closest exclusions measure 8: '<' '>' '?' '@' '^' ',' U+00AF and the
+// letters a f l o x A F. Then '|' '(' ')' '$' '\\' at 4, '{' '}' '[' ']' '&' and
+// both quotes at 2, U+2000 U+205F U+2029 at 1.5, U+2028 U+202F at 3, and every
+// ASCII control byte plus U+0085 next line and U+1680 ogham space mark at one
+// real token per byte.
 //
 // That last group is why this is not the simpler test it looks like it should
 // be. Collapsing whitespace by the Unicode White_Space property gives away real
@@ -113,11 +128,27 @@ func estimateCompletionTokens(text string) int64 {
 // to nothing, and restricting the collapse to ASCII whitespace does not fix it,
 // because U+000B vertical tab and U+000C form feed are ASCII whitespace and also
 // cost a token per byte. Testing for non-alphanumeric instead over-collapses in
-// the same way. Membership has to follow the measured compression ratio, and
-// nothing else: the two directions are a vice, and a rule that is not measured
-// escapes it on one side or the other. Letters and digits are absent because
-// they are measured too: the longest same-byte run of one costs 8 real bytes per
-// token or fewer, so they need no collapse.
+// the same way, and would also miss 'X', which is a member because a run of it
+// measures 16. Membership has to follow the measured ratio and nothing else: the
+// two directions are a vice, and a rule that is not measured escapes it on one
+// side or the other.
+//
+// Cost of the conservative statistic, stated rather than hidden: for a rune
+// whose ratio splits across encodings, the collapse gives up more against the
+// encoding that splits the run. U+25A1 is the widest, 48 bytes per token on
+// o200k_base and o200k_harmony but 1.5 on cl100k_base, so a pure run of it pays
+// about 1 percent of what a cl100k-family model would count. That is the
+// customer-favouring direction, it is bounded by the route's context window, and
+// it buys the removal of a 2.5x over-charge on output models emit routinely.
+//
+// Families swept to build this list, each rune measured, not assumed: ASCII
+// printable including letters and digits, Latin-1 punctuation and symbols,
+// general punctuation U+2000 to U+206F, arrows, math operators, box drawing,
+// block elements, geometric shapes, miscellaneous symbols, dingbats, CJK symbols
+// and punctuation, katakana, halfwidth and fullwidth forms, the invisible format
+// characters, and a sample of the emoji a model repeats to draw a bar. The
+// measured rows live in token_estimate_scripts_test.go, which also fails if this
+// switch ever collapses a rune with no row.
 //
 // ponytail: a fixed measured set, re-measure it (not just the divisor) if we
 // onboard a tokenizer outside the o200k and cl100k families. Deriving the set at
@@ -127,7 +158,13 @@ func runCollapsible(r rune) bool {
 	switch r {
 	case ' ', '\t', '\n',
 		'-', '=', '_', '/', '.', '*', '#', '%', '+', '~', ';',
-		'\u00a0', '\u200b', '\u3000': // NBSP, zero width space, ideographic space
+		'!', ':', 'X',
+		'\u00a0', '\u200b', '\u3000', // NBSP, zero width space, ideographic space
+		'\u2013', '\u2014', '\u2026', // en dash, em dash, horizontal ellipsis
+		'\u2500', '\u2501', '\u2550', // box drawings light, heavy, double horizontal
+		'\u2588', '\u25a1', '\u2605', '\u2640', // full block, white square, black star, female sign
+		'\u30fb', '\u30fc', // katakana middle dot, prolonged sound mark
+		'\uff01', '\uff0a', '\uff1d': // fullwidth exclamation, asterisk, equals
 		return true
 	}
 	return false

--- a/apps/edge-api/internal/inference/usage_clamp.go
+++ b/apps/edge-api/internal/inference/usage_clamp.go
@@ -4,22 +4,101 @@ import (
 	"encoding/json"
 	"log"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 )
 
-// estimateCompletionTokens returns a conservative cl100k-style approximation
-// of the token count for a piece of text. The exact formula does not matter —
-// it only kicks in when the upstream provider returns completion_tokens=0 on
-// a non-empty assistant message, which is a billing-leak case (see git
-// history for the flaky-usage-tokens root-cause debug notes).
+// bytesPerToken is the divisor estimateCompletionTokens uses. It is calibrated
+// to UNDER-count real tokenization for every writing system, because the number
+// it produces is charged to a customer for usage nobody measured (issue #673).
 //
-// Heuristic: ceil(byte_len / 4), with a minimum of 1 when there is any text.
+// Unit: UTF-8 bytes, not characters. Every tokenizer our providers serve is a
+// byte-level BPE, so a token is always at least one byte ("the token sequence
+// is shorter than the bytes corresponding to the original text", tiktoken
+// README, github.com/openai/tiktoken), which makes byte length a structural
+// upper bound on the token count and character count no bound at all: measured
+// emoji cost 1.17 tokens per character, so a rune count can sit below the truth
+// by any margin. Byte length also tracks real tokenization far more evenly
+// across scripts than character count does, because a script the vocabulary
+// covers poorly degrades toward one token per byte. Measured on the eight
+// scripts in token_estimate_scripts_test.go, bytes per token spans 2.6 to 9.4
+// (3.6x) while characters per token spans 0.9 to 7.1 (7.9x). Calibrating a rune
+// divisor the same way this one is calibrated (9, clearing the sparsest script)
+// would charge English 79 percent of its real usage and Japanese 13 percent of
+// theirs, so the customer's writing system would decide their discount.
+//
+// Value: 12, from measurement, not from a rule of thumb. Real bytes per token
+// for representative prose (tiktoken 0.13.0, o200k_base) is 7.1 for English,
+// 7.5 for Bengali, 5.4 for Arabic, 4.1 for Chinese, 3.4 for Japanese, 2.6 for
+// emoji and 9.4 for Devanagari, the sparsest of the eight. 12 clears that
+// sparsest case by about 25 percent, so the estimate lands at 21 to 79 percent
+// of real usage across all eight rather than above it.
+//
+// The 4 this replaced was the average byte-per-token ratio the tiktoken README
+// quotes ("on average, in practice, each token corresponds to about 4 bytes").
+// An average is the wrong statistic for a figure that must never exceed the
+// truth: measured against o200k_base it overcharged six of the eight scripts,
+// English by 1.77x, Bengali by 1.87x and Devanagari by 2.36x.
+//
+// ponytail: one global divisor, recalibrate if we onboard a tokenizer
+// materially more efficient than o200k_base on Devanagari (the thinnest margin
+// here at 0.79 of real). A per-script divisor would tighten the 21-to-79 band
+// but needs a rune classifier and re-measurement per script, and every error it
+// would remove is currently in the customer's favour.
+const bytesPerToken = 12
+
+// estimateCompletionTokens approximates the token count of a piece of text for
+// settlement paths where the provider reported no usable usage: a missing usage
+// block (issue #636) or completion_tokens=0 on a non-empty message.
+//
+// It errs low by construction, and that direction is deliberate: the estimate is
+// billed, so any error has to favour the customer. See bytesPerToken for the
+// measured margins, and the tests in token_estimate_scripts_test.go for the
+// bound this must keep holding.
+//
+// Whitespace runs collapse to one byte each before counting. BPE vocabularies
+// carry multi-whitespace tokens, so 40,000 spaces is 313 real tokens, not
+// 10,000: the old formula billed a whitespace-padded prompt the entire 10,000
+// credit hold. Collapsing is the cheap way to stop a run of anything the
+// tokenizer compresses hard from dominating the estimate.
+//
+// The result is not a lower bound for every conceivable input: BPE can compress
+// a long repeated word into one 17-byte token, so pathological text can still
+// estimate above its true count. The hold clamp in control-plane's
+// finalizeLocked (accounting/service.go) remains the backstop that keeps an
+// unconfirmed charge inside the authorization the customer already granted.
 func estimateCompletionTokens(text string) int64 {
 	if text == "" {
 		return 0
 	}
-	n := int64((len(text) + 3) / 4)
+	n := int64((collapsedByteLen(text) + bytesPerToken - 1) / bytesPerToken)
 	if n < 1 {
 		return 1
+	}
+	return n
+}
+
+// collapsedByteLen is the UTF-8 byte length of text with every run of
+// whitespace counted as a single byte. It allocates nothing, because the text
+// it is handed can be megabytes of prompt.
+func collapsedByteLen(text string) int {
+	n := 0
+	inSpace := true // leading whitespace contributes nothing
+	for i := 0; i < len(text); {
+		// DecodeRuneInString rather than range plus utf8.RuneLen: RuneLen
+		// reports 3 for the replacement rune a malformed byte decodes to, which
+		// would count invalid input as larger than it is.
+		r, size := utf8.DecodeRuneInString(text[i:])
+		i += size
+		if unicode.IsSpace(r) {
+			if !inSpace {
+				n++
+				inSpace = true
+			}
+			continue
+		}
+		inSpace = false
+		n += size
 	}
 	return n
 }

--- a/apps/edge-api/internal/inference/usage_clamp.go
+++ b/apps/edge-api/internal/inference/usage_clamp.go
@@ -141,7 +141,7 @@ func runCollapsible(r rune) bool {
 // One byte per bytesPerToken bytes is the calibration, not a round number: it
 // makes a pure run cost bytesPerToken squared, 144 bytes per estimated token,
 // which clears the sparsest measured run (128 real bytes per token, for spaces)
-// with about 12 percent of headroom. Dividing by less would over-charge a
+// with about 12 percent of headroom. Any divisor under 11 would over-charge a
 // space-padded prompt; collapsing a run to a single byte the way this used to
 // makes the charge independent of the run's length, which is the shape that
 // hands out unbilled inference.

--- a/apps/edge-api/internal/inference/usage_clamp_test.go
+++ b/apps/edge-api/internal/inference/usage_clamp_test.go
@@ -8,6 +8,10 @@ import (
 func ptrStr(s string) *string { return &s }
 
 func TestEstimateCompletionTokens(t *testing.T) {
+	// These pin the floor and the shape of the formula only. Everything that
+	// matters about the arithmetic is asserted in token_estimate_scripts_test.go
+	// at thousands of tokens, because the 1-credit floor below swallows any
+	// mispricing at this size (issue #673).
 	tests := []struct {
 		name string
 		in   string
@@ -16,10 +20,12 @@ func TestEstimateCompletionTokens(t *testing.T) {
 		{"empty", "", 0},
 		{"single char", "x", 1},
 		{"three chars", "abc", 1},
-		{"four chars", "abcd", 1},
-		{"five chars", "abcde", 2},
-		{"hello world", "hello world", 3},
-		{"long sentence", "The quick brown fox jumps over the lazy dog", 11},
+		{"twelve bytes is one token", "abcdefghijkl", 1},
+		{"thirteen bytes rounds up", "abcdefghijklm", 2},
+		{"hello world", "hello world", 1},
+		{"long sentence", "The quick brown fox jumps over the lazy dog", 4},
+		{"whitespace only floors at one, never zero", "          ", 1},
+		{"a whitespace run counts as one byte", "a" + strings.Repeat(" ", 100) + "b", 1},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/apps/edge-api/internal/inference/usage_clamp_test.go
+++ b/apps/edge-api/internal/inference/usage_clamp_test.go
@@ -25,7 +25,9 @@ func TestEstimateCompletionTokens(t *testing.T) {
 		{"hello world", "hello world", 1},
 		{"long sentence", "The quick brown fox jumps over the lazy dog", 4},
 		{"whitespace only floors at one, never zero", "          ", 1},
-		{"a whitespace run counts as one byte", "a" + strings.Repeat(" ", 100) + "b", 1},
+		{"a whitespace run costs one byte per twelve", "a" + strings.Repeat(" ", 100) + "b", 1},
+		{"a separator run costs one byte per twelve", "a" + strings.Repeat("-", 100) + "b", 1},
+		{"a control byte run is counted in full", strings.Repeat("\v", 100), 9},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #673. The unconfirmed-usage estimator charged `ceil(byte_len / 4)` credits when a provider returned no usable usage. That divisor is the *average* byte per token ratio the tiktoken README quotes, and an average is the wrong statistic for a number that is billed to a customer for usage nobody measured. Measured with tiktoken 0.13.0 it overcharged six of eight writing systems.

The divisor is now **12 bytes per token**, and runs of whitespace collapse to one byte before counting. Every one of the eight scripts now lands **below** its real token count, and English and Bengali are charged within 6 percent of the same fraction of real usage.

## The same sentence, before and after

`Artificial intelligence is changing how businesses work in Bangladesh.` and its Bengali translation, charged in credits (this path bills one credit per token today).

| | chars | bytes | before | after | real tokens (o200k_base) | before vs real | after vs real |
|---|---|---|---|---|---|---|---|
| English, one sentence | 70 | 70 | 18 | 6 | 10 | 1.80x | 0.60x |
| Bengali, one sentence | 65 | 179 | 45 | 15 | 24 | 1.88x | 0.63x |
| English, 60 copies | 4260 | 4260 | 1065 | 355 | 601 | 1.77x | 0.59x |
| Bengali, 60 copies | 3960 | 10800 | 2700 | 900 | 1441 | 1.87x | 0.62x |

The 60-copy rows are the ones that prove anything. At `CreditsPerUSD = 100_000` the 1-credit floor hides any amount of mispricing at single-sentence size, so every assertion in the new test is sized in thousands of tokens.

## Every script, measured

`minRealTokens` is the smallest count across `o200k_base`, `cl100k_base` and `o200k_harmony` for 60 copies of the sentence. The smallest is the binding reference: an estimate at or below it cannot overcharge on any of the three. `o200k_harmony` is the tokenizer of the gpt-oss model the `hive-fast` alias pins to under D-032, so this is not a hypothetical tokenizer family.

| script | min real | before | after | before vs real | after vs real |
|---|---|---|---|---|---|
| Latin (English) | 601 | 1065 | 355 | **1.77x** | 0.59x |
| Bengali | 1441 | 2700 | 900 | **1.87x** | 0.62x |
| Chinese | 900 | 915 | 305 | **1.02x** | 0.34x |
| Japanese | 1620 | 1365 | 455 | 0.84x | 0.28x |
| Korean | 1261 | 1380 | 460 | **1.09x** | 0.36x |
| Arabic | 1081 | 1455 | 485 | **1.35x** | 0.45x |
| Devanagari (Hindi) | 1322 | 3120 | 1040 | **2.36x** | 0.79x |
| Emoji, including a ZWJ family sequence and a flag | 1261 | 810 | 270 | 0.64x | 0.21x |

And the worst-case input the issue names:

| input | real tokens | before | after |
|---|---|---|---|
| 40,000 spaces | 313 | 10,000 (the entire hold) | 1 |
| 1,000 newlines | 32 | 250 | 1 |
| `word` padded to 54 bytes, 200 times | 400 | 2700 | 84 |

Reproduce any figure with:

```
pip install tiktoken==0.13.0
python -c 'import tiktoken; print(len(tiktoken.get_encoding("o200k_base").encode(SENTENCE * 60)))'
```

## Why the unit stays UTF-8 bytes

The issue proposed counting runes. Measurement says that is the worse of the two, and the reason the byte-per-character skew looked indefensible is that the per-character token rate genuinely does differ by script.

1. **Byte length is a structural bound on the token count; character count is no bound at all.** Every tokenizer our providers serve is a byte-level BPE, and per the tiktoken README "the token sequence is shorter than the bytes corresponding to the original text", so tokens are always at most bytes. Measured emoji cost 1.17 tokens per character, so a rune count can sit below the truth by any margin.
2. **Bytes track real tokenization more evenly across scripts than characters do.** Across the eight scripts above, bytes per token spans 2.6 to 9.4 (3.6x); characters per token spans 0.9 to 7.1 (7.9x). A script the vocabulary covers poorly degrades toward one token per byte, which is exactly why byte length keeps up and character count does not.
3. **A rune-based estimate calibrated the same way would be less fair, not more.** Clearing the sparsest script needs 9 characters per token, which charges English 79 percent of its real usage and Japanese 13 percent of theirs. The customer's writing system would then decide their discount, which is the same defect in the opposite direction.
4. **Bengali really does consume about 2.6x the tokens per character English does** (0.36 against 0.14, o200k_base). The issue flagged this as unmeasured. It is now measured, and the 3x per-character rate the byte formula assigned to Bengali was approximately correct. What was actually broken was the divisor.

## The bound this holds to, and one deliberate deviation

The stated bound is on **the fraction of true usage each script is charged**, not on the raw charge for semantically identical content, and this is a deliberate departure from the bound as originally framed. Real tokenizers are not script-neutral: the same sentence costs 601 tokens in English and 1441 in Bengali on o200k_base. Equal raw charges would therefore require deliberately mispricing one of them by 2.4x, and to also never overcharge it would have to anchor everyone at the cheapest script, which cross-subsidizes non-Latin content out of Latin content rather than pricing either correctly.

What is asserted instead, in `TestEstimateCompletionTokens_ChargeParityAcrossScripts`:

- Bengali is charged within 10 percent of the fraction of real usage English is charged. Measured: English 59 percent, Bengali 62 percent, so 6 percent apart.
- The spread across English, Bengali and Chinese is at most 2x. Measured 1.8x, with Chinese the cheapest at 34 percent.
- No script exceeds 100 percent of real usage. This is the clause that was red before the fix, at 177, 187 and 101 percent.

That assertion is invariant to the divisor, because both ratios are linear in it. It therefore tests the *unit* the estimator counts in, which is what #673 is about, and a rune-based implementation fails it at 61 percent apart. If the owner prefers equal raw charges across languages (a cross-subsidy toward non-Latin scripts) that is a policy call, and the measurements to calibrate it are in the test file.

## Invariants honoured

- **Errs low, proven not asserted.** The direction of the error is a table-driven assertion against measured tokenizer output for eight scripts, not a comment. The stale comments claiming the old formula erred low are corrected, which was option 3 of the issue.
- **Never zero either.** The estimate is floored at 1 credit and asserted to stay above 15 percent of real usage for every script. Free inference on provider-controlled input is the failure mode that took billing down for three days, so erring low must not become erring to nothing.
- **The hold clamp is untouched.** `accounting/service.go:288` still clamps unconfirmed settlements to the reservation hold. It remains the backstop, and it is still needed: BPE can compress a long repeated word into one 17-byte token, so no length heuristic is a lower bound for *every* input. What changed is that the estimate is now defensible on its own for real content instead of relying on the clamp.
- **One terminal state per reservation.** No settlement, release or context handling is touched. No new call sites, no shared contexts, no second finalize.
- **No error classification added.** No string matching on failures; the reservation path's `errors.As` on `StatusError.StatusCode` is untouched.
- **Root cause, not the reported symptom.** The change is in `estimateCompletionTokens`, the single function all three consumers route through, so the missing usage block path (#636), the `completion_tokens=0` clamp and the stream settlement estimate are corrected together. The clamp path mattered most: it rewrites the customer-visible `usage` block and is then billed as *confirmed*, past the hold clamp, so the byte formula's overcharge reached a surface the issue did not name.
- **No customer-visible provider names or USD.** Nothing here touches a response surface except `usage.completion_tokens`, which now moves down.

## Test plan

Red first. `apps/edge-api/internal/inference/token_estimate_scripts_test.go` fails on the pre-fix formula for six scripts, the parity clause and all three whitespace cases:

```
--- FAIL: TestEstimateCompletionTokens_NeverOverchargesAnyScript/bengali
    estimate 2700 exceeds real usage 1441 tokens (1.87x): an unmeasured charge must favour the customer
--- FAIL: TestEstimateCompletionTokens_NeverOverchargesAnyScript/devanagari
    estimate 3120 exceeds real usage 1322 tokens (2.36x): an unmeasured charge must favour the customer
--- FAIL: TestEstimateCompletionTokens_WhitespaceRunsDoNotInflate/forty_thousand_spaces
    estimate 10000 exceeds real usage 313 tokens: a whitespace run is not tokens
```

Then green.

```
cd deploy/docker && docker compose --profile tools run toolchain \
  "cd /workspace && go test ./apps/edge-api/... -count=1 -short"
```

Full `./apps/edge-api/...` suite green, 25 packages. `gofmt` and `go vet` clean on every changed file. Two existing tests were retuned to the new divisor: `TestEstimateCompletionTokens`'s small-string table, and the `#636` sync fixture, whose no-usage response grew from 4,000 to 12,000 bytes so its assertion stays in the thousands of tokens where it proves something (1003 credits becomes 1001).

## Not in this PR

- `internal/rag/chunk.go` uses a 4-characters-per-token approximation for chunk sizing. It is not a money path, nothing is billed from it, and changing chunk sizes would change retrieval behaviour, so it is left alone.
- Per-script divisors. They would tighten the 21-to-79 percent band, but they need a rune classifier plus per-script re-measurement, and every error they would remove is currently in the customer's favour.
- No `.wolf/buglog.jsonl` entry: that file is main-agent territory, and every branch that appends to it conflicts on GitHub's server-side merge.

No UI surface is touched, so no visual proof applies. This is server-side settlement arithmetic.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved completion usage estimates across multilingual text, formatting, whitespace, and Unicode content.
  * Reduced overestimation risk while preserving minimum charges for non-empty responses.
  * Corrected settlement totals for responses without reported usage.

* **Tests**
  * Added comprehensive coverage for token estimation across scripts, whitespace patterns, and formatted output.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->