### PR TITLE
fix: close six missing paths in deploy-demo-box's trigger filter

### DIFF
--- a/.github/workflows/deploy-demo-box.yml
+++ b/.github/workflows/deploy-demo-box.yml
@@ -24,9 +24,35 @@ on:
       - 'apps/control-plane/**'
       - 'apps/agent-console/**'
       - 'apps/agent-engine/**'
+      # console-hive.scubed.co is web-console-prod (docker-compose.yml, chat
+      # profile), built straight from this directory by
+      # Dockerfile.web-console.prod's `COPY apps/web-console/ ./`. This entry
+      # was missing entirely until 2026-08-08: PR #786 changed only files
+      # under here, merged to main, and triggered no deploy at all. It sat on
+      # main, undeployed and silently absent from the box, until a manual
+      # workflow_dispatch shipped it. Same failure class as the
+      # supabase/migrations and hive_jwt_forward gaps below: a paths filter
+      # with a missing entry does not fail loud, it just never runs.
+      - 'apps/web-console/**'
       - 'packages/**'
       - 'deploy/docker/**'
       - 'deploy/litellm/**'
+      # Copied first, by name, in every Go service Dockerfile this workflow
+      # builds (edge-api, control-plane, agent-engine): `COPY go.work
+      # go.work.sum* ./`. A change here (e.g. adding or repointing a `use`
+      # directive) is a real build input with no entry of its own, so it
+      # would silently ride along on the next unrelated deploy instead of
+      # shipping when it lands, the same blind spot as apps/web-console above.
+      - 'go.work'
+      - 'go.work.sum'
+      # Every Dockerfile in deploy/docker/ builds with repo root as its
+      # context (`../../`), so this file directly controls what BuildKit
+      # sees. It is not itself under deploy/docker/, so it had no entry. Its
+      # own header documents why it exists: the confirmed root cause of 16+
+      # red deploy runs (2026-07-26 on) before it was added. A future edit
+      # here is exactly the kind of change that must not wait for an
+      # unrelated commit to ship it.
+      - '.dockerignore'
       # A schema-only merge used to match nothing here, so it deployed nothing
       # and applied nothing. That is literally how PR #624's
       # 20260731_01_tenant_billing_account_backfill_v2.sql and PR #602's
@@ -37,6 +63,12 @@ on:
       - 'scripts/apply-migrations.sh'
       - 'scripts/migration-baseline.conf'
       - 'scripts/probe-applied-migrations.py'
+      # Directly invoked by the migrate job's retention-schedule report step
+      # and the deploy job's pooler-DSN derivation step respectively (both
+      # below in this same file). Neither had an entry, so a fix to either
+      # script would merge and never redeploy to pick the fix up.
+      - 'scripts/check-retention-schedule.sh'
+      - 'scripts/derive-pooler-dsn.py'
       # Both halves of the hive_jwt_forward install (#556). Without these
       # entries a fix to the installer itself would merge and never deploy,
       # the same blind spot the supabase/migrations entry above exists for.


### PR DESCRIPTION
## Summary

- `deploy-demo-box.yml`'s `paths:` trigger filter had no entry for `apps/web-console`, the source directory `web-console-prod` (the service serving console-hive.scubed.co under the `chat` profile this workflow deploys) is built from. PR #786 changed only files under that path, merged to main, and triggered no deploy at all. It sat on main, undeployed and silently absent from the box, until a manual `workflow_dispatch` shipped it.
- Audited the full filter against every path each actively deployed service's Docker build reads (every build context in this compose file is repo root, `../../`) and found five more gaps of the same shape: `go.work` / `go.work.sum` (copied first by every Go service Dockerfile), `.dockerignore` (controls what every Docker build context sees at all; this file's own header documents it as the confirmed root cause of 16+ prior red deploy runs), and two scripts the workflow itself invokes directly by name (`scripts/derive-pooler-dsn.py`, `scripts/check-retention-schedule.sh`).
- Added all six, each with a comment explaining what it covers and why it was missing, matching the file's existing convention for the `supabase/migrations` and `hive_jwt_forward` entries.

## Full path-to-service mapping (as of this audit)

Deploy job runs `docker compose --profile local --profile chat --profile monitoring up -d --build`. Services live in that set: `edge-api`, `control-plane`, `litellm` (no profile gate, always on), `redis`, `open-webui`, `caddy-owui`, `caddy-artifacts` (`local`), `agent-console`, `web-console-prod`, `caddy-console` (`chat`), `prometheus`, `grafana`, `alertmanager` (`monitoring`).

| Path | Covers |
|---|---|
| `apps/edge-api/**` | `edge-api` build |
| `apps/control-plane/**` | `control-plane` build |
| `apps/agent-console/**` | `agent-console` build |
| `apps/agent-engine/**` | not itself deployed here (`agent` profile, not in this job's profile set), but a real Go module dependency `control-plane`'s and `edge-api`'s Dockerfiles `COPY` in full |
| `apps/web-console/**` (added) | `web-console-prod` build — the gap that caused this PR |
| `packages/**` | shared Go modules (`storage`, `audit-canonical`, `embedmodel`) + `openai-contract` matrix/openapi files, all `COPY`ed into `edge-api`/`control-plane`/`agent-engine` images |
| `deploy/docker/**` | every Dockerfile, `docker-compose.yml`, all three Caddyfiles, `open-webui` patch scripts, and this workflow's own compose invocations |
| `deploy/litellm/**` | LiteLLM seed config |
| `go.work`, `go.work.sum` (added) | first `COPY` in every Go service Dockerfile; a workspace `use` change is a real build input |
| `.dockerignore` (added) | governs every Docker build context (`../../`) for every service above |
| `supabase/migrations/**` + 3 scripts | `migrate` job |
| `scripts/check-retention-schedule.sh`, `scripts/derive-pooler-dsn.py` (added) | invoked directly by name in the `migrate` and `deploy` jobs |
| `scripts/install-owui-jwt-forward.py`, `scripts/owui-mint-admin-token.py` | `deploy` job's OWUI JWT-forward install step |
| `.github/workflows/deploy-demo-box.yml` | itself |

No gap found for `apps/desktop`, `apps/desktop-sandbox`, `website/`, `docs/`, or the root `package.json` — none of them feed any Docker build this job runs.

## Is a `paths:` allowlist even the right mechanism here?

No, not as the long-term shape, though this PR keeps it. An allowlist fails silent by construction: every miss (this one, the `supabase/migrations` gap from before, the `hive_jwt_forward` gap from before) looks identical to "nothing relevant changed" until someone notices the box is stale, sometimes a day later. A denylist (`paths-ignore:` naming `website/`, `docs/`, `apps/desktop*/`, `.wolf/`, and other paths genuinely known not to feed this stack) fails safe instead: an unlisted new path defaults to triggering a deploy rather than defaulting to being silently skipped, which matches the owner's stated preference that an unnecessary deploy is cheap and a silently skipped one is not.

I did not make that switch here. It changes the trigger semantics for the whole workflow rather than closing named gaps, so it deserves its own review and its own verification pass (confirming the denylist doesn't have to be as exhaustively risk-assessed as an allowlist, which paths genuinely never touch this stack, whether removing `apps/agent-engine/**`'s special case still holds, etc.) rather than riding along on a fix framed as closing specific holes. Recommend it as a fast-follow, reviewed on its own.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-demo-box.yml'))"` — valid YAML
- [x] Diff reviewed: additive only, no existing entries touched, comments match the file's established convention
- [ ] Not merging this PR per the runbook; a fresh `main` deploy is being triggered separately via `workflow_dispatch` regardless of this PR's merge state, since main already carries undeployed changes independent of this fix
