### PR TITLE
fix: stop the console auth forms submitting before hydration, which silently drops ?next=

### DIFF
--- a/.github/workflows/owui-nightly.yml
+++ b/.github/workflows/owui-nightly.yml
@@ -347,7 +347,12 @@ jobs:
           # (e.g. the hive_jwt_forward JWT-claims probe) out of a 300-line
           # tail before this step runs (run 28688900087). 2000 covers a full
           # 6-spec run with room to spare.
-          docker compose --env-file ../../.env.ci logs --no-color --tail 2000 \
+          # --timestamps: only open-webui and (partly) edge-api stamp their own
+          # lines, so litellm's access log had no clock at all. Attributing a
+          # slow or missing request across layers means lining these logs up
+          # against Playwright's wall-clock trace, which is impossible for a
+          # service whose lines carry no time (run 31042840516).
+          docker compose --env-file ../../.env.ci logs --no-color --timestamps --tail 2000 \
             open-webui litellm edge-api control-plane > $GITHUB_WORKSPACE/compose-logs.txt 2>&1 || true
       - name: SOC2 coverage report
         if: always()

--- a/apps/web-console/__tests__/sign-in-next-redirect.test.tsx
+++ b/apps/web-console/__tests__/sign-in-next-redirect.test.tsx
@@ -7,6 +7,7 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen } from "@testing-library/react";
+import { renderToStaticMarkup } from "react-dom/server";
 
 const mockSignInWithPassword = vi.fn();
 
@@ -117,6 +118,34 @@ describe("app/auth/sign-in/page.tsx next-target redirect", () => {
         "/oauth/consent?authorization_id=auth-req-123",
       )}`,
     );
+  });
+
+  // OWUI nightly run 31042840516: the OIDC setup click landed before React
+  // hydrated, so the browser submitted the form natively. The form has no
+  // `action` and its inputs have no `name`, so that GET rewrote
+  // /auth/sign-in?next=%2Foauth%2Fconsent%3Fauthorization_id%3D... to
+  // /auth/sign-in? -- `next` gone. The retry then signed in for real and
+  // landed on /console, abandoning the consent round-trip, which cost the run
+  // 86s and read as flake. The pre-hydration markup must therefore not offer
+  // a submittable button at all (a disabled default button also blocks
+  // implicit Enter submission).
+  it("does not expose a submittable button before hydration", () => {
+    // Parse the markup instead of substring-matching it: the Button's class
+    // list carries Tailwind `disabled:*` variants, so a text search for
+    // "disabled" passes even on an enabled button.
+    const container = document.createElement("div");
+    container.innerHTML = renderToStaticMarkup(<SignInPage />);
+    const submit = container.querySelector<HTMLButtonElement>(
+      'button[type="submit"]',
+    );
+    expect(submit).not.toBeNull();
+    expect(submit?.disabled).toBe(true);
+  });
+
+  it("enables the submit button once mounted", async () => {
+    render(<SignInPage />);
+    const button = await screen.findByRole("button", { name: /continue/i });
+    expect((button as HTMLButtonElement).disabled).toBe(false);
   });
 
   it("does not redirect when sign-in fails", async () => {

--- a/apps/web-console/app/auth/sign-in/page.tsx
+++ b/apps/web-console/app/auth/sign-in/page.tsx
@@ -23,9 +23,22 @@ export default function SignInPage() {
   // sign-up instead of stranding them on the plain console dashboard after
   // signup (issue found in live UI/UX pass, 2026-07-26).
   const [nextParam, setNextParam] = useState<string | null>(null);
+  // This form has no `action` and its inputs carry no `name`, so a submit that
+  // lands before React attaches onSubmit is handled natively: the browser does
+  // a GET to the current path with an empty form data set, which REPLACES the
+  // query string and silently discards `?next=`. Sign-in then succeeds on the
+  // reloaded page and sends the user to /console, abandoning whatever journey
+  // sent them here (OWUI nightly run 31042840516: the OIDC consent round-trip
+  // died exactly this way -- /auth/sign-in?next=%2Foauth%2Fconsent... became
+  // /auth/sign-in? one second later, still visible in the deployed console's
+  // server HTML today). Gating the submit button on mount makes the
+  // pre-hydration submit impossible instead of merely unlikely; a disabled
+  // default button also blocks implicit Enter submission.
+  const [hydrated, setHydrated] = useState(false);
 
   useEffect(() => {
     setNextParam(new URLSearchParams(window.location.search).get("next"));
+    setHydrated(true);
   }, []);
 
   async function handleSubmit(e: FormEvent<HTMLFormElement>) {
@@ -116,7 +129,7 @@ export default function SignInPage() {
           type="submit"
           variant="primary"
           size="lg"
-          disabled={loading}
+          disabled={loading || !hydrated}
           className="w-full"
         >
           {loading ? (

--- a/apps/web-console/app/auth/sign-up/page.tsx
+++ b/apps/web-console/app/auth/sign-up/page.tsx
@@ -50,12 +50,19 @@ export default function SignUpPage() {
   // instead of dropping the user onto the plain console dashboard (issue
   // found in live UI/UX pass, 2026-07-26).
   const [nextParam, setNextParam] = useState<string | null>(null);
+  // Same pre-hydration submit hazard as /auth/sign-in (see the comment there):
+  // no form `action` and no input `name` attributes mean a submit fired before
+  // onSubmit is attached does a native GET that wipes the query string, taking
+  // `?next=` with it, so the signup half of the OIDC round-trip lands on
+  // /console instead of consent. Gate the submit button on mount.
+  const [hydrated, setHydrated] = useState(false);
 
   const turnstileContainerRef = useRef<HTMLDivElement | null>(null);
   const widgetIdRef = useRef<string | null>(null);
 
   useEffect(() => {
     setNextParam(new URLSearchParams(window.location.search).get("next"));
+    setHydrated(true);
   }, []);
 
   // Load the Turnstile script and render the widget when a site key is
@@ -251,7 +258,7 @@ export default function SignUpPage() {
           type="submit"
           variant="primary"
           size="lg"
-          disabled={loading}
+          disabled={loading || !hydrated}
           className="w-full"
         >
           {loading ? "Creating account…" : "Create account"}

--- a/apps/web-console/e2e/phase-19/owui/01-chat-send-stream.spec.ts
+++ b/apps/web-console/e2e/phase-19/owui/01-chat-send-stream.spec.ts
@@ -19,7 +19,23 @@ test("chat message streams a response", async ({ page }) => {
   // id="chat-input" (MessageInput.svelte + RichTextInput.svelte); no
   // "message" placeholder exists (run 28683831193).
   await page.locator("#chat-input").fill("Reply with only the single word: hello.");
+  // Run 31042840516: this first attempt burned 150s and reported as flake
+  // while the browser never sent anything. Open WebUI dropped the submit
+  // (the trace shows the prompt still sitting in the input at timeout, zero
+  // requests after the Enter, and edge-api saw no /v1/chat/completions until
+  // the retry two and a half minutes later), so the wait below was waiting
+  // for a reply to a message that was never sent. Proving the submit left
+  // the browser separates "we never asked" from "the model was slow" in
+  // seconds instead of minutes -- deliberately NOT a longer timeout or a
+  // resend, both of which would hide it again.
+  const chatRequest = page.waitForRequest(
+    (request) =>
+      request.method() === "POST" &&
+      request.url().includes("/api/chat/completions"),
+    { timeout: 15_000 },
+  );
   await page.keyboard.press("Enter");
+  await chatRequest;
   // `[data-role="assistant"]` never matches anything: OWUI's Messages.svelte
   // renders the conversation as role="log" > listitem, with no data-role
   // attribute anywhere in its component tree (confirmed against source;

--- a/apps/web-console/e2e/phase-19/owui/02-chat-multi-turn.spec.ts
+++ b/apps/web-console/e2e/phase-19/owui/02-chat-multi-turn.spec.ts
@@ -35,7 +35,17 @@ test("second turn references first turn context", async ({ page }) => {
   await page.locator("#chat-input").fill(
     "My favourite colour is purple. Reply in one short sentence.",
   );
+  // Run 31042840516: same silent dropped submit as 01 (see the comment
+  // there). Prove the request left the browser so "we never asked" fails in
+  // seconds instead of consuming the 150s reply budget.
+  const firstTurnRequest = page.waitForRequest(
+    (request) =>
+      request.method() === "POST" &&
+      request.url().includes("/api/chat/completions"),
+    { timeout: 15_000 },
+  );
   await page.keyboard.press("Enter");
+  await firstTurnRequest;
   // A completed assistant turn is the only one that grows a "Copy" action
   // button, so its visibility is a structural proof the pipeline
   // delivered a response -- free-tier model output content is not


### PR DESCRIPTION
## Primary fix: the console auth forms submit before hydration and lose `?next=`

`/auth/sign-in` renders `<form onSubmit={handleSubmit}>` with no `action`, and its inputs carry `id` but no `name`. A submit that lands before React attaches `onSubmit` is therefore handled natively: the browser issues a GET to the current path with an empty form data set, which **replaces the query string** and discards `?next=`. Sign-in then succeeds on the reloaded page, reads `next` from `window.location.search`, finds nothing, and sends the user to `/console`, abandoning whatever journey sent them there.

Evidence, from the OWUI nightly setup trace in run 31042840516 (artifact `owui-playwright-report`, `data/27e6ddbf…zip`), one second apart:

```
20:15:51.370  GET /auth/sign-in?next=%2Foauth%2Fconsent%3Fauthorization_id%3D62jwumnl…  200
20:15:52.407  GET /auth/sign-in?                                                        200   <- next gone, coincident with the Continue click
20:15:58.151  POST supabase /auth/v1/token?grant_type=password                           200
20:15:58.589  GET /console                                                               200 (9916 ms)
```

The OIDC consent round trip died there. The spec then spent 30s polling for an Approve button and 30s in `waitForURL` for an OWUI origin that could never arrive, which is the whole 86s "flaky" setup failure. The failure page snapshot is the console Overview page, not the consent screen.

This is not a test-only concern. The deployed console serves that form today with no `action`, no input `name` attributes, and an **enabled** submit button:

```
<form class="flex flex-col gap-4">
<input type="email" ... id="email" ... />        <- no name
<button type="submit" class="…">                 <- enabled in the server HTML
```

So a real user who is fast, or a password manager that submits on fill, or anyone on a connection where the bundle lags, can hit the same window and be dropped on `/console` mid OAuth authorization.

Fix: gate the submit button on mount in `app/auth/sign-in/page.tsx` and `app/auth/sign-up/page.tsx` (`disabled={loading || !hydrated}`, `hydrated` set in the effect that already reads `next` post mount). That makes the pre-hydration submit impossible rather than merely unlikely, and a disabled default button also blocks implicit Enter submission. Sign-up carries the same `?next=` on the same journey, hence the same gate.

## RED evidence for the new test

`apps/web-console/__tests__/sign-in-next-redirect.test.tsx` gains the pre-hydration invariant, asserted against `renderToStaticMarkup` output (effects never run there, so it is the real pre-hydration markup) and parsed as DOM rather than substring matched.

Run by the required check **Web console (type + unit + build)**, via `npm run test:unit` in `apps/web-console`.

With the fix reverted to `disabled={loading}`:

```
❯ __tests__/sign-in-next-redirect.test.tsx (9 tests | 1 failed)
  × does not expose a submittable button before hydration
    → expected false to be true // Object.is equality
 Tests  1 failed | 8 passed (9)
```

With the fix applied: `Tests 9 passed (9)`.

Two traps caught while establishing that RED, both worth naming because each one produced a check that could not fail:

1. The first draft substring matched `"disabled"` in the rendered `<button>` tag. The shared `Button` class list contains Tailwind `disabled:opacity-50 disabled:pointer-events-none`, so the assertion passed on an enabled button. It now parses the markup and reads the `disabled` DOM property.
2. **The `web-console` compose service has no volume: `deploy/docker/docker-compose.yml` gives it `image: hive-web-console:ci` with a build context and no bind mount, so the source is baked into the image.** `docker compose run web-console npm run test:unit` therefore tests whatever was in the tree when that image was last built, not the working tree. My first two runs reported 7 tests instead of 9 and the reverted fix falsely passed. Rebuild the image, or bind mount the specific files, before believing a local result:

```
docker compose run --rm \
  -v $PWD/../../apps/web-console/app/auth/sign-in/page.tsx:/app/apps/web-console/app/auth/sign-in/page.tsx:ro \
  web-console npm run test:unit -- sign-in-next-redirect
```

## Diagnosis guards on specs 01 and 02, not masking

Same run, the two 2.7m chat failures that retried green in 10s. The 2.7m was **not** latency anywhere. After the Enter keypress the browser sent nothing at all for 150s except SvelteKit's `_app/version.json` poll, Open WebUI logged nothing between 20:17:39.387 and 20:20:17.487, and edge-api saw its first `/v1/chat/completions` of the entire run at 20:20:20, during the retry. The failure screenshot shows the prompt still sitting in the chat input after 150 seconds with no message bubbles. The submit was silently dropped, so the wait was for a reply to a message that was never sent.

`01-chat-send-stream.spec.ts` and `02-chat-multi-turn.spec.ts` now arm a `page.waitForRequest` for the outgoing `POST /api/chat/completions` before pressing Enter, 15s. A dropped submit fails in 15 seconds naming the real cause instead of consuming the 150s reply budget and reading as flake.

Explicitly: **no timeout was raised and no resend was added.** Either would hide the same defect again. The 150s reply budget is untouched, and the guard only separates "we never asked" from "the model was slow".

The `Copy` button assertions in those specs are deliberately left alone. They are owned by `fix/chat-tool-use-routing`, which is fixing the underlying routing first so the strengthened assertion lands green rather than red. These guards are compatible with that work and should not be reverted by it.

## `docker compose logs --timestamps` in the nightly

Attributing this required lining the Playwright trace's wall clock up against per service activity. Open WebUI stamps its own lines and edge-api stamps some of its own, but **LiteLLM's access log carries no clock at all**, which is the one service in the middle of the path. The Playwright trace was the only shared clock in the artifact set, which is a bad place to be when the question is "which layer spent the time". `--timestamps` fixes that for the next occurrence at the cost of one flag.

## Test plan

- [x] `docker compose run --rm web-console npm run test:unit -- sign-in-next-redirect` with the fix bind mounted: 9 passed
- [x] Same command with `disabled={loading}` restored: 1 failed, the new pre-hydration test, message above
- [x] `docker compose run --rm web-console npm run test:unit -- sign-up` with the sign-up gate bind mounted: 6 passed
- [x] Deployed console HTML inspected read only to confirm the defect is live: no form `action`, no input `name`, submit button enabled in the server markup
- [ ] Required checks on this head (reported separately)

Not in this PR, deliberately:

- The error bubble assertion in specs 01 and 02, owned by `fix/chat-tool-use-routing`.
- `forgot-password` and `reset-password` share the pre-hydration submit shape but neither has a post mount effect to hang the flag on, and their consequences differ (a lost typed email versus a reload during an active recovery session), so they need their own reasoning rather than a copy of this one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
