### PR TITLE
fix: retry the control-plane database pool at boot

### DIFF
--- a/apps/control-plane/cmd/server/main.go
+++ b/apps/control-plane/cmd/server/main.go
@@ -79,6 +79,18 @@ import (
 // /metrics, kept off the public listener so the Prometheus series stay internal.
 const metricsListenAddr = ":9101"
 
+// Boot-time database retry budget. The shared session-mode pool refuses new
+// clients for a few seconds when CI, the demo box and local stacks overlap
+// (issue #631), which used to leave the process permanently poolless (issue
+// #816). Worst case here is roughly 25s of retries inside a 45s ceiling, well
+// under the 120s healthcheck start_period, so a stack that is genuinely
+// misconfigured still reports unhealthy promptly rather than hanging.
+const (
+	dbOpenAttempts   = 6
+	dbOpenRetryDelay = 5 * time.Second
+	dbOpenBudget     = 45 * time.Second
+)
+
 // ledgerGrantAdapter wraps *ledger.Service to satisfy the paymentStub.LedgerGranter
 // interface (which returns only error, discarding the LedgerEntry return value).
 // Used only when HIVE_PAYMENTS_STUB=true is set.
@@ -237,7 +249,17 @@ func main() {
 	// Open the database pool. A missing SUPABASE_DB_URL is treated as a
 	// non-fatal warning at startup so the service can still respond to /health
 	// in environments where the DB URL is not yet provisioned.
-	pool, dbErr := platformdb.Open(ctx, cfg.SupabaseDBURL)
+	// Retried because the failure this most often hits is transient: the shared
+	// session-mode pool runs out of client slots for a few seconds when CI, the
+	// demo box and local stacks overlap (issue #631). Six attempts five seconds
+	// apart is at most ~25s, well inside the 120s healthcheck start_period, and
+	// exhausting the budget is still non-fatal so the state stays inspectable.
+	// Its own context: the startup ctx above is capped at 10s, which would cut
+	// the retry budget off after the first delay.
+	dbCtx, dbCancel := context.WithTimeout(context.Background(), dbOpenBudget)
+	defer dbCancel()
+
+	pool, dbErr := platformdb.OpenWithRetry(dbCtx, cfg.SupabaseDBURL, dbOpenAttempts, dbOpenRetryDelay)
 	if dbErr != nil {
 		log.Printf("WARNING: database not available at startup: %v", dbErr)
 	} else {

--- a/apps/control-plane/internal/platform/db/pool.go
+++ b/apps/control-plane/internal/platform/db/pool.go
@@ -3,6 +3,8 @@ package db
 import (
 	"context"
 	"fmt"
+	"log"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 )
@@ -65,4 +67,65 @@ func Open(ctx context.Context, databaseURL string) (*pgxpool.Pool, error) {
 	}
 
 	return pool, nil
+}
+
+// OpenWithRetry calls Open until it succeeds or the attempt budget runs out.
+//
+// The session-mode pool this connects to is small and shared: CI runs, the demo
+// box and local stacks all draw from the same pool_size 15 (see issue #631), so
+// a boot that lands during a burst gets EMAXCONNSESSION on the first ping. That
+// is a transient condition that clears in seconds, but a single failed ping used
+// to leave the process permanently without a pool, serving none of its DB-backed
+// routes for the rest of its life (issue #816). Retrying rides through the burst.
+//
+// Giving up remains safe rather than fatal: the caller keeps a nil pool, and
+// /health reports degraded so nothing routes traffic to the process.
+//
+// An empty URL is a configuration error, not a transient one, so it fails on the
+// first attempt instead of burning the whole budget.
+func OpenWithRetry(ctx context.Context, databaseURL string, attempts int, delay time.Duration) (*pgxpool.Pool, error) {
+	if databaseURL == "" {
+		return Open(ctx, databaseURL)
+	}
+	return openWithRetry(ctx, attempts, delay, func(attemptCtx context.Context) (*pgxpool.Pool, error) {
+		return Open(attemptCtx, databaseURL)
+	})
+}
+
+// openWithRetry holds the retry loop separately from the connection itself so
+// the backoff, the budget and the context handling are testable without a
+// database.
+func openWithRetry(
+	ctx context.Context,
+	attempts int,
+	delay time.Duration,
+	open func(context.Context) (*pgxpool.Pool, error),
+) (*pgxpool.Pool, error) {
+	if attempts < 1 {
+		attempts = 1
+	}
+
+	var err error
+	for attempt := 1; attempt <= attempts; attempt++ {
+		var pool *pgxpool.Pool
+		pool, err = open(ctx)
+		if err == nil {
+			if attempt > 1 {
+				log.Printf("database pool opened on attempt %d of %d", attempt, attempts)
+			}
+			return pool, nil
+		}
+		if attempt == attempts {
+			break
+		}
+
+		log.Printf("database not ready (attempt %d of %d), retrying in %s: %v", attempt, attempts, delay, err)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(delay):
+		}
+	}
+
+	return nil, err
 }

--- a/apps/control-plane/internal/platform/db/pool_retry_test.go
+++ b/apps/control-plane/internal/platform/db/pool_retry_test.go
@@ -1,0 +1,105 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// The failure this exists for is transient: the shared session-mode pool
+// refuses new clients for a few seconds under load, and the boot that lands in
+// that window used to give up permanently (issue #816). A later attempt must be
+// able to succeed.
+func TestOpenWithRetrySucceedsAfterTransientFailures(t *testing.T) {
+	calls := 0
+	open := func(context.Context) (*pgxpool.Pool, error) {
+		calls++
+		if calls < 3 {
+			return nil, errors.New("FATAL: (EMAXCONNSESSION) max clients reached in session mode")
+		}
+		return nil, nil
+	}
+
+	if _, err := openWithRetry(context.Background(), 6, time.Millisecond, open); err != nil {
+		t.Fatalf("openWithRetry after transient failures = %v, want nil", err)
+	}
+	if calls != 3 {
+		t.Fatalf("open called %d times, want 3", calls)
+	}
+}
+
+// Exhausting the budget must surface the last error rather than a nil pool with
+// a nil error, which the caller would treat as a working database.
+func TestOpenWithRetryGivesUpAndReturnsLastError(t *testing.T) {
+	calls := 0
+	last := errors.New("last failure")
+	open := func(context.Context) (*pgxpool.Pool, error) {
+		calls++
+		return nil, last
+	}
+
+	_, err := openWithRetry(context.Background(), 4, time.Millisecond, open)
+	if !errors.Is(err, last) {
+		t.Fatalf("openWithRetry error = %v, want %v", err, last)
+	}
+	if calls != 4 {
+		t.Fatalf("open called %d times, want 4", calls)
+	}
+}
+
+// A success on the first attempt must not pay any delay, so a healthy boot is
+// not slowed down by the retry budget existing.
+func TestOpenWithRetryDoesNotDelayOnFirstAttemptSuccess(t *testing.T) {
+	calls := 0
+	open := func(context.Context) (*pgxpool.Pool, error) {
+		calls++
+		return nil, nil
+	}
+
+	start := time.Now()
+	if _, err := openWithRetry(context.Background(), 6, time.Hour, open); err != nil {
+		t.Fatalf("openWithRetry = %v, want nil", err)
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("first-attempt success waited %s, want no delay", elapsed)
+	}
+	if calls != 1 {
+		t.Fatalf("open called %d times, want 1", calls)
+	}
+}
+
+// Shutdown during the backoff must abandon the retries instead of holding the
+// process for the rest of the budget.
+func TestOpenWithRetryStopsWhenContextIsCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	calls := 0
+	open := func(context.Context) (*pgxpool.Pool, error) {
+		calls++
+		cancel()
+		return nil, errors.New("boom")
+	}
+
+	_, err := openWithRetry(ctx, 6, time.Hour, open)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("openWithRetry error = %v, want context.Canceled", err)
+	}
+	if calls != 1 {
+		t.Fatalf("open called %d times after cancellation, want 1", calls)
+	}
+}
+
+// An empty URL is a misconfiguration, not a transient fault, so it must fail
+// immediately rather than burn the retry budget on a result that cannot change.
+func TestOpenWithRetryDoesNotRetryEmptyURL(t *testing.T) {
+	start := time.Now()
+	_, err := OpenWithRetry(context.Background(), "", 6, time.Hour)
+	if err == nil {
+		t.Fatal("OpenWithRetry with an empty URL = nil error, want an error")
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("empty URL waited %s, want an immediate failure", elapsed)
+	}
+}


### PR DESCRIPTION
Follow up to #817. Same issue, #816.

## Why this is needed

#817 made `/health` honest: a control-plane that came up without a database pool now reports `503 degraded` instead of `200 ok`. That was the right fix for the misdiagnosis, and it worked, but it does not reduce the failure rate. The first `main` run after that merge failed at `Start core stack` with:

```
control-plane-1 is unhealthy
dependency failed
```

and the compose logs show the same cause as the original red run:

```
WARNING: database not available at startup: failed to ping database:
  FATAL: (EMAXCONNSESSION) max clients reached in session mode
  - max clients are limited to pool_size: 15
```

So the failure is now loud, early and correctly attributed, which is what #817 was for. It is still a failure.

## Root cause of the remaining redness

The pool ping was attempted exactly once. The shared session-mode pool refuses new clients for a few seconds when CI runs, the demo box and local stacks overlap, which is #631. A boot landing inside that window gave up permanently on a condition that clears by itself in seconds.

A service that bricks for its whole lifetime because one connection attempt at startup lost a race is simply wrong, independent of how small the pool is.

## Change

`Open` is retried six times, five seconds apart, under a 45s ceiling.

The retry runs on its own context. The existing startup context is capped at 10s, so reusing it would have cut the budget off after the first delay and the retry would have been decorative. That is the kind of detail worth stating because it is invisible in the diff at the call site.

Worst case is roughly 25s of retries inside a 45s ceiling, against a 120s healthcheck `start_period`, so a genuinely misconfigured stack still reports unhealthy promptly rather than hanging.

Exhausting the budget stays non-fatal. The process still starts without a pool so the state remains inspectable, and #817 guarantees nothing routes traffic to it.

An empty database URL short circuits on the first attempt. That is a configuration error, not a transient one, and retrying cannot change the answer.

## Proof each assertion can fail

Five new tests, each watched red before green.

| Mutation | Result |
| --- | --- |
| Break out of the loop after the first failure, restoring the old single-attempt behavior | `TestOpenWithRetrySucceedsAfterTransientFailures` fails carrying the production error text `EMAXCONNSESSION`; `TestOpenWithRetryGivesUpAndReturnsLastError` fails on `open called 1 times, want 4`; `TestOpenWithRetryStopsWhenContextIsCancelled` fails on the error identity |
| Remove the empty-URL short circuit | `TestOpenWithRetryDoesNotRetryEmptyURL` hangs on the backoff and dies at the test timeout |
| Pay the delay on a first-attempt success | `TestOpenWithRetryDoesNotDelayOnFirstAttemptSuccess` hangs likewise, so a healthy boot cannot start quietly costing the retry budget |

The retry loop is kept separate from the connection itself specifically so the budget, the backoff and the context handling are testable without a database.

## What this does not fix

The pool is still shared and still small. This makes a boot survive a burst; it does not create capacity. #631 remains the place for that, and it is the reason CI keeps landing in these windows in the first place.

## Test plan

- [x] `go vet ./apps/control-plane/...`
- [x] `go test ./apps/control-plane/... -count=1 -short`, full suite green
- [x] `gofmt -l` clean on all changed files
- [x] Every new assertion watched failing under a deliberate mutation, per the table above

## Visual proof

Not applicable. No UI surface: this changes process startup behavior for a backend service.
