### PR TITLE
fix: pin openai sdk-tests-python dep below the httpx2 rename in 3.0.0

### DIFF
--- a/packages/sdk-tests/python/pyproject.toml
+++ b/packages/sdk-tests/python/pyproject.toml
@@ -9,7 +9,11 @@ dependencies = [
     # collection). httpx is pinned as its own direct dependency below so this
     # suite never again depends on openai's internal HTTP client naming.
     "openai>=2.30.0,<3.0.0",
-    "httpx>=0.28.0,<1.0.0",
+    # httpx is pre-1.0; bounded to the next minor (not major) since httpx has
+    # shipped breaking changes across 0.x minor releases before. Matches how
+    # npm caret (used for sibling package sdk-tests-js's "openai": "^6.33.0")
+    # treats a 0.x version: bounds at the next minor, not the next major.
+    "httpx>=0.28.0,<0.29.0",
 ]
 
 [project.optional-dependencies]

--- a/packages/sdk-tests/python/pyproject.toml
+++ b/packages/sdk-tests/python/pyproject.toml
@@ -3,7 +3,13 @@ name = "hive-sdk-tests-python"
 version = "0.0.1"
 requires-python = ">=3.11"
 dependencies = [
-    "openai>=2.30.0",
+    # Bounded below the openai 3.0.0 major bump: 3.x renamed its transitive
+    # HTTP client dependency from `httpx` to `httpx2`, which silently dropped
+    # the `httpx` module our tests import directly (ModuleNotFoundError on
+    # collection). httpx is pinned as its own direct dependency below so this
+    # suite never again depends on openai's internal HTTP client naming.
+    "openai>=2.30.0,<3.0.0",
+    "httpx>=0.28.0,<1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/packages/sdk-tests/python/pyproject.toml
+++ b/packages/sdk-tests/python/pyproject.toml
@@ -10,9 +10,7 @@ dependencies = [
     # suite never again depends on openai's internal HTTP client naming.
     "openai>=2.30.0,<3.0.0",
     # httpx is pre-1.0; bounded to the next minor (not major) since httpx has
-    # shipped breaking changes across 0.x minor releases before. Matches how
-    # npm caret (used for sibling package sdk-tests-js's "openai": "^6.33.0")
-    # treats a 0.x version: bounds at the next minor, not the next major.
+    # shipped breaking changes across 0.x minor releases before.
     "httpx>=0.28.0,<0.29.0",
 ]
 


### PR DESCRIPTION
## Summary

- `main` is red on both `deploy-demo-box` and `CI` (Live integration) at the same Python step: pytest collection fails with `ModuleNotFoundError: No module named 'httpx'`. Predates the latest merge (also failing at `c3f72c07` and `85475af9`).
- Root cause: `packages/sdk-tests/python/pyproject.toml` declared `openai>=2.30.0` unbounded, so pip resolves the latest release, `openai==3.0.0`. That 3.x line renamed its transitive HTTP client dependency from `httpx` to `httpx2`. Our test modules (`test_health.py`, `test_headers.py`, `test_error_shape.py`) `import httpx` directly, independent of what openai bundles internally, so collection aborts as soon as pip resolves 3.0.0.
- Both failing workflows install from this same `pyproject.toml` (`deploy-demo-box.yml`'s SDK replay step and `ci.yml`'s Docker-built `sdk-tests-py` image via `Dockerfile.sdk-tests-py`), so one fix in this file covers both callers. No install-gap found in the JS or Java suites in the same CI step; both already pin bounded versions (`sdk-tests-js`'s `package.json` uses `"openai": "^6.33.0"`).
- Why this matters beyond a red check: `deploy-demo-box`'s SDK replay runs *after* deploy, as the only automated verification that the live demo box actually works. A collection error asserts nothing, so a genuinely broken deploy and this dependency gap were indistinguishable from the outside.

## Fix

- Bound `openai` to `<3.0.0` (matches the existing convention in `sdk-tests-js/package.json`, which pins `^6.33.0`, i.e. allow-minor/patch, block-major).
- Added `httpx` as its own direct, version-bounded dependency (`>=0.28.0,<0.29.0`, bounded to the next minor rather than the next major since httpx is pre-1.0 and has shipped breaking changes across 0.x minor releases before), so this suite no longer depends on whatever HTTP client name openai's SDK happens to use internally.

## Zero-collected-tests failure mode (explicitly checked, not assumed)

Verified locally rather than adding defensive flags: pytest already fails loudly on both relevant conditions.
- A collection error (this bug) already exits 2 (`Interrupted: 1 error during collection`), confirmed in the original job log.
- A hypothetical run that collects zero tests with no error already exits 5 (pytest's default "no tests ran" behavior), verified locally against the same pinned `pytest>=8.0.0` constraint (resolved to 9.1.1).

No `pytest.ini` / `addopts` change made; the existing config already fails the step correctly in both cases.

## Verification (local, Python 3.12, the version `deploy-demo-box.yml`'s `actions/setup-python` installs)

```
$ pip install -e '.[dev]'
Successfully installed ... httpx-0.28.1 openai-2.54.0 ...

$ pytest tests/test_health.py tests/test_models.py tests/test_embeddings.py --collect-only -q
tests/test_health.py::test_health_returns_200_with_status_ok
tests/test_models.py::test_list_models_returns_valid_list
tests/test_embeddings.py::test_embeddings_basic
tests/test_embeddings.py::test_embeddings_batch
4 tests collected in 0.05s

$ pytest --collect-only -q   # full suite, matches ci.yml's docker CMD
14 tests collected in 0.10s
```

Before the fix, on unpatched `main`, the same install resolves `openai==3.0.0` + `httpx2==2.10.0` and `import httpx` fails at collection, reproducing the CI error exactly.

## Buglog entry

Per `.claude/rules/openwolf.md`, this does not land on this branch. JSON line for the follow-up buglog-only PR after merge:

```json
{"error_message": "ModuleNotFoundError: No module named 'httpx' during pytest collection in packages/sdk-tests/python", "root_cause": "pyproject.toml pinned openai>=2.30.0 unbounded; pip resolved openai 3.0.0, whose 3.x line renamed its transitive HTTP client dependency from httpx to httpx2, silently dropping the httpx module that sdk-tests-python's test files import directly", "fix": "bounded openai to <3.0.0 and added httpx as its own direct, version-bounded dependency in packages/sdk-tests/python/pyproject.toml, matching sdk-tests-js's existing caret-pin convention", "tags": ["ci", "python", "sdk-tests", "dependency", "deploy-demo-box", "post-deploy-verification"]}
```

## Test plan

- [x] Reproduced the failure locally on Python 3.12 against unpatched `pyproject.toml` (openai resolves to 3.0.0, `import httpx` fails)
- [x] Confirmed the fix locally on Python 3.12 (openai resolves to 2.54.0, httpx 0.28.1 present, both the replay's 3-file selection and the full 14-test suite collect cleanly)
- [x] Confirmed pytest's existing exit-code behavior already fails loudly on both a collection error (exit 2) and a hypothetical zero-collected-tests run (exit 5); no config change needed
- [ ] CI (`ci.yml`) green on this PR
- [ ] `deploy-demo-box.yml`'s SDK replay green after merge to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Python SDK test dependencies for improved compatibility.
  * Added a supported `httpx` version range and constrained the OpenAI dependency to versions below 3.0.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
