### PR TITLE
fix: stop one lost agent session from throttling every tenant's poll cadence

### DIFF
--- a/apps/control-plane/internal/agentengine/engine.go
+++ b/apps/control-plane/internal/agentengine/engine.go
@@ -46,11 +46,18 @@ func (e *Engine) Launch(ctx context.Context, t agenttask.Task) (string, error) {
 // past running.
 func (e *Engine) Status(ctx context.Context, sessionRef string) (status agenttask.Status, resultSummary, errMessage string, err error) {
 	s, resultSummary, errMessage, err := e.sandbox.Status(ctx, sessionRef)
-	if err != nil && errors.Is(err, engineapi.ErrUnknownSession) {
-		// Mirrors Remote.post's 404 mapping so the poller can tell "this
-		// session can never answer again" apart from a transient failure
-		// regardless of which agenttask.Engine arm is wired in.
-		return "", "", "", fmt.Errorf("%w: %s", agenttask.ErrEngineSessionGone, err)
+	if errors.Is(err, engineapi.ErrUnknownSession) {
+		// Same scoping as Remote.post's 404 mapping, so the poller can tell
+		// "this session can never answer again" apart from a transient
+		// failure regardless of which agenttask.Engine arm is wired in.
+		// %w twice keeps errors.Is(result, engineapi.ErrUnknownSession)
+		// working too, in case anything ever depends on the original chain.
+		// Unlike Remote.post, this error never crosses a process boundary —
+		// it only ever reaches the poller's own WARN log (see
+		// agenttask.Poller.pollTask), never a customer-visible field — so
+		// embedding sessionRef here is not the provider-blind leak it would
+		// be on the socket arm.
+		return "", "", "", fmt.Errorf("%w: %w", agenttask.ErrEngineSessionGone, err)
 	}
 	return agenttask.Status(s), resultSummary, errMessage, err
 }
@@ -58,6 +65,17 @@ func (e *Engine) Status(ctx context.Context, sessionRef string) (status agenttas
 // Cancel interrupts sessionRef's conversation and terminates its sandbox
 // process, which is what releases the session's concurrency slot on the
 // launcher side. Called by agenttask.Service.Cancel (issue #886).
+//
+// Maps engineapi.ErrUnknownSession the same way Status does above, for the
+// same arm-agnostic reason Remote.post's /cancel mapping exists: a session
+// the engine has no memory of holds no concurrency slot either (the quota
+// manager lives in the same in-memory state as the session registry), so
+// Service.stopEngineSession's ErrEngineSessionGone branch (its doc comment)
+// applies here too and there is nothing to warn an operator about.
 func (e *Engine) Cancel(ctx context.Context, sessionRef string) error {
-	return e.sandbox.Cancel(ctx, sessionRef)
+	err := e.sandbox.Cancel(ctx, sessionRef)
+	if errors.Is(err, engineapi.ErrUnknownSession) {
+		return fmt.Errorf("%w: %w", agenttask.ErrEngineSessionGone, err)
+	}
+	return err
 }

--- a/apps/control-plane/internal/agentengine/engine.go
+++ b/apps/control-plane/internal/agentengine/engine.go
@@ -10,6 +10,8 @@ package agentengine
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"github.com/sakibsadmanshajib/hive/apps/agent-engine/engineapi"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/agenttask"
@@ -44,6 +46,12 @@ func (e *Engine) Launch(ctx context.Context, t agenttask.Task) (string, error) {
 // past running.
 func (e *Engine) Status(ctx context.Context, sessionRef string) (status agenttask.Status, resultSummary, errMessage string, err error) {
 	s, resultSummary, errMessage, err := e.sandbox.Status(ctx, sessionRef)
+	if err != nil && errors.Is(err, engineapi.ErrUnknownSession) {
+		// Mirrors Remote.post's 404 mapping so the poller can tell "this
+		// session can never answer again" apart from a transient failure
+		// regardless of which agenttask.Engine arm is wired in.
+		return "", "", "", fmt.Errorf("%w: %s", agenttask.ErrEngineSessionGone, err)
+	}
 	return agenttask.Status(s), resultSummary, errMessage, err
 }
 

--- a/apps/control-plane/internal/agentengine/engine_test.go
+++ b/apps/control-plane/internal/agentengine/engine_test.go
@@ -1,0 +1,32 @@
+package agentengine
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/sakibsadmanshajib/hive/apps/agent-engine/engineapi"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/agenttask"
+)
+
+// TestEngineStatusUnknownSessionMapsToEngineSessionGone is the in-process
+// arm's half of the same fix Remote.post carries for the socket arm
+// (remote_test.go's TestRemoteStatus404MapsToEngineSessionGone): a session
+// reference the wrapped SandboxEngine has no memory of must map onto
+// agenttask.ErrEngineSessionGone here too, so the poller's "this can never
+// answer again" handling does not depend on which agenttask.Engine arm is
+// wired in. Constructing a zero-value engineapi.Config is enough: lookup
+// against an empty in-memory session map needs no sandbox, socket, or
+// external process.
+func TestEngineStatusUnknownSessionMapsToEngineSessionGone(t *testing.T) {
+	sandbox := engineapi.New(engineapi.Config{})
+	e := New(sandbox)
+
+	_, _, _, err := e.Status(context.Background(), "00000000-0000-0000-0000-000000000000")
+	if err == nil {
+		t.Fatal("expected an error for an unknown session reference")
+	}
+	if !errors.Is(err, agenttask.ErrEngineSessionGone) {
+		t.Fatalf("expected errors.Is(err, agenttask.ErrEngineSessionGone), got: %v", err)
+	}
+}

--- a/apps/control-plane/internal/agentengine/remote.go
+++ b/apps/control-plane/internal/agentengine/remote.go
@@ -150,6 +150,17 @@ func (r *Remote) post(ctx context.Context, path string, body any, out any) error
 		// container's log, not in a value callers may surface, so the
 		// returned error carries only the operation and the status code.
 		log.Printf("agentengine: %s: status %d: %s", path, resp.StatusCode, detail)
+		if resp.StatusCode == http.StatusNotFound {
+			// The launcher maps engineapi.ErrUnknownSession onto 404
+			// (apps/agent-engine/cmd/agent-engine/serve.go), which happens
+			// only for /status and /cancel: the session reference is gone
+			// from its in-memory registry (a launcher restart lost it) and
+			// can never answer again. Wrapping agenttask.ErrEngineSessionGone
+			// here, rather than only in the in-process agentengine.Engine
+			// arm, is what lets the poller tell this definitive case apart
+			// from a transient failure regardless of which arm is wired in.
+			return fmt.Errorf("agentengine: %s: status %d: %w", path, resp.StatusCode, agenttask.ErrEngineSessionGone)
+		}
 		return fmt.Errorf("agentengine: %s: status %d", path, resp.StatusCode)
 	}
 	if out == nil {

--- a/apps/control-plane/internal/agentengine/remote.go
+++ b/apps/control-plane/internal/agentengine/remote.go
@@ -150,15 +150,20 @@ func (r *Remote) post(ctx context.Context, path string, body any, out any) error
 		// container's log, not in a value callers may surface, so the
 		// returned error carries only the operation and the status code.
 		log.Printf("agentengine: %s: status %d: %s", path, resp.StatusCode, detail)
-		if resp.StatusCode == http.StatusNotFound {
-			// The launcher maps engineapi.ErrUnknownSession onto 404
-			// (apps/agent-engine/cmd/agent-engine/serve.go), which happens
-			// only for /status and /cancel: the session reference is gone
-			// from its in-memory registry (a launcher restart lost it) and
-			// can never answer again. Wrapping agenttask.ErrEngineSessionGone
-			// here, rather than only in the in-process agentengine.Engine
-			// arm, is what lets the poller tell this definitive case apart
-			// from a transient failure regardless of which arm is wired in.
+		// The launcher maps engineapi.ErrUnknownSession onto 404
+		// (apps/agent-engine/cmd/agent-engine/serve.go), which happens only
+		// for /status and /cancel: the session reference is gone from its
+		// in-memory registry (a launcher restart lost it) and can never
+		// answer again. Scoped to those two paths deliberately: post also
+		// serves /launch, and net/http.ServeMux answers 404 for ANY path it
+		// has no handler for, so an unscoped check would call a routing
+		// miss (e.g. control-plane and the host launcher binary drifting out
+		// of sync) session-gone instead of the ordinary transient error it
+		// actually is. Wrapping agenttask.ErrEngineSessionGone here, rather
+		// than only in the in-process agentengine.Engine arm, is what lets
+		// the poller tell this definitive case apart from a transient
+		// failure regardless of which arm is wired in.
+		if resp.StatusCode == http.StatusNotFound && (path == "/status" || path == "/cancel") {
 			return fmt.Errorf("agentengine: %s: status %d: %w", path, resp.StatusCode, agenttask.ErrEngineSessionGone)
 		}
 		return fmt.Errorf("agentengine: %s: status %d", path, resp.StatusCode)

--- a/apps/control-plane/internal/agentengine/remote_test.go
+++ b/apps/control-plane/internal/agentengine/remote_test.go
@@ -2,6 +2,7 @@ package agentengine
 
 import (
 	"context"
+	"errors"
 	"io"
 	"log"
 	"net"
@@ -10,6 +11,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/agenttask"
 )
 
 // TestRemoteErrorDoesNotLeakDaemonDetail is the provider-blind boundary guard:
@@ -46,6 +49,43 @@ func TestRemoteErrorDoesNotLeakDaemonDetail(t *testing.T) {
 		t.Fatalf("daemon detail crossed the boundary: %v", err)
 	}
 	if !strings.Contains(err.Error(), "502") || !strings.Contains(err.Error(), "/status") {
+		t.Fatalf("error should still identify the operation and status, got: %v", err)
+	}
+}
+
+// TestRemoteStatus404MapsToEngineSessionGone proves the launcher's 404
+// response (apps/agent-engine/cmd/agent-engine/serve.go maps
+// engineapi.ErrUnknownSession onto it) becomes agenttask.ErrEngineSessionGone
+// on this side, so the poller can tell "this session can never answer again"
+// apart from a transient failure — the root-cause fix for a lost session
+// polling forever and degrading the shared poll cadence for every tenant.
+func TestRemoteStatus404MapsToEngineSessionGone(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "engine.sock")
+	ln, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = io.WriteString(w, `{"error":"engine: unknown session reference: session-ref"}`)
+	})}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = srv.Close() })
+
+	log.SetOutput(io.Discard)
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+
+	_, _, _, err = NewRemote(socketPath, "").Status(context.Background(), "session-ref")
+	if err == nil {
+		t.Fatal("expected an error for a 404 daemon response")
+	}
+	if !errors.Is(err, agenttask.ErrEngineSessionGone) {
+		t.Fatalf("expected errors.Is(err, agenttask.ErrEngineSessionGone), got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "404") || !strings.Contains(err.Error(), "/status") {
 		t.Fatalf("error should still identify the operation and status, got: %v", err)
 	}
 }

--- a/apps/control-plane/internal/agentengine/remote_test.go
+++ b/apps/control-plane/internal/agentengine/remote_test.go
@@ -89,3 +89,57 @@ func TestRemoteStatus404MapsToEngineSessionGone(t *testing.T) {
 		t.Fatalf("error should still identify the operation and status, got: %v", err)
 	}
 }
+
+// TestRemoteLaunch404DoesNotMapToEngineSessionGone is the negative case the
+// path-scoping fix above exists for: net/http.ServeMux answers 404 for ANY
+// path it has no handler for, not just the launcher's own deliberate
+// unknown-session case, and post also serves /launch. A control-plane build
+// calling an endpoint a mismatched launcher binary does not have (a routing
+// miss, not "this session is gone") must not be misread as
+// agenttask.ErrEngineSessionGone — Launch has no session reference to be
+// gone in the first place.
+func TestRemoteLaunch404DoesNotMapToEngineSessionGone(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "engine.sock")
+	ln, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	// A bare http.NotFoundHandler models a routing miss: every path, every
+	// method, 404 — not a launcher that specifically recognizes
+	// engineapi.ErrUnknownSession.
+	srv := &http.Server{Handler: http.NotFoundHandler()}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = srv.Close() })
+
+	log.SetOutput(io.Discard)
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+
+	_, err = NewRemote(socketPath, "").Launch(context.Background(), agenttask.Task{})
+	if err == nil {
+		t.Fatal("expected an error for a 404 daemon response")
+	}
+	if errors.Is(err, agenttask.ErrEngineSessionGone) {
+		t.Fatalf("a /launch 404 (a routing miss, no session involved) must not map to ErrEngineSessionGone: %v", err)
+	}
+}
+
+// TestRemoteTransportFailureDoesNotMapToEngineSessionGone proves a dial
+// failure (the launcher is not running at all) never becomes
+// agenttask.ErrEngineSessionGone: that error is returned above the status
+// code branch entirely, so treating "unreachable" the same as "reachable and
+// says gone" cannot happen here. This is the discrimination the earlier
+// transport-collapsed-into-401 defect was missing.
+func TestRemoteTransportFailureDoesNotMapToEngineSessionGone(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "engine.sock")
+	// Deliberately never listened on: dialing it fails immediately.
+
+	_, _, _, err := NewRemote(socketPath, "").Status(context.Background(), "session-ref")
+	if err == nil {
+		t.Fatal("expected a dial error against a socket nothing is listening on")
+	}
+	if errors.Is(err, agenttask.ErrEngineSessionGone) {
+		t.Fatalf("a transport failure must not map to ErrEngineSessionGone: %v", err)
+	}
+}

--- a/apps/control-plane/internal/agenttask/poller.go
+++ b/apps/control-plane/internal/agenttask/poller.go
@@ -22,6 +22,28 @@ type StatusChecker interface {
 // loop's interval to (see loop's doc comment).
 const maxPollerBackoff = 5 * time.Minute
 
+// ErrEngineSessionGone is a StatusChecker implementation's definitive answer
+// that sessionRef no longer exists anywhere the engine can reach it — the
+// launcher restarted and lost its in-memory session registry, and its own
+// /status endpoint answers 404 for exactly that reason (see
+// agentengine.Remote.post and agentengine.Engine.Status, which map their
+// respective 404/engineapi.ErrUnknownSession cases onto this sentinel).
+// Unlike every other StatusChecker error, this one is not retried next pass:
+// a session the engine has no memory of can never report progress again, so
+// RunOnce fails the task immediately instead of leaving it queued/running
+// forever. Left unhandled, a single such task sits in ListActive's
+// cross-tenant result set and errors on every single pass, which used to
+// hold the whole poller's shared backoff at maxPollerBackoff (see loop's doc
+// comment) for as long as that one row existed, throttling poll cadence for
+// every other tenant's tasks too (measured live 2026-08-16, task f9409763).
+var ErrEngineSessionGone = errors.New("agenttask: engine has no memory of this session")
+
+// engineSessionGoneMessage is the customer-visible error_message persisted
+// when ErrEngineSessionGone fires. Provider-blind, same rationale as
+// Service's engineLaunchFailedMessage: no session reference, sandbox path,
+// or engine detail ever reaches a customer-facing field.
+const engineSessionGoneMessage = "agent task session is no longer reachable"
+
 // PollerConfig controls Poller behaviour.
 type PollerConfig struct {
 	// Interval between poll passes when the previous pass had no errors.
@@ -69,11 +91,23 @@ func NewPoller(repo Repository, checker StatusChecker, cfg PollerConfig) *Poller
 
 // RunOnce performs exactly one poll pass: every active task gets exactly one
 // StatusChecker.Status call and, if terminal, one Repository.Transition
-// call. A single task's engine error is logged and skipped — it stays
-// active and is retried next pass, it does not abort the rest of the pass.
-// The returned error, when non-nil, reports that at least one task had a
-// problem this pass (see loop's backoff); it does not mean the pass failed
-// outright unless ListActive itself errored.
+// call. A single task's transient engine error is logged and skipped — it
+// stays active and is retried next pass, it does not abort the rest of the
+// pass. ErrEngineSessionGone is not transient and is not retried: it fails
+// the task in this same pass (see its doc comment).
+//
+// The returned error, when non-nil, is loop's sole backoff signal (see
+// loop's doc comment) and means this PASS looks systemically degraded: every
+// active task's status check failed, or ListActive itself failed. It is
+// deliberately NOT "at least one task had a problem": a sweep where some
+// tasks succeed and one fails is not a failed sweep in any useful sense, and
+// ListActive is cross-tenant, so treating any single task-level error as
+// pass-level failure let one permanently broken task hold the whole poller's
+// shared backoff at maxPollerBackoff for as long as that row existed,
+// throttling poll cadence for every other tenant's tasks too (measured live
+// 2026-08-16, task f9409763: a lost session 404ing forever kept every sweep
+// erroring, so consecutiveFailures never reset). A pass with zero active
+// tasks is never systemically degraded.
 func (p *Poller) RunOnce(ctx context.Context) (advanced int, err error) {
 	tasks, err := p.repo.ListActive(ctx)
 	if err != nil {
@@ -84,6 +118,23 @@ func (p *Poller) RunOnce(ctx context.Context) (advanced int, err error) {
 	for _, t := range tasks {
 		status, resultSummary, errMessage, statusErr := p.checker.Status(ctx, t.EngineSessionRef)
 		if statusErr != nil {
+			if errors.Is(statusErr, ErrEngineSessionGone) {
+				p.logger.WarnContext(ctx, "agenttask: engine has no memory of this session, failing the task",
+					"task_id", t.ID, "error", statusErr)
+				if _, transErr := p.repo.Transition(ctx, t.TenantID, t.UserID, t.ID, StatusFailed, "", "", engineSessionGoneMessage); transErr != nil {
+					if errors.Is(transErr, ErrTerminalState) {
+						// Lost a race with a concurrent Cancel or a previous
+						// pass that already resolved this: already terminal.
+						continue
+					}
+					errCount++
+					p.logger.WarnContext(ctx, "agenttask: poller transition failed, retrying next pass",
+						"task_id", t.ID, "error", transErr)
+					continue
+				}
+				advanced++
+				continue
+			}
 			errCount++
 			p.logger.WarnContext(ctx, "agenttask: poller status check failed, retrying next pass",
 				"task_id", t.ID, "error", statusErr)
@@ -119,8 +170,8 @@ func (p *Poller) RunOnce(ctx context.Context) (advanced int, err error) {
 		advanced++
 	}
 
-	if errCount > 0 {
-		return advanced, fmt.Errorf("agenttask: poller pass had %d task-level error(s)", errCount)
+	if len(tasks) > 0 && errCount == len(tasks) {
+		return advanced, fmt.Errorf("agenttask: poller pass had %d/%d task-level error(s), sweep looks systemically degraded", errCount, len(tasks))
 	}
 	return advanced, nil
 }

--- a/apps/control-plane/internal/agenttask/poller.go
+++ b/apps/control-plane/internal/agenttask/poller.go
@@ -56,6 +56,15 @@ var ErrEngineSessionGone = errors.New("agenttask: engine has no memory of this s
 // unrecoverable outcome rather than an assertion of failure: the sandbox may
 // well have finished the work before the launcher lost the reference to it,
 // so "failed" would be stating something this code cannot actually know.
+//
+// The split between this message and engineUnreachableAfterRetriesMessage
+// below is deliberate and only half done: the row this text is attached to
+// is still persisted as status = StatusFailed either way, so a machine
+// reader (Handler.handleGet, the console, any future metric) counts both
+// the same as a confirmed failure. Telling "outcome unrecoverable" apart
+// from "confirmed failed" programmatically needs a distinct terminal status
+// or a reason code, not built here — tracked alongside the rest of the
+// operator-visibility follow-up in issue #921.
 const engineSessionGoneMessage = "this task's outcome could not be recovered: its session was lost"
 
 // maxTaskFailureDuration bounds, in wall-clock time rather than a raw pass

--- a/apps/control-plane/internal/agenttask/poller.go
+++ b/apps/control-plane/internal/agenttask/poller.go
@@ -34,13 +34,29 @@ const maxPollerBackoff = 5 * time.Minute
 // session the engine has no memory of can never report progress again, so
 // RunOnce fails the task immediately instead of leaving it queued/running
 // forever or charging it against maxTaskFailureBudget first.
+//
+// The routine producer of this path on the demo box is a DEPLOY, not a rare
+// crash: deploy-demo-box.yml runs scripts/install-agent-engine-host.sh
+// unconditionally on every merge to main, which always stops and restarts
+// the launcher unit, and every in-flight session's registry entry dies with
+// it. So a merge to main now terminally fails every in-flight Cowork task
+// within one poll interval of the restart completing, including one whose
+// sandbox had already finished successfully but whose result the poller had
+// not yet read — the truthful state there is "outcome unrecoverable," not
+// "the task failed," which is why engineSessionGoneMessage below is worded
+// the way it is rather than asserting failure. Mitigating this (a drain, or
+// a registry that survives a restart) is tracked separately, issue #921;
+// this fix intentionally does not build it.
 var ErrEngineSessionGone = errors.New("agenttask: engine has no memory of this session")
 
 // engineSessionGoneMessage is the customer-visible error_message persisted
 // when ErrEngineSessionGone fires. Provider-blind, same rationale as
 // Service's engineLaunchFailedMessage: no session reference, sandbox path,
-// or engine detail ever reaches a customer-facing field.
-const engineSessionGoneMessage = "agent task session is no longer reachable"
+// or engine detail ever reaches a customer-facing field. Worded as an
+// unrecoverable outcome rather than an assertion of failure: the sandbox may
+// well have finished the work before the launcher lost the reference to it,
+// so "failed" would be stating something this code cannot actually know.
+const engineSessionGoneMessage = "this task's outcome could not be recovered: its session was lost"
 
 // maxTaskFailureBudget bounds how many consecutive passes a single task's
 // status check (or, once it reports a real terminal status, the transition
@@ -65,9 +81,11 @@ const maxTaskFailureBudget = 20
 
 // engineUnreachableAfterRetriesMessage is the customer-visible
 // error_message persisted when a task exhausts maxTaskFailureBudget without
-// ErrEngineSessionGone ever firing. Provider-blind, same rationale as
-// engineSessionGoneMessage.
-const engineUnreachableAfterRetriesMessage = "agent task could not reach its session after repeated attempts"
+// ErrEngineSessionGone ever firing. Provider-blind and worded the same
+// unrecoverable-outcome way as engineSessionGoneMessage, for the same
+// reason: repeated Status failures mean this code cannot learn what
+// happened, not that the task is confirmed to have failed.
+const engineUnreachableAfterRetriesMessage = "this task's outcome could not be recovered: its session stopped answering"
 
 // PollerConfig controls Poller behaviour.
 type PollerConfig struct {
@@ -158,11 +176,26 @@ func (p *Poller) RunOnce(ctx context.Context) (advanced int, err error) {
 	}
 
 	active := make(map[uuid.UUID]bool, len(tasks))
+	var declaredDead int
 	for _, t := range tasks {
 		active[t.ID] = true
-		if p.pollTask(ctx, t) {
+		res := p.pollTask(ctx, t)
+		if res.advanced {
 			advanced++
 		}
+		if res.declaredDead {
+			declaredDead++
+		}
+	}
+
+	// One line per pass, not one per task: the signature that actually
+	// matters operationally (a launcher restart killed every tenant's
+	// in-flight task at once, see ErrEngineSessionGone's doc comment) is
+	// otherwise invisible in a log made of N separate per-task WARN lines
+	// with no total anywhere.
+	if declaredDead > 0 {
+		p.logger.WarnContext(ctx, "agenttask: poller declared task(s) dead this pass",
+			"declared_dead", declaredDead, "active_this_pass", len(tasks))
 	}
 
 	// Forget the failure streak of any task no longer active (resolved this
@@ -176,24 +209,39 @@ func (p *Poller) RunOnce(ctx context.Context) (advanced int, err error) {
 	return advanced, nil
 }
 
-// pollTask advances one task and reports whether it reached a terminal
-// state this pass. Every failure path here is scoped to t alone — nothing
-// it does is visible to RunOnce's own return value, by design (see
-// RunOnce's doc comment).
-func (p *Poller) pollTask(ctx context.Context, t Task) (advanced bool) {
+// pollResult is pollTask's outcome for one task.
+type pollResult struct {
+	// advanced reports whether the task reached a terminal state this pass,
+	// for whatever reason: the engine's own report, or the poller giving up
+	// on it (declaredDead below covers exactly the latter).
+	advanced bool
+	// declaredDead reports whether THIS pass is the one where the poller
+	// itself decided the task is dead (ErrEngineSessionGone or an exhausted
+	// maxTaskFailureBudget) — never true for a task the engine reported
+	// succeeded/failed/cancelled on its own.
+	declaredDead bool
+}
+
+// pollTask advances one task and reports its outcome this pass (see
+// pollResult). Every failure path here is scoped to t alone — nothing it
+// does is visible to RunOnce's own return value, by design (see RunOnce's
+// doc comment).
+func (p *Poller) pollTask(ctx context.Context, t Task) pollResult {
 	status, resultSummary, errMessage, statusErr := p.checker.Status(ctx, t.EngineSessionRef)
 	if statusErr != nil {
 		if errors.Is(statusErr, ErrEngineSessionGone) {
 			p.logger.WarnContext(ctx, "agenttask: engine has no memory of this session, failing the task",
 				"task_id", t.ID, "error", statusErr)
-			return p.failTask(ctx, t, engineSessionGoneMessage)
+			ok := p.failTask(ctx, t, engineSessionGoneMessage)
+			return pollResult{advanced: ok, declaredDead: ok}
 		}
-		return p.chargeFailureBudget(ctx, t, statusErr)
+		ok := p.chargeFailureBudget(ctx, t, statusErr)
+		return pollResult{advanced: ok, declaredDead: ok}
 	}
 	delete(p.taskFailures, t.ID) // a clean answer this pass, whatever it was
 
 	if status != StatusSucceeded && status != StatusFailed && status != StatusCancelled {
-		return false
+		return pollResult{}
 	}
 
 	// Provider-blind boundary: errMessage came from StatusChecker, an
@@ -212,23 +260,23 @@ func (p *Poller) pollTask(ctx context.Context, t Task) (advanced bool) {
 			// Lost a race with a concurrent Cancel (or a previous pass that
 			// already advanced this task): already terminal, nothing left
 			// to do.
-			return false
+			return pollResult{}
 		}
 		// A real database write failure for an ALREADY-KNOWN outcome:
 		// retried next pass forever, exactly as before this fix. Not
 		// charged against the failure budget — see RunOnce's doc comment.
 		p.logger.WarnContext(ctx, "agenttask: poller transition failed, retrying next pass",
 			"task_id", t.ID, "error", transErr)
-		return false
+		return pollResult{}
 	}
-	return true
+	return pollResult{advanced: true} // the engine's own report, not the poller giving up
 }
 
 // chargeFailureBudget counts one more consecutive failure against t and, once
 // that reaches maxTaskFailureBudget, gives up on the task for good instead of
 // retrying it forever (see maxTaskFailureBudget's doc comment for why this
 // exists alongside ErrEngineSessionGone rather than instead of it).
-func (p *Poller) chargeFailureBudget(ctx context.Context, t Task, cause error) (advanced bool) {
+func (p *Poller) chargeFailureBudget(ctx context.Context, t Task, cause error) (declaredDead bool) {
 	p.taskFailures[t.ID]++
 	if p.taskFailures[t.ID] < maxTaskFailureBudget {
 		p.logger.WarnContext(ctx, "agenttask: poller status check failed, retrying next pass",

--- a/apps/control-plane/internal/agenttask/poller.go
+++ b/apps/control-plane/internal/agenttask/poller.go
@@ -7,6 +7,8 @@ import (
 	"log/slog"
 	"sync"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 // StatusChecker is the narrow surface the Poller needs from an Engine
@@ -28,14 +30,10 @@ const maxPollerBackoff = 5 * time.Minute
 // /status endpoint answers 404 for exactly that reason (see
 // agentengine.Remote.post and agentengine.Engine.Status, which map their
 // respective 404/engineapi.ErrUnknownSession cases onto this sentinel).
-// Unlike every other StatusChecker error, this one is not retried next pass:
-// a session the engine has no memory of can never report progress again, so
+// Unlike every other StatusChecker error, this one is not retried at all: a
+// session the engine has no memory of can never report progress again, so
 // RunOnce fails the task immediately instead of leaving it queued/running
-// forever. Left unhandled, a single such task sits in ListActive's
-// cross-tenant result set and errors on every single pass, which used to
-// hold the whole poller's shared backoff at maxPollerBackoff (see loop's doc
-// comment) for as long as that one row existed, throttling poll cadence for
-// every other tenant's tasks too (measured live 2026-08-16, task f9409763).
+// forever or charging it against maxTaskFailureBudget first.
 var ErrEngineSessionGone = errors.New("agenttask: engine has no memory of this session")
 
 // engineSessionGoneMessage is the customer-visible error_message persisted
@@ -43,6 +41,33 @@ var ErrEngineSessionGone = errors.New("agenttask: engine has no memory of this s
 // Service's engineLaunchFailedMessage: no session reference, sandbox path,
 // or engine detail ever reaches a customer-facing field.
 const engineSessionGoneMessage = "agent task session is no longer reachable"
+
+// maxTaskFailureBudget bounds how many consecutive passes a single task's
+// status check (or, once it reports a real terminal status, the transition
+// that records it) may fail before RunOnce gives up on that ONE task and
+// fails it directly, regardless of what shape the error took. 20 passes is
+// about 5 minutes at the default 15s interval, the same order of magnitude
+// maxPollerBackoff used to cap the whole poller's shared interval at, now
+// scoped to one task instead of every tenant's sweep.
+//
+// This exists because ErrEngineSessionGone only covers one definitive
+// failure shape: a 404 from a launcher whose in-memory registry never had
+// (or lost) the session. A sandbox killed some other way — OOM, an
+// Apptainer crash, anything that does not go through Cancel or a normal
+// terminal status — never reaches SandboxEngine.reap (it runs only on
+// terminal status or Cancel), so its /status call fails forever too, but
+// with a 502, not a 404 (apps/agent-engine/cmd/agent-engine/serve.go's
+// default error-mapping branch). Same dead task as f9409763, a different,
+// non-enumerable error shape. A per-task budget catches that case and any
+// future one without needing to name every failure mode a StatusChecker
+// implementation could return.
+const maxTaskFailureBudget = 20
+
+// engineUnreachableAfterRetriesMessage is the customer-visible
+// error_message persisted when a task exhausts maxTaskFailureBudget without
+// ErrEngineSessionGone ever firing. Provider-blind, same rationale as
+// engineSessionGoneMessage.
+const engineUnreachableAfterRetriesMessage = "agent task could not reach its session after repeated attempts"
 
 // PollerConfig controls Poller behaviour.
 type PollerConfig struct {
@@ -63,6 +88,12 @@ type Poller struct {
 	checker  StatusChecker
 	interval time.Duration
 	logger   *slog.Logger
+
+	// taskFailures counts each task's CONSECUTIVE per-pass failures (see
+	// maxTaskFailureBudget). Only ever touched from RunOnce, which loop
+	// guarantees is never running concurrently with itself (Start/Stop's own
+	// mutex serializes passes), so this needs no lock of its own.
+	taskFailures map[uuid.UUID]int
 
 	mu      sync.Mutex
 	cancel  context.CancelFunc
@@ -86,94 +117,152 @@ func NewPoller(repo Repository, checker StatusChecker, cfg PollerConfig) *Poller
 	if logger == nil {
 		logger = slog.Default()
 	}
-	return &Poller{repo: repo, checker: checker, interval: interval, logger: logger}
+	return &Poller{repo: repo, checker: checker, interval: interval, logger: logger, taskFailures: make(map[uuid.UUID]int)}
 }
 
 // RunOnce performs exactly one poll pass: every active task gets exactly one
 // StatusChecker.Status call and, if terminal, one Repository.Transition
-// call. A single task's transient engine error is logged and skipped — it
-// stays active and is retried next pass, it does not abort the rest of the
-// pass. ErrEngineSessionGone is not transient and is not retried: it fails
-// the task in this same pass (see its doc comment).
+// call.
 //
 // The returned error, when non-nil, is loop's sole backoff signal (see
-// loop's doc comment) and means this PASS looks systemically degraded: every
-// active task's status check failed, or ListActive itself failed. It is
-// deliberately NOT "at least one task had a problem": a sweep where some
-// tasks succeed and one fails is not a failed sweep in any useful sense, and
-// ListActive is cross-tenant, so treating any single task-level error as
-// pass-level failure let one permanently broken task hold the whole poller's
-// shared backoff at maxPollerBackoff for as long as that row existed,
-// throttling poll cadence for every other tenant's tasks too (measured live
-// 2026-08-16, task f9409763: a lost session 404ing forever kept every sweep
-// erroring, so consecutiveFailures never reset). A pass with zero active
-// tasks is never systemically degraded.
+// loop's doc comment) and means ListActive itself failed — a real
+// database/connectivity problem, the only thing that is actually poller-wide.
+// No per-task problem ever feeds it. Repository.ListActive is cross-tenant,
+// so treating any single task's trouble as pass-level failure let one
+// permanently broken task hold the whole poller's shared backoff at
+// maxPollerBackoff for as long as that row existed, throttling poll cadence
+// for every other tenant's tasks too (measured live 2026-08-16, task
+// f9409763). Worse, the demo box's own quota (2 per user, 4 per tenant)
+// makes a single active task the ORDINARY shape, not a corner case, so any
+// rule keyed on a fraction of active tasks (an earlier version of this fix
+// used errCount == len(tasks)) collapses back to "this one task" exactly
+// when it matters most — caught in review before merge, not shipped.
+//
+// Instead, every task-level problem is scoped to that ONE task via
+// pollTask/chargeFailureBudget: a StatusChecker error definitively
+// identified as ErrEngineSessionGone fails the task immediately; anything
+// else is retried per pass, up to maxTaskFailureBudget consecutive times,
+// after which RunOnce gives up on that task and fails it directly regardless
+// of the error's shape (see maxTaskFailureBudget's doc comment for why a
+// budget, not an enumeration, is what actually closes this class of bug). A
+// Repository.Transition failure for an ALREADY-KNOWN terminal status (the
+// engine told us the task succeeded or failed, but persisting that failed)
+// is retried forever exactly as before this fix and is never charged
+// against the budget or forced to a status we cannot confirm — that budget
+// exists for "we cannot even ask what happened," not for "we know and can't
+// write it yet."
 func (p *Poller) RunOnce(ctx context.Context) (advanced int, err error) {
 	tasks, err := p.repo.ListActive(ctx)
 	if err != nil {
 		return 0, fmt.Errorf("agenttask: poller list active: %w", err)
 	}
 
-	var errCount int
+	active := make(map[uuid.UUID]bool, len(tasks))
 	for _, t := range tasks {
-		status, resultSummary, errMessage, statusErr := p.checker.Status(ctx, t.EngineSessionRef)
-		if statusErr != nil {
-			if errors.Is(statusErr, ErrEngineSessionGone) {
-				p.logger.WarnContext(ctx, "agenttask: engine has no memory of this session, failing the task",
-					"task_id", t.ID, "error", statusErr)
-				if _, transErr := p.repo.Transition(ctx, t.TenantID, t.UserID, t.ID, StatusFailed, "", "", engineSessionGoneMessage); transErr != nil {
-					if errors.Is(transErr, ErrTerminalState) {
-						// Lost a race with a concurrent Cancel or a previous
-						// pass that already resolved this: already terminal.
-						continue
-					}
-					errCount++
-					p.logger.WarnContext(ctx, "agenttask: poller transition failed, retrying next pass",
-						"task_id", t.ID, "error", transErr)
-					continue
-				}
-				advanced++
-				continue
-			}
-			errCount++
-			p.logger.WarnContext(ctx, "agenttask: poller status check failed, retrying next pass",
-				"task_id", t.ID, "error", statusErr)
-			continue
+		active[t.ID] = true
+		if p.pollTask(ctx, t) {
+			advanced++
 		}
-		if status != StatusSucceeded && status != StatusFailed && status != StatusCancelled {
-			continue
-		}
-
-		// Provider-blind boundary: errMessage came from StatusChecker, an
-		// interface this package does not control the implementation of.
-		// error_message is customer-visible (Handler.handleGet), so a raw
-		// engine/provider detail must never reach it — log the real detail
-		// server-side, persist a generic message instead.
-		if errMessage != "" {
-			p.logger.WarnContext(ctx, "agenttask: task failed, engine detail",
-				"task_id", t.ID, "engine_detail", errMessage)
-			errMessage = "agent task failed"
-		}
-
-		if _, transErr := p.repo.Transition(ctx, t.TenantID, t.UserID, t.ID, status, "", resultSummary, errMessage); transErr != nil {
-			if errors.Is(transErr, ErrTerminalState) {
-				// Lost a race with a concurrent Cancel (or a previous pass
-				// that already advanced this task): already terminal,
-				// nothing left to do.
-				continue
-			}
-			errCount++
-			p.logger.WarnContext(ctx, "agenttask: poller transition failed, retrying next pass",
-				"task_id", t.ID, "error", transErr)
-			continue
-		}
-		advanced++
 	}
 
-	if len(tasks) > 0 && errCount == len(tasks) {
-		return advanced, fmt.Errorf("agenttask: poller pass had %d/%d task-level error(s), sweep looks systemically degraded", errCount, len(tasks))
+	// Forget the failure streak of any task no longer active (resolved this
+	// pass, by a concurrent Cancel, or anything else) so the map does not
+	// grow forever.
+	for id := range p.taskFailures {
+		if !active[id] {
+			delete(p.taskFailures, id)
+		}
 	}
 	return advanced, nil
+}
+
+// pollTask advances one task and reports whether it reached a terminal
+// state this pass. Every failure path here is scoped to t alone — nothing
+// it does is visible to RunOnce's own return value, by design (see
+// RunOnce's doc comment).
+func (p *Poller) pollTask(ctx context.Context, t Task) (advanced bool) {
+	status, resultSummary, errMessage, statusErr := p.checker.Status(ctx, t.EngineSessionRef)
+	if statusErr != nil {
+		if errors.Is(statusErr, ErrEngineSessionGone) {
+			p.logger.WarnContext(ctx, "agenttask: engine has no memory of this session, failing the task",
+				"task_id", t.ID, "error", statusErr)
+			return p.failTask(ctx, t, engineSessionGoneMessage)
+		}
+		return p.chargeFailureBudget(ctx, t, statusErr)
+	}
+	delete(p.taskFailures, t.ID) // a clean answer this pass, whatever it was
+
+	if status != StatusSucceeded && status != StatusFailed && status != StatusCancelled {
+		return false
+	}
+
+	// Provider-blind boundary: errMessage came from StatusChecker, an
+	// interface this package does not control the implementation of.
+	// error_message is customer-visible (Handler.handleGet), so a raw
+	// engine/provider detail must never reach it — log the real detail
+	// server-side, persist a generic message instead.
+	if errMessage != "" {
+		p.logger.WarnContext(ctx, "agenttask: task failed, engine detail",
+			"task_id", t.ID, "engine_detail", errMessage)
+		errMessage = "agent task failed"
+	}
+
+	if _, transErr := p.repo.Transition(ctx, t.TenantID, t.UserID, t.ID, status, "", resultSummary, errMessage); transErr != nil {
+		if errors.Is(transErr, ErrTerminalState) {
+			// Lost a race with a concurrent Cancel (or a previous pass that
+			// already advanced this task): already terminal, nothing left
+			// to do.
+			return false
+		}
+		// A real database write failure for an ALREADY-KNOWN outcome:
+		// retried next pass forever, exactly as before this fix. Not
+		// charged against the failure budget — see RunOnce's doc comment.
+		p.logger.WarnContext(ctx, "agenttask: poller transition failed, retrying next pass",
+			"task_id", t.ID, "error", transErr)
+		return false
+	}
+	return true
+}
+
+// chargeFailureBudget counts one more consecutive failure against t and, once
+// that reaches maxTaskFailureBudget, gives up on the task for good instead of
+// retrying it forever (see maxTaskFailureBudget's doc comment for why this
+// exists alongside ErrEngineSessionGone rather than instead of it).
+func (p *Poller) chargeFailureBudget(ctx context.Context, t Task, cause error) (advanced bool) {
+	p.taskFailures[t.ID]++
+	if p.taskFailures[t.ID] < maxTaskFailureBudget {
+		p.logger.WarnContext(ctx, "agenttask: poller status check failed, retrying next pass",
+			"task_id", t.ID, "consecutive_failures", p.taskFailures[t.ID], "error", cause)
+		return false
+	}
+	p.logger.WarnContext(ctx, "agenttask: task exceeded its failure budget, failing it",
+		"task_id", t.ID, "consecutive_failures", p.taskFailures[t.ID], "error", cause)
+	return p.failTask(ctx, t, engineUnreachableAfterRetriesMessage)
+}
+
+// failTask transitions t straight to StatusFailed with a provider-blind
+// message. Deliberately does not clear t's failure streak when the
+// Transition call itself fails with a real (non-ErrTerminalState) error: the
+// streak is already at or past maxTaskFailureBudget by the time this runs
+// (chargeFailureBudget only calls it once the budget is exhausted, and
+// ErrEngineSessionGone routes straight here on its own), so leaving the
+// count where it is makes the next pass retry this same transition
+// immediately rather than waiting out a fresh maxTaskFailureBudget cycle
+// first.
+func (p *Poller) failTask(ctx context.Context, t Task, message string) (advanced bool) {
+	if _, transErr := p.repo.Transition(ctx, t.TenantID, t.UserID, t.ID, StatusFailed, "", "", message); transErr != nil {
+		if errors.Is(transErr, ErrTerminalState) {
+			// Already resolved, e.g. by a concurrent Cancel: not a failure
+			// of this attempt, forget the streak.
+			delete(p.taskFailures, t.ID)
+			return false
+		}
+		p.logger.WarnContext(ctx, "agenttask: poller transition failed, retrying next pass",
+			"task_id", t.ID, "error", transErr)
+		return false
+	}
+	delete(p.taskFailures, t.ID)
+	return true
 }
 
 // Start launches the poll loop on a background goroutine. Subsequent Start
@@ -224,10 +313,13 @@ func (p *Poller) Stop() {
 
 // loop ticks RunOnce on p.interval, doubling the delay (capped at
 // maxPollerBackoff) each pass that reports an error and resetting to
-// p.interval on the first clean pass — an engine outage or a run of DB
-// errors backs the poller off instead of hammering at full frequency, while
-// a single transient task-level error only costs one doubled wait, not a
-// standing degraded state.
+// p.interval on the first clean pass — a run of ListActive/database errors
+// backs the poller off instead of hammering a struggling database at full
+// frequency. An engine-side problem (the agent-engine daemon itself
+// unreachable, one task's session gone, or anything else RunOnce's own doc
+// comment scopes to a single task) never reaches this signal at all: it is
+// bounded per task by maxTaskFailureBudget instead, so it costs that one
+// task some retries, never the whole poller's cadence.
 func (p *Poller) loop(ctx context.Context, doneCh chan<- struct{}) {
 	defer close(doneCh)
 

--- a/apps/control-plane/internal/agenttask/poller.go
+++ b/apps/control-plane/internal/agenttask/poller.go
@@ -228,6 +228,15 @@ func (p *Poller) clearTaskFailure(id uuid.UUID) {
 // in active, so the map does not grow forever once a task stops showing up
 // in ListActive (resolved this pass, by a concurrent Cancel, or anything
 // else).
+//
+// active is only ever populated from one pass's ListActive result, and
+// Repository.ListActive's agent_tasks_list_active() function caps at LIMIT
+// 500 oldest-first: above 500 genuinely active tasks, a task outside that
+// window has its streak dropped here even though it is still active, exactly
+// as if it had just answered cleanly. That only ever RESETS a budget, never
+// shortens one, so it is safe in the direction that matters, just worth
+// knowing before assuming this map is a complete picture of every active
+// task's history above that row count.
 func (p *Poller) pruneInactiveTaskFailures(active map[uuid.UUID]bool) {
 	p.taskFailuresMu.Lock()
 	defer p.taskFailuresMu.Unlock()

--- a/apps/control-plane/internal/agenttask/poller.go
+++ b/apps/control-plane/internal/agenttask/poller.go
@@ -33,7 +33,7 @@ const maxPollerBackoff = 5 * time.Minute
 // Unlike every other StatusChecker error, this one is not retried at all: a
 // session the engine has no memory of can never report progress again, so
 // RunOnce fails the task immediately instead of leaving it queued/running
-// forever or charging it against maxTaskFailureBudget first.
+// forever or charging it against its failure budget first.
 //
 // The routine producer of this path on the demo box is a DEPLOY, not a rare
 // crash: deploy-demo-box.yml runs scripts/install-agent-engine-host.sh
@@ -58,13 +58,26 @@ var ErrEngineSessionGone = errors.New("agenttask: engine has no memory of this s
 // so "failed" would be stating something this code cannot actually know.
 const engineSessionGoneMessage = "this task's outcome could not be recovered: its session was lost"
 
-// maxTaskFailureBudget bounds how many consecutive passes a single task's
-// status check (or, once it reports a real terminal status, the transition
-// that records it) may fail before RunOnce gives up on that ONE task and
-// fails it directly, regardless of what shape the error took. 20 passes is
-// about 5 minutes at the default 15s interval, the same order of magnitude
+// maxTaskFailureDuration bounds, in wall-clock time rather than a raw pass
+// count, how long a single task's status check (or, once it reports a real
+// terminal status, the transition that records it) may keep failing before
+// RunOnce gives up on that ONE task and fails it directly, regardless of
+// what shape the error took. About 5 minutes, the same order of magnitude
 // maxPollerBackoff used to cap the whole poller's shared interval at, now
 // scoped to one task instead of every tenant's sweep.
+//
+// Expressed as a duration and converted to a pass count via
+// Poller.taskFailureBudget (using the poller's OWN configured interval)
+// rather than a fixed pass count, deliberately: HIVE_AGENT_TASK_POLL_INTERVAL
+// is operator-tunable, and lowering it is the obvious reaction to this very
+// incident. A fixed pass count
+// would have silently shortened the real kill timeout in proportion — at a
+// tuned 3s interval a fixed 20-pass budget would give up on a task in 60
+// seconds instead of 5 minutes, against Cowork tasks that routinely run
+// sixteen to twenty-two minutes, killing legitimately slow-to-report work
+// instead of only genuinely dead sessions. Tying the budget to the
+// interval keeps its documented ~5 minute meaning invariant regardless of
+// how that knob is tuned.
 //
 // This exists because ErrEngineSessionGone only covers one definitive
 // failure shape: a 404 from a launcher whose in-memory registry never had
@@ -77,15 +90,35 @@ const engineSessionGoneMessage = "this task's outcome could not be recovered: it
 // non-enumerable error shape. A per-task budget catches that case and any
 // future one without needing to name every failure mode a StatusChecker
 // implementation could return.
-const maxTaskFailureBudget = 20
+const maxTaskFailureDuration = 5 * time.Minute
 
 // engineUnreachableAfterRetriesMessage is the customer-visible
-// error_message persisted when a task exhausts maxTaskFailureBudget without
-// ErrEngineSessionGone ever firing. Provider-blind and worded the same
-// unrecoverable-outcome way as engineSessionGoneMessage, for the same
-// reason: repeated Status failures mean this code cannot learn what
-// happened, not that the task is confirmed to have failed.
+// error_message persisted when a task exhausts its failure budget (see
+// Poller.taskFailureBudget) without ErrEngineSessionGone ever firing.
+// Provider-blind and worded the same unrecoverable-outcome way as
+// engineSessionGoneMessage, for the same reason: repeated Status failures
+// mean this code cannot learn what happened, not that the task is confirmed
+// to have failed.
 const engineUnreachableAfterRetriesMessage = "this task's outcome could not be recovered: its session stopped answering"
+
+// budgetExceededCanceler is the narrow surface chargeFailureBudget needs to
+// best-effort stop a session before giving up on its row: StatusChecker
+// itself has no Cancel method (by design, per its own doc comment), but
+// every concrete StatusChecker cmd/server/main.go's buildAgentEngine wires
+// (agentengine.Remote for the socket arm, agentengine.Engine in-process) is
+// also an agenttask.Engine, so it has one. Without this, exhausting the
+// budget only marked the row failed and never told the engine to let go: a
+// non-404 error means the launcher answered from its own handler, so the
+// session is still live in SandboxEngine.sessions holding a concurrency
+// slot (reap runs only from a terminal Status or Cancel), and once the row
+// is terminal, Service.Cancel's own atomic guard returns ErrTerminalState
+// before it ever reaches stopEngineSession — nothing else would ever free
+// that slot, reproducing issue #886's leaked-slot symptom through a new
+// door. Deliberately NOT used on the ErrEngineSessionGone path: there is
+// nothing left to stop, the engine already said so.
+type budgetExceededCanceler interface {
+	Cancel(ctx context.Context, sessionRef string) error
+}
 
 // PollerConfig controls Poller behaviour.
 type PollerConfig struct {
@@ -107,10 +140,15 @@ type Poller struct {
 	interval time.Duration
 	logger   *slog.Logger
 
+	// taskFailuresMu guards taskFailures. RunOnce is exported, so a caller
+	// besides loop (which Start/Stop's own mutex serializes) could call it
+	// concurrently; loop's own serialization guarantee protects loop against
+	// itself, not this method against an arbitrary caller, and an
+	// unsynchronized concurrent map write is a process-fatal throw with no
+	// recover, not merely a data race. Cheap to close, so closed.
+	taskFailuresMu sync.Mutex
 	// taskFailures counts each task's CONSECUTIVE per-pass failures (see
-	// maxTaskFailureBudget). Only ever touched from RunOnce, which loop
-	// guarantees is never running concurrently with itself (Start/Stop's own
-	// mutex serializes passes), so this needs no lock of its own.
+	// taskFailureBudget).
 	taskFailures map[uuid.UUID]int
 
 	mu      sync.Mutex
@@ -138,6 +176,59 @@ func NewPoller(repo Repository, checker StatusChecker, cfg PollerConfig) *Poller
 	return &Poller{repo: repo, checker: checker, interval: interval, logger: logger, taskFailures: make(map[uuid.UUID]int)}
 }
 
+// taskFailureBudget converts maxTaskFailureDuration to a pass count using
+// THIS poller's own configured interval, so the budget's documented ~5
+// minute meaning does not silently drift when HIVE_AGENT_TASK_POLL_INTERVAL
+// is tuned (see maxTaskFailureDuration's doc comment). At least 1: an
+// interval tuned coarser than the duration itself still gets one retry
+// before giving up, never zero.
+func (p *Poller) taskFailureBudget() int {
+	n := int(maxTaskFailureDuration / p.interval)
+	if n < 1 {
+		return 1
+	}
+	return n
+}
+
+// taskFailureCount returns id's current consecutive-failure streak, 0 if it
+// has none.
+func (p *Poller) taskFailureCount(id uuid.UUID) int {
+	p.taskFailuresMu.Lock()
+	defer p.taskFailuresMu.Unlock()
+	return p.taskFailures[id]
+}
+
+// incrementTaskFailure counts one more consecutive failure against id and
+// returns the new total.
+func (p *Poller) incrementTaskFailure(id uuid.UUID) int {
+	p.taskFailuresMu.Lock()
+	defer p.taskFailuresMu.Unlock()
+	p.taskFailures[id]++
+	return p.taskFailures[id]
+}
+
+// clearTaskFailure forgets id's failure streak (a clean pass, a resolved
+// terminal state, or the task no longer being active at all).
+func (p *Poller) clearTaskFailure(id uuid.UUID) {
+	p.taskFailuresMu.Lock()
+	defer p.taskFailuresMu.Unlock()
+	delete(p.taskFailures, id)
+}
+
+// pruneInactiveTaskFailures forgets every tracked task's streak that is not
+// in active, so the map does not grow forever once a task stops showing up
+// in ListActive (resolved this pass, by a concurrent Cancel, or anything
+// else).
+func (p *Poller) pruneInactiveTaskFailures(active map[uuid.UUID]bool) {
+	p.taskFailuresMu.Lock()
+	defer p.taskFailuresMu.Unlock()
+	for id := range p.taskFailures {
+		if !active[id] {
+			delete(p.taskFailures, id)
+		}
+	}
+}
+
 // RunOnce performs exactly one poll pass: every active task gets exactly one
 // StatusChecker.Status call and, if terminal, one Repository.Transition
 // call.
@@ -159,9 +250,9 @@ func NewPoller(repo Repository, checker StatusChecker, cfg PollerConfig) *Poller
 // Instead, every task-level problem is scoped to that ONE task via
 // pollTask/chargeFailureBudget: a StatusChecker error definitively
 // identified as ErrEngineSessionGone fails the task immediately; anything
-// else is retried per pass, up to maxTaskFailureBudget consecutive times,
-// after which RunOnce gives up on that task and fails it directly regardless
-// of the error's shape (see maxTaskFailureBudget's doc comment for why a
+// else is retried per pass, up to taskFailureBudget consecutive times, after
+// which RunOnce gives up on that task and fails it directly regardless of
+// the error's shape (see maxTaskFailureDuration's doc comment for why a
 // budget, not an enumeration, is what actually closes this class of bug). A
 // Repository.Transition failure for an ALREADY-KNOWN terminal status (the
 // engine told us the task succeeded or failed, but persisting that failed)
@@ -198,14 +289,7 @@ func (p *Poller) RunOnce(ctx context.Context) (advanced int, err error) {
 			"declared_dead", declaredDead, "active_this_pass", len(tasks))
 	}
 
-	// Forget the failure streak of any task no longer active (resolved this
-	// pass, by a concurrent Cancel, or anything else) so the map does not
-	// grow forever.
-	for id := range p.taskFailures {
-		if !active[id] {
-			delete(p.taskFailures, id)
-		}
-	}
+	p.pruneInactiveTaskFailures(active)
 	return advanced, nil
 }
 
@@ -217,7 +301,7 @@ type pollResult struct {
 	advanced bool
 	// declaredDead reports whether THIS pass is the one where the poller
 	// itself decided the task is dead (ErrEngineSessionGone or an exhausted
-	// maxTaskFailureBudget) — never true for a task the engine reported
+	// failure budget) — never true for a task the engine reported
 	// succeeded/failed/cancelled on its own.
 	declaredDead bool
 }
@@ -238,7 +322,7 @@ func (p *Poller) pollTask(ctx context.Context, t Task) pollResult {
 		ok := p.chargeFailureBudget(ctx, t, statusErr)
 		return pollResult{advanced: ok, declaredDead: ok}
 	}
-	delete(p.taskFailures, t.ID) // a clean answer this pass, whatever it was
+	p.clearTaskFailure(t.ID) // a clean answer this pass, whatever it was
 
 	if status != StatusSucceeded && status != StatusFailed && status != StatusCancelled {
 		return pollResult{}
@@ -273,43 +357,62 @@ func (p *Poller) pollTask(ctx context.Context, t Task) pollResult {
 }
 
 // chargeFailureBudget counts one more consecutive failure against t and, once
-// that reaches maxTaskFailureBudget, gives up on the task for good instead of
-// retrying it forever (see maxTaskFailureBudget's doc comment for why this
+// that reaches taskFailureBudget, gives up on the task for good instead of
+// retrying it forever (see maxTaskFailureDuration's doc comment for why this
 // exists alongside ErrEngineSessionGone rather than instead of it).
 func (p *Poller) chargeFailureBudget(ctx context.Context, t Task, cause error) (declaredDead bool) {
-	p.taskFailures[t.ID]++
-	if p.taskFailures[t.ID] < maxTaskFailureBudget {
+	count := p.incrementTaskFailure(t.ID)
+	if count < p.taskFailureBudget() {
 		p.logger.WarnContext(ctx, "agenttask: poller status check failed, retrying next pass",
-			"task_id", t.ID, "consecutive_failures", p.taskFailures[t.ID], "error", cause)
+			"task_id", t.ID, "consecutive_failures", count, "error", cause)
 		return false
 	}
 	p.logger.WarnContext(ctx, "agenttask: task exceeded its failure budget, failing it",
-		"task_id", t.ID, "consecutive_failures", p.taskFailures[t.ID], "error", cause)
+		"task_id", t.ID, "consecutive_failures", count, "error", cause)
+
+	// This branch (unlike ErrEngineSessionGone) means the launcher answered
+	// from its own handler, so the session is very likely still live and
+	// holding its concurrency slot (SandboxEngine.reap runs only from a
+	// terminal Status or Cancel). Failing the row below without stopping the
+	// engine first would leave that slot held forever: once the row is
+	// terminal, Service.Cancel's own atomic guard returns ErrTerminalState
+	// before it ever reaches stopEngineSession, so nothing else can free it.
+	// Best-effort and before the Transition: if the session really did just
+	// finish, Cancel is a documented no-op on it (agenttask.Engine's doc
+	// comment), and if the Transition below then loses a race to a
+	// concurrent Cancel or completion, that path's own stop attempt (or the
+	// fact that a successful completion needs no stop at all) makes this one
+	// redundant, not wrong.
+	if canceler, ok := p.checker.(budgetExceededCanceler); ok {
+		if err := canceler.Cancel(ctx, t.EngineSessionRef); err != nil {
+			p.logger.WarnContext(ctx, "agenttask: best-effort session stop failed after exhausting the failure budget, its concurrency slot may still be held",
+				"task_id", t.ID, "error", err)
+		}
+	}
 	return p.failTask(ctx, t, engineUnreachableAfterRetriesMessage)
 }
 
 // failTask transitions t straight to StatusFailed with a provider-blind
 // message. Deliberately does not clear t's failure streak when the
 // Transition call itself fails with a real (non-ErrTerminalState) error: the
-// streak is already at or past maxTaskFailureBudget by the time this runs
+// streak is already at or past taskFailureBudget by the time this runs
 // (chargeFailureBudget only calls it once the budget is exhausted, and
 // ErrEngineSessionGone routes straight here on its own), so leaving the
 // count where it is makes the next pass retry this same transition
-// immediately rather than waiting out a fresh maxTaskFailureBudget cycle
-// first.
+// immediately rather than waiting out a fresh budget cycle first.
 func (p *Poller) failTask(ctx context.Context, t Task, message string) (advanced bool) {
 	if _, transErr := p.repo.Transition(ctx, t.TenantID, t.UserID, t.ID, StatusFailed, "", "", message); transErr != nil {
 		if errors.Is(transErr, ErrTerminalState) {
 			// Already resolved, e.g. by a concurrent Cancel: not a failure
 			// of this attempt, forget the streak.
-			delete(p.taskFailures, t.ID)
+			p.clearTaskFailure(t.ID)
 			return false
 		}
 		p.logger.WarnContext(ctx, "agenttask: poller transition failed, retrying next pass",
 			"task_id", t.ID, "error", transErr)
 		return false
 	}
-	delete(p.taskFailures, t.ID)
+	p.clearTaskFailure(t.ID)
 	return true
 }
 
@@ -366,7 +469,7 @@ func (p *Poller) Stop() {
 // frequency. An engine-side problem (the agent-engine daemon itself
 // unreachable, one task's session gone, or anything else RunOnce's own doc
 // comment scopes to a single task) never reaches this signal at all: it is
-// bounded per task by maxTaskFailureBudget instead, so it costs that one
+// bounded per task by its own failure budget instead, so it costs that one
 // task some retries, never the whole poller's cadence.
 func (p *Poller) loop(ctx context.Context, doneCh chan<- struct{}) {
 	defer close(doneCh)

--- a/apps/control-plane/internal/agenttask/poller_test.go
+++ b/apps/control-plane/internal/agenttask/poller_test.go
@@ -3,6 +3,7 @@ package agenttask_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"strings"
@@ -119,8 +120,16 @@ func TestPoller_RunOnce_EngineErrorIsRetriedNotFailed(t *testing.T) {
 	p := agenttask.NewPoller(repo, checker, agenttask.PollerConfig{Logger: quietPollerLogger()})
 
 	advanced, err := p.RunOnce(context.Background())
-	if err == nil {
-		t.Fatal("expected RunOnce to report the per-task engine error")
+	// A mixed pass (one task erroring, another succeeding in the same sweep)
+	// is not a systemically degraded pass: the healthy task proves the
+	// engine itself is reachable, so this must not feed loop's backoff.
+	// Before this fix RunOnce reported an error for ANY per-task problem,
+	// which let one permanently broken task (ListActive is cross-tenant) pin
+	// the whole poller's shared interval at maxPollerBackoff for as long as
+	// that row existed, throttling every other tenant's poll cadence too
+	// (measured live 2026-08-16, task f9409763).
+	if err != nil {
+		t.Fatalf("expected a mixed pass (one error, one success) to report no error, got %v", err)
 	}
 	// "Retried not failed": the broken task is untouched (still active, will
 	// be retried next pass), and the healthy task in the same pass still
@@ -135,6 +144,108 @@ func TestPoller_RunOnce_EngineErrorIsRetriedNotFailed(t *testing.T) {
 	gotHealthy, _ := repo.Get(context.Background(), healthy.TenantID, healthy.UserID, healthy.ID)
 	if gotHealthy.Status != agenttask.StatusSucceeded {
 		t.Fatalf("healthy task status=%q want succeeded", gotHealthy.Status)
+	}
+}
+
+// TestPoller_RunOnce_AllTasksErroringIsSystemicFailure locks in the other
+// side of the same rule: when EVERY active task's status check fails this
+// pass (no evidence the engine is reachable at all), RunOnce must still
+// report an error so loop's backoff engages — that is the genuine outage
+// case the mechanism exists for.
+func TestPoller_RunOnce_AllTasksErroringIsSystemicFailure(t *testing.T) {
+	repo := newFakeRepository()
+	newActiveTask(repo, agenttask.StatusRunning, "session-a")
+	newActiveTask(repo, agenttask.StatusRunning, "session-b")
+	checker := &fakeStatusChecker{responses: map[string]checkerResponse{
+		"session-a": {err: errors.New("agent-server unreachable")},
+		"session-b": {err: errors.New("agent-server unreachable")},
+	}}
+	p := agenttask.NewPoller(repo, checker, agenttask.PollerConfig{Logger: quietPollerLogger()})
+
+	advanced, err := p.RunOnce(context.Background())
+	if err == nil {
+		t.Fatal("expected RunOnce to report an error when every active task's status check failed")
+	}
+	if advanced != 0 {
+		t.Fatalf("advanced=%d want 0", advanced)
+	}
+}
+
+// TestPoller_ConsecutiveFailures_OnePermanentlyFailingTaskDoesNotBackOffTheSweep
+// is the loop-level regression guard for the same bug, driven across several
+// simulated passes the way loop() itself does: a task whose engine session is
+// permanently unreachable (any ordinary error, not ErrEngineSessionGone) sits
+// in ListActive next to a perfectly healthy task that answers cleanly every
+// pass without ever reaching a terminal state. consecutiveFailures must stay
+// at 0 the whole time, which is exactly the input pollerBackoffDelay needs to
+// keep returning the configured base interval (see TestPollerBackoffDelay);
+// before this fix it grew without bound and pinned the shared poll cadence at
+// maxPollerBackoff for every other tenant's tasks too.
+func TestPoller_ConsecutiveFailures_OnePermanentlyFailingTaskDoesNotBackOffTheSweep(t *testing.T) {
+	repo := newFakeRepository()
+	newActiveTask(repo, agenttask.StatusRunning, "session-broken")
+	newActiveTask(repo, agenttask.StatusRunning, "session-healthy")
+	checker := &fakeStatusChecker{responses: map[string]checkerResponse{
+		"session-broken":  {err: errors.New("agent-server unreachable")},
+		"session-healthy": {status: agenttask.StatusRunning},
+	}}
+	p := agenttask.NewPoller(repo, checker, agenttask.PollerConfig{Logger: quietPollerLogger()})
+
+	consecutiveFailures := 0
+	for pass := 0; pass < 10; pass++ {
+		if _, err := p.RunOnce(context.Background()); err != nil {
+			consecutiveFailures++
+		} else {
+			consecutiveFailures = 0
+		}
+	}
+	if consecutiveFailures != 0 {
+		t.Fatalf("consecutiveFailures=%d after 10 passes with one permanently broken task alongside a healthy one, want 0 (base interval, no backoff)", consecutiveFailures)
+	}
+}
+
+// TestPoller_RunOnce_EngineSessionGoneFailsTaskInstead is the specific
+// root-cause fix: a StatusChecker error wrapping agenttask.ErrEngineSessionGone
+// (the launcher has no memory of this session, e.g. it restarted) is a
+// definitive answer, not a transient one, and must fail the task in this
+// same pass rather than being retried forever.
+func TestPoller_RunOnce_EngineSessionGoneFailsTaskInstead(t *testing.T) {
+	repo := newFakeRepository()
+	task := newActiveTask(repo, agenttask.StatusRunning, "session-lost")
+	checker := &fakeStatusChecker{responses: map[string]checkerResponse{
+		"session-lost": {err: fmt.Errorf("agentengine: /status: status 404: %w", agenttask.ErrEngineSessionGone)},
+	}}
+	p := agenttask.NewPoller(repo, checker, agenttask.PollerConfig{Logger: quietPollerLogger()})
+
+	advanced, err := p.RunOnce(context.Background())
+	if err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if advanced != 1 {
+		t.Fatalf("advanced=%d want 1 (session-gone resolves the task immediately, not a retry)", advanced)
+	}
+	got, getErr := repo.Get(context.Background(), task.TenantID, task.UserID, task.ID)
+	if getErr != nil {
+		t.Fatalf("Get: %v", getErr)
+	}
+	if got.Status != agenttask.StatusFailed {
+		t.Fatalf("status=%q want failed", got.Status)
+	}
+	if got.ErrorMessage == "" {
+		t.Fatal("expected a non-empty customer-visible error_message")
+	}
+	if strings.Contains(got.ErrorMessage, "404") || strings.Contains(got.ErrorMessage, "session-lost") {
+		t.Fatalf("error_message=%q leaked engine detail (provider-blind violation)", got.ErrorMessage)
+	}
+
+	// Second pass: the now-failed task is no longer active, so it is never
+	// checked again — proof this does not retry forever.
+	callsBefore := checker.Calls()
+	if _, err := p.RunOnce(context.Background()); err != nil {
+		t.Fatalf("second RunOnce: %v", err)
+	}
+	if got := checker.Calls(); got != callsBefore {
+		t.Fatalf("expected 0 additional Status calls once the task is terminal, calls went from %d to %d", callsBefore, got)
 	}
 }
 

--- a/apps/control-plane/internal/agenttask/poller_test.go
+++ b/apps/control-plane/internal/agenttask/poller_test.go
@@ -121,19 +121,20 @@ func TestPoller_RunOnce_EngineErrorIsRetriedNotFailed(t *testing.T) {
 
 	advanced, err := p.RunOnce(context.Background())
 	// A mixed pass (one task erroring, another succeeding in the same sweep)
-	// is not a systemically degraded pass: the healthy task proves the
-	// engine itself is reachable, so this must not feed loop's backoff.
-	// Before this fix RunOnce reported an error for ANY per-task problem,
-	// which let one permanently broken task (ListActive is cross-tenant) pin
-	// the whole poller's shared interval at maxPollerBackoff for as long as
-	// that row existed, throttling every other tenant's poll cadence too
-	// (measured live 2026-08-16, task f9409763).
+	// must never feed loop's backoff: RunOnce's returned error means
+	// ListActive itself failed, nothing else. Before this fix RunOnce
+	// reported an error for ANY per-task problem, which let one permanently
+	// broken task (ListActive is cross-tenant) pin the whole poller's shared
+	// interval at maxPollerBackoff for as long as that row existed,
+	// throttling every other tenant's poll cadence too (measured live
+	// 2026-08-16, task f9409763).
 	if err != nil {
 		t.Fatalf("expected a mixed pass (one error, one success) to report no error, got %v", err)
 	}
 	// "Retried not failed": the broken task is untouched (still active, will
-	// be retried next pass), and the healthy task in the same pass still
-	// advanced despite the other task's error.
+	// be retried next pass, charged against its own failure budget), and the
+	// healthy task in the same pass still advanced despite the other task's
+	// error.
 	if advanced != 1 {
 		t.Fatalf("advanced=%d want 1 (only the healthy task)", advanced)
 	}
@@ -147,12 +148,12 @@ func TestPoller_RunOnce_EngineErrorIsRetriedNotFailed(t *testing.T) {
 	}
 }
 
-// TestPoller_RunOnce_AllTasksErroringIsSystemicFailure locks in the other
-// side of the same rule: when EVERY active task's status check fails this
-// pass (no evidence the engine is reachable at all), RunOnce must still
-// report an error so loop's backoff engages — that is the genuine outage
-// case the mechanism exists for.
-func TestPoller_RunOnce_AllTasksErroringIsSystemicFailure(t *testing.T) {
+// TestPoller_RunOnce_AllTasksErroringNeverBacksOffEither locks in that even
+// the "everything looks down" pass (no task anywhere succeeds) still does not
+// feed loop's backoff: RunOnce's error is scoped to ListActive alone. A
+// widespread engine outage costs each task its own maxTaskFailureBudget
+// retries, never the shared poll cadence.
+func TestPoller_RunOnce_AllTasksErroringNeverBacksOffEither(t *testing.T) {
 	repo := newFakeRepository()
 	newActiveTask(repo, agenttask.StatusRunning, "session-a")
 	newActiveTask(repo, agenttask.StatusRunning, "session-b")
@@ -163,8 +164,8 @@ func TestPoller_RunOnce_AllTasksErroringIsSystemicFailure(t *testing.T) {
 	p := agenttask.NewPoller(repo, checker, agenttask.PollerConfig{Logger: quietPollerLogger()})
 
 	advanced, err := p.RunOnce(context.Background())
-	if err == nil {
-		t.Fatal("expected RunOnce to report an error when every active task's status check failed")
+	if err != nil {
+		t.Fatalf("expected no error even when every active task's status check failed, got %v", err)
 	}
 	if advanced != 0 {
 		t.Fatalf("advanced=%d want 0", advanced)
@@ -180,7 +181,11 @@ func TestPoller_RunOnce_AllTasksErroringIsSystemicFailure(t *testing.T) {
 // at 0 the whole time, which is exactly the input pollerBackoffDelay needs to
 // keep returning the configured base interval (see TestPollerBackoffDelay);
 // before this fix it grew without bound and pinned the shared poll cadence at
-// maxPollerBackoff for every other tenant's tasks too.
+// maxPollerBackoff for every other tenant's tasks too. Runs fewer passes than
+// maxTaskFailureBudget so the broken task's own budget never exhausts either —
+// this test is purely about the shared cadence, not the per-task ceiling
+// (see TestPoller_RunOnce_TaskExceedingFailureBudgetFailsRegardlessOfErrorShape
+// for that).
 func TestPoller_ConsecutiveFailures_OnePermanentlyFailingTaskDoesNotBackOffTheSweep(t *testing.T) {
 	repo := newFakeRepository()
 	newActiveTask(repo, agenttask.StatusRunning, "session-broken")
@@ -201,6 +206,134 @@ func TestPoller_ConsecutiveFailures_OnePermanentlyFailingTaskDoesNotBackOffTheSw
 	}
 	if consecutiveFailures != 0 {
 		t.Fatalf("consecutiveFailures=%d after 10 passes with one permanently broken task alongside a healthy one, want 0 (base interval, no backoff)", consecutiveFailures)
+	}
+}
+
+// TestPoller_RunOnce_SingleTaskErroringForeverDoesNotBackOffTheSweep is the
+// direct regression guard for the reviewed HIGH: the demo box's own quota (2
+// per user, 4 per tenant) makes a SINGLE active task the ordinary shape, not
+// a corner case, and an earlier version of this fix (errCount == len(tasks))
+// collapsed back to "any single task's own error" exactly in that shape,
+// since a fraction of 1 out of 1 is trivially 100%. With only one active task
+// in the whole system erroring every single pass (never reaching
+// maxTaskFailureBudget within this loop), RunOnce must still report no error
+// on every pass.
+func TestPoller_RunOnce_SingleTaskErroringForeverDoesNotBackOffTheSweep(t *testing.T) {
+	repo := newFakeRepository()
+	newActiveTask(repo, agenttask.StatusRunning, "session-only")
+	checker := &fakeStatusChecker{responses: map[string]checkerResponse{
+		"session-only": {err: errors.New("agent-server unreachable")},
+	}}
+	p := agenttask.NewPoller(repo, checker, agenttask.PollerConfig{Logger: quietPollerLogger()})
+
+	for pass := 0; pass < 10; pass++ {
+		if _, err := p.RunOnce(context.Background()); err != nil {
+			t.Fatalf("pass %d: expected no error with a single perpetually-erroring active task, got %v", pass, err)
+		}
+	}
+}
+
+// TestPoller_RunOnce_TaskExceedingFailureBudgetFailsRegardlessOfErrorShape is
+// the per-task-budget regression guard the review found missing: a task
+// whose engine session was killed some way other than through Cancel or a
+// normal terminal status (an OOM, an Apptainer crash) never reaches
+// SandboxEngine.reap and fails its Status call forever with a plain error —
+// NOT one wrapping ErrEngineSessionGone, since the launcher's serve.go only
+// maps engineapi.ErrUnknownSession (a 404) onto that sentinel; this failure
+// shape is whatever the daemon's default error-mapping branch produces (a
+// 502 in practice). RunOnce must still eventually give up on it, exactly
+// maxTaskFailureBudget consecutive passes in.
+func TestPoller_RunOnce_TaskExceedingFailureBudgetFailsRegardlessOfErrorShape(t *testing.T) {
+	repo := newFakeRepository()
+	task := newActiveTask(repo, agenttask.StatusRunning, "session-dead-sandbox")
+	checker := &fakeStatusChecker{responses: map[string]checkerResponse{
+		// A plain error, deliberately NOT wrapping agenttask.ErrEngineSessionGone
+		// — stands in for the 502 an externally killed sandbox produces.
+		"session-dead-sandbox": {err: errors.New("agentengine: /status: status 502")},
+	}}
+	p := agenttask.NewPoller(repo, checker, agenttask.PollerConfig{Logger: quietPollerLogger()})
+
+	const budget = 20 // must match agenttask.maxTaskFailureBudget
+	for pass := 1; pass < budget; pass++ {
+		if _, err := p.RunOnce(context.Background()); err != nil {
+			t.Fatalf("pass %d: expected no error (per-task budget, not systemic), got %v", pass, err)
+		}
+		got, getErr := repo.Get(context.Background(), task.TenantID, task.UserID, task.ID)
+		if getErr != nil {
+			t.Fatalf("pass %d: Get: %v", pass, getErr)
+		}
+		if got.Status != agenttask.StatusRunning {
+			t.Fatalf("pass %d: status=%q want still running (budget not yet exhausted)", pass, got.Status)
+		}
+	}
+
+	// The budget-exhausting pass.
+	if _, err := p.RunOnce(context.Background()); err != nil {
+		t.Fatalf("final pass: expected no error, got %v", err)
+	}
+	got, getErr := repo.Get(context.Background(), task.TenantID, task.UserID, task.ID)
+	if getErr != nil {
+		t.Fatalf("Get: %v", getErr)
+	}
+	if got.Status != agenttask.StatusFailed {
+		t.Fatalf("status=%q want failed once the failure budget is exhausted", got.Status)
+	}
+	if got.ErrorMessage == "" || strings.Contains(got.ErrorMessage, "502") {
+		t.Fatalf("error_message=%q want a non-empty, provider-blind message", got.ErrorMessage)
+	}
+
+	// Never rechecked again once terminal.
+	callsBefore := checker.Calls()
+	if _, err := p.RunOnce(context.Background()); err != nil {
+		t.Fatalf("post-failure RunOnce: %v", err)
+	}
+	if got := checker.Calls(); got != callsBefore {
+		t.Fatalf("expected 0 additional Status calls once the task is terminal, calls went from %d to %d", callsBefore, got)
+	}
+}
+
+// TestPoller_RunOnce_FailureBudgetResetsOnCleanPass proves the budget counts
+// CONSECUTIVE failures, not a lifetime total: a task that fails, then
+// answers cleanly once, then fails again must not be any closer to its
+// budget ceiling than a task that only ever failed the second run.
+func TestPoller_RunOnce_FailureBudgetResetsOnCleanPass(t *testing.T) {
+	repo := newFakeRepository()
+	task := newActiveTask(repo, agenttask.StatusRunning, "session-flaky")
+	checker := &fakeStatusChecker{responses: map[string]checkerResponse{
+		"session-flaky": {err: errors.New("agent-server unreachable")},
+	}}
+	p := agenttask.NewPoller(repo, checker, agenttask.PollerConfig{Logger: quietPollerLogger()})
+
+	const budget = 20 // must match agenttask.maxTaskFailureBudget
+	for pass := 0; pass < budget-1; pass++ {
+		if _, err := p.RunOnce(context.Background()); err != nil {
+			t.Fatalf("pass %d: %v", pass, err)
+		}
+	}
+	// One clean pass resets the streak.
+	checker.mu.Lock()
+	checker.responses["session-flaky"] = checkerResponse{status: agenttask.StatusRunning}
+	checker.mu.Unlock()
+	if _, err := p.RunOnce(context.Background()); err != nil {
+		t.Fatalf("clean pass: %v", err)
+	}
+	checker.mu.Lock()
+	checker.responses["session-flaky"] = checkerResponse{err: errors.New("agent-server unreachable")}
+	checker.mu.Unlock()
+
+	// budget-1 more failures: still short of a fresh budget-1 threshold, so
+	// the task must remain running, not failed.
+	for pass := 0; pass < budget-1; pass++ {
+		if _, err := p.RunOnce(context.Background()); err != nil {
+			t.Fatalf("post-reset pass %d: %v", pass, err)
+		}
+	}
+	got, getErr := repo.Get(context.Background(), task.TenantID, task.UserID, task.ID)
+	if getErr != nil {
+		t.Fatalf("Get: %v", getErr)
+	}
+	if got.Status != agenttask.StatusRunning {
+		t.Fatalf("status=%q want still running: the one clean pass should have reset the failure streak", got.Status)
 	}
 }
 

--- a/apps/control-plane/internal/agenttask/poller_test.go
+++ b/apps/control-plane/internal/agenttask/poller_test.go
@@ -24,11 +24,17 @@ func quietPollerLogger() *slog.Logger {
 
 // fakeStatusChecker is a hand-built agenttask.StatusChecker stub: a fixed
 // per-sessionRef response table, with an optional call counter for the
-// Start/Stop loop tests.
+// Start/Stop loop tests. Also implements Cancel (agentengine.Remote and
+// agentengine.Engine both do, structurally satisfying the unexported
+// budgetExceededCanceler interface chargeFailureBudget type-asserts for),
+// so tests can assert on the best-effort stop a budget-exhausted task
+// triggers.
 type fakeStatusChecker struct {
 	mu        sync.Mutex
 	responses map[string]checkerResponse
 	calls     int
+	cancelled []string
+	cancelErr error
 }
 
 type checkerResponse struct {
@@ -49,10 +55,23 @@ func (f *fakeStatusChecker) Status(_ context.Context, sessionRef string) (agentt
 	return resp.status, resp.resultSummary, resp.errMessage, resp.err
 }
 
+func (f *fakeStatusChecker) Cancel(_ context.Context, sessionRef string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.cancelled = append(f.cancelled, sessionRef)
+	return f.cancelErr
+}
+
 func (f *fakeStatusChecker) Calls() int {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.calls
+}
+
+func (f *fakeStatusChecker) Cancelled() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.cancelled...)
 }
 
 func newActiveTask(repo *fakeRepository, status agenttask.Status, sessionRef string) agenttask.Task {
@@ -241,8 +260,13 @@ func TestPoller_RunOnce_SingleTaskErroringForeverDoesNotBackOffTheSweep(t *testi
 // NOT one wrapping ErrEngineSessionGone, since the launcher's serve.go only
 // maps engineapi.ErrUnknownSession (a 404) onto that sentinel; this failure
 // shape is whatever the daemon's default error-mapping branch produces (a
-// 502 in practice). RunOnce must still eventually give up on it, exactly
-// maxTaskFailureBudget consecutive passes in.
+// 502 in practice). RunOnce must still eventually give up on it, exactly at
+// the poller's own taskFailureBudget()'th consecutive pass (20 at the
+// default 15s interval, since maxTaskFailureDuration is 5 minutes). It must
+// also best-effort stop the still-live session at that point: a non-404
+// error means the launcher answered from its own handler, so
+// SandboxEngine.reap never ran and the session is still holding its
+// concurrency slot.
 func TestPoller_RunOnce_TaskExceedingFailureBudgetFailsRegardlessOfErrorShape(t *testing.T) {
 	repo := newFakeRepository()
 	task := newActiveTask(repo, agenttask.StatusRunning, "session-dead-sandbox")
@@ -253,7 +277,7 @@ func TestPoller_RunOnce_TaskExceedingFailureBudgetFailsRegardlessOfErrorShape(t 
 	}}
 	p := agenttask.NewPoller(repo, checker, agenttask.PollerConfig{Logger: quietPollerLogger()})
 
-	const budget = 20 // must match agenttask.maxTaskFailureBudget
+	const budget = 20 // default interval 15s, maxTaskFailureDuration 5m: 5m/15s = 20
 	for pass := 1; pass < budget; pass++ {
 		if _, err := p.RunOnce(context.Background()); err != nil {
 			t.Fatalf("pass %d: expected no error (per-task budget, not systemic), got %v", pass, err)
@@ -265,6 +289,9 @@ func TestPoller_RunOnce_TaskExceedingFailureBudgetFailsRegardlessOfErrorShape(t 
 		if got.Status != agenttask.StatusRunning {
 			t.Fatalf("pass %d: status=%q want still running (budget not yet exhausted)", pass, got.Status)
 		}
+	}
+	if cancelled := checker.Cancelled(); len(cancelled) != 0 {
+		t.Fatalf("expected no Cancel calls before the budget is exhausted, got %v", cancelled)
 	}
 
 	// The budget-exhausting pass.
@@ -281,6 +308,9 @@ func TestPoller_RunOnce_TaskExceedingFailureBudgetFailsRegardlessOfErrorShape(t 
 	if got.ErrorMessage == "" || strings.Contains(got.ErrorMessage, "502") {
 		t.Fatalf("error_message=%q want a non-empty, provider-blind message", got.ErrorMessage)
 	}
+	if cancelled := checker.Cancelled(); len(cancelled) != 1 || cancelled[0] != "session-dead-sandbox" {
+		t.Fatalf("expected exactly one best-effort Cancel(\"session-dead-sandbox\") once the budget was exhausted, got %v", cancelled)
+	}
 
 	// Never rechecked again once terminal.
 	callsBefore := checker.Calls()
@@ -290,6 +320,74 @@ func TestPoller_RunOnce_TaskExceedingFailureBudgetFailsRegardlessOfErrorShape(t 
 	if got := checker.Calls(); got != callsBefore {
 		t.Fatalf("expected 0 additional Status calls once the task is terminal, calls went from %d to %d", callsBefore, got)
 	}
+}
+
+// TestPoller_RunOnce_FailureBudgetScalesWithConfiguredInterval is the
+// regression guard for the review finding that a fixed 20-pass budget would
+// silently shorten the real kill timeout whenever
+// HIVE_AGENT_TASK_POLL_INTERVAL is tuned. At a 1 minute interval,
+// maxTaskFailureDuration (5 minutes) must yield a 5-pass budget, not 20.
+func TestPoller_RunOnce_FailureBudgetScalesWithConfiguredInterval(t *testing.T) {
+	repo := newFakeRepository()
+	task := newActiveTask(repo, agenttask.StatusRunning, "session-dead-sandbox")
+	checker := &fakeStatusChecker{responses: map[string]checkerResponse{
+		"session-dead-sandbox": {err: errors.New("agentengine: /status: status 502")},
+	}}
+	p := agenttask.NewPoller(repo, checker, agenttask.PollerConfig{Interval: time.Minute, Logger: quietPollerLogger()})
+
+	const budget = 5 // maxTaskFailureDuration (5m) / 1m interval
+	for pass := 1; pass < budget; pass++ {
+		if _, err := p.RunOnce(context.Background()); err != nil {
+			t.Fatalf("pass %d: %v", pass, err)
+		}
+		got, getErr := repo.Get(context.Background(), task.TenantID, task.UserID, task.ID)
+		if getErr != nil {
+			t.Fatalf("pass %d: Get: %v", pass, getErr)
+		}
+		if got.Status != agenttask.StatusRunning {
+			t.Fatalf("pass %d: status=%q want still running (budget not yet exhausted at a 1m interval)", pass, got.Status)
+		}
+	}
+	if _, err := p.RunOnce(context.Background()); err != nil {
+		t.Fatalf("final pass: %v", err)
+	}
+	got, getErr := repo.Get(context.Background(), task.TenantID, task.UserID, task.ID)
+	if getErr != nil {
+		t.Fatalf("Get: %v", getErr)
+	}
+	if got.Status != agenttask.StatusFailed {
+		t.Fatalf("status=%q want failed on the 5th consecutive failure at a 1m interval, not the 15s-interval default of 20", got.Status)
+	}
+}
+
+// TestPoller_RunOnce_ConcurrentCallsDoNotCorruptTaskFailures is the
+// contract-regression guard the review flagged: RunOnce is exported, and
+// loop's own serialization (Start/Stop's mutex) protects loop against
+// itself, not this method against a second, direct caller. An
+// unsynchronized concurrent map write is a process-fatal throw Go's runtime
+// detects on its own, with no recover, even without -race. This is a
+// contract regression today (no shipped caller does this), not a live bug;
+// still cheap to close.
+func TestPoller_RunOnce_ConcurrentCallsDoNotCorruptTaskFailures(t *testing.T) {
+	repo := newFakeRepository()
+	for i := range 5 {
+		newActiveTask(repo, agenttask.StatusRunning, fmt.Sprintf("session-%d", i))
+	}
+	checker := &fakeStatusChecker{responses: map[string]checkerResponse{
+		"session-0": {err: errors.New("boom")},
+		"session-1": {err: errors.New("boom")},
+	}}
+	p := agenttask.NewPoller(repo, checker, agenttask.PollerConfig{Logger: quietPollerLogger()})
+
+	var wg sync.WaitGroup
+	for range 20 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = p.RunOnce(context.Background())
+		}()
+	}
+	wg.Wait()
 }
 
 // TestPoller_RunOnce_FailureBudgetResetsOnCleanPass proves the budget counts
@@ -304,7 +402,7 @@ func TestPoller_RunOnce_FailureBudgetResetsOnCleanPass(t *testing.T) {
 	}}
 	p := agenttask.NewPoller(repo, checker, agenttask.PollerConfig{Logger: quietPollerLogger()})
 
-	const budget = 20 // must match agenttask.maxTaskFailureBudget
+	const budget = 20 // default interval 15s, maxTaskFailureDuration 5m: 5m/15s = 20
 	for pass := 0; pass < budget-1; pass++ {
 		if _, err := p.RunOnce(context.Background()); err != nil {
 			t.Fatalf("pass %d: %v", pass, err)
@@ -341,7 +439,10 @@ func TestPoller_RunOnce_FailureBudgetResetsOnCleanPass(t *testing.T) {
 // root-cause fix: a StatusChecker error wrapping agenttask.ErrEngineSessionGone
 // (the launcher has no memory of this session, e.g. it restarted) is a
 // definitive answer, not a transient one, and must fail the task in this
-// same pass rather than being retried forever.
+// same pass rather than being retried forever. It must also NOT attempt a
+// best-effort Cancel the way an exhausted failure budget does: the engine
+// already said it has no memory of the session, so there is nothing left to
+// stop.
 func TestPoller_RunOnce_EngineSessionGoneFailsTaskInstead(t *testing.T) {
 	repo := newFakeRepository()
 	task := newActiveTask(repo, agenttask.StatusRunning, "session-lost")
@@ -369,6 +470,9 @@ func TestPoller_RunOnce_EngineSessionGoneFailsTaskInstead(t *testing.T) {
 	}
 	if strings.Contains(got.ErrorMessage, "404") || strings.Contains(got.ErrorMessage, "session-lost") {
 		t.Fatalf("error_message=%q leaked engine detail (provider-blind violation)", got.ErrorMessage)
+	}
+	if cancelled := checker.Cancelled(); len(cancelled) != 0 {
+		t.Fatalf("expected no Cancel calls on the session-gone path (nothing left to stop), got %v", cancelled)
 	}
 
 	// Second pass: the now-failed task is no longer active, so it is never

--- a/apps/control-plane/internal/agenttask/service.go
+++ b/apps/control-plane/internal/agenttask/service.go
@@ -283,10 +283,23 @@ func (s *Service) stopEngineSession(ctx context.Context, taskID uuid.UUID, sessi
 	}
 	stopCtx, done := context.WithTimeout(context.WithoutCancel(ctx), engineCancelTimeout)
 	defer done()
-	if err := s.engine.Cancel(stopCtx, sessionRef); err != nil {
-		slog.Default().WarnContext(stopCtx, "agenttask: engine cancel failed, the session may still hold its concurrency slot",
-			"task_id", taskID, "session_ref", sessionRef, "error", err)
+	err := s.engine.Cancel(stopCtx, sessionRef)
+	if err == nil {
+		return
 	}
+	if errors.Is(err, ErrEngineSessionGone) {
+		// The engine already has no memory of this session (its in-memory
+		// registry lost it, e.g. a launcher restart), so it holds no
+		// concurrency slot for it either: the quota manager lives in the
+		// same in-memory state as the session registry
+		// (apps/agent-engine/internal/engine.SandboxEngine). Nothing leaked,
+		// nothing for an operator to chase — warning here would point them
+		// at a slot that does not exist, on exactly the path (issue #886)
+		// where leaked slots are the thing they've been trained to hunt.
+		return
+	}
+	slog.Default().WarnContext(stopCtx, "agenttask: engine cancel failed, the session may still hold its concurrency slot",
+		"task_id", taskID, "session_ref", sessionRef, "error", err)
 }
 
 // WaitIdle blocks until every background launch and engine stop this Service

--- a/apps/control-plane/internal/agenttask/service_test.go
+++ b/apps/control-plane/internal/agenttask/service_test.go
@@ -1,9 +1,11 @@
 package agenttask_test
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 	"sync"
 	"testing"
@@ -414,6 +416,53 @@ func TestService_Cancel_TerminalStateRejected(t *testing.T) {
 	svc.WaitIdle()
 	if got := eng.cancelCount(); got != 1 {
 		t.Errorf("expected exactly one engine cancel across a double cancel, got %d", got)
+	}
+}
+
+// sessionGoneEngine's Cancel always answers as if the launcher has already
+// forgotten the session — the engine-side counterpart to
+// TestPoller_RunOnce_EngineSessionGoneFailsTaskInstead, exercising the same
+// sentinel on Service.stopEngineSession's consumption side instead of the
+// poller's.
+type sessionGoneEngine struct {
+	sessionRef string
+}
+
+func (e sessionGoneEngine) Launch(context.Context, agenttask.Task) (string, error) {
+	return e.sessionRef, nil
+}
+
+func (e sessionGoneEngine) Cancel(context.Context, string) error {
+	return fmt.Errorf("agentengine: /cancel: status 404: %w", agenttask.ErrEngineSessionGone)
+}
+
+// TestService_Cancel_EngineSessionGoneDoesNotWarnAboutALeakedSlot proves
+// stopEngineSession does not log its "may still hold its concurrency slot"
+// warning when the engine's answer is specifically ErrEngineSessionGone: a
+// launcher with no memory of the session holds no slot for it either (the
+// quota manager lives in the same in-memory state as the session registry),
+// so that warning would send an operator chasing a leak that does not exist.
+func TestService_Cancel_EngineSessionGoneDoesNotWarnAboutALeakedSlot(t *testing.T) {
+	var logBuf bytes.Buffer
+	prevDefault := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logBuf, nil)))
+	t.Cleanup(func() { slog.SetDefault(prevDefault) })
+
+	svc := agenttask.NewService(newFakeRepository(), sessionGoneEngine{sessionRef: "session-gone"})
+	tenantID, userID := uuid.New(), uuid.New()
+	created := createSettled(t, svc, tenantID, userID, agenttask.PackCoding)
+
+	cancelled, err := svc.Cancel(context.Background(), tenantID, userID, created.ID)
+	if err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+	if cancelled.Status != agenttask.StatusCancelled {
+		t.Fatalf("expected StatusCancelled, got %v", cancelled.Status)
+	}
+	svc.WaitIdle()
+
+	if strings.Contains(logBuf.String(), "may still hold its concurrency slot") {
+		t.Fatalf("expected no leaked-slot warning for ErrEngineSessionGone, got log output: %s", logBuf.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

`agenttask.Poller.RunOnce` reported the whole sweep as failed whenever ANY active task's status check errored, so a single permanently unreachable session (a lost engine session ref after a launcher restart) kept `consecutiveFailures` climbing forever and pinned the shared loop at `maxPollerBackoff` (5 minutes) instead of the configured 15 second interval. Since `Repository.ListActive` is cross-tenant by design, that one stuck row degraded poll cadence for every other tenant's tasks too.

Measured live 2026-08-16: task `f9409763` had been stuck in `running` since 2026-08-14 with a 404ing `/status` call. Control-plane logs showed sweeps five minutes apart for hours; two unrelated completed tasks had `finished_at` timestamps 1203.77s apart, exactly 4 x 300.94s.

This PR went through three review passes before landing on the design below. Each pass's findings and how they were addressed are kept in full further down, since they document real defects two earlier "fixed" versions actually shipped.

### Root cause, confirmed by reading the code (not assumed)

- The backoff is global to the poller, not per-task: `loop()` holds one `consecutiveFailures` counter for the whole pass, and `RunOnce` used to return a non-nil error whenever `errCount > 0`, regardless of how many other tasks succeeded in the same sweep.
- `consecutiveFailures` never reset because the same task 404'd on every single pass forever.
- A `/status` 404 is a definitive answer, not a transient one: the launcher's `/status` handler (`apps/agent-engine/cmd/agent-engine/serve.go`) maps `engineapi.ErrUnknownSession` onto exactly that status code when its in-memory session registry (lost on a launcher restart) has no memory of the session.
- A second, separate dead-task shape is also reachable today: `SandboxEngine.reap` only runs on a terminal status or `Cancel`, so a sandbox killed some other way (OOM, an Apptainer crash, or its agent-server control socket dying while the sandbox itself stays up) never gets reaped. Its `Status` call fails forever too, but with a 502, not a 404 -- same incident class as `f9409763`, a different, non-enumerable error shape.

### Current design (third pass, final)

1. `RunOnce`'s returned error (loop's sole backoff signal) means only that `ListActive` itself failed -- a real database/connectivity problem, the only thing that is actually poller-wide. No task-level problem, of any shape or count, ever feeds it.
2. Every task-level problem is scoped to that ONE task via `pollTask`/`chargeFailureBudget`:
   - A `StatusChecker` error definitively identified as `agenttask.ErrEngineSessionGone` (the engine's "I have no memory of this session" answer -- mapped from `agentengine.Remote`'s 404 for the socket arm, and the in-process `agentengine.Engine` arm's `engineapi.ErrUnknownSession`, for consistency across both arms) fails the task immediately. Nothing to stop on this path: the engine already said the session is gone.
   - Anything else is retried per pass, up to `Poller.taskFailureBudget()` consecutive times (a duration, `maxTaskFailureDuration` = 5 minutes, converted to a pass count using the poller's OWN configured interval, so tuning `HIVE_AGENT_TASK_POLL_INTERVAL` cannot silently shrink the real kill timeout), after which `RunOnce` gives up on that task and fails it directly regardless of the error's shape. Before failing the row, it best-effort stops the session (`budgetExceededCanceler`, type-asserted against the checker, since `buildAgentEngine` wires the same object as both `agenttask.Engine` and `agenttask.StatusChecker`): a non-404 error means the session is still live and holding its concurrency slot, and once the row is terminal nothing else (not even a user's own `Cancel`) can ever free that slot otherwise.
   - A `Repository.Transition` failure for an ALREADY-KNOWN terminal status (the engine told us the task succeeded or failed, but persisting that failed) is retried forever exactly as before this PR and is never charged against the budget or forced to a status we can't confirm.
3. `taskFailures` (the per-task consecutive-failure map) is guarded by its own mutex: `RunOnce` is exported and callable concurrently with itself in principle, even though nothing in production does that today.

The `agent_tasks` terminal guard clause (`status NOT IN ('succeeded', 'failed', 'cancelled')`) that `Cancel` and the poller both rely on to resolve races is unchanged: every terminal path here reuses the exact same `Repository.Transition` call, so a concurrent `Cancel` still wins the atomic race exactly as before (`ErrTerminalState` is swallowed, not retried, not surfaced as a pass error).

**Pre-existing race, worth naming explicitly (not introduced or changed by this PR):** when the poller wins a race against a user's `Cancel` call, the user's `Cancel` gets back `ErrTerminalState` and the row reads `failed` (or `succeeded`) rather than `cancelled`. Correct and atomic, just surprising to whoever clicked cancel.

**Known, deliberately deferred residual:** the row is persisted as `status = failed` regardless of whether it was a confirmed failure or an unrecoverable-outcome case (`ErrEngineSessionGone` or a budget exhaustion). The `error_message` text is honest about the distinction; the machine-readable `status` column is not. Telling the two apart programmatically needs a distinct terminal status or a reason code, folded into issue **#921** alongside the deploy-drain question rather than built here.

### Stranded row f9409763

Per owner authorization (gated on the fix landing and on showing the exact statement plus affected row count before running), transitioned `f9409763-02b4-41bd-870b-7a91d04b6154` on the demo database directly:

- Looked it up by id prefix first: exactly one row matched, `status=running`, `engine_session_ref` set, stuck since `2026-08-14T17:17:16Z`.
- Ran, scoped by primary key (mirrors `Repository.Transition`'s own atomic guard):

```sql
UPDATE public.agent_tasks
   SET status = 'failed',
       error_message = 'agent task session is no longer reachable',
       finished_at = COALESCE(finished_at, now()),
       updated_at = now()
 WHERE id = 'f9409763-02b4-41bd-870b-7a91d04b6154'
   AND status NOT IN ('succeeded', 'failed', 'cancelled')
```

- Affected exactly 1 row. Deleting was never on the table; this is a transition.

## Review pass 1 (stage 6) findings and fixes

Single reviewer stream ran (CodeRabbit rate limited, Codex out of quota, Bugbot disabled, all three declared SKIPPED).

- **HIGH, `poller.go:173` (first version): `errCount == len(tasks)` collapses to a single task's own error when exactly one task is active** -- the ordinary shape under this deployment's quota (2/user, 4/tenant). Fixed: the fraction rule removed entirely; `RunOnce`'s error means only "`ListActive` failed." Test: `TestPoller_RunOnce_SingleTaskErroringForeverDoesNotBackOffTheSweep`.
- **Second dead-task shape (502, not 404) that `ErrEngineSessionGone` alone didn't cover.** Fixed via the per-task failure budget: any task-level error, of any shape, eventually fails the task once the budget is exhausted. Test: `TestPoller_RunOnce_TaskExceedingFailureBudgetFailsRegardlessOfErrorShape`.
- **Operational consequence: `deploy-demo-box.yml`'s unconditional installer restart terminally fails every in-flight Cowork task within ~15s of a merge to `main`.** Failing fast beats hanging forever silently, not reverted. Named in the `ErrEngineSessionGone` doc comment; drain/reconnect mitigation tracked as **#921**.
- **Test discrimination gap**: the original all-erroring test passed identically against the unfixed rule, and there was no test for the single-task collapse. Replaced/added the tests named above plus `TestPoller_RunOnce_AllTasksErroringNeverBacksOffEither`, `TestPoller_RunOnce_FailureBudgetResetsOnCleanPass`.
- **404-as-terminal reasoning survived every attack** (transport errors never become 404-shaped, the registry is memory-only with no restore path, no double-launcher window). Kept, supplemented by the budget rather than replaced.

## Review pass 2 findings and fixes (commit `caf40886`)

- **Doc comment claimed more than the code could know** (a biased-sample argument against the now-removed fraction rule): moot once that rule was removed.
- **Deploy-restart consequence named explicitly in the doc comment**, plus filed **#921**.
- **Message honesty**: `engineSessionGoneMessage` / `engineUnreachableAfterRetriesMessage` no longer assert failure; both read as an unrecoverable outcome, since the sandbox may have finished before the launcher lost the reference.
- **Pass-level aggregate log**: `RunOnce` now counts how many tasks it personally declared dead this pass and logs one summary line when nonzero, instead of N unrelated per-task lines with no total.
- **404-to-`ErrEngineSessionGone` mapping scoped to exactly `/status` and `/cancel`** (not `/launch`, which `post` also serves): `net/http.ServeMux` answers 404 for any unmatched path, so an unscoped check would call a routing miss session-gone. New negative tests: `TestRemoteLaunch404DoesNotMapToEngineSessionGone`, `TestRemoteTransportFailureDoesNotMapToEngineSessionGone`.
- **Cancel-path honesty**: `Service.stopEngineSession` no longer warns about a leaked slot when the engine's answer is `ErrEngineSessionGone` (a launcher with no memory of a session holds no slot for it either); `agentengine.Engine.Cancel` now maps `ErrUnknownSession` the same way `Engine.Status` does, for arm consistency. Test: `TestService_Cancel_EngineSessionGoneDoesNotWarnAboutALeakedSlot`.
- **Two LOW nits** in `engine.go`: dropped a redundant `err != nil` guard, switched to `fmt.Errorf`'s two-`%w` form so wrapping `ErrEngineSessionGone` doesn't silently drop `errors.Is(result, engineapi.ErrUnknownSession)`.

## Review pass 3 findings and fixes (commits `574200ee`, `70975837`)

- **HIGH: budget exhaustion failed the row but never stopped the session.** A non-404 error means the launcher answered from its own handler, so `SandboxEngine.reap` never ran and the session was still holding a concurrency slot; once the row went terminal, `Service.Cancel`'s own atomic guard returned `ErrTerminalState` before it ever reached `stopEngineSession`, so nothing could ever free that slot -- issue #886's leaked-slot symptom through a new door, and at 2 slots per user, two such events would lock a user out of agent tasks entirely. Fixed with a best-effort `Cancel` on the budget-exhaustion path only (never on the session-gone path, where there is nothing left to stop): new unexported `budgetExceededCanceler` interface, type-asserted against `p.checker`. Tests: the budget test above now also asserts `Cancel` fires exactly once, only at exhaustion; the session-gone test now asserts `Cancel` never fires.
- **MEDIUM: the budget was counted in passes but documented in minutes, and the interval is operator-tunable via `HIVE_AGENT_TASK_POLL_INTERVAL`.** Lowering that interval is the obvious reaction to this very incident and would have silently shortened the real kill timeout in proportion. Fixed: `maxTaskFailureDuration` (5 minutes) is now converted to a pass count via `Poller.taskFailureBudget()`, using the poller's own configured interval, so the documented ceiling cannot drift. At the default 15s interval this is still exactly 20 (no existing test's numbers changed). Test: `TestPoller_RunOnce_FailureBudgetScalesWithConfiguredInterval` (a 1 minute interval yields a 5-pass budget).
- **MEDIUM: `RunOnce` is exported and was mutating an unsynchronized map**; the "no lock needed" argument was about `loop`'s own serialization, not a property of the exported method itself, and a concurrent map write is a process-fatal throw with no recover. Fixed: a dedicated `taskFailuresMu` guards every access via small helper methods. Not a live bug today (no shipped caller does this), a contract regression; cheap to close. Test: `TestPoller_RunOnce_ConcurrentCallsDoNotCorruptTaskFailures`.
- **Wording judged correct, two residuals noted, one now resolved as a side effect of the HIGH fix above** (the budget-path message no longer invites an unsafe retry, since the session is now actually stopped), the other (row still reads `status = failed` regardless of the honest message text) named explicitly in the doc comment and folded into #921.

## Buglog entry

```json
{"date":"2026-08-16","tags":["agenttask","poller","backoff","cross-tenant","agent-engine"],"error_message":"agenttask.Poller polled every tenant's active tasks at ~300s (maxPollerBackoff) instead of the configured 15s for hours, and a per-task failure budget's first two drafts left a slot-leak and an interval-coupling defect of their own","root_cause":"RunOnce returned a non-nil error, feeding loop's exponential backoff, whenever a task-level problem occurred; a first fix attempt narrowed this to errCount == len(tasks), which still collapses to a single task's own error whenever exactly one task is active, the ordinary shape under this deployment's quota. ErrEngineSessionGone alone did not cover every dead-session shape (a 502 from a session the launcher still accounts for, not a 404). A second fix attempt (a per-task failure budget) then failed a budget-exhausted row without ever stopping its still-live engine session, reproducing issue #886's leaked-slot symptom, and expressed the budget as a fixed pass count that would have silently shortened under a tuned poll interval.","fix":"RunOnce's returned error now means only that ListActive itself failed. Every task-level problem is scoped to a per-task consecutive-failure budget expressed as a duration (maxTaskFailureDuration, 5 minutes) and converted to a pass count via the poller's own configured interval: ErrEngineSessionGone still fails a task immediately (nothing to stop), any other error is retried until the budget is exhausted, best-effort stops the session via a type-asserted Cancel, then fails the task directly regardless of error shape, without ever feeding the shared backoff. The per-task failure map is mutex-guarded since RunOnce is exported."}
```

## Test plan

- [x] `apps/control-plane/internal/agenttask` unit suite (docker toolchain), all tests named above plus the full pre-existing suite
- [x] `apps/control-plane/internal/agentengine` unit suite
- [x] Full `apps/control-plane` short suite green
- [x] `gofmt -l` and `go vet` clean on both touched packages
- [ ] CI (this PR)

This is a backend-only fix to a background poller loop; no UI surface is touched, so the visual-proof-before-merge requirement does not apply here.
