### PR TITLE
fix: switch route-groq-fast to the cheapest available Groq model

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -135,8 +135,10 @@ OPENROUTER_FAST_FALLBACK_MODEL=openrouter/free
 OPENROUTER_EMBEDDING_MODEL=openrouter/nvidia/llama-nemotron-embed-vl-1b-v2:free
 OPENROUTER_EMBEDDING_FALLBACK_MODEL=openrouter/qwen/qwen3-embedding-8b
 
-# Groq free chat/reasoning models (gpt-oss-20b primary, 120b reasoning).
-GROQ_FAST_MODEL=groq/openai/gpt-oss-20b
+# Groq free chat/reasoning models (llama-3.1-8b-instant primary, cheapest
+# Groq model as of 2026-08-03: $0.05 in / $0.08 out per million tokens vs
+# gpt-oss-20b's $0.075 / $0.30; 120b reasoning unchanged).
+GROQ_FAST_MODEL=groq/llama-3.1-8b-instant
 GROQ_REASONING_MODEL=groq/openai/gpt-oss-120b
 
 # ─── RAG query embeddings (issue #232) ──────────────────────────────

--- a/.github/workflows/owui-nightly.yml
+++ b/.github/workflows/owui-nightly.yml
@@ -175,7 +175,7 @@ jobs:
           OPENROUTER_AUTO_MODEL=openrouter/free
           OPENROUTER_EMBEDDING_MODEL=openrouter/nvidia/llama-nemotron-embed-vl-1b-v2:free
           OPENROUTER_EMBEDDING_FALLBACK_MODEL=openrouter/qwen/qwen3-embedding-8b
-          GROQ_FAST_MODEL=groq/openai/gpt-oss-20b
+          GROQ_FAST_MODEL=groq/llama-3.1-8b-instant
           GROQ_REASONING_MODEL=groq/openai/gpt-oss-120b
           NEXT_PUBLIC_SUPABASE_URL=${NEXT_PUBLIC_SUPABASE_URL:-$SUPABASE_URL}
           NEXT_PUBLIC_SUPABASE_ANON_KEY=${NEXT_PUBLIC_SUPABASE_ANON_KEY:-$SUPABASE_ANON_KEY}

--- a/apps/control-plane/internal/routing/catalog_pricing_integration_test.go
+++ b/apps/control-plane/internal/routing/catalog_pricing_integration_test.go
@@ -10,7 +10,8 @@ package routing
 //
 // Prerequisites:
 //   - A Postgres database with the FULL supabase/migrations chain applied,
-//     including 20260801_01_alias_pricing_correction.sql.
+//     including 20260801_01_alias_pricing_correction.sql and
+//     20260801_14_route_groq_fast_cheapest_model.sql.
 //   - ROUTING_TEST_DB_URL pointing at it.
 //
 // Run with:
@@ -124,11 +125,12 @@ func TestSeededAliasHasExactlyOneEnabledRoute(t *testing.T) {
 
 // TestHiveFastIsPinnedToGroqAtCorrectedPrice is requirement (c) at the data
 // level. The expected credit figures are derived by hand from Groq's
-// published rate for openai/gpt-oss-20b so a later price change has to fail
-// this test and be re-derived rather than drift silently:
+// published rate for llama-3.1-8b-instant (20260801_14_route_groq_fast_cheapest_model.sql,
+// the cheapest available Groq model as of 2026-08-03) so a later price change
+// has to fail this test and be re-derived rather than drift silently:
 //
-//	input:  0.075 USD/M * 1.4 = 0.105 USD/M * 100_000 credits/USD = 10_500
-//	output: 0.300 USD/M * 1.4 = 0.420 USD/M * 100_000 credits/USD = 42_000
+//	input:  0.05 USD/M * 1.4 = 0.070 USD/M * 100_000 credits/USD =  7_000
+//	output: 0.08 USD/M * 1.4 = 0.112 USD/M * 100_000 credits/USD = 11_200
 func TestHiveFastIsPinnedToGroqAtCorrectedPrice(t *testing.T) {
 	pool := connectCatalogDB(t)
 
@@ -144,8 +146,8 @@ func TestHiveFastIsPinnedToGroqAtCorrectedPrice(t *testing.T) {
 	if provider != "groq" {
 		t.Errorf("hive-fast provider = %q, want groq", provider)
 	}
-	if providerModel != "groq/openai/gpt-oss-20b" {
-		t.Errorf("hive-fast provider_model = %q, want groq/openai/gpt-oss-20b", providerModel)
+	if providerModel != "groq/llama-3.1-8b-instant" {
+		t.Errorf("hive-fast provider_model = %q, want groq/llama-3.1-8b-instant", providerModel)
 	}
 
 	var input, output int64
@@ -155,11 +157,11 @@ func TestHiveFastIsPinnedToGroqAtCorrectedPrice(t *testing.T) {
 	`).Scan(&input, &output); err != nil {
 		t.Fatalf("read hive-fast pricing: %v", err)
 	}
-	if input != 10_500 {
-		t.Errorf("hive-fast input_price_credits = %d, want 10500", input)
+	if input != 7_000 {
+		t.Errorf("hive-fast input_price_credits = %d, want 7000", input)
 	}
-	if output != 42_000 {
-		t.Errorf("hive-fast output_price_credits = %d, want 42000", output)
+	if output != 11_200 {
+		t.Errorf("hive-fast output_price_credits = %d, want 11200", output)
 	}
 }
 

--- a/apps/control-plane/internal/routing/service_test.go
+++ b/apps/control-plane/internal/routing/service_test.go
@@ -36,7 +36,7 @@ type stubRepository struct {
 // a stub left at its zero value would make every fixture that does not care
 // about price fail closed for the wrong reason. Tests that do care set
 // pricing explicitly, or set unpriced.
-var defaultStubPricing = catalog.CatalogPricing{InputPriceCredits: 10_500, OutputPriceCredits: 42_000}
+var defaultStubPricing = catalog.CatalogPricing{InputPriceCredits: 7_000, OutputPriceCredits: 11_200}
 
 func (s *stubRepository) LoadAliasPolicy(_ context.Context, _ string) (catalog.AliasPolicySnapshot, error) {
 	s.loadPolicyCalls++
@@ -997,7 +997,9 @@ func TestSelectRouteSkipsPricingLookupOnEarlyRefusal(t *testing.T) {
 
 // TestSelectRouteHiveFastResolvesToGroqAtGroqPrice is requirement (c) of the
 // issue #617 correction, at the code level: with hive-fast reduced to its
-// single enabled route (Groq openai/gpt-oss-20b), SelectRoute must resolve
+// single enabled route (Groq llama-3.1-8b-instant, the cheapest available
+// Groq model as of 2026-08-03 per
+// 20260801_14_route_groq_fast_cheapest_model.sql), SelectRoute must resolve
 // that route, offer no fallback, and carry the Groq-derived price.
 //
 // The route shape here mirrors what
@@ -1020,7 +1022,7 @@ func TestSelectRouteHiveFastResolvesToGroqAtGroqPrice(t *testing.T) {
 				RouteID:                 "route-groq-fast",
 				AliasID:                 "hive-fast",
 				Provider:                "groq",
-				ProviderModel:           "groq/openai/gpt-oss-20b",
+				ProviderModel:           "groq/llama-3.1-8b-instant",
 				LiteLLMModelName:        "route-groq-fast",
 				PriceClass:              "standard",
 				HealthState:             "healthy",
@@ -1039,8 +1041,8 @@ func TestSelectRouteHiveFastResolvesToGroqAtGroqPrice(t *testing.T) {
 				SupportsChatCompletions: true,
 			},
 		},
-		// 0.075 in / 0.30 out USD per million * 1.4 * CreditsPerUSD (100_000).
-		pricing: catalog.CatalogPricing{InputPriceCredits: 10_500, OutputPriceCredits: 42_000},
+		// 0.05 in / 0.08 out USD per million * 1.4 * CreditsPerUSD (100_000).
+		pricing: catalog.CatalogPricing{InputPriceCredits: 7_000, OutputPriceCredits: 11_200},
 	}
 
 	svc := NewService(repo, &stubEntitlements{visible: true})
@@ -1063,10 +1065,10 @@ func TestSelectRouteHiveFastResolvesToGroqAtGroqPrice(t *testing.T) {
 	if len(result.FallbackRouteIDs) != 0 {
 		t.Fatalf("expected no fallback routes, got %v", result.FallbackRouteIDs)
 	}
-	if result.Pricing.InputPriceCredits != 10_500 {
-		t.Fatalf("expected input price 10500, got %d", result.Pricing.InputPriceCredits)
+	if result.Pricing.InputPriceCredits != 7_000 {
+		t.Fatalf("expected input price 7000, got %d", result.Pricing.InputPriceCredits)
 	}
-	if result.Pricing.OutputPriceCredits != 42_000 {
-		t.Fatalf("expected output price 42000, got %d", result.Pricing.OutputPriceCredits)
+	if result.Pricing.OutputPriceCredits != 11_200 {
+		t.Fatalf("expected output price 11200, got %d", result.Pricing.OutputPriceCredits)
 	}
 }

--- a/apps/edge-api/internal/metering/precedence_test.go
+++ b/apps/edge-api/internal/metering/precedence_test.go
@@ -254,12 +254,14 @@ func TestPriceEstimate_LegacyIsFlatTokenSum(t *testing.T) {
 // the test -- it has to fail and be re-derived.
 
 // correctedHiveFast mirrors the post-migration public.model_aliases row for
-// hive-fast: Groq openai/gpt-oss-20b at 0.075 in / 0.30 out USD per million,
-// times the 1.4 margin multiplier, times CreditsPerUSD (100_000).
+// hive-fast: Groq llama-3.1-8b-instant at 0.05 in / 0.08 out USD per million
+// (20260801_14_route_groq_fast_cheapest_model.sql, the cheapest available
+// Groq model as of 2026-08-03), times the 1.4 margin multiplier, times
+// CreditsPerUSD (100_000).
 //
-//	input:  0.075 * 1.4 * 100_000 = 10_500
-//	output: 0.300 * 1.4 * 100_000 = 42_000
-var correctedHiveFast = RouteInfo{InputPriceCredits: 10_500, OutputPriceCredits: 42_000}
+//	input:  0.05 * 1.4 * 100_000 =  7_000
+//	output: 0.08 * 1.4 * 100_000 = 11_200
+var correctedHiveFast = RouteInfo{InputPriceCredits: 7_000, OutputPriceCredits: 11_200}
 
 // correctedHiveDefault mirrors hive-default: OpenRouter openai/gpt-4o-mini
 // at 0.15 in / 0.60 out USD per million.
@@ -273,13 +275,14 @@ var correctedHiveDefault = RouteInfo{InputPriceCredits: 21_000, OutputPriceCredi
 // credit the placeholder prices produced.
 func TestPriceEstimate_CorrectedPricesBillHighTokenRequests(t *testing.T) {
 	// hive-fast, 40k prompt + 12k completion:
-	//   40_000 * 10_500 =   420_000_000
-	//   12_000 * 42_000 =   504_000_000
-	//   sum             =   924_000_000
-	//   / 1_000_000     =           924 exactly, remainder 0
+	//   40_000 *  7_000 =   280_000_000
+	//   12_000 * 11_200 =   134_400_000
+	//   sum             =   414_400_000
+	//   / 1_000_000     =           414, remainder 400_000 -- 2*400_000 <
+	//   1_000_000, so round-half-up leaves it at 414 rather than bumping to 415
 	_, fast := priceEstimate(correctedHiveFast, 40_000, 12_000, VerdictBillable)
-	if fast != 924 {
-		t.Errorf("hive-fast perModel = %d, want 924", fast)
+	if fast != 414 {
+		t.Errorf("hive-fast perModel = %d, want 414", fast)
 	}
 
 	// hive-default, 50k prompt + 10k completion:
@@ -312,8 +315,8 @@ func TestPriceEstimate_PlaceholderPricesUnderchargedAtHighTokenCounts(t *testing
 	if corrected <= placeholder {
 		t.Fatalf("corrected (%d) must exceed placeholder (%d)", corrected, placeholder)
 	}
-	if corrected/placeholder != 924 {
-		t.Errorf("corrected/placeholder = %d, want 924x", corrected/placeholder)
+	if corrected/placeholder != 414 {
+		t.Errorf("corrected/placeholder = %d, want 414x", corrected/placeholder)
 	}
 }
 

--- a/supabase/migrations/20260801_14_route_groq_fast_cheapest_model.sql
+++ b/supabase/migrations/20260801_14_route_groq_fast_cheapest_model.sql
@@ -1,0 +1,65 @@
+-- =============================================================================
+-- Owner instruction (2026-08-03): for the demo, route-groq-fast should run the
+-- cheapest available Groq model. Move it off groq/openai/gpt-oss-20b onto
+-- groq/llama-3.1-8b-instant, which is both cheaper and, per Groq's tool-use
+-- docs, strictly better at tool calling: llama-3.1-8b-instant supports
+-- parallel tool use, gpt-oss-20b does not. Both report a 131k context window.
+-- provider_capabilities.supports_reasoning for route-groq-fast is already
+-- false, so no catalog claim becomes untrue by this change.
+--
+-- FORMULA (same mechanical shape as 20260801_01 and PR #651)
+--   credits_per_million = ceil(provider_list_usd_per_million * MARGIN * CREDITS_PER_USD)
+--     MARGIN          = 1.4
+--     CREDITS_PER_USD = 100000   (apps/control-plane/internal/payments/types.go)
+--
+-- PROVIDER RATES, re-fetched 2026-08-03
+--   Groq llama-3.1-8b-instant   $0.05 in / $0.08 out USD per million tokens
+--     source: https://groq.com/pricing ("Llama 3.1 8B Instant 128k" row) and
+--     https://console.groq.com/docs/models (context_window: 131072, i.e. 131k)
+--   Groq openai/gpt-oss-20b (outgoing) $0.075 in / $0.30 out USD per million,
+--     confirmed unchanged against the same two sources, matching the rate
+--     20260801_01_alias_pricing_correction.sql already derived hive-fast from.
+--
+-- WORKED DERIVATION
+--   hive-fast  in  0.05 * 1.4 * 100000 =  7000
+--   hive-fast  out 0.08 * 1.4 * 100000 = 11200
+--   Both products are whole numbers, so the ceiling is a no-op here.
+--
+-- OUT OF SCOPE (deliberately unchanged)
+--   * litellm_model_name: that column is the LiteLLM gateway alias name, not
+--     the upstream model, and route-groq-fast's litellm_model_name already
+--     equals the route id. Not touched.
+--   * alias_route_policies, provider_capabilities: untouched. hive-fast keeps
+--     exactly one enabled route (route-groq-fast); no route or fallback added.
+--   * The upstream model the running gateway actually calls is read from the
+--     GROQ_FAST_MODEL environment variable, not this catalog (issue #684:
+--     deploy/litellm/config.yaml is only copied into the litellm named volume
+--     on first boot, so a config-file edit alone would never reach a running
+--     stack). That variable is updated separately in .env.example and the
+--     compose/CI wiring that reference it; this migration only corrects the
+--     credit catalog (control-plane's price and routing record of what the
+--     alias is billed as and pointed at), which is a distinct concern from
+--     the gateway's own model-string wiring.
+--
+-- RE-RUNNABILITY
+--   Both statements are UPDATEs keyed on a primary key, each carrying its own
+--   WHERE guard that excludes rows already at the target value, so a second
+--   run of this file affects zero rows and errors on nothing. Guarded
+--   per statement rather than relying on a single file-level check, because a
+--   file-level guard has previously let unguarded statements ride along
+--   beside a guarded one.
+-- =============================================================================
+
+-- 1. Point route-groq-fast at the cheaper upstream model.
+UPDATE public.provider_routes
+   SET provider_model = 'groq/llama-3.1-8b-instant'
+ WHERE route_id = 'route-groq-fast'
+   AND provider_model <> 'groq/llama-3.1-8b-instant';
+
+-- 2. Re-derive hive-fast's price from the new model's published rate.
+UPDATE public.model_aliases
+   SET input_price_credits  = 7000,
+       output_price_credits = 11200,
+       updated_at           = now()
+ WHERE alias_id = 'hive-fast'
+   AND (input_price_credits <> 7000 OR output_price_credits <> 11200);


### PR DESCRIPTION
## Summary

Owner instruction for the demo: `route-groq-fast` should serve the cheapest available Groq model.

Re-verified live on 2026-08-03 against https://groq.com/pricing and https://console.groq.com/docs/models:

| Model | Input $/M | Output $/M | Context |
|---|---|---|---|
| `groq/llama-3.1-8b-instant` (new) | $0.05 | $0.08 | 131,072 |
| `groq/openai/gpt-oss-20b` (outgoing) | $0.075 | $0.30 | 131,072 |

That is 33% cheaper input, 73% cheaper output. Per Groq's tool-use docs, `llama-3.1-8b-instant` supports parallel tool use and JSON mode; `gpt-oss-20b` does not support parallel tool use, so tool calling is strictly better on top of being cheaper. `provider_capabilities.supports_reasoning` for `route-groq-fast` is already `false`, so no catalog claim becomes untrue.

## Migration

`supabase/migrations/20260801_14_route_groq_fast_cheapest_model.sql`, styled after `20260801_13_alias_price_unit.sql`:

- Repoints `provider_routes.provider_model` for `route_id = 'route-groq-fast'` to `groq/llama-3.1-8b-instant`.
- Re-derives `hive-fast`'s credit price at the same margin formula PR #651 established (1.4x margin, `CreditsPerUSD = 100_000`): `0.05 * 1.4 * 100000 = 7000` input, `0.08 * 1.4 * 100000 = 11200` output.

Both statements carry their own `WHERE` guard (excluding rows already at the target value), so each is independently idempotent rather than relying on a single file-level check. `litellm_model_name`, `alias_route_policies`, and `provider_capabilities` are untouched. `hive-fast` keeps exactly one enabled route; no route or fallback added.

## Delivery half (env var, not the config file)

`route-groq-fast` reads its upstream model from the `GROQ_FAST_MODEL` environment variable, not `deploy/litellm/config.yaml`. Per issue #684, that config file is only copied into the `litellm` named volume on first boot, so a config-file edit alone never reaches a running stack, and `POST /internal/litellm/sync` was not used either since `litellmconfig.Generate`/`WriteAndRestart` would replace the whole `model_list` and drop the `model_info.mode` annotations, `extra_body` provider pinning, `route-doc-vlm`, and `bge-m3`.

This PR updates `GROQ_FAST_MODEL`'s default in `.env.example` and in `.github/workflows/owui-nightly.yml`.

**Operational step required on the demo box (not done by this PR):** update `GROQ_FAST_MODEL=groq/llama-3.1-8b-instant` in the box's own `.env`, then **recreate** (not restart) the `litellm` container, since a changed compose environment variable is only picked up on recreate.

Box access in this environment was read-only via `ssh hive-demo-cf`, which requires an interactive Cloudflare Access browser login unavailable here, so the current live `GROQ_FAST_MODEL` value on the box could not be independently re-confirmed in this session; treat the operational step above as still pending until verified.

## Out of scope

The gateway currently bills one credit per token rather than reading this catalog. This PR does not touch that; it only corrects the catalog's routing and price record.

## Test plan

- [x] `docker compose --profile tools run toolchain "cd /workspace && go test ./apps/control-plane/... -count=1 -short"` — all packages pass, including `internal/routing`.
- [x] `docker compose --profile tools run toolchain "cd /workspace && go test ./apps/edge-api/... -count=1 -short"` — all packages pass, including `internal/metering` and `internal/chat`.
- [x] Updated fixtures that encoded the outgoing model id or its now-superseded credit prices: `apps/control-plane/internal/routing/service_test.go`, `apps/control-plane/internal/routing/catalog_pricing_integration_test.go`, `apps/edge-api/internal/metering/precedence_test.go` (worked derivations recomputed for the new 7000/11200 price).
- [ ] Update `GROQ_FAST_MODEL` in the demo box's `.env` and recreate the `litellm` container (operator action, not automated by this PR).