### PR TITLE
fix: let the gateway own model visibility in Open WebUI

### DIFF
--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -659,7 +659,30 @@ services:
       ENABLE_ADMIN_PANEL: "false"
       ENABLE_ADMIN_EXPORT: "false"
       ENABLE_COMMUNITY_SHARING: "false"
-      ENABLE_MODEL_FILTER: "true"
+      # Model visibility belongs to the gateway, not to Open WebUI. edge-api
+      # already filters /v1/models per tenant (AliasVisibleToTenant, PR #205),
+      # so a second independent filter here adds nothing and actively hides
+      # upstream state: Open WebUI's own access control shows a session whose
+      # role is "user" only models present in Open WebUI's Models registry,
+      # and this deployment never populates that registry (ENABLE_ADMIN_PANEL
+      # is "false", so nothing can curate it). An empty picker therefore looks
+      # identical whether edge-api served six models or refused the shim key
+      # outright, which is exactly how a gateway 403 stayed hidden for four
+      # nights (#717).
+      #
+      # BYPASS_MODEL_ACCESS_CONTROL makes the gateway the single source of
+      # truth. In the pinned v0.10.2 image it skips get_filtered_models on
+      # /openai/models (routers/openai.py:705), skips check_model_access on
+      # the completion path (main.py:1032), and forces bypass_filter for the
+      # chat and embedding helper paths (routers/openai.py:1120), so picker,
+      # chat and document RAG all reflect exactly what edge-api serves.
+      #
+      # This replaces ENABLE_MODEL_FILTER: "true", which was dead. That name
+      # arrived with the rest of this service block in #143 and does not exist
+      # anywhere in v0.10.2 (upstream removed it long before that tag), so it
+      # never filtered anything; the filtering was Open WebUI's default access
+      # control the whole time.
+      BYPASS_MODEL_ACCESS_CONTROL: "true"
       ENABLE_EVALUATION_ARENA_MODELS: "false"
       # Web search. Opt-in via .env, default off (same pattern as
       # OWUI_E2E_MODE below) -- this service block is shared with the


### PR DESCRIPTION
## Problem

The chat model picker on the demo box is empty for every ordinary user, and chat fails with `Model not found` off that empty list. Open WebUI's own model access control is the cause, not the gateway.

In the pinned `v0.10.2` image, `get_filtered_models` drops any model that has no row in Open WebUI's private Models registry for a session whose Open WebUI role is `user`, with the comment "only admins can see unconfigured models". This deployment never populates that registry, and `ENABLE_ADMIN_PANEL` is `"false"`, so nothing can populate it. A member session therefore sees zero models no matter what edge-api serves. Tenant MEMBER maps to Open WebUI role `user`, which is the demo user shape.

The same filter also made the failure mode opaque. An empty picker looked identical whether edge-api returned six models or refused the shim key with 403 `account_not_provisioned`, which is precisely how the #717 gateway defect stayed hidden for four nights and sent the investigation to the credential instead of the catalog.

## Change

One line of compose. `BYPASS_MODEL_ACCESS_CONTROL: "true"` replaces `ENABLE_MODEL_FILTER: "true"`.

The gateway already enforces tenant model visibility on the listing path (`AliasVisibleToTenant`, PR #205), so Open WebUI's filter was redundant on top of it. With the bypass set, the picker faithfully reflects what edge-api serves and the gateway becomes the single source of truth. Verified against the v0.10.2 source at the pinned tag:

| Path | Guard | Effect of the bypass |
| --- | --- | --- |
| `GET /openai/models` | `routers/openai.py:705` | `get_filtered_models` is skipped, so the picker shows the gateway list |
| Chat completion | `main.py:1032` | `check_model_access` is skipped, so a member can send to a gateway-served model |
| Chat and embedding helpers | `routers/openai.py:1120` | `bypass_filter` is forced true, so document RAG embeddings pass the same gate |

## The removed variable was dead

`ENABLE_MODEL_FILTER` does not exist anywhere in Open WebUI `v0.10.2`. It is absent from both `backend/open_webui/env.py` and `backend/open_webui/config.py` at that tag, and a repository wide code search for the name returns zero hits, so upstream removed it well before this image. `git log -L 662,662` shows it arrived in #143 with the rest of the Open WebUI service block, replacing the LibreChat block that previously occupied those lines, and PR #143's own description never mentions model filtering. It was carried along, not chosen, and it never filtered anything: the filtering has been Open WebUI's default access control the whole time. Leaving a dead name in place that appears to explain the behaviour is worse than removing it, since it already misdirected one investigation.

## Effect on `06-tenant-model-visibility`

`apps/web-console/e2e/phase-19/owui/06-tenant-model-visibility.spec.ts` was left untouched, and it should pass after this change rather than fail.

That spec opens the picker, asserts the option list is non empty, and asserts no option matches `grok`. Today it fails in about two seconds on the non empty guard, because the option list is zero length for the `user` role session it authenticates as. With the bypass in place the gateway list reaches the picker, so the guard is satisfied by the six catalog aliases, and none of them is grok shaped. There is no grok alias anywhere in the catalog or the seed path, so that half of the assertion is vestigial either way.

The important part is what the spec now measures. Before, it could only observe Open WebUI's private registry. After, it observes the gateway's tenant filtered listing, which is the thing PR #205 actually implements and the thing we want covered.

## Deployment note

`deploy/docker/**` is inside the push path filter of `deploy-demo-box.yml`, so merging this auto deploys to the demo box and recreates the Open WebUI service. Visual proof of a populated picker on the running box, taken after that deploy, will be posted on #717 against the deploy run id.

The Open WebUI service block is shared with the enterprise profile, which inherits this setting. That is consistent with the product posture: gateway side tenant visibility is the mechanism in both modes, and the enterprise profile also runs with the admin panel disabled, so its registry cannot be curated either.

Refs #717
