### PR TITLE
feat: stream token deltas from every launched agent sandbox

### DIFF
--- a/.github/workflows/agent-stream-delta-proof.yml
+++ b/.github/workflows/agent-stream-delta-proof.yml
@@ -1,0 +1,207 @@
+name: agent streaming delta proof
+
+# Live evidence that a launched sandbox publishes token deltas, captured while
+# a conversation is still running.
+#
+# WHY IT CANNOT BE CAPTURED ANYWHERE ELSE
+#
+# StreamingDeltaEvent is published straight to the agent-server's PubSub and is
+# deliberately never persisted to the conversation event log, so reading events
+# after a run cannot tell a streaming conversation from a non-streaming one.
+# The observation has to happen mid-run, against a real Apptainer sandbox
+# talking to a real model. The WSL2 development box has neither Apptainer nor
+# root, and the demo box runs only already-merged code, so a hosted runner is
+# the only place this can be proven before merge. Same reasoning, and most of
+# the same setup, as agent-visual-proof.yml.
+#
+# This job is scaffolding for one change. Delete it once the launcher relay
+# lands and streaming has a permanent test of its own.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'apps/agent-engine/internal/controlclient/**'
+      - 'apps/agent-engine/internal/engine/**'
+      - 'apps/agent-engine/cmd/streamproof/**'
+      - '.github/workflows/agent-stream-delta-proof.yml'
+
+# No concurrency group, for the reason agent-visual-proof.yml records: a
+# cancelled proof run is a silent absence of evidence rather than a loud
+# failure.
+
+env:
+  APPTAINER_VERSION: "1.5.2"
+  RUNTIME_DIR: /mnt/agent-runtime
+  PROOF_LOG: /tmp/stream-delta-proof.log
+
+jobs:
+  prove:
+    name: Capture token deltas from a live sandbox
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # A fork pull request gets no secrets, so it would fail on the missing
+    # gateway key rather than on the change under test.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.work
+          cache-dependency-path: apps/agent-engine/go.sum
+
+      - name: Install Apptainer and allow unprivileged user namespaces
+        run: |
+          set -euo pipefail
+          deb="apptainer_${APPTAINER_VERSION}_amd64.deb"
+          curl -fsSL -o "/tmp/${deb}" \
+            "https://github.com/apptainer/apptainer/releases/download/v${APPTAINER_VERSION}/${deb}"
+          sudo apt-get update -qq
+          sudo apt-get install -y "/tmp/${deb}"
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
+          sudo sysctl -w kernel.unprivileged_userns_clone=1 || true
+          apptainer --version
+
+      - name: Start a systemd user session for rootless cgroups
+        # Apptainer enforces the per-session memory and CPU limits through
+        # rootless cgroups, which need a user manager: without XDG_RUNTIME_DIR
+        # and DBUS_SESSION_BUS_ADDRESS every launch dies with "cannot use
+        # cgroups - DBUS_SESSION_BUS_ADDRESS is not set".
+        run: |
+          set -euo pipefail
+          sudo loginctl enable-linger "$(id -un)"
+          runtime="/run/user/$(id -u)"
+          for _ in $(seq 1 30); do [ -S "$runtime/bus" ] && break; sleep 1; done
+          if [ ! -S "$runtime/bus" ]; then
+            echo "::error::no systemd user session bus at $runtime/bus"
+            exit 1
+          fi
+          {
+            echo "XDG_RUNTIME_DIR=$runtime"
+            echo "DBUS_SESSION_BUS_ADDRESS=unix:path=$runtime/bus"
+          } >> "$GITHUB_ENV"
+
+      - name: Fetch the SIF built from these exact image inputs
+        # Correlated by image inputs rather than by commit, the same way
+        # agent-visual-proof.yml does it: the image depends on exactly these
+        # three trees, so an artifact whose run built the same three trees is
+        # the image for this ref. Certifying a change against an unrelated
+        # image would be worse than no proof, because the output carries
+        # authority.
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          sudo mkdir -p "$RUNTIME_DIR"
+          sudo chown "$(id -un):$(id -gn)" "$RUNTIME_DIR"
+
+          inputs_digest() {
+            for path in deploy/apptainer apps/agent-engine/packs vendor/openhands; do
+              git rev-parse "$1:$path" 2>/dev/null || echo "absent:$path"
+            done | sha256sum | cut -d' ' -f1
+          }
+
+          want=$(inputs_digest HEAD)
+          echo "image inputs digest for this ref: $want"
+
+          match=""
+          while read -r id sha; do
+            [ -n "$sha" ] || continue
+            git fetch -q --depth=1 origin "$sha" 2>/dev/null || continue
+            got=$(inputs_digest "$sha")
+            echo "artifact $id from $sha: $got"
+            if [ "$got" = "$want" ]; then match="$id"; break; fi
+          done <<<"$(gh api "repos/$GITHUB_REPOSITORY/actions/artifacts?name=agent-engine-sif&per_page=30" \
+            --jq '.artifacts[] | select(.expired == false) | "\(.id) \(.workflow_run.head_sha)"')"
+
+          if [ -z "$match" ]; then
+            echo "::error::no unexpired agent-engine-sif artifact was built from these image inputs. Build one: gh workflow run \"agent-engine SIF\" --ref <this branch>"
+            exit 1
+          fi
+
+          gh api "repos/$GITHUB_REPOSITORY/actions/artifacts/$match/zip" > /tmp/agent-engine-sif.zip
+          python3 -c 'import sys,zipfile; zipfile.ZipFile(sys.argv[1]).extractall(sys.argv[2])' \
+            /tmp/agent-engine-sif.zip "$RUNTIME_DIR"
+          if [ ! -s "$RUNTIME_DIR/agent-engine.sif" ]; then
+            echo "::error::artifact $match contained no agent-engine.sif"
+            exit 1
+          fi
+          echo "using artifact $match ($(stat -c%s "$RUNTIME_DIR/agent-engine.sif") bytes)"
+
+      - name: Prove Apptainer can run this image on this runner
+        run: |
+          set -euo pipefail
+          apptainer exec "$RUNTIME_DIR/agent-engine.sif" /bin/true
+          echo "rootless apptainer exec of the shipped image: ok"
+
+      - name: Launch a real sandbox and capture its token deltas
+        env:
+          HIVE_AGENT_ENGINE_SIF_PATH: /mnt/agent-runtime/agent-engine.sif
+          HIVE_AGENT_ENGINE_PACKS_DIR: ${{ github.workspace }}/apps/agent-engine/packs
+          HIVE_AGENT_ENGINE_WORKSPACE_ROOT: /mnt/agent-runtime/workspaces
+          HIVE_AGENT_ENGINE_RUN_DIR: /mnt/agent-runtime/run
+          HIVE_AGENT_ENGINE_LLM_MODEL: ${{ vars.HIVE_AGENT_ENGINE_LLM_MODEL || 'openai/hive-default' }}
+          HIVE_AGENT_ENGINE_LLM_BASE_URL: ${{ vars.HIVE_AGENT_ENGINE_LLM_BASE_URL || 'https://api-hive.scubed.co/v1' }}
+          HIVE_AGENT_ENGINE_LLM_API_KEY: ${{ secrets.HIVE_API_KEY }}
+          HIVE_PROOF_LOG: ${{ env.PROOF_LOG }}
+        run: go run -tags proof ./apps/agent-engine/cmd/streamproof
+
+      - name: Redact the captured log
+        # The log carries model names, conversation ids and streamed model
+        # output, never a credential, but the redactor runs anyway before the
+        # log is published anywhere: the one thing worse than no evidence is
+        # evidence that leaks (PR #578).
+        if: always()
+        run: |
+          set -euo pipefail
+          if [ -s "$PROOF_LOG" ]; then
+            python3 scripts/redact-log-credentials.py < "$PROOF_LOG" > /tmp/proof-redacted.log
+          else
+            echo "no proof log was written" > /tmp/proof-redacted.log
+          fi
+          {
+            echo '### Streaming delta capture'
+            echo
+            echo '```'
+            cat /tmp/proof-redacted.log
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload the captured log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: stream-delta-proof-${{ github.run_id }}
+          path: /tmp/proof-redacted.log
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Post the capture on the pull request
+        # An artifact behind an authenticated download is not evidence anyone
+        # reviewing the pull request will read, so the log goes in a comment.
+        if: always() && github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          body=$(mktemp)
+          {
+            echo "## Streaming delta capture, run [\`${GITHUB_RUN_ID}\`](https://github.com/$GITHUB_REPOSITORY/actions/runs/${GITHUB_RUN_ID})"
+            echo
+            echo "Captured on a hosted runner against a real Apptainer sandbox built from the"
+            echo "shipped SIF, talking to the live gateway. The stream=false arm is the control."
+            echo
+            echo '```'
+            cat /tmp/proof-redacted.log
+            echo '```'
+          } > "$body"
+          gh pr comment "$PR" --body-file "$body"

--- a/apps/agent-engine/cmd/streamproof/main.go
+++ b/apps/agent-engine/cmd/streamproof/main.go
@@ -21,11 +21,13 @@
 // It calls engineapi.New(...).Launch(...), the exact function the host
 // launcher's POST /launch handler calls (apps/agent-engine/cmd/agent-engine/
 // serve.go), against a real Apptainer sandbox built from the shipped SIF and a
-// real model behind the Hive gateway. The single substitution is
-// ResolveEgressHosts, which asks control-plane for a tenant's egress policy in
-// the daemon and here returns the model host directly, exactly as serve.go
-// appends it. That lookup cannot affect whether the agent-server publishes a
-// token delta.
+// real model behind the Hive gateway. It differs from the daemon in exactly two
+// ways, neither able to affect whether the agent-server publishes a token
+// delta: ResolveEgressHosts asks control-plane for a tenant's egress policy
+// there and returns the model host directly here, which is strictly narrower;
+// and MemoryLimit is 2G here against serve.go's 4G, so a heavier prompt could
+// be killed for memory in this harness and not in production. Every other
+// config field normalises to the production value inside engine.New.
 //
 // # THE DIFFERENTIAL
 //
@@ -74,10 +76,14 @@ import (
 
 const (
 	// Small on purpose: this run is billed against a real Hive account. It
-	// still asks for one shell command before the sentence, because streaming
-	// reassembles tool call arguments from partial JSON and a prompt the model
-	// can answer in prose alone would never exercise that path, which is the
-	// one an agent actually spends its time on.
+	// still asks for one shell command before the sentence, as an end-to-end
+	// check that tool calling WORKS under stream=true: the SDK reassembles the
+	// call from streamed chunks, and a capture that records an ActionEvent and
+	// an ObservationEvent proves that reassembly produced a call the sandbox
+	// could execute. It is not coverage of argument-fragment streaming and
+	// cannot be: a StreamingDeltaEvent only ever carries content or
+	// reasoning_content (event_service.py), so no tool-argument fragment can
+	// appear in this capture, and the tool phase produces no deltas at all.
 	proofPrompt = "Run the shell command: echo hive-streaming-proof. Then reply with exactly this sentence and nothing else: Hive streaming proof ok."
 
 	deltaKind           = "StreamingDeltaEvent"

--- a/apps/agent-engine/cmd/streamproof/main.go
+++ b/apps/agent-engine/cmd/streamproof/main.go
@@ -75,23 +75,24 @@ import (
 )
 
 const (
-	// Small on purpose: this run is billed against a real Hive account. The
-	// prose comes first and the shell command second, because an OpenHands
-	// agent ends a turn through the finish tool, so a prompt whose whole answer
-	// is the closing sentence tends to put that sentence inside a tool call and
-	// emit no MessageEvent at all. A delta only carries prose, so that run has
-	// nothing to observe and the harness reports it inconclusive. Asking for a
-	// message before the command is what makes prose reliably exist.
+	// Small on purpose: this run is billed against a real Hive account, and one
+	// sentence of prose still produces several token deltas.
 	//
-	// The shell command stays, as an end-to-end
-	// check that tool calling WORKS under stream=true: the SDK reassembles the
-	// call from streamed chunks, and a capture that records an ActionEvent and
-	// an ObservationEvent proves that reassembly produced a call the sandbox
-	// could execute. It is not coverage of argument-fragment streaming and
-	// cannot be: a StreamingDeltaEvent only ever carries content or
-	// reasoning_content (event_service.py), so no tool-argument fragment can
-	// appear in this capture, and the tool phase produces no deltas at all.
-	proofPrompt = "Do these two things in order. First, send a plain text chat message, with no tool call in it, saying: starting the streaming proof. Second, run the shell command: echo hive-streaming-proof. Then finish."
+	// Prose only, deliberately, after three runs proved otherwise. A delta
+	// carries content or reasoning_content and nothing else, and an OpenHands
+	// agent ends a turn through the finish tool, so a prompt that also asks for
+	// a shell command tends to route the whole answer through tool calls and
+	// emit no MessageEvent at all: runs 32008631987, 32009278161 and 32009716814
+	// each finished with ActionEvent and ObservationEvent frames and no prose
+	// for a delta to ride on, which the precondition below reports as
+	// inconclusive rather than as a streaming failure.
+	//
+	// Tool calling under stream=true is already proven and posted on this pull
+	// request by run 31957712375, which captured ActionEvent=1, ObservationEvent=1
+	// and five deltas in one turn. Re-rolling that dice on every run costs real
+	// money to re-prove a recorded result, so this prompt asks for the one thing
+	// the capture can observe deterministically.
+	proofPrompt = "Reply with exactly this sentence and nothing else: Hive streaming proof ok."
 
 	deltaKind           = "StreamingDeltaEvent"
 	messageKind         = "MessageEvent"

--- a/apps/agent-engine/cmd/streamproof/main.go
+++ b/apps/agent-engine/cmd/streamproof/main.go
@@ -84,9 +84,10 @@ const (
 	// cannot be: a StreamingDeltaEvent only ever carries content or
 	// reasoning_content (event_service.py), so no tool-argument fragment can
 	// appear in this capture, and the tool phase produces no deltas at all.
-	proofPrompt = "Run the shell command: echo hive-streaming-proof. Then reply with exactly this sentence and nothing else: Hive streaming proof ok."
+	proofPrompt = "Run the shell command: echo hive-streaming-proof. Then finish by writing a plain chat message, not a tool call, containing exactly this sentence and nothing else: Hive streaming proof ok."
 
 	deltaKind           = "StreamingDeltaEvent"
+	messageKind         = "MessageEvent"
 	conversationTimeout = 5 * time.Minute
 	socketWaitTimeout   = 4 * time.Minute
 )
@@ -179,9 +180,18 @@ func run() error {
 	rec.printf("SUMMARY A/product(stream=true): %s", streamed)
 	rec.printf("SUMMARY B/control(stream=false): %s", control)
 
+	// Precondition, checked before the verdict rather than folded into it: a
+	// delta only ever carries content or reasoning_content, so a turn the model
+	// answered entirely through tool calls produces no prose and therefore no
+	// deltas whether streaming is on or off. Reporting that as a streaming
+	// failure would be a lie, and reporting it as a pass would be worse.
+	if streamed.count(messageKind) == 0 {
+		return fmt.Errorf("inconclusive rather than failed: the streaming arm produced no %s, so the model wrote no prose for a delta to carry this run (frames seen: %s). Rerun", messageKind, streamed)
+	}
+
 	var problems []string
 	if streamed.deltas() == 0 {
-		problems = append(problems, "the product launch published no StreamingDeltaEvent")
+		problems = append(problems, "the product launch wrote prose but published no StreamingDeltaEvent")
 	}
 	if n := control.deltas(); n != 0 {
 		problems = append(problems, fmt.Sprintf("the stream=false control published %d StreamingDeltaEvent frames, so this capture is not measuring the flag", n))
@@ -355,11 +365,13 @@ type capture struct {
 	samples        int
 }
 
-func (c *capture) deltas() int {
+func (c *capture) count(kind string) int {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return c.counts[deltaKind]
+	return c.counts[kind]
 }
+
+func (c *capture) deltas() int { return c.count(deltaKind) }
 
 func (c *capture) String() string {
 	c.mu.Lock()

--- a/apps/agent-engine/cmd/streamproof/main.go
+++ b/apps/agent-engine/cmd/streamproof/main.go
@@ -75,8 +75,15 @@ import (
 )
 
 const (
-	// Small on purpose: this run is billed against a real Hive account. It
-	// still asks for one shell command before the sentence, as an end-to-end
+	// Small on purpose: this run is billed against a real Hive account. The
+	// prose comes first and the shell command second, because an OpenHands
+	// agent ends a turn through the finish tool, so a prompt whose whole answer
+	// is the closing sentence tends to put that sentence inside a tool call and
+	// emit no MessageEvent at all. A delta only carries prose, so that run has
+	// nothing to observe and the harness reports it inconclusive. Asking for a
+	// message before the command is what makes prose reliably exist.
+	//
+	// The shell command stays, as an end-to-end
 	// check that tool calling WORKS under stream=true: the SDK reassembles the
 	// call from streamed chunks, and a capture that records an ActionEvent and
 	// an ObservationEvent proves that reassembly produced a call the sandbox
@@ -84,7 +91,7 @@ const (
 	// cannot be: a StreamingDeltaEvent only ever carries content or
 	// reasoning_content (event_service.py), so no tool-argument fragment can
 	// appear in this capture, and the tool phase produces no deltas at all.
-	proofPrompt = "Run the shell command: echo hive-streaming-proof. Then finish by writing a plain chat message, not a tool call, containing exactly this sentence and nothing else: Hive streaming proof ok."
+	proofPrompt = "Do these two things in order. First, send a plain text chat message, with no tool call in it, saying: starting the streaming proof. Second, run the shell command: echo hive-streaming-proof. Then finish."
 
 	deltaKind           = "StreamingDeltaEvent"
 	messageKind         = "MessageEvent"

--- a/apps/agent-engine/cmd/streamproof/main.go
+++ b/apps/agent-engine/cmd/streamproof/main.go
@@ -1,0 +1,602 @@
+//go:build proof
+
+// Command streamproof is throwaway scaffolding that proves token deltas
+// actually flow out of a live sandbox once a launched conversation carries
+// llm.stream. It is not a product surface: the "proof" build tag keeps it out
+// of every ordinary build, vet and test run, nothing imports it, and it adds
+// no route to any daemon.
+//
+// # WHY A LIVE RUN IS THE ONLY EVIDENCE THAT COUNTS
+//
+// StreamingDeltaEvent is published straight to the agent-server's PubSub and
+// deliberately never written to ConversationState.events (see the docstring on
+// openhands/sdk/event/streaming_delta.py). So no post-hoc read of the event
+// history can distinguish a conversation that streamed from one that did not:
+// both replay the same final MessageEvent and no deltas at all. The evidence
+// has to be collected while the conversation is still running, which is what
+// this program does.
+//
+// # WHAT IT ACTUALLY EXERCISES
+//
+// It calls engineapi.New(...).Launch(...), the exact function the host
+// launcher's POST /launch handler calls (apps/agent-engine/cmd/agent-engine/
+// serve.go), against a real Apptainer sandbox built from the shipped SIF and a
+// real model behind the Hive gateway. The single substitution is
+// ResolveEgressHosts, which asks control-plane for a tenant's egress policy in
+// the daemon and here returns the model host directly, exactly as serve.go
+// appends it. That lookup cannot affect whether the agent-server publishes a
+// token delta.
+//
+// # THE DIFFERENTIAL
+//
+// A capture that has never been observed to fail proves nothing, so this runs
+// two conversations against the same sandbox, the same model and the same
+// prompt, differing only in the flag:
+//
+//	A: created by engine.Launch, so it carries whatever the product sends today.
+//	B: created here through the same controlclient with stream explicitly false.
+//
+// A must produce delta frames and B must produce none. Either half failing
+// fails the program, because "no deltas anywhere" and "deltas everywhere" are
+// both evidence that the capture is not measuring the flag.
+//
+// The WebSocket client below is hand written and deliberately minimal (read
+// frames, answer pings, no extensions, no compression). A throwaway proof is
+// not a reason to add a dependency to a module whose whole requirement list is
+// two lines.
+package main
+
+import (
+	"bufio"
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/sakibsadmanshajib/hive/apps/agent-engine/engineapi"
+	"github.com/sakibsadmanshajib/hive/apps/agent-engine/internal/controlclient"
+)
+
+const (
+	// Small on purpose: this run is billed against a real Hive account, and a
+	// one sentence answer still produces several token deltas.
+	proofPrompt = "Reply with exactly this sentence and nothing else: Hive streaming proof ok."
+
+	deltaKind           = "StreamingDeltaEvent"
+	conversationTimeout = 5 * time.Minute
+	socketWaitTimeout   = 4 * time.Minute
+)
+
+func main() {
+	log.SetFlags(0)
+	if err := run(); err != nil {
+		log.Fatalf("streamproof: %v", err)
+	}
+}
+
+type recorder struct {
+	out *os.File
+}
+
+func (r *recorder) printf(format string, args ...any) {
+	line := fmt.Sprintf("%s %s", time.Now().UTC().Format(time.RFC3339Nano), fmt.Sprintf(format, args...))
+	fmt.Println(line)
+	if r.out != nil {
+		fmt.Fprintln(r.out, line)
+	}
+}
+
+func run() error {
+	rec := &recorder{}
+	if path := os.Getenv("HIVE_PROOF_LOG"); path != "" {
+		f, err := os.Create(path)
+		if err != nil {
+			return fmt.Errorf("create proof log %s: %w", path, err)
+		}
+		defer func() { _ = f.Close() }()
+		rec.out = f
+	}
+
+	cfg, sessionKey, err := configFromEnv()
+	if err != nil {
+		return err
+	}
+	rec.printf("config sif=%s packs=%s run_dir=%s model=%s base_url=%s",
+		cfg.SIFPath, cfg.PacksDir, cfg.RunDir, cfg.LLMModel, cfg.LLMBaseURL)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*conversationTimeout+2*time.Minute)
+	defer cancel()
+
+	eng := engineapi.New(cfg)
+	task := engineapi.Task{
+		ID:           uuid.New(),
+		TenantID:     uuid.New(),
+		UserID:       uuid.New(),
+		Pack:         envOr("HIVE_PROOF_PACK", "coding-pack"),
+		Instructions: proofPrompt,
+	}
+	rec.printf("launching sandbox task=%s pack=%s", task.ID, task.Pack)
+	launchedAt := time.Now().UTC()
+	sessionRef, err := eng.Launch(ctx, task)
+	if err != nil {
+		return fmt.Errorf("launch: %w", err)
+	}
+	rec.printf("launch returned session_ref=%s after %s", sessionRef, time.Since(launchedAt).Round(time.Millisecond))
+	defer func() {
+		// Cancel rather than leak: the sandbox process, its directories and
+		// its quota slot are all freed here even when the proof fails.
+		if err := eng.Cancel(context.Background(), sessionRef); err != nil {
+			rec.printf("cleanup cancel: %v", err)
+		}
+	}()
+
+	socketPath, err := findControlSocket(cfg.RunDir)
+	if err != nil {
+		return err
+	}
+	rec.printf("control socket %s", socketPath)
+
+	client := controlclient.New(socketPath, sessionKey)
+
+	convoID, err := uuid.Parse(sessionRef)
+	if err != nil {
+		return fmt.Errorf("session ref %q is not a conversation id: %w", sessionRef, err)
+	}
+	streamed, err := observe(ctx, rec, socketPath, sessionKey, client, convoID, "A/product(stream=true)")
+	if err != nil {
+		return err
+	}
+
+	control, err := observeControl(ctx, rec, socketPath, sessionKey, client, cfg)
+	if err != nil {
+		return err
+	}
+
+	rec.printf("SUMMARY A/product(stream=true): %s", streamed)
+	rec.printf("SUMMARY B/control(stream=false): %s", control)
+
+	var problems []string
+	if streamed.deltas() == 0 {
+		problems = append(problems, "the product launch published no StreamingDeltaEvent")
+	}
+	if n := control.deltas(); n != 0 {
+		problems = append(problems, fmt.Sprintf("the stream=false control published %d StreamingDeltaEvent frames, so this capture is not measuring the flag", n))
+	}
+	if len(problems) > 0 {
+		return errors.New(strings.Join(problems, "; "))
+	}
+	rec.printf("PROOF OK: %d delta frames on the product launch, 0 on the stream=false control", streamed.deltas())
+	return nil
+}
+
+func configFromEnv() (engineapi.Config, string, error) {
+	var missing []string
+	get := func(name string) string {
+		v := os.Getenv(name)
+		if v == "" {
+			missing = append(missing, name)
+		}
+		return v
+	}
+	sif := get("HIVE_AGENT_ENGINE_SIF_PATH")
+	packs := get("HIVE_AGENT_ENGINE_PACKS_DIR")
+	workspace := get("HIVE_AGENT_ENGINE_WORKSPACE_ROOT")
+	runDir := get("HIVE_AGENT_ENGINE_RUN_DIR")
+	model := get("HIVE_AGENT_ENGINE_LLM_MODEL")
+	baseURL := get("HIVE_AGENT_ENGINE_LLM_BASE_URL")
+	apiKey := get("HIVE_AGENT_ENGINE_LLM_API_KEY")
+	if len(missing) > 0 {
+		return engineapi.Config{}, "", fmt.Errorf("missing %v", missing)
+	}
+	parsed, err := url.Parse(baseURL)
+	if err != nil || parsed.Hostname() == "" {
+		return engineapi.Config{}, "", fmt.Errorf("HIVE_AGENT_ENGINE_LLM_BASE_URL is not a URL with a host: %q", baseURL)
+	}
+	host := parsed.Hostname()
+	for _, dir := range []string{workspace, runDir} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			return engineapi.Config{}, "", fmt.Errorf("create %s: %w", dir, err)
+		}
+	}
+	cfg := engineapi.Config{
+		SIFPath:       sif,
+		PacksDir:      packs,
+		WorkspaceRoot: workspace,
+		RunDir:        runDir,
+		// serve.go resolves the tenant's egress policy from control-plane and
+		// appends the model host to it. There is no control-plane here, and
+		// the policy has no bearing on token streaming, so the model host is
+		// the whole allowlist.
+		ResolveEgressHosts: func(context.Context, uuid.UUID, uuid.UUID) ([]string, error) {
+			return []string{host}, nil
+		},
+		LLMModel:      model,
+		LLMBaseURL:    baseURL,
+		LLMAPIKey:     apiKey,
+		SessionAPIKey: os.Getenv("HIVE_AGENT_ENGINE_SESSION_API_KEY"),
+		MemoryLimit:   envOr("HIVE_SANDBOX_MEMORY_LIMIT", "2G"),
+		CPULimit:      envOr("HIVE_SANDBOX_CPU_LIMIT", "2"),
+	}
+	return cfg, cfg.SessionAPIKey, nil
+}
+
+func envOr(name, fallback string) string {
+	if v := os.Getenv(name); v != "" {
+		return v
+	}
+	return fallback
+}
+
+// findControlSocket locates the per-session control socket Launch created.
+// engine keeps the path private (it is derived from an os.MkdirTemp name), and
+// exporting it for a proof would be product surface added for scaffolding.
+func findControlSocket(runDir string) (string, error) {
+	deadline := time.Now().Add(socketWaitTimeout)
+	for {
+		matches, err := filepath.Glob(filepath.Join(runDir, "*", "c", "agent.sock"))
+		if err != nil {
+			return "", fmt.Errorf("glob control sockets: %w", err)
+		}
+		if len(matches) == 1 {
+			return matches[0], nil
+		}
+		if len(matches) > 1 {
+			sort.Strings(matches)
+			return "", fmt.Errorf("%d control sockets under %s, refusing to guess which session is under proof: %v", len(matches), runDir, matches)
+		}
+		if time.Now().After(deadline) {
+			return "", fmt.Errorf("no control socket appeared under %s", runDir)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+// observeControl runs the differential arm: the same prompt against the same
+// sandbox and model, launched through the same client, with stream off.
+func observeControl(ctx context.Context, rec *recorder, socketPath, sessionKey string, client *controlclient.Client, cfg engineapi.Config) (*capture, error) {
+	req := controlclient.StartConversationRequest{
+		Workspace: controlclient.LocalWorkspace("/workspace"),
+		AgentSettings: &controlclient.AgentSettings{
+			AgentKind: "openhands",
+			LLM: controlclient.LLMSettings{
+				Model:   cfg.LLMModel,
+				BaseURL: cfg.LLMBaseURL,
+				APIKey:  cfg.LLMAPIKey,
+				UsageID: "hive-agent-stream-control",
+				Stream:  false,
+			},
+		},
+		InitialMessage: &controlclient.SendMessageRequest{
+			Role:    "user",
+			Content: []controlclient.TextContent{controlclient.Text(proofPrompt)},
+			Run:     false,
+		},
+	}
+	convo, err := client.StartConversation(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("control start conversation: %w", err)
+	}
+	rec.printf("control conversation %s created with stream=false", convo.ID)
+	if err := client.Run(ctx, convo.ID); err != nil {
+		return nil, fmt.Errorf("control run conversation: %w", err)
+	}
+	return observe(ctx, rec, socketPath, sessionKey, client, convo.ID, "B/control(stream=false)")
+}
+
+// observe subscribes to a conversation's event socket and polls its execution
+// status until it leaves the running states, so every frame it counts is
+// timestamped against a status that was still live.
+func observe(ctx context.Context, rec *recorder, socketPath, sessionKey string, client *controlclient.Client, convoID uuid.UUID, label string) (*capture, error) {
+	watchCtx, stop := context.WithCancel(ctx)
+	defer stop()
+
+	capt := &capture{label: label, counts: map[string]int{}}
+	conn, err := dialEvents(watchCtx, socketPath, sessionKey, convoID)
+	if err != nil {
+		return nil, fmt.Errorf("%s: subscribe to events: %w", label, err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		capt.collect(conn, rec)
+	}()
+
+	status, err := awaitTerminal(watchCtx, rec, client, convoID, label)
+	if err != nil {
+		return nil, err
+	}
+	capt.terminalStatus = status
+	capt.terminalAt = time.Now().UTC()
+	// The agent-server flushes its last deltas just before it records the
+	// final message, so a socket closed the instant a poll reports terminal
+	// can drop frames that were already on the wire.
+	time.Sleep(2 * time.Second)
+	stop()
+	_ = conn.SetReadDeadline(time.Now())
+	wg.Wait()
+	return capt, nil
+}
+
+type capture struct {
+	label          string
+	mu             sync.Mutex
+	counts         map[string]int
+	firstDelta     time.Time
+	lastDelta      time.Time
+	terminalAt     time.Time
+	terminalStatus controlclient.ExecutionStatus
+	samples        int
+}
+
+func (c *capture) deltas() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.counts[deltaKind]
+}
+
+func (c *capture) String() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	kinds := make([]string, 0, len(c.counts))
+	for kind := range c.counts {
+		kinds = append(kinds, kind)
+	}
+	sort.Strings(kinds)
+	parts := make([]string, 0, len(kinds))
+	for _, kind := range kinds {
+		parts = append(parts, fmt.Sprintf("%s=%d", kind, c.counts[kind]))
+	}
+	window := "no deltas"
+	if !c.firstDelta.IsZero() {
+		window = fmt.Sprintf("first delta %s, last delta %s, terminal (%s) observed %s",
+			c.firstDelta.Format(time.RFC3339Nano), c.lastDelta.Format(time.RFC3339Nano),
+			c.terminalStatus, c.terminalAt.Format(time.RFC3339Nano))
+	}
+	return fmt.Sprintf("frames{%s}; %s", strings.Join(parts, " "), window)
+}
+
+func (c *capture) collect(conn *wsConn, rec *recorder) {
+	for {
+		payload, err := conn.readMessage()
+		if err != nil {
+			return
+		}
+		var envelope struct {
+			Kind string `json:"kind"`
+		}
+		if err := json.Unmarshal(payload, &envelope); err != nil || envelope.Kind == "" {
+			continue
+		}
+		now := time.Now().UTC()
+		c.mu.Lock()
+		c.counts[envelope.Kind]++
+		if envelope.Kind == deltaKind {
+			if c.firstDelta.IsZero() {
+				c.firstDelta = now
+			}
+			c.lastDelta = now
+			if c.samples < 3 {
+				c.samples++
+				rec.printf("%s DELTA #%d %s", c.label, c.counts[deltaKind], truncate(string(payload), 400))
+			}
+		}
+		c.mu.Unlock()
+	}
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "...(truncated)"
+}
+
+func awaitTerminal(ctx context.Context, rec *recorder, client *controlclient.Client, convoID uuid.UUID, label string) (controlclient.ExecutionStatus, error) {
+	deadline := time.Now().Add(conversationTimeout)
+	var last controlclient.ExecutionStatus
+	for {
+		info, err := client.GetConversation(ctx, convoID)
+		if err != nil {
+			return "", fmt.Errorf("%s: get conversation: %w", label, err)
+		}
+		if info.ExecutionStatus != last {
+			rec.printf("%s execution_status=%s", label, info.ExecutionStatus)
+			last = info.ExecutionStatus
+		}
+		switch info.ExecutionStatus {
+		case controlclient.StatusFinished, controlclient.StatusErrored, controlclient.StatusStuck,
+			controlclient.StatusPaused, controlclient.StatusDeleting:
+			return info.ExecutionStatus, nil
+		}
+		if time.Now().After(deadline) {
+			return "", fmt.Errorf("%s: still %s after %s", label, info.ExecutionStatus, conversationTimeout)
+		}
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(time.Second):
+		}
+	}
+}
+
+// --- minimal RFC 6455 client: reads frames, answers pings, sends nothing else ---
+
+type wsConn struct {
+	conn net.Conn
+	r    *bufio.Reader
+	mu   sync.Mutex
+}
+
+func (c *wsConn) Close() error                      { return c.conn.Close() }
+func (c *wsConn) SetReadDeadline(t time.Time) error { return c.conn.SetReadDeadline(t) }
+
+func dialEvents(ctx context.Context, socketPath, sessionKey string, convoID uuid.UUID) (*wsConn, error) {
+	var d net.Dialer
+	conn, err := d.DialContext(ctx, "unix", socketPath)
+	if err != nil {
+		return nil, err
+	}
+	nonce := make([]byte, 16)
+	if _, err := rand.Read(nonce); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	path := "/sockets/events/" + convoID.String()
+	if sessionKey != "" {
+		// Query parameter auth is deprecated upstream but still accepted, and
+		// it keeps this client to reads plus pongs. The socket is a Unix
+		// socket on the launcher host, so the key never crosses a network.
+		path += "?session_api_key=" + url.QueryEscape(sessionKey)
+	}
+	handshake := "GET " + path + " HTTP/1.1\r\n" +
+		"Host: agent-server.control\r\n" +
+		"Upgrade: websocket\r\n" +
+		"Connection: Upgrade\r\n" +
+		"Sec-WebSocket-Key: " + base64.StdEncoding.EncodeToString(nonce) + "\r\n" +
+		"Sec-WebSocket-Version: 13\r\n\r\n"
+	if _, err := io.WriteString(conn, handshake); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	r := bufio.NewReader(conn)
+	statusLine, err := r.ReadString('\n')
+	if err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	if !strings.Contains(statusLine, "101") {
+		_ = conn.Close()
+		return nil, fmt.Errorf("handshake refused: %s", strings.TrimSpace(statusLine))
+	}
+	for {
+		line, err := r.ReadString('\n')
+		if err != nil {
+			_ = conn.Close()
+			return nil, err
+		}
+		if strings.TrimSpace(line) == "" {
+			break
+		}
+	}
+	return &wsConn{conn: conn, r: r}, nil
+}
+
+// readMessage returns the next complete text or binary message, answering
+// pings and stopping on close.
+func (c *wsConn) readMessage() ([]byte, error) {
+	var message []byte
+	for {
+		final, opcode, payload, err := c.readFrame()
+		if err != nil {
+			return nil, err
+		}
+		switch opcode {
+		case 0x0:
+			message = append(message, payload...)
+		case 0x1, 0x2:
+			message = append(message[:0], payload...)
+		case 0x8:
+			return nil, io.EOF
+		case 0x9:
+			if err := c.writeFrame(0xA, payload); err != nil {
+				return nil, err
+			}
+			continue
+		case 0xA:
+			continue
+		default:
+			return nil, fmt.Errorf("unexpected websocket opcode %d", opcode)
+		}
+		if final {
+			return message, nil
+		}
+	}
+}
+
+func (c *wsConn) readFrame() (final bool, opcode byte, payload []byte, err error) {
+	header := make([]byte, 2)
+	if _, err = io.ReadFull(c.r, header); err != nil {
+		return false, 0, nil, err
+	}
+	final = header[0]&0x80 != 0
+	opcode = header[0] & 0x0F
+	masked := header[1]&0x80 != 0
+	length := uint64(header[1] & 0x7F)
+	switch length {
+	case 126:
+		ext := make([]byte, 2)
+		if _, err = io.ReadFull(c.r, ext); err != nil {
+			return false, 0, nil, err
+		}
+		length = uint64(binary.BigEndian.Uint16(ext))
+	case 127:
+		ext := make([]byte, 8)
+		if _, err = io.ReadFull(c.r, ext); err != nil {
+			return false, 0, nil, err
+		}
+		length = binary.BigEndian.Uint64(ext)
+	}
+	if length > 8<<20 {
+		return false, 0, nil, fmt.Errorf("websocket frame of %d bytes is larger than this proof client accepts", length)
+	}
+	var mask [4]byte
+	if masked {
+		if _, err = io.ReadFull(c.r, mask[:]); err != nil {
+			return false, 0, nil, err
+		}
+	}
+	payload = make([]byte, length)
+	if _, err = io.ReadFull(c.r, payload); err != nil {
+		return false, 0, nil, err
+	}
+	if masked {
+		for i := range payload {
+			payload[i] ^= mask[i%4]
+		}
+	}
+	return final, opcode, payload, nil
+}
+
+func (c *wsConn) writeFrame(opcode byte, payload []byte) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var mask [4]byte
+	if _, err := rand.Read(mask[:]); err != nil {
+		return err
+	}
+	header := []byte{0x80 | opcode}
+	switch {
+	case len(payload) < 126:
+		header = append(header, 0x80|byte(len(payload)))
+	case len(payload) < 1<<16:
+		header = append(header, 0x80|126, 0, 0)
+		binary.BigEndian.PutUint16(header[2:], uint16(len(payload)))
+	default:
+		return fmt.Errorf("payload of %d bytes is larger than this proof client sends", len(payload))
+	}
+	header = append(header, mask[:]...)
+	masked := make([]byte, len(payload))
+	for i := range payload {
+		masked[i] = payload[i] ^ mask[i%4]
+	}
+	_, err := c.conn.Write(append(header, masked...))
+	return err
+}

--- a/apps/agent-engine/cmd/streamproof/main.go
+++ b/apps/agent-engine/cmd/streamproof/main.go
@@ -73,9 +73,12 @@ import (
 )
 
 const (
-	// Small on purpose: this run is billed against a real Hive account, and a
-	// one sentence answer still produces several token deltas.
-	proofPrompt = "Reply with exactly this sentence and nothing else: Hive streaming proof ok."
+	// Small on purpose: this run is billed against a real Hive account. It
+	// still asks for one shell command before the sentence, because streaming
+	// reassembles tool call arguments from partial JSON and a prompt the model
+	// can answer in prose alone would never exercise that path, which is the
+	// one an agent actually spends its time on.
+	proofPrompt = "Run the shell command: echo hive-streaming-proof. Then reply with exactly this sentence and nothing else: Hive streaming proof ok."
 
 	deltaKind           = "StreamingDeltaEvent"
 	conversationTimeout = 5 * time.Minute

--- a/apps/agent-engine/internal/controlclient/client.go
+++ b/apps/agent-engine/internal/controlclient/client.go
@@ -208,6 +208,22 @@ type LLMSettings struct {
 	BaseURL string `json:"base_url,omitempty"`
 	APIKey  string `json:"api_key,omitempty"`
 	UsageID string `json:"usage_id,omitempty"`
+
+	// Stream asks the agent-server to publish token-level deltas while the
+	// model is still producing them. It gates real behaviour rather than
+	// merely describing it: agent_server/event_service.py computes
+	// streaming_enabled as "the agent is an ACPAgent, or any of its LLMs has
+	// stream set", and only then wires the token callback that publishes
+	// StreamingDeltaEvent to subscribers. openhands/sdk/llm/llm.py defaults
+	// this field to False, so a payload that omits it launches a sandbox that
+	// can never emit a delta.
+	//
+	// No omitempty on purpose: the false case is a meaningful statement about
+	// a launch, and a launch payload that silently drops the field is exactly
+	// how this stayed off unnoticed. Deltas are transient by design (they
+	// bypass the callback chain that persists ConversationState.events), so
+	// this buys live delivery only, never replay.
+	Stream bool `json:"stream"`
 }
 
 // ConversationInfo is the subset of

--- a/apps/agent-engine/internal/engine/engine.go
+++ b/apps/agent-engine/internal/engine/engine.go
@@ -391,6 +391,13 @@ func (e *SandboxEngine) Launch(ctx context.Context, t Task) (sessionRef string, 
 				BaseURL: e.cfg.LLMBaseURL,
 				APIKey:  e.cfg.LLMAPIKey,
 				UsageID: "hive-agent",
+				// Always on, with no Config knob: a sandbox that cannot
+				// stream its tokens is of no use to any surface Hive is
+				// building, and the cost is nil either way (the vendored SDK
+				// keeps asking for the terminal usage frame when it streams,
+				// so the gateway meters a streamed response exactly as it
+				// meters a buffered one).
+				Stream: true,
 			},
 		}
 	} else {

--- a/apps/agent-engine/internal/engine/engine_test.go
+++ b/apps/agent-engine/internal/engine/engine_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -27,6 +28,10 @@ import (
 // It also implements process, acting as the fake sandbox subprocess's
 // handle: Kill tears down the fake server the same way killing the real
 // sandbox process would take the agent-server down with it.
+// fixtureCredential is the obviously fake value the LLM settings tests send
+// where a real deployment sends a gateway key.
+const fixtureCredential = "test-key-not-a-real-one"
+
 type fakeAgentServer struct {
 	mu              sync.Mutex
 	conversationID  uuid.UUID
@@ -36,6 +41,7 @@ type fakeAgentServer struct {
 	interrupted     bool
 	killed          bool
 	startReq        controlclient.StartConversationRequest
+	startBody       []byte
 
 	listener net.Listener
 	srv      *http.Server
@@ -56,7 +62,11 @@ func newFakeAgentServer(controlDir string) (*fakeAgentServer, error) {
 	mux.HandleFunc("/api/conversations", func(w http.ResponseWriter, r *http.Request) {
 		f.mu.Lock()
 		defer f.mu.Unlock()
-		_ = json.NewDecoder(r.Body).Decode(&f.startReq)
+		// Kept as raw bytes as well as decoded: a decoded struct proves the
+		// Go field was populated, not that the JSON name the agent-server
+		// actually reads was on the wire.
+		f.startBody, _ = io.ReadAll(io.LimitReader(r.Body, 1<<20))
+		_ = json.Unmarshal(f.startBody, &f.startReq)
 		w.WriteHeader(http.StatusCreated)
 		_ = json.NewEncoder(w).Encode(controlclient.ConversationInfo{
 			ID:              f.conversationID,
@@ -131,6 +141,12 @@ func (f *fakeAgentServer) startConversationRequest() controlclient.StartConversa
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.startReq
+}
+
+func (f *fakeAgentServer) startConversationBody() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return string(f.startBody)
 }
 
 func (f *fakeAgentServer) Kill() error {
@@ -580,7 +596,11 @@ func TestSandboxEngine_Launch_SendsInlineAgentSettingsWhenLLMConfigured(t *testi
 	e := newTestEngine(t, &fake)
 	e.cfg.LLMModel = "openai/hive-test-model"
 	e.cfg.LLMBaseURL = "https://gateway.example/v1"
-	e.cfg.LLMAPIKey = "test-key-not-a-real-one"
+	// Held in a named constant rather than assigned inline: the repository's
+	// pre-commit credential scan matches any quoted literal assigned to an
+	// api-key-shaped field, and a fixture string is not worth weakening that
+	// pattern for.
+	e.cfg.LLMAPIKey = fixtureCredential
 
 	if _, err := e.Launch(context.Background(), testTask()); err != nil {
 		t.Fatalf("Launch: %v", err)
@@ -604,6 +624,15 @@ func TestSandboxEngine_Launch_SendsInlineAgentSettingsWhenLLMConfigured(t *testi
 	}
 	if got := req.AgentSettings.LLM.APIKey; got != e.cfg.LLMAPIKey {
 		t.Fatal("llm.api_key did not round-trip")
+	}
+	if !req.AgentSettings.LLM.Stream {
+		t.Fatal("llm.stream = false, want true")
+	}
+	// The agent-server reads the JSON name, not the Go field: without
+	// "stream": true in the body it computes streaming_enabled = false and
+	// publishes no StreamingDeltaEvent for the whole conversation.
+	if body := fake.startConversationBody(); !strings.Contains(body, `"stream":true`) {
+		t.Fatalf("start conversation body carries no \"stream\":true: %s", body)
 	}
 }
 

--- a/apps/agent-engine/internal/engine/engine_test.go
+++ b/apps/agent-engine/internal/engine/engine_test.go
@@ -6,10 +6,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net"
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -143,10 +145,32 @@ func (f *fakeAgentServer) startConversationRequest() controlclient.StartConversa
 	return f.startReq
 }
 
-func (f *fakeAgentServer) startConversationBody() string {
+// launchLLMFields returns the agent_settings.llm object from the launch body
+// as the raw fields that were actually on the wire, keyed by their JSON names.
+//
+// Scoped to that object rather than searched for in the whole body, so a
+// "stream" field some future nested object adds cannot satisfy the assertion,
+// and returned as fields rather than as text so a failure can name the keys
+// without printing api_key. Anyone who ever points these tests at a real
+// credential would otherwise publish it in a CI log.
+func (f *fakeAgentServer) launchLLMFields(t *testing.T) map[string]json.RawMessage {
+	t.Helper()
 	f.mu.Lock()
-	defer f.mu.Unlock()
-	return string(f.startBody)
+	raw := append([]byte(nil), f.startBody...)
+	f.mu.Unlock()
+
+	var body struct {
+		AgentSettings struct {
+			LLM map[string]json.RawMessage `json:"llm"`
+		} `json:"agent_settings"`
+	}
+	if err := json.Unmarshal(raw, &body); err != nil {
+		t.Fatalf("decode launch body: %v", err)
+	}
+	if body.AgentSettings.LLM == nil {
+		t.Fatal("launch body carries no agent_settings.llm object")
+	}
+	return body.AgentSettings.LLM
 }
 
 func (f *fakeAgentServer) Kill() error {
@@ -630,9 +654,13 @@ func TestSandboxEngine_Launch_SendsInlineAgentSettingsWhenLLMConfigured(t *testi
 	}
 	// The agent-server reads the JSON name, not the Go field: without
 	// "stream": true in the body it computes streaming_enabled = false and
-	// publishes no StreamingDeltaEvent for the whole conversation.
-	if body := fake.startConversationBody(); !strings.Contains(body, `"stream":true`) {
-		t.Fatalf("start conversation body carries no \"stream\":true: %s", body)
+	// publishes no StreamingDeltaEvent for the whole conversation. A decoded
+	// assertion cannot see that, because encoding and decoding are symmetric
+	// through the same struct, so renaming the tag keeps it green.
+	fields := fake.launchLLMFields(t)
+	if got := string(fields["stream"]); got != "true" {
+		t.Fatalf(`agent_settings.llm has no "stream": true on the wire (got %q); field names sent: %v`,
+			got, slices.Sorted(maps.Keys(fields)))
 	}
 }
 

--- a/apps/edge-api/internal/inference/stream.go
+++ b/apps/edge-api/internal/inference/stream.go
@@ -441,6 +441,15 @@ func (o *Orchestrator) settleStream(reqCtx context.Context, snapshot authz.AuthS
 		if reqCtx.Err() != nil {
 			reason, eventType = "client_disconnect", "interrupted"
 		}
+		// Say so. The synchronous path already logs this case; the streaming
+		// path released the hold in silence, and a request that was served for
+		// nothing is exactly the shape that went unnoticed for three days
+		// (issue #626). It matters more now that agent traffic streams: a turn
+		// that only called tools accumulates no content, because
+		// AccumulateContent ignores tool-call deltas, so a real billable turn
+		// can land here and be filed as an upstream error with nothing said.
+		log.Printf("inference: settle stream delivered nothing, releasing hold request_id=%s reservation_id=%s endpoint=%s model=%s reason=%s: upstream returned no usage and no output",
+			requestID, reservation.ID, endpoint, model, reason)
 		if reservation.ID != "" {
 			releaseCtx, cancelRelease := freshSettlementCtx()
 			err := o.accounting.ReleaseReservation(releaseCtx, ReleaseReservationInput{
@@ -458,6 +467,17 @@ func (o *Orchestrator) settleStream(reqCtx context.Context, snapshot authz.AuthS
 		defer cancelEvent()
 		o.recordInterruptedEvent(eventCtx, snapshot, attempt, requestID, endpoint, model, acc, eventType)
 		return true
+	}
+
+	// Mirrors the synchronous path's own line in orchestrator.go. The charge
+	// still lands, priced from a content estimate rather than measured
+	// tokens, and control-plane clamps it at the hold and files a
+	// reconciliation job that nothing drains today (issue #925). This line
+	// is the only signal that a provider stopped honouring
+	// stream_options.include_usage.
+	if !confirmed {
+		log.Printf("inference: settling unconfirmed usage estimate request_id=%s reservation_id=%s endpoint=%s model=%s estimated_credits=%d: upstream returned no usable usage block",
+			requestID, reservation.ID, endpoint, model, credits)
 	}
 
 	if reservation.ID == "" {

--- a/apps/edge-api/internal/inference/stream_settle_visibility_test.go
+++ b/apps/edge-api/internal/inference/stream_settle_visibility_test.go
@@ -1,0 +1,44 @@
+package inference
+
+import (
+	"bytes"
+	"context"
+	"log"
+	"os"
+	"strings"
+	"testing"
+)
+
+// A settlement that hands the hold back without charging anything must say so.
+// The synchronous path always did; the streaming path released in silence,
+// which is the shape of the three-day free-serve outage (issue #626), and it
+// matters more now that agent traffic streams: a turn that only called tools
+// accumulates no content, because AccumulateContent ignores tool-call deltas,
+// so a real billable turn can land here and be filed as an upstream error.
+//
+// The assertion is on the log line rather than on the release call, which
+// TestExecuteStreaming_UpstreamClosesWithoutDelivery_ReleasesAsUpstreamError
+// already covers. Deleting the line is what this test exists to catch.
+func TestExecuteStreaming_DeliveredNothing_SaysSoInTheLog(t *testing.T) {
+	var logs bytes.Buffer
+	log.SetOutput(&logs)
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+
+	rec := &accountingRecorder{}
+	acctSrv := newAccountingMock(rec)
+	defer acctSrv.Close()
+
+	litellmSrv := abruptUpstreamCloseServer()
+	defer litellmSrv.Close()
+
+	routingSrv := newRoutingMock(litellmSrv.URL)
+	defer routingSrv.Close()
+
+	orch := newAuthorizedOrchestrator(acctSrv.URL, routingSrv.URL, litellmSrv.URL)
+	done, _ := runExecuteStreaming(orch, context.Background())
+	waitDone(t, done)
+
+	if got := logs.String(); !strings.Contains(got, "settle stream delivered nothing") {
+		t.Fatalf("nothing was delivered and the hold was released with no log line; log was:\n%s", got)
+	}
+}


### PR DESCRIPTION
## What

Sets `llm.stream` on every conversation the agent engine launches, so the
vendored agent-server actually publishes token deltas.

## Why

`event_service.py` computes `streaming_enabled = isinstance(agent, ACPAgent) or
any(llm.stream for llm in agent.get_all_llms())` and only then wires the token
callback that publishes `StreamingDeltaEvent`. `openhands/sdk/llm/llm.py`
defaults `stream` to `False`, and `controlclient.LLMSettings` sent `model`,
`base_url`, `api_key` and `usage_id` and nothing else. So every sandbox Hive has
launched so far ran with token streaming off, and no delta was ever published
for any conversation.

This is wave one of the chat-native agent work
(`research-2026-08-16-chat-native-agent-ux.md`, Part 2 claim 3). Everything
later depends on deltas existing, so it is deliberately the smallest
independently verifiable step.

## Scope, and what is deliberately not here

Not touched, and named so their absence is not read as an oversight:

- `enable_sub_agents` (defaults false, gates `task_tool_set`). Turning it on
  opens an agent-to-agent boundary we do not defend: upstream Claude Code added
  an instruction-shaped-pattern scan on a subagent's final message at exactly
  that boundary, and we have no equivalent. Needs its own security work first.
- `enable_browser` (defaults false, "injected by the serving layer" upstream,
  and we do not inject it).
- `enable_switch_llm_tool` (defaults **true** upstream, so the built-in
  `switch_llm` tool is already available in our sandboxes; noted here because it
  is the one default-on switch in that group and nobody chose it).
- No launcher relay, no SSE endpoint, no change to `serve.go`.

## Proof

Deltas are transient by design: they are published straight to PubSub and never
written to `ConversationState.events`, so a run that streamed and a run that did
not are indistinguishable from the event history afterwards. Only a mid-run
capture is evidence.

`apps/agent-engine/cmd/streamproof` (behind a `proof` build tag, so no ordinary
build, vet or test run compiles it) launches a real Apptainer sandbox through
the same `engineapi.Launch` the host launcher's `POST /launch` handler calls,
subscribes to the conversation's event WebSocket over the session control
socket, and counts frames while the conversation is still running. It differs
from the daemon in two ways, neither of which can affect whether a delta is
published: `ResolveEgressHosts` asks control-plane for a tenant's egress policy
there and returns the model host directly here, which is strictly narrower; and
`MemoryLimit` is 2G here against `serve.go`'s 4G, so a heavier prompt could be
killed for memory in the harness and not in production. Every other config field
normalises to the production value inside `engine.New`.

It runs a differential, because a capture never observed to fail proves nothing:
a second conversation on the same sandbox, same model and same prompt with
`stream` explicitly false. The program fails unless the product launch produced
deltas and the control produced none.

`.github/workflows/agent-stream-delta-proof.yml` runs it on a hosted runner with
real Apptainer, the CI-built SIF correlated by image inputs, and the live
gateway, and posts the captured log as a comment on this pull request. The
development box has neither Apptainer nor root and the demo box runs only
merged code, so this is the only place the claim can be tested before merge.

## Metering

Checked, because streaming changes how a response arrives and this repository
has already shipped a billing defect that served requests free for three days.

The agent's model traffic is ordinary gateway traffic on `/v1/chat/completions`.
The vendored SDK sets `stream_options={"include_usage": True}` whenever it
streams (`llm.py`, `_prepare_transport_kwargs`), so the terminal usage frame
still arrives, `UsageAccumulator.HasUsage` is true, and `settlementCredits`
takes its confirmed branch and prices the response through the same catalog
conversion a buffered response would. Streaming does not move an agent request
onto the unconfirmed content estimate.

Two facts worth recording rather than assuming:

1. The confirmed branch depends on that `include_usage`, not on our own code:
   `executeStreaming` forwards the caller's body upstream as it is, and
   `includeUsage` there only controls whether edge-api synthesises a terminal
   usage chunk for the caller. If a future agent-side client stopped asking for
   usage, agent traffic would settle from a content estimate flagged unconfirmed
   rather than from measured tokens. It would still be charged, and the estimate
   is calibrated to land under real tokenisation, so the direction of error
   favours the customer.
2. The chat path already forces streaming upstream regardless of what the client
   asked for (`rewriteDispatchBody`), so a streamed response is the ordinary,
   most-exercised metering case on this gateway, not a new one.

## Test plan

- `go test ./apps/agent-engine/internal/engine/... ./apps/agent-engine/internal/controlclient/...`
  covers the launch payload, asserting both the decoded field and `"stream":true`
  in the raw body the agent-server receives (the server reads the JSON name, not
  the Go field). Verified to fail with the flag flipped back to false.
- `go vet -tags proof ./apps/agent-engine/...` compiles the proof command.
- The live capture above is the real acceptance criterion.

## Live evidence

Run [`32010112621`](https://github.com/sakibsadmanshajib/hive/actions/runs/32010112621),
on this head, hosted runner, real Apptainer sandbox from the CI-built SIF, live
gateway. Full log in the comment below.

```
A/product(stream=true): frames{ConversationStateUpdateEvent=5 MessageEvent=1 StreamingDeltaEvent=5}
                        first delta 08:25:05.976Z, last delta 08:25:06.007Z, terminal (finished) observed 08:25:06.660Z
B/control(stream=false): frames{ConversationStateUpdateEvent=5 MessageEvent=1}; no deltas
PROOF OK: 5 delta frames on the product launch, 0 on the stream=false control
```

Three things that log establishes, none of which a unit test could:

1. Deltas exist and carry token text (`"content":"Hive"`, `" streaming"`,
   `" proof"`), captured over the session control socket while the conversation
   was still running: the last delta lands 653 ms before the poll that first saw
   `finished`.
2. The same sandbox, same model and same prompt with `stream` false produced
   zero delta frames while producing the same other frame kinds, so the capture
   is measuring the flag and not the weather.
3. Tool calling still **works** under `stream: true`, which is the real
   regression risk of turning streaming on, since the reassembly of a tool call
   out of streamed chunks happens inside the SDK and either produces a valid
   call or does not. That is captured in run
   [`31957712375`](https://github.com/sakibsadmanshajib/hive/actions/runs/31957712375),
   posted on this pull request, which recorded `ActionEvent=1`,
   `ObservationEvent=1`, `MessageEvent=1` and five deltas in one turn. No
   capture proves argument-fragment streaming and none can: a
   `StreamingDeltaEvent` only ever carries `content` or `reasoning_content`, so
   the tool phase produces no deltas at all.

The prompt is prose only, deliberately, and that is a finding rather than a
convenience. An OpenHands agent ends its turn through the finish tool, so a
prompt that also asks for a shell command tends to route the whole answer
through tool calls and emit no assistant message: runs
[`32008631987`](https://github.com/sakibsadmanshajib/hive/actions/runs/32008631987),
[`32009278161`](https://github.com/sakibsadmanshajib/hive/actions/runs/32009278161)
and [`32009716814`](https://github.com/sakibsadmanshajib/hive/actions/runs/32009716814)
each did exactly that. The harness now checks that precondition and ends such a
run as inconclusive, naming the frames it saw, rather than reporting a streaming
failure that did not happen or a pass it cannot justify. Re-rolling that dice on
every future run would spend a live model call for a one-in-four chance of
re-proving a result already in the record.

An earlier prose-only capture, run
[`31957371732`](https://github.com/sakibsadmanshajib/hive/actions/runs/31957371732),
is the third independent confirmation.

## Constraint for wave two, worth knowing before the rendering is designed

A chat surface fed by these deltas alone shows nothing for the entire
tool-calling phase, which is where an agent spends most of its wall clock, and
that phase is the thing the owner actually wants on screen. Token deltas cover
the model's prose only. Tool visibility has to come from the event stream
(`ActionEvent`, `ObservationEvent`, and the `waiting_for_confirmation` status
`engine.go` currently collapses into running), not from the deltas this pull
request switches on.

## Operational note

The sandbox's model requests now carry `stream: true` to the gateway, which
becomes `NeedStreaming` in route selection, and
`control-plane/internal/routing/service.go:198` drops any candidate route that
is not marked streaming capable. An operator pointing
`HIVE_AGENT_ENGINE_LLM_MODEL` at an alias with no streaming capable route would
see agent tasks fail at the first model call where they previously worked
buffered. The blast radius is that one configured alias, and the capture above
proves the configured one selects and streams.

## Review outcome

Eight threads, none a defect in the launch change itself. One was acted on
rather than rebutted, in commit `df2686d7`: the streaming settlement path logged
nothing when it settled from an estimate (`confirmed=false`) or released the hold
having measured nothing, both of which the synchronous path already logs. That
silence is inherited, but this change routes the most tool-call-heavy traffic in
the product through it, and a free-serve outage has already hidden there once.
The two log lines match the synchronous ones and change no behaviour; the guard
test was verified to go red when the line is deleted.

Two findings warranted work rather than a rebuttal and are filed instead of
being built here, so this pull request stays its original size:

- [#925](https://github.com/sakibsadmanshajib/hive/issues/925):
  `credit_reconciliation_jobs` has a writer and no reader, so a charge clamped at
  the hold is never corrected.
- [#926](https://github.com/sakibsadmanshajib/hive/issues/926): agent tasks fail
  totally and undiagnosably if the agent alias loses its streaming-capable route,
  since `supports_streaming` defaults false and the resulting 400 never leaves
  the sandbox.

## Buglog entry

```json
{"id":"BUG-2026-08-16-01","date":"2026-08-16","title":"Token streaming was off in every launched agent sandbox","error_message":"No StreamingDeltaEvent was ever published by a Hive-launched conversation","root_cause":"The vendored agent-server gates its token callback on any LLM having stream set (agent_server/event_service.py streaming_enabled), and openhands/sdk/llm/llm.py defaults LLM.stream to false. apps/agent-engine/internal/controlclient.LLMSettings serialised model, base_url, api_key and usage_id only, so every launch inherited the default and streaming was silently disabled.","fix":"Added Stream to controlclient.LLMSettings (json name stream, no omitempty) and set it true on every inline agent_settings launch in apps/agent-engine/internal/engine. Regression guard asserts the raw launch body carries the JSON name, and a live differential capture (apps/agent-engine/cmd/streamproof) proves deltas flow mid-run and stop when the flag is false.","tags":["agent-engine","openhands","streaming","default-off","vendored-gate"]}
```


