### PR TITLE
docs: make the frontend Docker test commands rebuild before running

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,16 +111,20 @@ cd deploy/docker && docker compose --profile tools run toolchain \
 cd deploy/docker && docker compose --profile tools run toolchain \
   "cd /workspace && go test ./apps/edge-api/... -count=1 -short"
 
-# Frontend type check + build
-cd deploy/docker && docker compose run web-console npm run build
+# Frontend type check + build. Unlike toolchain, the web-console service mounts
+# no volume and Dockerfile.web-console COPYs the source in at image build time,
+# so without `--build` the run silently exercises whatever `hive-web-console:ci`
+# was last built and reports a green result for stale code.
+cd deploy/docker && docker compose run --build web-console npm run build
 
 # Frontend unit tests
-cd deploy/docker && docker compose run web-console npm run test:unit
+cd deploy/docker && docker compose run --build web-console npm run test:unit
 
 # SDK integration tests (requires healthy core stack)
 cd deploy/docker && docker compose --env-file ../../.env --profile test up --build
 
-# E2E tests
+# E2E tests. Host-run against the working tree, so no image staleness here, but
+# it needs a stack already running.
 cd apps/web-console && npx playwright test
 ```
 


### PR DESCRIPTION
## Problem

`CLAUDE.md` documented the frontend test command as:

```bash
cd deploy/docker && docker compose run web-console npm run test:unit
```

That command does not test the working tree. Verified against `deploy/docker/docker-compose.yml`:

- The `web-console` service (line 458) declares `image: hive-web-console:ci` with a `build:` block and **no `volumes:` entry**, so nothing from the checkout reaches the container at run time.
- `deploy/docker/Dockerfile.web-console` does `COPY apps/web-console/ ./`, which bakes the source into the image at build time.
- `docker compose run` does not rebuild by default, so it starts the last `hive-web-console:ci` that happened to be built on that machine.

The contrast is with the `toolchain` service in the same file, which bind mounts `../../:/workspace` and therefore always sees live source. The Go commands directly above the frontend ones are correct for exactly that reason, which is what made the frontend commands look trustworthy.

The failure mode is the dangerous kind. A real run during PR #751 reported 408 tests passing against an image that was missing two tests already on `main`. A stale image does not error. It returns a confident green for code that was never executed.

## Change

Add `--build` to the two frontend commands, and record the reason inline in the same terse style as the existing toolchain warning about double wrapping `sh -c`:

```bash
cd deploy/docker && docker compose run --build web-console npm run build
cd deploy/docker && docker compose run --build web-console npm run test:unit
```

`--build` is supported by the installed Compose (`Docker Compose version v5.3.1`, `--build  Build image before starting container`).

## Consistency check on the neighbouring commands

Both other commands in the section were checked:

- **SDK integration tests** already pass `--build`. No change needed.
- **E2E tests** run on the host with `npx playwright test` against the working tree directly, so no image is involved and there is no staleness problem. It does need a stack already running, so it gets a one line note saying so rather than a `--build` it has no use for.

## Visual proof

Not applicable. This change touches documentation only. No live UI or UX surface is affected, no runtime behavior changes, and there is nothing to screenshot.

## Test plan

- [x] Confirmed the `web-console` service has no volume mount in `deploy/docker/docker-compose.yml`
- [x] Confirmed `Dockerfile.web-console` copies source at build time
- [x] Confirmed `docker compose run --build` is a valid flag on the installed Compose version
- [x] Confirmed `toolchain` bind mounts `../../:/workspace` and is therefore correctly left alone
