### PR TITLE
fix: normalize x-api-key before the JWT/API-key auth selector

### DIFF
--- a/apps/edge-api/cmd/server/main.go
+++ b/apps/edge-api/cmd/server/main.go
@@ -1022,6 +1022,17 @@ func authSelectorMiddleware(jwtMW func(http.Handler) http.Handler, next http.Han
 		ShimKey: strings.TrimSpace(os.Getenv("OWUI_SHIM_KEY")),
 	})
 	selector = owuiUnwrap(selector)
+	// A real Anthropic SDK client (Anthropic(api_key=...), the default and
+	// documented construction) sends the credential on x-api-key, never
+	// Authorization. auth.Selector only inspects Authorization, and
+	// anthropic.APIKeyNormalizer used to be wired solely at the mux leaf
+	// (mux.Handle("/v1/messages", anthropic.APIKeyNormalizer(...))), which
+	// sits inside this middleware, not outside it: the selector above always
+	// ran first and never saw the header. Every x-api-key-only request fell
+	// through to the JWT path and 401'd regardless of key validity. Applying
+	// the same normalizer here, before the selector, fixes that for every
+	// /v1/* route (a no-op wherever Authorization is already set).
+	selector = anthropic.APIKeyNormalizer(selector)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !strings.HasPrefix(r.URL.Path, "/v1/") {
 			next.ServeHTTP(w, r)

--- a/apps/edge-api/cmd/server/main_test.go
+++ b/apps/edge-api/cmd/server/main_test.go
@@ -1101,6 +1101,91 @@ func (b *syncBuffer) String() string {
 	return b.buf.String()
 }
 
+// TestAuthSelectorMiddlewareAcceptsXAPIKeyHeader is the regression guard for the
+// bug that blocked every real Anthropic SDK client from ever authenticating: a
+// caller built with only base_url + api_key overridden sends "x-api-key",
+// never "Authorization". anthropic.APIKeyNormalizer, which rewrites that
+// header to "Authorization: Bearer", was wired only at the mux leaf
+// (mux.Handle("/v1/messages", anthropic.APIKeyNormalizer(anthropicHandler))),
+// but auth.Selector runs OUTSIDE the mux, in authSelectorMiddleware, and
+// inspects Authorization before the leaf-level normalizer ever gets a chance
+// to run. A request bearing only x-api-key therefore had no Authorization
+// header at the point Selector decided which path to take, fell through to
+// the JWT path unconditionally, and 401'd with "missing bearer" regardless of
+// how valid the key was. This test drives authSelectorMiddleware directly, the
+// same construction main() performs, with a jwtMW stand-in that always 401s so
+// a pass can only happen by reaching the API-key path.
+func TestAuthSelectorMiddlewareAcceptsXAPIKeyHeader(t *testing.T) {
+	t.Setenv("OWUI_SHIM_KEY", "")
+
+	var jwtInvoked, apiKeyInvoked bool
+	var sawAuthorization string
+	jwtMW := func(http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			jwtInvoked = true
+			w.WriteHeader(http.StatusUnauthorized)
+		})
+	}
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		apiKeyInvoked = true
+		sawAuthorization = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := authSelectorMiddleware(jwtMW, next)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{}`))
+	req.Header.Set("x-api-key", "hk_live_test_key")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if jwtInvoked {
+		t.Errorf("an x-api-key request must never reach the JWT path")
+	}
+	if !apiKeyInvoked {
+		t.Fatalf("an x-api-key request must reach the API-key path")
+	}
+	if sawAuthorization != "Bearer hk_live_test_key" {
+		t.Errorf("x-api-key must be normalised to Authorization: Bearer before the API-key path runs, got %q", sawAuthorization)
+	}
+	if rr.Code != http.StatusOK {
+		t.Errorf("status: want 200 got %d", rr.Code)
+	}
+}
+
+// TestAuthSelectorMiddlewareStillRoutesJWTBearerToJWTPath pins the JWT half of
+// the same selector, so the x-api-key normalisation added above cannot regress
+// a session bearer token (never hk_-prefixed, never x-api-key) onto the
+// API-key path.
+func TestAuthSelectorMiddlewareStillRoutesJWTBearerToJWTPath(t *testing.T) {
+	t.Setenv("OWUI_SHIM_KEY", "")
+
+	var jwtInvoked, apiKeyInvoked bool
+	jwtMW := func(http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			jwtInvoked = true
+			w.WriteHeader(http.StatusOK)
+		})
+	}
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		apiKeyInvoked = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := authSelectorMiddleware(jwtMW, next)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{}`))
+	req.Header.Set("Authorization", "Bearer some.jwt.token")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if !jwtInvoked || apiKeyInvoked {
+		t.Errorf("a non-hk_ Authorization bearer must route to the JWT path only, jwtInvoked=%v apiKeyInvoked=%v", jwtInvoked, apiKeyInvoked)
+	}
+}
+
 func waitFor(t *testing.T, cond func() bool) {
 	t.Helper()
 	deadline := time.Now().Add(2 * time.Second)

--- a/apps/edge-api/internal/anthropic/errors.go
+++ b/apps/edge-api/internal/anthropic/errors.go
@@ -1,0 +1,118 @@
+package anthropic
+
+import (
+	"encoding/json"
+	"net/http"
+
+	apierr "github.com/sakibsadmanshajib/hive/apps/edge-api/internal/errors"
+)
+
+// anthropicErrorEnvelope is the wire shape every real Anthropic Messages error
+// response uses: a top-level "type":"error" plus a nested error object, e.g.
+//
+//	{"type":"error","error":{"type":"authentication_error","message":"..."}}
+//
+// The rest of edge-api uses the OpenAI envelope ({"error":{"message","type",
+// "param","code"}}, no top-level "type"), which this surface used
+// unconditionally before this file existed. The Anthropic SDK's exception
+// CLASS selection keys off HTTP status, not body shape, so that half kept
+// working either way; but anthropic._exceptions.APIStatusError reads
+// body["error"]["type"] into its own .type attribute, and the OpenAI envelope
+// both lacks the wrapping "type":"error" and carries the wrong enum member
+// there (e.g. "UNAUTHORIZED", which is not one of Anthropic's documented
+// error types). A caller inspecting either field got nothing usable.
+type anthropicErrorEnvelope struct {
+	Type  string             `json:"type"`
+	Error anthropicErrorBody `json:"error"`
+}
+
+type anthropicErrorBody struct {
+	Type    string `json:"type"`
+	Message string `json:"message"`
+	// Code is a Hive extension carrying the finer-grained OpenAI-style error
+	// code where the delegated chain supplied one (e.g. "invalid_api_key").
+	// The real Anthropic API never sends this field; an Anthropic SDK ignores
+	// unknown JSON fields, so surfacing it here is additive, not a compliance
+	// risk, and keeps the detail available for anyone inspecting the raw body.
+	Code string `json:"code,omitempty"`
+}
+
+// anthropicErrorType maps an HTTP status to the closest member of Anthropic's
+// documented error-type enum: invalid_request_error, authentication_error,
+// permission_error, not_found_error, rate_limit_error, api_error,
+// overloaded_error, request_too_large. Status is authoritative here, not
+// whatever "type" string a delegated OpenAI-shaped body carried: status is
+// what actually drives the real SDK's exception class, so it is the one
+// value this surface must never get wrong.
+func anthropicErrorType(status int) string {
+	switch status {
+	case http.StatusBadRequest:
+		return "invalid_request_error"
+	case http.StatusUnauthorized:
+		return "authentication_error"
+	case http.StatusForbidden:
+		return "permission_error"
+	case http.StatusNotFound:
+		return "not_found_error"
+	case http.StatusRequestEntityTooLarge:
+		return "request_too_large"
+	case http.StatusTooManyRequests:
+		return "rate_limit_error"
+	case 529: // Anthropic's own "overloaded" status; we do not emit it today.
+		return "overloaded_error"
+	default:
+		return "api_error"
+	}
+}
+
+// writeAnthropicError writes the Anthropic-shaped error envelope. code is the
+// optional Hive-extension field (see anthropicErrorBody.Code) and may be "".
+func writeAnthropicError(w http.ResponseWriter, status int, message string, code string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(anthropicErrorEnvelope{
+		Type: "error",
+		Error: anthropicErrorBody{
+			Type:    anthropicErrorType(status),
+			Message: message,
+			Code:    code,
+		},
+	})
+}
+
+// reshapeToAnthropicError re-emits an already-sanitized OpenAI-shaped error
+// body (the delegated chat/inference chain's own refusal, which already ran
+// through the provider-blind sanitizer at the upstream boundary) in
+// Anthropic's envelope. message and code are extracted best-effort from raw;
+// raw may be non-JSON, carry no error object, or be empty, in which case a
+// generic message for the status is used instead. This never re-sanitizes:
+// it only reshapes an envelope that was already safe to return.
+func reshapeToAnthropicError(w http.ResponseWriter, status int, raw []byte) {
+	message, code := extractOpenAIErrorFields(raw)
+	if message == "" {
+		message = genericMessageForStatus(status)
+	}
+	writeAnthropicError(w, status, message, code)
+}
+
+func extractOpenAIErrorFields(raw []byte) (message string, code string) {
+	var body apierr.OpenAIError
+	if err := json.Unmarshal(raw, &body); err != nil {
+		return "", ""
+	}
+	if body.Error.Code != nil {
+		code = *body.Error.Code
+	}
+	return body.Error.Message, code
+}
+
+func genericMessageForStatus(status int) string {
+	switch status {
+	case http.StatusTooManyRequests:
+		return "the request was rate limited."
+	case http.StatusServiceUnavailable, http.StatusGatewayTimeout, http.StatusBadGateway:
+		return "the request could not be completed."
+	default:
+		return "the request failed."
+	}
+}

--- a/apps/edge-api/internal/anthropic/handler.go
+++ b/apps/edge-api/internal/anthropic/handler.go
@@ -12,7 +12,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/auth"
 	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/authz"
-	apierr "github.com/sakibsadmanshajib/hive/apps/edge-api/internal/errors"
 )
 
 const maxBodyBytes = 4 << 20 // 4 MiB
@@ -51,7 +50,7 @@ func NewHandler(deps Deps) *Handler {
 // ServeHTTP handles both POST /v1/messages and POST /v1/messages/count_tokens.
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		apierr.WriteError(w, http.StatusMethodNotAllowed, "invalid_request_error", "Method not allowed", nil)
+		writeAnthropicError(w, http.StatusMethodNotAllowed, "Method not allowed", "")
 		return
 	}
 
@@ -70,43 +69,43 @@ func (h *Handler) handleMessages(w http.ResponseWriter, r *http.Request) {
 	// for an API-key principal, which carries no session user.
 	if user, ok := auth.UserFrom(r.Context()); ok && user != nil {
 		if user.TenantID == uuid.Nil {
-			apierr.Write(w, http.StatusForbidden, apierr.CodeNoTenant, "no tenant for user")
+			writeAnthropicError(w, http.StatusForbidden, "no tenant for user", "")
 			return
 		}
 		if !authz.RoleHas(authz.Role(user.Role), authz.PermChatInvoke) {
-			apierr.Write(w, http.StatusForbidden, apierr.CodeForbidden, "chat not allowed")
+			writeAnthropicError(w, http.StatusForbidden, "chat not allowed", "")
 			return
 		}
 	}
 	if h.deps.OpenAIChat == nil {
 		// Fail closed. Without the delegated chain there is no route resolution
 		// and no metering, and this surface must never dispatch without both.
-		apierr.WriteError(w, http.StatusInternalServerError, "api_error", "internal error", nil)
+		writeAnthropicError(w, http.StatusInternalServerError, "internal error", "")
 		return
 	}
 
 	raw, err := io.ReadAll(io.LimitReader(r.Body, maxBodyBytes))
 	if err != nil {
-		apierr.WriteError(w, http.StatusBadRequest, "invalid_request_error", "body read error", nil)
+		writeAnthropicError(w, http.StatusBadRequest, "body read error", "")
 		return
 	}
 
 	var req MessagesRequest
 	if err := json.Unmarshal(raw, &req); err != nil {
-		apierr.WriteError(w, http.StatusBadRequest, "invalid_request_error", "invalid JSON body", nil)
+		writeAnthropicError(w, http.StatusBadRequest, "invalid JSON body", "")
 		return
 	}
 
 	if req.Model == "" {
-		apierr.WriteError(w, http.StatusBadRequest, "invalid_request_error", "model is required", nil)
+		writeAnthropicError(w, http.StatusBadRequest, "model is required", "")
 		return
 	}
 	if len(req.Messages) == 0 {
-		apierr.WriteError(w, http.StatusBadRequest, "invalid_request_error", "messages is required and must be non-empty", nil)
+		writeAnthropicError(w, http.StatusBadRequest, "messages is required and must be non-empty", "")
 		return
 	}
 	if req.MaxTokens <= 0 {
-		apierr.WriteError(w, http.StatusBadRequest, "invalid_request_error", "max_tokens is required and must be greater than 0", nil)
+		writeAnthropicError(w, http.StatusBadRequest, "max_tokens is required and must be greater than 0", "")
 		return
 	}
 
@@ -116,7 +115,7 @@ func (h *Handler) handleMessages(w http.ResponseWriter, r *http.Request) {
 
 	oaiReq, err := ToOAIRequest(req)
 	if err != nil {
-		apierr.WriteError(w, http.StatusBadRequest, "invalid_request_error", "request translation failed", nil)
+		writeAnthropicError(w, http.StatusBadRequest, "request translation failed", "")
 		return
 	}
 
@@ -131,7 +130,7 @@ func (h *Handler) handleMessages(w http.ResponseWriter, r *http.Request) {
 
 	body, err := json.Marshal(oaiReq)
 	if err != nil {
-		apierr.WriteError(w, http.StatusInternalServerError, "api_error", "internal error", nil)
+		writeAnthropicError(w, http.StatusInternalServerError, "internal error", "")
 		return
 	}
 
@@ -158,27 +157,27 @@ func (h *Handler) handleMessages(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) handleCountTokens(w http.ResponseWriter, r *http.Request) {
 	user, ok := auth.UserFrom(r.Context())
 	if !ok || user == nil {
-		apierr.Write(w, http.StatusUnauthorized, apierr.CodeUnauthenticated, "missing user")
+		writeAnthropicError(w, http.StatusUnauthorized, "missing user", "")
 		return
 	}
 	if user.TenantID == uuid.Nil {
-		apierr.Write(w, http.StatusForbidden, apierr.CodeNoTenant, "no tenant for user")
+		writeAnthropicError(w, http.StatusForbidden, "no tenant for user", "")
 		return
 	}
 	if !authz.RoleHas(authz.Role(user.Role), authz.PermChatInvoke) {
-		apierr.Write(w, http.StatusForbidden, apierr.CodeForbidden, "chat not allowed")
+		writeAnthropicError(w, http.StatusForbidden, "chat not allowed", "")
 		return
 	}
 
 	raw, err := io.ReadAll(io.LimitReader(r.Body, maxBodyBytes))
 	if err != nil {
-		apierr.WriteError(w, http.StatusBadRequest, "invalid_request_error", "body read error", nil)
+		writeAnthropicError(w, http.StatusBadRequest, "body read error", "")
 		return
 	}
 
 	var req MessagesRequest
 	if err := json.Unmarshal(raw, &req); err != nil {
-		apierr.WriteError(w, http.StatusBadRequest, "invalid_request_error", "invalid JSON body", nil)
+		writeAnthropicError(w, http.StatusBadRequest, "invalid JSON body", "")
 		return
 	}
 

--- a/apps/edge-api/internal/anthropic/handler_test.go
+++ b/apps/edge-api/internal/anthropic/handler_test.go
@@ -534,6 +534,100 @@ func TestHandler_CountTokens(t *testing.T) {
 	}
 }
 
+// anthropicErrorEnvelope mirrors the wire shape a real Anthropic SDK parses
+// (top-level "type":"error", nested error.type/error.message), decoded here
+// rather than via an exported Hive type: what matters is the JSON a client
+// actually receives, not an internal Go representation of it.
+type anthropicErrorEnvelope struct {
+	Type  string `json:"type"`
+	Error struct {
+		Type    string `json:"type"`
+		Message string `json:"message"`
+		Code    string `json:"code"`
+	} `json:"error"`
+}
+
+// TestHandler_ValidationErrorUsesAnthropicEnvelope is the compliance guard for
+// this surface's own refusals (never delegated): before this, every one used
+// the OpenAI envelope ({"error":{"message","type"}}, no top-level "type"),
+// which the real Anthropic SDK's exception .type attribute reads as
+// body["error"]["type"] and never finds without the wrapper.
+func TestHandler_ValidationErrorUsesAnthropicEnvelope(t *testing.T) {
+	h := anthropic.NewHandler(anthropic.Deps{OpenAIChat: &fakeChat{}})
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, newAuthedRequest(t, `{"model":"m","messages":[{"role":"user","content":"hi"}]}`)) // missing max_tokens
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: want 400 got %d", rec.Code)
+	}
+	var got anthropicErrorEnvelope
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v body=%s", err, rec.Body.String())
+	}
+	if got.Type != "error" {
+		t.Errorf(`top-level type: want "error" got %q`, got.Type)
+	}
+	if got.Error.Type != "invalid_request_error" {
+		t.Errorf("error.type: want invalid_request_error got %q", got.Error.Type)
+	}
+	if got.Error.Message == "" {
+		t.Error("error.message: want non-empty")
+	}
+}
+
+// TestHandler_DownstreamErrorUsesAnthropicEnvelope is the same guard for a
+// delegated refusal, reshaped rather than forwarded verbatim in the OpenAI
+// envelope it arrived in.
+func TestHandler_DownstreamErrorUsesAnthropicEnvelope(t *testing.T) {
+	chat := &fakeChat{respond: respondStatus(http.StatusForbidden,
+		`{"error":{"message":"model not available for this workspace","type":"forbidden"}}`)}
+	h := anthropic.NewHandler(anthropic.Deps{OpenAIChat: chat})
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, newAuthedRequest(t,
+		`{"model":"hive-premium","messages":[{"role":"user","content":"hi"}],"max_tokens":5}`))
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status: want 403 got %d", rec.Code)
+	}
+	var got anthropicErrorEnvelope
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v body=%s", err, rec.Body.String())
+	}
+	if got.Type != "error" {
+		t.Errorf(`top-level type: want "error" got %q`, got.Type)
+	}
+	// Status drives the mapped type, not whatever the delegated chain's own
+	// OpenAI-shaped "type" string said ("forbidden" is not a member of
+	// Anthropic's error-type enum; "permission_error" is the 403 mapping).
+	if got.Error.Type != "permission_error" {
+		t.Errorf("error.type: want permission_error got %q", got.Error.Type)
+	}
+	if got.Error.Message != "model not available for this workspace" {
+		t.Errorf("error.message: want the delegated refusal text got %q", got.Error.Message)
+	}
+}
+
+// TestHandler_UpstreamErrorUsesAnthropicEnvelope pins the same shape on the
+// writeUpstreamError path (an empty or oversized delegated response).
+func TestHandler_UpstreamErrorUsesAnthropicEnvelope(t *testing.T) {
+	chat := &fakeChat{respond: func(w http.ResponseWriter, r *http.Request) {}}
+	h := anthropic.NewHandler(anthropic.Deps{OpenAIChat: chat})
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, newAuthedRequest(t,
+		`{"model":"hive-fast","messages":[{"role":"user","content":"hi"}],"max_tokens":5}`))
+
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status: want 502 got %d", rec.Code)
+	}
+	var got anthropicErrorEnvelope
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v body=%s", err, rec.Body.String())
+	}
+	if got.Type != "error" || got.Error.Type != "api_error" {
+		t.Errorf("envelope: want type=error error.type=api_error got type=%q error.type=%q", got.Type, got.Error.Type)
+	}
+}
+
 func TestHandler_CountTokens_BadJSON(t *testing.T) {
 	h := anthropic.NewHandler(anthropic.Deps{OpenAIChat: &fakeChat{}})
 	req := newAuthedRequest(t, `{bad}`)

--- a/apps/edge-api/internal/anthropic/translate_writer.go
+++ b/apps/edge-api/internal/anthropic/translate_writer.go
@@ -11,6 +11,28 @@ import (
 	apierr "github.com/sakibsadmanshajib/hive/apps/edge-api/internal/errors"
 )
 
+// headerlessRecorder is a minimal http.ResponseWriter that only captures a
+// status and body, used to invoke apierr.WriteProviderBlindUpstreamError (the
+// single source of truth for the provider-blind sanitizer) without a real
+// client connection, so its OpenAI-shaped output can be reshaped into the
+// Anthropic envelope below rather than duplicating the sanitizer's regexes.
+type headerlessRecorder struct {
+	header http.Header
+	status int
+	body   bytes.Buffer
+}
+
+func (r *headerlessRecorder) Header() http.Header {
+	if r.header == nil {
+		r.header = make(http.Header)
+	}
+	return r.header
+}
+
+func (r *headerlessRecorder) WriteHeader(status int) { r.status = status }
+
+func (r *headerlessRecorder) Write(p []byte) (int, error) { return r.body.Write(p) }
+
 // maxTranslatedBodyBytes bounds how much of a buffered response the translator
 // holds in memory, matching the ceiling the OpenAI sync path already applies
 // when reading an upstream body.
@@ -181,18 +203,21 @@ func (t *translatingWriter) finish() error {
 	}
 }
 
+// forwardError reshapes a non-2xx delegated response into the Anthropic error
+// envelope. The delegated chain already ran the response through the
+// provider-blind sanitizer at the upstream boundary (WriteProviderBlindUpstreamError
+// for the empty/overflow case, or its own refusal body otherwise); this only
+// changes the wire shape, never the sanitized content, so a real Anthropic
+// SDK client can parse the result instead of silently getting an envelope its
+// exception classes were never built to read.
 func (t *translatingWriter) forwardError() {
 	if t.overflow || t.body.Len() == 0 {
-		apierr.WriteProviderBlindUpstreamError(t.dst, t.clientAlias, t.status, "")
+		rec := &headerlessRecorder{}
+		apierr.WriteProviderBlindUpstreamError(rec, t.clientAlias, t.status, "")
+		reshapeToAnthropicError(t.dst, t.status, rec.body.Bytes())
 		return
 	}
-	contentType := t.header.Get("Content-Type")
-	if contentType == "" {
-		contentType = "application/json"
-	}
-	t.dst.Header().Set("Content-Type", contentType)
-	t.dst.WriteHeader(t.status)
-	_, _ = t.dst.Write(t.body.Bytes())
+	reshapeToAnthropicError(t.dst, t.status, t.body.Bytes())
 }
 
 func (t *translatingWriter) writeTranslated() error {
@@ -225,8 +250,7 @@ func (t *translatingWriter) writeTranslated() error {
 }
 
 func (t *translatingWriter) writeUpstreamError(message string) {
-	code := "upstream_error"
-	apierr.WriteError(t.dst, http.StatusBadGateway, "api_error", message, &code)
+	writeAnthropicError(t.dst, http.StatusBadGateway, message, "upstream_error")
 }
 
 // parseOAIResult reads a completed OpenAI-shaped response, accepting either a

--- a/docs/anthropic-sdk-integration.md
+++ b/docs/anthropic-sdk-integration.md
@@ -1,0 +1,160 @@
+# Pointing a real Anthropic SDK at Hive
+
+This is the exact, tested path for using an unmodified Anthropic SDK client
+(or an Anthropic-Messages-compatible agent CLI) against Hive by changing only
+the base URL and the API key. Every claim below was verified against the live
+deployed gateway and the real, installed `anthropic` SDK (Python 0.122.0) on
+2026-08-17, not assumed from memory. See
+`apps/edge-api/internal/anthropic/` for the implementation and
+`apps/edge-api/internal/anthropic/*_test.go` for the test suite this doc is
+backed by.
+
+## Base URL
+
+```
+https://api-hive.scubed.co
+```
+
+No `/v1` suffix. The Anthropic SDK's default `base_url` convention
+(`https://api.anthropic.com`) carries no path suffix; the SDK appends
+`/v1/messages` itself. This is the opposite convention from the
+OpenAI-compatible surface, whose base URL in this repo already includes `/v1`
+(`https://api-hive.scubed.co/v1`) — getting this backwards is the most common
+way to break an otherwise-correct integration.
+
+## Auth header
+
+`x-api-key: <API_KEY>` — the SDK's default when constructed with `api_key=`.
+Hive also accepts `Authorization: Bearer <API_KEY>` (the `auth_token=`
+constructor argument in the Python/TS SDKs), which reaches the same code path.
+The key itself is a Hive API key (`hk_...`), minted from the developer console
+(`https://console-hive.scubed.co/console/api-keys`), not an Anthropic key —
+Hive never talks to Anthropic itself; it translates the wire protocol and
+dispatches to whichever provider the requested alias routes to.
+
+## Python
+
+```python
+from anthropic import Anthropic
+
+client = Anthropic(
+    base_url="https://api-hive.scubed.co",
+    api_key="<API_KEY>",
+)
+
+message = client.messages.create(
+    model="hive-fast",
+    max_tokens=256,
+    messages=[{"role": "user", "content": "Hello"}],
+)
+print(message.content[0].text)
+```
+
+Streaming:
+
+```python
+with client.messages.stream(
+    model="hive-fast",
+    max_tokens=256,
+    messages=[{"role": "user", "content": "Hello"}],
+) as stream:
+    for text in stream.text_stream:
+        print(text, end="", flush=True)
+```
+
+## TypeScript
+
+```ts
+import Anthropic from "@anthropic-ai/sdk";
+
+const client = new Anthropic({
+  baseURL: "https://api-hive.scubed.co",
+  apiKey: "<API_KEY>",
+});
+
+const message = await client.messages.create({
+  model: "hive-fast",
+  max_tokens: 256,
+  messages: [{ role: "user", content: "Hello" }],
+});
+```
+
+## Model aliases that actually work on /v1/messages
+
+Live from `GET https://api-hive.scubed.co/catalog/models` (no auth required,
+provider-blind by design — it never names the upstream provider):
+
+| Alias | What it is |
+| --- | --- |
+| `hive-default` | Balanced default, stable |
+| `hive-fast` | Low-latency, stable |
+| `hive-auto` | Preview, widens internally when needed |
+
+`hive-embedding-default`, `hive-stt`, `hive-tts` also appear in the catalog but
+are not chat models and do not answer `/v1/messages`. An alias not in this
+list, or a real upstream route id (e.g. anything starting `route-`), is
+refused with a provider-blind 404 before any upstream dispatch happens — this
+is enforced behavior, not a bug (see `TestMessages_RawLiteLLMRouteIDIsRefused
+AndNeverDispatched`).
+
+## Agent CLI config (OpenCode / Claude-Code-compatible clients)
+
+Any CLI that lets you override an Anthropic-compatible provider's base URL and
+key works the same way. For a config shaped like OpenCode's provider block:
+
+```json
+{
+  "provider": {
+    "hive": {
+      "npm": "@ai-sdk/anthropic",
+      "options": {
+        "baseURL": "https://api-hive.scubed.co",
+        "apiKey": "<API_KEY>"
+      },
+      "models": {
+        "hive-fast": {},
+        "hive-default": {},
+        "hive-auto": {}
+      }
+    }
+  }
+}
+```
+
+## Known limitations (verified, not guessed)
+
+- **`x-api-key` authentication requires this PR's fix to be deployed.**
+  Before it, every `/v1/messages` request authenticated with the SDK's default
+  `api_key=` construction 401s with `missing bearer`, regardless of key
+  validity — reproduced live against the deployed box with the real SDK. If
+  you hit that specific error, the fix has not deployed yet; using
+  `auth_token=` instead of `api_key=` (forcing an `Authorization: Bearer`
+  header) is the workaround, not a normal part of this integration.
+- **Error envelope is Anthropic-shaped only for errors this surface itself
+  raises or forwards from a resolved request** (bad model, bad request body,
+  a resolved key's own refusal). A request that fails before it ever resolves
+  a key at all (a session-only guard, a global rate limit) still returns the
+  pre-existing generic envelope. The SDK still raises the correct exception
+  **class** either way (`AuthenticationError`, `RateLimitError`, etc., driven
+  by HTTP status), but `err.type` and `err.request_id` may be empty on that
+  narrower set of errors.
+- **Extended thinking, prompt caching, and server-side tools
+  (`thinking`/`redacted_thinking` blocks, `cache_control`, `container`,
+  `service_tier`, `inference_geo`) are not implemented.** Neither of Hive's two
+  configured providers (OpenRouter, Groq) supports Anthropic's native versions
+  of these, so this is a provider-capability gap, not an oversight. Sending
+  these fields is silently ignored rather than erroring.
+- **`top_k` is not passed through.** OpenAI-shaped chat completions (what
+  every request is lowered to before dispatch) has no equivalent field.
+- **`stop_reason` is never `"stop_sequence"` and `stop_sequence` is always
+  null**, even when a custom stop sequence was actually what stopped
+  generation. The underlying OpenAI-shaped `finish_reason` never distinguishes
+  "stopped naturally" from "matched a stop sequence," so this cannot be
+  recovered without a provider-side capability neither OpenRouter nor Groq
+  exposes today.
+- **A non-streaming request with a very large `max_tokens` may be rejected
+  client-side by the SDK itself** before any request reaches Hive at all (the
+  SDK estimates whether a non-streaming call could exceed ~10 minutes and
+  raises `ValueError` rather than sending it). Use `stream=True` /
+  `.messages.stream(...)` for long-running generations, which is standard
+  Anthropic SDK guidance, not a Hive-specific requirement.


### PR DESCRIPTION
## Summary

A real Anthropic SDK client constructed the documented way (`Anthropic(api_key=...)`) sends its credential on `x-api-key`, never `Authorization`. Confirmed directly from the installed SDK's own source: `_api_key_auth` returns `{"X-Api-Key": api_key}`; `Authorization` only appears when the caller passes `auth_token=` instead.

`apps/edge-api/internal/anthropic/handler.go` already ships `APIKeyNormalizer`, unit-tested in isolation, which rewrites `x-api-key` to `Authorization: Bearer`. The bug was entirely in where it was wired: `main.go` applied it only at the mux leaf (`mux.Handle("/v1/messages", anthropic.APIKeyNormalizer(anthropicHandler))`), but `authSelectorMiddleware` (which decides API-key vs JWT path by inspecting `Authorization`) wraps the **entire mux** and runs first. Every `x-api-key`-only request had no `Authorization` header at the point the selector decided, fell through to the JWT path unconditionally, and 401'd with `"missing bearer"` regardless of key validity.

**Reproduced live** against the deployed gateway (`https://api-hive.scubed.co`) with the real `anthropic` Python SDK (0.122.0): the default `api_key=` construction always 401s with `missing bearer`; the same call with `auth_token=` (forcing an `Authorization` header directly) reaches the real API-key path instead. This is the empirical confirmation that the owner's literal ask — point a real SDK at Hive by changing only `base_url` and the key — could not have worked on any key before this fix.

## Fix

- `authSelectorMiddleware` (`apps/edge-api/cmd/server/main.go`): apply `anthropic.APIKeyNormalizer` around the selector itself, so `x-api-key` is normalized before `auth.Selector` inspects `Authorization`, for every `/v1/*` route. No-op wherever `Authorization` is already set.
- New `apps/edge-api/internal/anthropic/errors.go`: reshapes every `/v1/messages` error this surface owns (its own validation refusals, and delegated-chain errors it forwards) into Anthropic's real error envelope (`{"type":"error","error":{"type","message"}}`) instead of the OpenAI-shaped one used unconditionally before. Verified live against `api.anthropic.com` and the installed SDK's `_exceptions.py`: the SDK's exception **class** is driven by HTTP status, not body shape, so this never crashed a client, but `err.type` read values outside Anthropic's documented enum and `err.request_id` was always empty. Reuses the existing provider-blind sanitizer verbatim (through a small local `http.ResponseWriter` capture) rather than duplicating its regexes; no sanitization logic changed.
- `docs/anthropic-sdk-integration.md`: exact base URL, auth header, copy-pasteable Python/TypeScript snippets, an OpenCode-style config, the model aliases that actually answer `/v1/messages` (`hive-default`, `hive-fast`, `hive-auto`, live from `GET /catalog/models`), and every known limitation found during this pass, each one verified rather than assumed.

## Documented, not fixed here (filed as follow-up, out of this pass's scope)

- Errors emitted **before** the request reaches the anthropic package at all (the selector's own 401, `budgetGate`'s 429) still use the generic envelope: fixing those touches shared `internal/middleware`/`internal/errors` code used by every other surface, a materially larger blast radius, deliberately deferred.
- `middleware.CompatHeaders()` (global, unconditional) stamps `x-request-id`/`openai-version`/`openai-processing-ms` on every response including `/v1/messages` — confirmed live. Harmless to the SDK (unknown headers ignored) but means `.request_id` stays empty and leaks OpenAI-family headers onto an Anthropic-shaped endpoint.
- `top_k`, extended thinking (`thinking`/`redacted_thinking` blocks), prompt caching (`cache_control`), `container`/server tools, `service_tier`, `inference_geo`, and stop-sequence identification in the response are not implemented. Neither of Hive's two configured providers (OpenRouter, Groq) supports Anthropic's native versions of these, so these are provider-capability gaps, not oversights.

## Test plan

- [x] `TestAuthSelectorMiddlewareAcceptsXAPIKeyHeader` — RED before the fix (confirmed), GREEN after
- [x] `TestAuthSelectorMiddlewareStillRoutesJWTBearerToJWTPath` — regression guard, a non-hk_ session bearer still routes to the JWT path only
- [x] `TestHandler_ValidationErrorUsesAnthropicEnvelope`, `TestHandler_DownstreamErrorUsesAnthropicEnvelope`, `TestHandler_UpstreamErrorUsesAnthropicEnvelope` — new envelope shape assertions
- [x] Full existing `apps/edge-api/internal/anthropic/...` suite passes unchanged (message/status assertions matched verbatim; only the envelope changed)
- [x] Full `apps/edge-api/...` suite green (`go test ./apps/edge-api/... -count=1 -short`)
- [x] `go vet ./apps/edge-api/...` clean
- [x] Live reproduction of the bug and the intended fix behavior against the deployed box, with the real Anthropic Python SDK, both pre- and post-fix code paths (not deployed yet; deploy is the orchestrator's step)

## Buglog entry

```json
{"date":"2026-08-17","error_message":"real Anthropic SDK client 401s with 'missing bearer' regardless of API key validity when pointed at Hive with only base_url and api_key set","root_cause":"authSelectorMiddleware inspects only the Authorization header and runs outside the mux; anthropic.APIKeyNormalizer (x-api-key -> Authorization: Bearer) was wired only at the mux leaf for /v1/messages, so it never ran before the selector's routing decision","fix":"apply anthropic.APIKeyNormalizer around the selector itself in authSelectorMiddleware (apps/edge-api/cmd/server/main.go), before auth.Selector inspects Authorization","tags":["anthropic","auth","edge-api","x-api-key","routing"]}
```

## Boundary honored

No billing, reservation, ledger, or metering code touched (a separate agent owns that concurrently). No API key, token, or credential value printed anywhere in this PR or its tests (all test keys are obvious literals: `hk_test_key`, `hk_bogus_test_key_...`).