### PR TITLE
docs: name the real agent-engine gate, and move buglog entries off feature branches

### DIFF
--- a/.claude/rules/openwolf.md
+++ b/.claude/rules/openwolf.md
@@ -23,13 +23,23 @@ globs: **/*
 
 ## Bug memory
 
-- .wolf/buglog.jsonl = source of truth, deliberate entries only. One JSON object per line, append only. .gitattributes declares `merge=union`, so parallel branches merge appends automatically. Never rewrite an existing line.
+- .wolf/buglog.jsonl = source of truth, deliberate entries only. One JSON object per line, append only. Never rewrite an existing line.
 - .wolf/buglog.json = generated aggregate, gitignored. Keeps `openwolf bug search` and the dashboard working. Rebuilt by the session-start hook; rebuild by hand w/ `node .wolf/hooks/bugstore.js sync`
 - The post-write hook's `auto-detected` guesses land in the aggregate only, never in the tracked .jsonl. Searchable for the session, dropped on rebuild. Do not promote them by hand: a real bug gets a real entry.
 - BEFORE fix any bug/error: `openwolf bug search <term>`, or grep .wolf/buglog.jsonl (one entry per line, grep-friendly)
-- AFTER fix any bug, error, failed test, failed build, user-reported problem: ALWAYS log it w/ error_message, root_cause, fix, tags. Use `node .wolf/hooks/bugstore.js add '<json>'`, or append one line to .wolf/buglog.jsonl
+- AFTER fix any bug, error, failed test, failed build, user-reported problem: ALWAYS log it w/ error_message, root_cause, fix, tags. The requirement is unchanged. What changed is where the line is written: see "Entries land on main" below.
 - Edit file >2x per session → likely bug → log it
 - Store self-check: `node .wolf/hooks/bugstore.selfcheck.js`
+
+### Entries land on main, never on a feature branch (issue #873)
+
+- NEVER append to .wolf/buglog.jsonl on a fix or feature branch. Not "prefer not to": never. A branch that appends a line conflicts with every other branch that appended one, and while a pull request is unmergeable GitHub builds no `refs/pull/N/merge`, creates no `pull_request` run, and shows zero checks. The required-status gate then blocks the merge for a reason the page never states, which reads as a broken workflow and sends the next agent to debug CI triggers that were never broken.
+- `merge=union` in .gitattributes stays, and still resolves concurrent appends in local merges and rebases. It does NOT apply on GitHub: the server-side merge ignores the union driver, so two branches that both appended are in hard conflict there. Do not re-derive this the hard way.
+- The route today is manual, and there is no post-merge automation yet. After the fix has merged to main, open a separate pull request whose diff is .wolf/buglog.jsonl and nothing else, and merge that. Keep one such pull request open at a time across all agents, so no two of them ever hold competing versions of the file. Batching several entries into one of these is fine and preferred.
+- Those pull requests merge cheaply: .wolf/buglog.jsonl is on the inert-path allowlist in .github/workflows/ci.yml, so the six required checks report green without running their heavy steps.
+- While the fix is still in flight, carry the entry in the fix pull request's body, under a "Buglog entry" heading, as the JSON line to be appended. That keeps the record attached to the fix and reviewable, and it is what the follow-up pull request copies from. Do not let the entry live only in a session transcript.
+- Automating this (a post-merge job that appends the entry from the merged pull request body) is tracked in issue #873. Until it exists, do it by hand rather than skipping it.
+- `node .wolf/hooks/bugstore.js add '<json>'` appends to the tracked .wolf/buglog.jsonl itself, so do NOT run it while on a fix branch: it dirties the tracked file in the working tree and the next `git add -A` sweeps it into the fix commit. Run it on the buglog-only branch cut from main, where appending is the whole point of the branch.
 
 ## UI
 

--- a/.claude/skills/memory-tools.md
+++ b/.claude/skills/memory-tools.md
@@ -20,7 +20,7 @@ Projects work well with optional memory/context tools. **None required.** Detect
 
 - **Before start work:** claude-mem available? Run `mem-search` for prior work same area. OpenWolf available? Check `.wolf/anatomy.md` before Reading project files and `.wolf/cerebrum.md` Do-Not-Repeat before generating code.
 - **After user correction:** update active memory store — OpenWolf `cerebrum.md`, or Claude Code auto-memory (`feedback_*.md`), or both. Never persist corrections to multiple stores inconsistently.
-- **After fix bug:** `.wolf/buglog.json` exists? Append bug entry per OpenWolf schema. Else skip.
+- **After fix bug:** `.wolf/` exists? Recording an entry is mandatory, but on a feature branch it goes in the PR body, not into `.wolf/buglog.jsonl`. It is appended to `main` afterwards in a separate buglog-only PR. Protocol: `.claude/rules/openwolf.md`. Else skip.
 - **Large-output shell or web fetch:** prefer `ctx_batch_execute` / `ctx_fetch_and_index` over raw Bash/WebFetch when context-mode present.
 - **Session wrap:** OpenWolf active? Append line to `.wolf/memory.md`. claude-mem active? Capture automatic — no manual action.
 

--- a/.env.example
+++ b/.env.example
@@ -741,10 +741,13 @@ FASTER_WHISPER_BASE_URL=http://faster-whisper:8000
 #   Example: /opt/hive/models/parakeet
 # PARAKEET_MODEL_DIR=/opt/hive/models/parakeet
 
-# ── agent-engine sandbox runtime (Apptainer) ─────────────────────────────────
-# Absolute host path to the prebuilt agent-engine Apptainer image. agent-engine
-# launches every agent session inside a container built from this .sif and
-# refuses to start without it. Build it with `make agent-sif` on a linux/amd64
-# host, or download the `agent-engine-sif` CI artifact. See
-# deploy/apptainer/README.md. Leave blank on the WSL2 dev box (no apptainer).
+# ── agent-engine smoke-test container (Apptainer) ────────────────────────────
+# This does NOT gate real agent task launches. Those go through the host
+# launcher, configured by HIVE_AGENT_ENGINE_SOCKET and friends further up this
+# file. HIVE_AGENT_SIF_PATH only supplies the `-sif` default for the standalone
+# agent-engine binary and for the compose smoke-test service under
+# `--profile agent`, so setting it changes nothing about whether Cowork works
+# (issue #781). Build the image with `make agent-sif` on a linux/amd64 host, or
+# download the `agent-engine-sif` CI artifact. See deploy/apptainer/README.md.
+# Leave blank on the WSL2 dev box (no apptainer).
 HIVE_AGENT_SIF_PATH=

--- a/.wolf/hooks/post-write.js
+++ b/.wolf/hooks/post-write.js
@@ -139,7 +139,7 @@ async function main() {
         session.edit_counts[editKey] = (session.edit_counts[editKey] || 0) + 1;
         writeJSON(sessionFile, session);
         if (session.edit_counts[editKey] >= 3) {
-            process.stderr.write(`⚠️ OpenWolf: ${baseName} has been edited ${session.edit_counts[editKey]} times this session. If you're fixing a bug, remember to log it to .wolf/buglog.json.\n`);
+            process.stderr.write(`⚠️ OpenWolf: ${baseName} has been edited ${session.edit_counts[editKey]} times this session. If you're fixing a bug, remember to record it: on a feature branch the entry goes in the PR body, not into .wolf/buglog.jsonl (.claude/rules/openwolf.md).\n`);
         }
     }
     catch { }

--- a/.wolf/hooks/stop.js
+++ b/.wolf/hooks/stop.js
@@ -127,7 +127,7 @@ function checkForMissingBugLogs(wolfDir, session) {
     // a hook guess cannot satisfy a check that is about the durable log.
     const buglogWritten = readBugs(wolfDir).length > (session.buglog_entries_at_start ?? 0);
     if (!buglogWritten) {
-        process.stderr.write(`⚠️ OpenWolf: Files edited 3+ times this session (${multiEditFiles.join(", ")}) but buglog.jsonl was not updated. If you fixed bugs, please log them.\n`);
+        process.stderr.write(`⚠️ OpenWolf: Files edited 3+ times this session (${multiEditFiles.join(", ")}) but buglog.jsonl was not updated. If you fixed bugs, record them. On a feature branch the entry goes in the PR body, not into buglog.jsonl (.claude/rules/openwolf.md).\n`);
     }
 }
 /**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Project use OpenWolf for context mgmt. Read + follow `.claude/rules/openwolf.md` every session. Check .wolf/cerebrum.md before gen code. Check .wolf/anatomy.md before read files. Check .wolf/decisions.md before any design, spec, plan, or implementation, and inject the relevant decisions into every subagent brief (detail lives in the vault, this is the terse index).
 
-**.wolf/ state files.** Tracked and curated: `cerebrum.md`, `decisions.md`, `buglog.jsonl`, `GOAL.md`, `fleet.json`, `cost-ledger.md`, `hooks/*.js`. Untracked telemetry, hook-owned and gitignored: `anatomy.md`, `memory.md`, `token-ledger.json`, `hooks/_session.json`, `buglog.json`. Never hand-edit or commit telemetry and never `git add -f` it: the hooks rewrite it on every tool call, which blocks `git pull --ff-only` on the shared checkout and produces competing versions across parallel worktrees. Bug memory is appended to `.wolf/buglog.jsonl`, one JSON object per line, `merge=union` per `.gitattributes`. Full protocol: `.claude/rules/openwolf.md`.
+**.wolf/ state files.** Tracked and curated: `cerebrum.md`, `decisions.md`, `buglog.jsonl`, `GOAL.md`, `fleet.json`, `cost-ledger.md`, `hooks/*.js`. Untracked telemetry, hook-owned and gitignored: `anatomy.md`, `memory.md`, `token-ledger.json`, `hooks/_session.json`, `buglog.json`. Never hand-edit or commit telemetry and never `git add -f` it: the hooks rewrite it on every tool call, which blocks `git pull --ff-only` on the shared checkout and produces competing versions across parallel worktrees. Bug memory is appended to `.wolf/buglog.jsonl`, one JSON object per line. Logging every fixed bug, error, failed test or failed build is still mandatory, but the line never lands on a feature branch: carry it in the fix PR body under a "Buglog entry" heading, then append it to `main` in a separate buglog-only PR once the fix has merged, one such PR open at a time. `merge=union` in `.gitattributes` resolves concurrent appends locally but is ignored by GitHub's server-side merge, so branch appends conflict serially and an unmergeable PR gets no `pull_request` CI run at all (issue #873). Full protocol: `.claude/rules/openwolf.md`.
 
 ## Orchestrator Contract
 
@@ -45,9 +45,9 @@ docker compose --env-file ../../.env --profile local up --build
 # Full demo surface (agent subsystem): core + agent-console sidecar (chat) +
 # agent-engine (agent) + in-stack Redis (local), in ONE command. RAG query
 # embeddings run serverless via LiteLLM (EMBEDDING_BASE_URL default). Live
-# agent-task sandbox launch additionally needs a built Apptainer runtime image
-# (HIVE_AGENT_SIF_PATH); build it from deploy/apptainer/agent-engine.def on a
-# host with apptainer (unavailable on WSL2), then set HIVE_AGENT_SIF_PATH in .env.
+# agent-task sandbox launch additionally needs the host launcher running and
+# HIVE_AGENT_ENGINE_SOCKET set (see section 4); the `agent` profile's
+# agent-engine service is a build and smoke-test container only.
 docker compose --env-file ../../.env --profile local --profile chat --profile agent up --build
 
 # Hive Cloud (hosted SaaS): core services expecting managed Upstash Redis.
@@ -76,27 +76,50 @@ supabase db push                    # If Supabase CLI is linked
 # Or apply supabase/migrations/ files in order via SQL editor
 ```
 
-### 4. Agent-engine runtime image (Apptainer)
+### 4. Agent-engine runtime (Apptainer sandbox)
 
-The agent-engine service launches each agent session inside an Apptainer
-sandbox built from `deploy/apptainer/agent-engine.def`. It needs a prebuilt
-`.sif` and reads its path from `HIVE_AGENT_SIF_PATH`. The image is `linux/amd64`
-only and cannot be built on the WSL2 dev box.
+Each agent session runs inside an Apptainer sandbox built from
+`deploy/apptainer/agent-engine.def`. The image is `linux/amd64` only and cannot
+be built on the WSL2 dev box, so take it from CI (`gh run download -n
+agent-engine-sif -D /opt/hive`) or build it on an apptainer host with
+`make agent-sif`.
 
-```bash
-# Demo/prod host with apptainer installed:
-make agent-sif                       # -> deploy/apptainer/agent-engine.sif
-export HIVE_AGENT_SIF_PATH=$(pwd)/deploy/apptainer/agent-engine.sif
+What actually gates a task launch is in `buildAgentEngine`
+(`apps/control-plane/cmd/server/main.go`), and it has two arms, checked in this
+order.
 
-# No local apptainer: download the CI-built image instead.
-gh workflow run "agent-engine SIF"   # or use the latest successful run
-gh run download -n agent-engine-sif -D /opt/hive
-export HIVE_AGENT_SIF_PATH=/opt/hive/agent-engine.sif
-```
+**Socket arm, which is what the demo box runs.** If `HIVE_AGENT_ENGINE_SOCKET`
+is set, control-plane hands every launch to the unprivileged host launcher over
+that Unix socket, authenticating with `CONTROL_PLANE_INTERNAL_TOKEN`, and none
+of the path variables below are read at all. Control-plane cannot exec Apptainer
+itself (Alpine base, no `/dev/fuse`, no `CAP_SYS_ADMIN`), and granting it that
+privilege was refused deliberately, so this is the only arm that runs a real
+task on any deployment this repo ships. Stand the launcher up with
+`scripts/install-agent-engine-host.sh`; it reads its own variable set in
+`apps/agent-engine/cmd/agent-engine/serve.go`, including the four paths and
+`HIVE_AGENT_ENGINE_LLM_MODEL`, `HIVE_AGENT_ENGINE_LLM_BASE_URL` and
+`HIVE_AGENT_ENGINE_LLM_API_KEY`.
 
-The `agent-engine SIF` workflow builds the `.sif` in CI (which also validates
-the def) and uploads it as the `agent-engine-sif` artifact. Full detail:
-`deploy/apptainer/README.md`.
+**In-process arm.** With no socket set, control-plane tries to exec Apptainer
+itself. That needs a non-nil egress service (so, a live DB pool) plus five
+variables, all of them: `HIVE_AGENT_ENGINE_SIF_PATH`,
+`HIVE_AGENT_ENGINE_PACKS_DIR`, `HIVE_AGENT_ENGINE_WORKSPACE_ROOT`,
+`HIVE_AGENT_ENGINE_RUN_DIR`, `HIVE_AGENT_ENGINE_PROFILE_ID`. Miss any one and
+the engine falls back to `NotConfiguredEngine`, every submitted task fails
+immediately, and a boot WARN names what was missing
+(`docker compose logs control-plane | grep "agent engine not configured"`).
+Under docker compose this arm cannot succeed regardless of the variables.
+
+Optional, all defaulted: `HIVE_AGENT_ENGINE_SESSION_API_KEY`,
+`HIVE_QUOTA_TENANT_CONCURRENCY` (4), `HIVE_QUOTA_USER_CONCURRENCY` (2),
+`HIVE_SANDBOX_MEMORY_LIMIT` (4G), `HIVE_SANDBOX_CPU_LIMIT` (2),
+`HIVE_SANDBOX_PIDS_LIMIT` (512).
+
+`HIVE_AGENT_SIF_PATH` gates nothing. It survives only as the `-sif` flag default
+for the standalone `agent-engine` binary
+(`apps/agent-engine/cmd/agent-engine/main.go`) and for the compose smoke-test
+service under `--profile agent`. Setting it does not make Cowork work. Full
+detail: `deploy/apptainer/README.md`.
 
 ## Commands
 

--- a/DEMO.md
+++ b/DEMO.md
@@ -37,19 +37,26 @@ The agent-engine runs each session inside an Apptainer SIF built from `deploy/ap
 Control-plane never execs Apptainer itself. It hands each launch to an unprivileged host launcher over a Unix socket, so the SIF has to sit on the host beside that launcher, not inside a container.
 
 ```bash
-# On the host, once per deploy. Fetches the CI-built .sif if the host has none,
-# builds the launcher, and restarts its systemd user unit.
+# On the host, once per deploy, run from the repository root (the compose step
+# above leaves the shell in deploy/docker). Fetches the CI-built .sif if the
+# host has none, builds the launcher, and restarts its systemd user unit.
+# RUNTIME_DIR defaults to /home/sakib/agent-runtime inside the script, so set
+# it explicitly and reuse the same path in HIVE_AGENT_ENGINE_SOCKET_DIR below.
+cd "$(git rev-parse --show-toplevel)"
+RUNTIME_DIR="$HOME/agent-runtime" \
 HIVE_AGENT_ENGINE_LLM_MODEL=openai/hive-default \
 HIVE_AGENT_ENGINE_LLM_BASE_URL=https://api-hive.scubed.co/v1 \
-HIVE_AGENT_ENGINE_LLM_API_KEY=<gateway key> \
-CONTROL_PLANE_INTERNAL_TOKEN=<internal token> \
+HIVE_AGENT_ENGINE_LLM_API_KEY=REPLACE_WITH_GATEWAY_KEY \
+CONTROL_PLANE_INTERNAL_TOKEN=REPLACE_WITH_INTERNAL_TOKEN \
   bash scripts/install-agent-engine-host.sh
 ```
 
-Then point control-plane at the socket in `.env`:
+Then point control-plane at the socket in `.env`. A dotenv file does no shell
+expansion, so write the same absolute path the installer used, with `/run`
+appended (for example `/home/hive/agent-runtime/run`):
 
 ```dotenv
-HIVE_AGENT_ENGINE_SOCKET_DIR=/home/<user>/agent-runtime/run
+HIVE_AGENT_ENGINE_SOCKET_DIR=/home/REPLACE_WITH_HOST_USER/agent-runtime/run
 HIVE_AGENT_ENGINE_SOCKET=/run/hive-agent/engine.sock
 ```
 

--- a/DEMO.md
+++ b/DEMO.md
@@ -30,18 +30,30 @@ docker compose \
 
 Optional local inference: set `OLLAMA_BASE_URL=http://ollama:11434` in `.env` and uncomment the ollama entries in `deploy/litellm/config.yaml`.
 
-### Agent-engine SIF (required for agent/coding surfaces)
+### Agent-engine runtime (required for agent/coding surfaces)
 
 The agent-engine runs each session inside an Apptainer SIF built from `deploy/apptainer/agent-engine.def`. It is `linux/amd64` only and cannot be built on WSL2.
 
+Control-plane never execs Apptainer itself. It hands each launch to an unprivileged host launcher over a Unix socket, so the SIF has to sit on the host beside that launcher, not inside a container.
+
 ```bash
-# On an apptainer host:
-make agent-sif          # -> deploy/apptainer/agent-engine.sif
-# Or pull the CI-built image:
-gh run download -n agent-engine-sif -D /opt/hive
+# On the host, once per deploy. Fetches the CI-built .sif if the host has none,
+# builds the launcher, and restarts its systemd user unit.
+HIVE_AGENT_ENGINE_LLM_MODEL=openai/hive-default \
+HIVE_AGENT_ENGINE_LLM_BASE_URL=https://api-hive.scubed.co/v1 \
+HIVE_AGENT_ENGINE_LLM_API_KEY=<gateway key> \
+CONTROL_PLANE_INTERNAL_TOKEN=<internal token> \
+  bash scripts/install-agent-engine-host.sh
 ```
 
-Set `HIVE_AGENT_SIF_PATH` in `.env` to the resulting `.sif` path.
+Then point control-plane at the socket in `.env`:
+
+```dotenv
+HIVE_AGENT_ENGINE_SOCKET_DIR=/home/<user>/agent-runtime/run
+HIVE_AGENT_ENGINE_SOCKET=/run/hive-agent/engine.sock
+```
+
+`deploy-demo-box.yml` already does both on every deploy. `HIVE_AGENT_SIF_PATH` is a different variable that gates nothing here: it only feeds the standalone binary's `-sif` default and the compose smoke-test service. Full detail, including the in-process fallback arm and its five variables: `deploy/apptainer/README.md`.
 
 ### Verify
 


### PR DESCRIPTION
Documentation and protocol only. No runtime behaviour changes. The two `.wolf/hooks` edits are message strings.

## 1. CLAUDE.md and DEMO.md named the wrong agent-engine gate

`deploy/apptainer/README.md` was corrected by #870, but `CLAUDE.md` and `DEMO.md` still said `HIVE_AGENT_SIF_PATH` is what makes an agent task launch. They contradicted both the README and the code.

This is worse than an ordinary stale document. `CLAUDE.md` is loaded into every agent's context in every session, so a wrong statement in it propagates into new briefs indefinitely. That exact mechanism kept a revoked business rule alive for nine weeks in this repository.

Re-derived from `buildAgentEngine` in `apps/control-plane/cmd/server/main.go` at `c1ca04d5` rather than from the previous documentation:

* **Socket arm, checked first, and what the demo box actually runs.** When `HIVE_AGENT_ENGINE_SOCKET` is set, control-plane hands every launch to the unprivileged host launcher over that Unix socket, authenticating with `CONTROL_PLANE_INTERNAL_TOKEN`, and none of the path variables are read at all. Both files now lead with this.
* **In-process arm.** Needs a non-nil egress service, so a live DB pool, plus five variables, all of them: `HIVE_AGENT_ENGINE_SIF_PATH`, `HIVE_AGENT_ENGINE_PACKS_DIR`, `HIVE_AGENT_ENGINE_WORKSPACE_ROOT`, `HIVE_AGENT_ENGINE_RUN_DIR`, `HIVE_AGENT_ENGINE_PROFILE_ID`. Missing any one falls back to `NotConfiguredEngine`, every submitted task fails immediately, and the boot WARN names what was missing. Under docker compose this arm cannot succeed regardless of the variables.
* **Defaulted, so optional:** `HIVE_AGENT_ENGINE_SESSION_API_KEY`, `HIVE_QUOTA_TENANT_CONCURRENCY` (4), `HIVE_QUOTA_USER_CONCURRENCY` (2), `HIVE_SANDBOX_MEMORY_LIMIT` (4G), `HIVE_SANDBOX_CPU_LIMIT` (2), `HIVE_SANDBOX_PIDS_LIMIT` (512).
* **The daemon reads its own set** in `apps/agent-engine/cmd/agent-engine/serve.go`, including the three `HIVE_AGENT_ENGINE_LLM_*` variables.
* **`HIVE_AGENT_SIF_PATH` gates nothing.** It survives only as the `-sif` flag default at `apps/agent-engine/cmd/agent-engine/main.go:41` and for the compose smoke-test service under `--profile agent`.

The stale `.env.example` block that repeated the same claim ("refuses to start without it") is corrected in the same way. The socket variables were already documented higher up that file by #870.

## 2. Buglog entries move off feature branches, adopting #873

Appending to the tracked `.wolf/buglog.jsonl` from a feature branch has two proven failure modes: every parallel fix pull request conflicts serially with every other one, and an unmergeable branch produces **zero** `pull_request` CI runs, which reads as a broken workflow rather than an unmergeable branch. Both come from concurrent writes to one file.

`merge=union` stays in `.gitattributes` because it still resolves concurrent appends in local merges and rebases. The protocol now states plainly that GitHub's server-side merge ignores it, so nobody re-derives the trap.

**Recording a bug entry is still mandatory.** Only the destination changed:

1. While the fix is in flight, the entry rides in the fix pull request body under a "Buglog entry" heading, as the JSON line to be appended. It is reviewable there and attached to the fix.
2. After the fix merges, it lands on `main` through a separate pull request whose diff is `.wolf/buglog.jsonl` and nothing else. One such pull request open at a time across all agents, and batching several entries into one is preferred.

That route is manual, and the protocol says so rather than describing a process nobody can perform. The post-merge automation that would replace it does not exist yet and is tracked in #873. Those pull requests merge cheaply because `.wolf/*` is on the inert-path allowlist in `.github/workflows/ci.yml`, so the six required checks report green without running their heavy steps. The rule also warns that `bugstore.js add` writes the tracked file directly, so running it on a fix branch dirties the working tree and the next `git add -A` sweeps it into the fix commit.

Updated wherever the protocol is stated: `.claude/rules/openwolf.md`, the OpenWolf section of `CLAUDE.md`, `.claude/skills/memory-tools.md` (which also still pointed at the gitignored `buglog.json`), and the two `.wolf/hooks` nudges that previously told an agent to append the line right where it was standing.

## Verification

* Every claim above read out of the code at `c1ca04d5`, not from the documentation being replaced.
* `.wolf/*` allowlist and the `if: always()` required jobs confirmed in `.github/workflows/ci.yml`, which is what makes the buglog-only pull request route cheap.
* Both edited hooks pass `node --check`. No test asserts either message string.
* `npm run lint:proof-tokens` passes. No credential appears in this diff; variables are referenced by name only.
* No UI surface is touched, so no screenshot applies.

Note that this pull request edits two `.wolf/hooks/*.js` files, which the CI path filter denies by executable extension, so it deliberately runs the full required suite rather than taking the inert-path skip.

Closes #873


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified agent-engine setup, host launcher configuration, socket-based task execution, and standalone smoke-test behavior.
  * Updated environment-variable guidance, including the limited role of the agent-engine SIF path.
  * Documented bug-log workflows, merge-conflict handling, pull-request coordination, and feature-branch requirements.
  * Revised automated reminders to record feature-branch bug fixes in pull-request details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->