### PR TITLE
test: pin API key expiry enforcement at the authorization entry point

### DIFF
--- a/apps/edge-api/internal/authz/expiry_regression_test.go
+++ b/apps/edge-api/internal/authz/expiry_regression_test.go
@@ -1,0 +1,124 @@
+package authz
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	apierrors "github.com/sakibsadmanshajib/hive/apps/edge-api/internal/errors"
+)
+
+// Issue #915. These two tests pin the answer to "does presenting an expired
+// Hive API key authorize a request?" at the entry point that actually decides
+// it, Authorizer.Authorize, rather than at either half of the check in
+// isolation.
+//
+// Expiry is enforced twice, independently, and each layer already has its own
+// unit test:
+//
+//   - control-plane derives the status: apikeys.Service.ResolveSnapshot calls
+//     applyExpiry before projecting the snapshot, so a key whose durable
+//     api_keys.status is still 'active' resolves as "expired"
+//     (TestResolveSnapshotReturnsExpiredWhenExpiresAtHasPassed).
+//   - edge-api re-checks the timestamp: CheckAccess step 2 compares
+//     snapshot.ExpiresAt against the current time regardless of the status it
+//     was handed (TestCheckAccessExpiredKey).
+//
+// What neither of those pins is the composition, which is what the incident
+// behind #915 was actually about: six keys whose stored status read 'active'
+// while expires_at had passed. Both tests below use exactly that shape, so
+// removing either layer turns one of them red.
+//
+// The shape is also what a stale cached snapshot looks like. The edge caches a
+// resolved snapshot in Redis for up to snapshotTTL, so a snapshot minted while
+// the key was still live keeps its "active" status for the rest of that TTL
+// after the key expires. The second test drives that path through the cache
+// itself.
+
+// pastExpiryActiveSnapshot returns the incident shape: a key whose durable
+// status is still active, with expires_at an hour in the past.
+func pastExpiryActiveSnapshot() AuthSnapshot {
+	past := time.Now().Add(-1 * time.Hour).UTC().Format(time.RFC3339)
+	return AuthSnapshot{
+		KeyID:          "key-1",
+		AccountID:      "acc-1",
+		TenantID:       "11111111-1111-1111-1111-111111111111",
+		Status:         "active",
+		ExpiresAt:      &past,
+		AllowAllModels: true,
+		BudgetKind:     "none",
+	}
+}
+
+// assertExpiredDenial fails unless err is the specific expired-key denial.
+// Asserting the message, not just the code, matters: a resolve failure or any
+// other invalid_api_key branch would satisfy a code-only assertion and let the
+// test pass for the wrong reason.
+func assertExpiredDenial(t *testing.T, err *apierrors.OpenAIError) {
+	t.Helper()
+
+	if err == nil {
+		t.Fatal("expired key was authorized: Authorize returned no error")
+	}
+	if err.Error.Code == nil || *err.Error.Code != "invalid_api_key" {
+		t.Fatalf("code = %v, want %q", err.Error.Code, "invalid_api_key")
+	}
+	const want = "Incorrect API key provided: API key has expired"
+	if err.Error.Message != want {
+		t.Fatalf("message = %q, want %q", err.Error.Message, want)
+	}
+}
+
+// TestAuthorizeDeniesExpiredKeyWhoseStoredStatusIsStillActive is the direct
+// answer to #915: an expired-but-not-revoked key does not authorize, and the
+// denial does not depend on the durable status column having been rewritten.
+func TestAuthorizeDeniesExpiredKeyWhoseStoredStatusIsStillActive(t *testing.T) {
+	client := &Client{
+		ResolveOverride: func(_ context.Context, _ string) (AuthSnapshot, error) {
+			return pastExpiryActiveSnapshot(), nil
+		},
+	}
+
+	_, _, err := NewAuthorizer(client, nil).
+		Authorize(context.Background(), "Bearer hk_expired", "hive-default", 50, 100, 20)
+
+	assertExpiredDenial(t, err)
+}
+
+// TestCachedSnapshotCannotOutliveKeyExpiry covers the cache half of the same
+// question. A snapshot cached while the key was still live carries
+// status "active" for the rest of snapshotTTL, and the cache hit returns
+// before any control-plane call, so the only thing standing between that
+// cached value and a served request is CheckAccess re-reading expires_at.
+//
+// baseURL is deliberately unroutable: if the cache were missed, the fallback
+// HTTP resolve would fail and produce an upstream_unavailable error instead,
+// which assertExpiredDenial rejects. So this cannot pass without the cache
+// having actually been read and the expiry having actually been enforced on it.
+func TestCachedSnapshotCannotOutliveKeyExpiry(t *testing.T) {
+	cached, err := json.Marshal(pastExpiryActiveSnapshot())
+	if err != nil {
+		t.Fatalf("marshal snapshot: %v", err)
+	}
+
+	// Same key derivation as Client.Resolve: sha256 of the raw token, wrapped
+	// in the Redis hash tag.
+	const rawToken = "hk_cached_expired"
+	store := &fakeSnapshotStore{
+		values: map[string]string{
+			"auth:key:{" + HashBearerToken("Bearer "+rawToken) + "}": string(cached),
+		},
+	}
+
+	client := &Client{cache: store, baseURL: "http://control-plane.invalid"}
+
+	_, _, authErr := NewAuthorizer(client, nil).
+		Authorize(context.Background(), "Bearer "+rawToken, "hive-default", 50, 100, 20)
+
+	assertExpiredDenial(t, authErr)
+
+	if len(store.getKeys) == 0 {
+		t.Fatal("cache was never read, so this test did not exercise the cached path")
+	}
+}


### PR DESCRIPTION
## Answer to issue #915

**An expired-but-not-revoked key does not authorize. A revoked key does not authorize.** The premise of #915 is wrong on one specific point, and that is worth stating plainly because it is the whole reason the gap looked real: of the seven `applyExpiry` call sites listed in the issue, **line 365 is not an account-surface read**. It sits inside `ResolveSnapshot`, which is the resolver the issue said it could not find.

### The path, end to end

A `Bearer hk_*` credential arrives at edge-api and is routed to the API-key path by `auth.Selector` (`apps/edge-api/internal/auth/selector.go:25`), which only chooses a handler and validates nothing. Every hk_ surface (inference, RAG, files, batches, images, audio) reaches the same entry point: `authz.Authorizer.Authorize` (`apps/edge-api/internal/authz/authorizer.go:112`). That hashes the raw token with SHA-256 (`client.go:223`), reads `auth:key:{hash}` from Redis, and on a miss POSTs the hash to control-plane's `/internal/apikeys/resolve`, which is authenticated by edge-api's own internal token and never by the customer's key.

Control-plane answers from `apikeys.Service.ResolveSnapshot` (`apps/control-plane/internal/apikeys/service.go:359`). The row is fetched by token hash with no status predicate in the SQL (`repository.go:525`), so an expired, disabled or revoked key is found rather than 404ing, and the verdict is carried in the snapshot instead. Then the snapshot is denied on either of two independent predicates.

### The deciding lines

| Question | Verdict | Deciding line |
| --- | --- | --- |
| Does an expired-but-not-revoked key authorize? | **No** | `apps/control-plane/internal/apikeys/service.go:365` derives `status: "expired"`, denied at `apps/edge-api/internal/authz/authz.go:146`. Independently, `apps/edge-api/internal/authz/authz.go:155` re-parses `expires_at` against the current time and denies regardless of the status it was handed. |
| Does a revoked key authorize? | **No** | `apps/edge-api/internal/authz/authz.go:146`. `RevokeKey` writes `status = 'revoked'` durably (`service.go:230` onward), the resolver projects it verbatim, and `CheckAccess` denies anything that is not exactly `active`. Already pinned by `TestCheckAccessRevokedKey` and `TestAuthorizeLogsDeniedReasonForRevokedKey`. |
| Is expiry enforcement missing, or deliberate and elsewhere? | **Deliberate, in two places** | Not missing. `applyExpiry` is called inside the resolver itself, and edge-api re-derives the same rule from the raw timestamp. Neither layer depends on the durable `status` column ever being rewritten. |

### Can a cached resolution outlive an expiry or a revocation?

Expiry, no. `CheckAccess` step 2 (`authz.go:155`) compares `expires_at` to `time.Now()` on every request, so a snapshot cached while the key was live is still refused the moment the key expires.

Revocation, bounded. A revoked key has no `expires_at` to catch it, so it relies on the cache being cleared. Control-plane DELETEs `auth:key:{hash}` on revoke, disable, enable, rotate, and policy or limit updates, and `snapshotTTL` (`apps/edge-api/internal/authz/client.go:101`, 60s) is the deliberate backstop if that DELETE is missed. Documented in that comment and in issue #113. Not changed here.

## What this PR adds

Both layers already had a unit test. Neither pinned the **composition**, and the composition is exactly what the incident exercised: a durable `status` column still reading `active` while `expires_at` had passed. That is also what a cached snapshot looks like for the rest of its TTL after the key expires.

Two tests at `Authorizer.Authorize`, the entry point that actually decides:

- `TestAuthorizeDeniesExpiredKeyWhoseStoredStatusIsStillActive` drives the resolver result in the incident shape.
- `TestCachedSnapshotCannotOutliveKeyExpiry` drives a cached snapshot through the real cache path with an unroutable control-plane URL, so a cache miss would surface as `upstream_unavailable` and fail the assertion rather than passing for the wrong reason.

Both assert the specific deny message, not just the `invalid_api_key` code, so no other denial branch can satisfy them.

## Verification

Both tests were confirmed able to go red, not merely observed green:

- Disabling the edge check (`authz.go:155`): both new tests fail with `expired key was authorized: Authorize returned no error`.
- Disabling `applyExpiry` (`service.go:621`): the existing control-plane tests fail with `expected expired snapshot status, got active`.
- Restored, full suite green: `go test ./apps/edge-api/internal/authz/... ./apps/control-plane/internal/apikeys/... -count=1 -short`, plus `go vet` and `gofmt` clean on the new file.

## Behaviour change

**None, and none proposed.** The gap #915 suspected does not exist, so there is nothing to turn on and no live integration at risk. If the owner wants the durable `status` column reconciled to `expired` by a job, that is a separate cosmetic change with no authorization effect, and it is the owner's call rather than mine.

## Known bound, not fixed here

`OWUI_SHIM_KEY` is compared as a static string in the OWUI unwrap middleware (`apps/edge-api/internal/auth/owui_unwrap.go`), so expiring or revoking that key does not by itself disable the unwrap path. This is not an authorization bypass: the unwrap swaps in a per-user Supabase JWT that is then validated normally, and the shim key's own health probe does check status. Flagged only so nobody treats revoking the shim key as a kill switch.

## Buglog entry

Not applicable. No bug was fixed: the investigation established that the suspected defect does not exist, and the diff is test-only.

Refs #915