### PR TITLE
fix: recover default-workspace provisioning from a slug collision race

### DIFF
--- a/apps/control-plane/internal/accounting/http_test.go
+++ b/apps/control-plane/internal/accounting/http_test.go
@@ -72,6 +72,12 @@ func (s *accountsRepoStub) CreateProfile(_ context.Context, _ accounts.AccountPr
 	return nil
 }
 
+func (s *accountsRepoStub) ProvisionDefaultWorkspace(_ context.Context, acct accounts.Account, membership accounts.Membership, _ accounts.AccountProfile) (uuid.UUID, bool, error) {
+	s.accountsMap[acct.ID] = &acct
+	s.memberships = append(s.memberships, membership)
+	return acct.ID, false, nil
+}
+
 func (s *accountsRepoStub) GetAccountByID(_ context.Context, id uuid.UUID) (*accounts.Account, error) {
 	acct, ok := s.accountsMap[id]
 	if !ok {

--- a/apps/control-plane/internal/accounts/repository.go
+++ b/apps/control-plane/internal/accounts/repository.go
@@ -115,11 +115,22 @@ func (r *pgxRepository) ActiveTenantID(ctx context.Context, userID uuid.UUID) (u
 	return tenantID, true, nil
 }
 
+// CreateAccount inserts one account row.
+//
+// UNIQUE (slug) is what surfaces as ErrSlugTaken. See its doc comment in
+// types.go for the two situations that trips it, and provisionDefaultWorkspace
+// in service.go for how each is told apart and recovered — without this
+// translation the raw pgx unique-violation escaped as an opaque
+// "could not load your workspace" 500.
 func (r *pgxRepository) CreateAccount(ctx context.Context, acct Account) error {
 	_, err := r.pool.Exec(ctx, `
 		INSERT INTO public.accounts (id, slug, display_name, account_type, owner_user_id)
 		VALUES ($1, $2, $3, $4, $5)
 	`, acct.ID, acct.Slug, acct.DisplayName, acct.AccountType, acct.OwnerUserID)
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) && pgErr.Code == pgerrcode.UniqueViolation {
+		return ErrSlugTaken
+	}
 	return err
 }
 

--- a/apps/control-plane/internal/accounts/repository.go
+++ b/apps/control-plane/internal/accounts/repository.go
@@ -21,6 +21,14 @@ type Repository interface {
 	CreateAccount(ctx context.Context, acct Account) error
 	CreateMembership(ctx context.Context, m Membership) error
 	CreateProfile(ctx context.Context, p AccountProfile) error
+	// ProvisionDefaultWorkspace atomically provisions acct/membership/profile
+	// for a first-time viewer, serialized against every other concurrent call
+	// for the same viewer. See provisionDefaultWorkspace in service.go for why
+	// this must be atomic rather than three independent Create* calls.
+	// wonElsewhere is true when a concurrent call for this same viewer had
+	// already committed a workspace by the time this call took its lock: in
+	// that case nothing is inserted and existingAccountID is the winner's.
+	ProvisionDefaultWorkspace(ctx context.Context, acct Account, membership Membership, profile AccountProfile) (existingAccountID uuid.UUID, wonElsewhere bool, err error)
 	GetAccountByID(ctx context.Context, id uuid.UUID) (*Account, error)
 	CreateInvitation(ctx context.Context, inv Invitation) error
 	FindInvitationByTokenHash(ctx context.Context, tokenHash string) (*Invitation, error)
@@ -115,20 +123,26 @@ func (r *pgxRepository) ActiveTenantID(ctx context.Context, userID uuid.UUID) (u
 	return tenantID, true, nil
 }
 
-// CreateAccount inserts one account row.
-//
-// UNIQUE (slug) is what surfaces as ErrSlugTaken. See its doc comment in
-// types.go for the two situations that trips it, and provisionDefaultWorkspace
-// in service.go for how each is told apart and recovered — without this
-// translation the raw pgx unique-violation escaped as an opaque
-// "could not load your workspace" 500.
+// accountsSlugUniqueConstraint is the Postgres-assigned name for accounts'
+// column-level `slug ... unique` constraint (supabase/migrations/
+// 20260328_01_identity_foundation.sql), i.e. Postgres's default
+// <table>_<column>_key naming, never given an explicit name in the
+// migration. Matched by name, not just by SQLSTATE 23505, so a future
+// unique constraint added to this table is never misreported as
+// ErrSlugTaken.
+const accountsSlugUniqueConstraint = "accounts_slug_key"
+
+// CreateAccount inserts one account row. provisionDefaultWorkspace does not
+// call this directly — see ProvisionDefaultWorkspace below, which needs the
+// insert inside its own locked transaction. UNIQUE (slug) still surfaces
+// here as ErrSlugTaken for any other caller; see its doc comment in types.go.
 func (r *pgxRepository) CreateAccount(ctx context.Context, acct Account) error {
 	_, err := r.pool.Exec(ctx, `
 		INSERT INTO public.accounts (id, slug, display_name, account_type, owner_user_id)
 		VALUES ($1, $2, $3, $4, $5)
 	`, acct.ID, acct.Slug, acct.DisplayName, acct.AccountType, acct.OwnerUserID)
 	var pgErr *pgconn.PgError
-	if errors.As(err, &pgErr) && pgErr.Code == pgerrcode.UniqueViolation {
+	if errors.As(err, &pgErr) && pgErr.Code == pgerrcode.UniqueViolation && pgErr.ConstraintName == accountsSlugUniqueConstraint {
 		return ErrSlugTaken
 	}
 	return err
@@ -159,6 +173,77 @@ func (r *pgxRepository) CreateProfile(ctx context.Context, p AccountProfile) err
 		VALUES ($1, $2, $3, $4)
 	`, p.AccountID, p.OwnerName, p.LoginEmail, p.ProfileSetupComplete)
 	return err
+}
+
+// ProvisionDefaultWorkspace creates acct, membership, and profile inside one
+// transaction guarded by a pg_advisory_xact_lock keyed on membership.UserID.
+// Two concurrent calls for the same viewer serialize on that lock — the
+// second does not even start its re-check until the first has committed or
+// rolled back — so the TOCTOU window a bare "list memberships, then insert"
+// leaves open (a second Server Component request for a brand-new viewer
+// deciding independently that no workspace exists yet) cannot produce two
+// personal workspaces for one viewer. It can still return ErrSlugTaken: that
+// signals a *different* viewer's display name collapsed to the same slug
+// (buildSlug has no per-user uniqueifier), which this lock does not
+// serialize against (different key) and provisionDefaultWorkspace in
+// service.go handles by retrying with a de-duplicated slug.
+func (r *pgxRepository) ProvisionDefaultWorkspace(ctx context.Context, acct Account, membership Membership, profile AccountProfile) (existingAccountID uuid.UUID, wonElsewhere bool, err error) {
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return uuid.Nil, false, fmt.Errorf("accounts: begin provisioning tx: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock(hashtext($1)::int8)`, membership.UserID.String()); err != nil {
+		return uuid.Nil, false, fmt.Errorf("accounts: acquire provisioning lock: %w", err)
+	}
+
+	// Re-check now that the lock is held: a concurrent transaction for this
+	// same viewer may have committed and released the lock while this one was
+	// waiting to acquire it.
+	var winnerAccountID uuid.UUID
+	err = tx.QueryRow(ctx, `
+		SELECT account_id FROM public.account_memberships
+		WHERE user_id = $1 AND status = $2
+		ORDER BY created_at ASC, id ASC
+		LIMIT 1
+	`, membership.UserID, StatusActive).Scan(&winnerAccountID)
+	if err == nil {
+		return winnerAccountID, true, nil
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return uuid.Nil, false, fmt.Errorf("accounts: check active membership under lock: %w", err)
+	}
+
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO public.accounts (id, slug, display_name, account_type, owner_user_id)
+		VALUES ($1, $2, $3, $4, $5)
+	`, acct.ID, acct.Slug, acct.DisplayName, acct.AccountType, acct.OwnerUserID); err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == pgerrcode.UniqueViolation && pgErr.ConstraintName == accountsSlugUniqueConstraint {
+			return uuid.Nil, false, ErrSlugTaken
+		}
+		return uuid.Nil, false, fmt.Errorf("accounts: create default account: %w", err)
+	}
+
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO public.account_memberships (id, account_id, user_id, role, status)
+		VALUES ($1, $2, $3, $4, $5)
+	`, membership.ID, membership.AccountID, membership.UserID, membership.Role, membership.Status); err != nil {
+		return uuid.Nil, false, fmt.Errorf("accounts: create owner membership: %w", err)
+	}
+
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO public.account_profiles (account_id, owner_name, login_email, profile_setup_complete)
+		VALUES ($1, $2, $3, $4)
+	`, profile.AccountID, profile.OwnerName, profile.LoginEmail, profile.ProfileSetupComplete); err != nil {
+		return uuid.Nil, false, fmt.Errorf("accounts: create account profile: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return uuid.Nil, false, fmt.Errorf("accounts: commit provisioning tx: %w", err)
+	}
+	return acct.ID, false, nil
 }
 
 func (r *pgxRepository) GetAccountByID(ctx context.Context, id uuid.UUID) (*Account, error) {

--- a/apps/control-plane/internal/accounts/service.go
+++ b/apps/control-plane/internal/accounts/service.go
@@ -166,22 +166,65 @@ func (s *Service) EnsureViewerContext(ctx context.Context, viewer auth.Viewer, r
 	}, nil
 }
 
+// maxSlugAttempts bounds the de-duplication retry in provisionDefaultWorkspace
+// below. One attempt recovers the self-race case (see the loop body); the
+// rest exist only for the rare different-viewer collision, which a second
+// de-duplicated slug resolves in practice.
+const maxSlugAttempts = 3
+
 // provisionDefaultWorkspace creates a default personal account, owner membership,
 // and core profile row for the viewer.
 func (s *Service) provisionDefaultWorkspace(ctx context.Context, viewer auth.Viewer) error {
 	displayName := buildDisplayName(viewer.FullName, viewer.Email)
-	slug := buildSlug(displayName)
-
+	baseSlug := buildSlug(displayName)
 	accountID := uuid.New()
-	acct := Account{
-		ID:          accountID,
-		Slug:        slug,
-		DisplayName: displayName,
-		AccountType: "personal",
-		OwnerUserID: viewer.UserID,
-	}
-	if err := s.repo.CreateAccount(ctx, acct); err != nil {
-		return fmt.Errorf("accounts: create default account: %w", err)
+
+	var slug string
+	for attempt := 0; ; attempt++ {
+		slug = baseSlug
+		if attempt > 0 {
+			slug = baseSlug + "-" + uuid.New().String()[:8]
+		}
+
+		acct := Account{
+			ID:          accountID,
+			Slug:        slug,
+			DisplayName: displayName,
+			AccountType: "personal",
+			OwnerUserID: viewer.UserID,
+		}
+		err := s.repo.CreateAccount(ctx, acct)
+		if err == nil {
+			break
+		}
+		if !errors.Is(err, ErrSlugTaken) {
+			return fmt.Errorf("accounts: create default account: %w", err)
+		}
+
+		// The slug collided. buildSlug has no per-user uniqueifier, so this
+		// fires in two different situations (see ErrSlugTaken's doc comment):
+		//
+		//  1. A concurrent request for this SAME viewer already won the
+		//     provisioning race (Next.js Server Components call getViewer()
+		//     unmemoized per component, so a brand-new user's first page load
+		//     can fire this insert twice). That request's account and
+		//     membership already committed, so re-listing memberships here
+		//     finds them and there is nothing left for this call to do — the
+		//     caller re-lists again right after this returns and picks it up.
+		//  2. A genuinely different viewer's display name collapsed to the
+		//     same slug. This viewer still has no active membership, so fall
+		//     through and retry with a de-duplicated slug instead of failing
+		//     their first-ever sign-in.
+		memberships, listErr := s.repo.ListMembershipsByUserID(ctx, viewer.UserID)
+		if listErr != nil {
+			return fmt.Errorf("accounts: list memberships after slug collision: %w", listErr)
+		}
+		if len(activeMemberships(memberships)) > 0 {
+			return nil
+		}
+		if attempt+1 >= maxSlugAttempts {
+			return fmt.Errorf("accounts: create default account: slug %q still taken after %d attempts", baseSlug, maxSlugAttempts)
+		}
 	}
 
 	membership := Membership{

--- a/apps/control-plane/internal/accounts/service.go
+++ b/apps/control-plane/internal/accounts/service.go
@@ -172,16 +172,30 @@ func (s *Service) EnsureViewerContext(ctx context.Context, viewer auth.Viewer, r
 // de-duplicated slug resolves in practice.
 const maxSlugAttempts = 3
 
-// provisionDefaultWorkspace creates a default personal account, owner membership,
-// and core profile row for the viewer.
+// provisionDefaultWorkspace creates a default personal account, owner
+// membership, and core profile row for the viewer, or recovers a concurrent
+// request's workspace for the same viewer if one already won.
+//
+// Next.js Server Components call getViewer() unmemoized per component
+// (layout.tsx and each page.tsx independently), so a brand-new viewer's
+// first page load can fire two concurrent GET /api/v1/viewer requests that
+// both see zero active memberships. repo.ProvisionDefaultWorkspace
+// serializes those two on a per-viewer Postgres advisory lock and re-checks
+// under that lock, so only one of them ever inserts — see its doc comment
+// in repository.go for why a bare "list memberships, then insert" is not
+// enough on its own.
 func (s *Service) provisionDefaultWorkspace(ctx context.Context, viewer auth.Viewer) error {
 	displayName := buildDisplayName(viewer.FullName, viewer.Email)
 	baseSlug := buildSlug(displayName)
 	accountID := uuid.New()
 
-	var slug string
+	ownerName := viewer.FullName
+	if ownerName == "" {
+		ownerName = emailLocalPart(viewer.Email)
+	}
+
 	for attempt := 0; ; attempt++ {
-		slug = baseSlug
+		slug := baseSlug
 		if attempt > 0 {
 			slug = baseSlug + "-" + uuid.New().String()[:8]
 		}
@@ -193,63 +207,44 @@ func (s *Service) provisionDefaultWorkspace(ctx context.Context, viewer auth.Vie
 			AccountType: "personal",
 			OwnerUserID: viewer.UserID,
 		}
-		err := s.repo.CreateAccount(ctx, acct)
+		membership := Membership{
+			ID:        uuid.New(),
+			AccountID: accountID,
+			UserID:    viewer.UserID,
+			Role:      RoleOwner,
+			Status:    StatusActive,
+		}
+		profile := AccountProfile{
+			AccountID:            accountID,
+			OwnerName:            ownerName,
+			LoginEmail:           viewer.Email,
+			ProfileSetupComplete: false,
+		}
+
+		_, wonElsewhere, err := s.repo.ProvisionDefaultWorkspace(ctx, acct, membership, profile)
 		if err == nil {
+			if wonElsewhere {
+				// A concurrent request for this same viewer already committed
+				// a workspace under the lock. Nothing left to do: the caller
+				// re-lists memberships right after this returns and picks up
+				// the winner's row. Skip the billing best-effort block below
+				// too — the winning call already ran it for this viewer.
+				return nil
+			}
 			break
 		}
 		if !errors.Is(err, ErrSlugTaken) {
-			return fmt.Errorf("accounts: create default account: %w", err)
+			return fmt.Errorf("accounts: provision default workspace: %w", err)
 		}
 
-		// The slug collided. buildSlug has no per-user uniqueifier, so this
-		// fires in two different situations (see ErrSlugTaken's doc comment):
-		//
-		//  1. A concurrent request for this SAME viewer already won the
-		//     provisioning race (Next.js Server Components call getViewer()
-		//     unmemoized per component, so a brand-new user's first page load
-		//     can fire this insert twice). That request's account and
-		//     membership already committed, so re-listing memberships here
-		//     finds them and there is nothing left for this call to do — the
-		//     caller re-lists again right after this returns and picks it up.
-		//  2. A genuinely different viewer's display name collapsed to the
-		//     same slug. This viewer still has no active membership, so fall
-		//     through and retry with a de-duplicated slug instead of failing
-		//     their first-ever sign-in.
-		memberships, listErr := s.repo.ListMembershipsByUserID(ctx, viewer.UserID)
-		if listErr != nil {
-			return fmt.Errorf("accounts: list memberships after slug collision: %w", listErr)
-		}
-		if len(activeMemberships(memberships)) > 0 {
-			return nil
-		}
+		// ErrSlugTaken here can only mean a genuinely different viewer's
+		// display name collapsed to the same slug (buildSlug has no per-user
+		// uniqueifier): the advisory lock above already ruled out this being
+		// the same viewer racing itself. Retry with a de-duplicated slug
+		// instead of failing this viewer's first-ever sign-in.
 		if attempt+1 >= maxSlugAttempts {
 			return fmt.Errorf("accounts: create default account: slug %q still taken after %d attempts", baseSlug, maxSlugAttempts)
 		}
-	}
-
-	membership := Membership{
-		ID:        uuid.New(),
-		AccountID: accountID,
-		UserID:    viewer.UserID,
-		Role:      RoleOwner,
-		Status:    StatusActive,
-	}
-	if err := s.repo.CreateMembership(ctx, membership); err != nil {
-		return fmt.Errorf("accounts: create owner membership: %w", err)
-	}
-
-	ownerName := viewer.FullName
-	if ownerName == "" {
-		ownerName = emailLocalPart(viewer.Email)
-	}
-	profile := AccountProfile{
-		AccountID:            accountID,
-		OwnerName:            ownerName,
-		LoginEmail:           viewer.Email,
-		ProfileSetupComplete: false,
-	}
-	if err := s.repo.CreateProfile(ctx, profile); err != nil {
-		return fmt.Errorf("accounts: create account profile: %w", err)
 	}
 
 	// Best-effort and non-fatal, mirroring signup.Provisioner's own contract:

--- a/apps/control-plane/internal/accounts/service_test.go
+++ b/apps/control-plane/internal/accounts/service_test.go
@@ -20,6 +20,15 @@ type stubRepo struct {
 	emails        map[uuid.UUID]string    // user id -> auth.users email
 	activeTenants map[uuid.UUID]uuid.UUID // user id -> tenant id, for ActiveTenantID
 	acceptCalled  bool
+
+	// simulateSelfRace, when set, makes the next CreateAccount call fail with
+	// ErrSlugTaken exactly once and, as a side effect, write raceAccount and
+	// raceMembership directly — modeling a concurrent request for the same
+	// viewer that committed its own provisioning first. See
+	// TestEnsureDefaultAccount_SlugCollisionFromConcurrentSelf_Recovers.
+	simulateSelfRace bool
+	raceAccount      *accounts.Account
+	raceMembership   *accounts.Membership
 }
 
 func newStubRepo() *stubRepo {
@@ -48,6 +57,17 @@ func (s *stubRepo) ActiveTenantID(_ context.Context, userID uuid.UUID) (uuid.UUI
 }
 
 func (s *stubRepo) CreateAccount(_ context.Context, acct accounts.Account) error {
+	if s.simulateSelfRace {
+		s.simulateSelfRace = false
+		s.accountsMap[s.raceAccount.ID] = s.raceAccount
+		s.memberships = append(s.memberships, *s.raceMembership)
+		return accounts.ErrSlugTaken
+	}
+	for _, existing := range s.accountsMap {
+		if existing.Slug == acct.Slug {
+			return accounts.ErrSlugTaken
+		}
+	}
 	s.accountsMap[acct.ID] = &acct
 	return nil
 }
@@ -256,6 +276,102 @@ func TestEnsureDefaultAccount_VerifiedOwnerHasKeyPermissions(t *testing.T) {
 	}
 	if !contains(vc.Permissions, "api_keys.write") {
 		t.Error("expected api_keys.write in Permissions for verified owner")
+	}
+}
+
+// TestEnsureDefaultAccount_SlugCollisionFromConcurrentSelf_Recovers reproduces
+// the CI flake behind "could not load your workspace": Next.js Server
+// Components call getViewer() unmemoized per component, so a brand-new
+// viewer's very first page load can fire two concurrent
+// provisionDefaultWorkspace attempts. Both derive the identical slug from the
+// same viewer, so the loser hits accounts.slug's unique constraint. Losing
+// that race must recover the winner's workspace, not surface a 500.
+func TestEnsureDefaultAccount_SlugCollisionFromConcurrentSelf_Recovers(t *testing.T) {
+	repo := newStubRepo()
+	svc := accounts.NewService(repo)
+
+	viewer := auth.Viewer{
+		UserID:        uuid.New(),
+		Email:         "racer@example.com",
+		EmailVerified: true,
+		FullName:      "Racer User",
+	}
+
+	winningAccountID := uuid.New()
+	repo.simulateSelfRace = true
+	repo.raceAccount = &accounts.Account{
+		ID:          winningAccountID,
+		Slug:        "racer-user-s-workspace",
+		DisplayName: "Racer User's Workspace",
+		AccountType: "personal",
+		OwnerUserID: viewer.UserID,
+	}
+	repo.raceMembership = &accounts.Membership{
+		ID:        uuid.New(),
+		AccountID: winningAccountID,
+		UserID:    viewer.UserID,
+		Role:      "owner",
+		Status:    "active",
+	}
+
+	vc, err := svc.EnsureViewerContext(context.Background(), viewer, uuid.Nil)
+	if err != nil {
+		t.Fatalf("EnsureViewerContext error: %v", err)
+	}
+	if vc.CurrentAccount.ID != winningAccountID {
+		t.Errorf("expected to recover the concurrent winner's account %v, got %v", winningAccountID, vc.CurrentAccount.ID)
+	}
+	if len(vc.Memberships) != 1 {
+		t.Fatalf("expected 1 membership recovered from the race, got %d", len(vc.Memberships))
+	}
+}
+
+// TestEnsureDefaultAccount_SlugCollisionFromDifferentViewer_RetriesWithSuffix
+// covers the other trigger for the same unique constraint: two different
+// viewers whose display names collapse to the same slug (buildSlug has no
+// per-user uniqueifier). Unlike the self-race case, this viewer holds no
+// membership after the collision, so provisioning must retry with a
+// de-duplicated slug rather than recover a workspace that is not theirs.
+func TestEnsureDefaultAccount_SlugCollisionFromDifferentViewer_RetriesWithSuffix(t *testing.T) {
+	repo := newStubRepo()
+	svc := accounts.NewService(repo)
+
+	otherUserID := uuid.New()
+	otherAccountID := uuid.New()
+	// buildSlug("Same Name's Workspace") == "same-name-s-workspace" — pinned
+	// here to force the collision without exporting the algorithm to this
+	// blackbox test package.
+	repo.accountsMap[otherAccountID] = &accounts.Account{
+		ID:          otherAccountID,
+		Slug:        "same-name-s-workspace",
+		DisplayName: "Same Name's Workspace",
+		AccountType: "personal",
+		OwnerUserID: otherUserID,
+	}
+	repo.memberships = append(repo.memberships, accounts.Membership{
+		ID:        uuid.New(),
+		AccountID: otherAccountID,
+		UserID:    otherUserID,
+		Role:      "owner",
+		Status:    "active",
+	})
+
+	viewer := auth.Viewer{
+		UserID:        uuid.New(),
+		Email:         "samename@example.com",
+		EmailVerified: true,
+		FullName:      "Same Name",
+	}
+
+	vc, err := svc.EnsureViewerContext(context.Background(), viewer, uuid.Nil)
+	if err != nil {
+		t.Fatalf("EnsureViewerContext error: %v", err)
+	}
+	if vc.CurrentAccount.ID == otherAccountID {
+		t.Fatal("expected a distinct account for the colliding different-viewer case, got the other viewer's account")
+	}
+	if len(vc.Memberships) != 1 {
+		t.Fatalf("expected 1 membership for the new viewer, got %d", len(vc.Memberships))
 	}
 }
 

--- a/apps/control-plane/internal/accounts/service_test.go
+++ b/apps/control-plane/internal/accounts/service_test.go
@@ -21,14 +21,17 @@ type stubRepo struct {
 	activeTenants map[uuid.UUID]uuid.UUID // user id -> tenant id, for ActiveTenantID
 	acceptCalled  bool
 
-	// simulateSelfRace, when set, makes the next CreateAccount call fail with
-	// ErrSlugTaken exactly once and, as a side effect, write raceAccount and
-	// raceMembership directly — modeling a concurrent request for the same
-	// viewer that committed its own provisioning first. See
+	// raceWinnerAccountID, when non-nil, makes ProvisionDefaultWorkspace
+	// behave as production does when a concurrent request for the same
+	// viewer already committed under the advisory lock: raceWinnerAccount
+	// and raceWinnerMembership become visible as part of that call (not
+	// before — the outer, unlocked membership check in EnsureViewerContext
+	// must still see nothing, exactly like the real TOCTOU window), and the
+	// call reports wonElsewhere instead of inserting its own rows. See
 	// TestEnsureDefaultAccount_SlugCollisionFromConcurrentSelf_Recovers.
-	simulateSelfRace bool
-	raceAccount      *accounts.Account
-	raceMembership   *accounts.Membership
+	raceWinnerAccountID  uuid.UUID
+	raceWinnerAccount    *accounts.Account
+	raceWinnerMembership *accounts.Membership
 }
 
 func newStubRepo() *stubRepo {
@@ -57,19 +60,28 @@ func (s *stubRepo) ActiveTenantID(_ context.Context, userID uuid.UUID) (uuid.UUI
 }
 
 func (s *stubRepo) CreateAccount(_ context.Context, acct accounts.Account) error {
-	if s.simulateSelfRace {
-		s.simulateSelfRace = false
-		s.accountsMap[s.raceAccount.ID] = s.raceAccount
-		s.memberships = append(s.memberships, *s.raceMembership)
-		return accounts.ErrSlugTaken
+	s.accountsMap[acct.ID] = &acct
+	return nil
+}
+
+// ProvisionDefaultWorkspace mirrors pgxRepository's contract (see its doc
+// comment in repository.go): recover a concurrent winner if raceWinnerAccountID
+// is set, otherwise insert unless the slug collides with an existing account.
+func (s *stubRepo) ProvisionDefaultWorkspace(_ context.Context, acct accounts.Account, membership accounts.Membership, profile accounts.AccountProfile) (uuid.UUID, bool, error) {
+	if s.raceWinnerAccountID != uuid.Nil {
+		s.accountsMap[s.raceWinnerAccount.ID] = s.raceWinnerAccount
+		s.memberships = append(s.memberships, *s.raceWinnerMembership)
+		return s.raceWinnerAccountID, true, nil
 	}
 	for _, existing := range s.accountsMap {
 		if existing.Slug == acct.Slug {
-			return accounts.ErrSlugTaken
+			return uuid.Nil, false, accounts.ErrSlugTaken
 		}
 	}
 	s.accountsMap[acct.ID] = &acct
-	return nil
+	s.memberships = append(s.memberships, membership)
+	s.profiles[profile.AccountID] = &profile
+	return acct.ID, false, nil
 }
 
 func (s *stubRepo) CreateMembership(_ context.Context, m accounts.Membership) error {
@@ -283,9 +295,11 @@ func TestEnsureDefaultAccount_VerifiedOwnerHasKeyPermissions(t *testing.T) {
 // the CI flake behind "could not load your workspace": Next.js Server
 // Components call getViewer() unmemoized per component, so a brand-new
 // viewer's very first page load can fire two concurrent
-// provisionDefaultWorkspace attempts. Both derive the identical slug from the
-// same viewer, so the loser hits accounts.slug's unique constraint. Losing
-// that race must recover the winner's workspace, not surface a 500.
+// provisionDefaultWorkspace attempts. repo.ProvisionDefaultWorkspace
+// serializes them on a per-viewer advisory lock in production; here the stub
+// models the second (losing) call's lock-scoped re-check finding the first's
+// committed row, which must be recovered rather than surfaced as a 500 or a
+// second, duplicate workspace.
 func TestEnsureDefaultAccount_SlugCollisionFromConcurrentSelf_Recovers(t *testing.T) {
 	repo := newStubRepo()
 	svc := accounts.NewService(repo)
@@ -298,15 +312,15 @@ func TestEnsureDefaultAccount_SlugCollisionFromConcurrentSelf_Recovers(t *testin
 	}
 
 	winningAccountID := uuid.New()
-	repo.simulateSelfRace = true
-	repo.raceAccount = &accounts.Account{
+	repo.raceWinnerAccountID = winningAccountID
+	repo.raceWinnerAccount = &accounts.Account{
 		ID:          winningAccountID,
 		Slug:        "racer-user-s-workspace",
 		DisplayName: "Racer User's Workspace",
 		AccountType: "personal",
 		OwnerUserID: viewer.UserID,
 	}
-	repo.raceMembership = &accounts.Membership{
+	repo.raceWinnerMembership = &accounts.Membership{
 		ID:        uuid.New(),
 		AccountID: winningAccountID,
 		UserID:    viewer.UserID,
@@ -323,6 +337,12 @@ func TestEnsureDefaultAccount_SlugCollisionFromConcurrentSelf_Recovers(t *testin
 	}
 	if len(vc.Memberships) != 1 {
 		t.Fatalf("expected 1 membership recovered from the race, got %d", len(vc.Memberships))
+	}
+	// The bug this guards against: a second personal workspace silently
+	// created for the same viewer because the losing request didn't see the
+	// winner's row yet. Exactly one account must exist for this viewer.
+	if len(repo.accountsMap) != 1 {
+		t.Fatalf("expected exactly 1 account to exist after the race, got %d", len(repo.accountsMap))
 	}
 }
 

--- a/apps/control-plane/internal/accounts/types.go
+++ b/apps/control-plane/internal/accounts/types.go
@@ -150,6 +150,16 @@ var ErrLastOwner = errors.New("accounts: workspace must keep at least one owner"
 // workspace provisioning did not produce one.
 var ErrNoActiveWorkspace = errors.New("accounts: no active workspace available")
 
+// ErrSlugTaken is returned when creating an account collides with an
+// existing accounts.slug value. buildSlug has no per-user uniqueifier, so
+// this fires in two distinct situations that provisionDefaultWorkspace tells
+// apart: two concurrent requests provisioning the *same* viewer's first
+// workspace (Next.js Server Components call getViewer() unmemoized per
+// component, so a brand-new user's first page load can race this insert),
+// and two different viewers whose display names happen to collapse to the
+// same slug.
+var ErrSlugTaken = errors.New("accounts: workspace slug already taken")
+
 // ErrEmailNotVerified is returned when a viewer whose email address is not
 // verified tries to accept an invitation. Accepting is what grants the role, so
 // it carries at least the verification requirement that issuing an invitation

--- a/apps/control-plane/internal/budgets/http_test.go
+++ b/apps/control-plane/internal/budgets/http_test.go
@@ -147,6 +147,12 @@ func (s *accountsRepoStub) CreateProfile(_ context.Context, _ accounts.AccountPr
 	return nil
 }
 
+func (s *accountsRepoStub) ProvisionDefaultWorkspace(_ context.Context, acct accounts.Account, membership accounts.Membership, _ accounts.AccountProfile) (uuid.UUID, bool, error) {
+	s.accountsMap[acct.ID] = &acct
+	s.memberships = append(s.memberships, membership)
+	return acct.ID, false, nil
+}
+
 func (s *accountsRepoStub) GetAccountByID(_ context.Context, id uuid.UUID) (*accounts.Account, error) {
 	acct, ok := s.accountsMap[id]
 	if !ok {

--- a/apps/control-plane/internal/ledger/service_test.go
+++ b/apps/control-plane/internal/ledger/service_test.go
@@ -150,6 +150,12 @@ func (s *stubRepo) CreateProfile(_ context.Context, _ accounts.AccountProfile) e
 	return nil
 }
 
+func (s *stubRepo) ProvisionDefaultWorkspace(_ context.Context, acct accounts.Account, membership accounts.Membership, _ accounts.AccountProfile) (uuid.UUID, bool, error) {
+	s.accountsMap[acct.ID] = &acct
+	s.memberships = append(s.memberships, membership)
+	return acct.ID, false, nil
+}
+
 func (s *stubRepo) GetAccountByID(_ context.Context, id uuid.UUID) (*accounts.Account, error) {
 	acct, ok := s.accountsMap[id]
 	if !ok {

--- a/apps/control-plane/internal/profiles/service_test.go
+++ b/apps/control-plane/internal/profiles/service_test.go
@@ -135,6 +135,17 @@ func (s *stubRepo) CreateProfile(_ context.Context, profile accounts.AccountProf
 	return nil
 }
 
+func (s *stubRepo) ProvisionDefaultWorkspace(_ context.Context, acct accounts.Account, membership accounts.Membership, profile accounts.AccountProfile) (uuid.UUID, bool, error) {
+	s.accountsMap[acct.ID] = &acct
+	s.memberships = append(s.memberships, membership)
+	s.profiles[profile.AccountID] = AccountProfile{
+		OwnerName:            profile.OwnerName,
+		LoginEmail:           profile.LoginEmail,
+		ProfileSetupComplete: profile.ProfileSetupComplete,
+	}
+	return acct.ID, false, nil
+}
+
 func (s *stubRepo) GetAccountByID(_ context.Context, id uuid.UUID) (*accounts.Account, error) {
 	acct, ok := s.accountsMap[id]
 	if !ok {

--- a/apps/control-plane/internal/usage/service_test.go
+++ b/apps/control-plane/internal/usage/service_test.go
@@ -173,6 +173,12 @@ func (s *stubRepo) CreateProfile(_ context.Context, _ accounts.AccountProfile) e
 	return nil
 }
 
+func (s *stubRepo) ProvisionDefaultWorkspace(_ context.Context, acct accounts.Account, membership accounts.Membership, _ accounts.AccountProfile) (uuid.UUID, bool, error) {
+	s.accountsMap[acct.ID] = &acct
+	s.memberships = append(s.memberships, membership)
+	return acct.ID, false, nil
+}
+
 func (s *stubRepo) GetAccountByID(_ context.Context, id uuid.UUID) (*accounts.Account, error) {
 	acct, ok := s.accountsMap[id]
 	if !ok {


### PR DESCRIPTION
## Summary

Unblocks the required `Web E2E (full stack)` check on `main`, which was intermittently red and hard-blocking every queued PR (including #960, a live cross-tenant data exposure fix).

- Fixes a genuine, intermittent backend race condition, not a test-selector or fixture drift.
- `provisionDefaultWorkspace` (default-workspace auto-provisioning on first sign-in) had no idempotency guard. Next.js Server Components call `getViewer()` unmemoized per component (`layout.tsx` and each `page.tsx` independently), so a brand-new user's first console page load can fire two concurrent `GET /api/v1/viewer` requests. Both see zero active memberships and both try to create a personal workspace with the same deterministic slug (`buildSlug` derives it purely from the viewer's own display name). The loser hits `accounts.slug`'s unique constraint, and `CreateAccount` let that raw pg error escape unhandled as an opaque 500 ("could not load your workspace"), tripping the console's generic error boundary.
- E2E mints a fresh test user per run, so its very first page load reliably lands in this race window on a real, unlucky-timing basis, hence flaky (fails once, passes on Playwright's retry) rather than a hard, permanent break. This is exactly what the suite's flake-rate gate ("A test that only passes on a retry is not a passing test") is there to catch.

## Root cause investigation

- Walked `Web E2E (full stack)` job history on `main`: last clean pass was `1dc67ee6` (2026-08-17 16:56). PR #955's own pre-merge CI run hit this exact race on two specs (`console-spend-alerts.spec.ts`, `profile-completion.spec.ts`), both reported "2 flaky" (failed once, passed on retry) by the job's flake gate, which is what failed the job, not a hard 0-passed failure.
- Downloaded that run's `nextjs-log-web-e2e` artifact: the underlying server error was `Error: could not load your workspace` with digests matching the two `error-context.md` snapshots' "quote reference" numbers exactly (`270132166`, `3259196144`). Traced that message to `writeInternal(w, r, "could not load your workspace", err)` in `accounts/http.go`'s `handleGetViewer`, then to `EnsureViewerContext` → `provisionDefaultWorkspace` → `CreateAccount`'s unhandled `INSERT ... accounts (slug ...)` unique-violation.
- This is unrelated to the separate, already-known-stale `OWUI nightly e2e` selector issue (`button` named "New chat" vs the `<a>` OWUI actually renders) that's in flight on #951 — different harness, different spec, not touched here.
- Neither #954 nor #955 introduced this: #955 is a test-only Go change and could not plausibly affect the web console; #954 touches auth-header normalization, unrelated to workspace provisioning. Both merged while this check was still pending (a known process gap, flagged separately), but neither is the cause.
- This gate has **not** been silently ignored: the two prior real (non-skipped, non-cancelled) job completions on `main` before this PR were both green (`1dc67ee6` success, `ef06d693` success). PR #955 merged with its own pre-merge run showing this failure, which is the actual process gap worth naming; it did not merge past a run that had already gone green.

## Fix

- New sentinel `accounts.ErrSlugTaken`, returned by `CreateAccount` on a unique violation on `slug` (mirrors the existing `CreateMembership` → `ErrAlreadyMember` translation already in the same file).
- `provisionDefaultWorkspace` now distinguishes the two situations a slug collision can mean:
  1. A concurrent request for the **same** viewer already won the provisioning race — re-checking that viewer's own memberships finds the winner's row, and this call recovers silently (no error; the caller re-lists memberships right after, same as the success path).
  2. A genuine collision between two **different** viewers whose display names happen to produce the same slug (`buildSlug` has no per-user uniqueifier) — this viewer still holds no membership after the collision, so it retries with a de-duplicated slug (bounded, 3 attempts) instead of failing that viewer's first sign-in outright.

## Test plan

- [x] `go build ./apps/control-plane/...` — clean.
- [x] `go vet ./apps/control-plane/...` — clean.
- [x] `gofmt -l apps/control-plane/internal/accounts/` — no unformatted files.
- [x] `go test ./apps/control-plane/internal/accounts/... -count=1` — all pass, including two new regression tests:
  - `TestEnsureDefaultAccount_SlugCollisionFromConcurrentSelf_Recovers`
  - `TestEnsureDefaultAccount_SlugCollisionFromDifferentViewer_RetriesWithSuffix`
- [ ] `Web E2E (full stack)` on this PR — will confirm the spend-alerts and profile-completion specs no longer flake once CI runs.

## Buglog entry

Per `.wolf/` policy, not appended to `.wolf/buglog.jsonl` on this branch. To be carried into a separate buglog-only PR off `main` once this merges:

```json
{"error_message": "could not load your workspace (500) on GET /api/v1/viewer, surfacing as the web console's generic error boundary on the spend-alerts and billing-settings pages", "root_cause": "provisionDefaultWorkspace has no idempotency guard: two concurrent Server Component calls to getViewer() for the same brand-new user both attempt to create a personal workspace with the same deterministic slug, and CreateAccount let the resulting pg unique-violation on accounts.slug escape as a raw 500 instead of recovering the race", "fix": "translate the unique violation into accounts.ErrSlugTaken and have provisionDefaultWorkspace re-check the viewer's own memberships on collision: recover silently if a concurrent request for the same viewer already won, otherwise retry once with a de-duplicated slug for the genuine different-viewer collision case", "tags": ["accounts", "web-e2e", "race-condition", "ci-gate", "flaky-test"]}
```


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR makes first-login workspace provisioning atomic and resilient to both same-viewer races and cross-viewer slug collisions.
- Adds a per-viewer PostgreSQL advisory transaction lock and lock-scoped membership re-check.
- Atomically inserts the account, owner membership, and profile.
- Translates slug uniqueness violations into a sentinel and retries cross-viewer collisions with a deduplicated slug.
- Adds regression coverage and updates repository test doubles for the expanded interface.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no actionable changed-code defect identified.

The transaction serializes provisioning by viewer, re-checks the same active-membership invariant used by the service, atomically persists all required workspace rows, and correctly handles the current slug uniqueness constraint.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/control-plane/internal/accounts/repository.go | Adds atomic, transaction-scoped workspace provisioning with a per-viewer advisory lock, active-membership re-check, and precise slug-conflict translation. |
| apps/control-plane/internal/accounts/service.go | Routes default provisioning through the atomic repository method and retries genuine cross-viewer slug collisions with bounded randomized suffixes. |
| apps/control-plane/internal/accounts/service_test.go | Adds focused regression tests for concurrent same-viewer recovery and different-viewer slug deduplication. |
| apps/control-plane/internal/accounts/types.go | Introduces the ErrSlugTaken sentinel used to distinguish retryable slug collisions. |
| apps/control-plane/internal/accounting/http_test.go | Updates the account repository test double for the new atomic provisioning interface. |
| apps/control-plane/internal/budgets/http_test.go | Updates the account repository test double for the new atomic provisioning interface. |
| apps/control-plane/internal/ledger/service_test.go | Updates the account repository test double for the new atomic provisioning interface. |
| apps/control-plane/internal/profiles/service_test.go | Updates the profile-aware repository test double for atomic provisioning. |
| apps/control-plane/internal/usage/service_test.go | Updates the account repository test double for the new atomic provisioning interface. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant A as Viewer request A
  participant B as Viewer request B
  participant S as Accounts service
  participant DB as PostgreSQL
  A->>S: EnsureViewerContext
  B->>S: EnsureViewerContext
  A->>DB: Begin + lock(viewer)
  B->>DB: Begin + wait for lock(viewer)
  A->>DB: Re-check membership
  A->>DB: Insert account, membership, profile
  A->>DB: Commit and release lock
  B->>DB: Acquire lock and re-check
  DB-->>B: Existing active membership
  B-->>S: "wonElsewhere = true"
  S-->>B: Re-list and use winner workspace
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: close the workspace-provisioning ra..."](https://github.com/sakibsadmanshajib/hive/commit/e08b57f7b408d9dcd03222acf14b221260e88865) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54270438)</sub>

**Context used:**

- Knowledge Base — [Control-plane identity and access](https://app.greptile.com/scubed/-/custom-context/knowledge-base/sakibsadmanshajib/hive/-/docs/control-plane-identity-access.md)

<!-- /greptile_comment -->