### PR TITLE
fix: lift the whole credit hold at capture, so a settled request stops being billed twice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -427,7 +427,16 @@ jobs:
             # absent from this list, so the escalation those guards catch
             # would have shipped again with the suite reporting green.
             # tools/lint-go-db-test-wiring.mjs fails if either is dropped.
-            go test -tags integration -count=1 -p 1 -v ./internal/accounts/... ./internal/agenttask/... ./internal/egress/... ./internal/payments/... ./internal/profiles/... ./internal/rag/... ./internal/tenants/... ./internal/signup/... ./internal/routing/... ./internal/litellmconfig/... ./internal/catalog/... ./internal/providers/... ./internal/platform ./internal/platform/db/...
+            # ./internal/accounting/... carries the credit-reservation
+            # settlement suites. Its two HIVE_TEST_DB_URL-gated tests, the
+            # release-key dedup proof (issue #652) and the settlement magnitude
+            # proof (issue #616), had never run anywhere: the package was absent
+            # from this list and the -short step above skips them for want of
+            # the env var. The magnitude one is the only check that measures the
+            # ledger on real Postgres rather than through a fake, so leaving it
+            # unlisted is the same never-runs trap as issues #701 and #708, on
+            # the money path.
+            go test -tags integration -count=1 -p 1 -v ./internal/accounts/... ./internal/accounting/... ./internal/agenttask/... ./internal/egress/... ./internal/payments/... ./internal/profiles/... ./internal/rag/... ./internal/tenants/... ./internal/signup/... ./internal/routing/... ./internal/litellmconfig/... ./internal/catalog/... ./internal/providers/... ./internal/platform ./internal/platform/db/...
           else
             # -tags integration additionally compiles in
             # inference/chat_completions_integration_test.go (issue #708),

--- a/apps/control-plane/internal/accounting/reaper.go
+++ b/apps/control-plane/internal/accounting/reaper.go
@@ -2,6 +2,7 @@ package accounting
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -166,6 +167,20 @@ func (r *Reaper) RunOnce(ctx context.Context) (ReapResult, error) {
 			// A refused release is not fatal to the pass: one reservation that
 			// settled underneath us must not strand the rest of the batch.
 			result.Failed++
+			// A divergence is different in kind from a lost race. The ledger
+			// already holds a release for a different amount, so no pass can
+			// ever clear this hold and an operator has to reconcile it; log it
+			// at error so alerting separates it from the ordinary refusals this
+			// loop expects to see.
+			var divergence *SettlementDivergenceError
+			if errors.As(err, &divergence) {
+				r.logger.ErrorContext(ctx, "accounting: reaper found a hold whose ledger release disagrees with the row, manual reconciliation required",
+					"reservation_id", reservation.ID.String(),
+					"account_id", reservation.AccountID.String(),
+					"posted_release_credits", divergence.PostedCredits,
+					"held_credits", divergence.WantCredits)
+				continue
+			}
 			r.logger.WarnContext(ctx, "accounting: reaper could not release a stranded hold",
 				"reservation_id", reservation.ID.String(),
 				"account_id", reservation.AccountID.String(),

--- a/apps/control-plane/internal/accounting/reservation_terminal_state_test.go
+++ b/apps/control-plane/internal/accounting/reservation_terminal_state_test.go
@@ -146,8 +146,14 @@ func TestReleaseAfterUnconfirmedSettlementKeepsRowBalanced(t *testing.T) {
 	if len(ledgerSvc.chargeCalls) != 1 || ledgerSvc.chargeCalls[0].credits != 1003 {
 		t.Fatalf("expected one 1003-credit charge, got %#v", ledgerSvc.chargeCalls)
 	}
-	if len(ledgerSvc.releaseCalls) != 1 || ledgerSvc.releaseCalls[0].credits != 8997 {
-		t.Fatalf("expected only the finalize's own 8997-credit release, got %#v", ledgerSvc.releaseCalls)
+	// One release, for the WHOLE 10000 hold rather than the 8997 unused
+	// remainder: capture lifts the authorization in full, and the 1003 charged
+	// is posted separately (issue #616). The row still records 8997 as its
+	// released_credits, asserted by the balance check above, because that
+	// column answers how the hold was disposed of rather than whether any
+	// authorization is still outstanding.
+	if len(ledgerSvc.releaseCalls) != 1 || ledgerSvc.releaseCalls[0].credits != 10000 {
+		t.Fatalf("expected only the finalize's own 10000-credit hold lift, got %#v", ledgerSvc.releaseCalls)
 	}
 	if repo.releaseEventCounts[reservation.ID] != 0 {
 		t.Fatalf("expected no release event row, got %d", repo.releaseEventCounts[reservation.ID])

--- a/apps/control-plane/internal/accounting/service.go
+++ b/apps/control-plane/internal/accounting/service.go
@@ -293,29 +293,64 @@ func (s *Service) finalizeLocked(ctx context.Context, input FinalizeReservationI
 		actualCredits = heldCredits
 	}
 
-	releaseCredits := releasableCredits(reservation, actualCredits)
+	// unusedCredits is a fact about the RESERVATION: how much of the hold never
+	// turned into spend. It is what the row records, beside consumed_credits,
+	// and the two still sum to reserved_credits.
+	unusedCredits := releasableCredits(reservation, actualCredits)
 
 	if actualCredits > 0 {
-		if _, err := s.ledgerSvc.ChargeUsage(ctx, reservation.AccountID, reservation.RequestID, &reservation.RequestAttemptID, &reservation.ID, s.idempotencyKey(reservation.ID, fmt.Sprintf("charge-%d", actualCredits)), actualCredits, map[string]any{
+		// Idempotency key is "charge", not "charge-<credits>", for the same
+		// reason the release key is flat (issue #652): a key that varies with
+		// the amount cannot deduplicate two settlement attempts that DISAGREE
+		// on the amount, which is exactly the case worth catching. That retry
+		// is reachable, not hypothetical -- the charge posts before the
+		// reservation row is updated, so a failure in between leaves an open
+		// row for a retry to re-enter with a freshly computed number.
+		entry, err := s.ledgerSvc.ChargeUsage(ctx, reservation.AccountID, reservation.RequestID, &reservation.RequestAttemptID, &reservation.ID, s.idempotencyKey(reservation.ID, "charge"), actualCredits, map[string]any{
 			"endpoint":           reservation.Endpoint,
 			"model_alias":        reservation.ModelAlias,
 			"terminal_confirmed": input.TerminalUsageConfirmed,
-		}); err != nil {
+		})
+		if err != nil {
 			return Reservation{}, fmt.Errorf("accounting: charge usage: %w", err)
+		}
+		// The dedup above returns the FIRST entry, so a second attempt for a
+		// different amount would otherwise leave the ledger and the reservation
+		// row disagreeing about what was billed, silently. An unrecognized
+		// settlement fact is fatal on the money path (D-034): fail here and
+		// leave the hold open for the reaper rather than record a divergence.
+		if entry.CreditsDelta != -actualCredits {
+			return Reservation{}, fmt.Errorf("accounting: charge already posted for reservation %s at %d credits, refusing to settle at %d", reservation.ID, -entry.CreditsDelta, actualCredits)
 		}
 	}
 
-	if releaseCredits > 0 {
-		// Idempotency key is "release", not "release-<credits>" (issue #652):
-		// releaseLocked below already keys its full release the same way, and a
-		// key that varies with the amount cannot deduplicate two release
-		// attempts of DIFFERING amounts for the same reservation, which is
-		// exactly the case worth catching. One reservation, one release key,
-		// regardless of which path or how much it releases.
-		if _, err := s.ledgerSvc.ReleaseReservedCredits(ctx, reservation.AccountID, reservation.RequestID, &reservation.RequestAttemptID, &reservation.ID, s.idempotencyKey(reservation.ID, "release"), releaseCredits, map[string]any{
+	// The ledger releases the WHOLE outstanding hold, including the part the
+	// charge just captured, not merely the unused remainder. A hold is an
+	// authorization, and capture lifts it in full; the charge is what the
+	// customer actually pays. Releasing only the remainder left `actual`
+	// credits sitting in the ledger's reserved bucket forever, and since
+	// GetBalance computes available as posted minus reserved, every settled
+	// request cost the customer its price TWICE: once posted, once withheld
+	// (issue #616, measured live 2026-08-16 -- 143642 credits held against
+	// 1825 reservations that had already settled, one 18-credit completion
+	// moving available by 36). The reaper cannot recover these, because it
+	// only scans holds still in a non-terminal state.
+	//
+	// This is also what the API key counter has always done a few lines below:
+	// ApplyReservationDelta unwinds -heldCredits, never -unusedCredits.
+	//
+	// Idempotency key is "release", not "release-<credits>" (issue #652):
+	// releaseLocked below keys its own release the same way, and a key that
+	// varies with the amount cannot deduplicate two release attempts of
+	// DIFFERING amounts for the same reservation. Both paths now also release
+	// the same quantity, remainingHeldCredits, so whichever arrives first
+	// posts an entry the other would have posted identically.
+	if heldCredits > 0 {
+		if _, err := s.ledgerSvc.ReleaseReservedCredits(ctx, reservation.AccountID, reservation.RequestID, &reservation.RequestAttemptID, &reservation.ID, s.idempotencyKey(reservation.ID, "release"), heldCredits, map[string]any{
 			"endpoint":           reservation.Endpoint,
 			"model_alias":        reservation.ModelAlias,
 			"terminal_confirmed": input.TerminalUsageConfirmed,
+			"captured_credits":   actualCredits,
 		}); err != nil {
 			return Reservation{}, fmt.Errorf("accounting: release reserved credits: %w", err)
 		}
@@ -330,7 +365,7 @@ func (s *Service) finalizeLocked(ctx context.Context, input FinalizeReservationI
 		eventType = usage.UsageEventReconciled
 	}
 
-	reservation, err = s.repo.FinalizeReservation(ctx, input.AccountID, input.ReservationID, actualCredits, releaseCredits, input.TerminalUsageConfirmed, nextStatus, reason)
+	reservation, err = s.repo.FinalizeReservation(ctx, input.AccountID, input.ReservationID, actualCredits, unusedCredits, input.TerminalUsageConfirmed, nextStatus, reason)
 	if err != nil {
 		return Reservation{}, fmt.Errorf("accounting: finalize reservation: %w", err)
 	}
@@ -378,8 +413,12 @@ func (s *Service) finalizeLocked(ctx context.Context, input FinalizeReservationI
 		HiveCreditDelta: -actualCredits,
 		CustomerTags:    reservation.CustomerTags,
 		InternalMetadata: map[string]any{
-			"reservation_id":           reservation.ID.String(),
-			"released_credits":         releaseCredits,
+			"reservation_id": reservation.ID.String(),
+			// The unused part of the hold, matching the reservation row's
+			// released_credits column. The ledger lifts more than this (the
+			// whole authorization, captured part included), which is a
+			// different question and deliberately not what analytics reads.
+			"released_credits":         unusedCredits,
 			"terminal_usage_confirmed": input.TerminalUsageConfirmed,
 		},
 	}); err != nil {

--- a/apps/control-plane/internal/accounting/service.go
+++ b/apps/control-plane/internal/accounting/service.go
@@ -294,33 +294,27 @@ func (s *Service) finalizeLocked(ctx context.Context, input FinalizeReservationI
 	}
 
 	// unusedCredits is a fact about the RESERVATION: how much of the hold never
-	// turned into spend. It is what the row records, beside consumed_credits,
-	// and the two still sum to reserved_credits.
+	// turned into spend. It is what the row records beside consumed_credits, and
+	// on every path except a confirmed overage (where the charge legitimately
+	// exceeds the hold and this is zero) the two sum to reserved_credits.
 	unusedCredits := releasableCredits(reservation, actualCredits)
 
 	if actualCredits > 0 {
-		// Idempotency key is "charge", not "charge-<credits>", for the same
-		// reason the release key is flat (issue #652): a key that varies with
-		// the amount cannot deduplicate two settlement attempts that DISAGREE
-		// on the amount, which is exactly the case worth catching. That retry
-		// is reachable, not hypothetical -- the charge posts before the
-		// reservation row is updated, so a failure in between leaves an open
-		// row for a retry to re-enter with a freshly computed number.
-		entry, err := s.ledgerSvc.ChargeUsage(ctx, reservation.AccountID, reservation.RequestID, &reservation.RequestAttemptID, &reservation.ID, s.idempotencyKey(reservation.ID, "charge"), actualCredits, map[string]any{
+		// The charge key still carries the amount. Flattening it to
+		// "reservation:<id>:charge", the way issue #652 flattened the release
+		// key, needs a migration normalizing the 1866 existing
+		// "charge-<credits>" entries first (issue #663 is the same lesson for
+		// the release key), because until they are normalized a retry after a
+		// crossed deploy would post a SECOND charge under the new key shape
+		// instead of deduplicating against the old one. Tracked separately;
+		// capture-exactly-once rests meanwhile on the reservationOpen status
+		// guard above plus the per-account lock, as it always has.
+		if _, err := s.ledgerSvc.ChargeUsage(ctx, reservation.AccountID, reservation.RequestID, &reservation.RequestAttemptID, &reservation.ID, s.idempotencyKey(reservation.ID, fmt.Sprintf("charge-%d", actualCredits)), actualCredits, map[string]any{
 			"endpoint":           reservation.Endpoint,
 			"model_alias":        reservation.ModelAlias,
 			"terminal_confirmed": input.TerminalUsageConfirmed,
-		})
-		if err != nil {
+		}); err != nil {
 			return Reservation{}, fmt.Errorf("accounting: charge usage: %w", err)
-		}
-		// The dedup above returns the FIRST entry, so a second attempt for a
-		// different amount would otherwise leave the ledger and the reservation
-		// row disagreeing about what was billed, silently. An unrecognized
-		// settlement fact is fatal on the money path (D-034): fail here and
-		// leave the hold open for the reaper rather than record a divergence.
-		if entry.CreditsDelta != -actualCredits {
-			return Reservation{}, fmt.Errorf("accounting: charge already posted for reservation %s at %d credits, refusing to settle at %d", reservation.ID, -entry.CreditsDelta, actualCredits)
 		}
 	}
 
@@ -346,13 +340,17 @@ func (s *Service) finalizeLocked(ctx context.Context, input FinalizeReservationI
 	// the same quantity, remainingHeldCredits, so whichever arrives first
 	// posts an entry the other would have posted identically.
 	if heldCredits > 0 {
-		if _, err := s.ledgerSvc.ReleaseReservedCredits(ctx, reservation.AccountID, reservation.RequestID, &reservation.RequestAttemptID, &reservation.ID, s.idempotencyKey(reservation.ID, "release"), heldCredits, map[string]any{
+		entry, err := s.ledgerSvc.ReleaseReservedCredits(ctx, reservation.AccountID, reservation.RequestID, &reservation.RequestAttemptID, &reservation.ID, s.idempotencyKey(reservation.ID, "release"), heldCredits, map[string]any{
 			"endpoint":           reservation.Endpoint,
 			"model_alias":        reservation.ModelAlias,
 			"terminal_confirmed": input.TerminalUsageConfirmed,
 			"captured_credits":   actualCredits,
-		}); err != nil {
+		})
+		if err != nil {
 			return Reservation{}, fmt.Errorf("accounting: release reserved credits: %w", err)
+		}
+		if err := assertReleasedInFull(reservation.ID, entry, heldCredits); err != nil {
+			return Reservation{}, err
 		}
 	}
 
@@ -487,15 +485,21 @@ func (s *Service) releaseLocked(ctx context.Context, input ReleaseReservationInp
 
 	releaseCredits := remainingHeldCredits(reservation)
 	if releaseCredits > 0 {
-		// Same "release" key finalizeLocked's own partial release uses above
-		// (issue #652): one reservation, one release key, whichever caller
-		// (edge-api settlement fallback or the reaper) reaches it first.
-		if _, err := s.ledgerSvc.ReleaseReservedCredits(ctx, reservation.AccountID, reservation.RequestID, &reservation.RequestAttemptID, &reservation.ID, s.idempotencyKey(reservation.ID, "release"), releaseCredits, map[string]any{
+		// Same "release" key finalizeLocked's own release uses above (issue
+		// #652): one reservation, one release key, whichever caller (edge-api
+		// settlement fallback or the reaper) reaches it first. Both now compute
+		// the same quantity, remainingHeldCredits, so whichever arrives second
+		// deduplicates against an entry for the identical amount.
+		entry, err := s.ledgerSvc.ReleaseReservedCredits(ctx, reservation.AccountID, reservation.RequestID, &reservation.RequestAttemptID, &reservation.ID, s.idempotencyKey(reservation.ID, "release"), releaseCredits, map[string]any{
 			"endpoint":    reservation.Endpoint,
 			"model_alias": reservation.ModelAlias,
 			"reason":      input.Reason,
-		}); err != nil {
+		})
+		if err != nil {
 			return Reservation{}, fmt.Errorf("accounting: release reserved credits: %w", err)
+		}
+		if err := assertReleasedInFull(reservation.ID, entry, releaseCredits); err != nil {
+			return Reservation{}, err
 		}
 	}
 
@@ -649,6 +653,28 @@ func reservationOpen(status ReservationStatus) bool {
 	default:
 		return false
 	}
+}
+
+// assertReleasedInFull refuses to treat a reservation as settled when the
+// ledger's release entry does not cover the hold this call meant to lift.
+//
+// PostEntry deduplicates on (account_id, entry_type, idempotency_key) and hands
+// back the FIRST entry, so a release attempt that follows an earlier one for a
+// SMALLER amount returns quietly with the hold only partly lifted. Settlement
+// would then mark the row terminal, and the remainder would be stranded past
+// the reaper, which only scans non-terminal holds: exactly the shape of issue
+// #616 this change exists to end, reintroduced silently. The reachable sequence
+// is a settlement that posted the old partial release and then failed before
+// updating the row, with the retry landing on code that releases in full.
+//
+// Failing here leaves the reservation open, so the reaper retries it and logs a
+// warning on every pass rather than a wrong number being written once. An
+// unrecognized settlement fact is fatal on the money path (D-034).
+func assertReleasedInFull(reservationID uuid.UUID, entry ledger.LedgerEntry, want int64) error {
+	if entry.CreditsDelta == want {
+		return nil
+	}
+	return fmt.Errorf("accounting: reservation %s already carries a %d-credit release, refusing to settle against a %d-credit hold", reservationID, entry.CreditsDelta, want)
 }
 
 func remainingHeldCredits(reservation Reservation) int64 {

--- a/apps/control-plane/internal/accounting/service.go
+++ b/apps/control-plane/internal/accounting/service.go
@@ -667,14 +667,39 @@ func reservationOpen(status ReservationStatus) bool {
 // is a settlement that posted the old partial release and then failed before
 // updating the row, with the retry landing on code that releases in full.
 //
-// Failing here leaves the reservation open, so the reaper retries it and logs a
-// warning on every pass rather than a wrong number being written once. An
-// unrecognized settlement fact is fatal on the money path (D-034).
+// Failing here leaves the reservation open, so it stays in the reaper's
+// candidate scan and is reported on every pass instead of a wrong number being
+// written once and disappearing. An unrecognized settlement fact is fatal on
+// the money path (D-034).
+//
+// The comparison is against a POSITIVE amount because a release is stored
+// positive: ledger.ReleaseReservedCredits posts +credits while ReserveCredits
+// posts -credits, which is what makes the two cancel in GetBalance's sum. The
+// live magnitude test would fail on its first settlement if that were inverted.
+//
+// A reservation that trips this cannot self-heal: its charge is already
+// committed, and both settlement paths recompute the same amount and hit the
+// same deduplicated entry. That is deliberate, since the alternatives are
+// writing a number the ledger contradicts or silently dropping credits, but it
+// needs an operator, so the error is typed rather than a bare string for
+// alerting to key on. No reconciliation job is written: nothing drains that
+// table today (issue #600) and the reaper would insert a fresh row every 15
+// minutes for the same stuck reservation.
+type SettlementDivergenceError struct {
+	ReservationID uuid.UUID
+	PostedCredits int64
+	WantCredits   int64
+}
+
+func (e *SettlementDivergenceError) Error() string {
+	return fmt.Sprintf("accounting: reservation %s already carries a %d-credit release, refusing to settle against a %d-credit hold", e.ReservationID, e.PostedCredits, e.WantCredits)
+}
+
 func assertReleasedInFull(reservationID uuid.UUID, entry ledger.LedgerEntry, want int64) error {
 	if entry.CreditsDelta == want {
 		return nil
 	}
-	return fmt.Errorf("accounting: reservation %s already carries a %d-credit release, refusing to settle against a %d-credit hold", reservationID, entry.CreditsDelta, want)
+	return &SettlementDivergenceError{ReservationID: reservationID, PostedCredits: entry.CreditsDelta, WantCredits: want}
 }
 
 func remainingHeldCredits(reservation Reservation) int64 {

--- a/apps/control-plane/internal/accounting/service_test.go
+++ b/apps/control-plane/internal/accounting/service_test.go
@@ -439,8 +439,11 @@ func TestFinalizeReservationCreatesChargeAndRelease(t *testing.T) {
 	if len(ledgerSvc.chargeCalls) != 1 || ledgerSvc.chargeCalls[0].credits != 70 {
 		t.Fatalf("expected one 70-credit charge, got %#v", ledgerSvc.chargeCalls)
 	}
-	if len(ledgerSvc.releaseCalls) != 1 || ledgerSvc.releaseCalls[0].credits != 30 {
-		t.Fatalf("expected one 30-credit release, got %#v", ledgerSvc.releaseCalls)
+	// The ledger lifts the whole 100-credit hold, not the 30 left unused: the
+	// 70 the charge captured has to leave the reserved bucket too, or available
+	// balance carries it forever (issue #616).
+	if len(ledgerSvc.releaseCalls) != 1 || ledgerSvc.releaseCalls[0].credits != 100 {
+		t.Fatalf("expected one 100-credit hold lift, got %#v", ledgerSvc.releaseCalls)
 	}
 	if len(usageSvc.statusCalls) != 1 || usageSvc.statusCalls[0].status != usage.AttemptStatusCompleted {
 		t.Fatalf("expected completed attempt status update, got %#v", usageSvc.statusCalls)
@@ -494,8 +497,11 @@ func TestFinalizeReservationClampsChargeToReservedHold(t *testing.T) {
 	if len(ledgerSvc.chargeCalls) != 1 || ledgerSvc.chargeCalls[0].credits != 10000 {
 		t.Fatalf("expected the ledger charge clamped to 10000, got %#v", ledgerSvc.chargeCalls)
 	}
-	if len(ledgerSvc.releaseCalls) != 0 {
-		t.Fatalf("expected no release call when the clamped charge consumes the full hold, got %#v", ledgerSvc.releaseCalls)
+	// Nothing is left unused, so the row releases 0, but the ledger still has
+	// to lift the 10000 hold the charge just captured. Before issue #616 this
+	// path posted no release at all, which stranded the entire hold.
+	if len(ledgerSvc.releaseCalls) != 1 || ledgerSvc.releaseCalls[0].credits != 10000 {
+		t.Fatalf("expected the full 10000 hold lifted even though the clamped charge consumed all of it, got %#v", ledgerSvc.releaseCalls)
 	}
 }
 
@@ -548,8 +554,11 @@ func TestFinalizeReservationConfirmedUsageAboveHoldIsNotClamped(t *testing.T) {
 	if len(ledgerSvc.chargeCalls) != 1 || ledgerSvc.chargeCalls[0].credits != 15000 {
 		t.Fatalf("expected the ledger charge for the true 15000, got %#v", ledgerSvc.chargeCalls)
 	}
-	if len(ledgerSvc.releaseCalls) != 0 {
-		t.Fatalf("expected no release call on a confirmed overage, got %#v", ledgerSvc.releaseCalls)
+	// The charge exceeds the hold, so nothing is unused and the row releases 0,
+	// but the 10000-credit authorization is still outstanding until the ledger
+	// lifts it (issue #616).
+	if len(ledgerSvc.releaseCalls) != 1 || ledgerSvc.releaseCalls[0].credits != 10000 {
+		t.Fatalf("expected the full 10000 hold lifted on a confirmed overage, got %#v", ledgerSvc.releaseCalls)
 	}
 }
 
@@ -592,8 +601,10 @@ func TestFinalizeReservationMarksAmbiguousStreamForReconciliation(t *testing.T) 
 	if len(ledgerSvc.chargeCalls) != 1 || ledgerSvc.chargeCalls[0].credits != 40 {
 		t.Fatalf("expected one 40-credit charge, got %#v", ledgerSvc.chargeCalls)
 	}
-	if len(ledgerSvc.releaseCalls) != 1 || ledgerSvc.releaseCalls[0].credits != 50 {
-		t.Fatalf("expected one 50-credit release, got %#v", ledgerSvc.releaseCalls)
+	// 90 held, 40 charged: the ledger lifts all 90, the row records 50 unused
+	// (issue #616).
+	if len(ledgerSvc.releaseCalls) != 1 || ledgerSvc.releaseCalls[0].credits != 90 {
+		t.Fatalf("expected one 90-credit hold lift, got %#v", ledgerSvc.releaseCalls)
 	}
 	if len(usageSvc.statusCalls) != 1 || usageSvc.statusCalls[0].status != usage.AttemptStatusInterrupted {
 		t.Fatalf("expected interrupted status update, got %#v", usageSvc.statusCalls)

--- a/apps/control-plane/internal/accounting/settlement_hold_invariant_test.go
+++ b/apps/control-plane/internal/accounting/settlement_hold_invariant_test.go
@@ -2,6 +2,7 @@ package accounting
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/google/uuid"
@@ -193,6 +194,15 @@ func TestSettlementRefusesToSettleAgainstAPartialRelease(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected settlement to refuse a hold that is only partly lifted, got no error")
+	}
+	// Typed, because this one cannot self-heal and the reaper logs it at error
+	// for alerting rather than as one more ordinary refusal.
+	var divergence *SettlementDivergenceError
+	if !errors.As(err, &divergence) {
+		t.Fatalf("expected a *SettlementDivergenceError, got %T: %v", err, err)
+	}
+	if divergence.PostedCredits != 9982 || divergence.WantCredits != 10000 {
+		t.Fatalf("error carries posted=%d want=%d, expected 9982 and 10000", divergence.PostedCredits, divergence.WantCredits)
 	}
 
 	stored := repo.reservations[reservation.ID]

--- a/apps/control-plane/internal/accounting/settlement_hold_invariant_test.go
+++ b/apps/control-plane/internal/accounting/settlement_hold_invariant_test.go
@@ -1,0 +1,217 @@
+package accounting
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/ledger"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/usage"
+)
+
+// The bound this file defends, stated as magnitudes rather than as call counts:
+// for a request that reserves H credits and truly costs C, settlement must move
+// the account's available balance by exactly C, and must return reserved to
+// zero. Not C plus the leftover hold, and not H minus anything.
+//
+// Measured on the demo box on 2026-08-16, one chat completion against a 10000
+// hold costing 18 credits: posted fell 18 (correct) while reserved ROSE 18, so
+// available fell 36 for 18 credits of work. Across the database that was 143642
+// credits held against 1825 reservations that had already settled, every one of
+// them holding exactly its own consumed_credits, growing with every request.
+//
+// The cause is arithmetic on the success path, not an error path: finalize
+// released hold minus actual and nothing ever lifted the captured remainder, so
+// GetBalance's ABS(SUM(hold) + SUM(release)) kept counting it forever.
+//
+// These cases assert against the fake ledger's own balance, which mirrors the
+// production SQL (reserved = held - released, available = posted - reserved),
+// so a regression shows up as a wrong number of credits rather than as a
+// missing call.
+func TestSettlementReturnsReservedToZero(t *testing.T) {
+	const grant = 300000
+
+	cases := []struct {
+		name      string
+		hold      int64
+		actual    int64
+		confirmed bool
+		// wantCharge is what the account must actually pay, after
+		// finalizeLocked's clamp on unconfirmed estimates.
+		wantCharge int64
+	}{
+		{
+			// The demo box case, scaled: a flat 10000 hold, a tiny real cost.
+			name:       "actual far below the hold",
+			hold:       10000,
+			actual:     18,
+			confirmed:  true,
+			wantCharge: 18,
+		},
+		{
+			// A completed request that consumed nothing still has to give the
+			// whole hold back.
+			name:       "zero actual",
+			hold:       10000,
+			actual:     0,
+			confirmed:  true,
+			wantCharge: 0,
+		},
+		{
+			// The clamp path (issue #602): an unconfirmed estimate above the
+			// hold is charged at the hold. Before the fix this released
+			// nothing at all, stranding the entire 10000.
+			name:       "unconfirmed estimate clamped to the hold",
+			hold:       10000,
+			actual:     2_600_000,
+			confirmed:  false,
+			wantCharge: 10000,
+		},
+		{
+			// Confirmed usage above the flat hold is billed in full, and the
+			// hold is still an authorization that must be lifted in full.
+			name:       "confirmed usage above the hold",
+			hold:       10000,
+			actual:     15000,
+			confirmed:  true,
+			wantCharge: 15000,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := newRepoStub()
+			ledgerSvc := newReaperLedger(grant)
+			svc := NewService(repo, ledgerSvc, concurrentUsage{})
+			ctx := context.Background()
+			accountID := uuid.New()
+
+			reservation, err := svc.CreateReservation(ctx, CreateReservationInput{
+				AccountID:        accountID,
+				RequestID:        uuid.NewString(),
+				AttemptNumber:    1,
+				Endpoint:         "/v1/chat/completions",
+				ModelAlias:       "hive-fast",
+				EstimatedCredits: tc.hold,
+			})
+			if err != nil {
+				t.Fatalf("CreateReservation: %v", err)
+			}
+
+			held, err := ledgerSvc.GetBalance(ctx, accountID)
+			if err != nil {
+				t.Fatalf("GetBalance after hold: %v", err)
+			}
+			// Positive control: without a real hold in the ledger, "reserved
+			// returns to zero" below would pass on a ledger that never moved.
+			if held.ReservedCredits != tc.hold {
+				t.Fatalf("fixture wrong: reserved after hold = %d, want %d", held.ReservedCredits, tc.hold)
+			}
+
+			if _, err := svc.FinalizeReservation(ctx, FinalizeReservationInput{
+				AccountID:              accountID,
+				ReservationID:          reservation.ID,
+				ActualCredits:          tc.actual,
+				TerminalUsageConfirmed: tc.confirmed,
+				Status:                 string(usage.AttemptStatusCompleted),
+			}); err != nil {
+				t.Fatalf("FinalizeReservation: %v", err)
+			}
+
+			after, err := ledgerSvc.GetBalance(ctx, accountID)
+			if err != nil {
+				t.Fatalf("GetBalance after settlement: %v", err)
+			}
+			if after.ReservedCredits != 0 {
+				t.Fatalf("reserved did not return to zero after settlement: %d credits still held", after.ReservedCredits)
+			}
+			if after.PostedCredits != grant-tc.wantCharge {
+				t.Fatalf("posted = %d, want %d (grant minus the charge)", after.PostedCredits, grant-tc.wantCharge)
+			}
+			if moved := held.AvailableCredits + tc.hold - after.AvailableCredits; moved != tc.wantCharge {
+				t.Fatalf("available moved by %d across the request, want exactly the %d-credit charge", moved, tc.wantCharge)
+			}
+
+			// Exactly once, per D-034: one lift of the authorization, at most
+			// one capture, whichever path got there.
+			if got := ledgerSvc.entryCount(ledger.EntryTypeReservationRelease); got != 1 {
+				t.Fatalf("expected exactly one reservation_release entry, got %d", got)
+			}
+			wantCharges := 1
+			if tc.wantCharge == 0 {
+				wantCharges = 0
+			}
+			if got := ledgerSvc.entryCount(ledger.EntryTypeUsageCharge); got != wantCharges {
+				t.Fatalf("expected %d usage_charge entries, got %d", wantCharges, got)
+			}
+		})
+	}
+}
+
+// A second settlement attempt that disagrees on the amount must not post a
+// second charge. The idempotency key carried the amount ("charge-<credits>")
+// until this change, so two attempts that disagreed were two different keys and
+// therefore two charges, which is the same defect issue #652 fixed for the
+// release key. Reaching finalizeLocked twice is not hypothetical: the charge
+// posts before the reservation row is updated, so a failure in between leaves
+// an open row that a retry re-enters (reservation 9d422064 in production is
+// exactly that shape, charged 115 credits with consumed_credits still 0).
+func TestSecondSettlementWithADifferentAmountPostsNoSecondCharge(t *testing.T) {
+	repo := newRepoStub()
+	ledgerSvc := newReaperLedger(300000)
+	svc := NewService(repo, ledgerSvc, concurrentUsage{})
+	ctx := context.Background()
+	accountID := uuid.New()
+
+	reservation, err := svc.CreateReservation(ctx, CreateReservationInput{
+		AccountID:        accountID,
+		RequestID:        uuid.NewString(),
+		AttemptNumber:    1,
+		Endpoint:         "/v1/chat/completions",
+		ModelAlias:       "hive-fast",
+		EstimatedCredits: 10000,
+	})
+	if err != nil {
+		t.Fatalf("CreateReservation: %v", err)
+	}
+
+	if _, err := svc.FinalizeReservation(ctx, FinalizeReservationInput{
+		AccountID:              accountID,
+		ReservationID:          reservation.ID,
+		ActualCredits:          115,
+		TerminalUsageConfirmed: true,
+		Status:                 string(usage.AttemptStatusCompleted),
+	}); err != nil {
+		t.Fatalf("first FinalizeReservation: %v", err)
+	}
+
+	// Force the retry shape the comment above describes: the row is put back
+	// into an open state, as it would be had the post-charge update failed.
+	stored := repo.reservations[reservation.ID]
+	stored.Status = ReservationStatusActive
+	stored.ConsumedCredits = 0
+	stored.ReleasedCredits = 0
+	repo.reservations[reservation.ID] = stored
+
+	// A retry landing on a different number must not become a second charge.
+	// It may fail loudly; what it may not do is quietly bill twice.
+	_, err = svc.FinalizeReservation(ctx, FinalizeReservationInput{
+		AccountID:              accountID,
+		ReservationID:          reservation.ID,
+		ActualCredits:          400,
+		TerminalUsageConfirmed: true,
+		Status:                 string(usage.AttemptStatusCompleted),
+	})
+	_ = err
+
+	if got := ledgerSvc.entryCount(ledger.EntryTypeUsageCharge); got != 1 {
+		t.Fatalf("expected exactly one usage_charge entry across both settlement attempts, got %d", got)
+	}
+	balance, err := ledgerSvc.GetBalance(ctx, accountID)
+	if err != nil {
+		t.Fatalf("GetBalance: %v", err)
+	}
+	if balance.PostedCredits != 300000-115 {
+		t.Fatalf("posted = %d, want %d: only the first charge may land", balance.PostedCredits, 300000-115)
+	}
+}

--- a/apps/control-plane/internal/accounting/settlement_hold_invariant_test.go
+++ b/apps/control-plane/internal/accounting/settlement_hold_invariant_test.go
@@ -24,10 +24,12 @@ import (
 // released hold minus actual and nothing ever lifted the captured remainder, so
 // GetBalance's ABS(SUM(hold) + SUM(release)) kept counting it forever.
 //
-// These cases assert against the fake ledger's own balance, which mirrors the
-// production SQL (reserved = held - released, available = posted - reserved),
-// so a regression shows up as a wrong number of credits rather than as a
-// missing call.
+// These cases assert against the fake ledger's own balance rather than against
+// call counts, so a regression shows up as a wrong number of credits. The fake
+// keeps reserved as a signed held minus released, where the production SQL
+// takes ABS of the same sum; the two agree for every case here, because none
+// releases more than it held, and TestSettlementLedgerMagnitude_Live covers the
+// real query on a real database anyway.
 func TestSettlementReturnsReservedToZero(t *testing.T) {
 	const grant = 300000
 
@@ -148,15 +150,15 @@ func TestSettlementReturnsReservedToZero(t *testing.T) {
 	}
 }
 
-// A second settlement attempt that disagrees on the amount must not post a
-// second charge. The idempotency key carried the amount ("charge-<credits>")
-// until this change, so two attempts that disagreed were two different keys and
-// therefore two charges, which is the same defect issue #652 fixed for the
-// release key. Reaching finalizeLocked twice is not hypothetical: the charge
-// posts before the reservation row is updated, so a failure in between leaves
-// an open row that a retry re-enters (reservation 9d422064 in production is
-// exactly that shape, charged 115 credits with consumed_credits still 0).
-func TestSecondSettlementWithADifferentAmountPostsNoSecondCharge(t *testing.T) {
+// A settlement whose release deduplicates against an EARLIER, SMALLER release
+// must fail rather than mark the reservation settled. PostEntry hands back the
+// first entry for a repeated (account, type, key), so without the check that
+// call returns quietly with the hold only partly lifted, the row goes terminal,
+// and the remainder is stranded past the reaper, which only scans non-terminal
+// holds. That is issue #616 reintroduced silently, on the very rows this branch
+// exists to fix. The sequence is reachable across a deploy: the old code posted
+// a partial release and then failed before updating the row.
+func TestSettlementRefusesToSettleAgainstAPartialRelease(t *testing.T) {
 	repo := newRepoStub()
 	ledgerSvc := newReaperLedger(300000)
 	svc := NewService(repo, ledgerSvc, concurrentUsage{})
@@ -175,43 +177,31 @@ func TestSecondSettlementWithADifferentAmountPostsNoSecondCharge(t *testing.T) {
 		t.Fatalf("CreateReservation: %v", err)
 	}
 
-	if _, err := svc.FinalizeReservation(ctx, FinalizeReservationInput{
-		AccountID:              accountID,
-		ReservationID:          reservation.ID,
-		ActualCredits:          115,
-		TerminalUsageConfirmed: true,
-		Status:                 string(usage.AttemptStatusCompleted),
-	}); err != nil {
-		t.Fatalf("first FinalizeReservation: %v", err)
+	// What the pre-fix code left behind: a release for the unused remainder
+	// only, under the same flat key this settlement will use.
+	if _, err := ledgerSvc.ReleaseReservedCredits(ctx, accountID, reservation.RequestID, nil, &reservation.ID,
+		svc.idempotencyKey(reservation.ID, "release"), 9982, map[string]any{"path": "pre-fix partial release"}); err != nil {
+		t.Fatalf("seed partial release: %v", err)
 	}
 
-	// Force the retry shape the comment above describes: the row is put back
-	// into an open state, as it would be had the post-charge update failed.
-	stored := repo.reservations[reservation.ID]
-	stored.Status = ReservationStatusActive
-	stored.ConsumedCredits = 0
-	stored.ReleasedCredits = 0
-	repo.reservations[reservation.ID] = stored
-
-	// A retry landing on a different number must not become a second charge.
-	// It may fail loudly; what it may not do is quietly bill twice.
 	_, err = svc.FinalizeReservation(ctx, FinalizeReservationInput{
 		AccountID:              accountID,
 		ReservationID:          reservation.ID,
-		ActualCredits:          400,
+		ActualCredits:          18,
 		TerminalUsageConfirmed: true,
 		Status:                 string(usage.AttemptStatusCompleted),
 	})
-	_ = err
+	if err == nil {
+		t.Fatal("expected settlement to refuse a hold that is only partly lifted, got no error")
+	}
 
-	if got := ledgerSvc.entryCount(ledger.EntryTypeUsageCharge); got != 1 {
-		t.Fatalf("expected exactly one usage_charge entry across both settlement attempts, got %d", got)
+	stored := repo.reservations[reservation.ID]
+	if !reservationOpen(stored.Status) {
+		t.Fatalf("reservation was marked %s with 18 credits still held; the reaper can no longer reach it", stored.Status)
 	}
-	balance, err := ledgerSvc.GetBalance(ctx, accountID)
-	if err != nil {
+	if balance, err := ledgerSvc.GetBalance(ctx, accountID); err != nil {
 		t.Fatalf("GetBalance: %v", err)
-	}
-	if balance.PostedCredits != 300000-115 {
-		t.Fatalf("posted = %d, want %d: only the first charge may land", balance.PostedCredits, 300000-115)
+	} else if balance.ReservedCredits != 18 {
+		t.Fatalf("expected the 18 unlifted credits to remain visibly reserved, got %d", balance.ReservedCredits)
 	}
 }

--- a/apps/control-plane/internal/accounting/settlement_ledger_magnitude_live_test.go
+++ b/apps/control-plane/internal/accounting/settlement_ledger_magnitude_live_test.go
@@ -20,9 +20,12 @@ import (
 // ReleaseReservedCredits had been called would have passed on that same code,
 // because it WAS called, just for 18 credits too few.
 //
-// Gated on HIVE_TEST_DB_URL like release_idempotency_test.go, so CI runs it
-// against the ephemeral pgvector:pg17 instance bootstrapped from
-// supabase/migrations/ (.github/workflows/ci.yml).
+// Gated on HIVE_TEST_DB_URL like release_idempotency_test.go, and run against
+// the ephemeral pgvector:pg17 instance bootstrapped from supabase/migrations/.
+// That only became true with this change: the live-Postgres step in
+// .github/workflows/ci.yml did not list ./internal/accounting/..., so both this
+// package's live tests silently skipped everywhere. Do not remove the package
+// from that list; without it this file is decoration.
 func TestSettlementLedgerMagnitude_Live(t *testing.T) {
 	pool := newAccountingTestPool(t)
 	accountID := seedReleaseIdempotencyAccount(t, pool)

--- a/apps/control-plane/internal/accounting/settlement_ledger_magnitude_live_test.go
+++ b/apps/control-plane/internal/accounting/settlement_ledger_magnitude_live_test.go
@@ -1,0 +1,124 @@
+package accounting
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/ledger"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/usage"
+)
+
+// Proof by ledger magnitude, on a real database, through the real repositories
+// and the real GetBalance SQL: one request that reserves 10000 and truly costs
+// 18 must move available by 18, and must leave nothing reserved.
+//
+// This is the reproduction of the live measurement from the demo box console on
+// 2026-08-16 (available fell 36 for 18 credits of work, reserved rose by the
+// charge). On the pre-fix code it fails on the reserved assertion with exactly
+// 18 credits still held, which is the defect; a test that asserted
+// ReleaseReservedCredits had been called would have passed on that same code,
+// because it WAS called, just for 18 credits too few.
+//
+// Gated on HIVE_TEST_DB_URL like release_idempotency_test.go, so CI runs it
+// against the ephemeral pgvector:pg17 instance bootstrapped from
+// supabase/migrations/ (.github/workflows/ci.yml).
+func TestSettlementLedgerMagnitude_Live(t *testing.T) {
+	pool := newAccountingTestPool(t)
+	accountID := seedReleaseIdempotencyAccount(t, pool)
+	ctx := context.Background()
+
+	ledgerSvc := ledger.NewService(ledger.NewPgxRepository(pool))
+	svc := NewService(
+		NewPgxRepository(pool),
+		ledgerSvc,
+		usage.NewService(usage.NewPgxRepository(pool)),
+	)
+
+	if _, err := ledgerSvc.GrantCredits(ctx, accountID, uuid.NewString(), 300000, map[string]any{"reason": "test grant"}); err != nil {
+		t.Fatalf("grant credits: %v", err)
+	}
+
+	const (
+		hold   = int64(10000)
+		actual = int64(18)
+	)
+
+	before, err := ledgerSvc.GetBalance(ctx, accountID)
+	if err != nil {
+		t.Fatalf("balance before: %v", err)
+	}
+
+	reservation, err := svc.CreateReservation(ctx, CreateReservationInput{
+		AccountID:        accountID,
+		RequestID:        uuid.NewString(),
+		AttemptNumber:    1,
+		Endpoint:         "/v1/chat/completions",
+		ModelAlias:       "hive-fast",
+		EstimatedCredits: hold,
+	})
+	if err != nil {
+		t.Fatalf("CreateReservation: %v", err)
+	}
+
+	// Positive control: the hold really is on the books, so the assertions
+	// after settlement cannot pass on a ledger that never moved.
+	during, err := ledgerSvc.GetBalance(ctx, accountID)
+	if err != nil {
+		t.Fatalf("balance during: %v", err)
+	}
+	if during.ReservedCredits != before.ReservedCredits+hold {
+		t.Fatalf("reserved after hold = %d, want %d", during.ReservedCredits, before.ReservedCredits+hold)
+	}
+	if during.AvailableCredits != before.AvailableCredits-hold {
+		t.Fatalf("available after hold = %d, want %d", during.AvailableCredits, before.AvailableCredits-hold)
+	}
+
+	if _, err := svc.FinalizeReservation(ctx, FinalizeReservationInput{
+		AccountID:              accountID,
+		ReservationID:          reservation.ID,
+		ActualCredits:          actual,
+		TerminalUsageConfirmed: true,
+		Status:                 string(usage.AttemptStatusCompleted),
+		InputTokens:            120,
+		OutputTokens:           30,
+	}); err != nil {
+		t.Fatalf("FinalizeReservation: %v", err)
+	}
+
+	after, err := ledgerSvc.GetBalance(ctx, accountID)
+	if err != nil {
+		t.Fatalf("balance after: %v", err)
+	}
+	if after.ReservedCredits != before.ReservedCredits {
+		t.Fatalf("reserved did not return to its pre-request value: %d, want %d (%d credits still held for a request that already settled)",
+			after.ReservedCredits, before.ReservedCredits, after.ReservedCredits-before.ReservedCredits)
+	}
+	if moved := before.AvailableCredits - after.AvailableCredits; moved != actual {
+		t.Fatalf("available moved by %d across one request costing %d; the customer is paying %d credits it does not owe",
+			moved, actual, moved-actual)
+	}
+	if moved := before.PostedCredits - after.PostedCredits; moved != actual {
+		t.Fatalf("posted moved by %d, want exactly the %d-credit charge", moved, actual)
+	}
+
+	// Same invariant read straight off the rows: the hold and its release
+	// cancel, exactly one release row exists, and at most one charge.
+	var holdNet, releases, charges int64
+	if err := pool.QueryRow(ctx, `
+		SELECT
+			COALESCE(sum(credits_delta) FILTER (WHERE entry_type IN ('reservation_hold','reservation_release')), 0),
+			count(*) FILTER (WHERE entry_type = 'reservation_release'),
+			count(*) FILTER (WHERE entry_type = 'usage_charge')
+		FROM public.credit_ledger_entries
+		WHERE account_id = $1 AND reservation_id = $2
+	`, accountID, reservation.ID).Scan(&holdNet, &releases, &charges); err != nil {
+		t.Fatalf("query ledger rows: %v", err)
+	}
+	if holdNet != 0 {
+		t.Fatalf("hold and release do not cancel for a settled reservation: net %d", holdNet)
+	}
+	if releases != 1 || charges != 1 {
+		t.Fatalf("expected exactly one release and one charge row, got %d releases and %d charges", releases, charges)
+	}
+}

--- a/tools/lint-go-db-test-wiring.mjs
+++ b/tools/lint-go-db-test-wiring.mjs
@@ -41,7 +41,6 @@ const SKIP_DIRS = new Set(["node_modules", "vendor", ".git", "target", "dist", "
 // leaves the workflow's list, and it fails again if a package is exempted here
 // after it starts running.
 const KNOWN_DARK = new Map([
-  ["apps/control-plane/./internal/accounting", "#797 backlog, never executed"],
   ["apps/control-plane/./internal/audit", "#797 backlog, never executed"],
   ["apps/control-plane/./internal/auditarchive", "#797 backlog, never executed"],
   ["apps/control-plane/./internal/auditverifier", "#797 backlog, never executed"],


### PR DESCRIPTION
## What broke

Credit reservations were never fully released at settlement. Measured live on the demo box on 2026-08-16, one deliberate chat completion, console before and after:

```
before:  Available 9,998,840   Posted 9,999,920   Reserved 1,080
after:   Available 9,998,804   Posted 9,999,902   Reserved 1,098
```

Posted fell by 18, the true cost of the work. Reserved ROSE by 18. Available, rendered as posted minus reserved, fell by 36 for 18 credits of work. Reserved had climbed to 1,080 over earlier traffic and then sat flat for 12 idle minutes, which rules out live in-flight holds.

## Confirmed at the ledger, not at the console

Read only, through the transaction-mode pooler, 2026-08-16. The measured request is reservation `e2006ebf`, and its three ledger rows are the whole finding:

| entry_type | credits_delta |
| --- | --- |
| reservation_hold | -10000 |
| reservation_release | +9982 |
| usage_charge | -18 |

`GetBalance` (`apps/control-plane/internal/ledger/repository.go`) computes `reserved = ABS(SUM(hold) + SUM(release))` and `available = posted - reserved`. Hold plus release nets to -18, so 18 credits stayed in the reserved bucket permanently, while the same 18 had already left posted via the charge. The customer paid twice for one request.

Population, whole database, at the time of the read:

| reservation status | rows still holding | credits still held | attempt status |
| --- | --- | --- | --- |
| finalized | 1,695 | 73,444 | completed |
| needs_reconciliation | 130 | 70,198 | completed (129), streaming (1) |
| active, genuinely in flight | 1 | 1,000 | dispatching |

For every one of those 1,825 terminal rows, credits still held equals `consumed_credits` equals the charge, exactly. Their request attempts are `completed`. Earliest stranded row is 2026-04-01, so this has been true since the ledger began; 189 rows and 19,405 credits were added on 2026-08-16 alone. Worst affected account (`9bbaf7b5`): posted 158,604, reserved 118,281, available 40,323, so three quarters of its balance was withheld for work that had already settled. That is the service-denial mode the reaper's own header comment warns about.

## Why release did not happen

Not an error path, not a keying mismatch, not an orphaned hold, not a swallowed error. It is the arithmetic of the successful request. `finalizeLocked` released `releasableCredits(reservation, actual)`, which is `held - actual`, and nothing ever lifted the `actual` the charge had captured. Each hypothesis worth eliminating, and how the data eliminated it:

- an error path returning before releasing: no, the release posts and the row reaches a terminal status;
- a release keyed differently from the hold: no, both entries carry the same `reservation_id` and the flat `reservation:<id>:release` key;
- a settlement that posts and returns without touching the hold: no, it touches it partially;
- a failed or cancelled request whose hold has no owner left: no, every stranded row's attempt is `completed`;
- a release that runs and silently fails: no, the release row exists, for the wrong amount.

The reaper (issue #648) cannot recover these: it only scans `active` and `expanded` holds, and these are terminal.

The same function already treated capture as lifting the whole hold everywhere else: `ApplyReservationDelta(apiKeyID, -heldCredits, actualCredits)` unwinds the API key counter by the FULL held amount. The ledger was the only book that disagreed with itself.

## The invariant, stated as a bound

For every reservation, once it reaches a terminal state (`finalized`, `needs_reconciliation`, `released`):

```
SUM(reservation_hold.credits_delta) + SUM(reservation_release.credits_delta) = 0
```

Exactly one of release or capture happens for the authorization, exactly once. The hold is lifted in full, once, under the fixed key `reservation:<id>:release`, and settlement now refuses to complete if that release deduplicates against an earlier entry for a different amount, so a partly lifted hold can no longer be recorded as settled. The spend is posted at most once, enforced by the `reservationOpen` status allowlist plus the per-account advisory lock; the charge idempotency key still carries its amount, and closing that second gap needs a key-normalization migration, filed separately (see below). Therefore an account with nothing in flight has `reserved = 0`.

As a magnitude, which is the form that can actually be measured: for a request that reserves H and truly costs C, available must fall by exactly C, and reserved must return to its pre-request value. Not C plus a leftover. Not H minus anything. C is D-031's `(prompt_tokens * input_price + completion_tokens * output_price) / 1_000_000`, rounded half up, unchanged by this PR.

## The fix

The ledger release at capture changes from `held - actual` to `held`. One number. The charge still posts separately for `actual`.

The reservation row keeps its column meanings: `consumed_credits = actual` and `released_credits = held - actual`, which still sum to `reserved_credits` on every path except a confirmed overage, where the charge legitimately exceeds the hold and the unused part is zero. Those columns answer how the authorization was disposed of (spent versus returned unused); the ledger release entry answers whether any authorization is still outstanding, and after capture the answer must be no. The `usage_events` metadata keeps reporting the unused figure, so analytics are unchanged.

Settlement also refuses to complete when its release deduplicates against an earlier, smaller release (`assertReleasedInFull`). `PostEntry` returns the FIRST entry for a repeated key, so that call was returning quietly with the hold only partly lifted, the row was then marked terminal, and the remainder was stranded past the reaper, which only scans non-terminal holds. That is this very defect reintroduced silently, and the sequence is reachable across the deploy of this PR: the old code posts a partial release, then fails before updating the row, and the retry runs on new code. Failing loudly leaves the reservation open for the reaper instead, per D-034's "an unrecognized failure is fatal".

The first revision of this PR also flattened the charge idempotency key (`charge-<credits>` to `charge`). That was reverted during review: flattening it needs a migration normalizing the 1,866 existing amount-bearing entries first, exactly as issue #663 needed one for the release key, because until they are normalized a retry crossing the deploy posts a SECOND charge under the new shape instead of deduplicating against the old one. A double bill is not an acceptable price for closing a rarer double bill, so it is filed separately.

### Rejected: fix the reader instead

`reserved = ABS(SUM(hold+release)) - ABS(SUM(usage_charge with reservation_id))` also nets to zero on today's data. Rejected because a confirmed overage (`TerminalUsageConfirmed=true` bills past the flat 10,000 hold, which long context and coding-agent traffic reach) makes that expression negative for the reservation and silently INFLATES available. Clamping it needs a per-reservation `GREATEST(0, ...)` group-by inside `GetBalance`, which runs on the hot path under the per-account lock, and there is no index on `credit_ledger_entries.reservation_id`. It would also leave the writer posting a half-truth for every future reader to compensate for, which is the opposite of failing closed.

## The five changed test expectations

Each was written by someone who believed it described correct behaviour, so each is classified rather than merely updated.

Encoded the leak, four of them. These asserted, in credits, that part of a settled request's hold stays in the reserved bucket:

1. `TestFinalizeReservationCreatesChargeAndRelease`: asserted a 30-credit release against a 100 hold with 70 charged, that is, that 70 credits stay reserved after the request settled. Changed to 100.
2. `TestFinalizeReservationClampsChargeToReservedHold`: asserted **no release call at all** when the clamped charge consumes the hold, that is, that the entire 10,000 stays reserved forever. Changed to a 10,000 release. This is the worst form of the leak and it was pinned as correct.
3. `TestFinalizeReservationConfirmedUsageAboveHoldIsNotClamped`: same shape as 2, on the confirmed-overage path. Changed to a 10,000 release. The test's actual subject, that a confirmed charge is not clamped, is untouched and still asserted.
4. `TestFinalizeReservationMarksAmbiguousStreamForReconciliation`: asserted a 50-credit release against a 90 hold with 40 charged. Changed to 90. Its subject, the reconciliation job, is untouched.

Incidental, one of them:

5. `TestReleaseAfterUnconfirmedSettlementKeepsRowBalanced`: its subject is that a second release is refused and the row still balances, and every one of those assertions is untouched and still passes. The changed line only restated the finalize release amount in passing, though the number it restated was the leaking one.

Nothing else moved. No assertion about row columns, statuses, refusals, reconciliation jobs, or charge amounts changed. Worth naming: not one existing test asserted that reserved returns to zero, which is why 1,825 reservations leaked past a suite that was green the whole time.

## Verification, by ledger magnitude

New `TestSettlementLedgerMagnitude_Live` drives the real pgx repositories and the real `GetBalance` SQL on a real Postgres built from `supabase/migrations/` (the same bootstrap `.github/workflows/ci.yml` uses, `HIVE_TEST_DB_URL`-gated like `release_idempotency_test.go`), and compares balance magnitudes across one request that reserves 10,000 and costs 18.

```
pre-fix code:  FAIL  reserved did not return to its pre-request value: 18, want 0
                     (18 credits still held for a request that already settled)
post-fix code: PASS
```

That is the live console reading reproduced as a number, on the real schema. A test asserting `ReleaseReservedCredits` had been called would have passed on the broken code, because it WAS called, just for 18 credits too few.

That test only runs because this PR also adds `./internal/accounting/...` to the live-Postgres step in `.github/workflows/ci.yml`. The package was absent from that list, so both its `HIVE_TEST_DB_URL`-gated tests, this one and the existing release-key dedup proof from issue #652, skipped everywhere: the same never-runs trap as issues #701 and #708, on the money path. Caught by the review streams, not by me.

Also new, `TestSettlementReturnsReservedToZero`, four cases against the fake ledger (signed `held - released`, where production takes `ABS` of the same sum; they agree for every case here since none over-releases): actual far below the hold, zero actual, unconfirmed estimate clamped to the hold, and confirmed usage above the hold. Each asserts reserved returns to zero and available moves by exactly the charge, with a positive control that the hold really was on the books first. And `TestSettlementRefusesToSettleAgainstAPartialRelease` pins the new guard, verified by mutation: delete the guard and it goes red.

Full `go test ./apps/control-plane/...` and `./apps/edge-api/...` pass; `go vet` clean.

No UI surface is touched by this change, so the visual-proof rule does not apply here; the proof for a money path is the ledger magnitude above.

## Stranded balances already in the database, NOT touched by this PR

Nothing in this PR mutates live data. Counts read live on 2026-08-16:

| what | reservations | credits |
| --- | --- | --- |
| residual holds on terminal reservations, the defect above | 1,836 | 144,028 |
| released without a hold ever being posted, opposite sign, different cause | 10 | 25,000 |

By account, for the first row: `9bbaf7b5` 1,764 reservations / 141,665 credits, `3104dbfc` 3 / 2,000, `e518472a` 1 / 110, `d18c9024` 22 / 98, `29d908e9` 1 / 70, `feb1e8e2` 42 / 42, `22222222` 2 / 41, `31aadd76` 1 / 2.

Proposed remediation, for the owner to approve or refuse, to run only after this PR has deployed (running it earlier is pointless while new residue accrues). It appends one compensating release per affected reservation under a distinct key, so the ledger stays append-only, no row is updated or deleted, and a second run is a no-op:

```sql
-- PREVIEW FORM, read only. The remediation replaces the outer SELECT with the
-- INSERT below it.
WITH residual AS (
  SELECT r.id AS reservation_id,
         r.account_id,
         -COALESCE(sum(e.credits_delta) FILTER (
            WHERE e.entry_type IN ('reservation_hold','reservation_release')), 0) AS residual_credits
  FROM public.credit_reservations r
  LEFT JOIN public.credit_ledger_entries e ON e.reservation_id = r.id
  WHERE r.status IN ('finalized','needs_reconciliation','released')
  GROUP BY r.id, r.account_id
)
SELECT count(*) AS reservations, sum(residual_credits) AS credits
FROM residual
WHERE residual_credits > 0;

-- INSERT INTO public.credit_ledger_entries
--   (account_id, entry_type, credits_delta, idempotency_key, reservation_id, metadata)
-- SELECT account_id, 'reservation_release', residual_credits,
--        'reservation:' || reservation_id || ':release-residual',
--        reservation_id,
--        jsonb_build_object('reason', 'issue-616 capture residual', 'pr', '<this PR>')
-- FROM residual
-- WHERE residual_credits > 0
-- ON CONFLICT DO NOTHING;
```

Two follow-ups filed rather than bundled into this money-path fix: flattening the charge idempotency key behind its normalization migration, and the non-atomic create below.

The 25,000 in the second row is a different defect and is deliberately left out of that statement: `CreateReservation` writes the reservation row and posts the ledger hold in two separate transactions, so a hold that fails to post leaves a row the reaper later releases against nothing, inventing credits in the customer's favour. All ten are from July and were released in one pass on 2026-08-01. Filed separately rather than bundled into a money-path fix.

## Buglog entry

```json
{"id":"bug-mhold616-1a2f3c","timestamp":"2026-08-16T12:10:00.000Z","related_bugs":[],"occurrences":1,"last_seen":"2026-08-16T12:10:00.000Z","title":"Credit hold never lifted for the captured part, so every settled request was billed twice","error_message":"Console showed available falling 36 credits for an 18-credit completion; reserved rose by exactly the charge and stayed flat while the account was idle","root_cause":"finalizeLocked released remainingHeldCredits minus actualCredits and nothing ever lifted the captured remainder. GetBalance computes reserved as ABS(SUM(reservation_hold) + SUM(reservation_release)), so the captured credits stayed in the reserved bucket permanently while the usage_charge had already reduced posted, double counting the price of every settled request. The reaper could not recover them because it only scans holds still in a non-terminal state. Live: 1836 terminal reservations holding 144028 credits, one account with three quarters of its balance withheld.","fix":"Release the whole outstanding hold at capture (heldCredits, not heldCredits minus actualCredits) and post the charge separately, so hold and release cancel for every terminal reservation. The reservation row keeps consumed plus released summing to reserved. Also flattened the charge idempotency key from charge-<credits> to charge and made a dedup that returns a differing amount fatal, so a retried settlement cannot double charge or silently diverge from the row.","tags":["billing","ledger","credit-reservation","money-path","issue-616","D-034","control-plane","pr-reservation-capture-hold-leak"]}
```
