### PR TITLE
fix: budget an ephemeral CI stack a share of the session pool it can actually get

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1495,7 +1495,7 @@ jobs:
           if-no-files-found: ignore
           retention-days: 5
 
-      - name: Upload the Next.js server log on failure
+      - name: Redact the Next.js server log on failure
         if: failure()
         # The console renders an error boundary ("Something went wrong on this
         # page", plus a digest) when a server component throws, and the cause is

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1464,12 +1464,61 @@ jobs:
         # Piped through the redactor: see the sdk-tests dump step above.
         run: docker compose logs --no-color --timestamps --tail=500 2>&1 | python3 ../../scripts/redact-log-credentials.py > /tmp/compose-web-e2e-api.log || true
 
+      - name: Name a shared session-pool exhaustion on failure
+        if: failure()
+        # Diagnosis, not dispensation. The run has already failed and stays
+        # failed; this only saves the next reader the archaeology.
+        #
+        # On 2026-08-16 this job failed the flake gate with three unrelated
+        # specs passing only on a retry, and every one of them was a timeout
+        # caused by `FATAL: (EMAXCONNSESSION) max clients reached in session
+        # mode`, which appeared 258 times in the dump this step now reads.
+        # Finding that meant downloading the compose artifact and grepping it by
+        # hand, while the job log said nothing but "3 flaky". A retry-pass is
+        # still a failure and the gate is untouched; what changes is that the
+        # log now says which failure it was.
+        run: |
+          set -uo pipefail
+          log=/tmp/compose-web-e2e-api.log
+          [ -f "$log" ] || exit 0
+          n=$(grep -c EMAXCONNSESSION "$log" || true)
+          if [ "${n:-0}" -gt 0 ]; then
+            echo "::error title=Shared session pool exhausted::${n} EMAXCONNSESSION refusals in this job's container logs. The Supabase project's Supavisor session-mode ceiling is 15 clients, shared by this job, every other CI stack booted at the same time and the always-on demo box. Failures in this run are contention, not necessarily a product defect; see issues #631 and #841. Do not raise the retry count or the timeouts to survive it."
+          fi
+
       - name: Upload compose logs
         if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: compose-logs-web-e2e-api
           path: /tmp/compose-web-e2e-api.log
+          if-no-files-found: ignore
+          retention-days: 5
+
+      - name: Upload the Next.js server log on failure
+        if: failure()
+        # The console renders an error boundary ("Something went wrong on this
+        # page", plus a digest) when a server component throws, and the cause is
+        # only ever in this log. On 2026-08-16 an invitation-acceptance spec
+        # timed out waiting for a workspace switcher that the error boundary had
+        # replaced, and nothing in any uploaded artifact said why: this file was
+        # written and then discarded with the runner.
+        #
+        # Redacted on the way out, like the compose dump: artifacts on a public
+        # repository are downloadable by anyone with the run URL, and this job
+        # drives /invitations/accept?token=<live token>.
+        run: |
+          set -uo pipefail
+          if [ -f /tmp/nextjs.log ]; then
+            python3 scripts/redact-log-credentials.py < /tmp/nextjs.log > /tmp/nextjs-redacted.log || true
+          fi
+
+      - name: Upload the redacted Next.js server log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nextjs-log-web-e2e
+          path: /tmp/nextjs-redacted.log
           if-no-files-found: ignore
           retention-days: 5
 

--- a/.github/workflows/deploy-demo-box.yml
+++ b/.github/workflows/deploy-demo-box.yml
@@ -452,7 +452,15 @@ jobs:
           python3 scripts/derive-pooler-dsn.py --self-test
           # stdout is the KEY=value pairs; the script logs a password-free
           # host/port/params summary on stderr.
-          python3 scripts/derive-pooler-dsn.py --dsn "$existing" >> "$GITHUB_ENV"
+          #
+          # --session-max-conns 6 keeps this box's budget exactly where it has
+          # been. Six is no longer the script's default: an ephemeral consumer
+          # now gets four, because three CI stacks boot per push and six each
+          # asked for 18 of the project's 15 session slots before this box's own
+          # share was counted. This is the one long-lived deployment, it serves
+          # real chat traffic, and it is the consumer that budget was written
+          # for, so it asks for it by name.
+          python3 scripts/derive-pooler-dsn.py --dsn "$existing" --session-max-conns 6 >> "$GITHUB_ENV"
 
       - name: Rebuild + recreate changed services
         # `--build` only rebuilds layers whose inputs changed (Docker build

--- a/scripts/derive-pooler-dsn.py
+++ b/scripts/derive-pooler-dsn.py
@@ -43,6 +43,16 @@ below for the arithmetic: with the old single value of six, one push asked for
 18 of the 15 slots across its three CI stacks, and the visible symptom was
 unrelated browser specs passing only on a retry.
 
+That split reduces demand; it does not create headroom, and nothing in this
+file can. Three ephemeral stacks at four plus the long-lived six is still 18
+against a ceiling of 15, so two pushes landing together can still exhaust the
+pool. The changes that add capacity are raising the project's Supavisor
+`pool_size` (the database itself has room: `max_connections` is 60) or moving
+CI onto its own project, which are issues #841 and #631. Serialising the jobs
+instead was tried and reverted, because a GitHub Actions concurrency group
+holds only one queued run and cancels the rest, which trades a noisy failure
+for a silent absence.
+
 The session DSN additionally carries `pool_max_conn_idle_time` and
 `pool_health_check_period`. A cap alone bounds how many slots a consumer may
 take; it does nothing about how long it keeps them. pgxpool holds an idle
@@ -223,14 +233,6 @@ def derive(
     session_max_conns is this consumer's share of the project's 15 session slots.
     It defaults to the ephemeral budget; a long-lived deployment passes its own.
     """
-    if session_max_conns < MIN_SESSION_MAX_CONNS:
-        raise ValueError(
-            f"session_max_conns={session_max_conns} is below {MIN_SESSION_MAX_CONNS}: "
-            "control-plane pins one pool connection for the life of the process on "
-            "LISTEN tenant_settings_changed, so a smaller cap leaves nothing to run "
-            "queries on"
-        )
-
     parts = urlsplit(dsn)
     host = parts.hostname
     if not host:
@@ -242,6 +244,23 @@ def derive(
         pool_max_conn_idle_time=SESSION_MAX_CONN_IDLE_TIME,
         pool_health_check_period=SESSION_HEALTH_CHECK_PERIOD,
     )
+
+    # Validate what the session DSN ENDS UP carrying, not the argument. An
+    # explicit `pool_max_conns` in the input wins over this script's value (see
+    # with_params), so checking only `session_max_conns` would let an input DSN
+    # of `?pool_max_conns=1` through and wedge control-plane on its first query:
+    # the tenant-settings listener would hold the single connection for the life
+    # of the process and nothing would be left to run anything on.
+    effective = dict(parse_qsl(urlsplit(session).query)).get("pool_max_conns", "")
+    if not effective.isdigit() or int(effective) < MIN_SESSION_MAX_CONNS:
+        raise ValueError(
+            f"effective session pool_max_conns={effective!r} is unusable: it must be an "
+            f"integer of at least {MIN_SESSION_MAX_CONNS}, because control-plane pins one "
+            "pool connection for the life of the process on LISTEN "
+            "tenant_settings_changed and needs at least one more to run queries on. The "
+            "value comes from the input DSN if it carries one, otherwise from "
+            "--session-max-conns"
+        )
 
     if not is_pooler_host(host):
         # A direct Postgres serves every mode on its one port. Capping is still
@@ -296,6 +315,18 @@ def self_test() -> int:
             pass
         else:
             raise AssertionError(f"session_max_conns={rejected} must be rejected")
+
+    # The floor has to hold on the EFFECTIVE value. An explicit parameter in the
+    # input DSN outranks this script's own (see with_params), so a DSN that pins
+    # an unusable cap must be refused even though the flag was never touched, and
+    # a non-numeric value must not reach pgx as a live DSN either.
+    for bad_input in ("?pool_max_conns=1", "?pool_max_conns=0", "?pool_max_conns=lots"):
+        try:
+            derive(pooler + bad_input)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError(f"input DSN {bad_input} must be rejected")
     # A cap without an idle release still lets one consumer squat six of the
     # fifteen session slots for pgxpool's default 30 idle minutes, which is how
     # three idle consumers exhaust the pool between them.
@@ -367,7 +398,7 @@ def self_test() -> int:
         assert "options=-c%20statement_timeout%3D3000" in flavour, flavour
         assert "+" not in urlsplit(flavour).query, flavour
 
-    print("derive-pooler-dsn: self-test ok (40 assertions)")
+    print("derive-pooler-dsn: self-test ok (43 assertions)")
     return 0
 
 

--- a/scripts/derive-pooler-dsn.py
+++ b/scripts/derive-pooler-dsn.py
@@ -37,6 +37,12 @@ them and leave nothing for Open WebUI, which is exactly the observed failure.
 An explicit cap makes the budget a property of the deployment rather than of
 whatever hardware it lands on.
 
+The session cap defaults to the EPHEMERAL budget, and `--session-max-conns`
+raises it for the one long-lived deployment. See `DEFAULT_SESSION_MAX_CONNS`
+below for the arithmetic: with the old single value of six, one push asked for
+18 of the 15 slots across its three CI stacks, and the visible symptom was
+unrelated browser specs passing only on a retry.
+
 The session DSN additionally carries `pool_max_conn_idle_time` and
 `pool_health_check_period`. A cap alone bounds how many slots a consumer may
 take; it does nothing about how long it keeps them. pgxpool holds an idle
@@ -49,6 +55,7 @@ Usage
 -----
     derive-pooler-dsn.py --dsn "postgresql://user:pw@host:5432/postgres"
     derive-pooler-dsn.py --host H --port 5432 --user U --dbname D --password P
+    derive-pooler-dsn.py --dsn "..." --session-max-conns 6
     derive-pooler-dsn.py --self-test
 
 Prints three `KEY=value` lines, ready to append to $GITHUB_ENV:
@@ -82,10 +89,39 @@ SESSION_PORT = 5432
 TRANSACTION_PORT = 6543
 
 # Session slots are a hard 15 shared by everything, so control-plane gets a
-# budget rather than the whole pool. Six covers the permanent LISTEN connection
-# plus normal query traffic plus a held account advisory lock, and leaves room
-# for a second control-plane instance and any transient psql.
-SESSION_MAX_CONNS = 6
+# budget rather than the whole pool.
+#
+# The default is the EPHEMERAL budget, and that is the important part. Six was
+# the original value and it was sized for one long-lived deployment; every
+# ephemeral consumer inherited it. Three stacks boot per push (ci.yml's web-e2e
+# job, ci.yml's live-integration job, agent-visual-proof.yml), so a single push
+# asked for 18 of the 15 slots before the always-on demo box's own six was
+# counted. On 2026-08-16 that produced 258 `EMAXCONNSESSION` refusals inside one
+# Web E2E job, whose visible symptom was three unrelated specs passing only on a
+# retry and the repository's flake gate failing `main` for it.
+#
+# Four, and the arithmetic behind it is the reservation path rather than a round
+# number. `accounting.PgxAccountLocker.WithAccountLock` checks out one connection
+# per account currently holding the advisory lock and then runs `fn`, which needs
+# a further connection for its own ledger and usage writes; `pglock.go` says so
+# in its own comment and gates per account in-process for exactly this reason. So
+# a pool of `max` survives `max - 2` concurrent account locks: one connection is
+# pinned for the life of the process by `LISTEN tenant_settings_changed`, K are
+# held by lock holders, and at least one has to stay free or the holders starve
+# and the reservation path deadlocks until their contexts expire. Four leaves
+# room for two concurrent accounts, which is above anything CI drives; three
+# would allow exactly one, and trading a contention timeout for a starvation
+# timeout is not a fix.
+#
+# A deployment that needs more asks for it with --session-max-conns, so the large
+# budget is explicit and local to the one consumer that earned it, and a new
+# workflow that forgets the flag fails safe.
+DEFAULT_SESSION_MAX_CONNS = 4
+
+# Below two, the listener's permanently checked-out connection leaves nothing for
+# queries and control-plane wedges on its first one. Refuse it here, where the
+# message can say why.
+MIN_SESSION_MAX_CONNS = 2
 
 # A session slot is held for as long as the pgxpool connection that owns it
 # exists, not for as long as it is in use, and pgxpool's own defaults are
@@ -176,12 +212,25 @@ def with_port(dsn: str, port: int) -> str:
     return urlunsplit(parts._replace(netloc=netloc))
 
 
-def derive(dsn: str) -> tuple[str, str, str]:
+def derive(
+    dsn: str, session_max_conns: int = DEFAULT_SESSION_MAX_CONNS
+) -> tuple[str, str, str]:
     """Return (session_dsn, transaction_dsn, transaction_libpq_dsn) for one DSN.
 
     The third value is the transaction DSN as libpq will accept it: same host,
     port and credential, with pgx's own parameters stripped.
+
+    session_max_conns is this consumer's share of the project's 15 session slots.
+    It defaults to the ephemeral budget; a long-lived deployment passes its own.
     """
+    if session_max_conns < MIN_SESSION_MAX_CONNS:
+        raise ValueError(
+            f"session_max_conns={session_max_conns} is below {MIN_SESSION_MAX_CONNS}: "
+            "control-plane pins one pool connection for the life of the process on "
+            "LISTEN tenant_settings_changed, so a smaller cap leaves nothing to run "
+            "queries on"
+        )
+
     parts = urlsplit(dsn)
     host = parts.hostname
     if not host:
@@ -189,7 +238,7 @@ def derive(dsn: str) -> tuple[str, str, str]:
 
     session = with_params(
         dsn,
-        pool_max_conns=str(SESSION_MAX_CONNS),
+        pool_max_conns=str(session_max_conns),
         pool_max_conn_idle_time=SESSION_MAX_CONN_IDLE_TIME,
         pool_health_check_period=SESSION_HEALTH_CHECK_PERIOD,
     )
@@ -222,7 +271,31 @@ def self_test() -> int:
     session, transaction, libpq = derive(pooler)
 
     assert ":5432/" in session, session
-    assert "pool_max_conns=6" in session, session
+    # The default is the ephemeral budget, so a consumer that asks for nothing
+    # gets the small one instead of a third of the project's whole session
+    # ceiling. Never below three: see DEFAULT_SESSION_MAX_CONNS for why a pool
+    # of `max` only survives `max - 2` concurrent account locks.
+    assert "pool_max_conns=4" in session, session
+    assert DEFAULT_SESSION_MAX_CONNS >= 3, DEFAULT_SESSION_MAX_CONNS
+
+    # A long-lived deployment asks for its larger budget explicitly.
+    big_session, big_transaction, big_libpq = derive(pooler, session_max_conns=6)
+    assert "pool_max_conns=6" in big_session, big_session
+    # The transaction flavours are not session slots and must not move with it.
+    assert "pool_max_conns=8" in big_transaction, big_transaction
+    assert "pool_max_conns" not in big_libpq, big_libpq
+
+    # settings.Resolver.StartListener acquires a pool connection and holds it for
+    # the life of the process, so a cap of 1 leaves zero connections for queries
+    # and control-plane wedges on its first request. Refuse it here, where the
+    # message can say why, rather than in a container that merely hangs.
+    for rejected in (1, 0, -1):
+        try:
+            derive(pooler, session_max_conns=rejected)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError(f"session_max_conns={rejected} must be rejected")
     # A cap without an idle release still lets one consumer squat six of the
     # fifteen session slots for pgxpool's default 30 idle minutes, which is how
     # three idle consumers exhaust the pool between them.
@@ -294,7 +367,7 @@ def self_test() -> int:
         assert "options=-c%20statement_timeout%3D3000" in flavour, flavour
         assert "+" not in urlsplit(flavour).query, flavour
 
-    print("derive-pooler-dsn: self-test ok (33 assertions)")
+    print("derive-pooler-dsn: self-test ok (40 assertions)")
     return 0
 
 
@@ -306,6 +379,16 @@ def main(argv: list[str]) -> int:
     ap.add_argument("--user")
     ap.add_argument("--dbname")
     ap.add_argument("--password")
+    ap.add_argument(
+        "--session-max-conns",
+        type=int,
+        default=DEFAULT_SESSION_MAX_CONNS,
+        help=(
+            "this consumer's share of the project's 15 session-mode slots "
+            f"(default {DEFAULT_SESSION_MAX_CONNS}, the ephemeral budget; a "
+            "long-lived deployment passes a larger one explicitly)"
+        ),
+    )
     ap.add_argument("--self-test", action="store_true")
     args = ap.parse_args(argv)
 
@@ -323,7 +406,10 @@ def main(argv: list[str]) -> int:
             ap.error(f"--dsn, or all of --host --user --dbname --password (missing: {', '.join(missing)})")
         dsn = build_dsn(args.host, args.port, args.user, args.dbname, args.password)
 
-    session, transaction, libpq = derive(dsn)
+    try:
+        session, transaction, libpq = derive(dsn, session_max_conns=args.session_max_conns)
+    except ValueError as err:
+        ap.error(str(err))
     print(f"SUPABASE_DB_URL={session}")
     print(f"SUPABASE_DB_POOL_URL={transaction}")
     print(f"SUPABASE_DB_POOL_URL_LIBPQ={libpq}")


### PR DESCRIPTION
## The three retry-passes are one cause, and it is not in the specs

`Web E2E (full stack)` failed on `main` in run 31958356695 for flakiness alone: 24 passed, 0 failed, 3 passed only on retry, gate tripped at `MAX_FLAKY_TESTS = 0`. Nothing here raises the retry count, quarantines a test, extends a timeout or touches the gate.

### First correction: which three

The dispatch named `profile-completion.spec.ts:39` and `:65`. Those two passed on the first attempt in that run. The gate's own table and the job log name these:

| Spec | Test | Attempts |
| --- | --- | --- |
| `auth-shell.spec.ts:51` | accepting an invitation keeps current workspace until switcher changes it | 2 |
| `profile-completion.spec.ts:94` | profile settings stay reachable while unverified | 3 |
| `profile-completion.spec.ts:145` | dashboard does not introduce a billing reminder | 3 |

`profile-completion.spec.ts` runs `test.describe.configure({ mode: "serial" })`, so the failure of `:94` skipped the four tests after it and retried the whole file from `:39`. That is why `:39` and `:65` appear three times in the log with `(retry #1)` and `(retry #2)` while never having failed, and it is the likeliest source of the misattribution.

### What the failing attempts show

Every failing first attempt is a timeout, not an assertion mismatch.

- `auth-shell.spec.ts:51`: `locator.inputValue` on `select[name='account_id']` never resolved, and the error context captured for that attempt is the console error boundary, `Something went wrong on this page ... reference 3955933083`. The workspace switcher was genuinely absent: the page had failed to render.
- `profile-completion.spec.ts:94` and `:145`: `page.waitForURL` in the shared `signIn` helper timed out at 25000ms, with the submit button still reading `Signing in...`.

### The environment, in the same job

- `[e2e-auth-fixtures] reseed took ...` ranged from 315ms to **76188ms** within the one run.
- Job wall time 9.1m. The previous seven Web E2E runs on `main` took 1.4m, 1.9m, 2.1m, 3.2m, 4.4m, 4.6m and 1.6m and every one of them reported `27 executed, 0 passed only on retry`. These specs have a clean record under this gate since it landed on 2026-08-10, so they are not marginal tests that finally tipped over.
- The job's own `compose-logs-web-e2e-api` artifact carries **258** lines of:

  `FATAL: (EMAXCONNSESSION) max clients reached in session mode - max clients are limited to pool_size: 15 (SQLSTATE XX000)`

- Control-plane errors in that same dump map onto the failures one for one: `ERROR could not load your workspace err="accounts: list memberships: failed to connect ..."` (the error boundary) and `ERROR auth: tenant membership check failed, denying selected tenant`, from 16:29:55 through 16:38:51.
- The same CI run's `Live integration` job hit `EMAXCONNSESSION` too, at 16:30:13. The two jobs overlapped: web-e2e 16:24:39 to 16:39:04, live-integration 16:24:41 to 16:31:59.
- Other stack-booting runs were live in the same window: two PR `CI` runs (16:22 to 16:39, 16:30 to 16:46) and an `agent visual proof` run (16:22 to 16:31).

Verdict: contention, not a spec-level code change. #908 and #906 are not implicated; the suite passed twice after they merged and the run that tripped the gate is the one whose reseeds ran 25x slower than the same reseed in the same job.

### The arithmetic

One Supabase project serves the always-on demo box and every CI job that boots a stack. Supavisor's session-mode ceiling for it is 15 clients, and a session-mode client pins one server connection for its whole session. control-plane must be on session mode (`LISTEN tenant_settings_changed`, session-scoped `pg_advisory_lock`), which `platformdb.Open` enforces at startup.

`scripts/derive-pooler-dsn.py` budgeted **6** of those 15 to every control-plane it derived a DSN for. That number was written for the single long-lived deployment. Three ephemeral CI stacks boot per push:

| Consumer | Session budget before | after |
| --- | --- | --- |
| `ci.yml` web-e2e control-plane | 6 | 4 |
| `ci.yml` live-integration control-plane | 6 | 4 |
| `agent-visual-proof.yml` control-plane | 6 | 4 |
| demo box control-plane (always on) | 6 | 6, now asked for by name |
| **one push, ephemeral total** | **18 of 15** | **12 of 15** |

### Measured, not assumed

Taken from a developer machine on 2026-08-16 with no CI job running, over the transaction-mode port so the probe itself costs no session slot:

- `max_connections` = 60 with 26 client backends. The database is not the constraint; Supavisor's per-tenant `pool_size` of 15 is.
- Six parallel session-mode connections: **2 accepted, 4 refused** with `EMAXCONNSESSION`.

So roughly two session slots are free at rest and the long-lived consumers hold the rest, which matches issue #841's own measurement of 2026-08-10.

**This has to be said plainly: this pull request reduces demand, it does not create headroom.** A single ephemeral stack asking for even two slots is asking for most of what is free. The changes that add capacity are raising the project's pooler ceiling (#841's acceptance item, and `max_connections` says there is room at the database) or moving CI onto its own project or a stack-local Postgres (#631). Neither is applied here: the first is a live-project config change while sibling agents are verifying against the live box, which `.wolf/cerebrum.md` warns against, and the second is #631's whole scope.

## What changed

**`scripts/derive-pooler-dsn.py`**
- Default session budget 6 to 4, with `--session-max-conns` for a consumer that needs more. Four is what the reservation path needs, not a round number: `PgxAccountLocker.WithAccountLock` checks out one connection per account holding the advisory lock and then runs `fn`, which needs a further connection for its ledger and usage writes, so a pool of `max` survives `max - 2` concurrent account locks once the listener's permanent connection is subtracted. Four leaves room for two concurrent accounts; three would allow exactly one, and trading a contention timeout for a starvation timeout is not a fix (`pglock.go` documents that starvation shape in its own comment).
- Below 2 is refused with a message that says why, rather than producing a DSN that wedges control-plane on its first query.
- The default is now the ephemeral value, so a future workflow that forgets the flag fails safe instead of demanding a third of the ceiling.
- Self-test extended from 33 to 40 assertions, watched failing first (`AssertionError: ...pool_max_conns=6...`).

**`.github/workflows/deploy-demo-box.yml`**
- Passes `--session-max-conns 6`. The live surface's budget is unchanged in value; it is now explicit and local to the consumer it was written for.

**`.github/workflows/ci.yml`** (web-e2e job, failure path only)
- Counts `EMAXCONNSESSION` in the compose dump it already writes and emits a GitHub error annotation naming it. Diagnosis, not dispensation: the run has already failed and stays failed. Finding this cause today meant downloading a 460KB artifact and grepping it by hand while the job log said only `3 flaky`.
- Uploads the Next.js server log, piped through `scripts/redact-log-credentials.py` exactly as the compose dump is, because this job drives `/invitations/accept?token=<live token>` and artifacts on a public repository are downloadable by anyone with the run URL. The `auth-shell:51` error boundary's cause exists only in that log, which is currently written to `/tmp/nextjs.log` and thrown away with the runner.

## Test plan

- [x] `python3 scripts/derive-pooler-dsn.py --self-test` fails on the new assertions before the change (`AssertionError` showing the old `pool_max_conns=6`), passes after: `self-test ok (40 assertions)`.
- [x] CLI checked by hand: no flag gives `pool_max_conns=4`, `--session-max-conns 6` gives 6, `--session-max-conns 1` exits non-zero naming the listener.
- [x] Transaction-mode DSNs unmoved by the session flag (`pool_max_conns=8`, and still stripped for libpq).
- [x] Both edited workflows parse.
- [ ] Repeated `Web E2E (full stack)` runs on this branch, reported in a comment below with the run count and the retry-pass count. A green sequence cannot disprove a probabilistic contention flake and is not offered as if it could; the deterministic evidence is the arithmetic and the measured free-slot count above.

## Buglog entry

```json
{"id":"BUG-2026-08-16-web-e2e-session-pool","date":"2026-08-16","title":"Web E2E failed the flake gate on main: three specs passed only on retry because the shared Supabase session pool was exhausted","error_message":"FATAL: (EMAXCONNSESSION) max clients reached in session mode - max clients are limited to pool_size: 15 (SQLSTATE XX000); surfaced as page.waitForURL timeout 25000ms and locator.inputValue timeout in three unrelated specs","root_cause":"scripts/derive-pooler-dsn.py budgeted 6 of the project's 15 Supavisor session-mode slots to every control-plane it derived a DSN for, a number sized for the single long-lived demo box. Three ephemeral CI stacks boot per push (ci.yml web-e2e, ci.yml live-integration, agent-visual-proof.yml), so one push demanded 18 of 15 before the box's own 6, and control-plane's DB calls were refused mid-run. The console then rendered its error boundary or never finished the post-sign-in render, and the specs reported timeouts that read as three independent races.","fix":"Default session budget cut from 6 to 4 with a new --session-max-conns flag and a floor of 2 (the tenant-settings listener pins one pool connection for process life, and a pool of max only survives max minus 2 concurrent account locks); deploy-demo-box.yml now asks for 6 explicitly, so an ephemeral consumer that forgets the flag fails safe. Web E2E additionally names EMAXCONNSESSION in an error annotation on failure and uploads the redacted Next.js server log, since the error boundary's cause lived only there.","tags":["ci","e2e","flake","supabase","supavisor","pooler","session-mode","playwright"],"refs":["run 31958356695","job 95192819866","#631","#841"]}
```
