### PR TITLE
fix: release the Cowork concurrency slot on cancel and return create promptly

### DIFF
--- a/apps/agent-engine/internal/engine/engine_test.go
+++ b/apps/agent-engine/internal/engine/engine_test.go
@@ -491,6 +491,37 @@ func TestSandboxEngine_Cancel_CleansUpDirs(t *testing.T) {
 	assertDirEmpty(t, e.cfg.WorkspaceRoot)
 }
 
+// The launcher half of issue #886. Control-plane now calls Cancel when a task
+// is cancelled, and the only reason that helps is this: the cancelled
+// session's concurrency slot has to go back to the pool immediately, not
+// whenever the sandbox happens to finish on its own (roughly sixteen minutes
+// on the demo box, which is how two cancels exhausted a user's ceiling).
+func TestSandboxEngine_Cancel_FreesQuotaSlot(t *testing.T) {
+	var fake *fakeAgentServer
+	e := newTestEngineWithQuota(t, &fake, 1, 1)
+
+	task := testTask()
+	sessionRef, err := e.Launch(context.Background(), task)
+	if err != nil {
+		t.Fatalf("Launch: %v", err)
+	}
+	if err := e.Cancel(context.Background(), sessionRef); err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+
+	if tenant, user := e.q.InUse(task.TenantID, task.UserID); tenant != 0 || user != 0 {
+		t.Fatalf("cancel left quota held: tenant=%d user=%d, want 0/0", tenant, user)
+	}
+
+	// The observable consequence: the same user can start work again at once.
+	next := testTask()
+	next.TenantID = task.TenantID
+	next.UserID = task.UserID
+	if _, err := e.Launch(context.Background(), next); err != nil {
+		t.Fatalf("expected the cancelled session's slot to be reusable, got %v", err)
+	}
+}
+
 func assertDirEmpty(t *testing.T, dir string) {
 	t.Helper()
 	entries, err := os.ReadDir(dir)

--- a/apps/agent-engine/internal/engine/engine_test.go
+++ b/apps/agent-engine/internal/engine/engine_test.go
@@ -491,11 +491,18 @@ func TestSandboxEngine_Cancel_CleansUpDirs(t *testing.T) {
 	assertDirEmpty(t, e.cfg.WorkspaceRoot)
 }
 
-// The launcher half of issue #886. Control-plane now calls Cancel when a task
-// is cancelled, and the only reason that helps is this: the cancelled
-// session's concurrency slot has to go back to the pool immediately, not
-// whenever the sandbox happens to finish on its own (roughly sixteen minutes
-// on the demo box, which is how two cancels exhausted a user's ceiling).
+// Characterisation test for pre-existing behaviour, NOT regression coverage
+// for issue #886. Nothing in this package changed in that fix, so every
+// assertion below passes with the fix fully reverted; it exists to pin the
+// invariant control-plane now depends on, which is that ending a session
+// through Cancel returns its slot to the pool immediately rather than whenever
+// the sandbox finishes on its own (roughly sixteen minutes on the demo box).
+//
+// The actual regression coverage for issue #886 is in
+// apps/control-plane/internal/agenttask/service_test.go, where
+// TestService_Cancel_ReleasesEngineConcurrencySlot and its two siblings fail
+// on revert because they drive Service.Cancel and assert on counters that only
+// move when Service reaches the engine.
 func TestSandboxEngine_Cancel_FreesQuotaSlot(t *testing.T) {
 	var fake *fakeAgentServer
 	e := newTestEngineWithQuota(t, &fake, 1, 1)

--- a/apps/control-plane/internal/agentengine/engine.go
+++ b/apps/control-plane/internal/agentengine/engine.go
@@ -48,9 +48,8 @@ func (e *Engine) Status(ctx context.Context, sessionRef string) (status agenttas
 }
 
 // Cancel interrupts sessionRef's conversation and terminates its sandbox
-// process. Not called by agenttask.Service.Cancel yet (that method only
-// transitions the DB row today); wiring it in is the same follow-up as
-// Status above.
+// process, which is what releases the session's concurrency slot on the
+// launcher side. Called by agenttask.Service.Cancel (issue #886).
 func (e *Engine) Cancel(ctx context.Context, sessionRef string) error {
 	return e.sandbox.Cancel(ctx, sessionRef)
 }

--- a/apps/control-plane/internal/agenttask/SYNC_CONTRACT.md
+++ b/apps/control-plane/internal/agenttask/SYNC_CONTRACT.md
@@ -55,7 +55,7 @@ by the authenticated caller, never round-tripped.
 
 | Method | Path | Body | Notes |
 |---|---|---|---|
-| POST | `/v1/agent/tasks` | `{"pack": "...", "instructions": "..."}` | 201 with the created Task; `instructions` is optional |
+| POST | `/v1/agent/tasks` | `{"pack": "...", "instructions": "..."}` | 201 with the created Task in `queued`; `instructions` is optional |
 | GET | `/v1/agent/tasks` | — | `{"tasks": [Task, ...]}`, newest first, scoped to the caller |
 | GET | `/v1/agent/tasks/{id}` | — | 404 if the task belongs to a different user or does not exist |
 | POST | `/v1/agent/tasks/{id}/cancel` | — | 409 if the task already reached a terminal state |
@@ -85,10 +85,57 @@ untrusted client input.
 | GET | `/internal/agent-tasks/{tenant_id}/{user_id}/{task_id}` | — |
 | POST | `/internal/agent-tasks/{tenant_id}/{user_id}/{task_id}/cancel` | — |
 
+## Create is asynchronous over the launch (issue #881)
+
+`POST` returns the persisted `queued` task as soon as the row exists. The
+sandbox launch runs on a background goroutine and moves the task to `running`
+(or to `failed`, with a sanitized `error_message`) on its own; callers learn
+the outcome from the same poll they already use for every later state change.
+
+Create used to block on the launch, which is bounded at five minutes because a
+cold sandbox mount routinely takes tens of seconds. edge-api's control-plane
+client gives up at 15 seconds, so a create measured live on 2026-08-11 answered
+`500` after 18.0 seconds for a task that reached `succeeded`. Aligning the two
+timeouts was rejected: it would make an interactive request legitimately able
+to hang for five minutes, and every intermediate proxy is free to cut it
+anyway.
+
+## Cancel stops the launcher session (issue #886)
+
+`Service.Cancel` transitions the row first, because that UPDATE is the atomic
+gate that decides which caller owns the cancellation, and only the winner then
+calls `Engine.Cancel(ctx, engine_session_ref)`. Stopping the session is what
+frees the launcher's per-tenant and per-user concurrency slot
+(`apps/agent-engine/internal/quota`): the slot belongs to the live sandbox and
+is released when that session ends, so a cancel that only wrote a row left the
+slot held until the sandbox finished on its own, about sixteen minutes on the
+demo box. Two cancels therefore exhausted `HIVE_QUOTA_USER_CONCURRENCY` and
+every later create was refused.
+
+Orderings, all three settled deliberately:
+
+- **Double cancel.** The second loses the row's terminal guard, returns
+  `ErrTerminalState` (HTTP 409) and never reaches the engine.
+- **Cancel racing a completion.** Whichever transition commits first wins. If
+  the poller already recorded a terminal status, the cancel is rejected and
+  the engine is left alone, which is correct because a terminal status is
+  exactly what makes the launcher reap that session itself.
+- **Cancel before the launch finishes.** The row has no
+  `engine_session_ref` yet, so there is nothing to stop at cancel time. The
+  in-flight launch goroutine finds the task already terminal when it tries to
+  record `running`, and stops the session it just started. The same path
+  covers a launch whose `running` transition fails for any other reason: an
+  unrecorded session can never be polled or cancelled by anything else, so it
+  is torn down rather than left holding a slot.
+
+An engine stop failure is logged for the operator and never returned to the
+caller: the cancellation itself is already recorded, and a stuck launcher is
+not something a customer can act on.
+
 ## Engine seam
 
-`Service.CreateTask` calls `Engine.Launch(ctx, task)` right after persisting
-a `queued` row. Issue #305 closes the control-channel half of this gap:
+`Service.CreateTask` hands the task to `Engine.Launch(ctx, task)` right after
+persisting a `queued` row, on a background goroutine. Issue #305 closes the control-channel half of this gap:
 `apps/agent-engine/internal/sandbox` bind-mounts a second Unix socket (the
 control channel) alongside the existing egress-proxy one, so the host can
 now reach the agent-server's REST API inside the sandbox
@@ -110,11 +157,12 @@ Apptainer, which requires an Apptainer install and a built SIF on whatever
 host runs this process — not true of every `control-plane` deployment today
 (task tracked separately: "Live Apptainer validation of agent-engine on
 x86-64 host"). Without that env var, `NotConfiguredEngine` is still wired,
-and `Service.CreateTask` transitions the task immediately to `StatusFailed`
-with a sanitized generic customer message. Callers receive HTTP 201 with the
-failed task body rather than a queued task. Startup logs a WARN naming each
-empty `HIVE_AGENT_ENGINE_*` variable individually. The `Service` and HTTP
-surface do change in this scenario; the alternative is only the `Engine`
+and the background launch transitions the task to `StatusFailed` with a
+sanitized generic customer message. Callers receive HTTP 201 with the queued
+task and see the failure on their next read, rather than polling a task that
+will never move. Startup logs a WARN naming each empty
+`HIVE_AGENT_ENGINE_*` variable individually. Neither the `Service` nor the
+HTTP surface changes in this scenario; the only difference is the `Engine`
 implementation passed to `NewService`.
 
 **Implemented** (issue #311 follow-up): `Poller` (`poller.go`) periodically

--- a/apps/control-plane/internal/agenttask/engine.go
+++ b/apps/control-plane/internal/agenttask/engine.go
@@ -12,9 +12,21 @@ import (
 var ErrEngineNotConfigured = errors.New("agenttask: engine not configured")
 
 // Engine launches an agent-engine (Wave 2.2) session for a queued task and
-// returns an engine session reference to persist on the task row.
+// returns an engine session reference to persist on the task row, and stops
+// a session it launched.
+//
+// Cancel is part of this interface rather than an optional extra because a
+// launcher that cannot be told to stop is the whole of issue #886: the slot
+// a session holds is released by the launcher when the session ends, so a
+// task cancelled without a stop call kept its concurrency slot until the
+// sandbox finished on its own (roughly sixteen minutes on the demo box), and
+// two cancels exhausted a user's ceiling. Cancel is expected to be
+// idempotent-safe for an unknown or already-finished session: Service treats
+// an error from it as an operator-visible warning, not a caller-visible
+// failure.
 type Engine interface {
 	Launch(ctx context.Context, t Task) (sessionRef string, err error)
+	Cancel(ctx context.Context, sessionRef string) error
 }
 
 // NotConfiguredEngine is the default Engine wired until the host -> agent-
@@ -33,3 +45,7 @@ type NotConfiguredEngine struct{}
 func (NotConfiguredEngine) Launch(context.Context, Task) (string, error) {
 	return "", ErrEngineNotConfigured
 }
+
+// Cancel succeeds trivially: this engine never launched anything, so there is
+// no session holding a slot and nothing for a caller to act on.
+func (NotConfiguredEngine) Cancel(context.Context, string) error { return nil }

--- a/apps/control-plane/internal/agenttask/http_test.go
+++ b/apps/control-plane/internal/agenttask/http_test.go
@@ -21,7 +21,7 @@ import (
 //
 // Both helpers return the Service alongside the Handler because create is now
 // asynchronous over the launch (issue #881): any assertion about a launch
-// outcome has to wait for it with Service.WaitForLaunches first.
+// outcome has to wait for it with Service.WaitIdle first.
 func newTestHandler() (*agenttask.Handler, *agenttask.Service) {
 	svc := agenttask.NewService(newFakeRepository(), agenttask.NotConfiguredEngine{})
 	return agenttask.NewHandler(svc), svc
@@ -62,7 +62,7 @@ func TestHandler_Create_HappyPath(t *testing.T) {
 	}
 
 	// The launch still lands, it just lands on the read path.
-	svc.WaitForLaunches()
+	svc.WaitIdle()
 	getW := httptest.NewRecorder()
 	h.InternalMux().ServeHTTP(getW, httptest.NewRequest(http.MethodGet,
 		"/internal/agent-tasks/"+tenantID.String()+"/"+userID.String()+"/"+resp["id"].(string), nil))
@@ -99,7 +99,7 @@ func TestHandler_Create_EngineNotConfigured_FailsVisibly(t *testing.T) {
 		t.Fatalf("decode: %v", err)
 	}
 
-	svc.WaitForLaunches()
+	svc.WaitIdle()
 	getW := httptest.NewRecorder()
 	h.InternalMux().ServeHTTP(getW, httptest.NewRequest(http.MethodGet,
 		"/internal/agent-tasks/"+tenantID.String()+"/"+userID.String()+"/"+created["id"].(string), nil))
@@ -155,7 +155,7 @@ func TestHandler_ListThenGet_RoundTrip(t *testing.T) {
 	var created map[string]any
 	_ = json.NewDecoder(createW.Body).Decode(&created)
 	taskID := created["id"].(string)
-	svc.WaitForLaunches()
+	svc.WaitIdle()
 
 	listReq := httptest.NewRequest(http.MethodGet, "/internal/agent-tasks/"+tenantID.String()+"/"+userID.String(), nil)
 	listW := httptest.NewRecorder()
@@ -206,7 +206,7 @@ func TestHandler_Cancel_HappyPath(t *testing.T) {
 	taskID := created["id"].(string)
 	// Cancel a task whose launch has landed, so this covers the running-task
 	// path rather than racing the background launch.
-	svc.WaitForLaunches()
+	svc.WaitIdle()
 
 	cancelReq := httptest.NewRequest(http.MethodPost, "/internal/agent-tasks/"+tenantID.String()+"/"+userID.String()+"/"+taskID+"/cancel", nil)
 	cancelW := httptest.NewRecorder()

--- a/apps/control-plane/internal/agenttask/http_test.go
+++ b/apps/control-plane/internal/agenttask/http_test.go
@@ -18,21 +18,28 @@ import (
 // validation), and for the dedicated unconfigured-engine coverage below.
 // Tests that need a task to land somewhere non-terminal (running) use
 // newRunningTestHandler instead.
-func newTestHandler() *agenttask.Handler {
+//
+// Both helpers return the Service alongside the Handler because create is now
+// asynchronous over the launch (issue #881): any assertion about a launch
+// outcome has to wait for it with Service.WaitForLaunches first.
+func newTestHandler() (*agenttask.Handler, *agenttask.Service) {
 	svc := agenttask.NewService(newFakeRepository(), agenttask.NotConfiguredEngine{})
-	return agenttask.NewHandler(svc)
+	return agenttask.NewHandler(svc), svc
 }
 
 // newRunningTestHandler wires a fakeEngine that always launches
 // successfully, so created tasks land in StatusRunning rather than
 // immediately StatusFailed.
-func newRunningTestHandler() *agenttask.Handler {
+func newRunningTestHandler() (*agenttask.Handler, *agenttask.Service) {
 	svc := agenttask.NewService(newFakeRepository(), &fakeEngine{sessionRef: "session-http-test"})
-	return agenttask.NewHandler(svc)
+	return agenttask.NewHandler(svc), svc
 }
 
+// Create answers with the persisted queued task rather than waiting for the
+// sandbox launch (issue #881). The caller learns the launch outcome from the
+// same poll it already does for every later state change.
 func TestHandler_Create_HappyPath(t *testing.T) {
-	h := newRunningTestHandler()
+	h, svc := newRunningTestHandler()
 	tenantID, userID := uuid.New(), uuid.New()
 
 	body, _ := json.Marshal(map[string]string{"pack": "coding-pack"})
@@ -47,21 +54,36 @@ func TestHandler_Create_HappyPath(t *testing.T) {
 	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if resp["status"] != "running" {
-		t.Errorf("expected status running, got %v", resp["status"])
+	if resp["status"] != "queued" {
+		t.Errorf("expected status queued, got %v", resp["status"])
 	}
 	if _, ok := resp["tenant_id"]; ok {
 		t.Error("response must never echo tenant_id")
+	}
+
+	// The launch still lands, it just lands on the read path.
+	svc.WaitForLaunches()
+	getW := httptest.NewRecorder()
+	h.InternalMux().ServeHTTP(getW, httptest.NewRequest(http.MethodGet,
+		"/internal/agent-tasks/"+tenantID.String()+"/"+userID.String()+"/"+resp["id"].(string), nil))
+	var got map[string]any
+	if err := json.NewDecoder(getW.Body).Decode(&got); err != nil {
+		t.Fatalf("decode get: %v", err)
+	}
+	if got["status"] != "running" {
+		t.Errorf("expected the launched task to read as running, got %v", got["status"])
 	}
 }
 
 // TestHandler_Create_EngineNotConfigured_FailsVisibly is the HTTP-layer
 // guard for the bug report ("agents don't work, stuck in queue forever, no
-// error surfaced"): a create call against an unconfigured engine must come
-// back as a task the caller can see is dead, not a healthy-looking queued
-// one, and the error text must stay customer-safe.
+// error surfaced"): a task submitted against an unconfigured engine must
+// become one the caller can see is dead, not sit queued forever, and the
+// error text must stay customer-safe. Since issue #881 the create response
+// itself is the queued row and the failure arrives on the next read, which
+// is the same path every other state change already travels.
 func TestHandler_Create_EngineNotConfigured_FailsVisibly(t *testing.T) {
-	h := newTestHandler()
+	h, svc := newTestHandler()
 	tenantID, userID := uuid.New(), uuid.New()
 
 	body, _ := json.Marshal(map[string]string{"pack": "coding-pack"})
@@ -72,9 +94,18 @@ func TestHandler_Create_EngineNotConfigured_FailsVisibly(t *testing.T) {
 	if w.Code != http.StatusCreated {
 		t.Fatalf("expected 201 (task row is still persisted), got %d: %s", w.Code, w.Body.String())
 	}
-	var resp map[string]any
-	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+	var created map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&created); err != nil {
 		t.Fatalf("decode: %v", err)
+	}
+
+	svc.WaitForLaunches()
+	getW := httptest.NewRecorder()
+	h.InternalMux().ServeHTTP(getW, httptest.NewRequest(http.MethodGet,
+		"/internal/agent-tasks/"+tenantID.String()+"/"+userID.String()+"/"+created["id"].(string), nil))
+	var resp map[string]any
+	if err := json.NewDecoder(getW.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode get: %v", err)
 	}
 	if resp["status"] != "failed" {
 		t.Errorf("expected status failed (never queued forever), got %v", resp["status"])
@@ -89,7 +120,7 @@ func TestHandler_Create_EngineNotConfigured_FailsVisibly(t *testing.T) {
 }
 
 func TestHandler_Create_InvalidPack_Returns400(t *testing.T) {
-	h := newTestHandler()
+	h, _ := newTestHandler()
 	tenantID, userID := uuid.New(), uuid.New()
 
 	body, _ := json.Marshal(map[string]string{"pack": "not-a-pack"})
@@ -103,7 +134,7 @@ func TestHandler_Create_InvalidPack_Returns400(t *testing.T) {
 }
 
 func TestHandler_Create_InvalidTenantID_Returns400(t *testing.T) {
-	h := newTestHandler()
+	h, _ := newTestHandler()
 	req := httptest.NewRequest(http.MethodPost, "/internal/agent-tasks/not-a-uuid/"+uuid.New().String(), nil)
 	w := httptest.NewRecorder()
 	h.InternalMux().ServeHTTP(w, req)
@@ -114,7 +145,7 @@ func TestHandler_Create_InvalidTenantID_Returns400(t *testing.T) {
 }
 
 func TestHandler_ListThenGet_RoundTrip(t *testing.T) {
-	h := newRunningTestHandler()
+	h, svc := newRunningTestHandler()
 	tenantID, userID := uuid.New(), uuid.New()
 
 	body, _ := json.Marshal(map[string]string{"pack": "knowledge-work-pack"})
@@ -150,7 +181,7 @@ func TestHandler_ListThenGet_RoundTrip(t *testing.T) {
 }
 
 func TestHandler_Get_UnknownTask_Returns404(t *testing.T) {
-	h := newTestHandler()
+	h, _ := newTestHandler()
 	tenantID, userID := uuid.New(), uuid.New()
 	req := httptest.NewRequest(http.MethodGet, "/internal/agent-tasks/"+tenantID.String()+"/"+userID.String()+"/"+uuid.New().String(), nil)
 	w := httptest.NewRecorder()
@@ -162,7 +193,7 @@ func TestHandler_Get_UnknownTask_Returns404(t *testing.T) {
 }
 
 func TestHandler_Cancel_HappyPath(t *testing.T) {
-	h := newRunningTestHandler()
+	h, svc := newRunningTestHandler()
 	tenantID, userID := uuid.New(), uuid.New()
 
 	body, _ := json.Marshal(map[string]string{"pack": "coding-pack"})
@@ -194,7 +225,7 @@ func TestHandler_Cancel_HappyPath(t *testing.T) {
 }
 
 func TestHandler_MethodNotAllowed(t *testing.T) {
-	h := newTestHandler()
+	h, _ := newTestHandler()
 	tenantID, userID := uuid.New(), uuid.New()
 	req := httptest.NewRequest(http.MethodDelete, "/internal/agent-tasks/"+tenantID.String()+"/"+userID.String(), nil)
 	w := httptest.NewRecorder()

--- a/apps/control-plane/internal/agenttask/http_test.go
+++ b/apps/control-plane/internal/agenttask/http_test.go
@@ -155,6 +155,7 @@ func TestHandler_ListThenGet_RoundTrip(t *testing.T) {
 	var created map[string]any
 	_ = json.NewDecoder(createW.Body).Decode(&created)
 	taskID := created["id"].(string)
+	svc.WaitForLaunches()
 
 	listReq := httptest.NewRequest(http.MethodGet, "/internal/agent-tasks/"+tenantID.String()+"/"+userID.String(), nil)
 	listW := httptest.NewRecorder()
@@ -203,6 +204,9 @@ func TestHandler_Cancel_HappyPath(t *testing.T) {
 	var created map[string]any
 	_ = json.NewDecoder(createW.Body).Decode(&created)
 	taskID := created["id"].(string)
+	// Cancel a task whose launch has landed, so this covers the running-task
+	// path rather than racing the background launch.
+	svc.WaitForLaunches()
 
 	cancelReq := httptest.NewRequest(http.MethodPost, "/internal/agent-tasks/"+tenantID.String()+"/"+userID.String()+"/"+taskID+"/cancel", nil)
 	cancelW := httptest.NewRecorder()

--- a/apps/control-plane/internal/agenttask/service.go
+++ b/apps/control-plane/internal/agenttask/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -18,7 +19,7 @@ type Service struct {
 	engine Engine
 
 	// launches counts the background launch goroutines CreateTask starts.
-	// Nothing on the request path waits on it; see WaitForLaunches.
+	// Nothing on the request path waits on it; see WaitIdle.
 	launches sync.WaitGroup
 }
 
@@ -102,13 +103,39 @@ func (s *Service) CreateTask(ctx context.Context, tenantID, userID uuid.UUID, pa
 	// Worse, the Transition calls would inherit the same dead context and
 	// fail too, leaving the row queued forever.
 	opCtx := context.WithoutCancel(ctx)
+	s.background(func() { s.launch(opCtx, t) }, func() {
+		// Panic path. Before this work ran on its own goroutine it ran inside
+		// the HTTP handler, where net/http's per-connection recover contained a
+		// panic to one connection; a bare goroutine would instead take the
+		// whole process down, every tenant with it. Recovering keeps the blast
+		// radius at one task and still records that task as failed, so the
+		// customer is not left watching a queued row that will never move.
+		s.recordLaunchFailure(opCtx, t, engineLaunchFailedMessage)
+	})
+
+	return t, nil
+}
+
+// background runs work on a goroutine tracked by WaitIdle, recovering any
+// panic so one bad launch or stop cannot take the process down. onPanic runs
+// after the panic is logged and may be nil.
+func (s *Service) background(work func(), onPanic func()) {
 	s.launches.Add(1)
 	go func() {
 		defer s.launches.Done()
-		s.launch(opCtx, t)
+		defer func() {
+			r := recover()
+			if r == nil {
+				return
+			}
+			slog.Default().Error("agenttask: recovered panic in background work",
+				"panic", r, "stack", string(debug.Stack()))
+			if onPanic != nil {
+				onPanic()
+			}
+		}()
+		work()
 	}()
-
-	return t, nil
 }
 
 // launch performs one launch attempt and records its outcome. Runs on a
@@ -126,15 +153,24 @@ func (s *Service) launch(ctx context.Context, t Task) {
 			// The session started but its reference could not be recorded, so
 			// nothing can ever poll or stop it and it would hold its
 			// concurrency slot for its full natural life. Stop it here.
+			s.stopEngineSession(ctx, t.ID, sessionRef)
+
 			// ErrTerminalState is the expected case: a cancel won the race
 			// while this launch was still in flight, and it had no session
 			// reference to stop at the time, so this goroutine owns the
-			// teardown.
-			if !errors.Is(terr, ErrTerminalState) {
-				slog.Default().WarnContext(ctx, "agenttask: could not record a launched session, stopping it",
-					"task_id", t.ID, "error", terr)
+			// teardown. The task's terminal state is already correct.
+			if errors.Is(terr, ErrTerminalState) {
+				return
 			}
-			s.stopEngineSession(ctx, t.ID, sessionRef)
+			// Anything else is a real database failure, and leaving the row
+			// queued with no session reference would strand it: ListActive
+			// excludes exactly that shape, so the poller would never touch it
+			// and the customer would watch a task that can never move and
+			// carries no error. Record the failure instead. Best effort by
+			// definition, since the same database just refused a write.
+			slog.Default().WarnContext(ctx, "agenttask: could not record a launched session, stopped it and failing the task",
+				"task_id", t.ID, "error", terr)
+			s.recordLaunchFailure(ctx, t, engineLaunchFailedMessage)
 		}
 	case errors.Is(err, ErrEngineNotConfigured):
 		s.recordLaunchFailure(ctx, t, engineUnavailableMessage)
@@ -174,21 +210,31 @@ func (s *Service) stopEngineSession(ctx context.Context, taskID uuid.UUID, sessi
 	}
 }
 
-// WaitForLaunches blocks until every background launch this Service started
-// has finished. Nothing on the request path calls it; it exists so tests can
-// assert on a settled task, and so a drain can let in-flight launches record
-// their outcome before the process exits.
+// WaitIdle blocks until every background launch and engine stop this Service
+// started has finished. Nothing on the request path calls it; it exists so
+// tests can assert on a settled task, and so a drain could let in-flight work
+// record its outcome before the process exits.
 //
-// Deliberately not wired into cmd/server's shutdown: a launch is bounded at
-// launchTimeout (five minutes) and container stop is bounded far lower, so
-// waiting there would only trade a clean stop for a SIGKILL. A process that
-// dies mid-launch leaves its task queued with no engine_session_ref, which
-// Repository.ListActive excludes, so the poller never advances it. That
-// window is unchanged by making the launch asynchronous: the launch always
-// outlived the caller's context, so a restart always stranded it. A sweep for
-// stale queued rows is the fix if it ever shows up in practice; nothing has
-// asked for one yet (ponytail).
-func (s *Service) WaitForLaunches() { s.launches.Wait() }
+// Deliberately not wired into cmd/server's shutdown, and the shutdown window
+// this leaves is genuinely worse than before, so it is written down rather
+// than glossed. Previously the launch ran inside the HTTP handler, so
+// srv.Shutdown's 10 second budget (cmd/server/main.go) waited on that
+// connection and an in-flight launch had up to 10 seconds of grace. The
+// handler now returns as soon as the row is persisted, so Shutdown has
+// nothing to wait for and the background goroutine is killed with
+// approximately none.
+//
+// A task stranded that way sits queued with no engine_session_ref, which
+// Repository.ListActive excludes, so the poller never advances it. Waiting on
+// WaitIdle in Shutdown is not the fix: a launch is bounded at launchTimeout
+// (five minutes) while container stop is bounded far lower, so it would only
+// trade a clean exit for a SIGKILL at the same point. The fix, when a
+// mid-deploy stranded task actually shows up, is a sweep that fails queued
+// rows older than launchTimeout, which needs a change to the
+// agent_tasks_list_active() function and therefore a migration. Not built here
+// (ponytail), and named so the next person does not reason from a false
+// premise.
+func (s *Service) WaitIdle() { s.launches.Wait() }
 
 // Get returns one task, scoped to (tenantID, userID) so a task started by
 // one user is never resumable by a different user in the same tenant.
@@ -233,6 +279,16 @@ func (s *Service) Cancel(ctx context.Context, tenantID, userID, id uuid.UUID) (T
 	// An empty EngineSessionRef means the launch has not reported back yet;
 	// the in-flight launch goroutine sees this task is already terminal and
 	// tears its own session down (see launch).
-	s.stopEngineSession(ctx, id, cancelled.EngineSessionRef)
+	//
+	// The stop runs in the background for the same reason create no longer
+	// waits on a launch (issue #881). Blocking here put up to
+	// engineCancelTimeout (10 seconds) plus the database write inside a request
+	// edge-api abandons at 15 seconds, and the box where this matters is by
+	// definition the loaded one. The caller's answer does not depend on the
+	// stop anyway: the cancellation is already committed, and a stop failure is
+	// logged for an operator rather than returned. Tests wait on WaitIdle.
+	sessionRef := cancelled.EngineSessionRef
+	stopCtx := context.WithoutCancel(ctx)
+	s.background(func() { s.stopEngineSession(stopCtx, id, sessionRef) }, nil)
 	return cancelled, nil
 }

--- a/apps/control-plane/internal/agenttask/service.go
+++ b/apps/control-plane/internal/agenttask/service.go
@@ -173,17 +173,35 @@ func (s *Service) launch(ctx context.Context, t Task) {
 	// ever held, and nothing else could ever stop it. Stopping comes first
 	// because it frees the concurrency slot without touching the database,
 	// which is the dependency most likely to have caused the panic.
-	var sessionRef string
+	var (
+		sessionRef  string
+		teardownRun bool // this launch already attempted its own teardown
+	)
 	defer func() {
 		r := recover()
 		if r == nil {
 			return
 		}
+		// Residual, deliberately not wrapped: a panic from this logging call
+		// (or from debug.Stack) escapes into background's recover, which logs
+		// through the same slog call, so the two nets are not independent for
+		// that one case. Reaching it needs a slog handler that panics, and
+		// control-plane installs none: there is no slog.SetDefault in
+		// cmd/server, so this is the stdlib text handler, and fmt recovers from
+		// a panicking String or Error on the panic value itself. Revisit if a
+		// structured handler is ever installed.
 		slog.Default().Error("agenttask: recovered panic during launch",
 			"task_id", t.ID, "panic", r, "stack", string(debug.Stack()))
-		safely("stopping the session of a panicking launch", func() {
-			s.stopEngineSession(ctx, t.ID, sessionRef)
-		})
+		// Skipped when the launch already tore its own session down: repeating
+		// it is harmless for accounting (quota's release is a sync.Once and
+		// reap is idempotent) but it logs a leaked-slot warning for a slot that
+		// was correctly freed, because the control socket directory is gone by
+		// then and Interrupt fails.
+		if !teardownRun {
+			safely("stopping the session of a panicking launch", func() {
+				s.stopEngineSession(ctx, t.ID, sessionRef)
+			})
+		}
 		safely("recording a panicking launch as failed", func() {
 			s.recordLaunchFailure(ctx, t, engineLaunchFailedMessage)
 		})
@@ -196,6 +214,7 @@ func (s *Service) launch(ctx context.Context, t Task) {
 			// The session started but its reference could not be recorded, so
 			// nothing can ever poll or stop it and it would hold its
 			// concurrency slot for its full natural life. Stop it here.
+			teardownRun = true
 			s.stopEngineSession(ctx, t.ID, sessionRef)
 
 			// ErrTerminalState is the expected case: a cancel won the race
@@ -251,6 +270,13 @@ func (s *Service) recordLaunchFailure(ctx context.Context, t Task, message strin
 // recorded, and a failure here is an operator problem (a leaked slot), not
 // something the customer can act on or should see as a failed request. The
 // engine detail goes to the log only, never to a customer-visible field.
+//
+// The warning carries session_ref because on two paths that reach it (a cancel
+// that won the race before the launch reported back, and the panic path above)
+// the reference exists nowhere else by then: the row's engine_session_ref was
+// never written, the poller cannot see the task, and the launcher's registry is
+// in memory with no listing endpoint. Without it the only remedy left is
+// restarting the launcher, which drops every other tenant's live sandbox too.
 func (s *Service) stopEngineSession(ctx context.Context, taskID uuid.UUID, sessionRef string) {
 	if sessionRef == "" {
 		return // never launched, so nothing holds a slot
@@ -259,7 +285,7 @@ func (s *Service) stopEngineSession(ctx context.Context, taskID uuid.UUID, sessi
 	defer done()
 	if err := s.engine.Cancel(stopCtx, sessionRef); err != nil {
 		slog.Default().WarnContext(stopCtx, "agenttask: engine cancel failed, the session may still hold its concurrency slot",
-			"task_id", taskID, "error", err)
+			"task_id", taskID, "session_ref", sessionRef, "error", err)
 	}
 }
 

--- a/apps/control-plane/internal/agenttask/service.go
+++ b/apps/control-plane/internal/agenttask/service.go
@@ -91,6 +91,12 @@ func (s *Service) CreateTask(ctx context.Context, tenantID, userID uuid.UUID, pa
 	}
 }
 
+// WaitForLaunches blocks until every background launch this Service started
+// has finished. Nothing on the request path calls it; it exists so tests can
+// assert on a settled task, and so a future graceful drain can let in-flight
+// launches record their outcome before the process exits.
+func (s *Service) WaitForLaunches() {}
+
 // Get returns one task, scoped to (tenantID, userID) so a task started by
 // one user is never resumable by a different user in the same tenant.
 func (s *Service) Get(ctx context.Context, tenantID, userID, id uuid.UUID) (Task, error) {

--- a/apps/control-plane/internal/agenttask/service.go
+++ b/apps/control-plane/internal/agenttask/service.go
@@ -176,8 +176,18 @@ func (s *Service) stopEngineSession(ctx context.Context, taskID uuid.UUID, sessi
 
 // WaitForLaunches blocks until every background launch this Service started
 // has finished. Nothing on the request path calls it; it exists so tests can
-// assert on a settled task, and so a graceful drain can let in-flight
-// launches record their outcome before the process exits.
+// assert on a settled task, and so a drain can let in-flight launches record
+// their outcome before the process exits.
+//
+// Deliberately not wired into cmd/server's shutdown: a launch is bounded at
+// launchTimeout (five minutes) and container stop is bounded far lower, so
+// waiting there would only trade a clean stop for a SIGKILL. A process that
+// dies mid-launch leaves its task queued with no engine_session_ref, which
+// Repository.ListActive excludes, so the poller never advances it. That
+// window is unchanged by making the launch asynchronous: the launch always
+// outlived the caller's context, so a restart always stranded it. A sweep for
+// stale queued rows is the fix if it ever shows up in practice; nothing has
+// asked for one yet (ponytail).
 func (s *Service) WaitForLaunches() { s.launches.Wait() }
 
 // Get returns one task, scoped to (tenantID, userID) so a task started by

--- a/apps/control-plane/internal/agenttask/service.go
+++ b/apps/control-plane/internal/agenttask/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -15,6 +16,10 @@ import (
 type Service struct {
 	repo   Repository
 	engine Engine
+
+	// launches counts the background launch goroutines CreateTask starts.
+	// Nothing on the request path waits on it; see WaitForLaunches.
+	launches sync.WaitGroup
 }
 
 // NewService constructs a Service. repo must not be nil. A nil engine
@@ -50,12 +55,34 @@ const engineLaunchFailedMessage = "agent engine could not start the task"
 // anything, so this is minutes rather than seconds.
 const launchTimeout = 5 * time.Minute
 
-// CreateTask persists a new task and attempts to hand it to the agent-engine.
-// Any Launch error, including ErrEngineNotConfigured, transitions the task
-// straight to StatusFailed so a caller never polls a task that can never
-// progress: previously ErrEngineNotConfigured left the task in StatusQueued
-// forever with no signal, which is exactly the silent-stuck-queue behavior
-// this now closes.
+// engineCancelTimeout bounds one stop call to the engine. Deliberately well
+// under the 15 second budget edge-api's control-plane client allows
+// (apps/edge-api/internal/agenttask.NewClient): a cancel that outlived that
+// budget would answer the browser "failed" for a task that is in fact
+// cancelled, which is the shape issue #881 is about. Stopping a session is a
+// socket round trip plus a process kill, so seconds are generous; the
+// launcher frees the slot even if this call's context dies first.
+const engineCancelTimeout = 10 * time.Second
+
+// CreateTask persists a new task and hands it to the agent-engine on a
+// background goroutine, returning the persisted StatusQueued task as soon as
+// the row exists (issue #881).
+//
+// Waiting for the launch inline was the bug: a launch is bounded at
+// launchTimeout (five minutes) because a cold sandbox mount routinely takes
+// tens of seconds, while edge-api's control-plane client gives up after 15
+// seconds. Measured live on 2026-08-11, create answered the browser 500
+// after 18.0 seconds for a task that went on to reach succeeded, so the user
+// was told their work had failed while it was running and a retry started a
+// second sandbox. Widening the client timeout to match the server's five
+// minute bound was rejected: it makes an interactive request legitimately
+// able to hang for five minutes and leaves every intermediate proxy free to
+// cut it anyway. The queued row plus the existing poll path is what the code
+// was already shaped for, and it is what the console already renders.
+//
+// A launch failure still reaches the caller, just on the next poll rather
+// than in the create response: the background launch transitions the task to
+// StatusFailed, so a task never sits queued forever with no signal.
 func (s *Service) CreateTask(ctx context.Context, tenantID, userID uuid.UUID, pack Pack, instructions string) (Task, error) {
 	if !pack.Valid() {
 		return Task{}, ErrInvalidPack
@@ -66,36 +93,92 @@ func (s *Service) CreateTask(ctx context.Context, tenantID, userID uuid.UUID, pa
 		return Task{}, err
 	}
 
-	// Everything from here on runs on a context detached from the caller's.
-	// A launch cold-starts a sandbox, which takes tens of seconds, and the
-	// browser tab that submitted the task is free to go away in the middle
-	// of that. Measured on the demo box: closing the tab cancelled the
-	// request context, the launch died with "context canceled", and the task
-	// was recorded as failed for a reason that had nothing to do with the
-	// task. Worse, the Transition calls below would inherit the same dead
-	// context and fail too, leaving the row queued forever.
+	// The launch runs on a context detached from the caller's. A launch
+	// cold-starts a sandbox, which takes tens of seconds, and the browser tab
+	// that submitted the task is free to go away in the middle of that.
+	// Measured on the demo box: closing the tab cancelled the request
+	// context, the launch died with "context canceled", and the task was
+	// recorded as failed for a reason that had nothing to do with the task.
+	// Worse, the Transition calls would inherit the same dead context and
+	// fail too, leaving the row queued forever.
 	opCtx := context.WithoutCancel(ctx)
-	launchCtx, cancel := context.WithTimeout(opCtx, launchTimeout)
+	s.launches.Add(1)
+	go func() {
+		defer s.launches.Done()
+		s.launch(opCtx, t)
+	}()
+
+	return t, nil
+}
+
+// launch performs one launch attempt and records its outcome. Runs on a
+// background goroutine; it never returns anything to the caller of
+// CreateTask, so every failure path ends in either a persisted status or an
+// operator-visible log line.
+func (s *Service) launch(ctx context.Context, t Task) {
+	launchCtx, cancel := context.WithTimeout(ctx, launchTimeout)
 	defer cancel()
 
 	sessionRef, err := s.engine.Launch(launchCtx, t)
 	switch {
 	case err == nil:
-		return s.repo.Transition(opCtx, tenantID, userID, t.ID, StatusRunning, sessionRef, "", "")
+		if _, terr := s.repo.Transition(ctx, t.TenantID, t.UserID, t.ID, StatusRunning, sessionRef, "", ""); terr != nil {
+			// The session started but its reference could not be recorded, so
+			// nothing can ever poll or stop it and it would hold its
+			// concurrency slot for its full natural life. Stop it here.
+			// ErrTerminalState is the expected case: a cancel won the race
+			// while this launch was still in flight, and it had no session
+			// reference to stop at the time, so this goroutine owns the
+			// teardown.
+			if !errors.Is(terr, ErrTerminalState) {
+				slog.Default().WarnContext(ctx, "agenttask: could not record a launched session, stopping it",
+					"task_id", t.ID, "error", terr)
+			}
+			s.stopEngineSession(ctx, t.ID, sessionRef)
+		}
 	case errors.Is(err, ErrEngineNotConfigured):
-		return s.repo.Transition(opCtx, tenantID, userID, t.ID, StatusFailed, "", "", engineUnavailableMessage)
+		s.recordLaunchFailure(ctx, t, engineUnavailableMessage)
 	default:
-		slog.Default().WarnContext(opCtx, "agenttask: launch failed, engine detail",
+		slog.Default().WarnContext(ctx, "agenttask: launch failed, engine detail",
 			"task_id", t.ID, "error", err)
-		return s.repo.Transition(opCtx, tenantID, userID, t.ID, StatusFailed, "", "", engineLaunchFailedMessage)
+		s.recordLaunchFailure(ctx, t, engineLaunchFailedMessage)
+	}
+}
+
+// recordLaunchFailure persists a failed launch. ErrTerminalState is expected
+// and ignored: the user cancelled while the launch was failing, and their
+// cancellation is the truthful record.
+func (s *Service) recordLaunchFailure(ctx context.Context, t Task, message string) {
+	if _, err := s.repo.Transition(ctx, t.TenantID, t.UserID, t.ID, StatusFailed, "", "", message); err != nil &&
+		!errors.Is(err, ErrTerminalState) {
+		slog.Default().WarnContext(ctx, "agenttask: could not record a failed launch",
+			"task_id", t.ID, "error", err)
+	}
+}
+
+// stopEngineSession stops one launcher session, which is what releases the
+// concurrency slot that session holds (issue #886). Errors are logged and
+// never returned: by the time this runs the task's terminal state is already
+// recorded, and a failure here is an operator problem (a leaked slot), not
+// something the customer can act on or should see as a failed request. The
+// engine detail goes to the log only, never to a customer-visible field.
+func (s *Service) stopEngineSession(ctx context.Context, taskID uuid.UUID, sessionRef string) {
+	if sessionRef == "" {
+		return // never launched, so nothing holds a slot
+	}
+	stopCtx, done := context.WithTimeout(context.WithoutCancel(ctx), engineCancelTimeout)
+	defer done()
+	if err := s.engine.Cancel(stopCtx, sessionRef); err != nil {
+		slog.Default().WarnContext(stopCtx, "agenttask: engine cancel failed, the session may still hold its concurrency slot",
+			"task_id", taskID, "error", err)
 	}
 }
 
 // WaitForLaunches blocks until every background launch this Service started
 // has finished. Nothing on the request path calls it; it exists so tests can
-// assert on a settled task, and so a future graceful drain can let in-flight
+// assert on a settled task, and so a graceful drain can let in-flight
 // launches record their outcome before the process exits.
-func (s *Service) WaitForLaunches() {}
+func (s *Service) WaitForLaunches() { s.launches.Wait() }
 
 // Get returns one task, scoped to (tenantID, userID) so a task started by
 // one user is never resumable by a different user in the same tenant.
@@ -110,12 +193,36 @@ func (s *Service) List(ctx context.Context, tenantID, userID uuid.UUID) ([]Task,
 	return s.repo.List(ctx, tenantID, userID)
 }
 
-// Cancel transitions a task to StatusCancelled. Only reachable from
-// StatusQueued or StatusRunning; a task already in a terminal state returns
-// ErrTerminalState. No read-then-act check here — Repository.Transition's
-// UPDATE carries the "not already terminal" precondition atomically, so a
-// concurrent engine callback finishing the task can never be clobbered by a
-// racing Cancel (or vice versa).
+// Cancel transitions a task to StatusCancelled and stops the launcher
+// session behind it. Only reachable from StatusQueued or StatusRunning; a
+// task already in a terminal state returns ErrTerminalState. No read-then-act
+// check here — Repository.Transition's UPDATE carries the "not already
+// terminal" precondition atomically, so a concurrent engine callback
+// finishing the task can never be clobbered by a racing Cancel (or vice
+// versa).
+//
+// The order matters. The row transition runs first because it is the atomic
+// gate: exactly one caller can win it, so the engine is asked to stop a
+// session exactly once. A double cancel, and a cancel that lost the race to a
+// completion the poller already recorded, both fail that gate and return here
+// without touching the engine (in the completion case the launcher has
+// already reaped that session itself). Stopping the engine first would risk
+// killing a sandbox for a task the database then reports as succeeded.
+//
+// Stopping the session is the point (issue #886): the concurrency slot is
+// held by the live sandbox and released by the launcher when the session
+// ends, so a cancel that only wrote a database row left the slot held until
+// the sandbox finished on its own. Measured on the demo box, that was about
+// sixteen minutes, and two cancels exhausted the user's ceiling and refused
+// every subsequent create.
 func (s *Service) Cancel(ctx context.Context, tenantID, userID, id uuid.UUID) (Task, error) {
-	return s.repo.Transition(ctx, tenantID, userID, id, StatusCancelled, "", "", "")
+	cancelled, err := s.repo.Transition(ctx, tenantID, userID, id, StatusCancelled, "", "", "")
+	if err != nil {
+		return Task{}, err
+	}
+	// An empty EngineSessionRef means the launch has not reported back yet;
+	// the in-flight launch goroutine sees this task is already terminal and
+	// tears its own session down (see launch).
+	s.stopEngineSession(ctx, id, cancelled.EngineSessionRef)
+	return cancelled, nil
 }

--- a/apps/control-plane/internal/agenttask/service.go
+++ b/apps/control-plane/internal/agenttask/service.go
@@ -94,6 +94,19 @@ func (s *Service) CreateTask(ctx context.Context, tenantID, userID uuid.UUID, pa
 		return Task{}, err
 	}
 
+	// Nothing bounds how many of these goroutines can be in flight, and the
+	// launcher's quota does not: it gates the sandbox launch, which happens
+	// inside the goroutine, after this row has already been inserted. There is
+	// no rate limiter in front of POST /v1/agent/tasks either (verified in
+	// apps/edge-api/cmd/server/main.go: the chain is unsupported-endpoint,
+	// budget gate which is inert for JWT session traffic, auth selector,
+	// metrics, compat headers, max bytes, plus a feature gate on the route;
+	// authz.Limiter is only reached through authorizer.Authorize, which this
+	// handler never calls). So an authenticated caller can spend rows,
+	// goroutines and pool checkouts without a ceiling today. Tracked in issue
+	// #900 rather than papered over with a comment claiming a control that is
+	// not shipped.
+	//
 	// The launch runs on a context detached from the caller's. A launch
 	// cold-starts a sandbox, which takes tens of seconds, and the browser tab
 	// that submitted the task is free to go away in the middle of that.
@@ -103,39 +116,47 @@ func (s *Service) CreateTask(ctx context.Context, tenantID, userID uuid.UUID, pa
 	// Worse, the Transition calls would inherit the same dead context and
 	// fail too, leaving the row queued forever.
 	opCtx := context.WithoutCancel(ctx)
-	s.background(func() { s.launch(opCtx, t) }, func() {
-		// Panic path. Before this work ran on its own goroutine it ran inside
-		// the HTTP handler, where net/http's per-connection recover contained a
-		// panic to one connection; a bare goroutine would instead take the
-		// whole process down, every tenant with it. Recovering keeps the blast
-		// radius at one task and still records that task as failed, so the
-		// customer is not left watching a queued row that will never move.
-		s.recordLaunchFailure(opCtx, t, engineLaunchFailedMessage)
-	})
+	s.background(func() { s.launch(opCtx, t) })
 
 	return t, nil
 }
 
 // background runs work on a goroutine tracked by WaitIdle, recovering any
-// panic so one bad launch or stop cannot take the process down. onPanic runs
-// after the panic is logged and may be nil.
-func (s *Service) background(work func(), onPanic func()) {
+// panic so one bad launch or stop cannot take the process down. Before this
+// work ran on its own goroutine it ran inside the HTTP handler, where
+// net/http's per-connection recover contained a panic to one connection; a
+// bare goroutine would instead take the whole process down, every tenant with
+// it. This recover is the outer net only: launch does its own task-level
+// recovery, because only launch knows the session reference that has to be
+// stopped.
+func (s *Service) background(work func()) {
 	s.launches.Add(1)
 	go func() {
 		defer s.launches.Done()
 		defer func() {
-			r := recover()
-			if r == nil {
-				return
-			}
-			slog.Default().Error("agenttask: recovered panic in background work",
-				"panic", r, "stack", string(debug.Stack()))
-			if onPanic != nil {
-				onPanic()
+			if r := recover(); r != nil {
+				slog.Default().Error("agenttask: recovered panic in background work",
+					"panic", r, "stack", string(debug.Stack()))
 			}
 		}()
 		work()
 	}()
+}
+
+// safely runs f and swallows any panic it raises, logging it against what.
+// Only for use from inside a recovery path: a panic raised there is a fresh
+// panic in an already-unwinding deferred function, with no recover above it,
+// so it would kill the process. That matters most when the original panic came
+// from a shared dependency (a nil pool, a driver fault), because then the
+// recovery handler re-enters the very code that just failed and the second
+// panic is the deterministic one.
+func safely(what string, f func()) {
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Default().Error("agenttask: panic while "+what+", giving up on it", "panic", r)
+		}
+	}()
+	f()
 }
 
 // launch performs one launch attempt and records its outcome. Runs on a
@@ -145,6 +166,28 @@ func (s *Service) background(work func(), onPanic func()) {
 func (s *Service) launch(ctx context.Context, t Task) {
 	launchCtx, cancel := context.WithTimeout(ctx, launchTimeout)
 	defer cancel()
+
+	// sessionRef is declared before the recover that reads it: a panic between
+	// a successful Launch and the transition that records the reference would
+	// otherwise strand a live sandbox whose reference only the panicking frame
+	// ever held, and nothing else could ever stop it. Stopping comes first
+	// because it frees the concurrency slot without touching the database,
+	// which is the dependency most likely to have caused the panic.
+	var sessionRef string
+	defer func() {
+		r := recover()
+		if r == nil {
+			return
+		}
+		slog.Default().Error("agenttask: recovered panic during launch",
+			"task_id", t.ID, "panic", r, "stack", string(debug.Stack()))
+		safely("stopping the session of a panicking launch", func() {
+			s.stopEngineSession(ctx, t.ID, sessionRef)
+		})
+		safely("recording a panicking launch as failed", func() {
+			s.recordLaunchFailure(ctx, t, engineLaunchFailedMessage)
+		})
+	}()
 
 	sessionRef, err := s.engine.Launch(launchCtx, t)
 	switch {
@@ -175,6 +218,16 @@ func (s *Service) launch(ctx context.Context, t Task) {
 	case errors.Is(err, ErrEngineNotConfigured):
 		s.recordLaunchFailure(ctx, t, engineUnavailableMessage)
 	default:
+		// Known gap, deliberately not closed here (issue #899). A Launch that
+		// fails in transport rather than at the launcher (the response is lost,
+		// launchTimeout fires, or this process dies mid-deploy) can leave a
+		// session that the launcher registered and this process never learned
+		// the reference for. That session holds its slots until the launcher
+		// restarts, because reap only runs from Status or Cancel and the
+		// poller's input requires a non-empty engine_session_ref. Closing it
+		// needs a way to re-derive the reference, which only the launcher can
+		// offer (a lookup by task id, or its own orphan sweep). The row is
+		// still recorded failed here, which is the half this service owns.
 		slog.Default().WarnContext(ctx, "agenttask: launch failed, engine detail",
 			"task_id", t.ID, "error", err)
 		s.recordLaunchFailure(ctx, t, engineLaunchFailedMessage)
@@ -289,6 +342,6 @@ func (s *Service) Cancel(ctx context.Context, tenantID, userID, id uuid.UUID) (T
 	// logged for an operator rather than returned. Tests wait on WaitIdle.
 	sessionRef := cancelled.EngineSessionRef
 	stopCtx := context.WithoutCancel(ctx)
-	s.background(func() { s.stopEngineSession(stopCtx, id, sessionRef) }, nil)
+	s.background(func() { s.stopEngineSession(stopCtx, id, sessionRef) })
 	return cancelled, nil
 }

--- a/apps/control-plane/internal/agenttask/service_test.go
+++ b/apps/control-plane/internal/agenttask/service_test.go
@@ -218,6 +218,35 @@ func createSettled(t *testing.T, svc *agenttask.Service, tenantID, userID uuid.U
 	return settled
 }
 
+// createWithoutWaiting creates a task against an engine whose launch is
+// gated open, and fails the test if the create call does not return promptly.
+// It runs the call on its own goroutine so a create that blocks on the launch
+// (issue #881) fails this one test with a legible message instead of hanging
+// the whole package until the go test timeout.
+func createWithoutWaiting(t *testing.T, svc *agenttask.Service, tenantID, userID uuid.UUID) agenttask.Task {
+	t.Helper()
+	type result struct {
+		task agenttask.Task
+		err  error
+	}
+	done := make(chan result, 1)
+	go func() {
+		task, err := svc.CreateTask(context.Background(), tenantID, userID, agenttask.PackCoding, "")
+		done <- result{task: task, err: err}
+	}()
+
+	select {
+	case got := <-done:
+		if got.err != nil {
+			t.Fatalf("CreateTask: %v", got.err)
+		}
+		return got.task
+	case <-time.After(2 * time.Second):
+		t.Fatal("CreateTask blocked on the engine launch (issue #881): edge-api gives up at 15s and reports a failure for a task that is in fact starting")
+		return agenttask.Task{}
+	}
+}
+
 func TestService_CreateTask_InvalidPack(t *testing.T) {
 	svc := agenttask.NewService(newFakeRepository(), &fakeEngine{})
 	_, err := svc.CreateTask(context.Background(), uuid.New(), uuid.New(), agenttask.Pack("not-a-pack"), "")
@@ -430,10 +459,7 @@ func TestService_CancelDuringLaunch_ReleasesTheSlotThatLaunchTook(t *testing.T) 
 	svc := agenttask.NewService(newFakeRepository(), eng)
 	tenantID, userID := uuid.New(), uuid.New()
 
-	created, err := svc.CreateTask(context.Background(), tenantID, userID, agenttask.PackCoding, "")
-	if err != nil {
-		t.Fatalf("CreateTask: %v", err)
-	}
+	created := createWithoutWaiting(t, svc, tenantID, userID)
 	if created.Status != agenttask.StatusQueued {
 		t.Fatalf("expected a queued task while the launch is in flight, got %v", created.Status)
 	}
@@ -498,28 +524,9 @@ func TestService_CreateTask_DoesNotBlockOnLaunch(t *testing.T) {
 	svc := agenttask.NewService(newFakeRepository(), eng)
 	tenantID, userID := uuid.New(), uuid.New()
 
-	type result struct {
-		task agenttask.Task
-		err  error
-	}
-	done := make(chan result, 1)
-	go func() {
-		task, err := svc.CreateTask(context.Background(), tenantID, userID, agenttask.PackCoding, "")
-		done <- result{task: task, err: err}
-	}()
-
-	var created agenttask.Task
-	select {
-	case got := <-done:
-		if got.err != nil {
-			t.Fatalf("CreateTask: %v", got.err)
-		}
-		if got.task.Status != agenttask.StatusQueued {
-			t.Fatalf("expected the caller to get a queued task, got %v", got.task.Status)
-		}
-		created = got.task
-	case <-time.After(2 * time.Second):
-		t.Fatal("CreateTask blocked on the engine launch (issue #881): the caller times out and is told the task failed while it is in fact starting")
+	created := createWithoutWaiting(t, svc, tenantID, userID)
+	if created.Status != agenttask.StatusQueued {
+		t.Fatalf("expected the caller to get a queued task, got %v", created.Status)
 	}
 
 	close(eng.launchGate)

--- a/apps/control-plane/internal/agenttask/service_test.go
+++ b/apps/control-plane/internal/agenttask/service_test.go
@@ -3,7 +3,9 @@ package agenttask_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -15,7 +17,11 @@ import (
 // fakeRepository is a hand-built agenttask.Repository stub for unit tests
 // that never need a live Postgres connection. Mirrors
 // apps/control-plane/internal/marketplace/service_test.go's fakeRepository.
+// Guarded by a mutex because CreateTask now launches on a background
+// goroutine (issue #881), so a launch's Transition can land while the test
+// goroutine is reading.
 type fakeRepository struct {
+	mu    sync.Mutex
 	tasks map[uuid.UUID]agenttask.Task
 }
 
@@ -24,6 +30,8 @@ func newFakeRepository() *fakeRepository {
 }
 
 func (f *fakeRepository) Create(_ context.Context, tenantID, userID uuid.UUID, pack agenttask.Pack, instructions string) (agenttask.Task, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	t := agenttask.Task{
 		ID: uuid.New(), TenantID: tenantID, UserID: userID, Pack: pack, Instructions: instructions,
 		Status: agenttask.StatusQueued, CreatedAt: time.Now(), UpdatedAt: time.Now(),
@@ -33,6 +41,8 @@ func (f *fakeRepository) Create(_ context.Context, tenantID, userID uuid.UUID, p
 }
 
 func (f *fakeRepository) Get(_ context.Context, tenantID, userID, id uuid.UUID) (agenttask.Task, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	t, ok := f.tasks[id]
 	if !ok || t.TenantID != tenantID || t.UserID != userID {
 		return agenttask.Task{}, agenttask.ErrNotFound
@@ -41,6 +51,8 @@ func (f *fakeRepository) Get(_ context.Context, tenantID, userID, id uuid.UUID) 
 }
 
 func (f *fakeRepository) List(_ context.Context, tenantID, userID uuid.UUID) ([]agenttask.Task, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	var out []agenttask.Task
 	for _, t := range f.tasks {
 		if t.TenantID == tenantID && t.UserID == userID {
@@ -51,6 +63,8 @@ func (f *fakeRepository) List(_ context.Context, tenantID, userID uuid.UUID) ([]
 }
 
 func (f *fakeRepository) Transition(_ context.Context, tenantID, userID, id uuid.UUID, status agenttask.Status, sessionRef, resultSummaryRef, errMsg string) (agenttask.Task, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	t, ok := f.tasks[id]
 	if !ok || t.TenantID != tenantID || t.UserID != userID {
 		return agenttask.Task{}, agenttask.ErrNotFound
@@ -75,6 +89,8 @@ func (f *fakeRepository) Transition(_ context.Context, tenantID, userID, id uuid
 }
 
 func (f *fakeRepository) ListActive(context.Context) ([]agenttask.Task, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	var out []agenttask.Task
 	for _, t := range f.tasks {
 		if (t.Status == agenttask.StatusQueued || t.Status == agenttask.StatusRunning) && t.EngineSessionRef != "" {
@@ -88,10 +104,118 @@ func (f *fakeRepository) ListActive(context.Context) ([]agenttask.Task, error) {
 type fakeEngine struct {
 	sessionRef string
 	err        error
+
+	mu        sync.Mutex
+	cancelled []string
 }
 
 func (f *fakeEngine) Launch(context.Context, agenttask.Task) (string, error) {
 	return f.sessionRef, f.err
+}
+
+func (f *fakeEngine) Cancel(_ context.Context, sessionRef string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.cancelled = append(f.cancelled, sessionRef)
+	return nil
+}
+
+func (f *fakeEngine) cancelCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.cancelled)
+}
+
+// errNoSlot stands in for apps/agent-engine/internal/quota's
+// ErrUserQuotaExceeded, which control-plane cannot import across the module
+// boundary (that package is under apps/agent-engine/internal).
+var errNoSlot = errors.New("test engine: user concurrency limit reached")
+
+// slotEngine models the launcher's per-user concurrency accounting
+// (apps/agent-engine/internal/quota.Manager): Launch takes a slot and refuses
+// once the ceiling is reached, and only ending the session (Cancel here, or a
+// terminal Status on the real launcher) gives one back.
+//
+// It is deliberately the smallest stand-in that can tell "cancel reached the
+// engine" apart from "cancel wrote a database row and nothing else", which is
+// the whole of issue #886: a test that asserted only the returned status would
+// have passed against the broken code.
+type slotEngine struct {
+	mu     sync.Mutex
+	limit  int
+	live   map[string]bool
+	seq    int
+	cancel int
+
+	// launchGate, when non-nil, blocks each Launch after it has taken its
+	// slot and before it returns a session reference — the window in which a
+	// cancel can arrive before the launch finishes.
+	launchGate chan struct{}
+}
+
+func newSlotEngine(limit int) *slotEngine {
+	return &slotEngine{limit: limit, live: make(map[string]bool)}
+}
+
+func (s *slotEngine) Launch(context.Context, agenttask.Task) (string, error) {
+	s.mu.Lock()
+	if len(s.live) >= s.limit {
+		s.mu.Unlock()
+		return "", errNoSlot
+	}
+	s.seq++
+	ref := fmt.Sprintf("session-%d", s.seq)
+	s.live[ref] = true
+	gate := s.launchGate
+	s.mu.Unlock()
+
+	if gate != nil {
+		<-gate
+	}
+	return ref, nil
+}
+
+func (s *slotEngine) Cancel(_ context.Context, sessionRef string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.cancel++
+	if !s.live[sessionRef] {
+		return fmt.Errorf("test engine: unknown session %q", sessionRef)
+	}
+	delete(s.live, sessionRef)
+	return nil
+}
+
+// slotsInUse is the assertion that matters: it is the counter the live demo
+// box exhausted, not the task's status column.
+func (s *slotEngine) slotsInUse() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.live)
+}
+
+func (s *slotEngine) cancelCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.cancel
+}
+
+// createSettled creates a task and waits for its background launch to
+// finish, returning the task as the store holds it afterwards. CreateTask
+// returns as soon as the row exists (issue #881), so every assertion about a
+// launch outcome has to read the settled row rather than the create return.
+func createSettled(t *testing.T, svc *agenttask.Service, tenantID, userID uuid.UUID, pack agenttask.Pack) agenttask.Task {
+	t.Helper()
+	created, err := svc.CreateTask(context.Background(), tenantID, userID, pack, "")
+	if err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	svc.WaitForLaunches()
+	settled, err := svc.Get(context.Background(), tenantID, userID, created.ID)
+	if err != nil {
+		t.Fatalf("Get after launch: %v", err)
+	}
+	return settled
 }
 
 func TestService_CreateTask_InvalidPack(t *testing.T) {
@@ -111,10 +235,7 @@ func TestService_CreateTask_InvalidPack(t *testing.T) {
 // forever in queue, no error surfaced").
 func TestService_CreateTask_EngineNotConfigured_FailsVisibly(t *testing.T) {
 	svc := agenttask.NewService(newFakeRepository(), agenttask.NotConfiguredEngine{})
-	task, err := svc.CreateTask(context.Background(), uuid.New(), uuid.New(), agenttask.PackCoding, "")
-	if err != nil {
-		t.Fatalf("CreateTask() unexpected err: %v", err)
-	}
+	task := createSettled(t, svc, uuid.New(), uuid.New(), agenttask.PackCoding)
 	if task.Status != agenttask.StatusFailed {
 		t.Errorf("expected StatusFailed when engine not configured (must not stay queued forever), got %v", task.Status)
 	}
@@ -128,10 +249,7 @@ func TestService_CreateTask_EngineNotConfigured_FailsVisibly(t *testing.T) {
 
 func TestService_CreateTask_NilEngineDefaultsToNotConfigured(t *testing.T) {
 	svc := agenttask.NewService(newFakeRepository(), nil)
-	task, err := svc.CreateTask(context.Background(), uuid.New(), uuid.New(), agenttask.PackKnowledgeWork, "")
-	if err != nil {
-		t.Fatalf("CreateTask() unexpected err: %v", err)
-	}
+	task := createSettled(t, svc, uuid.New(), uuid.New(), agenttask.PackKnowledgeWork)
 	if task.Status != agenttask.StatusFailed {
 		t.Errorf("expected StatusFailed with nil engine (defaults to NotConfiguredEngine), got %v", task.Status)
 	}
@@ -139,10 +257,7 @@ func TestService_CreateTask_NilEngineDefaultsToNotConfigured(t *testing.T) {
 
 func TestService_CreateTask_EngineLaunchSucceeds_TransitionsToRunning(t *testing.T) {
 	svc := agenttask.NewService(newFakeRepository(), &fakeEngine{sessionRef: "session-123"})
-	task, err := svc.CreateTask(context.Background(), uuid.New(), uuid.New(), agenttask.PackCoding, "")
-	if err != nil {
-		t.Fatalf("CreateTask() unexpected err: %v", err)
-	}
+	task := createSettled(t, svc, uuid.New(), uuid.New(), agenttask.PackCoding)
 	if task.Status != agenttask.StatusRunning {
 		t.Errorf("expected StatusRunning, got %v", task.Status)
 	}
@@ -162,10 +277,7 @@ func TestService_CreateTask_EngineLaunchSucceeds_TransitionsToRunning(t *testing
 func TestService_CreateTask_EngineLaunchFails_SanitizesErrorMessage(t *testing.T) {
 	rawErr := "dial tcp acme-inference-provider.internal:443: connection refused"
 	svc := agenttask.NewService(newFakeRepository(), &fakeEngine{err: errors.New(rawErr)})
-	task, err := svc.CreateTask(context.Background(), uuid.New(), uuid.New(), agenttask.PackCoding, "")
-	if err != nil {
-		t.Fatalf("CreateTask() unexpected err: %v", err)
-	}
+	task := createSettled(t, svc, uuid.New(), uuid.New(), agenttask.PackCoding)
 	if task.Status != agenttask.StatusFailed {
 		t.Errorf("expected StatusFailed, got %v", task.Status)
 	}
@@ -225,12 +337,10 @@ func TestService_Cancel_FromRunning(t *testing.T) {
 	// A NotConfiguredEngine seed would now land the task in StatusFailed
 	// (terminal) rather than StatusQueued, so this uses a launching
 	// fakeEngine to reach the other cancellable state, StatusRunning.
-	svc := agenttask.NewService(newFakeRepository(), &fakeEngine{sessionRef: "session-cancel"})
+	eng := &fakeEngine{sessionRef: "session-cancel"}
+	svc := agenttask.NewService(newFakeRepository(), eng)
 	tenantID, userID := uuid.New(), uuid.New()
-	created, err := svc.CreateTask(context.Background(), tenantID, userID, agenttask.PackCoding, "")
-	if err != nil {
-		t.Fatalf("seed CreateTask: %v", err)
-	}
+	created := createSettled(t, svc, tenantID, userID, agenttask.PackCoding)
 
 	cancelled, err := svc.Cancel(context.Background(), tenantID, userID, created.ID)
 	if err != nil {
@@ -239,21 +349,191 @@ func TestService_Cancel_FromRunning(t *testing.T) {
 	if cancelled.Status != agenttask.StatusCancelled {
 		t.Errorf("expected StatusCancelled, got %v", cancelled.Status)
 	}
+	if got := eng.cancelCount(); got != 1 {
+		t.Errorf("expected the engine session to be cancelled exactly once, got %d calls", got)
+	}
 }
 
+// A second cancel must be rejected by the row's own terminal guard and must
+// never reach the engine again: the first cancel already reaped that session,
+// so a second engine call could only ever hit an unknown session (or, worse
+// on a future launcher that recycles references, somebody else's).
 func TestService_Cancel_TerminalStateRejected(t *testing.T) {
-	svc := agenttask.NewService(newFakeRepository(), &fakeEngine{sessionRef: "s1"})
+	eng := &fakeEngine{sessionRef: "s1"}
+	svc := agenttask.NewService(newFakeRepository(), eng)
 	tenantID, userID := uuid.New(), uuid.New()
-	created, err := svc.CreateTask(context.Background(), tenantID, userID, agenttask.PackCoding, "")
-	if err != nil {
-		t.Fatalf("seed CreateTask: %v", err)
-	}
+	created := createSettled(t, svc, tenantID, userID, agenttask.PackCoding)
 	if _, err := svc.Cancel(context.Background(), tenantID, userID, created.ID); err != nil {
 		t.Fatalf("first Cancel: %v", err)
 	}
 
 	if _, err := svc.Cancel(context.Background(), tenantID, userID, created.ID); !errors.Is(err, agenttask.ErrTerminalState) {
 		t.Fatalf("expected ErrTerminalState on a second cancel, got %v", err)
+	}
+	if got := eng.cancelCount(); got != 1 {
+		t.Errorf("expected exactly one engine cancel across a double cancel, got %d", got)
+	}
+}
+
+// =============================================================================
+// Issue #886 — cancelling a task must release the launcher concurrency slot
+// =============================================================================
+
+// TestService_Cancel_ReleasesEngineConcurrencySlot reproduces the live
+// symptom measured on the demo box on 2026-08-11: two cancelled tasks held
+// both of HIVE_QUOTA_USER_CONCURRENCY's slots for over half an hour, and
+// every create after that was refused instantly.
+//
+// The assertion is the slot counter, not the task status. Service.Cancel
+// already returned a cancelled task before this fix; what it never did was
+// tell the engine, so the sandbox kept running and kept its slot.
+func TestService_Cancel_ReleasesEngineConcurrencySlot(t *testing.T) {
+	eng := newSlotEngine(1)
+	svc := agenttask.NewService(newFakeRepository(), eng)
+	tenantID, userID := uuid.New(), uuid.New()
+
+	first := createSettled(t, svc, tenantID, userID, agenttask.PackCoding)
+	if first.Status != agenttask.StatusRunning {
+		t.Fatalf("seed task: expected running, got %v", first.Status)
+	}
+
+	// With the only slot held, a second create fails. This is the "Blocked"
+	// the console showed, and it is correct behaviour while the first task
+	// really is running.
+	blocked := createSettled(t, svc, tenantID, userID, agenttask.PackCoding)
+	if blocked.Status != agenttask.StatusFailed {
+		t.Fatalf("expected the second create to fail while the slot is held, got %v", blocked.Status)
+	}
+
+	if _, err := svc.Cancel(context.Background(), tenantID, userID, first.ID); err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+	if got := eng.slotsInUse(); got != 0 {
+		t.Fatalf("cancel did not release the launcher slot: %d still in use (issue #886)", got)
+	}
+
+	// The point of releasing it: the same user can work again straight away.
+	next := createSettled(t, svc, tenantID, userID, agenttask.PackCoding)
+	if next.Status != agenttask.StatusRunning {
+		t.Fatalf("expected a create after cancel to run, got %v (%q)", next.Status, next.ErrorMessage)
+	}
+}
+
+// A cancel that lands while the launch is still in flight is the nastiest
+// ordering: the row has no engine_session_ref yet, so Cancel has nothing to
+// stop, and the launch then completes into a task that is already terminal.
+// Whoever learns the session reference last owns the teardown, which is the
+// background launch.
+func TestService_CancelDuringLaunch_ReleasesTheSlotThatLaunchTook(t *testing.T) {
+	eng := newSlotEngine(1)
+	eng.launchGate = make(chan struct{})
+	svc := agenttask.NewService(newFakeRepository(), eng)
+	tenantID, userID := uuid.New(), uuid.New()
+
+	created, err := svc.CreateTask(context.Background(), tenantID, userID, agenttask.PackCoding, "")
+	if err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	if created.Status != agenttask.StatusQueued {
+		t.Fatalf("expected a queued task while the launch is in flight, got %v", created.Status)
+	}
+
+	cancelled, err := svc.Cancel(context.Background(), tenantID, userID, created.ID)
+	if err != nil {
+		t.Fatalf("Cancel during launch: %v", err)
+	}
+	if cancelled.Status != agenttask.StatusCancelled {
+		t.Fatalf("expected StatusCancelled, got %v", cancelled.Status)
+	}
+
+	close(eng.launchGate) // the launch now finishes into a cancelled task
+	svc.WaitForLaunches()
+
+	if got := eng.slotsInUse(); got != 0 {
+		t.Fatalf("a launch that finished into a cancelled task kept its slot: %d in use", got)
+	}
+	if got := eng.cancelCount(); got != 1 {
+		t.Fatalf("expected exactly one engine cancel for a cancel-during-launch, got %d", got)
+	}
+}
+
+// Cancel racing a completion the poller already recorded: the row's atomic
+// terminal guard rejects the cancel, and the engine must not be asked to stop
+// a session the launcher has already reaped on its own.
+func TestService_Cancel_LosesRaceWithCompletion_LeavesEngineAlone(t *testing.T) {
+	repo := newFakeRepository()
+	eng := &fakeEngine{sessionRef: "session-race"}
+	svc := agenttask.NewService(repo, eng)
+	tenantID, userID := uuid.New(), uuid.New()
+
+	created := createSettled(t, svc, tenantID, userID, agenttask.PackCoding)
+	// Stand in for the poller winning: the task is terminal before Cancel runs.
+	if _, err := repo.Transition(context.Background(), tenantID, userID, created.ID, agenttask.StatusSucceeded, "", "summary", ""); err != nil {
+		t.Fatalf("seed completion: %v", err)
+	}
+
+	if _, err := svc.Cancel(context.Background(), tenantID, userID, created.ID); !errors.Is(err, agenttask.ErrTerminalState) {
+		t.Fatalf("expected ErrTerminalState, got %v", err)
+	}
+	if got := eng.cancelCount(); got != 0 {
+		t.Errorf("expected no engine cancel for an already-terminal task, got %d", got)
+	}
+}
+
+// =============================================================================
+// Issue #881 — create must not block the caller on the sandbox launch
+// =============================================================================
+
+// TestService_CreateTask_DoesNotBlockOnLaunch reproduces the live symptom:
+// edge-api's control-plane client gives up at 15 seconds while CreateTask
+// blocked inline on a launch bounded at five minutes, so the browser was told
+// 500 for a task that went on to succeed.
+//
+// The fix is that create returns the persisted queued task as soon as the row
+// exists; the launch continues in the background and the existing poll path
+// carries the task to running and beyond.
+func TestService_CreateTask_DoesNotBlockOnLaunch(t *testing.T) {
+	eng := newSlotEngine(1)
+	eng.launchGate = make(chan struct{})
+	svc := agenttask.NewService(newFakeRepository(), eng)
+	tenantID, userID := uuid.New(), uuid.New()
+
+	type result struct {
+		task agenttask.Task
+		err  error
+	}
+	done := make(chan result, 1)
+	go func() {
+		task, err := svc.CreateTask(context.Background(), tenantID, userID, agenttask.PackCoding, "")
+		done <- result{task: task, err: err}
+	}()
+
+	var created agenttask.Task
+	select {
+	case got := <-done:
+		if got.err != nil {
+			t.Fatalf("CreateTask: %v", got.err)
+		}
+		if got.task.Status != agenttask.StatusQueued {
+			t.Fatalf("expected the caller to get a queued task, got %v", got.task.Status)
+		}
+		created = got.task
+	case <-time.After(2 * time.Second):
+		t.Fatal("CreateTask blocked on the engine launch (issue #881): the caller times out and is told the task failed while it is in fact starting")
+	}
+
+	close(eng.launchGate)
+	svc.WaitForLaunches()
+
+	settled, err := svc.Get(context.Background(), tenantID, userID, created.ID)
+	if err != nil {
+		t.Fatalf("Get after launch: %v", err)
+	}
+	if settled.Status != agenttask.StatusRunning {
+		t.Fatalf("expected the background launch to advance the task to running, got %v", settled.Status)
+	}
+	if settled.EngineSessionRef == "" {
+		t.Error("expected the background launch to persist the engine session ref")
 	}
 }
 

--- a/apps/control-plane/internal/agenttask/service_test.go
+++ b/apps/control-plane/internal/agenttask/service_test.go
@@ -23,6 +23,14 @@ import (
 type fakeRepository struct {
 	mu    sync.Mutex
 	tasks map[uuid.UUID]agenttask.Task
+
+	// failTransitionTo makes Transition return failTransitionErr for that
+	// target status, standing in for a real database failure (pool exhausted,
+	// statement timeout, connectivity blip) rather than a state-machine
+	// rejection. Without it no test could reach the branches that only a
+	// non-ErrTerminalState error takes.
+	failTransitionTo  agenttask.Status
+	failTransitionErr error
 }
 
 func newFakeRepository() *fakeRepository {
@@ -65,6 +73,9 @@ func (f *fakeRepository) List(_ context.Context, tenantID, userID uuid.UUID) ([]
 func (f *fakeRepository) Transition(_ context.Context, tenantID, userID, id uuid.UUID, status agenttask.Status, sessionRef, resultSummaryRef, errMsg string) (agenttask.Task, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	if f.failTransitionErr != nil && status == f.failTransitionTo {
+		return agenttask.Task{}, f.failTransitionErr
+	}
 	t, ok := f.tasks[id]
 	if !ok || t.TenantID != tenantID || t.UserID != userID {
 		return agenttask.Task{}, agenttask.ErrNotFound
@@ -210,7 +221,7 @@ func createSettled(t *testing.T, svc *agenttask.Service, tenantID, userID uuid.U
 	if err != nil {
 		t.Fatalf("CreateTask: %v", err)
 	}
-	svc.WaitForLaunches()
+	svc.WaitIdle()
 	settled, err := svc.Get(context.Background(), tenantID, userID, created.ID)
 	if err != nil {
 		t.Fatalf("Get after launch: %v", err)
@@ -378,6 +389,7 @@ func TestService_Cancel_FromRunning(t *testing.T) {
 	if cancelled.Status != agenttask.StatusCancelled {
 		t.Errorf("expected StatusCancelled, got %v", cancelled.Status)
 	}
+	svc.WaitIdle() // the engine stop runs in the background, same as the launch
 	if got := eng.cancelCount(); got != 1 {
 		t.Errorf("expected the engine session to be cancelled exactly once, got %d calls", got)
 	}
@@ -399,6 +411,7 @@ func TestService_Cancel_TerminalStateRejected(t *testing.T) {
 	if _, err := svc.Cancel(context.Background(), tenantID, userID, created.ID); !errors.Is(err, agenttask.ErrTerminalState) {
 		t.Fatalf("expected ErrTerminalState on a second cancel, got %v", err)
 	}
+	svc.WaitIdle()
 	if got := eng.cancelCount(); got != 1 {
 		t.Errorf("expected exactly one engine cancel across a double cancel, got %d", got)
 	}
@@ -437,6 +450,7 @@ func TestService_Cancel_ReleasesEngineConcurrencySlot(t *testing.T) {
 	if _, err := svc.Cancel(context.Background(), tenantID, userID, first.ID); err != nil {
 		t.Fatalf("Cancel: %v", err)
 	}
+	svc.WaitIdle()
 	if got := eng.slotsInUse(); got != 0 {
 		t.Fatalf("cancel did not release the launcher slot: %d still in use (issue #886)", got)
 	}
@@ -473,7 +487,7 @@ func TestService_CancelDuringLaunch_ReleasesTheSlotThatLaunchTook(t *testing.T) 
 	}
 
 	close(eng.launchGate) // the launch now finishes into a cancelled task
-	svc.WaitForLaunches()
+	svc.WaitIdle()
 
 	if got := eng.slotsInUse(); got != 0 {
 		t.Fatalf("a launch that finished into a cancelled task kept its slot: %d in use", got)
@@ -501,8 +515,82 @@ func TestService_Cancel_LosesRaceWithCompletion_LeavesEngineAlone(t *testing.T) 
 	if _, err := svc.Cancel(context.Background(), tenantID, userID, created.ID); !errors.Is(err, agenttask.ErrTerminalState) {
 		t.Fatalf("expected ErrTerminalState, got %v", err)
 	}
+	svc.WaitIdle()
 	if got := eng.cancelCount(); got != 0 {
 		t.Errorf("expected no engine cancel for an already-terminal task, got %d", got)
+	}
+}
+
+// A launch that succeeds and then cannot record itself is the nastiest
+// failure in this file, and review found it uncovered: the session is stopped,
+// but if the task is left in queued with an empty engine_session_ref then
+// Repository.ListActive excludes it, the poller never touches it, and the
+// customer watches a task that will never move and carries no error. That is
+// the silent-stuck-queue shape this package already closed once, and it is
+// worse than the 500 the create path used to return.
+func TestService_LaunchSucceedsButTransitionFails_TaskFailsVisibly(t *testing.T) {
+	repo := newFakeRepository()
+	repo.failTransitionTo = agenttask.StatusRunning
+	repo.failTransitionErr = errors.New("pgx: connection pool exhausted")
+	eng := newSlotEngine(1)
+	svc := agenttask.NewService(repo, eng)
+	tenantID, userID := uuid.New(), uuid.New()
+
+	created, err := svc.CreateTask(context.Background(), tenantID, userID, agenttask.PackCoding, "")
+	if err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	svc.WaitIdle()
+
+	settled, err := svc.Get(context.Background(), tenantID, userID, created.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if settled.Status != agenttask.StatusFailed {
+		t.Fatalf("expected StatusFailed so the task is not stranded in queued forever, got %v", settled.Status)
+	}
+	if settled.ErrorMessage == "" {
+		t.Error("expected a customer-visible error_message rather than a silent stuck task")
+	}
+	if strings.Contains(settled.ErrorMessage, "pgx") || strings.Contains(settled.ErrorMessage, "pool") {
+		t.Errorf("error_message must not carry the raw database failure: %q", settled.ErrorMessage)
+	}
+	if got := eng.slotsInUse(); got != 0 {
+		t.Errorf("expected the unrecorded session to be stopped and its slot freed, %d still in use", got)
+	}
+}
+
+// panickingEngine models a bug in an Engine implementation. Before the launch
+// moved to its own goroutine this ran inside the HTTP handler, where
+// net/http's per-connection recover contained it; a goroutine without its own
+// recover turns the same bug into a process-wide crash.
+type panickingEngine struct{}
+
+func (panickingEngine) Launch(context.Context, agenttask.Task) (string, error) {
+	panic("engine implementation bug")
+}
+
+func (panickingEngine) Cancel(context.Context, string) error { return nil }
+
+func TestService_LaunchPanic_DoesNotCrashTheProcess(t *testing.T) {
+	svc := agenttask.NewService(newFakeRepository(), panickingEngine{})
+	tenantID, userID := uuid.New(), uuid.New()
+
+	created, err := svc.CreateTask(context.Background(), tenantID, userID, agenttask.PackCoding, "")
+	if err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	svc.WaitIdle() // an unrecovered panic here takes the whole test binary down
+
+	settled, err := svc.Get(context.Background(), tenantID, userID, created.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if settled.Status != agenttask.StatusFailed {
+		t.Fatalf("expected a panicking launch to leave the task failed, got %v", settled.Status)
+	}
+	if settled.ErrorMessage == "" {
+		t.Error("expected a customer-visible error_message after a panicking launch")
 	}
 }
 
@@ -530,7 +618,7 @@ func TestService_CreateTask_DoesNotBlockOnLaunch(t *testing.T) {
 	}
 
 	close(eng.launchGate)
-	svc.WaitForLaunches()
+	svc.WaitIdle()
 
 	settled, err := svc.Get(context.Background(), tenantID, userID, created.ID)
 	if err != nil {

--- a/apps/control-plane/internal/agenttask/service_test.go
+++ b/apps/control-plane/internal/agenttask/service_test.go
@@ -572,6 +572,73 @@ func (panickingEngine) Launch(context.Context, agenttask.Task) (string, error) {
 
 func (panickingEngine) Cancel(context.Context, string) error { return nil }
 
+// panickingRepository panics on a Transition to panicOn (or on every
+// Transition when panicOn is empty), standing in for the realistic shape of a
+// repository-layer fault: a nil pool after a reconnect, a nil dereference
+// inside a driver call. Everything else delegates, so a task can still be
+// created and read back.
+type panickingRepository struct {
+	*fakeRepository
+	panicOn agenttask.Status
+}
+
+func (p *panickingRepository) Transition(ctx context.Context, tenantID, userID, id uuid.UUID, status agenttask.Status, sessionRef, resultSummaryRef, errMsg string) (agenttask.Task, error) {
+	if p.panicOn == "" || status == p.panicOn {
+		panic("repository layer fault")
+	}
+	return p.fakeRepository.Transition(ctx, tenantID, userID, id, status, sessionRef, resultSummaryRef, errMsg)
+}
+
+// A panic between a successful launch and its running transition leaves a live
+// sandbox whose reference only the panicking frame ever held. Recovering
+// without stopping it strands the slot permanently, since nothing else knows
+// the session exists.
+func TestService_PanicAfterLaunch_StopsTheSessionAndFailsTheTask(t *testing.T) {
+	repo := &panickingRepository{fakeRepository: newFakeRepository(), panicOn: agenttask.StatusRunning}
+	eng := newSlotEngine(1)
+	svc := agenttask.NewService(repo, eng)
+	tenantID, userID := uuid.New(), uuid.New()
+
+	created, err := svc.CreateTask(context.Background(), tenantID, userID, agenttask.PackCoding, "")
+	if err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	svc.WaitIdle()
+
+	if got := eng.slotsInUse(); got != 0 {
+		t.Errorf("expected the launched session to be stopped after the panic, %d slot(s) still in use", got)
+	}
+	settled, err := svc.Get(context.Background(), tenantID, userID, created.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if settled.Status != agenttask.StatusFailed {
+		t.Errorf("expected the task to end failed after a panic, got %v", settled.Status)
+	}
+}
+
+// The panic handler itself runs code that can panic for the same reason the
+// launch did, and a panic raised inside a recover that is already unwinding
+// escapes it. That would turn "one task dies" into "the process dies" exactly
+// when the fault is deterministic rather than a one-off.
+func TestService_PanicInsidePanicHandler_DoesNotCrashTheProcess(t *testing.T) {
+	repo := &panickingRepository{fakeRepository: newFakeRepository()} // every Transition panics
+	eng := newSlotEngine(1)
+	svc := agenttask.NewService(repo, eng)
+	tenantID, userID := uuid.New(), uuid.New()
+
+	if _, err := svc.CreateTask(context.Background(), tenantID, userID, agenttask.PackCoding, ""); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	svc.WaitIdle() // a panic escaping the recover takes the whole test binary down
+
+	// The task cannot be recorded failed, because recording is what panics.
+	// Freeing the slot does not touch the database, so it must still happen.
+	if got := eng.slotsInUse(); got != 0 {
+		t.Errorf("expected the session to be stopped even when the failure cannot be recorded, %d in use", got)
+	}
+}
+
 func TestService_LaunchPanic_DoesNotCrashTheProcess(t *testing.T) {
 	svc := agenttask.NewService(newFakeRepository(), panickingEngine{})
 	tenantID, userID := uuid.New(), uuid.New()

--- a/apps/edge-api/internal/agenttask/client.go
+++ b/apps/edge-api/internal/agenttask/client.go
@@ -24,6 +24,17 @@ type Client struct {
 }
 
 // NewClient creates a Client pointing at the control-plane base URL.
+//
+// The 15 second timeout is deliberate and is not the bound on a sandbox
+// launch. Create used to block control-plane side on the launch itself (up to
+// five minutes), so a cold sandbox routinely outlived this timeout and the
+// browser was told 500 for a task that then ran to completion (issue #881).
+// Control-plane now answers create with the persisted queued task and
+// launches in the background, so every call this client makes is a short
+// database operation plus, for cancel, a bounded stop call to the launcher
+// (agenttask.engineCancelTimeout, 10 seconds, deliberately under this
+// budget). Raising this to match a blocking server call would only have made
+// an interactive request able to hang for five minutes.
 func NewClient(controlPlaneURL string) *Client {
 	return &Client{
 		baseURL:    strings.TrimRight(controlPlaneURL, "/"),


### PR DESCRIPTION
Fixes #886. Fixes #881.

Two Cowork defects found by the live coverage suite and reproduced directly against the API on the demo box on 2026-08-11. Both are demo blockers, and PR #799 (a post-deploy job that launches and cancels a real sandbox on every push) cannot merge until this does.

## Issue #886, cancel never reached the engine

Root cause: the `Engine` interface in `apps/control-plane/internal/agenttask/engine.go` had exactly one method, `Launch`, so `Service.Cancel` could only ever be a bare `repo.Transition(..., StatusCancelled, ...)`. The row went cancelled while the sandbox behind it kept running, and the launcher releases a concurrency slot when its session ends (`apps/agent-engine/internal/quota` hands `Acquire` a release func called on session end). The slot therefore stayed held until the sandbox finished on its own, roughly sixteen minutes on the demo box. Two cancels exhausted `HIVE_QUOTA_USER_CONCURRENCY` and every later create was refused with "agent engine could not start the task", which the console renders as `Blocked` for a user whose task list shows nothing running.

Fix: `Engine` now carries `Cancel(ctx, sessionRef) error`, and `Service.Cancel` calls it. Both real implementations already had the method (`agentengine.Remote` for the socket arm the demo box runs, `agentengine.Engine` for the in-process arm), so the change is the interface plus the call, not new launcher logic. `NotConfiguredEngine` gets a trivially successful `Cancel`, since it never launched anything.

Why on the interface rather than an optional runtime type assertion: the defect is precisely that the seam could not express "stop". A compile-time method makes it impossible to wire an engine with no cancel path, and there is no implementation that legitimately lacks one.

## Issue #881, create reported failure for work that succeeded

Root cause: `CreateTask` called `engine.Launch` inline with `launchTimeout = 5 * time.Minute` while `apps/edge-api/internal/agenttask.NewClient` builds its HTTP client with `Timeout: 15 * time.Second`. A cold sandbox mount is routinely slower than 15 seconds, so edge-api gave up first and answered the browser `500`, while control-plane carried on (it deliberately detaches the launch from the caller's context) and the task reached `succeeded`. Measured live: `CREATE status=500 elapsed=18.0s` for a task that finished 78 seconds later.

Fix: create returns the persisted `queued` task as soon as the row exists and the launch runs on a background goroutine, which transitions the task to `running` or to `failed` on its own. The console already polls queued to running to done, and `CreateTask` already ran the launch on a detached context, so this is the shape the code was built for.

Why not simply align the timeouts: raising edge-api's client to five minutes makes an interactive create legitimately able to hang for five minutes, and every intermediate proxy is free to cut it anyway, which reproduces the same wrong answer with a longer fuse. edge-api's 15 seconds now bounds only short database work plus, for cancel, a stop call bounded at 10 seconds inside control-plane (`engineCancelTimeout`), deliberately under the client budget so a slow launcher can never reproduce the same "failure reported for work that happened" shape.

A launch failure still reaches the caller, just on the next poll rather than in the create response, so no task sits queued forever with no signal.

## Concurrency decisions

The row transition is the atomic gate throughout. `Repository.Transition`'s UPDATE carries the "not already terminal" precondition, so exactly one caller can win it, and only the winner touches the engine.

- **Double cancel.** The second cancel loses that guard, returns `ErrTerminalState` (HTTP 409) and never reaches the engine. Asked for exactly once, asserted in `TestService_Cancel_TerminalStateRejected`.
- **Cancel racing a completion.** Whichever transition commits first wins. If the poller already recorded a terminal status the cancel is rejected and the engine is left alone, which is correct: a terminal status is what makes the launcher reap that session itself (`SandboxEngine.Status` reaps on terminal). Asserted in `TestService_Cancel_LosesRaceWithCompletion_LeavesEngineAlone`.
- **Cancel arriving before the launch finishes.** The row has no `engine_session_ref` yet, so `Service.Cancel` has nothing to stop. The in-flight launch goroutine then finds the task already terminal when it tries to record `running`, and stops the session it just started. The same path covers a `running` transition that fails for any other reason: a session whose reference was never persisted can never be polled or cancelled by anything else, so it is torn down rather than left holding a slot for its full natural life. Asserted in `TestService_CancelDuringLaunch_ReleasesTheSlotThatLaunchTook`.

Cancel order is transition first, engine second, deliberately. Stopping the engine first would risk killing a sandbox for a task the database then reports as succeeded.

An engine stop failure is logged for the operator (with the engine detail, which never reaches a customer-visible field) and never returned to the caller. The cancellation itself is already recorded, and a stuck launcher is not something a customer can act on. Returning 500 for a task that really is cancelled would be issue #881's shape all over again.

## Tests, and how they were watched red

The cancel test asserts the concurrency slot, not the status code. A status-code assertion passes against the broken code, which is how this survived: `Service.Cancel` already returned a cancelled task.

`slotEngine` in `service_test.go` models the launcher's accounting (`Launch` takes a slot and refuses at the ceiling, `Cancel` gives one back), because `apps/agent-engine/internal/quota` is under another module's `internal` and control-plane cannot import it.

Red baseline, run before any production change, with only the interface method and a no-op `WaitForLaunches` stub added so the package compiled:

```
=== RUN   TestService_Cancel_FromRunning
    service_test.go:382: expected the engine session to be cancelled exactly once, got 0 calls
--- FAIL: TestService_Cancel_FromRunning (0.00s)
=== RUN   TestService_Cancel_TerminalStateRejected
    service_test.go:403: expected exactly one engine cancel across a double cancel, got 0
--- FAIL: TestService_Cancel_TerminalStateRejected (0.00s)
=== RUN   TestService_Cancel_ReleasesEngineConcurrencySlot
    service_test.go:441: cancel did not release the launcher slot: 1 still in use (issue #886)
--- FAIL: TestService_Cancel_ReleasesEngineConcurrencySlot (0.00s)
=== RUN   TestService_CancelDuringLaunch_ReleasesTheSlotThatLaunchTook
    service_test.go:462: CreateTask blocked on the engine launch (issue #881): edge-api gives up at 15s and reports a failure for a task that is in fact starting
--- FAIL: TestService_CancelDuringLaunch_ReleasesTheSlotThatLaunchTook (2.01s)
=== RUN   TestService_Cancel_LosesRaceWithCompletion_LeavesEngineAlone
--- PASS: TestService_Cancel_LosesRaceWithCompletion_LeavesEngineAlone (0.00s)
=== RUN   TestService_CreateTask_DoesNotBlockOnLaunch
    service_test.go:527: CreateTask blocked on the engine launch (issue #881): edge-api gives up at 15s and reports a failure for a task that is in fact starting
--- FAIL: TestService_CreateTask_DoesNotBlockOnLaunch (2.00s)
FAIL
```

An earlier run of the same tests hung the whole package for 600 seconds, because against the broken code `CreateTask` blocks on the gated launch forever. The create call now runs on its own goroutine inside the test helper, so the defect fails one test in two seconds with a legible message instead of timing out the suite.

Green after the fix, both packages, plus the full short suite for control-plane, agent-engine and edge-api:

```
ok  github.com/sakibsadmanshajib/hive/apps/control-plane/internal/agenttask  0.115s
ok  github.com/sakibsadmanshajib/hive/apps/agent-engine/internal/engine      0.128s
```

`TestSandboxEngine_Cancel_FreesQuotaSlot` is added on the launcher side as a characterisation test, not as coverage for this change: nothing in `apps/agent-engine/internal/engine` changed here, so every assertion in it survives a full revert of the fix. It pins the invariant control-plane now depends on (ending a session frees its slot immediately) and is labelled that way in the code. The regression coverage for issue #886 is `TestService_Cancel_ReleasesEngineConcurrencySlot`, `TestService_CancelDuringLaunch_ReleasesTheSlotThatLaunchTook` and `TestService_Cancel_LosesRaceWithCompletion_LeavesEngineAlone`, which drive `Service.Cancel` and fail on revert.

Review round two added two more, both watched red first: `TestService_LaunchSucceedsButTransitionFails_TaskFailsVisibly` (a launch that succeeds and then cannot record itself must end failed, not stranded in queued) and `TestService_LaunchPanic_DoesNotCrashTheProcess` (a panicking engine must cost one task, not the process).

`-race` could not run locally (the toolchain image has no gcc, so cgo is unavailable). CI runs `-race` on the module legs.

## These tests actually run in CI

`.github/workflows/ci.yml`'s explicit Go package list is on the `-tags integration` step only. The plain unit-test step is `go test -count=1 -short -race -timeout 5m ./...` run per module against a matrix that includes both `./apps/control-plane` and `./apps/agent-engine`, so both touched packages are in scope. Neither new test carries a build tag, an environment gate, or a `testing.Short()` skip. The only skip in either package is the pre-existing `HIVE_TEST_DB_URL` gate in `repository_test.go`, and `./internal/agenttask/...` is in the control-plane integration list too.

## Known gaps this does not close, and the condition attached to one of them

Both were found by the security review stream, both were confirmed by tracing them myself, and neither blocks this merge.

- **Issue #899**: a sandbox the launcher registered whose reference never reaches control-plane (a lost response, `launchTimeout` firing, or this process dying mid-deploy) holds its slots until the launcher restarts, because `reap` only runs from `Status` or `Cancel` and the poller cannot see a row with no `engine_session_ref`. This change closes the database-failure half of that shape; the transport half needs the launcher to offer a way to re-derive a lost reference, so it cannot be closed from this service. Mitigant: every deploy restarts the launcher and clears the leak.
- **Issue #900**: `POST /v1/agent/tasks` has no rate limit, verified through the edge middleware chain, so rows, goroutines and pool checkouts are per-tenant unbounded. The launcher's quota gates the sandbox launch, which happens after the row insert.

**Condition on #900, recorded here because it is a merge condition rather than a nice-to-know:** it is tolerable only while Cowork stays feature-gated. `featuregate.Require(FeatureCowork)` is doing the containment a limiter would otherwise do. Opening `FeatureCowork` broadly makes it intolerable, so whoever widens that gate owns closing #900 first. Written into the issue as well.

## Not touched

The demo box, `role_pgx.go`, the accounts package, container capabilities. No new dependency. No behaviour change to the launcher itself.

## Buglog entry

To be appended to `.wolf/buglog.jsonl` on `main` in a separate buglog-only pull request after this merges, per `.claude/rules/openwolf.md`.

```json
{"id":"bug-2026-08-12-cowork-cancel-slot-and-blocking-create","date":"2026-08-12","title":"Cancelling a Cowork task leaked its concurrency slot, and create reported failure for a task that succeeded","error_message":"agent engine could not start the task (console: Blocked) after two cancels; CREATE status=500 elapsed=18.0s for a task that reached succeeded","root_cause":"The agenttask.Engine interface carried only Launch, so Service.Cancel was a bare database transition and never stopped the sandbox; the launcher only releases a concurrency slot when the session ends, so a cancelled task held its slot for the sandbox's full life. Separately, CreateTask blocked inline on a launch bounded at five minutes while edge-api's control-plane client times out at fifteen seconds, so the browser was told 500 for work that kept running.","fix":"Added Cancel to the Engine interface and called it from Service.Cancel after the row's atomic terminal guard, so the slot is released at cancel time. Made CreateTask return the persisted queued task and run the launch on a background goroutine, with the in-flight launch stopping its own session if it finds the task already terminal.","tags":["cowork","agent-engine","quota","concurrency","timeout","control-plane","issue-886","issue-881"]}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Task creation now returns immediately with a queued status while launch proceeds in the background.
  * Task status updates to running or failed after launch completes.
  * Cancellation stops active sessions and promptly frees available concurrency capacity.
* **Bug Fixes**
  * Improved handling of cancellation during task launch, including race conditions and cancellations before launch begins.
  * Failed launches now report safe, provider-neutral error messages.
* **Documentation**
  * Updated task lifecycle and cancellation behavior documentation, including asynchronous launch and bounded cancellation timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

