### PR TITLE
ci: bound every workflow job with a measured timeout (#875)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,6 +275,7 @@ jobs:
   go-tests:
     name: Go tests (${{ matrix.module }})
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     # REQUIRED CHECK. Always runs and always reports its own conclusion; the
     # docs-only decision is applied per step. See the note above `changes`.
     needs: changes
@@ -444,6 +445,7 @@ jobs:
   rust-tests:
     name: Rust tests (desktop-sandbox)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: changes
     if: needs.changes.outputs.run == 'true'
     defaults:
@@ -505,6 +507,7 @@ jobs:
   desktop-tests:
     name: Desktop app (Rust + TS)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: changes
     if: needs.changes.outputs.run == 'true'
     steps:
@@ -642,6 +645,7 @@ jobs:
   agent-console-unit:
     name: Agent console (type + unit + build)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: changes
     if: needs.changes.outputs.run == 'true'
     defaults:
@@ -674,6 +678,7 @@ jobs:
   web-unit:
     name: Web console (type + unit + build)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     # REQUIRED CHECK. Always runs and always reports its own conclusion; the
     # docs-only decision is applied per step. See the note above `changes`.
     needs: changes
@@ -741,6 +746,7 @@ jobs:
   docker-build:
     name: Docker build smoke (fork PRs only)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: changes
     if: >-
       needs.changes.outputs.run == 'true' &&
@@ -1402,6 +1408,7 @@ jobs:
   egress-firewall-e2e:
     name: Egress firewall e2e (bwrap)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: changes
     if: needs.changes.outputs.run == 'true'
     defaults:

--- a/.github/workflows/deploy-web-console-workers.yml
+++ b/.github/workflows/deploy-web-console-workers.yml
@@ -37,6 +37,7 @@ jobs:
   deploy-workers:
     name: Deploy web-console to Cloudflare Workers (OpenNext)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
     defaults:


### PR DESCRIPTION
Closes #875 (the `timeout-minutes` half; the stuck check-run itself is a GitHub data-plane artifact the workflow file cannot prevent, and the issue says so).

## What this changes

One scalar key per job. Seven jobs in `ci.yml` and the single job in `deploy-web-console-workers.yml` had no `timeout-minutes`, so they inherited GitHub's 360 minute default. Five of the six required contexts on `main` come from those jobs, so a genuinely wedged required job would have blocked every merge for six hours before saying anything.

Nothing else moved. No step, no condition, no matrix, no trigger, no job name. `git diff --stat` is 8 insertions across 2 files.

## How the numbers were derived

Sampled the last 30 completed runs of each workflow, took `started_at` to `completed_at` on every successful job, and grouped by job name. The ceiling matters more than the presence: too high and a wedged required check sits for hours, too low and a normal slow day goes red and teaches people to re-run without reading. So each ceiling is roughly five times the observed maximum.

| Job | Required contexts | Samples | Median | Observed max | Ceiling | Headroom |
| --- | --- | --- | --- | --- | --- | --- |
| `go-tests` (control-plane) | yes | 30 | 2.5 min | 2.8 min | 15 | 5.4x |
| `go-tests` (edge-api) | yes | 30 | 2.6 min | 2.9 min | 15 | 5.2x |
| `go-tests` (storage) | yes | 30 | 0.8 min | 1.0 min | 15 | 15x |
| `go-tests` (agent-engine) | yes | 30 | 0.8 min | 1.0 min | 15 | 15x |
| `web-unit` | yes | 29 | 2.9 min | 3.8 min | 15 | 3.9x |
| `desktop-tests` | no | 27 | 1.4 min | 2.5 min | 15 | 6.0x |
| `rust-tests` | no | 29 | 0.8 min | 1.1 min | 10 | 9.1x |
| `agent-console-unit` | no | 29 | 0.9 min | 1.0 min | 10 | 10x |
| `egress-firewall-e2e` | no | 29 | 0.7 min | 0.9 min | 10 | 11x |
| `docker-build` | no | 0 | no data | no data | 30 | see below |
| `deploy-workers` | no | 30 | 1.8 min | 2.0 min | 15 | 7.5x |

`timeout-minutes` is a single job-level value, so all four `go-tests` matrix legs share one ceiling sized on the slowest leg.

## Where my measurements differ from the issue

Two jobs came in slower than the issue's table, because my window is the last 30 runs rather than the last twelve successful `main` runs:

- `web-unit`: issue recorded max 3.1 min, I measured 3.8 min. Kept 15, which is still 3.9x the observed maximum, the tightest ratio in the table but comfortably outside any plausible healthy run.
- `desktop-tests`: issue recorded max 2.3 min, I measured 2.5 min. Kept 15.

Neither proposal needed raising. Nothing else moved enough to matter.

## `docker-build`, the one with no data

It runs only on fork pull requests (`github.event.pull_request.head.repo.full_name != github.repository`), and there is no successful sample in the window, so there is no maximum to multiply. The closest proxy in this repository is the `Build stack images (buildx + GHA cache)` step inside `live-integration`, which builds the same `edge-api`, `control-plane` and `web-console` targets: 1.2 to 2.1 minutes across the last four runs, warm cache. The case the ceiling has to survive is a cold GHA cache on a first-ever fork build, which is the whole reason 30 rather than 10. It is deliberately the loosest bound here, because a ceiling that trips on a fork contributor's first build is worse than the six hour default it replaces.

## `deploy-workers` and the deploy-side count

The issue says `deploy-web-console-workers.yml` has three jobs. It has one. The other two (`detect-changes`, `build-images`) were removed when the OCI VM tier retired in favour of `deploy-demo-box.yml`; the file header documents this and points at the git history. So the deploy-side change is one job, not three.

It gets 15 rather than the 10 its 2.0 minute maximum would suggest, because its slowest step is a `wrangler deploy` against the Cloudflare API. A network-bound external call has more variance than a local build, and this is the only production deploy path for web-console, so it gets the wider bound.

## Jobs already carrying timeouts, left alone

`changes` at 5, `repo-policy-lints` at 5, `live-integration` at 30, `web-e2e` at 25. Style matches: the key sits directly under `runs-on:` in every job, which is where all four existing ones already sit.

## Verification

- `yaml.safe_load` on both files parses, and every job now reports a `timeout-minutes`: `changes` 5, `go-tests` 15, `rust-tests` 10, `desktop-tests` 15, `repo-policy-lints` 5, `agent-console-unit` 10, `web-unit` 15, `docker-build` 30, `live-integration` 30, `web-e2e` 25, `egress-firewall-e2e` 10, `deploy-workers` 15. Zero jobs left on the inherited default.
- No job name changed, so `.github/ci/lint-workflow-check-names.mjs` has nothing new to disagree with; it runs on this pull request as part of `repo-policy-lints` regardless.
- No UI surface is touched, so no screenshot proof is owed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
