### PR TITLE
ci: capture Cowork visual proof on the pull request, before merge

### DIFF
--- a/.github/workflows/agent-visual-proof.yml
+++ b/.github/workflows/agent-visual-proof.yml
@@ -152,6 +152,9 @@ jobs:
       # image is built with; Caddyfile.agent-proof is the same-origin front.
       NEXT_PUBLIC_EDGE_API_BASE_URL: ''
       E2E_RUN_KEY: ${{ github.run_id }}-${{ github.run_attempt }}
+      # Off the root filesystem, which Docker also lives on. See the reclaim
+      # step below.
+      PLAYWRIGHT_BROWSERS_PATH: /mnt/ms-playwright
     steps:
       - name: Resolve the pull request under proof
         id: target
@@ -178,6 +181,26 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ steps.target.outputs.ref }}
+
+      - name: Reclaim disk space
+        # This job holds a one gigabyte SIF, five container images including
+        # a Next.js production build, node_modules and a Chromium. Run
+        # 31730077938 filled the root filesystem and failed inside `npx
+        # playwright install` with ENOSPC, which reads as a browser problem
+        # rather than a disk one. The SIF and the browser live on /mnt, which
+        # is the runner's large volume; these preinstalled toolchains, which
+        # nothing here uses, are what frees room for Docker on the root disk.
+        run: |
+          set -euo pipefail
+          # The hosted tool cache is deliberately left alone: setup-node and
+          # the actions runtime live there, and reclaiming it to save a few
+          # more gigabytes breaks the steps below in a way that is much
+          # harder to read than ENOSPC.
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /usr/local/share/boost || true
+          sudo mkdir -p /mnt/ms-playwright
+          sudo chown "$(id -un):$(id -gn)" /mnt/ms-playwright
+          df -h / /mnt
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/agent-visual-proof.yml
+++ b/.github/workflows/agent-visual-proof.yml
@@ -452,7 +452,28 @@ jobs:
               );
             if (error) throw new Error(`ENABLE_COWORK upsert failed: ${error.message}`);
             console.log("ENABLE_COWORK enabled for this run tenant");
-          '
+            console.log(`PROOF_TENANT_ID=${ids.verifiedTenantId}`);
+          ' | tee /tmp/seed.log
+          grep -E '^PROOF_TENANT_ID=' /tmp/seed.log >> "$GITHUB_ENV"
+
+      - name: Assert the Cowork gate reads as on
+        # Run 31816249902 reached the console signed in and rendered "The
+        # agent workspace is turned off for your organization", which is a
+        # capture of a real page and no proof of anything. Asserting the gate
+        # here separates the three places it can be off (the row, the
+        # registry join, the token's tenant claim) from a browser that simply
+        # shows the disabled panel, and it fails on the step that owns the
+        # cause rather than on the one that noticed.
+        run: |
+          set -euo pipefail
+          gates=$(curl -sS --fail-with-body \
+            -H "Authorization: Bearer $CONTROL_PLANE_INTERNAL_TOKEN" \
+            "http://localhost:8081/internal/featuregate/$PROOF_TENANT_ID")
+          # One line: a `python3 -c` program written across several lines
+          # inside a YAML block has to be indented, and Python rejects a
+          # uniformly indented program.
+          python3 -c 'import json,sys; g=json.loads(sys.argv[1]).get("gates",{}); print("gates:", json.dumps(g,sort_keys=True)); sys.exit(0 if g.get("ENABLE_COWORK") else 1)' "$gates" \
+            || { echo "::error::ENABLE_COWORK is off for the run tenant, so the console renders no Cowork surface"; exit 1; }
 
       - name: Make the launch impossible (deliberate sabotage run)
         # The negative control for the whole job: with the launcher stopped

--- a/.github/workflows/agent-visual-proof.yml
+++ b/.github/workflows/agent-visual-proof.yml
@@ -170,7 +170,9 @@ jobs:
           # refs/pull/N/merge is what would land, which is what rule 8 asks
           # to be proven, and it is also always current with main.
           echo "ref=refs/pull/$pr/merge" >> "$GITHUB_OUTPUT"
-          gh pr view "$pr" --json number,title,headRefOid \
+          # -R is load bearing: this step runs before the checkout, so there
+          # is no git repository for gh to infer the repository from.
+          gh pr view "$pr" -R "$GITHUB_REPOSITORY" --json number,title,headRefOid \
             --jq '"proving PR #\(.number): \(.title) at head \(.headRefOid)"'
 
       - uses: actions/checkout@v4
@@ -426,6 +428,7 @@ jobs:
           echo "::warning::launcher stopped on purpose; this run is expected to fail"
 
       - name: Capture the proof
+        id: capture
         env:
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           PROOF_BASE_URL: ${{ env.PROOF_ORIGIN }}
@@ -461,7 +464,10 @@ jobs:
         run: npm run lint:proof-tokens
 
       - name: Upload the captures
-        if: always()
+        # Whenever the capture ran at all, including when it failed partway:
+        # a failure shot is evidence too. Not when it never started, where an
+        # empty directory is the earlier step's failure, not this one's.
+        if: always() && steps.capture.conclusion != 'skipped'
         uses: actions/upload-artifact@v4
         with:
           name: agent-visual-proof-${{ github.run_id }}
@@ -494,21 +500,28 @@ jobs:
             echo "engine, in run [\`${GITHUB_RUN_ID}\`](https://github.com/$GITHUB_REPOSITORY/actions/runs/${GITHUB_RUN_ID})."
             echo
           } > "$body"
+          # The payload goes in on stdin, not on argv: a full page PNG is a
+          # few hundred kilobytes base64, and an argument list is not the
+          # place to discover the limit.
+          upload() {
+            python3 -c '
+import base64, json, sys
+print(json.dumps({
+    "message": sys.argv[2],
+    "branch": sys.argv[3],
+    "content": base64.b64encode(open(sys.argv[1], "rb").read()).decode(),
+}))' "$1" "ci: visual proof for PR #${PR} (run ${GITHUB_RUN_ID})" "$branch" \
+              | gh api -X PUT "repos/$GITHUB_REPOSITORY/contents/$dir/$(basename "$1")" --input - >/dev/null
+          }
           for file in "$CAPTURE_DIR"/*.png; do
             name=$(basename "$file")
-            gh api -X PUT "repos/$GITHUB_REPOSITORY/contents/$dir/$name" \
-              -f message="ci: visual proof for PR #${PR} (run ${GITHUB_RUN_ID})" \
-              -f branch="$branch" \
-              -f content="$(base64 -w0 "$file")" >/dev/null
+            upload "$file"
             echo "### ${name%.png}" >> "$body"
             echo >> "$body"
             echo "![${name%.png}](https://raw.githubusercontent.com/$GITHUB_REPOSITORY/$branch/$dir/$name)" >> "$body"
             echo >> "$body"
           done
-          gh api -X PUT "repos/$GITHUB_REPOSITORY/contents/$dir/proof-log.txt" \
-            -f message="ci: visual proof log for PR #${PR} (run ${GITHUB_RUN_ID})" \
-            -f branch="$branch" \
-            -f content="$(base64 -w0 "$CAPTURE_DIR/proof-log.txt")" >/dev/null
+          upload "$CAPTURE_DIR/proof-log.txt"
           {
             echo "<details><summary>Run log (screenshot stamps carry no URL, and the log is"
             echo "redacted and linted by \`lint:proof-tokens\`)</summary>"
@@ -523,13 +536,16 @@ jobs:
 
       - name: Dump the launcher and stack logs on failure
         if: failure()
-        working-directory: deploy/docker
+        # No working-directory: a run that failed before the checkout has no
+        # deploy/docker, and a step that cannot even start its shell reports
+        # a directory error instead of the failure that actually happened.
         run: |
-          set -euo pipefail
           journalctl --user -u hive-agent-engine --no-pager -n 200 2>&1 \
-            | python3 ../../scripts/redact-log-credentials.py > /tmp/launcher.log || true
-          docker compose logs --no-color --timestamps --tail=500 2>&1 \
-            | python3 ../../scripts/redact-log-credentials.py > /tmp/compose.log || true
+            | python3 scripts/redact-log-credentials.py > /tmp/launcher.log || true
+          if [ -d deploy/docker ]; then
+            (cd deploy/docker && docker compose logs --no-color --timestamps --tail=500 2>&1) \
+              | python3 scripts/redact-log-credentials.py > /tmp/compose.log || true
+          fi
 
       - name: Upload the failure logs
         if: failure()
@@ -544,8 +560,9 @@ jobs:
 
       - name: Tear down
         if: always()
-        working-directory: deploy/docker
         run: |
           docker rm -f agent-proof-proxy || true
-          docker compose down -v --remove-orphans || true
+          if [ -d deploy/docker ]; then
+            (cd deploy/docker && docker compose down -v --remove-orphans) || true
+          fi
           systemctl --user stop hive-agent-engine.service || true

--- a/.github/workflows/agent-visual-proof.yml
+++ b/.github/workflows/agent-visual-proof.yml
@@ -561,7 +561,7 @@ jobs:
         # The negative control for the whole job: with the launcher stopped
         # nothing can launch, and this run must go red rather than pass with
         # an empty capture directory.
-        if: github.event.inputs.sabotage == 'true' || true # TEMPORARY: re-demonstrating the empty-capture guard after the review fixes, reverted in the next commit
+        if: github.event.inputs.sabotage == 'true'
         run: |
           set -euo pipefail
           systemctl --user stop hive-agent-engine.service

--- a/.github/workflows/agent-visual-proof.yml
+++ b/.github/workflows/agent-visual-proof.yml
@@ -119,6 +119,15 @@ jobs:
       COMPOSE_PROFILES: local
       SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
       SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+      # Without both of these edge-api logs "phase-19 JWT auth wiring
+      # skipped" at boot and then answers 403 to every Supabase-JWT caller,
+      # which the console renders as "the agent workspace is turned off for
+      # your organization": a real page, and proof of nothing. Measured in
+      # run 31819555736, where the token carried the right tenant and
+      # control-plane reported the gate on. Derived from SUPABASE_URL rather
+      # than added as two more secrets, since both are public URLs.
+      SUPABASE_JWT_ISSUER: ${{ secrets.SUPABASE_URL }}/auth/v1
+      SUPABASE_JWKS_URL: ${{ secrets.SUPABASE_URL }}/auth/v1/.well-known/jwks.json
       REDIS_URL: redis://redis:6379/0
       CONTROL_PLANE_PORT: '8081'
       CONTROL_PLANE_BASE_URL: http://localhost:8081
@@ -390,6 +399,14 @@ jobs:
             exit 1
           fi
           echo "control-plane is on the socket arm and the daemon answered /health"
+          # Same class of silent misconfiguration, one service over: edge-api
+          # logs this and then denies every Supabase-JWT caller, which reads
+          # as a disabled feature rather than as a broken deployment.
+          if docker compose logs --no-color edge-api | grep -q "JWT auth wiring skipped"; then
+            echo "::error::edge-api skipped JWT auth wiring, so no browser session can authenticate"
+            exit 1
+          fi
+          echo "edge-api wired Supabase JWT auth"
 
       - name: Serve the console and edge-api from one origin
         working-directory: deploy/docker

--- a/.github/workflows/agent-visual-proof.yml
+++ b/.github/workflows/agent-visual-proof.yml
@@ -466,8 +466,11 @@ jobs:
         # cause rather than on the one that noticed.
         run: |
           set -euo pipefail
+          # X-Internal-Token, not a bearer: control-plane's /internal/* gate is
+          # RequireInternalToken (platform/http/internalauth.go), which fails
+          # closed on anything else and answered 401 to a bearer.
           gates=$(curl -sS --fail-with-body \
-            -H "Authorization: Bearer $CONTROL_PLANE_INTERNAL_TOKEN" \
+            -H "X-Internal-Token: $CONTROL_PLANE_INTERNAL_TOKEN" \
             "http://localhost:8081/internal/featuregate/$PROOF_TENANT_ID")
           # One line: a `python3 -c` program written across several lines
           # inside a YAML block has to be indented, and Python rejects a

--- a/.github/workflows/agent-visual-proof.yml
+++ b/.github/workflows/agent-visual-proof.yml
@@ -499,7 +499,7 @@ jobs:
         # The negative control for the whole job: with the launcher stopped
         # nothing can launch, and this run must go red rather than pass with
         # an empty capture directory.
-        if: github.event.inputs.sabotage == 'true'
+        if: github.event.inputs.sabotage == 'true' || true # TEMPORARY: demonstrating the empty-capture guard, reverted in the next commit
         run: |
           set -euo pipefail
           systemctl --user stop hive-agent-engine.service

--- a/.github/workflows/agent-visual-proof.yml
+++ b/.github/workflows/agent-visual-proof.yml
@@ -1,0 +1,551 @@
+name: agent visual proof
+
+# Visual proof of the Cowork agent-task surface, produced in CI on the pull
+# request, before it merges (orchestrator rule 8, owner ruling 2026-08-13).
+#
+# WHY IT CANNOT BE CAPTURED ANYWHERE ELSE
+#
+# A Cowork task only really launches through the socket arm of
+# buildAgentEngine (apps/control-plane/cmd/server/main.go): control-plane
+# hands the launch to an unprivileged host launcher over a Unix socket, and
+# the launcher execs Apptainer. The sandbox image is linux/amd64 and cannot
+# be built on the WSL2 dev box, so a local capture proves nothing: the engine
+# falls back to NotConfiguredEngine and every task fails immediately. Until
+# this workflow existed, the only stack that could launch a task was the demo
+# box, which only runs already-merged code, so proof-before-merge was
+# circular. This job breaks the circle by standing the real thing up per run.
+#
+# The control-plane container is NOT given CAP_SYS_ADMIN or /dev/fuse here,
+# and must never be: the socket arm exists precisely so the process holding
+# the payment and database secrets never needs sandbox-escape-class
+# privilege. The launcher runs as the ordinary runner user instead.
+#
+# WHICH RUNNER, AND WHY THIS ONE
+#
+# GitHub-hosted ubuntu-latest, not the self-hosted demo-box runner.
+#
+#   * Verified, not assumed: the "Prove Apptainer can run this image" step
+#     below execs the real SIF and fails the job when the runner will not
+#     allow it. The hosted image already runs an unprivileged bubblewrap
+#     sandbox in ci.yml's egress-firewall-e2e job with the same two AppArmor
+#     sysctls this job sets, so unprivileged user namespaces are known to
+#     work there; the exec step is what turns that from an inference into a
+#     per-run fact.
+#   * The self-hosted runner was rejected on two counts. It executes pull
+#     request code on the machine that serves the live demo, and
+#     scripts/install-agent-engine-host.sh restarts the hive-agent-engine
+#     systemd unit and rewrites /home/sakib/agent-runtime, so a proof run
+#     would reach straight into the live launcher's state. Running an
+#     untrusted branch on a persistent public-repo runner is also the exact
+#     configuration GitHub warns against. A hosted runner is disposable, so
+#     neither question arises.
+#
+# HOW TO AIM IT AT A PULL REQUEST
+#
+#   gh workflow run "agent visual proof" -f pr=891
+#
+# The checkout below takes refs/pull/<pr>/merge, so the proof is of what
+# would land, and the captures are pushed to a side branch and posted as a
+# comment on that pull request. A capture that lives only in a workflow
+# artifact does not satisfy rule 8.
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: Pull request number to prove and to post the captures on
+        required: true
+        type: string
+      scenarios:
+        description: Comma separated scenario names, or "all"
+        required: false
+        default: all
+        type: string
+      sabotage:
+        description: >-
+          Stop the launcher before capturing, to demonstrate that a run which
+          cannot launch anything fails instead of passing with no proof
+        required: false
+        default: false
+        type: boolean
+  pull_request:
+    branches: [main]
+    paths:
+      - 'apps/agent-console/**'
+      - 'apps/agent-engine/**'
+      - 'apps/control-plane/internal/agenttask/**'
+      - 'apps/control-plane/internal/agentengine/**'
+      - 'apps/edge-api/internal/agenttask/**'
+      - 'deploy/apptainer/**'
+      - 'deploy/docker/Caddyfile.agent-proof'
+      - 'scripts/install-agent-engine-host.sh'
+      - '.github/workflows/agent-visual-proof.yml'
+
+# No concurrency group on purpose. GitHub holds only one run per group as
+# pending, so a third run cancels the second outright, and a cancelled proof
+# run is a silent absence of proof rather than a loud failure (the lesson
+# ci.yml's web-e2e job records at length). This job is rare and expensive
+# enough that overlapping runs are not the problem worth that trade.
+
+env:
+  # Same pinned release the agent-engine SIF workflow builds with.
+  APPTAINER_VERSION: "1.5.2"
+  RUNTIME_DIR: /mnt/agent-runtime
+  # Inside docs/proof/ on purpose: that is the one directory
+  # tools/lint-no-token-in-proof-captures.mjs scans, and it is the only
+  # automated check that a captured credential never reaches a proof log.
+  CAPTURE_DIR: ${{ github.workspace }}/docs/proof/agent-visual-proof/run-${{ github.run_id }}
+  PROOF_ORIGIN: http://127.0.0.1:3030
+
+jobs:
+  capture:
+    name: Capture Cowork proof (real Apptainer launch)
+    runs-on: ubuntu-latest
+    # Measured: SIF fetch and launcher build ~8 min, stack build and boot
+    # ~12 min, three scenarios with real cold sandboxes ~15 min. 45 leaves
+    # headroom without letting a wedged sandbox burn an hour.
+    timeout-minutes: 45
+    # Every step needs repository secrets, which a fork pull request never
+    # gets, and a fork run would fail on a missing secret rather than on the
+    # change under test. Same gate ci.yml's web-e2e job uses.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: write
+      actions: read
+      pull-requests: write
+    env:
+      COMPOSE_PROFILES: local
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+      REDIS_URL: redis://redis:6379/0
+      CONTROL_PLANE_PORT: '8081'
+      CONTROL_PLANE_BASE_URL: http://localhost:8081
+      EDGE_CONTROL_PLANE_BASE_URL: http://control-plane:8081
+      LITELLM_MASTER_KEY: ${{ secrets.LITELLM_MASTER_KEY }}
+      # No live provider keys: nothing in this job asks a model for a
+      # completion, it only proves that a sandbox launches and that its slot
+      # is released. Stubs satisfy LiteLLM's startup validation.
+      OPENROUTER_API_KEY: 'ci-stub-not-used'
+      GROQ_API_KEY: 'ci-stub-not-used'
+      NVIDIA_NIM_API_KEY: 'ci-stub-not-used'
+      OPENROUTER_DEFAULT_MODEL: ${{ vars.OPENROUTER_DEFAULT_MODEL }}
+      OPENROUTER_AUTO_MODEL: ${{ vars.OPENROUTER_AUTO_MODEL }}
+      OPENROUTER_FAST_FALLBACK_MODEL: ${{ vars.OPENROUTER_FAST_FALLBACK_MODEL }}
+      OPENROUTER_EMBEDDING_MODEL: ${{ vars.OPENROUTER_EMBEDDING_MODEL }}
+      OPENROUTER_EMBEDDING_FALLBACK_MODEL: ${{ vars.OPENROUTER_EMBEDDING_FALLBACK_MODEL }}
+      GROQ_FAST_MODEL: ${{ vars.GROQ_FAST_MODEL }}
+      GROQ_REASONING_MODEL: ${{ vars.GROQ_REASONING_MODEL }}
+      NVIDIA_NIM_EMBEDDING_MODEL: ${{ vars.NVIDIA_NIM_EMBEDDING_MODEL }}
+      S3_ENDPOINT: ${{ secrets.S3_ENDPOINT }}
+      S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}
+      S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}
+      S3_REGION: ${{ secrets.S3_REGION }}
+      S3_USE_SSL: 'true'
+      S3_BUCKET_FILES: ${{ secrets.S3_BUCKET_FILES }}
+      S3_BUCKET_IMAGES: ${{ secrets.S3_BUCKET_IMAGES }}
+      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+      # The console's browser fetches must stay same-origin: edge-api serves
+      # no CORS headers. Empty means relative, which is what the shipped
+      # image is built with; Caddyfile.agent-proof is the same-origin front.
+      NEXT_PUBLIC_EDGE_API_BASE_URL: ''
+      E2E_RUN_KEY: ${{ github.run_id }}-${{ github.run_attempt }}
+    steps:
+      - name: Resolve the pull request under proof
+        id: target
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_PR: ${{ github.event.inputs.pr }}
+          EVENT_PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          pr="${INPUT_PR:-$EVENT_PR}"
+          if [ -z "$pr" ]; then
+            echo "::error::no pull request number to prove"
+            exit 1
+          fi
+          echo "pr=$pr" >> "$GITHUB_OUTPUT"
+          # refs/pull/N/merge is what would land, which is what rule 8 asks
+          # to be proven, and it is also always current with main.
+          echo "ref=refs/pull/$pr/merge" >> "$GITHUB_OUTPUT"
+          gh pr view "$pr" --json number,title,headRefOid \
+            --jq '"proving PR #\(.number): \(.title) at head \(.headRefOid)"'
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.target.outputs.ref }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: apps/web-console/package-lock.json
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Mint this run's internal service token
+        # Random per run and masked. It authenticates control-plane to the
+        # launcher socket and never leaves this job; the demo box's own token
+        # is never used here, so a leak of one cannot reach the other.
+        run: |
+          set -euo pipefail
+          token="$(openssl rand -hex 32)"
+          echo "::add-mask::$token"
+          echo "CONTROL_PLANE_INTERNAL_TOKEN=$token" >> "$GITHUB_ENV"
+
+      - name: Install Apptainer and allow unprivileged user namespaces
+        run: |
+          set -euo pipefail
+          deb="apptainer_${APPTAINER_VERSION}_amd64.deb"
+          curl -fsSL -o "/tmp/${deb}" \
+            "https://github.com/apptainer/apptainer/releases/download/v${APPTAINER_VERSION}/${deb}"
+          sudo apt-get update -qq
+          sudo apt-get install -y "/tmp/${deb}"
+          # Ubuntu's AppArmor restriction blocks unprivileged userns by
+          # default; the same two sysctls ci.yml's egress-firewall-e2e job
+          # sets before it runs bubblewrap.
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
+          sudo sysctl -w kernel.unprivileged_userns_clone=1 || true
+          apptainer --version
+
+      - name: Start a systemd user session for the launcher
+        # Apptainer enforces the per-session memory, CPU and PID limits
+        # through rootless cgroups, which need a user manager: without
+        # XDG_RUNTIME_DIR and DBUS_SESSION_BUS_ADDRESS every launch dies with
+        # "cannot use cgroups - DBUS_SESSION_BUS_ADDRESS is not set". A
+        # hosted runner has no login session, so linger creates one.
+        run: |
+          set -euo pipefail
+          sudo loginctl enable-linger "$(id -un)"
+          runtime="/run/user/$(id -u)"
+          for _ in $(seq 1 30); do [ -S "$runtime/bus" ] && break; sleep 1; done
+          if [ ! -S "$runtime/bus" ]; then
+            echo "::error::no systemd user session bus at $runtime/bus"
+            exit 1
+          fi
+          {
+            echo "XDG_RUNTIME_DIR=$runtime"
+            echo "DBUS_SESSION_BUS_ADDRESS=unix:path=$runtime/bus"
+          } >> "$GITHUB_ENV"
+
+      - name: Install the agent-engine launch daemon (socket arm)
+        # The shipped installer, unmodified: it fetches the newest CI-built
+        # SIF when the host has none, builds the launcher statically, writes
+        # a 0600 env file and starts a transient systemd user unit. /mnt is
+        # the runner's large volume; the root filesystem has no room for a
+        # multi-gigabyte image.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO_DIR: ${{ github.workspace }}
+          HIVE_AGENT_ENGINE_LLM_MODEL: ${{ vars.HIVE_AGENT_ENGINE_LLM_MODEL || 'openai/hive-default' }}
+          HIVE_AGENT_ENGINE_LLM_BASE_URL: ${{ vars.HIVE_AGENT_ENGINE_LLM_BASE_URL || 'https://api-hive.scubed.co/v1' }}
+          HIVE_AGENT_ENGINE_LLM_API_KEY: ${{ secrets.HIVE_API_KEY }}
+          HIVE_AGENT_ENGINE_SESSION_API_KEY: ${{ secrets.HIVE_AGENT_ENGINE_SESSION_API_KEY }}
+          # One slot per user and per tenant, so the ceiling is observable
+          # with a single running task instead of two. This is what makes
+          # "the cancelled task's slot came back" a differential the capture
+          # can show rather than a claim.
+          HIVE_QUOTA_USER_CONCURRENCY: '1'
+          HIVE_QUOTA_TENANT_CONCURRENCY: '1'
+          HIVE_SANDBOX_MEMORY_LIMIT: 2G
+          HIVE_SANDBOX_CPU_LIMIT: '2'
+        run: |
+          set -euo pipefail
+          sudo mkdir -p "$RUNTIME_DIR"
+          sudo chown "$(id -un):$(id -gn)" "$RUNTIME_DIR"
+          RUNTIME_DIR="$RUNTIME_DIR" bash scripts/install-agent-engine-host.sh
+
+      - name: Prove Apptainer can run this image on this runner
+        # The evidence behind the runner choice at the top of this file. The
+        # installer's own health check proves the daemon answers; this proves
+        # the sandbox itself can start here, which is the capability the
+        # hosted runner was in question for.
+        run: |
+          set -euo pipefail
+          sif="$RUNTIME_DIR/agent-engine.sif"
+          if [ ! -s "$sif" ]; then
+            echo "::error::no SIF at $sif; run the 'agent-engine SIF' workflow"
+            exit 1
+          fi
+          apptainer exec "$sif" /bin/true
+          echo "rootless apptainer exec of the shipped image: ok"
+
+      - name: Reconstruct SUPABASE_DB_URL
+        env:
+          SUPABASE_DB_HOST: ${{ secrets.SUPABASE_DB_HOST }}
+          SUPABASE_DB_PORT: ${{ secrets.SUPABASE_DB_PORT }}
+          SUPABASE_DB_USER: ${{ secrets.SUPABASE_DB_USER }}
+          SUPABASE_DB_NAME: ${{ secrets.SUPABASE_DB_NAME }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+        run: |
+          set -euo pipefail
+          # Session-mode clients are capped at the shared project's pool_size
+          # of 15 and shared with the live demo stack, so a job that booted a
+          # stack on session mode alone could take chat-hive offline.
+          python3 scripts/derive-pooler-dsn.py --self-test
+          python3 scripts/derive-pooler-dsn.py \
+            --host "$SUPABASE_DB_HOST" --port "$SUPABASE_DB_PORT" \
+            --user "$SUPABASE_DB_USER" --dbname "$SUPABASE_DB_NAME" \
+            --password "$SUPABASE_DB_PASSWORD" >> "$GITHUB_ENV"
+
+      - name: Build the stack images
+        run: |
+          set -euo pipefail
+          docker pull -q redis:8.4-alpine
+          docker pull -q ghcr.io/berriai/litellm:v1.77.7-stable
+          docker buildx bake -f deploy/docker/docker-bake.hcl edge-api control-plane \
+            --load --set '*.cache-from=type=gha,scope=stack' \
+            --set '*.cache-to=type=gha,scope=stack,mode=max'
+
+      - name: Build the agent console image
+        working-directory: deploy/docker
+        run: docker compose --profile local --profile chat build agent-console
+
+      - name: Start the stack with the launcher socket wired in
+        working-directory: deploy/docker
+        env:
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          # THE variable that matters: with it set, buildAgentEngine forwards
+          # every launch to the host daemon and reads none of the path
+          # variables. The directory is bind-mounted into control-plane; the
+          # container gets a socket, not a privilege.
+          HIVE_AGENT_ENGINE_SOCKET: /run/hive-agent/engine.sock
+        run: |
+          set -euo pipefail
+          export HIVE_AGENT_ENGINE_SOCKET_DIR="$RUNTIME_DIR/run"
+          docker compose --profile local --profile chat up -d --no-build \
+            redis litellm control-plane edge-api agent-console
+
+      - name: Wait for the services to become healthy
+        working-directory: deploy/docker
+        run: |
+          set -euo pipefail
+          deadline=$(( $(date +%s) + 300 ))
+          for svc in control-plane edge-api; do
+            while :; do
+              state=$(docker inspect --format '{{.State.Health.Status}}' \
+                "$(docker compose ps -q $svc)" 2>/dev/null || echo "starting")
+              [ "$state" = "healthy" ] && { echo "$svc: healthy"; break; }
+              if [ "$(date +%s)" -gt "$deadline" ]; then
+                echo "::error::$svc did not become healthy (last state: $state)"
+                docker compose logs --tail=200 "$svc"
+                exit 1
+              fi
+              sleep 5
+            done
+          done
+
+      - name: Assert control-plane took the socket arm
+        # Without this the job could boot a NotConfiguredEngine stack, watch
+        # every task fail instantly, and call the screenshots proof of
+        # something. The negative match matters as much as the positive one.
+        working-directory: deploy/docker
+        run: |
+          set -euo pipefail
+          logs=$(docker compose logs --no-color control-plane)
+          if grep -q "agent engine not configured" <<<"$logs"; then
+            echo "::error::control-plane fell back to NotConfiguredEngine; no task can launch"
+            grep "agent engine not configured" <<<"$logs" | tail -3
+            exit 1
+          fi
+          if ! grep -q "agent-engine daemon reachable" <<<"$logs"; then
+            echo "::error::control-plane never reported the launch daemon reachable"
+            grep -i "agent-engine" <<<"$logs" | tail -10 || true
+            exit 1
+          fi
+          echo "control-plane is on the socket arm and the daemon answered /health"
+
+      - name: Serve the console and edge-api from one origin
+        working-directory: deploy/docker
+        run: |
+          set -euo pipefail
+          net=$(docker inspect -f '{{range $k, $v := .NetworkSettings.Networks}}{{$k}}{{end}}' \
+            "$(docker compose ps -q edge-api)")
+          docker run -d --name agent-proof-proxy --network "$net" -p 3030:80 \
+            -v "$PWD/Caddyfile.agent-proof:/etc/caddy/Caddyfile:ro" \
+            caddy:2-alpine@sha256:86deaf5e3d3408a6ccec08fbb79989783dd26e206ae10bcf78a801dc8c9ab794
+          for _ in $(seq 1 30); do
+            code=$(curl -s -o /dev/null -w '%{http_code}' "$PROOF_ORIGIN/agent-workspace/tasks" || true)
+            [ "$code" != "000" ] && { echo "proxy up (HTTP $code)"; exit 0; }
+            sleep 2
+          done
+          echo "::error::the proof origin never answered"
+          docker logs agent-proof-proxy
+          exit 1
+
+      - name: Install the harness dependencies
+        working-directory: apps/web-console
+        run: |
+          set -euo pipefail
+          npm ci
+          npx playwright install --with-deps chromium
+
+      - name: Seed this run's fixture tenant
+        working-directory: apps/web-console
+        env:
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          E2E_VERIFIED_EMAIL: e2e-verified+${{ github.run_id }}-${{ github.run_attempt }}@scubed.com.bd
+          E2E_VERIFIED_PASSWORD: ${{ secrets.E2E_VERIFIED_PASSWORD }}
+          E2E_UNVERIFIED_EMAIL: e2e-unverified+${{ github.run_id }}-${{ github.run_attempt }}@scubed.com.bd
+          E2E_UNVERIFIED_PASSWORD: ${{ secrets.E2E_UNVERIFIED_PASSWORD }}
+        run: |
+          set -euo pipefail
+          # Run scoped, so nothing here touches a shared account: E2E_RUN_KEY
+          # namespaces every address, and runScopedEmail throws without it.
+          # The invitation token is generated rather than derived from the
+          # public run id, because the seeder stores its sha256 as a live
+          # pending invitation.
+          token="$(openssl rand -hex 24)"
+          echo "::add-mask::$token"
+          E2E_INVITATION_TOKEN="$token" node tests/e2e/support/e2e-auth-fixtures.mjs reset
+          # Cowork is a per-tenant gate and edge-api fails closed on it, so
+          # the console would render no composer at all without this row.
+          node --input-type=module -e '
+            import { buildIds, createAdminClient } from "./tests/e2e/support/e2e-fixture-seed.mjs";
+            const ids = buildIds(process.env.E2E_RUN_KEY);
+            const { error } = await createAdminClient()
+              .from("tenant_settings")
+              .upsert(
+                { tenant_id: ids.verifiedTenantId, key: "ENABLE_COWORK", enabled: true },
+                { onConflict: "tenant_id,key" },
+              );
+            if (error) throw new Error(`ENABLE_COWORK upsert failed: ${error.message}`);
+            console.log("ENABLE_COWORK enabled for this run tenant");
+          '
+
+      - name: Make the launch impossible (deliberate sabotage run)
+        # The negative control for the whole job: with the launcher stopped
+        # nothing can launch, and this run must go red rather than pass with
+        # an empty capture directory.
+        if: github.event.inputs.sabotage == 'true'
+        run: |
+          set -euo pipefail
+          systemctl --user stop hive-agent-engine.service
+          echo "::warning::launcher stopped on purpose; this run is expected to fail"
+
+      - name: Capture the proof
+        env:
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          PROOF_BASE_URL: ${{ env.PROOF_ORIGIN }}
+          PROOF_EMAIL: e2e-verified+${{ github.run_id }}-${{ github.run_attempt }}@scubed.com.bd
+          PROOF_RUNTIME_DIR: ${{ env.RUNTIME_DIR }}
+          PROOF_OUT: ${{ env.CAPTURE_DIR }}
+          PROOF_RUN_TAG: proof-${{ github.run_id }}
+          PROOF_NOTE: PR #${{ steps.target.outputs.pr }} · run ${{ github.run_id }}
+          # On an automatic pull request run only the liveness scenario is in
+          # scope: it proves the surface still launches, which is the part
+          # every agent-surface change can be held to. The behaviour specific
+          # scenarios are what a dispatch aims at a particular fix, because
+          # only the dispatcher knows which behaviours that pull request
+          # claims to change.
+          PROOF_SCENARIOS: ${{ github.event.inputs.scenarios || 'launch-liveness' }}
+          HARNESS_PLAYWRIGHT_ROOT: ${{ github.workspace }}
+        run: node apps/agent-console/proof/harness/capture-live.mjs
+
+      - name: Refuse an empty capture
+        # Belt and braces over the harness's own check: a capture directory
+        # with no images has to fail the job, never pass quietly.
+        run: |
+          set -euo pipefail
+          count=$(find "$CAPTURE_DIR" -name '*.png' | wc -l)
+          echo "captured $count screenshots"
+          [ "$count" -gt 0 ] || { echo "::error::no screenshots captured"; exit 1; }
+
+      - name: Check the text log carries no credential
+        # Scans docs/proof/ whole, which the captures were written into, so
+        # the same guard that fails a hand-committed leak fails this one.
+        # It cannot inspect pixels; that half is handled by stamp.mjs, whose
+        # footer never carries a URL.
+        run: npm run lint:proof-tokens
+
+      - name: Upload the captures
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: agent-visual-proof-${{ github.run_id }}
+          path: ${{ env.CAPTURE_DIR }}
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Post the captures on the pull request
+        # An artifact is a zip behind an authenticated download, so it is not
+        # proof "posted in the pull request". The images go to a side branch
+        # and are embedded in a comment from their raw URLs. The side branch
+        # is never merged and never touches the pull request's own branch.
+        if: success()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ steps.target.outputs.pr }}
+        run: |
+          set -euo pipefail
+          branch="ci-proof/pr-${PR}-run-${GITHUB_RUN_ID}"
+          dir="docs/proof/agent-visual-proof/pr-${PR}-run-${GITHUB_RUN_ID}"
+          base=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/main" --jq '.object.sha')
+          gh api -X POST "repos/$GITHUB_REPOSITORY/git/refs" \
+            -f ref="refs/heads/$branch" -f sha="$base" >/dev/null
+          body=$(mktemp)
+          {
+            echo "## Cowork visual proof, captured in CI"
+            echo
+            echo "Captured against a stack booted from \`refs/pull/${PR}/merge\` on a hosted"
+            echo "runner, with a real Apptainer sandbox behind the socket arm of the agent"
+            echo "engine, in run [\`${GITHUB_RUN_ID}\`](https://github.com/$GITHUB_REPOSITORY/actions/runs/${GITHUB_RUN_ID})."
+            echo
+          } > "$body"
+          for file in "$CAPTURE_DIR"/*.png; do
+            name=$(basename "$file")
+            gh api -X PUT "repos/$GITHUB_REPOSITORY/contents/$dir/$name" \
+              -f message="ci: visual proof for PR #${PR} (run ${GITHUB_RUN_ID})" \
+              -f branch="$branch" \
+              -f content="$(base64 -w0 "$file")" >/dev/null
+            echo "### ${name%.png}" >> "$body"
+            echo >> "$body"
+            echo "![${name%.png}](https://raw.githubusercontent.com/$GITHUB_REPOSITORY/$branch/$dir/$name)" >> "$body"
+            echo >> "$body"
+          done
+          gh api -X PUT "repos/$GITHUB_REPOSITORY/contents/$dir/proof-log.txt" \
+            -f message="ci: visual proof log for PR #${PR} (run ${GITHUB_RUN_ID})" \
+            -f branch="$branch" \
+            -f content="$(base64 -w0 "$CAPTURE_DIR/proof-log.txt")" >/dev/null
+          {
+            echo "<details><summary>Run log (screenshot stamps carry no URL, and the log is"
+            echo "redacted and linted by \`lint:proof-tokens\`)</summary>"
+            echo
+            echo '```'
+            cat "$CAPTURE_DIR/proof-log.txt"
+            echo '```'
+            echo
+            echo "</details>"
+          } >> "$body"
+          gh pr comment "$PR" --body-file "$body"
+
+      - name: Dump the launcher and stack logs on failure
+        if: failure()
+        working-directory: deploy/docker
+        run: |
+          set -euo pipefail
+          journalctl --user -u hive-agent-engine --no-pager -n 200 2>&1 \
+            | python3 ../../scripts/redact-log-credentials.py > /tmp/launcher.log || true
+          docker compose logs --no-color --timestamps --tail=500 2>&1 \
+            | python3 ../../scripts/redact-log-credentials.py > /tmp/compose.log || true
+
+      - name: Upload the failure logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: agent-visual-proof-logs-${{ github.run_id }}
+          path: |
+            /tmp/launcher.log
+            /tmp/compose.log
+          if-no-files-found: ignore
+          retention-days: 5
+
+      - name: Tear down
+        if: always()
+        working-directory: deploy/docker
+        run: |
+          docker rm -f agent-proof-proxy || true
+          docker compose down -v --remove-orphans || true
+          systemctl --user stop hive-agent-engine.service || true

--- a/.github/workflows/agent-visual-proof.yml
+++ b/.github/workflows/agent-visual-proof.yml
@@ -504,13 +504,8 @@ jobs:
           # few hundred kilobytes base64, and an argument list is not the
           # place to discover the limit.
           upload() {
-            python3 -c '
-import base64, json, sys
-print(json.dumps({
-    "message": sys.argv[2],
-    "branch": sys.argv[3],
-    "content": base64.b64encode(open(sys.argv[1], "rb").read()).decode(),
-}))' "$1" "ci: visual proof for PR #${PR} (run ${GITHUB_RUN_ID})" "$branch" \
+            python3 -c 'import base64,json,sys;print(json.dumps({"message":sys.argv[2],"branch":sys.argv[3],"content":base64.b64encode(open(sys.argv[1],"rb").read()).decode()}))' \
+              "$1" "ci: visual proof for PR #${PR} (run ${GITHUB_RUN_ID})" "$branch" \
               | gh api -X PUT "repos/$GITHUB_REPOSITORY/contents/$dir/$(basename "$1")" --input - >/dev/null
           }
           for file in "$CAPTURE_DIR"/*.png; do

--- a/.github/workflows/agent-visual-proof.yml
+++ b/.github/workflows/agent-visual-proof.yml
@@ -561,7 +561,7 @@ jobs:
         # The negative control for the whole job: with the launcher stopped
         # nothing can launch, and this run must go red rather than pass with
         # an empty capture directory.
-        if: github.event.inputs.sabotage == 'true'
+        if: github.event.inputs.sabotage == 'true' || true # TEMPORARY: re-demonstrating the empty-capture guard after the review fixes, reverted in the next commit
         run: |
           set -euo pipefail
           systemctl --user stop hive-agent-engine.service

--- a/.github/workflows/agent-visual-proof.yml
+++ b/.github/workflows/agent-visual-proof.yml
@@ -310,10 +310,19 @@ jobs:
           # of 15 and shared with the live demo stack, so a job that booted a
           # stack on session mode alone could take chat-hive offline.
           python3 scripts/derive-pooler-dsn.py --self-test
-          python3 scripts/derive-pooler-dsn.py \
+          # Masked before it is exported. Actions masks the secrets it knows,
+          # but a DSN is a derived value it has never seen, and it carries the
+          # password inside it, so a later step that echoes the variable would
+          # print the credential in clear.
+          dsns=$(python3 scripts/derive-pooler-dsn.py \
             --host "$SUPABASE_DB_HOST" --port "$SUPABASE_DB_PORT" \
             --user "$SUPABASE_DB_USER" --dbname "$SUPABASE_DB_NAME" \
-            --password "$SUPABASE_DB_PASSWORD" >> "$GITHUB_ENV"
+            --password "$SUPABASE_DB_PASSWORD")
+          while IFS= read -r line; do
+            [ -z "$line" ] && continue
+            echo "::add-mask::${line#*=}"
+            echo "$line" >> "$GITHUB_ENV"
+          done <<<"$dsns"
 
       - name: Build the stack images
         run: |
@@ -393,7 +402,12 @@ jobs:
             caddy:2-alpine@sha256:86deaf5e3d3408a6ccec08fbb79989783dd26e206ae10bcf78a801dc8c9ab794
           for _ in $(seq 1 30); do
             code=$(curl -s -o /dev/null -w '%{http_code}' "$PROOF_ORIGIN/agent-workspace/tasks" || true)
-            [ "$code" != "000" ] && { echo "proxy up (HTTP $code)"; exit 0; }
+            # A success or a redirect to sign-in, nothing else. "Answered at
+            # all" is what let run 31730077938 report "proxy up (HTTP 404)"
+            # and carry a misrouted proxy into the capture.
+            case "$code" in
+              2??|3??) echo "proxy up (HTTP $code)"; exit 0 ;;
+            esac
             sleep 2
           done
           echo "::error::the proof origin never answered"

--- a/.github/workflows/agent-visual-proof.yml
+++ b/.github/workflows/agent-visual-proof.yml
@@ -499,7 +499,7 @@ jobs:
         # The negative control for the whole job: with the launcher stopped
         # nothing can launch, and this run must go red rather than pass with
         # an empty capture directory.
-        if: github.event.inputs.sabotage == 'true' || true # TEMPORARY: demonstrating the empty-capture guard, reverted in the next commit
+        if: github.event.inputs.sabotage == 'true'
         run: |
           set -euo pipefail
           systemctl --user stop hive-agent-engine.service

--- a/.github/workflows/agent-visual-proof.yml
+++ b/.github/workflows/agent-visual-proof.yml
@@ -264,6 +264,67 @@ jobs:
             echo "DBUS_SESSION_BUS_ADDRESS=unix:path=$runtime/bus"
           } >> "$GITHUB_ENV"
 
+      - name: Fetch the SIF built from these exact image inputs
+        # The installer's own fallback takes the newest artifact called
+        # agent-engine-sif, repo wide, with no relation to the code under
+        # test. That is fine on the demo box and wrong here: a pull request
+        # that changes deploy/apptainer, vendor/openhands or the packs is
+        # precisely a pull request that rebuilds this image, and it would
+        # otherwise be certified with a stale, unrelated one. A proof job
+        # that proves the wrong artifact is worse than no proof job, because
+        # its output carries authority.
+        #
+        # Correlation is by image inputs rather than by commit: the SIF
+        # depends on exactly these three trees, so an artifact whose run
+        # built the same three trees IS the image for this ref, and a run
+        # that changed none of them does not need a rebuild. Matching on the
+        # head SHA alone would demand a fresh build for every unrelated
+        # commit and fail every pull request that touches nothing here.
+        #
+        # Downloaded into RUNTIME_DIR, so the installer below finds a SIF
+        # already in place and never reaches its own fallback.
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          sudo mkdir -p "$RUNTIME_DIR"
+          sudo chown "$(id -un):$(id -gn)" "$RUNTIME_DIR"
+
+          inputs_digest() {
+            for path in deploy/apptainer apps/agent-engine/packs vendor/openhands; do
+              # A path absent at that commit hashes as absent rather than
+              # being skipped, so "the directory was added" is a difference.
+              git rev-parse "$1:$path" 2>/dev/null || echo "absent:$path"
+            done | sha256sum | cut -d' ' -f1
+          }
+
+          want=$(inputs_digest HEAD)
+          echo "image inputs digest for this ref: $want"
+
+          match=""
+          while read -r id sha; do
+            [ -n "$sha" ] || continue
+            git fetch -q --depth=1 origin "$sha" 2>/dev/null || continue
+            got=$(inputs_digest "$sha")
+            echo "artifact $id from $sha: $got"
+            if [ "$got" = "$want" ]; then match="$id"; break; fi
+          done <<<"$(gh api "repos/$GITHUB_REPOSITORY/actions/artifacts?name=agent-engine-sif&per_page=30" \
+            --jq '.artifacts[] | select(.expired == false) | "\(.id) \(.workflow_run.head_sha)"')"
+
+          if [ -z "$match" ]; then
+            echo "::error::no unexpired agent-engine-sif artifact was built from these image inputs, so there is no image to prove this ref with. Build one: gh workflow run \"agent-engine SIF\" --ref <this branch>"
+            exit 1
+          fi
+
+          gh api "repos/$GITHUB_REPOSITORY/actions/artifacts/$match/zip" > /tmp/agent-engine-sif.zip
+          python3 -c 'import sys,zipfile; zipfile.ZipFile(sys.argv[1]).extractall(sys.argv[2])' \
+            /tmp/agent-engine-sif.zip "$RUNTIME_DIR"
+          if [ ! -s "$RUNTIME_DIR/agent-engine.sif" ]; then
+            echo "::error::artifact $match contained no agent-engine.sif"
+            exit 1
+          fi
+          echo "using artifact $match ($(stat -c%s "$RUNTIME_DIR/agent-engine.sif") bytes)"
+
       - name: Install the agent-engine launch daemon (socket arm)
         # The shipped installer, unmodified: it fetches the newest CI-built
         # SIF when the host has none, builds the launcher statically, writes
@@ -287,8 +348,9 @@ jobs:
           HIVE_SANDBOX_CPU_LIMIT: '2'
         run: |
           set -euo pipefail
-          sudo mkdir -p "$RUNTIME_DIR"
-          sudo chown "$(id -un):$(id -gn)" "$RUNTIME_DIR"
+          # RUNTIME_DIR is created, owned and populated with the correlated
+          # SIF by the step above, so the installer's own artifact fallback
+          # never runs here.
           RUNTIME_DIR="$RUNTIME_DIR" bash scripts/install-agent-engine-host.sh
 
       - name: Prove Apptainer can run this image on this runner
@@ -535,17 +597,30 @@ jobs:
           [ "$count" -gt 0 ] || { echo "::error::no screenshots captured"; exit 1; }
 
       - name: Check the text log carries no credential
+        id: lint
         # Scans docs/proof/ whole, which the captures were written into, so
         # the same guard that fails a hand-committed leak fails this one.
         # It cannot inspect pixels; that half is handled by stamp.mjs, whose
         # footer never carries a URL.
+        #
+        # No continue-on-error: a detected credential fails the job outright.
+        # Every step after this one that could republish the captures is
+        # gated on it below, so the guard cannot fire and be ignored.
         run: npm run lint:proof-tokens
 
       - name: Upload the captures
         # Whenever the capture ran at all, including when it failed partway:
         # a failure shot is evidence too. Not when it never started, where an
         # empty directory is the earlier step's failure, not this one's.
-        if: always() && steps.capture.conclusion != 'skipped'
+        #
+        # And never when the credential lint failed. This artifact is
+        # downloadable by anyone with the run URL on a public repository, so
+        # an `always()` upload would have detected a leak, blocked it from
+        # the pull request comment, and published it anyway: exactly the PR
+        # #578 leak class the lint exists to stop. A skipped upload here is
+        # not a silent absence either, because the lint step itself is red
+        # and names the file it found.
+        if: always() && steps.capture.conclusion != 'skipped' && steps.lint.conclusion != 'failure'
         uses: actions/upload-artifact@v4
         with:
           name: agent-visual-proof-${{ github.run_id }}

--- a/apps/agent-console/proof/harness/README.md
+++ b/apps/agent-console/proof/harness/README.md
@@ -92,3 +92,34 @@ string `stub-anon-key-not-a-credential`. No value in this directory is
 accepted by any real system, and no captured URL carries a token in its query
 string. Keep it that way: `npm run lint:proof-tokens` guards the text half of
 that rule for `docs/proof/`, and nothing can inspect screenshot pixels for you.
+
+## The live sibling: `capture-live.mjs`
+
+`capture.mjs` proves rendering. It cannot prove anything that only exists when
+a sandbox really starts, because it starts none. `capture-live.mjs` is the
+other half: it drives the same console against a booted edge-api,
+control-plane and agent-engine launch daemon, so a task it creates runs inside
+a real Apptainer sandbox.
+
+It is not run by hand on the dev box. The sandbox image is `linux/amd64` and
+unbuildable under WSL2, so the stack that can run it is stood up by
+`.github/workflows/agent-visual-proof.yml`:
+
+```bash
+gh workflow run "agent visual proof" -f pr=<number>
+```
+
+That checks out `refs/pull/<number>/merge`, boots the stack with the launcher
+on the socket arm, runs the scenarios below, pushes the captures to a side
+branch and posts them as a comment on that pull request.
+
+| Scenario | What it proves |
+| --- | --- |
+| `launch-liveness` | A task created in the browser reaches Running because a real sandbox came up for it. Asserts nothing version specific, so it doubles as the workflow's own self-test. |
+| `create-returns-queued` | Issue #881: create answers 201 with a `queued` task inside edge-api's 15 second client bound, instead of blocking on a cold sandbox and 500ing. |
+| `cancel-frees-slot` | Issue #886: with `HIVE_QUOTA_USER_CONCURRENCY=1`, a second create is refused while the slot is held, the cancel takes the launcher's live session count from 1 to 0, and the next create launches. |
+
+The slot count is read from the launcher's `sessions/` directory rather than
+from a status badge: `SandboxEngine.Launch` creates exactly one directory
+there per live session and `reap()` removes it in the same call that releases
+the quota slot, so the number is the slot, not a proxy for it.

--- a/apps/agent-console/proof/harness/capture-live.mjs
+++ b/apps/agent-console/proof/harness/capture-live.mjs
@@ -378,6 +378,22 @@ async function main() {
     }),
   );
   log(`signed in as user ${session.userId}`);
+  /*
+   * Claim names and the tenant claim, never the token. edge-api resolves the
+   * caller's tenant from this claim and answers 403 without it, which is the
+   * difference between "the gate is off" (a row) and "this session has no
+   * tenant" (a token), and the two are indistinguishable from the rendered
+   * page. A user id and a tenant id are identifiers, not credentials, and the
+   * user id is already logged above.
+   */
+  const claims = JSON.parse(
+    Buffer.from(session.access_token.split(".")[1], "base64url").toString(),
+  );
+  log(`token claims: ${Object.keys(claims).sort().join(",")}`);
+  log(
+    `token tenant claim: ${claims.selected_tenant_id ?? claims.tenant_id ?? "ABSENT"}` +
+      ` · role=${claims.role ?? "-"} · aal=${claims.aal ?? "-"}`,
+  );
 
   const page = await context.newPage();
   page.on("pageerror", (err) => log(`[browser pageerror] ${err.message}`));

--- a/apps/agent-console/proof/harness/capture-live.mjs
+++ b/apps/agent-console/proof/harness/capture-live.mjs
@@ -88,6 +88,18 @@ function liveSessions() {
   }
 }
 
+async function waitForSessionsAtLeast(want, timeoutMs, what) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const now = liveSessions();
+    if (now >= want) return now;
+    if (Date.now() > deadline) {
+      throw new Error(`${what}: launcher never reached ${want} live session(s), saw ${now}`);
+    }
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+}
+
 async function waitForSessions(want, timeoutMs, what) {
   const deadline = Date.now() + timeoutMs;
   for (;;) {
@@ -179,21 +191,40 @@ const SCENARIOS = [
      */
     async run(page) {
       const instructions = `${RUN_TAG} liveness: list the files in the workspace and stop.`;
-      await shoot(page, "launch-liveness", "01-empty-console", `slots=${liveSessions()}`);
+      await shoot(page, "launch-liveness", "01-empty-console", `launcher slots in use=${liveSessions()}`);
 
-      await createTask(page, instructions);
-      await waitForRowStatus(page, instructions, "Running", 300_000);
-      const slots = liveSessions();
-      if (slots < 1) {
-        throw new Error(
-          "the task reads as Running but the launcher holds no session directory, " +
-            "so nothing was actually launched",
-        );
+      const created = await createTask(page, instructions);
+      /*
+       * The launcher's own session count is the assertion, not the row's
+       * status, and deliberately so. On a tree that predates #881 the create
+       * blocks on the launch, edge-api gives up at 15 seconds and cancels the
+       * request, and control-plane can lose the row to that cancelled
+       * context: the sandbox still started, but the row may never read
+       * Running. Asserting on the row would make this scenario fail for the
+       * bug it is not measuring. A session directory appearing means an
+       * Apptainer sandbox really came up on this host, which is the one thing
+       * every agent-surface change can be held to, and it is exactly what the
+       * sabotage run removes.
+       */
+      const slots = await waitForSessionsAtLeast(
+        1,
+        300_000,
+        "after creating a task from the console",
+      );
+      await shoot(
+        page,
+        "launch-liveness",
+        "02-sandbox-launched",
+        `launcher slots in use=${slots} · create HTTP ${created.status} in ${created.elapsedMs}ms`,
+      );
+
+      // Best effort: a row that already reached a terminal state has no
+      // Cancel control, and that is not this scenario's business.
+      const cancel = taskRow(page, instructions).getByRole("button", { name: "Cancel" });
+      if (await cancel.count()) {
+        await cancel.click();
+        await waitForRowStatus(page, instructions, "Cancelled", 120_000);
       }
-      await shoot(page, "launch-liveness", "02-running-on-a-real-sandbox", `slots=${slots}`);
-
-      await cancelRow(page, instructions);
-      await waitForRowStatus(page, instructions, "Cancelled", 120_000);
     },
   },
   {

--- a/apps/agent-console/proof/harness/capture-live.mjs
+++ b/apps/agent-console/proof/harness/capture-live.mjs
@@ -341,7 +341,12 @@ async function main() {
   const page = await context.newPage();
   page.on("pageerror", (err) => log(`[browser pageerror] ${err.message}`));
   await page.goto(`${BASE_URL}${BASE_PATH}/tasks`, { waitUntil: "domcontentloaded" });
-  if (!(await page.getByLabel("What should the agent do?").count())) {
+  // Waited for, not counted once: the console is a client component, so an
+  // immediate count races the first render and would report a working surface
+  // as missing.
+  try {
+    await page.getByLabel("What should the agent do?").waitFor({ timeout: 60_000 });
+  } catch {
     throw new Error(
       "the task composer never rendered: the session is not signed in, or ENABLE_COWORK is off " +
         "for this tenant, so there is no Cowork surface to prove",

--- a/apps/agent-console/proof/harness/capture-live.mjs
+++ b/apps/agent-console/proof/harness/capture-live.mjs
@@ -142,11 +142,25 @@ async function createTask(page, instructions) {
 }
 
 async function waitForRowStatus(page, instructions, label, timeoutMs) {
-  await taskRow(page, instructions)
-    .getByText(label, { exact: true })
-    .waitFor({ timeout: timeoutMs });
-  log(`row "${instructions.slice(0, 40)}…" reached ${label}`);
+  // A string is matched exactly; a RegExp is for the states the console
+  // renders under more than one label.
+  const target =
+    label instanceof RegExp
+      ? taskRow(page, instructions).getByText(label)
+      : taskRow(page, instructions).getByText(label, { exact: true });
+  await target.waitFor({ timeout: timeoutMs });
+  log(`row "${instructions.slice(0, 40)}…" reached ${await target.innerText()}`);
 }
+
+/*
+ * A launch the engine refused reads as "Blocked", not "Failed": the console
+ * gives ENGINE_LAUNCH_FAILED_MESSAGE its own label so a deployment problem
+ * does not read to the user as a problem with what they asked for (see
+ * isEngineLaunchFailure in lib/edge-api/tasks.ts). Both are terminal and both
+ * mean the same thing here, so the refusal wait accepts either rather than
+ * pinning the proof to today's copy.
+ */
+const REFUSED = /^(Blocked|Failed)$/;
 
 async function cancelRow(page, instructions) {
   await taskRow(page, instructions).getByRole("button", { name: "Cancel" }).click();
@@ -251,7 +265,7 @@ const SCENARIOS = [
       // The refusal arrives on the read path (the launch is asynchronous), so
       // this waits for the row rather than reading the create response.
       await createTask(page, blocked);
-      await waitForRowStatus(page, blocked, "Failed", 180_000);
+      await waitForRowStatus(page, blocked, REFUSED, 180_000);
       await shoot(
         page,
         "cancel-frees-slot",

--- a/apps/agent-console/proof/harness/capture-live.mjs
+++ b/apps/agent-console/proof/harness/capture-live.mjs
@@ -1,0 +1,381 @@
+// Visual proof of the Cowork task surface against a REAL stack: a booted
+// edge-api and control-plane, and an agent-engine launch daemon that starts
+// an actual Apptainer sandbox per task. The sibling capture.mjs proves
+// rendering against stubs; this one proves behaviour that only exists when
+// something really launches.
+//
+//   node apps/agent-console/proof/harness/capture-live.mjs
+//
+// Driven by .github/workflows/agent-visual-proof.yml, which stands the whole
+// thing up. It is a plain script, not a Playwright project, on purpose: the
+// web-console Playwright projects boot no launcher and would report this
+// suite as skipped, which is indistinguishable from passing.
+//
+// ponytail: no test runner. Scenarios are functions in an array, the same
+// shape capture.mjs already uses.
+//
+// WHAT IT NEVER DOES
+//   * Rotate a password. The session comes from the admin one-time-token
+//     flow in live-auth.mjs (docs/live-test-auth.md).
+//   * Print a secret. Every line it writes goes through redactSecrets, and
+//     the screenshot stamp carries no URL (see stamp.mjs).
+
+import { mkdirSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { loadChromium, shoot as shootStamped, waitForHttp } from "./stamp.mjs";
+import { redactSecrets } from "../../../web-console/tests/e2e/support/e2e-fixture-seed.mjs";
+import { reauthenticate } from "../../../web-console/tests/e2e/support/live-auth.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const BASE_PATH = "/agent-workspace";
+
+function requiredEnv(name, why) {
+  const value = (process.env[name] ?? "").trim();
+  if (!value) {
+    throw new Error(`${name} is required: ${why}`);
+  }
+  return value;
+}
+
+// The origin that serves the console and proxies /v1/agent/* to edge-api, so
+// the browser's fetches stay same-origin exactly as they do behind
+// Caddyfile.owui in production.
+const BASE_URL = (process.env.PROOF_BASE_URL || "http://127.0.0.1:3030").replace(/\/$/, "");
+const EMAIL = requiredEnv("PROOF_EMAIL", "the run-scoped fixture address to mint a session for");
+// The launcher's state directory (RUNTIME_DIR in
+// scripts/install-agent-engine-host.sh). Its sessions/ subdirectory is the
+// slot count this proof turns on; see liveSessions below.
+const RUNTIME_DIR = requiredEnv(
+  "PROOF_RUNTIME_DIR",
+  "the agent-engine launcher's runtime directory, whose sessions/ entries are the observable slot count",
+);
+const OUT_DIR = resolve(process.env.PROOF_OUT || join(HERE, "captures-live"));
+const NOTE = process.env.PROOF_NOTE || "";
+const SELECTED = (process.env.PROOF_SCENARIOS || "all").trim();
+// Every task this run creates carries it, so a row is addressable in the UI
+// and so a leftover row is traceable to the run that made it.
+const RUN_TAG = process.env.PROOF_RUN_TAG || `local-${Date.now()}`;
+
+// #881's bound, and the reason this proof exists: edge-api's control-plane
+// client gives up at 15 seconds, so a create that waits for a cold sandbox
+// answers 500 to the browser. Kept slightly under the real ceiling so a
+// create that only just squeaks in still reads as the bug.
+const CREATE_BUDGET_MS = 14_000;
+
+const logLines = [];
+function log(line) {
+  const safe = redactSecrets(String(line));
+  logLines.push(safe);
+  console.log(`[capture-live] ${safe}`);
+}
+
+/**
+ * The launcher's in-use concurrency slots, counted from outside the process.
+ *
+ * SandboxEngine.Launch creates exactly one directory here per live session
+ * (os.MkdirTemp under RunDir) and reap() removes it in the same call that
+ * runs the quota release, so this number is the slot count rather than a
+ * proxy for it. That pairing is the whole point: a cancelled task's status
+ * badge turning grey proves a row was written, not that anything was freed.
+ */
+function liveSessions() {
+  try {
+    return readdirSync(join(RUNTIME_DIR, "sessions")).length;
+  } catch (err) {
+    throw new Error(`cannot read the launcher's session directory: ${err.message}`);
+  }
+}
+
+async function waitForSessions(want, timeoutMs, what) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const now = liveSessions();
+    if (now === want) return now;
+    if (Date.now() > deadline) {
+      throw new Error(`${what}: launcher still reports ${now} live session(s), wanted ${want}`);
+    }
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+}
+
+const shots = [];
+async function shoot(page, scenario, name, extra = "") {
+  const note = [NOTE, extra].filter(Boolean).join("  ·  ");
+  const file = await shootStamped(page, { outDir: OUT_DIR, scenario, name, note });
+  shots.push(file);
+  log(`wrote ${file}`);
+  return file;
+}
+
+function taskRow(page, instructions) {
+  return page.getByRole("listitem").filter({ hasText: instructions });
+}
+
+/**
+ * Fills the composer, submits, and reports what the create call actually
+ * answered and how long it took. The response is read from the wire rather
+ * than from the rendered row: #881 is a status code and a latency, and a
+ * screenshot of a row cannot show either.
+ */
+async function createTask(page, instructions) {
+  const started = Date.now();
+  const responsePromise = page.waitForResponse(
+    (r) => r.request().method() === "POST" && new URL(r.url()).pathname === "/v1/agent/tasks",
+    { timeout: 120_000 },
+  );
+  await page.getByLabel("What should the agent do?").fill(instructions);
+  await page.getByRole("button", { name: /start task/i }).click();
+  const response = await responsePromise;
+  const elapsedMs = Date.now() - started;
+  let body = {};
+  try {
+    body = await response.json();
+  } catch {
+    // A 500 from the timeout path is not JSON; the status carries the story.
+  }
+  log(
+    `create answered HTTP ${response.status()} in ${elapsedMs}ms, status=${body.status ?? "n/a"}`,
+  );
+  return { status: response.status(), elapsedMs, id: body.id, taskStatus: body.status };
+}
+
+async function waitForRowStatus(page, instructions, label, timeoutMs) {
+  await taskRow(page, instructions)
+    .getByText(label, { exact: true })
+    .waitFor({ timeout: timeoutMs });
+  log(`row "${instructions.slice(0, 40)}…" reached ${label}`);
+}
+
+async function cancelRow(page, instructions) {
+  await taskRow(page, instructions).getByRole("button", { name: "Cancel" }).click();
+}
+
+const SCENARIOS = [
+  {
+    name: "launch-liveness",
+    /*
+     * The floor every other scenario stands on, and the one that fails when
+     * the plumbing is wrong rather than when the product is: a task created
+     * in the browser reaches Running because a real Apptainer sandbox came
+     * up for it on the host. It asserts nothing about #881 or #886, so it
+     * passes on a tree that predates both, which is what makes it usable as
+     * this workflow's own self-test.
+     */
+    async run(page) {
+      const instructions = `${RUN_TAG} liveness: list the files in the workspace and stop.`;
+      await shoot(page, "launch-liveness", "01-empty-console", `slots=${liveSessions()}`);
+
+      await createTask(page, instructions);
+      await waitForRowStatus(page, instructions, "Running", 300_000);
+      const slots = liveSessions();
+      if (slots < 1) {
+        throw new Error(
+          "the task reads as Running but the launcher holds no session directory, " +
+            "so nothing was actually launched",
+        );
+      }
+      await shoot(page, "launch-liveness", "02-running-on-a-real-sandbox", `slots=${slots}`);
+
+      await cancelRow(page, instructions);
+      await waitForRowStatus(page, instructions, "Cancelled", 120_000);
+    },
+  },
+  {
+    name: "create-returns-queued",
+    /*
+     * Issue #881. Create answers with the persisted queued task instead of
+     * blocking on the launch, so a cold sandbox (tens of seconds) no longer
+     * outlives edge-api's 15 second client bound and 500s an interactive
+     * request. Measured on the wire, then screenshotted with the measurement
+     * stamped into the image.
+     */
+    async run(page) {
+      const instructions = `${RUN_TAG} create: summarise the repository README in three bullets.`;
+      const created = await createTask(page, instructions);
+
+      const failures = [];
+      if (created.status !== 201) failures.push(`create answered HTTP ${created.status}, want 201`);
+      if (created.taskStatus !== "queued") {
+        failures.push(`create body status was ${created.taskStatus ?? "absent"}, want queued`);
+      }
+      if (created.elapsedMs > CREATE_BUDGET_MS) {
+        failures.push(`create took ${created.elapsedMs}ms, over the ${CREATE_BUDGET_MS}ms budget`);
+      }
+      await shoot(
+        page,
+        "create-returns-queued",
+        "01-queued-immediately",
+        `HTTP ${created.status} in ${created.elapsedMs}ms`,
+      );
+      if (failures.length) throw new Error(failures.join("; "));
+
+      // The launch still lands, it just lands on the read path.
+      await waitForRowStatus(page, instructions, "Running", 300_000);
+      await shoot(
+        page,
+        "create-returns-queued",
+        "02-launch-landed-on-the-poll",
+        `slots=${liveSessions()}`,
+      );
+
+      await cancelRow(page, instructions);
+      await waitForRowStatus(page, instructions, "Cancelled", 120_000);
+      await waitForSessions(0, 120_000, "after the cleanup cancel");
+    },
+  },
+  {
+    name: "cancel-frees-slot",
+    /*
+     * Issue #886. Needs HIVE_QUOTA_USER_CONCURRENCY=1 on the launcher, which
+     * makes the ceiling observable in one task instead of two.
+     *
+     * The sequence is a differential: the same create is refused while the
+     * slot is held and accepted once it is released, and the launcher's own
+     * session count moves 1 -> 0 across the cancel. Before the fix, cancel
+     * wrote a row and left the sandbox running, so the count stayed at 1 and
+     * the second create stayed refused for the roughly sixteen minutes the
+     * sandbox took to finish by itself.
+     */
+    async run(page) {
+      const first = `${RUN_TAG} slot A: hold the only concurrency slot.`;
+      const blocked = `${RUN_TAG} slot B: submitted while the slot is held.`;
+      const after = `${RUN_TAG} slot C: submitted after the cancel.`;
+
+      await createTask(page, first);
+      await waitForRowStatus(page, first, "Running", 300_000);
+      const held = await waitForSessions(1, 60_000, "with one task running");
+      await shoot(page, "cancel-frees-slot", "01-slot-held", `launcher slots in use=${held}`);
+
+      // The refusal arrives on the read path (the launch is asynchronous), so
+      // this waits for the row rather than reading the create response.
+      await createTask(page, blocked);
+      await waitForRowStatus(page, blocked, "Failed", 180_000);
+      await shoot(
+        page,
+        "cancel-frees-slot",
+        "02-second-create-refused",
+        `launcher slots in use=${liveSessions()}`,
+      );
+
+      await cancelRow(page, first);
+      await waitForRowStatus(page, first, "Cancelled", 120_000);
+      const freed = await waitForSessions(0, 180_000, "after cancelling the running task");
+      await shoot(
+        page,
+        "cancel-frees-slot",
+        "03-slot-released-on-cancel",
+        `launcher slots in use=${freed}`,
+      );
+
+      await createTask(page, after);
+      await waitForRowStatus(page, after, "Running", 300_000);
+      await shoot(
+        page,
+        "cancel-frees-slot",
+        "04-next-task-launched",
+        `launcher slots in use=${liveSessions()}`,
+      );
+
+      await cancelRow(page, after);
+      await waitForRowStatus(page, after, "Cancelled", 120_000);
+      await waitForSessions(0, 180_000, "after the cleanup cancel");
+    },
+  },
+];
+
+async function cancelLeftovers(page) {
+  // A row left non-terminal outlives this run in a shared database, where
+  // every control-plane poller keeps asking a launcher that no longer exists
+  // about it. Best effort, and never the reason a run fails.
+  for (let i = 0; i < 10; i += 1) {
+    const buttons = page.getByRole("button", { name: "Cancel" });
+    const count = await buttons.count().catch(() => 0);
+    if (!count) return;
+    await buttons.first().click().catch(() => {});
+    await page.waitForTimeout(500);
+  }
+}
+
+async function main() {
+  rmSync(OUT_DIR, { recursive: true, force: true });
+  mkdirSync(OUT_DIR, { recursive: true });
+
+  const selected =
+    SELECTED === "all"
+      ? SCENARIOS
+      : SCENARIOS.filter((s) => SELECTED.split(",").map((n) => n.trim()).includes(s.name));
+  if (selected.length === 0) {
+    throw new Error(`no scenario matched "${SELECTED}". Known: ${SCENARIOS.map((s) => s.name).join(", ")}`);
+  }
+  log(`scenarios: ${selected.map((s) => s.name).join(", ")}`);
+  log(`launcher runtime dir: ${RUNTIME_DIR}, live sessions at start: ${liveSessions()}`);
+
+  await waitForHttp(`${BASE_URL}${BASE_PATH}/tasks`, 120_000, "the console origin");
+
+  const browser = await loadChromium().launch();
+  const context = await browser.newContext({ viewport: { width: 1280, height: 1000 } });
+  // Mints a one-shot token for an EXISTING account and exchanges it. No
+  // password is read, written or rotated.
+  const { userId } = await reauthenticate(context, {
+    email: EMAIL,
+    targetUrl: `${BASE_URL}${BASE_PATH}/tasks`,
+  });
+  log(`signed in as user ${userId}`);
+
+  const page = await context.newPage();
+  page.on("pageerror", (err) => log(`[browser pageerror] ${err.message}`));
+  await page.goto(`${BASE_URL}${BASE_PATH}/tasks`, { waitUntil: "domcontentloaded" });
+  if (!(await page.getByLabel("What should the agent do?").count())) {
+    throw new Error(
+      "the task composer never rendered: the session is not signed in, or ENABLE_COWORK is off " +
+        "for this tenant, so there is no Cowork surface to prove",
+    );
+  }
+
+  let failure = null;
+  for (const scenario of selected) {
+    log(`--- scenario: ${scenario.name} ---`);
+    try {
+      await scenario.run(page);
+      log(`scenario ${scenario.name}: ok`);
+    } catch (err) {
+      failure = failure ?? err;
+      log(`scenario ${scenario.name}: FAILED ${err.message}`);
+      // A failure capture is evidence too: it is what the missing fix looks
+      // like. It is not counted as proof, because the run still exits non-zero.
+      await shoot(page, scenario.name, "FAILED", err.message.slice(0, 120)).catch(() => {});
+      break;
+    }
+  }
+
+  await cancelLeftovers(page).catch(() => {});
+  await context.close();
+  await browser.close();
+
+  writeFileSync(join(OUT_DIR, "proof-log.txt"), `${logLines.join("\n")}\n`);
+
+  // A run that captured nothing must never read as a pass. This is the
+  // property the workflow's deliberate-sabotage run exercises.
+  if (!failure && shots.length === 0) {
+    throw new Error("no screenshots were captured, so there is no proof here");
+  }
+  if (failure) throw failure;
+  log(`captured ${shots.length} screenshots into ${OUT_DIR}`);
+}
+
+process.on("unhandledRejection", (err) => {
+  console.error("[capture-live] unhandled rejection:", err);
+  process.exit(1);
+});
+
+main().catch((err) => {
+  try {
+    writeFileSync(join(OUT_DIR, "proof-log.txt"), `${logLines.join("\n")}\n${err.message}\n`);
+  } catch {
+    // the throw below is the report either way
+  }
+  console.error("[capture-live] failed:", err.message);
+  process.exit(1);
+});

--- a/apps/agent-console/proof/harness/capture-live.mjs
+++ b/apps/agent-console/proof/harness/capture-live.mjs
@@ -393,6 +393,17 @@ async function main() {
     // credential in the fragment.
     await shoot(page, "setup", "00-no-composer").catch(() => {});
     log(`landed on ${new URL(page.url()).pathname}`);
+    // What edge-api answers for this exact session. Paired with the
+    // control-plane assertion the workflow already made, this says which hop
+    // dropped the gate: same answer means the row is off, a disagreement
+    // means the token's tenant claim is.
+    const gates = await context.request
+      .get(`${BASE_URL}/v1/featuregate`, {
+        headers: { Authorization: `Bearer ${session.access_token}` },
+      })
+      .then(async (r) => `HTTP ${r.status()} ${(await r.text()).slice(0, 300)}`)
+      .catch((err) => `unreachable: ${err.message}`);
+    log(`edge-api /v1/featuregate for this session: ${gates}`);
     const text = await page
       .locator("body")
       .innerText()

--- a/apps/agent-console/proof/harness/capture-live.mjs
+++ b/apps/agent-console/proof/harness/capture-live.mjs
@@ -26,7 +26,7 @@ import { fileURLToPath } from "node:url";
 
 import { loadChromium, shoot as shootStamped, waitForHttp } from "./stamp.mjs";
 import { redactSecrets } from "../../../web-console/tests/e2e/support/e2e-fixture-seed.mjs";
-import { reauthenticate } from "../../../web-console/tests/e2e/support/live-auth.mjs";
+import { mintSession, sessionCookies } from "../../../web-console/tests/e2e/support/live-auth.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const BASE_PATH = "/agent-workspace";
@@ -363,11 +363,21 @@ async function main() {
   const context = await browser.newContext({ viewport: { width: 1280, height: 1000 } });
   // Mints a one-shot token for an EXISTING account and exchanges it. No
   // password is read, written or rotated.
-  const { userId } = await reauthenticate(context, {
-    email: EMAIL,
-    targetUrl: `${BASE_URL}${BASE_PATH}/tasks`,
-  });
-  log(`signed in as user ${userId}`);
+  //
+  // reauthenticate() inlined rather than called, for one reason: it would
+  // build the cookies with the same project identity it minted with, and
+  // @supabase/ssr names its cookie after the project ref in the URL it is
+  // given. The browser bundle is built with NEXT_PUBLIC_SUPABASE_URL, so a
+  // deployment where that differs from the admin SUPABASE_URL gets a cookie
+  // under the wrong name and a console that is simply signed out.
+  const session = await mintSession({ email: EMAIL });
+  await context.addCookies(
+    await sessionCookies(session, `${BASE_URL}${BASE_PATH}/tasks`, {
+      supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL,
+      anonKey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY,
+    }),
+  );
+  log(`signed in as user ${session.userId}`);
 
   const page = await context.newPage();
   page.on("pageerror", (err) => log(`[browser pageerror] ${err.message}`));
@@ -378,6 +388,16 @@ async function main() {
   try {
     await page.getByLabel("What should the agent do?").waitFor({ timeout: 60_000 });
   } catch {
+    // Say which of the two it was, instead of leaving the next run to guess.
+    // The path only, never the full URL: an auth redirect carries its
+    // credential in the fragment.
+    await shoot(page, "setup", "00-no-composer").catch(() => {});
+    log(`landed on ${new URL(page.url()).pathname}`);
+    const text = await page
+      .locator("body")
+      .innerText()
+      .catch(() => "");
+    log(`page said: ${text.replace(/\s+/g, " ").slice(0, 400)}`);
     throw new Error(
       "the task composer never rendered: the session is not signed in, or ENABLE_COWORK is off " +
         "for this tenant, so there is no Cowork surface to prove",

--- a/apps/agent-console/proof/harness/capture.mjs
+++ b/apps/agent-console/proof/harness/capture.mjs
@@ -12,16 +12,16 @@
 // ponytail: no test runner and no config file. Scenarios are functions in an
 // array; a framework here would be more scaffolding than scenarios.
 
-import { spawn, execSync } from "node:child_process";
+import { spawn } from "node:child_process";
 import { mkdirSync, rmSync } from "node:fs";
-import { createRequire } from "node:module";
 import net from "node:net";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { loadChromium, shoot as shootStamped, waitForHttp } from "./stamp.mjs";
+
 const HERE = dirname(fileURLToPath(import.meta.url));
 const APP_DIR = resolve(HERE, "..", "..");
-const REPO_ROOT = resolve(APP_DIR, "..", "..");
 
 const args = new Map(
   process.argv.slice(2).map((arg) => {
@@ -56,67 +56,6 @@ function log(line) {
   console.log(`[capture] ${line}`);
 }
 
-function commitStamp() {
-  try {
-    const sha = execSync("git rev-parse --short HEAD", { cwd: REPO_ROOT }).toString().trim();
-    const dirty = execSync("git status --porcelain", { cwd: REPO_ROOT }).toString().trim();
-    return dirty ? `${sha}+local-edits` : sha;
-  } catch {
-    return "unknown-commit";
-  }
-}
-
-function loadChromium() {
-  // playwright is a devDependency of apps/web-console, the only app in this
-  // repo that already needs a browser. Borrowing it keeps this harness at
-  // zero dependencies of its own.
-  const candidates = [
-    // A git worktree has no node_modules of its own, so point this at a
-    // checkout that does: HARNESS_PLAYWRIGHT_ROOT=/path/to/hive.
-    process.env.HARNESS_PLAYWRIGHT_ROOT
-      ? join(process.env.HARNESS_PLAYWRIGHT_ROOT, "apps", "web-console", "package.json")
-      : null,
-    join(REPO_ROOT, "apps", "web-console", "package.json"),
-    join(APP_DIR, "package.json"),
-  ].filter(Boolean);
-  for (const from of candidates) {
-    try {
-      return createRequire(from)("playwright").chromium;
-    } catch {
-      // try the next resolution root
-    }
-  }
-  throw new Error(
-    "playwright not resolvable. Run `npm install` in apps/web-console, or set " +
-      "HARNESS_PLAYWRIGHT_ROOT to a checkout that has it.",
-  );
-}
-
-function portInUse(port) {
-  return new Promise((resolve) => {
-    const probe = net.createServer();
-    probe.once("error", () => resolve(true));
-    probe.once("listening", () => probe.close(() => resolve(false)));
-    probe.listen(port, "127.0.0.1");
-  });
-}
-
-async function waitForHttp(url, timeoutMs, what) {
-  const deadline = Date.now() + timeoutMs;
-  for (;;) {
-    try {
-      const response = await fetch(url);
-      if (response.status < 500) return;
-    } catch {
-      // not up yet
-    }
-    if (Date.now() > deadline) {
-      throw new Error(`${what} did not come up at ${url} within ${timeoutMs}ms`);
-    }
-    await new Promise((r) => setTimeout(r, 400));
-  }
-}
-
 async function control(patch) {
   const response = await fetch(`${STUB_ORIGIN}/__control`, {
     method: "POST",
@@ -134,39 +73,19 @@ async function stubState() {
   return response.json();
 }
 
-async function shoot(page, scenario, name) {
-  const stamp = [scenario, name, commitStamp(), NOTE].filter(Boolean).join("  ·  ");
-  // Stamped into the pixels so an image cannot drift from the tree it proves.
-  await page.evaluate((text) => {
-    // `next dev` paints a floating build-status badge that is an artefact of
-    // the harness, not of the app under proof.
-    document.querySelectorAll("nextjs-portal").forEach((el) => el.remove());
-
-    const existing = document.getElementById("harness-stamp");
-    if (existing) existing.remove();
-    const el = document.createElement("div");
-    el.id = "harness-stamp";
-    el.textContent = text;
-    el.style.cssText = [
-      "position:fixed",
-      "left:0",
-      "right:0",
-      "bottom:0",
-      "z-index:2147483647",
-      "padding:6px 10px",
-      "font:12px ui-monospace,SFMono-Regular,Menlo,monospace",
-      "background:#111",
-      "color:#f5f5f5",
-      "letter-spacing:0.02em",
-    ].join(";");
-    document.body.appendChild(el);
-  }, stamp);
-
-  const file = join(OUT_DIR, `${scenario}-${name}.png`);
-  await page.screenshot({ path: file, fullPage: true });
-  log(`wrote ${file}`);
-  await page.evaluate(() => document.getElementById("harness-stamp")?.remove());
+function portInUse(port) {
+  return new Promise((resolve) => {
+    const probe = net.createServer();
+    probe.once("error", () => resolve(true));
+    probe.once("listening", () => probe.close(() => resolve(false)));
+    probe.listen(port, "127.0.0.1");
+  });
 }
+
+// Call-site-compatible wrapper over the shared stamper: OUT_DIR and NOTE
+// are module state here, arguments there.
+const shoot = (page, scenario, name) =>
+  shootStamped(page, { outDir: OUT_DIR, scenario, name, note: NOTE });
 
 async function signIn(page) {
   await page.goto(`${CONSOLE_ORIGIN}${BASE_PATH}/auth/sign-in`, { waitUntil: "networkidle" });

--- a/apps/agent-console/proof/harness/stamp.mjs
+++ b/apps/agent-console/proof/harness/stamp.mjs
@@ -15,8 +15,20 @@ const HERE = dirname(fileURLToPath(import.meta.url));
 const APP_DIR = resolve(HERE, "..", "..");
 const REPO_ROOT = resolve(APP_DIR, "..", "..");
 
-/** Short commit of the tree under proof, marked when the tree is dirty. */
+/**
+ * Short commit of the tree under proof, marked when the tree is dirty.
+ *
+ * Resolved once. Every shot stamps the same tree by definition, and the
+ * uncached version ran two git subprocesses per screenshot.
+ */
+let cachedStamp = null;
 export function commitStamp() {
+  if (cachedStamp !== null) return cachedStamp;
+  cachedStamp = resolveCommitStamp();
+  return cachedStamp;
+}
+
+function resolveCommitStamp() {
   try {
     const sha = execSync("git rev-parse --short HEAD", { cwd: REPO_ROOT }).toString().trim();
     const dirty = execSync("git status --porcelain", { cwd: REPO_ROOT }).toString().trim();

--- a/apps/agent-console/proof/harness/stamp.mjs
+++ b/apps/agent-console/proof/harness/stamp.mjs
@@ -1,0 +1,115 @@
+// Screenshot stamping and browser loading, shared by the two harnesses in
+// this directory: capture.mjs (stubbed, no stack) and capture-live.mjs (a
+// real booted stack with a real Apptainer sandbox behind it).
+//
+// Extracted rather than copied: an image whose footer says one thing while
+// the other harness stamps another is exactly the drift these stamps exist
+// to prevent.
+
+import { execSync } from "node:child_process";
+import { createRequire } from "node:module";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const APP_DIR = resolve(HERE, "..", "..");
+const REPO_ROOT = resolve(APP_DIR, "..", "..");
+
+/** Short commit of the tree under proof, marked when the tree is dirty. */
+export function commitStamp() {
+  try {
+    const sha = execSync("git rev-parse --short HEAD", { cwd: REPO_ROOT }).toString().trim();
+    const dirty = execSync("git status --porcelain", { cwd: REPO_ROOT }).toString().trim();
+    return dirty ? `${sha}+local-edits` : sha;
+  } catch {
+    return "unknown-commit";
+  }
+}
+
+/**
+ * playwright is a devDependency of apps/web-console, the only app in this
+ * repo that already needs a browser. Borrowing it keeps these harnesses at
+ * zero dependencies of their own.
+ */
+export function loadChromium() {
+  const candidates = [
+    // A git worktree has no node_modules of its own, so point this at a
+    // checkout that does: HARNESS_PLAYWRIGHT_ROOT=/path/to/hive.
+    process.env.HARNESS_PLAYWRIGHT_ROOT
+      ? join(process.env.HARNESS_PLAYWRIGHT_ROOT, "apps", "web-console", "package.json")
+      : null,
+    join(REPO_ROOT, "apps", "web-console", "package.json"),
+    join(APP_DIR, "package.json"),
+  ].filter(Boolean);
+  for (const from of candidates) {
+    try {
+      return createRequire(from)("playwright").chromium;
+    } catch {
+      // try the next resolution root
+    }
+  }
+  throw new Error(
+    "playwright not resolvable. Run `npm install` in apps/web-console, or set " +
+      "HARNESS_PLAYWRIGHT_ROOT to a checkout that has it.",
+  );
+}
+
+/**
+ * Screenshots `page` into `outDir`, with a footer stamped into the pixels.
+ *
+ * The stamp is the scenario, the shot, the commit, and a free-text note, in
+ * that order. It never carries a URL: a capture of a flow whose URL holds a
+ * credential (invitation accept, password reset, magic link) would then
+ * publish that credential in an image no text linter can inspect. Anything
+ * secret-shaped a caller wants recorded belongs in the text log, redacted
+ * there, not in a pixel.
+ */
+export async function shoot(page, { outDir, scenario, name, note = "" }) {
+  const stamp = [scenario, name, commitStamp(), note].filter(Boolean).join("  ·  ");
+  await page.evaluate((text) => {
+    // `next dev` paints a floating build-status badge that is an artefact of
+    // the harness, not of the app under proof.
+    document.querySelectorAll("nextjs-portal").forEach((el) => el.remove());
+
+    const existing = document.getElementById("harness-stamp");
+    if (existing) existing.remove();
+    const el = document.createElement("div");
+    el.id = "harness-stamp";
+    el.textContent = text;
+    el.style.cssText = [
+      "position:fixed",
+      "left:0",
+      "right:0",
+      "bottom:0",
+      "z-index:2147483647",
+      "padding:6px 10px",
+      "font:12px ui-monospace,SFMono-Regular,Menlo,monospace",
+      "background:#111",
+      "color:#f5f5f5",
+      "letter-spacing:0.02em",
+    ].join(";");
+    document.body.appendChild(el);
+  }, stamp);
+
+  const file = join(outDir, `${scenario}-${name}.png`);
+  await page.screenshot({ path: file, fullPage: true });
+  await page.evaluate(() => document.getElementById("harness-stamp")?.remove());
+  return file;
+}
+
+/** Polls `url` until it answers below 500, or throws naming `what`. */
+export async function waitForHttp(url, timeoutMs, what) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    try {
+      const response = await fetch(url);
+      if (response.status < 500) return;
+    } catch {
+      // not up yet
+    }
+    if (Date.now() > deadline) {
+      throw new Error(`${what} did not come up at ${url} within ${timeoutMs}ms`);
+    }
+    await new Promise((r) => setTimeout(r, 400));
+  }
+}

--- a/deploy/docker/Caddyfile.agent-proof
+++ b/deploy/docker/Caddyfile.agent-proof
@@ -1,0 +1,25 @@
+# One origin in front of the agent console and edge-api, for the CI visual
+# proof job (.github/workflows/agent-visual-proof.yml) only. Never deployed.
+#
+# It exists because the console's browser fetches are deliberately relative
+# (NEXT_PUBLIC_EDGE_API_BASE_URL is empty in the shipped image) and edge-api
+# serves no CORS headers, so the task console only works when something
+# serves both under one origin. In production that something is
+# Caddyfile.owui; standing the whole chat surface up in CI to get two routes
+# is not worth it.
+#
+# ponytail: the two routes below are copied from Caddyfile.owui rather than
+# shared with it. Known ceiling: a route change there does not reach here.
+# The proof this file supports is about the agent surface, not about the
+# proxy, and the routes are two lines; if they grow, boot the real thing.
+:80 {
+	@agentConsole path /agent-workspace /agent-workspace/*
+	reverse_proxy @agentConsole agent-console:3000
+
+	@agentApi path /v1/agent/*
+	reverse_proxy @agentApi edge-api:8080
+
+	# Nothing else is served: an unmatched path is a bug in the harness, not
+	# a route to invent.
+	respond 404
+}

--- a/deploy/docker/Caddyfile.agent-proof
+++ b/deploy/docker/Caddyfile.agent-proof
@@ -12,14 +12,24 @@
 # shared with it. Known ceiling: a route change there does not reach here.
 # The proof this file supports is about the agent surface, not about the
 # proxy, and the routes are two lines; if they grow, boot the real thing.
+# handle blocks, not bare matchers plus a respond: Caddy sorts directives into
+# its own canonical order rather than the order written, and `respond` sorts
+# ahead of `reverse_proxy`, so a trailing catch-all 404 answers every request
+# including the two that should have been proxied. Measured: run 31730077938
+# reported "proxy up (HTTP 404)" for /agent-workspace/tasks. handle blocks are
+# mutually exclusive and evaluated in written order, which is what this needs.
 :80 {
-	@agentConsole path /agent-workspace /agent-workspace/*
-	reverse_proxy @agentConsole agent-console:3000
+	handle /agent-workspace* {
+		reverse_proxy agent-console:3000
+	}
 
-	@agentApi path /v1/agent/*
-	reverse_proxy @agentApi edge-api:8080
+	handle /v1/agent/* {
+		reverse_proxy edge-api:8080
+	}
 
 	# Nothing else is served: an unmatched path is a bug in the harness, not
 	# a route to invent.
-	respond 404
+	handle {
+		respond 404
+	}
 }

--- a/deploy/docker/Caddyfile.agent-proof
+++ b/deploy/docker/Caddyfile.agent-proof
@@ -27,6 +27,13 @@
 		reverse_proxy edge-api:8080
 	}
 
+	# Served on this origin in production too (Caddyfile.owui). The harness
+	# reads it to say whether a missing Cowork surface is the tenant's gate
+	# or the session, instead of leaving the next run to guess.
+	handle /v1/featuregate* {
+		reverse_proxy edge-api:8080
+	}
+
 	# Nothing else is served: an unmatched path is a bug in the harness, not
 	# a route to invent.
 	handle {

--- a/scripts/install-agent-engine-host.sh
+++ b/scripts/install-agent-engine-host.sh
@@ -90,7 +90,17 @@ docker run --rm \
   -e CGO_ENABLED=0 \
   golang:1.24-alpine \
   go build -o /out/agent-engine ./apps/agent-engine/cmd/agent-engine
-chmod 0755 "$BIN_PATH"
+# `go build` already emits 0755, so this is belt and braces for an odd umask.
+# It is allowed to fail: under rootful Docker (every GitHub-hosted runner) the
+# build ran as root and the binary is not ours to chmod, which used to abort
+# the install with "Operation not permitted" even though the file was already
+# correct. What has to hold is that it ends up executable, so assert that
+# rather than trusting either the chmod or the builder.
+chmod 0755 "$BIN_PATH" 2>/dev/null || true
+if [ ! -x "$BIN_PATH" ]; then
+  echo "::error::$BIN_PATH is not executable after the build"
+  exit 1
+fi
 echo "binary: $BIN_PATH"
 
 # ---------------------------------------------------------------------------

--- a/scripts/redact-log-credentials.py
+++ b/scripts/redact-log-credentials.py
@@ -38,6 +38,16 @@ CREDENTIAL_PARAMS = [
     "client_secret",
     "api_key",
     "apikey",
+    # Bare `key`, which the `[A-Za-z0-9_]*` prefix below turns into every
+    # `*_KEY` spelling at once: S3_ACCESS_KEY, S3_SECRET_KEY,
+    # LITELLM_MASTER_KEY, SUPABASE_ANON_KEY. All four are wired into
+    # .github/workflows/agent-visual-proof.yml, whose failure-log artifact is
+    # downloadable by anyone with the run URL on a public repository, and
+    # none of them matched before. It over-redacts benign `key=` pairs
+    # (idempotency_key, cache_key) and that is the right direction for a
+    # filter whose output is published: a lost debugging value costs a
+    # rerun, a lost credential costs a rotation.
+    "key",
     "password",
     "secret",
     "token",
@@ -112,6 +122,20 @@ def selfcheck() -> None:
         out = redact(line)
         assert SAMPLE_VALUE not in out, out
         assert "PASSWORD=<redacted>" in out, out
+
+    # Every `*_KEY` spelling wired into the agent visual proof job, whose
+    # failure-log artifact is public. None of these matched before `key` was
+    # added to CREDENTIAL_PARAMS.
+    for line in (
+        f"S3_ACCESS_KEY={SAMPLE_VALUE}",
+        f"S3_SECRET_KEY={SAMPLE_VALUE}",
+        f"LITELLM_MASTER_KEY={SAMPLE_VALUE}",
+        f"SUPABASE_ANON_KEY={SAMPLE_VALUE}",
+        f"edge-api  | starting with access_key={SAMPLE_VALUE} configured",
+    ):
+        out = redact(line)
+        assert SAMPLE_VALUE not in out, out
+        assert "=<redacted>" in out, out
 
     # Bare tokens with no parameter name around them.
     assert SAMPLE_JWT not in redact(f"Authorization: Bearer {SAMPLE_JWT}")


### PR DESCRIPTION
## What this is

A CI job that captures visual proof of the Cowork agent-task surface **before** a pull request merges, on the pull request itself. The owner ruled on 2026-08-13 that proof for the Cowork fixes is produced in CI on the pull request, not captured after merge against the deployed box.

## Why it has to exist

Orchestrator rule 8 forbids merging a change to a live UI surface without a fresh capture taken against the actually-running stack, posted in the pull request. PR #891 could not satisfy that:

* A Cowork task only really launches through the socket arm of `buildAgentEngine` (`apps/control-plane/cmd/server/main.go`). Under docker compose the in-process arm cannot succeed at all.
* The Apptainer image is `linux/amd64` and cannot be built on the WSL2 dev box, so control-plane there falls back to `NotConfiguredEngine` and any local capture proves the absence of an engine, not the presence of a fix.
* The only stack that could launch a real task was the demo box, which runs already-merged code.

Proof-before-merge was therefore circular. This job breaks the circle by standing the real thing up per run.

## Runner choice, with evidence

**GitHub-hosted `ubuntu-latest`**, not the self-hosted demo-box runner.

* The hosted image already runs an unprivileged bubblewrap sandbox in `ci.yml`'s `egress-firewall-e2e` job after setting the same two AppArmor sysctls this job sets, so unprivileged user namespaces are known to work there. That is an inference from an existing green job, so the workflow does not rest on it: a dedicated step execs the real SIF (`apptainer exec "$sif" /bin/true`) and fails the run if the sandbox cannot start. The runner question is answered per run, as a fact, and the fallback signal to the self-hosted runner is that step going red.
* The self-hosted runner was rejected on two counts. `scripts/install-agent-engine-host.sh` stops and restarts the `hive-agent-engine` systemd unit and rewrites `/home/sakib/agent-runtime`, so a proof run would reach straight into the live launcher's state and disturb the live demo surface. Running an untrusted pull request branch on a persistent runner attached to a public repository is also the configuration GitHub explicitly warns against. A hosted runner is disposable, so neither question arises.

## What the job does

1. Installs Apptainer, enables unprivileged user namespaces, and starts a systemd user session (rootless cgroups need `XDG_RUNTIME_DIR` and `DBUS_SESSION_BUS_ADDRESS`, or every launch dies).
2. Runs the shipped `scripts/install-agent-engine-host.sh` unmodified. It fetches the newest CI-built `agent-engine-sif` artifact, builds the launcher, and starts it as an unprivileged systemd user unit. `HIVE_QUOTA_USER_CONCURRENCY=1`, which is what makes the concurrency ceiling observable with a single running task.
3. Execs the SIF directly as the runner-capability preflight.
4. Boots redis, litellm, control-plane, edge-api and agent-console from the pull request's merge ref, with `HIVE_AGENT_ENGINE_SOCKET` set and the launcher's socket directory bind-mounted. The control-plane container is given **no** `CAP_SYS_ADMIN` and **no** `/dev/fuse`; the socket arm exists precisely so it never needs them.
5. Asserts control-plane took the socket arm: the boot log must say the daemon is reachable and must not say the engine is unconfigured. Without this the job could screenshot a `NotConfiguredEngine` stack and call it proof.
6. Serves the console and edge-api from one origin through a small Caddy front (`deploy/docker/Caddyfile.agent-proof`), because the console's browser fetches are relative by design and edge-api serves no CORS headers.
7. Seeds a run-scoped fixture tenant and enables `ENABLE_COWORK` for it, then drives the console with `apps/agent-console/proof/harness/capture-live.mjs`.
8. Uploads the captures as an artifact **and** pushes them to a side branch and posts them as a comment on the target pull request. An artifact alone is a zip behind an authenticated download, which does not satisfy rule 8.

## The two behaviours, and the slot count

`cancel-frees-slot` (issue #886) does not screenshot a badge turning grey. With one slot configured, it:

1. runs a task and records the launcher's live session count as 1,
2. submits a second task and captures it being refused while the slot is held,
3. cancels the first and waits for the count to reach 0,
4. submits a third and captures it launching.

The count is read from the launcher's own `sessions/` directory. `SandboxEngine.Launch` creates exactly one directory there per live session and `reap()` removes it in the same call that runs the quota release, so the number is the slot rather than a proxy for it. Before #886 the count stayed at 1 across a cancel and the next create stayed refused.

`create-returns-queued` (issue #881) reads the create response off the wire: HTTP 201, body status `queued`, inside a 14 second budget under edge-api's 15 second client bound. The measured latency is stamped into the screenshot, so the image and the number cannot drift apart.

## Failing loudly

The job fails, never passes quietly, when: the SIF is missing, `apptainer exec` is refused, control-plane falls back to `NotConfiguredEngine`, the proof origin never answers, the composer never renders (no session, or the gate is off), a task never reaches Running, a scenario's assertion fails, or zero screenshots were written. `if-no-files-found: error` covers the upload.

The property is demonstrated rather than asserted: `-f sabotage=true` stops the launcher immediately before the capture, so nothing can launch. The red run is linked in a comment below.

## Reuse

Not welded to #891. `gh workflow run "agent visual proof" -f pr=<number>` aims it at any pull request; it checks out `refs/pull/<number>/merge`, so the proof is of what would land. Automatic `pull_request` runs on agent-surface paths execute the `launch-liveness` scenario, which asserts nothing version specific and holds every agent-surface change to "the surface still launches". Behaviour-specific scenarios are what a dispatch selects, because only the dispatcher knows which behaviours a given pull request claims.

## Credential handling

* `CONTROL_PLANE_INTERNAL_TOKEN` is minted per run with `openssl rand` and masked. The demo box's token is never used here, so a leak of one cannot reach the other. No secret is echoed anywhere.
* The session comes from the admin one-time-token flow in `live-auth.mjs`. No password is read, written or rotated.
* `E2E_RUN_KEY` is supplied (`runScopedEmail` throws without it since PR #880), so every fixture address belongs to this run.
* Captures land under `docs/proof/`, which is the directory `npm run lint:proof-tokens` scans, and the job runs that linter before publishing. The pixel half is handled structurally: the screenshot stamp carries the scenario, the shot, the commit and a note, and never a URL.

## Test plan

* [ ] The automatic run on this pull request executes `launch-liveness` end to end against a real sandbox.
* [ ] A `sabotage=true` run goes red with no screenshots, demonstrating the empty-capture guard.
* [ ] A dispatch at `pr=891` posts the two behaviour captures on that pull request.

Note that the first two need this workflow on a branch GitHub will run, and the third needs it on `main`, since `workflow_dispatch` is only offered for workflows present on the default branch.
