### PR TITLE
fix: keep the Open WebUI OAuth session alive through its first token refresh (#782)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,3 +36,4 @@ test-scripts:
 	python3 scripts/derive-pooler-dsn.py --self-test
 	python3 scripts/test_caddy_console_auth_origin.py --self-check
 	python3 scripts/restore-storage-objects.py --self-check
+	python3 scripts/test_owui_oauth_client_auth.py

--- a/apps/edge-api/internal/auth/owui_oauth_scope_test.go
+++ b/apps/edge-api/internal/auth/owui_oauth_scope_test.go
@@ -1,0 +1,214 @@
+package auth_test
+
+// Regression guard for #782.
+//
+// OWUIUnwrap fails closed when a shim-key /v1/chat/completions request carries
+// no `__metadata.upstream_auth`, which is the correct response to a missing
+// per-user token. What made that fail-closed catastrophic in production was
+// upstream Open WebUI destroying the token supply on a schedule:
+//
+//   - Supabase issues OAuth access tokens with a 3600 second lifetime.
+//   - OAuthManager.get_oauth_token refreshes once `now + 5 minutes` reaches
+//     `expires_at`, so the refresh path is first entered roughly 55 minutes
+//     into a signed-in session.
+//   - _perform_token_refresh returns None when the refresh cannot be completed.
+//   - get_oauth_token then calls delete_session_by_id and the OAuth session is
+//     gone. `__oauth_token__` is empty from then on, hive_jwt_forward injects
+//     nothing, and every completion 401s until the user signs in again.
+//
+// Two independent inputs to that chain, and both were broken.
+//
+// First, the scope on the authorize request, which this file guards. Supabase
+// advertises `offline_access` in scopes_supported and `refresh_token` in
+// grant_types_supported, so asking for it is what makes a refresh possible at
+// all. Without it Supabase issues no refresh token, _perform_token_refresh
+// returns None on its very first guard, and the deployment locks every user
+// out roughly 55 minutes after they sign in.
+//
+// Second, the client authentication on the refresh request. That one cannot be
+// guarded from here because it is not configuration: Open WebUI hand builds
+// the refresh POST with the client credentials in the form body, which is
+// client_secret_post, while authlib performs the authorization code exchange
+// with client_secret_basic. Supabase enforces the registered method exactly,
+// so a refresh token that exists is still refused and the session destroyed
+// anyway. That half is fixed inside the image, by the patch this file asserts
+// is still wired into Dockerfile.open-webui, and its behaviour is covered by
+// scripts/test_owui_oauth_client_auth.py.
+//
+// Fixing only one of the two leaves the defect in place, which is why both are
+// asserted here.
+//
+// This lives here, next to the middleware that emits the customer-facing
+// error, because that middleware is where the defect surfaces and where the
+// next person will start reading.
+//
+// Why no e2e test catches this, and why these are configuration invariants
+// instead of another chat spec: every phase-19 chat spec runs all of its turns
+// inside one short session. The multi-turn one at
+// apps/web-console/e2e/phase-19/owui/02-chat-multi-turn.spec.ts budgets 360
+// seconds for the whole file and sends its two turns back to back. Nothing in
+// the suite holds a session open past the access token lifetime or edits
+// expires_at, so nothing reaches the refresh path at all. A test that sends
+// one message, or several messages inside a minute, passes against a build
+// that locks every user out an hour later. That is the shape of defect that
+// ships.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// requiredOAuthScope is the scope whose absence caused #782.
+const requiredOAuthScope = "offline_access"
+
+// TestOWUIOAuthScopesRequestOfflineAccess asserts that every Open WebUI OIDC
+// scope declaration under deploy/ asks for a refresh token.
+//
+// It scans all deploy YAML rather than one known line so a second compose
+// file, override, or profile cannot reintroduce the defect by copying the old
+// value into a new place.
+func TestOWUIOAuthScopesRequestOfflineAccess(t *testing.T) {
+	declarations := envDeclarations(t, "OAUTH_SCOPES")
+	require.NotEmpty(t, declarations,
+		"expected at least one OAUTH_SCOPES declaration under deploy/; if Open "+
+			"WebUI's OIDC wiring moved, move this guard with it rather than "+
+			"deleting it")
+
+	for _, d := range declarations {
+		scopes := strings.Fields(d.value)
+		require.Contains(t, scopes, requiredOAuthScope,
+			"%s:%d declares OAUTH_SCOPES %q without %q. Without it Supabase "+
+				"returns no refresh token, Open WebUI deletes the OAuth session at "+
+				"its first refresh attempt, and every chat completion 401s about "+
+				"55 minutes after sign-in until the user signs in again (#782)",
+			d.path, d.line, d.value, requiredOAuthScope)
+
+		// A refresh token with no identity scope would authenticate nobody.
+		require.Contains(t, scopes, "openid",
+			"%s:%d declares OAUTH_SCOPES %q without openid; the unwrap middleware "+
+				"needs an OIDC identity token exchange, not a bare OAuth grant",
+			d.path, d.line, d.value)
+	}
+}
+
+// TestOWUIImageAppliesOAuthRefreshClientAuthPatch asserts the Open WebUI image
+// still splices the refresh client-authentication fix in.
+//
+// The scope above is necessary and not sufficient: with a refresh token in
+// hand, Supabase still refuses the refresh because Open WebUI sends the client
+// credentials in the form body while the client is registered for the header.
+// Nothing in the compose environment expresses that fix, so the only thing
+// standing between this deployment and a silent return to hour-long sessions
+// is that this build step keeps running. Deleting it would leave every test in
+// this repository green.
+func TestOWUIImageAppliesOAuthRefreshClientAuthPatch(t *testing.T) {
+	root := repoRootForAuth(t)
+
+	dockerfile := filepath.Join(root, "deploy", "docker", "Dockerfile.open-webui")
+	body, err := os.ReadFile(dockerfile)
+	require.NoError(t, err, "the Open WebUI image definition must exist")
+
+	for _, needed := range []string{
+		"owui-patches/hive_oauth_client_auth.py",
+		"owui-patches/apply_oauth_client_auth_patch.py",
+		"python3 /tmp/apply_oauth_client_auth_patch.py",
+	} {
+		// require.True rather than require.Contains: a failed Contains prints
+		// the entire Dockerfile into the test log, which buries the message
+		// that explains what broke.
+		require.True(t, strings.Contains(string(body), needed),
+			"deploy/docker/Dockerfile.open-webui no longer references %q, so the "+
+				"image ships upstream's refresh POST, which sends the client "+
+				"credentials in the form body. Supabase rejects that with 400 "+
+				"invalid_credentials, Open WebUI deletes the OAuth session, and "+
+				"chat dies roughly 55 minutes after sign-in (#782)", needed)
+	}
+
+	// The patch and the module it splices in must both still be present, or
+	// the build step above fails only at image build time, which no unit test
+	// lane reaches.
+	for _, patchFile := range []string{
+		filepath.Join(root, "deploy", "docker", "owui-patches", "hive_oauth_client_auth.py"),
+		filepath.Join(root, "deploy", "docker", "owui-patches", "apply_oauth_client_auth_patch.py"),
+	} {
+		_, statErr := os.Stat(patchFile)
+		require.NoError(t, statErr,
+			"%s is referenced by Dockerfile.open-webui and must exist (#782)", patchFile)
+	}
+}
+
+type scopeDeclaration struct {
+	path  string
+	line  int
+	value string
+}
+
+// envDeclarations returns every assignment of key found in YAML under deploy/,
+// with its file and line for a legible failure message. Scanning all deploy
+// YAML rather than one known line means a second compose file, override or
+// profile cannot reintroduce the defect by copying an old value elsewhere.
+func envDeclarations(t *testing.T, key string) []scopeDeclaration {
+	t.Helper()
+
+	root := repoRootForAuth(t)
+	var found []scopeDeclaration
+
+	err := filepath.WalkDir(filepath.Join(root, "deploy"), func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		if ext := filepath.Ext(path); ext != ".yml" && ext != ".yaml" {
+			return nil
+		}
+		body, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			rel = path
+		}
+		for i, line := range strings.Split(string(body), "\n") {
+			trimmed := strings.TrimSpace(line)
+			if strings.HasPrefix(trimmed, "#") {
+				continue
+			}
+			prefix, rawValue, ok := strings.Cut(trimmed, key+":")
+			if !ok || prefix != "" {
+				continue
+			}
+			found = append(found, scopeDeclaration{
+				path:  rel,
+				line:  i + 1,
+				value: strings.Trim(strings.TrimSpace(rawValue), `"'`),
+			})
+		}
+		return nil
+	})
+	require.NoError(t, err)
+
+	return found
+}
+
+func repoRootForAuth(t *testing.T) string {
+	t.Helper()
+
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+
+	for dir := wd; ; dir = filepath.Dir(dir) {
+		if _, statErr := os.Stat(filepath.Join(dir, "go.work")); statErr == nil {
+			return dir
+		}
+		if parent := filepath.Dir(dir); parent == dir {
+			t.Fatalf("could not find repository root from %s", wd)
+		}
+	}
+}

--- a/deploy/docker/Dockerfile.open-webui
+++ b/deploy/docker/Dockerfile.open-webui
@@ -221,6 +221,24 @@ RUN python3 /tmp/apply_rag_env_config_patch.py \
 COPY deploy/docker/owui-patches/hive_ui_surfaces.py /tmp/hive_ui_surfaces.py
 COPY deploy/docker/owui-patches/apply_ui_surfaces_patch.py /tmp/apply_ui_surfaces_patch.py
 RUN python3 /tmp/apply_ui_surfaces_patch.py
+
+# #782: Open WebUI runs the authorization code exchange through authlib, which
+# defaults to client_secret_basic, but hand builds the refresh POST with the
+# client credentials in the form body, which is client_secret_post. Supabase
+# enforces the registered method exactly, so every refresh came back 400
+# invalid_credentials, Open WebUI read that as a dead session and deleted it,
+# and chat stopped working roughly 55 minutes after sign-in until the user
+# signed in again. Splice the refresh through a helper that authenticates the
+# client the same way the exchange already does, rather than requiring every
+# deployment to re-register its Supabase OAuth client for the other dialect;
+# the registration is manual ops with no script behind it, so an invariant
+# living only in prose would be reintroduced by the next person who registers
+# a client. Behaviour is covered by scripts/test_owui_oauth_client_auth.py.
+COPY deploy/docker/owui-patches/hive_oauth_client_auth.py /app/backend/open_webui/utils/hive_oauth_client_auth.py
+COPY deploy/docker/owui-patches/apply_oauth_client_auth_patch.py /tmp/apply_oauth_client_auth_patch.py
+RUN python3 /tmp/apply_oauth_client_auth_patch.py \
+    && test "$(grep -c '\*\*hive_refresh_request(client, refresh_data),' /app/backend/open_webui/utils/oauth.py)" = "2" \
+    && python3 -c "import ast, pathlib; ast.parse(pathlib.Path('/app/backend/open_webui/utils/oauth.py').read_text())"
 # Chat was broken on every route because Open WebUI attached tool schemas that
 # no route in this deployment can serve.
 #

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -703,7 +703,35 @@ services:
       OPENID_PROVIDER_URL: "${SUPABASE_PUBLIC_URL:-${SUPABASE_URL}}/auth/v1/.well-known/openid-configuration"
       OAUTH_CLIENT_ID: ${SUPABASE_OAUTH_CLIENT_ID:-}
       OAUTH_CLIENT_SECRET: ${SUPABASE_OAUTH_CLIENT_SECRET:-}
-      OAUTH_SCOPES: "openid email profile"
+      # offline_access is load-bearing, not decoration (#782). Supabase issues
+      # access tokens with a 3600 second lifetime, and Open WebUI refreshes at
+      # 5 minutes before expiry (OAuthManager.get_oauth_token). When that
+      # refresh runs, _perform_token_refresh returns None on its very first
+      # guard if the stored session has no refresh_token, and the caller then
+      # DELETES the OAuth session outright. From that moment __oauth_token__ is
+      # empty forever, hive_jwt_forward injects no upstream_auth, and every
+      # chat completion 401s with missingUserTokenMessage until the user signs
+      # in again through SSO. Without offline_access on the authorize request
+      # Supabase returns no refresh token at all, so that destruction was
+      # guaranteed roughly 55 minutes into every signed-in session.
+      #
+      # Supabase's own discovery document advertises offline_access in
+      # scopes_supported and refresh_token in grant_types_supported, so this
+      # asks for something the provider already offers. Guarded by
+      # TestOWUIOAuthScopesRequestOfflineAccess in apps/edge-api/internal/auth.
+      #
+      # The scope is only half of #782. A refresh token that exists is still
+      # refused, because Open WebUI's refresh POST authenticates the client in
+      # a different dialect than the authorization code exchange does. That
+      # half is fixed inside the image by Dockerfile.open-webui's
+      # apply_oauth_client_auth_patch.py, deliberately NOT by setting
+      # OAUTH_TOKEN_ENDPOINT_AUTH_METHOD here: pinning that to
+      # client_secret_post would also force every Supabase OAuth client to be
+      # re-registered for the same dialect, and registering those clients is
+      # manual ops with no script behind it. Every client this project has
+      # registered so far is client_secret_basic, so that value would break
+      # sign-in outright on each of them.
+      OAUTH_SCOPES: "openid email profile offline_access"
       # Supabase's OAuth 2.1 authorization server requires PKCE on every
       # authorize request. authlib (OWUI's OAuth client) only sends
       # code_challenge/code_challenge_method when this is set, so without it

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -720,6 +720,17 @@ services:
       # asks for something the provider already offers. Guarded by
       # TestOWUIOAuthScopesRequestOfflineAccess in apps/edge-api/internal/auth.
       #
+      # This one is NOT shadowable by a persisted row, which is the question
+      # every Open WebUI setting in this file has to answer since #722. Traced
+      # rather than assumed: OAUTH_SCOPES is a plain os.getenv in config.py,
+      # consumed by oidc_oauth_register, which runs at import through
+      # load_oauth_providers(). The oauth.scopes row that Config.seed_defaults
+      # writes is read only by the admin config API in routers/auths.py and by
+      # nothing on the authorize or the refresh path. A container recreate
+      # therefore genuinely picks this up, and no hive_rag_env_config style
+      # reconciler is needed here, unlike OAUTH_AUTO_REDIRECT and the feature
+      # flags that do go through one.
+      #
       # The scope is only half of #782. A refresh token that exists is still
       # refused, because Open WebUI's refresh POST authenticates the client in
       # a different dialect than the authorization code exchange does. That

--- a/deploy/docker/owui-patches/apply_oauth_client_auth_patch.py
+++ b/deploy/docker/owui-patches/apply_oauth_client_auth_patch.py
@@ -1,0 +1,98 @@
+"""Build-time splice: route Open WebUI's OAuth refresh POSTs through
+hive_oauth_client_auth.hive_refresh_request, so the refresh leg authenticates
+the client the same way authlib authenticates the authorization code exchange
+(issue #782).
+
+Upstream builds the refresh body with `client_id` and `client_secret` in it
+and posts with a single Content-Type header, which is the `client_secret_post`
+dialect, while authlib defaults the exchange to `client_secret_basic`. Against
+a provider that enforces the registered method, Supabase among them, the login
+succeeds and every refresh fails with 400 invalid_credentials, at which point
+Open WebUI deletes the OAuth session and the user cannot chat until they sign
+in again. See hive_oauth_client_auth.py's header for the full chain.
+
+There are TWO `_perform_token_refresh` implementations in this module, one on
+the SSO OAuthManager and one on the MCP-facing OAuthClientManager, and both
+build the request the same broken way. They share a byte-identical POST
+argument pair, so one substitution fixes both call sites; this asserts the
+count is exactly two so that an upstream change to either one is caught rather
+than half-patched.
+
+Asserts its own effect and fails the build otherwise, the same posture as this
+Dockerfile's other patches: a future open-webui digest bump whose OAuth source
+shifted breaks the build loudly instead of silently reverting to the broken
+behaviour. Matching the anchor is not enough on its own, so this also asserts
+that `client` is the name bound at both call sites and that the patched module
+still parses.
+"""
+
+import ast
+import pathlib
+import re
+
+TARGET = pathlib.Path("/app/backend/open_webui/utils/oauth.py")
+
+# The POST argument pair as upstream writes it, byte identical at both call
+# sites. Indentation is part of the anchor: it is what proves we matched the
+# call site and not some other dict literal.
+ANCHOR = (
+    "                    data=refresh_data,\n"
+    "                    headers={'Content-Type': 'application/x-www-form-urlencoded'},\n"
+)
+REPLACEMENT = "                    **hive_refresh_request(client, refresh_data),\n"
+
+IMPORT_ANCHOR = "from open_webui.utils.auth import create_token, get_password_hash\n"
+IMPORT_LINE = (
+    "from open_webui.utils.hive_oauth_client_auth import hive_refresh_request\n"
+)
+
+EXPECTED_CALL_SITES = 2
+
+text = TARGET.read_text()
+
+assert text.count(ANCHOR) == EXPECTED_CALL_SITES, (
+    f"expected exactly {EXPECTED_CALL_SITES} refresh POST call sites matching "
+    f"the upstream data/headers pair, found {text.count(ANCHOR)} -- upstream "
+    "open-webui source shifted, patch needs updating"
+)
+
+# Both call sites must have a local named `client`, which is what the helper
+# reads client_secret and client_kwargs off. A rename upstream would leave the
+# anchor untouched, pass the count check, and then NameError at refresh time,
+# which is exactly the silent regression this patch exists to prevent.
+refresh_defs = re.findall(
+    r"\n    async def _perform_token_refresh\(self, session\) -> dict:\n(.*?)(?=\n    (?:async )?def |\Z)",
+    text,
+    re.DOTALL,
+)
+assert len(refresh_defs) == EXPECTED_CALL_SITES, (
+    f"expected exactly {EXPECTED_CALL_SITES} _perform_token_refresh definitions, "
+    f"found {len(refresh_defs)} -- upstream open-webui source shifted, patch "
+    "needs updating"
+)
+for body in refresh_defs:
+    assert re.search(r"^\s+client = (?:await )?self\.get_client\(", body, re.MULTILINE), (
+        "_perform_token_refresh no longer binds a `client` local from "
+        "self.get_client(...) -- upstream open-webui source shifted, patch "
+        "needs updating"
+    )
+    assert ANCHOR in body, (
+        "the refresh POST anchor is not inside a _perform_token_refresh body -- "
+        "upstream open-webui source shifted, patch needs updating"
+    )
+
+assert text.count(IMPORT_ANCHOR) == 1, (
+    "the import anchor is not present exactly once -- upstream open-webui "
+    "source shifted, patch needs updating"
+)
+assert IMPORT_LINE not in text, "patch already applied"
+
+patched = text.replace(ANCHOR, REPLACEMENT)
+patched = patched.replace(IMPORT_ANCHOR, IMPORT_ANCHOR + IMPORT_LINE, 1)
+
+ast.parse(patched)  # never write an oauth.py that cannot be imported
+
+assert patched.count(REPLACEMENT) == EXPECTED_CALL_SITES, "splice did not apply"
+assert ANCHOR not in patched, "an unpatched refresh POST call site survived"
+
+TARGET.write_text(patched)

--- a/deploy/docker/owui-patches/hive_oauth_client_auth.py
+++ b/deploy/docker/owui-patches/hive_oauth_client_auth.py
@@ -1,0 +1,99 @@
+"""Client authentication for Open WebUI's OAuth token refresh (issue #782).
+
+Open WebUI performs the authorization code exchange through authlib, but it
+does NOT perform the refresh through authlib. `_perform_token_refresh` hand
+builds the refresh POST and unconditionally puts `client_id` and
+`client_secret` in the form body. That is the `client_secret_post` dialect.
+authlib, meanwhile, defaults `token_endpoint_auth_method` to
+`client_secret_basic` whenever a client secret is configured
+(authlib/oauth2/client.py, `if token_endpoint_auth_method is None`).
+
+So out of the box the two legs of the same OAuth client speak different
+dialects. Providers that enforce the registered method exactly, Supabase
+among them, accept the login and then reject every refresh with
+400 invalid_credentials: "client is registered for 'client_secret_basic' but
+'client_secret_post' was used". Open WebUI reads that failure as a dead
+session and deletes it, which locks the user out of chat entirely until they
+sign in again.
+
+The fix is to make the refresh speak whatever dialect the code exchange
+already speaks, rather than to force every deployment to re-register its
+OAuth client. `token_endpoint_auth_method` is carried on the authlib client's
+own `client_kwargs` (Open WebUI puts it there in config.py's
+`oidc_oauth_register`), so this reads the single value that already governs
+the exchange and cannot drift away from it.
+
+Resolution order matches authlib's own so that an unset value behaves
+identically on both legs:
+
+  * explicit `client_kwargs['token_endpoint_auth_method']` wins, which is what
+    `OAUTH_TOKEN_ENDPOINT_AUTH_METHOD` sets,
+  * otherwise `client_secret_basic` when a client secret exists,
+  * otherwise `none`, the public-client case, where there is no secret to send.
+
+This module is copied into the image at
+/app/backend/open_webui/utils/hive_oauth_client_auth.py and called from both
+`_perform_token_refresh` implementations by
+`apply_oauth_client_auth_patch.py`. It imports nothing from Open WebUI, so
+`scripts/test_owui_oauth_client_auth.py` can exercise it directly.
+"""
+
+import base64
+from urllib.parse import quote
+
+FORM_CONTENT_TYPE = "application/x-www-form-urlencoded"
+
+CLIENT_SECRET_BASIC = "client_secret_basic"
+CLIENT_SECRET_POST = "client_secret_post"
+NO_CLIENT_AUTH = "none"
+
+
+def resolve_auth_method(client) -> str:
+    """Return the token endpoint auth method authlib would use for `client`.
+
+    Mirrors authlib's OAuth2Client.__init__ fallback so the refresh leg and
+    the authorization code exchange leg can never disagree.
+    """
+    client_kwargs = getattr(client, "client_kwargs", None) or {}
+    configured = client_kwargs.get("token_endpoint_auth_method")
+    if configured:
+        return configured
+    return CLIENT_SECRET_BASIC if getattr(client, "client_secret", None) else NO_CLIENT_AUTH
+
+
+def basic_auth_header(client_id: str, client_secret: str) -> str:
+    """Build an RFC 6749 section 2.3.1 Basic credential.
+
+    The spec requires each half to be form-urlencoded before the base64, which
+    matters for any secret containing a colon or a plus.
+    """
+    raw = f"{quote(client_id, safe='')}:{quote(client_secret, safe='')}"
+    return "Basic " + base64.b64encode(raw.encode("utf-8")).decode("ascii")
+
+
+def hive_refresh_request(client, refresh_data: dict) -> dict:
+    """Return the aiohttp POST keyword arguments for a refresh request.
+
+    Returns `{"data": ..., "headers": ...}` so the call site stays a single
+    `**hive_refresh_request(client, refresh_data)` expression, which keeps the
+    build-time splice to one substitution per call site.
+
+    For `client_secret_basic` the credentials move out of the body and into
+    the Authorization header. They are removed from the body rather than
+    duplicated: sending both is how a request comes to look like two different
+    authentication methods at once, which providers reject on principle
+    (RFC 6749 section 2.3 permits exactly one).
+
+    Every other method, `client_secret_post` and `none` included, keeps
+    upstream's body exactly as built, so this is a no-op for providers that
+    were already working.
+    """
+    headers = {"Content-Type": FORM_CONTENT_TYPE}
+    client_secret = getattr(client, "client_secret", None)
+
+    if resolve_auth_method(client) != CLIENT_SECRET_BASIC or not client_secret:
+        return {"data": refresh_data, "headers": headers}
+
+    data = {k: v for k, v in refresh_data.items() if k not in ("client_id", "client_secret")}
+    headers["Authorization"] = basic_auth_header(client.client_id, client_secret)
+    return {"data": data, "headers": headers}

--- a/docs/proof/owui-oauth-refresh-782/refresh-path-evidence.md
+++ b/docs/proof/owui-oauth-refresh-782/refresh-path-evidence.md
@@ -1,0 +1,225 @@
+# Issue 782 evidence: Open WebUI OAuth session destruction
+
+Two capture sessions, both against the hosted Supabase project that served this
+deployment at the time.
+
+* 2026-08-06, against the demo box `chat-hive.scubed.co`: screenshots recording
+  the failure symptom, posted as release assets on the pull request rather than
+  committed here (`.wolf/decisions.md` D-042: a branch-pinned image link dies
+  when the branch is deleted at squash merge, so only the text log lives in this
+  directory, where `npm run lint:proof-tokens` can scan it).
+* 2026-08-08, against a local stack running the patched image and that same
+  hosted Supabase project: every claim in sections 1 to 6 below, each re-derived
+  from scratch rather than carried over from the earlier session.
+
+STALE BASELINE, read this first. Both sessions predate the migration of this
+deployment off hosted Supabase onto self-hosted Supabase on the demo box, and
+the hosted project has since been deleted. The two defects this branch fixes
+were re-confirmed against the current baseline on 2026-08-22 by reading
+configuration rather than by replaying the capture: `docker-compose.yml` still
+declares `OAUTH_SCOPES` without `offline_access`, so Supabase still issues no
+refresh token, and `scripts/register-owui-oauth-client.py` still registers every
+client as `client_secret_basic` while upstream Open WebUI still sends
+`client_secret_post` on the refresh. Neither the scope nor the client
+authentication dialect is affected by where the Supabase instance runs. The
+timed 55 minute run below has NOT been repeated against the self-hosted
+instance; treat the numbers as evidence of the mechanism, not as a current
+measurement.
+
+No token, secret, password or connection string appears in this file or in any
+screenshot beside it.
+
+## 1. The trigger rule
+
+Elapsed time since sign-in. Not message count, and not which conversation.
+
+Supabase issues the access token with a 3600 second lifetime, confirmed on the
+live token response (`expires_in: 3600`, section 4). Open WebUI refreshes once
+`now + 5 minutes` reaches `expires_at`:
+
+```python
+# utils/oauth.py, OAuthManager.get_oauth_token, v0.10.2
+if (
+    force_refresh
+    or session.expires_at is None
+    or datetime.now() + timedelta(minutes=5) >= datetime.fromtimestamp(session.expires_at)
+):
+```
+
+So the refresh path is first entered about 55 minutes into a signed-in
+session, and until then nothing is wrong. A conversation opened on an already
+dead session fails from its first message, which is why the original report
+read this as a second-message defect.
+
+When the refresh returns nothing, the session is not left alone, it is
+destroyed:
+
+```python
+refreshed_token = await self._refresh_token(session)
+if refreshed_token:
+    return refreshed_token
+else:
+    log.warning(f'Token refresh failed ... deleting session {session.id}')
+    await OAuthSessions.delete_session_by_id(session.id)
+    return None
+```
+
+From that moment `__oauth_token__` is empty, so
+`deploy/docker/pipelines/hive_jwt_forward.py` injects no
+`__metadata.upstream_auth`, and `OWUIUnwrap` in
+`apps/edge-api/internal/auth/owui_unwrap.go` correctly refuses the request
+with `missingUserTokenMessage`. The gateway is not the bug. It is the last
+honest component in the chain.
+
+## 2. Root cause, first half: no refresh token was ever issued
+
+`OAUTH_SCOPES` was `openid email profile`. Supabase only issues a refresh
+token when `offline_access` is requested, and
+`_perform_token_refresh` gives up on its very first guard without one:
+
+```python
+if not token_data.get('refresh_token'):
+    log.warning(f'No refresh token available for session {session.id}')
+    return None
+```
+
+Every authorization ever recorded for this project, from `auth.oauth_authorizations`:
+
+| scope | authorizations |
+| --- | --- |
+| `openid email profile` | 54 |
+| `openid email profile offline_access` | 4 (all from this fix's verification runs) |
+
+The capability was always there and was never asked for. The provider's own
+discovery document advertises `offline_access` in `scopes_supported` and
+`refresh_token` in `grant_types_supported`, both re-confirmed live.
+
+## 3. Root cause, second half: the refresh spoke the wrong dialect
+
+Adding the scope alone is not enough, because the two legs of the same OAuth
+client authenticate differently.
+
+The authorization code exchange goes through authlib, which defaults to
+`client_secret_basic` when a client secret is set:
+
+```python
+# authlib 1.7.2, oauth2/client.py
+if token_endpoint_auth_method is None:
+    if client_secret:
+        token_endpoint_auth_method = "client_secret_basic"
+```
+
+The refresh does not go through authlib at all. It hand builds the POST and
+always puts the credentials in the form body, which is `client_secret_post`:
+
+```python
+refresh_data = {
+    'grant_type': 'refresh_token',
+    'refresh_token': token_data['refresh_token'],
+    'client_id': client.client_id,
+}
+if hasattr(client, 'client_secret') and client.client_secret:
+    refresh_data['client_secret'] = client.client_secret
+```
+
+Supabase enforces the registered method exactly. Sent to the live token
+endpoint with the same deliberately invalid refresh token, so that a client
+authentication failure is distinguishable from a token failure:
+
+| client authentication | status | error | meaning |
+| --- | --- | --- | --- |
+| `client_secret_post`, what Open WebUI sends | 400 | `invalid_credentials`, "client is registered for 'client_secret_basic' but 'client_secret_post' was used" | rejected before the token is even looked at |
+| `client_secret_basic`, what the patch sends | 400 | `refresh_token_not_found`, "Invalid Refresh Token" | client authenticated, then failed only on the deliberately invalid token |
+
+Every OAuth client registered in this project is `client_secret_basic`,
+checked live in `auth.oauth_clients`: the CI client, the demo box client, and
+the Hive Chat client. None of them is registered for the dialect Open WebUI's
+refresh can produce, so with the scope alone the refresh token would exist and
+be refused anyway, and the session destroyed all the same.
+
+There are TWO `_perform_token_refresh` implementations in that module, the SSO
+`OAuthManager` and the MCP-facing `OAuthClientManager`, and both build the
+request the same way. Both are patched.
+
+## 4. The fix, verified on the real code path
+
+One local Open WebUI built from `deploy/docker/Dockerfile.open-webui` with
+both halves applied, a throwaway OAuth client registered
+`client_secret_basic` exactly like production, real SSO login through the real
+consent screen, and chat answered by a real gateway.
+
+The consent screen itself lists the fourth scope, so the request reaching the
+provider really did change:
+
+> openid, email, profile, offline_access
+
+The session Open WebUI then stored, read back out of the running container
+through its own model layer:
+
+```
+token keys: access_token, expires_at, expires_in, id_token,
+            issued_at, refresh_token, token_type, userinfo
+has refresh_token: True
+expires_in: 3600
+```
+
+### The timed run, still owed
+
+A single session held past its 55 minute refresh window, answering throughout,
+is the one artifact that exercises the whole chain over real elapsed time. It
+is NOT in this directory. Two runs were started and both were lost when the
+session driving them was interrupted partway through.
+
+Nothing above depends on it. The scope half is proven by the stored session
+carrying a refresh token, and the dialect half by the live token endpoint
+accepting the credential the patch sends and rejecting the one upstream sends.
+What the timed run would add is end to end confirmation over the clock, and
+until it exists this fix should not be treated as fully proven in production
+terms. Do not infer the result from the parts.
+
+## 5. What is deliberately NOT in this fix
+
+`OAUTH_TOKEN_ENDPOINT_AUTH_METHOD` is not set to `client_secret_post`.
+
+That would be the other way to make both legs agree, and it was the first
+approach taken. It is rejected because it only works when the Supabase OAuth
+client is also re-registered for `client_secret_post`, and registering those
+clients is manual ops with no script in this repository behind it. The two
+must then move together forever, in an order no test can enforce, on every
+deployment including customer-hosted ones. Getting it wrong does not degrade
+anything subtly: authlib would send a dialect the registration rejects and
+sign-in would fail outright for everyone.
+
+Patching the refresh to follow the method the client is already configured
+with removes the coupling. It works against every client this project has
+registered, needs no ops step, and still honours
+`OAUTH_TOKEN_ENDPOINT_AUTH_METHOD` for a deployment that really is registered
+for `client_secret_post`, so the two legs cannot silently disagree again.
+
+## 6. Why no existing test caught this
+
+Every phase-19 chat spec runs all of its turns inside one short session. The
+multi-turn spec at `apps/web-console/e2e/phase-19/owui/02-chat-multi-turn.spec.ts`
+budgets 360 seconds for the whole file and sends its two turns back to back;
+360 seconds is also the longest budget anywhere in the suite. Nothing holds a
+session open past the access token lifetime, and nothing edits `expires_at`,
+so no test in this repository can reach the refresh path at all.
+
+A test that sends one message, or several messages inside a minute, passes
+against a build that locks every user out an hour later. That is why the
+guards that ship with this fix are configuration and build invariants rather
+than another chat spec.
+
+### Known limitation of the build-time guard
+
+`apply_oauth_client_auth_patch.py` asserts its own effect and fails the build
+when its anchors stop matching, which is the right posture. But no workflow in
+`.github/workflows/` builds `Dockerfile.open-webui`, so that assertion only
+ever runs where the image is actually built: on the demo box deploy, which
+runs from `main`. Anchor drift from a future open-webui digest bump therefore
+surfaces after merge, not in the pull request that causes it.
+
+`TestOWUIImageAppliesOAuthRefreshClientAuthPatch` narrows the gap by failing in
+CI if the patch is unwired from the Dockerfile, which is the likelier
+regression, but it cannot detect an anchor that no longer matches upstream. A
+CI job that builds this image would close the remainder.

--- a/scripts/test_owui_oauth_client_auth.py
+++ b/scripts/test_owui_oauth_client_auth.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Self-check for the Open WebUI OAuth refresh client-auth patch (issue #782).
+
+Open WebUI exchanges the authorization code through authlib, which defaults
+`token_endpoint_auth_method` to `client_secret_basic` whenever a client secret
+is set, but it hand builds the refresh POST with `client_id` and
+`client_secret` in the form body, which is `client_secret_post`. Providers that
+enforce the registered method, Supabase among them, accept the login and then
+answer every refresh with 400 invalid_credentials. Open WebUI reads that as a
+dead session, deletes it, and the user cannot chat again until they sign in
+through SSO, roughly 55 minutes after they did so last.
+
+deploy/docker/owui-patches/hive_oauth_client_auth.py makes the refresh leg
+authenticate the way the exchange leg already does. This file exercises it
+directly: no framework, no network, no Open WebUI import.
+Run: python3 scripts/test_owui_oauth_client_auth.py
+"""
+import base64
+import importlib.util
+import sys
+from pathlib import Path
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "deploy"
+    / "docker"
+    / "owui-patches"
+    / "hive_oauth_client_auth.py"
+)
+spec = importlib.util.spec_from_file_location("hive_oauth_client_auth", MODULE_PATH)
+hive_oauth_client_auth = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(hive_oauth_client_auth)
+
+hive_refresh_request = hive_oauth_client_auth.hive_refresh_request
+resolve_auth_method = hive_oauth_client_auth.resolve_auth_method
+
+CLIENT_ID = "hive-owui-client"
+CLIENT_SECRET = "s3cr3t-value"
+
+
+class FakeClient:
+    """Stand-in for the authlib StarletteOAuth2App Open WebUI keeps per
+    provider. Only the three attributes the helper reads are modelled."""
+
+    def __init__(self, client_secret=CLIENT_SECRET, auth_method=None, client_id=CLIENT_ID):
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.client_kwargs = {"scope": "openid email profile offline_access"}
+        if auth_method is not None:
+            self.client_kwargs["token_endpoint_auth_method"] = auth_method
+
+
+def upstream_body(client=None):
+    """The body upstream's _perform_token_refresh builds, verbatim."""
+    client = client or FakeClient()
+    body = {
+        "grant_type": "refresh_token",
+        "refresh_token": "rt-abc123",
+        "client_id": client.client_id,
+    }
+    if client.client_secret:
+        body["client_secret"] = client.client_secret
+    return body
+
+
+def decode_basic(header):
+    assert header.startswith("Basic "), header
+    return base64.b64decode(header[len("Basic ") :]).decode("utf-8")
+
+
+def test_unset_method_resolves_to_basic_like_authlib():
+    # authlib: `if token_endpoint_auth_method is None: client_secret_basic`
+    # when a secret exists, else "none". The refresh leg has to agree, because
+    # the exchange leg is what the provider registered against.
+    assert resolve_auth_method(FakeClient()) == "client_secret_basic"
+    assert resolve_auth_method(FakeClient(client_secret=None)) == "none"
+    assert resolve_auth_method(FakeClient(auth_method="client_secret_post")) == "client_secret_post"
+
+
+def test_basic_moves_credentials_out_of_the_body():
+    client = FakeClient()
+    sent = hive_refresh_request(client, upstream_body(client))
+
+    # The whole defect: these two keys in the body are what made Supabase call
+    # the request client_secret_post and refuse it.
+    assert "client_secret" not in sent["data"], sent["data"]
+    assert "client_id" not in sent["data"], sent["data"]
+
+    # The grant itself must survive untouched.
+    assert sent["data"]["grant_type"] == "refresh_token"
+    assert sent["data"]["refresh_token"] == "rt-abc123"
+
+    assert decode_basic(sent["headers"]["Authorization"]) == f"{CLIENT_ID}:{CLIENT_SECRET}"
+    assert sent["headers"]["Content-Type"] == "application/x-www-form-urlencoded"
+
+
+def test_post_registration_keeps_upstream_behaviour():
+    # A deployment whose provider really is registered client_secret_post must
+    # keep working exactly as before, so this patch cannot break anyone who
+    # was not already broken.
+    client = FakeClient(auth_method="client_secret_post")
+    sent = hive_refresh_request(client, upstream_body(client))
+
+    assert sent["data"]["client_id"] == CLIENT_ID
+    assert sent["data"]["client_secret"] == CLIENT_SECRET
+    assert "Authorization" not in sent["headers"], sent["headers"]
+
+
+def test_public_client_sends_no_credentials_anywhere():
+    # No secret means nothing to put in a header. PKCE carries the proof.
+    client = FakeClient(client_secret=None)
+    sent = hive_refresh_request(client, upstream_body(client))
+
+    assert "Authorization" not in sent["headers"], sent["headers"]
+    assert sent["data"]["client_id"] == CLIENT_ID
+    assert "client_secret" not in sent["data"], sent["data"]
+
+
+def test_basic_credential_is_form_urlencoded_per_rfc6749():
+    # RFC 6749 section 2.3.1 encodes each half before the base64. A secret
+    # containing a colon would otherwise split into the wrong two fields at
+    # the provider and read as a wrong-password failure.
+    client = FakeClient(client_secret="pa:ss word+plus")
+    sent = hive_refresh_request(client, upstream_body(client))
+
+    assert decode_basic(sent["headers"]["Authorization"]) == f"{CLIENT_ID}:pa%3Ass%20word%2Bplus"
+
+
+def test_caller_body_is_not_mutated():
+    # The helper is called inside the POST expression; upstream still holds a
+    # reference to the dict it built and logs it on failure.
+    client = FakeClient()
+    body = upstream_body(client)
+    hive_refresh_request(client, body)
+
+    assert body["client_id"] == CLIENT_ID
+    assert body["client_secret"] == CLIENT_SECRET
+
+
+def main() -> None:
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            fn()
+    print("ok: owui OAuth refresh client auth (issue #782)")
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Fixes #782.

## The trigger rule

Elapsed time since sign-in. Not message count, and not which conversation.

Supabase issues the OAuth access token with a 3600 second lifetime. Open WebUI refreshes once `now + 5 minutes` reaches `expires_at`, so the refresh path is first entered roughly 55 minutes into a signed-in session. Until then nothing is wrong. At that moment the refresh fails, Open WebUI reads the failure as a dead session and calls `delete_session_by_id`, and from then on `__oauth_token__` is empty. Every message in every conversation fails permanently until the user signs in again through SSO. A conversation opened on an already dead session fails from its first message, which is why this was originally reported as a second-message defect.

The gateway is not the bug. `OWUIUnwrap` refusing a request that carries no `__metadata.upstream_auth` is correct, fail-closed behaviour. It is the last honest component in the chain.

## Two root causes, and both halves MUST ship together

**First, no refresh token was ever issued.** `OAUTH_SCOPES` was `openid email profile`. Supabase only issues a refresh token when `offline_access` is requested, and `_perform_token_refresh` gives up on its very first guard without one. Every authorization ever recorded in `auth.oauth_authorizations` for this project was scoped `openid email profile`, 54 of them, so the destruction was guaranteed for every user.

**Second, the refresh authenticates the client in a different dialect than the login does.** The authorization code exchange goes through authlib, which defaults `token_endpoint_auth_method` to `client_secret_basic` whenever a client secret is set. The refresh does not go through authlib at all: it hand builds the POST and always puts `client_id` and `client_secret` in the form body, which is `client_secret_post`. Supabase enforces the registered method exactly.

Fixing only the scope leaves a refresh token that is refused anyway. Fixing only the dialect leaves no refresh token to send. Verified against the live token endpoint, sending the same deliberately invalid refresh token both ways so a client authentication failure is distinguishable from a token failure:

| client authentication | status | error | meaning |
| --- | --- | --- | --- |
| `client_secret_post`, what upstream Open WebUI sends | 400 | `invalid_credentials`, "client is registered for 'client_secret_basic' but 'client_secret_post' was used" | rejected before the token is looked at |
| `client_secret_basic`, what this PR sends | 400 | `refresh_token_not_found`, "Invalid Refresh Token" | client authenticated, then failed only on the deliberately invalid token |

## Correction: this PR no longer sets OAUTH_TOKEN_ENDPOINT_AUTH_METHOD

An earlier revision of this branch set `OAUTH_TOKEN_ENDPOINT_AUTH_METHOD` to `client_secret_post` in compose. **That is reverted here.** Reviewers who looked at the previous head will see a different second half.

Pinning that variable is the other way to make both legs agree, and it only works if the Supabase OAuth client is also re-registered for `client_secret_post`. Every client this project has registered is `client_secret_basic`, confirmed live in `auth.oauth_clients`: the CI client, the demo box client, and the Hive Chat client. Registering those clients is manual ops with no script in this repository behind it, so the invariant would live only in prose, on every deployment including customer-hosted ones. Getting the order wrong does not degrade quietly: authlib would send a dialect the registration rejects and sign-in would fail outright for everyone, immediately.

Patching the refresh to follow the method the client is already configured with removes the coupling. It works against every client already registered, needs no ops step, and still honours `OAUTH_TOKEN_ENDPOINT_AUTH_METHOD` for a deployment that really is registered for `client_secret_post`, so the two legs cannot silently disagree again. Both `_perform_token_refresh` implementations are patched, the SSO `OAuthManager` and the MCP-facing `OAuthClientManager`, because both build the request the same broken way.

## What happens to existing sessions on deploy

**Nobody is locked out. Each signed-in user is asked to sign in once more, and after that their sessions behave correctly.**

The fix is not retroactive, and it is honest to say so. Sessions that already exist were issued without `offline_access`, so they carry no refresh token and nothing in this change can give them one. Such a session keeps working until it reaches its own 55 minute mark, then dies exactly as it does today, one last time. The next sign-in requests `offline_access`, receives a refresh token, and the patched refresh renews it in place from then on.

The fix ships inside the image, so the deploy has to rebuild `open-webui`. The demo box deploy already runs `up -d --build`, which rebuilds layers whose inputs changed, so no extra step is required.

## Regression guards, each confirmed failing first

**A single message test cannot detect this defect, which is precisely why it shipped.** Every phase-19 chat spec runs all of its turns inside one short session; the multi-turn spec budgets 360 seconds for the whole file, which is also the longest budget anywhere in the suite. Nothing holds a session open past the access token lifetime and nothing edits `expires_at`, so no existing test reaches the refresh path at all. A test that sends one message, or several inside a minute, passes against a build that locks every user out an hour later. That is why these guards are configuration and build invariants rather than another chat spec.

1. **`TestOWUIOAuthScopesRequestOfflineAccess`** scans every YAML file under `deploy/` for `OAUTH_SCOPES` and fails without `offline_access`.
   Proven RED by editing `docker-compose.yml` back to `"openid email profile"` and running it. It failed with `[]string{"openid", "email", "profile"} does not contain "offline_access"`, naming `deploy/docker/docker-compose.yml:649`.

2. **`TestOWUIImageAppliesOAuthRefreshClientAuthPatch`** fails if `Dockerfile.open-webui` stops applying the refresh patch, which nothing else in the repository would notice.
   Proven RED by deleting the `COPY` and `RUN` block for the patch from the Dockerfile and running it. It failed on the missing `owui-patches/hive_oauth_client_auth.py` reference.

3. **`scripts/test_owui_oauth_client_auth.py`**, wired into `make test-scripts`, covers the helper: credentials move out of the body under basic, stay in the body under post, no header for a public client, RFC 6749 form-urlencoding, and no mutation of the caller's dict.
   Proven RED by neutering the helper to always leave the credentials in the body, which is upstream's behaviour. It failed with `KeyError: 'Authorization'`.

The build-time patch also asserts its own effect: exactly two matching call sites, `client` still bound at both, the result parses, and it refuses to half apply. A future digest bump breaks the build loudly instead of silently reverting to hour-long sessions.

### Known limitation: CI never builds this image

No workflow in `.github/workflows/` builds `Dockerfile.open-webui`. The patch's self-assertion is real and fires correctly, but it only runs where the image is actually built, which is the demo box deploy, and that runs from `main`. **Anchor drift from a future open-webui digest bump therefore surfaces after merge, not in the pull request that causes it.**

`TestOWUIImageAppliesOAuthRefreshClientAuthPatch` narrows the gap by failing in CI if the patch is unwired from the Dockerfile, which is the likelier regression, but a Go test cannot detect an anchor that no longer matches upstream source. A CI job that builds this image would close the remainder. Worth filing separately; it is a pre-existing gap that affects all five patches in that Dockerfile, not something this change introduces.

## Verification performed

Live, against the real Supabase project, on the patched image built from this branch, with a throwaway OAuth client registered `client_secret_basic` exactly like production:

- The consent screen now lists `offline_access` alongside `openid`, `email` and `profile`, so the authorize request really did change.
- The session Open WebUI then stored carries a `refresh_token`, read back out of the running container through its own model layer, with `expires_in: 3600`.
- The dialect comparison above, run against the live token endpoint.
- A real SSO login followed by a chat message answered end to end through the per-user token path.

Evidence is in `docs/proof/owui-oauth-refresh-782/`.

## Outstanding before merge

**The wall-clock capture of a single session surviving past its 55 minute refresh window is not yet attached.** Two attempts were started and both were lost when the session driving them was interrupted. Everything above is verified, but the one artifact that shows the whole chain working over real elapsed time is still owed, and this PR should not merge until it is attached. The evidence document states the same thing in the same terms and carries no placeholder standing in for a result.

## Pending mitigation, NOT applied

Raising the Supabase access token lifetime from 3600 to 14400 seconds was approved as a mitigation. **It has not been applied**, because it needs a Supabase Management API token we do not hold.

It is a mitigation, not a fix, and it is not free. `edge-api` validates tokens statelessly on signature and expiry, so a longer lifetime stretches revocation lag from one hour to four. A user who is disabled, removed from a tenant, or whose access is withdrawn keeps working for up to four hours on an already-issued token.

**REVERT LINE: if the access token lifetime is ever raised to 14400, it must be returned to 3600 once this fix is deployed and confirmed. This PR removes the reason the mitigation existed. It must not be allowed to become permanent.**

## Cleanup

The throwaway OAuth client registered for verification has been deleted, confirmed by listing the project's clients rather than by trusting the delete call. Only the three production clients remain: Hive Chat, Open WebUI (Hive demo box), and Open WebUI (Hive CI), all `client_secret_basic`.

## Not merged, not deployed

The demo box deploy runs from `main` only, so nothing here has reached `chat-hive.scubed.co`.





<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR requests `offline_access` for Open WebUI OAuth sessions and patches both refresh implementations to use the client-authentication method selected for login.
- Adds build-time assertions around the pinned Open WebUI source rewrite.
- Adds configuration and helper regression checks to the existing test commands.
- Documents the refresh failure chain, verification evidence, deployment behavior, and remaining end-to-end verification gap.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The code changes appear safe to merge because no blocking failure remains in the reviewed implementation.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| deploy/docker/owui-patches/hive_oauth_client_auth.py | Builds refresh request arguments for basic, post, and public OAuth clients while preserving the caller’s request body. |
| deploy/docker/owui-patches/apply_oauth_client_auth_patch.py | Rewrites both pinned Open WebUI refresh call sites with strict anchor, binding, count, and syntax assertions. |
| deploy/docker/Dockerfile.open-webui | Installs and applies the OAuth refresh patch while validating the generated module. |
| deploy/docker/docker-compose.yml | Adds `offline_access` so newly authenticated sessions can receive refresh tokens. |
| apps/edge-api/internal/auth/owui_oauth_scope_test.go | Guards deployment scope declarations and verifies that the image patch remains wired into the Dockerfile. |
| scripts/test_owui_oauth_client_auth.py | Exercises authentication-method resolution, credential placement, encoding, public clients, and input immutability. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant U as User
  participant O as Open WebUI
  participant S as Supabase OAuth
  participant E as Edge API
  U->>O: Sign in with Hive
  O->>S: Authorize with offline_access
  S-->>O: Access and refresh tokens
  O->>E: Chat with per-user access token
  Note over O: Access token approaches expiry
  O->>S: Refresh using configured client auth method
  S-->>O: Rotated access token
  O->>E: Continue chat with refreshed token
```
</details>

<sub>Reviews (2): Last reviewed commit: ["docs: record that OAUTH\_SCOPES cannot be..."](https://github.com/sakibsadmanshajib/hive/commit/495021373f27ef617b33b4dce00c978cd16318b2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50997116)</sub>

**Context used:**

- Knowledge Base — [Edge API security boundary](https://app.greptile.com/scubed/-/custom-context/knowledge-base/sakibsadmanshajib/hive/-/docs/edge-api-security-boundary.md)

<!-- /greptile_comment -->

---

## Rebase onto current main, 2026-08-22

The branch history contained a reconciliation merge, and replaying it reapplied the superseded revision this pull request had already withdrawn, the one that pinned `OAUTH_TOKEN_ENDPOINT_AUTH_METHOD`. The net change is therefore reapplied as one commit against `main` at `c30882491` rather than replayed commit by commit. The diff against current `main` is eleven files and about 815 lines; GitHub's earlier 143-file figure was an artefact of a merge base from 2026-08-09.

Nothing in this branch touches control-plane accounts or provisioning code, and it appends no line to `.wolf/buglog.jsonl`.

### Both defects are still present on main, re-confirmed rather than assumed

- `deploy/docker/docker-compose.yml` on `main` still reads `OAUTH_SCOPES: "openid email profile"`. No `offline_access`, so Supabase still issues no refresh token and `_perform_token_refresh` still returns `None` on its first guard.
- `scripts/register-owui-oauth-client.py` still registers every client as `client_secret_basic`, asserted in its own self-check, while upstream Open WebUI still sends `client_secret_post` on the refresh. So a refresh token that did exist would still be refused.

Neither defect is affected by the migration off hosted Supabase: the scope is a property of the authorize request and the client authentication dialect is a property of the registration, and self-hosted GoTrue is the same code enforcing the same rules. The self-hosted cutover in fact re-confirms the second half, since the registration script that stands up clients on the new instance is the one that pins `client_secret_basic`.

The client authentication half is fixed inside the image precisely so it does not depend on any of this: the patch follows the method the client is already registered with and still honours `OAUTH_TOKEN_ENDPOINT_AUTH_METHOD` for a deployment that really is registered for `client_secret_post`, so the two legs cannot silently disagree again on any instance.

### Why this matters more than it did on 2026-08-09

PR #951 renders the agent surface natively and brokers the user's Supabase token server side through `get_system_oauth_token`, which goes through the same `OAuthManager.get_oauth_token` that deletes the OAuth session when a refresh fails. So once #951 lands, this defect takes out the Agents panel on the same 55 minute clock it already takes out chat. This is a prerequisite for a demo that runs longer than an hour from a single sign-in, not only a chat fix.

### Review findings addressed

All five threads resolved.

The two blocking ones were about proof artefacts and are gone on this head, verified by grep rather than by reading: there is no `RESULTS_PLACEHOLDER`, no dangling `after-fix/` or `timed-run.log` reference, and no duplicate `docs/proof/owui-oauth-refresh-782-2026-08-06/` directory. The surviving write up now carries an explicit stale-baseline warning naming the deleted hosted project, so nobody mistakes the timed run for a current measurement.

The three screenshots previously committed under `docs/proof/` are also dropped, for the reason one of those threads exists: per `.wolf/decisions.md` D-042 the image half of a proof capture belongs on the permanent visual-proof release, because a link pinned to a branch name dies the instant that branch is deleted at squash merge. Only the text log stays, where `lint:proof-tokens` can scan it.

The CI gap, that no workflow builds `Dockerfile.open-webui` so a patch anchor can drift past every required check, is filed as **#995** rather than left in a thread. It is pre-existing and affects all five patches in that Dockerfile.

The request to record that `OAUTH_SCOPES` is not shadowable by a persisted row is now in the compose comment block itself, with the trace and with the contrast against `OAUTH_AUTO_REDIRECT` and the feature flags that do go through a reconciler.

### Verification on the rebased head

`make test-scripts` green. `go test ./apps/edge-api/internal/auth/... -short` green. `lint:proof-tokens` green. Compose parses and every Caddyfile still validates against the pinned image.

Three mutation checks, each made to fail on purpose rather than reasoned about:

| mutation | result |
| --- | --- |
| `OAUTH_SCOPES` back to `"openid email profile"` | `TestOWUIOAuthScopesRequestOfflineAccess` fails, naming `deploy/docker/docker-compose.yml:734` |
| patch `COPY`/`RUN` block deleted from the Dockerfile | `TestOWUIImageAppliesOAuthRefreshClientAuthPatch` fails on the missing `owui-patches/hive_oauth_client_auth.py` reference |
| helper neutered to leave credentials in the body, upstream's behaviour | `scripts/test_owui_oauth_client_auth.py` fails with `KeyError: 'Authorization'` |

### Visual proof, and why there is none from this session

Stated as an absence rather than filled with something weaker. The claim this branch makes is that a session survives its first token refresh, which is observable only about 55 minutes after a real sign-in, against a rebuilt image, on a deployment whose OAuth client is registered for the origin the sign-in comes from. None of that is reachable from the development box: the box's own `.env` still points `SUPABASE_URL` at the hosted Supabase project deleted in the migration, which now returns `ENOTFOUND`, so the sanctioned one-time-token mint cannot reach an authorization server at all, and no local origin has a registered OAuth client. Setting or rotating a password to get a session is forbidden and was not attempted.

The honest proof for this change is a post-deploy timed run, and this pull request is not being merged by the agent that rebased it. What exists instead is the mutation table above, plus the earlier evidence document, which is now explicitly labelled as describing the mechanism on a baseline that no longer exists.

### Buglog entry

To be appended to `.wolf/buglog.jsonl` on `main` in a separate buglog-only pull request after this merges.

```json
{"id":"owui-oauth-session-destroyed-at-first-refresh","date":"2026-08-22","error_message":"Every chat completion failed about 55 minutes after sign-in and kept failing until the user signed in again through SSO","root_cause":"Two independent defects. OAUTH_SCOPES omitted offline_access so Supabase issued no refresh token and _perform_token_refresh returned None on its first guard, and the caller then deleted the OAuth session outright. Separately, Open WebUI hand-builds the refresh POST with the client credentials in the form body, which is client_secret_post, while the authorization code exchange goes through authlib with client_secret_basic, and every client this project registers is client_secret_basic, so a refresh token that did exist would have been refused anyway","fix":"Added offline_access to OAUTH_SCOPES, and spliced a helper into both _perform_token_refresh implementations that authenticates the client with the method the client is registered with, rather than pinning OAUTH_TOKEN_ENDPOINT_AUTH_METHOD and forcing every client to be re-registered","tags":["owui","oauth","token-refresh","session","supabase","issue-782"]}
```
