### PR TITLE
fix: include monitoring profile in demo box deploy so it stays in sync

### DIFF
--- a/.github/workflows/deploy-demo-box.yml
+++ b/.github/workflows/deploy-demo-box.yml
@@ -206,7 +206,20 @@ jobs:
         # This is the exact profile combo documented in the repo's own
         # CLAUDE.md "Getting Started" section for the chat-enabled local/demo
         # surface: core services (edge-api, control-plane, litellm) plus the
-        # chat front-end (open-webui, agent-console) plus in-stack redis.
+        # chat front-end (open-webui, agent-console) plus in-stack redis --
+        # plus `monitoring` (prometheus, grafana, alertmanager).
+        #
+        # `monitoring` was missing here until 2026-08-03. That gap is why a
+        # box reboot left those three containers dead for 22 hours with no
+        # alert (Alertmanager itself was one of the dead containers): PR #596
+        # added `restart: unless-stopped` to their compose definitions, but
+        # this job never recreates them, so the live containers kept the
+        # stale `no` restart policy they were created with on 2026-07-26,
+        # from before that fix. Any future change to the monitoring service
+        # definitions had the same blind spot. Including the profile here
+        # keeps the running containers in sync with docker-compose.yml on
+        # every deploy, the same way it already works for the other
+        # services, so this class of drift cannot recur.
         #
         # The chronic failure here (16+ red runs since 2026-07-26, "cannot
         # replace to directory .../node_modules/@opennextjs/cloudflare with
@@ -217,17 +230,17 @@ jobs:
         run: |
           set -euo pipefail
           docker compose --env-file ../../.env --profile local --profile chat \
-            up -d --build --remove-orphans
+            --profile monitoring up -d --build --remove-orphans
 
       - name: Dump container status + logs on failure
         if: failure()
         working-directory: /home/sakib/hive/deploy/docker
         run: |
-          COMPOSE=(docker compose --env-file ../../.env --profile local --profile chat)
+          COMPOSE=(docker compose --env-file ../../.env --profile local --profile chat --profile monitoring)
           echo "::group::docker compose ps"
           "${COMPOSE[@]}" ps || true
           echo "::endgroup::"
-          for svc in edge-api control-plane agent-console open-webui litellm redis; do
+          for svc in edge-api control-plane agent-console open-webui litellm redis prometheus grafana alertmanager; do
             echo "::group::logs ($svc)"
             "${COMPOSE[@]}" logs --tail=200 --no-color "$svc" 2>&1 || true
             echo "::endgroup::"


### PR DESCRIPTION
## Summary

Fixes #693.

The demo box rebooted roughly 22 hours before this PR. Every product container recovered; `hive-prometheus-1`, `hive-grafana-1`, and `hive-alertmanager-1` stayed `Exited (255)` because their live `HostConfig.RestartPolicy` was `no`.

`docker-compose.yml` already declares `restart: unless-stopped` on all three, added by PR #596 (merged 2026-07-28). The actual running containers on the box were created 2026-07-26, before that PR merged, and the automated deploy workflow (`deploy-demo-box.yml`) never recreates them because it only ever ran `--profile local --profile chat`, never `--profile monitoring`. So the fix shipped in git but never reached the live containers. A reboot then exposed the stale pre-fix restart policy.

Container logs for all three show normal operation up to the moment of the reboot, no config error, no OOM, no permission failure, ruling out a genuine startup crash as the cause.

## Changes

`deploy/docker/docker-compose.yml`: no change needed, the restart policy was already correct.

`.github/workflows/deploy-demo-box.yml`:
- Add `--profile monitoring` to the main `up -d --build --remove-orphans` invocation, so Prometheus, Grafana, and Alertmanager get recreated on every deploy alongside the rest of the stack and can no longer silently drift from what the compose file declares.
- Add `--profile monitoring` to the failure-diagnostics compose invocation, and add `prometheus`, `grafana`, `alertmanager` to the failure-path log dump loop, for parity with the other services.

## Verified on the box

- Recreated the three containers by hand (`docker compose --profile monitoring up -d --no-deps prometheus grafana alertmanager`) to restore them immediately rather than wait for the next `main` push.
- Confirmed all three now carry `RestartPolicy.Name = unless-stopped` and stayed up (no crash loop).
- Confirmed no product container was disturbed: edge-api, control-plane, open-webui, agent-console, web-console(-prod), litellm, redis, and all three Caddy fronts remained running throughout (a concurrent, unrelated deploy from PR #692 recreated the local/chat-profile containers in the same window; verified via `gh run list`/`gh run watch` that it succeeded independently of this change).
- Public checks still hold:
  - `https://api-hive.scubed.co/v1/models` → 401, `application/json`
  - `https://chat-hive.scubed.co/` → 200, `text/html`
  - `https://chat-hive.scubed.co/v1/featuregate` → 401, `application/json`

## Test plan

- [x] YAML syntax validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Three monitoring containers recreated live on the demo box and confirmed running with `unless-stopped`
- [x] Product containers confirmed undisturbed
- [x] Three public smoke checks re-run and passing
- [ ] Next `main` deploy run will exercise the new `--profile monitoring` path in CI end to end (this PR's merge itself will trigger it)