### PR TITLE
fix: wire litellm's DB config sync into the deploy pipeline

### DIFF
--- a/.github/workflows/deploy-demo-box.yml
+++ b/.github/workflows/deploy-demo-box.yml
@@ -806,6 +806,60 @@ jobs:
           echo "SMOKE FAIL"
           exit 1
 
+      - name: Sync LiteLLM model list from the DB catalog (issue #713)
+        # control-plane's litellmconfig service (Phase 20 Plan 03) already
+        # generates deploy/litellm/config.yaml's model_list directly from
+        # provider_routes.provider_model and can trigger a LiteLLM restart via
+        # the Docker socket it already has mounted, but nothing in this
+        # pipeline ever called it, so every deploy kept running whatever
+        # env-var template (os.environ/GROQ_FAST_MODEL and siblings) was last
+        # baked into the box's own .env. That is exactly the two-mechanisms-
+        # one-checked shape that let hive-fast silently point at a Groq model
+        # the catalog had already been corrected away from (issue #965): a
+        # migration can update the DB and still never reach the running
+        # gateway. Calling this endpoint on every deploy makes the DB the
+        # only source of truth for every DB-managed route's upstream model,
+        # which is the fix issue #713 asked for rather than another env var.
+        #
+        # POST /internal/litellm/sync is guarded by RequireInternalToken
+        # (X-Internal-Token), the same internal auth edge-api already uses
+        # for service-to-service calls to control-plane, so no new secret is
+        # introduced here. CONTROL_PLANE_INTERNAL_TOKEN is read from the
+        # box's own .env, same pattern as the agent-engine launcher step
+        # above. Retried briefly since this runs immediately after the smoke
+        # test above already confirmed control-plane healthy over HTTPS, so a
+        # failure here past the first attempt or two is a real one, not a
+        # cold-start race, and is intentionally not swallowed: a sync failure
+        # (a genuine 5xx, not a transient connection reset while the
+        # container finishes booting) fails this job rather than silently
+        # leaving LiteLLM on a stale model list.
+        working-directory: /home/sakib/hive
+        run: |
+          set -euo pipefail
+
+          token=$(grep -E '^CONTROL_PLANE_INTERNAL_TOKEN=' .env | head -1 | cut -d= -f2-)
+          if [ -z "$token" ]; then
+            echo "::error::CONTROL_PLANE_INTERNAL_TOKEN is missing or empty in the box's .env"
+            exit 1
+          fi
+
+          status=""
+          for i in 1 2 3; do
+            status=$(curl -sS -o /tmp/litellm-sync-response.json -w '%{http_code}' \
+              --connect-timeout 2 --max-time 10 \
+              -X POST -H "X-Internal-Token: $token" \
+              http://localhost:8081/internal/litellm/sync) || status="000"
+            if [ "$status" = "200" ]; then
+              echo "LiteLLM config synced from provider_routes"
+              exit 0
+            fi
+            echo "attempt $i: sync returned $status, retry in 5s"
+            sleep 5
+          done
+          echo "::error::litellm sync failed after 3 attempts, last status $status"
+          cat /tmp/litellm-sync-response.json 2>/dev/null || true
+          exit 1
+
       - name: Assert model catalog prices agree with the model LiteLLM will call
         # Issue #689. provider_routes.provider_model is metadata nobody reads at
         # dispatch time: the model LiteLLM actually sends upstream resolves at
@@ -875,20 +929,27 @@ jobs:
         # two-mechanisms-one-checked shape as #689 itself, just moved one
         # field over.
         #
-        # Known circularity, not solved here: apps/control-plane/internal/
-        # litellmconfig's config sync (issue #701, fixed by #705; #707 tracks
-        # the remaining gaps in what it preserves) writes a DB-managed route's
-        # `litellm_params.model` straight from provider_routes.provider_model,
-        # the same column this step's DB side reads. After that sync runs
-        # against a DB-managed route, this comparison cannot fail even if the
-        # env-var mechanism the sync bypasses is wrong, because both sides
-        # would trace back to the identical database value. Today the check
-        # is real: the live config on a freshly recreated box is still the
-        # first-boot seed with `os.environ/...` templates, genuinely
-        # independent of the DB. The api_base comparison above only partially
-        # covers the gap (it still catches an api_base drift after a sync);
-        # it does not restore independence to the model-string comparison.
-        # See issue #713 for the actual fix; not attempted here.
+        # Known circularity (issue #713, wired in by the preceding step): the
+        # previous step now calls apps/control-plane/internal/litellmconfig's
+        # config sync (issue #701, fixed by #705; #707 tracks the remaining
+        # gaps in what it preserves) on every deploy, which writes a
+        # DB-managed route's `litellm_params.model` straight from
+        # provider_routes.provider_model, the same column this step's DB side
+        # reads. That means this comparison can no longer fail for a
+        # DB-managed route even if the sync's own query or the generator's
+        # adapter logic is wrong, because both sides trace back to the
+        # identical database read. What this step still catches: the sync
+        # step above failing outright (it fails the job itself before this
+        # one runs), a route this catalog thinks is DB-managed but the sync
+        # query's join excludes (a real drift the two steps would otherwise
+        # disagree on), or an api_base mismatch on a route the sync does not
+        # cover. It no longer catches a bad `provider_model` value reaching a
+        # stale env-var template, because that mechanism is no longer in the
+        # loop for any route the sync's query returns. This is an accepted,
+        # narrower scope for this step now that issue #713 is fixed, not a
+        # regression: the two-mechanisms-one-checked shape #689 and #965 both
+        # hit is what #713 removed, and a check that could still fail on it
+        # would mean the sync had not actually taken effect.
         working-directory: /home/sakib/hive/deploy/docker
         run: |
           set -euo pipefail

--- a/.github/workflows/deploy-demo-box.yml
+++ b/.github/workflows/deploy-demo-box.yml
@@ -824,29 +824,39 @@ jobs:
         # POST /internal/litellm/sync is guarded by RequireInternalToken
         # (X-Internal-Token), the same internal auth edge-api already uses
         # for service-to-service calls to control-plane, so no new secret is
-        # introduced here. CONTROL_PLANE_INTERNAL_TOKEN is read from the
-        # box's own .env, same pattern as the agent-engine launcher step
-        # above. Retried briefly since this runs immediately after the smoke
-        # test above already confirmed control-plane healthy over HTTPS, so a
-        # failure here past the first attempt or two is a real one, not a
-        # cold-start race, and is intentionally not swallowed: a sync failure
-        # (a genuine 5xx, not a transient connection reset while the
-        # container finishes booting) fails this job rather than silently
-        # leaving LiteLLM on a stale model list.
+        # introduced here. CONTROL_PLANE_INTERNAL_TOKEN is read directly from
+        # the box's own .env: compose always sources control-plane's real
+        # token from there regardless of whether a GitHub secret is also set
+        # for other steps, so there is no fallback to try. Retried since this
+        # runs immediately after the smoke test above already confirmed
+        # control-plane healthy over HTTPS, so a failure here past the first
+        # attempt or two is a real one, not a cold-start race, and is
+        # intentionally not swallowed: a sync failure (a genuine non-200, not
+        # a transient connection reset while the container finishes booting)
+        # fails this job rather than silently leaving LiteLLM on a stale
+        # model list. --max-time is 35s, not the more typical 10s used
+        # elsewhere in this file: the endpoint's own work is a DB query, an
+        # atomic config write, and a Docker container restart bounded by its
+        # own 30s internal timeout (litellmconfig/restart.go), so a shorter
+        # client timeout would fire while the server side is still legitimately
+        # working and misreport a slow-but-successful sync as a failure.
         working-directory: /home/sakib/hive
         run: |
           set -euo pipefail
 
-          token=$(grep -E '^CONTROL_PLANE_INTERNAL_TOKEN=' .env | head -1 | cut -d= -f2-)
+          token=$(grep -E '^CONTROL_PLANE_INTERNAL_TOKEN=' .env | head -1 | cut -d= -f2- || true)
           if [ -z "$token" ]; then
             echo "::error::CONTROL_PLANE_INTERNAL_TOKEN is missing or empty in the box's .env"
             exit 1
           fi
 
+          response_file=$(mktemp)
+          trap 'rm -f "$response_file"' EXIT
+
           status=""
           for i in 1 2 3; do
-            status=$(curl -sS -o /tmp/litellm-sync-response.json -w '%{http_code}' \
-              --connect-timeout 2 --max-time 10 \
+            status=$(curl -sS -o "$response_file" -w '%{http_code}' \
+              --connect-timeout 2 --max-time 35 \
               -X POST -H "X-Internal-Token: $token" \
               http://localhost:8081/internal/litellm/sync) || status="000"
             if [ "$status" = "200" ]; then
@@ -857,7 +867,7 @@ jobs:
             sleep 5
           done
           echo "::error::litellm sync failed after 3 attempts, last status $status"
-          cat /tmp/litellm-sync-response.json 2>/dev/null || true
+          cat "$response_file" 2>/dev/null || true
           exit 1
 
       - name: Assert model catalog prices agree with the model LiteLLM will call

--- a/.github/workflows/deploy-demo-box.yml
+++ b/.github/workflows/deploy-demo-box.yml
@@ -840,6 +840,19 @@ jobs:
         # own 30s internal timeout (litellmconfig/restart.go), so a shorter
         # client timeout would fire while the server side is still legitimately
         # working and misreport a slow-but-successful sync as a failure.
+        #
+        # A 200 here is not trusted blindly. Traced through WriteAndRestart
+        # (litellmconfig/generator.go): it writes the new config, and only
+        # calls Restart() if that write succeeded; Restart()'s own error
+        # propagates straight back up, so any half-applied outcome (write
+        # failed, or write succeeded but the container restart call failed)
+        # is a non-200 here, caught by the retry loop below. The one gap that
+        # design can't close on its own is the restart API call succeeding
+        # while the LiteLLM process itself fails to come up with the new
+        # config (a bad merge, a crash loop). That is exactly what the next
+        # step re-derives independently from LiteLLM's own live /model/info
+        # rather than from this step's exit code, so a sync that reports
+        # success but reconciled nothing still fails the job, one step later.
         working-directory: /home/sakib/hive
         run: |
           set -euo pipefail

--- a/apps/control-plane/internal/litellmconfig/generator.go
+++ b/apps/control-plane/internal/litellmconfig/generator.go
@@ -5,6 +5,7 @@
 package litellmconfig
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -160,7 +161,9 @@ func WriteAndRestart(ctx context.Context, configPath string, cfg Config, restart
 		existingPath = configPath
 	}
 
-	if existingRaw, readErr := os.ReadFile(existingPath); readErr == nil {
+	existingRaw, readErr := os.ReadFile(existingPath)
+	fileExisted := readErr == nil
+	if fileExisted {
 		var existingMap map[string]interface{}
 		if parseErr := yaml.Unmarshal(existingRaw, &existingMap); parseErr != nil {
 			return fmt.Errorf("litellmconfig: parse existing config: %w", parseErr)
@@ -176,6 +179,19 @@ func WriteAndRestart(ctx context.Context, configPath string, cfg Config, restart
 	finalData, err := yaml.Marshal(merged)
 	if err != nil {
 		return fmt.Errorf("litellmconfig: marshal merged: %w", err)
+	}
+
+	// No-op guard: every caller (including the deploy pipeline, on every
+	// deploy regardless of whether anything routing-related changed) hits
+	// this unconditionally, and a LiteLLM restart is a real, if brief, chat
+	// interruption. yaml.v3 marshals map[string]interface{} keys in a fixed
+	// order, and this function is the only writer of configPath, so once one
+	// sync has run, its own output is exactly what the next no-op sync's
+	// merge would reproduce byte for byte. Skipping here means every future
+	// caller gets this for free, rather than each one needing its own diff.
+	if fileExisted && bytes.Equal(existingRaw, finalData) {
+		slog.Info("litellmconfig: write and restart: config unchanged, skipping restart")
+		return nil
 	}
 
 	// Ensure the target directory exists.

--- a/apps/control-plane/internal/litellmconfig/generator_test.go
+++ b/apps/control-plane/internal/litellmconfig/generator_test.go
@@ -282,6 +282,31 @@ func TestWriteAndRestartCallsRestarterOnSuccess(t *testing.T) {
 	assert.True(t, strings.Contains(string(data), "model_list"), "written file must contain model_list")
 }
 
+func TestWriteAndRestartSkipsRestartWhenConfigUnchanged(t *testing.T) {
+	// A DB-managed route's model can't change without this same Sync/
+	// WriteAndRestart call, and this call fires on every deploy regardless
+	// of whether anything model-related changed, so a second call with
+	// identical inputs must be a true no-op: no second restart, no second
+	// live-chat interruption.
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+
+	cfg := litellmconfig.Config{
+		Models: twoModels(),
+		GeneralSettings: litellmconfig.GeneralSettings{
+			MasterKey: "test-key",
+		},
+		ExistingConfigPath: configPath,
+	}
+
+	r := &mockRestarter{}
+	require.NoError(t, litellmconfig.WriteAndRestart(context.Background(), configPath, cfg, r))
+	assert.Equal(t, 1, r.calls, "first call writes a new file and must restart")
+
+	require.NoError(t, litellmconfig.WriteAndRestart(context.Background(), configPath, cfg, r))
+	assert.Equal(t, 1, r.calls, "second call with identical config must skip the restart")
+}
+
 func TestWriteAndRestartPreservesExistingKeys(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "config.yaml")


### PR DESCRIPTION
Closes #713. Follow-up to #965/#970, requested by the orchestrator: merging the catalog fix in #970 does not make the deployed box actually serve the new model, because the running gateway resolves its upstream model from an environment variable baked into the box's own `.env` at container boot, not from the database. This PR closes that gap at the mechanism level instead of patching the env var again, which is the same pattern that caused the outage in the first place.

**This is now demonstrated, not theoretical.** The deploy triggered by #970's merge failed at exactly the "Assert model catalog prices agree with the model LiteLLM will call" step: the catalogue named the corrected Groq model, the box's `GROQ_FAST_MODEL` still named the decommissioned one, and the assertion refused to ship a box whose two sources of truth disagreed. That is the guard working exactly as designed, and it will keep refusing every deploy until the two sides can agree, which requires this PR. The guard and this fix were built to fit each other: the guard is what proves the divergence is real, this PR is what makes the guard satisfiable again.

## The two-mechanisms problem this closes

`hive-fast`'s route lived in two places that could disagree: `provider_routes.provider_model` in Postgres, and `os.environ/GROQ_FAST_MODEL` templated into `deploy/litellm/config.yaml` at container boot. #970 corrected the first. Nothing corrected the second, because nothing in the deploy pipeline was calling the fix that already exists for exactly this: `apps/control-plane/internal/litellmconfig`, a service that generates LiteLLM's model list straight from `provider_routes.provider_model` and restarts the container, shipped under issues #701/#705/#707 as Phase 20 Plan 03, and never wired into `deploy-demo-box.yml`. Issue #713 tracked this remaining gap.

## What this PR does

Adds one step to `.github/workflows/deploy-demo-box.yml`, right after the existing public smoke test confirms control-plane is healthy:

```
POST http://localhost:8081/internal/litellm/sync
Header: X-Internal-Token: $CONTROL_PLANE_INTERNAL_TOKEN
```

This is the existing `litellmSyncHandler` (`apps/control-plane/internal/litellmconfig/http.go`), already registered at `/internal/litellm/sync` and already guarded by `RequireInternalToken`. Calling it regenerates `deploy/litellm/config.yaml`'s `model_list` directly from `provider_routes.provider_model` for every active, DB-managed route, and restarts the `litellm` container over the Docker socket control-plane already has mounted read-write (`deploy/docker/docker-compose.yml`, `litellm-config` volume + `/var/run/docker.sock`, both already there for exactly this).

No new secret, no new privilege, no new code path: everything this step calls already exists and already ships. `CONTROL_PLANE_INTERNAL_TOKEN` is read from the box's own `.env` using the same pattern the agent-engine launcher step above it already uses. Retried 3 times with a 5 second backoff since it runs immediately after the smoke test, so a persistent failure here is treated as real and fails the job loudly, not swallowed.

Also updated the following step's ("Assert model catalog prices agree with the model LiteLLM will call") own comment, which explicitly called this out as an unsolved circularity risk pending issue #713. Its scope narrows now that the sync runs: it can no longer catch a stale env-var template for a DB-managed route (that mechanism is out of the loop entirely), but it still catches the sync step failing, a route the sync's join unexpectedly excludes, or an api_base drift on a route the sync doesn't touch. Explained in the updated comment rather than left implicit.

## Why this and not another environment variable

The orchestrator's framing, which I agree with: an alias whose real model comes from an env var while its catalog says something else is exactly how #965 happened, and patching `GROQ_FAST_MODEL` again on the box would leave the identical class of bug in place for the next model this alias (or any DB-managed route) needs. This PR makes the database the single source of truth for every DB-managed route's upstream model on every deploy, going forward, not just for `hive-fast` today.

## What this does not do

- Does not touch `provider_routes`, `model_aliases`, or any catalog data.
- Does not change `LITELLM_CONFIG_MODE` (stays default/`file`; `db` mode is explicitly `log.Fatalf`'d as not-yet-implemented in `main.go` and this PR does not touch that).
- Does not remove the `os.environ/GROQ_FAST_MODEL` template from `deploy/litellm/config.yaml` itself; it becomes a fallback the sync's merge preserves for anything the DB doesn't manage, not a delete-on-sight.
- **Update:** `WriteAndRestart` now skips both the write and the restart when the generated config is byte-identical to what is already on disk (`apps/control-plane/internal/litellmconfig/generator.go`, `bytes.Equal` check added in this PR after review). This step runs after the public smoke test has already confirmed the box is serving real traffic, so an unconditional restart would have been a live chat-completions interruption on every single deploy, most of which touch nothing about model routing. The fix lives in the generator, not the deploy script, so every future caller of the sync gets the same behavior for free rather than each one needing its own diff check. New test: `TestWriteAndRestartSkipsRestartWhenConfigUnchanged`. The very first sync (replacing the hand-authored seed file's comments/formatting) still restarts once, correctly.

## Verification

This cannot be exercised in CI: `deploy-demo-box.yml` triggers only on `push` to `main` (self-hosted runner on the box itself, no PR-time run). Verification is the next real deploy actually succeeding, specifically the new step passing and the following "Assert model catalog prices agree" step staying green against whatever route the DB currently holds. To be watched via `gh run watch` on the triggered run after merge, per the orchestrator contract's deploy-verification stage.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-demo-box.yml'))"` parses without error.
- [x] Confirmed every component this step calls already exists and is already deployed: the handler, its route registration, its auth guard, the docker socket mount, the litellm-config volume, the `custom_providers` row the sync's query joins against for `groq`.
- [ ] Security review (mandatory: internal-auth-guarded endpoint, docker restart capability).
- [ ] Live verification against the box (post-merge, cannot run in CI, see above).