### PR TITLE
fix: memoize control-plane session revalidation per request

### DIFF
--- a/apps/web-console/__tests__/control-plane-get-user-retry.test.ts
+++ b/apps/web-console/__tests__/control-plane-get-user-retry.test.ts
@@ -1,0 +1,103 @@
+/**
+ * getRequestContext() (lib/control-plane/client.ts) retries supabase.auth.getUser()
+ * once before giving up: a transient upstream hiccup (the failure class that
+ * crashed the budget settings page in CI -- console-budgets.spec.ts failed
+ * with the console's generic error boundary instead of the budget form)
+ * usually clears on a second attempt a moment later.
+ *
+ * This guards the retry bound on both sides: a transient failure followed by
+ * success must not surface as an error, and a call that keeps failing must
+ * not retry a third time (that would be a silent behavior change, and an
+ * unbounded retry on a genuinely revoked token is its own bug).
+ *
+ * Does not (and cannot, in this jsdom-based vitest environment) exercise
+ * getRequestContext()'s React cache() memoization: that dedup only activates
+ * under the "react-server" module condition Next.js's bundler selects for
+ * real Server Components, which the client "react" build resolved here does
+ * not apply outside of it. See the PR discussion this test's commit
+ * accompanies for why a jsdom test asserting that specifically was written,
+ * found to fail identically with and without the fix, and removed rather
+ * than shipped.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetUser = vi.fn();
+const mockGetSession = vi.fn();
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn(async () => ({
+    get: vi.fn(() => undefined),
+    getAll: vi.fn(() => []),
+  })),
+}));
+
+vi.mock("../lib/supabase/server", () => ({
+  createClient: vi.fn(() => ({
+    auth: { getUser: mockGetUser, getSession: mockGetSession },
+  })),
+}));
+
+const BASE_URL = "http://control-plane.internal:8081";
+
+const VIEWER_PAYLOAD = {
+  user: { id: "u1", email: "owner@example.com", email_verified: true },
+  current_account: {
+    id: "acc1",
+    display_name: "Acme",
+    account_type: "workspace",
+    role: "owner",
+  },
+  memberships: [],
+  permissions: [],
+};
+
+describe("getRequestContext retries getUser once on a transient failure", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    process.env.CONTROL_PLANE_BASE_URL = BASE_URL;
+    mockGetSession.mockResolvedValue({
+      data: { session: { access_token: "<ACCESS_TOKEN>" } },
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve(new Response(JSON.stringify(VIEWER_PAYLOAD), { status: 200 }))
+      )
+    );
+  });
+
+  it("succeeds when the first getUser call fails and the second succeeds", async () => {
+    mockGetUser
+      .mockResolvedValueOnce({ data: { user: null }, error: new Error("upstream hiccup") })
+      .mockResolvedValueOnce({ data: { user: { id: "u1" } }, error: null });
+
+    const client = await import("../lib/control-plane/client");
+
+    await expect(client.getViewer()).resolves.toMatchObject({
+      user: { id: "u1" },
+    });
+    expect(mockGetUser).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws after the second getUser call also fails, without a third attempt", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: null },
+      error: new Error("still failing"),
+    });
+
+    const client = await import("../lib/control-plane/client");
+
+    await expect(client.getViewer()).rejects.toThrow();
+    expect(mockGetUser).toHaveBeenCalledTimes(2);
+  });
+
+  it("makes exactly one getUser call when the first attempt already succeeds", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "u1" } }, error: null });
+
+    const client = await import("../lib/control-plane/client");
+
+    await client.getViewer();
+    expect(mockGetUser).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web-console/app/console/billing/budget/page.tsx
+++ b/apps/web-console/app/console/billing/budget/page.tsx
@@ -9,21 +9,44 @@
 import { redirect } from "next/navigation";
 
 import {
+  EMPTY_ACCOUNT_PROFILE,
   getAccountProfile,
   getBudget,
   getViewer,
+  type Viewer,
 } from "@/lib/control-plane/client";
 import { BudgetForm } from "@/components/billing/budget-form";
 import { ConsoleShell } from "@/components/app-shell/console-shell";
 import { PageHeader } from "@/components/ui/page-header";
 
 export default async function BudgetSettingsPage() {
-  const viewer = await getViewer();
+  // getViewer() already retries one transient Supabase Auth hiccup
+  // (lib/control-plane/client.ts). A second failure means the session
+  // genuinely cannot be resolved, so this redirects to sign-in -- the same
+  // destination an expired session already takes (tests/e2e/unauth.spec.ts)
+  // -- instead of letting the throw reach the generic error boundary. There
+  // is nothing else this page can render without a viewer: no role, no
+  // workspace id, no email.
+  let viewer: Viewer;
+  try {
+    viewer = await getViewer();
+  } catch (error) {
+    console.error("BudgetSettingsPage: could not load viewer", error);
+    redirect("/auth/sign-in");
+  }
   if (viewer.user.email_verified === false) {
     redirect("/console/settings/profile");
   }
 
-  const profile = await getAccountProfile();
+  // A profile-fetch failure is not a session problem -- the page still knows
+  // who the viewer is and which workspace this is, so it degrades to the
+  // same empty/not-yet-set-up profile a fresh account already renders
+  // (EMPTY_ACCOUNT_PROFILE), rather than crashing on a field this page only
+  // needs for a display name fallback.
+  const profile = await getAccountProfile().catch((error: unknown) => {
+    console.error("BudgetSettingsPage: could not load account profile", error);
+    return EMPTY_ACCOUNT_PROFILE;
+  });
   const workspaceId = viewer.current_account.id;
   const isOwner = viewer.current_account.role === "owner";
 

--- a/apps/web-console/app/console/layout.tsx
+++ b/apps/web-console/app/console/layout.tsx
@@ -6,6 +6,7 @@ import {
   getViewer,
   getBalance,
   getBudgetThreshold,
+  type Viewer,
 } from "@/lib/control-plane/client";
 import { readTenantIdClaim } from "@/lib/auth/tenant-claim";
 import { createClient } from "@/lib/supabase/server";
@@ -22,7 +23,20 @@ interface ConsoleLayoutProps {
 // components/workspace-switcher.tsx) so each page picks its own `active`
 // route.
 export default async function ConsoleLayout({ children }: ConsoleLayoutProps) {
-  const viewer = await getViewer();
+  // getViewer() already retries one transient Supabase Auth hiccup
+  // (lib/control-plane/client.ts). A second failure means the session
+  // genuinely cannot be resolved right now, and every page under this layout
+  // shares this one call, so this is the one place that closes the crash for
+  // all of them: redirect to sign-in, the same destination an expired
+  // session already takes (tests/e2e/unauth.spec.ts), instead of letting the
+  // throw reach the generic error boundary.
+  let viewer: Viewer;
+  try {
+    viewer = await getViewer();
+  } catch (error) {
+    console.error("ConsoleLayout: could not load viewer", error);
+    redirect("/auth/sign-in");
+  }
 
   // A signed-in user can legitimately hold no tenant membership: the Supabase
   // access-token hook issues a valid token with no tenant_id claim rather than

--- a/apps/web-console/lib/control-plane/client.ts
+++ b/apps/web-console/lib/control-plane/client.ts
@@ -52,6 +52,20 @@ export interface AccountProfile {
   profile_setup_complete: boolean;
 }
 
+// The not-yet-set-up shape: a fresh account with no profile row (control-plane
+// 404s), and the fallback a page takes when the profile fetch itself fails.
+// Same reasoning as the 404 case below — render the needs-setup state rather
+// than crash.
+export const EMPTY_ACCOUNT_PROFILE: AccountProfile = {
+  owner_name: "",
+  login_email: "",
+  display_name: "",
+  account_type: "",
+  country_code: "",
+  state_region: "",
+  profile_setup_complete: false,
+};
+
 export interface UpdateAccountProfileInput {
   ownerName: string;
   loginEmail: string;
@@ -125,26 +139,32 @@ interface RequestContext {
   headers: Record<string, string>;
 }
 
-// Memoized per request with React's cache(): every exported function below
-// calls this before its own control-plane fetch, and a single server page can
-// legitimately call several of them (the budget settings page alone calls
-// getViewer, getAccountProfile, and getBudget; its parent layout calls
-// getViewer, getBalance, and getBudgetThreshold on the very same navigation).
-// Unmemoized, that is six separate real network round-trips to Supabase
-// Auth's getUser() for one page load, each one a chance for a transient
-// upstream hiccup to throw "No active session" and crash the whole Server
-// Components tree — confirmed live: a CI run of
-// tests/e2e/console-budgets.spec.ts failed with the console's generic error
-// boundary ("Something went wrong on this page") on a page whose only two
-// unguarded upstream calls are getViewer() and getAccountProfile(), and eight
-// of the eighteen console pages (this one included) make three or more of
-// these calls on one render, with the shared layout adding four more of its
-// own on every single one of them. cache() scopes the memoized
-// promise to a single request (Next.js's per-request React cache, reset on
-// the next navigation), so this does not change session freshness across
-// page loads, only how many times one page load re-derives it. Cuts the
-// external-call surface, and therefore the flake surface, without weakening
-// or skipping the session check itself.
+// Memoized per request with React's cache(): confirmed benefit is scoped to
+// the ~16 page.tsx/layout.tsx Server Components that call these exports (the
+// budget settings page alone calls getViewer, getAccountProfile, and
+// getBudget; its parent layout calls getViewer, getBalance, and
+// getBudgetThreshold on the same navigation — up to 6 calls per page load,
+// unmemoized). cache() dedup is scoped by React to the render of that
+// component tree; it does not apply to the ~15 Route Handlers under
+// app/api/**/route.ts that import this module, but each of those calls a
+// getRequestContext-consuming function once per invocation, so there is no
+// multi-call dedup to lose there either way.
+//
+// Each of those (up to 6, per Server Component render) calls was a real
+// network round trip to Supabase Auth's getUser(), and a chance for a
+// transient upstream hiccup to throw "No active session" — confirmed live: a
+// CI run of tests/e2e/console-budgets.spec.ts failed with the console's
+// generic error boundary ("Something went wrong on this page") instead of
+// the budget page. cache() collapses those up-to-6 chances into 1 per
+// request (scoped to that one request; reset on the next navigation, so this
+// does not change session freshness). The one-retry below closes most of
+// what's left of that one remaining chance. Neither eliminates it: a retry
+// exhausted or a memoized rejection is still a thrown error, and the two
+// call sites that throw uncaught on it (getViewer, getAccountProfile in
+// app/console/billing/budget/page.tsx and its layout) now catch it and
+// redirect to sign-in instead of letting it reach the generic boundary — see
+// those two files. The other 16 console pages that call getViewer() directly
+// still have the bare crash-on-throw path; known follow-up, not closed here.
 const getRequestContext = cache(async (): Promise<RequestContext> => {
   const cookieStore = await cookies();
   const supabase = createClient(cookieStore);
@@ -152,10 +172,21 @@ const getRequestContext = cache(async (): Promise<RequestContext> => {
   // Validate the JWT against Supabase (getUser does a server round-trip
   // and rejects revoked tokens) before trusting the session. getSession
   // only reads the cookie and would accept a revoked token.
-  const {
-    data: { user },
-    error: userError,
-  } = await supabase.auth.getUser();
+  //
+  // One retry only: a transient upstream hiccup (the failure class that
+  // crashed the budget page, see above) usually clears on a second attempt
+  // a moment later. A genuinely revoked or invalid token fails identically
+  // both times, so this cannot turn a real refusal into a false accept.
+  let user: Awaited<ReturnType<typeof supabase.auth.getUser>>["data"]["user"] =
+    null;
+  let userError: Awaited<ReturnType<typeof supabase.auth.getUser>>["error"] =
+    null;
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const result = await supabase.auth.getUser();
+    user = result.data.user;
+    userError = result.error;
+    if (!userError && user) break;
+  }
   if (userError || !user) {
     throw new Error("No active session");
   }
@@ -905,15 +936,7 @@ export async function getAccountProfile(): Promise<AccountProfile> {
   // and billing pages can render their needs-setup state instead of
   // crashing the whole Server Components tree.
   if (response.status === 404) {
-    return {
-      owner_name: "",
-      login_email: "",
-      display_name: "",
-      account_type: "",
-      country_code: "",
-      state_region: "",
-      profile_setup_complete: false,
-    };
+    return EMPTY_ACCOUNT_PROFILE;
   }
 
   if (!response.ok) {

--- a/apps/web-console/lib/control-plane/client.ts
+++ b/apps/web-console/lib/control-plane/client.ts
@@ -1,3 +1,4 @@
+import { cache } from "react";
 import { cookies } from "next/headers";
 import { createClient } from "@/lib/supabase/server";
 import {
@@ -124,7 +125,27 @@ interface RequestContext {
   headers: Record<string, string>;
 }
 
-async function getRequestContext(): Promise<RequestContext> {
+// Memoized per request with React's cache(): every exported function below
+// calls this before its own control-plane fetch, and a single server page can
+// legitimately call several of them (the budget settings page alone calls
+// getViewer, getAccountProfile, and getBudget; its parent layout calls
+// getViewer, getBalance, and getBudgetThreshold on the very same navigation).
+// Unmemoized, that is six separate real network round-trips to Supabase
+// Auth's getUser() for one page load, each one a chance for a transient
+// upstream hiccup to throw "No active session" and crash the whole Server
+// Components tree — confirmed live: a CI run of
+// tests/e2e/console-budgets.spec.ts failed with the console's generic error
+// boundary ("Something went wrong on this page") on a page whose only two
+// unguarded upstream calls are getViewer() and getAccountProfile(), and eight
+// of the eighteen console pages (this one included) make three or more of
+// these calls on one render, with the shared layout adding four more of its
+// own on every single one of them. cache() scopes the memoized
+// promise to a single request (Next.js's per-request React cache, reset on
+// the next navigation), so this does not change session freshness across
+// page loads, only how many times one page load re-derives it. Cuts the
+// external-call surface, and therefore the flake surface, without weakening
+// or skipping the session check itself.
+const getRequestContext = cache(async (): Promise<RequestContext> => {
   const cookieStore = await cookies();
   const supabase = createClient(cookieStore);
 
@@ -163,7 +184,7 @@ async function getRequestContext(): Promise<RequestContext> {
   }
 
   return { baseUrl, headers };
-}
+});
 
 function isJsonObject(value: JsonValue | null): value is JsonObject {
   return typeof value === "object" && value !== null && !Array.isArray(value);


### PR DESCRIPTION
## Summary

`tests/e2e/console-budgets.spec.ts`'s "budget caps are editable for the owner and disabled for a member" intermittently fails `expect(locator).toBeVisible()` on the page's static "Budget settings" heading. A downloaded CI artifact (`error-context.md` from PR #891's run) shows why: the console's own generic error boundary had rendered ("Something went wrong on this page") instead of the budget page at all.

## The two hypotheses this was asked to confirm or refute, both refuted with evidence

1. **PR #878 split a shared 403 response code (`email_verification_required`) into two (`permission_denied` / `email_verification_required`) in `apps/control-plane/internal/budgets/http.go`.** True, but that split lives entirely in `resolveCurrentAccountID`, which only backs the legacy `/api/v1/accounts/current/budget` endpoints. The console's budget settings page and this test both call the separate Phase 14 workspace surface (`/api/v1/budgets/{workspace_id}`, `requireWorkspaceOwner`/`requireWorkspaceMembership`), which PR #878 did not change in behavior (only a literal-to-constant rename, same value). This code path is not reachable from the failing test.
2. **"PR #878 touched only Go files, so CI's path filter marked Web E2E as skipped on main."** Also false. PR #878's diff includes `apps/web-console/app/console/account-switch/route.ts`, `apps/web-console/components/workspace-switcher.tsx`, `apps/web-console/app/invitations/accept/page.tsx`, and a unit test. Its own PR ran `Web E2E (full stack)` and it was green (`gh pr view 878` shows conclusion SUCCESS), and the direct push-to-main run for that exact merge commit also ran the suite green with 0% flake. Independently, `.github/workflows/ci.yml`'s `web_e2e` path filter already treats `apps/control-plane/*` as a trigger (line ~249), so even a Go-only change under `apps/control-plane/internal/*` would not have been skipped. Audited the filter against `go.work`'s actual members; it already covers everything this job boots. No blind spot found for this scenario.

## The real, demonstrated defect

`lib/control-plane/client.ts`'s `getRequestContext()` calls `supabase.auth.getUser()`, a real network round trip to Supabase Auth, and is called by every one of the ~45 exported client functions before their own control-plane fetch. Nothing memoized it. One navigation to `/console/billing/budget` fires it 3 times from `page.tsx` (`getViewer`, `getAccountProfile`, `getBudget`) plus 3 more from the parent `layout.tsx` (`getViewer`, `getBalance`, `getBudgetThreshold`): up to 6 independent external round trips per page load. `getViewer()` and `getAccountProfile()` had no failure handling for a non-404 error (unlike the adjacent `getBudget(...).catch(() => null)`), so any one of those redundant round trips hitting a transient upstream hiccup threw uncaught and took down the entire page.

The confirmed benefit of memoizing that function is scoped to the **~16 `page.tsx`/`layout.tsx` Server Components** that call it (this was verified with a grep, not assumed). Roughly 15 of the ~45 callers are App Router Route Handlers under `app/api/**/route.ts`; React's `cache()` dedup only applies within a Server Component render, so it does nothing there, but each of those handlers calls a `getRequestContext`-backed function once per invocation anyway, so there is no multi-call dedup opportunity lost.

## Fix

Three parts, the second and third added after `typescript-reviewer`'s pass on this PR flagged that the first part alone reduces the crash's frequency without closing it:

1. **Memoization.** Wrapped `getRequestContext()` in React's `cache()`, so every control-plane client call within one server request shares a single session-revalidation result instead of repeating it once per call. Cuts the budget page's per-load session round trips from up to 6 to 1, and does the same for the other 7 console pages that make 3+ such calls per render.
2. **Retry.** `getRequestContext()` now retries `supabase.auth.getUser()` once before giving up. `cache()` memoizes a rejected promise exactly the same way it memoizes a resolved one, so without this, one failure on the single shared call would still crash the page, just less often than the pre-fix six independent chances. A transient upstream hiccup usually clears on a second attempt a moment later; a genuinely revoked or invalid token fails identically both times, so this cannot turn a real refusal into a false accept.
3. **Closing the throw path on this page.** `app/console/layout.tsx` (which wraps every console page, including budget) and `app/console/billing/budget/page.tsx` now catch a `getViewer()` failure and redirect to `/auth/sign-in`, the same destination an expired session already takes, instead of letting the throw reach the generic error boundary. There is nothing else either can render without a viewer (no role, no workspace id, no email). The budget page's `getAccountProfile()` failure degrades to the same `EMPTY_ACCOUNT_PROFILE` shape a fresh account's 404 response already renders, since a profile-fetch failure is not a session problem and the page still knows who the viewer is.

Not fixed here, flagged as a follow-up: the other ~16 console pages that call `getViewer()` directly still have the bare crash-on-throw path this PR closes only for `layout.tsx` (and therefore every page it wraps) and the budget page's own second call site (`getAccountProfile`).

## Verification

- `npx tsc --noEmit`: clean.
- `npx vitest run` (web-console): 530/530 passing (527 + 3 new).
- `tests/e2e/console-budgets.spec.ts` run 9 times total against a locally rebuilt stack across the two commits on this branch (8 consecutive runs before the review-response commit, 1 more after it), fresh run-scoped fixtures per run per `docs/live-test-auth.md`: 9/9 passed.
- CI's own `Web E2E (full stack)` check on this PR passed (11m33s) before the review-response commit.
- Added `__tests__/control-plane-get-user-retry.test.ts` for the retry bound in both directions (a transient failure followed by success must succeed; a call that keeps failing must not retry a third time). Verified red without the fix (`git stash` of `client.ts`, confirmed the test fails), green with it.
- The `cache()` memoization itself remains unguarded by a unit test: it only activates under the `react-server` module condition Next.js's bundler selects for real Server Components, which this project's jsdom-based vitest never applies. Wrote and ran an equivalent test; it failed identically with and without the fix, so it was removed rather than shipped as a check that cannot fail for the right reason. The alternative suggested in review (a Playwright network-interception count) does not apply either: `getUser()` runs server-side, inside the Next.js process talking to Supabase Auth over its own connection, which is invisible to Playwright's `page.route()` (browser-initiated requests only). Left guarded by the 9 consecutive green e2e runs above rather than by an automated regression check for this specific property.

## Buglog entry

```json
{"id": "BUG-2026-08-16-console-request-context-unmemoized", "date": "2026-08-16", "title": "Unmemoized per-call Supabase session revalidation crashed console pages on any transient hiccup", "error_message": "tests/e2e/console-budgets.spec.ts intermittently failed toBeVisible on a static page heading; a CI artifact showed the Next.js generic error boundary (Something went wrong on this page) had rendered instead of the budget settings page", "root_cause": "lib/control-plane/client.ts's getRequestContext() calls supabase.auth.getUser(), a real network round trip, and every one of its ~45 exported client functions calls it first with no memoization. The budget settings page alone makes 3 such calls (getViewer, getAccountProfile, getBudget) and its parent layout makes 3 more (getViewer, getBalance, getBudgetThreshold) on the same navigation, for up to 6 independent round trips per page load. getViewer() and getAccountProfile() had no failure handling for a non-404 error, unlike the adjacent getBudget().catch(() => null), so any one of those six calls hitting a transient upstream hiccup threw uncaught and crashed the whole Server Components tree. Investigated as a suspected regression from PR #878's budgets/http.go 403-code split and Go-only-PR path-filter skip; both refuted: that split only reaches the legacy /api/v1/accounts/current/budget endpoints this page never calls, #878 also touched web-console files and its own CI run (and the direct push-to-main run) were green with 0% flake, and ci.yml's web_e2e path filter already treats apps/control-plane/* as a trigger.", "fix": "Wrapped getRequestContext() in React's cache() so every control-plane client call within one server request shares a single session-revalidation result (scoped to the ~16 page.tsx/layout.tsx Server Components that see the benefit; ~15 Route Handler callers make one such call per invocation regardless and gain nothing from the dedup). Added a single retry on the underlying getUser() call, since cache() memoizes a rejection the same as a resolved value and would otherwise still crash on one failure per request instead of six. Closed the remaining throw path on the console layout and the budget page specifically: both now catch a getViewer() failure and redirect to sign-in instead of reaching the generic error boundary, and the budget page's getAccountProfile() failure degrades to the existing empty-profile shape. The other console pages that call getViewer() directly remain a separate follow-up.", "tags": ["web-console", "control-plane", "flaky-test", "performance", "resilience", "ci-investigation"], "issue": null}
```

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` -- 530/530 passing
- [x] `tests/e2e/console-budgets.spec.ts` -- 9 total local runs across both commits, 9/9 passed
- [x] CI `Web E2E (full stack)` passed on this PR
- [x] Confirmed via `gh pr view 878` and `gh api .../check-runs` that PR #878's own CI run and the direct push-to-main run both executed and passed `Web E2E (full stack)` with 0% flake, refuting the "invisible on main" premise
- [x] Confirmed `apps/control-plane/internal/budgets/http.go`'s 403-code split only affects `/api/v1/accounts/current/budget`, not the workspace budget surface this page and test use
- [x] Audited `.github/workflows/ci.yml`'s `web_e2e` path filter against `go.work` members; no gap found for this scenario
- [x] Regression guard for the retry bound (red-without/green-with confirmed); `cache()` dedup itself deliberately left without a unit-level guard, reasoning above
