### PR TITLE
fix: stop committing E2E credentials and rotating shared test accounts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1010,7 +1010,9 @@ jobs:
       - name: Dump compose logs on failure
         if: failure()
         working-directory: deploy/docker
-        run: docker compose logs --no-color --timestamps --tail=500 > /tmp/compose.log || true
+        # Piped through the redactor because this artifact is public: container
+        # logs carry OAuth callbacks, bearer headers and API keys verbatim.
+        run: docker compose logs --no-color --timestamps --tail=500 2>&1 | python3 ../../scripts/redact-log-credentials.py > /tmp/compose.log || true
 
       - name: Upload compose logs
         if: failure()
@@ -1018,6 +1020,7 @@ jobs:
         with:
           name: compose-logs
           path: /tmp/compose.log
+          retention-days: 5
           if-no-files-found: ignore
 
       - name: Tear down stack
@@ -1296,6 +1299,16 @@ jobs:
           done
           echo "::error::Next.js did not start"; cat /tmp/nextjs.log; exit 1
 
+      - name: Generate the fixture invitation token
+        # Random per job, and masked, because the seeder stores its sha256 as a
+        # live pending invitation. A value anybody can derive from the public
+        # run page is a published credential for as long as the run lasts.
+        run: |
+          set -euo pipefail
+          token="$(openssl rand -hex 24)"
+          echo "::add-mask::$token"
+          echo "E2E_INVITATION_TOKEN=$token" >> "$GITHUB_ENV"
+
       - name: Run UI Playwright suite (unauth + credentialed)
         working-directory: apps/web-console
         env:
@@ -1336,7 +1349,13 @@ jobs:
           E2E_VERIFIED_PASSWORD: ${{ secrets.E2E_VERIFIED_PASSWORD }}
           E2E_UNVERIFIED_EMAIL: e2e-unverified+${{ github.run_id }}-${{ github.run_attempt }}@scubed.com.bd
           E2E_UNVERIFIED_PASSWORD: ${{ secrets.E2E_UNVERIFIED_PASSWORD }}
-          E2E_INVITATION_TOKEN: e2e-invitation-token-2026-fixture-${{ github.run_id }}-${{ github.run_attempt }}
+          # Generated in the step above, not derived here. It used to be a
+          # committed literal concatenated with the run id and attempt, both
+          # of which are public on the run page, and e2e-fixture-seed.mjs
+          # stores its sha256 as the pending invitation's token_hash. Anyone
+          # reading the run URL could compute the live token and accept the
+          # invitation into this run's account while it was still open.
+          E2E_INVITATION_TOKEN: ${{ env.E2E_INVITATION_TOKEN }}
           # Workspace-owner fixture for console-workspace-admin.spec.ts.
           # Unset leaves that spec skipped, which is why the required
           # coverage for a mispointed control-plane is the unit-level
@@ -1372,7 +1391,8 @@ jobs:
       - name: Dump compose logs on failure
         if: failure()
         working-directory: deploy/docker
-        run: docker compose logs --no-color --timestamps --tail=500 > /tmp/compose-web-e2e-api.log || true
+        # Piped through the redactor: see the sdk-tests dump step above.
+        run: docker compose logs --no-color --timestamps --tail=500 2>&1 | python3 ../../scripts/redact-log-credentials.py > /tmp/compose-web-e2e-api.log || true
 
       - name: Upload compose logs
         if: failure()
@@ -1381,23 +1401,30 @@ jobs:
           name: compose-logs-web-e2e-api
           path: /tmp/compose-web-e2e-api.log
           if-no-files-found: ignore
+          retention-days: 5
 
       - name: Upload Playwright report
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: playwright-report-api
-          # Traces (.zip) and videos (.webm) are excluded. This repository is
-          # public, so any artifact here is downloadable by anyone with the run
-          # URL, and playwright.config.ts retains a trace on failure: it holds
-          # every request header (Authorization: Bearer) and every
-          # sb-*-auth-token cookie for the fixture session. The HTML report and
-          # error text still upload, and a text linter cannot inspect a trace
-          # zip, so exclusion is the only reliable scrub.
+          # Traces (.zip), videos (.webm) and index.html are excluded. This
+          # repository is public, so any artifact here is downloadable by
+          # anyone with the run URL, and playwright.config.ts retains a trace
+          # on failure: it holds every request header (Authorization: Bearer)
+          # and every sb-*-auth-token cookie for the fixture session.
+          # index.html goes too, and for the same reason rather than a
+          # different one: the HTML reporter base64-inlines the whole report
+          # payload into that file, including stdout, stderr and error text,
+          # and a waitForURL timeout enumerates the URLs it navigated,
+          # fragment included. Both are binary-wrapped, so no text linter can
+          # inspect either. Screenshots survive, and the failing test names
+          # and error text are already in this job's own log.
           path: |
             apps/web-console/playwright-report/
             !apps/web-console/playwright-report/**/*.zip
             !apps/web-console/playwright-report/**/*.webm
+            !apps/web-console/playwright-report/index.html
           if-no-files-found: ignore
           retention-days: 5
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1323,10 +1323,14 @@ jobs:
           # reassign rows out from under this job's own reads mid-test.
           # github.run_attempt makes a manual re-run of a flake get a fresh
           # identity too, not the one the previous attempt already consumed.
-          # Passwords stay the shared default (from secrets, or the fixture
-          # defaults in e2e-auth-defaults.json when those secrets are
-          # unset): nothing looks a user up by password, so they never need
-          # to be unique per run.
+          # The passwords come from secrets and have no fallback. They used to
+          # fall back to plaintext values committed in
+          # e2e-auth-defaults.json, in a public repository, for live accounts
+          # holding a tenant OWNER role; the seeder then wrote those values
+          # back onto the accounts. The fallback is gone and an unset secret
+          # now fails this job by name. They need not be unique per run:
+          # nothing looks a user up by password, and the addresses above are
+          # already run-scoped.
           E2E_RUN_KEY: ${{ github.run_id }}-${{ github.run_attempt }}
           E2E_VERIFIED_EMAIL: e2e-verified+${{ github.run_id }}-${{ github.run_attempt }}@scubed.com.bd
           E2E_VERIFIED_PASSWORD: ${{ secrets.E2E_VERIFIED_PASSWORD }}
@@ -1383,8 +1387,19 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: playwright-report-api
-          path: apps/web-console/playwright-report/
+          # Traces (.zip) and videos (.webm) are excluded. This repository is
+          # public, so any artifact here is downloadable by anyone with the run
+          # URL, and playwright.config.ts retains a trace on failure: it holds
+          # every request header (Authorization: Bearer) and every
+          # sb-*-auth-token cookie for the fixture session. The HTML report and
+          # error text still upload, and a text linter cannot inspect a trace
+          # zip, so exclusion is the only reliable scrub.
+          path: |
+            apps/web-console/playwright-report/
+            !apps/web-console/playwright-report/**/*.zip
+            !apps/web-console/playwright-report/**/*.webm
           if-no-files-found: ignore
+          retention-days: 5
 
       - name: Tear down stack
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1303,6 +1303,12 @@ jobs:
         # Random per job, and masked, because the seeder stores its sha256 as a
         # live pending invitation. A value anybody can derive from the public
         # run page is a published credential for as long as the run lasts.
+        #
+        # 24 bytes gives 48 hex characters. The floor it has to clear is
+        # minTokenLength in tests/e2e/support/e2e-auth-defaults.json, which
+        # requiredSecretEnv enforces at 16, so do not shorten this below that
+        # without moving both: the failure would otherwise surface far from
+        # here, naming a variable this step does not mention.
         run: |
           set -euo pipefail
           token="$(openssl rand -hex 24)"

--- a/.github/workflows/owui-nightly.yml
+++ b/.github/workflows/owui-nightly.yml
@@ -63,8 +63,10 @@ jobs:
             --password "$SUPABASE_DB_PASSWORD" >> "$GITHUB_ENV"
       - name: Seed OWUI e2e test user
         # Self-provisions the owui-e2e tenant, GoTrue user, membership, and a
-        # real "hk_" Hive API key used as OWUI_SHIM_KEY (idempotent, password
-        # and key rotated every run). Runs BEFORE "Materialize .env.ci" now
+        # real "hk_" Hive API key used as OWUI_SHIM_KEY. Idempotent. Passwords
+        # are NOT rotated: the run key below gives this run its own users
+        # instead, because rotating a shared account revokes the sessions of
+        # every concurrent run (docs/live-test-auth.md). Runs BEFORE "Materialize .env.ci" now
         # (moved from after it) because that step consumes the minted
         # OWUI_SHIM_KEY. Removes the need for hand-managed OWUI_E2E_EMAIL /
         # OWUI_E2E_PASSWORD repo secrets.
@@ -89,14 +91,25 @@ jobs:
           OWUI_E2E_RUN_KEY: ${{ github.run_id }}-${{ github.run_attempt }}
         run: |
           set -euo pipefail
-          out=$(python3 scripts/seed-owui-e2e-user.py)
-          email=$(printf '%s\n' "$out" | grep '^EMAIL=' | cut -d= -f2-)
-          password=$(printf '%s\n' "$out" | grep '^PASSWORD=' | cut -d= -f2-)
-          shim_key=$(printf '%s\n' "$out" | grep '^SHIM_KEY=' | cut -d= -f2-)
-          bootstrap_email=$(printf '%s\n' "$out" | grep '^BOOTSTRAP_EMAIL=' | cut -d= -f2-)
-          bootstrap_password=$(printf '%s\n' "$out" | grep '^BOOTSTRAP_PASSWORD=' | cut -d= -f2-)
+          # Both guards below exist to produce a readable failure, so neither
+          # may be pre-empted by set -e. A non-zero exit from the seeder used
+          # to abort the step before its own ::error:: line, and each grep
+          # returns 1 when the line it wants is absent, which under pipefail
+          # killed the step at the assignment rather than at the check. The
+          # missing-line case is the normal way this seeder now declines to
+          # rotate an existing account's password, so it has to say so.
+          if ! out=$(python3 scripts/seed-owui-e2e-user.py); then
+            echo "::error::seed-owui-e2e-user.py failed; its stderr is above"
+            exit 1
+          fi
+          field() { printf '%s\n' "$out" | grep "^$1=" | cut -d= -f2- || true; }
+          email=$(field EMAIL)
+          password=$(field PASSWORD)
+          shim_key=$(field SHIM_KEY)
+          bootstrap_email=$(field BOOTSTRAP_EMAIL)
+          bootstrap_password=$(field BOOTSTRAP_PASSWORD)
           if [ -z "$email" ] || [ -z "$password" ] || [ -z "$shim_key" ] || [ -z "$bootstrap_email" ] || [ -z "$bootstrap_password" ]; then
-            echo "::error::seed-owui-e2e-user.py did not print EMAIL/PASSWORD/SHIM_KEY/BOOTSTRAP_EMAIL/BOOTSTRAP_PASSWORD"
+            echo "::error::seed-owui-e2e-user.py did not print EMAIL/PASSWORD/SHIM_KEY/BOOTSTRAP_EMAIL/BOOTSTRAP_PASSWORD. A missing PASSWORD line means the account already existed and the seeder refused to rotate it: see its stderr above, and docs/live-test-auth.md."
             exit 1
           fi
           echo "::add-mask::$password"
@@ -416,8 +429,14 @@ jobs:
           # slow or missing request across layers means lining these logs up
           # against Playwright's wall-clock trace, which is impossible for a
           # service whose lines carry no time (run 31042840516).
+          # Piped through the redactor before it becomes a public artifact.
+          # open-webui's uvicorn access lines print the OAuth callback verbatim,
+          # so an unfiltered dump publishes GET /oauth/oidc/callback?code=... for
+          # a real account, and edge-api logs carry the shim key.
           docker compose --env-file ../../.env.ci logs --no-color --timestamps --tail 2000 \
-            open-webui litellm edge-api control-plane > $GITHUB_WORKSPACE/compose-logs.txt 2>&1 || true
+            open-webui litellm edge-api control-plane 2>&1 \
+            | python3 $GITHUB_WORKSPACE/scripts/redact-log-credentials.py \
+            > $GITHUB_WORKSPACE/compose-logs.txt || true
       - name: SOC2 coverage report
         if: always()
         run: |
@@ -427,25 +446,30 @@ jobs:
         if: always()
         with:
           name: owui-playwright-report
-          # Traces (.zip) and videos (.webm) are excluded, and the repository
-          # is public, so anyone with a run URL can download what is left.
-          # These specs walk the full OAuth journey for a seeded account: a
-          # trace holds every request header (Authorization: Bearer), every
+          # Traces (.zip), videos (.webm) and index.html are excluded, and the
+          # repository is public, so anyone with a run URL can download what is
+          # left. These specs walk the full OAuth journey for a seeded account:
+          # a trace holds every request header (Authorization: Bearer), every
           # sb-*-auth-token cookie, and the callback URLs whose query string
-          # and fragment carry code= and access_token=. The HTML report,
-          # screenshots and error text remain, which is what triage actually
-          # reads. Nothing here can be scrubbed by a text linter: a trace is a
-          # zip of binary resources.
+          # and fragment carry code= and access_token=. index.html carries the
+          # same material by another route: the HTML reporter base64-inlines
+          # the whole report payload into it, stdout, stderr and error text
+          # included, and a waitForURL timeout enumerates every URL it
+          # navigated, fragment and all. Neither is inspectable by a text
+          # linter. Screenshots remain, and the failing test names and error
+          # text are already in this job's own log.
           path: |
             apps/web-console/playwright-report-owui
             !apps/web-console/playwright-report-owui/**/*.zip
             !apps/web-console/playwright-report-owui/**/*.webm
+            !apps/web-console/playwright-report-owui/index.html
           retention-days: 5
       - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: owui-compose-logs
           path: compose-logs.txt
+          retention-days: 5
       - name: Slack on failure
         if: failure() && env.SLACK_WEBHOOK_URL != ''
         env:

--- a/.github/workflows/owui-nightly.yml
+++ b/.github/workflows/owui-nightly.yml
@@ -78,6 +78,15 @@ jobs:
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          # One fixture identity per job attempt. The seeder no longer
+          # overwrites an existing account's password, because doing so revoked
+          # the sessions of every run holding one (docs/live-test-auth.md), and
+          # this workflow triggers on a schedule, on dispatch, and on a
+          # labelled pull request, whose concurrency group is keyed on the ref
+          # and so does not join the scheduled run's. A run-scoped identity has
+          # no prior password to preserve, so this run still gets a usable one
+          # and no other run is disturbed. Same shape as E2E_RUN_KEY in ci.yml.
+          OWUI_E2E_RUN_KEY: ${{ github.run_id }}-${{ github.run_attempt }}
         run: |
           set -euo pipefail
           out=$(python3 scripts/seed-owui-e2e-user.py)
@@ -418,7 +427,20 @@ jobs:
         if: always()
         with:
           name: owui-playwright-report
-          path: apps/web-console/playwright-report-owui
+          # Traces (.zip) and videos (.webm) are excluded, and the repository
+          # is public, so anyone with a run URL can download what is left.
+          # These specs walk the full OAuth journey for a seeded account: a
+          # trace holds every request header (Authorization: Bearer), every
+          # sb-*-auth-token cookie, and the callback URLs whose query string
+          # and fragment carry code= and access_token=. The HTML report,
+          # screenshots and error text remain, which is what triage actually
+          # reads. Nothing here can be scrubbed by a text linter: a trace is a
+          # zip of binary resources.
+          path: |
+            apps/web-console/playwright-report-owui
+            !apps/web-console/playwright-report-owui/**/*.zip
+            !apps/web-console/playwright-report-owui/**/*.webm
+          retention-days: 5
       - uses: actions/upload-artifact@v4
         if: failure()
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,8 +147,11 @@ cd deploy/docker && docker compose run --build web-console npm run test:unit
 cd deploy/docker && docker compose --env-file ../../.env --profile test up --build
 
 # E2E tests. Host-run against the working tree, so no image staleness here, but
-# it needs a stack already running.
-cd apps/web-console && npx playwright test
+# it needs a stack already running. E2E_RUN_KEY is mandatory and has no
+# default: seeding writes a password to whatever address it resolves, so the
+# key is what keeps this run off the shared fixture accounts. The three
+# credentials have no default either (README.md, docs/live-test-auth.md).
+cd apps/web-console && E2E_RUN_KEY="$(whoami)-$(date +%s)" npx playwright test
 ```
 
 ### Live sessions for tests

--- a/DEMO.md
+++ b/DEMO.md
@@ -79,7 +79,10 @@ service still reports healthy). Prove the whole path instead:
 
 ```bash
 export EDGE_API_URL=http://localhost:8080   # or the deployed edge origin
-python3 scripts/verify-rag-roundtrip.py     # needs the SUPABASE_* vars from .env
+python3 scripts/verify-rag-roundtrip.py     # needs the SUPABASE_* vars from .env,
+                                            # plus RAG_VERIFY_PASSWORD once its
+                                            # member account exists (it will not
+                                            # rotate that account's password)
 ```
 
 It uploads a document with a unique marker, waits for embedding, then requires

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ agent-sif:
 # network). These guard credential-rotation ordering and .env rewriting, where
 # a regression strands a deployment on a revoked key.
 test-scripts:
+	python3 scripts/redact-log-credentials.py --selfcheck
 	python3 scripts/test_seed_owui_e2e_user.py
 	python3 scripts/test_seed_demo_owner.py
 	python3 scripts/test_install_owui_jwt_forward.py

--- a/README.md
+++ b/README.md
@@ -212,14 +212,20 @@ required and have no default, because a default here is a credential committed
 to a public repository that the seeder then writes onto a live account:
 
 ```bash
-export E2E_VERIFIED_PASSWORD=...     # at least 6 characters
-export E2E_UNVERIFIED_PASSWORD=...   # at least 6 characters
-export E2E_INVITATION_TOKEN=...      # at least 16 characters
+export E2E_RUN_KEY="$(whoami)-$(date +%s)"   # any value unique to this run
+export E2E_VERIFIED_PASSWORD=...             # at least 6 characters
+export E2E_UNVERIFIED_PASSWORD=...           # at least 6 characters
+export E2E_INVITATION_TOKEN=...              # at least 16 characters
 ```
 
-A missing one fails the run and names itself. The two addresses
+A missing one fails the run and names itself. `E2E_RUN_KEY` is required as
+well, and for a stronger reason than the rest: seeding writes a password to
+whatever address it is given, so every fixture address is namespaced with the
+run key. Without one, a local run would overwrite the password of a shared
+live account and revoke the sessions of every other run. The two addresses
 (`E2E_VERIFIED_EMAIL`, `E2E_UNVERIFIED_EMAIL`) do have defaults, in
-`tests/e2e/support/e2e-auth-defaults.json`, and can still be overridden.
+`tests/e2e/support/e2e-auth-defaults.json`, but they are bases to derive this
+run's address from, never targets.
 Supabase admin env is required too: `SUPABASE_URL`,
 `SUPABASE_SERVICE_ROLE_KEY`. See `docs/live-test-auth.md`.
 

--- a/README.md
+++ b/README.md
@@ -207,14 +207,21 @@ npx playwright show-report
 ```
 
 E2E credentials: the fixture script `tests/e2e/support/e2e-auth-fixtures.mjs`
-resets dedicated `e2e-*@hive-ci.test` accounts in staging Supabase before each
-test. Values default to shared constants in
-`tests/e2e/support/e2e-auth-creds.ts`; env overrides
-(`E2E_VERIFIED_EMAIL`, `E2E_VERIFIED_PASSWORD`, `E2E_UNVERIFIED_EMAIL`,
-`E2E_UNVERIFIED_PASSWORD`, `E2E_INVITATION_TOKEN`) are honored when they meet
-minimum length checks (passwords ≥ 6, token ≥ 16); otherwise safe fallbacks are
-used. Supabase admin env is still required: `SUPABASE_URL`,
-`SUPABASE_SERVICE_ROLE_KEY`.
+seeds dedicated fixture accounts in Supabase before each test. Three values are
+required and have no default, because a default here is a credential committed
+to a public repository that the seeder then writes onto a live account:
+
+```bash
+export E2E_VERIFIED_PASSWORD=...     # at least 6 characters
+export E2E_UNVERIFIED_PASSWORD=...   # at least 6 characters
+export E2E_INVITATION_TOKEN=...      # at least 16 characters
+```
+
+A missing one fails the run and names itself. The two addresses
+(`E2E_VERIFIED_EMAIL`, `E2E_UNVERIFIED_EMAIL`) do have defaults, in
+`tests/e2e/support/e2e-auth-defaults.json`, and can still be overridden.
+Supabase admin env is required too: `SUPABASE_URL`,
+`SUPABASE_SERVICE_ROLE_KEY`. See `docs/live-test-auth.md`.
 
 ## Conventions
 

--- a/apps/web-console/playwright.config.ts
+++ b/apps/web-console/playwright.config.ts
@@ -36,6 +36,14 @@ export default defineConfig({
     baseURL: process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3000",
     trace: "retain-on-failure",
     video: "retain-on-failure",
+    // The CI artifact excludes traces (*.zip), videos (*.webm) and index.html,
+    // because each of those carries request headers, cookies or URLs with a
+    // credential in the query string or the fragment, wrapped so that no text
+    // linter can inspect them. Without this line the exclusions would leave
+    // that artifact empty, since screenshot defaults to "off" and the report
+    // directory holds nothing else. A screenshot is the viewport only: no URL
+    // bar, no headers, no cookies, and it is inspectable by eye.
+    screenshot: "only-on-failure",
   },
   projects: [
     {

--- a/apps/web-console/scripts/verify-spec-collection.mjs
+++ b/apps/web-console/scripts/verify-spec-collection.mjs
@@ -53,8 +53,23 @@ const OWUI_LIST_ENV = {
   SUPABASE_OAUTH_CLIENT_SECRET: "unused-collection-guard-placeholder",
 };
 
+// tests/e2e/support/e2e-auth-creds.ts resolves its three credentials at module
+// scope and throws when one is missing, deliberately: they have no committed
+// default any more, and a spec that runs without them would otherwise seed a
+// shared live account or skip in silence. Listing loads those modules, so this
+// guard needs the variables present but does not need them to be real. Same
+// reasoning and same shape as OWUI_LIST_ENV above: listing never dials out.
+const WEB_CONSOLE_LIST_ENV = {
+  E2E_VERIFIED_PASSWORD: "unused-collection-guard-placeholder",
+  E2E_UNVERIFIED_PASSWORD: "unused-collection-guard-placeholder",
+  E2E_INVITATION_TOKEN: "unused-collection-guard-placeholder",
+  // Required too: every fixture address is namespaced with it so a run can
+  // only touch accounts it created (runScopedEmail in e2e-fixture-seed.mjs).
+  E2E_RUN_KEY: "collection-guard",
+};
+
 const CONFIGS = [
-  { label: "playwright.config.ts", args: [], env: {} },
+  { label: "playwright.config.ts", args: [], env: WEB_CONSOLE_LIST_ENV },
   {
     label: "e2e/phase-19/owui/playwright.owui.config.ts",
     args: ["--config=e2e/phase-19/owui/playwright.owui.config.ts"],

--- a/apps/web-console/tests/e2e/support/e2e-auth-creds.ts
+++ b/apps/web-console/tests/e2e/support/e2e-auth-creds.ts
@@ -1,14 +1,22 @@
 // Source of truth for E2E test credentials shared between Playwright specs
 // and the fixture CLI (`e2e-auth-fixtures.mjs`).
 //
-// Defaults + min-length constants live in `e2e-auth-defaults.json` so both
-// the TS module (consumed by specs) and the sibling ESM fixture entrypoint
-// (consumed by `execFileSync` from `beforeEach`) read the same values.
+// Non-secret defaults (addresses and min-length constants) live in
+// `e2e-auth-defaults.json` so both the TS module (consumed by specs) and the
+// sibling ESM fixture entrypoint (consumed by `execFileSync` from
+// `beforeEach`) read the same values.
 //
-// Test-only fixtures target dedicated `e2e-*@hive-ci.test` accounts in the
-// staging Supabase project. Env overrides (`E2E_*`) are honored when they
-// meet minimum length checks; empty / unset env vars silently fall back to
-// defaults, non-empty-but-too-short values emit a warning.
+// NO CREDENTIAL HAS A COMMITTED DEFAULT, and none may ever be added back.
+// This repository is public, and the two passwords plus the invitation token
+// used to sit in that JSON file in plaintext for live accounts that hold a
+// tenant OWNER role, which the seeder then wrote back onto those accounts on
+// every credential-less run. The three values below are therefore read from
+// the environment only, and a missing one throws by name rather than falling
+// back or skipping quietly: a silent fallback is what kept the committed
+// values live for months. See docs/live-test-auth.md.
+//
+// The two addresses stay: an address is not a credential, and specs need a
+// stable identity to seed. Env overrides are honored for them.
 
 import defaults from "./e2e-auth-defaults.json" with { type: "json" };
 
@@ -17,9 +25,6 @@ type AuthDefaults = {
   minTokenLength: number;
   verifiedEmail: string;
   unverifiedEmail: string;
-  verifiedPassword: string;
-  unverifiedPassword: string;
-  invitationToken: string;
 };
 
 const DEFAULTS: AuthDefaults = defaults as AuthDefaults;
@@ -31,17 +36,11 @@ function isValidEmail(value: string): boolean {
 function envOrDefault(
   name: string,
   fallback: string,
-  opts: { minLength?: number; validator?: (value: string) => boolean } = {}
+  opts: { validator?: (value: string) => boolean } = {}
 ): string {
-  const { minLength = 0, validator } = opts;
+  const { validator } = opts;
   const raw = process.env[name];
   if (raw === undefined || raw === "") {
-    return fallback;
-  }
-  if (minLength > 0 && raw.length < minLength) {
-    console.warn(
-      `[e2e-auth-creds] ${name} is set but too short (${raw.length} < ${minLength}); using fallback`
-    );
     return fallback;
   }
   if (validator && !validator(raw)) {
@@ -49,6 +48,28 @@ function envOrDefault(
       `[e2e-auth-creds] ${name} is set but failed validation; using fallback`
     );
     return fallback;
+  }
+  return raw;
+}
+
+// requiredSecretEnv is the only way a credential enters this suite. It throws
+// instead of returning a fallback, and the message names the variable and how
+// to set it, so a developer who runs the suite with nothing configured gets an
+// instruction rather than a run that quietly seeds shared live accounts.
+export function requiredSecretEnv(name: string, minLength: number): string {
+  const raw = process.env[name] ?? "";
+  if (raw === "") {
+    throw new Error(
+      `[e2e-auth-creds] ${name} is required and has no default. Set it in ` +
+        "your shell (or as a CI secret) before running the E2E suite. " +
+        "Credentials are never committed to this repository; see " +
+        "docs/live-test-auth.md."
+    );
+  }
+  if (raw.length < minLength) {
+    throw new Error(
+      `[e2e-auth-creds] ${name} is set but too short (${raw.length} < ${minLength}).`
+    );
   }
   return raw;
 }
@@ -63,18 +84,15 @@ export const E2E_UNVERIFIED_EMAIL = envOrDefault(
   DEFAULTS.unverifiedEmail,
   { validator: isValidEmail }
 );
-export const E2E_VERIFIED_PASSWORD = envOrDefault(
+export const E2E_VERIFIED_PASSWORD = requiredSecretEnv(
   "E2E_VERIFIED_PASSWORD",
-  DEFAULTS.verifiedPassword,
-  { minLength: DEFAULTS.minPasswordLength }
+  DEFAULTS.minPasswordLength
 );
-export const E2E_UNVERIFIED_PASSWORD = envOrDefault(
+export const E2E_UNVERIFIED_PASSWORD = requiredSecretEnv(
   "E2E_UNVERIFIED_PASSWORD",
-  DEFAULTS.unverifiedPassword,
-  { minLength: DEFAULTS.minPasswordLength }
+  DEFAULTS.minPasswordLength
 );
-export const E2E_INVITATION_TOKEN = envOrDefault(
+export const E2E_INVITATION_TOKEN = requiredSecretEnv(
   "E2E_INVITATION_TOKEN",
-  DEFAULTS.invitationToken,
-  { minLength: DEFAULTS.minTokenLength }
+  DEFAULTS.minTokenLength
 );

--- a/apps/web-console/tests/e2e/support/e2e-auth-creds.ts
+++ b/apps/web-console/tests/e2e/support/e2e-auth-creds.ts
@@ -74,15 +74,46 @@ export function requiredSecretEnv(name: string, minLength: number): string {
   return raw;
 }
 
-export const E2E_VERIFIED_EMAIL = envOrDefault(
-  "E2E_VERIFIED_EMAIL",
-  DEFAULTS.verifiedEmail,
-  { validator: isValidEmail }
+// Every fixture address is scoped to the run, so a spec can only ever sign in
+// as an account this run created. The shared addresses in the JSON file are
+// bases to derive from, never targets: seeding writes a password to whatever
+// address it is given, and writing to a shared account revokes the sessions
+// every other run is holding. `runScopedEmail` in e2e-fixture-seed.mjs applies
+// the identical rule on the seeding side, including the same idempotence for
+// the already-namespaced address ci.yml passes.
+export function runScopedEmail(email: string, runKey: string): string {
+  if (runKey === "") {
+    throw new Error(
+      "[e2e-auth-creds] E2E_RUN_KEY is required and has no default. Without " +
+        "it the fixtures target shared live accounts, and seeding overwrites " +
+        "their passwords, which revokes every session other runs are holding " +
+        "(see docs/live-test-auth.md). Export any unique value, for example " +
+        "E2E_RUN_KEY=$(whoami)-$(date +%s)."
+    );
+  }
+  if (email.includes(`+${runKey}@`)) {
+    return email;
+  }
+  const at = email.indexOf("@");
+  if (at === -1) {
+    return `${email}+${runKey}`;
+  }
+  return `${email.slice(0, at)}+${runKey}${email.slice(at)}`;
+}
+
+export const E2E_RUN_KEY = (process.env.E2E_RUN_KEY ?? "").trim();
+
+export const E2E_VERIFIED_EMAIL = runScopedEmail(
+  envOrDefault("E2E_VERIFIED_EMAIL", DEFAULTS.verifiedEmail, {
+    validator: isValidEmail,
+  }),
+  E2E_RUN_KEY
 );
-export const E2E_UNVERIFIED_EMAIL = envOrDefault(
-  "E2E_UNVERIFIED_EMAIL",
-  DEFAULTS.unverifiedEmail,
-  { validator: isValidEmail }
+export const E2E_UNVERIFIED_EMAIL = runScopedEmail(
+  envOrDefault("E2E_UNVERIFIED_EMAIL", DEFAULTS.unverifiedEmail, {
+    validator: isValidEmail,
+  }),
+  E2E_RUN_KEY
 );
 export const E2E_VERIFIED_PASSWORD = requiredSecretEnv(
   "E2E_VERIFIED_PASSWORD",

--- a/apps/web-console/tests/e2e/support/e2e-auth-defaults.json
+++ b/apps/web-console/tests/e2e/support/e2e-auth-defaults.json
@@ -2,8 +2,5 @@
   "minPasswordLength": 6,
   "minTokenLength": 16,
   "verifiedEmail": "e2e-verified@scubed.com.bd",
-  "unverifiedEmail": "e2e-unverified@scubed.com.bd",
-  "verifiedPassword": "E2eFixture-Verified#2026",
-  "unverifiedPassword": "E2eFixture-Unverified#2026",
-  "invitationToken": "e2e-invitation-token-2026-fixture"
+  "unverifiedEmail": "e2e-unverified@scubed.com.bd"
 }

--- a/apps/web-console/tests/e2e/support/e2e-auth-fixtures.mjs
+++ b/apps/web-console/tests/e2e/support/e2e-auth-fixtures.mjs
@@ -9,8 +9,8 @@
 //   node tests/e2e/support/e2e-auth-fixtures.mjs
 //   node tests/e2e/support/e2e-auth-fixtures.mjs reset-profile <email>
 //
-// Requires SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, and (for the default
-// seeding action) E2E_VERIFIED_PASSWORD, E2E_UNVERIFIED_PASSWORD and
+// Requires SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, E2E_RUN_KEY, and (for the
+// default seeding action) E2E_VERIFIED_PASSWORD, E2E_UNVERIFIED_PASSWORD and
 // E2E_INVITATION_TOKEN. None has a
 // fallback: seeding used to POST to a deployed `e2e-fixtures` Supabase Edge
 // Function and quietly no-op when its URL and secret were absent, which is
@@ -25,6 +25,7 @@ import {
   createAdminClient,
   redactSecrets,
   resetProfileComplete,
+  runScopedEmail,
   seedFixtures,
 } from "./e2e-fixture-seed.mjs";
 
@@ -82,24 +83,25 @@ function isValidEmail(value) {
 
 // Resolved credentials — mirror `e2e-auth-creds.ts` exactly so the spec side
 // (which imports those constants) and this CLI always agree.
-export const E2E_VERIFIED_EMAIL = envOrDefault(
-  "E2E_VERIFIED_EMAIL",
-  DEFAULTS.verifiedEmail,
-  { validator: isValidEmail }
+// Set by CI to one value per job attempt, and required everywhere else too:
+// runScopedEmail throws without it. See its comment in e2e-fixture-seed.mjs.
+export const E2E_RUN_KEY = (process.env.E2E_RUN_KEY ?? "").trim();
+
+export const E2E_VERIFIED_EMAIL = runScopedEmail(
+  envOrDefault("E2E_VERIFIED_EMAIL", DEFAULTS.verifiedEmail, {
+    validator: isValidEmail,
+  }),
+  E2E_RUN_KEY
 );
-export const E2E_UNVERIFIED_EMAIL = envOrDefault(
-  "E2E_UNVERIFIED_EMAIL",
-  DEFAULTS.unverifiedEmail,
-  { validator: isValidEmail }
+export const E2E_UNVERIFIED_EMAIL = runScopedEmail(
+  envOrDefault("E2E_UNVERIFIED_EMAIL", DEFAULTS.unverifiedEmail, {
+    validator: isValidEmail,
+  }),
+  E2E_RUN_KEY
 );
 // The three credentials are resolved inside prepareE2EAuthFixtures rather
 // than at module scope, so the `reset-profile <email>` action (which needs no
 // credential at all) still runs when they are unset.
-// Set by CI to one value per job attempt (see .github/workflows/ci.yml),
-// e.g. `${{ github.run_id }}-${{ github.run_attempt }}`. Empty for local and
-// manual runs, which means "no run key": the seeder then uses the single
-// shared fixture identity instead of a namespaced one.
-export const E2E_RUN_KEY = process.env.E2E_RUN_KEY || undefined;
 
 function maskEmail(value) {
   const [local = "", domain = ""] = value.split("@");

--- a/apps/web-console/tests/e2e/support/e2e-auth-fixtures.mjs
+++ b/apps/web-console/tests/e2e/support/e2e-auth-fixtures.mjs
@@ -9,7 +9,9 @@
 //   node tests/e2e/support/e2e-auth-fixtures.mjs
 //   node tests/e2e/support/e2e-auth-fixtures.mjs reset-profile <email>
 //
-// Requires SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY. Neither has a
+// Requires SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, and (for the default
+// seeding action) E2E_VERIFIED_PASSWORD, E2E_UNVERIFIED_PASSWORD and
+// E2E_INVITATION_TOKEN. None has a
 // fallback: seeding used to POST to a deployed `e2e-fixtures` Supabase Edge
 // Function and quietly no-op when its URL and secret were absent, which is
 // what let a caller change while the deployed seeder stayed behind, with
@@ -26,8 +28,12 @@ import {
   seedFixtures,
 } from "./e2e-fixture-seed.mjs";
 
-// Shared defaults with `e2e-auth-creds.ts`. Both modules read the same JSON
-// so the spec-side env lookup and this CLI cannot drift apart.
+// Shared non-secret defaults with `e2e-auth-creds.ts`. Both modules read the
+// same JSON so the spec-side env lookup and this CLI cannot drift apart. That
+// file carries addresses and length limits only. No credential has a committed
+// default here or there, and none may be added back: this repository is
+// public, and the values that used to live in that JSON were live ones this
+// very CLI then wrote back onto shared accounts on every credential-less run.
 const DEFAULTS = JSON.parse(
   readFileSync(
     join(dirname(fileURLToPath(import.meta.url)), "e2e-auth-defaults.json"),
@@ -35,15 +41,9 @@ const DEFAULTS = JSON.parse(
   )
 );
 
-function envOrDefault(name, fallback, { minLength = 0, validator } = {}) {
+function envOrDefault(name, fallback, { validator } = {}) {
   const raw = process.env[name];
   if (raw === undefined || raw === "") {
-    return fallback;
-  }
-  if (minLength > 0 && raw.length < minLength) {
-    console.warn(
-      `[e2e-auth-fixtures] ${name} is set but too short (${raw.length} < ${minLength}); using fallback`
-    );
     return fallback;
   }
   if (validator && !validator(raw)) {
@@ -51,6 +51,27 @@ function envOrDefault(name, fallback, { minLength = 0, validator } = {}) {
       `[e2e-auth-fixtures] ${name} is set but failed validation; using fallback`
     );
     return fallback;
+  }
+  return raw;
+}
+
+// Mirrors requiredSecretEnv in `e2e-auth-creds.ts`. Throws rather than
+// returning a fallback, so a run with nothing configured stops here with the
+// name of the variable to set instead of seeding shared live accounts with a
+// value that is public in this repository's history.
+function requiredSecretEnv(name, minLength) {
+  const raw = process.env[name] ?? "";
+  if (raw === "") {
+    throw new Error(
+      `[e2e-auth-fixtures] ${name} is required and has no default. Set it in ` +
+        "your shell (or as a CI secret) before seeding fixtures. Credentials " +
+        "are never committed to this repository; see docs/live-test-auth.md."
+    );
+  }
+  if (raw.length < minLength) {
+    throw new Error(
+      `[e2e-auth-fixtures] ${name} is set but too short (${raw.length} < ${minLength}).`
+    );
   }
   return raw;
 }
@@ -71,21 +92,9 @@ export const E2E_UNVERIFIED_EMAIL = envOrDefault(
   DEFAULTS.unverifiedEmail,
   { validator: isValidEmail }
 );
-export const E2E_VERIFIED_PASSWORD = envOrDefault(
-  "E2E_VERIFIED_PASSWORD",
-  DEFAULTS.verifiedPassword,
-  { minLength: DEFAULTS.minPasswordLength }
-);
-export const E2E_UNVERIFIED_PASSWORD = envOrDefault(
-  "E2E_UNVERIFIED_PASSWORD",
-  DEFAULTS.unverifiedPassword,
-  { minLength: DEFAULTS.minPasswordLength }
-);
-export const E2E_INVITATION_TOKEN = envOrDefault(
-  "E2E_INVITATION_TOKEN",
-  DEFAULTS.invitationToken,
-  { minLength: DEFAULTS.minTokenLength }
-);
+// The three credentials are resolved inside prepareE2EAuthFixtures rather
+// than at module scope, so the `reset-profile <email>` action (which needs no
+// credential at all) still runs when they are unset.
 // Set by CI to one value per job attempt (see .github/workflows/ci.yml),
 // e.g. `${{ github.run_id }}-${{ github.run_attempt }}`. Empty for local and
 // manual runs, which means "no run key": the seeder then uses the single
@@ -114,9 +123,18 @@ export async function prepareE2EAuthFixtures() {
     runKey: E2E_RUN_KEY,
     verifiedEmail: E2E_VERIFIED_EMAIL,
     unverifiedEmail: E2E_UNVERIFIED_EMAIL,
-    verifiedPassword: E2E_VERIFIED_PASSWORD,
-    unverifiedPassword: E2E_UNVERIFIED_PASSWORD,
-    invitationToken: E2E_INVITATION_TOKEN,
+    verifiedPassword: requiredSecretEnv(
+      "E2E_VERIFIED_PASSWORD",
+      DEFAULTS.minPasswordLength
+    ),
+    unverifiedPassword: requiredSecretEnv(
+      "E2E_UNVERIFIED_PASSWORD",
+      DEFAULTS.minPasswordLength
+    ),
+    invitationToken: requiredSecretEnv(
+      "E2E_INVITATION_TOKEN",
+      DEFAULTS.minTokenLength
+    ),
   });
 }
 

--- a/apps/web-console/tests/e2e/support/e2e-auth-fixtures.mjs
+++ b/apps/web-console/tests/e2e/support/e2e-auth-fixtures.mjs
@@ -141,7 +141,22 @@ export async function prepareE2EAuthFixtures() {
 }
 
 export async function resetProfileBetweenSpecs(email) {
-  return resetProfileComplete(createAdminClient(), email || E2E_VERIFIED_EMAIL);
+  const target = email || E2E_VERIFIED_EMAIL;
+  // The address arrives on argv, so it is the one fixture write that is not
+  // derived from runScopedEmail. It sets a profile flag rather than a
+  // credential, so it cannot revoke a session, but it is still a write, and
+  // this change's whole invariant is that a fixture write belongs to the run.
+  // E2E_RUN_KEY is non-empty by the time this runs: module scope resolves the
+  // two addresses through runScopedEmail, which throws without it.
+  if (!target.includes(`+${E2E_RUN_KEY}@`)) {
+    throw new Error(
+      `[e2e-auth-fixtures] refusing to reset the profile of ${target}: it is ` +
+        `not scoped to this run (E2E_RUN_KEY=${E2E_RUN_KEY}). Fixture writes ` +
+        "target accounts this run created, never a shared one. See " +
+        "docs/live-test-auth.md."
+    );
+  }
+  return resetProfileComplete(createAdminClient(), target);
 }
 
 function runCli(argv) {

--- a/apps/web-console/tests/e2e/support/e2e-fixture-seed.mjs
+++ b/apps/web-console/tests/e2e/support/e2e-fixture-seed.mjs
@@ -18,7 +18,10 @@
 // Nothing here is browser code. The service-role key stays in this Node
 // process and its callers, never reaches page context, and must never be
 // written to stdout, stderr, a screenshot, or an artifact. Route any error
-// text that could embed it through `redactSecrets` first.
+// text that could embed it through `redactSecrets` first. That is a rule
+// about every printing site in this file, not only the ones at the CLI
+// boundary: the sweep below relays raw client-library messages, and those
+// messages are exactly where a key or a token ends up embedded.
 
 import { createHash, randomBytes } from "node:crypto";
 import { createClient } from "@supabase/supabase-js";
@@ -660,7 +663,9 @@ async function sweepStaleFixtureRuns(admin) {
       .eq("account_id", acct.id);
     if (delMapErr) {
       console.error(
-        `sweep: unmap billing account ${acct.id} failed: ${delMapErr.message}`
+        redactSecrets(
+          `sweep: unmap billing account ${acct.id} failed: ${delMapErr.message}`
+        )
       );
       continue;
     }
@@ -675,7 +680,7 @@ async function sweepStaleFixtureRuns(admin) {
       .eq("id", acct.id);
     if (delAcctErr) {
       console.error(
-        `sweep: delete account ${acct.id} failed: ${delAcctErr.message}`
+        redactSecrets(`sweep: delete account ${acct.id} failed: ${delAcctErr.message}`)
       );
       continue;
     }
@@ -684,7 +689,9 @@ async function sweepStaleFixtureRuns(admin) {
     );
     if (delUserErr) {
       console.error(
-        `sweep: delete user ${acct.owner_user_id} failed: ${delUserErr.message}`
+        redactSecrets(
+          `sweep: delete user ${acct.owner_user_id} failed: ${delUserErr.message}`
+        )
       );
     }
   }

--- a/apps/web-console/tests/e2e/support/e2e-fixture-seed.mjs
+++ b/apps/web-console/tests/e2e/support/e2e-fixture-seed.mjs
@@ -54,10 +54,12 @@ const LOCAL_IDS = {
   slugSuffix: "",
 };
 
-const DEFAULT_EMAILS = {
-  verified: "e2e-verified@scubed.com.bd",
-  unverified: "e2e-unverified@scubed.com.bd",
-};
+// No DEFAULT_EMAILS constant lives here any more. It used to supply the two
+// shared live addresses whenever a caller passed none, which made every
+// credential-less local run write a password onto a shared tenant-OWNER
+// account through ensureUser below and revoke every session a concurrent run
+// was holding. A default that silently targets a shared account is the bug, so
+// there is no default: see runScopedEmail.
 
 function sha256Hex(input) {
   return createHash("sha256").update(input, "utf8").digest("hex");
@@ -87,6 +89,32 @@ export function withRunKey(email, runKey) {
   const at = email.indexOf("@");
   if (at === -1) return `${email}+${runKey}`;
   return `${email.slice(0, at)}+${runKey}${email.slice(at)}`;
+}
+
+// runScopedEmail is the gate on every address this module writes a password
+// to. ensureUser sends `password:` on both of its update paths, so an address
+// that is not scoped to this run means overwriting the credential of an
+// account other runs are signed in as. There is no fallback and no shared
+// default: an empty run key throws, and an address that does not already carry
+// the key gets it. Idempotent, because ci.yml passes an address that is
+// already namespaced alongside the same key.
+export function runScopedEmail(email, runKey) {
+  if (typeof email !== "string" || email === "") {
+    throw new Error(
+      "E2E fixture seeding requires an explicit address for every fixture " +
+        "user. It has no default, because the default was a shared live account."
+    );
+  }
+  if (!runKey) {
+    throw new Error(
+      "E2E fixture seeding requires E2E_RUN_KEY. Without it the fixtures " +
+        "target shared live accounts, and seeding overwrites their passwords, " +
+        "which revokes every session other runs are holding (see " +
+        "docs/live-test-auth.md). Export any unique value, for example " +
+        "E2E_RUN_KEY=$(whoami)-$(date +%s)."
+    );
+  }
+  return email.includes(`+${runKey}@`) ? email : withRunKey(email, runKey);
 }
 
 // buildIds returns LOCAL_IDS unchanged when runKey is empty, or a full set of
@@ -705,8 +733,10 @@ async function sweepStaleFixtureRuns(admin) {
 export async function seedFixtures(admin, opts) {
   const runKey = typeof opts.runKey === "string" ? opts.runKey.trim() : "";
   const ids = buildIds(runKey);
-  const verifiedEmail = opts.verifiedEmail ?? DEFAULT_EMAILS.verified;
-  const unverifiedEmail = opts.unverifiedEmail ?? DEFAULT_EMAILS.unverified;
+  // Throws on an empty run key, so LOCAL_IDS above is now only ever reached by
+  // a caller that has already been rejected here.
+  const verifiedEmail = runScopedEmail(opts.verifiedEmail, runKey);
+  const unverifiedEmail = runScopedEmail(opts.unverifiedEmail, runKey);
 
   await sweepStaleFixtureRuns(admin);
 

--- a/apps/web-console/tests/unit/e2e-auth-creds.test.ts
+++ b/apps/web-console/tests/unit/e2e-auth-creds.test.ts
@@ -1,0 +1,79 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+
+// This repository is public. Its E2E fixture file used to carry two live
+// account passwords and a live invitation token in plaintext, and the seeder
+// wrote those exact values back onto the accounts on every credential-less
+// run, so they were real credentials rather than inert sample data. These
+// guards exist so that cannot come back quietly.
+
+const DEFAULTS_PATH = join(
+  __dirname,
+  "..",
+  "e2e",
+  "support",
+  "e2e-auth-defaults.json"
+);
+
+describe("e2e-auth-defaults.json", () => {
+  it("carries addresses and limits only, never a credential", () => {
+    const parsed = JSON.parse(readFileSync(DEFAULTS_PATH, "utf8"));
+    expect(Object.keys(parsed).sort()).toEqual([
+      "minPasswordLength",
+      "minTokenLength",
+      "unverifiedEmail",
+      "verifiedEmail",
+    ]);
+  });
+
+  // Belt to the braces above: a future field named something other than
+  // "verifiedPassword" would pass the key check, so assert on shape too. Every
+  // legitimate value here is an address or a small integer.
+  it("holds no free-form secret-shaped string", () => {
+    const parsed = JSON.parse(readFileSync(DEFAULTS_PATH, "utf8"));
+    for (const [key, value] of Object.entries(parsed)) {
+      if (typeof value === "string") {
+        expect(value, `${key} must be an email address, not a secret`).toMatch(
+          /^[^@\s]+@[^@\s]+\.[^@\s]+$/
+        );
+      } else {
+        expect(typeof value, `${key} must be a number`).toBe("number");
+      }
+    }
+  });
+});
+
+describe("requiredSecretEnv", () => {
+  it("names the missing variable instead of falling back or skipping", async () => {
+    // Set the three the module resolves at import time, so importing it here
+    // exercises the helper rather than the module's own startup failure.
+    vi.stubEnv("E2E_VERIFIED_PASSWORD", "set-for-import-only");
+    vi.stubEnv("E2E_UNVERIFIED_PASSWORD", "set-for-import-only");
+    vi.stubEnv("E2E_INVITATION_TOKEN", "set-for-import-only-token");
+    const { requiredSecretEnv } = await import(
+      "../e2e/support/e2e-auth-creds"
+    );
+
+    expect(() => requiredSecretEnv("E2E_ABSENT_FIXTURE_VAR", 1)).toThrow(
+      /E2E_ABSENT_FIXTURE_VAR is required and has no default/
+    );
+
+    vi.stubEnv("E2E_PRESENT_FIXTURE_VAR", "");
+    expect(() => requiredSecretEnv("E2E_PRESENT_FIXTURE_VAR", 1)).toThrow(
+      /E2E_PRESENT_FIXTURE_VAR is required and has no default/
+    );
+
+    vi.stubEnv("E2E_PRESENT_FIXTURE_VAR", "short");
+    expect(() => requiredSecretEnv("E2E_PRESENT_FIXTURE_VAR", 12)).toThrow(
+      /too short/
+    );
+
+    vi.stubEnv("E2E_PRESENT_FIXTURE_VAR", "long-enough-value");
+    expect(requiredSecretEnv("E2E_PRESENT_FIXTURE_VAR", 12)).toBe(
+      "long-enough-value"
+    );
+
+    vi.unstubAllEnvs();
+  });
+});

--- a/apps/web-console/tests/unit/e2e-auth-creds.test.ts
+++ b/apps/web-console/tests/unit/e2e-auth-creds.test.ts
@@ -79,6 +79,93 @@ describe("requiredSecretEnv", () => {
   });
 });
 
+// The rotation of the two exposed live credentials is gated on one claim: no
+// path can hand the seeder a shared address. The trace that supports it is a
+// fact about today's call graph, so these two tests are what make it hold for
+// the next caller as well.
+describe("seedFixtures refuses to touch anything without a run key", () => {
+  // Any property access on this client is a failure: it means seeding reached
+  // the Supabase admin API before the run-key guard, which is the only way a
+  // password could land on a shared account.
+  const explodingAdmin = new Proxy(
+    {},
+    {
+      get(_target, property) {
+        throw new Error(
+          `admin client was touched before the guard: ${String(property)}`
+        );
+      },
+    }
+  );
+
+  const opts = {
+    verifiedEmail: "e2e-verified@scubed.com.bd",
+    unverifiedEmail: "e2e-unverified@scubed.com.bd",
+    verifiedPassword: "irrelevant",
+    unverifiedPassword: "irrelevant",
+    invitationToken: "irrelevant-token",
+  };
+
+  it.each([
+    ["empty", ""],
+    ["whitespace", "   "],
+    ["undefined", undefined],
+    ["not a string", 42],
+  ])("throws on a %s run key, before any admin call", async (_label, runKey) => {
+    const { seedFixtures } = await import("../e2e/support/e2e-fixture-seed.mjs");
+    await expect(
+      seedFixtures(explodingAdmin, { ...opts, runKey })
+    ).rejects.toThrow(/E2E_RUN_KEY/);
+  });
+
+  it("also refuses when an address is missing entirely", async () => {
+    const { seedFixtures } = await import("../e2e/support/e2e-fixture-seed.mjs");
+    await expect(
+      seedFixtures(explodingAdmin, { ...opts, verifiedEmail: undefined, runKey: "k" })
+    ).rejects.toThrow(/requires an explicit address/);
+  });
+});
+
+// The idempotence rule is written out twice, once in the TS module the specs
+// import and once in the ESM module the seeder runs, because Playwright
+// compiles specs to CommonJS and cannot import the .mjs. They decide which
+// live account gets written, so their agreement is pinned rather than assumed.
+describe("both runScopedEmail implementations agree", () => {
+  it("produces identical output for every case that matters", async () => {
+    vi.stubEnv("E2E_VERIFIED_PASSWORD", "set-for-import-only");
+    vi.stubEnv("E2E_UNVERIFIED_PASSWORD", "set-for-import-only");
+    vi.stubEnv("E2E_INVITATION_TOKEN", "set-for-import-only-token");
+    vi.stubEnv("E2E_RUN_KEY", "unit-test");
+    const specSide = await import("../e2e/support/e2e-auth-creds");
+    const seedSide = await import("../e2e/support/e2e-fixture-seed.mjs");
+
+    const cases: ReadonlyArray<readonly [string, string]> = [
+      ["e2e-verified@scubed.com.bd", "99-1"],
+      ["e2e-unverified@scubed.com.bd", "99-1"],
+      ["e2e-verified+99-1@scubed.com.bd", "99-1"],
+      ["e2e-verified+other@scubed.com.bd", "99-1"],
+      ["e2e-verified@scubed.com.bd", "undefined"],
+      ["no-at-sign", "99-1"],
+    ];
+    for (const [email, runKey] of cases) {
+      expect(
+        specSide.runScopedEmail(email, runKey),
+        `${email} with ${runKey}`
+      ).toBe(seedSide.runScopedEmail(email, runKey));
+    }
+
+    // And they refuse the empty key the same way.
+    expect(() => specSide.runScopedEmail("e2e-verified@scubed.com.bd", "")).toThrow(
+      /E2E_RUN_KEY/
+    );
+    expect(() => seedSide.runScopedEmail("e2e-verified@scubed.com.bd", "")).toThrow(
+      /E2E_RUN_KEY/
+    );
+
+    vi.unstubAllEnvs();
+  });
+});
+
 // Seeding writes a password to whatever address it is given. Before this
 // guard, a run with no run key targeted the two shared live tenant-OWNER
 // accounts, so every local run revoked the sessions of every other run.

--- a/apps/web-console/tests/unit/e2e-auth-creds.test.ts
+++ b/apps/web-console/tests/unit/e2e-auth-creds.test.ts
@@ -51,6 +51,7 @@ describe("requiredSecretEnv", () => {
     vi.stubEnv("E2E_VERIFIED_PASSWORD", "set-for-import-only");
     vi.stubEnv("E2E_UNVERIFIED_PASSWORD", "set-for-import-only");
     vi.stubEnv("E2E_INVITATION_TOKEN", "set-for-import-only-token");
+    vi.stubEnv("E2E_RUN_KEY", "unit-test");
     const { requiredSecretEnv } = await import(
       "../e2e/support/e2e-auth-creds"
     );
@@ -72,6 +73,41 @@ describe("requiredSecretEnv", () => {
     vi.stubEnv("E2E_PRESENT_FIXTURE_VAR", "long-enough-value");
     expect(requiredSecretEnv("E2E_PRESENT_FIXTURE_VAR", 12)).toBe(
       "long-enough-value"
+    );
+
+    vi.unstubAllEnvs();
+  });
+});
+
+// Seeding writes a password to whatever address it is given. Before this
+// guard, a run with no run key targeted the two shared live tenant-OWNER
+// accounts, so every local run revoked the sessions of every other run.
+describe("runScopedEmail", () => {
+  it("refuses to resolve an address without a run key, and namespaces once", async () => {
+    vi.stubEnv("E2E_VERIFIED_PASSWORD", "set-for-import-only");
+    vi.stubEnv("E2E_UNVERIFIED_PASSWORD", "set-for-import-only");
+    vi.stubEnv("E2E_INVITATION_TOKEN", "set-for-import-only-token");
+    vi.stubEnv("E2E_RUN_KEY", "unit-test");
+    const { runScopedEmail } = await import("../e2e/support/e2e-auth-creds");
+
+    expect(() => runScopedEmail("e2e-verified@scubed.com.bd", "")).toThrow(
+      /E2E_RUN_KEY is required and has no default/
+    );
+
+    // A shared base address becomes this run's own address.
+    expect(runScopedEmail("e2e-verified@scubed.com.bd", "99-1")).toBe(
+      "e2e-verified+99-1@scubed.com.bd"
+    );
+
+    // Idempotent: CI already passes a namespaced address alongside the same
+    // key, and doubling the suffix would seed an account no spec signs in as.
+    expect(runScopedEmail("e2e-verified+99-1@scubed.com.bd", "99-1")).toBe(
+      "e2e-verified+99-1@scubed.com.bd"
+    );
+
+    // Two runs never resolve to the same account.
+    expect(runScopedEmail("e2e-verified@scubed.com.bd", "99-1")).not.toBe(
+      runScopedEmail("e2e-verified@scubed.com.bd", "99-2")
     );
 
     vi.unstubAllEnvs();

--- a/docs/live-test-auth.md
+++ b/docs/live-test-auth.md
@@ -8,7 +8,36 @@ apps/web-console/tests/e2e/support/live-auth.mjs   # the implementation, also a 
 apps/web-console/tests/e2e/support/live-auth.ts    # the spec-side entry point
 ```
 
-## Rotating the shared demo password is forbidden
+## No credential is ever committed
+
+This repository is public. A test credential in a tracked file is a published
+credential, and a fixture password is not inert: the seeder writes it back onto
+the live account on every run, so the committed value is the account's actual
+password.
+
+The sanctioned pattern is an environment variable with **no fallback**. A
+missing one fails loudly and names itself. It never falls back to a default and
+never turns into a silent skip, because a silent skip is how a committed value
+survives unnoticed:
+
+```js
+// apps/web-console/tests/e2e/support/e2e-auth-creds.ts
+export const E2E_VERIFIED_PASSWORD = requiredSecretEnv(
+  "E2E_VERIFIED_PASSWORD",
+  DEFAULTS.minPasswordLength
+);
+```
+
+`e2e-auth-defaults.json` carries addresses and length limits only. Two unit
+guards in `apps/web-console/tests/unit/e2e-auth-creds.test.ts` fail if a
+credential-shaped field reappears there. Addresses may stay: an address is not
+a credential.
+
+Local runs therefore need `E2E_VERIFIED_PASSWORD`, `E2E_UNVERIFIED_PASSWORD`
+and `E2E_INVITATION_TOKEN` exported before `npx playwright test`. CI passes the
+first two from repository secrets and derives the third per run.
+
+## Rotating a shared account's password is forbidden
 
 Never set, reset or rotate the password of a shared test account to obtain a
 session. Not as a fallback, not "just this once", not behind a flag.
@@ -18,6 +47,40 @@ bearer against GoTrue on each request, so changing the password invalidates
 every session that any other run currently holds. On 2026-08-08 a scratch
 script did exactly that and broke three agents working concurrently; four
 separate agents were blocked on credentials across that day and the one after.
+
+### What this repository does about it
+
+Three scripts here used to rotate unconditionally. They no longer do, and the
+shape they now share is the one to copy:
+
+| script | account | how it behaves now |
+| --- | --- | --- |
+| `scripts/seed-demo-owner.py` | `demo@hive-demo.invalid` | `password_to_set` leaves an existing account alone unless `HIVE_DEMO_PASSWORD` is set. Creation still generates one. |
+| `scripts/seed-owui-e2e-user.py` | `owui-e2e@…`, `owui-e2e-bootstrap@…` | Same helper. Prints a `PASSWORD` line only for a password it actually set. `OWUI_E2E_RUN_KEY` namespaces both addresses per run, which is how the nightly gets a usable credential without touching a shared one. |
+| `scripts/verify-rag-roundtrip.py` | `rag-verify-e2e@hive-e2e.invalid` | Signs in with `RAG_VERIFY_PASSWORD` and refuses to rotate. Only a first run, which creates the account, generates one. |
+
+`scripts/seed-owui-e2e-user.py` matters most of the three: it is the only one
+invoked automatically. `.github/workflows/owui-nightly.yml` runs it on a
+schedule, on `workflow_dispatch`, and on any pull request labelled
+`run-owui-e2e`. That workflow's `concurrency.group` is keyed on the ref, so a
+labelled pull request run and the scheduled run are in different groups and can
+overlap. Before the run key, they rotated the same two accounts out from under
+each other.
+
+The web-console fixture seeder
+(`apps/web-console/tests/e2e/support/e2e-fixture-seed.mjs`) writes the resolved
+passwords onto its fixture accounts too. In CI the addresses are run-scoped, so
+it only ever touches its own run's users. Run locally with no `E2E_RUN_KEY`, it
+targets the shared `e2e-verified@scubed.com.bd` and
+`e2e-unverified@scubed.com.bd` accounts, which is why the credentials it seeds
+with must come from your environment and why that path must never silently
+default.
+
+`scripts/verify-control-plane.py` states the same rule in its docstring and
+signs in with an existing password it is given. That is fine. Inventing a new
+password is not.
+
+### The scratch script to avoid
 
 The scratch helper `demo_login.py` (agent scratchpad, not in this repository)
 is the specific script to avoid. Its only login path is:
@@ -31,10 +94,6 @@ Step 1 has also been returning intermittent `500 Database error finding users`
 (issue #791), and step 2 is the rotation described above. It is left in place
 only because other agents still reference it; do not use it to log in, and do
 not copy its shape into anything new.
-
-`scripts/verify-control-plane.py` states the same rule in its docstring and
-signs in with an existing password it is given. That is fine. Inventing a new
-password is not.
 
 ## What the helper does instead
 
@@ -140,3 +199,22 @@ token, so the fix cannot be quietly regressed into the version that leaked.
 Related: `npm run lint:proof-tokens` catches credentials in committed proof
 text, but cannot inspect screenshot pixels. Masking an image is still on the
 agent capturing it.
+
+## Playwright artifacts are public
+
+A workflow artifact on this repository is downloadable by anyone holding the
+run URL, for as long as it is retained. A Playwright trace is not a log: it
+records every request header (`Authorization: Bearer`), every cookie
+(`sb-*-auth-token`), and every navigation URL, including an OAuth callback
+whose `code=` and `access_token=` sit in the query string and the fragment. No
+text linter can see inside it, because it is a zip of binary resources.
+
+So the two report uploads exclude `*.zip` and `*.webm` and set
+`retention-days: 5`:
+
+* `playwright-report-api` in `.github/workflows/ci.yml`
+* `owui-playwright-report` in `.github/workflows/owui-nightly.yml`
+
+The HTML report, the screenshots and the error text still upload, which is what
+triage reads. Renaming an artifact is not a fix. If you add a job that uploads
+Playwright output, exclude the same two patterns and set a short retention.

--- a/docs/live-test-auth.md
+++ b/docs/live-test-auth.md
@@ -33,9 +33,44 @@ guards in `apps/web-console/tests/unit/e2e-auth-creds.test.ts` fail if a
 credential-shaped field reappears there. Addresses may stay: an address is not
 a credential.
 
-Local runs therefore need `E2E_VERIFIED_PASSWORD`, `E2E_UNVERIFIED_PASSWORD`
-and `E2E_INVITATION_TOKEN` exported before `npx playwright test`. CI passes the
-first two from repository secrets and derives the third per run.
+Local runs therefore need this before `npx playwright test`:
+
+```bash
+export E2E_RUN_KEY="$(whoami)-$(date +%s)"
+export E2E_VERIFIED_PASSWORD=...
+export E2E_UNVERIFIED_PASSWORD=...
+export E2E_INVITATION_TOKEN=...
+```
+
+CI passes the two passwords from repository secrets, generates the invitation
+token randomly per job (it used to be a committed literal joined to the public
+run id, and the seeder stores its sha256 as a live pending invitation, so
+anyone reading the run page could compute it), and sets the run key to
+`run_id-run_attempt`.
+
+`E2E_RUN_KEY` is not optional, and the next section is why.
+
+## Every fixture address belongs to the run
+
+Seeding writes a password to whatever address it is handed. So the address it
+is handed must never be a shared one:
+
+* `runScopedEmail` (`e2e-fixture-seed.mjs`, mirrored in `e2e-auth-creds.ts`)
+  throws without a run key, and otherwise turns the shared base address into
+  this run's own (`e2e-verified+<key>@...`). It is idempotent, because CI
+  passes an already-namespaced address alongside the same key.
+* There is no default address anywhere in the seeding path. The `DEFAULT_EMAILS`
+  constant that used to supply the two shared live accounts is gone.
+* Stale run-scoped rows are swept after three hours by `sweepStaleFixtureRuns`,
+  so this costs no permanent rows.
+
+This closes a real hole rather than a theoretical one. `ensureUser` sends
+`password:` on both of its update paths, so before the guard, every
+credential-less local run overwrote the password of two shared live accounts
+that hold a tenant OWNER role, and revoked every session other runs held on
+them. A committed default made that write idempotent and therefore invisible;
+removing the default without this guard would have made each operator write a
+different value.
 
 ## Rotating a shared account's password is forbidden
 
@@ -56,8 +91,15 @@ shape they now share is the one to copy:
 | script | account | how it behaves now |
 | --- | --- | --- |
 | `scripts/seed-demo-owner.py` | `demo@hive-demo.invalid` | `password_to_set` leaves an existing account alone unless `HIVE_DEMO_PASSWORD` is set. Creation still generates one. |
-| `scripts/seed-owui-e2e-user.py` | `owui-e2e@…`, `owui-e2e-bootstrap@…` | Same helper. Prints a `PASSWORD` line only for a password it actually set. `OWUI_E2E_RUN_KEY` namespaces both addresses per run, which is how the nightly gets a usable credential without touching a shared one. |
-| `scripts/verify-rag-roundtrip.py` | `rag-verify-e2e@hive-e2e.invalid` | Signs in with `RAG_VERIFY_PASSWORD` and refuses to rotate. Only a first run, which creates the account, generates one. |
+| `scripts/seed-owui-e2e-user.py` | `owui-e2e@…`, `owui-e2e-bootstrap@…` | Same helper. Prints a `PASSWORD` line only for a password it actually set. `OWUI_E2E_RUN_KEY` namespaces both addresses per run, which is how the nightly gets a usable credential without touching a shared one, and `sweep_stale_fixture_users` clears what earlier runs left. |
+| `scripts/verify-rag-roundtrip.py` | `rag-verify-e2e@hive-e2e.invalid` | Signs in with `RAG_VERIFY_PASSWORD` and refuses to rotate. The run that creates the account generates one and prints it on stderr, once. Save it. |
+
+The shim API key that `seed-owui-e2e-user.py` mints is a separate hazard with
+the same shape. Its billing account stays shared (a tenant bills to exactly one
+account, so a per-run account needs a per-run tenant and leaves a permanent row
+behind), so the revocation of previously minted keys is bounded by age rather
+than by "every key except mine". An identity-bounded delete had two overlapping
+runs revoking each other's key mid-flight.
 
 `scripts/seed-owui-e2e-user.py` matters most of the three: it is the only one
 invoked automatically. `.github/workflows/owui-nightly.yml` runs it on a
@@ -209,12 +251,28 @@ records every request header (`Authorization: Bearer`), every cookie
 whose `code=` and `access_token=` sit in the query string and the fragment. No
 text linter can see inside it, because it is a zip of binary resources.
 
-So the two report uploads exclude `*.zip` and `*.webm` and set
+`index.html` is no better. The HTML reporter base64-inlines the entire report
+payload into it, stdout, stderr and error text included, and a `waitForURL`
+timeout enumerates every URL it navigated, fragment and all. Same material,
+same binary wrapper, same blindness in any text linter.
+
+So both report uploads exclude `*.zip`, `*.webm` and `index.html`, and set
 `retention-days: 5`:
 
 * `playwright-report-api` in `.github/workflows/ci.yml`
 * `owui-playwright-report` in `.github/workflows/owui-nightly.yml`
 
-The HTML report, the screenshots and the error text still upload, which is what
-triage reads. Renaming an artifact is not a fix. If you add a job that uploads
-Playwright output, exclude the same two patterns and set a short retention.
+Screenshots still upload, and the failing test names and error text are already
+in the job log. Renaming an artifact is not a fix.
+
+Container log dumps are the same problem in plain text: Open WebUI's uvicorn
+access lines print `GET /oauth/oidc/callback?code=...` verbatim, and edge-api
+logs carry the shim key. The three log artifacts
+(`compose-logs`, `compose-logs-web-e2e-api`, `owui-compose-logs`) pipe through
+`scripts/redact-log-credentials.py`, which mirrors `redactSecrets`, handles
+fragments as well as query strings, and carries its own self-check
+(`python3 scripts/redact-log-credentials.py --selfcheck`, also in
+`make test-scripts`).
+
+If you add a job that uploads Playwright output or container logs, apply the
+same exclusions, pipe the logs through the redactor, and set a short retention.

--- a/scripts/redact-log-credentials.py
+++ b/scripts/redact-log-credentials.py
@@ -46,8 +46,17 @@ CREDENTIAL_PARAMS = [
 ]
 
 # Longest names first so `provider_refresh_token` never degrades to `token`.
+#
+# The optional leading `[A-Za-z0-9_]*` matters more than it looks. `\b` treats
+# `_` as a word character, so a bare `\bpassword=` does NOT match
+# `RAG_VERIFY_PASSWORD=`, and environment-variable spelling is the dominant
+# shape of a credential in a container log dump, which is precisely what this
+# script is pointed at. Without the prefix the redactor would miss the case it
+# meets most often.
 CREDENTIAL_PARAM_RE = re.compile(
-    r"\b(" + "|".join(sorted(CREDENTIAL_PARAMS, key=len, reverse=True)) + r")=([^&#\s\"'\\]+)",
+    r"\b([A-Za-z0-9_]*(?:"
+    + "|".join(sorted(CREDENTIAL_PARAMS, key=len, reverse=True))
+    + r"))=([^&#\s\"'\\]+)",
     re.IGNORECASE,
 )
 
@@ -81,6 +90,18 @@ def selfcheck() -> None:
     # Longest-name-first: the specific name survives, the value does not.
     out = redact("provider_refresh_token=zzz")
     assert out == "provider_refresh_token=<redacted>", out
+
+    # Environment-variable spelling. `\b` treats `_` as a word character, so a
+    # bare `\bpassword=` misses these, and they are the common shape in a
+    # container log dump and in what verify-rag-roundtrip.py prints.
+    for line in (
+        "export RAG_VERIFY_PASSWORD=hunter2live",
+        "OWUI_E2E_PASSWORD=hunter2live",
+        "E2E_VERIFIED_PASSWORD=hunter2live",
+    ):
+        out = redact(line)
+        assert "hunter2live" not in out, out
+        assert "PASSWORD=<redacted>" in out, out
 
     # Bare tokens with no parameter name around them.
     jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTYifQ.dBjftJeZ4CVPmB92K27uhbUJU1p1r"

--- a/scripts/redact-log-credentials.py
+++ b/scripts/redact-log-credentials.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Scrub credential-bearing values out of a log stream on its way to a file.
+
+Reads stdin, writes stdout. Used by the workflow steps that dump container
+logs into an artifact, because this repository is public and every artifact is
+downloadable by anyone holding the run URL. Open WebUI's uvicorn access lines
+carry the OAuth callback verbatim, so an unfiltered dump publishes
+`GET /oauth/oidc/callback?code=...` for a real account.
+
+The parameter list and the bare-JWT pattern mirror `redactSecrets` in
+apps/web-console/tests/e2e/support/e2e-fixture-seed.mjs. Keep them in step.
+
+CREDENTIALS AFTER A FRAGMENT COUNT. A redactor that only understands query
+strings is not a redactor: GoTrue hands a session back as a redirect whose
+credentials live after the "#", and an agent's own query-string-only scrubber
+printed a live session token to stdout on 2026-08-08 while looking like it was
+protecting the log. The pattern below matches `name=value` wherever it appears.
+
+Run: docker compose logs ... | python3 scripts/redact-log-credentials.py > out
+Self-check: python3 scripts/redact-log-credentials.py --selfcheck
+"""
+import re
+import sys
+
+CREDENTIAL_PARAMS = [
+    "access_token",
+    "refresh_token",
+    "provider_token",
+    "provider_refresh_token",
+    "id_token",
+    "token_hash",
+    "hashed_token",
+    "confirmation_token",
+    "recovery_token",
+    "invitation_token",
+    "invite_token",
+    "email_otp",
+    "client_secret",
+    "api_key",
+    "apikey",
+    "password",
+    "secret",
+    "token",
+    "code",
+    "otp",
+]
+
+# Longest names first so `provider_refresh_token` never degrades to `token`.
+CREDENTIAL_PARAM_RE = re.compile(
+    r"\b(" + "|".join(sorted(CREDENTIAL_PARAMS, key=len, reverse=True)) + r")=([^&#\s\"'\\]+)",
+    re.IGNORECASE,
+)
+
+# A bare JWT with no parameter name around it: a session token on its own line,
+# an `Authorization: Bearer ...` header, or a service-role key.
+BARE_JWT_RE = re.compile(r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}")
+
+# `hk_` is this project's API key prefix (see random_api_key in
+# scripts/seed-owui-e2e-user.py), and a shim key reaches the logs on every
+# edge-api request that carries one.
+HIVE_API_KEY_RE = re.compile(r"\bhk_[A-Za-z0-9_-]{8,}")
+
+
+def redact(text: str) -> str:
+    text = CREDENTIAL_PARAM_RE.sub(lambda m: f"{m.group(1)}=<redacted>", text)
+    text = BARE_JWT_RE.sub("<redacted>", text)
+    return HIVE_API_KEY_RE.sub("<redacted>", text)
+
+
+def selfcheck() -> None:
+    # The whole point: a fragment-borne session token, which is the exact shape
+    # that leaked on 2026-08-08.
+    out = redact("redirect to https://app.example/#access_token=abc123&refresh_token=def456")
+    assert "abc123" not in out and "def456" not in out, out
+
+    # The OAuth callback an OWUI access line prints verbatim.
+    out = redact('INFO: GET /oauth/oidc/callback?code=4%2F0Ab_live&state=xyz HTTP/1.1" 302')
+    assert "4%2F0Ab_live" not in out, out
+    assert "state=xyz" in out, "only credential parameters are scrubbed"
+
+    # Longest-name-first: the specific name survives, the value does not.
+    out = redact("provider_refresh_token=zzz")
+    assert out == "provider_refresh_token=<redacted>", out
+
+    # Bare tokens with no parameter name around them.
+    jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTYifQ.dBjftJeZ4CVPmB92K27uhbUJU1p1r"
+    assert jwt not in redact(f"Authorization: Bearer {jwt}")
+    assert "hk_livekeyvalue123" not in redact("used key hk_livekeyvalue123 for request")
+
+    # Ordinary log text is untouched, so a scrubbed dump is still readable.
+    plain = "control-plane  | 2026-08-11T00:00:00Z INFO served 200 in 12ms"
+    assert redact(plain) == plain
+
+    print("ok: redact-log-credentials scrubs fragments, query strings, bare tokens")
+
+
+def main() -> None:
+    if "--selfcheck" in sys.argv[1:]:
+        selfcheck()
+        return
+    for line in sys.stdin:
+        sys.stdout.write(redact(line))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/redact-log-credentials.py
+++ b/scripts/redact-log-credentials.py
@@ -76,6 +76,16 @@ def redact(text: str) -> str:
     return HIVE_API_KEY_RE.sub("<redacted>", text)
 
 
+# Every sample below is assembled at runtime rather than written as a literal.
+# The checks need strings shaped like real credentials, and a secret scanner
+# reading this file cannot tell a test fixture from the real thing, so a
+# literal here costs a false finding on every scan of this repository. Keep the
+# shapes, keep them out of the source text.
+SAMPLE_VALUE = "not-a-real-secret-value"
+SAMPLE_JWT = ".".join(("eyJ" + "hbGciOiJIUzI1NiJ9", "eyJ" + "zdWIiOiIxMjM0NTYifQ", "dBjftJeZ4CVPmB92K27uhbUJU1p1r"))
+SAMPLE_API_KEY = "hk_" + SAMPLE_VALUE.replace("-", "")
+
+
 def selfcheck() -> None:
     # The whole point: a fragment-borne session token, which is the exact shape
     # that leaked on 2026-08-08.
@@ -95,18 +105,17 @@ def selfcheck() -> None:
     # bare `\bpassword=` misses these, and they are the common shape in a
     # container log dump and in what verify-rag-roundtrip.py prints.
     for line in (
-        "export RAG_VERIFY_PASSWORD=hunter2live",
-        "OWUI_E2E_PASSWORD=hunter2live",
-        "E2E_VERIFIED_PASSWORD=hunter2live",
+        f"export RAG_VERIFY_PASSWORD={SAMPLE_VALUE}",
+        f"OWUI_E2E_PASSWORD={SAMPLE_VALUE}",
+        f"E2E_VERIFIED_PASSWORD={SAMPLE_VALUE}",
     ):
         out = redact(line)
-        assert "hunter2live" not in out, out
+        assert SAMPLE_VALUE not in out, out
         assert "PASSWORD=<redacted>" in out, out
 
     # Bare tokens with no parameter name around them.
-    jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTYifQ.dBjftJeZ4CVPmB92K27uhbUJU1p1r"
-    assert jwt not in redact(f"Authorization: Bearer {jwt}")
-    assert "hk_livekeyvalue123" not in redact("used key hk_livekeyvalue123 for request")
+    assert SAMPLE_JWT not in redact(f"Authorization: Bearer {SAMPLE_JWT}")
+    assert SAMPLE_API_KEY not in redact(f"used key {SAMPLE_API_KEY} for request")
 
     # Ordinary log text is untouched, so a scrubbed dump is still readable.
     plain = "control-plane  | 2026-08-11T00:00:00Z INFO served 200 in 12ms"

--- a/scripts/seed-owui-e2e-user.py
+++ b/scripts/seed-owui-e2e-user.py
@@ -3,9 +3,26 @@
 
 Run before the phase-19 OWUI nightly Playwright suite so OWUI_E2E_EMAIL /
 OWUI_E2E_PASSWORD never need to be hand-managed GitHub secrets. Safe to
-re-run: the tenant and membership rows are upserted, the GoTrue user is
-found-or-created, and its password is always rotated to a fresh random
-value so no run reuses a prior credential.
+re-run: the tenant and membership rows are upserted and the GoTrue user is
+found-or-created.
+
+PASSWORDS ARE NOT ROTATED. This script used to overwrite both fixture
+users' passwords on every run, which is the shape docs/live-test-auth.md
+forbids: the control-plane resolves every bearer against GoTrue per
+request, so rotating an account revokes the sessions every concurrent run
+is holding on it, and this script runs automatically from
+.github/workflows/owui-nightly.yml on a schedule, on dispatch, and on any
+pull request labelled run-owui-e2e (whose concurrency group is keyed on the
+ref, so it does not join the scheduled run's group). An existing account is
+now left alone, and a PASSWORD line is printed only for a password this run
+actually set. See password_to_set.
+
+OWUI_E2E_RUN_KEY is how the nightly keeps working under that rule: it
+namespaces both fixture addresses per run (foo@x -> foo+key@x), so every
+run provisions its own users, meets no existing account, and shares no
+credential with any other run. Same idea as E2E_RUN_KEY in the web-console
+fixture seeder. Left unset, the script uses the shared addresses below and
+will refuse to overwrite their passwords.
 
 Also mints a real, resolvable Hive API key to use as OWUI_SHIM_KEY. OWUI's
 own GET /v1/models connection probe sends OPENAI_API_KEY with no request
@@ -30,9 +47,11 @@ passes its own --account-slug must pass its own --tenant-slug as well;
 see provision_billing_mapping.
 
 ROTATION AND ACCOUNT SCOPING. Every run mints a fresh key and revokes the
-account's previous ones, the same rotate-every-run posture as the GoTrue
-password: a key's raw secret only exists in the response to its own mint,
-so a re-run cannot hand back an existing key's value. That makes the
+account's previous ones: a key's raw secret only exists in the response to
+its own mint, so a re-run cannot hand back an existing key's value. (The
+GoTrue passwords above no longer rotate. An API key is not a login: nothing
+holds a session against it, and the revocation here is deferred until every
+configured consumer carries the replacement.) That makes the
 account boundary load-bearing. --account-slug defaults to the CI account,
 which the nightly OWUI job rotates on a schedule; a long-lived deployment
 MUST pass its own slug (for example --account-slug owui-shim-demo-box) so
@@ -61,6 +80,9 @@ consumer IS configured and its update fails, the old keys are left active
 and the script exits non-zero.
 
 Required env: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY
+Optional env (fixture identity): OWUI_E2E_RUN_KEY (namespace both fixture
+addresses for this run), OWUI_E2E_PASSWORD and OWUI_E2E_BOOTSTRAP_PASSWORD
+(write these passwords deliberately, including onto an existing account)
 Optional env (OWUI config sync): OWUI_BASE_URL (default
 http://localhost:3003), OWUI_ADMIN_TOKEN, OWUI_ADMIN_EMAIL,
 OWUI_ADMIN_PASSWORD, EDGE_API_URL_FOR_OWUI (default
@@ -80,13 +102,14 @@ first so the real fixture user is provably the second OWUI account, the same
 position every real tenant's OWNER is in once the OWUI instance already has
 at least one user.
 
-Prints exactly five lines to stdout (and nothing else):
+Prints to stdout (and nothing else):
   EMAIL=<email>
-  PASSWORD=<password>
+  PASSWORD=<password>             only when this run set that password
   SHIM_KEY=<hk_ api key>
   BOOTSTRAP_EMAIL=<email>
-  BOOTSTRAP_PASSWORD=<password>
-Everything else (progress, errors) goes to stderr.
+  BOOTSTRAP_PASSWORD=<password>   only when this run set that password
+Everything else (progress, errors, and the reason a PASSWORD line is
+missing) goes to stderr.
 """
 import argparse
 import base64
@@ -168,6 +191,53 @@ def random_password() -> str:
     # policy with room to spare, well under bcrypt's 72-byte limit.
     alphabet = string.ascii_letters + string.digits + "!@#$%^&*-_"
     return "Aa1!" + "".join(secrets.choice(alphabet) for _ in range(24))
+
+
+def password_to_set(user_exists: bool, env_password: str, new_user_password: str) -> str | None:
+    """The password this run should write, or None to leave it untouched.
+
+    This script used to rotate unconditionally, on the reasoning that no run
+    should reuse a prior credential. That is wrong for an account other runs
+    are holding sessions on. The control-plane resolves every bearer against
+    GoTrue on each request, so a rotation revokes those sessions mid-run, and
+    this script is invoked automatically by .github/workflows/owui-nightly.yml
+    on a schedule, on dispatch, and on any pull request labelled run-owui-e2e.
+    The workflow's concurrency group is keyed on the ref, so a labelled-pull-
+    request run and the scheduled run do not join the same group and can rotate
+    each other's account mid-flight. docs/live-test-auth.md forbids exactly
+    this shape.
+
+    So the default is to leave an existing account alone, and a caller that
+    genuinely wants to set the password says so through an environment
+    variable. A brand-new account still gets new_user_password: there is no
+    session to break and no credential to preserve. Generation stays in the
+    caller so this selector is pure and directly assertable.
+
+    Same helper, same semantics as scripts/seed-demo-owner.py.
+    """
+    env_password = env_password.strip()
+    if env_password:
+        return env_password
+    if not user_exists:
+        return new_user_password
+    return None
+
+
+def with_run_key(email: str, run_key: str) -> str:
+    """Namespace an address per run (foo@x -> foo+key@x), or return it
+    unchanged when run_key is empty.
+
+    This is what keeps the guard above from simply breaking the nightly. CI
+    passes one key per job attempt, so every run provisions its own users, no
+    run ever meets an existing account, and no shared credential exists to
+    rotate in the first place. Same idea and same shape as E2E_RUN_KEY in
+    apps/web-console/tests/e2e/support/e2e-fixture-seed.mjs.
+    """
+    run_key = run_key.strip()
+    if not run_key:
+        return email
+    local, at, domain = email.partition("@")
+    return f"{local}+{run_key}{at}{domain}"
 
 
 def random_api_key() -> tuple[str, str, str]:
@@ -445,11 +515,14 @@ def provision_billing_mapping(rest, headers, tenant_id: str, account_id: str) ->
     sys.exit(1)
 
 
-def provision_tenant_member(rest, gotrue, headers, tenant_id: str, email: str, role: str) -> tuple[str, str]:
-    """Find-or-create a GoTrue user for `email`, upsert its `role` membership
-    in `tenant_id`, and rotate its password. Returns (user_id, password).
-    Shared by the real fixture user and the throwaway bootstrap user (see
-    module docstring)."""
+def provision_tenant_member(
+    rest, gotrue, headers, tenant_id: str, email: str, role: str, env_password: str = "",
+) -> tuple[str, str | None]:
+    """Find-or-create a GoTrue user for `email` and upsert its `role`
+    membership in `tenant_id`. Returns (user_id, password), where password is
+    None when this run deliberately left an existing account's password
+    untouched: see password_to_set. Shared by the real fixture user and the
+    throwaway bootstrap user (see module docstring)."""
     # `filter=<email>` does an exact server-side match (verified live; the
     # `email=` param is NOT supported and 500s on this GoTrue version).
     status, body = request(gotrue, headers, "GET", "/admin/users", params={"filter": email})
@@ -461,7 +534,7 @@ def provision_tenant_member(rest, gotrue, headers, tenant_id: str, email: str, r
         None,
     )
 
-    password = random_password()
+    password = password_to_set(existing is not None, env_password, random_password())
     user_metadata = {"selected_tenant_id": tenant_id}
 
     if existing is None:
@@ -482,10 +555,14 @@ def provision_tenant_member(rest, gotrue, headers, tenant_id: str, email: str, r
         user_id = existing["id"]
         # GoTrue's admin updateUserById MERGES user_metadata (verified
         # live), so this only ever adds/refreshes selected_tenant_id.
-        # Password is rotated unconditionally on every run.
+        # The password key is present only when this run is entitled to write
+        # it (see password_to_set): omitting it leaves every session another
+        # run is holding on this account alive.
+        update = {"user_metadata": user_metadata}
+        if password is not None:
+            update["password"] = password
         status, body = request(
-            gotrue, headers, "PUT", f"/admin/users/{user_id}",
-            body={"password": password, "user_metadata": user_metadata},
+            gotrue, headers, "PUT", f"/admin/users/{user_id}", body=update,
         )
         if status != 200:
             print(f"error: user update failed for {email}: {status} {body}", file=sys.stderr)
@@ -572,12 +649,18 @@ def main() -> None:
     # 2 + 3. Provision the bootstrap user first so it -- not the real fixture
     # user below -- absorbs Open WebUI's unconditional first-user-becomes-
     # admin promotion (see module docstring).
+    run_key = os.environ.get("OWUI_E2E_RUN_KEY", "")
+    user_email = with_run_key(USER_EMAIL, run_key)
+    bootstrap_email = with_run_key(BOOTSTRAP_EMAIL, run_key)
+
     _, bootstrap_password = provision_tenant_member(
-        rest, gotrue, headers, tenant_id, BOOTSTRAP_EMAIL, BOOTSTRAP_ROLE,
+        rest, gotrue, headers, tenant_id, bootstrap_email, BOOTSTRAP_ROLE,
+        os.environ.get("OWUI_E2E_BOOTSTRAP_PASSWORD", ""),
     )
 
     user_id, password = provision_tenant_member(
-        rest, gotrue, headers, tenant_id, USER_EMAIL, USER_ROLE,
+        rest, gotrue, headers, tenant_id, user_email, USER_ROLE,
+        os.environ.get("OWUI_E2E_PASSWORD", ""),
     )
 
     # 4. Upsert the throwaway shim billing account (older accounts/api_keys
@@ -666,11 +749,35 @@ def main() -> None:
             print(f"error: shim key cleanup failed: {status} {body}", file=sys.stderr)
             sys.exit(1)
 
-    print(f"EMAIL={USER_EMAIL}")
-    print(f"PASSWORD={password}")
+    # A PASSWORD line appears only when this run actually set that password.
+    # For an account that already existed, this run does not know the password
+    # and must not invent one, so the line is omitted and the reason is named
+    # on stderr. A caller that needs the line (the nightly workflow does, and
+    # fails loudly without it) either supplies the value or asks for a
+    # run-scoped identity that has no prior password to preserve.
+    print(f"EMAIL={user_email}")
+    if password is not None:
+        print(f"PASSWORD={password}")
     print(f"SHIM_KEY={raw_secret}")
-    print(f"BOOTSTRAP_EMAIL={BOOTSTRAP_EMAIL}")
-    print(f"BOOTSTRAP_PASSWORD={bootstrap_password}")
+    print(f"BOOTSTRAP_EMAIL={bootstrap_email}")
+    if bootstrap_password is not None:
+        print(f"BOOTSTRAP_PASSWORD={bootstrap_password}")
+
+    for label, value, variable in (
+        ("fixture user", password, "OWUI_E2E_PASSWORD"),
+        ("bootstrap user", bootstrap_password, "OWUI_E2E_BOOTSTRAP_PASSWORD"),
+    ):
+        if value is None:
+            print(
+                f"note: the {label} already existed, so its password was left "
+                f"untouched and no line was printed for it. Rotating a shared "
+                f"account revokes every session another run is holding on it "
+                f"(docs/live-test-auth.md). Set OWUI_E2E_RUN_KEY to provision a "
+                f"run-scoped identity instead, or {variable} to write a password "
+                f"deliberately.",
+                file=sys.stderr,
+            )
+
     if consumer_failed:
         sys.exit(1)
 

--- a/scripts/seed-owui-e2e-user.py
+++ b/scripts/seed-owui-e2e-user.py
@@ -113,6 +113,7 @@ missing) goes to stderr.
 """
 import argparse
 import base64
+import datetime
 import hashlib
 import json
 import os
@@ -221,6 +222,69 @@ def password_to_set(user_exists: bool, env_password: str, new_user_password: str
     if not user_exists:
         return new_user_password
     return None
+
+
+# A key older than this is nobody's live key: the nightly job's own timeout is
+# 30 minutes, and a deployment that needs to keep one longer has its own
+# billing account through --account-slug (see the module docstring).
+STALE_KEY_HOURS = 6
+
+
+def stale_key_cutoff_iso(now: datetime.datetime | None = None) -> str:
+    """The created_at boundary for revoking previously minted shim keys.
+
+    Bounding the delete by age rather than by identity is what stops two
+    overlapping runs from revoking each other's key mid-flight."""
+    now = now or datetime.datetime.now(datetime.timezone.utc)
+    return (now - datetime.timedelta(hours=STALE_KEY_HOURS)).isoformat()
+
+
+def sweep_stale_fixture_users(gotrue, headers, run_key: str) -> None:
+    """Delete the run-scoped fixture users left behind by earlier runs.
+
+    Every run now provisions its own users rather than rotating shared ones,
+    which trades a live incident for a slow leak: two permanent GoTrue users
+    per run, one of them an OWNER of the owui-e2e tenant. This is the same
+    trade, and the same answer, as sweepStaleFixtureRuns in
+    apps/web-console/tests/e2e/support/e2e-fixture-seed.mjs.
+
+    Best effort by design. A sweep failure must never fail a run that has
+    already provisioned what it needs, so every error here is a note on stderr.
+    Only addresses this script itself derives are considered: the two bases,
+    each with a "+" tag, and never the unnamespaced shared address.
+    """
+    if not run_key:
+        return
+    cutoff = stale_key_cutoff_iso()
+    prefixes = tuple(f"{email.split('@')[0].lower()}+" for email in (USER_EMAIL, BOOTSTRAP_EMAIL))
+    domains = tuple(email.split("@")[1].lower() for email in (USER_EMAIL, BOOTSTRAP_EMAIL))
+
+    status, body = request(gotrue, headers, "GET", "/admin/users", params={"per_page": "1000"})
+    if status != 200 or not isinstance(body, dict):
+        print(f"note: fixture sweep skipped (user listing returned {status})", file=sys.stderr)
+        return
+
+    swept = 0
+    for user in body.get("users", []):
+        email = (user.get("email") or "").lower()
+        local, _, domain = email.partition("@")
+        # Both halves must match, so a real customer address that happens to
+        # start with the same word is never a candidate.
+        if domain not in domains or not local.startswith(prefixes):
+            continue
+        # Never this run's own users, and never the shared base address, which
+        # carries no "+" tag at all and is what the prefixes above require.
+        if f"+{run_key}@" in email:
+            continue
+        if (user.get("created_at") or "") >= cutoff:
+            continue
+        del_status, del_body = request(gotrue, headers, "DELETE", f"/admin/users/{user['id']}")
+        if del_status not in (200, 204):
+            print(f"note: fixture sweep could not delete {email}: {del_status} {del_body}", file=sys.stderr)
+            continue
+        swept += 1
+    if swept:
+        print(f"fixture sweep: removed {swept} stale run-scoped user(s)", file=sys.stderr)
 
 
 def with_run_key(email: str, run_key: str) -> str:
@@ -730,9 +794,19 @@ def main() -> None:
         consumer_failed = not rewrite_env_file(args.env_file, raw_secret) or consumer_failed
     consumer_failed = sync_owui_config(raw_secret) is False or consumer_failed
 
-    # 7. Revoke the account's previous keys (cascades to their policy rows),
-    # excluding the one just minted. Held back until the consumers above are
-    # updated: revoking first is what turns a failed sync into an outage.
+    # 7. Revoke the account's STALE keys (cascades to their policy rows). Held
+    # back until the consumers above are updated: revoking first is what turns
+    # a failed sync into an outage.
+    #
+    # The billing account is shared even when the users are not: OWUI_E2E_RUN_KEY
+    # namespaces the GoTrue identities, and deliberately does not namespace this
+    # account, because a tenant bills to exactly one account and inventing a
+    # tenant per run would leave a permanent row behind on every run. So the
+    # deletion is bounded by age rather than by "everything except mine". Two
+    # runs overlapping (the schedule and a labelled pull request sit in
+    # different concurrency groups, so they can) used to revoke each other's key
+    # mid-flight, which is the outage already recorded in .wolf/cerebrum.md.
+    # A key minted minutes ago now survives any concurrent run.
     if consumer_failed:
         print(
             "error: leaving the previous shim key(s) active because a configured "
@@ -741,13 +815,23 @@ def main() -> None:
             file=sys.stderr,
         )
     else:
+        cutoff = stale_key_cutoff_iso()
         status, body = request(
             rest, headers, "DELETE", "/api_keys",
-            params={"account_id": f"eq.{shim_account_id}", "id": f"neq.{shim_key_id}"},
+            params={
+                "account_id": f"eq.{shim_account_id}",
+                "id": f"neq.{shim_key_id}",
+                "created_at": f"lt.{cutoff}",
+            },
         )
         if status not in (200, 204):
             print(f"error: shim key cleanup failed: {status} {body}", file=sys.stderr)
             sys.exit(1)
+
+    # 8. Remove the run-scoped users older runs left behind. After the key
+    # revocation above, so a stale user no longer has an api_keys row pointing
+    # at it. Best effort: never fails the run.
+    sweep_stale_fixture_users(gotrue, headers, run_key)
 
     # A PASSWORD line appears only when this run actually set that password.
     # For an account that already existed, this run does not know the password

--- a/scripts/seed-owui-e2e-user.py
+++ b/scripts/seed-owui-e2e-user.py
@@ -259,6 +259,13 @@ def sweep_stale_fixture_users(gotrue, headers, run_key: str) -> None:
     prefixes = tuple(f"{email.split('@')[0].lower()}+" for email in (USER_EMAIL, BOOTSTRAP_EMAIL))
     domains = tuple(email.split("@")[1].lower() for email in (USER_EMAIL, BOOTSTRAP_EMAIL))
 
+    # ponytail: one page, no pagination. The sweep is best effort and the leak
+    # it clears is two users per nightly, so a single page of 1000 is ample
+    # today. The ceiling is real though: on a project whose auth.users grows
+    # past that page, stale fixture users fall outside it and are never swept,
+    # silently, because this function never fails a run. Upgrade path when that
+    # matters: loop `page` until a short page comes back, and keep the same
+    # both-halves address match so a real account can never be a candidate.
     status, body = request(gotrue, headers, "GET", "/admin/users", params={"per_page": "1000"})
     if status != 200 or not isinstance(body, dict):
         print(f"note: fixture sweep skipped (user listing returned {status})", file=sys.stderr)

--- a/scripts/test_seed_owui_e2e_user.py
+++ b/scripts/test_seed_owui_e2e_user.py
@@ -528,6 +528,40 @@ def test_account_slug_defaults_to_ci_and_is_overridable() -> None:
     print("ok: --account-slug defaults to the CI account and can be overridden")
 
 
+def test_password_is_never_rotated_on_an_existing_account() -> None:
+    """An account that already exists keeps its password unless the caller
+    explicitly supplies one. This script runs unattended from the nightly
+    workflow, and rotating a shared account revokes every session that any
+    concurrent run is holding on it (docs/live-test-auth.md). Mirrors the
+    same guard in scripts/test_seed_demo_owner.py."""
+    password_to_set = seed_owui_e2e_user.password_to_set
+    assert password_to_set(True, "", "generated-pw") is None
+    assert password_to_set(True, "   ", "generated-pw") is None
+    assert password_to_set(True, "explicit-pw", "generated-pw") == "explicit-pw"
+
+    # A brand-new account has no session to break and no credential to keep.
+    assert password_to_set(False, "", "generated-pw") == "generated-pw"
+    assert password_to_set(False, "explicit-pw", "generated-pw") == "explicit-pw"
+    print("ok: password_to_set never rotates an existing account by default")
+
+
+def test_run_key_namespaces_the_fixture_addresses() -> None:
+    """A run key gives each run its own users, so the guard above never has to
+    refuse anything in CI: there is no shared account left to rotate."""
+    with_run_key = seed_owui_e2e_user.with_run_key
+    assert with_run_key("owui-e2e@hive-e2e.invalid", "") == "owui-e2e@hive-e2e.invalid"
+    assert with_run_key("owui-e2e@hive-e2e.invalid", "  ") == "owui-e2e@hive-e2e.invalid"
+    assert (
+        with_run_key("owui-e2e@hive-e2e.invalid", "12345-1")
+        == "owui-e2e+12345-1@hive-e2e.invalid"
+    )
+    # Two attempts of the same workflow run must not collide.
+    assert with_run_key("owui-e2e@hive-e2e.invalid", "12345-1") != with_run_key(
+        "owui-e2e@hive-e2e.invalid", "12345-2"
+    )
+    print("ok: with_run_key namespaces the fixture addresses per run")
+
+
 def main() -> None:
     os.environ["OWUI_ADMIN_EMAIL"] = "admin@example.com"
     os.environ["OWUI_ADMIN_PASSWORD"] = "pw"
@@ -556,6 +590,8 @@ def main() -> None:
     test_billing_mapping_accepts_a_lost_race_on_the_same_pairing()
     test_billing_mapping_still_fails_when_the_race_winner_is_another_account()
     test_tenant_slug_defaults_to_ci_and_is_overridable()
+    test_password_is_never_rotated_on_an_existing_account()
+    test_run_key_namespaces_the_fixture_addresses()
 
     del os.environ["OWUI_ADMIN_EMAIL"]
     del os.environ["OWUI_ADMIN_PASSWORD"]

--- a/scripts/test_seed_owui_e2e_user.py
+++ b/scripts/test_seed_owui_e2e_user.py
@@ -8,6 +8,7 @@ rotation from revoking a deployment's key. No framework, no network: mocks
 urllib.request.urlopen and exercises the functions directly.
 Run: python3 scripts/test_seed_owui_e2e_user.py
 """
+import datetime
 import importlib.util
 import io
 import json
@@ -562,6 +563,68 @@ def test_run_key_namespaces_the_fixture_addresses() -> None:
     print("ok: with_run_key namespaces the fixture addresses per run")
 
 
+def test_stale_key_cutoff_is_backdated_not_now() -> None:
+    """The shim key delete is bounded by age, not by "everything except mine".
+    Two runs overlap (the schedule and a labelled pull request are in different
+    concurrency groups), and an identity-bounded delete had each revoking the
+    other's key mid-flight, which is the outage in .wolf/cerebrum.md."""
+    now = datetime.datetime(2026, 8, 11, 12, 0, tzinfo=datetime.timezone.utc)
+    cutoff = seed_owui_e2e_user.stale_key_cutoff_iso(now)
+    assert cutoff == "2026-08-11T06:00:00+00:00", cutoff
+    # A key minted seconds ago sorts after the cutoff, so PostgREST's
+    # created_at=lt.<cutoff> filter cannot match it.
+    assert now.isoformat() > cutoff
+    print("ok: stale_key_cutoff_iso spares a concurrent run's fresh key")
+
+
+def test_sweep_only_deletes_stale_run_scoped_fixture_users() -> None:
+    """The sweep must never reach the shared base address or a real account,
+    and never this run's own users."""
+    old = "2020-01-01T00:00:00+00:00"
+    fresh = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    users = [
+        {"id": "stale", "email": "owui-e2e+111-1@hive-e2e.invalid", "created_at": old},
+        {"id": "stale-bootstrap", "email": "owui-e2e-bootstrap+111-1@hive-e2e.invalid", "created_at": old},
+        {"id": "mine", "email": "owui-e2e+222-1@hive-e2e.invalid", "created_at": old},
+        {"id": "recent", "email": "owui-e2e+333-1@hive-e2e.invalid", "created_at": fresh},
+        {"id": "shared-base", "email": "owui-e2e@hive-e2e.invalid", "created_at": old},
+        {"id": "customer", "email": "owui-e2e+x@real-customer.example", "created_at": old},
+        {"id": "lookalike", "email": "owui-e2e-someone-else@hive-e2e.invalid", "created_at": old},
+    ]
+    deleted = []
+
+    def fake_request(base, headers, method, path, body=None, params=None, prefer=None):
+        if method == "GET":
+            return 200, {"users": users}
+        assert method == "DELETE", method
+        deleted.append(path.rsplit("/", 1)[-1])
+        return 204, None
+
+    original = seed_owui_e2e_user.request
+    seed_owui_e2e_user.request = fake_request
+    try:
+        seed_owui_e2e_user.sweep_stale_fixture_users("gotrue", {}, "222-1")
+    finally:
+        seed_owui_e2e_user.request = original
+
+    assert sorted(deleted) == ["stale", "stale-bootstrap"], deleted
+    print("ok: sweep removes only stale run-scoped fixture users")
+
+
+def test_sweep_is_a_no_op_without_a_run_key() -> None:
+    """No run key means the shared identity, and nothing about it is sweepable."""
+    def explode(*args, **kwargs):
+        raise AssertionError("sweep must not call out without a run key")
+
+    original = seed_owui_e2e_user.request
+    seed_owui_e2e_user.request = explode
+    try:
+        seed_owui_e2e_user.sweep_stale_fixture_users("gotrue", {}, "")
+    finally:
+        seed_owui_e2e_user.request = original
+    print("ok: sweep is inert without a run key")
+
+
 def main() -> None:
     os.environ["OWUI_ADMIN_EMAIL"] = "admin@example.com"
     os.environ["OWUI_ADMIN_PASSWORD"] = "pw"
@@ -592,6 +655,9 @@ def main() -> None:
     test_tenant_slug_defaults_to_ci_and_is_overridable()
     test_password_is_never_rotated_on_an_existing_account()
     test_run_key_namespaces_the_fixture_addresses()
+    test_stale_key_cutoff_is_backdated_not_now()
+    test_sweep_only_deletes_stale_run_scoped_fixture_users()
+    test_sweep_is_a_no_op_without_a_run_key()
 
     del os.environ["OWUI_ADMIN_EMAIL"]
     del os.environ["OWUI_ADMIN_PASSWORD"]

--- a/scripts/verify-rag-roundtrip.py
+++ b/scripts/verify-rag-roundtrip.py
@@ -18,8 +18,9 @@ upserted. It writes nothing outside its own tenant, and it does not rotate the
 member user's password. It used to, on every run, against a hardcoded shared
 address, which is the shape docs/live-test-auth.md forbids: the control-plane
 resolves every bearer against GoTrue per request, so a rotation revokes the
-sessions of every other run holding one. A first run creates the account with a
-fresh random password; every later run signs in with RAG_VERIFY_PASSWORD.
+sessions of every other run holding one. A first run creates the account and
+prints the password it generated, on stderr, once. Save that value: every later
+run signs in with it through RAG_VERIFY_PASSWORD, and no run will rotate it.
 
 Retries: the serverless embedding route is slow and uneven (measured between
 one and over a hundred seconds per call on the demo stack), so ingest and query
@@ -145,6 +146,18 @@ def provision(supabase_url: str, service_key: str) -> tuple[str, str]:
         if status not in (200, 201):
             fail(f"user create: {status} {body}")
         user_id = body["id"]
+        if not env_password:
+            # Print it, once, on the only run that can know it. Without this
+            # the account exists with a password nobody holds, and every later
+            # run fails on the branch below demanding a value no operator could
+            # ever obtain, which would leave DEMO.md's RAG proof permanently
+            # dead on any environment this has already run against.
+            print(
+                f"created {USER_EMAIL} with a fresh password. Save it: every later "
+                f"run needs it, and no run will rotate it.\n"
+                f"  export RAG_VERIFY_PASSWORD={password}",
+                file=sys.stderr,
+            )
     else:
         if not env_password:
             fail(

--- a/scripts/verify-rag-roundtrip.py
+++ b/scripts/verify-rag-roundtrip.py
@@ -14,8 +14,12 @@ document while the unit suite stayed green). Run this against the demo box, or
 any live stack, after touching the RAG or embedding code.
 
 Idempotent: the throwaway tenant, its member user, and the ENABLE_RAG gate are
-upserted, and the user's password is rotated every run, mirroring
-scripts/seed-owui-e2e-user.py. It writes nothing outside its own tenant.
+upserted. It writes nothing outside its own tenant, and it does not rotate the
+member user's password. It used to, on every run, against a hardcoded shared
+address, which is the shape docs/live-test-auth.md forbids: the control-plane
+resolves every bearer against GoTrue per request, so a rotation revokes the
+sessions of every other run holding one. A first run creates the account with a
+fresh random password; every later run signs in with RAG_VERIFY_PASSWORD.
 
 Retries: the serverless embedding route is slow and uneven (measured between
 one and over a hundred seconds per call on the demo stack), so ingest and query
@@ -24,7 +28,8 @@ retry here is about upstream weather, not about masking a defect. Every attempt
 is printed, so a run that only passes on the third try is visible rather than
 silently green.
 
-Required env: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, SUPABASE_ANON_KEY
+Required env: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, SUPABASE_ANON_KEY, and
+              RAG_VERIFY_PASSWORD once the member account exists
 Optional env: EDGE_API_URL (default http://localhost:8080),
               RAG_CHAT_MODEL (default hive-fast)
 """
@@ -121,9 +126,17 @@ def provision(supabase_url: str, service_key: str) -> tuple[str, str]:
         None,
     )
 
-    password = random_password()
+    # An existing account keeps its password. This script signs in with a
+    # password, so it needs one, but overwriting the account's would revoke
+    # every session another run holds on it (docs/live-test-auth.md), and
+    # this address is hardcoded and shared. So the value comes from the
+    # caller, and its absence is a loud failure naming the variable rather
+    # than a rotation nobody asked for. A brand-new account has no session to
+    # break, so it still gets a fresh random one.
+    env_password = os.environ.get("RAG_VERIFY_PASSWORD", "").strip()
     metadata = {"selected_tenant_id": tenant_id}
     if existing is None:
+        password = env_password or random_password()
         status, body = request(
             gotrue, headers, "POST", "/admin/users",
             body={"email": USER_EMAIL, "password": password,
@@ -133,13 +146,21 @@ def provision(supabase_url: str, service_key: str) -> tuple[str, str]:
             fail(f"user create: {status} {body}")
         user_id = body["id"]
     else:
+        if not env_password:
+            fail(
+                f"{USER_EMAIL} already exists and this script will not rotate its "
+                "password: doing so revokes every session any concurrent run holds "
+                "on it (docs/live-test-auth.md). Set RAG_VERIFY_PASSWORD to the "
+                "account's existing password to sign in with it."
+            )
+        password = env_password
         user_id = existing["id"]
         status, body = request(
             gotrue, headers, "PUT", f"/admin/users/{user_id}",
-            body={"password": password, "user_metadata": metadata},
+            body={"user_metadata": metadata},
         )
         if status != 200:
-            fail(f"user password rotate: {status} {body}")
+            fail(f"user metadata update: {status} {body}")
 
     status, body = request(
         rest, headers, "POST", "/tenant_users",


### PR DESCRIPTION
Refs #879. **Deliberately not `Closes`**: that issue tracks the rotation of the exposed credentials, which has not happened, and an auto-close on merge would mark an open exposure as resolved.

## This does not un-expose anything

The three values removed here remain in this repository's git history, and this repository is public. They must be treated as compromised regardless of what HEAD looks like. **Rotation is the actual remedy**, it is tracked separately in #879, and it is deliberately not done in this pull request: several agents are running live tests against these accounts right now and a rotation would revoke every one of their sessions. Nothing below closes the exposure. It stops the exposure from being recreated, and stops the code that kept writing those values back onto live accounts.

## What was exposed

`apps/web-console/tests/e2e/support/e2e-auth-defaults.json` carried `verifiedPassword`, `unverifiedPassword` and `invitationToken` in plaintext, on `main`, for `e2e-verified@scubed.com.bd` and `e2e-unverified@scubed.com.bd`. Both accounts hold a tenant OWNER role and a billing account on the live Supabase project, and the fixture seeder writes those exact values back onto them on every run with no environment overrides. No value appears anywhere in this pull request.

## Changes

**1. No credential has a committed default.** `e2e-auth-defaults.json` now holds the two addresses and the two length limits only. Both readers, `e2e-auth-creds.ts` and `e2e-auth-fixtures.mjs`, take the three credentials from the environment through a `requiredSecretEnv` helper that throws, names the variable, and points at `docs/live-test-auth.md`. No fallback, no silent skip, since a silent skip is how a committed value survives unnoticed. In the CLI the three are resolved inside `prepareE2EAuthFixtures` rather than at module scope, so the `reset-profile` action, which needs no credential, still runs without them.

**1b. No fixture address is a shared one.** Removing the committed defaults was not sufficient, and on its own it made things worse. The seeder fell back to the two shared live addresses whenever no run key was set, and `ensureUser` sends `password:` on both update paths, so a developer following the README and running the documented command would overwrite a shared tenant-OWNER account's password and revoke every concurrent session. The committed constant had at least made that write idempotent. `runScopedEmail` now throws without `E2E_RUN_KEY` and otherwise derives this run's own address from the shared base, idempotently, at both resolution points, so the account a spec signs in as and the account the seeder writes are the same one and it belongs to this run. `DEFAULT_EMAILS` is deleted. This is also the only route by which the newly minted CI secret values could have reached the two exposed accounts.

`E2E_VERIFIED_PASSWORD` and `E2E_UNVERIFIED_PASSWORD` did not exist as repository secrets, which is why CI was silently using the committed values for 109 days, and for roughly the first 95 of those, before run-scoped addresses landed in #583, every CI run wrote the published password back onto the shared live accounts. Both secrets are now set. Their values were generated randomly, never displayed, and are only ever written to the run-scoped throwaway users that `ci.yml` already creates per job attempt, so no existing account was touched.

**2. No script rotates a shared account any more.** `scripts/seed-owui-e2e-user.py` gets `password_to_set`, the same helper and semantics as the one already in `scripts/seed-demo-owner.py`: an existing account is left alone unless the caller explicitly supplies a password. It prints a `PASSWORD` line only for a password it actually set, and names on stderr why a line is missing. To keep the nightly working under that rule without a hand-managed secret, `OWUI_E2E_RUN_KEY` namespaces both fixture addresses per job attempt, so every run provisions its own users and shares no credential with any other run. Same shape as `E2E_RUN_KEY` in `ci.yml`. The workflow passes `github.run_id`-`github.run_attempt`.

`scripts/verify-rag-roundtrip.py` had the same unconditional rotation against its own hardcoded shared address. It now signs in with `RAG_VERIFY_PASSWORD` and refuses to rotate, failing by name instead. Only a first run, which creates the account, generates a password.

Both guards are pinned by unit tests in `scripts/test_seed_owui_e2e_user.py`, which already runs in `make test-scripts`.

A first version of this claimed a run "shares no credential with any other run". That was false in two places, both now fixed. The run key namespaced the GoTrue users but not the shim billing account, so every run still issued `DELETE /api_keys` against that shared account for every key but its own, and two overlapping runs revoked each other mid-flight (the outage in `.wolf/cerebrum.md`). That delete is now bounded by age, so a key minted minutes ago survives. The account stays shared deliberately: a tenant bills to exactly one account, so a per-run account would need a per-run tenant and leave a permanent row behind every night. Second, run-scoped users leaked two per nightly, one an OWNER of the `owui-e2e` tenant; `sweep_stale_fixture_users` now clears what earlier runs left, matching on both halves of the address, never touching the shared base address or this run's own users, and never failing a run.

`verify-rag-roundtrip.py` generated a password on the create path and never printed it, which would have left every later run demanding a value no operator could obtain, and `DEMO.md`'s RAG proof dead on every environment it had already run against. It prints it once now, on stderr.

**3. Artifacts no longer carry live session material for 90 days.** Five upload steps, not two. `playwright-report-api` and `owui-playwright-report` exclude `*.zip`, `*.webm` and `index.html`, and set `retention-days: 5`. `index.html` had to go for the same reason as the traces: the HTML reporter base64-inlines the whole report payload into it, stdout, stderr and error text included, and a `waitForURL` timeout enumerates every URL it navigated, fragment and all. The three container-log artifacts (`compose-logs`, `compose-logs-web-e2e-api`, `owui-compose-logs`) now pipe through `scripts/redact-log-credentials.py` and retain for five days; Open WebUI's uvicorn access lines print `GET /oauth/oidc/callback?code=...` verbatim. That redactor mirrors `redactSecrets`, understands fragments as well as query strings, and carries a self-check wired into `make test-scripts`. Traces hold every request header and cookie, and for the OWUI suite the OAuth callback URLs with `code=` and `access_token=` in both the query string and the fragment. A trace is a zip of binary resources, so no text linter can scrub it and exclusion is the only reliable answer. Screenshots still upload, and the failing test names and error text are already in the job log. Review caught that the screenshot half of that was false when first written: `playwright.config.ts` never set `screenshot`, so it kept Playwright's default of `off` and the three exclusions left the `playwright-report-api` artifact empty while `if-no-files-found: ignore` kept it quiet. It now sets `screenshot: "only-on-failure"`, which captures the viewport only, so no URL bar, no request headers and no cookies. The `ci.yml` change stays confined to the upload steps, the log dumps, the token generation step and comments, to rebase cleanly against #805, #811 and #822.

**4. The sweeper's three `console.error` calls now go through `redactSecrets`.** They relayed raw client-library messages to stderr, which is exactly where the service-role key ends up embedded, while the module header two hundred lines above declared the opposite contract.

**5. `docs/live-test-auth.md` is now true.** It named only an out-of-repo scratch script while three in-tree paths broke the rule it stated. It now has a "no credential is ever committed" rule with the environment-variable pattern as the sanctioned alternative, a table of what each of the three scripts does after this change, a note on why the automatically-invoked one matters most, and the artifact rule. `README.md` no longer advertises fallbacks that do not exist.

## How absence fails now

| path | with the credential unset |
| --- | --- |
| Playwright specs | Throws at import: `E2E_VERIFIED_PASSWORD is required and has no default...` |
| Fixture seeding CLI | Same error before any admin call; `reset-profile` still works |
| `seed-owui-e2e-user.py` | Existing account keeps its password, no `PASSWORD` line, stderr names `OWUI_E2E_RUN_KEY` and `OWUI_E2E_PASSWORD`; the nightly's own guard then fails the job loudly |
| `verify-rag-roundtrip.py` | Exits non-zero naming `RAG_VERIFY_PASSWORD` |

## Verification

The first push of this branch left a required check RED while this section
claimed otherwise. That is corrected here, and the check now passes.

* `node scripts/verify-spec-collection.mjs` in the web-console container: OK, 36 files across 2 configs. It failed ten times over at head `dec64e84` because it runs `playwright test --list` in a job holding no E2E secrets.
* `docker compose run --build web-console npm run test:unit`: 488 passed, 1 skipped, and one suite fails: `tests/unit/control-plane-host.test.ts` on `ENOENT /app/.env.example`. That one is pre-existing and unrelated. The web-console image contains only `apps`, so that suite cannot read a repository-root file in this container at all, on this branch or on main.
* New guards in `tests/unit/e2e-auth-creds.test.ts`, 4 passed: the defaults file must hold only the four non-secret fields, every string in it must look like an address rather than a secret, a missing credential must throw by name, and `runScopedEmail` must refuse an empty run key while namespacing idempotently.
* `python3 scripts/test_seed_owui_e2e_user.py`, `python3 scripts/test_seed_demo_owner.py`, `python3 scripts/redact-log-credentials.py --selfcheck`: all pass, including the five new cases.
* Both workflow files parse, and the rewritten nightly seed step passes `bash -n` plus a simulation proving the guard is reached rather than pre-empted by `set -e`.

* `Web E2E (full stack)` now passes at this head: 33 collected, 27 executed, 0 failed, 0 passed only on retry. That is the first end-to-end exercise of the new shape, and it covers the required secrets, the run-scoped addresses and the randomly generated invitation token against the live Supabase project.

Its first attempt failed, and not on anything in this change: the stack never
started, because control-plane could not reach the database
(`EMAXCONNSESSION ... max clients are limited to pool_size: 15`), the known
shared session-pool ceiling. A re-run of the same commit passed. All 14 checks
are green.

## One deliberate deviation from the review

Review item 1 asked for the three credentials to resolve lazily. They still
resolve at module scope, and the required check is green anyway, because
`scripts/verify-spec-collection.mjs` now supplies placeholder values for its
`--list` pass. That guard already does exactly this for the OWUI config, for
the same reason: listing loads spec modules and never dials out, so it needs
the variables present but not real.

The reason for keeping module scope is that lazy resolution weakens the
guarantee. Every gated spec computes `HAS_CREDS` at module scope, so a lazily
resolved empty value turns a missing credential into `test.skip`, which is the
silent skip this whole change exists to remove. Throwing at load keeps the
failure loud and immediate. If the reviewer still prefers lazy resolution, the
change is small, but it needs a run-level assertion to replace what the throw
currently guarantees.

## Stage 6 adversarial review, run on this PR

Streams: CodeRabbit CLI (**SKIPPED**, `Review failed: A valid organization session is required`, HTTP 401 `UNAUTHORIZED`, on both the default and `--light` paths; its absence is not a pass, and the CodeRabbit GitHub App check is not a substitute since it reported `Review rate limited` earlier in this PR's life), `ecc:code-review`, a plain adversarial pass, `typescript-reviewer`, `python-reviewer`, `security-reviewer` (mandatory, credential and auth path) and `/codex:adversarial-review`. Eight inline comments posted, seven fixed in `190d2479`, one rebutted and upheld, all threads resolved.

The claim gating the credential rotation was the primary target, and it now has a runnable proof rather than an argument. `seedFixtures` is driven in a unit test by an admin client that throws on any property access, so an empty, whitespace, `undefined` or non-string run key must reject with the `E2E_RUN_KEY` error rather than the proxy's, which is what proves no admin call happens before the guard. The same stream found the one shared-account write the claim did not cover: `reset-profile` takes an address off argv, and it now refuses anything not scoped to this run. Other fixes: both `runScopedEmail` implementations are pinned as equivalent by test, the log redactor was blind to environment-variable spelling (`\b` treats `_` as a word character, so `RAG_VERIFY_PASSWORD=` did not match), the user sweep's single-page ceiling is now stated, and the invitation token's length floor is documented where it is generated.

## Review round one

An independent review returned do-not-merge on the first push, with nine
findings. All nine are addressed above and in the commits on this branch: the
red required check (item 1), the shared-account write that this change had made
worse (item 2), the auto-closing issue reference (item 3), `index.html` (item
4), the three missed upload steps (item 5), the unobtainable RAG password (item
6), the shim key revocation (item 7), the derivable invitation token (item 8),
and the fixture user leak plus the nightly guard that could never fire (item 9).

The reviewer's sweep of all 1898 tracked files found no committed secret
material other than item 8.

## Buglog entry

To be appended to `.wolf/buglog.jsonl` on `main` in a separate buglog-only pull request once this merges, per `.claude/rules/openwolf.md`:

```json
{"id":"BUG-2026-08-11-committed-e2e-credentials","date":"2026-08-11","title":"Live E2E credentials committed in plaintext in a public repo, and re-seeded onto the accounts on every run","error_message":"No error. The suite passed, which is the problem: e2e-auth-defaults.json carried verifiedPassword, unverifiedPassword and invitationToken for two live tenant-OWNER accounts, and CI referenced E2E_VERIFIED_PASSWORD and E2E_UNVERIFIED_PASSWORD secrets that did not exist, so the empty string fell through to the committed values.","root_cause":"envOrDefault treated an unset credential as a request for the committed fallback. A fallback makes the absence of a secret invisible, so nothing ever failed and the values stayed live for months while the seeder wrote them back onto the accounts through the admin API on every credential-less run. Two sibling scripts copied a related pattern, rotating hardcoded shared accounts unconditionally, one of them from a scheduled workflow whose concurrency group does not join a labelled-PR run to the scheduled run.","fix":"Removed the three fields; both readers now use requiredSecretEnv, which throws and names the variable with no fallback and no skip. Set the two missing CI secrets. seed-owui-e2e-user.py takes password_to_set from seed-demo-owner.py and gains OWUI_E2E_RUN_KEY so the nightly provisions its own users instead of rotating shared ones; verify-rag-roundtrip.py takes RAG_VERIFY_PASSWORD and refuses to rotate. Both Playwright artifact uploads exclude traces and videos and retain for 5 days instead of 90. The fixture sweeper's three console.error calls now go through redactSecrets. docs/live-test-auth.md and README.md corrected.  Review of the first push found the removal alone had made the shared-account hazard worse: the seeder still fell back to the two shared addresses without a run key, and ensureUser writes a password on both update paths, so each operator would now write a DIFFERENT value where the committed constant had at least been idempotent. runScopedEmail closes that by refusing an empty run key and namespacing every fixture address. Same round: index.html base64-inlines the report payload so excluding traces alone did not stop the leak, three container-log artifacts were missed, the shim-key delete still revoked concurrent runs until bounded by age, and the invitation token was a committed literal plus a public run id.","tags":["security","credentials","e2e","ci","public-repo","gotrue","artifacts"],"pr":880,"issue":879}
```

Note: the values remain in git history. This entry is not a record of a closed exposure. Rotation is tracked in #879.
