### PR TITLE
test: prove reaper SQL and panic-survives-release live, full billing audit

### DIFF
--- a/apps/control-plane/internal/accounting/reaper_live_test.go
+++ b/apps/control-plane/internal/accounting/reaper_live_test.go
@@ -1,0 +1,174 @@
+package accounting
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/ledger"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/usage"
+)
+
+// The reaper's own regression suite (reaper_test.go) proves RunOnce's control
+// flow against a hand-written reaperLedger and an in-memory staleReservationLister
+// stub: neither ever executes ListStaleReservations' real SQL. That query is the
+// entire reason the reaper exists (issue #616): a hold the money path failed to
+// release is only ever found by it, and it is the one piece of this package
+// that has never run against a real Postgres before this file. A wrong column,
+// an inverted cutoff comparison, or a type mismatch between
+// credit_reservations.id and batches.reservation_id (uuid vs text, cast with
+// ::text in the query) would pass every mocked test in this package and still
+// leave every stranded hold on the demo box un-found.
+//
+// Gated on HIVE_TEST_DB_URL, same convention as the package's other _live tests.
+
+func TestReaperRunOnce_Live(t *testing.T) {
+	pool := newAccountingTestPool(t)
+	ctx := context.Background()
+
+	accountID := seedReleaseIdempotencyAccount(t, pool)
+	ledgerSvc := ledger.NewService(ledger.NewPgxRepository(pool))
+	usageSvc := usage.NewService(usage.NewPgxRepository(pool))
+	repo := NewPgxRepository(pool)
+	svc := NewService(repo, ledgerSvc, usageSvc)
+
+	if _, err := ledgerSvc.GrantCredits(ctx, accountID, uuid.NewString(), 100000, map[string]any{"reason": "reaper live test grant"}); err != nil {
+		t.Fatalf("grant credits: %v", err)
+	}
+
+	// Genuinely stale: a hold nothing ever settled, backdated past the TTL.
+	stale := createTestReservation(t, ctx, svc, accountID, "/v1/chat/completions", "hive-fast", 4000)
+	backdateReservation(t, ctx, pool, stale.ID, 2*time.Hour)
+
+	// Positive control: a reservation created moments ago must not be treated
+	// as abandoned. Without this, a reaper that released EVERY active/expanded
+	// row regardless of age would still pass the assertion on `stale` alone.
+	fresh := createTestReservation(t, ctx, svc, accountID, "/v1/chat/completions", "hive-fast", 1500)
+
+	// Stale AND attached to a batch still in flight: ListStaleReservations must
+	// exclude it structurally (a batch legitimately holds credits for its whole
+	// 24h completion window), never by the age check alone.
+	inFlightBatch := createTestReservation(t, ctx, svc, accountID, "/v1/batches", "hive-fast", 9000)
+	backdateReservation(t, ctx, pool, inFlightBatch.ID, 2*time.Hour)
+	seedBatchRow(t, ctx, pool, accountID, inFlightBatch.ID, "in_progress")
+
+	// Stale AND attached to a batch that has already reached a terminal status:
+	// the batch link must not exclude it forever, only while the batch is
+	// genuinely running. This is the case that would silently strand a hold
+	// permanently if the NOT IN status list in the query were wrong (e.g. it
+	// listed no terminal statuses at all, or listed the wrong ones).
+	doneBatch := createTestReservation(t, ctx, svc, accountID, "/v1/batches", "hive-fast", 2500)
+	backdateReservation(t, ctx, pool, doneBatch.ID, 2*time.Hour)
+	seedBatchRow(t, ctx, pool, accountID, doneBatch.ID, "completed")
+
+	reaper := NewReaper(repo, svc, ReaperConfig{TTL: time.Hour})
+	result, err := reaper.RunOnce(ctx)
+	if err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	released := map[uuid.UUID]bool{}
+	for _, r := range []Reservation{stale, inFlightBatch, doneBatch, fresh} {
+		row, err := repo.GetReservation(ctx, accountID, r.ID)
+		if err != nil {
+			t.Fatalf("reload reservation %s: %v", r.ID, err)
+		}
+		released[r.ID] = row.Status == ReservationStatusReleased
+	}
+
+	if !released[stale.ID] {
+		t.Fatalf("expected the genuinely stale reservation to be released by RunOnce, status stayed unreleased")
+	}
+	if released[fresh.ID] {
+		t.Fatalf("RunOnce released a reservation created moments ago; ListStaleReservations must only match rows older than the TTL cutoff")
+	}
+	if released[inFlightBatch.ID] {
+		t.Fatalf("RunOnce released a hold whose batch is still in_progress; the batch-exclusion subquery must keep this reservation out of the candidate scan")
+	}
+	if !released[doneBatch.ID] {
+		t.Fatalf("RunOnce left a stale hold alone because its batch was 'completed'; a terminal batch status must not exclude the reservation from reaping")
+	}
+
+	if result.Scanned < 2 {
+		t.Fatalf("expected RunOnce to have scanned at least the two eligible stale reservations (stale, doneBatch), got Scanned=%d", result.Scanned)
+	}
+	if result.Released < 2 {
+		t.Fatalf("expected RunOnce to report at least 2 released, got %d", result.Released)
+	}
+
+	// The released hold's credits must actually be back on the books, read
+	// straight off GetBalance rather than trusting the reservation row alone.
+	balance, err := ledgerSvc.GetBalance(ctx, accountID)
+	if err != nil {
+		t.Fatalf("GetBalance: %v", err)
+	}
+	// Only the in-flight batch's 9000 should still be held: stale (4000),
+	// fresh is not reaped but is still open (1500), and doneBatch (2500) was
+	// released. So reserved = fresh's 1500 + inFlightBatch's 9000 = 10500.
+	const wantReserved = int64(1500 + 9000)
+	if balance.ReservedCredits != wantReserved {
+		t.Fatalf("reserved credits after reaping = %d, want %d (fresh 1500 + in-flight-batch 9000 still held; stale 4000 and doneBatch 2500 released)",
+			balance.ReservedCredits, wantReserved)
+	}
+}
+
+func createTestReservation(t *testing.T, ctx context.Context, svc *Service, accountID uuid.UUID, endpoint, alias string, credits int64) Reservation {
+	t.Helper()
+	reservation, err := svc.CreateReservation(ctx, CreateReservationInput{
+		AccountID:        accountID,
+		RequestID:        uuid.NewString(),
+		AttemptNumber:    1,
+		Endpoint:         endpoint,
+		ModelAlias:       alias,
+		EstimatedCredits: credits,
+	})
+	if err != nil {
+		t.Fatalf("CreateReservation: %v", err)
+	}
+	return reservation
+}
+
+// backdateReservation pushes created_at and updated_at back by `age`, the only
+// way to make a reservation look abandoned to ListStaleReservations without
+// waiting out a real TTL. Both columns move together, matching what a
+// never-touched-since-creation row looks like; the query requires both to
+// precede the cutoff.
+func backdateReservation(t *testing.T, ctx context.Context, pool *pgxpool.Pool, reservationID uuid.UUID, age time.Duration) {
+	t.Helper()
+	cutoff := time.Now().UTC().Add(-age)
+	if _, err := pool.Exec(ctx,
+		`UPDATE public.credit_reservations SET created_at = $2, updated_at = $2 WHERE id = $1`,
+		reservationID, cutoff); err != nil {
+		t.Fatalf("backdate reservation: %v", err)
+	}
+}
+
+// seedBatchRow inserts the minimum public.files + public.batches rows needed
+// to exercise ListStaleReservations' batch-exclusion subquery, which joins on
+// b.reservation_id = cr.id::text. Real column types, real cast, no shortcuts:
+// a mismatch here is exactly what would make the subquery silently match
+// nothing and let a genuinely in-flight batch's hold be reaped out from under it.
+func seedBatchRow(t *testing.T, ctx context.Context, pool *pgxpool.Pool, accountID, reservationID uuid.UUID, status string) {
+	t.Helper()
+	fileID := "file-" + uuid.NewString()
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO public.files (id, account_id, purpose, filename, bytes, storage_path)
+		 VALUES ($1, $2, 'batch', 'input.jsonl', 10, 'test/'||$1)`,
+		fileID, accountID.String()); err != nil {
+		t.Fatalf("seed batch input file: %v", err)
+	}
+	batchID := "batch-" + uuid.NewString()
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO public.batches (id, account_id, input_file_id, endpoint, status, reservation_id)
+		 VALUES ($1, $2, $3, '/v1/chat/completions', $4, $5)`,
+		batchID, accountID.String(), fileID, status, reservationID.String()); err != nil {
+		t.Fatalf("seed batch row: %v", err)
+	}
+	t.Cleanup(func() {
+		cleanupCtx := context.Background()
+		_, _ = pool.Exec(cleanupCtx, `DELETE FROM public.batches WHERE id = $1`, batchID)
+		_, _ = pool.Exec(cleanupCtx, `DELETE FROM public.files WHERE id = $1`, fileID)
+	})
+}

--- a/apps/edge-api/internal/chat/dispatch_panic_test.go
+++ b/apps/edge-api/internal/chat/dispatch_panic_test.go
@@ -1,0 +1,113 @@
+package chat_test
+
+// Panic-survives-defer regression guard for the session chat dispatch path.
+//
+// dispatch.go registers its reservation release via `defer func() { ... }()`
+// immediately after the hold is taken, specifically so a client disconnect,
+// an upstream drop, or any other abnormal exit still frees the customer's
+// credits (#616, #746). Go's defer semantics already guarantee this holds
+// even across a panic unwind, but nothing in the existing suite exercises
+// that: every other test in this package returns normally or via a plain
+// error path. A refactor that swapped the deferred release for an
+// if-err-then-release check at the tail of ServeHTTP would drop this
+// protection silently -- every other test would stay green, because none of
+// them panics mid-dispatch -- and a request that happened to panic in
+// production (a nil-pointer bug in response parsing, say) would strand the
+// hold forever with no test catching the regression. This proves the
+// structural guarantee directly rather than trusting it never gets refactored
+// away.
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/auth"
+	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/chat"
+	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/inference"
+	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/metering"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// panicOnBodyReadTransport performs the real round trip to the fake upstream,
+// then swaps the response body for one that panics on its first Read call.
+// The panic therefore surfaces exactly where dispatch.go's SSE scanner reads
+// the upstream body: deep inside ServeHTTP, well after the reservation hold
+// and its deferred release are already registered, and before settled is ever
+// set true.
+type panicOnBodyReadTransport struct {
+	inner http.RoundTripper
+}
+
+func (t panicOnBodyReadTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.inner.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+	_ = resp.Body.Close()
+	resp.Body = panicReadCloser{}
+	return resp, nil
+}
+
+type panicReadCloser struct{}
+
+func (panicReadCloser) Read(_ []byte) (int, error) {
+	panic("simulated: upstream response body panicked mid-read")
+}
+
+func (panicReadCloser) Close() error { return nil }
+
+func TestDispatchReleasesReservationEvenWhenTheResponseBodyPanics(t *testing.T) {
+	// The real body upstream sends is irrelevant: panicOnBodyReadTransport
+	// discards it and substitutes a reader that panics on first Read. Only
+	// the status code and headers dispatch.go inspects before reading the
+	// body (200, text/event-stream) need to be real.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\n"))
+	}))
+	t.Cleanup(upstream.Close)
+
+	tenantID := uuid.New()
+	userID := uuid.New()
+
+	fake := &fakeAccounting{}
+	accounting := inference.NewAccountingClient(fake.server(t).URL)
+	billing := stubBilling{state: metering.TenantBillingState{
+		AccountID: uuid.New(), Found: true, Deployment: metering.DeploymentHiveCloud,
+	}}
+
+	handler := chat.NewDispatch(chat.Deps{
+		Routing:    pricedRouting(t, "route-hive-fast", 10_500, 42_000),
+		Accounting: accounting,
+		Billing:    billing,
+		LiteLLMURL: upstream.URL,
+		DeploySHA:  "test",
+		Env:        "test",
+		HTTP:       &http.Client{Transport: panicOnBodyReadTransport{inner: http.DefaultTransport}},
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"hive-fast","messages":[{"role":"user","content":"hi"}]}`))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(auth.WithUser(req.Context(), &auth.User{
+		ID: userID, TenantID: tenantID, Role: "member", Email: "member@example.test",
+	}))
+	rec := httptest.NewRecorder()
+
+	func() {
+		defer func() {
+			r := recover()
+			require.NotNil(t, r, "expected the simulated body-read panic to propagate out of ServeHTTP; if it did not, this test no longer exercises the panic path it exists to guard")
+		}()
+		handler.ServeHTTP(rec, req)
+	}()
+
+	_, finalized, released := fake.calls()
+	require.Empty(t, finalized, "a request that panicked mid-stream produced nothing billable; it must not be finalized as a charge")
+	require.Len(t, released, 1, "reservation must be released even though the handler panicked before reaching its normal settlement path")
+}


### PR DESCRIPTION
## Summary

Owner asked for a full audit of the billing/metering/reservation/ledger path: reservations released on every terminal path, no path serves a request unbilled, both directions billed correctly, math/big everywhere, Anthropic surface metered identically to OpenAI. This PR is the audit's code output: two new regression tests proving the two real gaps found. No production code changed.

## Audit method

1. Read `.wolf/decisions.md` D-031 through D-034 (credit unit, one-model-one-price, non-token modality rejection, fail-closed money path) and the extensive in-code documentation of prior incidents (#616 stranded holds, #626 three days unbilled, #652/#663/#672 idempotency key shape, #688 catalog-price settlement, #746 session chat free-serve, #918 reservation/hold atomicity).
2. Read every dispatch site end to end: `apps/edge-api/internal/chat/dispatch.go` and `billing.go` (session chat), `apps/edge-api/internal/inference/orchestrator.go` and `stream.go` (API-key sync and streaming), `apps/edge-api/internal/anthropic/handler.go` (Anthropic Messages surface), and the control-plane side: `apps/control-plane/internal/accounting/service.go`, `repository.go`, `reaper.go`, `apps/control-plane/internal/ledger/service.go`.
3. Enumerated the existing test suite by name (`grep '^func Test'` across every `*_test.go` in `accounting`, `ledger`, `chat`, `inference`, `anthropic`) before writing anything new, to avoid duplicating coverage. Result: every terminal path the owner named (success, upstream error, client disconnect mid-stream, context cancellation, timeout via finalize failure, no-usage-block stream) already has a named regression test (`TestExecuteStreaming_ClientDisconnect_*`, `TestExecuteStreaming_FinalizeError_ReleasesReservationInstead`, `TestSessionChatReleasesTheHoldWhenSettlementFails`, `TestFinalizeReservationTwiceChargesOnce`, `TestMessages_APIKeyStreamingPathReservesAndSettlesCredits`, etc).
4. Confirmed `math/big` is the only arithmetic path: `apps/edge-api/internal/metering/precedence.go` (`ChargeCredits`), never float64.
5. Confirmed the Anthropic surface is a pure translator that always forces `stream=true` and `stream_options.include_usage=true` before delegating to the exact same `/v1/chat/completions` handler chain used by the OpenAI surface (`anthropic/handler.go`), so it cannot drift from that surface's metering. `routing_metering_test.go` already asserts reservation and settlement on both the session and API-key paths, streaming included.
6. Ran the full `accounting`, `ledger`, `chat`, `inference`, `anthropic`, `audio`, `images`, `batches`, `usage` test suites (`go test -short ./apps/edge-api/... ./apps/control-plane/...`): all green. Two unrelated failures surfaced (`auditworker` serialization retry, `marketplace` RLS permission) from gaps in my locally-bootstrapped ephemeral schema versus the full CI bootstrap; neither package is in this audit's scope (billing/metering/reservation/ledger) and neither was touched.

## Live evidence

Read the real demo Supabase project (pooler, read-only) directly:

- Reservation status counts, all time: 1964 `finalized`, 149 `needs_reconciliation`, 65 `released`. Zero rows in `active`/`expanded` right now.
- Stranded holds (active/expanded, >1h old, no in-flight batch): **0**.
- Over-released reservations (`released_credits > reserved_credits`, the D-918 corruption signal): **0**.

Then stood up an ephemeral `pgvector/pgvector:pg17` database, applied the full `supabase/migrations/*.sql` chain plus `.github/ci/test-db-bootstrap.sql` (the same recipe `ci.yml` uses), and ran every `HIVE_TEST_DB_URL`-gated live test in `internal/accounting` against it for real: `TestReservationRowAndHoldAreWrittenAtomically_Live`, `TestExpandReservationRaisesTheRowAndTheHoldTogether_Live`, `TestSettlementLedgerMagnitude_Live`, plus the two new tests below. All pass against genuine Postgres, not mocks.

## What's new

**`TestReaperRunOnce_Live`** (`apps/control-plane/internal/accounting/reaper_live_test.go`). The existing reaper suite only ever drives `RunOnce` against a hand-written in-memory ledger and lister stub, so `ListStaleReservations`' actual SQL, including the batch-exclusion subquery that joins `credit_reservations.id` (uuid) against `batches.reservation_id` (text) via an explicit `::text` cast, had never run against real Postgres. This test backdates a real reservation past the TTL, seeds real `batches` rows in both an in-flight and a terminal status, and asserts the reaper releases exactly the eligible rows and leaves the rest alone, checked against `GetBalance`'s own arithmetic. Mutation-checked: replacing the cast comparison with a value that can never match turned the test red (confirmed locally, reverted before commit).

**`TestDispatchReleasesReservationEvenWhenTheResponseBodyPanics`** (`apps/edge-api/internal/chat/dispatch_panic_test.go`). Proves the session chat path's deferred reservation release survives a literal panic mid-stream (a panicking `io.Reader` standing in for a bug in response parsing), not just an error return. Go's `defer` semantics already guarantee this, but nothing in the existing suite exercised it. Mutation-checked: disabling the `defer` turned the test red (confirmed locally, reverted before commit).

## Test plan

- [x] `go vet ./apps/edge-api/... ./apps/control-plane/...`
- [x] `go test -count=1 -short ./apps/edge-api/... ./apps/control-plane/...` (all packages touched by this audit green; two unrelated pre-existing environment gaps noted above, out of scope)
- [x] Both new tests pass against a real, migrated Postgres instance
- [x] Both new tests mutation-checked (proven to fail when the invariant they guard is broken)
- [x] Live read of the real demo ledger: zero stranded holds, zero over-released reservations

## Buglog entry

No bug found in production code; this PR is regression-test coverage only. No buglog entry.