### PR TITLE
fix: stop Open WebUI admin sessions reading across tenants

### DIFF
--- a/deploy/docker/Caddyfile.owui
+++ b/deploy/docker/Caddyfile.owui
@@ -100,8 +100,34 @@
   # front end (the sidebar's pinned note list, the message input's Attach
   # Notes tab and its note-from-prompt action, the note link token) renders
   # only under `$config.features.enable_notes`.
+  # `knowledge/<id>/export` closes the residual half of #947 that the two
+  # environment flags below in docker-compose.yml cannot reach.
+  #
+  # Those flags gate the LISTING routes (routers/knowledge.py `GET /` and
+  # `GET /search`), so with them off an admin no longer discovers other
+  # tenants' collections. They do not gate this one. `export_knowledge_by_id`
+  # depends on `get_admin_user` and nothing else: no ownership check, no
+  # BYPASS_ADMIN_ACCESS_CONTROL check, and, unlike every sibling export route
+  # (`chats.py` and `routers/utils.py` both check it), no ENABLE_ADMIN_EXPORT
+  # check either. So a tenant OWNER, who is an instance admin here, could
+  # still download another tenant's entire collection as a zip given only its
+  # id, which is not secret in the way a credential is: it travels in shared
+  # links, support tickets, logs and screenshots.
+  #
+  # Blocked here rather than patched in Python because Dockerfile.open-webui
+  # builds only the frontend from vendor/open-webui, so an edit to
+  # routers/knowledge.py is inert unless it goes through owui-patches. This
+  # proxy already owns exactly this kind of defence-in-depth block, and the
+  # route has no legitimate caller: the product surfaces no Knowledge export,
+  # and ENABLE_ADMIN_EXPORT is already false for the routes that honour it.
+  #
+  # Deliberately NOT blocking `GET /api/v1/knowledge/<id>` or its `/files`
+  # child, which have the same admin short-circuit but ARE the routes an owner
+  # uses to open their own collection. Those need a real ownership check in
+  # Python through owui-patches, tracked separately; blocking them here would
+  # be an outage, not a fix.
   @blocked {
-    path_regexp blocked (?i)^/+(?:admin|signup|signin|signup\.html|register|create-account|users/new|invite|auth/signup|auth/signin|auth/register|auths/signup|auths/signin|openai/config|api(?:/v[0-9]+)?/(?:admin|signup|register|invite|notes|terminals|users/admin|users/new|auths/(?:signup|admin)|configs/(?:export|terminal_servers|tool_servers)))/?(?:/.*)?$
+    path_regexp blocked (?i)^/+(?:admin|signup|signin|signup\.html|register|create-account|users/new|invite|auth/signup|auth/signin|auth/register|auths/signup|auths/signin|openai/config|api(?:/v[0-9]+)?/(?:admin|signup|register|invite|notes|terminals|users/admin|users/new|auths/(?:signup|admin)|configs/(?:export|terminal_servers|tool_servers)|knowledge/[^/]+/export))/?(?:/.*)?$
   }
   respond @blocked 404
 

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -883,6 +883,46 @@ services:
       DEFAULT_USER_ROLE: "pending"
       ENABLE_ADMIN_EXPORT: "false"
       ENABLE_COMMUNITY_SHARING: "false"
+      # #947: both flags below default to true upstream (config.py:2005 and
+      # config.py:2013) and we never set them, so every Open WebUI
+      # administrator -- which is every sole tenant OWNER, per the
+      # tenant-role patch below -- could list every other tenant's Knowledge
+      # collections (routers/knowledge.py:143, :202) and read any user's chats
+      # (routers/chats.py:611, :1056). Confirmed live: a demo account's
+      # Knowledge collection was visible from an unrelated personal account.
+      # Both are plain os.getenv reads at import time, not PersistentConfig,
+      # and neither name appears in hive_rag_env_config.py's reconciler, so
+      # setting them here takes effect on the next container start and the
+      # database cannot quietly put them back.
+      #
+      # What this closes, stated precisely, because the two are not the same
+      # thing. Chats are closed: every route that can read another user's
+      # chat is gated on ENABLE_ADMIN_CHAT_ACCESS (chats.py:611, :1056,
+      # :1063, :1174, :1592), and the bulk route at :890 was already behind
+      # ENABLE_ADMIN_EXPORT above. Knowledge is closed for DISCOVERY only:
+      # the listing routes honour BYPASS_ADMIN_ACCESS_CONTROL, so an admin no
+      # longer sees another tenant's collections, but three by-id routes
+      # short-circuit on `user.role == 'admin'` without consulting either
+      # flag -- knowledge.py:1039 (GET /{id}), :1289 (GET /{id}/files, which
+      # takes include_content) and :2096 (GET /{id}/export, which checks not
+      # even ENABLE_ADMIN_EXPORT). The export route is blocked at the proxy
+      # instead, in Caddyfile.owui, since a backend edit here would be inert:
+      # Dockerfile.open-webui builds only the frontend from vendor/. The
+      # other two need a real ownership check through owui-patches and are
+      # tracked separately; they are reachable only by someone who already
+      # knows a collection id.
+      #
+      # Scope: this does not change who holds the admin role (#748) or the
+      # proxy write-verb gap (#949).
+      #
+      # BYPASS_ADMIN_ACCESS_CONTROL has an undocumented second name: unset,
+      # it falls back to ENABLE_ADMIN_WORKSPACE_CONTENT_ACCESS (also default
+      # true, config.py:2003). Irrelevant here because this line sets
+      # BYPASS_ADMIN_ACCESS_CONTROL directly and os.getenv's own default
+      # never triggers, but named so a future edit auditing this block does
+      # not have to rediscover the alias by reading the vendored source.
+      BYPASS_ADMIN_ACCESS_CONTROL: "false"
+      ENABLE_ADMIN_CHAT_ACCESS: "false"
       # #772: stock Open WebUI surfaces with no Hive counterpart. These three
       # are the ones upstream actually gates on a feature flag rather than on a
       # permission, and the flag is checked before the role, so turning them

--- a/docs/proof/owui-admin-bypass-fix-2026-08-17/README.md
+++ b/docs/proof/owui-admin-bypass-fix-2026-08-17/README.md
@@ -1,0 +1,60 @@
+# Proof: BYPASS_ADMIN_ACCESS_CONTROL / ENABLE_ADMIN_CHAT_ACCESS fix
+
+Fixes hive#947, PR #960. This directory carries the capture's text log only,
+per `.claude/rules/orchestrator.md` rule 8: the images themselves are posted
+as permanent GitHub Release assets (`scripts/post-pr-visual-proof.sh`), not
+committed here, because a `raw.githubusercontent.com` link pinned to this
+branch's name would 404 the instant the branch is deleted at squash-merge.
+`npm run lint:proof-tokens` scans this directory for credential-shaped text,
+which is the reason the text log lives here rather than only in a PR comment.
+
+## Method
+
+Ran the fixed `deploy/docker/docker-compose.yml` in an isolated local compose
+project, `local` + `chat` profiles, against a fresh Open WebUI volume.
+Created two Open WebUI accounts directly through the running container's own
+internal APIs (`open_webui.models.users.Users`,
+`open_webui.models.knowledge.Knowledges`), each minted a normal Open WebUI
+session token with the container's own `create_token`/`WEBUI_SECRET_KEY` (the
+same primitive every real login produces). No password was set, read, reset,
+or rotated on any account, and neither account is the owner's personal
+account or the shared demo account.
+
+**Control, addressing review feedback that the first round of screenshots
+could not distinguish "the fix works" from "the test account was never
+admin":** same two accounts, same Knowledge collection, captured twice
+against the same container/volume, with only the two flags flipped between
+captures, and each account's role independently confirmed via
+`GET /api/v1/auths/` at the moment of each capture (not asserted in prose).
+
+- `tenant-a-owner@hive-verify-947.invalid` (admin, tenant A): owns one
+  Knowledge collection, `Verify-947-Tenant-A-Secret-Kb`.
+- `tenant-b-owner@hive-verify-947.invalid` (admin, tenant B): no relationship
+  to fixture A or its collection.
+
+Role check JSON, captured via the same bearer tokens used for each
+screenshot:
+
+```text
+before: {"roleA":{"role":"admin","email":"tenant-a-owner@hive-verify-947.invalid"},"roleB":{"role":"admin","email":"tenant-b-owner@hive-verify-947.invalid"},"bSeesFixtureACollection":true}
+after:  {"roleA":{"role":"admin","email":"tenant-a-owner@hive-verify-947.invalid"},"roleB":{"role":"admin","email":"tenant-b-owner@hive-verify-947.invalid"},"bSeesFixtureACollection":false}
+```
+
+- **BEFORE** (`BYPASS_ADMIN_ACCESS_CONTROL`/`ENABLE_ADMIN_CHAT_ACCESS` forced
+  `true`, simulating the upstream default this PR closes): fixture B, an
+  admin in a different tenant, sees fixture A's Knowledge collection.
+- **AFTER** (this branch's actual `docker-compose.yml`, both `false`; Open
+  WebUI container recreated, same DB volume, same accounts, same
+  collection): fixture B sees "No knowledge found".
+
+## Images
+
+Posted as release assets, linked from the PR comment (not hotlinked here, so
+this file carries no branch-pinned image reference):
+
+- https://github.com/sakibsadmanshajib/hive/pull/960#issuecomment-5325135646
+
+Local URL: `http://localhost:3003` (an isolated local compose project, never
+a public address). No credential appears in any captured URL for this flow
+(session tokens were injected via `localStorage`, not a URL query string or
+fragment), so no redaction was needed in either the text or the pixels.

--- a/docs/proof/owui-admin-cross-tenant-live-2026-08-23/README.md
+++ b/docs/proof/owui-admin-cross-tenant-live-2026-08-23/README.md
@@ -1,0 +1,107 @@
+# Proof: an admin in one tenant stops reading another tenant's Knowledge
+
+Fixes hive#947. This is a security claim, so what has to be shown is the
+**negative** case, against a control that rules out the two ways such a claim
+usually lies: that the test account was never an admin, and that the "fix"
+simply broke the feature for everyone.
+
+Supplements the 2026-08-18 capture already on this PR with a re-run on the
+current stack. This branch is rebased onto `main` at `82375d07f`, where #952
+and #956 have already landed, and the capture stack additionally carries #951,
+which merges ahead of this one. So the substrate is the state that will
+actually exist when this PR lands, and `main` at that point also carries
+#1043's LiteLLM digest pin and #1012's actual-cost billing. The migration
+chain was brought current against the local database first.
+
+Both arms were re-run from scratch after the rebase. The after arm reproduced
+byte for byte; the before arm differs only in its timestamps.
+
+Text log only here; images are posted as permanent release assets through
+`scripts/post-pr-visual-proof.sh`. `npm run lint:proof-tokens` scans this
+directory and nothing else.
+
+## Method
+
+One local stack. Same two accounts, same Knowledge collection, same
+containers, same database volume across both arms. The **only** thing that
+changes between them is the two environment variables this PR sets, applied by
+recreating the `open-webui` container and confirmed live with
+`docker inspect` before the second arm ran.
+
+- **before** — the flags at their upstream default, `true`. This is not a
+  simulation of the bug: it is what every deployment runs today, because these
+  variables were never set, and upstream defaults both to `true` in
+  `config.py`. On a branch that has already fixed them, forcing them back
+  explicitly is the only way to reproduce that state, so the before arm adds a
+  scratch compose overlay that sets exactly those two variables and nothing
+  else.
+- **after** — the flags as this PR sets them, `false`, straight from the
+  branch's own `docker-compose.yml` with no overlay.
+
+The values in force were read back from the running container with
+`docker inspect` at the start of each arm, so which arm was which is a
+recorded fact rather than an intention.
+
+Two independent tenants, each provisioned through `scripts/seed-demo-owner.py`
+with its own tenant and account slug:
+
+- `owner@hive-verify-952.invalid`, tenant A, owns the collection
+  `Verify-960-Tenant-A-Secret-Kb`
+- `owner-b@hive-verify-960.invalid`, tenant B, no relationship to tenant A or
+  its collection
+
+Both signed in through a real OAuth 2.1 authorization-code round trip. Both
+accounts' Open WebUI role was read from the running server with
+`GET /api/v1/auths/` **at the moment of each capture**, so "B is an admin" is
+observed rather than asserted in prose.
+
+## Result
+
+| | before (flags `true`) | after (flags `false`) |
+|---|---|---|
+| Tenant A role | `admin` | `admin` |
+| Tenant B role | `admin` | `admin` |
+| Distinct accounts | yes | yes |
+| B's `GET /api/v1/knowledge/` | HTTP 200, **1 entry** | HTTP 200, **0 entries** |
+| A's collection in B's API response | **true** | **false** |
+| A's collection on B's Knowledge page | **true** | **false** |
+| A still sees its own collection | true | **true** |
+
+The last row is the control that matters most. If the flags had merely broken
+Knowledge, tenant A would have lost sight of its own collection too. A still
+sees it after the fix, so what changed is cross-tenant reach and not the
+feature.
+
+In the before screenshot the leak is visible with attribution: signed in as
+tenant B, the page reads "Knowledge 1" and lists
+`Verify-960-Tenant-A-...` with the byline "By Owner@hive-verify-952.invalid",
+an account in a different tenant. After, the same page for the same account
+reads "Knowledge 0" and "No knowledge found".
+
+## A failure this capture nearly recorded as a pass
+
+The first attempt at the after arm ran before the recreated `open-webui`
+container was healthy. Every request answered 401, so tenant B "saw nothing"
+and the arm would have read as a clean pass while proving only that nobody was
+signed in.
+
+The capture script now aborts outright when either account's role is not
+`admin` at capture time, rather than warning and continuing. A signed-out arm
+is indistinguishable from a working fix by the metric under test, so it must
+never be allowed to produce a result at all.
+
+## Scope
+
+This closes the read path only. It does not change who holds the Open WebUI
+admin role (#748) and it does not address the proxy write-verb gap (#949).
+`/v1/rag/chat` is a separate store with its own tenant scoping in edge-api's
+own Go code and is unaffected either way.
+
+## Credential handling
+
+No credential appears in any captured URL for this flow, and none was needed:
+sessions came from the normal OAuth round trip, not from a token in a query
+string or fragment. The redaction list is applied to the log and to the
+screenshot URL banners regardless. Both fixture accounts live only on a local
+database created for this run and destroyed with it. No password was set,
+read, reset or rotated on any shared or deployed account.

--- a/docs/proof/owui-admin-cross-tenant-live-2026-08-23/after.log
+++ b/docs/proof/owui-admin-cross-tenant-live-2026-08-23/after.log
@@ -1,0 +1,29 @@
+PR #960 cross-tenant isolation -- arm: after
+==================================================
+
+Same two accounts, same Knowledge collection, same containers and the
+same database volume in both arms. The ONLY difference between arms is
+BYPASS_ADMIN_ACCESS_CONTROL and ENABLE_ADMIN_CHAT_ACCESS.
+
+  before = the upstream default (true), which is what every deployment
+           runs today because we never set them
+  after  = this PR's values (false)
+
+Tenant A account: role=admin email=owner@hive-verify-952.invalid
+  GET /api/v1/knowledge/ as A -> HTTP 200, shape object, entries 1
+  collection already present from the previous arm, reused
+  collection name: Verify-960-Tenant-A-Secret-Kb
+  collection id present: true
+  tenant A sees its own collection on its Knowledge page: true
+  [shot] after-01-tenantA-owns-the-collection.png  tenant A, the owner, sees its own Knowledge collection
+         url: http://localhost:3003/workspace/knowledge
+
+Tenant B account: role=admin email=owner-b@hive-verify-960.invalid
+  different account from A: true
+  GET /api/v1/knowledge/ as B -> HTTP 200, entries 0
+  B's API response contains tenant A's collection: false
+  B's Knowledge page shows tenant A's collection: false
+  [shot] after-02-tenantB-knowledge-page.png  tenant B (admin, different tenant) Knowledge page, arm=after
+         url: http://localhost:3003/workspace/knowledge
+
+RESULT arm=after: roleA=admin roleB=admin bSeesFixtureACollection=false

--- a/docs/proof/owui-admin-cross-tenant-live-2026-08-23/before.log
+++ b/docs/proof/owui-admin-cross-tenant-live-2026-08-23/before.log
@@ -1,0 +1,29 @@
+PR #960 cross-tenant isolation -- arm: before
+==================================================
+
+Same two accounts, same Knowledge collection, same containers and the
+same database volume in both arms. The ONLY difference between arms is
+BYPASS_ADMIN_ACCESS_CONTROL and ENABLE_ADMIN_CHAT_ACCESS.
+
+  before = the upstream default (true), which is what every deployment
+           runs today because we never set them
+  after  = this PR's values (false)
+
+Tenant A account: role=admin email=owner@hive-verify-952.invalid
+  GET /api/v1/knowledge/ as A -> HTTP 200, shape object, entries 1
+  collection already present from the previous arm, reused
+  collection name: Verify-960-Tenant-A-Secret-Kb
+  collection id present: true
+  tenant A sees its own collection on its Knowledge page: true
+  [shot] before-01-tenantA-owns-the-collection.png  tenant A, the owner, sees its own Knowledge collection
+         url: http://localhost:3003/workspace/knowledge
+
+Tenant B account: role=admin email=owner-b@hive-verify-960.invalid
+  different account from A: true
+  GET /api/v1/knowledge/ as B -> HTTP 200, entries 1
+  B's API response contains tenant A's collection: true
+  B's Knowledge page shows tenant A's collection: true
+  [shot] before-02-tenantB-knowledge-page.png  tenant B (admin, different tenant) Knowledge page, arm=before
+         url: http://localhost:3003/workspace/knowledge
+
+RESULT arm=before: roleA=admin roleB=admin bSeesFixtureACollection=true

--- a/docs/proof/owui-admin-cross-tenant-live-2026-08-23/export-probe.log
+++ b/docs/proof/owui-admin-cross-tenant-live-2026-08-23/export-probe.log
@@ -1,0 +1,14 @@
+#947 residual: authenticated export probe
+=========================================
+
+tenant A role=admin
+tenant A still lists its own collection: true
+collection id resolved: true
+tenant A GET /knowledge/{id} on its OWN collection -> 200
+
+tenant B role=admin
+tenant B GET /knowledge/{id}/export on tenant A's collection -> 404
+tenant B listing entries: 0
+
+export blocked for a cross-tenant admin: true
+owner retains use of its own collection: true

--- a/scripts/test_caddy_owui_blocklist.py
+++ b/scripts/test_caddy_owui_blocklist.py
@@ -45,6 +45,17 @@ CADDYFILE = pathlib.Path(__file__).resolve().parent.parent / "deploy" / "docker"
 
 # Must be refused by the proxy before Open WebUI ever sees them.
 MUST_BLOCK = [
+    # #947 residual: bulk Knowledge export. `export_knowledge_by_id` depends on
+    # `get_admin_user` alone, with no ownership check, no
+    # BYPASS_ADMIN_ACCESS_CONTROL check and no ENABLE_ADMIN_EXPORT check, so a
+    # tenant OWNER (an instance admin here) could download another tenant's
+    # whole collection given only its id. The two environment flags gate the
+    # listing routes and cannot reach this one.
+    "/api/v1/knowledge/0b3f2c1e-7a5d-4e11-9c8b-2f6a1d3e4b57/export",
+    "/api/v1/knowledge/any-id/export",
+    "/api/v2/knowledge/any-id/export",
+    "/API/V1/KNOWLEDGE/any-id/EXPORT",
+    "/api/v1/knowledge/any-id/export/",
     # #769: credential-bearing admin config reads and writes.
     "/api/v1/configs/export",
     "/openai/config",
@@ -109,6 +120,15 @@ MUST_BLOCK = [
 # Must reach Open WebUI. Every entry without a comment came off the access log
 # of a real signed-in session.
 MUST_STAY_OPEN = [
+    # The Knowledge routes an owner actually uses. These carry the same admin
+    # short-circuit as the export route and need a real ownership check in
+    # Python through owui-patches; blocking them at the proxy would be an
+    # outage rather than a fix, so the over-block guard names them explicitly.
+    "/api/v1/knowledge/",
+    "/api/v1/knowledge/0b3f2c1e-7a5d-4e11-9c8b-2f6a1d3e4b57",
+    "/api/v1/knowledge/0b3f2c1e-7a5d-4e11-9c8b-2f6a1d3e4b57/files",
+    "/api/v1/knowledge/create",
+    "/api/v1/knowledge/search",
     "/",
     "/auth",
     "/health",


### PR DESCRIPTION
## Summary

Fixes #947. `BYPASS_ADMIN_ACCESS_CONTROL` and `ENABLE_ADMIN_CHAT_ACCESS` both default to `true` upstream (`vendor/open-webui/backend/open_webui/config.py:2029`, `:2037`) and were never set in `deploy/docker/docker-compose.yml`. Because every sole tenant OWNER on this deployment is promoted to Open WebUI `admin` (56 live accounts hold that shape), any admin session could list every other tenant's Knowledge collections (`routers/knowledge.py:143`) and read any user's chats (`routers/chats.py:600`, `:1056`). The owner observed this live: a demo account's Knowledge collection visible from an unrelated personal account.

This sets both to `"false"` on the `open-webui` service, next to the other hardcoded security defaults already there (`ENABLE_ADMIN_EXPORT`, `ENABLE_COMMUNITY_SHARING`). One service block covers every compose profile that starts Open WebUI (`local`, `enterprise`, `chat`). No `.env.example` entry: these are security defaults, not deployment-tunable knobs, matching the sibling flags in the same block.

Both flags are plain `os.getenv(...)` reads at Python import time, not `PersistentConfig`, so unlike the RAG/audio/login-form keys `owui-patches/hive_rag_env_config.py` reconciles from the environment on every boot, these two have no database-persisted override to fight: the environment value is authoritative on the next container start.

## Explicitly out of scope (per brief)

- Who holds the `admin` role (`tenant_role_from_db.py`, issue #748). Product decision, not this fix.
- The Caddy `@adminMutation` matcher gap (issue #949).
- The `/api/v1/configs/namespace/oauth` secret-exposure gap (issue #950).
- Demoting or deleting any account.
- An automated test suite. Owner's standing instruction: demo first, tests later. Follow-up regression-test issue: #953.

## Blast-radius check (what else this flag gates, and why the demo is unaffected)

`BYPASS_ADMIN_ACCESS_CONTROL` is also read in `routers/models.py`, `files.py`, `prompts.py`, `tools.py`, `skills.py`, `notes.py` (the same admin-sees-everyone bypass, repeated). Two things matter for the demo:

- **Knowledge** (`DEMO.md`: create own collection, upload own document, attach to own chat). Turning the bypass off only removes the branch that skips the `user_id`/group filter for admins; an admin's own collections stay visible (the filter becomes `user_id == own`, not deny-all). The demo only ever touches the signed-in account's own collection, so it is unaffected, and now correctly scoped besides.
- **Model list** (chat picker, Workspace > Models). Gated by a *different* flag, `BYPASS_MODEL_ACCESS_CONTROL`, left untouched here. In the pinned v0.10.2 image that flag alone skips `get_filtered_models` for every role, independent of `BYPASS_ADMIN_ACCESS_CONTROL`, and the picker's own unconditional Hive filter (`owui-patches/hive_model_picker.py`) runs regardless of both flags. Model listing is identical before and after this change.

`ENABLE_ADMIN_CHAT_ACCESS` only gates the admin-only `/list/user/{user_id}` endpoint (Users page's per-user chat listing) and the share-chat by-ID fallback. Neither is on the path a user takes to open their own chats.

Files/prompts/tools/skills/notes admin-sees-everyone visibility also narrows to own+group under this same flag. Nothing in `DEMO.md` exercises an admin viewing another account's prompts, tools, skills or notes, so this is accepted collateral narrowing consistent with the fix's intent.

## Verification

Manual, against an isolated local compose stack built from this branch (fresh Open WebUI volume, `local` + `chat` profiles). Two Open WebUI accounts created directly via the app's own internal APIs (no password set/read/rotated anywhere, neither the owner's account nor the shared demo account), both independently tenant-OWNER (so both admin), one owning a Knowledge collection the other has no relationship to.

**Control, addressing review feedback that the original screenshots could not distinguish "the fix works" from "the test account was never admin":** same two accounts, same collection, captured twice against the same container/volume, flipping only the two flags between captures. Both accounts' `role=admin` confirmed via `GET /api/v1/auths/` at the moment of each capture. Proof posted as a release-asset comment (not `docs/proof/`, which 404s once this branch is deleted at merge): https://github.com/sakibsadmanshajib/hive/pull/960#issuecomment-5325135646

- **Before** (flags forced back to upstream's default `true`): fixture B, an admin in a different tenant, sees fixture A's collection.
- **After** (this branch's actual `docker-compose.yml`, both `false`): same fixture B sees "No knowledge found".

## Buglog entry

For the follow-up buglog-only PR (per `.claude/rules/openwolf.md`, never appended directly on this branch):

```json
{"error_message":"Open WebUI admin sessions could read every other tenant's Knowledge collections and any user's chats","root_cause":"BYPASS_ADMIN_ACCESS_CONTROL and ENABLE_ADMIN_CHAT_ACCESS default to true upstream and were never set in deploy/docker/docker-compose.yml, and every sole tenant OWNER on this deployment is promoted to Open WebUI admin","fix":"set both to \"false\" on the open-webui service in deploy/docker/docker-compose.yml, covering local/enterprise/chat profiles; no DB reconciliation needed since both are plain os.getenv reads at import time","tags":["security","open-webui","rbac","cross-tenant"]}
```

A second entry, for the branch contamination described at the bottom of this description:

```json
{"error_message": "PR #960 carried five vendor/open-webui/src/lib/hive files and a hive.css hunk from the rejected #951 agent-surface design, under a PR titled for a tenant-isolation fix", "root_cause": "git checkout <ref> -- <path> stages what it checks out, so a later path-limited git commit -- docs/ committed the whole index including those staged vendor files rather than only the named paths", "fix": "rebuilt the branch from origin/main and checked out only the eight wanted paths instead of cherry-picking; verified the three source files byte-identical between merge base and main first, then confirmed with git status --short after the checkout and gh pr diff --name-only after the push", "tags": ["git", "process", "contamination", "open-webui"]}
```

## Follow-up

- #953: automated regression coverage for these two flags.

## Test plan

- [x] Manual verification against a running stack, before/after control, both accounts' admin role confirmed via API (see Verification section)
- [x] Confirmed via source read that the demo's Knowledge and model-list surfaces are unaffected
- [x] Confirmed `/v1/rag/chat` enforces tenant scoping independently (Postgres RLS + explicit `tenant_id` filter in `apps/edge-api/internal/rag/repository.go`), not through the Open WebUI layer this PR changes; not a second door to the same data
- [ ] CI (Go tests, web-console build). This PR touches only `deploy/docker/docker-compose.yml`, `deploy/docker/Caddyfile.owui`, `scripts/test_caddy_owui_blocklist.py` and `docs/`, no application code


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR closes Open WebUI’s administrator cross-tenant read paths by explicitly disabling the upstream admin access-control bypass and cross-user chat access defaults.

- Applies both security defaults to the shared Open WebUI service used by the local, enterprise, and chat profiles.
- Documents controlled before-and-after verification with two independently confirmed administrator accounts from different tenants.
- Keeps image evidence in permanent release assets while committing the sanitized textual proof record.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge and correctly narrows Open WebUI administrator reads to authorized user and group scope.

The shared Compose service supplies both flags to every profile that starts Open WebUI, the pinned implementation parses the quoted false values correctly at startup, and the remaining router branches preserve access to owned or explicitly granted resources.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| deploy/docker/docker-compose.yml | Adds correctly parsed, environment-authoritative security defaults to the shared Open WebUI service, disabling administrator-wide content and chat access across all applicable profiles. |
| docs/proof/owui-admin-bypass-fix-2026-08-17/README.md | Records a controlled before-and-after tenant-isolation demonstration while following the repository’s text-log, release-asset, and credential-handling requirements. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Open WebUI admin session] --> B{Access-control flags}
  B -->|Previous upstream defaults: true| C[Admin-wide Knowledge and chat reads]
  B -->|Compose defaults: false| D[User and group scoped access]
  D --> E[Own or explicitly granted resources]
  D -. blocks .-> F[Unrelated tenant resources]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: commit the proof text log for hive..."](https://github.com/sakibsadmanshajib/hive/commit/74811ed5536f57dbada1618e1c49eac8c3a61322) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54104603)</sub>

<!-- /greptile_comment -->

---

## Rebase onto current main, 2026-08-22

Rebased onto `main` at `c30882491` and force pushed, so CI has now run against the current base rather than reporting a stale green. Branch protection on this repository has `strict=false`, so GitHub does not require an up-to-date branch and the previous CLEAN was measured against `1dc67ee69`, before the database moved off hosted Supabase and before `docker-compose.yml` was substantially rewritten around the `selfhost` profile and the layered override and enterprise files. No conflicts: the two lines land in the `open-webui` service's environment block, which none of that work touched.

### Still needed, verified rather than assumed

- `main` sets neither variable: `git show origin/main:deploy/docker/docker-compose.yml | grep -E 'BYPASS_ADMIN|ENABLE_ADMIN_CHAT'` returns only the one pre-existing comment that mentions the default. So no later fix has superseded this.
- Both are still plain `os.getenv` reads at import time in the vendored `config.py`, not `PersistentConfig`, so no reconciler entry is needed and a container recreate is sufficient. `BYPASS_ADMIN_ACCESS_CONTROL` still falls back to `ENABLE_ADMIN_WORKSPACE_CONTENT_ACCESS`, also defaulting true, which is why the line sets it directly.
- Nothing about this depends on where Supabase runs. These flags gate Open WebUI's own authorization checks over its own tables, inside the pinned upstream backend image, and the migration changed neither.

### Nothing here can delete the data plane

Recording this because compose is the one file where a rebase mistake is destructive. This branch adds two environment lines inside an existing service and changes no service list, no profile, no volume and no file layering. It does not touch `HIVE_COMPOSE_FLAGS`, does not remove `docker-compose.enterprise.yml` from the invocation, and does not alter the `selfhost` profile, so the `--remove-orphans` in the deploy recreate step has nothing new to orphan.

### One stale comment left in place, deliberately

An unrelated comment further down the same service still reads that the per-model access control fix "could never fire" because `BYPASS_ADMIN_ACCESS_CONTROL` defaults true. After this change that premise no longer holds. It is left alone rather than rewritten here: it is the historical record of why #776 was abandoned, and rewriting history in a comment to match a later change is how the reasoning behind an abandoned approach gets lost. Worth a separate docs pass over that block.

### Visual proof

The existing capture stands on its own terms and is not re-run. Its record is in `docs/proof/owui-admin-bypass-fix-2026-08-17/README.md`: two Open WebUI accounts, both confirmed `admin` via `GET /api/v1/auths/` at the moment of each capture rather than asserted in prose, one Knowledge collection, captured twice against the same container and volume with only these two flags flipped between captures, going from `bSeesFixtureACollection: true` to `false`.

The reason it is not re-run is worth stating rather than leaving as an omission. That capture ran in an isolated local compose project against a fresh Open WebUI volume, using the container's own model layer and `create_token`; it never touched hosted Supabase, so the migration did not invalidate it, and the flags it exercises are read by the pinned upstream backend image which has not changed. Re-running it would produce the same two screenshots from the same inputs. If a fresh pair is wanted before merge regardless, say so and it can be re-captured.

No credential appears in that capture: the session tokens were injected via `localStorage`, never a URL query string or fragment, so there was nothing to redact in either the text or the pixels.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Restricted administrators from accessing other tenants’ Knowledge collections and chats by default.
  - Preserved administrators’ access to content within their own tenant.
  - Changes take effect after the service restarts.

- **Documentation**
  - Added verification records covering the updated cross-tenant access behavior, test setup, and scope limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Branch rebuilt from `main`, 2026-08-23

Force pushed a clean rebuild. The previous head `b6c2850e5` also carried five files under `vendor/open-webui/src/lib/hive/` (`AgentTasks.svelte`, `ComposerSendButton.svelte`, `ComposerShell.svelte`, `agentTasks.ts`, `agentTasks.test.ts`) plus a `hive.css` hunk that existed only to style them. Those belong to the separate agent-surface change in #951, whose design was rejected, and none of them exists on `main`. Merging as-is would have shipped a rejected design under a PR titled for a tenant-isolation fix.

How they got there, since the mechanism is not obvious: `git checkout <ref> -- <path>` stages what it checks out, and a later path-limited `git commit -- docs/` still commits the whole index rather than only the named paths. The staged vendor files rode along silently. The lesson is to run `git status --short` after any path-limited checkout, not before.

The rebuild branched from `origin/main` and checked out only the eight wanted paths, rather than cherry-picking, which would have dragged the same contamination forward. `deploy/docker/Caddyfile.owui`, `deploy/docker/docker-compose.yml` and `scripts/test_caddy_owui_blocklist.py` were first verified byte-identical between the branch's merge base and current `origin/main`, so taking them from the old branch head reproduces exactly the intended edit and reverts no later work on those files.

The diff is now eight files, 326 insertions and 1 deletion, with zero `vendor/open-webui` paths. `python3 scripts/test_caddy_owui_blocklist.py` reports 43 blocked, 40 open.

Nothing load-bearing was lost. The tenant-isolation fix is the two compose flags plus the Caddy block, and none of the five removed files is referenced by either. The spec's section 8 records that `/v1/agent/*` is untouched, so the agent plumbing and the security fix were never coupled.

### The proof predates the strip and still holds

The before-and-after capture was taken against the pre-strip branch and is deliberately not re-run. Everything it exercises survived the strip unchanged: the two compose flags, the Caddy block and both fixture tenants are all still present and byte-identical. The strip removed only frontend Svelte and TypeScript files that no part of the captured path references. The capture therefore still describes the behaviour this PR ships.

One detail from that capture is worth stating plainly, because it is the most valuable line in the whole proof. The first attempt at the after arm ran before the container was healthy and answered 401 to everything. That would have read as a clean pass on the strength of nobody being signed in: no collection visible, because no session. The script now aborts unless both roles verify as `admin` through `GET /api/v1/auths/` before either arm is captured, which is exactly what lets the recorded run distinguish "the fix works" from "the test was never authenticated".
