### PR TITLE
fix: write a reservation and its hold in one transaction, and stop rendering an over-release as a hold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -436,7 +436,11 @@ jobs:
             # ledger on real Postgres rather than through a fake, so leaving it
             # unlisted is the same never-runs trap as issues #701 and #708, on
             # the money path.
-            go test -tags integration -count=1 -p 1 -v ./internal/accounts/... ./internal/accounting/... ./internal/agenttask/... ./internal/egress/... ./internal/payments/... ./internal/profiles/... ./internal/rag/... ./internal/tenants/... ./internal/signup/... ./internal/routing/... ./internal/litellmconfig/... ./internal/catalog/... ./internal/providers/... ./internal/platform ./internal/platform/db/...
+            # ./internal/ledger/... joins the list with issue #918: its balance
+            # query is the only place an over-released reservation can be caught,
+            # and the proof that it no longer renders one as a hold has to run
+            # against real Postgres.
+            go test -tags integration -count=1 -p 1 -v ./internal/accounts/... ./internal/accounting/... ./internal/ledger/... ./internal/agenttask/... ./internal/egress/... ./internal/payments/... ./internal/profiles/... ./internal/rag/... ./internal/tenants/... ./internal/signup/... ./internal/routing/... ./internal/litellmconfig/... ./internal/catalog/... ./internal/providers/... ./internal/platform ./internal/platform/db/...
           else
             # -tags integration additionally compiles in
             # inference/chat_completions_integration_test.go (issue #708),

--- a/apps/control-plane/internal/accounting/repository.go
+++ b/apps/control-plane/internal/accounting/repository.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -43,6 +44,18 @@ func NewPgxRepository(pool *pgxpool.Pool) Repository {
 }
 
 func (r *pgxRepository) CreateReservation(ctx context.Context, reservation Reservation, reason string, hold ReservationHold) (Reservation, error) {
+	// Boundary guard, before any database work. A zero-value hold would post a
+	// 0-credit entry under an empty idempotency key and commit, leaving a row
+	// that looks authorized against a ledger holding nothing: the very state
+	// this signature exists to prevent. The service validates its own input,
+	// but the next caller of this method is not bound by that.
+	if hold.Credits <= 0 {
+		return Reservation{}, fmt.Errorf("accounting: reservation hold must be greater than zero, got %d", hold.Credits)
+	}
+	if strings.TrimSpace(hold.IdempotencyKey) == "" {
+		return Reservation{}, fmt.Errorf("accounting: reservation hold requires an idempotency key")
+	}
+
 	metadata, err := json.Marshal(map[string]any{
 		"policy_mode":    reservation.PolicyMode,
 		"request_id":     reservation.RequestID,

--- a/apps/control-plane/internal/accounting/repository.go
+++ b/apps/control-plane/internal/accounting/repository.go
@@ -10,10 +10,22 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/ledger"
 )
 
+// ReservationHold is the ledger hold that must land in the same transaction as
+// the reservation row it authorizes (issue #918). Passing it into
+// CreateReservation rather than posting it separately afterwards is what makes
+// "a reservation row exists if and only if its hold exists" a database
+// guarantee instead of an ordering convention.
+type ReservationHold struct {
+	IdempotencyKey string
+	Credits        int64
+	Metadata       map[string]any
+}
+
 type Repository interface {
-	CreateReservation(ctx context.Context, reservation Reservation, reason string) (Reservation, error)
+	CreateReservation(ctx context.Context, reservation Reservation, reason string, hold ReservationHold) (Reservation, error)
 	GetReservation(ctx context.Context, accountID, reservationID uuid.UUID) (Reservation, error)
 	ExpandReservation(ctx context.Context, accountID, reservationID uuid.UUID, additionalCredits int64, reason string) (Reservation, error)
 	FinalizeReservation(ctx context.Context, accountID, reservationID uuid.UUID, consumedCredits, releasedCredits int64, terminalUsageConfirmed bool, status ReservationStatus, reason string) (Reservation, error)
@@ -30,7 +42,7 @@ func NewPgxRepository(pool *pgxpool.Pool) Repository {
 	return &pgxRepository{pool: pool}
 }
 
-func (r *pgxRepository) CreateReservation(ctx context.Context, reservation Reservation, reason string) (Reservation, error) {
+func (r *pgxRepository) CreateReservation(ctx context.Context, reservation Reservation, reason string, hold ReservationHold) (Reservation, error) {
 	metadata, err := json.Marshal(map[string]any{
 		"policy_mode":    reservation.PolicyMode,
 		"request_id":     reservation.RequestID,
@@ -69,6 +81,24 @@ func (r *pgxRepository) CreateReservation(ctx context.Context, reservation Reser
 		VALUES ($1, 'reserved', $2, $3, $4::jsonb)
 	`, created.ID, created.ReservedCredits, reason, metadata); err != nil {
 		return Reservation{}, fmt.Errorf("accounting: insert reserved event: %w", err)
+	}
+
+	// The hold goes in THIS transaction (issue #918). It used to be posted by
+	// the service afterwards, through the ledger's own transaction, so a hold
+	// that failed to post left a committed reservation row claiming credits the
+	// ledger never held; the reaper then released that row and credited the
+	// account for credits it never had taken. Ten production reservations, 25000
+	// credits, are in that state. Here a failed hold rolls the row back with it.
+	if _, err := ledger.PostEntryTx(ctx, tx, created.AccountID, ledger.PostEntryInput{
+		EntryType:      ledger.EntryTypeReservationHold,
+		CreditsDelta:   -hold.Credits,
+		IdempotencyKey: hold.IdempotencyKey,
+		RequestID:      reservation.RequestID,
+		AttemptID:      &created.RequestAttemptID,
+		ReservationID:  &created.ID,
+		Metadata:       hold.Metadata,
+	}); err != nil {
+		return Reservation{}, fmt.Errorf("accounting: post reservation hold: %w", err)
 	}
 
 	if err := tx.Commit(ctx); err != nil {

--- a/apps/control-plane/internal/accounting/repository.go
+++ b/apps/control-plane/internal/accounting/repository.go
@@ -28,7 +28,7 @@ type ReservationHold struct {
 type Repository interface {
 	CreateReservation(ctx context.Context, reservation Reservation, reason string, hold ReservationHold) (Reservation, error)
 	GetReservation(ctx context.Context, accountID, reservationID uuid.UUID) (Reservation, error)
-	ExpandReservation(ctx context.Context, accountID, reservationID uuid.UUID, additionalCredits int64, reason string) (Reservation, error)
+	ExpandReservation(ctx context.Context, accountID, reservationID uuid.UUID, additionalCredits int64, reason string, hold ReservationHold) (Reservation, error)
 	FinalizeReservation(ctx context.Context, accountID, reservationID uuid.UUID, consumedCredits, releasedCredits int64, terminalUsageConfirmed bool, status ReservationStatus, reason string) (Reservation, error)
 	ReleaseReservation(ctx context.Context, accountID, reservationID uuid.UUID, releasedCredits int64, reason string) (Reservation, error)
 	CreateReconciliationJob(ctx context.Context, reservationID, requestAttemptID uuid.UUID, reason string) error
@@ -102,16 +102,8 @@ func (r *pgxRepository) CreateReservation(ctx context.Context, reservation Reser
 	// ledger never held; the reaper then released that row and credited the
 	// account for credits it never had taken. Ten production reservations, 25000
 	// credits, are in that state. Here a failed hold rolls the row back with it.
-	if _, err := ledger.PostEntryTx(ctx, tx, created.AccountID, ledger.PostEntryInput{
-		EntryType:      ledger.EntryTypeReservationHold,
-		CreditsDelta:   -hold.Credits,
-		IdempotencyKey: hold.IdempotencyKey,
-		RequestID:      reservation.RequestID,
-		AttemptID:      &created.RequestAttemptID,
-		ReservationID:  &created.ID,
-		Metadata:       hold.Metadata,
-	}); err != nil {
-		return Reservation{}, fmt.Errorf("accounting: post reservation hold: %w", err)
+	if err := postReservationHold(ctx, tx, created.AccountID, created.ID, created.RequestAttemptID, reservation.RequestID, hold); err != nil {
+		return Reservation{}, err
 	}
 
 	if err := tx.Commit(ctx); err != nil {
@@ -119,6 +111,37 @@ func (r *pgxRepository) CreateReservation(ctx context.Context, reservation Reser
 	}
 
 	return created, nil
+}
+
+// postReservationHold writes one hold inside the caller's transaction and
+// refuses to accept a deduplicated entry that belongs to a DIFFERENT
+// reservation.
+//
+// PostEntryTx returns the stored entry when the idempotency key has already
+// been used, which is right for a replay and wrong here: an entry carrying
+// another reservation's id means this row would commit with no hold of its own,
+// the exact state issue #918 exists to eliminate, and the reaper would later
+// release it against nothing. Unreachable from the service today, which derives
+// the key from a freshly generated reservation id, but Repository is exported
+// and its contract promises the row and its hold exist together
+// unconditionally.
+func postReservationHold(ctx context.Context, tx pgx.Tx, accountID, reservationID, attemptID uuid.UUID, requestID string, hold ReservationHold) error {
+	entry, err := ledger.PostEntryTx(ctx, tx, accountID, ledger.PostEntryInput{
+		EntryType:      ledger.EntryTypeReservationHold,
+		CreditsDelta:   -hold.Credits,
+		IdempotencyKey: hold.IdempotencyKey,
+		RequestID:      requestID,
+		AttemptID:      &attemptID,
+		ReservationID:  &reservationID,
+		Metadata:       hold.Metadata,
+	})
+	if err != nil {
+		return fmt.Errorf("accounting: post reservation hold: %w", err)
+	}
+	if entry.ReservationID == nil || *entry.ReservationID != reservationID {
+		return fmt.Errorf("accounting: post reservation hold: idempotency key %q already holds credits for another reservation", hold.IdempotencyKey)
+	}
+	return nil
 }
 
 func (r *pgxRepository) GetReservation(ctx context.Context, accountID, reservationID uuid.UUID) (Reservation, error) {
@@ -134,7 +157,14 @@ func (r *pgxRepository) GetReservation(ctx context.Context, accountID, reservati
 	return reservation, nil
 }
 
-func (r *pgxRepository) ExpandReservation(ctx context.Context, accountID, reservationID uuid.UUID, additionalCredits int64, reason string) (Reservation, error) {
+func (r *pgxRepository) ExpandReservation(ctx context.Context, accountID, reservationID uuid.UUID, additionalCredits int64, reason string, hold ReservationHold) (Reservation, error) {
+	if hold.Credits <= 0 {
+		return Reservation{}, fmt.Errorf("accounting: expansion hold must be greater than zero, got %d", hold.Credits)
+	}
+	if strings.TrimSpace(hold.IdempotencyKey) == "" {
+		return Reservation{}, fmt.Errorf("accounting: expansion hold requires an idempotency key")
+	}
+
 	metadata, err := json.Marshal(map[string]any{"additional_credits": additionalCredits})
 	if err != nil {
 		return Reservation{}, fmt.Errorf("accounting: marshal expand metadata: %w", err)
@@ -155,7 +185,8 @@ func (r *pgxRepository) ExpandReservation(ctx context.Context, accountID, reserv
 		RETURNING id, account_id, request_attempt_id, reservation_key, policy_mode, status, reserved_credits, consumed_credits, released_credits, terminal_usage_confirmed, created_at, updated_at
 	`, accountID, reservationID, additionalCredits)
 
-	if _, err := scanReservationCore(row); err != nil {
+	expanded, err := scanReservationCore(row)
+	if err != nil {
 		return Reservation{}, err
 	}
 
@@ -165,6 +196,14 @@ func (r *pgxRepository) ExpandReservation(ctx context.Context, accountID, reserv
 		VALUES ($1, 'expanded', $2, $3, $4::jsonb)
 	`, reservationID, additionalCredits, reason, metadata); err != nil {
 		return Reservation{}, fmt.Errorf("accounting: insert expanded event: %w", err)
+	}
+
+	// Same transaction as the raised reserved_credits, for the same reason the
+	// create path posts its hold here (issue #918), and it matters more on this
+	// path: settlement releases what the ROW says is held, so a row raised
+	// without its matching ledger hold hands back credits that were never taken.
+	if err := postReservationHold(ctx, tx, accountID, reservationID, expanded.RequestAttemptID, expanded.RequestID, hold); err != nil {
+		return Reservation{}, err
 	}
 
 	if err := tx.Commit(ctx); err != nil {

--- a/apps/control-plane/internal/accounting/reservation_hold_atomicity_live_test.go
+++ b/apps/control-plane/internal/accounting/reservation_hold_atomicity_live_test.go
@@ -1,0 +1,153 @@
+package accounting
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/ledger"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/usage"
+)
+
+// Issue #918. A reservation row and its ledger hold were written in two
+// separate transactions, so a hold that failed to post left a row claiming
+// credits the ledger never held. The stranded-hold reaper later released that
+// row, posting a reservation_release with no matching reservation_hold, which
+// credits an account for credits that were never taken from it. Ten such
+// reservations exist in production, 25000 credits, every one of them created
+// before this change.
+//
+// The bound, as magnitudes rather than call counts: across any attempt to
+// create a reservation, successful or not, the number of reservation rows and
+// the number of hold entries move together. Either both exist or neither does.
+//
+// The failure is injected at the database, not through a stub, because the
+// guarantee under test IS a transaction boundary and a fake cannot have one.
+// The injected shape is real: a claimed idempotency key whose ledger entry is
+// missing, which is the poisoned-key state issue #663 documented, and which
+// makes the hold write fail after the reservation row has been inserted, at
+// exactly the point the old sequence committed the row anyway.
+func TestReservationRowAndHoldAreWrittenAtomically_Live(t *testing.T) {
+	pool := newAccountingTestPool(t)
+	accountID := seedReleaseIdempotencyAccount(t, pool)
+	ctx := context.Background()
+
+	repo := NewPgxRepository(pool)
+	usageSvc := usage.NewService(usage.NewPgxRepository(pool))
+
+	attempt, err := usageSvc.StartAttempt(ctx, usage.StartAttemptInput{
+		AccountID:     accountID,
+		RequestID:     uuid.NewString(),
+		AttemptNumber: 1,
+		Endpoint:      "/v1/audio/transcriptions",
+		ModelAlias:    "hive-stt",
+		Status:        usage.AttemptStatusAccepted,
+	})
+	if err != nil {
+		t.Fatalf("start attempt: %v", err)
+	}
+
+	reservationID := uuid.New()
+	holdKey := "reservation:" + reservationID.String() + ":reserve"
+
+	// Claim the hold's idempotency key without its ledger entry. PostEntryTx
+	// then takes the duplicate branch, finds no entry, and fails.
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO public.credit_idempotency_keys (account_id, operation_type, idempotency_key)
+		 VALUES ($1, 'reservation_hold', $2)`, accountID, holdKey); err != nil {
+		t.Fatalf("poison idempotency key: %v", err)
+	}
+
+	_, err = repo.CreateReservation(ctx, Reservation{
+		ID:               reservationID,
+		AccountID:        accountID,
+		RequestAttemptID: attempt.ID,
+		ReservationKey:   buildReservationKey(accountID, attempt.RequestID, 1),
+		RequestID:        attempt.RequestID,
+		AttemptNumber:    1,
+		Endpoint:         "/v1/audio/transcriptions",
+		ModelAlias:       "hive-stt",
+		PolicyMode:       PolicyModeStrict,
+		Status:           ReservationStatusActive,
+		ReservedCredits:  500,
+	}, "reserved", ReservationHold{IdempotencyKey: holdKey, Credits: 500})
+	if err == nil {
+		t.Fatal("expected CreateReservation to fail when the hold cannot be posted")
+	}
+
+	rows, holds := countRowsAndHolds(t, pool, accountID)
+	if rows != holds {
+		t.Fatalf("reservation rows (%d) and hold entries (%d) diverged: a row with no hold is what the reaper later releases against nothing", rows, holds)
+	}
+	if rows != 0 {
+		t.Fatalf("expected the failed create to leave nothing behind, got %d reservation rows", rows)
+	}
+	// The events table must not carry an orphan either: all ten production rows
+	// have a 'reserved' event, which is how they looked legitimate.
+	var events int64
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM public.credit_reservation_events WHERE reservation_id = $1`,
+		reservationID).Scan(&events); err != nil {
+		t.Fatalf("count events: %v", err)
+	}
+	if events != 0 {
+		t.Fatalf("expected no reservation events from a rolled-back create, got %d", events)
+	}
+
+	// Positive control: the same repository, with a key nobody has claimed,
+	// writes both. Without this the assertions above would pass on a repository
+	// that never writes anything at all.
+	controlID := uuid.New()
+	if _, err := repo.CreateReservation(ctx, Reservation{
+		ID:               controlID,
+		AccountID:        accountID,
+		RequestAttemptID: attempt.ID,
+		ReservationKey:   buildReservationKey(accountID, attempt.RequestID, 2),
+		RequestID:        attempt.RequestID,
+		AttemptNumber:    2,
+		Endpoint:         "/v1/audio/transcriptions",
+		ModelAlias:       "hive-stt",
+		PolicyMode:       PolicyModeStrict,
+		Status:           ReservationStatusActive,
+		ReservedCredits:  500,
+	}, "reserved", ReservationHold{
+		IdempotencyKey: "reservation:" + controlID.String() + ":reserve",
+		Credits:        500,
+	}); err != nil {
+		t.Fatalf("control CreateReservation: %v", err)
+	}
+
+	rows, holds = countRowsAndHolds(t, pool, accountID)
+	if rows != 1 || holds != 1 {
+		t.Fatalf("control: expected one row and one hold, got %d rows and %d holds", rows, holds)
+	}
+
+	// And the hold is the real thing, in the right direction and amount: a
+	// reservation whose hold went in with the wrong sign would still count as
+	// one row and one entry above.
+	balance, err := ledger.NewService(ledger.NewPgxRepository(pool)).GetBalance(ctx, accountID)
+	if err != nil {
+		t.Fatalf("GetBalance: %v", err)
+	}
+	if balance.ReservedCredits != 500 {
+		t.Fatalf("reserved = %d, want the 500 the control reservation holds", balance.ReservedCredits)
+	}
+	if balance.OverReleasedReservations != 0 {
+		t.Fatalf("expected no over-released reservations, got %d", balance.OverReleasedReservations)
+	}
+}
+
+func countRowsAndHolds(t *testing.T, pool *pgxpool.Pool, accountID uuid.UUID) (int64, int64) {
+	t.Helper()
+	var rows, holds int64
+	if err := pool.QueryRow(context.Background(), `
+		SELECT
+			(SELECT count(*) FROM public.credit_reservations WHERE account_id = $1),
+			(SELECT count(*) FROM public.credit_ledger_entries
+			 WHERE account_id = $1 AND entry_type = 'reservation_hold')
+	`, accountID).Scan(&rows, &holds); err != nil {
+		t.Fatalf("count rows: %v", err)
+	}
+	return rows, holds
+}

--- a/apps/control-plane/internal/accounting/reservation_hold_atomicity_live_test.go
+++ b/apps/control-plane/internal/accounting/reservation_hold_atomicity_live_test.go
@@ -2,6 +2,7 @@ package accounting
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -74,6 +75,15 @@ func TestReservationRowAndHoldAreWrittenAtomically_Live(t *testing.T) {
 	}, "reserved", ReservationHold{IdempotencyKey: holdKey, Credits: 500})
 	if err == nil {
 		t.Fatal("expected CreateReservation to fail when the hold cannot be posted")
+	}
+	// WHICH failure matters. Every assertion below also holds for a call
+	// rejected before the transaction opened (the guards on hold.Credits and
+	// hold.IdempotencyKey do exactly that), so without pinning the failure to
+	// the hold post itself, moving poisoned-key detection into a pre-flight
+	// check would keep this test green while proving nothing about the
+	// transaction boundary it exists to pin.
+	if !strings.Contains(err.Error(), "post reservation hold") {
+		t.Fatalf("expected the failure to come from the hold post inside the transaction, got %v", err)
 	}
 
 	rows, holds := countRowsAndHolds(t, pool, accountID)
@@ -150,4 +160,83 @@ func countRowsAndHolds(t *testing.T, pool *pgxpool.Pool, accountID uuid.UUID) (i
 		t.Fatalf("count rows: %v", err)
 	}
 	return rows, holds
+}
+
+// The expand path had the identical defect, and worse consequences, so it gets
+// the identical proof. Settlement releases what the ROW says is held, so a row
+// raised to 2500 while the ledger still holds 500 hands back 2500 against 500
+// ever taken: 2000 credits created out of nothing, the same mechanism and the
+// same magnitude class as the ten production rows.
+func TestExpandReservationRaisesTheRowAndTheHoldTogether_Live(t *testing.T) {
+	pool := newAccountingTestPool(t)
+	accountID := seedReleaseIdempotencyAccount(t, pool)
+	ctx := context.Background()
+
+	repo := NewPgxRepository(pool)
+	usageSvc := usage.NewService(usage.NewPgxRepository(pool))
+	ledgerSvc := ledger.NewService(ledger.NewPgxRepository(pool))
+
+	attempt, err := usageSvc.StartAttempt(ctx, usage.StartAttemptInput{
+		AccountID:     accountID,
+		RequestID:     uuid.NewString(),
+		AttemptNumber: 1,
+		Endpoint:      "/v1/chat/completions",
+		ModelAlias:    "hive-fast",
+		Status:        usage.AttemptStatusAccepted,
+	})
+	if err != nil {
+		t.Fatalf("start attempt: %v", err)
+	}
+
+	reservationID := uuid.New()
+	if _, err := repo.CreateReservation(ctx, Reservation{
+		ID:               reservationID,
+		AccountID:        accountID,
+		RequestAttemptID: attempt.ID,
+		ReservationKey:   buildReservationKey(accountID, attempt.RequestID, 1),
+		RequestID:        attempt.RequestID,
+		AttemptNumber:    1,
+		Endpoint:         "/v1/chat/completions",
+		ModelAlias:       "hive-fast",
+		PolicyMode:       PolicyModeStrict,
+		Status:           ReservationStatusActive,
+		ReservedCredits:  500,
+	}, "reserved", ReservationHold{
+		IdempotencyKey: "reservation:" + reservationID.String() + ":reserve",
+		Credits:        500,
+	}); err != nil {
+		t.Fatalf("CreateReservation: %v", err)
+	}
+
+	expandKey := "reservation:" + reservationID.String() + ":expand-2000"
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO public.credit_idempotency_keys (account_id, operation_type, idempotency_key)
+		 VALUES ($1, 'reservation_hold', $2)`, accountID, expandKey); err != nil {
+		t.Fatalf("poison idempotency key: %v", err)
+	}
+
+	_, err = repo.ExpandReservation(ctx, accountID, reservationID, 2000, "expanded",
+		ReservationHold{IdempotencyKey: expandKey, Credits: 2000})
+	if err == nil {
+		t.Fatal("expected ExpandReservation to fail when its hold cannot be posted")
+	}
+	if !strings.Contains(err.Error(), "post reservation hold") {
+		t.Fatalf("expected the failure to come from the hold post inside the transaction, got %v", err)
+	}
+
+	stored, err := repo.GetReservation(ctx, accountID, reservationID)
+	if err != nil {
+		t.Fatalf("reload reservation: %v", err)
+	}
+	if stored.ReservedCredits != 500 {
+		t.Fatalf("row was raised to %d while the ledger still holds 500; settlement would release the difference against credits never taken", stored.ReservedCredits)
+	}
+
+	balance, err := ledgerSvc.GetBalance(ctx, accountID)
+	if err != nil {
+		t.Fatalf("GetBalance: %v", err)
+	}
+	if balance.ReservedCredits != 500 {
+		t.Fatalf("reserved = %d, want the original 500", balance.ReservedCredits)
+	}
 }

--- a/apps/control-plane/internal/accounting/service.go
+++ b/apps/control-plane/internal/accounting/service.go
@@ -203,18 +203,23 @@ func (s *Service) ExpandReservation(ctx context.Context, input ExpandReservation
 			return err
 		}
 
-		reservation, err = s.repo.ExpandReservation(ctx, input.AccountID, input.ReservationID, input.AdditionalCredits, "expanded")
+		// Expansion carries its hold in the same transaction as the row, for
+		// the reason create does (issue #918). This path had the identical
+		// defect and it is worse here, because settlement releases from the ROW:
+		// a row raised to 2500 while the ledger still holds 500 releases 2500
+		// against 500 ever taken, crediting the account 2000 it never paid.
+		reservation, err = s.repo.ExpandReservation(ctx, input.AccountID, input.ReservationID, input.AdditionalCredits, "expanded", ReservationHold{
+			IdempotencyKey: s.idempotencyKey(input.ReservationID, fmt.Sprintf("expand-%d", input.AdditionalCredits)),
+			Credits:        input.AdditionalCredits,
+			Metadata: map[string]any{
+				"endpoint":           reservation.Endpoint,
+				"model_alias":        reservation.ModelAlias,
+				"additional_credits": input.AdditionalCredits,
+				"policy_mode":        reservation.PolicyMode,
+			},
+		})
 		if err != nil {
 			return fmt.Errorf("accounting: expand reservation: %w", err)
-		}
-
-		if _, err := s.ledgerSvc.ReserveCredits(ctx, reservation.AccountID, reservation.RequestID, &reservation.RequestAttemptID, &reservation.ID, s.idempotencyKey(reservation.ID, fmt.Sprintf("expand-%d", input.AdditionalCredits)), input.AdditionalCredits, map[string]any{
-			"endpoint":           reservation.Endpoint,
-			"model_alias":        reservation.ModelAlias,
-			"additional_credits": input.AdditionalCredits,
-			"policy_mode":        reservation.PolicyMode,
-		}); err != nil {
-			return fmt.Errorf("accounting: reserve expanded credits: %w", err)
 		}
 
 		if attempt, err := s.findAttempt(ctx, reservation.AccountID, reservation.RequestID, reservation.RequestAttemptID); err != nil {

--- a/apps/control-plane/internal/accounting/service.go
+++ b/apps/control-plane/internal/accounting/service.go
@@ -102,8 +102,17 @@ func (s *Service) CreateReservation(ctx context.Context, input CreateReservation
 			return fmt.Errorf("accounting: start attempt: %w", err)
 		}
 
+		reservationID := uuid.New()
+
+		// Row and hold, one transaction (issue #918). The hold used to be a
+		// separate ledger call made right here, after the row had already
+		// committed, so a hold that failed left a reservation claiming credits
+		// the ledger never held, and the reaper later released that row against
+		// nothing, crediting an account for credits never taken from it. The
+		// repository writes both or neither now, so the invariant is the
+		// database's to keep rather than this function's.
 		reservation, err = s.repo.CreateReservation(ctx, Reservation{
-			ID:               uuid.New(),
+			ID:               reservationID,
 			AccountID:        input.AccountID,
 			RequestAttemptID: attempt.ID,
 			ReservationKey:   buildReservationKey(input.AccountID, input.RequestID, input.AttemptNumber),
@@ -115,17 +124,17 @@ func (s *Service) CreateReservation(ctx context.Context, input CreateReservation
 			PolicyMode:       input.PolicyMode,
 			Status:           ReservationStatusActive,
 			ReservedCredits:  input.EstimatedCredits,
-		}, "reserved")
+		}, "reserved", ReservationHold{
+			IdempotencyKey: s.idempotencyKey(reservationID, "reserve"),
+			Credits:        input.EstimatedCredits,
+			Metadata: map[string]any{
+				"policy_mode": input.PolicyMode,
+				"endpoint":    input.Endpoint,
+				"model_alias": input.ModelAlias,
+			},
+		})
 		if err != nil {
 			return fmt.Errorf("accounting: create reservation: %w", err)
-		}
-
-		if _, err := s.ledgerSvc.ReserveCredits(ctx, input.AccountID, input.RequestID, &attempt.ID, &reservation.ID, s.idempotencyKey(reservation.ID, "reserve"), input.EstimatedCredits, map[string]any{
-			"policy_mode": input.PolicyMode,
-			"endpoint":    input.Endpoint,
-			"model_alias": input.ModelAlias,
-		}); err != nil {
-			return fmt.Errorf("accounting: reserve credits: %w", err)
 		}
 
 		if _, err := s.usageSvc.RecordEvent(ctx, usage.RecordEventInput{

--- a/apps/control-plane/internal/accounting/service_concurrency_test.go
+++ b/apps/control-plane/internal/accounting/service_concurrency_test.go
@@ -76,7 +76,7 @@ func (r *concurrentRepo) CreateReservation(ctx context.Context, reservation Rese
 func (r *concurrentRepo) GetReservation(context.Context, uuid.UUID, uuid.UUID) (Reservation, error) {
 	return Reservation{}, ErrNotFound
 }
-func (r *concurrentRepo) ExpandReservation(context.Context, uuid.UUID, uuid.UUID, int64, string) (Reservation, error) {
+func (r *concurrentRepo) ExpandReservation(context.Context, uuid.UUID, uuid.UUID, int64, string, ReservationHold) (Reservation, error) {
 	return Reservation{}, ErrNotFound
 }
 func (r *concurrentRepo) FinalizeReservation(context.Context, uuid.UUID, uuid.UUID, int64, int64, bool, ReservationStatus, string) (Reservation, error) {
@@ -169,14 +169,32 @@ type countingLocker struct {
 	mu       sync.Mutex
 	calls    int
 	accounts []uuid.UUID
+	// held is true while the guarded function runs, so a fake repository can
+	// record whether IT ran inside the lock. Without it the assertion fires
+	// only if the service stops taking a hold at all, and moving the repository
+	// call outside WithAccountLock would keep the test green.
+	held bool
 }
 
 func (l *countingLocker) WithAccountLock(ctx context.Context, accountID uuid.UUID, fn func(context.Context) error) error {
 	l.mu.Lock()
 	l.calls++
 	l.accounts = append(l.accounts, accountID)
+	l.held = true
 	l.mu.Unlock()
-	return fn(ctx)
+
+	err := fn(ctx)
+
+	l.mu.Lock()
+	l.held = false
+	l.mu.Unlock()
+	return err
+}
+
+func (l *countingLocker) heldNow() bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.held
 }
 
 // TestCreateReservationAcquiresAccountLock deterministically proves the
@@ -188,6 +206,7 @@ func TestCreateReservationAcquiresAccountLock(t *testing.T) {
 	locker := &countingLocker{}
 	accountID := uuid.New()
 
+	repo.lockProbe = locker
 	svc := NewService(repo, ledgerSvc, &usageStub{}).WithAccountLocker(locker)
 	if _, err := svc.CreateReservation(context.Background(), CreateReservationInput{
 		AccountID:        accountID,
@@ -208,9 +227,15 @@ func TestCreateReservationAcquiresAccountLock(t *testing.T) {
 		t.Fatalf("expected lock keyed on account %s, got %#v", accountID, locker.accounts)
 	}
 	// The hold is written with the row now (issue #918), so the thing that must
-	// happen inside the lock is the repository call that carries it.
+	// happen inside the lock is the repository call that carries it. Asserted
+	// on where it ran, not merely that it ran: repoStub records the locker's
+	// held flag at call time, so moving s.repo.CreateReservation outside
+	// WithAccountLock fails this.
 	if len(repo.holds) != 1 || repo.holds[0].Credits != 50 {
 		t.Fatalf("expected the 50-credit hold to be written inside the lock, got %#v", repo.holds)
+	}
+	if !repo.createdUnderLock {
+		t.Fatal("the reservation and its hold were written outside the per-account lock, which is the double-spend window issue #106 closed")
 	}
 }
 

--- a/apps/control-plane/internal/accounting/service_concurrency_test.go
+++ b/apps/control-plane/internal/accounting/service_concurrency_test.go
@@ -51,16 +51,26 @@ func (l *serializingLedger) RefundCredits(_ context.Context, _ uuid.UUID, _ stri
 	return ledger.LedgerEntry{ID: uuid.New(), EntryType: ledger.EntryTypeRefund, CreditsDelta: credits}, nil
 }
 
-// concurrentRepo is a goroutine-safe repoStub for the race test.
+// concurrentRepo is a goroutine-safe repoStub for the race test. It applies the
+// hold to the shared balance itself, because the production repository writes
+// the hold in the same transaction as the row (issue #918); modelling it
+// anywhere else would leave the race test measuring a sequence the system no
+// longer performs.
 type concurrentRepo struct {
-	mu    sync.Mutex
-	count int
+	mu     sync.Mutex
+	count  int
+	ledger *serializingLedger
 }
 
-func (r *concurrentRepo) CreateReservation(_ context.Context, reservation Reservation, _ string) (Reservation, error) {
+func (r *concurrentRepo) CreateReservation(ctx context.Context, reservation Reservation, _ string, hold ReservationHold) (Reservation, error) {
 	r.mu.Lock()
 	r.count++
 	r.mu.Unlock()
+	if r.ledger != nil {
+		if _, err := r.ledger.ReserveCredits(ctx, reservation.AccountID, reservation.RequestID, nil, &reservation.ID, hold.IdempotencyKey, hold.Credits, hold.Metadata); err != nil {
+			return Reservation{}, err
+		}
+	}
 	return reservation, nil
 }
 func (r *concurrentRepo) GetReservation(context.Context, uuid.UUID, uuid.UUID) (Reservation, error) {
@@ -103,8 +113,8 @@ func (concurrentUsage) ListAttempts(context.Context, uuid.UUID, string, int) ([]
 // using the supplied account locker, and returns how many succeeded.
 func runConcurrentReservations(t *testing.T, locker AccountLocker, balance, each int64, n int) (int, *serializingLedger) {
 	t.Helper()
-	repo := &concurrentRepo{}
 	ledgerSvc := &serializingLedger{available: balance}
+	repo := &concurrentRepo{ledger: ledgerSvc}
 	svc := NewService(repo, ledgerSvc, concurrentUsage{}).WithAccountLocker(locker)
 
 	accountID := uuid.New()
@@ -197,8 +207,10 @@ func TestCreateReservationAcquiresAccountLock(t *testing.T) {
 	if len(locker.accounts) != 1 || locker.accounts[0] != accountID {
 		t.Fatalf("expected lock keyed on account %s, got %#v", accountID, locker.accounts)
 	}
-	if len(ledgerSvc.reserveCalls) != 1 {
-		t.Fatalf("expected the reserve hold to be posted inside the lock, got %d reserve calls", len(ledgerSvc.reserveCalls))
+	// The hold is written with the row now (issue #918), so the thing that must
+	// happen inside the lock is the repository call that carries it.
+	if len(repo.holds) != 1 || repo.holds[0].Credits != 50 {
+		t.Fatalf("expected the 50-credit hold to be written inside the lock, got %#v", repo.holds)
 	}
 }
 

--- a/apps/control-plane/internal/accounting/service_test.go
+++ b/apps/control-plane/internal/accounting/service_test.go
@@ -221,6 +221,12 @@ type repoStub struct {
 	releaseEventCounts map[uuid.UUID]int
 	holds              []ReservationHold
 
+	// Optional lock probe. When set, CreateReservation records whether the
+	// per-account lock was held at the moment it ran, which is the only way an
+	// assertion can tell "inside the lock" from "called at all" (issue #106).
+	lockProbe        interface{ heldNow() bool }
+	createdUnderLock bool
+
 	// Optional fake ledger. The production repository posts the hold in its own
 	// transaction (issue #918), so a test whose subject is the account balance
 	// has to see the hold land here, or its fixture silently starts from an
@@ -251,6 +257,9 @@ func (r *repoStub) CreateReservation(ctx context.Context, reservation Reservatio
 	reservation.UpdatedAt = now
 	r.reservations[reservation.ID] = reservation
 	r.holds = append(r.holds, hold)
+	if r.lockProbe != nil {
+		r.createdUnderLock = r.lockProbe.heldNow()
+	}
 	poster := r.ledger
 	r.mu.Unlock()
 
@@ -297,11 +306,11 @@ func (r *repoStub) ListStaleReservations(_ context.Context, olderThan time.Time,
 	return stale, nil
 }
 
-func (r *repoStub) ExpandReservation(_ context.Context, accountID, reservationID uuid.UUID, additionalCredits int64, reason string) (Reservation, error) {
+func (r *repoStub) ExpandReservation(ctx context.Context, accountID, reservationID uuid.UUID, additionalCredits int64, reason string, hold ReservationHold) (Reservation, error) {
 	r.mu.Lock()
-	defer r.mu.Unlock()
 	reservation, err := r.getLocked(accountID, reservationID)
 	if err != nil {
+		r.mu.Unlock()
 		return Reservation{}, err
 	}
 
@@ -309,6 +318,18 @@ func (r *repoStub) ExpandReservation(_ context.Context, accountID, reservationID
 	reservation.Status = ReservationStatusExpanded
 	reservation.UpdatedAt = time.Now().UTC()
 	r.reservations[reservationID] = reservation
+	r.holds = append(r.holds, hold)
+	poster := r.ledger
+	r.mu.Unlock()
+
+	// Expansion writes its hold with the raised row (issue #918), so the fake
+	// applies it the same way, or a balance-based fixture would credit an
+	// expansion the ledger never took.
+	if poster != nil {
+		if _, err := poster.ReserveCredits(ctx, reservation.AccountID, reservation.RequestID, &reservation.RequestAttemptID, &reservation.ID, hold.IdempotencyKey, hold.Credits, hold.Metadata); err != nil {
+			return Reservation{}, err
+		}
+	}
 	return reservation, nil
 }
 

--- a/apps/control-plane/internal/accounting/service_test.go
+++ b/apps/control-plane/internal/accounting/service_test.go
@@ -219,6 +219,17 @@ type repoStub struct {
 	reservations       map[uuid.UUID]Reservation
 	reconciliationJobs []reconciliationJob
 	releaseEventCounts map[uuid.UUID]int
+	holds              []ReservationHold
+
+	// Optional fake ledger. The production repository posts the hold in its own
+	// transaction (issue #918), so a test whose subject is the account balance
+	// has to see the hold land here, or its fixture silently starts from an
+	// unreserved balance.
+	ledger holdPoster
+}
+
+type holdPoster interface {
+	ReserveCredits(ctx context.Context, accountID uuid.UUID, requestID string, attemptID, reservationID *uuid.UUID, idempotencyKey string, credits int64, metadata map[string]any) (ledger.LedgerEntry, error)
 }
 
 func newRepoStub() *repoStub {
@@ -228,13 +239,26 @@ func newRepoStub() *repoStub {
 	}
 }
 
-func (r *repoStub) CreateReservation(_ context.Context, reservation Reservation, reason string) (Reservation, error) {
+// CreateReservation records the hold alongside the row, because the production
+// repository now writes both in one transaction (issue #918). Tests assert on
+// r.holds where they used to assert on the ledger's reserve calls; without
+// recording it here, the assertion that a hold is taken at all would quietly
+// stop checking anything.
+func (r *repoStub) CreateReservation(ctx context.Context, reservation Reservation, reason string, hold ReservationHold) (Reservation, error) {
 	r.mu.Lock()
-	defer r.mu.Unlock()
 	now := time.Now().UTC()
 	reservation.CreatedAt = now
 	reservation.UpdatedAt = now
 	r.reservations[reservation.ID] = reservation
+	r.holds = append(r.holds, hold)
+	poster := r.ledger
+	r.mu.Unlock()
+
+	if poster != nil {
+		if _, err := poster.ReserveCredits(ctx, reservation.AccountID, reservation.RequestID, &reservation.RequestAttemptID, &reservation.ID, hold.IdempotencyKey, hold.Credits, hold.Metadata); err != nil {
+			return Reservation{}, err
+		}
+	}
 	return reservation, nil
 }
 
@@ -386,8 +410,13 @@ func TestCreateReservationAllowsTemporaryOverageWithinBuffer(t *testing.T) {
 	if reservation.Status != ReservationStatusActive {
 		t.Fatalf("expected active reservation, got %s", reservation.Status)
 	}
-	if len(ledgerSvc.reserveCalls) != 1 {
-		t.Fatalf("expected one reserve ledger call, got %d", len(ledgerSvc.reserveCalls))
+	// The hold rides with the row now (issue #918), so it is recorded by the
+	// repository rather than posted through the ledger service afterwards.
+	if len(repo.holds) != 1 || repo.holds[0].Credits != 10100 {
+		t.Fatalf("expected one 10100-credit hold written with the reservation, got %#v", repo.holds)
+	}
+	if len(ledgerSvc.reserveCalls) != 0 {
+		t.Fatalf("hold must not be posted in a second transaction, got %#v", ledgerSvc.reserveCalls)
 	}
 	if len(usageSvc.startCalls) != 1 {
 		t.Fatalf("expected one usage start call, got %d", len(usageSvc.startCalls))

--- a/apps/control-plane/internal/accounting/settlement_hold_invariant_test.go
+++ b/apps/control-plane/internal/accounting/settlement_hold_invariant_test.go
@@ -85,6 +85,9 @@ func TestSettlementReturnsReservedToZero(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			repo := newRepoStub()
 			ledgerSvc := newReaperLedger(grant)
+			// The hold lands with the row (issue #918), so the fake repository
+			// posts it to the fake ledger the way production does.
+			repo.ledger = ledgerSvc
 			svc := NewService(repo, ledgerSvc, concurrentUsage{})
 			ctx := context.Background()
 			accountID := uuid.New()
@@ -162,6 +165,7 @@ func TestSettlementReturnsReservedToZero(t *testing.T) {
 func TestSettlementRefusesToSettleAgainstAPartialRelease(t *testing.T) {
 	repo := newRepoStub()
 	ledgerSvc := newReaperLedger(300000)
+	repo.ledger = ledgerSvc
 	svc := NewService(repo, ledgerSvc, concurrentUsage{})
 	ctx := context.Background()
 	accountID := uuid.New()

--- a/apps/control-plane/internal/ledger/balance_over_release_live_test.go
+++ b/apps/control-plane/internal/ledger/balance_over_release_live_test.go
@@ -1,0 +1,141 @@
+package ledger
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Issue #918, the reader half. GetBalance used to compute
+//
+//	reserved = ABS(SUM(hold) + SUM(release))
+//
+// over the whole account. That ABS is what let a sign error render as a
+// plausible number: a reservation released without ever having been held pushes
+// the sum positive, and ABS presents that positive number as though credits
+// were on hold. Two production accounts sit in exactly that state, and their
+// customer-facing available balance is wrong in BOTH directions because the
+// phantom nets against genuine in-flight holds before the ABS is taken.
+//
+// The bound: reserved is the sum, over reservations, of what each one still
+// holds, never less than zero for any single reservation and never netted
+// across them. A reservation that shows more released than held contributes
+// nothing to reserved and is counted separately as an anomaly, because a
+// positive net is a corruption signal, not a hold.
+//
+// Fixture below reproduces the production shape exactly: one settled
+// reservation, one genuinely in flight, one released with no hold.
+func TestGetBalanceDoesNotRenderAnOverReleaseAsAHold_Live(t *testing.T) {
+	pool := newLedgerTestPool(t)
+	accountID := seedLedgerAccount(t, pool)
+	ctx := context.Background()
+
+	svc := NewService(NewPgxRepository(pool))
+	if _, err := svc.GrantCredits(ctx, accountID, uuid.NewString(), 100000, map[string]any{"reason": "test grant"}); err != nil {
+		t.Fatalf("grant: %v", err)
+	}
+
+	settled := uuid.New()
+	inFlight := uuid.New()
+	phantom := uuid.New()
+
+	// Settled: held 10000, lifted in full, charged 20. Contributes nothing.
+	post(t, svc, accountID, settled, "reserve", 10000, false)
+	post(t, svc, accountID, settled, "release", 10000, true)
+	if _, err := svc.ChargeUsage(ctx, accountID, "req-settled", nil, &settled, "reservation:"+settled.String()+":charge-20", 20, nil); err != nil {
+		t.Fatalf("charge: %v", err)
+	}
+
+	// Genuinely in flight: held 12000, not yet released.
+	post(t, svc, accountID, inFlight, "reserve", 12000, false)
+
+	// The #918 shape: released without ever having been held.
+	post(t, svc, accountID, phantom, "release", 23000, true)
+
+	balance, err := svc.GetBalance(ctx, accountID)
+	if err != nil {
+		t.Fatalf("GetBalance: %v", err)
+	}
+
+	if balance.PostedCredits != 100000-20 {
+		t.Fatalf("posted = %d, want %d", balance.PostedCredits, 100000-20)
+	}
+	if balance.ReservedCredits != 12000 {
+		t.Fatalf("reserved = %d, want 12000: only the one hold that is genuinely outstanding. "+
+			"ABS over the account nets the 23000 phantom against it and reports 11000, a hold that does not exist",
+			balance.ReservedCredits)
+	}
+	if balance.AvailableCredits != 100000-20-12000 {
+		t.Fatalf("available = %d, want %d", balance.AvailableCredits, 100000-20-12000)
+	}
+	if balance.OverReleasedCredits != 23000 || balance.OverReleasedReservations != 1 {
+		t.Fatalf("expected the corruption reported as 23000 credits across 1 reservation, got %d across %d",
+			balance.OverReleasedCredits, balance.OverReleasedReservations)
+	}
+}
+
+func post(t *testing.T, svc *Service, accountID, reservationID uuid.UUID, action string, credits int64, release bool) {
+	t.Helper()
+	key := "reservation:" + reservationID.String() + ":" + action
+	var err error
+	if release {
+		_, err = svc.ReleaseReservedCredits(context.Background(), accountID, "req-"+action, nil, &reservationID, key, credits, nil)
+	} else {
+		_, err = svc.ReserveCredits(context.Background(), accountID, "req-"+action, nil, &reservationID, key, credits, nil)
+	}
+	if err != nil {
+		t.Fatalf("post %s: %v", action, err)
+	}
+}
+
+// Same gating convention as accounting's live suites.
+func newLedgerTestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("HIVE_TEST_DB_URL")
+	if dsn == "" {
+		t.Skip("HIVE_TEST_DB_URL not set")
+	}
+	if !strings.Contains(strings.ToLower(dsn), "test") {
+		t.Fatalf("refusing to run: HIVE_TEST_DB_URL must point at a test database (DSN missing 'test' marker)")
+	}
+	pool, err := pgxpool.New(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+func seedLedgerAccount(t *testing.T, pool *pgxpool.Pool) uuid.UUID {
+	t.Helper()
+	ctx := context.Background()
+
+	var userID uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO auth.users (id, email, raw_user_meta_data)
+		 VALUES (gen_random_uuid(), $1, '{}'::jsonb) RETURNING id`,
+		"ledger-balance-"+uuid.NewString()+"@test.local",
+	).Scan(&userID); err != nil {
+		t.Skipf("seed auth.users failed (is this a migrated test DB?): %v", err)
+	}
+
+	var accountID uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO public.accounts (id, slug, display_name, account_type, owner_user_id)
+		 VALUES (gen_random_uuid(), $1, 'ledger balance test', 'personal', $2) RETURNING id`,
+		"ledger-balance-"+uuid.NewString(), userID,
+	).Scan(&accountID); err != nil {
+		t.Fatalf("seed account: %v", err)
+	}
+
+	t.Cleanup(func() {
+		cleanupCtx := context.Background()
+		_, _ = pool.Exec(cleanupCtx, `DELETE FROM public.accounts WHERE id = $1`, accountID)
+		_, _ = pool.Exec(cleanupCtx, `DELETE FROM auth.users WHERE id = $1`, userID)
+	})
+	return accountID
+}

--- a/apps/control-plane/internal/ledger/balance_over_release_live_test.go
+++ b/apps/control-plane/internal/ledger/balance_over_release_live_test.go
@@ -120,7 +120,11 @@ func seedLedgerAccount(t *testing.T, pool *pgxpool.Pool) uuid.UUID {
 		 VALUES (gen_random_uuid(), $1, '{}'::jsonb) RETURNING id`,
 		"ledger-balance-"+uuid.NewString()+"@test.local",
 	).Scan(&userID); err != nil {
-		t.Skipf("seed auth.users failed (is this a migrated test DB?): %v", err)
+		// Fatal, not Skip. The CI leg that runs this suite bootstraps the full
+		// migration chain, so a seed failure here is a schema regression, and
+		// skipping would report it green: the never-runs trap this suite was
+		// added to close.
+		t.Fatalf("seed auth.users failed (is this a migrated test DB?): %v", err)
 	}
 
 	var accountID uuid.UUID

--- a/apps/control-plane/internal/ledger/repository.go
+++ b/apps/control-plane/internal/ledger/repository.go
@@ -123,18 +123,35 @@ func PostEntryTx(ctx context.Context, tx pgx.Tx, accountID uuid.UUID, input Post
 // separately in OverReleasedCredits, and Service.GetBalance logs it, rather
 // than being folded into a number a customer would read as a hold.
 //
-// Cost: the same rows the old query already scanned on the (account_id,
-// created_at) index, with a hash aggregate on reservation_id on top. No extra
-// index, and reservation_id needs none, since the grouping never leaves the
-// account's own slice.
+// Cost, measured on a scratch database with the real schema, one account
+// holding 5000 entries across 1667 reservations among 55000 rows: 6.2ms against
+// the old query's 3.4ms, two index-driven scans and a hash aggregate instead of
+// one streaming pass. That is the price of not lying about the number, paid
+// inside the per-account critical section on the create path.
+//
+// It is deliberately NOT written as a CTE referenced twice: Postgres inlines a
+// CTE only when it is referenced exactly once, so the obvious shape
+// materializes the account's whole ledger slice into a tuplestore on every
+// call. There is no Materialize or CTE Scan node in the plan above.
+//
+// ponytail: the hash aggregate is sized by the account's RESERVATION count
+// (465kB at 1667 of them), so an account with a hundred thousand reservations
+// spills past a default work_mem. Nothing near that exists today, and the
+// upgrade path when it does is a rolled-up per-account balance rather than a
+// smarter query.
 func (r *pgxRepository) GetBalance(ctx context.Context, accountID uuid.UUID) (BalanceSummary, error) {
 	row := r.pool.QueryRow(ctx, `
-		WITH entries AS (
-			SELECT id, entry_type, credits_delta, reservation_id
-			FROM public.credit_ledger_entries
-			WHERE account_id = $1
-		),
-		holds AS (
+		SELECT
+			COALESCE((
+				SELECT SUM(credits_delta)
+				FROM public.credit_ledger_entries
+				WHERE account_id = $1
+				  AND entry_type IN ('grant', 'adjustment', 'usage_charge', 'refund')
+			), 0) AS posted_credits,
+			COALESCE(SUM(GREATEST(-holds.net, 0)), 0) AS reserved_credits,
+			COALESCE(SUM(GREATEST(holds.net, 0)), 0) AS over_released_credits,
+			COALESCE(COUNT(*) FILTER (WHERE holds.net > 0), 0) AS over_released_reservations
+		FROM (
 			-- Grouped per reservation, and a NULL reservation_id groups per ROW.
 			-- SQL puts every NULL in one bucket, which would net unrelated
 			-- entries against each other and reintroduce, for exactly those
@@ -143,18 +160,11 @@ func (r *pgxRepository) GetBalance(ctx context.Context, accountID uuid.UUID) (Ba
 			-- not in this set), but PostEntryInput.ReservationID is a pointer,
 			-- so nothing stops one, and it would hide inside the shared bucket.
 			SELECT SUM(credits_delta) AS net
-			FROM entries
-			WHERE entry_type IN ('reservation_hold', 'reservation_release')
+			FROM public.credit_ledger_entries
+			WHERE account_id = $1
+			  AND entry_type IN ('reservation_hold', 'reservation_release')
 			GROUP BY reservation_id, CASE WHEN reservation_id IS NULL THEN id END
-		)
-		SELECT
-			COALESCE((
-				SELECT SUM(credits_delta) FROM entries
-				WHERE entry_type IN ('grant', 'adjustment', 'usage_charge', 'refund')
-			), 0) AS posted_credits,
-			COALESCE((SELECT SUM(GREATEST(-net, 0)) FROM holds), 0) AS reserved_credits,
-			COALESCE((SELECT SUM(GREATEST(net, 0)) FROM holds), 0) AS over_released_credits,
-			COALESCE((SELECT COUNT(*) FROM holds WHERE net > 0), 0) AS over_released_reservations
+		) AS holds
 	`, accountID)
 
 	var balance BalanceSummary

--- a/apps/control-plane/internal/ledger/repository.go
+++ b/apps/control-plane/internal/ledger/repository.go
@@ -30,16 +30,41 @@ func NewPgxRepository(pool *pgxpool.Pool) Repository {
 }
 
 func (r *pgxRepository) PostEntry(ctx context.Context, accountID uuid.UUID, input PostEntryInput) (LedgerEntry, error) {
-	metadataBytes, err := json.Marshal(normalizeMetadata(input.Metadata))
-	if err != nil {
-		return LedgerEntry{}, fmt.Errorf("ledger: marshal metadata: %w", err)
-	}
-
 	tx, err := r.pool.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return LedgerEntry{}, fmt.Errorf("ledger: begin tx: %w", err)
 	}
 	defer tx.Rollback(ctx)
+
+	entry, err := PostEntryTx(ctx, tx, accountID, input)
+	if err != nil {
+		return LedgerEntry{}, err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return LedgerEntry{}, fmt.Errorf("ledger: commit tx: %w", err)
+	}
+
+	return entry, nil
+}
+
+// PostEntryTx writes one ledger entry inside a transaction the CALLER owns and
+// commits. It exists so a write that must be atomic with a ledger entry can be
+// exactly that, rather than two transactions and a hope.
+//
+// The caller today is the accounting repository's reservation create (issue
+// #918): a reservation row and its hold used to be written separately, so a
+// hold that failed to post left a row claiming credits the ledger never held,
+// and the reaper later released that row against nothing. One transaction makes
+// the invariant structural: the row exists if and only if its hold does.
+//
+// Same body as PostEntry, deliberately not duplicated: two implementations of a
+// ledger write is how the two books drift apart.
+func PostEntryTx(ctx context.Context, tx pgx.Tx, accountID uuid.UUID, input PostEntryInput) (LedgerEntry, error) {
+	metadataBytes, err := json.Marshal(normalizeMetadata(input.Metadata))
+	if err != nil {
+		return LedgerEntry{}, fmt.Errorf("ledger: marshal metadata: %w", err)
+	}
 
 	result, err := tx.Exec(ctx, `
 		INSERT INTO public.credit_idempotency_keys
@@ -52,14 +77,10 @@ func (r *pgxRepository) PostEntry(ctx context.Context, accountID uuid.UUID, inpu
 	}
 
 	if result.RowsAffected() == 0 {
-		existing, err := r.lookupExistingEntry(ctx, tx, accountID, input.EntryType, input.IdempotencyKey)
-		if err != nil {
-			return LedgerEntry{}, err
-		}
-		if err := tx.Commit(ctx); err != nil {
-			return LedgerEntry{}, fmt.Errorf("ledger: commit duplicate tx: %w", err)
-		}
-		return existing, nil
+		// Already posted under this key: hand back the stored entry. The caller
+		// commits, so a duplicate is still a clean no-op for whatever else its
+		// transaction is doing.
+		return lookupExistingEntry(ctx, tx, accountID, input.EntryType, input.IdempotencyKey)
 	}
 
 	row := tx.QueryRow(ctx, `
@@ -83,30 +104,59 @@ func (r *pgxRepository) PostEntry(ctx context.Context, accountID uuid.UUID, inpu
 		return LedgerEntry{}, fmt.Errorf("ledger: update idempotency key: %w", err)
 	}
 
-	if err := tx.Commit(ctx); err != nil {
-		return LedgerEntry{}, fmt.Errorf("ledger: commit tx: %w", err)
-	}
-
 	return entry, nil
 }
 
+// GetBalance sums the account's ledger into posted, reserved and available.
+//
+// Reserved is computed PER RESERVATION and clamped at zero, then added up. It
+// used to be ABS of one account-wide sum, and that ABS is how issue #918 stayed
+// invisible: a reservation released without ever having been held pushes the
+// sum positive, and ABS renders that positive number as though credits were on
+// hold. Worse, the phantom nets against genuine in-flight holds first, so the
+// customer-facing available balance was wrong in BOTH directions on the two
+// production accounts in that state, understating one by 2000 and overstating
+// the other by 1000.
+//
+// A positive net for a single reservation is not a balance to render, it is a
+// corruption signal: more credits came back than ever went out. It is reported
+// separately in OverReleasedCredits, and Service.GetBalance logs it, rather
+// than being folded into a number a customer would read as a hold.
+//
+// Cost: the same rows the old query already scanned on the (account_id,
+// created_at) index, with a hash aggregate on reservation_id on top. No extra
+// index, and reservation_id needs none, since the grouping never leaves the
+// account's own slice.
 func (r *pgxRepository) GetBalance(ctx context.Context, accountID uuid.UUID) (BalanceSummary, error) {
 	row := r.pool.QueryRow(ctx, `
+		WITH entries AS (
+			SELECT entry_type, credits_delta, reservation_id
+			FROM public.credit_ledger_entries
+			WHERE account_id = $1
+		),
+		holds AS (
+			SELECT reservation_id, SUM(credits_delta) AS net
+			FROM entries
+			WHERE entry_type IN ('reservation_hold', 'reservation_release')
+			GROUP BY reservation_id
+		)
 		SELECT
-			COALESCE(SUM(CASE
-				WHEN entry_type IN ('grant', 'adjustment', 'usage_charge', 'refund') THEN credits_delta
-				ELSE 0
-			END), 0) AS posted_credits,
-			ABS(COALESCE(SUM(CASE
-				WHEN entry_type IN ('reservation_hold', 'reservation_release') THEN credits_delta
-				ELSE 0
-			END), 0)) AS reserved_credits
-		FROM public.credit_ledger_entries
-		WHERE account_id = $1
+			COALESCE((
+				SELECT SUM(credits_delta) FROM entries
+				WHERE entry_type IN ('grant', 'adjustment', 'usage_charge', 'refund')
+			), 0) AS posted_credits,
+			COALESCE((SELECT SUM(GREATEST(-net, 0)) FROM holds), 0) AS reserved_credits,
+			COALESCE((SELECT SUM(GREATEST(net, 0)) FROM holds), 0) AS over_released_credits,
+			COALESCE((SELECT COUNT(*) FROM holds WHERE net > 0), 0) AS over_released_reservations
 	`, accountID)
 
 	var balance BalanceSummary
-	if err := row.Scan(&balance.PostedCredits, &balance.ReservedCredits); err != nil {
+	if err := row.Scan(
+		&balance.PostedCredits,
+		&balance.ReservedCredits,
+		&balance.OverReleasedCredits,
+		&balance.OverReleasedReservations,
+	); err != nil {
 		return BalanceSummary{}, fmt.Errorf("ledger: get balance: %w", err)
 	}
 	balance.AvailableCredits = balance.PostedCredits - balance.ReservedCredits
@@ -276,7 +326,7 @@ func scanInvoiceRow(scanner entryScanner) (InvoiceRow, error) {
 	return inv, nil
 }
 
-func (r *pgxRepository) lookupExistingEntry(ctx context.Context, tx pgx.Tx, accountID uuid.UUID, entryType EntryType, idempotencyKey string) (LedgerEntry, error) {
+func lookupExistingEntry(ctx context.Context, tx pgx.Tx, accountID uuid.UUID, entryType EntryType, idempotencyKey string) (LedgerEntry, error) {
 	row := tx.QueryRow(ctx, `
 		SELECT id, account_id, entry_type, credits_delta, idempotency_key, request_id, attempt_id, reservation_id, metadata, created_at
 		FROM public.credit_ledger_entries

--- a/apps/control-plane/internal/ledger/repository.go
+++ b/apps/control-plane/internal/ledger/repository.go
@@ -130,15 +130,22 @@ func PostEntryTx(ctx context.Context, tx pgx.Tx, accountID uuid.UUID, input Post
 func (r *pgxRepository) GetBalance(ctx context.Context, accountID uuid.UUID) (BalanceSummary, error) {
 	row := r.pool.QueryRow(ctx, `
 		WITH entries AS (
-			SELECT entry_type, credits_delta, reservation_id
+			SELECT id, entry_type, credits_delta, reservation_id
 			FROM public.credit_ledger_entries
 			WHERE account_id = $1
 		),
 		holds AS (
-			SELECT reservation_id, SUM(credits_delta) AS net
+			-- Grouped per reservation, and a NULL reservation_id groups per ROW.
+			-- SQL puts every NULL in one bucket, which would net unrelated
+			-- entries against each other and reintroduce, for exactly those
+			-- rows, the account-wide netting this query exists to remove. No
+			-- hold or release carries a NULL today (only grants do, and they are
+			-- not in this set), but PostEntryInput.ReservationID is a pointer,
+			-- so nothing stops one, and it would hide inside the shared bucket.
+			SELECT SUM(credits_delta) AS net
 			FROM entries
 			WHERE entry_type IN ('reservation_hold', 'reservation_release')
-			GROUP BY reservation_id
+			GROUP BY reservation_id, CASE WHEN reservation_id IS NULL THEN id END
 		)
 		SELECT
 			COALESCE((

--- a/apps/control-plane/internal/ledger/service.go
+++ b/apps/control-plane/internal/ledger/service.go
@@ -5,12 +5,17 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/google/uuid"
 )
 
 type Service struct {
 	repo Repository
+
+	// account id -> last time its over-release anomaly was logged (issue #918).
+	anomalyLogged sync.Map
 }
 
 func NewService(repo Repository) *Service {
@@ -24,19 +29,41 @@ func (s *Service) GetBalance(ctx context.Context, accountID uuid.UUID) (BalanceS
 	}
 	// A reservation cannot legitimately have more released than held, so this
 	// is a corruption signal and the only place the system notices it (issue
-	// #918). Logged at error, on every read, deliberately: it is not
+	// #918). Logged at error, throttled per account below, because it is not
 	// self-healing, it needs an operator, and it stayed hidden for a month
 	// while ABS made it look like an ordinary hold. It does not fail the read,
 	// because refusing to answer would take an affected account off the air
 	// without repairing anything, and the balance being returned is now the
 	// honest one.
-	if balance.OverReleasedReservations > 0 {
+	if balance.OverReleasedReservations > 0 && s.shouldLogAnomaly(accountID) {
 		slog.ErrorContext(ctx, "ledger: account has reservations released beyond what was ever held, manual reconciliation required",
 			"account_id", accountID.String(),
 			"over_released_reservations", balance.OverReleasedReservations,
 			"over_released_credits", balance.OverReleasedCredits)
 	}
 	return balance, nil
+}
+
+// shouldLogAnomaly rate-limits the line above to once per account per interval.
+//
+// The condition is persistent by construction: it needs an operator and cannot
+// clear itself. GetBalance runs on every reservation create and on every
+// balance read, so logging each time would emit at whatever rate the tenant
+// sends traffic, which makes the error stream useless exactly for the account
+// that needs attention.
+//
+// ponytail: in-process and per instance, so N instances emit N lines per
+// interval. That is the right ceiling for a signal meant to be noticed rather
+// than counted; if it ever needs to be counted, this is where a metric goes.
+func (s *Service) shouldLogAnomaly(accountID uuid.UUID) bool {
+	const interval = 15 * time.Minute
+	now := time.Now()
+	last, seen := s.anomalyLogged.Load(accountID)
+	if seen && now.Sub(last.(time.Time)) < interval {
+		return false
+	}
+	s.anomalyLogged.Store(accountID, now)
+	return true
 }
 
 func (s *Service) ListEntries(ctx context.Context, accountID uuid.UUID, limit int) ([]LedgerEntry, error) {

--- a/apps/control-plane/internal/ledger/service.go
+++ b/apps/control-plane/internal/ledger/service.go
@@ -3,6 +3,7 @@ package ledger
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/google/uuid"
@@ -17,7 +18,25 @@ func NewService(repo Repository) *Service {
 }
 
 func (s *Service) GetBalance(ctx context.Context, accountID uuid.UUID) (BalanceSummary, error) {
-	return s.repo.GetBalance(ctx, accountID)
+	balance, err := s.repo.GetBalance(ctx, accountID)
+	if err != nil {
+		return balance, err
+	}
+	// A reservation cannot legitimately have more released than held, so this
+	// is a corruption signal and the only place the system notices it (issue
+	// #918). Logged at error, on every read, deliberately: it is not
+	// self-healing, it needs an operator, and it stayed hidden for a month
+	// while ABS made it look like an ordinary hold. It does not fail the read,
+	// because refusing to answer would take an affected account off the air
+	// without repairing anything, and the balance being returned is now the
+	// honest one.
+	if balance.OverReleasedReservations > 0 {
+		slog.ErrorContext(ctx, "ledger: account has reservations released beyond what was ever held, manual reconciliation required",
+			"account_id", accountID.String(),
+			"over_released_reservations", balance.OverReleasedReservations,
+			"over_released_credits", balance.OverReleasedCredits)
+	}
+	return balance, nil
 }
 
 func (s *Service) ListEntries(ctx context.Context, accountID uuid.UUID, limit int) ([]LedgerEntry, error) {

--- a/apps/control-plane/internal/ledger/types.go
+++ b/apps/control-plane/internal/ledger/types.go
@@ -35,6 +35,15 @@ type BalanceSummary struct {
 	PostedCredits    int64 `json:"posted_credits"`
 	ReservedCredits  int64 `json:"reserved_credits"`
 	AvailableCredits int64 `json:"available_credits"`
+
+	// Corruption counters, not balance components (issue #918). A reservation
+	// whose releases exceed its holds is impossible by construction and means
+	// credits were returned that were never taken. Reported so the condition is
+	// visible instead of being folded into a plausible-looking hold, and kept
+	// off the wire (json:"-") so the customer-facing payload keeps its shape;
+	// the operator signal is the error log in Service.GetBalance.
+	OverReleasedCredits      int64 `json:"-"`
+	OverReleasedReservations int64 `json:"-"`
 }
 
 type PostEntryInput struct {


### PR DESCRIPTION
Closes #918.

## Root cause verdict: still reachable, not historical residue

The mechanism is the two-transaction create, and the sequence that produces it is this one:

1. `accounting.Service.CreateReservation` starts the attempt, then calls `repo.CreateReservation`, which commits the `credit_reservations` row and its `reserved` event in its own transaction.
2. It then calls `ledgerSvc.ReserveCredits`, a second, independent transaction.
3. That second transaction fails (a pool timeout, a cancelled statement, any transient database error). `CreateReservation` returns the error and the caller fails closed, correctly refusing to serve.
4. The committed row survives with no hold behind it. An hour later the stranded-hold reaper sees a non-terminal reservation, releases it, and posts a `reservation_release` against a hold that never existed. The account is credited for credits that were never taken from it.

Evidence for that sequence rather than the alternatives, read live and read only:

- All ten reservations have their `reserved` event, so step 1 committed.
- None has a `reservation_hold` **ledger entry**, and none has a `reservation_hold` row in `credit_idempotency_keys` either. That second fact rules out deduplication as the explanation: a hold that had been deduplicated against an earlier entry would have left the key row behind. The entry write never ran, or ran and rolled back whole.
- Each has exactly one request attempt, a unique `request_id`, `attempt_number` 1. Not retries.
- Their release entries are all present, eight stamped `stranded_hold_reaper` on 2026-08-01 and two `probe_cleanup` on 2026-07-26, which is step 4.
- Endpoints: six `/v1/audio/transcriptions`, two `/v1/audio/speech`, two `completions`. Three different callers, all of which route through this one create path, so nothing about the shape is specific to one caller.
- Neighbouring reservations on the same account in the same minute do have holds, so the ledger was working generally; this is transient failure, not an outage.

**Still reachable.** `git log -S` puts the `ledgerSvc.ReserveCredits` call in `CreateReservation` since the original Go port (#89), and no commit since has touched that ordering. The four changes to `service.go` in July and August are all on the settlement side. Nothing has closed this window; the ten rows cluster in July because that is when the trigger fired, not because the path changed afterwards.

## Is `ABS()` in `GetBalance` defensible

No, and it is why this went unnoticed for a month.

The signed sum of `reservation_hold` plus `reservation_release` over an account can only be negative or zero, because a release can only ever return what a hold took. A positive sum is not a balance, it is proof that the ledger is internally inconsistent for that account. `ABS()` takes that impossible number, strips the sign, and hands it to the customer as though it were credits on hold.

It is worse than a wrong sign, because the netting happens first. `9bbaf7b5` has three genuine in-flight holds worth 12,000 and 23,000 of phantom credit; the account-wide sum is +11,000, so `ABS` reports 11,000 reserved and the customer's available balance is **overstated by 1,000**. `3104dbfc` has nothing in flight and 2,000 of phantom credit; it reports 2,000 reserved and its available is **understated by 2,000**. Wrong in both directions, on the same defect, as this PR's regression test reproduces with those exact numbers.

The right response, and what this PR does:

- Compute reserved per reservation, clamped at zero, then sum. A reservation that shows more released than held contributes nothing, so a corrupt row can no longer move a customer-facing number in either direction. `9bbaf7b5` will read 12,000 reserved, its true in-flight position; `3104dbfc` will read zero.
- Report the corruption instead of absorbing it. `BalanceSummary` gains `OverReleasedCredits` and `OverReleasedReservations`, and `Service.GetBalance` logs them at error level on every read, naming the account. Both fields are `json:"-"`, so the customer-facing payload keeps its shape and the signal goes to operators.
- Do not fail the read. Refusing to answer would take an affected account off the air without repairing anything, and the number now being returned is the honest one. Failing closed is for authorizing spend, and that path reads the same corrected number.

As you predicted, this surfaces both accounts loudly: every balance read for them logs an error until the ledger rows are reconciled.

Cost: the same rows the old query already scanned under the `(account_id, created_at)` index, with a hash aggregate on `reservation_id` on top. No new index, and no cross-account work.

## The invariant, as a bound

For every reservation, at every moment, in the database rather than in a convention:

```
a row in credit_reservations exists  <=>  a reservation_hold entry exists for it
```

and therefore, for every account, `SUM(hold) + SUM(release) <= 0` per reservation, with any positive value being corruption rather than a hold.

As magnitudes: across any attempt to create a reservation, successful or not, the count of reservation rows and the count of hold entries move together. Either both increase by one, or neither moves. A partially applied create leaves nothing behind, not a row, not an event, not a key.

## Proof by ledger magnitude on real Postgres, red before and green after

Both halves are proven against the real schema built from `supabase/migrations/`, through the real repositories, not through fakes.

`TestReservationRowAndHoldAreWrittenAtomically_Live` injects the failure at the database rather than through a stub, because the guarantee under test IS a transaction boundary. The injected shape is real: an idempotency key claimed without its ledger entry, the poisoned-key state from issue #663, which makes the hold write fail after the row insert, at exactly the point the old sequence committed the row anyway.

```
pre-fix (hold posted in a second transaction):
  FAIL  reservation rows (1) and hold entries (0) diverged:
        a row with no hold is what the reaper later releases against nothing
post-fix:
  PASS  (and the positive control still writes one row and one hold)
```

`TestGetBalanceDoesNotRenderAnOverReleaseAsAHold_Live` builds the production shape exactly: one settled reservation, one genuinely in flight worth 12,000, one released without ever being held worth 23,000.

```
pre-fix (ABS over the account):
  FAIL  reserved = 11000, want 12000: only the one hold that is genuinely
        outstanding. ABS nets the 23000 phantom against it and reports 11000,
        a hold that does not exist
post-fix:
  PASS  reserved 12000, over-released 23000 across 1 reservation
```

Both are `HIVE_TEST_DB_URL`-gated, and `./internal/ledger/...` is added to the live-Postgres CI step so the second one actually runs; `tools/lint-go-db-test-wiring.mjs` passes with 20 wired pairs.

Full `go test ./apps/control-plane/... ./apps/edge-api/...` green, `go vet` clean.

## Also fixed here: the expand path had the identical defect

`ExpandReservation` committed the raised `reserved_credits` and then posted its hold in a second transaction, the same shape as create, with worse consequences: settlement releases what the ROW says is held, so a row raised from 500 to 2500 whose hold post failed would hand back 2500 against 500 ever taken. Nothing calls it in production today, which is why no row shows that shape, but it is exported and one caller away from reproducing this issue. It is now atomic, with its own live proof.

Both write paths go through one helper, which also refuses a deduplicated hold entry that belongs to a different reservation: `PostEntryTx` returns the stored entry when a key was already used, and an entry carrying another reservation's id would leave this row committed with no hold of its own.

## Test fakes that had to move with the code

The hold is no longer posted through the ledger service on create, so two fakes were changed rather than left asserting a call the system no longer makes:

- `repoStub` records the hold and, when a test's subject is the balance, posts it to that test's fake ledger, because otherwise those fixtures would silently start from an unreserved balance and their assertions would stop meaning anything.
- `concurrentRepo` applies the hold to the shared balance itself, since the TOCTOU race test (#106) is about the balance read and the hold write being serialized, and the hold write now lives in the repository.

Three assertions that counted `ledgerSvc.reserveCalls` on create now assert on the recorded hold, and one asserts that no second-transaction reserve happens at all.

## Cleanup for the 25,000, enumerated and NOT run

Not bundled into this change, and not executed. After this deploys the phantom stops affecting any balance, because a per-reservation clamp ignores it; the cleanup exists to make the rows self-consistent so that future queries, and any tool that nets per account, do not trip over them.

The truthful repair is a compensating `reservation_hold` for the hold that never posted, which makes each of the ten reservations net to zero. Not an `adjustment`: posted was never inflated by this defect, so moving posted would take real credits away.

```sql
-- PREVIEW, read only. Ten rows, 25000 credits as of 2026-08-17.
WITH orphan AS (
  SELECT r.id AS reservation_id,
         r.account_id,
         COALESCE(sum(e.credits_delta) FILTER (
            WHERE e.entry_type IN ('reservation_hold','reservation_release')), 0) AS net
  FROM public.credit_reservations r
  LEFT JOIN public.credit_ledger_entries e ON e.reservation_id = r.id
  GROUP BY r.id, r.account_id
)
SELECT count(*) AS reservations, sum(net) AS credits_released_without_a_hold
FROM orphan
WHERE net > 0;

-- REPAIR, to run only with the owner's go-ahead:
-- INSERT INTO public.credit_ledger_entries
--   (account_id, entry_type, credits_delta, idempotency_key, reservation_id, metadata)
-- SELECT account_id, 'reservation_hold', -net,
--        'reservation:' || reservation_id || ':reserve-missing',
--        reservation_id,
--        jsonb_build_object('reason', 'issue-918 hold that never posted', 'pr', '<this PR>')
-- FROM orphan
-- WHERE net > 0
-- ON CONFLICT DO NOTHING;
```

Append-only, no UPDATE, no DELETE, re-runnable, and the key shape `reserve-missing` cannot collide with a real hold's `reserve` key. Expect it to change no displayed balance after this PR ships, which is the point: it repairs the record, and the fix already stopped the record from lying.

## Buglog entries

```json
{"id":"bug-mhold918-4c7e21","timestamp":"2026-08-17T09:20:00.000Z","related_bugs":[],"occurrences":10,"last_seen":"2026-07-26T12:51:04.000Z","title":"Reservation row and its ledger hold were written in two transactions, so the reaper released credits that were never held","error_message":"Ten reservations carry a reservation_release entry with no matching reservation_hold, 25000 credits, and GetBalance rendered the resulting positive sum as a phantom hold","root_cause":"accounting.Service.CreateReservation committed the credit_reservations row and its reserved event in one transaction, then posted the ledger hold in a second. A transient failure on the second left a committed row claiming credits the ledger never held; the stranded-hold reaper later released that row and credited the account for credits never taken. Compounded by ledger.GetBalance computing reserved as ABS of one account-wide sum, which turned the resulting positive sum into a plausible-looking hold and netted it against genuine in-flight holds, making customer-facing available wrong in both directions.","fix":"The accounting repository writes the row, its reserved event and the hold in one transaction via the new ledger.PostEntryTx, so a failed hold rolls the row back with it. GetBalance sums reserved per reservation clamped at zero instead of taking ABS of the account-wide sum, and reports a positive per-reservation net separately as OverReleasedCredits, logged at error level on every read.","tags":["billing","ledger","credit-reservation","money-path","atomicity","issue-918","issue-616","control-plane","D-034"]}
{"id":"bug-mpool-ro-9a13f2","timestamp":"2026-08-16T17:04:00.000Z","related_bugs":[],"occurrences":1,"last_seen":"2026-08-16T17:04:00.000Z","title":"SET default_transaction_read_only outside a transaction persists on the shared Supavisor backend and makes later clients read-only","error_message":"cannot execute INSERT in a read-only transaction, on a connection that had issued no such SET, with pg_settings reporting source=session and the role config carrying no such setting","root_cause":"A read-only guard was issued as a bare `SET default_transaction_read_only = on` at the top of psql query files run through the transaction-mode pooler on port 6543. A SET outside a transaction applies to the pooled SERVER connection, not to the client session, and Supavisor does not reset it between clients, so every later client handed that backend inherits it. Three distinct backends were left read-only this way.","fix":"Reset the setting on each affected backend with RESET default_transaction_read_only, repeated until every backend the pooler hands out reports off, and never issue a bare SET on 6543 again. The correct read-only guard on a transaction-mode pooler is BEGIN TRANSACTION READ ONLY ... COMMIT, which is scoped to the transaction and cannot leak to the next client.","tags":["postgres","supabase","pooler","supavisor","transaction-mode","port-6543","read-only","tooling","gotcha"]}
```
