### PR TITLE
ci: raise agent-engine-sif artifact retention to 90 days

### DIFF
--- a/.github/workflows/agent-engine-sif.yml
+++ b/.github/workflows/agent-engine-sif.yml
@@ -94,5 +94,8 @@ jobs:
         with:
           name: agent-engine-sif
           path: deploy/apptainer/agent-engine.sif
-          retention-days: 14
+          # 90 days is GitHub's hard ceiling for a public repo (private/internal
+          # repos can go to 400); this SIF can only be rebuilt on an apptainer
+          # host, none of which we have on demand, so use the widest margin.
+          retention-days: 90
           if-no-files-found: error


### PR DESCRIPTION
## Summary
- Raises `retention-days` for the `agent-engine-sif` CI artifact from 14 to 90 in `.github/workflows/agent-engine-sif.yml`, the maximum GitHub allows for a public repository.
- Adds a one-line comment explaining why: the 1 GB apptainer `.sif` can only be rebuilt on a host with apptainer installed, which we do not have on demand (the WSL2 dev box cannot run apptainer), so a short retention window turns into a hard cliff whenever CI has downtime near expiry.

## Context
On 2026-08-08, the artifact from run 30220783800 (built 2026-07-26) was one day from expiring under the previous 14-day retention, and GitHub Actions had been in a platform-wide outage on 2026-08-06. A fresh build was triggered manually (run 31266000682) to cover this instance, but the retention window itself was the root cause of the near-miss. This PR fixes the underlying window; it does not change the build or its reproducibility.

## Test plan
- [ ] CI passes on this branch (no functional change, YAML-only edit to an existing, working step)
- [ ] Confirm the next scheduled/triggered build of `agent-engine SIF` uploads with a 90-day expiry (`expires_at` ~90 days out via `gh api repos/sakibsadmanshajib/hive/actions/artifacts`)

Not merging this PR as part of this change; leaving it open for review per standing merge policy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended retention for uploaded build artifacts from 14 to 90 days, improving access to historical artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->