### PR TITLE
feat: render the agent surface natively instead of framing a second application

### DIFF
--- a/.github/workflows/owui-nightly.yml
+++ b/.github/workflows/owui-nightly.yml
@@ -470,6 +470,18 @@ jobs:
             !apps/web-console/playwright-report-owui/index.html
           retention-days: 5
       - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          # Proof captures, kept out of the HTML report's own folder because
+          # that folder is cleared when the report is written. Page screenshots
+          # only: Playwright captures the page, not browser chrome, and the
+          # routes captured carry no credential in their URLs.
+          name: owui-proof-captures
+          path: apps/web-console/playwright-report-owui-proof
+          if-no-files-found: warn
+          retention-days: 5
+
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: owui-compose-logs

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ test-scripts:
 	python3 scripts/test_caddy_console_auth_origin.py --self-check
 	python3 scripts/restore-storage-objects.py --self-check
 	python3 scripts/test_owui_oauth_client_auth.py
+	python3 scripts/test_owui_agent_proxy.py
 
 # Node, not python, and it downloads a pinned vitest, so it is deliberately not
 # folded into test-scripts, which is pure python with no network.

--- a/apps/edge-api/internal/auth/owui_unwrap.go
+++ b/apps/edge-api/internal/auth/owui_unwrap.go
@@ -12,6 +12,16 @@
 // OWUI would carry the shim key in Authorization, route through the
 // API-key path, and bind to the shim's principal — defeating per-user
 // audit attribution, RLS, and tenant scoping.
+//
+// The same middleware accepts that token on the UpstreamAuthHeader request
+// header, because a JSON body is not a carrier every request has. Three of
+// the four agent-task calls the chat container proxies are bodyless (GET
+// /v1/agent/tasks, GET /v1/agent/tasks/{id}, and the bodyless POST
+// .../cancel — see apps/edge-api/internal/agenttask/handler.go), so
+// `__metadata.upstream_auth` cannot reach them at all. The header is a
+// second carrier on the same trust boundary, not a second boundary: it is
+// honoured only when Authorization is exactly the shim key, which is the
+// identical gate the body carrier already sits behind.
 package auth
 
 import (
@@ -55,6 +65,13 @@ const maxOWUIUnwrapBody = 2 << 20 // 2 MiB
 // anyway but failing early here keeps the JWT path cheap.
 const maxOWUIBearerToken = 8 << 10 // 8 KiB
 
+// UpstreamAuthHeader carries the signed-in user's token on requests that
+// have no JSON body to hide it in. It is meaningful to this middleware and
+// to nothing else, so it is removed from every request that passes through
+// here — honoured, ignored, or rejected — before any handler, log or audit
+// sink can read it. Exported for the tests that assert exactly that.
+const UpstreamAuthHeader = "X-Hive-Upstream-Auth"
+
 // OWUIUnwrapConfig configures the OWUI body-metadata Authorization
 // rewrite. ShimKey is the static OPENAI_API_KEY value Open WebUI sends
 // on every upstream call; when this exact token arrives, the body is
@@ -77,6 +94,12 @@ type OWUIUnwrapConfig struct {
 //
 // Behaviour matrix:
 //
+//   - UpstreamAuthHeader present                               → always removed
+//     from the forwarded request, on every branch below. Honoured
+//     as the per-user token only under the shim key, in which case
+//     it wins over the body carrier: it is read before the body so
+//     that a bodyless request, the case it exists for, is not
+//     rejected before the header is ever consulted.
 //   - Authorization != shim key                                → pass through unchanged.
 //   - ShimKey == "" (disabled)                                 → pass through unchanged.
 //   - Content-Type not application/json (multipart, audio,
@@ -106,12 +129,39 @@ type OWUIUnwrapConfig struct {
 func OWUIUnwrap(cfg OWUIUnwrapConfig) func(http.Handler) http.Handler {
 	shimKey := strings.TrimSpace(cfg.ShimKey)
 	return func(next http.Handler) http.Handler {
-		if shimKey == "" {
-			return next
-		}
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if !hasShimAuthorization(r.Header.Get("Authorization"), shimKey) {
+			// Take the carrier off the request before anything else runs,
+			// including when the middleware is disabled and when the
+			// credential is not the shim key. It is ours alone, so a handler
+			// that can read it is a handler that could later be taught to
+			// trust it, and a header a client controls must never become a
+			// principal by that route.
+			carrier := strings.TrimSpace(r.Header.Get(UpstreamAuthHeader))
+			if carrier != "" {
+				r = r.Clone(r.Context())
+				r.Header.Del(UpstreamAuthHeader)
+			}
+			if shimKey == "" || !hasShimAuthorization(r.Header.Get("Authorization"), shimKey) {
 				next.ServeHTTP(w, r)
+				return
+			}
+			if carrier != "" {
+				// Fail closed on a carrier that is present but unusable. The
+				// only thing that sets this header is our own forwarder, so a
+				// value it cannot mean is a broken forwarder, and forwarding
+				// with the shim key still on Authorization would bill and
+				// audit the call against the shim's principal.
+				token := ""
+				if len(carrier) <= maxOWUIBearerToken {
+					token = normalizeUpstreamAuth(carrier)
+				}
+				if token == "" {
+					writeAuthError(w, http.StatusUnauthorized, "UNAUTHENTICATED", "invalid token")
+					return
+				}
+				r2 := r.Clone(context.WithValue(r.Context(), owuiUnwrappedKey{}, true))
+				r2.Header.Set("Authorization", "Bearer "+token)
+				next.ServeHTTP(w, r2)
 				return
 			}
 			// This check has to come before the pass-through below, not
@@ -235,18 +285,40 @@ func hasShimAuthorization(header, shimKey string) bool {
 // carry a per-user token, i.e. whether a missing `__metadata.upstream_auth`
 // is a failure rather than the expected shape.
 //
-// Chat completions are the only path the `hive_jwt_forward` Function
-// decorates, and the only path where running under the shim principal
-// silently mis-attributes billing and audit. Open WebUI's other upstream
-// calls (document-RAG embeddings via RAG_OPENAI_API_KEY, and text-to-speech)
-// are never decorated and authenticate as the shim account by design, so
-// they must keep passing through.
+// Two families qualify, for the same reason. Chat completions are the path
+// the `hive_jwt_forward` Function decorates. The agent-task lifecycle is the
+// path the chat container's own agent proxy decorates
+// (deploy/docker/owui-patches/hive_agent_proxy.py). On both, running under
+// the shim principal silently mis-attributes billing and audit, and on the
+// agent path it would additionally list and cancel the shim account's tasks
+// rather than the signed-in user's. Open WebUI's other upstream calls
+// (document-RAG embeddings via RAG_OPENAI_API_KEY, and text-to-speech) are
+// never decorated and authenticate as the shim account by design, so they
+// must keep passing through.
 //
-// ponytail: exact-path list rather than a prefix rule, because /v1/chat is
-// the only prefix at stake today. If a second per-user OWUI path appears
-// (for example a future OWUI RAG chat route), add it here.
+// The agent arm is a prefix rather than an exact list because the subtree
+// carries a task id: /v1/agent/tasks/{id} and /v1/agent/tasks/{id}/cancel.
 func requiresPerUserAuth(path string) bool {
-	return path == "/v1/chat/completions"
+	return path == "/v1/chat/completions" ||
+		path == "/v1/agent/tasks" ||
+		strings.HasPrefix(path, "/v1/agent/tasks/")
+}
+
+// normalizeUpstreamAuth reduces a carried credential to a bare token,
+// tolerating both "Bearer <token>" (what the forwarders write today) and a
+// bare token (so a future revision that drops the scheme word is not a
+// silent auth failure). Returns "" for anything with no token in it, which
+// every caller treats as fail-closed.
+//
+// Shared by the header carrier and the body carrier so the two cannot drift
+// into accepting different shapes of the same credential.
+func normalizeUpstreamAuth(value string) string {
+	value = strings.TrimSpace(value)
+	scheme, rest, hasSpace := strings.Cut(value, " ")
+	if hasSpace && strings.EqualFold(scheme, "Bearer") {
+		return strings.TrimSpace(rest)
+	}
+	return value
 }
 
 // isJSONContent reports whether the Content-Type media type is
@@ -325,11 +397,13 @@ func unwrapOWUIBody(raw []byte) (rewritten []byte, token string, status unwrapSt
 	if len(authStr) > maxOWUIBearerToken {
 		return out, "", unwrapTokenTooLong
 	}
-	scheme, tokenPart, hasSpace := strings.Cut(authStr, " ")
-	if hasSpace && strings.EqualFold(scheme, "Bearer") {
-		return out, strings.TrimSpace(tokenPart), unwrapOK
+	token = normalizeUpstreamAuth(authStr)
+	if token == "" {
+		// A present-but-empty upstream_auth is a pipeline that stopped
+		// forwarding, not a request that meant to run as the shim. Reported
+		// as a missing carrier so it takes the fail-closed arm and the warn
+		// log, rather than forwarding with the shim key on Authorization.
+		return out, "", unwrapNoMetadata
 	}
-	// Tolerate raw token (no scheme word). The pipeline writes
-	// "Bearer <jwt>" today but a future revision may drop the prefix.
-	return out, authStr, unwrapOK
+	return out, token, unwrapOK
 }

--- a/apps/edge-api/internal/auth/owui_unwrap.go
+++ b/apps/edge-api/internal/auth/owui_unwrap.go
@@ -140,10 +140,23 @@ func OWUIUnwrap(cfg OWUIUnwrapConfig) func(http.Handler) http.Handler {
 			// value, so a whitespace-only or repeated header is removed too.
 			// Header.Del drops every value under the key, which is what makes
 			// "stripped on every branch" true rather than nearly true.
+			//
+			// The removal is in place, on the inbound request, and not on a
+			// clone. A clone would only protect code reachable through `next`,
+			// and this header has to disappear for everyone: an outer
+			// middleware still holding the original pointer would otherwise
+			// keep seeing a live per-user token, and no branch that answers
+			// without calling `next` at all, which is every rejection path
+			// below, would strip anything observable. In place makes the
+			// invariant one fact rather than one fact per branch, and lets a
+			// test assert it on the rejection paths too. Mutating the inbound
+			// header map is safe here because net/http never re-reads request
+			// headers after the handler returns, and this header is ours: no
+			// caller upstream of edge-api has any reason to send it, and none
+			// is permitted to.
 			_, carrierPresent := r.Header[http.CanonicalHeaderKey(UpstreamAuthHeader)]
 			carrier := strings.TrimSpace(r.Header.Get(UpstreamAuthHeader))
 			if carrierPresent {
-				r = r.Clone(r.Context())
 				r.Header.Del(UpstreamAuthHeader)
 			}
 			if shimKey == "" || !hasShimAuthorization(r.Header.Get("Authorization"), shimKey) {

--- a/apps/edge-api/internal/auth/owui_unwrap.go
+++ b/apps/edge-api/internal/auth/owui_unwrap.go
@@ -136,8 +136,13 @@ func OWUIUnwrap(cfg OWUIUnwrapConfig) func(http.Handler) http.Handler {
 			// that can read it is a handler that could later be taught to
 			// trust it, and a header a client controls must never become a
 			// principal by that route.
+			// Presence is tested on the header map rather than on the trimmed
+			// value, so a whitespace-only or repeated header is removed too.
+			// Header.Del drops every value under the key, which is what makes
+			// "stripped on every branch" true rather than nearly true.
+			_, carrierPresent := r.Header[http.CanonicalHeaderKey(UpstreamAuthHeader)]
 			carrier := strings.TrimSpace(r.Header.Get(UpstreamAuthHeader))
-			if carrier != "" {
+			if carrierPresent {
 				r = r.Clone(r.Context())
 				r.Header.Del(UpstreamAuthHeader)
 			}
@@ -145,24 +150,20 @@ func OWUIUnwrap(cfg OWUIUnwrapConfig) func(http.Handler) http.Handler {
 				next.ServeHTTP(w, r)
 				return
 			}
-			if carrier != "" {
-				// Fail closed on a carrier that is present but unusable. The
-				// only thing that sets this header is our own forwarder, so a
-				// value it cannot mean is a broken forwarder, and forwarding
-				// with the shim key still on Authorization would bill and
-				// audit the call against the shim's principal.
-				token := ""
+			// Fail closed on a carrier that is present but unusable. The only
+			// thing that sets this header is our own forwarder, so a value it
+			// cannot mean is a broken forwarder, and forwarding with the shim
+			// key still on Authorization would bill and audit the call against
+			// the shim's principal.
+			headerToken := ""
+			if carrierPresent {
 				if len(carrier) <= maxOWUIBearerToken {
-					token = normalizeUpstreamAuth(carrier)
+					headerToken = normalizeUpstreamAuth(carrier)
 				}
-				if token == "" {
+				if headerToken == "" {
 					writeAuthError(w, http.StatusUnauthorized, "UNAUTHENTICATED", "invalid token")
 					return
 				}
-				r2 := r.Clone(context.WithValue(r.Context(), owuiUnwrappedKey{}, true))
-				r2.Header.Set("Authorization", "Bearer "+token)
-				next.ServeHTTP(w, r2)
-				return
 			}
 			// This check has to come before the pass-through below, not
 			// after it. A per-user path can only receive its user token in a
@@ -172,6 +173,12 @@ func OWUIUnwrap(cfg OWUIUnwrapConfig) func(http.Handler) http.Handler {
 			// rejection further down simply by omitting Content-Type.
 			jsonBody := r.Body != nil && isJSONContent(r.Header.Get("Content-Type"))
 			if !jsonBody {
+				// The bodyless case the header carrier exists for. Nothing to
+				// read, nothing to strip, so forward immediately.
+				if headerToken != "" {
+					forwardUnwrapped(w, r, next, headerToken, nil)
+					return
+				}
 				if requiresPerUserAuth(r.URL.Path) {
 					warnMissingUpstreamAuth(r, 0, true)
 					writeAuthError(w, http.StatusUnauthorized, "UNAUTHENTICATED", missingUserTokenMessage)
@@ -199,7 +206,22 @@ func OWUIUnwrap(cfg OWUIUnwrapConfig) func(http.Handler) http.Handler {
 				writeAuthError(w, http.StatusRequestEntityTooLarge, "PAYLOAD_TOO_LARGE", "request body too large")
 				return
 			}
-			rewritten, token, status := unwrapOWUIBody(raw)
+			// The body is parsed even when the header already supplied the
+			// token, because __metadata must be stripped either way. Forwarding
+			// it would leak proxy-layer fields to downstream handlers, to the
+			// audit chain and on to a provider, which is the reason the strip
+			// is unconditional in unwrapOWUIBody.
+			rewritten, bodyToken, status := unwrapOWUIBody(raw)
+			token := bodyToken
+			if headerToken != "" {
+				// The header wins. It is the carrier our own forwarder sets on
+				// the request line, and a body that also carries one is either
+				// a second forwarder or a caller trying its luck; neither
+				// should be able to displace the credential already accepted.
+				token = headerToken
+				forwardUnwrapped(w, r, next, token, rewritten)
+				return
+			}
 			switch status {
 			case unwrapTokenTooLong:
 				writeAuthError(w, http.StatusUnauthorized, "UNAUTHENTICATED", "invalid token")
@@ -225,21 +247,43 @@ func OWUIUnwrap(cfg OWUIUnwrapConfig) func(http.Handler) http.Handler {
 				// Authorization, which is the intended credential for
 				// this path (see requiresPerUserAuth).
 			}
-			// Forward a clone rather than mutating the inbound request
-			// in place — keeps this middleware side-effect free for any
-			// handler or middleware that retains a reference to the
-			// original *http.Request. r.Clone deep-copies the header map.
-			r2 := r.Clone(r.Context())
-			r2.Body = io.NopCloser(bytes.NewReader(rewritten))
-			r2.ContentLength = int64(len(rewritten))
-			r2.Header.Set("Content-Length", strconv.Itoa(len(rewritten)))
-			if token != "" {
-				r2.Header.Set("Authorization", "Bearer "+token)
-				r2 = r2.WithContext(context.WithValue(r2.Context(), owuiUnwrappedKey{}, true))
-			}
-			next.ServeHTTP(w, r2)
+			forwardUnwrapped(w, r, next, token, rewritten)
 		})
 	}
+}
+
+// forwardUnwrapped hands the request on with the per-user token on
+// Authorization and the context marked unwrapped, which is what lets
+// JWTMiddleware apply its tenant fallback (#269). An empty token forwards
+// unchanged credentials, which is the pass-through case on a path where the
+// shim key is itself the intended credential.
+//
+// A nil body leaves the request's own body alone, for the bodyless carrier
+// case where there is nothing to rewrite; a non-nil body replaces it with the
+// version that has __metadata stripped.
+//
+// Forwarding a clone rather than mutating the inbound request in place keeps
+// this middleware side-effect free for any handler or middleware that retains
+// a reference to the original *http.Request. r.Clone deep-copies the header
+// map.
+func forwardUnwrapped(
+	w http.ResponseWriter,
+	r *http.Request,
+	next http.Handler,
+	token string,
+	body []byte,
+) {
+	r2 := r.Clone(r.Context())
+	if body != nil {
+		r2.Body = io.NopCloser(bytes.NewReader(body))
+		r2.ContentLength = int64(len(body))
+		r2.Header.Set("Content-Length", strconv.Itoa(len(body)))
+	}
+	if token != "" {
+		r2.Header.Set("Authorization", "Bearer "+token)
+		r2 = r2.WithContext(context.WithValue(r2.Context(), owuiUnwrappedKey{}, true))
+	}
+	next.ServeHTTP(w, r2)
 }
 
 // missingUserTokenMessage is the customer-facing reason for a shim-key

--- a/apps/edge-api/internal/auth/owui_unwrap.go
+++ b/apps/edge-api/internal/auth/owui_unwrap.go
@@ -165,12 +165,12 @@ func OWUIUnwrap(cfg OWUIUnwrapConfig) func(http.Handler) http.Handler {
 					return
 				}
 			}
-			// This check has to come before the pass-through below, not
-			// after it. A per-user path can only receive its user token in a
-			// JSON __metadata block, so a shim-key request there with a
-			// missing or non-JSON Content-Type can never be legitimate.
-			// Passing it through first would let any caller skip the
-			// rejection further down simply by omitting Content-Type.
+			// The rejection has to come before the pass-through, not after it.
+			// With no carrier on the header, a per-user path can only receive
+			// its user token in a JSON __metadata block, so a shim-key request
+			// there with a missing or non-JSON Content-Type can never be
+			// legitimate. Passing it through first would let any caller skip
+			// the rejection simply by omitting Content-Type.
 			jsonBody := r.Body != nil && isJSONContent(r.Header.Get("Content-Type"))
 			if !jsonBody {
 				// The bodyless case the header carrier exists for. Nothing to

--- a/apps/edge-api/internal/auth/owui_unwrap.go
+++ b/apps/edge-api/internal/auth/owui_unwrap.go
@@ -362,6 +362,15 @@ func normalizeUpstreamAuth(value string) string {
 	if hasSpace && strings.EqualFold(scheme, "Bearer") {
 		return strings.TrimSpace(rest)
 	}
+	// A scheme word and nothing else is not a bare token. Without this, a
+	// carrier of "Bearer " arrives here as "Bearer" after the trim above, takes
+	// the bare-token arm, and is promoted to the credential "Bearer Bearer" --
+	// a nonsense token that then fails JWKS validation and reports itself as
+	// the user's session being invalid. Refusing it here names the real cause
+	// at the boundary that produced it.
+	if strings.EqualFold(value, "Bearer") {
+		return ""
+	}
 	return value
 }
 

--- a/apps/edge-api/internal/auth/owui_unwrap_header_test.go
+++ b/apps/edge-api/internal/auth/owui_unwrap_header_test.go
@@ -128,6 +128,59 @@ func TestOWUIUnwrap_HeaderCarrierStrippedWhenDisabled(t *testing.T) {
 	}
 }
 
+// The case that made the strip presence-gated rather than value-gated.
+//
+// Go's wire-level parser trims only ASCII space and tab (RFC 7230 OWS), while
+// strings.TrimSpace treats U+00A0 as whitespace too, so a header carrying a
+// non-breaking space arrives with a non-empty value that trims to "". A strip
+// gated on the trimmed value would leave that header on the request and hand
+// it to the handler, which is the one thing this header must never do.
+func TestOWUIUnwrap_HeaderCarrierPresentButBlank_StrippedAndRejected(t *testing.T) {
+	for name, value := range map[string]string{
+		"spaces":             "   ",
+		"tab":                "\t",
+		"non-breaking space": " ",
+		"bare scheme":        "Bearer ",
+	} {
+		t.Run(name, func(t *testing.T) {
+			mw := auth.OWUIUnwrap(auth.OWUIUnwrapConfig{ShimKey: testShimKey})
+			next, captured := newCarrierHandler()
+
+			req := carrierRequest(http.MethodGet, "/v1/agent/tasks", "Bearer "+testShimKey, "")
+			req.Header.Set(auth.UpstreamAuthHeader, value)
+
+			rec := httptest.NewRecorder()
+			mw(next).ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusUnauthorized {
+				t.Fatalf("status = %d, want 401 for a carrier that carries nothing", rec.Code)
+			}
+			if captured.served {
+				t.Fatal("a blank carrier must not reach the handler")
+			}
+		})
+	}
+}
+
+// The same shape on a request that is otherwise a plain pass-through: the
+// header is not honoured, and it still does not survive.
+func TestOWUIUnwrap_BlankHeaderCarrierStrippedOnPassThrough(t *testing.T) {
+	mw := auth.OWUIUnwrap(auth.OWUIUnwrapConfig{ShimKey: testShimKey})
+	next, captured := newCarrierHandler()
+
+	req := carrierRequest(http.MethodGet, "/v1/models", "Bearer hk_live_real_key", "")
+	req.Header.Set(auth.UpstreamAuthHeader, " ")
+
+	mw(next).ServeHTTP(httptest.NewRecorder(), req)
+
+	if !captured.served {
+		t.Fatal("a non-shim request must pass through")
+	}
+	if captured.carrierSeen {
+		t.Fatal("a blank carrier must be stripped even when it is ignored")
+	}
+}
+
 func TestOWUIUnwrap_HeaderCarrierOverLongToken_Rejects401(t *testing.T) {
 	mw := auth.OWUIUnwrap(auth.OWUIUnwrapConfig{ShimKey: testShimKey})
 	next, captured := newCarrierHandler()

--- a/apps/edge-api/internal/auth/owui_unwrap_header_test.go
+++ b/apps/edge-api/internal/auth/owui_unwrap_header_test.go
@@ -158,6 +158,17 @@ func TestOWUIUnwrap_HeaderCarrierPresentButBlank_StrippedAndRejected(t *testing.
 			if captured.served {
 				t.Fatal("a blank carrier must not reach the handler")
 			}
+			// The "Stripped" half of this test's name. Without it the test
+			// asserts only "Rejected": `next` never runs on a 401, so the
+			// capture handler observes nothing, and moving the strip out of
+			// its unconditional position into the success branches alone
+			// would leave every assertion above green while the rejection
+			// paths stopped stripping. The middleware removes the header from
+			// the inbound request itself, so the request this test still
+			// holds is the one to inspect.
+			if _, seen := req.Header[http.CanonicalHeaderKey(auth.UpstreamAuthHeader)]; seen {
+				t.Fatal("the carrier must be stripped on the rejection path too")
+			}
 		})
 	}
 }
@@ -195,6 +206,12 @@ func TestOWUIUnwrap_HeaderCarrierOverLongToken_Rejects401(t *testing.T) {
 	}
 	if captured.served {
 		t.Fatal("an over-long carrier must not reach the handler")
+	}
+	// Same reasoning as the blank-carrier case: the 401 arms are exactly the
+	// arms `next` cannot observe, so the strip is asserted on the request the
+	// middleware was handed.
+	if _, seen := req.Header[http.CanonicalHeaderKey(auth.UpstreamAuthHeader)]; seen {
+		t.Fatal("an over-long carrier must still be stripped")
 	}
 }
 

--- a/apps/edge-api/internal/auth/owui_unwrap_header_test.go
+++ b/apps/edge-api/internal/auth/owui_unwrap_header_test.go
@@ -3,6 +3,7 @@ package auth_test
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -221,6 +222,51 @@ func TestOWUIUnwrap_HeaderCarrierWinsOverBodyMetadata(t *testing.T) {
 
 	if captured.authorization != "Bearer header-jwt" {
 		t.Fatalf("authorization = %q, want the header carrier to win", captured.authorization)
+	}
+}
+
+// The header winning must not skip the body rewrite. __metadata is stripped
+// unconditionally because forwarding proxy-layer fields would leak them to
+// downstream handlers, into the audit chain and on to a provider, and a carrier
+// that returned early would have quietly reintroduced exactly that.
+func TestOWUIUnwrap_HeaderCarrierStillStripsMetadataFromTheBody(t *testing.T) {
+	mw := auth.OWUIUnwrap(auth.OWUIUnwrapConfig{ShimKey: testShimKey})
+
+	var forwarded []byte
+	var authorization string
+	next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		forwarded, _ = io.ReadAll(r.Body)
+		authorization = r.Header.Get("Authorization")
+	})
+
+	body, err := json.Marshal(map[string]any{
+		"model": "hive-fast",
+		"__metadata": map[string]any{
+			"upstream_auth": "Bearer body-jwt",
+			"chat_id":       "internal-only",
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+testShimKey)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(auth.UpstreamAuthHeader, "Bearer header-jwt")
+
+	mw(next).ServeHTTP(httptest.NewRecorder(), req)
+
+	if authorization != "Bearer header-jwt" {
+		t.Fatalf("authorization = %q, want the header carrier to win", authorization)
+	}
+	if bytes.Contains(forwarded, []byte("__metadata")) {
+		t.Fatalf("__metadata survived to the handler: %s", forwarded)
+	}
+	if bytes.Contains(forwarded, []byte("body-jwt")) {
+		t.Fatalf("a token survived in the forwarded body: %s", forwarded)
+	}
+	if !bytes.Contains(forwarded, []byte("hive-fast")) {
+		t.Fatalf("the rest of the body did not survive: %s", forwarded)
 	}
 }
 

--- a/apps/edge-api/internal/auth/owui_unwrap_header_test.go
+++ b/apps/edge-api/internal/auth/owui_unwrap_header_test.go
@@ -1,0 +1,245 @@
+package auth_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/auth"
+)
+
+// The header carrier exists because three of the four agent-task calls are
+// bodyless -- GET /v1/agent/tasks, GET /v1/agent/tasks/{id} and the bodyless
+// POST .../cancel (apps/edge-api/internal/agenttask/handler.go:38-72) -- so
+// __metadata.upstream_auth, which only a JSON body can carry, cannot reach
+// them at all. It sits behind exactly the same gate as the body carrier: the
+// inbound Authorization must be the shim key and nothing else.
+
+type carrierCapture struct {
+	authorization string
+	carrier       string
+	carrierSeen   bool
+	unwrapped     bool
+	served        bool
+}
+
+func newCarrierHandler() (http.Handler, *carrierCapture) {
+	captured := &carrierCapture{}
+	h := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		captured.served = true
+		captured.authorization = r.Header.Get("Authorization")
+		captured.carrier = r.Header.Get(auth.UpstreamAuthHeader)
+		_, captured.carrierSeen = r.Header[http.CanonicalHeaderKey(auth.UpstreamAuthHeader)]
+		captured.unwrapped = auth.IsOWUIUnwrapped(r.Context())
+	})
+	return h, captured
+}
+
+func carrierRequest(method, path, authorization, carrier string) *http.Request {
+	req := httptest.NewRequest(method, path, nil)
+	if authorization != "" {
+		req.Header.Set("Authorization", authorization)
+	}
+	if carrier != "" {
+		req.Header.Set(auth.UpstreamAuthHeader, carrier)
+	}
+	return req
+}
+
+func TestOWUIUnwrap_HeaderCarrierUnderShimKeyRewritesAuthorization(t *testing.T) {
+	mw := auth.OWUIUnwrap(auth.OWUIUnwrapConfig{ShimKey: testShimKey})
+	next, captured := newCarrierHandler()
+
+	req := carrierRequest(http.MethodGet, "/v1/agent/tasks", "Bearer "+testShimKey, "Bearer user-jwt")
+	mw(next).ServeHTTP(httptest.NewRecorder(), req)
+
+	if captured.authorization != "Bearer user-jwt" {
+		t.Fatalf("authorization = %q, want the per-user token", captured.authorization)
+	}
+	if !captured.unwrapped {
+		t.Fatal("request must be marked unwrapped so the tenant fallback applies")
+	}
+	if captured.carrierSeen {
+		t.Fatalf("%s must never reach a handler, got %q", auth.UpstreamAuthHeader, captured.carrier)
+	}
+}
+
+func TestOWUIUnwrap_HeaderCarrierAcceptsBareToken(t *testing.T) {
+	mw := auth.OWUIUnwrap(auth.OWUIUnwrapConfig{ShimKey: testShimKey})
+	next, captured := newCarrierHandler()
+
+	req := carrierRequest(http.MethodGet, "/v1/agent/tasks", "Bearer "+testShimKey, "user-jwt")
+	mw(next).ServeHTTP(httptest.NewRecorder(), req)
+
+	if captured.authorization != "Bearer user-jwt" {
+		t.Fatalf("authorization = %q, want the bare token promoted to a Bearer credential", captured.authorization)
+	}
+}
+
+// Without the shim key the carrier is worthless and must also be unreadable:
+// a handler that could see it is a handler that could be taught to trust it.
+func TestOWUIUnwrap_HeaderCarrierIgnoredAndStrippedWithoutShimKey(t *testing.T) {
+	for name, authorization := range map[string]string{
+		"api key":          "Bearer hk_live_real_key",
+		"real jwt":         "Bearer some.other.jwt",
+		"no authorization": "",
+	} {
+		t.Run(name, func(t *testing.T) {
+			mw := auth.OWUIUnwrap(auth.OWUIUnwrapConfig{ShimKey: testShimKey})
+			next, captured := newCarrierHandler()
+
+			req := carrierRequest(http.MethodGet, "/v1/agent/tasks", authorization, "Bearer smuggled-jwt")
+			mw(next).ServeHTTP(httptest.NewRecorder(), req)
+
+			if !captured.served {
+				t.Fatal("request must pass through untouched")
+			}
+			if captured.authorization != authorization {
+				t.Fatalf("authorization = %q, want it unchanged at %q", captured.authorization, authorization)
+			}
+			if captured.unwrapped {
+				t.Fatal("a request without the shim key must never be marked unwrapped")
+			}
+			if captured.carrierSeen {
+				t.Fatalf("%s must be stripped even when it is ignored", auth.UpstreamAuthHeader)
+			}
+		})
+	}
+}
+
+// The middleware is a no-op with no shim key configured, but the carrier is
+// still ours alone, so it is still taken off the request.
+func TestOWUIUnwrap_HeaderCarrierStrippedWhenDisabled(t *testing.T) {
+	mw := auth.OWUIUnwrap(auth.OWUIUnwrapConfig{ShimKey: ""})
+	next, captured := newCarrierHandler()
+
+	req := carrierRequest(http.MethodGet, "/v1/agent/tasks", "Bearer anything", "Bearer smuggled-jwt")
+	mw(next).ServeHTTP(httptest.NewRecorder(), req)
+
+	if captured.authorization != "Bearer anything" {
+		t.Fatalf("disabled middleware must pass through, got %q", captured.authorization)
+	}
+	if captured.carrierSeen {
+		t.Fatalf("%s must be stripped even when the middleware is disabled", auth.UpstreamAuthHeader)
+	}
+}
+
+func TestOWUIUnwrap_HeaderCarrierOverLongToken_Rejects401(t *testing.T) {
+	mw := auth.OWUIUnwrap(auth.OWUIUnwrapConfig{ShimKey: testShimKey})
+	next, captured := newCarrierHandler()
+
+	req := carrierRequest(http.MethodGet, "/v1/agent/tasks", "Bearer "+testShimKey,
+		"Bearer "+strings.Repeat("a", 9<<10))
+	rec := httptest.NewRecorder()
+	mw(next).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+	if captured.served {
+		t.Fatal("an over-long carrier must not reach the handler")
+	}
+}
+
+// The fail-closed half. Without this the proxy losing its token would bill and
+// audit every agent task against the shim's own principal instead of the
+// signed-in user, silently, which is the exact failure owui_unwrap exists to
+// prevent on the chat path.
+func TestOWUIUnwrap_ShimKeyOnAgentPathWithoutCarrier_Rejects401(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{"list", http.MethodGet, "/v1/agent/tasks"},
+		{"get one", http.MethodGet, "/v1/agent/tasks/2f1c9d0e-0000-4000-8000-000000000000"},
+		{"cancel", http.MethodPost, "/v1/agent/tasks/2f1c9d0e-0000-4000-8000-000000000000/cancel"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mw := auth.OWUIUnwrap(auth.OWUIUnwrapConfig{ShimKey: testShimKey})
+			next, captured := newCarrierHandler()
+
+			req := carrierRequest(tc.method, tc.path, "Bearer "+testShimKey, "")
+			rec := httptest.NewRecorder()
+			mw(next).ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusUnauthorized {
+				t.Fatalf("status = %d, want 401", rec.Code)
+			}
+			if captured.served {
+				t.Fatal("a shim-key agent request with no per-user token must never reach the handler")
+			}
+		})
+	}
+}
+
+func TestOWUIUnwrap_ShimKeyOnAgentCreateWithoutCarrier_Rejects401(t *testing.T) {
+	mw := auth.OWUIUnwrap(auth.OWUIUnwrapConfig{ShimKey: testShimKey})
+	next, captured := newCarrierHandler()
+
+	body, err := json.Marshal(map[string]any{"pack": "coding-pack", "instructions": "do a thing"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/v1/agent/tasks", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+testShimKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	rec := httptest.NewRecorder()
+	mw(next).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+	if captured.served {
+		t.Fatal("a shim-key create with no per-user token must never reach the handler")
+	}
+}
+
+// The carrier is read before the body is, because a bodyless request is the
+// case it exists for and reading the body first would 401 such a request
+// before the carrier was ever consulted.
+func TestOWUIUnwrap_HeaderCarrierWinsOverBodyMetadata(t *testing.T) {
+	mw := auth.OWUIUnwrap(auth.OWUIUnwrapConfig{ShimKey: testShimKey})
+	next, captured := newCarrierHandler()
+
+	body, err := json.Marshal(map[string]any{
+		"__metadata": map[string]any{"upstream_auth": "Bearer body-jwt"},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+testShimKey)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(auth.UpstreamAuthHeader, "Bearer header-jwt")
+
+	mw(next).ServeHTTP(httptest.NewRecorder(), req)
+
+	if captured.authorization != "Bearer header-jwt" {
+		t.Fatalf("authorization = %q, want the header carrier to win", captured.authorization)
+	}
+}
+
+// Paths where the shim key is itself the intended credential are unchanged.
+func TestOWUIUnwrap_NonAgentBodylessShimRequestStillPassesThrough(t *testing.T) {
+	mw := auth.OWUIUnwrap(auth.OWUIUnwrapConfig{ShimKey: testShimKey})
+	next, captured := newCarrierHandler()
+
+	req := carrierRequest(http.MethodGet, "/v1/models", "Bearer "+testShimKey, "")
+	rec := httptest.NewRecorder()
+	mw(next).ServeHTTP(rec, req)
+
+	if !captured.served {
+		t.Fatalf("GET /v1/models must pass through with the shim key, got status %d", rec.Code)
+	}
+	if captured.authorization != "Bearer "+testShimKey {
+		t.Fatalf("authorization = %q, want the shim key intact", captured.authorization)
+	}
+	if captured.unwrapped {
+		t.Fatal("a pass-through must not be marked unwrapped")
+	}
+}

--- a/apps/web-console/e2e/phase-19/owui/09-agent-workspace-nav.spec.ts
+++ b/apps/web-console/e2e/phase-19/owui/09-agent-workspace-nav.spec.ts
@@ -290,6 +290,30 @@ test("proof capture: the agent surface, natively, in both palettes", async ({
   await page.screenshot({ path: `${PROOF_DIR}/chat-after.png`, fullPage: false });
 
   /*
+   * The same two composers again at 1280 by 720.
+   *
+   * This is Playwright's default viewport, which is what owui.setup.ts runs at,
+   * and therefore the width of the only "before" capture of chat's composer
+   * that exists: the signed-in page in main's own nightly failure screenshot.
+   * A before at 1280 and an after at 1440 is not a comparison, because a reader
+   * cannot tell a layout change from a reflow, and that is exactly the
+   * judgement these images are for. Same width or it proves nothing.
+   */
+  await page.setViewportSize({ width: 1280, height: 720 });
+
+  await page.goto("/agents");
+  const agentComposer1280 = page
+    .locator("#hive-agent-instructions")
+    .locator("xpath=ancestor::*[contains(@class,'rounded-3xl')]")
+    .first();
+  await expect(agentComposer1280).toBeVisible();
+  await agentComposer1280.screenshot({ path: `${PROOF_DIR}/composer-agent-1280.png` });
+
+  await page.goto("/");
+  await expect(chatComposer).toBeVisible();
+  await chatComposer.screenshot({ path: `${PROOF_DIR}/composer-chat-1280.png` });
+
+  /*
    * The extraction has to be invisible on the chat surface, and two images a
    * human eyeballs is a weak way to prove that. These are the classes that
    * carry the composer's shape, asserted on chat's own container, so drift in

--- a/apps/web-console/e2e/phase-19/owui/09-agent-workspace-nav.spec.ts
+++ b/apps/web-console/e2e/phase-19/owui/09-agent-workspace-nav.spec.ts
@@ -31,7 +31,14 @@ const NAV_ROW = (id: string) => `[data-hive-nav="${id}"]`;
 const SIDEBAR = "#sidebar";
 const REMOVED_LAUNCHER = "#hive-agent-launcher";
 const TASKS_ENDPOINT = "/api/v1/hive/agent/tasks";
-const PROOF_DIR = "playwright-report-owui/proof";
+/*
+ * Deliberately NOT inside playwright-report-owui. The HTML reporter owns that
+ * folder and clears it before writing the report at the end of the run, which
+ * would delete these images after they were captured and leave an absence that
+ * looks exactly like a test that never ran. The workflow uploads this
+ * directory separately.
+ */
+const PROOF_DIR = "playwright-report-owui-proof";
 
 test("the sidebar carries labelled Chats, Agents and Knowledge destinations", async ({
   page,

--- a/apps/web-console/e2e/phase-19/owui/09-agent-workspace-nav.spec.ts
+++ b/apps/web-console/e2e/phase-19/owui/09-agent-workspace-nav.spec.ts
@@ -82,9 +82,18 @@ test("the agent workspace opens inside the shell and frames nothing", async ({
   // Recorded rather than asserted inline so the failure message can name the
   // status, which is the whole diagnostic value of this check.
   let tasksStatus: number | null = null;
-  page.on("response", (response) => {
-    if (new URL(response.url()).pathname === TASKS_ENDPOINT) {
-      tasksStatus = response.status();
+  let tasksBody: { tasks?: unknown } | null = null;
+  page.on("response", async (response) => {
+    if (new URL(response.url()).pathname !== TASKS_ENDPOINT) {
+      return;
+    }
+    tasksStatus = response.status();
+    if (response.status() === 200) {
+      try {
+        tasksBody = await response.json();
+      } catch {
+        tasksBody = null;
+      }
     }
   });
 
@@ -107,20 +116,30 @@ test("the agent workspace opens inside the shell and frames nothing", async ({
     "the agent surface must not frame anything, on this route or anywhere in it",
   ).toHaveCount(0);
 
-  // The composer is this application's own DOM, and it is the chat composer's
-  // container rather than a form that resembles one.
+  // An iframe count of zero is also true of a page that rendered nothing at
+  // all, so every assertion below is a positive one: the surface has to paint
+  // and work, not merely fail to contain a frame.
+  //
+  // The composer is this application's own DOM, it is the chat composer's
+  // container rather than a form that resembles one, and it takes input.
   const composer = page.locator("#hive-agent-instructions");
   await expect(composer).toBeVisible();
   await expect(page.locator("#hive-agent-send")).toBeVisible();
+  await composer.fill("Audit the webhook handlers for unvalidated input");
+  await expect(composer).toHaveValue(
+    "Audit the webhook handlers for unvalidated input",
+  );
+  // The container is the shared one, not a lookalike: this id belongs to the
+  // component MessageInput.svelte renders too.
+  await expect(page.locator("#hive-agent-instructions").locator("xpath=ancestor::*[contains(@class,'rounded-3xl')]").first()).toBeVisible();
   for (const label of ["Knowledge work", "Coding"]) {
+    const option = page.getByText(label, { exact: true });
     await expect(
-      page.getByText(label, { exact: true }),
+      option,
       `the ${label} toggle is missing from the composer`,
     ).toBeVisible();
+    await option.click();
   }
-
-  // The list region renders, whether or not this fixture tenant has any tasks.
-  await expect(page.getByRole("heading", { name: "Your tasks" })).toBeAttached();
 
   await expect
     .poll(() => tasksStatus, {
@@ -136,6 +155,42 @@ test("the agent workspace opens inside the shell and frames nothing", async ({
       "after the principal and its tenant already resolved.",
   ).not.toBe(401);
   expect([200, 403]).toContain(tasksStatus);
+
+  // The list has to paint what the API actually returned. Without this, a
+  // surface that mounted and then rendered nothing would still satisfy every
+  // assertion above, which is the shape of green that cannot go red.
+  if (tasksStatus === 200) {
+    const rows = Array.isArray(tasksBody?.tasks) ? (tasksBody!.tasks as Array<Record<string, unknown>>) : [];
+    if (rows.length > 0) {
+      await expect(
+        page.locator("[data-hive-task-row]"),
+        "the API returned tasks and the list painted a different number of rows",
+      ).toHaveCount(rows.length);
+      // One row's own text, taken from the response rather than from a fixture.
+      // Rows that predate the goal field carry no instructions and must say so
+      // deliberately rather than rendering an empty line.
+      const first = rows[0];
+      const expected =
+        typeof first.instructions === "string" && first.instructions.trim() !== ""
+          ? first.instructions
+          : "No description was recorded for this task.";
+      await expect(
+        page.locator(`[data-hive-task-row="${first.id}"]`),
+      ).toContainText(expected);
+    } else {
+      await expect(
+        page.getByText("Nothing submitted yet"),
+        "no tasks came back, so the genuine empty state must be on screen",
+      ).toBeVisible();
+    }
+  } else {
+    // 403 is the Cowork gate. The surface must say so in the server's own
+    // words rather than showing a blank list that implies zero tasks.
+    await expect(
+      page.getByRole("alert"),
+      "a refused list must be stated, not rendered as an empty one",
+    ).toBeVisible();
+  }
 
   expect(documentLoads, "the hop into the agent must be client-side").toBe(0);
 });
@@ -161,16 +216,64 @@ test("proof capture: the agent surface, natively, in both palettes", async ({
     });
   }
 
-  // The chat composer, from the same build, because its container and send
-  // button were extracted into the components the agent composer renders and
-  // the extraction has to be provably invisible on this surface.
+  // The two composers, cropped to the control itself, from one build and one
+  // browser, so they can be put side by side and judged as one product or not.
+  // This is the owner's actual acceptance criterion: sharing a component is the
+  // means, looking like one control is the requirement.
   await page.emulateMedia({ colorScheme: "light" });
+
+  await page.goto("/agents");
+  const agentComposer = page
+    .locator("#hive-agent-instructions")
+    .locator("xpath=ancestor::*[contains(@class,'rounded-3xl')]")
+    .first();
+  await expect(agentComposer).toBeVisible();
+  // Typed so the send button is in its enabled state for the capture, which is
+  // the state a reader is judging, and so the geometry below is asserted on a
+  // live control rather than a disabled one.
+  await page.locator("#hive-agent-instructions").fill("Rename the payslips in ascending order");
+  for (const cls of ["rounded-full", "p-1.5", "self-center"]) {
+    await expect(
+      page.locator("#hive-agent-send"),
+      `the shared send button lost ${cls}`,
+    ).toHaveClass(new RegExp(`(^|\\s)${cls}(\\s|$)`));
+  }
+  await expect(page.locator("#hive-agent-send")).toHaveAttribute(
+    "aria-label",
+    /\S/,
+  );
+  await agentComposer.screenshot({ path: `${PROOF_DIR}/composer-agent.png` });
+
   await page.goto("/");
-  await expect(page.locator("#message-input-container")).toBeVisible();
-  await page.screenshot({
-    path: `${PROOF_DIR}/chat-composer-after.png`,
-    fullPage: false,
-  });
+  const chatComposer = page.locator("#message-input-container");
+  await expect(chatComposer).toBeVisible();
+  await chatComposer.screenshot({ path: `${PROOF_DIR}/composer-chat.png` });
+  await page.screenshot({ path: `${PROOF_DIR}/chat-after.png`, fullPage: false });
+
+  /*
+   * The extraction has to be invisible on the chat surface, and two images a
+   * human eyeballs is a weak way to prove that. These are the classes that
+   * carry the composer's shape, asserted on chat's own container, so drift in
+   * the extracted component fails here in words rather than in a screenshot
+   * comparison nobody can diff.
+   *
+   * Asserted class by class rather than as one pinned string: the class
+   * attribute is assembled from a conditional expression whose branches carry
+   * their own leading and trailing spaces, so an exact-string match would fail
+   * on whitespace and teach the next person to delete the assertion.
+   */
+  for (const cls of [
+    "rounded-3xl",
+    "shadow-lg",
+    "backdrop-blur-sm",
+    "border",
+    "px-1",
+  ]) {
+    await expect(
+      chatComposer,
+      `chat's composer container lost ${cls}, so the extraction was not invisible`,
+    ).toHaveClass(new RegExp(`(^|\\s)${cls}(\\s|$)`));
+  }
 });
 
 test("the collapsed rail keeps every destination", async ({ page }) => {

--- a/apps/web-console/e2e/phase-19/owui/09-agent-workspace-nav.spec.ts
+++ b/apps/web-console/e2e/phase-19/owui/09-agent-workspace-nav.spec.ts
@@ -3,23 +3,35 @@ import { test, expect } from "@playwright/test";
 test.use({ storageState: "e2e/phase-19/owui/.auth/owui-user.json" });
 
 /*
- * The agent workspace as a destination in the shell.
+ * The agent workspace as a destination in the shell, rendered natively.
  *
- * This file replaces 09-agent-workspace-launcher.spec.ts, which measured a
+ * This file replaced 09-agent-workspace-launcher.spec.ts, which measured a
  * body-level overlay that loader.js pinned into Open WebUI's header band by
- * viewport measurement. That overlay existed because the pinned image shipped a
- * compiled bundle with no navigation slot. The frontend is built from source
- * now (vendor/open-webui), so the agent workspace is a labelled row in the
- * sidebar and the overlay is deleted.
+ * viewport measurement. That overlay went when the frontend started building
+ * from source (vendor/open-webui) and the agent became a labelled sidebar row.
  *
- * What is asserted here is the property the owner asked for and the launcher
- * could never have: reaching the agent does not leave the shell. The sidebar
- * stays, the origin stays, and no second page opens.
+ * It then asserted, for one release, that /agents rendered an
+ * `iframe[title="Agent workspace"]` and reached into it with a frameLocator.
+ * Those assertions are inverted here, deliberately and by owner directive: the
+ * frame booted apps/agent-console, a second whole application, inside the page,
+ * which is why the agent surface never looked like the rest of the product.
+ * What is asserted now is that there is no frame at all and that the composer
+ * and the task list are this application's own DOM.
+ *
+ * The list assertion is deliberately about the credential path rather than
+ * about rows. The browser holds no credential edge-api accepts, so every call
+ * goes through the chat container's own proxy, which resolves the signed-in
+ * user's Supabase token server side. A 401 there is exactly the failure mode
+ * that design has, so a 401 must fail this test. A 403 must not: it is the
+ * Cowork feature gate answering, which can only happen after the principal and
+ * its tenant resolved, and the seeded fixture tenant does not hold that gate.
  */
 
 const NAV_ROW = (id: string) => `[data-hive-nav="${id}"]`;
 const SIDEBAR = "#sidebar";
 const REMOVED_LAUNCHER = "#hive-agent-launcher";
+const TASKS_ENDPOINT = "/api/v1/hive/agent/tasks";
+const PROOF_DIR = "playwright-report-owui/proof";
 
 test("the sidebar carries labelled Chats, Agents and Knowledge destinations", async ({
   page,
@@ -32,6 +44,7 @@ test("the sidebar carries labelled Chats, Agents and Knowledge destinations", as
   for (const [id, label, href] of [
     ["chats", "Chats", "/"],
     ["agents", "Agents", "/agents"],
+    // The full path. /knowledge alone is a 404 on this deployment.
     ["knowledge", "Knowledge", "/workspace/knowledge"],
   ] as const) {
     // `.first()` because the same list renders twice, once expanded and once on
@@ -55,7 +68,7 @@ test("the injected launcher overlay is gone", async ({ page }) => {
   ).toHaveCount(0);
 });
 
-test("the agent workspace opens inside the shell, with the sidebar still there", async ({
+test("the agent workspace opens inside the shell and frames nothing", async ({
   page,
 }) => {
   await page.setViewportSize({ width: 1440, height: 900 });
@@ -66,34 +79,98 @@ test("the agent workspace opens inside the shell, with the sidebar still there",
     documentLoads += 1;
   });
 
+  // Recorded rather than asserted inline so the failure message can name the
+  // status, which is the whole diagnostic value of this check.
+  let tasksStatus: number | null = null;
+  page.on("response", (response) => {
+    if (new URL(response.url()).pathname === TASKS_ENDPOINT) {
+      tasksStatus = response.status();
+    }
+  });
+
   const row = page.locator(`${SIDEBAR} ${NAV_ROW("agents")}`).first();
   await expect(row).toBeVisible();
   await row.click();
 
   await page.waitForURL((url) => url.pathname === "/agents", { timeout: 15_000 });
 
-  // The whole point: the shell survives the hop.
+  // The shell survives the hop.
   await expect(
     page.locator(SIDEBAR),
     "the sidebar disappeared, so this is still a separate page",
   ).toBeVisible();
   await expect(row).toHaveAttribute("aria-current", "page");
 
-  const panel = page.locator('iframe[title="Agent workspace"]');
-  await expect(panel).toBeVisible();
+  // The claim this whole change exists to make.
+  await expect(
+    page.locator("iframe"),
+    "the agent surface must not frame anything, on this route or anywhere in it",
+  ).toHaveCount(0);
 
-  // The panel is the real agent workspace and it is running embedded, so it
-  // draws no second brand row over the shell's own chrome.
-  const frame = page.frameLocator('iframe[title="Agent workspace"]');
-  await expect(
-    frame.getByRole("heading", { name: "Give the agent a task" }),
-  ).toBeVisible({ timeout: 30_000 });
-  await expect(
-    frame.locator('[data-hv-embedded="1"]'),
-    "the embedded panel should know it is embedded",
-  ).toHaveCount(1);
+  // The composer is this application's own DOM, and it is the chat composer's
+  // container rather than a form that resembles one.
+  const composer = page.locator("#hive-agent-instructions");
+  await expect(composer).toBeVisible();
+  await expect(page.locator("#hive-agent-send")).toBeVisible();
+  for (const label of ["Knowledge work", "Coding"]) {
+    await expect(
+      page.getByText(label, { exact: true }),
+      `the ${label} toggle is missing from the composer`,
+    ).toBeVisible();
+  }
+
+  // The list region renders, whether or not this fixture tenant has any tasks.
+  await expect(page.getByRole("heading", { name: "Your tasks" })).toBeAttached();
+
+  await expect
+    .poll(() => tasksStatus, {
+      message: "the agent surface never called its own backend",
+      timeout: 20_000,
+    })
+    .not.toBeNull();
+  expect(
+    tasksStatus,
+    `GET ${TASKS_ENDPOINT} answered ${tasksStatus}. 401 means the server-side ` +
+      "proxy could not resolve the signed-in user's token, which is the one " +
+      "failure this design has; 403 is the Cowork gate, which can only answer " +
+      "after the principal and its tenant already resolved.",
+  ).not.toBe(401);
+  expect([200, 403]).toContain(tasksStatus);
 
   expect(documentLoads, "the hop into the agent must be client-side").toBe(0);
+});
+
+test("proof capture: the agent surface, natively, in both palettes", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+
+  for (const scheme of ["light", "dark"] as const) {
+    await page.emulateMedia({ colorScheme: scheme });
+    await page.goto("/agents");
+    await expect(page.locator("#hive-agent-instructions")).toBeVisible();
+
+    // The DOM evidence travels with the image rather than being asserted only
+    // in a log: a screenshot cannot show the absence of a frame on its own.
+    const frames = await page.locator("iframe").count();
+    expect(frames, "iframe count must be zero in the captured DOM").toBe(0);
+
+    await page.screenshot({
+      path: `${PROOF_DIR}/agents-native-${scheme}.png`,
+      fullPage: true,
+    });
+  }
+
+  // The chat composer, from the same build, because its container and send
+  // button were extracted into the components the agent composer renders and
+  // the extraction has to be provably invisible on this surface.
+  await page.emulateMedia({ colorScheme: "light" });
+  await page.goto("/");
+  await expect(page.locator("#message-input-container")).toBeVisible();
+  await page.screenshot({
+    path: `${PROOF_DIR}/chat-composer-after.png`,
+    fullPage: false,
+  });
 });
 
 test("the collapsed rail keeps every destination", async ({ page }) => {

--- a/apps/web-console/e2e/phase-19/owui/09-agent-workspace-nav.spec.ts
+++ b/apps/web-console/e2e/phase-19/owui/09-agent-workspace-nav.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 
 test.use({ storageState: "e2e/phase-19/owui/.auth/owui-user.json" });
 
@@ -40,6 +40,38 @@ const TASKS_ENDPOINT = "/api/v1/hive/agent/tasks";
  */
 const PROOF_DIR = "playwright-report-owui-proof";
 
+
+/*
+ * Put the sidebar in the state the assertion is about, rather than assuming it.
+ *
+ * Both nav variants are always in the DOM: an icon-only rail whose name lives
+ * on `aria-label`, and an expanded row that renders the same string as text.
+ * Only one is visible at a time, and `.first()` resolves to the rail either
+ * way, so a text assertion written against `.first()` reads the icon and finds
+ * "".
+ *
+ * This fixture's sidebar starts collapsed, which is the other half: the
+ * expanded-state assertions never had their precondition, and the collapsed
+ * test waited forever for a "Close Sidebar" control that is only present when
+ * the sidebar is open. Neither had ever actually run before the sign-in
+ * readiness fix in this branch, so neither had ever been observed failing.
+ */
+async function setSidebar(page: Page, state: "expanded" | "collapsed") {
+  const opener = page.getByLabel("Open Sidebar").first();
+  const closer = page.getByLabel("Close Sidebar").first();
+  const toPress = state === "expanded" ? opener : closer;
+  if (await toPress.isVisible().catch(() => false)) {
+    await toPress.click();
+  }
+  // The opposite control is what proves the new state, through Open WebUI's
+  // own chrome rather than through its store.
+  await expect(state === "expanded" ? closer : opener).toBeVisible();
+}
+
+/** The nav row a person can actually see, of the two the DOM always holds. */
+const visibleNavRow = (page: Page, id: string) =>
+  page.locator(`${NAV_ROW(id)}:visible`).first();
+
 test("the sidebar carries labelled Chats, Agents and Knowledge destinations", async ({
   page,
 }) => {
@@ -47,6 +79,7 @@ test("the sidebar carries labelled Chats, Agents and Knowledge destinations", as
   await page.goto("/");
 
   await expect(page.locator(SIDEBAR)).toBeVisible();
+  await setSidebar(page, "expanded");
 
   for (const [id, label, href] of [
     ["chats", "Chats", "/"],
@@ -54,9 +87,8 @@ test("the sidebar carries labelled Chats, Agents and Knowledge destinations", as
     // The full path. /knowledge alone is a 404 on this deployment.
     ["knowledge", "Knowledge", "/workspace/knowledge"],
   ] as const) {
-    // `.first()` because the same list renders twice, once expanded and once on
-    // the collapsed rail, and only one of the two is on screen at a time.
-    const row = page.locator(`${SIDEBAR} ${NAV_ROW(id)}`).first();
+    // The visible one of the two, not `.first()`: see setSidebar above.
+    const row = visibleNavRow(page, id);
     await expect(row, `${id} row missing from the sidebar`).toBeVisible();
     await expect(row).toHaveAttribute("href", href);
     // A label, not an unlabelled icon. This is the specific complaint.
@@ -289,13 +321,10 @@ test("the collapsed rail keeps every destination", async ({ page }) => {
 
   await expect(page.locator(SIDEBAR)).toBeVisible();
 
-  // Collapse through Open WebUI's own control rather than by writing its store:
-  // the assertion is about what a person sees after pressing it.
-  await page.getByLabel("Close Sidebar").first().click();
-  await expect(page.getByLabel("Open Sidebar").first()).toBeVisible();
+  await setSidebar(page, "collapsed");
 
   for (const id of ["chats", "agents", "knowledge"]) {
-    const row = page.locator(NAV_ROW(id)).first();
+    const row = visibleNavRow(page, id);
     await expect(row, `${id} vanished when the sidebar collapsed`).toBeVisible();
     // Collapsed rows carry no visible label, so the accessible name is the only
     // thing naming them and it must not be empty.

--- a/apps/web-console/e2e/phase-19/owui/deployed-login.spec.ts
+++ b/apps/web-console/e2e/phase-19/owui/deployed-login.spec.ts
@@ -54,7 +54,22 @@ test("OIDC sign-in completes against the deployed origin", async ({ page }) => {
   const emailBox = page.getByRole("textbox", { name: /email/i });
   const passwordBox = page.getByRole("textbox", { name: /password/i });
   const approveButton = page.getByRole("button", { name: /approve/i });
-  const newChatButton = page.getByRole("button", { name: /new chat/i });
+  /*
+   * Either role, because the control is an <a>.
+   *
+   * Open WebUI renders both New Chat controls (the collapsed rail's icon and
+   * the expanded sidebar's row) as anchors with an aria-label, so their
+   * implicit role is `link` and a `button` query can never match. This
+   * readiness signal has therefore been failing since the control changed
+   * shape, taking every OWUI end-to-end run with it: the sign-in it guards
+   * actually succeeds, and the run fails 60 seconds later looking for an
+   * element that cannot exist. e2e/chat-coverage/surfaces.ts already matches
+   * both roles for exactly this reason; these two call sites were missed.
+   */
+  const newChatButton = page
+    .getByRole("button", { name: /new chat/i })
+    .or(page.getByRole("link", { name: /new chat/i }))
+    .first();
 
   // Consent renders first and only bounces to sign-in once its client-side
   // session check returns empty, so a URL check can observe the transient

--- a/apps/web-console/e2e/phase-19/owui/owui.setup.ts
+++ b/apps/web-console/e2e/phase-19/owui/owui.setup.ts
@@ -159,7 +159,22 @@ setup("OWUI OIDC sign-in via Hive consent", async ({ page, browser }) => {
   }
 
   const owuiOrigin = new URL(OWUI_URL).origin;
-  const newChatButton = page.getByRole("button", { name: /new chat/i });
+  /*
+   * Either role, because the control is an <a>.
+   *
+   * Open WebUI renders both New Chat controls (the collapsed rail's icon and
+   * the expanded sidebar's row) as anchors with an aria-label, so their
+   * implicit role is `link` and a `button` query can never match. This
+   * readiness signal has therefore been failing since the control changed
+   * shape, taking every OWUI end-to-end run with it: the sign-in it guards
+   * actually succeeds, and the run fails 60 seconds later looking for an
+   * element that cannot exist. e2e/chat-coverage/surfaces.ts already matches
+   * both roles for exactly this reason; these two call sites were missed.
+   */
+  const newChatButton = page
+    .getByRole("button", { name: /new chat/i })
+    .or(page.getByRole("link", { name: /new chat/i }))
+    .first();
 
   // Bootstrap login: Open WebUI auto-promotes the very first user it ever
   // sees to admin, bypassing OAUTH_ALLOWED_ROLES/OAUTH_ROLES_CLAIM entirely.
@@ -184,7 +199,10 @@ setup("OWUI OIDC sign-in via Hive consent", async ({ page, browser }) => {
   await bootstrapPage.goto(OWUI_URL);
   await signInWithHive(bootstrapPage, bootstrapEmail, bootstrapPassword, owuiOrigin);
   await expect(
-    bootstrapPage.getByRole("button", { name: /new chat/i }),
+    bootstrapPage
+      .getByRole("button", { name: /new chat/i })
+      .or(bootstrapPage.getByRole("link", { name: /new chat/i }))
+      .first(),
   ).toBeVisible({ timeout: 60_000 });
   await bootstrapContext.close();
 

--- a/apps/web-console/e2e/phase-19/sign-in-with-hive.ts
+++ b/apps/web-console/e2e/phase-19/sign-in-with-hive.ts
@@ -49,6 +49,27 @@ export async function signInWithHive(
   // observe the transient consent pathname and wrongly decide login is
   // done. Wait on the DOM instead: either we need to sign in (email box
   // visible) or we're already on consent (Approve visible).
+  // Wait for the consent app to be serving before timing the login.
+  //
+  // The consent and sign-in pages are web-console's, on a different origin,
+  // and web-console runs in dev mode here (see the note below), so it compiles
+  // its routes on first request. Measured on run 32112158077: the first two
+  // attempts never left the Open WebUI origin and timed out at 30s, and the
+  // third completed the whole exchange in 21 seconds once the route was warm.
+  // That is a one-off compile at the start of a run, not a slow login.
+  //
+  // The budget here is deliberately NOT the login budget, and the login budget
+  // below is deliberately unchanged. Raising the 30s assertion would have
+  // buried a cold compile inside a per-login timeout and made every future slow
+  // login indistinguishable from this one, which is the failure that hides the
+  // next real regression.
+  //
+  // This adds no new failure mode: the assertion on the next line already
+  // requires a DOM that only exists on the consent origin, so requiring the
+  // browser to reach that origin first is strictly weaker than what was
+  // already being demanded.
+  await page.waitForURL((u) => u.origin !== owuiOrigin, { timeout: 120_000 });
+
   await expect(emailBox.or(approveButton)).toBeVisible({ timeout: 30_000 });
 
   // web-console runs in dev mode in CI; React hydration can remount the

--- a/deploy/docker/Caddyfile.owui
+++ b/deploy/docker/Caddyfile.owui
@@ -167,6 +167,26 @@
     }
   }
 
+  # `/api/v1/hive/*` is deliberately left to the catch-all below, and the
+  # reason is written here so a future reviewer does not have to re-derive it
+  # from three regexes.
+  #
+  # That prefix is Hive's own FastAPI router inside the chat container
+  # (deploy/docker/owui-patches/hive_agent_proxy.py), and it has to stay
+  # browser-reachable: the native agent surface calls it from the page. It
+  # matches none of the blocks above, which is correct rather than accidental.
+  # `@blocked` lists literal segments after `api/v1/` and `hive` is not one;
+  # `@removedSurfaces` matches page routes only; `@adminMutation` globs
+  # `configs*`, `users/*`, `groups*`, `functions*` and `models*`, none of which
+  # match `hive/agent/tasks`, so the create and cancel POSTs stay reachable.
+  #
+  # It is not the shape #770 and #771 blocked. Those are stock Open WebUI
+  # routers that proxy to a caller-supplied destination with a stored
+  # credential, and this deployment offers no such feature. This router is four
+  # named operations, every one behind Open WebUI's own `get_verified_user`,
+  # with the task id validated as a UUID and the outbound body rebuilt from two
+  # named fields. Blocking it here would break the feature and secure nothing.
+
   # Agent-task API on the chat origin. The task console runs in the browser
   # and calls edge-api directly, but edge-api serves no CORS headers at all,
   # so a cross-origin base URL (api-hive.scubed.co while the page is served

--- a/deploy/docker/Dockerfile.open-webui
+++ b/deploy/docker/Dockerfile.open-webui
@@ -41,6 +41,17 @@ COPY vendor/open-webui ./
 
 ENV APP_BUILD_HASH=hive-fork
 ENV NODE_OPTIONS=--max-old-space-size=4096
+
+# The fork's own unit tests, run here because there is nowhere else they run.
+# ci.yml has vitest lanes for apps/desktop, apps/web-console and
+# apps/agent-console and none for vendor/open-webui, so every test written
+# under src/lib/hive was coverage on paper only. Running them in this stage
+# means they gate the nightly image build and the demo deploy, which is not the
+# same as gating a pull request and is not being claimed as such: a PR-time
+# lane for this tree is a follow-up. What it does buy is that a broken test
+# cannot reach the box.
+RUN npm run test:frontend -- --run
+
 RUN npm run build && test -f build/index.html
 #
 # Upstream Open WebUI hardcodes a license-enforcement suffix: any custom
@@ -316,6 +327,27 @@ COPY deploy/docker/owui-patches/apply_model_picker_patch.py /tmp/apply_model_pic
 RUN python3 /tmp/apply_model_picker_patch.py \
     && grep -q 'hive_model_picker' /app/backend/open_webui/main.py \
     && python3 -c "import ast, pathlib; ast.parse(pathlib.Path('/app/backend/open_webui/main.py').read_text())"
+
+# The agent surface renders natively in the chat frontend now, so it needs a
+# server-side hop to /v1/agent/* that carries the signed-in user's own token.
+# It cannot be done from the browser: this frontend holds Open WebUI's session
+# token, which edge-api has never heard of, plus a Supabase OAuth-server token
+# that carries no tenant_id and that edge-api fails closed on by design
+# (.wolf/decisions.md D-023). That OAuth token is not in the browser either --
+# Open WebUI resolves it server side and refreshes it -- so handing it to page
+# JavaScript would be a downgrade rather than a fix.
+#
+# This router does for the agent-task calls exactly what the hive_jwt_forward
+# Function already does for chat completions: present the shim key, carry the
+# per-user token alongside it, and let edge-api's OWUIUnwrap middleware swap
+# the two. It adds no configuration, because OPENAI_API_BASE_URL and
+# OPENAI_API_KEY are already set on this container, so the shim key gains no
+# new home. Frontend counterpart: vendor/open-webui/src/lib/hive/agentTasks.ts.
+COPY deploy/docker/owui-patches/hive_agent_proxy.py /app/backend/open_webui/utils/hive_agent_proxy.py
+COPY deploy/docker/owui-patches/apply_agent_proxy_patch.py /tmp/apply_agent_proxy_patch.py
+RUN python3 /tmp/apply_agent_proxy_patch.py \
+    && grep -q 'hive_agent_router' /app/backend/open_webui/main.py \
+    && python3 -c "import ast, pathlib; ast.parse(pathlib.Path('/app/backend/open_webui/utils/hive_agent_proxy.py').read_text())"
 
 # #771: drop the Settings > Integrations tab, the chat UI's only entry point to
 # "Manage Tool Servers" and "Open Terminal". Both accept an arbitrary URL and an

--- a/deploy/docker/owui-patches/apply_agent_proxy_patch.py
+++ b/deploy/docker/owui-patches/apply_agent_proxy_patch.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Mount hive_agent_proxy's router on Open WebUI's FastAPI application.
+
+Only the frontend of this image is built from the fork; the Python backend
+stays upstream's pinned release on purpose (see the header of
+deploy/docker/Dockerfile.open-webui), so a backend addition arrives as a copied
+module plus one asserted splice, exactly like hive_model_picker and
+hive_rag_env_config before it.
+
+The splice is one anchored insertion and it asserts everything it assumed: that
+the anchor exists exactly once, that the file was not already patched, that the
+insertion landed, and that the result still parses. A digest bump that moves
+upstream's router block therefore fails the build rather than silently shipping
+an image whose agent surface 404s.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+import re
+import sys
+
+MAIN = pathlib.Path('/app/backend/open_webui/main.py')
+
+# Anchored on the utils router because it is one of the last unconditional
+# include_router calls in the block, so the insertion lands after the routers
+# our module never touches and before the conditional ones.
+ANCHOR = re.compile(
+    r'^app\.include_router\(\s*utils\.router,\s*prefix=(["\'])/api/v1/utils\1,\s*tags=\[(["\'])utils\2\]\s*\)$',
+    re.MULTILINE,
+)
+
+INSERTION = """
+# hive: the agent-task lifecycle, proxied server side so the chat frontend can
+# reach /v1/agent/* with the signed-in user's own token rather than the shim's
+# principal. See deploy/docker/owui-patches/hive_agent_proxy.py.
+from open_webui.utils.hive_agent_proxy import router as hive_agent_router
+
+app.include_router(hive_agent_router, prefix='/api/v1/hive/agent', tags=['hive'])
+"""
+
+MARKER = 'hive_agent_router'
+
+
+def main() -> int:
+    source = MAIN.read_text()
+
+    if MARKER in source:
+        print(f'hive: {MAIN} already mounts the agent proxy, nothing to do')
+        return 0
+
+    matches = list(ANCHOR.finditer(source))
+    if len(matches) != 1:
+        print(
+            f'hive: expected exactly 1 utils include_router anchor in {MAIN}, found {len(matches)}',
+            file=sys.stderr,
+        )
+        return 1
+
+    end = matches[0].end()
+    patched = source[:end] + '\n' + INSERTION + source[end:]
+
+    if patched.count(MARKER) != 2:
+        print('hive: agent proxy insertion did not land exactly once', file=sys.stderr)
+        return 1
+
+    # Parse before writing, so a broken splice never reaches the image.
+    ast.parse(patched)
+
+    MAIN.write_text(patched)
+    print('hive: mounted the agent proxy router at /api/v1/hive/agent')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/deploy/docker/owui-patches/hive_agent_proxy.py
+++ b/deploy/docker/owui-patches/hive_agent_proxy.py
@@ -1,0 +1,234 @@
+"""hive_agent_proxy: the agent-task lifecycle, reachable from the chat frontend.
+
+Why this exists at all.
+
+The chat frontend renders the agent surface natively now, so it has to call
+`/v1/agent/tasks` on edge-api. It cannot do that from the browser. It holds Open
+WebUI's own session token, which edge-api has never heard of, and a Supabase
+access token minted through Supabase's OAuth-server grant, which does not run
+this project's `custom_access_token_hook` and therefore carries no `tenant_id`.
+edge-api's `JWTMiddleware` fails such a token closed, deliberately, and that is
+`.wolf/decisions.md` D-023 working rather than a bug to route around.
+
+That OAuth token is also not in the browser. Open WebUI keeps it server side and
+resolves it per request through `get_system_oauth_token`, refreshing it when it
+has expired. Handing it to page JavaScript would be a downgrade, not a fix.
+
+So the hop happens here, server side, on exactly the mechanism this deployment
+already runs for chat completions: Open WebUI presents the static shim key on
+`Authorization`, the signed-in user's token rides alongside it, and edge-api's
+`OWUIUnwrap` middleware swaps the two and grants the tenant fallback precisely
+because the shim key was presented. `hive_jwt_forward.py` does the same thing
+for `/v1/chat/completions` and carries the token in the JSON body under
+`__metadata.upstream_auth`. That carrier cannot serve this surface, because
+three of the four calls below have no JSON body at all, so the token rides on
+the `X-Hive-Upstream-Auth` header instead. Same gate, same trust decision, a
+carrier a bodyless request can use. See
+`apps/edge-api/internal/auth/owui_unwrap.go`.
+
+The security properties this file is responsible for, all of them load bearing:
+
+  * The principal is whoever Open WebUI says is signed in, and nothing else.
+    Every route depends on `get_verified_user`. No route reads a user id, a
+    tenant id, an email or a token from the request, so a caller cannot
+    influence which principal edge-api resolves.
+  * Neither the shim key nor the user's token is ever returned to the browser,
+    logged, or echoed in an error.
+  * The upstream path is built from a fixed set of four operations, with the
+    task id validated as a UUID before it is interpolated. This is not a
+    general-purpose proxy, which is the shape #770 removed from this image.
+  * The request body forwarded upstream is rebuilt from two named fields rather
+    than passed through, so nothing a caller invents (a `__metadata` block, for
+    one) reaches edge-api.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+from uuid import UUID
+
+import aiohttp
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import JSONResponse
+
+from open_webui.utils.auth import get_verified_user
+
+router = APIRouter()
+
+# One request should never hold a worker for long. The agent-task endpoints are
+# all small database reads and one control-plane call; a launch that is slow is
+# slow on the far side of edge-api and reports itself through the task's own
+# status, not by holding this connection open.
+UPSTREAM_TIMEOUT_SECONDS = 30
+
+# Bodies here are a pack name and a goal. edge-api applies its own 64 KiB limit
+# on the create route; this one exists so a chat container worker never buffers
+# more than it could possibly need.
+MAX_REQUEST_BODY_BYTES = 64 * 1024
+
+# The header edge-api reads the per-user token from. Must match
+# `UpstreamAuthHeader` in apps/edge-api/internal/auth/owui_unwrap.go.
+UPSTREAM_AUTH_HEADER = 'X-Hive-Upstream-Auth'
+
+
+def _upstream_base() -> str:
+    """The `/v1` root of the Hive gateway, from Open WebUI's own configuration.
+
+    `OPENAI_API_BASE_URL` is already `http://edge-api:8080/v1` in this
+    container, and `OPENAI_API_KEY` is already the shim key, so this proxy adds
+    no new configuration and gives the shim key no new place to live.
+    """
+    base = (os.environ.get('OPENAI_API_BASE_URL') or '').strip().rstrip('/')
+    return base
+
+
+def _shim_key() -> str:
+    return (os.environ.get('OPENAI_API_KEY') or '').strip()
+
+
+async def _user_token(request: Request, user) -> str:
+    """The signed-in user's Supabase access token, resolved server side.
+
+    Imported here rather than at module scope: `open_webui.utils.middleware`
+    pulls in a large part of the application, and this module is imported from
+    `main.py` while that graph is still being built.
+    """
+    from open_webui.utils.middleware import get_system_oauth_token
+
+    token = await get_system_oauth_token(request, user)
+    return ((token or {}).get('access_token') or '').strip()
+
+
+def _task_id(raw: str) -> str:
+    """Refuse anything that is not a UUID before it reaches a URL.
+
+    edge-api validates this too. It is validated here as well because this is
+    the boundary where a caller-supplied string first becomes part of a URL,
+    and a boundary that trusts its input because something downstream will
+    check it is a boundary that stops being safe the moment downstream moves.
+    """
+    try:
+        return str(UUID(raw))
+    except (ValueError, AttributeError, TypeError):
+        raise HTTPException(status_code=400, detail='Invalid task id.')
+
+
+async def _call(
+    request: Request,
+    user,
+    method: str,
+    path: str,
+    payload: dict[str, Any] | None = None,
+) -> JSONResponse:
+    """One upstream call, with the shim key on Authorization and the user's
+    token on the carrier header.
+
+    Every failure below is reported to the browser as a plain sentence with no
+    internal detail in it: no URL, no upstream error text, no credential, and
+    no provider identity, which is this repository's standing rule for anything
+    that crosses a customer boundary.
+    """
+    base = _upstream_base()
+    shim = _shim_key()
+    if not base or not shim:
+        # A deployment that never configured the gateway. Say what is true
+        # without naming what is missing.
+        raise HTTPException(
+            status_code=503,
+            detail='The agent service is not configured on this deployment.',
+        )
+
+    token = await _user_token(request, user)
+    if not token:
+        # Fail closed rather than proceeding with the shim key alone, which
+        # edge-api would now refuse anyway (requiresPerUserAuth covers these
+        # paths) but which would otherwise have run as the shim's own account.
+        raise HTTPException(
+            status_code=401,
+            detail='Your Hive sign-in could not be confirmed. Sign in again and retry.',
+        )
+
+    headers = {
+        'Authorization': f'Bearer {shim}',
+        UPSTREAM_AUTH_HEADER: f'Bearer {token}',
+        'Accept': 'application/json',
+    }
+    if payload is not None:
+        headers['Content-Type'] = 'application/json'
+
+    timeout = aiohttp.ClientTimeout(total=UPSTREAM_TIMEOUT_SECONDS)
+    try:
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.request(
+                method, f'{base}{path}', headers=headers, json=payload
+            ) as response:
+                body = await response.json(content_type=None)
+                # edge-api's own JSON is returned verbatim, including its error
+                # shape, because the front end already knows how to read it and
+                # re-wrapping it here would mean two error vocabularies for one
+                # surface. It is provider-blind at the source.
+                return JSONResponse(status_code=response.status, content=body)
+    except aiohttp.ClientError:
+        raise HTTPException(
+            status_code=502,
+            detail='The agent service could not be reached. Try again shortly.',
+        )
+    except TimeoutError:
+        raise HTTPException(
+            status_code=504,
+            detail='The agent service took too long to answer. Try again shortly.',
+        )
+    except ValueError:
+        # A non-JSON upstream body. Nothing honest to hand the front end.
+        raise HTTPException(
+            status_code=502,
+            detail='The agent service returned an unreadable response.',
+        )
+
+
+@router.get('/tasks')
+async def list_tasks(request: Request, user=Depends(get_verified_user)):
+    return await _call(request, user, 'GET', '/agent/tasks')
+
+
+@router.post('/tasks')
+async def create_task(request: Request, user=Depends(get_verified_user)):
+    raw = await request.body()
+    if len(raw) > MAX_REQUEST_BODY_BYTES:
+        raise HTTPException(status_code=413, detail='That task description is too long.')
+    try:
+        submitted = await request.json()
+    except ValueError:
+        raise HTTPException(status_code=400, detail='Invalid request body.')
+    if not isinstance(submitted, dict):
+        raise HTTPException(status_code=400, detail='Invalid request body.')
+
+    pack = submitted.get('pack')
+    instructions = submitted.get('instructions')
+    if not isinstance(pack, str) or not pack.strip():
+        raise HTTPException(status_code=400, detail='Choose what kind of task this is.')
+    if not isinstance(instructions, str) or not instructions.strip():
+        raise HTTPException(status_code=400, detail='Describe the task first.')
+
+    # Rebuilt from two named fields, never forwarded wholesale. The pack
+    # vocabulary itself is deliberately not duplicated here: edge-api owns it
+    # and answers an unknown pack with its own error, so there is one list of
+    # packs in the system rather than two that can disagree.
+    return await _call(
+        request,
+        user,
+        'POST',
+        '/agent/tasks',
+        {'pack': pack.strip(), 'instructions': instructions.strip()},
+    )
+
+
+@router.get('/tasks/{task_id}')
+async def get_task(task_id: str, request: Request, user=Depends(get_verified_user)):
+    return await _call(request, user, 'GET', f'/agent/tasks/{_task_id(task_id)}')
+
+
+@router.post('/tasks/{task_id}/cancel')
+async def cancel_task(task_id: str, request: Request, user=Depends(get_verified_user)):
+    return await _call(request, user, 'POST', f'/agent/tasks/{_task_id(task_id)}/cancel')

--- a/deploy/docker/owui-patches/hive_agent_proxy.py
+++ b/deploy/docker/owui-patches/hive_agent_proxy.py
@@ -44,6 +44,7 @@ The security properties this file is responsible for, all of them load bearing:
 
 from __future__ import annotations
 
+import asyncio
 import os
 from typing import Any
 from uuid import UUID
@@ -169,15 +170,28 @@ async def _call(
                 # re-wrapping it here would mean two error vocabularies for one
                 # surface. It is provider-blind at the source.
                 return JSONResponse(status_code=response.status, content=body)
+    # Timeouts are caught before ClientError on purpose, and the exception is
+    # named as asyncio.TimeoutError rather than the builtin.
+    #
+    # Measured against the pinned image (ghcr.io/open-webui/open-webui:v0.10.2)
+    # rather than assumed: Python 3.11.15, aiohttp 3.13.5, and there
+    # `asyncio.TimeoutError is TimeoutError` is True, so the builtin would work
+    # today. It stops working on any interpreter older than 3.11, where the two
+    # are different classes and a total-timeout breach would escape as an
+    # unhandled exception, which on this path means a 500 carrying a traceback.
+    #
+    # The ordering matters for the same reason: aiohttp's ServerTimeoutError
+    # inherits from ClientError as well as from TimeoutError, so catching
+    # ClientError first would report a connect timeout as unreachable.
+    except asyncio.TimeoutError:
+        raise HTTPException(
+            status_code=504,
+            detail='The agent service took too long to answer. Try again shortly.',
+        )
     except aiohttp.ClientError:
         raise HTTPException(
             status_code=502,
             detail='The agent service could not be reached. Try again shortly.',
-        )
-    except TimeoutError:
-        raise HTTPException(
-            status_code=504,
-            detail='The agent service took too long to answer. Try again shortly.',
         )
     except ValueError:
         # A non-JSON upstream body. Nothing honest to hand the front end.

--- a/docs/proof/agents-native-live-2026-08-23/README.md
+++ b/docs/proof/agents-native-live-2026-08-23/README.md
@@ -1,0 +1,88 @@
+# Proof: the agent surface renders natively inside chat, live and signed in
+
+Replaces the bundle-level captures on this PR. Those said so in their own text:
+sign-in on the deployed instance was failing with an unsupported-scope error
+from the authorization server, so no chat session could be minted through the
+sanctioned flow and the panel had to be reached with the backend stubbed and
+the origin on loopback. That blocker is gone (#1003), so this is a real signed
+-in walk.
+
+Text log only here. Images are posted as permanent GitHub Release assets via
+`scripts/post-pr-visual-proof.sh`, because a `raw.githubusercontent.com` link
+pinned to this branch would 404 the moment the branch is deleted at
+squash-merge. `npm run lint:proof-tokens` scans this directory and nothing
+else, which is why the log is committed here.
+
+## Substrate
+
+One complete local stack, nothing stubbed:
+
+- self-hosted Supabase data plane (`selfhost` profile): Postgres, GoTrue
+  v2.189.0, PostgREST, storage, `caddy-supabase`
+- `control-plane`, `edge-api`, `litellm`, `redis`
+- `web-console-prod` behind `caddy-console`, serving `/auth/v1`
+- Open WebUI behind `caddy-owui`
+
+Built from **`main` merged with #952, #956 and this branch**, which is the
+state that will exist after all three land, not this branch in isolation. The
+one merge conflict, in the `Makefile` `test-scripts` recipe, was resolved by
+keeping both sides: #952's `test-owui-frontend` target and this branch's
+`test_owui_agent_proxy.py` entry.
+
+Signed in through a real OAuth 2.1 authorization-code round trip. No session
+injected, no token minted by hand.
+
+## What is shown
+
+`01-chat-signed-in-agents-in-sidebar.png` — the signed-in chat surface with
+`Agents` in the sidebar.
+
+`02-agent-surface-native-no-credential-prompt.png` — where clicking that entry
+lands. No URL was typed; the surface is reached from inside the chat UI. The
+chat sidebar and the account chip are still there, which is the integration
+the owner asked for rather than a second application bolted on.
+
+Measured in the live DOM at both hops, not asserted:
+
+| Measurement | Chat landing | Agent surface |
+|---|---|---|
+| Password inputs | 0 | 0 |
+| `iframe` elements | 0 | 0 |
+| Child browsing contexts | 0 | 0 |
+| "sign in" / "log in" text nodes | 0 | 0 |
+| Anchors to `/agent-workspace` | 0 | 0 |
+
+`GET /api/v1/agent/tasks` answered **200** through the running proxy chain.
+That is the part that makes this more than a rendering check: the request goes
+Open WebUI → `hive_agent_proxy` → `edge-api`, carrying the signed-in user's own
+token on the new `X-Hive-Upstream-Auth` header this PR adds, and it is accepted.
+
+## What is deliberately not claimed
+
+The task list reads "Nothing submitted yet". Submitting a task for real needs
+the unprivileged host launcher and `HIVE_AGENT_ENGINE_SOCKET`; under docker
+compose that arm cannot succeed at all, by design, per the agent-engine section
+of `CLAUDE.md`. So the empty state is the honest ceiling on this substrate.
+What is proven here is the claim this PR actually makes: the surface is native,
+reached from inside chat, asks for no second credential, and its authenticated
+data path works end to end.
+
+The `/agent-workspace` path still 307s to agent-console's own form when typed
+directly. That is deliberate and is not a regression: the Tauri desktop app
+targets that base path.
+
+## Security review of the auth change
+
+The new header carrier in `apps/edge-api/internal/auth/owui_unwrap.go` is an
+auth boundary, so it had a dedicated security review. Verdict: safe to merge,
+with one LOW finding about a test guard that could not fail, now fixed on this
+branch and verified by mutation. Details are in the PR thread.
+
+## Credential handling
+
+Credential-bearing query parameters are redacted in this log and in the URL
+banner burned into each screenshot: `code`, `state`, `nonce`, `code_challenge`,
+`client_id`, `authorization_id`, any token parameter, and any URL fragment. The
+fixture address is a throwaway on a local database created for this run and
+destroyed with it. No password was set, read, reset or rotated on any shared or
+deployed account.

--- a/docs/proof/agents-native-live-2026-08-23/README.md
+++ b/docs/proof/agents-native-live-2026-08-23/README.md
@@ -23,11 +23,25 @@ One complete local stack, nothing stubbed:
 - `web-console-prod` behind `caddy-console`, serving `/auth/v1`
 - Open WebUI behind `caddy-owui`
 
-Built from **`main` merged with #952, #956 and this branch**, which is the
-state that will exist after all three land, not this branch in isolation. The
-one merge conflict, in the `Makefile` `test-scripts` recipe, was resolved by
-keeping both sides: #952's `test-owui-frontend` target and this branch's
-`test_owui_agent_proxy.py` entry.
+Built from this branch **rebased onto `main` at `82375d07f`**, which is the
+commit where #952 and #956 have already landed. So the substrate is the real
+post-merge state and not this branch in isolation. `main` at that point also
+carries #1043's LiteLLM digest pin and #1012's actual-cost billing, and the
+migration chain was brought current against the local database before the
+capture (`20260822_30_openrouter_auto_variable_pricing.sql` applied).
+
+The rebase hit one conflict, in the `Makefile` `test-scripts` recipe, resolved
+by keeping both sides rather than either wholesale: #952's `test-owui-frontend`
+target, which is now on `main`, and this branch's `test_owui_agent_proxy.py`
+entry.
+
+The capture was re-run from scratch on that rebased build. The result is
+identical to the pre-rebase run, including the `200` from the proxied task
+endpoint.
+
+`/agent-workspace` still answers `307` to `/agent-workspace/tasks`, verified
+after the rebase. That redirect is deliberate, because the Tauri desktop app
+targets that base path, and nothing here changes it.
 
 Signed in through a real OAuth 2.1 authorization-code round trip. No session
 injected, no token minted by hand.

--- a/docs/proof/agents-native-live-2026-08-23/capture.log
+++ b/docs/proof/agents-native-live-2026-08-23/capture.log
@@ -1,0 +1,37 @@
+PR #951 live capture: the agent surface rendered natively inside chat
+====================================================================
+
+Local full stack: self-hosted GoTrue v2.189.0, PostgREST, storage,
+Caddy gateway, control-plane, edge-api, litellm, web-console and Open
+WebUI, all built from main merged with #952, #956 and this branch.
+Signed in through a real OAuth authorization-code round trip; no
+session injected and no backend stubbed.
+
+1. Signed in. origin: http://localhost:3003
+   chat landing, signed in:
+     password inputs                : 0
+     iframe elements                : 0
+     child browsing contexts        : 0
+     "sign in"/"log in" text nodes  : 0
+     anchors to /agent-workspace    : 0
+  [shot] 01-chat-signed-in-agents-in-sidebar.png  signed-in chat with Agents in the sidebar
+         url: http://localhost:3003/
+
+2. Click 'Agents' in the chat sidebar. No URL typed.
+   landed on: http://localhost:3003/agents
+   agent surface:
+     password inputs                : 0
+     iframe elements                : 0
+     child browsing contexts        : 0
+     "sign in"/"log in" text nodes  : 0
+     anchors to /agent-workspace    : 0
+   GET /api/v1/agent/tasks -> 200
+  [shot] 02-agent-surface-native-no-credential-prompt.png  the agent surface, reached from inside chat, rendered natively
+         url: http://localhost:3003/agents
+
+3. Verdict on the three parts of the claim, from the numbers above.
+   reached from inside chat  : /agents
+   rendered natively         : 0 iframes, 0 child contexts
+   no second credential      : 0 password inputs
+
+   Chat landing for comparison: 0 iframes, 0 password inputs.

--- a/docs/proof/agents-native-no-iframe-2026-08-22/README.md
+++ b/docs/proof/agents-native-no-iframe-2026-08-22/README.md
@@ -6,6 +6,11 @@ through `scripts/post-pr-visual-proof.sh`, per `.wolf/decisions.md` D-042. The
 log lives here rather than only in a PR comment because
 `npm run lint:proof-tokens` scans this directory and nothing else.
 
+Recaptured on 2026-08-22 after the branch was rebased onto `main` at
+`851003b7b`, which is the merge of PR #787. The rebase conflicted in one place
+only, a single line in the Makefile's `test-scripts` list, and both sides were
+kept.
+
 ## What is being proved
 
 Issue #540, re-confirmed live on the demo box on 2026-08-22, is the top demo
@@ -17,15 +22,23 @@ the `sb-...-auth-token` cookie that the embedded `apps/agent-console` reads, so
 the embedded application falls back to its own sign in.
 
 This branch removes the embedded application from that route. The claim under
-test is therefore narrow and checkable: **on `/agents`, the built bundle renders
-the workspace natively, with no iframe and no credential prompt.**
+test is therefore narrow and checkable: **starting from the chat landing page,
+clicking the sidebar's Agents entry renders the workspace natively, with no
+iframe and no credential prompt anywhere on the way.**
 
 ## Method, and what is real in it
 
 - **The bundle is real.** It is the output of
   `docker build -f deploy/docker/Dockerfile.open-webui --target frontend` on
-  this branch, rebased onto `main` at `c30882491`: byte for byte the artefact
-  the image copies into `/app/build`. Nothing was hand-edited into it.
+  this branch as rebased: byte for byte the artefact the image copies into
+  `/app/build`. Nothing was hand-edited into it. That build also runs the
+  fork's own unit tests, which this branch adds to the frontend stage, and they
+  passed there: three files, thirty-one tests, including this branch's
+  `agentTasks.test.ts`.
+- **The navigation is real.** The capture loads `/`, screenshots the chat
+  landing, then clicks the sidebar entry and screenshots where it lands. It
+  does not type `/agents` into the address bar, because a typed URL would not
+  answer the question the issue asks.
 - **The backend is stubbed.** A local static server serves the bundle and
   Playwright fulfils `/api/*` with the shapes Open WebUI's own handlers emit,
   including the authenticated `/api/config` block and two agent tasks, one
@@ -34,62 +47,81 @@ the workspace natively, with no iframe and no credential prompt.**
 
 ## Why the live deployment could not be used, stated plainly
 
-Two independent blockers, neither of them a property of this branch:
+Three independent blockers. None of them is a property of this branch, and the
+first one is new since the previous capture:
 
-1. **The surface depends on a backend patch, not only on the bundle.** The
+1. **Sign in on the deployed instance is currently broken outright, and it
+   broke on `main`, not here.** `GET https://chat-hive.scubed.co/oauth/oidc/login`
+   redirects to the authorization server with
+   `scope=openid+email+profile+offline_access`, and that request comes straight
+   back to the callback with `error=invalid_request` and
+   `error_description=unsupported scope: offline_access`. The same URL with the
+   scope reduced to `openid email profile` reaches the consent page normally.
+   The self-hosted GoTrue the box now runs advertises
+   `scopes_supported = ["openid","profile","email","phone"]` in its own
+   discovery document, with no `offline_access` in it. So nobody can sign into
+   chat through the sanctioned flow at the moment. A separate change owns that
+   fix; this pull request must not touch it.
+2. **The surface depends on a backend patch, not only on the bundle.** The
    native panel calls `/api/v1/hive/agent/*`, a router this branch adds through
    `deploy/docker/owui-patches/hive_agent_proxy.py`. That router exists only in
    a rebuilt image. Intercepting the bundle against the deployed origin, the
    technique PR #956 used for its timings, cannot conjure it: those paths would
    404 on the currently deployed image.
-2. **No live chat session can be minted from this machine.** The sanctioned
-   one-time-token flow (`apps/web-console/tests/e2e/support/live-auth.mjs`)
-   needs `SUPABASE_URL` to resolve, and the development box's `.env` still
-   points it at the hosted Supabase project that was deleted in the self-hosted
-   migration. That host now returns `ENOTFOUND`. Working around it by setting or
-   rotating any password is forbidden and was not attempted.
+3. **No live chat session can be minted from this machine either.** The
+   sanctioned one-time-token flow
+   (`apps/web-console/tests/e2e/support/live-auth.mjs`) needs `SUPABASE_URL` to
+   resolve, and the development box's `.env` still points it at the hosted
+   Supabase project that was deleted in the self-hosted migration. That host
+   now returns `ENOTFOUND`. Working around it by setting or rotating any
+   password is forbidden and was not attempted.
 
 So the faithful "signed in through chat, click Agents, real task runs" capture
-is a post-deploy artefact, and this pull request is not being merged by the
-agent that produced this directory. What is captured here is the part that can
-be captured before merge, and the limits are stated rather than papered over.
+is a post-deploy artefact and is still owed. It is scheduled: once the sign in
+fix lands and deploys, this surface gets recaptured live before anyone treats
+the demo blocker as closed. What is captured here is the part that can be
+captured before merge, and the limits are stated rather than papered over.
 
 ## Result
 
 From `capture.log`, measured in the page rather than asserted in prose:
 
 ```
-password inputs on /agents: 0
-iframes on /agents: 0
-"Sign in" appears in body text: false
+chat landing:                                            password inputs=0, iframes=0
+sidebar entries pointing at /agents:                     1
+links anywhere in the signed-in chat UI to /agent-workspace: 0
+url after clicking Agents:                               .../agents
+after clicking Agents:                                   password inputs=0, iframes=0
 ```
 
-The screenshot shows the Hive shell with **Agents** selected in the sidebar, the
-native composer captioned "Describe the task in your own words", the Knowledge
-work and Coding pack selector, and the task list rendering one task as Done and
-one as Running with a Cancel control. There is no second application in the
-page and nothing asks for a password.
+The first screenshot is the chat shell signed in, with **Agents** in the
+sidebar. The second is where clicking that entry lands: the same shell with
+Agents selected, the native composer captioned "Describe the task in your own
+words", the Knowledge work and Coding pack selector, and the task list
+rendering one task as Done and one as Running with a Cancel control. There is
+no second application in the page and nothing asks for a password at either
+hop.
 
-## Known artefacts of the stub, not of the branch
-
-- The sidebar's Recents column reads "Loading...", and the console shows
-  `fe.sort is not a function` and `a.map is not a function`. Those come from the
-  catch-all stub answering `{}` where the chat list endpoints return arrays.
-  They are not reachable on a real deployment and are called out here rather
-  than cropped out.
-- The WebSocket handshake errors are the static file server answering the
-  socket.io upgrade with a 200. Same cause.
-
-## Residual, and it is a real one
+## The residual, re-confirmed on the rebased head rather than carried over
 
 `/agent-workspace/*` is still proxied to `apps/agent-console` by
-`deploy/docker/Caddyfile.owui`, and that application still renders its own email
-and password form. This branch changes no Caddy route: its only edit to that
-file is a comment. So a **typed or bookmarked** `https://chat-hive.scubed.co/agent-workspace`
-still reaches a password prompt, even though no route inside the chat interface
-leads there any more (`vendor/open-webui/src/lib/hive/nav.ts` points the sidebar
-entry at `/agents`, and the only two remaining mentions of the old path in the
-front end are historical comments).
+`deploy/docker/Caddyfile.owui`, and that application still renders its own
+email and password form. This branch changes no Caddy route: its only edit to
+that file is a comment. So a **typed or bookmarked**
+`https://chat-hive.scubed.co/agent-workspace` still reaches a password prompt.
+
+What is confirmed is that no route inside the chat interface leads there.
+Checked three ways on the rebased tree, not assumed:
+
+- `vendor/open-webui/src/lib/hive/nav.ts` points the sidebar entry at
+  `/agents`, and its `activePaths` list names only `/agents`.
+- The only two occurrences of the string `agent-workspace` anywhere under
+  `vendor/open-webui/src/` are historical comments, one in `app.html` and one
+  in the `/agents` route file explaining what that route used to hold.
+- In the running bundle, the capture counted every anchor in the signed-in
+  chat UI pointing at `/agent-workspace`, and there are zero. The only
+  occurrences in the built output are the same `app.html` comment and a source
+  map.
 
 Closing that route is deliberately not done here. The Tauri desktop app targets
 `/agent-workspace` as its console base path (`apps/desktop/src/settings.ts`,
@@ -99,12 +131,22 @@ coverage ledger over that surface. Answering it 404 would break both. Retiring
 `apps/agent-console` or moving the desktop app onto the native surface is a
 separate decision with a much larger blast radius than this pull request.
 
+## Known artefacts of the stub, not of the branch
+
+- The console shows `Pe is not iterable` and
+  `(l(...) ?? []).some is not a function`. Those come from the catch-all stub
+  answering `{}` where some chat endpoints return a differently shaped object.
+  They are not reachable on a real deployment and are called out here rather
+  than cropped out.
+- The WebSocket handshake errors are the static file server answering the
+  socket.io upgrade with a 200. Same cause.
+
 ## Credential handling
 
-No credential appears in any captured URL or in this log. The three URLs are
-`/agents` on a loopback origin with no query string; the injected session value
-is the literal string `stub-session-token`; the stubbed account is
-`e2e-verified@scubed.com.bd`, which is an address, not a credential. Headless
-Playwright screenshots carry no browser chrome, so there is no URL overlay in
-the pixels to redact either. Nothing was read from, written to, or captured
-about any real account.
+No credential appears in any captured URL or in this log. The two URLs are `/`
+and `/agents` on a loopback origin, neither with a query string; the injected
+session value is the literal string `stub-session-token`; the stubbed account
+is `e2e-verified@scubed.com.bd`, which is an address, not a credential.
+Headless Playwright screenshots carry no browser chrome, so there is no URL
+overlay in the pixels to redact either. Nothing was read from, written to, or
+captured about any real account.

--- a/docs/proof/agents-native-no-iframe-2026-08-22/README.md
+++ b/docs/proof/agents-native-no-iframe-2026-08-22/README.md
@@ -1,0 +1,110 @@
+# Proof: the Agents surface asks for no second credential
+
+PR #951, issue #540. This directory carries the capture's text log only
+(`capture.log`); the screenshots are posted as permanent GitHub Release assets
+through `scripts/post-pr-visual-proof.sh`, per `.wolf/decisions.md` D-042. The
+log lives here rather than only in a PR comment because
+`npm run lint:proof-tokens` scans this directory and nothing else.
+
+## What is being proved
+
+Issue #540, re-confirmed live on the demo box on 2026-08-22, is the top demo
+blocker: a user who signs into `chat-hive.scubed.co` normally and then clicks
+**Agents** is shown a second email and password form, captioned that the
+workspace is separate from chat. The mechanism was proved there by difference,
+not guessed: chat's OAuth handshake mints an Open WebUI token and never writes
+the `sb-...-auth-token` cookie that the embedded `apps/agent-console` reads, so
+the embedded application falls back to its own sign in.
+
+This branch removes the embedded application from that route. The claim under
+test is therefore narrow and checkable: **on `/agents`, the built bundle renders
+the workspace natively, with no iframe and no credential prompt.**
+
+## Method, and what is real in it
+
+- **The bundle is real.** It is the output of
+  `docker build -f deploy/docker/Dockerfile.open-webui --target frontend` on
+  this branch, rebased onto `main` at `c30882491`: byte for byte the artefact
+  the image copies into `/app/build`. Nothing was hand-edited into it.
+- **The backend is stubbed.** A local static server serves the bundle and
+  Playwright fulfils `/api/*` with the shapes Open WebUI's own handlers emit,
+  including the authenticated `/api/config` block and two agent tasks, one
+  succeeded and one running.
+- **The origin is `127.0.0.1`, not the deployed host.**
+
+## Why the live deployment could not be used, stated plainly
+
+Two independent blockers, neither of them a property of this branch:
+
+1. **The surface depends on a backend patch, not only on the bundle.** The
+   native panel calls `/api/v1/hive/agent/*`, a router this branch adds through
+   `deploy/docker/owui-patches/hive_agent_proxy.py`. That router exists only in
+   a rebuilt image. Intercepting the bundle against the deployed origin, the
+   technique PR #956 used for its timings, cannot conjure it: those paths would
+   404 on the currently deployed image.
+2. **No live chat session can be minted from this machine.** The sanctioned
+   one-time-token flow (`apps/web-console/tests/e2e/support/live-auth.mjs`)
+   needs `SUPABASE_URL` to resolve, and the development box's `.env` still
+   points it at the hosted Supabase project that was deleted in the self-hosted
+   migration. That host now returns `ENOTFOUND`. Working around it by setting or
+   rotating any password is forbidden and was not attempted.
+
+So the faithful "signed in through chat, click Agents, real task runs" capture
+is a post-deploy artefact, and this pull request is not being merged by the
+agent that produced this directory. What is captured here is the part that can
+be captured before merge, and the limits are stated rather than papered over.
+
+## Result
+
+From `capture.log`, measured in the page rather than asserted in prose:
+
+```
+password inputs on /agents: 0
+iframes on /agents: 0
+"Sign in" appears in body text: false
+```
+
+The screenshot shows the Hive shell with **Agents** selected in the sidebar, the
+native composer captioned "Describe the task in your own words", the Knowledge
+work and Coding pack selector, and the task list rendering one task as Done and
+one as Running with a Cancel control. There is no second application in the
+page and nothing asks for a password.
+
+## Known artefacts of the stub, not of the branch
+
+- The sidebar's Recents column reads "Loading...", and the console shows
+  `fe.sort is not a function` and `a.map is not a function`. Those come from the
+  catch-all stub answering `{}` where the chat list endpoints return arrays.
+  They are not reachable on a real deployment and are called out here rather
+  than cropped out.
+- The WebSocket handshake errors are the static file server answering the
+  socket.io upgrade with a 200. Same cause.
+
+## Residual, and it is a real one
+
+`/agent-workspace/*` is still proxied to `apps/agent-console` by
+`deploy/docker/Caddyfile.owui`, and that application still renders its own email
+and password form. This branch changes no Caddy route: its only edit to that
+file is a comment. So a **typed or bookmarked** `https://chat-hive.scubed.co/agent-workspace`
+still reaches a password prompt, even though no route inside the chat interface
+leads there any more (`vendor/open-webui/src/lib/hive/nav.ts` points the sidebar
+entry at `/agents`, and the only two remaining mentions of the old path in the
+front end are historical comments).
+
+Closing that route is deliberately not done here. The Tauri desktop app targets
+`/agent-workspace` as its console base path (`apps/desktop/src/settings.ts`,
+`apps/desktop/src-tauri/src/settings.rs`), and
+`apps/web-console/tests/e2e/_probe/agent-workspace-flows.spec.ts` is a whole
+coverage ledger over that surface. Answering it 404 would break both. Retiring
+`apps/agent-console` or moving the desktop app onto the native surface is a
+separate decision with a much larger blast radius than this pull request.
+
+## Credential handling
+
+No credential appears in any captured URL or in this log. The three URLs are
+`/agents` on a loopback origin with no query string; the injected session value
+is the literal string `stub-session-token`; the stubbed account is
+`e2e-verified@scubed.com.bd`, which is an address, not a credential. Headless
+Playwright screenshots carry no browser chrome, so there is no URL overlay in
+the pixels to redact either. Nothing was read from, written to, or captured
+about any real account.

--- a/docs/proof/agents-native-no-iframe-2026-08-22/capture.log
+++ b/docs/proof/agents-native-no-iframe-2026-08-22/capture.log
@@ -1,0 +1,15 @@
+local static server serving the branch bundle at http://127.0.0.1:36019
+bundle: /tmp/claude-1001/-home-sakib-hive/47b1dc44-1a51-42c2-8e34-41475aa46c9d/scratchpad/b951
+password inputs on /agents: 0
+iframes on /agents: 0
+"Sign in" appears in body text: false
+captured 01-agents-native-no-credential-prompt.png at http://127.0.0.1:36019/agents :: password inputs=0, iframes=0
+captured 02-agents-composer-accepts-a-brief.png at http://127.0.0.1:36019/agents :: native composer, no second application
+
+console transcript:
+  [error] WebSocket connection to 'ws://127.0.0.1:36019/ws/socket.io/?EIO=4&transport=websocket' failed: Error during WebSocket handshake: Unexpected response code: 200
+  [pageerror] fe.sort is not a function
+  [pageerror] fe.sort is not a function
+  [pageerror] a.map is not a function
+  [error] WebSocket connection to 'ws://127.0.0.1:36019/ws/socket.io/?EIO=4&transport=websocket' failed: Error during WebSocket handshake: Unexpected response code: 200
+  [error] WebSocket connection to 'ws://127.0.0.1:36019/ws/socket.io/?EIO=4&transport=websocket' failed: Error during WebSocket handshake: Unexpected response code: 200

--- a/docs/proof/agents-native-no-iframe-2026-08-22/capture.log
+++ b/docs/proof/agents-native-no-iframe-2026-08-22/capture.log
@@ -1,15 +1,47 @@
-local static server serving the branch bundle at http://127.0.0.1:36019
-bundle: /tmp/claude-1001/-home-sakib-hive/47b1dc44-1a51-42c2-8e34-41475aa46c9d/scratchpad/b951
-password inputs on /agents: 0
-iframes on /agents: 0
-"Sign in" appears in body text: false
-captured 01-agents-native-no-credential-prompt.png at http://127.0.0.1:36019/agents :: password inputs=0, iframes=0
-captured 02-agents-composer-accepts-a-brief.png at http://127.0.0.1:36019/agents :: native composer, no second application
+local static server serving the rebased branch bundle at http://127.0.0.1:38693
+bundle: /tmp/claude-1001/-home-sakib-hive/47b1dc44-1a51-42c2-8e34-41475aa46c9d/scratchpad/rb951-build
+chat landing: password inputs=0, iframes=0, "sign in" in body text=false
+captured 01-chat-landing-signed-in.png at http://127.0.0.1:38693/ :: the chat shell, Agents in the sidebar
+sidebar entries pointing at /agents: 1
+links anywhere in the signed-in chat UI pointing at /agent-workspace: 0
+url after clicking Agents: http://127.0.0.1:38693/agents
+after clicking Agents: password inputs=0, iframes=0, "sign in" in body text=false
+captured 02-agents-native-no-credential-prompt.png at http://127.0.0.1:38693/agents :: reached by clicking the sidebar entry, password inputs=0, iframes=0
+captured 03-agents-composer-accepts-a-brief.png at http://127.0.0.1:38693/agents :: native composer, no second application
+
+api requests:
+  GET /api/config
+  GET /api/v1/auths/
+  GET /api/config
+  POST /api/v1/auths/update/timezone
+  GET /api/v1/folders/
+  GET /api/v1/folders/
+  GET /api/v1/chats/all/tags
+  GET /api/v1/chats/pinned
+  GET /api/v1/chats/?page=1
+  GET /api/v1/configs/banners
+  GET /api/v1/tools/
+  GET /api/v1/users/user/settings
+  GET /api/v1/users/11111111-2222-3333-4444-555555555555/profile/image
+  GET /api/v1/folders/shared
+  GET /api/v1/folders/shared
+  GET /api/models
+  GET /api/v1/terminals/
+  GET /api/v1/users/11111111-2222-3333-4444-555555555555/profile/image
+  GET /api/v1/models/model/profile/image?id=undefined&lang=en-US
+  GET /api/v1/functions/
+  GET /api/v1/models/model/profile/image?id=hive-auto&lang=en-US
+  GET /api/v1/chats/?page=2
+  GET /api/v1/skills/
+  GET /api/v1/hive/agent/tasks
+  GET /api/v1/hive/agent/tasks
+  GET /api/v1/hive/agent/tasks
 
 console transcript:
-  [error] WebSocket connection to 'ws://127.0.0.1:36019/ws/socket.io/?EIO=4&transport=websocket' failed: Error during WebSocket handshake: Unexpected response code: 200
-  [pageerror] fe.sort is not a function
-  [pageerror] fe.sort is not a function
-  [pageerror] a.map is not a function
-  [error] WebSocket connection to 'ws://127.0.0.1:36019/ws/socket.io/?EIO=4&transport=websocket' failed: Error during WebSocket handshake: Unexpected response code: 200
-  [error] WebSocket connection to 'ws://127.0.0.1:36019/ws/socket.io/?EIO=4&transport=websocket' failed: Error during WebSocket handshake: Unexpected response code: 200
+  [error] WebSocket connection to 'ws://127.0.0.1:38693/ws/socket.io/?EIO=4&transport=websocket' failed: Error during WebSocket handshake: Unexpected response code: 200
+  [pageerror] Pe is not iterable
+  [pageerror] Pe is not iterable
+  [pageerror] (l(...) ?? []).some is not a function
+  [error] WebSocket connection to 'ws://127.0.0.1:38693/ws/socket.io/?EIO=4&transport=websocket' failed: Error during WebSocket handshake: Unexpected response code: 200
+  [error] WebSocket connection to 'ws://127.0.0.1:38693/ws/socket.io/?EIO=4&transport=websocket' failed: Error during WebSocket handshake: Unexpected response code: 200
+  [error] WebSocket connection to 'ws://127.0.0.1:38693/ws/socket.io/?EIO=4&transport=websocket' failed: Error during WebSocket handshake: Unexpected response code: 200

--- a/scripts/test_owui_agent_proxy.py
+++ b/scripts/test_owui_agent_proxy.py
@@ -324,6 +324,10 @@ def check_upstream_body_is_returned_verbatim() -> None:
     response = run(proxy.list_tasks(Request(), USER))
     check(isinstance(response, JSONResponse), 'the proxy must answer with the upstream JSON')
     check(
+        response.status_code == 403,
+        f'the upstream status must survive rather than flatten to 200, got {response.status_code}',
+    )
+    check(
         response.content == {'error': {'message': 'Cowork is not enabled for this tenant.'}},
         "edge-api's own error sentence must survive to the browser",
     )

--- a/scripts/test_owui_agent_proxy.py
+++ b/scripts/test_owui_agent_proxy.py
@@ -98,6 +98,7 @@ class RecordingSession:
     calls: list[dict] = []
     status = 200
     payload: object = {'tasks': []}
+    raises: BaseException | None = None
 
     def __init__(self, *_args, **_kwargs) -> None:
         pass
@@ -112,6 +113,8 @@ class RecordingSession:
         RecordingSession.calls.append(
             {'method': method, 'url': url, 'headers': dict(headers or {}), 'json': json}
         )
+        if RecordingSession.raises is not None:
+            raise RecordingSession.raises
         return self
 
     async def json(self, content_type=None):  # noqa: ARG002
@@ -199,6 +202,7 @@ def reset() -> None:
     RecordingSession.calls = []
     RecordingSession.status = 200
     RecordingSession.payload = {'tasks': []}
+    RecordingSession.raises = None
     TOKEN_HOLDER['token'] = 'user-supabase-token'
 
 
@@ -347,6 +351,42 @@ def check_no_gateway_configuration_is_a_stated_503() -> None:
     check(RecordingSession.calls == [], 'no upstream call may be made with no shim key')
 
 
+def check_transport_failures_are_stated_not_raised() -> None:
+    """A transport failure must be a stated status, never a traceback.
+
+    An unhandled exception here becomes a 500 whose body carries a traceback,
+    on a request holding a gateway credential. The timeout arm is the one worth
+    pinning: aiohttp raises asyncio.TimeoutError for a total-timeout breach,
+    which is only the builtin TimeoutError on Python 3.11 and later, and
+    aiohttp's own ServerTimeoutError inherits from ClientError as well, so the
+    order the two arms are written in decides which status a connect timeout
+    reports.
+    """
+    import asyncio as _asyncio
+
+    reset()
+    RecordingSession.raises = _asyncio.TimeoutError()
+    try:
+        run(proxy.list_tasks(Request(), USER))
+    except HTTPException as exc:
+        check(exc.status_code == 504, f'a timeout must be a 504, got {exc.status_code}')
+    except BaseException as exc:  # noqa: BLE001 - the whole point of the check
+        failures.append(f'a timeout escaped as {type(exc).__name__}, so it becomes a 500')
+    else:
+        failures.append('a timeout must not read as a successful answer')
+
+    reset()
+    RecordingSession.raises = sys.modules['aiohttp'].ClientError()
+    try:
+        run(proxy.list_tasks(Request(), USER))
+    except HTTPException as exc:
+        check(exc.status_code == 502, f'an unreachable upstream must be a 502, got {exc.status_code}')
+    except BaseException as exc:  # noqa: BLE001
+        failures.append(f'a client error escaped as {type(exc).__name__}, so it becomes a 500')
+    else:
+        failures.append('an unreachable upstream must not read as a successful answer')
+
+
 def check_every_route_is_behind_the_session_dependency() -> None:
     source = SOURCE.read_text()
     routes = [
@@ -380,6 +420,7 @@ for check_fn in (
     check_task_id_must_be_a_uuid,
     check_upstream_body_is_returned_verbatim,
     check_no_gateway_configuration_is_a_stated_503,
+    check_transport_failures_are_stated_not_raised,
     check_every_route_is_behind_the_session_dependency,
 ):
     check_fn()

--- a/scripts/test_owui_agent_proxy.py
+++ b/scripts/test_owui_agent_proxy.py
@@ -404,12 +404,29 @@ def check_every_route_is_behind_the_session_dependency() -> None:
             f'{definition} must resolve its principal from the session, not the request',
         )
     # The inverse of the same rule: no route may read an identity off the wire.
-    for smell in ('user_id', 'tenant_id', "headers.get('Authorization')"):
+    #
+    # Two smells, not three. A third entry, "headers.get('Authorization')", used
+    # to sit in this tuple, where the accessor templates expanded it to
+    # `request.query_params.get('headers.get('Authorization')')`. No such string
+    # can occur in any Python source, so that iteration asserted nothing and
+    # reported a pass over the header read it was named after. Reading a
+    # credential off the incoming request needs its own direct test, below.
+    for smell in ('user_id', 'tenant_id'):
         check(
             f"request.query_params.get('{smell}')" not in source
             and f"submitted.get('{smell}')" not in source,
             f'the proxy must never read {smell} from the caller',
         )
+
+    # The proxy builds its outbound Authorization from the shim key and the
+    # session token the dependency resolved, never from anything the browser
+    # sent. `request.headers` is the accessor that would break that, in any of
+    # its forms (`.get`, subscript, iteration), so the whole attribute is the
+    # thing to refuse rather than one spelling of one lookup.
+    check(
+        'request.headers' not in source,
+        'the proxy must never read a credential off the incoming request headers',
+    )
 
 
 for check_fn in (

--- a/scripts/test_owui_agent_proxy.py
+++ b/scripts/test_owui_agent_proxy.py
@@ -1,0 +1,389 @@
+#!/usr/bin/env python3
+"""Self-checks for deploy/docker/owui-patches/hive_agent_proxy.py.
+
+Pure standard library, no test framework and no network, matching the other
+scripts/test_owui_*.py self-checks so `make test-scripts` can run it on a plain
+ubuntu-latest runner. FastAPI, aiohttp and open_webui only exist inside the
+chat image, so they are stubbed here: the module under test is imported against
+those stubs and its real logic runs unchanged.
+
+What is being protected. This proxy is the only thing standing between a
+signed-in chat user and a gateway credential, so the properties worth a test
+are the ones whose failure is silent:
+
+  * the shim key goes on Authorization and the user's token goes on the carrier
+    header, never the other way round and never both on one header;
+  * a request with no resolvable user token is refused before any upstream call,
+    rather than proceeding under the shim's own principal;
+  * neither credential is ever returned to the caller;
+  * the caller cannot choose the principal, and cannot smuggle extra fields
+    into the upstream body;
+  * a task id that is not a UUID never reaches a URL.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import pathlib
+import sys
+import types
+from uuid import uuid4
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+MODULE = REPO / 'deploy' / 'docker' / 'owui-patches' / 'hive_agent_proxy.py'
+
+failures: list[str] = []
+
+
+def check(condition: bool, message: str) -> None:
+    if not condition:
+        failures.append(message)
+
+
+# ---------------------------------------------------------------- stub layer
+
+
+class HTTPException(Exception):
+    def __init__(self, status_code: int, detail: str = '') -> None:
+        super().__init__(detail)
+        self.status_code = status_code
+        self.detail = detail
+
+
+class JSONResponse:
+    def __init__(self, status_code: int = 200, content=None) -> None:
+        self.status_code = status_code
+        self.content = content
+
+
+class APIRouter:
+    def __init__(self) -> None:
+        self.routes: dict[tuple[str, str], object] = {}
+
+    def _register(self, method: str, path: str):
+        def decorator(fn):
+            self.routes[(method, path)] = fn
+            return fn
+
+        return decorator
+
+    def get(self, path: str):
+        return self._register('GET', path)
+
+    def post(self, path: str):
+        return self._register('POST', path)
+
+
+def Depends(dependency):  # noqa: N802 - mirrors FastAPI's own name
+    return dependency
+
+
+class Request:
+    """Only the two surfaces the module touches."""
+
+    def __init__(self, body: bytes = b'') -> None:
+        self._body = body
+
+    async def body(self) -> bytes:
+        return self._body
+
+    async def json(self):
+        return json.loads(self._body.decode())
+
+
+class RecordingSession:
+    """Captures one upstream call instead of making it."""
+
+    calls: list[dict] = []
+    status = 200
+    payload: object = {'tasks': []}
+
+    def __init__(self, *_args, **_kwargs) -> None:
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_exc):
+        return False
+
+    def request(self, method, url, headers=None, json=None):  # noqa: A002
+        RecordingSession.calls.append(
+            {'method': method, 'url': url, 'headers': dict(headers or {}), 'json': json}
+        )
+        return self
+
+    async def json(self, content_type=None):  # noqa: ARG002
+        return RecordingSession.payload
+
+def install_stubs() -> None:
+    fastapi = types.ModuleType('fastapi')
+    fastapi.APIRouter = APIRouter
+    fastapi.Depends = Depends
+    fastapi.HTTPException = HTTPException
+    fastapi.Request = Request
+    responses = types.ModuleType('fastapi.responses')
+    responses.JSONResponse = JSONResponse
+    fastapi.responses = responses
+    sys.modules['fastapi'] = fastapi
+    sys.modules['fastapi.responses'] = responses
+
+    aiohttp = types.ModuleType('aiohttp')
+
+    class ClientTimeout:
+        def __init__(self, total=None) -> None:
+            self.total = total
+
+    class ClientError(Exception):
+        pass
+
+    aiohttp.ClientTimeout = ClientTimeout
+    aiohttp.ClientError = ClientError
+    aiohttp.ClientSession = RecordingSession
+    sys.modules['aiohttp'] = aiohttp
+
+    open_webui = types.ModuleType('open_webui')
+    utils = types.ModuleType('open_webui.utils')
+    auth = types.ModuleType('open_webui.utils.auth')
+
+    def get_verified_user():
+        raise AssertionError('the dependency must never be called directly in these checks')
+
+    auth.get_verified_user = get_verified_user
+    middleware = types.ModuleType('open_webui.utils.middleware')
+
+    async def get_system_oauth_token(_request, _user):
+        return {'access_token': TOKEN_HOLDER['token']} if TOKEN_HOLDER['token'] else None
+
+    middleware.get_system_oauth_token = get_system_oauth_token
+    open_webui.utils = utils
+    utils.auth = auth
+    utils.middleware = middleware
+    sys.modules['open_webui'] = open_webui
+    sys.modules['open_webui.utils'] = utils
+    sys.modules['open_webui.utils.auth'] = auth
+    sys.modules['open_webui.utils.middleware'] = middleware
+
+
+TOKEN_HOLDER = {'token': 'user-supabase-token'}
+
+install_stubs()
+
+import importlib.util  # noqa: E402
+
+# MODULE_OVERRIDE lets a caller point these checks at a mutated copy, which is
+# how the self-check proves it can go red rather than only green.
+SOURCE = pathlib.Path(sys.argv[1]) if len(sys.argv) > 1 else MODULE
+_spec = importlib.util.spec_from_file_location('hive_agent_proxy', SOURCE)
+assert _spec is not None and _spec.loader is not None
+proxy = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(proxy)
+
+
+# ------------------------------------------------------------------ fixtures
+
+import os  # noqa: E402
+
+os.environ['OPENAI_API_BASE_URL'] = 'http://edge-api:8080/v1'
+os.environ['OPENAI_API_KEY'] = 'hk_shim_key_for_tests'
+
+USER = types.SimpleNamespace(id='11111111-1111-4111-8111-111111111111')
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+def reset() -> None:
+    RecordingSession.calls = []
+    RecordingSession.status = 200
+    RecordingSession.payload = {'tasks': []}
+    TOKEN_HOLDER['token'] = 'user-supabase-token'
+
+
+# -------------------------------------------------------------------- checks
+
+
+def check_credentials_land_on_the_right_headers() -> None:
+    reset()
+    run(proxy.list_tasks(Request(), USER))
+
+    check(len(RecordingSession.calls) == 1, 'list must make exactly one upstream call')
+    call = RecordingSession.calls[0]
+    headers = call['headers']
+
+    check(
+        headers.get('Authorization') == 'Bearer hk_shim_key_for_tests',
+        'the shim key must be the Authorization credential, since that is what '
+        'grants edge-api the tenant fallback',
+    )
+    check(
+        headers.get(proxy.UPSTREAM_AUTH_HEADER) == 'Bearer user-supabase-token',
+        "the signed-in user's token must ride on the carrier header",
+    )
+    check(
+        'user-supabase-token' not in headers.get('Authorization', ''),
+        'the user token must never be the Authorization credential here',
+    )
+    check(
+        call['url'] == 'http://edge-api:8080/v1/agent/tasks',
+        f"unexpected upstream url {call['url']}",
+    )
+    check(call['method'] == 'GET', 'list must be a GET')
+
+
+def check_no_user_token_is_refused_before_any_upstream_call() -> None:
+    reset()
+    TOKEN_HOLDER['token'] = ''
+    try:
+        run(proxy.list_tasks(Request(), USER))
+    except HTTPException as exc:
+        check(exc.status_code == 401, f'expected 401 with no user token, got {exc.status_code}')
+        check(
+            'hk_shim_key_for_tests' not in str(exc.detail),
+            'the refusal must not leak the shim key',
+        )
+    else:
+        failures.append('a request with no user token must be refused, not forwarded')
+    check(
+        RecordingSession.calls == [],
+        'no upstream call may be made once the user token is missing',
+    )
+
+
+def check_create_forwards_only_the_two_named_fields() -> None:
+    reset()
+    body = json.dumps(
+        {
+            'pack': 'knowledge-work-pack',
+            'instructions': '  Summarise the policy  ',
+            # Everything below is what a caller would try. None of it may survive.
+            '__metadata': {'upstream_auth': 'Bearer attacker-token'},
+            'user_id': '22222222-2222-4222-8222-222222222222',
+            'tenant_id': '33333333-3333-4333-8333-333333333333',
+        }
+    ).encode()
+    RecordingSession.payload = {'id': str(uuid4())}
+
+    run(proxy.create_task(Request(body), USER))
+
+    forwarded = RecordingSession.calls[0]['json']
+    check(
+        forwarded == {'pack': 'knowledge-work-pack', 'instructions': 'Summarise the policy'},
+        f'create forwarded {forwarded}, which is not exactly the two named fields',
+    )
+
+
+def check_empty_create_fields_are_refused() -> None:
+    for body in (
+        {'pack': '', 'instructions': 'do a thing'},
+        {'pack': 'coding-pack', 'instructions': '   '},
+        {'pack': 'coding-pack'},
+        {'instructions': 'do a thing'},
+        ['not', 'an', 'object'],
+    ):
+        reset()
+        try:
+            run(proxy.create_task(Request(json.dumps(body).encode()), USER))
+        except HTTPException as exc:
+            check(exc.status_code == 400, f'expected 400 for {body}, got {exc.status_code}')
+        else:
+            failures.append(f'create must refuse {body}')
+        check(RecordingSession.calls == [], f'no upstream call may be made for {body}')
+
+
+def check_task_id_must_be_a_uuid() -> None:
+    for bad in ('../../admin', 'not-a-uuid', '', '1 OR 1=1'):
+        reset()
+        try:
+            run(proxy.get_task(bad, Request(), USER))
+        except HTTPException as exc:
+            check(exc.status_code == 400, f'expected 400 for task id {bad!r}')
+        else:
+            failures.append(f'a task id of {bad!r} must never reach a URL')
+        check(RecordingSession.calls == [], f'no upstream call may be made for task id {bad!r}')
+
+    reset()
+    good = str(uuid4())
+    RecordingSession.payload = {'id': good}
+    run(proxy.cancel_task(good, Request(), USER))
+    check(
+        RecordingSession.calls[0]['url'] == f'http://edge-api:8080/v1/agent/tasks/{good}/cancel',
+        'a valid uuid must reach the cancel path unchanged',
+    )
+
+
+def check_upstream_body_is_returned_verbatim() -> None:
+    reset()
+    RecordingSession.payload = {'error': {'message': 'Cowork is not enabled for this tenant.'}}
+    # aiohttp reports the upstream status on `.status`, and the module must
+    # pass it through rather than flattening every answer to 200.
+    RecordingSession.status = 403
+
+    response = run(proxy.list_tasks(Request(), USER))
+    check(isinstance(response, JSONResponse), 'the proxy must answer with the upstream JSON')
+    check(
+        response.content == {'error': {'message': 'Cowork is not enabled for this tenant.'}},
+        "edge-api's own error sentence must survive to the browser",
+    )
+
+
+def check_no_gateway_configuration_is_a_stated_503() -> None:
+    reset()
+    saved = os.environ.pop('OPENAI_API_KEY')
+    try:
+        run(proxy.list_tasks(Request(), USER))
+    except HTTPException as exc:
+        check(exc.status_code == 503, f'expected 503 with no shim key, got {exc.status_code}')
+    else:
+        failures.append('a deployment with no gateway credential must say so, not proceed')
+    finally:
+        os.environ['OPENAI_API_KEY'] = saved
+    check(RecordingSession.calls == [], 'no upstream call may be made with no shim key')
+
+
+def check_every_route_is_behind_the_session_dependency() -> None:
+    source = SOURCE.read_text()
+    routes = [
+        ("@router.get('/tasks')", 'async def list_tasks'),
+        ("@router.post('/tasks')", 'async def create_task'),
+        ("@router.get('/tasks/{task_id}')", 'async def get_task'),
+        ("@router.post('/tasks/{task_id}/cancel')", 'async def cancel_task'),
+    ]
+    for decorator, definition in routes:
+        check(decorator in source, f'missing route {decorator}')
+        start = source.index(definition)
+        signature = source[start : source.index(':\n', start)]
+        check(
+            'Depends(get_verified_user)' in signature,
+            f'{definition} must resolve its principal from the session, not the request',
+        )
+    # The inverse of the same rule: no route may read an identity off the wire.
+    for smell in ('user_id', 'tenant_id', "headers.get('Authorization')"):
+        check(
+            f"request.query_params.get('{smell}')" not in source
+            and f"submitted.get('{smell}')" not in source,
+            f'the proxy must never read {smell} from the caller',
+        )
+
+
+for check_fn in (
+    check_credentials_land_on_the_right_headers,
+    check_no_user_token_is_refused_before_any_upstream_call,
+    check_create_forwards_only_the_two_named_fields,
+    check_empty_create_fields_are_refused,
+    check_task_id_must_be_a_uuid,
+    check_upstream_body_is_returned_verbatim,
+    check_no_gateway_configuration_is_a_stated_503,
+    check_every_route_is_behind_the_session_dependency,
+):
+    check_fn()
+
+if failures:
+    print('hive_agent_proxy self-check FAILED:', file=sys.stderr)
+    for failure in failures:
+        print(f'  - {failure}', file=sys.stderr)
+    raise SystemExit(1)
+
+print('hive_agent_proxy self-check: all checks passed')

--- a/vendor/open-webui/src/lib/components/chat/MessageInput.svelte
+++ b/vendor/open-webui/src/lib/components/chat/MessageInput.svelte
@@ -77,7 +77,11 @@
 	import Tooltip from '../common/Tooltip.svelte';
 	import FileItem from '../common/FileItem.svelte';
 	import Image from '../common/Image.svelte';
-	import Spinner from '../common/Spinner.svelte';
+	// The composer's visual container and its send button, so this surface and
+	// the agent composer render the same control rather than two that resemble
+	// each other. Presentational only; nothing below this line changed.
+	import ComposerShell from '$lib/hive/ComposerShell.svelte';
+	import ComposerSendButton from '$lib/hive/ComposerSendButton.svelte';
 
 	import XMark from '../icons/XMark.svelte';
 	import GlobeAlt from '../icons/GlobeAlt.svelte';
@@ -1358,11 +1362,9 @@
 							</div>
 						{/if}
 
-						<div
+						<ComposerShell
 							id="message-input-container"
-							class="flex-1 flex flex-col relative w-full shadow-lg rounded-3xl border {$temporaryChatEnabled
-								? 'border-dashed border-gray-100 dark:border-gray-800 hover:border-gray-200 focus-within:border-gray-200 hover:dark:border-gray-700 focus-within:dark:border-gray-700'
-								: ' border-gray-100/30 dark:border-gray-850/30 hover:border-gray-200 focus-within:border-gray-100 hover:dark:border-gray-800 focus-within:dark:border-gray-800'}  transition px-1 bg-white/5 dark:bg-gray-500/5 backdrop-blur-sm dark:text-gray-100"
+							dashed={$temporaryChatEnabled}
 							dir={$settings?.chatDirection ?? 'auto'}
 						>
 							{#if atSelectedModel !== undefined}
@@ -2174,38 +2176,18 @@
 														? $i18n.t('Waiting for upload...')
 														: $i18n.t('Send message')}
 												>
-													<button
+													<ComposerSendButton
 														id="send-message-button"
-														class="{!(prompt === '' && files.length === 0) || uploadPending
-															? 'bg-black text-white hover:bg-gray-900 dark:bg-white dark:text-black dark:hover:bg-gray-100 '
-															: 'text-white bg-gray-200 dark:text-gray-900 dark:bg-gray-700 disabled'} transition rounded-full p-1.5 self-center"
-														type="submit"
 														disabled={(prompt === '' && files.length === 0) || uploadPending}
-													>
-														{#if uploadPending}
-															<Spinner className="size-5" />
-														{:else}
-															<svg
-																xmlns="http://www.w3.org/2000/svg"
-																viewBox="0 0 16 16"
-																fill="currentColor"
-																class="size-5"
-															>
-																<path
-																	fill-rule="evenodd"
-																	d="M8 14a.75.75 0 0 1-.75-.75V4.56L4.03 7.78a.75.75 0 0 1-1.06-1.06l4.5-4.5a.75.75 0 0 1 1.06 0l4.5 4.5a.75.75 0 0 1-1.06 1.06L8.75 4.56v8.69A.75.75 0 0 1 8 14Z"
-																	clip-rule="evenodd"
-																/>
-															</svg>
-														{/if}
-													</button>
+														pending={uploadPending}
+													/>
 												</Tooltip>
 											</div>
 										{/if}
 									{/if}
 								</div>
 							</div>
-						</div>
+						</ComposerShell>
 
 						{#if $config?.license_metadata?.input_footer}
 							<div class=" text-xs text-gray-500 text-center line-clamp-1 marked">

--- a/vendor/open-webui/src/lib/hive/AgentTasks.svelte
+++ b/vendor/open-webui/src/lib/hive/AgentTasks.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import { getContext, onDestroy, onMount } from 'svelte';
 
+	import { WEBUI_API_BASE_URL } from '$lib/constants';
+
 	import ComposerShell from './ComposerShell.svelte';
 	import ComposerSendButton from './ComposerSendButton.svelte';
 	import {
@@ -89,6 +91,18 @@
 	let pollTimer: ReturnType<typeof setTimeout> | null = null;
 	let clockTimer: ReturnType<typeof setInterval> | null = null;
 	let destroyed = false;
+	/*
+	 * Bumped by every local change to `tasks` that did not come from a list
+	 * response: a create, a cancel. A refresh captures it before its request
+	 * goes out and drops its own answer if it changed while the request was in
+	 * flight, because `tasks = await listTasks(...)` replaces the array whole
+	 * and a poll that started before a create knows nothing about the new row.
+	 * Without this, a poll overlapping a create loses the row the user just
+	 * submitted, or reverts a row they just cancelled, and if that stale list
+	 * happens to hold no in-flight task then schedulePoll stops too and the
+	 * screen never recovers on its own.
+	 */
+	let mutations = 0;
 
 	$: selectedPack = PACKS.find((option) => option.value === pack) ?? PACKS[0];
 	$: givenUp = failures >= MAX_POLL_FAILURES;
@@ -119,6 +133,12 @@
 	$: canSubmit = canStartTask({ instructions, submitting, blocked });
 
 	const sessionToken = (): string => localStorage.token ?? '';
+
+	// The one SvelteKit-resolved value the API module deliberately does not
+	// import for itself, so its unit tests can load at all. See the note at the
+	// top of agentTasks.ts. Passing it from here keeps `npm run dev` against the
+	// chat front end pointed at the backend's own port.
+	const apiBase = `${WEBUI_API_BASE_URL}/hive/agent`;
 
 	const schedulePoll = () => {
 		if (pollTimer) {
@@ -161,8 +181,17 @@
 	};
 
 	const refresh = async () => {
+		const startedAt = mutations;
 		try {
-			tasks = await listTasks(sessionToken());
+			const fetched = await listTasks(sessionToken(), apiBase);
+			// A create or a cancel landed while this request was open, so its
+			// answer predates a change the user made and must not overwrite it.
+			// Nothing else is rolled back: the request did reach the endpoint, so
+			// the failure count and any refusal are genuinely cleared, and the
+			// next poll fetches a list that includes the change.
+			if (startedAt === mutations) {
+				tasks = fetched;
+			}
 			error = null;
 			blocked = null;
 			failures = 0;
@@ -202,7 +231,7 @@
 		announcement = 'Starting task.';
 
 		try {
-			const task = await createTask(sessionToken(), pack, trimmed);
+			const task = await createTask(sessionToken(), pack, trimmed, apiBase);
 			// A create that round-trips is direct evidence the endpoint is back, so
 			// the failure count is stale. Without this the poll stays given up and
 			// the row the user just created sits under an alert telling them to
@@ -211,6 +240,7 @@
 			// A create that round-trips also disproves a refusal, so the refusal
 			// message goes with the failure count rather than outliving both.
 			blocked = null;
+			mutations = mutations + 1;
 			tasks = [task, ...tasks];
 			instructions = '';
 			resize();
@@ -233,7 +263,8 @@
 		// transition between the two identical sentences.
 		announcement = '';
 		try {
-			const updated = await cancelTask(sessionToken(), id);
+			const updated = await cancelTask(sessionToken(), id, apiBase);
+			mutations = mutations + 1;
 			tasks = tasks.map((task) => (task.id === updated.id ? updated : task));
 			announcement = 'Task cancelled.';
 			// Cancelling the last in-flight task should stop the loop now rather

--- a/vendor/open-webui/src/lib/hive/AgentTasks.svelte
+++ b/vendor/open-webui/src/lib/hive/AgentTasks.svelte
@@ -80,8 +80,6 @@
 
 	$: selectedPack = PACKS.find((option) => option.value === pack) ?? PACKS[0];
 	$: givenUp = failures >= MAX_POLL_FAILURES;
-	$: active = tasks.some((task) => IN_FLIGHT_STATUSES.has(task.status));
-	$: shouldPoll = failures > 0 ? !givenUp : active;
 	/*
 	 * The load failure reads off the failure count rather than being written into
 	 * `error`, so the sentence cannot outlive the retry it promises: when the loop
@@ -113,7 +111,24 @@
 			clearTimeout(pollTimer);
 			pollTimer = null;
 		}
-		if (destroyed || !shouldPoll) {
+		if (destroyed) {
+			return;
+		}
+		/*
+		 * Decided here from the current values rather than read off the `$:`
+		 * statements above. Svelte flushes reactive statements after the current
+		 * synchronous block, so a schedulePoll() called immediately after
+		 * assigning `tasks` or `failures` would decide on the previous values,
+		 * and the first poll after a submit would stop the loop that the newly
+		 * queued task is the whole reason to keep running.
+		 */
+		const stopped = failures >= MAX_POLL_FAILURES;
+		const anyInFlight = tasks.some((task) => IN_FLIGHT_STATUSES.has(task.status));
+		// Only a queued or running task can change without the user doing
+		// anything, so a healthy list of finished tasks stops polling entirely.
+		// A failure run keeps polling until it gives up, because the list on
+		// screen may be stale rather than settled.
+		if (!(failures > 0 ? !stopped : anyInFlight)) {
 			return;
 		}
 		/*
@@ -304,6 +319,7 @@
 						id="hive-agent-send"
 						disabled={!canSubmit}
 						pending={submitting}
+						label={$i18n.t('Start task')}
 					/>
 				</div>
 			</div>

--- a/vendor/open-webui/src/lib/hive/AgentTasks.svelte
+++ b/vendor/open-webui/src/lib/hive/AgentTasks.svelte
@@ -4,6 +4,7 @@
 	import ComposerShell from './ComposerShell.svelte';
 	import ComposerSendButton from './ComposerSendButton.svelte';
 	import {
+		AgentTaskError,
 		cancelTask,
 		createTask,
 		describeTask,
@@ -71,6 +72,15 @@
 	let error: string | null = null;
 	let announcement = '';
 	let failures = 0;
+	/*
+	 * A refusal no amount of retrying can change, carrying the server's own
+	 * sentence. 401 means this session cannot reach the agent service at all;
+	 * 403 means this tenant does not hold the Cowork gate. Both are separated
+	 * from the ordinary failure count because the ordinary copy promises a
+	 * retry, and a promise the loop cannot keep is the exact failure this
+	 * surface exists to stop making.
+	 */
+	let blocked: string | null = null;
 	let nowMs = Date.now();
 
 	let promptEl: HTMLTextAreaElement | null = null;
@@ -92,7 +102,9 @@
 				? 'Could not load your tasks. Reload the page to try again.'
 				: 'Could not load your tasks. Retrying automatically.';
 	// A stale list outranks a one-off create or cancel error.
-	$: alertMessage = loadFailure ?? error;
+	// A refusal outranks both, because it is the only one of the three that is
+	// still true after another attempt.
+	$: alertMessage = blocked ?? loadFailure ?? error;
 	/*
 	 * Current state, not history. `tasks` is newest first, so the newest task is
 	 * the only one that says anything about how this deployment is configured
@@ -111,7 +123,9 @@
 			clearTimeout(pollTimer);
 			pollTimer = null;
 		}
-		if (destroyed) {
+		// A refusal is not retried. Polling through a 401 or a 403 would issue a
+		// request every few seconds forever against an answer that cannot change.
+		if (destroyed || blocked !== null) {
 			return;
 		}
 		/*
@@ -148,9 +162,15 @@
 		try {
 			tasks = await listTasks(sessionToken());
 			error = null;
+			blocked = null;
 			failures = 0;
-		} catch {
-			failures = failures + 1;
+		} catch (e) {
+			if (e instanceof AgentTaskError && (e.status === 401 || e.status === 403)) {
+				blocked = e.message;
+				failures = 0;
+			} else {
+				failures = failures + 1;
+			}
 		}
 		nowMs = Date.now();
 		schedulePoll();
@@ -183,6 +203,9 @@
 			// the row the user just created sits under an alert telling them to
 			// reload, which the create just disproved.
 			failures = 0;
+			// A create that round-trips also disproves a refusal, so the refusal
+			// message goes with the failure count rather than outliving both.
+			blocked = null;
 			tasks = [task, ...tasks];
 			instructions = '';
 			resize();
@@ -358,7 +381,10 @@
 			<ul class="hv-agent-rows">
 				{#each tasks as task (task.id)}
 					{@const view = describeTask(task, nowMs)}
-					<li class="hv-agent-task">
+					<!-- Stable hook for the end-to-end spec, which asserts that every
+					     row the API returned actually painted. A styling class would
+					     do the job until someone renames it. -->
+					<li class="hv-agent-task" data-hive-task-row={task.id}>
 						<div class="hv-agent-task-head">
 							<!--
 								The brief the user wrote is the row's headline. Three rows on the

--- a/vendor/open-webui/src/lib/hive/AgentTasks.svelte
+++ b/vendor/open-webui/src/lib/hive/AgentTasks.svelte
@@ -4,16 +4,18 @@
 	import ComposerShell from './ComposerShell.svelte';
 	import ComposerSendButton from './ComposerSendButton.svelte';
 	import {
+		canStartTask,
 		cancelTask,
 		createTask,
+		describeRefusal,
 		describeTask,
 		elapsed,
 		IN_FLIGHT_STATUSES,
 		isEngineUnavailable,
-		isRefusal,
 		listTasks,
 		TERMINAL_STATUSES,
 		type AgentTask,
+		type Refusal,
 		type TaskPack
 	} from './agentTasks';
 
@@ -80,7 +82,7 @@
 	 * retry, and a promise the loop cannot keep is the exact failure this
 	 * surface exists to stop making.
 	 */
-	let blocked: string | null = null;
+	let blocked: Refusal | null = null;
 	let nowMs = Date.now();
 
 	let promptEl: HTMLTextAreaElement | null = null;
@@ -104,7 +106,7 @@
 	// A stale list outranks a one-off create or cancel error.
 	// A refusal outranks both, because it is the only one of the three that is
 	// still true after another attempt.
-	$: alertMessage = blocked ?? loadFailure ?? error;
+	$: alertMessage = blocked?.message ?? loadFailure ?? error;
 	/*
 	 * Current state, not history. `tasks` is newest first, so the newest task is
 	 * the only one that says anything about how this deployment is configured
@@ -114,7 +116,7 @@
 	 */
 	$: engineUnavailable = tasks.length > 0 && isEngineUnavailable(tasks[0]);
 	$: nearLimit = instructions.length > MAX_INSTRUCTIONS * 0.8;
-	$: canSubmit = instructions.trim().length > 0 && !submitting;
+	$: canSubmit = canStartTask({ instructions, submitting, blocked });
 
 	const sessionToken = (): string => localStorage.token ?? '';
 
@@ -165,8 +167,9 @@
 			blocked = null;
 			failures = 0;
 		} catch (e) {
-			if (isRefusal(e)) {
-				blocked = e.message;
+			const refusal = describeRefusal(e);
+			if (refusal) {
+				blocked = refusal;
 				failures = 0;
 			} else {
 				failures = failures + 1;
@@ -177,7 +180,9 @@
 	};
 
 	const submit = async () => {
-		if (submitting) {
+		// A refused surface must not take a submission it cannot deliver. The
+		// control is disabled too; this is the guard for the keyboard path.
+		if (submitting || blocked !== null) {
 			return;
 		}
 		const trimmed = instructions.trim();
@@ -323,7 +328,10 @@
 					aria-required="true"
 					aria-invalid={invalid}
 					aria-describedby={invalid ? 'hive-agent-error hive-agent-pack-hint' : 'hive-agent-pack-hint'}
-					placeholder={$i18n.t('Describe the task in your own words')}
+					disabled={blocked !== null}
+					placeholder={blocked
+						? $i18n.t('Tasks cannot be started right now')
+						: $i18n.t('Describe the task in your own words')}
 					class="hv-agent-input scrollbar-hidden"
 				></textarea>
 			</div>
@@ -344,6 +352,7 @@
 								name="hive-agent-pack"
 								value={option.value}
 								checked={pack === option.value}
+								disabled={blocked !== null}
 								on:change={() => (pack = option.value)}
 								class="sr-only"
 							/>
@@ -481,6 +490,18 @@
 
 	.hv-agent-input::placeholder {
 		color: var(--hv-ink-muted);
+	}
+
+	/* Refused, and it should look it. A control that reads as live and then
+	   does nothing is worse than one that says it is unavailable. */
+	.hv-agent-input:disabled {
+		color: var(--hv-ink-disabled);
+		cursor: not-allowed;
+	}
+
+	.hv-agent-pack input:disabled + .hv-agent-pack-label {
+		color: var(--hv-ink-disabled);
+		cursor: not-allowed;
 	}
 
 	.hv-agent-row {

--- a/vendor/open-webui/src/lib/hive/AgentTasks.svelte
+++ b/vendor/open-webui/src/lib/hive/AgentTasks.svelte
@@ -241,7 +241,13 @@
 			// message goes with the failure count rather than outliving both.
 			blocked = null;
 			mutations = mutations + 1;
-			tasks = [task, ...tasks];
+			// Deduplicated on id, which the mutation counter above cannot cover: it
+			// catches a refresh that lands AFTER the create, while this catches one
+			// that landed BEFORE the create response reached the browser but after
+			// the server had already committed the row. In that window the counter
+			// has not moved yet, so the refresh is applied, and prepending blindly
+			// would put the same id in a keyed list twice.
+			tasks = [task, ...tasks.filter((existing) => existing.id !== task.id)];
 			instructions = '';
 			resize();
 			announcement = `Task submitted. Status: ${describeTask(task, Date.now()).label}.`;

--- a/vendor/open-webui/src/lib/hive/AgentTasks.svelte
+++ b/vendor/open-webui/src/lib/hive/AgentTasks.svelte
@@ -1,0 +1,729 @@
+<script lang="ts">
+	import { getContext, onDestroy, onMount } from 'svelte';
+
+	import ComposerShell from './ComposerShell.svelte';
+	import ComposerSendButton from './ComposerSendButton.svelte';
+	import {
+		cancelTask,
+		createTask,
+		describeTask,
+		elapsed,
+		IN_FLIGHT_STATUSES,
+		isEngineUnavailable,
+		listTasks,
+		TERMINAL_STATUSES,
+		type AgentTask,
+		type TaskPack
+	} from './agentTasks';
+
+	const i18n: any = getContext('i18n');
+
+	/*
+	 * The agent surface, native.
+	 *
+	 * This replaced an <iframe> that booted apps/agent-console, a second whole
+	 * application, inside the shell. Function is at parity with what that frame
+	 * showed; layout deliberately is not. The composer here IS the chat
+	 * composer's container and send button (ComposerShell.svelte,
+	 * ComposerSendButton.svelte, both extracted from MessageInput.svelte), so
+	 * the two surfaces cannot drift into looking like two products.
+	 *
+	 * Not built here, on purpose, and separately specified: tool call cards, the
+	 * progress panel and the transcript. All three need an event relay that does
+	 * not exist yet (spec-2026-08-17-agent-run-surface, step S6), and a card with
+	 * nothing to render is worse than today's status row.
+	 */
+
+	const POLL_INTERVAL_MS = 3000;
+	const MAX_POLL_INTERVAL_MS = 30_000;
+	const MAX_POLL_FAILURES = 5;
+
+	// edge-api reads the create body through io.LimitReader(r.Body, 64<<10). This
+	// cap is far below that: it keeps the composer honest about what a task brief
+	// should be, it does not guard the wire.
+	const MAX_INSTRUCTIONS = 4000;
+
+	const PACKS: ReadonlyArray<{ value: TaskPack; label: string; hint: string }> = [
+		{
+			value: 'knowledge-work-pack',
+			label: 'Knowledge work',
+			hint: 'Researches, reads documents, and writes up an answer.'
+		},
+		{
+			value: 'coding-pack',
+			label: 'Coding',
+			hint: 'Reads and edits a codebase, runs commands, and reports what changed.'
+		}
+	];
+
+	const PACK_LABELS: Record<TaskPack, string> = {
+		'coding-pack': 'Coding',
+		'knowledge-work-pack': 'Knowledge work'
+	};
+
+	let tasks: AgentTask[] = [];
+	let instructions = '';
+	// Unchanged from the surface this replaces. The toggle's order changed, its
+	// default did not: this is a presentation change, not a capability change.
+	let pack: TaskPack = 'coding-pack';
+	let submitting = false;
+	let invalid = false;
+	let error: string | null = null;
+	let announcement = '';
+	let failures = 0;
+	let nowMs = Date.now();
+
+	let promptEl: HTMLTextAreaElement | null = null;
+	let pollTimer: ReturnType<typeof setTimeout> | null = null;
+	let clockTimer: ReturnType<typeof setInterval> | null = null;
+	let destroyed = false;
+
+	$: selectedPack = PACKS.find((option) => option.value === pack) ?? PACKS[0];
+	$: givenUp = failures >= MAX_POLL_FAILURES;
+	$: active = tasks.some((task) => IN_FLIGHT_STATUSES.has(task.status));
+	$: shouldPoll = failures > 0 ? !givenUp : active;
+	/*
+	 * The load failure reads off the failure count rather than being written into
+	 * `error`, so the sentence cannot outlive the retry it promises: when the loop
+	 * gives up, the copy stops claiming a retry is coming.
+	 */
+	$: loadFailure =
+		failures === 0
+			? null
+			: givenUp
+				? 'Could not load your tasks. Reload the page to try again.'
+				: 'Could not load your tasks. Retrying automatically.';
+	// A stale list outranks a one-off create or cancel error.
+	$: alertMessage = loadFailure ?? error;
+	/*
+	 * Current state, not history. `tasks` is newest first, so the newest task is
+	 * the only one that says anything about how this deployment is configured
+	 * right now. Asking whether ANY task was ever engine-blocked made the notice
+	 * permanent, and a run that succeeded sat under a banner saying there was no
+	 * sandbox to run it in.
+	 */
+	$: engineUnavailable = tasks.length > 0 && isEngineUnavailable(tasks[0]);
+	$: nearLimit = instructions.length > MAX_INSTRUCTIONS * 0.8;
+	$: canSubmit = instructions.trim().length > 0 && !submitting;
+
+	const sessionToken = (): string => localStorage.token ?? '';
+
+	const schedulePoll = () => {
+		if (pollTimer) {
+			clearTimeout(pollTimer);
+			pollTimer = null;
+		}
+		if (destroyed || !shouldPoll) {
+			return;
+		}
+		/*
+		 * One self-rescheduling timeout rather than setInterval or a websocket:
+		 * demo-scale task counts, and the sync contract ships no push channel yet.
+		 * Each consecutive failure doubles the wait, and after MAX_POLL_FAILURES
+		 * the loop stops and the screen says so rather than promising a retry that
+		 * never comes.
+		 */
+		const delay = Math.min(POLL_INTERVAL_MS * 2 ** failures, MAX_POLL_INTERVAL_MS);
+		pollTimer = setTimeout(() => {
+			void refresh();
+		}, delay);
+	};
+
+	const refresh = async () => {
+		try {
+			tasks = await listTasks(sessionToken());
+			error = null;
+			failures = 0;
+		} catch {
+			failures = failures + 1;
+		}
+		nowMs = Date.now();
+		schedulePoll();
+	};
+
+	const submit = async () => {
+		if (submitting) {
+			return;
+		}
+		const trimmed = instructions.trim();
+		if (!trimmed) {
+			// Hand-rolled rather than the `required` attribute: the native bubble
+			// cannot be styled and disappears on the next click, which is worse than
+			// an inline message the user can re-read.
+			invalid = true;
+			error = null;
+			promptEl?.focus();
+			return;
+		}
+
+		invalid = false;
+		submitting = true;
+		error = null;
+		announcement = 'Starting task.';
+
+		try {
+			const task = await createTask(sessionToken(), pack, trimmed);
+			// A create that round-trips is direct evidence the endpoint is back, so
+			// the failure count is stale. Without this the poll stays given up and
+			// the row the user just created sits under an alert telling them to
+			// reload, which the create just disproved.
+			failures = 0;
+			tasks = [task, ...tasks];
+			instructions = '';
+			resize();
+			announcement = `Task submitted. Status: ${describeTask(task, Date.now()).label}.`;
+			schedulePoll();
+		} catch (e) {
+			error =
+				e instanceof Error && e.message
+					? e.message
+					: 'Could not start the task. Your text is still here, try again.';
+			announcement = '';
+		} finally {
+			submitting = false;
+		}
+	};
+
+	const cancel = async (id: string) => {
+		// A polite region only speaks when its text changes, so cancelling a second
+		// task would otherwise be silent. Clearing before the await puts a real
+		// transition between the two identical sentences.
+		announcement = '';
+		try {
+			const updated = await cancelTask(sessionToken(), id);
+			tasks = tasks.map((task) => (task.id === updated.id ? updated : task));
+			announcement = 'Task cancelled.';
+		} catch {
+			error = 'Could not cancel that task.';
+		}
+	};
+
+	const onKeyDown = (event: KeyboardEvent) => {
+		// The chat composer's own behaviour, because this reads as the same
+		// control: Enter sends, Shift+Enter is a newline.
+		if (event.key === 'Enter' && !event.shiftKey && !event.isComposing) {
+			event.preventDefault();
+			void submit();
+		}
+	};
+
+	// Grows with its content up to the CSS max-height, then scrolls. Chat's
+	// composer does the same, and a task brief is usually more than one line.
+	const resize = () => {
+		if (!promptEl) {
+			return;
+		}
+		promptEl.style.height = '';
+		promptEl.style.height = `${promptEl.scrollHeight}px`;
+	};
+
+	onMount(() => {
+		void refresh();
+		// Relative timestamps go stale in place otherwise, and a row reading "less
+		// than a minute ago" an hour later is a row that lies quietly.
+		clockTimer = setInterval(() => {
+			nowMs = Date.now();
+		}, 30_000);
+	});
+
+	onDestroy(() => {
+		destroyed = true;
+		if (pollTimer) clearTimeout(pollTimer);
+		if (clockTimer) clearInterval(clockTimer);
+	});
+</script>
+
+<div class="hv-agents">
+	<!--
+		One polite live region for the whole screen. Per-row aria-live was the
+		previous approach and it re-announced every unchanged status on each poll.
+	-->
+	<p aria-live="polite" class="sr-only">{announcement}</p>
+
+	{#if engineUnavailable}
+		<div role="status" class="hv-agent-notice">
+			<p class="hv-agent-notice-title">
+				{$i18n.t('The agent runtime is not configured on this deployment')}
+			</p>
+			<p class="hv-agent-notice-body">
+				{$i18n.t(
+					'Tasks you submit are saved against your account, but there is no sandbox to run them in, so each one is marked blocked as soon as it is submitted. An administrator needs to configure the agent runtime for this deployment.'
+				)}
+			</p>
+		</div>
+	{/if}
+
+	<form on:submit|preventDefault={submit}>
+		<ComposerShell>
+			<div class="px-2.5 pt-2.5">
+				<label class="sr-only" for="hive-agent-instructions">
+					{$i18n.t('Describe the task')}
+				</label>
+				<textarea
+					id="hive-agent-instructions"
+					bind:this={promptEl}
+					bind:value={instructions}
+					on:input={() => {
+						if (invalid) invalid = false;
+						resize();
+					}}
+					on:keydown={onKeyDown}
+					rows="1"
+					maxlength={MAX_INSTRUCTIONS}
+					aria-required="true"
+					aria-invalid={invalid}
+					aria-describedby={invalid ? 'hive-agent-error hive-agent-pack-hint' : 'hive-agent-pack-hint'}
+					placeholder={$i18n.t('Describe the task in your own words')}
+					class="hv-agent-input scrollbar-hidden"
+				></textarea>
+			</div>
+
+			<div class="hv-agent-row">
+				<fieldset class="hv-agent-packs">
+					<legend class="sr-only">{$i18n.t('Kind of task')}</legend>
+					{#each PACKS as option (option.value)}
+						<label class="hv-agent-pack">
+							<input
+								type="radio"
+								name="hive-agent-pack"
+								value={option.value}
+								checked={pack === option.value}
+								on:change={() => (pack = option.value)}
+								class="sr-only"
+							/>
+							<span class="hv-agent-pack-label">{$i18n.t(option.label)}</span>
+						</label>
+					{/each}
+				</fieldset>
+
+				<div class="hv-agent-send">
+					{#if nearLimit}
+						<span class="hv-agent-count">{instructions.length}/{MAX_INSTRUCTIONS}</span>
+					{/if}
+					<ComposerSendButton
+						id="hive-agent-send"
+						disabled={!canSubmit}
+						pending={submitting}
+					/>
+				</div>
+			</div>
+		</ComposerShell>
+	</form>
+
+	<!--
+		The one line of guidance that survives. It says what the selected mode does,
+		it changes with the toggle, and it is deliberately the only prose near the
+		composer: a composer needs no instructions.
+	-->
+	<p id="hive-agent-pack-hint" class="hv-agent-hint">{$i18n.t(selectedPack.hint)}</p>
+
+	{#if invalid}
+		<p id="hive-agent-error" role="alert" class="hv-agent-alert hv-agent-alert-inline">
+			{$i18n.t('Describe the task first. The agent needs a goal to work from.')}
+		</p>
+	{/if}
+
+	{#if alertMessage}
+		<p role="alert" class="hv-agent-alert">{alertMessage}</p>
+	{/if}
+
+	<section aria-labelledby="hive-agent-list">
+		<h2 id="hive-agent-list" class="sr-only">{$i18n.t('Your tasks')}</h2>
+		{#if tasks.length === 0}
+			<div class="hv-agent-empty">
+				<p class="hv-agent-empty-title">{$i18n.t('Nothing submitted yet')}</p>
+				<p class="hv-agent-empty-body">
+					{$i18n.t(
+						'Tasks you start appear here with their status, and stay here when you come back in another session.'
+					)}
+				</p>
+			</div>
+		{:else}
+			<ul class="hv-agent-rows">
+				{#each tasks as task (task.id)}
+					{@const view = describeTask(task, nowMs)}
+					<li class="hv-agent-task">
+						<div class="hv-agent-task-head">
+							<!--
+								The brief the user wrote is the row's headline. Three rows on the
+								deployed list have none, because they predate the goal field, so
+								they say so rather than rendering an empty line that reads as a
+								broken row.
+							-->
+							<p class="hv-agent-task-title">
+								{#if task.instructions}
+									{task.instructions}
+								{:else}
+									<span class="hv-agent-task-untitled">
+										{$i18n.t('No description was recorded for this task.')}
+									</span>
+								{/if}
+							</p>
+							<span class="hv-agent-pill" data-tone={view.tone}>
+								<span aria-hidden="true" class="hv-agent-dot" class:hv-agent-dot-live={view.live}
+								></span>
+								{$i18n.t(view.label)}
+							</span>
+						</div>
+
+						<p class="hv-agent-task-detail">{view.detail}</p>
+
+						{#if task.result_summary_ref}
+							<p class="hv-agent-task-result">
+								{$i18n.t('Result')}: {task.result_summary_ref}
+							</p>
+						{/if}
+
+						<div class="hv-agent-task-meta">
+							<span>{$i18n.t(PACK_LABELS[task.pack])} &middot; {elapsed(task.created_at, nowMs)}</span>
+							{#if !TERMINAL_STATUSES.has(task.status)}
+								<button type="button" class="hv-agent-cancel" on:click={() => cancel(task.id)}>
+									{$i18n.t('Cancel')}
+								</button>
+							{/if}
+						</div>
+					</li>
+				{/each}
+			</ul>
+		{/if}
+	</section>
+</div>
+
+<style>
+	/*
+	 * Every value here is a Hive design token. Nothing is a hard-coded colour,
+	 * radius or step, so this surface moves with the rest of the product rather
+	 * than beside it. The composer's own container and send button are not styled
+	 * here at all: they are the chat composer's, shared as components.
+	 */
+	.hv-agents {
+		display: flex;
+		flex-direction: column;
+		gap: var(--hv-space-4);
+		width: 100%;
+		max-width: 48rem;
+		margin: 0 auto;
+		padding: var(--hv-space-6) var(--hv-space-4) var(--hv-space-10);
+	}
+
+	.hv-agent-input {
+		width: 100%;
+		resize: none;
+		border: 0;
+		background: transparent;
+		outline: none;
+		color: var(--hv-ink);
+		font-size: var(--hv-text-base);
+		line-height: var(--hv-leading-base);
+		max-height: 24rem;
+		overflow-y: auto;
+	}
+
+	.hv-agent-input::placeholder {
+		color: var(--hv-ink-muted);
+	}
+
+	.hv-agent-row {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: var(--hv-space-3);
+		margin: var(--hv-space-2) var(--hv-space-1) var(--hv-space-3);
+	}
+
+	.hv-agent-packs {
+		display: flex;
+		gap: 2px;
+		padding: 2px;
+		border: 0;
+		margin: 0;
+		border-radius: var(--hv-radius-pill);
+		background: var(--hv-surface-sunken);
+	}
+
+	.hv-agent-pack {
+		cursor: pointer;
+	}
+
+	.hv-agent-pack-label {
+		display: block;
+		padding: 0.3rem 0.75rem;
+		border-radius: var(--hv-radius-pill);
+		font-size: var(--hv-text-xs);
+		line-height: var(--hv-leading-xs);
+		font-weight: var(--hv-weight-label);
+		color: var(--hv-ink-secondary);
+		transition: background-color var(--hv-duration-fast) var(--hv-ease-out);
+	}
+
+	.hv-agent-pack input:checked + .hv-agent-pack-label {
+		background: var(--hv-surface);
+		color: var(--hv-ink);
+		box-shadow: var(--hv-shadow-1);
+	}
+
+	.hv-agent-pack input:focus-visible + .hv-agent-pack-label {
+		outline: var(--hv-focus-ring);
+		outline-offset: 2px;
+	}
+
+	.hv-agent-send {
+		display: flex;
+		align-items: center;
+		gap: var(--hv-space-2);
+	}
+
+	.hv-agent-count {
+		font-family: var(--hv-font-mono);
+		font-size: var(--hv-text-2xs);
+		color: var(--hv-ink-muted);
+	}
+
+	.hv-agent-hint {
+		margin: 0;
+		padding-inline: var(--hv-space-3);
+		font-size: var(--hv-text-xs);
+		line-height: var(--hv-leading-xs);
+		color: var(--hv-ink-muted);
+	}
+
+	/*
+	 * Ink on a tinted ground, never coloured text. The danger hue measures about
+	 * 3.8:1 against the surface in light and 3.5:1 in dark, so as text at this
+	 * size it fails WCAG AA in both. Hue moves to the border and the ground and
+	 * the text stays readable, which is also what 1.4.1 asks for: the word
+	 * carries the meaning and the colour reinforces it.
+	 */
+	.hv-agent-alert {
+		margin: 0;
+		border-left: 2px solid var(--hv-danger);
+		border-radius: var(--hv-radius-sm);
+		background: var(--hv-danger-soft);
+		padding: var(--hv-space-3) var(--hv-space-4);
+		font-size: var(--hv-text-sm);
+		line-height: var(--hv-leading-sm);
+		color: var(--hv-ink);
+	}
+
+	.hv-agent-alert-inline {
+		font-size: var(--hv-text-xs);
+		padding: var(--hv-space-2) var(--hv-space-3);
+	}
+
+	.hv-agent-notice {
+		display: flex;
+		flex-direction: column;
+		gap: var(--hv-space-1);
+		border: 1px solid var(--hv-border);
+		border-left: 2px solid var(--hv-warning);
+		border-radius: var(--hv-radius-md);
+		background: var(--hv-warning-soft);
+		padding: var(--hv-space-3) var(--hv-space-4);
+	}
+
+	.hv-agent-notice-title {
+		margin: 0;
+		font-size: var(--hv-text-sm);
+		font-weight: var(--hv-weight-label);
+		color: var(--hv-ink);
+	}
+
+	.hv-agent-notice-body {
+		margin: 0;
+		font-size: var(--hv-text-xs);
+		line-height: var(--hv-leading-xs);
+		color: var(--hv-ink-secondary);
+	}
+
+	.hv-agent-empty {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: var(--hv-space-1);
+		border: 1px solid var(--hv-border);
+		border-radius: var(--hv-radius-md);
+		background: var(--hv-surface);
+		padding: var(--hv-space-12) var(--hv-space-6);
+		text-align: center;
+	}
+
+	.hv-agent-empty-title {
+		margin: 0;
+		font-size: var(--hv-text-sm);
+		font-weight: var(--hv-weight-label);
+		color: var(--hv-ink);
+	}
+
+	.hv-agent-empty-body {
+		margin: 0;
+		max-width: 22rem;
+		font-size: var(--hv-text-xs);
+		line-height: var(--hv-leading-xs);
+		color: var(--hv-ink-secondary);
+	}
+
+	.hv-agent-rows {
+		display: flex;
+		flex-direction: column;
+		margin: 0;
+		padding: 0;
+		list-style: none;
+		border: 1px solid var(--hv-border);
+		border-radius: var(--hv-radius-md);
+		background: var(--hv-surface);
+		overflow: hidden;
+	}
+
+	.hv-agent-task {
+		display: flex;
+		flex-direction: column;
+		gap: var(--hv-space-2);
+		padding: var(--hv-space-4);
+	}
+
+	.hv-agent-task + .hv-agent-task {
+		border-top: 1px solid var(--hv-border);
+	}
+
+	.hv-agent-task-head {
+		display: flex;
+		align-items: flex-start;
+		justify-content: space-between;
+		gap: var(--hv-space-4);
+	}
+
+	.hv-agent-task-title {
+		margin: 0;
+		min-width: 0;
+		flex: 1 1 auto;
+		font-size: var(--hv-text-sm);
+		line-height: var(--hv-leading-sm);
+		color: var(--hv-ink);
+	}
+
+	.hv-agent-task-untitled {
+		color: var(--hv-ink-muted);
+		font-style: italic;
+	}
+
+	.hv-agent-pill {
+		display: inline-flex;
+		flex: none;
+		align-items: center;
+		gap: 0.375rem;
+		border-radius: var(--hv-radius-pill);
+		padding: 0.25rem 0.625rem;
+		font-size: var(--hv-text-2xs);
+		line-height: var(--hv-leading-2xs);
+		font-weight: var(--hv-weight-label);
+		color: var(--hv-ink);
+		background: var(--hv-surface-sunken);
+	}
+
+	.hv-agent-pill[data-tone='accent'] {
+		background: var(--hv-accent-soft);
+	}
+	.hv-agent-pill[data-tone='success'] {
+		background: var(--hv-success-soft);
+	}
+	.hv-agent-pill[data-tone='warning'] {
+		background: var(--hv-warning-soft);
+	}
+	.hv-agent-pill[data-tone='danger'] {
+		background: var(--hv-danger-soft);
+	}
+
+	.hv-agent-dot {
+		width: 0.375rem;
+		height: 0.375rem;
+		flex: none;
+		border-radius: 50%;
+		background: var(--hv-ink-muted);
+	}
+
+	.hv-agent-pill[data-tone='accent'] .hv-agent-dot {
+		background: var(--hv-accent);
+	}
+	.hv-agent-pill[data-tone='success'] .hv-agent-dot {
+		background: var(--hv-success);
+	}
+	.hv-agent-pill[data-tone='warning'] .hv-agent-dot {
+		background: var(--hv-warning);
+	}
+	.hv-agent-pill[data-tone='danger'] .hv-agent-dot {
+		background: var(--hv-danger);
+	}
+
+	/*
+	 * The one permitted pulse on this surface, and only because there is at most
+	 * a handful of running rows and it answers the only question a long run
+	 * raises. It oscillates opacity and never moves, so it is not a spinner.
+	 */
+	.hv-agent-dot-live {
+		animation: hv-agent-pulse 1200ms var(--hv-ease-in-out) infinite;
+	}
+
+	@keyframes hv-agent-pulse {
+		0%,
+		100% {
+			opacity: 1;
+		}
+		50% {
+			opacity: 0.45;
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.hv-agent-dot-live {
+			animation: none;
+		}
+		.hv-agent-pack-label {
+			transition: none;
+		}
+	}
+
+	.hv-agent-task-detail {
+		margin: 0;
+		font-size: var(--hv-text-xs);
+		line-height: var(--hv-leading-xs);
+		color: var(--hv-ink-secondary);
+	}
+
+	.hv-agent-task-result {
+		margin: 0;
+		font-family: var(--hv-font-mono);
+		font-size: var(--hv-text-xs);
+		word-break: break-all;
+		color: var(--hv-ink-secondary);
+	}
+
+	.hv-agent-task-meta {
+		display: flex;
+		align-items: center;
+		gap: var(--hv-space-3);
+		font-family: var(--hv-font-mono);
+		font-size: var(--hv-text-2xs);
+		color: var(--hv-ink-muted);
+	}
+
+	.hv-agent-cancel {
+		border: 1px solid var(--hv-border);
+		border-radius: var(--hv-radius-sm);
+		background: transparent;
+		padding: 0.125rem 0.5rem;
+		font-family: var(--hv-font-sans);
+		font-size: var(--hv-text-2xs);
+		color: var(--hv-ink-secondary);
+		cursor: pointer;
+	}
+
+	.hv-agent-cancel:hover {
+		background: var(--hv-surface-sunken);
+		color: var(--hv-ink);
+	}
+
+	.hv-agent-cancel:focus-visible {
+		outline: var(--hv-focus-ring);
+		outline-offset: 2px;
+	}
+</style>

--- a/vendor/open-webui/src/lib/hive/AgentTasks.svelte
+++ b/vendor/open-webui/src/lib/hive/AgentTasks.svelte
@@ -4,13 +4,13 @@
 	import ComposerShell from './ComposerShell.svelte';
 	import ComposerSendButton from './ComposerSendButton.svelte';
 	import {
-		AgentTaskError,
 		cancelTask,
 		createTask,
 		describeTask,
 		elapsed,
 		IN_FLIGHT_STATUSES,
 		isEngineUnavailable,
+		isRefusal,
 		listTasks,
 		TERMINAL_STATUSES,
 		type AgentTask,
@@ -165,7 +165,7 @@
 			blocked = null;
 			failures = 0;
 		} catch (e) {
-			if (e instanceof AgentTaskError && (e.status === 401 || e.status === 403)) {
+			if (isRefusal(e)) {
 				blocked = e.message;
 				failures = 0;
 			} else {
@@ -231,14 +231,26 @@
 			const updated = await cancelTask(sessionToken(), id);
 			tasks = tasks.map((task) => (task.id === updated.id ? updated : task));
 			announcement = 'Task cancelled.';
+			// Cancelling the last in-flight task should stop the loop now rather
+			// than after one more request against a list that cannot change.
+			schedulePoll();
 		} catch {
 			error = 'Could not cancel that task.';
 		}
 	};
 
 	const onKeyDown = (event: KeyboardEvent) => {
-		// The chat composer's own behaviour, because this reads as the same
-		// control: Enter sends, Shift+Enter is a newline.
+		/*
+		 * Enter sends, Shift+Enter is a newline. This is a deliberate change from
+		 * the surface being replaced, which used Ctrl or Cmd plus Enter and left
+		 * plain Enter to insert a newline "because a task brief is prose and often
+		 * more than one line". That reasoning was sound for a form. It stops
+		 * applying here: the owner's requirement is that this reads as the same
+		 * control as the chat composer, and a control that looks identical and
+		 * answers the same key differently is worse than one that looks different.
+		 * Shift+Enter still writes the multi-line brief the old comment was
+		 * protecting, and `isComposing` keeps an IME's own Enter out of it.
+		 */
 		if (event.key === 'Enter' && !event.shiftKey && !event.isComposing) {
 			event.preventDefault();
 			void submit();
@@ -317,7 +329,13 @@
 			</div>
 
 			<div class="hv-agent-row">
-				<fieldset class="hv-agent-packs">
+				<!--
+					aria-describedby points at the one line under the composer, so a
+					screen reader hears what the selected mode does when it lands on
+					this group. The surface this replaces wired the same relationship
+					and losing it would have made the hint sighted-only.
+				-->
+				<fieldset class="hv-agent-packs" aria-describedby="hive-agent-pack-hint">
 					<legend class="sr-only">{$i18n.t('Kind of task')}</legend>
 					{#each PACKS as option (option.value)}
 						<label class="hv-agent-pack">

--- a/vendor/open-webui/src/lib/hive/ComposerSendButton.svelte
+++ b/vendor/open-webui/src/lib/hive/ComposerSendButton.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+	import Spinner from '$lib/components/common/Spinner.svelte';
+
+	/*
+	 * The composer's send button, extracted alongside ComposerShell.svelte for
+	 * the same reason and lifted from the same place (MessageInput.svelte's
+	 * `#send-message-button`). Classes, geometry and glyph are unchanged.
+	 *
+	 * It is the one control both composers genuinely have, so it is the one
+	 * control worth sharing. Everything else in either toolbar row belongs to
+	 * exactly one surface.
+	 */
+
+	/** Upstream's own DOM hook on chat; the agent composer passes its own. */
+	export let id: string | undefined = undefined;
+	export let disabled = false;
+	/** Renders the spinner in place of the arrow. Chat's upload-pending state. */
+	export let pending = false;
+</script>
+
+<button
+	{id}
+	class="{!disabled || pending
+		? 'bg-black text-white hover:bg-gray-900 dark:bg-white dark:text-black dark:hover:bg-gray-100 '
+		: 'text-white bg-gray-200 dark:text-gray-900 dark:bg-gray-700 disabled'} transition rounded-full p-1.5 self-center"
+	type="submit"
+	{disabled}
+>
+	{#if pending}
+		<Spinner className="size-5" />
+	{:else}
+		<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="size-5">
+			<path
+				fill-rule="evenodd"
+				d="M8 14a.75.75 0 0 1-.75-.75V4.56L4.03 7.78a.75.75 0 0 1-1.06-1.06l4.5-4.5a.75.75 0 0 1 1.06 0l4.5 4.5a.75.75 0 0 1-1.06 1.06L8.75 4.56v8.69A.75.75 0 0 1 8 14Z"
+				clip-rule="evenodd"
+			/>
+		</svg>
+	{/if}
+</button>

--- a/vendor/open-webui/src/lib/hive/ComposerSendButton.svelte
+++ b/vendor/open-webui/src/lib/hive/ComposerSendButton.svelte
@@ -16,10 +16,21 @@
 	export let disabled = false;
 	/** Renders the spinner in place of the arrow. Chat's upload-pending state. */
 	export let pending = false;
+	/**
+	 * Accessible name. The button's only content is an arrow glyph, so without
+	 * this a screen reader reads it as "button" and nothing else.
+	 *
+	 * Undefined by default, which omits the attribute entirely, because chat
+	 * wraps this button in a Tooltip and adding an attribute there would make
+	 * the extraction visible on a surface it is supposed to leave untouched.
+	 * The agent composer has no tooltip and passes its own label.
+	 */
+	export let label: string | undefined = undefined;
 </script>
 
 <button
 	{id}
+	aria-label={label}
 	class="{!disabled || pending
 		? 'bg-black text-white hover:bg-gray-900 dark:bg-white dark:text-black dark:hover:bg-gray-100 '
 		: 'text-white bg-gray-200 dark:text-gray-900 dark:bg-gray-700 disabled'} transition rounded-full p-1.5 self-center"

--- a/vendor/open-webui/src/lib/hive/ComposerShell.svelte
+++ b/vendor/open-webui/src/lib/hive/ComposerShell.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+	/*
+	 * The composer's visual container, extracted so two surfaces share one.
+	 *
+	 * This markup was `#message-input-container` inside MessageInput.svelte and
+	 * nothing else. It is lifted here verbatim, unchanged, and MessageInput now
+	 * renders this component in its place, so chat's composer and the agent
+	 * composer cannot drift: there is one rounded surface, one border, one
+	 * focus-within treatment and one inner padding, in one file.
+	 *
+	 * Presentational only, deliberately. No store is read here, nothing is
+	 * submitted here, and every piece of chat state that used to compute this
+	 * container's classes arrives as a prop. That is what keeps the extraction
+	 * mechanical: MessageInput's behaviour, history, model selection and
+	 * submission are untouched by it.
+	 *
+	 * What is NOT shared, and why it is not a gap: the row of controls inside
+	 * the container is per surface by design. Chat's carries attach, tools,
+	 * skills, web search, voice and the model picker; the agent composer's
+	 * carries the pack toggle. Sharing the row would mean sharing chat state
+	 * with a surface that has none of it, which is the coupling this extraction
+	 * exists to avoid. The send button IS shared, in ComposerSendButton.svelte,
+	 * because it is the one control both surfaces really do have.
+	 */
+
+	/** Passed through so upstream's own DOM hook survives the extraction. */
+	export let id: string | undefined = undefined;
+	/** Text direction, chat's own `$settings?.chatDirection` on that surface. */
+	export let dir: string = 'auto';
+	/** Chat's temporary-chat treatment: a dashed border instead of a solid one. */
+	export let dashed = false;
+</script>
+
+<div
+	{id}
+	class="flex-1 flex flex-col relative w-full shadow-lg rounded-3xl border {dashed
+		? 'border-dashed border-gray-100 dark:border-gray-800 hover:border-gray-200 focus-within:border-gray-200 hover:dark:border-gray-700 focus-within:dark:border-gray-700'
+		: ' border-gray-100/30 dark:border-gray-850/30 hover:border-gray-200 focus-within:border-gray-100 hover:dark:border-gray-800 focus-within:dark:border-gray-800'}  transition px-1 bg-white/5 dark:bg-gray-500/5 backdrop-blur-sm dark:text-gray-100"
+	{dir}
+>
+	<slot />
+</div>

--- a/vendor/open-webui/src/lib/hive/agentTasks.test.ts
+++ b/vendor/open-webui/src/lib/hive/agentTasks.test.ts
@@ -6,8 +6,9 @@ import {
 	createTask,
 	decodeTask,
 	describeTask,
+	canStartTask,
+	describeRefusal,
 	ENGINE_UNAVAILABLE_MESSAGE,
-	isRefusal,
 	listTasks
 } from './agentTasks';
 
@@ -150,14 +151,21 @@ describe('the four calls', () => {
 
 	it('separates a refusal from a failure worth retrying', () => {
 		// The list stops polling on a refusal and keeps polling on anything else,
-		// so this predicate decides whether the screen promises a retry it cannot
-		// deliver.
-		expect(isRefusal(new AgentTaskError(401, 'no'))).toBe(true);
-		expect(isRefusal(new AgentTaskError(403, 'gated'))).toBe(true);
-		expect(isRefusal(new AgentTaskError(500, 'boom'))).toBe(false);
-		expect(isRefusal(new AgentTaskError(429, 'slow down'))).toBe(false);
-		expect(isRefusal(new Error('network'))).toBe(false);
-		expect(isRefusal(null)).toBe(false);
+		// so this decides whether the screen promises a retry it cannot deliver.
+		expect(describeRefusal(new AgentTaskError(401, 'access denied'))?.kind).toBe('signin');
+		expect(describeRefusal(new AgentTaskError(403, 'access denied'))?.kind).toBe('not-enabled');
+		expect(describeRefusal(new AgentTaskError(500, 'boom'))).toBeNull();
+		expect(describeRefusal(new AgentTaskError(429, 'slow down'))).toBeNull();
+		expect(describeRefusal(new Error('network'))).toBeNull();
+		expect(describeRefusal(null)).toBeNull();
+	});
+
+	it('replaces the raw server sentence with copy a person can act on', () => {
+		// edge-api's own words for a closed gate are accurate and useless: they
+		// say access was denied without saying who can change it.
+		const gated = describeRefusal(new AgentTaskError(403, 'access denied'))!;
+		expect(gated.message).not.toContain('access denied');
+		expect(gated.message).toContain('administrator');
 	});
 
 	it('reads a null tasks array as an empty list, because Go marshals nil that way', async () => {
@@ -172,5 +180,24 @@ describe('the four calls', () => {
 			fetchMock.mockResolvedValue(jsonResponse(body));
 			await expect(listTasks('t')).rejects.toThrow('Failed to parse tasks response');
 		}
+	});
+});
+
+describe('canStartTask', () => {
+	const base = { instructions: 'do a thing', submitting: false, blocked: null };
+
+	it('refuses to submit into a surface that is refused', () => {
+		// The rough edge this closes: a tenant without the feature could type a
+		// brief and press send into a surface that could only answer no.
+		expect(canStartTask(base)).toBe(true);
+		expect(
+			canStartTask({ ...base, blocked: { kind: 'not-enabled', message: 'x' } })
+		).toBe(false);
+		expect(canStartTask({ ...base, blocked: { kind: 'signin', message: 'x' } })).toBe(false);
+	});
+
+	it('still refuses an empty brief and a submission already in flight', () => {
+		expect(canStartTask({ ...base, instructions: '   ' })).toBe(false);
+		expect(canStartTask({ ...base, submitting: true })).toBe(false);
 	});
 });

--- a/vendor/open-webui/src/lib/hive/agentTasks.test.ts
+++ b/vendor/open-webui/src/lib/hive/agentTasks.test.ts
@@ -7,6 +7,7 @@ import {
 	decodeTask,
 	describeTask,
 	ENGINE_UNAVAILABLE_MESSAGE,
+	isRefusal,
 	listTasks
 } from './agentTasks';
 
@@ -141,7 +142,22 @@ describe('the four calls', () => {
 		fetchMock.mockResolvedValue(
 			jsonResponse({ detail: 'Your Hive sign-in could not be confirmed.' }, 401)
 		);
+		// The sentence, not only the type: extraction regressing to the generic
+		// fallback would still throw the right class with the wrong text.
+		await expect(listTasks('t')).rejects.toThrow('Your Hive sign-in could not be confirmed.');
 		await expect(listTasks('t')).rejects.toBeInstanceOf(AgentTaskError);
+	});
+
+	it('separates a refusal from a failure worth retrying', () => {
+		// The list stops polling on a refusal and keeps polling on anything else,
+		// so this predicate decides whether the screen promises a retry it cannot
+		// deliver.
+		expect(isRefusal(new AgentTaskError(401, 'no'))).toBe(true);
+		expect(isRefusal(new AgentTaskError(403, 'gated'))).toBe(true);
+		expect(isRefusal(new AgentTaskError(500, 'boom'))).toBe(false);
+		expect(isRefusal(new AgentTaskError(429, 'slow down'))).toBe(false);
+		expect(isRefusal(new Error('network'))).toBe(false);
+		expect(isRefusal(null)).toBe(false);
 	});
 
 	it('reads a null tasks array as an empty list, because Go marshals nil that way', async () => {

--- a/vendor/open-webui/src/lib/hive/agentTasks.test.ts
+++ b/vendor/open-webui/src/lib/hive/agentTasks.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+	AgentTaskError,
+	cancelTask,
+	createTask,
+	decodeTask,
+	describeTask,
+	ENGINE_UNAVAILABLE_MESSAGE,
+	listTasks
+} from './agentTasks';
+
+const row = (over: Record<string, unknown> = {}) => ({
+	id: 'a0f0d4d2-0000-4000-8000-000000000001',
+	pack: 'coding-pack',
+	instructions: 'Audit the webhook handlers',
+	status: 'running',
+	engine_session_ref: '',
+	result_summary_ref: '',
+	error_message: '',
+	created_at: '2026-08-17T10:00:00Z',
+	updated_at: '2026-08-17T10:01:00Z',
+	started_at: null,
+	finished_at: null,
+	...over
+});
+
+const jsonResponse = (body: unknown, status = 200) =>
+	new Response(JSON.stringify(body), {
+		status,
+		headers: { 'Content-Type': 'application/json' }
+	});
+
+describe('decodeTask', () => {
+	it('keeps a row whose status this build does not recognise', () => {
+		// The alternative this replaced was worse than blank: the row was dropped
+		// from the list, so a task the user submitted simply vanished.
+		const decoded = decodeTask(row({ status: 'reticulating' }));
+		expect(decoded?.status).toBe('unknown');
+	});
+
+	it('drops a row with no identity', () => {
+		expect(decodeTask(row({ id: undefined }))).toBeNull();
+		expect(decodeTask(row({ created_at: undefined }))).toBeNull();
+		expect(decodeTask(row({ pack: 'no-such-pack' }))).toBeNull();
+		expect(decodeTask('not an object')).toBeNull();
+	});
+
+	it('defaults the nullable text columns to empty strings', () => {
+		const decoded = decodeTask(row({ instructions: undefined, error_message: undefined }));
+		expect(decoded?.instructions).toBe('');
+		expect(decoded?.error_message).toBe('');
+	});
+});
+
+describe('describeTask', () => {
+	const now = Date.parse('2026-08-17T10:05:00Z');
+
+	it('renders a task with no recorded goal without pretending it has one', () => {
+		// Three rows on the deployed list are in exactly this state. They must
+		// read as deliberate, not broken.
+		const decoded = decodeTask(row({ instructions: '' }));
+		expect(decoded?.instructions).toBe('');
+		expect(describeTask(decoded!, now).label).toBe('Running');
+	});
+
+	it('separates a deployment with no runtime from a task that really failed', () => {
+		const blocked = decodeTask(
+			row({ status: 'failed', error_message: ENGINE_UNAVAILABLE_MESSAGE })
+		)!;
+		const failed = decodeTask(row({ status: 'failed', error_message: 'its session was lost' }))!;
+
+		expect(describeTask(blocked, now).label).toBe('Blocked');
+		expect(describeTask(blocked, now).tone).toBe('warning');
+		expect(describeTask(failed, now).label).toBe('Failed');
+		// The #921 row. Its own sentence survives rather than being replaced by a
+		// generic one, because the sentence is the only evidence the user gets.
+		expect(describeTask(failed, now).detail).toBe('its session was lost');
+	});
+
+	it('says plainly when a queued task has been sitting there', () => {
+		const stale = decodeTask(row({ status: 'queued', created_at: '2026-08-17T09:00:00Z' }))!;
+		expect(describeTask(stale, now).detail).toContain('nothing picking it up');
+	});
+});
+
+describe('the four calls', () => {
+	let fetchMock: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		fetchMock = vi.fn();
+		vi.stubGlobal('fetch', fetchMock);
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('lists through Open WebUI, never through edge-api directly', async () => {
+		// Load bearing. The browser has no credential edge-api accepts, so a call
+		// that went straight there would 401 for every signed-in user.
+		fetchMock.mockResolvedValue(jsonResponse({ tasks: [row()] }));
+
+		const tasks = await listTasks('owui-session-token');
+
+		expect(tasks).toHaveLength(1);
+		const [url, init] = fetchMock.mock.calls[0];
+		expect(url).toBe('/api/v1/hive/agent/tasks');
+		expect(init.method).toBe('GET');
+		expect(init.headers.authorization).toBe('Bearer owui-session-token');
+	});
+
+	it('sends the pack and the goal, and nothing else', async () => {
+		fetchMock.mockResolvedValue(jsonResponse(row()));
+
+		await createTask('owui-session-token', 'knowledge-work-pack', 'Summarise the policy');
+
+		const [url, init] = fetchMock.mock.calls[0];
+		expect(url).toBe('/api/v1/hive/agent/tasks');
+		expect(init.method).toBe('POST');
+		expect(JSON.parse(init.body)).toEqual({
+			pack: 'knowledge-work-pack',
+			instructions: 'Summarise the policy'
+		});
+	});
+
+	it('escapes the task id into the cancel path', async () => {
+		fetchMock.mockResolvedValue(jsonResponse(row({ status: 'cancelled' })));
+
+		await cancelTask('owui-session-token', 'a b/../c');
+
+		expect(fetchMock.mock.calls[0][0]).toBe('/api/v1/hive/agent/tasks/a%20b%2F..%2Fc/cancel');
+	});
+
+	it('surfaces the server sentence from either error vocabulary', async () => {
+		fetchMock.mockResolvedValue(
+			jsonResponse({ error: { message: 'Cowork is not enabled for this tenant.' } }, 403)
+		);
+		await expect(listTasks('t')).rejects.toThrow('Cowork is not enabled for this tenant.');
+
+		fetchMock.mockResolvedValue(
+			jsonResponse({ detail: 'Your Hive sign-in could not be confirmed.' }, 401)
+		);
+		await expect(listTasks('t')).rejects.toBeInstanceOf(AgentTaskError);
+	});
+
+	it('treats a response with no tasks array as an empty list', async () => {
+		fetchMock.mockResolvedValue(jsonResponse({}));
+		await expect(listTasks('t')).resolves.toEqual([]);
+	});
+});

--- a/vendor/open-webui/src/lib/hive/agentTasks.test.ts
+++ b/vendor/open-webui/src/lib/hive/agentTasks.test.ts
@@ -144,8 +144,17 @@ describe('the four calls', () => {
 		await expect(listTasks('t')).rejects.toBeInstanceOf(AgentTaskError);
 	});
 
-	it('treats a response with no tasks array as an empty list', async () => {
-		fetchMock.mockResolvedValue(jsonResponse({}));
+	it('reads a null tasks array as an empty list, because Go marshals nil that way', async () => {
+		fetchMock.mockResolvedValue(jsonResponse({ tasks: null }));
 		await expect(listTasks('t')).resolves.toEqual([]);
+	});
+
+	it('refuses to report an unreadable payload as an empty list', async () => {
+		// Saying "no tasks" when the truth is "could not read the answer" is the
+		// exact failure this surface exists to stop making.
+		for (const body of [{}, { tasks: 'nope' }, { tasks: { a: 1 } }]) {
+			fetchMock.mockResolvedValue(jsonResponse(body));
+			await expect(listTasks('t')).rejects.toThrow('Failed to parse tasks response');
+		}
 	});
 });

--- a/vendor/open-webui/src/lib/hive/agentTasks.ts
+++ b/vendor/open-webui/src/lib/hive/agentTasks.ts
@@ -19,9 +19,21 @@
  * are not: the `unknown` status and the two engine sentinels.
  */
 
-import { WEBUI_API_BASE_URL } from '$lib/constants';
-
-const AGENT_API_BASE_URL = `${WEBUI_API_BASE_URL}/hive/agent`;
+// The base is a parameter with a production default rather than an import of
+// `$lib/constants`, and that is load-bearing rather than stylistic.
+// `$lib/constants` reaches `$app/environment` for `browser` and `dev`, which
+// only SvelteKit's resolver can satisfy. scripts/test-owui-hive-frontend.sh,
+// the one runner that covers this front end, copies lib/hive/*.ts into a
+// scratch directory and runs plain vitest there with no alias resolution at
+// all, so while this module imported that path its own 203 line test file
+// could not be loaded: it reported no failures because it never ran, and it
+// would have turned that required check red the moment the runner reached it.
+//
+// The default is what `${WEBUI_API_BASE_URL}/hive/agent` evaluates to in every
+// built bundle, since `WEBUI_BASE_URL` is the empty string outside dev. The
+// caller passes the dev-aware value, so `npm run dev` against the chat front
+// end still reaches the backend on port 8080 exactly as before.
+export const DEFAULT_AGENT_API_BASE_URL = '/api/v1/hive/agent';
 
 export type TaskPack = 'coding-pack' | 'knowledge-work-pack';
 
@@ -224,8 +236,11 @@ export const canStartTask = (state: {
 }): boolean =>
 	state.instructions.trim().length > 0 && !state.submitting && state.blocked === null;
 
-export const listTasks = async (token: string): Promise<AgentTask[]> => {
-	const response = await fetch(`${AGENT_API_BASE_URL}/tasks`, {
+export const listTasks = async (
+	token: string,
+	apiBase: string = DEFAULT_AGENT_API_BASE_URL
+): Promise<AgentTask[]> => {
+	const response = await fetch(`${apiBase}/tasks`, {
 		method: 'GET',
 		headers: headers(token)
 	});
@@ -267,9 +282,10 @@ export const listTasks = async (token: string): Promise<AgentTask[]> => {
 export const createTask = async (
 	token: string,
 	pack: TaskPack,
-	instructions: string
+	instructions: string,
+	apiBase: string = DEFAULT_AGENT_API_BASE_URL
 ): Promise<AgentTask> => {
-	const response = await fetch(`${AGENT_API_BASE_URL}/tasks`, {
+	const response = await fetch(`${apiBase}/tasks`, {
 		method: 'POST',
 		headers: headers(token),
 		body: JSON.stringify({ pack, instructions })
@@ -284,9 +300,13 @@ export const createTask = async (
 	return decoded;
 };
 
-export const cancelTask = async (token: string, id: string): Promise<AgentTask> => {
+export const cancelTask = async (
+	token: string,
+	id: string,
+	apiBase: string = DEFAULT_AGENT_API_BASE_URL
+): Promise<AgentTask> => {
 	const response = await fetch(
-		`${AGENT_API_BASE_URL}/tasks/${encodeURIComponent(id)}/cancel`,
+		`${apiBase}/tasks/${encodeURIComponent(id)}/cancel`,
 		{
 			method: 'POST',
 			headers: headers(token)

--- a/vendor/open-webui/src/lib/hive/agentTasks.ts
+++ b/vendor/open-webui/src/lib/hive/agentTasks.ts
@@ -164,6 +164,22 @@ const raise = async (response: Response, fallback: string): Promise<never> => {
 	throw new AgentTaskError(response.status, message ?? `${fallback}: ${response.status}`);
 };
 
+/**
+ * Whether a failure is a refusal that another attempt cannot change.
+ *
+ * 401 means this session cannot reach the agent service at all; 403 means the
+ * tenant does not hold the Cowork gate. Everything else, a network blip, a 5xx,
+ * an unreadable payload, is worth retrying. The two must not share copy,
+ * because the retry message promises something a refusal can never deliver,
+ * and a poll that keeps asking a settled question is a request every few
+ * seconds forever.
+ *
+ * A function rather than an inline check in the component, so the decision has
+ * a test. The component itself has no test harness in this tree.
+ */
+export const isRefusal = (error: unknown): error is AgentTaskError =>
+	error instanceof AgentTaskError && (error.status === 401 || error.status === 403);
+
 export const listTasks = async (token: string): Promise<AgentTask[]> => {
 	const response = await fetch(`${AGENT_API_BASE_URL}/tasks`, {
 		method: 'GET',

--- a/vendor/open-webui/src/lib/hive/agentTasks.ts
+++ b/vendor/open-webui/src/lib/hive/agentTasks.ts
@@ -1,0 +1,377 @@
+/*
+ * The agent-task lifecycle, from the chat frontend.
+ *
+ * Hive authored. Everything under src/lib/hive/ is ours, so a rebase against a
+ * future upstream tag reads as a file list rather than an archaeology exercise.
+ *
+ * These four calls go to Open WebUI's own backend, not to edge-api, and that
+ * is the whole reason the agent surface can be native here at all. The browser
+ * has no credential edge-api accepts: it holds Open WebUI's session token,
+ * which edge-api has never heard of, and the Supabase OAuth-server token it
+ * would need is not in the browser at all. The server-side proxy
+ * (deploy/docker/owui-patches/hive_agent_proxy.py) resolves that token per
+ * request and forwards to /v1/agent/* on the same mechanism this deployment
+ * already runs for chat completions.
+ *
+ * The wire shape below is edge-api's, unchanged, because the proxy returns its
+ * JSON verbatim. Ported from apps/agent-console/lib/edge-api/tasks.ts,
+ * including the two decisions in it that are easy to mistake for accidents and
+ * are not: the `unknown` status and the two engine sentinels.
+ */
+
+import { WEBUI_API_BASE_URL } from '$lib/constants';
+
+const AGENT_API_BASE_URL = `${WEBUI_API_BASE_URL}/hive/agent`;
+
+export type TaskPack = 'coding-pack' | 'knowledge-work-pack';
+
+/*
+ * The five wire statuses, plus a local sixth.
+ *
+ * `unknown` is never sent by the server. It is what any status this build does
+ * not recognise decodes to, so that a row still reaches the list. A console
+ * that filtered the row out would make a task the user submitted vanish with
+ * no error, which reads as deletion.
+ */
+export type TaskStatus =
+	| 'queued'
+	| 'running'
+	| 'succeeded'
+	| 'failed'
+	| 'cancelled'
+	| 'unknown';
+
+export interface AgentTask {
+	id: string;
+	pack: TaskPack;
+	instructions: string;
+	status: TaskStatus;
+	engine_session_ref: string;
+	result_summary_ref: string;
+	error_message: string;
+	created_at: string;
+	updated_at: string;
+	started_at: string | null;
+	finished_at: string | null;
+}
+
+export class AgentTaskError extends Error {
+	public readonly status: number;
+	constructor(status: number, message: string) {
+		super(message);
+		this.name = 'AgentTaskError';
+		this.status = status;
+	}
+}
+
+const PACKS: ReadonlySet<string> = new Set(['coding-pack', 'knowledge-work-pack']);
+const STATUSES: ReadonlySet<string> = new Set([
+	'queued',
+	'running',
+	'succeeded',
+	'failed',
+	'cancelled'
+]);
+
+export const isTaskPack = (value: unknown): value is TaskPack =>
+	typeof value === 'string' && PACKS.has(value);
+
+const isWireStatus = (value: unknown): value is TaskStatus =>
+	typeof value === 'string' && STATUSES.has(value);
+
+const readString = (value: Record<string, unknown>, key: string): string | null => {
+	const raw = value[key];
+	return typeof raw === 'string' ? raw : null;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === 'object' && value !== null && !Array.isArray(value);
+
+/**
+ * Decodes one wire row, or null when it carries no identity.
+ *
+ * Identity fields only. A row without one of these is a malformed payload
+ * rather than a task in a state we have not met, and there is nothing honest to
+ * render for it. The status deliberately is not in this guard: see TaskStatus.
+ */
+export const decodeTask = (value: unknown): AgentTask | null => {
+	if (!isRecord(value)) {
+		return null;
+	}
+	const id = readString(value, 'id');
+	const pack = readString(value, 'pack');
+	const createdAt = readString(value, 'created_at');
+	const updatedAt = readString(value, 'updated_at');
+
+	if (!id || !isTaskPack(pack) || !createdAt || !updatedAt) {
+		return null;
+	}
+
+	const status = readString(value, 'status');
+
+	return {
+		id,
+		pack,
+		// Nullable column server side; the contract promises '' rather than null
+		// on read, but decode defensively so an older row cannot crash the list.
+		instructions: readString(value, 'instructions') ?? '',
+		status: isWireStatus(status) ? status : 'unknown',
+		engine_session_ref: readString(value, 'engine_session_ref') ?? '',
+		result_summary_ref: readString(value, 'result_summary_ref') ?? '',
+		error_message: readString(value, 'error_message') ?? '',
+		created_at: createdAt,
+		updated_at: updatedAt,
+		started_at: readString(value, 'started_at'),
+		finished_at: readString(value, 'finished_at')
+	};
+};
+
+const headers = (token: string): Record<string, string> => ({
+	Accept: 'application/json',
+	'Content-Type': 'application/json',
+	authorization: `Bearer ${token}`
+});
+
+const readBody = async (response: Response): Promise<unknown> => {
+	try {
+		return await response.json();
+	} catch {
+		return null;
+	}
+};
+
+/**
+ * Turns a non-2xx into an AgentTaskError carrying the server's own sentence.
+ *
+ * Two error vocabularies reach here: edge-api's `{error: {message}}`, returned
+ * verbatim by the proxy, and FastAPI's `{detail}` for the proxy's own
+ * refusals. Both are already written for a customer to read and neither names
+ * a provider, so both are surfaced rather than replaced with a generic line
+ * that would throw away the only useful thing in the response.
+ */
+const raise = async (response: Response, fallback: string): Promise<never> => {
+	const body = await readBody(response);
+	let message: string | null = null;
+	if (isRecord(body)) {
+		const error = body['error'];
+		if (isRecord(error)) {
+			message = readString(error, 'message');
+		}
+		if (!message) {
+			message = readString(body, 'detail');
+		}
+	}
+	throw new AgentTaskError(response.status, message ?? `${fallback}: ${response.status}`);
+};
+
+export const listTasks = async (token: string): Promise<AgentTask[]> => {
+	const response = await fetch(`${AGENT_API_BASE_URL}/tasks`, {
+		method: 'GET',
+		headers: headers(token)
+	});
+	if (!response.ok) {
+		await raise(response, 'Failed to load tasks');
+	}
+	const body = await readBody(response);
+	if (!isRecord(body)) {
+		throw new Error('Failed to parse tasks response');
+	}
+	const rows = body['tasks'];
+	if (!Array.isArray(rows)) {
+		return [];
+	}
+	const tasks: AgentTask[] = [];
+	for (const row of rows) {
+		const decoded = decodeTask(row);
+		if (decoded) {
+			tasks.push(decoded);
+		}
+	}
+	return tasks;
+};
+
+export const createTask = async (
+	token: string,
+	pack: TaskPack,
+	instructions: string
+): Promise<AgentTask> => {
+	const response = await fetch(`${AGENT_API_BASE_URL}/tasks`, {
+		method: 'POST',
+		headers: headers(token),
+		body: JSON.stringify({ pack, instructions })
+	});
+	if (!response.ok) {
+		await raise(response, 'Failed to create task');
+	}
+	const decoded = decodeTask(await readBody(response));
+	if (!decoded) {
+		throw new Error('Failed to parse task response');
+	}
+	return decoded;
+};
+
+export const cancelTask = async (token: string, id: string): Promise<AgentTask> => {
+	const response = await fetch(
+		`${AGENT_API_BASE_URL}/tasks/${encodeURIComponent(id)}/cancel`,
+		{
+			method: 'POST',
+			headers: headers(token)
+		}
+	);
+	if (!response.ok) {
+		await raise(response, 'Failed to cancel task');
+	}
+	const decoded = decodeTask(await readBody(response));
+	if (!decoded) {
+		throw new Error('Failed to parse task response');
+	}
+	return decoded;
+};
+
+// Polling and the cancel button both stop once a task reaches one of these
+// (matches apps/control-plane/internal/agenttask/SYNC_CONTRACT.md's state
+// machine). `unknown` is deliberately absent: a state we cannot name is not a
+// state we can call finished.
+export const TERMINAL_STATUSES: ReadonlySet<TaskStatus> = new Set([
+	'succeeded',
+	'failed',
+	'cancelled'
+]);
+
+// The states the server can move a task out of on its own, and therefore the
+// only reason to keep polling. Deliberately not the complement of
+// TERMINAL_STATUSES: `unknown` is neither finished nor known to be moving, so
+// it keeps its row but does not hold the poll timer open forever on a guess.
+export const IN_FLIGHT_STATUSES: ReadonlySet<TaskStatus> = new Set(['queued', 'running']);
+
+/*
+ * Deployment-configuration sentinels.
+ *
+ * Both strings are consts in apps/control-plane/internal/agenttask/service.go
+ * (`engineUnavailableMessage`, `engineLaunchFailedMessage`), persisted verbatim
+ * into `error_message` when Engine.Launch fails. They are deliberately
+ * provider-blind and generic, which also makes them stable enough to key
+ * presentation off: a task carrying one of them did not fail because of
+ * anything the user wrote, it never started at all.
+ *
+ * A drifted string degrades to the plain "failed" treatment, which is still
+ * honest, so this is a soft dependency rather than a coupling that can break.
+ */
+export const ENGINE_UNAVAILABLE_MESSAGE = 'agent engine is not available on this deployment';
+export const ENGINE_LAUNCH_FAILED_MESSAGE = 'agent engine could not start the task';
+
+export const isEngineUnavailable = (task: AgentTask): boolean =>
+	task.status === 'failed' && task.error_message === ENGINE_UNAVAILABLE_MESSAGE;
+
+export const isEngineLaunchFailure = (task: AgentTask): boolean =>
+	task.status === 'failed' && task.error_message === ENGINE_LAUNCH_FAILED_MESSAGE;
+
+export interface TaskView {
+	label: string;
+	detail: string;
+	/** Running is the only state whose dot is filled and live. */
+	live: boolean;
+	tone: 'neutral' | 'accent' | 'success' | 'warning' | 'danger';
+}
+
+// A queued task only moves when something on the far side of the engine seam
+// picks it up. Past this threshold the row says plainly that it is not
+// progressing rather than implying imminent work.
+const STALE_QUEUE_AFTER_MS = 10 * 60 * 1000;
+
+/** Coarse elapsed label: "4m", "3h", "6d". */
+export const elapsed = (iso: string, nowMs: number): string => {
+	const then = Date.parse(iso);
+	if (Number.isNaN(then)) {
+		return '';
+	}
+	const minutes = Math.floor(Math.max(0, nowMs - then) / 60_000);
+	if (minutes < 1) return 'less than a minute';
+	if (minutes < 60) return `${minutes}m`;
+	const hours = Math.floor(minutes / 60);
+	if (hours < 24) return `${hours}h`;
+	return `${Math.floor(hours / 24)}d`;
+};
+
+/**
+ * Maps a wire task onto what a person should read.
+ *
+ * The two engine sentinels are the reason this function exists. Both are
+ * deployment configuration, not user error and not really a task failure:
+ * nothing ran, nothing was wrong with the request. They get their own
+ * "Blocked" label in the warning register so they never sit next to a genuine
+ * failure wearing the same red.
+ */
+export const describeTask = (task: AgentTask, nowMs: number): TaskView => {
+	switch (task.status) {
+		case 'queued': {
+			const createdMs = Date.parse(task.created_at);
+			const stale = !Number.isNaN(createdMs) && nowMs - createdMs > STALE_QUEUE_AFTER_MS;
+			return {
+				label: 'Queued',
+				tone: 'neutral',
+				live: false,
+				detail: stale
+					? `Queued for ${elapsed(task.created_at, nowMs)} with nothing picking it up. Cancel it to clear it from the list.`
+					: 'Waiting for a sandbox to pick it up.'
+			};
+		}
+		case 'running':
+			return {
+				label: 'Running',
+				tone: 'accent',
+				live: true,
+				detail:
+					'Working now. There is no live transcript yet, so this view checks for a result every few seconds.'
+			};
+		case 'succeeded':
+			return {
+				label: 'Done',
+				tone: 'success',
+				live: false,
+				detail: task.result_summary_ref ? 'Finished. The result reference is below.' : 'Finished.'
+			};
+		case 'cancelled':
+			return {
+				label: 'Cancelled',
+				tone: 'neutral',
+				live: false,
+				detail: 'You stopped this task before it finished.'
+			};
+		case 'unknown':
+			return {
+				label: 'Unknown',
+				tone: 'neutral',
+				live: false,
+				detail:
+					'This task is in a state this page does not recognise, so there is nothing reliable to say about it yet. It is still recorded against your account. Reload to check it again.'
+			};
+		case 'failed':
+		default: {
+			if (isEngineUnavailable(task)) {
+				return {
+					label: 'Blocked',
+					tone: 'warning',
+					live: false,
+					detail:
+						'This deployment has no agent runtime configured, so the task was recorded but never started. Nothing was wrong with what you asked for.'
+				};
+			}
+			if (isEngineLaunchFailure(task)) {
+				return {
+					label: 'Blocked',
+					tone: 'warning',
+					live: false,
+					detail:
+						'The agent runtime refused to start this task, so nothing ran. Trying again may work; if it keeps happening it is a deployment problem, not your task.'
+				};
+			}
+			return {
+				label: 'Failed',
+				tone: 'danger',
+				live: false,
+				detail: task.error_message || 'The task stopped before producing a result.'
+			};
+		}
+	}
+};

--- a/vendor/open-webui/src/lib/hive/agentTasks.ts
+++ b/vendor/open-webui/src/lib/hive/agentTasks.ts
@@ -164,21 +164,65 @@ const raise = async (response: Response, fallback: string): Promise<never> => {
 	throw new AgentTaskError(response.status, message ?? `${fallback}: ${response.status}`);
 };
 
+export interface Refusal {
+	kind: 'signin' | 'not-enabled';
+	message: string;
+}
+
 /**
- * Whether a failure is a refusal that another attempt cannot change.
+ * A failure that another attempt cannot change, in words a person can act on.
  *
  * 401 means this session cannot reach the agent service at all; 403 means the
- * tenant does not hold the Cowork gate. Everything else, a network blip, a 5xx,
- * an unreadable payload, is worth retrying. The two must not share copy,
- * because the retry message promises something a refusal can never deliver,
- * and a poll that keeps asking a settled question is a request every few
- * seconds forever.
+ * feature is not enabled for this organization. Everything else, a network
+ * blip, a 5xx, an unreadable payload, is worth retrying and is not a refusal.
+ * The two must not share copy: the retry message promises something a refusal
+ * can never deliver, and a poll that keeps asking a settled question is a
+ * request every few seconds forever.
+ *
+ * The copy is ours, not the server's. edge-api's own sentence for a closed
+ * feature gate is accurate and useless to the person reading it: it says access
+ * was denied without saying who can change that or what is safe to do
+ * meanwhile. This is the same register the surface being replaced used for a
+ * deployment with no agent runtime, and for the same reason.
  *
  * A function rather than an inline check in the component, so the decision has
- * a test. The component itself has no test harness in this tree.
+ * a test; the component itself has no test harness in this tree.
  */
-export const isRefusal = (error: unknown): error is AgentTaskError =>
-	error instanceof AgentTaskError && (error.status === 401 || error.status === 403);
+export const describeRefusal = (error: unknown): Refusal | null => {
+	if (!(error instanceof AgentTaskError)) {
+		return null;
+	}
+	if (error.status === 401) {
+		return {
+			kind: 'signin',
+			message:
+				'Your sign-in could not be confirmed for the agent service, so tasks cannot be listed or started. Sign in again, and if it keeps happening contact your administrator.'
+		};
+	}
+	if (error.status === 403) {
+		return {
+			kind: 'not-enabled',
+			message:
+				'The agent service is not enabled for this organization, so there are no tasks to show and none can be started. An administrator can turn it on. Nothing is wrong with your account, and the rest of Hive is unaffected.'
+		};
+	}
+	return null;
+};
+
+/**
+ * Whether the composer should accept a submission.
+ *
+ * `blocked` is in here, and that is the point: a refused surface that still
+ * takes typing and still lights its send button invites a person to write a
+ * task brief and press a key that cannot work. Refusing at the control, with
+ * the reason on screen, is the honest shape.
+ */
+export const canStartTask = (state: {
+	instructions: string;
+	submitting: boolean;
+	blocked: Refusal | null;
+}): boolean =>
+	state.instructions.trim().length > 0 && !state.submitting && state.blocked === null;
 
 export const listTasks = async (token: string): Promise<AgentTask[]> => {
 	const response = await fetch(`${AGENT_API_BASE_URL}/tasks`, {

--- a/vendor/open-webui/src/lib/hive/agentTasks.ts
+++ b/vendor/open-webui/src/lib/hive/agentTasks.ts
@@ -176,9 +176,23 @@ export const listTasks = async (token: string): Promise<AgentTask[]> => {
 	if (!isRecord(body)) {
 		throw new Error('Failed to parse tasks response');
 	}
+	/*
+	 * `tasks` absent is a payload we cannot read; `tasks: null` is a real empty
+	 * list, because edge-api answers `map[string]any{"tasks": tasks}` and Go
+	 * marshals a nil slice as null (apps/edge-api/internal/agenttask/handler.go).
+	 * Returning an empty list for the first case would tell the user they have
+	 * no tasks when the truth is that we could not read the answer, which is the
+	 * failure mode this whole surface exists to stop making.
+	 */
+	if (!('tasks' in body)) {
+		throw new Error('Failed to parse tasks response');
+	}
 	const rows = body['tasks'];
-	if (!Array.isArray(rows)) {
+	if (rows === null) {
 		return [];
+	}
+	if (!Array.isArray(rows)) {
+		throw new Error('Failed to parse tasks response');
 	}
 	const tasks: AgentTask[] = [];
 	for (const row of rows) {

--- a/vendor/open-webui/src/lib/hive/hive.css
+++ b/vendor/open-webui/src/lib/hive/hive.css
@@ -234,41 +234,17 @@ samp,
 	background-color: var(--hv-canvas);
 }
 
-.hv-panel-region {
-	position: relative;
-	flex: 1 1 auto;
-	display: flex;
-	min-height: 0;
-}
-
-.hv-panel-frame {
-	flex: 1 1 auto;
-	width: 100%;
-	border: 0;
-	display: block;
-	background-color: transparent;
-	/* Colour scheme is inherited by the embedded document through its own
-	 * copy of these tokens; nothing here paints over it. */
-	color-scheme: inherit;
-}
-
 /*
- * The line sits behind the frame rather than the frame being hidden until it
- * loads. An unpainted frame is transparent, so the line shows through and the
- * panel's own ground covers it the moment it paints. Deliberate: hiding the
- * frame until a `load` event would leave a permanent "Opening the agent
- * workspace" on any request where that event never arrives, which is the
- * failure that looks like a hang.
+ * The destination's scrolling region.
+ *
+ * It used to host an <iframe> and carried the positioning that needed: a flex
+ * row for the frame to fill, and a loading line stacked behind it. Both are
+ * gone with the frame. The agent surface renders natively into this region now
+ * (src/lib/hive/AgentTasks.svelte), and there is nothing to wait for, so there
+ * is no loading state to draw and nothing to stack.
  */
-.hv-panel-loading {
-	position: absolute;
-	inset: 0;
-	z-index: 0;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	margin: 0;
-	color: var(--hv-ink-muted);
-	font-size: var(--hv-text-sm);
-	line-height: var(--hv-leading-sm);
+.hv-panel-region {
+	flex: 1 1 auto;
+	min-height: 0;
+	overflow-y: auto;
 }

--- a/vendor/open-webui/src/routes/(app)/agents/+page.svelte
+++ b/vendor/open-webui/src/routes/(app)/agents/+page.svelte
@@ -67,7 +67,7 @@
 		</nav>
 	{/if}
 
-	<div class="hv-panel-region overflow-y-auto">
+	<div class="hv-panel-region">
 		<AgentTasks />
 	</div>
 </div>

--- a/vendor/open-webui/src/routes/(app)/agents/+page.svelte
+++ b/vendor/open-webui/src/routes/(app)/agents/+page.svelte
@@ -1,63 +1,33 @@
 <script lang="ts">
-	import { getContext, onMount, onDestroy } from 'svelte';
+	import { getContext } from 'svelte';
 
-	import { WEBUI_NAME, showSidebar, mobile, theme } from '$lib/stores';
+	import { WEBUI_NAME, showSidebar, mobile } from '$lib/stores';
 
 	import Tooltip from '$lib/components/common/Tooltip.svelte';
 	import SidebarIcon from '$lib/components/icons/Sidebar.svelte';
+	import AgentTasks from '$lib/hive/AgentTasks.svelte';
 
 	const i18n: any = getContext('i18n');
 
 	/*
-	 * The agent workspace as a destination inside the shell.
+	 * The agent workspace as a destination inside the shell, rendered natively.
 	 *
-	 * Until the task console is ported to Svelte it stays the Next.js
-	 * application that already owns it, served by the same Caddy listener at
-	 * /agent-workspace on this origin (deploy/docker/Caddyfile.owui). Rendering
-	 * it here keeps the sidebar, the identity and the origin: the agent stops
-	 * being a link out of the product and becomes a room inside it.
+	 * This route used to hold a single <iframe> pointed at /agent-workspace/tasks,
+	 * which booted apps/agent-console, a second whole application, inside the
+	 * page. That frame is gone. The composer and the task list are Svelte
+	 * components in this application now (src/lib/hive/AgentTasks.svelte), and the
+	 * composer is built from the chat composer's own container and send button, so
+	 * the agent surface reads as the same product rather than a panel embedded in
+	 * it.
 	 *
-	 * ponytail: same origin frame, not a port. The port is real work and it is
-	 * blocked on a token bridge, because this frontend holds Open WebUI's own
-	 * session token in localStorage while /v1/agent/* authenticates the
-	 * Supabase bearer that only the embedded application carries. When that
-	 * bridge exists the frame is replaced by native rows and this file becomes
-	 * the transcript.
-	 *
-	 * Known ceiling, deliberately not papered over: if the embedded
-	 * application has no session of its own it renders its own sign in inside
-	 * this frame. The fix is the single sign on work, not a spinner here.
+	 * What made the port possible was never a layout problem, it was a credential
+	 * one: this frontend holds Open WebUI's session token, while /v1/agent/*
+	 * wants a Supabase token carrying a tenant claim, and the one the OAuth login
+	 * produces carries none and is not in the browser anyway. It is resolved
+	 * server side now, by the agent proxy in the chat container
+	 * (deploy/docker/owui-patches/hive_agent_proxy.py), on the same mechanism this
+	 * deployment already runs for chat completions.
 	 */
-	const AGENT_PANEL_PATH = '/agent-workspace/tasks';
-
-	let systemPrefersDark = false;
-	let media: MediaQueryList | null = null;
-
-	const onSystemThemeChange = (event: MediaQueryListEvent) => {
-		systemPrefersDark = event.matches;
-	};
-
-	onMount(() => {
-		media = window.matchMedia('(prefers-color-scheme: dark)');
-		systemPrefersDark = media.matches;
-		media.addEventListener('change', onSystemThemeChange);
-	});
-
-	onDestroy(() => {
-		media?.removeEventListener('change', onSystemThemeChange);
-	});
-
-	// Same resolution the layout applies to the document class, so the panel
-	// and the shell are never in two different themes.
-	$: resolvedTheme = $theme.includes('dark')
-		? 'dark'
-		: $theme === 'system' && systemPrefersDark
-			? 'dark'
-			: 'light';
-
-	$: panelSrc = `${AGENT_PANEL_PATH}?embed=1&theme=${resolvedTheme}`;
-
-	let panelReady = false;
 </script>
 
 <svelte:head>
@@ -97,31 +67,7 @@
 		</nav>
 	{/if}
 
-	<!--
-		Keyed on the resolved theme so a theme change reloads the panel with the
-		matching palette. Rebuilding the frame is acceptable here because a theme
-		change is a rare, deliberate act; nothing else remounts it.
-	-->
-	{#key resolvedTheme}
-		<div class="hv-panel-region">
-			{#if !panelReady}
-				<!--
-					Never a blank region: the panel is same origin and resolves fast, but
-					"fast" is not "instant" on a cold container, and an empty rectangle is
-					the state that reads as broken. One line, no spinner, and it sits
-					behind the frame rather than in front of it (see hive.css).
-				-->
-				<p class="hv-panel-loading">{$i18n.t('Opening the agent workspace')}</p>
-			{/if}
-			<iframe
-				class="hv-panel-frame"
-				src={panelSrc}
-				title={$i18n.t('Agent workspace')}
-				loading="eager"
-				on:load={() => {
-					panelReady = true;
-				}}
-			></iframe>
-		</div>
-	{/key}
+	<div class="hv-panel-region overflow-y-auto">
+		<AgentTasks />
+	</div>
 </div>


### PR DESCRIPTION
Owner directive, 2026-08-17: "stop using iframes and keep it native inside OpenWebUI."

`https://chat-hive.scubed.co/agents` rendered exactly one `<iframe>`, `loading="eager"`, pointed at `/agent-workspace/tasks`, which booted `apps/agent-console` (a second whole Next.js application) inside the page. That is why the agent surface still looked exactly as it did before the shell landed, why it was slow, and why a task could never become part of the conversation. The frame is gone.

Scope is bounded deliberately: visual and functional parity with what the frame showed, natively, which is the task composer and the task list. No tool call cards, no progress panel, no transcript. All three are specified in `spec-2026-08-17-agent-run-surface` and blocked on the event relay (its step S6), and a tool card with nothing to render is worse than today's status row.

## Two premises in the brief that were already stale

Both checked in the tree at `1dc67ee69`, both reported before building anything.

1. **`apps/agent-console/middleware.ts` does not send `X-Frame-Options: DENY` or `frame-ancestors 'none'`.** It sends `SAMEORIGIN` and `frame-ancestors 'self'` (`middleware.ts:80-84`), changed in #938 with a comment naming the shell as the reason. Nothing was working around anything: the frame was permitted because one Caddy listener serves both applications on one origin, so `'self'` is a real origin check that matches.
2. **The frame's `src` carried no credential.** It was `embed=1` and `theme=<light|dark>`, both re-validated and rebuilt rather than reflected (`middleware.ts:25-31`, `:93-100`).

What the credential path actually was: `apps/agent-console` holds its own first-party Supabase session in cookies on the shared origin, and its browser code calls `/v1/agent/*` directly with `session.access_token`. That token comes from a direct Supabase sign-in, so it carries the `tenant_id` claim the `custom_access_token_hook` mints, and `JWTMiddleware` accepts it with no fallback. The frame existed because a second application had a second, better token.

## The problem, and why the recommended fix needed one correction

The chat frontend holds Open WebUI's own session token, which edge-api has never heard of, plus a Supabase access token minted through Supabase's **OAuth-server** grant, which does not run `custom_access_token_hook` and therefore carries **no `tenant_id`**. `JWTMiddleware` rejects that (`middleware.go:123-129`). That is D-023 working, pinned by `inert_token_test.go`, and it is not relaxed here.

Worse for any browser-side fix: **that OAuth token is not in the browser at all.** Open WebUI keeps it server side and resolves it per request through `get_system_oauth_token`, refreshing it when expired (`utils/middleware.py:3012-3045`). Handing it to page JavaScript would be a downgrade, not a fix.

So the recommendation to reuse the mechanism `hive_jwt_forward.py` plus `owui_unwrap.go` already run in production is adopted. The correction: **`__metadata.upstream_auth` cannot serve this surface**, because three of the four agent-task calls have no JSON body to hide a token in.

| Call | Method | Body |
|---|---|---|
| `GET /v1/agent/tasks` | GET | none |
| `POST /v1/agent/tasks` | POST | JSON |
| `GET /v1/agent/tasks/{id}` | GET | none |
| `POST /v1/agent/tasks/{id}/cancel` | POST | none |

(`apps/edge-api/internal/agenttask/handler.go:38-72`.)

## The design, three layers

### 1. edge-api: a second carrier on the same boundary

`X-Hive-Upstream-Auth` carries the per-user token for requests with no body to carry it in. **This is not a new auth boundary.** The trust decision is unchanged and unchanged in strength: the header is honoured only when `Authorization` is exactly the shim key, which is the identical gate the body carrier already sits behind. What changes is the carrier, not who is allowed to use it.

Properties, each with a test:

* Honoured only under the shim key. Under a real API key, a real JWT, or no credential at all, it is ignored.
* **Stripped from the forwarded request on every branch**, including the ignored one and including when the middleware is disabled. A header a client controls must never be readable by a handler, a log or an audit sink, because a handler that can read it is one that could later be taught to trust it.
* Same 8 KiB cap as the body carrier, shared through one normaliser so the two cannot drift into accepting different shapes of the same credential.
* Fails closed when present but unusable, rather than forwarding with the shim key still on `Authorization`.

`requiresPerUserAuth` grows the agent-task paths. It previously covered `/v1/chat/completions` only, which meant a shim-key request to `/v1/agent/tasks` with no user token would pass through and **bind to the shim's own principal**, listing and cancelling the shim account's tasks instead of the user's. Nothing sent that request; this change is what keeps the new proxy from being one bug away from sending it. It is a tightening, not a widening: a silent mis-attribution becomes a 401.

One latent defect fixed while in the same function: a present-but-empty `__metadata.upstream_auth` previously returned `unwrapOK` with an empty token, which skipped the fail-closed arm and forwarded to `/v1/chat/completions` with the shim key intact. It now takes the missing-carrier arm, so it 401s and logs like every other missing token.

Not touched, deliberately: the tenant fallback is still gated on `IsOWUIUnwrapped` and is not widened by one line; `Selector` is unchanged; `inert_token_test.go` passes unmodified.

### 2. The chat container: a server-side proxy

Only the **frontend** of `hive-open-webui` is built from the fork; the Python backend stays upstream's pinned image on purpose (Dockerfile header, D-036). So this arrives as a copied module plus one asserted splice, the same shape as `hive_model_picker` and `hive_rag_env_config`. The frontend builds with `adapter-static`, so there is no SvelteKit server to put it in instead.

`deploy/docker/owui-patches/hive_agent_proxy.py`, mounted at `/api/v1/hive/agent`:

* Every route depends on `get_verified_user`, and **no route reads a user id, a tenant id, an email or a token from the request**, so a caller cannot influence which principal edge-api resolves.
* Presents the shim key on `Authorization` and the user's token on the carrier header. Neither is ever returned to the browser, logged, or included in an error.
* Four named operations with the task id validated as a UUID before it is interpolated. Deliberately not a general-purpose proxy, which is the shape #770 removed from this image.
* The create body is **rebuilt from two named fields** rather than passed through, so nothing a caller invents (a `__metadata` block, for one) reaches edge-api.
* Adds no configuration: `OPENAI_API_BASE_URL` and `OPENAI_API_KEY` are already set on this container, so the shim key gains no new home.

### 3. The frontend

`src/lib/hive/agentTasks.ts` and `AgentTasks.svelte`, plus the `/agents` route. Ported from the console, including two decisions that are easy to mistake for accidents and are not: the `unknown` status sentinel (a status this build cannot name still gets a row, because dropping it made a submitted task vanish) and the two engine sentinels (a deployment with no runtime reads "Blocked" in the warning register, never "Failed" in red next to a real failure).

## What happened to `/agent-workspace`, stated plainly

It still exists and it is still served. Nothing in this PR removes it, and the PR should not be read as removing it.

Three separate things get confused under that name, so all three, precisely:

* **The `agent-hive.scubed.co` subdomain is already gone**, and was before this PR. It is NXDOMAIN and decommissioned (D-026, verified 2026-07-28). There is no separate agent host and has not been one for some time.
* **`/agent-workspace` is a path on the chat host**, proxied to the `agent-console` container by `deploy/docker/Caddyfile.owui:161-168`. That rule is untouched here, so the path still resolves and still serves `apps/agent-console`.
* **Nothing in the product points at it any more.** The nav row goes to `/agents`, and `/agents` no longer loads it. A user reaches it only by typing the URL.

So after this PR the old surface is unreachable through the interface but still reachable by URL. Making it actually stop being a thing is the retirement described in the next section, and it is deliberately not in this PR: the console is the only surface that has ever launched a task against the live engine, so it is the control if the native path misbehaves on the box. Recommendation is to retire it once this has run there for a day.

## On the composer: the extraction was taken, not the fallback

Answering the directive's point 1 plainly.

`MessageInput.svelte` cannot be consumed wholesale: 2222 lines, 29 exported props, several required and chat-specific (`history`, `selectedModels`, `createMessagePair`, `stopResponse`, `taskIds`, `messageQueue`), and its container's classes are computed from chat stores. Cloning its CSS was banned, correctly.

So the **presentational shell was extracted**, which was the preferred option:

* `src/lib/hive/ComposerShell.svelte` is `#message-input-container` lifted verbatim: the rounded surface, the border, the hover and focus-within treatment, the inner padding. It reads no store; the two values that used to compute its classes arrive as props.
* `src/lib/hive/ComposerSendButton.svelte` is `#send-message-button` lifted verbatim, classes and glyph unchanged.
* `MessageInput.svelte` now renders both. **No behavioural edit was needed**, which was the stated condition for taking this option: the diff there is two tag swaps, one component swap and one import.

What is deliberately **not** shared is the row of controls inside the container. Chat's carries attach, tools, skills, web search, voice and the model picker; the agent composer's carries the pack toggle. Sharing that row would mean sharing chat state with a surface that has none of it, which is the coupling the extraction exists to avoid.

Per the directive: the heading block and the helper paragraph are deleted. The pack choice is a segmented **Knowledge work** / **Coding** toggle inside the composer. The one line describing the selected mode survives as a single muted line under the composer, because it is genuinely useful and it does not turn the composer back into a form. `Enter` sends and `Shift+Enter` is a newline, which is the chat composer's own behaviour. The two packs and their semantics are unchanged, and so is the default (`coding-pack`): this is a presentation change, not a capability change.

Chat's own composer is proved unchanged two ways, per the condition set: the vitest suite is green, and before and after screenshots of the **chat** composer are posted below alongside the agent one.

## Does `apps/agent-console` still need to exist?

Honest assessment, not acted on here.

**No route in it is reachable from the product any more.** Nothing frames it, and the only two links that ever pointed at it are gone: the nav row goes to `/agents`, and `/agents` no longer loads `/agent-workspace/tasks`. It is now a signed-out URL that a user reaches only by typing it.

What retiring it would take, in order:

1. Delete the `@agentConsole` matcher and its `reverse_proxy` from `deploy/docker/Caddyfile.owui` (lines 145 to 168), which is what makes `/agent-workspace` resolve at all.
2. Remove the `agent-console` service from `deploy/docker/docker-compose.yml` and its `Dockerfile.agent-console`, plus the `NEXT_PUBLIC_EDGE_API_BASE_URL` and `EDGE_API_INTERNAL_BASE_URL` wiring that exists only for it.
3. Remove the `agent-console-unit` job from `.github/workflows/ci.yml`, which is a required check, so branch protection needs updating in the same change or the merge gate waits forever on a job that no longer runs.
4. Delete `apps/agent-console/`.

Two things worth keeping first, and neither is code: its `proof/` harness, and the accessibility reasoning in `task-console.tsx` (it refuses `--color-ink-3` for body text on a measured contrast argument). The second is already carried across into `AgentTasks.svelte`'s comments and CSS.

One caveat against deleting it immediately: it is the only surface that has ever launched a task against the live engine, so it is the control if the native path misbehaves on the box. Recommendation is to retire it in a follow-up once this has run on the demo box for a day, not in this PR.

## Testing

* `go test ./apps/edge-api/... -count=1 -short` in the toolchain container: green, whole module, including nine new cases for the carrier and the fail-closed paths.
* `python3 scripts/test_owui_agent_proxy.py`, wired into `make test-scripts` (a required CI check). Pure standard library, no framework, matching the other `scripts/test_owui_*.py` self-checks. It is mutation tested: swapping the two credentials onto the wrong headers, deleting the missing-token guard, and forwarding the whole request body each make it fail.
* `npm run test:frontend` for the fork, covering the decoder, the status mapping and the four calls.

**A gap named rather than hidden.** `ci.yml` has vitest lanes for `apps/desktop`, `apps/web-console` and `apps/agent-console`, and none for `vendor/open-webui`, so every test ever written under `src/lib/hive` was coverage on paper only. This adds `npm run test:frontend -- --run` to the image's frontend build stage, which means the fork's tests gate the nightly build and the demo deploy. That is not the same as gating a pull request and is not claimed as such; a PR-time lane for this tree is a follow-up.

## Buglog entry

```json
{"id":"owui-agent-shim-principal-gap","date":"2026-08-17","title":"OWUI shim-key requests to /v1/agent/tasks would have bound to the shim's own principal","error_message":"none observed; latent","root_cause":"requiresPerUserAuth in apps/edge-api/internal/auth/owui_unwrap.go returned true only for /v1/chat/completions, so a shim-key request to any other path fell through with the shim key still on Authorization and resolved as the shim account. Correct for the paths that existed then (embeddings and text-to-speech authenticate as the shim by design), wrong the moment a second per-user OWUI path appeared. A present-but-empty __metadata.upstream_auth had the same effect on the chat path itself, because it returned unwrapOK with an empty token and skipped the fail-closed arm.","fix":"Extended requiresPerUserAuth to /v1/agent/tasks and its subtree, and made an empty upstream_auth report as a missing carrier so it takes the 401 arm and the warn log.","tags":["auth","edge-api","owui","fail-closed","tenancy"]}
```

## Visual proof: not posted yet, and exactly what exists today

Stated precisely, because an earlier version of this section said screenshots were "committed under `docs/proof/` and posted in a comment". Neither was true. Nothing is committed under `docs/proof/` in this diff, no image is on this PR, and `owui-nightly.yml` has no step that commits or comments; it only uploads a transient CI artifact. That sentence described intent before the run finished and read as completed work. It will not be restated until an image is actually visible on this page.

**What has been verified on a real stack with a real signed-in session**, run 32066161156, the OWUI end-to-end job on this branch:

- `the agent workspace opens inside the shell and frames nothing` passed. That is the load-bearing one: an `iframe` count of zero on `/agents`, the composer present and accepting typed input, both toggle options clickable, the list painting exactly the rows the API returned matched against that response's own text, and the call to the proxy answering something other than 401, which is the single failure mode this design has.
- `proof capture: the agent surface, natively, in both palettes` passed, so the images were produced.
- Every chat spec passed on that same build: send and stream, multi-turn, model switch, tenant model visibility, sign-out. That is evidence the composer extraction did not break chat, and it does not depend on anyone reading a screenshot.

**Why no image was attached at first, and a finding worth its own paragraph.** The captures were being written into `playwright-report-owui/proof`, inside the HTML reporter's own output folder. That reporter clears its folder before writing the report, so **every capture was produced and then deleted**, and the result looked exactly like a capture step that had never run. Nothing failed, nothing warned, and the test that wrote them passed. Confirmed by downloading the artifact and finding no `proof/` directory rather than by inferring it.

Anyone adding a capture step to a Playwright suite in this repository will walk into the same trap, which is why it is recorded here rather than only fixed: proof must never be written inside a reporter's output directory. The captures now go to a sibling directory with its own upload step. This is the same silent-absence shape that let the end-to-end gate rot unnoticed, where an artifact that is missing and an artifact that was never asked for are indistinguishable after the fact.

**Two attempts to re-capture since then both failed outside this branch**, and neither is counted as anything:

- Run 32112158077: the sign-in helper's consent hop exceeded its 30 second budget. The container log shows the token exchange completing 28 seconds after its redirect and the OAuth session being stored, so the login worked and was simply late.
- Runs 32113599893 and 32114089597: the seeder's first write returned `POST /tenants -> 522` in both. Without fixture credentials the OWUI project matches zero spec files, so nothing in this PR ran at all.

**Correction to an earlier version of this section**, which called that 522 an external Supabase problem. It is very probably ours. The same job log carries `(ECHECKOUTTIMEOUT) unable to check out connection from the pool after 15000ms in Session mode`, which is the documented 15-client session-mode pooler ceiling being hit, and that single cause explains both symptoms: a PostgREST request that cannot get a database connection hangs until Cloudflare gives up with a 522, while a direct `pg` client gets the checkout timeout by name. Blaming the provider was the comfortable read and the evidence does not support it.

I also want to retract a piece of reasoning rather than quietly drop it: I probed `/rest/v1/` unauthenticated, got a 401, and treated that as evidence the origin had recovered. An unauthenticated request never reaches the connection pool, so that probe could not have detected the condition that matters and proved nothing.

Neither failure touches a file in this diff, and a run that never reached the suite is an absence of information rather than a result. The captures are outstanding for that reason and for no other.

**How they will be posted.** Through `scripts/post-pr-visual-proof.sh`, which uploads to a release asset. A raw link pinned to this branch 404s the moment the branch is deleted, and this repo squash-merges and deletes branches, so that mechanism produces proof which expires exactly when the PR it proves gets merged.

## A third thing, and the budget I did not raise

Investigating why the proof runs kept failing turned up a cause that is not a test problem. The consent and sign-in pages are web-console's, on a different origin, and web-console is served by a development build, so it compiles each page the first time anyone requests it. On run 32112158077 the first two login attempts produced no page within 30 seconds and the third completed the whole exchange in 21 seconds once warm. That is a route compiling on demand, not a slow protocol.

The harness now waits for the consent app to be serving before it starts timing the login. **The 30 second login budget is deliberately unchanged.** Raising it was the obvious move and the wrong one: it would have buried a cold compile inside a per-login timeout, and every future slow login would then look exactly like this one, which is how the next real regression gets absorbed instead of noticed. The new wait is a separate budget for a separate thing, the app becoming reachable at all. It also adds no new failure mode, because the assertion it precedes already requires a DOM that exists only on the consent origin.

Why that app is served in dev mode is a product question, it is deliberate per D-022, and it is filed as #967 rather than decided here. It is a plausible cause of the slow sign-in being reported in real use.

## Two things a reviewer should know

**The OWUI end-to-end harness was red before this branch and is fixed here.** It still is on `main`, at that same readiness check, which is independent evidence this fix is real and not a symptom of something else on this branch. It is also a different defect from the provisioning race PR #963 is separately fixing, so the two should not be read as one problem. Its sign-in readiness signal waited for a `button` named "New chat", and Open WebUI renders both New Chat controls as anchors carrying an `aria-label`, so that query could never match. The sign-in it guards actually succeeds; the downloaded failure screenshot shows a working signed-in chat page. A sibling file already matched either role for exactly this reason. That fix is why any of the verification above exists, and it is separate from this feature.

**Two nav tests from #938 went red the first time they ever ran**, which was in this branch after that fix. Neither is a regression here and neither was weakened. Both assumed a sidebar that starts expanded while this fixture's starts collapsed, so a text assertion resolved to the icon-only rail and read "", and the collapsed-rail test waited for a control that only exists while the sidebar is open. Each test now drives the sidebar into the state it asserts about.










---

## Rebase onto current main, 2026-08-22, and what this closes

Rebased onto `main` at `c30882491`. The base this branch was validated against, `1dc67ee69`, predates the migration of the entire database off hosted Supabase onto the self-hosted instance on the demo box, the move of the public auth origin to a same-origin `/auth/v1` route on the console, and the switch to admin-provisioned-only signup. One conflict, in `Makefile`, where `main` had added seven self-checks to `test-scripts` and this branch adds one; both are kept.

### This is the fix for the top demo blocker, issue #540

Re-confirmed live on the box on 2026-08-22: a user signs into `chat-hive.scubed.co` normally, clicks **Agents**, and is presented with an email and password form captioned that the workspace is separate from chat. Proved there by difference rather than guessed: chat's OAuth handshake mints an Open WebUI token and never writes the `sb-...-auth-token` cookie that the embedded `apps/agent-console` reads, and injecting the same session's Supabase cookies on the `chat-hive` origin makes the real workspace render immediately.

That is the second-application problem this branch removes. The credential the embedded application was looking for is no longer needed by anything, because the surface is native and authenticates with the Open WebUI session the user already has: the panel calls `/api/v1/hive/agent/*` on the chat origin, and `deploy/docker/owui-patches/hive_agent_proxy.py` brokers it server side through `get_system_oauth_token`, which is the one place the user's Supabase token is reachable. #540's own analysis named that as the only possible broker.

### Does a second credential prompt remain reachable

**Yes, by one route, and this branch does not close it.** `/agent-workspace/*` is still proxied to `apps/agent-console` by `deploy/docker/Caddyfile.owui`, and that application still renders its own email and password form, so a typed or bookmarked `https://chat-hive.scubed.co/agent-workspace` still reaches one. This branch's only edit to that file is a comment; it changes no route.

No route inside the chat interface leads there any more. `vendor/open-webui/src/lib/hive/nav.ts` points the sidebar entry at `/agents`, and the only two remaining mentions of the old path anywhere in the front end are historical comments. So the demo path is fixed and the residual is a URL nobody is shown.

Answering that path 404 was considered and rejected here rather than skipped: the Tauri desktop app targets `/agent-workspace` as its console base path (`apps/desktop/src/settings.ts`, `apps/desktop/src-tauri/src/settings.rs`), and `apps/web-console/tests/e2e/_probe/agent-workspace-flows.spec.ts` is a coverage ledger over that surface. Retiring `apps/agent-console`, or moving the desktop app onto the native surface first, is a separate decision with a far larger blast radius than this pull request.

### One coupling worth knowing before this is demoed

The proxy reads the user's Supabase token through `get_system_oauth_token`, which goes through `OAuthManager.get_oauth_token`, which refreshes five minutes before expiry and **deletes the OAuth session outright when that refresh fails**. That is issue #782, still unfixed on `main` and fixed by PR #787. Until #787 lands, this agent surface stops working roughly 55 minutes after sign-in for the same reason chat does, and the panel will correctly report "Your Hive sign-in could not be confirmed. Sign in again and retry." A demo that runs longer than that from a single sign-in needs #787 merged first.

### Review findings addressed on the rebased head

Two threads, both fixed rather than argued, plus one defect found while verifying them.

A list refresh overlapping a create or a cancel replaced the whole task array with its older answer, dropping the row the user had just submitted or reverting one they had just cancelled, and when that stale answer held no in-flight task the poll loop stopped too and the screen did not recover without a reload. A refresh now captures a mutation counter before its request goes out and discards its own answer if a create or a cancel landed while the request was open.

The third entry in the identity smell tuple in `scripts/test_owui_agent_proxy.py` could not fail: for `headers.get('Authorization')` the accessor templates expanded to `request.query_params.get('headers.get('Authorization')')`, a string no Python source can contain, so that iteration reported a pass over the header read it was named after. The header read now has its own direct test against the whole `request.headers` attribute, and it fails on purpose when the string is planted on a line that never executes.

Found while running the above: `agentTasks.test.ts`, 203 lines of assertions, was running in no job at all. The module imported `$lib/constants`, which reaches `$app/environment`, and the only runner that covers this front end runs plain vitest with no alias resolution, so the file could not be loaded. It would have turned that required check red on whichever of #951 and #952 merged second. The API base is now a parameter with a production default and the component passes the dev-aware value, so a built bundle and `npm run dev` both behave exactly as before, and the tests load with no configuration: 16 of them, one of which fails when `encodeURIComponent` is dropped from the cancel path.

### Verification on the rebased head

- 31 vendored front end tests pass across three files, 16 of them in `agentTasks.test.ts`, which had never executed before this rebase.
- `make test-scripts` green, including `test_owui_agent_proxy.py` and the seven self-checks `main` added.
- `go test ./apps/edge-api/internal/auth/... -short` green, which covers the `owui_unwrap.go` change against `main`'s newer `x-api-key` normalisation (#954).
- `Caddyfile.owui` validates against the pinned Caddy image, using `main`'s new "Every Caddyfile adapts" CI step.

### Visual proof

Posted on this pull request as release assets, with the full method, the artefacts of the stub, and the `/agent-workspace` residual in `docs/proof/agents-native-no-iframe-2026-08-22/README.md`. Measured in the page rather than asserted: zero password inputs, zero iframes, and no "Sign in" text on `/agents`.

The capture uses the real bundle from `docker build --target frontend` on this branch with a stubbed backend on a loopback origin, and says so on every artefact. A live capture is not available before merge for two reasons that are not properties of this branch: the panel needs the `owui-patches` router this branch adds, which exists only in a rebuilt image, so bundle interception against the deployed origin would 404; and the development box's `.env` still points `SUPABASE_URL` at the hosted Supabase project deleted in the migration, which now returns `ENOTFOUND`, so no session can be minted. No password was set, reset or rotated to work around that.

### Buglog entry

To be appended to `.wolf/buglog.jsonl` on `main` in a separate buglog-only pull request after this merges, per the openwolf protocol.

```json
{"id":"owui-agents-second-credential-prompt","date":"2026-08-22","error_message":"Clicking Agents in the chat sidebar presented its own email and password form captioned that the workspace is separate from chat, one click after a successful chat sign-in","root_cause":"The Agents route embedded apps/agent-console in an iframe, and that application authenticates from a Supabase SSR cookie on the chat origin which chat's OAuth handshake never writes: the handshake mints an Open WebUI token only, and the user's Supabase token is reachable only server-side inside the chat container as the stored OAuth token","fix":"Removed the iframe and rendered the task surface natively in the chat application, authenticating with the Open WebUI session the user already holds and brokering the Supabase token server-side through a FastAPI router added by owui-patches/hive_agent_proxy.py","tags":["owui","auth","agents","iframe","session","demo-blocker","issue-540"]}
{"id":"agent-tasks-stale-poll-overwrites-mutation","date":"2026-08-22","error_message":"A newly created agent task row disappeared, or a cancelled row reverted, and polling sometimes stopped entirely until the page was reloaded","root_cause":"refresh assigned the fetched list over the whole tasks array, so a poll already in flight when a create or cancel completed landed afterwards and overwrote it, and schedulePoll then decided from that stale array and stopped when it held no in-flight task","fix":"A mutation counter captured before the request goes out; refresh discards its own answer when a create or cancel landed while the request was open","tags":["svelte","race","polling","agents"]}
{"id":"agenttasks-unit-tests-never-ran","date":"2026-08-22","error_message":"agentTasks.test.ts reported no failures because it was never loaded by any job","root_cause":"The module imported $lib/constants, which reaches $app/environment, and scripts/test-owui-hive-frontend.sh runs plain vitest over copied files with no SvelteKit alias resolution, so the test file could not be loaded at all","fix":"The API base is a parameter with a production default and the component passes the dev-aware value, so the module imports nothing and the tests load with no configuration","tags":["tests","unfailable-check","vitest","sveltekit"]}
{"id":"owui-agent-proxy-smell-check-unfailable","date":"2026-08-22","error_message":"The identity smell loop in test_owui_agent_proxy.py reported a pass over a header read it was named after","root_cause":"The tuple entry headers.get('Authorization') was expanded through accessor templates into request.query_params.get('headers.get('Authorization')'), a string no Python source can contain, so that iteration asserted nothing","fix":"Separated the header smell into a direct substring test against the whole request.headers attribute, demonstrated failing on purpose","tags":["tests","unfailable-check","security"]}
```




<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR replaces the iframe-hosted agent workspace with a native Open WebUI task surface and brokers per-user agent API credentials through a constrained server-side proxy.
- Adds a guarded upstream-auth header carrier and fail-closed agent-task authentication.
- Adds native task composition, listing, cancellation, polling, and shared composer presentation.
- Updates frontend, proxy, authentication, and end-to-end verification coverage.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the mutation-generation guard prevents stale refreshes from overwriting completed creates or cancellations, and ID filtering prevents the create/refresh duplicate-row race.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/edge-api/internal/auth/owui_unwrap.go | Adds a stripped, shim-gated header carrier for per-user agent credentials and extends fail-closed authentication to agent-task paths. |
| deploy/docker/owui-patches/hive_agent_proxy.py | Adds the authenticated server-side broker that resolves each user’s OAuth token and forwards only the four supported task operations. |
| vendor/open-webui/src/lib/hive/AgentTasks.svelte | Implements native task composition, polling, cancellation, stale-refresh suppression, and create-row deduplication; both previously reported races are fixed. |
| vendor/open-webui/src/lib/hive/agentTasks.ts | Defines the typed agent-task client, decoding, status handling, and constrained proxy calls used by the native surface. |
| vendor/open-webui/src/routes/(app)/agents/+page.svelte | Replaces the framed agent application with the native AgentTasks component. |
| vendor/open-webui/src/lib/components/chat/MessageInput.svelte | Adopts extracted composer shell and send-button components without changing the chat composer’s behavior. |
| apps/web-console/e2e/phase-19/owui/09-agent-workspace-nav.spec.ts | Verifies native rendering, absence of iframes, proxy authentication behavior, navigation, task rows, and visual-proof capture. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant U as Signed-in user
  participant UI as Native OWUI agent surface
  participant P as OWUI agent proxy
  participant A as Edge API auth middleware
  participant T as Agent-task API
  U->>UI: Open /agents
  UI->>P: "GET/POST /api/v1/hive/agent/*"
  P->>P: Resolve server-side OAuth token
  P->>A: Shim authorization + upstream-auth carrier
  A->>A: Validate shim gate, strip carrier, unwrap user token
  A->>T: Request authorized as signed-in user
  T-->>A: Task response
  A-->>P: Task response
  P-->>UI: Sanitized response
  UI-->>U: Native task list and composer
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix: deduplicate the created task row ag..."](https://github.com/sakibsadmanshajib/hive/commit/f3df569f5f19901e988ac0e2209af477185bfb15) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54086925)</sub>

**Context used:**

- Knowledge Base — [Control-plane marketplace-backed agent task workflow](https://app.greptile.com/scubed/-/custom-context/knowledge-base/sakibsadmanshajib/hive/-/docs/control-plane-agent-workflows.md)
- Knowledge Base — [Edge API security boundary](https://app.greptile.com/scubed/-/custom-context/knowledge-base/sakibsadmanshajib/hive/-/docs/edge-api-security-boundary.md)

<!-- /greptile_comment -->

---

## Buglog entry, third (added 2026-08-23)

Alongside the two above. To be appended to `.wolf/buglog.jsonl` on `main` in
the same buglog-only pull request after this merges, per the openwolf
protocol. Not appended on this branch: a branch that appends a line conflicts
with every other branch that appended one, and an unmergeable pull request
gets no CI run at all (issue #873).

```json
{"id":"owui-unwrap-carrier-strip-unobservable","date":"2026-08-23","title":"Header-carrier strip asserted on a path no test could observe","error_message":"TestOWUIUnwrap_HeaderCarrierPresentButBlank_StrippedAndRejected asserted only the Rejected half of its own name; the Stripped half was unobservable because next never runs on a 401","root_cause":"The strip was applied to a clone of the request, so the only observation point was the downstream handler. Every rejection branch answers without calling next, so nothing on those branches could be checked, and an outer middleware still holding the pre-clone pointer would also have kept seeing a live per-user token. Moving Header.Del into the forwarding branches alone would have left the whole test file green.","fix":"Strip the carrier from the inbound request in place instead of from a clone, making the invariant one fact rather than one fact per branch, and assert in both rejection tests that the header is gone from the request the middleware was handed. Safe because net/http never re-reads request headers after the handler returns and the header is ours alone.","verification":"Green confirmed on unmodified code first. The production strip was then narrowed to fire only for a usable carrier, which is the exact regression described; all four blank sub-cases and the over-long case went red naming the new assertion, and the pass-through case went red too. Restoring the unconditional strip returned ./apps/edge-api/... to green.","tags":["auth","edge-api","owui-unwrap","test-quality","guard-cannot-fail","security","pr-951"]}
```

## Visual proof: now posted, correcting the section above

The section headed "Visual proof: not posted yet" is out of date and its own
condition has been met. Images are now visible on this page, posted as
permanent release assets through `scripts/post-pr-visual-proof.sh`, from a
live signed-in capture against a complete local stack rather than a bundle or
a CI artifact.

The capture was taken after rebasing onto `main` at `82375d07f`, where #952
and #956 have landed, so it exercises the real post-merge state. Measured in
the live DOM at both hops: zero password inputs, zero iframes, zero child
browsing contexts, zero anchors to `/agent-workspace`. `GET
/api/v1/agent/tasks` answered 200 through the running proxy chain, so the
authenticated data path is exercised and not only the rendering.
`/agent-workspace` still answers 307 to `/agent-workspace/tasks`, verified
after the rebase and deliberately unchanged.

Method, substrate and credential handling:
`docs/proof/agents-native-live-2026-08-23/README.md`.
