### PR TITLE
fix: revert hive-fast to a live Groq model, collapse routing-internals leak

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -158,7 +158,7 @@ OPENROUTER_EMBEDDING_FALLBACK_MODEL=openrouter/qwen/qwen3-embedding-8b
 # Groq free chat/reasoning models (llama-3.1-8b-instant primary, cheapest
 # Groq model as of 2026-08-03: $0.05 in / $0.08 out per million tokens vs
 # gpt-oss-20b's $0.075 / $0.30; 120b reasoning unchanged).
-GROQ_FAST_MODEL=groq/llama-3.1-8b-instant
+GROQ_FAST_MODEL=groq/openai/gpt-oss-20b
 GROQ_REASONING_MODEL=groq/openai/gpt-oss-120b
 
 # ─── RAG query embeddings (issue #232) ──────────────────────────────

--- a/.env.example
+++ b/.env.example
@@ -155,9 +155,13 @@ OPENROUTER_FAST_FALLBACK_MODEL=openrouter/free
 OPENROUTER_EMBEDDING_MODEL=openrouter/nvidia/llama-nemotron-embed-vl-1b-v2:free
 OPENROUTER_EMBEDDING_FALLBACK_MODEL=openrouter/qwen/qwen3-embedding-8b
 
-# Groq free chat/reasoning models (llama-3.1-8b-instant primary, cheapest
-# Groq model as of 2026-08-03: $0.05 in / $0.08 out per million tokens vs
-# gpt-oss-20b's $0.075 / $0.30; 120b reasoning unchanged).
+# Groq free chat/reasoning models (gpt-oss-20b primary, 120b reasoning).
+# Reverted 2026-08-18 (issue #965): the previously-pinned llama-3.1-8b-instant
+# was cheaper as of 2026-08-03 but Groq has since decommissioned it entirely,
+# so hive-fast 404'd on every request. gpt-oss-20b is the closest fast/cheap
+# model Groq still serves live; do not repoint this to a specific low-cost
+# model id again without re-checking it against Groq's own /v1/models first,
+# that is exactly what broke last time.
 GROQ_FAST_MODEL=groq/openai/gpt-oss-20b
 GROQ_REASONING_MODEL=groq/openai/gpt-oss-120b
 

--- a/.github/workflows/owui-nightly.yml
+++ b/.github/workflows/owui-nightly.yml
@@ -214,7 +214,7 @@ jobs:
           OPENROUTER_AUTO_MODEL=openrouter/openai/gpt-4.1-mini
           OPENROUTER_EMBEDDING_MODEL=openrouter/nvidia/llama-nemotron-embed-vl-1b-v2:free
           OPENROUTER_EMBEDDING_FALLBACK_MODEL=openrouter/qwen/qwen3-embedding-8b
-          GROQ_FAST_MODEL=groq/llama-3.1-8b-instant
+          GROQ_FAST_MODEL=groq/openai/gpt-oss-20b
           GROQ_REASONING_MODEL=groq/openai/gpt-oss-120b
           NEXT_PUBLIC_SUPABASE_URL=${NEXT_PUBLIC_SUPABASE_URL:-$SUPABASE_URL}
           NEXT_PUBLIC_SUPABASE_ANON_KEY=${NEXT_PUBLIC_SUPABASE_ANON_KEY:-$SUPABASE_ANON_KEY}

--- a/apps/control-plane/internal/routing/catalog_pricing_integration_test.go
+++ b/apps/control-plane/internal/routing/catalog_pricing_integration_test.go
@@ -125,12 +125,16 @@ func TestSeededAliasHasExactlyOneEnabledRoute(t *testing.T) {
 
 // TestHiveFastIsPinnedToGroqAtCorrectedPrice is requirement (c) at the data
 // level. The expected credit figures are derived by hand from Groq's
-// published rate for llama-3.1-8b-instant (20260801_14_route_groq_fast_cheapest_model.sql,
-// the cheapest available Groq model as of 2026-08-03) so a later price change
-// has to fail this test and be re-derived rather than drift silently:
+// published rate for openai/gpt-oss-20b
+// (20260818_01_revert_hive_fast_groq_model_decommissioned.sql). Groq
+// decommissioned the previously-pinned llama-3.1-8b-instant sometime after
+// 2026-08-03, so hive-fast was reverted to gpt-oss-20b, the model this route
+// used before that cost migration, and its (unchanged) published rate. A
+// later price or route change has to fail this test and be re-derived rather
+// than drift silently:
 //
-//	input:  0.05 USD/M * 1.4 = 0.070 USD/M * 100_000 credits/USD =  7_000
-//	output: 0.08 USD/M * 1.4 = 0.112 USD/M * 100_000 credits/USD = 11_200
+//	input:  0.075 USD/M * 1.4 = 0.105 USD/M * 100_000 credits/USD = 10_500
+//	output: 0.300 USD/M * 1.4 = 0.420 USD/M * 100_000 credits/USD = 42_000
 func TestHiveFastIsPinnedToGroqAtCorrectedPrice(t *testing.T) {
 	pool := connectCatalogDB(t)
 
@@ -146,8 +150,8 @@ func TestHiveFastIsPinnedToGroqAtCorrectedPrice(t *testing.T) {
 	if provider != "groq" {
 		t.Errorf("hive-fast provider = %q, want groq", provider)
 	}
-	if providerModel != "groq/llama-3.1-8b-instant" {
-		t.Errorf("hive-fast provider_model = %q, want groq/llama-3.1-8b-instant", providerModel)
+	if providerModel != "groq/openai/gpt-oss-20b" {
+		t.Errorf("hive-fast provider_model = %q, want groq/openai/gpt-oss-20b", providerModel)
 	}
 
 	var input, output int64
@@ -157,11 +161,11 @@ func TestHiveFastIsPinnedToGroqAtCorrectedPrice(t *testing.T) {
 	`).Scan(&input, &output); err != nil {
 		t.Fatalf("read hive-fast pricing: %v", err)
 	}
-	if input != 7_000 {
-		t.Errorf("hive-fast input_price_credits = %d, want 7000", input)
+	if input != 10_500 {
+		t.Errorf("hive-fast input_price_credits = %d, want 10500", input)
 	}
-	if output != 11_200 {
-		t.Errorf("hive-fast output_price_credits = %d, want 11200", output)
+	if output != 42_000 {
+		t.Errorf("hive-fast output_price_credits = %d, want 42000", output)
 	}
 }
 

--- a/apps/edge-api/internal/errors/provider_blind.go
+++ b/apps/edge-api/internal/errors/provider_blind.go
@@ -80,6 +80,16 @@ func sanitizeProviderBlindMessage(alias string, httpStatus int, raw string) stri
 	if providerBlindLooksLikeTransportFailure(lowerRaw) || providerBlindLooksLikeTransportFailure(lowerMessage) {
 		return fmt.Sprintf("%s is temporarily unavailable.", resourceLabel)
 	}
+	if providerBlindLooksLikeRoutingInternals(lowerRaw) || providerBlindLooksLikeRoutingInternals(lowerMessage) {
+		// LiteLLM's own fallback-group bookkeeping (issue #965): "No fallback
+		// model group found for original model_group=X. Fallbacks=[...].
+		// Retried: N times." Carries no provider name, so the regexes above
+		// never touch it, but it is still internal routing detail no
+		// customer-facing error should carry. Collapse the whole message
+		// rather than trying to scrub an open-ended, LiteLLM-versioned
+		// bookkeeping format field by field.
+		return fmt.Sprintf("%s is not available.", resourceLabel)
+	}
 	if providerBlindLooksLikeAuthFailure(httpStatus, lowerRaw) || providerBlindLooksLikeAuthFailure(httpStatus, lowerMessage) {
 		return fmt.Sprintf("%s request was rejected by the upstream provider.", resourceLabel)
 	}
@@ -197,6 +207,20 @@ func providerBlindLooksLikeTransportFailure(message string) bool {
 		"temporarily unavailable",
 		"no such host",
 		"econnrefused",
+	} {
+		if strings.Contains(message, token) {
+			return true
+		}
+	}
+	return false
+}
+
+func providerBlindLooksLikeRoutingInternals(message string) bool {
+	for _, token := range []string{
+		"fallback model group",
+		"model_group=",
+		"fallbacks=[",
+		"retried:",
 	} {
 		if strings.Contains(message, token) {
 			return true

--- a/apps/edge-api/internal/errors/provider_blind.go
+++ b/apps/edge-api/internal/errors/provider_blind.go
@@ -216,12 +216,13 @@ func providerBlindLooksLikeTransportFailure(message string) bool {
 }
 
 func providerBlindLooksLikeRoutingInternals(message string) bool {
-	for _, token := range []string{
-		"fallback model group",
-		"model_group=",
-		"fallbacks=[",
-		"retried:",
-	} {
+	// "retried: N times" deliberately excluded: it is ordinary English a
+	// legitimate upstream message could use on its own, so alone it risked
+	// collapsing safe error text (security review finding on this PR). The
+	// three tokens below are specific to LiteLLM's own bookkeeping
+	// vocabulary and already fully cover issue #965's reported leak shape
+	// without it.
+	for _, token := range []string{"fallback model group", "model_group=", "fallbacks=["} {
 		if strings.Contains(message, token) {
 			return true
 		}

--- a/apps/edge-api/internal/errors/provider_blind_test.go
+++ b/apps/edge-api/internal/errors/provider_blind_test.go
@@ -137,6 +137,36 @@ func TestWriteProviderBlindUpstreamErrorHidesInternalTransportDetails(t *testing
 	assertNoProviderLeak(t, resp.Error.Message)
 }
 
+func TestWriteProviderBlindUpstreamErrorHidesFallbackRoutingInternals(t *testing.T) {
+	w := httptest.NewRecorder()
+
+	// Reproduces issue #965: a model_not_found upstream response wrapped in
+	// LiteLLM's own fallback-group bookkeeping. No literal provider name
+	// appears in "No fallback model group found ... Fallbacks=[...] ...
+	// Retried: 3 times", so the provider-name regex alone never catches it;
+	// the message must still not reach the customer.
+	raw := `upstream error - {"error":{"message":"The model ` + "`llama-3.1-8b-instant`" + ` does not exist or you do not have access to it.","type":"invalid_request_error","code":"model_not_found"}} No fallback model group found for original model_group=hive-fast. Fallbacks=[{'hive-fast': ['hive-fast']}, {'hive-fast': ['hive-fast']}, {'hive-fast': ['hive-fast']}]. Upstream provider Retried: 3 times`
+
+	WriteProviderBlindUpstreamError(w, "hive-fast", http.StatusNotFound, raw)
+
+	resp := decodeOpenAIError(t, w)
+	assertNoProviderLeak(t, resp.Error.Message)
+	for _, forbidden := range []string{
+		"fallback model group",
+		"model_group=",
+		"fallbacks=",
+		"retried:",
+		"llama-3.1-8b-instant",
+	} {
+		if strings.Contains(strings.ToLower(resp.Error.Message), forbidden) {
+			t.Fatalf("expected routing internals stripped, found %q in %q", forbidden, resp.Error.Message)
+		}
+	}
+	if !strings.Contains(resp.Error.Message, "hive-fast") {
+		t.Fatalf("expected alias in sanitized message, got %q", resp.Error.Message)
+	}
+}
+
 func decodeOpenAIError(t *testing.T, w *httptest.ResponseRecorder) OpenAIError {
 	t.Helper()
 

--- a/apps/edge-api/internal/errors/provider_blind_test.go
+++ b/apps/edge-api/internal/errors/provider_blind_test.go
@@ -149,6 +149,10 @@ func TestWriteProviderBlindUpstreamErrorHidesFallbackRoutingInternals(t *testing
 
 	WriteProviderBlindUpstreamError(w, "hive-fast", http.StatusNotFound, raw)
 
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusNotFound)
+	}
+
 	resp := decodeOpenAIError(t, w)
 	assertNoProviderLeak(t, resp.Error.Message)
 	for _, forbidden := range []string{
@@ -162,8 +166,24 @@ func TestWriteProviderBlindUpstreamErrorHidesFallbackRoutingInternals(t *testing
 			t.Fatalf("expected routing internals stripped, found %q in %q", forbidden, resp.Error.Message)
 		}
 	}
-	if !strings.Contains(resp.Error.Message, "hive-fast") {
-		t.Fatalf("expected alias in sanitized message, got %q", resp.Error.Message)
+	if resp.Error.Message != "hive-fast is not available." {
+		t.Fatalf("message = %q, want %q", resp.Error.Message, "hive-fast is not available.")
+	}
+}
+
+func TestProviderBlindLooksLikeRoutingInternalsRequiresSpecificToken(t *testing.T) {
+	w := httptest.NewRecorder()
+
+	// "retried:" alone, with none of LiteLLM's specific bookkeeping tokens,
+	// must NOT trigger the routing-internals collapse: a legitimate upstream
+	// message can plausibly use ordinary English like this, and over-collapsing
+	// it would throw away real detail for no safety gain (security review
+	// finding on this PR).
+	WriteProviderBlindUpstreamError(w, "hive-default", http.StatusBadGateway, "request failed, retried: 3 times before giving up")
+
+	resp := decodeOpenAIError(t, w)
+	if resp.Error.Message != "request failed, retried: 3 times before giving up" {
+		t.Fatalf("expected message to pass through unchanged, got %q", resp.Error.Message)
 	}
 }
 

--- a/supabase/migrations/20260818_01_revert_hive_fast_groq_model_decommissioned.sql
+++ b/supabase/migrations/20260818_01_revert_hive_fast_groq_model_decommissioned.sql
@@ -68,6 +68,15 @@
 --   second run of this file affects zero rows and errors on nothing.
 -- =============================================================================
 
+-- Wrapped in a transaction (database review finding on this PR): these two
+-- UPDATEs enforce the "one route, one price" invariant together. Without
+-- BEGIN/COMMIT, apply-migrations.sh commits each statement independently, and
+-- a request landing on ListRouteCandidates/LoadAliasPricing between them
+-- could read the new route with the old price, or vice versa. Same gap
+-- pre-existed in 20260801_01/20260801_14; closed here since this migration
+-- is specifically the one guarding that invariant.
+BEGIN;
+
 -- 1. Point route-groq-fast back at the model Groq currently serves.
 UPDATE public.provider_routes
    SET provider_model = 'groq/openai/gpt-oss-20b'
@@ -81,3 +90,5 @@ UPDATE public.model_aliases
        updated_at           = now()
  WHERE alias_id = 'hive-fast'
    AND (input_price_credits <> 10500 OR output_price_credits <> 42000);
+
+COMMIT;

--- a/supabase/migrations/20260818_01_revert_hive_fast_groq_model_decommissioned.sql
+++ b/supabase/migrations/20260818_01_revert_hive_fast_groq_model_decommissioned.sql
@@ -1,0 +1,83 @@
+-- =============================================================================
+-- Issue #965 (owner-ruled fix, 2026-08-18): hive-fast currently routes to
+-- Groq's llama-3.1-8b-instant, which Groq has removed from its live catalog
+-- since the 20260801_14 migration pinned it. Every hive-fast request 404s
+-- with model_not_found. Confirmed live 2026-08-18 against
+-- https://api.groq.com/openai/v1/models (Authorization: Bearer $GROQ_API_KEY):
+-- llama-3.1-8b-instant is absent from the response entirely. Groq's current
+-- catalog carries no small/fast Llama chat model at all; the closest fast,
+-- cheap, currently-live alternative is openai/gpt-oss-20b, which is also
+-- exactly what route-groq-fast pointed at before 20260801_14 repointed it
+-- for a (now moot) cost saving, so this is a revert to a config already
+-- proven live in production, not a fresh guess.
+--
+-- PROVIDER RATE, re-fetched 2026-08-18
+--   Groq openai/gpt-oss-20b   $0.075 in / $0.30 out USD per million tokens
+--     source: https://groq.com/pricing ("GPT OSS 20B" row) and
+--     https://console.groq.com/docs/models, both agree, unchanged since the
+--     20260801_01 migration derived hive-fast's price from the same figures.
+--
+-- FORMULA (same mechanical shape as 20260801_01 and 20260801_14)
+--   credits_per_million = ceil(provider_list_usd_per_million * MARGIN * CREDITS_PER_USD)
+--     MARGIN          = 1.4
+--     CREDITS_PER_USD = 100000   (apps/control-plane/internal/payments/types.go)
+--
+-- WORKED DERIVATION
+--   hive-fast  in  0.075 * 1.4 * 100000 = 10500
+--   hive-fast  out 0.300 * 1.4 * 100000 = 42000
+--   Both products are whole numbers, so the ceiling is a no-op here. These
+--   are the exact figures 20260801_01_alias_pricing_correction.sql already
+--   derived for this same model; 20260801_14 is the only migration that
+--   ever moved hive-fast off them.
+--
+-- KNOWN TRADE-OFF, DELIBERATELY ACCEPTED
+--   Per https://console.groq.com/docs/tool-use (checked 2026-08-18),
+--   openai/gpt-oss-20b supports tool use but not PARALLEL tool calls;
+--   llama-3.1-8b-instant did support parallel tool calls. This is a real
+--   capability step-down from what 20260801_14 intended, but
+--   llama-3.1-8b-instant no longer exists on Groq at any price, so there is
+--   no currently-live Groq model in hive-fast's fast/cheap tier that
+--   preserves parallel tool calls. provider_capabilities has no
+--   parallel-tool-call column (checked: supports_responses,
+--   supports_chat_completions, supports_completions, supports_embeddings,
+--   supports_streaming, supports_reasoning, supports_cache_read,
+--   supports_cache_write, plus the media flags added by
+--   20260414_01_provider_capabilities_media_columns.sql), so no catalog
+--   claim becomes untrue by this change, matching 20260801_14's own note
+--   about supports_reasoning.
+--
+-- OUT OF SCOPE (deliberately unchanged)
+--   * litellm_model_name: unchanged, same reasoning as 20260801_14 (it is
+--     the LiteLLM gateway alias name, not the upstream model).
+--   * alias_route_policies, provider_capabilities: untouched. hive-fast
+--     keeps exactly one enabled route (route-groq-fast).
+--   * The upstream model the running gateway actually calls is read from the
+--     GROQ_FAST_MODEL environment variable, not this catalog (issue #684).
+--     That variable is reverted separately in .env.example and the CI
+--     workflows that reference it; this migration only corrects the credit
+--     catalog. The demo box's own .env additionally needs
+--     GROQ_FAST_MODEL=groq/openai/gpt-oss-20b applied and the litellm
+--     container RECREATED (not restarted) for the live gateway to pick this
+--     up, per the same operational step 20260801_14 already required and
+--     per project_repo_is_not_the_running_system: this migration alone does
+--     not make the box serve the new model.
+--
+-- RE-RUNNABILITY
+--   Both statements are UPDATEs keyed on a primary key, each carrying its
+--   own WHERE guard that excludes rows already at the target value, so a
+--   second run of this file affects zero rows and errors on nothing.
+-- =============================================================================
+
+-- 1. Point route-groq-fast back at the model Groq currently serves.
+UPDATE public.provider_routes
+   SET provider_model = 'groq/openai/gpt-oss-20b'
+ WHERE route_id = 'route-groq-fast'
+   AND provider_model <> 'groq/openai/gpt-oss-20b';
+
+-- 2. Re-derive hive-fast's price from that model's published rate.
+UPDATE public.model_aliases
+   SET input_price_credits  = 10500,
+       output_price_credits = 42000,
+       updated_at           = now()
+ WHERE alias_id = 'hive-fast'
+   AND (input_price_credits <> 10500 OR output_price_credits <> 42000);


### PR DESCRIPTION
Fixes #965.

## What's broken

`hive-fast` 404s on every request with `model_not_found`. Groq removed
`llama-3.1-8b-instant` from its live catalog after
`20260801_14_route_groq_fast_cheapest_model.sql` pinned `route-groq-fast` to
it on 2026-08-01. Confirmed live 2026-08-18 against
`GET https://api.groq.com/openai/v1/models` with a real `GROQ_API_KEY`: the
model id is absent from the response entirely. Groq's current chat-capable
catalog has no small Llama model at all.

Secondary issue #965 also flagged: the failure forwards LiteLLM's own
fallback-group bookkeeping verbatim to the customer (`No fallback model
group found... Fallbacks=[{'hive-fast': ['hive-fast']}, ...]... Retried: 3
times`). No literal provider name appears, so the existing provider-name
sanitizer (`apps/edge-api/internal/errors/provider_blind.go`) never caught
it, but it's still internal routing detail with no place in a customer-facing
error.

## Fix

**1. Repoint + reprice (`supabase/migrations/20260818_01_revert_hive_fast_groq_model_decommissioned.sql`)**

One alias maps to exactly one route and one price; both are updated
together so nothing silently changes what customers are charged.

| | Before (dead) | After (live, confirmed 2026-08-18) |
|---|---|---|
| `route-groq-fast.provider_model` | `groq/llama-3.1-8b-instant` | `groq/openai/gpt-oss-20b` |
| `hive-fast` input credits/M | 7000 | 10500 |
| `hive-fast` output credits/M | 11200 | 42000 |

`openai/gpt-oss-20b` is the model `route-groq-fast` pointed at *before* the
2026-08-01 cost migration, and the closest fast/cheap chat model Groq still
serves live today (`groq/compound[-mini]` are agentic search products,
`gpt-oss-120b` is the flagship reasoning tier, `qwen/qwen3.6-27b` is a
general-purpose model with no established fast-tier track record here).
Its published rate ($0.075 in / $0.30 out per million, re-checked against
`groq.com/pricing` and `console.groq.com/docs/models` 2026-08-18) is
unchanged since this repo last priced it, so the reprice is a straight
revert to the figures `20260801_01_alias_pricing_correction.sql` already
derived, not a fresh guess. Full derivation and a documented, deliberately
accepted trade-off (gpt-oss-20b supports tool use but not *parallel* tool
calls, unlike the now-dead llama-3.1-8b-instant; no currently-live Groq
model in this tier has both) are in the migration file's own comment block.

**Also reverted:** `.env.example` and `.github/workflows/owui-nightly.yml`'s
hardcoded `GROQ_FAST_MODEL` default back to `groq/openai/gpt-oss-20b`. The
GitHub Actions repo variable `GROQ_FAST_MODEL` used by `ci.yml` and
`agent-visual-proof.yml` was already `groq/openai/gpt-oss-20b` (unchanged
since 2026-04-24) and needed no change.

**Operational step required on the demo box, not done by this PR** (same
shape as the original 2026-08-01 migration's own PR): the running gateway
resolves `route-groq-fast`'s upstream model from the box's own `.env`
`GROQ_FAST_MODEL` value, not from this catalog
(`deploy/litellm/config.yaml`'s `model: os.environ/GROQ_FAST_MODEL`; issue
#684). This migration alone does not make the box serve the new model.
After merge, the box's `.env` needs
`GROQ_FAST_MODEL=groq/openai/gpt-oss-20b` and the `litellm` container needs
a **recreate** (not restart) for the change to take effect, or the next
`deploy-demo-box.yml` run needs to already carry that `.env` value. Note:
`apps/control-plane/internal/litellmconfig` can now generate LiteLLM's
config directly from `provider_routes.provider_model` (issues #701/#705),
but per `deploy-demo-box.yml`'s own "Assert model catalog prices agree"
step comment, that sync is not yet wired into the automatic deploy path
(issue #713 tracks the remaining gap) — today the box still boots from the
static `os.environ/GROQ_FAST_MODEL` template, genuinely independent of this
migration. If the box's `.env` is not updated, `deploy-demo-box.yml`'s own
"Assert model catalog prices agree with the model LiteLLM will call" step
will fail loudly and block the deploy rather than silently serve a mismatch.

**2. Provider-blind leak fix (`apps/edge-api/internal/errors/provider_blind.go`)**

Added `providerBlindLooksLikeRoutingInternals()`, checked in
`sanitizeProviderBlindMessage` alongside the existing transport/auth/rate-limit
checks. On any message containing LiteLLM's fallback-group bookkeeping
(`fallback model group`, `model_group=`, `fallbacks=[`, `retried:`), the
whole message collapses to a fixed `"<resource> is not available."` rather
than trying to regex-scrub an open-ended, LiteLLM-versioned bookkeeping
format field by field. This is the single shared function every chat
completions/streaming/dispatch call site already routes error text through
(`inference/orchestrator.go`, `inference/stream.go`,
`inference/stream_responses.go`, `chat/dispatch.go`, plus the images/audio/RAG
handlers), so the fix applies to every caller at once, not just hive-fast's
path.

## Sibling alias check (per instruction, before fixing)

Enumerated the live catalog's aliases from migrations:
`hive-fast, hive-default, hive-auto, hive-embedding-default, hive-stt, hive-tts`.
`hive-default` and `hive-auto` were confirmed working at the time issue #965
was filed (2026-08-18), isolating the failure to `hive-fast`'s routing only.
**Separately**, at the time of my own verification pass a few hours later,
`/v1/chat/completions` and `/v1/models` were timing out for every alias
including `hive-default` and `hive-auto`, consistent with a known,
already-logged shared-DB-pool/authz degradation (unrelated to this fix,
not touched by this PR, and the reason live proof-of-fix below is pending).
Filed the "why did nothing catch this" gap as #969 (evidence only, not
built, per explicit instruction not to add a catalog health check in this
pass).

## Test plan

- [x] `TestWriteProviderBlindUpstreamErrorHidesFallbackRoutingInternals`
      (new): reproduces issue #965's exact leaked shape, confirmed RED
      before the fix, GREEN after.
- [x] Full `apps/edge-api/internal/errors` suite green, no regressions
      (`go test ./apps/edge-api/internal/errors/... -v -count=1`).
- [x] `apps/control-plane/internal/routing/catalog_pricing_integration_test.go`'s
      `TestHiveFastIsPinnedToGroqAtCorrectedPrice` updated to the reverted
      route/price and confirmed green in this PR's own CI run (it was red
      against the old expectations before this fix, see resolved review
      thread).
- [x] All CI checks green: `Go tests (control-plane)`, `Go tests (edge-api)`,
      `apply-migrations.sh against a throwaway Postgres` (validates the new
      migration's transaction wrapping applies cleanly), and every other
      required check.
- [x] Database review (mandatory: money/routing path). Ran, one real finding
      (missing transaction wrap) fixed in follow-up commit, thread resolved.
- [x] Security review (mandatory: customer-facing error content). Ran, one
      real finding (`retried:` false-positive risk) fixed in follow-up
      commit, thread resolved. Overall verdict: diff is security sound.
- [x] CodeRabbit CLI and `ecc:code-reviewer` streams also ran; all findings
      addressed, all 8 review threads on this PR resolved.
- [ ] Live proof that `hive-fast` answers correctly against the deployed
      gateway: blocked on the operational box step above (box's own
      `GROQ_FAST_MODEL` needs updating and `litellm` needs a recreate,
      neither of which this PR's merge does automatically). Also, the test
      API key used for this investigation was found revoked partway through
      this session (`invalid_api_key: API key is revoked`), independent of
      the box step, so no live call could be made with it regardless. Will
      post once merged, the box step is done, and a valid key is available,
      per the visual-proof-before-merge rule (no UI surface here, but the
      same "prove it against the real running system" standard applies to
      the alias actually answering).

Buglog entry (queued for the separate buglog-only PR per repo convention,
never appended on this branch):
```json
{"error_message":"hive-fast 404s with model_not_found; failure also leaked LiteLLM fallback-group bookkeeping","root_cause":"Groq decommissioned llama-3.1-8b-instant after the 2026-08-01 cost migration pinned route-groq-fast to it; separately, WriteProviderBlindUpstreamError's sanitizer only stripped literal provider names/classes, not LiteLLM's routing bookkeeping phrases (fallback model group, Fallbacks=[...], Retried: N times)","fix":"Reverted route-groq-fast to groq/openai/gpt-oss-20b (confirmed live) and hive-fast pricing to 10500/42000 credits; added providerBlindLooksLikeRoutingInternals() to collapse any message carrying LiteLLM fallback-group bookkeeping to a fixed generic message","tags":["routing","pricing","provider-blind","groq","catalog-drift"]}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)