### PR TITLE
fix: deny access when an API key's expiry timestamp is present but unparseable

### DIFF
--- a/apps/edge-api/internal/authz/authz.go
+++ b/apps/edge-api/internal/authz/authz.go
@@ -152,13 +152,42 @@ func CheckAccess(snapshot AuthSnapshot, requestedAlias string, estimatedCredits 
 	}
 
 	// 2. Check expiry.
+	//
+	// A non-empty expires_at that fails to parse is DENIED, not skipped.
+	// This is hardening rather than a fix for a reachable gap: issue #915
+	// and PR #919 established that expiry enforcement already works today
+	// through two independent layers, and that this branch is not
+	// reachable from control-plane, which is the only writer of this
+	// field and always formats it via Go's default time.Time JSON
+	// marshaling (RFC3339Nano), a value time.Parse(time.RFC3339, ...)
+	// already accepts. Producing an unparseable value here would require
+	// writing directly to the shared Redis cache, which is already a full
+	// compromise. Failing closed here is defence in depth against that
+	// state, so a future caller of CheckAccess (or a corrupted cache
+	// entry) cannot silently bypass the expiry check the way the old
+	// "err == nil &&" guard did.
+	//
+	// An empty string is treated the same as a nil pointer (no expiry
+	// set), not as a parse failure: both must keep authorizing exactly as
+	// they do today, since a hardening change that started denying
+	// non-expiring keys would be a live outage.
 	if snapshot.ExpiresAt != nil {
-		exp, err := time.Parse(time.RFC3339, *snapshot.ExpiresAt)
-		if err == nil && exp.Before(time.Now()) {
-			return CheckResult{
-				Allowed:  false,
-				DenyCode: "invalid_api_key",
-				DenyMsg:  "API key has expired",
+		raw := strings.TrimSpace(*snapshot.ExpiresAt)
+		if raw != "" {
+			exp, err := time.Parse(time.RFC3339, raw)
+			switch {
+			case err != nil:
+				return CheckResult{
+					Allowed:  false,
+					DenyCode: "invalid_api_key",
+					DenyMsg:  "API key has an invalid expiry",
+				}
+			case exp.Before(time.Now()):
+				return CheckResult{
+					Allowed:  false,
+					DenyCode: "invalid_api_key",
+					DenyMsg:  "API key has expired",
+				}
 			}
 		}
 	}

--- a/apps/edge-api/internal/authz/authz_test.go
+++ b/apps/edge-api/internal/authz/authz_test.go
@@ -55,6 +55,98 @@ func TestCheckAccessExpiredKey(t *testing.T) {
 	}
 }
 
+// TestCheckAccessDeniesUnparseableExpiresAt pins the hardening fix at
+// authz.go's expiry check: a present-but-unparseable expires_at must deny
+// the request, not silently skip the expiry check (fail-open on a parse
+// error). See authz.go step 2 for the reasoning on why this is defence in
+// depth rather than a fix for a reachable gap (issue #915 / PR #919
+// established expiry enforcement already works via two independent layers
+// on every real value control-plane emits).
+func TestCheckAccessDeniesUnparseableExpiresAt(t *testing.T) {
+	bad := "not-a-timestamp"
+	s := AuthSnapshot{
+		KeyID:          "key-1",
+		Status:         "active",
+		ExpiresAt:      &bad,
+		AllowAllModels: true,
+		BudgetKind:     "none",
+	}
+
+	r := CheckAccess(s, "hive-default", 0)
+	if r.Allowed {
+		t.Fatal("expected denied for unparseable expires_at, got allowed (fail-open on parse error)")
+	}
+	if r.DenyCode != "invalid_api_key" {
+		t.Fatalf("expected invalid_api_key code, got %s", r.DenyCode)
+	}
+	// Both this arm and the genuinely-expired arm return the same DenyCode,
+	// so DenyMsg is the only field an operator reading logs can use to tell
+	// a malformed cache entry apart from routine expiry. Pin it, or the
+	// message could silently drift to "API key has expired" and this test
+	// (and every other test in the package) would still pass.
+	if r.DenyMsg != "API key has an invalid expiry" {
+		t.Fatalf("expected the malformed-record message, got %q", r.DenyMsg)
+	}
+}
+
+// TestCheckAccessEmptyExpiresAtStillAllowed pins the "no live outage" side
+// of the same change: an empty expires_at string is treated the same as an
+// absent one (no expiry set), and must keep authorizing exactly as it does
+// today. Only a NON-empty unparseable value is denied.
+func TestCheckAccessEmptyExpiresAtStillAllowed(t *testing.T) {
+	empty := ""
+	s := AuthSnapshot{
+		KeyID:          "key-1",
+		Status:         "active",
+		ExpiresAt:      &empty,
+		AllowAllModels: true,
+		BudgetKind:     "none",
+	}
+
+	r := CheckAccess(s, "hive-default", 0)
+	if !r.Allowed {
+		t.Fatalf("expected allowed for empty expires_at (treated as absent), got denied: %s", r.DenyMsg)
+	}
+}
+
+// TestCheckAccessWhitespaceOnlyExpiresAtStillAllowed covers the distinct
+// branch TrimSpace introduces: a whitespace-only expires_at is trimmed down
+// to empty and takes the same no-expiry path as an empty string, rather than
+// being handed to time.Parse as a non-empty value that would fail.
+func TestCheckAccessWhitespaceOnlyExpiresAtStillAllowed(t *testing.T) {
+	whitespace := " \t\n"
+	s := AuthSnapshot{
+		KeyID:          "key-1",
+		Status:         "active",
+		ExpiresAt:      &whitespace,
+		AllowAllModels: true,
+		BudgetKind:     "none",
+	}
+
+	r := CheckAccess(s, "hive-default", 0)
+	if !r.Allowed {
+		t.Fatalf("expected allowed for whitespace-only expires_at, got denied: %s", r.DenyMsg)
+	}
+}
+
+// TestCheckAccessNilExpiresAtStillAllowed pins the other "no live outage"
+// side: a key with no expires_at set at all (nil pointer, the common case
+// for a non-expiring key) must keep authorizing exactly as it does today.
+func TestCheckAccessNilExpiresAtStillAllowed(t *testing.T) {
+	s := AuthSnapshot{
+		KeyID:          "key-1",
+		Status:         "active",
+		ExpiresAt:      nil,
+		AllowAllModels: true,
+		BudgetKind:     "none",
+	}
+
+	r := CheckAccess(s, "hive-default", 0)
+	if !r.Allowed {
+		t.Fatalf("expected allowed for nil expires_at (no expiry set), got denied: %s", r.DenyMsg)
+	}
+}
+
 func TestCheckAccessRejectsDisallowedAliasWithoutRemap(t *testing.T) {
 	s := AuthSnapshot{
 		KeyID:          "key-1",


### PR DESCRIPTION
## Summary

`CheckAccess`'s expiry check (`apps/edge-api/internal/authz/authz.go`, step 2) guarded the parse with `err == nil &&`, so a present `expires_at` value that failed to parse skipped the expiry check entirely instead of denying the request. That is fail-open on an authorization predicate, and this PR closes it: a non-empty `expires_at` that fails to parse now denies with `invalid_api_key`.

## Why this is hardening, not a vulnerability fix

Issue #915 asked whether an expired-but-not-revoked key authorizes, and PR #919 answered it: expiry enforcement already works today through two independent layers (the control-plane's `applyExpiry` derives `status: "expired"` on read, and edge-api's own `authz.go:155` re-parses `expires_at` against the current time). Neither of those layers relies on the branch this PR touches.

This branch specifically is not reachable in production. `expires_at` has exactly one writer, control-plane's `ResolveSnapshot`, which formats it via Go's default `time.Time` JSON marshaling (RFC3339Nano). `time.Parse(time.RFC3339, ...)` already accepts RFC3339Nano-formatted input (Go's `time.Parse` special-cases fractional seconds even when the layout does not declare them), so every value control-plane ever sends parses successfully. Producing an unparseable `expires_at` at the point `CheckAccess` reads it would mean writing a malformed value directly into the shared Redis auth-snapshot cache, and reaching that cache to write it is already a full compromise of the auth layer, not something this change could prevent.

So: no known live path reaches the branch this PR changes, and treating it as denied rather than skipped is defence in depth against a future caller of `CheckAccess` or a corrupted cache entry, not a fix for something exploitable today. Please do not read this commit as evidence that a live vulnerability existed; it did not, per #915/#919's own investigation.

## What does not change

An empty `expires_at` string is treated the same as a nil pointer (no expiry set) and keeps authorizing exactly as it does today. A hardening change that started denying non-expiring keys would itself be a live outage, and this PR does not make that mistake.

## Verification (red then green, not asserted)

Added `TestCheckAccessDeniesUnparseableExpiresAt` first, against the unpatched code:

```
=== RUN   TestCheckAccessDeniesUnparseableExpiresAt
    authz_test.go:79: expected invalid_api_key code, got model_not_allowed
--- FAIL: TestCheckAccessDeniesUnparseableExpiresAt (0.00s)
```

(The first version of the test denied for the wrong reason, model_not_allowed, because the snapshot did not set `AllowAllModels` and the fail-open branch fell through to the model-allowlist check. Corrected the snapshot to isolate the expiry check, confirmed the corrected test still fails the same way against unpatched code.)

After applying the fix, the same test and the full `authz` package:

```
=== RUN   TestCheckAccessDeniesUnparseableExpiresAt
--- PASS: TestCheckAccessDeniesUnparseableExpiresAt (0.00s)
...
ok  	github.com/sakibsadmanshajib/hive/apps/edge-api/internal/authz	0.006s
```

Regression guards added and confirmed passing both before and after (i.e. behaviour unchanged for these two cases):

- `TestCheckAccessEmptyExpiresAtStillAllowed`: empty-string `expires_at` still authorizes.
- `TestCheckAccessNilExpiresAtStillAllowed`: nil `expires_at` (no expiry set) still authorizes.

Full `apps/edge-api` suite green after the change (`go build`, `go vet`, `gofmt -l` clean, `go test ./apps/edge-api/... -count=1 -short`), run via the toolchain container per this repo's testing convention. `-race` is unavailable in the Alpine toolchain image (`CGO_ENABLED=0`), so it was not run; nothing in this change is concurrency-sensitive (pure value comparison, no shared state).

## Scope

Only `apps/edge-api/internal/authz/authz.go` and its test file change. No other file touched.

## Buglog entry

To be appended to `.wolf/buglog.jsonl` on main via a follow-up buglog-only PR, per this repo's convention of never appending on a feature branch:

```json
{"id":"bug-2026-08-16-authz-expiry-fail-open-on-parse-error","date":"2026-08-16","title":"CheckAccess skipped the API key expiry check on a parse error instead of denying","error_message":"time.Parse(time.RFC3339, *snapshot.ExpiresAt) guarded with err == nil && exp.Before(time.Now()), so a present-but-unparseable expires_at fell through the if-block entirely and the request was evaluated as if no expiry were set","root_cause":"The expiry check only executed its deny branch when the timestamp parsed cleanly; a parse failure silently skipped the check rather than being treated as a denial, which is fail-open on an authorization predicate. Not exploitable today: expires_at has one writer (control-plane's ResolveSnapshot), which always emits RFC3339Nano, a format time.Parse(time.RFC3339, ...) already accepts, so reaching this branch would require writing a malformed value directly into the shared Redis auth-snapshot cache, itself a full compromise. Filed as hardening after #915/#919 established expiry enforcement already works via two independent layers.","fix":"Treat a non-empty expires_at that fails to parse as invalid_api_key (deny), while continuing to treat an empty string the same as a nil pointer (no expiry set, still authorizes). Added TestCheckAccessDeniesUnparseableExpiresAt (confirmed red on unpatched code, green after the fix) plus TestCheckAccessEmptyExpiresAtStillAllowed and TestCheckAccessNilExpiresAtStillAllowed as regression guards for the no-expiry cases.","tags":["security","authz","fail-open","hardening","expiry","issue-915","pr-919"],"pr":"<fill in PR number after merge>"}
```

## Review

Stage 6 (adversarial review) for this PR needs to be independent of the agent that wrote this diff, per standing instruction on auth-behaviour changes. Requesting an independent review pass now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API key validation for expiry timestamps.
  * Malformed, non-empty expiry values are now rejected instead of being silently ignored.
  * Empty or unset expiry values continue to be accepted.
  * Expired API keys remain denied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->