### PR TITLE
fix: stop control-plane reporting health without a database pool

### DIFF
--- a/apps/control-plane/cmd/server/main.go
+++ b/apps/control-plane/cmd/server/main.go
@@ -990,6 +990,9 @@ func main() {
 	}
 
 	router := platformhttp.NewRouter(platformhttp.RouterConfig{
+		// Same condition that gates every DB-backed handler above, so /health
+		// cannot report ok while those routes are absent (issue #816).
+		DBReady:                  pool != nil,
 		AuthMiddleware:           authMiddleware,
 		AccountsHandler:          accountsHandler,
 		IdentityHandler:          identityHandler,

--- a/apps/control-plane/internal/platform/http/router.go
+++ b/apps/control-plane/internal/platform/http/router.go
@@ -25,6 +25,11 @@ import (
 // healthResponse is the JSON body returned by the /health endpoint.
 type healthResponse struct {
 	Status string `json:"status"`
+	// Reason names the missing dependency when Status is "degraded". It is a
+	// fixed string, never an error from the driver: the connection error
+	// carries the database user, host and pooler addresses, and /health is a
+	// public endpoint on the ingress tunnel.
+	Reason string `json:"reason,omitempty"`
 }
 
 // RouterConfig holds dependencies for building the HTTP router.
@@ -51,6 +56,16 @@ type RouterConfig struct {
 
 	// BudgetsHandler handles budget threshold CRUD and alert dismissal endpoints.
 	BudgetsHandler *budgets.Handler
+
+	// DBReady reports whether the database pool opened at startup. Every
+	// tenant-scoped and service-to-service route below is mounted only when its
+	// DB-backed handler exists, so a control-plane that came up without a pool
+	// serves none of them: /internal/apikeys/resolve 404s and edge-api reports
+	// the resulting resolution failure to the caller as "Incorrect API key
+	// provided". /health must therefore refuse to claim health without it,
+	// otherwise the container healthcheck passes and traffic is routed to a
+	// process that cannot authenticate a single request. See issue #816.
+	DBReady bool
 
 	// Mux is an optional pre-created *http.ServeMux. When provided, routes are
 	// registered on it (enabling callers to add routes after NewRouter returns).
@@ -146,7 +161,7 @@ func NewRouter(cfg RouterConfig) http.Handler {
 		mux = http.NewServeMux()
 	}
 
-	mux.HandleFunc("/health", handleHealth)
+	mux.HandleFunc("/health", healthHandler(cfg.DBReady))
 
 	// internal wraps a service-to-service handler with the shared-secret guard.
 	internal := func(h http.Handler) http.Handler {
@@ -366,8 +381,24 @@ func NewRouter(cfg RouterConfig) http.Handler {
 }
 
 // handleHealth responds with {"status":"ok"} for liveness probes.
-func handleHealth(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	_ = json.NewEncoder(w).Encode(healthResponse{Status: "ok"})
+// healthHandler reports readiness, not liveness. The process starts without a
+// database pool on purpose so the failure is inspectable rather than a crash
+// loop, but a poolless control-plane cannot serve any tenant-scoped route, so
+// reporting 200 here is what turns a transient database outage at boot into a
+// silent, permanent one: the compose healthcheck goes green, dependent services
+// start, and every caller gets a misleading credential error instead.
+func healthHandler(dbReady bool) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if !dbReady {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_ = json.NewEncoder(w).Encode(healthResponse{
+				Status: "degraded",
+				Reason: "database unavailable",
+			})
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(healthResponse{Status: "ok"})
+	}
 }

--- a/apps/control-plane/internal/platform/http/router_test.go
+++ b/apps/control-plane/internal/platform/http/router_test.go
@@ -1,8 +1,10 @@
 package http
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -25,12 +27,65 @@ func TestNewRouterDoesNotServeMetrics(t *testing.T) {
 // Guards the test above against passing vacuously: an unwired router would 404
 // on everything.
 func TestNewRouterServesHealth(t *testing.T) {
-	h := NewRouter(RouterConfig{})
+	h := NewRouter(RouterConfig{DBReady: true})
 
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("GET /health = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	var body healthResponse
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode /health body: %v", err)
+	}
+	if body.Status != "ok" {
+		t.Fatalf("GET /health status = %q, want %q", body.Status, "ok")
+	}
+}
+
+// A control-plane that came up without a database pool mounts none of its
+// DB-backed routes: /internal/apikeys/resolve is absent, so edge-api's key
+// resolution 404s and every caller is told "Incorrect API key provided". While
+// /health answered 200 in that state the compose healthcheck went green and CI
+// proceeded, which is how a transient pooler exhaustion at boot (Supabase
+// session mode, pool_size 15) turned into a red main with a misleading
+// credential error three steps downstream. See issue #816.
+func TestNewRouterHealthIsDegradedWithoutDatabase(t *testing.T) {
+	h := NewRouter(RouterConfig{DBReady: false})
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("GET /health without a database pool = %d, want %d", rec.Code, http.StatusServiceUnavailable)
+	}
+
+	var body healthResponse
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode /health body: %v", err)
+	}
+	if body.Status != "degraded" {
+		t.Fatalf("GET /health status = %q, want %q", body.Status, "degraded")
+	}
+	if body.Reason != "database unavailable" {
+		t.Fatalf("GET /health reason = %q, want %q", body.Reason, "database unavailable")
+	}
+}
+
+// The degraded body is served on a public endpoint, so it must not leak the
+// driver's connection error, which carries the database user, host and pooler
+// addresses.
+func TestNewRouterDegradedHealthDoesNotLeakConnectionDetail(t *testing.T) {
+	h := NewRouter(RouterConfig{DBReady: false})
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
+
+	for _, leak := range []string{"postgres", "pooler", "5432", "password", "supabase"} {
+		if strings.Contains(strings.ToLower(rec.Body.String()), leak) {
+			t.Fatalf("degraded /health body leaks %q: %s", leak, rec.Body.String())
+		}
 	}
 }


### PR DESCRIPTION
Fixes #816.

Triage of a red `main`. The conclusion is the opposite of the one the specs invited, so the evidence comes first.

## The specs were right, the product was broken

The reported failures were `auth-shell.spec.ts` and `console-workspace-admin.spec.ts`. Neither reading held up.

`console-workspace-admin.spec.ts` never failed. Both of its tests were **skipped** on that run, so it reported nothing at all. The actual second failure was `profile-completion.spec.ts:52`. Worth flagging separately: those two tests are gated behind a `test.skip()` that was satisfied on this run, which means the tenant OWNER gating they cover is currently unverified by the E2E suite.

The specs asserted a heading `Profile settings` and an `input[name="ownerName"]`. Both exist in the source at the failing commit, unchanged. Nothing was renamed, so there was no stale assertion to update. The pages had failed to render.

The distribution said the rest. Every credentialed spec failed or cascaded, and all five unauthenticated specs passed. The split is not "the sign in flow changed", it is "anything that talks to the control-plane is dead".

## Root cause

From the failing run's own `compose-logs` artifact, control-plane at boot:

```
WARNING: database not available at startup: failed to ping database:
  FATAL: (EMAXCONNSESSION) max clients reached in session mode
  - max clients are limited to pool_size: 15
```

Eight seconds later, edge-api:

```
authz: key resolution failed err=authz: status 404: 404 page not found
```

The chain:

1. `main.go` treats a failed pool ping as a non fatal warning and continues with `pool == nil`.
2. Every DB backed handler is constructed inside that same `if pool != nil`, so `apikeysHandler` stays nil.
3. `router.go` mounts `/internal/apikeys/resolve` only when `cfg.APIKeysHandler != nil`. The route does not exist.
4. edge-api POSTs it, gets `404 page not found`, and collapses the failure into `401 Incorrect API key provided`. That collapse is deliberate and correct for the caller, and the real cause was logged.
5. `handleHealth` returned `200 {"status":"ok"}` regardless.

Step 5 is the defect. The healthcheck went green on a process that could not authenticate a single request, so `Wait for services to become healthy` passed and the failure surfaced three steps later as a credential error pointing nowhere near the cause.

The same boot state explains the console failures: `getViewer` and `getAccountProfile` hit the same absent routes.

## Is a real user affected right now

No. The `deploy-demo-box` run at 21:35 UTC ran authenticated JS and Python SDK replays against the live box and passed, so the demo box holds a working pool. The trigger was CI's own concurrency against the shared session mode pooler, which #631 already tracks.

The latent risk is the point of this PR. Any control-plane boot coinciding with pooler exhaustion yields a process that advertises health while rejecting every key, and nothing restarts it or fails over, because the only readiness signal says ok.

## The fix

`/health` reports readiness rather than liveness: `503 {"status":"degraded","reason":"database unavailable"}` when the pool did not come up.

One guard in the single handler every caller routes through, which covers all DB backed routes rather than the apikeys path alone. The reason is a fixed string, never the driver error, which carries the database user, host and pooler addresses, because `/health` is public on the ingress tunnel.

The process still starts without a pool on purpose so the state stays inspectable rather than becoming a crash loop. What changes is that nothing routes traffic to it, and CI fails at the wait for healthy step with an honest message.

No flapping risk: `db.Open` pings eagerly and returns before the server listens, so `DBReady` is settled before `/health` can be reached. `start_period` is 120s.

## Proof each assertion can fail

This repository has shipped defects behind tests that could not fail, so every new assertion was watched going red before it went green.

| Mutation | Result |
| --- | --- |
| Neutralize the new branch, restoring the old always 200 behavior | `TestNewRouterHealthIsDegradedWithoutDatabase` fails: `GET /health without a database pool = 200, want 503`, which is the exact CI symptom |
| Put the real connection error in the reason | `TestNewRouterDegradedHealthDoesNotLeakConnectionDetail` fails on `postgres`, and the degraded test fails on the reason string |
| Return `degraded` on the ready path | `TestNewRouterServesHealth` fails: `status = "degraded", want "ok"` |

The pre-existing `TestNewRouterServesHealth` checked only the status code, so it would have passed against a body saying anything. It now asserts the body too.

## Not addressed here

The pool is still not retried after a failed boot, so recovery needs a restart. With an honest healthcheck the container is at least visibly unhealthy rather than silently useless. Noted in #816 as a follow up.

## Test plan

- [x] `go vet ./apps/control-plane/...`
- [x] `go test ./apps/control-plane/... -count=1 -short`, full package suite green
- [x] `gofmt -l` clean on all three changed files
- [x] Each new assertion watched failing under a deliberate mutation, per the table above

## Visual proof

Not applicable. This changes an HTTP status code on a JSON service endpoint with no UI surface. The customer facing behavior it protects, the 401, is shown in the log excerpts above.
