### PR TITLE
perf: measure where a metered inference request spends its time

### DIFF
--- a/apps/edge-api/cmd/server/main.go
+++ b/apps/edge-api/cmd/server/main.go
@@ -146,7 +146,8 @@ func main() {
 	routingClient := inference.NewRoutingClient(resolveControlPlaneBaseURL())
 	accountingClient := inference.NewAccountingClient(resolveControlPlaneBaseURL())
 	litellmClient := inference.NewLiteLLMClient(resolveLiteLLMBaseURL(), resolveLiteLLMMasterKey())
-	orchestrator := inference.NewOrchestrator(authorizer, routingClient, accountingClient, litellmClient)
+	orchestrator := inference.NewOrchestrator(authorizer, routingClient, accountingClient, litellmClient).
+		WithStageMetrics(inference.NewStageMetrics(promRegistry))
 	inferenceHandler := inference.NewHandler(orchestrator)
 	chatDispatchHandler := chat.NewDispatch(chat.Deps{
 		Pool:    dbPool,

--- a/apps/edge-api/internal/inference/orchestrator.go
+++ b/apps/edge-api/internal/inference/orchestrator.go
@@ -20,6 +20,18 @@ type Orchestrator struct {
 	routing    *RoutingClient
 	accounting *AccountingClient
 	litellm    *LiteLLMClient
+
+	// metrics is optional; a nil value records nothing. See StageMetrics.
+	metrics *StageMetrics
+}
+
+// WithStageMetrics attaches per-stage timing to this Orchestrator and returns
+// it, mirroring accounting.Service.WithAccountLocker rather than widening
+// NewOrchestrator's signature, so the many call sites that do not want metrics
+// (every test) are untouched.
+func (o *Orchestrator) WithStageMetrics(m *StageMetrics) *Orchestrator {
+	o.metrics = m
+	return o
 }
 
 // NewOrchestrator creates a new Orchestrator.
@@ -79,9 +91,13 @@ func (o *Orchestrator) executeSync(
 	dispatch dispatchFunc,
 	normalize normalizeFunc,
 ) {
+	endTotal := o.stage(endpoint, StageTotal)
+
 	// 1. Authorize
 	authHeader := r.Header.Get("Authorization")
+	endAuthorize := o.stage(endpoint, StageAuthorize)
 	snapshot, headers, authErr := o.authorizer.Authorize(ctx, authHeader, model, estimatedCredits, 0, 0)
+	endAuthorize()
 	if authErr != nil {
 		// apierrors.WriteAuthFailure is the single source of truth for
 		// mapping an authz failure to a wire response (rate-limit 429,
@@ -96,6 +112,7 @@ func (o *Orchestrator) executeSync(
 	}
 
 	// 2. Select route
+	endSelectRoute := o.stage(endpoint, StageSelectRoute)
 	route, err := o.selectRoute(ctx, snapshot, SelectRouteInput{
 		AliasID:             model,
 		NeedChatCompletions: needFlags.NeedChatCompletions,
@@ -105,6 +122,7 @@ func (o *Orchestrator) executeSync(
 		NeedReasoning:       needFlags.NeedReasoning,
 		RequireToolCapable:  needFlags.RequireToolCapable,
 	})
+	endSelectRoute()
 	if err != nil {
 		if errors.Is(err, ErrAccountNotProvisioned) {
 			writeAccountNotProvisionedError(w)
@@ -139,6 +157,7 @@ func (o *Orchestrator) executeSync(
 
 	// 3. Start attempt
 	requestID := uuid.New().String()
+	endStartAttempt := o.stage(endpoint, StageStartAttempt)
 	attempt, err := o.accounting.StartAttempt(ctx, StartAttemptInput{
 		AccountID:     snapshot.AccountID,
 		RequestID:     requestID,
@@ -148,11 +167,13 @@ func (o *Orchestrator) executeSync(
 		Status:        "dispatching",
 		APIKeyID:      snapshot.KeyID,
 	})
+	endStartAttempt()
 	if err != nil {
 		log.Printf("inference: start attempt failed (non-fatal): %v", err)
 	}
 
 	// 4. Create reservation
+	endCreateReservation := o.stage(endpoint, StageCreateReservation)
 	reservation, err := o.accounting.CreateReservation(ctx, CreateReservationInput{
 		AccountID:        snapshot.AccountID,
 		RequestID:        requestID,
@@ -163,6 +184,7 @@ func (o *Orchestrator) executeSync(
 		EstimatedCredits: estimatedCredits,
 		PolicyMode:       "strict",
 	})
+	endCreateReservation()
 	if err != nil && refuseOnReservationFailure(w, endpoint, model, err) {
 		return
 	}
@@ -184,7 +206,9 @@ func (o *Orchestrator) executeSync(
 	}()
 
 	// 5. Dispatch to LiteLLM with bounded retry on 429/5xx.
+	endDispatch := o.stage(endpoint, StageDispatch)
 	resp, err := dispatchWithRetry(ctx, route.LiteLLMModelName, body, dispatch)
+	endDispatch()
 	if err != nil {
 		if reservation.ID != "" {
 			releaseReason = "upstream_error"
@@ -288,6 +312,7 @@ func (o *Orchestrator) executeSync(
 			// context + accountingTimeout as releaseReservationBackground and
 			// settleStream (PR #602's pattern).
 			finalizeCtx, cancel := context.WithTimeout(context.Background(), accountingTimeout)
+			endFinalize := o.stage(endpoint, StageFinalizeReservation)
 			err := o.accounting.FinalizeReservation(finalizeCtx, FinalizeReservationInput{
 				AccountID:     snapshot.AccountID,
 				ReservationID: reservation.ID,
@@ -300,6 +325,7 @@ func (o *Orchestrator) executeSync(
 				TerminalUsageConfirmed: confirmed,
 				Status:                 "completed",
 			})
+			endFinalize()
 			cancel()
 			if err != nil {
 				log.Printf("inference: finalize reservation failed, releasing hold instead request_id=%s reservation_id=%s: %v", requestID, reservation.ID, err)
@@ -310,12 +336,23 @@ func (o *Orchestrator) executeSync(
 		}
 	}
 
+	// The gap this measures is the sharpest evidence the 2026-08-16 latency
+	// investigation produced: the client's body arrived 190 ms after the last
+	// ledger row was written, three times running, which is what showed the
+	// wait was Hive's own accounting rather than the agent or the provider.
+	// Keeping it as a metric is what makes a regression in that gap visible
+	// without repeating the investigation.
+	endRecordUsage := o.stage(endpoint, StageRecordUsage)
 	o.recordCompletedEvent(ctx, snapshot, attempt, requestID, endpoint, model, usage)
+	endRecordUsage()
 
 	// 9. Write response
+	endResponseWrite := o.stage(endpoint, StageResponseWrite)
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	w.Write(normalized)
+	endResponseWrite()
+	endTotal()
 }
 
 func (o *Orchestrator) recordErrorEvent(ctx context.Context, snapshot authz.AuthSnapshot, attempt AttemptResult, requestID, endpoint, model string, statusCode int, errBody string) {

--- a/apps/edge-api/internal/inference/orchestrator.go
+++ b/apps/edge-api/internal/inference/orchestrator.go
@@ -91,7 +91,13 @@ func (o *Orchestrator) executeSync(
 	dispatch dispatchFunc,
 	normalize normalizeFunc,
 ) {
-	endTotal := o.stage(endpoint, StageTotal)
+	// Deferred, unlike every other stage below: this one spans the whole
+	// function, and executeSync returns early on authorization, routing,
+	// reservation, upstream and normalization failures. Recording it at the
+	// bottom instead would mean the total only ever counts requests that
+	// succeeded, which is a metric that cannot go red on exactly the outcomes
+	// worth alerting on.
+	defer o.stage(endpoint, StageTotal)()
 
 	// 1. Authorize
 	authHeader := r.Header.Get("Authorization")
@@ -352,7 +358,6 @@ func (o *Orchestrator) executeSync(
 	w.WriteHeader(http.StatusOK)
 	w.Write(normalized)
 	endResponseWrite()
-	endTotal()
 }
 
 func (o *Orchestrator) recordErrorEvent(ctx context.Context, snapshot authz.AuthSnapshot, attempt AttemptResult, requestID, endpoint, model string, statusCode int, errBody string) {

--- a/apps/edge-api/internal/inference/stage_metrics.go
+++ b/apps/edge-api/internal/inference/stage_metrics.go
@@ -1,0 +1,91 @@
+package inference
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// StageMetrics records how long each stage of a metered inference request
+// takes, so the split between provider time and Hive's own time is a standing
+// signal rather than something that has to be re-derived by hand.
+//
+// It exists because that re-derivation was expensive and the conclusion was
+// counter-intuitive. Measured on the demo box on 2026-08-16, one metered
+// chat completion took 12.4 to 24.4 seconds end to end while the same prompt
+// straight through LiteLLM took 0.54 to 1.38 seconds. The gap was not the
+// provider, not the network (the full public round trip is 0.13 s), not DNS,
+// and not database execution (one request spends 216 ms of database server
+// time). It was the number of sequential statements the request makes against
+// a database roughly 240 ms away: about 86 of them, which multiplies out to
+// very nearly the observed wall clock.
+//
+// Nothing above is visible from the outside, which is the point of this type.
+// A per-stage histogram makes the same finding readable from /metrics in one
+// query, and makes a regression in any single stage obvious immediately.
+type StageMetrics struct {
+	duration *prometheus.HistogramVec
+}
+
+// Stage names. Fixed set, so the label stays low cardinality and a dashboard
+// can name the series it wants.
+const (
+	StageAuthorize           = "authorize"
+	StageSelectRoute         = "select_route"
+	StageStartAttempt        = "start_attempt"
+	StageCreateReservation   = "create_reservation"
+	StageDispatch            = "dispatch"
+	StageFinalizeReservation = "finalize_reservation"
+	StageRecordUsage         = "record_usage"
+	StageResponseWrite       = "response_write"
+	StageTotal               = "total"
+)
+
+// NewStageMetrics registers the stage histogram on reg.
+//
+// Buckets deliberately reach far past prometheus.DefBuckets, whose top bucket
+// is 10 s: the stages this measures are routinely 5 to 7 s each today and the
+// total has been observed at 24 s, so DefBuckets would put almost every
+// observation in +Inf and report nothing useful about exactly the values that
+// matter. 0.05 s doubling twelve times covers 50 ms to 102 s.
+func NewStageMetrics(reg prometheus.Registerer) *StageMetrics {
+	m := &StageMetrics{
+		duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "hive_metered_stage_duration_seconds",
+			Help:    "Duration of each stage of a metered inference request, by stage and endpoint.",
+			Buckets: prometheus.ExponentialBuckets(0.05, 2, 12),
+		}, []string{"stage", "endpoint"}),
+	}
+	reg.MustRegister(m.duration)
+	return m
+}
+
+// observe records one stage duration. Nil-safe on purpose: an Orchestrator
+// built without metrics (every existing test does exactly that) records
+// nothing rather than panicking, so instrumentation can never be the reason a
+// request fails.
+func (m *StageMetrics) observe(stage, endpoint string, d time.Duration) {
+	if m == nil || m.duration == nil {
+		return
+	}
+	m.duration.WithLabelValues(stage, endpoint).Observe(d.Seconds())
+}
+
+// stage starts timing one stage and returns the function that ends it. The
+// returned function is safe to call exactly once; calling it is what records
+// the observation.
+//
+//	done := o.stage(endpoint, StageCreateReservation)
+//	reservation, err := o.accounting.CreateReservation(ctx, ...)
+//	done()
+//
+// Deliberately not a defer-based helper: several of these stages sit in the
+// middle of a long function whose scope is the whole request, so a defer would
+// record every stage at the same moment, at the end.
+func (o *Orchestrator) stage(endpoint, name string) func() {
+	if o.metrics == nil {
+		return func() {}
+	}
+	start := time.Now()
+	return func() { o.metrics.observe(name, endpoint, time.Since(start)) }
+}

--- a/apps/edge-api/internal/inference/stage_metrics.go
+++ b/apps/edge-api/internal/inference/stage_metrics.go
@@ -79,9 +79,11 @@ func (m *StageMetrics) observe(stage, endpoint string, d time.Duration) {
 //	reservation, err := o.accounting.CreateReservation(ctx, ...)
 //	done()
 //
-// Deliberately not a defer-based helper: several of these stages sit in the
-// middle of a long function whose scope is the whole request, so a defer would
-// record every stage at the same moment, at the end.
+// Deliberately not defer-only: most of these stages sit in the middle of a
+// long function whose scope is the whole request, so deferring them all would
+// record every stage at the same moment, at the end. A stage that genuinely
+// does span the whole function (StageTotal) should still be deferred, so that
+// it is recorded on the early-return failure paths too.
 func (o *Orchestrator) stage(endpoint, name string) func() {
 	if o.metrics == nil {
 		return func() {}

--- a/apps/edge-api/internal/inference/stage_metrics_test.go
+++ b/apps/edge-api/internal/inference/stage_metrics_test.go
@@ -1,6 +1,8 @@
 package inference
 
 import (
+	"context"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -93,6 +95,35 @@ func TestStageBucketsCoverTheObservedRange(t *testing.T) {
 	}
 	if highestFiniteBound < 24 {
 		t.Fatalf("a 24 s observation must land in a finite bucket, but the highest bound is %.2fs", highestFiniteBound)
+	}
+}
+
+// A total that is only recorded after a successful response write is a metric
+// that cannot go red on the outcomes worth alerting on. executeSync returns
+// early on authorization, routing, reservation, upstream and normalization
+// failures, so the total has to be deferred. This drives the earliest of those
+// exits (authorization) and asserts the observation still lands.
+func TestTotalIsRecordedOnAFailedRequest(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	orch := upstreamUnavailableOrchestrator().WithStageMetrics(NewStageMetrics(reg))
+
+	req := httptest.NewRequest("POST", "/v1/chat/completions", nil)
+	req.Header.Set("Authorization", "Bearer test-token")
+	w := httptest.NewRecorder()
+
+	orch.executeSync(context.Background(), w, req, EndpointChatCompletions, []byte(`{}`), "gpt-4o", NeedFlags{}, 100, nil, nil)
+
+	if w.Code == 200 {
+		t.Fatalf("this test needs a failing request to be meaningful, got 200")
+	}
+	count, ok := stageSampleCount(t, reg, StageTotal, EndpointChatCompletions)
+	if !ok || count != 1 {
+		t.Fatalf("a failed request must still record one total observation, got count=%d present=%v", count, ok)
+	}
+	// The stage that did run before the failure is recorded too, so the total
+	// can be read against its parts rather than standing alone.
+	if _, ok := stageSampleCount(t, reg, StageAuthorize, EndpointChatCompletions); !ok {
+		t.Fatal("expected the authorize stage to be recorded on the failure path")
 	}
 }
 

--- a/apps/edge-api/internal/inference/stage_metrics_test.go
+++ b/apps/edge-api/internal/inference/stage_metrics_test.go
@@ -1,0 +1,107 @@
+package inference
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+// stageSampleCount returns how many observations the histogram holds for one
+// (stage, endpoint) pair, and whether that series exists at all.
+func stageSampleCount(t *testing.T, reg *prometheus.Registry, stage, endpoint string) (uint64, bool) {
+	t.Helper()
+	families, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	for _, f := range families {
+		if f.GetName() != "hive_metered_stage_duration_seconds" {
+			continue
+		}
+		for _, m := range f.GetMetric() {
+			var gotStage, gotEndpoint string
+			for _, l := range m.GetLabel() {
+				switch l.GetName() {
+				case "stage":
+					gotStage = l.GetValue()
+				case "endpoint":
+					gotEndpoint = l.GetValue()
+				}
+			}
+			if gotStage == stage && gotEndpoint == endpoint {
+				return m.GetHistogram().GetSampleCount(), true
+			}
+		}
+	}
+	return 0, false
+}
+
+func TestStageRecordsOneObservationPerCall(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	o := &Orchestrator{}
+	o.WithStageMetrics(NewStageMetrics(reg))
+
+	done := o.stage("chat_completions", StageCreateReservation)
+	time.Sleep(time.Millisecond)
+	done()
+
+	count, ok := stageSampleCount(t, reg, StageCreateReservation, "chat_completions")
+	if !ok {
+		t.Fatal("expected a hive_metered_stage_duration_seconds series for create_reservation")
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly 1 observation, got %d", count)
+	}
+
+	// A second stage on the same orchestrator must land on its own series, so
+	// the split between provider time and Hive's own time stays readable.
+	o.stage("chat_completions", StageDispatch)()
+	if _, ok := stageSampleCount(t, reg, StageDispatch, "chat_completions"); !ok {
+		t.Fatal("expected a separate series for the dispatch stage")
+	}
+}
+
+// The observation must survive being recorded even when the duration is long:
+// the whole reason this metric exists is that stages routinely run past
+// prometheus.DefBuckets' 10 s ceiling, and a bucket set that tops out below the
+// interesting values reports nothing about them.
+func TestStageBucketsCoverTheObservedRange(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := NewStageMetrics(reg)
+	m.observe(StageTotal, "chat_completions", 24*time.Second)
+
+	families, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	var hist *dto.Histogram
+	for _, f := range families {
+		if f.GetName() == "hive_metered_stage_duration_seconds" {
+			hist = f.GetMetric()[0].GetHistogram()
+		}
+	}
+	if hist == nil {
+		t.Fatal("expected the histogram to be registered")
+	}
+	var highestFiniteBound float64
+	for _, b := range hist.GetBucket() {
+		if b.GetUpperBound() > highestFiniteBound {
+			highestFiniteBound = b.GetUpperBound()
+		}
+	}
+	if highestFiniteBound < 24 {
+		t.Fatalf("a 24 s observation must land in a finite bucket, but the highest bound is %.2fs", highestFiniteBound)
+	}
+}
+
+// Instrumentation must never be the reason a request fails. Every existing
+// construction site builds an Orchestrator without metrics.
+func TestStageIsNilSafeWithoutMetrics(t *testing.T) {
+	o := &Orchestrator{}
+	o.stage("chat_completions", StageTotal)() // must not panic
+
+	var m *StageMetrics
+	m.observe(StageTotal, "chat_completions", time.Second) // must not panic
+}


### PR DESCRIPTION
## What this is

Instrumentation for the metered inference path, plus the measured answer to "where do the 19 to 23 seconds per gateway call go".

Read the honesty section first: **this PR does not make anything faster.** It makes the cost visible and names the one cut that will, along with the reason that cut is not in this diff.

## Measured, on the demo box, 2026-08-16

Same prompt, same box, same minute:

| path | wall clock |
|---|---|
| straight through LiteLLM, no gateway, no accounting | 0.54 - 1.38 s |
| through the Hive gateway | 12.4 - 24.4 s |

Per-stage, timed at every boundary:

| stage | measured |
|---|---|
| network and Caddy (unauthenticated 401 round trip) | 0.13 s |
| authorize (warm) | ~0.00 s, and 2.54 s on a cold cache |
| select_route | 0.71 s |
| start_attempt | 0.24 s |
| **create_reservation** | **~5 - 7 s** |
| dispatch (the provider actually working) | 0.6 - 1.4 s |
| **finalize_reservation** | **~5 - 6 s** |
| record_usage | 0.24 s |

Three hypotheses were named up front. Two are dead, measured rather than argued:

- **Settlement sitting on the critical path**: not the cause. `/internal/usage/events` answers in 0.24 s, measured directly against control-plane. Moving usage recording off the critical path would buy a quarter of a second.
- **The exhausted 15-client session pool (#436)**: not the cause of this. The pool is genuinely at its ceiling and that is a real problem, but one metered request executes 86 statements and all of them succeed; there is no starvation stall in the profile.
- **Round-trip count at 240 ms**: this is it. One metered chat completion runs **86 SQL statements** and consumes **216 ms of database server time**, against a database in `aws-1-us-east-1` whose measured round-trip latency from the box is **236 - 276 ms**. 86 statements times 240 ms is very nearly the observed wall clock. The database does 1.2% of the work and the speed of light does the rest.

Method: `pg_stat_statements` snapshotted per `queryid` before and after exactly one request, diffed. Provider baseline taken through LiteLLM on loopback (2 - 3 ms to reach it). Per-endpoint numbers taken by calling control-plane's internal endpoints directly.

`CreateReservation` costs what it costs because its locked critical section runs five independent transactions (balance read, attempt insert, reservation insert, ledger reserve, usage event, api-key delta), each paying its own BEGIN, its statements, and its COMMIT, plus a session advisory lock on a dedicated connection. That is roughly 21 to 24 sequential round trips. `FinalizeReservation` has the same shape.

## The invariant this preserves

Nothing on the money path moves. The reservation is still created before dispatch, the charge is still finalized before the response is written, both still run on the same contexts with the same error handling, and a reservation still reaches a terminal state exactly once: charged on finalize success, released by the existing deferred release on finalize failure, never both. This diff only reads a clock around calls that already existed, in the same order they already ran.

Concretely, on the unhappy path, the behaviour after this change is identical to before it, because settlement did **not** move asynchronous:

- Request succeeds, finalize succeeds: customer is charged the settled amount. Unchanged.
- Request succeeds, finalize fails: `finalized` stays false, the deferred release hands the hold back in full, the failure is logged with `request_id` and `reservation_id`, and the response is still returned. The customer is not charged for that call, and the reconciliation path that already exists is what picks it up. Unchanged, and deliberately so.
- Instrumentation itself fails: it cannot. `stage` is nil-safe and the observation is a histogram write with no error return, so it has no failure mode that can reach a request.

Making settlement faster by making it lossy would be a far worse bug than the latency, and this diff declines to trade that way. Hive has already served three days of unmetered traffic because a billing failure was silent; the fix for the latency is fewer round trips, not fewer guarantees.

## The cut, and why it is not here

The cut that removes the time is collapsing each money call's locked critical section into a single transaction on a single connection, which removes the redundant BEGIN and COMMIT pairs and is strictly more correct than today (a crash between the reservation insert and the ledger write currently leaves a reservation row with no ledger entry, which is the stranded-hold shape the repo already suffers from).

That refactor touches `apps/control-plane/internal/accounting/service.go` and `repository.go`, which is exactly where the in-flight reservation-release fix is working. Landing both at once would collide on the money path, which is the worst possible place to resolve a merge conflict. It should land after that fix, on top of it, with this metric already deployed so the improvement is measurable rather than asserted.

The second lever is not code at all: at 240 ms per round trip, even a four-fold reduction in statements leaves a five-second call. Only moving the database next to the services gets a metered call under a second, which is the self-hosted-Postgres direction the owner already has a standing directive for.

## Files touched

- `apps/edge-api/internal/inference/stage_metrics.go` (new)
- `apps/edge-api/internal/inference/stage_metrics_test.go` (new)
- `apps/edge-api/internal/inference/orchestrator.go` (timing calls only, no reordering, no semantic change)
- `apps/edge-api/cmd/server/main.go` (one construction site)

Deliberately **not** touched, to stay clear of the in-flight reservation-release work: `apps/control-plane/internal/accounting/*`, `releaseReservationBackground`, and every release path.

Also not touched: the streaming path (`stream.go`). The agent traffic this was investigated for is non-streaming, and adding stage timing there is a separate, larger change because settlement happens after the stream closes.

## The 190 ms instrument, kept

The sharpest single piece of evidence in the investigation was that the client's response body arrived 190 ms after the last ledger row was written, three times running. That is what proved the wait was Hive's own accounting rather than the agent or the provider. It now lives as the `record_usage` and `response_write` stages rather than as a one-off probe, so a regression in that gap is visible in one PromQL query instead of requiring the investigation to be repeated.

Suggested query:

```
histogram_quantile(0.95, sum by (stage, le) (rate(hive_metered_stage_duration_seconds_bucket[5m])))
```

## Before and after

Latency before and after are the same by construction, and that is the intended result of this PR:

| | before | after |
|---|---|---|
| metered chat completion, demo box | 12.4 - 24.4 s | 12.4 - 24.4 s |
| stages visible from `/metrics` | none | nine |

The numbers that change come from the follow-up, and this metric is what will measure them honestly.

## Tests

`go test ./apps/edge-api/... -count=1 -short` green in the toolchain container. Three new tests: one observation per `stage` call landing on its own series, the bucket range actually covering a 24 second observation (a `DefBuckets` histogram would silently report nothing about the values that matter here), and nil-safety for the many construction sites that pass no metrics.

## Buglog entry

```json
{"date":"2026-08-16","title":"metered gateway call costs 19 to 23 seconds of Hive-owned overhead per request","error_message":"none: no error is raised, the request succeeds and is simply 20x slower than the provider call it wraps","root_cause":"One metered chat completion executes 86 sequential SQL statements against a database in aws-1-us-east-1 whose round-trip latency from the box is 236 to 276 ms, while spending only 216 ms of actual database server time. CreateReservation and FinalizeReservation dominate at 5 to 7 s each because each runs five independent transactions inside its account advisory lock, so every logical operation pays its own BEGIN, statements and COMMIT. Neither settlement placement nor pool exhaustion is the cause; both were measured and excluded.","fix":"Not fixed here. This change instruments the path so the split is a standing metric (hive_metered_stage_duration_seconds). The cut is collapsing each money call's locked critical section into one transaction, sequenced after the in-flight reservation-release fix to avoid colliding on the same files, plus co-locating the database, which is the only lever that reaches sub-second.","tags":["edge-api","control-plane","accounting","latency","metrics","demo-box","round-trips"]}
```
