### PR TITLE
fix: /health reflects runtime pool contention; fix silent OWUI login timeout under transaction mode

### DIFF
--- a/apps/control-plane/cmd/server/db_ready_test.go
+++ b/apps/control-plane/cmd/server/db_ready_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	platformdb "github.com/sakibsadmanshajib/hive/apps/control-plane/internal/platform/db"
+)
+
+// TestDBReadyFuncCombinesBootAndRuntimeSignals pins the composition, not the
+// two halves. platform/db already proves ResolveHealth flips and clears, and
+// platform/http already proves /health calls DBReady per request. Neither
+// notices if this wiring drops one of its two terms: with the runtime term
+// deleted here the entire control-plane suite stayed green, which is the same
+// shape of unfailable health signal this change exists to remove.
+func TestDBReadyFuncCombinesBootAndRuntimeSignals(t *testing.T) {
+	// A non-nil pool value is all this needs. It is never dialled: dbReadyFunc
+	// only compares it against nil, which is exactly the boot-time condition
+	// that a live pool can never falsify again once opened.
+	pool := &pgxpool.Pool{}
+
+	t.Run("no pool is never ready", func(t *testing.T) {
+		if dbReadyFunc(nil, platformdb.NewResolveHealth())() {
+			t.Fatal("dbReadyFunc(nil pool) = true, want false")
+		}
+	})
+
+	t.Run("pool plus healthy resolve is ready", func(t *testing.T) {
+		if !dbReadyFunc(pool, platformdb.NewResolveHealth())() {
+			t.Fatal("dbReadyFunc(pool, fresh tracker) = false, want true")
+		}
+	})
+
+	t.Run("runtime degradation is reported even though the pool is open", func(t *testing.T) {
+		rh := platformdb.NewResolveHealth()
+		ready := dbReadyFunc(pool, rh)
+		if !ready() {
+			t.Fatal("ready() before any failure = false, want true")
+		}
+		rh.RecordFailure()
+		if ready() {
+			t.Fatal("ready() after a resolve failure = true, want false (same callback, no restart)")
+		}
+		rh.RecordSuccess()
+		if !ready() {
+			t.Fatal("ready() after recovery = false, want true")
+		}
+	})
+
+	t.Run("nil tracker degrades to the boot-time signal", func(t *testing.T) {
+		if !dbReadyFunc(pool, nil)() {
+			t.Fatal("dbReadyFunc(pool, nil tracker) = false, want true")
+		}
+	})
+}

--- a/apps/control-plane/cmd/server/main.go
+++ b/apps/control-plane/cmd/server/main.go
@@ -267,6 +267,13 @@ func main() {
 		log.Println("database pool ready")
 	}
 
+	// resolveHealth tracks /internal/apikeys/resolve outcomes at runtime so
+	// /health can report a pool that came up fine at boot and then started
+	// failing checkouts under contention — `pool != nil` alone cannot see
+	// that, because a pgxpool.Pool is never nil again once opened. See
+	// platform/db.ResolveHealth and issue #836.
+	resolveHealth := platformdb.NewResolveHealth()
+
 	// Budget for the remaining startup probes (the redis ping below). Created
 	// after the database open so a slow open cannot expire it in advance and
 	// turn an available redis into a spurious "redis not available" warning.
@@ -408,7 +415,7 @@ func main() {
 
 		apikeysRepo := apikeys.NewPgxRepository(pool)
 		apikeysSvc := apikeys.NewService(apikeysRepo, apikeys.NewRedisSnapshotCache(redisClient))
-		apikeysHandler = apikeys.NewHandler(apikeysSvc, accountsSvc)
+		apikeysHandler = apikeys.NewHandler(apikeysSvc, accountsSvc).WithResolveHealth(resolveHealth)
 
 		accountingRepo := accounting.NewPgxRepository(pool)
 		// Postgres advisory locker serializes the credit-reservation critical
@@ -1051,9 +1058,12 @@ func main() {
 	}
 
 	router := platformhttp.NewRouter(platformhttp.RouterConfig{
-		// Same condition that gates every DB-backed handler above, so /health
-		// cannot report ok while those routes are absent (issue #816).
-		DBReady: pool != nil,
+		// pool != nil is the same condition that gates every DB-backed
+		// handler above, so /health cannot report ok while those routes are
+		// absent (issue #816). resolveHealth.Degraded() adds the runtime
+		// half: a pool that opened fine at boot and later started failing
+		// checkouts under contention (issue #836).
+		DBReady:                  func() bool { return pool != nil && !resolveHealth.Degraded() },
 		// Signup provisioning readiness (D-023). A nil reconciler answers false
 		// through this same method value, so a deployment that failed to wire
 		// provisioning reports degraded rather than serving traffic quietly.

--- a/apps/control-plane/cmd/server/main.go
+++ b/apps/control-plane/cmd/server/main.go
@@ -1063,7 +1063,7 @@ func main() {
 		// absent (issue #816). resolveHealth.Degraded() adds the runtime
 		// half: a pool that opened fine at boot and later started failing
 		// checkouts under contention (issue #836).
-		DBReady:                  func() bool { return pool != nil && !resolveHealth.Degraded() },
+		DBReady: dbReadyFunc(pool, resolveHealth),
 		// Signup provisioning readiness (D-023). A nil reconciler answers false
 		// through this same method value, so a deployment that failed to wire
 		// provisioning reports degraded rather than serving traffic quietly.
@@ -1737,4 +1737,27 @@ func buildAgentEngine(egressSvc *egress.Service) (agenttask.Engine, agenttask.St
 	})
 	real := agentengine.New(sandbox)
 	return real, real
+}
+
+// dbReadyFunc builds the callback platformhttp.RouterConfig.DBReady calls on
+// every /health request.
+//
+// pool != nil is the same condition that gates every DB-backed handler, so
+// /health cannot report ok while those routes are absent (issue #816).
+// resolveHealth.Degraded() is the runtime half: a pgxpool.Pool is never nil
+// again after a successful boot, even when every checkout is timing out, so
+// the boot-time condition alone answers 200 straight through the outage this
+// exists to catch (issue #836).
+//
+// Extracted from the RouterConfig literal so both halves are reachable from a
+// test. Inline, deleting the resolveHealth term left the whole suite green:
+// the tracker and the callback plumbing were each covered, and their
+// composition here was not.
+func dbReadyFunc(pool *pgxpool.Pool, resolveHealth *platformdb.ResolveHealth) func() bool {
+	return func() bool {
+		if pool == nil {
+			return false
+		}
+		return resolveHealth == nil || !resolveHealth.Degraded()
+	}
 }

--- a/apps/control-plane/internal/apikeys/http.go
+++ b/apps/control-plane/internal/apikeys/http.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/auth"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/authz"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/platform"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/platform/db"
 )
 
 func errIs(err, target error) bool { return errors.Is(err, target) }
@@ -43,11 +44,26 @@ type Handler struct {
 	policy     authz.Policy
 	testVC     *accounts.ViewerContext // non-nil in tests to bypass real accounts service
 	testActor  *authz.Actor            // non-nil in tests to supply a canned Actor
+
+	// resolveHealth is optional and, when set, records whether
+	// /internal/apikeys/resolve — the endpoint edge-api's whole authorization
+	// path depends on — is currently reaching real verdicts or failing on
+	// something infrastructural. See platform/db.ResolveHealth.
+	resolveHealth *db.ResolveHealth
 }
 
 // NewHandler returns a new Handler.
 func NewHandler(svc *Service, accountSvc *accounts.Service) *Handler {
 	return &Handler{svc: svc, accountSvc: accountSvc, policy: authz.NewPolicy()}
+}
+
+// WithResolveHealth returns a copy of the handler wired to record resolve
+// outcomes into the given tracker, so /health can reflect runtime pool
+// contention rather than only the pool's state at boot.
+func (h *Handler) WithResolveHealth(rh *db.ResolveHealth) *Handler {
+	cloned := *h
+	cloned.resolveHealth = rh
+	return &cloned
 }
 
 // WithRoleService returns a copy of the handler wired with the platform role
@@ -537,11 +553,35 @@ func (h *Handler) handleInternalResolve(w http.ResponseWriter, r *http.Request) 
 
 	snapshot, err := h.svc.ResolveSnapshot(r.Context(), body.TokenHash)
 	if err != nil {
+		if h.resolveHealth != nil {
+			if isKeyVerdictError(err) {
+				// A real verdict (key not found, revoked, disabled, expired)
+				// means the database answered; this is not a pool problem.
+				h.resolveHealth.RecordSuccess()
+			} else {
+				h.resolveHealth.RecordFailure()
+			}
+		}
 		handleKeyError(w, err)
 		return
 	}
 
+	if h.resolveHealth != nil {
+		h.resolveHealth.RecordSuccess()
+	}
 	writeJSON(w, http.StatusOK, snapshot)
+}
+
+// isKeyVerdictError reports whether err is one of the sentinel errors that
+// mean control-plane reached a real, database-backed answer about the key,
+// as opposed to an infrastructural failure (pool checkout timeout,
+// connection error) that never reached one. Mirrors handleKeyError's own
+// classification, kept separate rather than folded into it: handleKeyError
+// backs every apikeys route, and a failure on, say, updating a key's limits
+// says nothing about whether resolve — the one endpoint edge-api's
+// authorization path depends on — is healthy.
+func isKeyVerdictError(err error) bool {
+	return errIs(err, ErrNotFound) || errIs(err, ErrRevoked) || errIs(err, ErrDisabled) || errIs(err, ErrNotActive)
 }
 
 // --- helpers ---

--- a/apps/control-plane/internal/apikeys/http_test.go
+++ b/apps/control-plane/internal/apikeys/http_test.go
@@ -3,6 +3,7 @@ package apikeys
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -11,6 +12,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/accounts"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/authz"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/platform/db"
 )
 
 // newTestHandler builds a Handler backed by a stub repo and a test viewerContext override.
@@ -321,6 +323,44 @@ func TestAPIKeyRoutesRequireVerifiedOwner(t *testing.T) {
 	body := decodeBody(t, rr)
 	if body["code"] != "api_key_management_forbidden" {
 		t.Fatalf("expected code api_key_management_forbidden, got %s", body["code"])
+	}
+}
+
+// TestInternalResolveRecordsInfraFailureAsDegraded verifies that a resolve
+// call which fails for an infrastructural reason (pool checkout timeout,
+// connection error — anything that is not a real key verdict) marks the
+// wired ResolveHealth tracker degraded, so /health can react to runtime pool
+// contention rather than only a database outage at boot.
+func TestInternalResolveRecordsInfraFailureAsDegraded(t *testing.T) {
+	h, repo := newTestHandler(ownerVC())
+	rh := db.NewResolveHealth()
+	h = h.WithResolveHealth(rh)
+	repo.forceGetPolicyErr = errors.New("pool: unable to check out connection")
+
+	rr := doRequest(t, h, http.MethodPost, "/internal/apikeys/resolve", map[string]string{"token_hash": "any"})
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("resolve with infra error: expected 500, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if !rh.Degraded() {
+		t.Fatalf("ResolveHealth.Degraded() = false after an infra-class resolve failure, want true")
+	}
+}
+
+// TestInternalResolveRecordsNotFoundAsHealthy verifies that a genuine key
+// verdict (not found, here) is NOT mistaken for a database problem: the
+// database answered, it just said the key does not exist.
+func TestInternalResolveRecordsNotFoundAsHealthy(t *testing.T) {
+	h, _ := newTestHandler(ownerVC())
+	rh := db.NewResolveHealth()
+	rh.RecordFailure() // start degraded, so a wrong classification would hide as "already false"
+	h = h.WithResolveHealth(rh)
+
+	rr := doRequest(t, h, http.MethodPost, "/internal/apikeys/resolve", map[string]string{"token_hash": "does-not-exist"})
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("resolve of unknown key: expected 404, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if rh.Degraded() {
+		t.Fatalf("ResolveHealth.Degraded() = true after a genuine not-found verdict, want false")
 	}
 }
 

--- a/apps/control-plane/internal/apikeys/service_test.go
+++ b/apps/control-plane/internal/apikeys/service_test.go
@@ -19,6 +19,11 @@ type stubRepo struct {
 	keyLimits         map[uuid.UUID]KeyLimits
 	tenantByAccount   map[uuid.UUID]uuid.UUID
 	events            []KeyEvent
+
+	// forceGetPolicyErr, when non-nil, is returned by GetPolicyByTokenHash
+	// instead of the normal lookup, simulating an infrastructural failure
+	// (pool checkout timeout, connection error) rather than a key verdict.
+	forceGetPolicyErr error
 }
 
 func newStubRepo() *stubRepo {
@@ -206,6 +211,9 @@ func (r *stubRepo) GetByTokenHash(_ context.Context, tokenHash string) (APIKey, 
 }
 
 func (r *stubRepo) GetPolicyByTokenHash(_ context.Context, tokenHash string) (APIKey, KeyPolicy, error) {
+	if r.forceGetPolicyErr != nil {
+		return APIKey{}, KeyPolicy{}, r.forceGetPolicyErr
+	}
 	var key APIKey
 	found := false
 	for _, k := range r.keys {

--- a/apps/control-plane/internal/platform/db/health.go
+++ b/apps/control-plane/internal/platform/db/health.go
@@ -1,0 +1,46 @@
+package db
+
+import "sync/atomic"
+
+// ResolveHealth tracks whether the most recent /internal/apikeys/resolve
+// attempt reached a real verdict or failed on something infrastructural
+// (pool checkout timeout, connection error) rather than a normal key outcome
+// (not found, revoked, disabled, expired).
+//
+// This is not a synthetic probe. It is fed by real traffic on the one
+// endpoint edge-api's whole authorization path depends on, so it costs
+// nothing beyond an atomic store per resolve call, and a control-plane that
+// booted successfully but has served no traffic yet reports healthy by
+// default rather than unknown-as-degraded.
+//
+// See platform/http.RouterConfig.DBReady: a pgxpool.Pool is never nil again
+// once opened, even when every checkout is timing out, so `pool != nil`
+// alone cannot detect this. This tracker is the runtime half of that signal.
+type ResolveHealth struct {
+	lastFailed atomic.Bool
+}
+
+// NewResolveHealth returns a tracker that reports healthy until a failure is
+// recorded.
+func NewResolveHealth() *ResolveHealth {
+	return &ResolveHealth{}
+}
+
+// RecordSuccess marks the most recent resolve attempt as having reached a
+// real verdict, whatever that verdict was (found, not found, revoked,
+// disabled, expired). All of those mean control-plane could reach the
+// database.
+func (h *ResolveHealth) RecordSuccess() {
+	h.lastFailed.Store(false)
+}
+
+// RecordFailure marks the most recent resolve attempt as having failed for
+// an infrastructural reason rather than reaching a key verdict.
+func (h *ResolveHealth) RecordFailure() {
+	h.lastFailed.Store(true)
+}
+
+// Degraded reports whether the most recent recorded outcome was a failure.
+func (h *ResolveHealth) Degraded() bool {
+	return h.lastFailed.Load()
+}

--- a/apps/control-plane/internal/platform/db/health_test.go
+++ b/apps/control-plane/internal/platform/db/health_test.go
@@ -1,0 +1,37 @@
+package db_test
+
+import (
+	"testing"
+
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/platform/db"
+)
+
+// TestResolveHealth_DefaultsHealthy verifies a freshly constructed tracker
+// reports healthy before any traffic has been observed. A control-plane that
+// booted seconds ago and has not yet served a resolve call must not report
+// degraded for having no data.
+func TestResolveHealth_DefaultsHealthy(t *testing.T) {
+	h := db.NewResolveHealth()
+	if h.Degraded() {
+		t.Fatalf("Degraded() = true on a fresh tracker, want false")
+	}
+}
+
+// TestResolveHealth_FlipsOnFailureThenClearsOnSuccess verifies the tracker
+// reflects only the most recent outcome: a single infra-class failure marks
+// it degraded, and the next success clears it. This is what lets /health
+// react to a pool-contention window without a synthetic probe or extra load —
+// it observes the same requests real traffic already drives.
+func TestResolveHealth_FlipsOnFailureThenClearsOnSuccess(t *testing.T) {
+	h := db.NewResolveHealth()
+
+	h.RecordFailure()
+	if !h.Degraded() {
+		t.Fatalf("Degraded() = false after RecordFailure, want true")
+	}
+
+	h.RecordSuccess()
+	if h.Degraded() {
+		t.Fatalf("Degraded() = true after RecordSuccess, want false")
+	}
+}

--- a/apps/control-plane/internal/platform/http/router.go
+++ b/apps/control-plane/internal/platform/http/router.go
@@ -72,15 +72,24 @@ type RouterConfig struct {
 	// BudgetsHandler handles budget threshold CRUD and alert dismissal endpoints.
 	BudgetsHandler *budgets.Handler
 
-	// DBReady reports whether the database pool opened at startup. Every
-	// tenant-scoped and service-to-service route below is mounted only when its
-	// DB-backed handler exists, so a control-plane that came up without a pool
-	// serves none of them: /internal/apikeys/resolve 404s and edge-api reports
-	// the resulting resolution failure to the caller as "Incorrect API key
-	// provided". /health must therefore refuse to claim health without it,
-	// otherwise the container healthcheck passes and traffic is routed to a
-	// process that cannot authenticate a single request. See issue #816.
-	DBReady bool
+	// DBReady is called on every /health request; it must not block or touch
+	// the network (no new query, no new connection) so /health cannot become
+	// another consumer of a pool it exists to report on.
+	//
+	// It reports whether the database is usable right now, not just whether
+	// the pool opened at startup. Every tenant-scoped and service-to-service
+	// route below is mounted only when its DB-backed handler exists, so a
+	// control-plane that came up without a pool serves none of them:
+	// /internal/apikeys/resolve 404s and edge-api reports the resulting
+	// resolution failure to the caller as "Incorrect API key provided". A
+	// callback rather than a bool captured once at startup: a pgxpool.Pool is
+	// never nil again after a successful boot even when every checkout is
+	// timing out under runtime pool contention, so a boot-time bool alone
+	// reports 200 through exactly the outage this exists to catch. The
+	// callback typically combines `pool != nil` with a live signal (see
+	// platform/db.ResolveHealth) fed by real traffic on the resolve path, not
+	// a synthetic probe. See issues #816 and #836.
+	DBReady func() bool
 
 	// ProvisioningReady reports whether signup tenant provisioning is wired
 	// and working (D-023). A nil func means nothing reported it, which is
@@ -408,10 +417,10 @@ func NewRouter(cfg RouterConfig) http.Handler {
 // reporting 200 here is what turns a transient database outage at boot into a
 // silent, permanent one: the compose healthcheck goes green, dependent services
 // start, and every caller gets a misleading credential error instead.
-func healthHandler(dbReady bool, provisioningReady func() (bool, string)) http.HandlerFunc {
+func healthHandler(dbReady func() bool, provisioningReady func() (bool, string)) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		if !dbReady {
+		if !dbReady() {
 			w.WriteHeader(http.StatusServiceUnavailable)
 			_ = json.NewEncoder(w).Encode(healthResponse{
 				Status: healthStatusDegraded,

--- a/apps/control-plane/internal/platform/http/router.go
+++ b/apps/control-plane/internal/platform/http/router.go
@@ -420,7 +420,7 @@ func NewRouter(cfg RouterConfig) http.Handler {
 func healthHandler(dbReady func() bool, provisioningReady func() (bool, string)) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		if !dbReady() {
+		if dbReady == nil || !dbReady() {
 			w.WriteHeader(http.StatusServiceUnavailable)
 			_ = json.NewEncoder(w).Encode(healthResponse{
 				Status: healthStatusDegraded,

--- a/apps/control-plane/internal/platform/http/router_health_provisioning_test.go
+++ b/apps/control-plane/internal/platform/http/router_health_provisioning_test.go
@@ -34,7 +34,7 @@ func getHealth(t *testing.T, cfg RouterConfig) (int, healthResponse) {
 // provisioning in cmd/server and every unit test still passes. It must not read
 // as healthy.
 func TestHealthIsDegradedWhenProvisioningIsNotReported(t *testing.T) {
-	code, body := getHealth(t, RouterConfig{DBReady: true})
+	code, body := getHealth(t, RouterConfig{DBReady: func() bool { return true }})
 
 	require.Equal(t, http.StatusServiceUnavailable, code)
 	require.Equal(t, healthStatusDegraded, body.Status)
@@ -49,7 +49,7 @@ func TestHealthIsDegradedWhenProvisioningReportsFailure(t *testing.T) {
 	reporter := func() (bool, string) {
 		return false, sweepFailingReason
 	}
-	code, body := getHealth(t, RouterConfig{DBReady: true, ProvisioningReady: reporter})
+	code, body := getHealth(t, RouterConfig{DBReady: func() bool { return true }, ProvisioningReady: reporter})
 
 	require.Equal(t, http.StatusServiceUnavailable, code)
 	require.Equal(t, healthStatusDegraded, body.Status)
@@ -63,7 +63,7 @@ func TestHealthIsOkWhenProvisioningIsReady(t *testing.T) {
 	reporter := func() (bool, string) {
 		return true, noReason
 	}
-	code, body := getHealth(t, RouterConfig{DBReady: true, ProvisioningReady: reporter})
+	code, body := getHealth(t, RouterConfig{DBReady: func() bool { return true }, ProvisioningReady: reporter})
 
 	require.Equal(t, http.StatusOK, code)
 	require.Equal(t, healthStatusOK, body.Status)

--- a/apps/control-plane/internal/platform/http/router_test.go
+++ b/apps/control-plane/internal/platform/http/router_test.go
@@ -105,7 +105,18 @@ func TestNewRouterDegradedHealthDoesNotLeakConnectionDetail(t *testing.T) {
 // differently as the callback's underlying state changes, with no restart.
 func TestNewRouterHealthReactsToRuntimeChange(t *testing.T) {
 	healthy := true
-	h := NewRouter(RouterConfig{DBReady: func() bool { return healthy }})
+	// ProvisioningReady is supplied because #993 made a nil reporter degrade
+	// this endpoint on purpose (D-023). Without it every assertion below that
+	// expects 200 would be answered 503 for an unrelated reason, and this test
+	// would stop testing DBReady at all. The two signals are independent: this
+	// test holds provisioning ready and moves DBReady;
+	// router_health_provisioning_test.go holds DBReady ready and moves
+	// provisioning.
+	ready := func() (bool, string) {
+		var noReason string
+		return true, noReason
+	}
+	h := NewRouter(RouterConfig{DBReady: func() bool { return healthy }, ProvisioningReady: ready})
 
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/health", nil))

--- a/apps/control-plane/internal/platform/http/router_test.go
+++ b/apps/control-plane/internal/platform/http/router_test.go
@@ -133,3 +133,20 @@ func TestNewRouterHealthReactsToRuntimeChange(t *testing.T) {
 		t.Fatalf("GET /health after recovery = %d, want %d", rec.Code, http.StatusOK)
 	}
 }
+
+// TestNewRouterHealthWithNilDBReadyDoesNotPanic is the regression guard for
+// PR #975 CodeRabbit review: RouterConfig{} (its zero value, e.g. from a test
+// or a caller that has not wired DBReady yet) leaves DBReady nil, and
+// healthHandler used to call it unconditionally, panicking the whole process
+// on the very first /health request. A nil callback must be treated as
+// "not ready" (503), the same as a callback that returns false, not as a
+// crash.
+func TestNewRouterHealthWithNilDBReadyDoesNotPanic(t *testing.T) {
+	h := NewRouter(RouterConfig{})
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("GET /health with nil DBReady = %d, want %d", rec.Code, http.StatusServiceUnavailable)
+	}
+}

--- a/apps/control-plane/internal/platform/http/router_test.go
+++ b/apps/control-plane/internal/platform/http/router_test.go
@@ -33,7 +33,7 @@ func TestNewRouterServesHealth(t *testing.T) {
 		var noReason string
 		return true, noReason
 	}
-	h := NewRouter(RouterConfig{DBReady: true, ProvisioningReady: ready})
+	h := NewRouter(RouterConfig{DBReady: func() bool { return true }, ProvisioningReady: ready})
 
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
@@ -59,7 +59,7 @@ func TestNewRouterServesHealth(t *testing.T) {
 // session mode, pool_size 15) turned into a red main with a misleading
 // credential error three steps downstream. See issue #816.
 func TestNewRouterHealthIsDegradedWithoutDatabase(t *testing.T) {
-	h := NewRouter(RouterConfig{DBReady: false})
+	h := NewRouter(RouterConfig{DBReady: func() bool { return false }})
 
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
@@ -84,7 +84,7 @@ func TestNewRouterHealthIsDegradedWithoutDatabase(t *testing.T) {
 // driver's connection error, which carries the database user, host and pooler
 // addresses.
 func TestNewRouterDegradedHealthDoesNotLeakConnectionDetail(t *testing.T) {
-	h := NewRouter(RouterConfig{DBReady: false})
+	h := NewRouter(RouterConfig{DBReady: func() bool { return false }})
 
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
@@ -93,5 +93,43 @@ func TestNewRouterDegradedHealthDoesNotLeakConnectionDetail(t *testing.T) {
 		if strings.Contains(strings.ToLower(rec.Body.String()), leak) {
 			t.Fatalf("degraded /health body leaks %q: %s", leak, rec.Body.String())
 		}
+	}
+}
+
+// TestNewRouterHealthReactsToRuntimeChange is the regression guard for the
+// actual gap this change closes: a pgxpool.Pool is never nil again once
+// opened, even when every checkout is timing out under runtime contention, so
+// a boot-time bool baked into the handler cannot detect that. DBReady must be
+// a live callback the handler calls per request, not a value captured once at
+// router construction — this test proves the SAME router instance answers
+// differently as the callback's underlying state changes, with no restart.
+func TestNewRouterHealthReactsToRuntimeChange(t *testing.T) {
+	healthy := true
+	h := NewRouter(RouterConfig{DBReady: func() bool { return healthy }})
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /health while healthy = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	// Simulate a pool that came up fine at boot and then started failing
+	// checkouts under contention, with no restart and no new pool object.
+	healthy = false
+
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("GET /health after runtime degradation = %d, want %d (same router instance, no restart)", rec.Code, http.StatusServiceUnavailable)
+	}
+
+	// And recovering (e.g. contention clears, or the next resolve succeeds)
+	// clears it again, same instance.
+	healthy = true
+
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /health after recovery = %d, want %d", rec.Code, http.StatusOK)
 	}
 }

--- a/apps/edge-api/cmd/server/main.go
+++ b/apps/edge-api/cmd/server/main.go
@@ -665,7 +665,15 @@ func handleHealth(degraded func() bool) http.HandlerFunc {
 			w.WriteHeader(http.StatusServiceUnavailable)
 			_ = json.NewEncoder(w).Encode(map[string]string{
 				"status": "degraded",
-				"reason": "control-plane resolve unavailable",
+				// Fixed string, and deliberately service-agnostic. This
+				// endpoint is unauthenticated on the public gateway, so the
+				// degraded body follows the same discipline control-plane's
+				// /health already enforces with a test: name the missing
+				// capability, never the internal component, the host or the
+				// upstream error. "authorization dependency unavailable" says
+				// what a caller can act on; the internal topology is not the
+				// caller's business.
+				"reason": "authorization dependency unavailable",
 			})
 			return
 		}

--- a/apps/edge-api/cmd/server/main.go
+++ b/apps/edge-api/cmd/server/main.go
@@ -638,32 +638,39 @@ const metricsListenAddr = ":9102"
 // the public mux. /metrics is deliberately not registered here; see
 // metricsListenAddr.
 //
-// healthy is called on every /health request; it must not block or touch the
-// network, so /health cannot become another consumer of a pool it exists to
-// report on. It typically wraps authz.Client.Degraded(), which is fed by real
+// degraded is called on every /health request; it must not block or touch
+// the network, so /health cannot become another consumer of a pool it exists
+// to report on. It is typically authz.Client.Degraded itself, fed by real
 // traffic on the authorize/budget-gate hot paths rather than a synthetic
 // probe: /health used to be a hardcoded 200 regardless of whether edge-api
 // could actually reach control-plane to resolve a key, so a pool-contention
 // window that made every real request fail still reported this endpoint
 // healthy throughout.
-func registerInfraRoutes(mux *http.ServeMux, specPath string, healthy func() bool) {
-	mux.HandleFunc("/health", handleHealth(healthy))
+//
+// The parameter is named and read as "degraded", not "healthy", on purpose
+// (PR #975 CodeRabbit review): authz.Client.Degraded already returns true
+// when unhealthy, and a "healthy" name checked as !healthy() silently
+// inverted that polarity, so a fully healthy edge-api reported 503 and an
+// actual control-plane outage reported 200 -- a second lie in the exact fix
+// meant to stop this endpoint from lying.
+func registerInfraRoutes(mux *http.ServeMux, specPath string, degraded func() bool) {
+	mux.HandleFunc("/health", handleHealth(degraded))
 	mux.Handle("/docs/", docs.SwaggerHandler(specPath))
 }
 
-func handleHealth(healthy func() bool) http.HandlerFunc {
+func handleHealth(degraded func() bool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		if healthy != nil && !healthy() {
+		if degraded != nil && degraded() {
 			w.WriteHeader(http.StatusServiceUnavailable)
-			json.NewEncoder(w).Encode(map[string]string{
+			_ = json.NewEncoder(w).Encode(map[string]string{
 				"status": "degraded",
 				"reason": "control-plane resolve unavailable",
 			})
 			return
 		}
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+		_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 	}
 }
 

--- a/apps/edge-api/cmd/server/main.go
+++ b/apps/edge-api/cmd/server/main.go
@@ -148,7 +148,7 @@ func main() {
 
 	// Infrastructure routes (no unsupported middleware). /metrics is not among
 	// them; it is served on metricsListenAddr instead.
-	registerInfraRoutes(mux, specPath)
+	registerInfraRoutes(mux, specPath, authzClient.Degraded)
 
 	// Inference routes
 	routingClient := inference.NewRoutingClient(resolveControlPlaneBaseURL())
@@ -637,15 +637,34 @@ const metricsListenAddr = ":9102"
 // registerInfraRoutes registers the unauthenticated infrastructure endpoints on
 // the public mux. /metrics is deliberately not registered here; see
 // metricsListenAddr.
-func registerInfraRoutes(mux *http.ServeMux, specPath string) {
-	mux.HandleFunc("/health", handleHealth)
+//
+// healthy is called on every /health request; it must not block or touch the
+// network, so /health cannot become another consumer of a pool it exists to
+// report on. It typically wraps authz.Client.Degraded(), which is fed by real
+// traffic on the authorize/budget-gate hot paths rather than a synthetic
+// probe: /health used to be a hardcoded 200 regardless of whether edge-api
+// could actually reach control-plane to resolve a key, so a pool-contention
+// window that made every real request fail still reported this endpoint
+// healthy throughout.
+func registerInfraRoutes(mux *http.ServeMux, specPath string, healthy func() bool) {
+	mux.HandleFunc("/health", handleHealth(healthy))
 	mux.Handle("/docs/", docs.SwaggerHandler(specPath))
 }
 
-func handleHealth(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+func handleHealth(healthy func() bool) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if healthy != nil && !healthy() {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			json.NewEncoder(w).Encode(map[string]string{
+				"status": "degraded",
+				"reason": "control-plane resolve unavailable",
+			})
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	}
 }
 
 func loadStorageConfigFromEnv() (storageConfig, error) {

--- a/apps/edge-api/cmd/server/main_test.go
+++ b/apps/edge-api/cmd/server/main_test.go
@@ -1267,3 +1267,28 @@ func waitFor(t *testing.T, cond func() bool) {
 	}
 	t.Fatalf("condition not met within 2s")
 }
+
+// TestDegradedHealthBodyNamesNoInternalComponent mirrors control-plane's
+// TestNewRouterDegradedHealthDoesNotLeakConnectionDetail. /health here is
+// unauthenticated on the public gateway, so its degraded body must name the
+// missing capability and nothing else. The first version of this response
+// said "control-plane resolve unavailable", which published an internal
+// service name and the internal call it makes to anyone who curled the
+// endpoint during an outage.
+func TestDegradedHealthBodyNamesNoInternalComponent(t *testing.T) {
+	mux := http.NewServeMux()
+	registerInfraRoutes(mux, "", func() bool { return true })
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("GET /health while degraded = %d, want %d", rec.Code, http.StatusServiceUnavailable)
+	}
+	body := strings.ToLower(rec.Body.String())
+	for _, leak := range []string{"control-plane", "controlplane", "resolve", "postgres", "pooler", "supabase", "redis", "5432", "8081"} {
+		if strings.Contains(body, leak) {
+			t.Fatalf("degraded /health body leaks %q: %s", leak, rec.Body.String())
+		}
+	}
+}

--- a/apps/edge-api/cmd/server/main_test.go
+++ b/apps/edge-api/cmd/server/main_test.go
@@ -357,7 +357,7 @@ func identityMiddleware(h http.Handler) http.Handler { return h }
 // be registered alongside the other unauthenticated infrastructure routes.
 func TestRegisterInfraRoutesDoesNotExposeMetrics(t *testing.T) {
 	mux := http.NewServeMux()
-	registerInfraRoutes(mux, "testdata/openapi.yaml")
+	registerInfraRoutes(mux, "testdata/openapi.yaml", func() bool { return true })
 
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
@@ -370,6 +370,54 @@ func TestRegisterInfraRoutesDoesNotExposeMetrics(t *testing.T) {
 	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("GET /health = %d, want %d", rec.Code, http.StatusOK)
+	}
+}
+
+// TestHealthReactsToRuntimeAuthzDegradation is the regression guard for the
+// gap this closes: /health used to be a hardcoded 200 with no dependency on
+// anything, so a control-plane pool-contention window that made every real
+// /v1/chat/completions and /v1/models call fail (retryable 503
+// upstream_unavailable, per authz.Client.Resolve's own classification) still
+// reported this endpoint healthy throughout the outage. The healthy callback
+// must be consulted per request, not baked in once at router construction.
+func TestHealthReactsToRuntimeAuthzDegradation(t *testing.T) {
+	healthy := true
+	mux := http.NewServeMux()
+	registerInfraRoutes(mux, "testdata/openapi.yaml", func() bool { return healthy })
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /health while healthy = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	healthy = false
+	rec = httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("GET /health while degraded = %d, want %d", rec.Code, http.StatusServiceUnavailable)
+	}
+
+	healthy = true
+	rec = httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /health after recovery = %d, want %d", rec.Code, http.StatusOK)
+	}
+}
+
+// TestHealthTreatsNilHealthyCallbackAsHealthy verifies a nil callback (e.g. a
+// caller that has not wired the authz client's Degraded method) does not
+// panic and defaults to healthy, matching the previous unconditional-200
+// behavior for any caller that has not opted in yet.
+func TestHealthTreatsNilHealthyCallbackAsHealthy(t *testing.T) {
+	mux := http.NewServeMux()
+	registerInfraRoutes(mux, "testdata/openapi.yaml", nil)
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /health with nil healthy callback = %d, want %d", rec.Code, http.StatusOK)
 	}
 }
 

--- a/apps/edge-api/cmd/server/main_test.go
+++ b/apps/edge-api/cmd/server/main_test.go
@@ -357,7 +357,7 @@ func identityMiddleware(h http.Handler) http.Handler { return h }
 // be registered alongside the other unauthenticated infrastructure routes.
 func TestRegisterInfraRoutesDoesNotExposeMetrics(t *testing.T) {
 	mux := http.NewServeMux()
-	registerInfraRoutes(mux, "testdata/openapi.yaml", func() bool { return true })
+	registerInfraRoutes(mux, "testdata/openapi.yaml", func() bool { return false })
 
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
@@ -378,12 +378,13 @@ func TestRegisterInfraRoutesDoesNotExposeMetrics(t *testing.T) {
 // anything, so a control-plane pool-contention window that made every real
 // /v1/chat/completions and /v1/models call fail (retryable 503
 // upstream_unavailable, per authz.Client.Resolve's own classification) still
-// reported this endpoint healthy throughout the outage. The healthy callback
-// must be consulted per request, not baked in once at router construction.
+// reported this endpoint healthy throughout the outage. The degraded
+// callback must be consulted per request, not baked in once at router
+// construction.
 func TestHealthReactsToRuntimeAuthzDegradation(t *testing.T) {
-	healthy := true
+	degraded := false
 	mux := http.NewServeMux()
-	registerInfraRoutes(mux, "testdata/openapi.yaml", func() bool { return healthy })
+	registerInfraRoutes(mux, "testdata/openapi.yaml", func() bool { return degraded })
 
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
@@ -391,14 +392,14 @@ func TestHealthReactsToRuntimeAuthzDegradation(t *testing.T) {
 		t.Fatalf("GET /health while healthy = %d, want %d", rec.Code, http.StatusOK)
 	}
 
-	healthy = false
+	degraded = true
 	rec = httptest.NewRecorder()
 	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
 	if rec.Code != http.StatusServiceUnavailable {
 		t.Fatalf("GET /health while degraded = %d, want %d", rec.Code, http.StatusServiceUnavailable)
 	}
 
-	healthy = true
+	degraded = false
 	rec = httptest.NewRecorder()
 	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
 	if rec.Code != http.StatusOK {
@@ -406,18 +407,39 @@ func TestHealthReactsToRuntimeAuthzDegradation(t *testing.T) {
 	}
 }
 
-// TestHealthTreatsNilHealthyCallbackAsHealthy verifies a nil callback (e.g. a
-// caller that has not wired the authz client's Degraded method) does not
+// TestHealthTreatsNilDegradedCallbackAsHealthy verifies a nil callback (e.g.
+// a caller that has not wired the authz client's Degraded method) does not
 // panic and defaults to healthy, matching the previous unconditional-200
 // behavior for any caller that has not opted in yet.
-func TestHealthTreatsNilHealthyCallbackAsHealthy(t *testing.T) {
+func TestHealthTreatsNilDegradedCallbackAsHealthy(t *testing.T) {
 	mux := http.NewServeMux()
 	registerInfraRoutes(mux, "testdata/openapi.yaml", nil)
 
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
 	if rec.Code != http.StatusOK {
-		t.Fatalf("GET /health with nil healthy callback = %d, want %d", rec.Code, http.StatusOK)
+		t.Fatalf("GET /health with nil degraded callback = %d, want %d", rec.Code, http.StatusOK)
+	}
+}
+
+// TestHealthPolarityMatchesRealAuthzClientDegraded is the regression guard
+// for PR #975 CodeRabbit review: the previous handleHealth checked
+// !healthy(), but main.go wired it directly to authz.Client.Degraded, which
+// returns true when UNHEALTHY -- the opposite polarity. A fully healthy
+// edge-api reported 503 and an actual control-plane outage reported 200,
+// silently, the exact "health endpoint lies" failure this PR exists to fix.
+// Exercises the real *authz.Client (not a hand-rolled bool) the way main.go
+// actually wires it, so a future re-introduction of the inversion fails this
+// test rather than only a unit test of handleHealth in isolation.
+func TestHealthPolarityMatchesRealAuthzClientDegraded(t *testing.T) {
+	client := &authz.Client{}
+	mux := http.NewServeMux()
+	registerInfraRoutes(mux, "testdata/openapi.yaml", client.Degraded)
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /health with a fresh, undegraded authz.Client = %d, want %d", rec.Code, http.StatusOK)
 	}
 }
 

--- a/apps/edge-api/internal/authz/client.go
+++ b/apps/edge-api/internal/authz/client.go
@@ -275,7 +275,20 @@ func (c *Client) Resolve(ctx context.Context, rawToken string) (snap AuthSnapsho
 		strings.NewReader(body),
 	)
 	if err != nil {
-		return AuthSnapshot{}, fmt.Errorf("authz: build request: %w", err)
+		// Never reached a control-plane verdict: the request was not even
+		// constructed, which on this path means a malformed base URL rather
+		// than anything about the caller's key. Classified as
+		// ErrUpstreamUnavailable for two reasons. The caller-facing one:
+		// authorizer.go answers an unclassified error with a permanent 401
+		// "Incorrect API key provided", which would tell every caller to
+		// rotate a perfectly good credential because CONTROL_PLANE_BASE_URL
+		// is wrong. The health one: the deferred tracker above clears the
+		// degraded flag for any error that is not ErrUpstreamUnavailable, so
+		// a base URL that fails on every single request would have cleared
+		// it on every single request and left /health reporting 200 straight
+		// through a total authorization outage -- the exact lie this change
+		// exists to remove (PR #975 CodeRabbit CLI finding 2).
+		return AuthSnapshot{}, fmt.Errorf("authz: build request: %w: %w", ErrUpstreamUnavailable, err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	cpauth.SetHeader(req)

--- a/apps/edge-api/internal/authz/client.go
+++ b/apps/edge-api/internal/authz/client.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/redis/go-redis/v9"
@@ -108,6 +109,16 @@ type Client struct {
 
 	// ResolveOverride is a test hook for bypassing Redis/control-plane I/O.
 	ResolveOverride func(ctx context.Context, rawToken string) (AuthSnapshot, error)
+
+	// resolveDegraded tracks whether the most recent resolve attempt that
+	// actually reached Redis or control-plane came back ErrUpstreamUnavailable
+	// rather than a real verdict. Fed by real traffic on Authorize's hot path
+	// and BudgetGate's workspace-identity resolver (the two callers that share
+	// this Client), so it costs nothing beyond an atomic store per call and
+	// needs no separate probe. Zero value is healthy: a freshly built Client
+	// that has served no traffic yet must not report degraded for having no
+	// data. See Degraded.
+	resolveDegraded atomic.Bool
 }
 
 // NewClient returns a new Client.
@@ -210,7 +221,7 @@ const resolveClientTimeout = 10 * time.Second
 
 // Resolve returns the AuthSnapshot for the given raw token or Bearer header.
 // It checks Redis first, then falls back to the control plane.
-func (c *Client) Resolve(ctx context.Context, rawToken string) (AuthSnapshot, error) {
+func (c *Client) Resolve(ctx context.Context, rawToken string) (snap AuthSnapshot, err error) {
 	if c != nil && c.ResolveOverride != nil {
 		return c.ResolveOverride(ctx, rawToken)
 	}
@@ -219,6 +230,18 @@ func (c *Client) Resolve(ctx context.Context, rawToken string) (AuthSnapshot, er
 	if rawToken == "" {
 		return AuthSnapshot{}, errors.New("authz: empty token")
 	}
+
+	// Everything below this line actually reaches Redis or control-plane, so
+	// it is what Degraded() reports on. A nil error, or a non-nil error that
+	// is a genuine verdict (not found, revoked, disabled, expired), both mean
+	// the dependency answered; only ErrUpstreamUnavailable means it did not.
+	defer func() {
+		if errors.Is(err, ErrUpstreamUnavailable) {
+			c.resolveDegraded.Store(true)
+		} else {
+			c.resolveDegraded.Store(false)
+		}
+	}()
 
 	h := sha256.Sum256([]byte(rawToken))
 	tokenHash := strings.ToLower(hex.EncodeToString(h[:]))
@@ -326,7 +349,6 @@ func (c *Client) Resolve(ctx context.Context, rawToken string) (AuthSnapshot, er
 		return AuthSnapshot{}, fmt.Errorf("authz: read response: %w: %w", ErrUpstreamUnavailable, err)
 	}
 
-	var snap AuthSnapshot
 	if err := json.Unmarshal(respBytes, &snap); err != nil {
 		// A malformed body is a control-plane-side bug, not a verdict on the
 		// key; same "no usable verdict" shape as the cases above.
@@ -345,4 +367,19 @@ func (c *Client) Resolve(ctx context.Context, rawToken string) (AuthSnapshot, er
 	}
 
 	return snap, nil
+}
+
+// Degraded reports whether the most recent Resolve call that reached Redis or
+// control-plane came back ErrUpstreamUnavailable. It is not a synthetic
+// probe — it costs nothing beyond an atomic read, and observes only real
+// traffic — so /health can react to runtime pool contention on control-plane
+// without edge-api adding a single extra connection or request anywhere.
+//
+// A c == nil receiver reports healthy rather than panicking, so /health stays
+// usable even if it is ever wired before the authz client is constructed.
+func (c *Client) Degraded() bool {
+	if c == nil {
+		return false
+	}
+	return c.resolveDegraded.Load()
 }

--- a/apps/edge-api/internal/authz/client.go
+++ b/apps/edge-api/internal/authz/client.go
@@ -231,18 +231,6 @@ func (c *Client) Resolve(ctx context.Context, rawToken string) (snap AuthSnapsho
 		return AuthSnapshot{}, errors.New("authz: empty token")
 	}
 
-	// Everything below this line actually reaches Redis or control-plane, so
-	// it is what Degraded() reports on. A nil error, or a non-nil error that
-	// is a genuine verdict (not found, revoked, disabled, expired), both mean
-	// the dependency answered; only ErrUpstreamUnavailable means it did not.
-	defer func() {
-		if errors.Is(err, ErrUpstreamUnavailable) {
-			c.resolveDegraded.Store(true)
-		} else {
-			c.resolveDegraded.Store(false)
-		}
-	}()
-
 	h := sha256.Sum256([]byte(rawToken))
 	tokenHash := strings.ToLower(hex.EncodeToString(h[:]))
 	redisKey := "auth:key:{" + tokenHash + "}"
@@ -253,6 +241,12 @@ func (c *Client) Resolve(ctx context.Context, rawToken string) (snap AuthSnapsho
 		if err == nil {
 			var snap AuthSnapshot
 			if err := json.Unmarshal([]byte(cached), &snap); err == nil {
+				// A cache hit never contacts control-plane, so it must not
+				// touch resolveDegraded either way: recording success here
+				// would clear a real, still-ongoing outage without having
+				// checked anything, which is exactly the failure mode this
+				// tracker exists to prevent. Leave it at whatever the last
+				// actual round trip observed (PR #975 review finding 2).
 				return snap, nil
 			}
 			// on decode error, fall through to fetch
@@ -261,6 +255,18 @@ func (c *Client) Resolve(ctx context.Context, rawToken string) (snap AuthSnapsho
 			// TODO: hook up logger
 		}
 	}
+
+	// Everything from here on actually reaches control-plane, so it is what
+	// Degraded() reports on. A nil error, or a non-nil error that is a
+	// genuine verdict (not found, revoked, disabled, expired), both mean
+	// control-plane answered; only ErrUpstreamUnavailable means it did not.
+	defer func() {
+		if errors.Is(err, ErrUpstreamUnavailable) {
+			c.resolveDegraded.Store(true)
+		} else {
+			c.resolveDegraded.Store(false)
+		}
+	}()
 
 	// 2. Fallback to control plane.
 	body := fmt.Sprintf(`{"token_hash":%q}`, tokenHash)

--- a/apps/edge-api/internal/authz/client_test.go
+++ b/apps/edge-api/internal/authz/client_test.go
@@ -496,3 +496,28 @@ func TestResolveClassifiesInternalTokenRejectionAsUpstreamUnavailable(t *testing
 		t.Fatalf("expected ErrInternalTokenRejected preserved for the operator-facing log, got %v", err)
 	}
 }
+
+// TestDegraded_RequestConstructionFailureDoesNotClearDegraded is the guard for
+// PR #975 CodeRabbit CLI finding 2. The deferred tracker in Resolve is
+// registered before the request is constructed, and it clears the degraded
+// flag for any error that is not ErrUpstreamUnavailable. A malformed base URL
+// fails at construction on every single call, so without this classification
+// it would have cleared the flag on every single call and left /health
+// reporting healthy through a total authorization outage.
+func TestDegraded_RequestConstructionFailureDoesNotClearDegraded(t *testing.T) {
+	c := &Client{
+		baseURL:    "http://\x7f-not-a-url",
+		httpClient: &http.Client{Timeout: time.Second},
+	}
+
+	_, err := c.Resolve(context.Background(), "hk_whatever")
+	if err == nil {
+		t.Fatal("Resolve with a malformed base URL returned no error")
+	}
+	if !errors.Is(err, ErrUpstreamUnavailable) {
+		t.Fatalf("Resolve error = %v, want it to wrap ErrUpstreamUnavailable so the caller gets a retryable 503 rather than a 401 on a valid key", err)
+	}
+	if !c.Degraded() {
+		t.Fatal("Degraded() = false after a request that never reached control-plane, want true")
+	}
+}

--- a/apps/edge-api/internal/authz/client_test.go
+++ b/apps/edge-api/internal/authz/client_test.go
@@ -303,6 +303,44 @@ func TestDegraded_ClearsAfterSubsequentSuccess(t *testing.T) {
 	}
 }
 
+// TestDegraded_CacheHitDoesNotClearAPriorFailure is the regression guard for
+// PR #975 review finding 2: a Redis cache hit never contacts control-plane,
+// so it must not touch resolveDegraded either way. The original code ran the
+// degraded-tracking defer before the cache-hit early return, so any cache hit
+// reset the tracker to healthy without having checked anything -- during a
+// real outage the cache-hit ratio is exactly when that matters most, so the
+// health signal would have reported healthy while the outage was ongoing.
+func TestDegraded_CacheHitDoesNotClearAPriorFailure(t *testing.T) {
+	rawToken := "Bearer hk_cached"
+	tokenHash := HashBearerToken(rawToken)
+	snap := AuthSnapshot{KeyID: "key-1", Status: "active"}
+	encoded, err := json.Marshal(snap)
+	if err != nil {
+		t.Fatalf("marshal snapshot: %v", err)
+	}
+
+	cache := &fakeSnapshotStore{values: map[string]string{
+		"auth:key:{" + tokenHash + "}": string(encoded),
+	}}
+
+	// No server at all: a cache hit must never dial out, so baseURL points at
+	// nothing reachable. If the code under test ever tries anyway, the
+	// request errors and the test's own assertions below catch it.
+	client := &Client{cache: cache, httpClient: http.DefaultClient, baseURL: "http://127.0.0.1:1"}
+	client.resolveDegraded.Store(true) // simulate an outage already in progress
+
+	got, err := client.Resolve(context.Background(), rawToken)
+	if err != nil {
+		t.Fatalf("expected the cache hit to resolve without error, got %v", err)
+	}
+	if got.KeyID != snap.KeyID {
+		t.Fatalf("expected cached snapshot %+v, got %+v", snap, got)
+	}
+	if !client.Degraded() {
+		t.Fatal("a cache hit cleared Degraded() without ever contacting control-plane; it must leave a prior failure in place")
+	}
+}
+
 // A 200 status only means the headers arrived; the client's own Timeout still
 // covers the body read (net/http cancels the request context mid-read when it
 // fires), so a response that starts with a 200 and then stalls before

--- a/apps/edge-api/internal/authz/client_test.go
+++ b/apps/edge-api/internal/authz/client_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/redis/go-redis/v9"
 )
 
@@ -238,6 +239,67 @@ func TestResolveClassifiesControlPlane5xxAsUpstreamUnavailable(t *testing.T) {
 	}
 	if !errors.Is(err, ErrUpstreamUnavailable) {
 		t.Fatalf("expected ErrUpstreamUnavailable for a control-plane 5xx, got %v", err)
+	}
+	if !client.Degraded() {
+		t.Fatalf("Degraded() = false after an ErrUpstreamUnavailable resolve, want true")
+	}
+}
+
+// TestDegraded_DefaultsHealthy verifies a freshly constructed Client reports
+// healthy before Resolve has ever been called: no traffic yet must not read
+// as degraded.
+func TestDegraded_DefaultsHealthy(t *testing.T) {
+	client := &Client{}
+	if client.Degraded() {
+		t.Fatalf("Degraded() = true on a fresh Client, want false")
+	}
+}
+
+// TestDegraded_NilClientReportsHealthy verifies a nil *Client (e.g. a health
+// handler wired before the real authz client exists) reports healthy rather
+// than panicking.
+func TestDegraded_NilClientReportsHealthy(t *testing.T) {
+	var client *Client
+	if client.Degraded() {
+		t.Fatalf("Degraded() = true on a nil Client, want false")
+	}
+}
+
+// TestDegraded_ClearsAfterSubsequentSuccess verifies Degraded reflects only
+// the most recent outcome: a resolve that reaches a real verdict after a
+// prior failure clears the flag, so /health recovers without a restart once
+// the underlying contention clears.
+func TestDegraded_ClearsAfterSubsequentSuccess(t *testing.T) {
+	failing := true
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if failing {
+			http.Error(w, `{"error":"request could not be completed"}`, http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"key_id":"` + uuid.NewString() + `","status":"active"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := &Client{
+		cache:      &fakeSnapshotStore{},
+		httpClient: server.Client(),
+		baseURL:    server.URL,
+	}
+
+	if _, err := client.Resolve(context.Background(), "Bearer hk_test"); !errors.Is(err, ErrUpstreamUnavailable) {
+		t.Fatalf("expected ErrUpstreamUnavailable while the server is failing, got %v", err)
+	}
+	if !client.Degraded() {
+		t.Fatal("expected Degraded() = true while the server is failing")
+	}
+
+	failing = false
+	if _, err := client.Resolve(context.Background(), "Bearer hk_test2"); err != nil {
+		t.Fatalf("expected a successful resolve once the server recovers, got %v", err)
+	}
+	if client.Degraded() {
+		t.Fatal("expected Degraded() = false after a successful resolve, want the flag cleared")
 	}
 }
 

--- a/deploy/docker/owui-patches/tenant_role_from_db.py
+++ b/deploy/docker/owui-patches/tenant_role_from_db.py
@@ -44,32 +44,29 @@ try:
     if hive_email and hive_db_url:
         import psycopg2 as hive_psycopg2
 
-        # PGVECTOR_DB_URL is meant to carry Supavisor's transaction-mode
-        # DSN (SUPABASE_DB_POOL_URL_LIBPQ), not the session-mode one --
-        # docker-compose.yml already maps it that way -- because this
-        # lookup runs on every single login and must not hold a session
-        # slot against the 15-client ceiling every other consumer shares
-        # (control-plane, edge-api, CI). SUPABASE_DB_POOL_URL_LIBPQ being
-        # unset falls back to the session DSN, which still works but
-        # costs a session slot per login; that gap is deployment
-        # configuration, tracked separately, not something this fragment
-        # can fix. What this fragment fixes: whichever DSN arrives here,
-        # the timeout mechanism below must actually work under
-        # transaction mode once that gap closes.
+        # This lookup runs on every login, so the query must be bounded.
+        # It used to be bounded with a libpq `options=-c statement_timeout=...`
+        # startup string. That mechanism is applied by whichever backend the
+        # client is handed at connection time, so it is honoured on a direct
+        # Postgres and on a session-mode pooler, but a transaction-mode pooler
+        # multiplexes many client sessions over fewer backends and does not
+        # reliably carry it: the connection still succeeds, with no error and
+        # no warning, and the requested timeout is simply never in effect.
+        # `SET LOCAL` inside the implicit transaction this cursor block already
+        # runs in is honoured in every one of those three cases, and it is the
+        # same pattern every RLS `set_config(..., true)` call here relies on,
+        # so it is used unconditionally rather than depending on what
+        # PGVECTOR_DB_URL happens to point at.
         #
-        # Verified live against the actual pooler, not assumed from
-        # documentation: a `-c statement_timeout=... -c lock_timeout=...`
-        # startup `options` string, which is what this used to pass to
-        # connect(), is silently accepted and then silently ignored by
-        # Supavisor transaction mode -- the connection succeeds and SHOW
-        # reports the role's untouched default (measured 2 minutes / no
-        # lock_timeout) instead of the requested 3 seconds. No error, no
-        # warning, just a much longer possible stall on this login-path
-        # query than intended. `SET LOCAL` after connecting, inside the
-        # one implicit transaction this cursor block runs in, measured
-        # correctly on the same pooler (3s/3s), and is the exact pattern
-        # every RLS `set_config(..., true)` call in this codebase already
-        # relies on for the same reason.
+        # Measured, not assumed. On the current self-hosted deployment
+        # (PGVECTOR_DB_URL -> supabase-db:5432, a direct Postgres with no
+        # pooler in front of it) both mechanisms report the requested 3s, and
+        # the role default with neither is 0, meaning unbounded. On the
+        # previous hosted Supavisor pooler in transaction mode the `options=`
+        # form measured as the role's untouched default instead of the
+        # requested 3s. The change is therefore a no-op on today's deployment
+        # and a real fix on any deployment that puts a transaction-mode pooler
+        # back in this path.
         hive_conn = hive_psycopg2.connect(hive_db_url, connect_timeout=5)
         try:
             with hive_conn.cursor() as hive_cur:

--- a/deploy/docker/owui-patches/tenant_role_from_db.py
+++ b/deploy/docker/owui-patches/tenant_role_from_db.py
@@ -44,13 +44,37 @@ try:
     if hive_email and hive_db_url:
         import psycopg2 as hive_psycopg2
 
-        hive_conn = hive_psycopg2.connect(
-            hive_db_url,
-            connect_timeout=5,
-            options="-c statement_timeout=3000 -c lock_timeout=3000",
-        )
+        # PGVECTOR_DB_URL is meant to carry Supavisor's transaction-mode
+        # DSN (SUPABASE_DB_POOL_URL_LIBPQ), not the session-mode one --
+        # docker-compose.yml already maps it that way -- because this
+        # lookup runs on every single login and must not hold a session
+        # slot against the 15-client ceiling every other consumer shares
+        # (control-plane, edge-api, CI). SUPABASE_DB_POOL_URL_LIBPQ being
+        # unset falls back to the session DSN, which still works but
+        # costs a session slot per login; that gap is deployment
+        # configuration, tracked separately, not something this fragment
+        # can fix. What this fragment fixes: whichever DSN arrives here,
+        # the timeout mechanism below must actually work under
+        # transaction mode once that gap closes.
+        #
+        # Verified live against the actual pooler, not assumed from
+        # documentation: a `-c statement_timeout=... -c lock_timeout=...`
+        # startup `options` string, which is what this used to pass to
+        # connect(), is silently accepted and then silently ignored by
+        # Supavisor transaction mode -- the connection succeeds and SHOW
+        # reports the role's untouched default (measured 2 minutes / no
+        # lock_timeout) instead of the requested 3 seconds. No error, no
+        # warning, just a much longer possible stall on this login-path
+        # query than intended. `SET LOCAL` after connecting, inside the
+        # one implicit transaction this cursor block runs in, measured
+        # correctly on the same pooler (3s/3s), and is the exact pattern
+        # every RLS `set_config(..., true)` call in this codebase already
+        # relies on for the same reason.
+        hive_conn = hive_psycopg2.connect(hive_db_url, connect_timeout=5)
         try:
             with hive_conn.cursor() as hive_cur:
+                hive_cur.execute("SET LOCAL statement_timeout = 3000")
+                hive_cur.execute("SET LOCAL lock_timeout = 3000")
                 hive_cur.execute(
                     "SELECT tu.role FROM public.tenant_users tu "
                     "JOIN auth.users u ON u.id = tu.user_id "


### PR DESCRIPTION
> ## Status: rebased and re-validated after the Supabase cutover, 2026-08-22
>
> This PR was written and validated against Supabase Cloud through a Supavisor pooler, on a base that predates #993. All of that changed. Rebased onto `c30882491`; the original write-up is kept below for history, with the corrections below taking precedence over it.
>
> **What no longer holds.** There is no Supavisor anywhere on this deployment. `PGVECTOR_DB_URL` resolves to `supabase-db:5432`, a direct Postgres; `max_connections` is 100 with roughly 12 in use. The 15-client session-mode ceiling that the "five failure threads" section below builds its whole argument on does not exist any more. **Do not act on the "raise Supavisor session pool_size" recommendation: there is no Supavisor project setting left to raise.** Issue #631's CI-versus-live-traffic coupling is a separate, still-open concern.
>
> **What the OWUI change is now.** Measured live on the current database from inside the Open WebUI container, on the same DSN this code reads: the `options="-c statement_timeout=... -c lock_timeout=..."` startup form reports `3s`/`3s`, `SET LOCAL` reports `3s`/`3s`, and with neither the role default is `0`, unbounded. So this half is a **no-op on today's deployment**, not a fix. It stays because `SET LOCAL` is also honoured under transaction-mode pooling and the `options=` form is not, making it strictly the more portable of two currently-equivalent choices, and because either one is required to keep this per-login query bounded at all. The inline comment asserting that the pooler silently drops the timeout on this deployment was wrong after the cutover and has been rewritten to say which deployment each measurement came from.
>
> **What still stands, and never depended on the pooler.** Both `/health` fixes are about a health signal that cannot report a runtime failure, which is a property of this code rather than of any pooler. `pool != nil` can never become false again once the pool opens, so every way the database becomes unreachable at runtime (the db container restarting, a docker network partition, connection exhaustion, the read-only-database incident of 2026-08-01) still leaves `/health` answering 200. edge-api's `/health` consulted nothing at all. The cutover strengthens this: the database is now a container on the same box that can be restarted or filled, with no managed pooler in front absorbing anything, and `/health` is what the compose healthcheck and every `depends_on: service_healthy` gate read.
>
> **Combined `/health` semantics with #993.** control-plane, in order: a nil or false `DBReady` gives 503 `"database unavailable"`; then a nil or false `ProvisioningReady` gives 503 with the reconciler's own reason; otherwise 200. `DBReady` is now `dbReadyFunc(pool, resolveHealth)`, false when the pool never opened and false when the most recent `/internal/apikeys/resolve` failed infrastructurally rather than reaching a key verdict. Either signal alone degrades the endpoint, and both nil cases read as not-ready rather than as fine. edge-api: 503 `{"status":"degraded","reason":"authorization dependency unavailable"}` when `authz.Client.Degraded()`, else 200.
>
> **Changes made during the rebase**, beyond conflict resolution: `router_health_provisioning_test.go` updated for the `func() bool` signature; `TestNewRouterHealthReactsToRuntimeChange` given a `ProvisioningReady` reporter, because after #993 it was being answered 503 for an unrelated reason and had stopped testing `DBReady` at all; `dbReadyFunc` extracted from the `RouterConfig` literal with `TestDBReadyFuncCombinesBootAndRuntimeSignals` added, after mutation testing showed the wiring of the two signals was itself unfalsifiable; and the edge-api degraded reason changed from `"control-plane resolve unavailable"` to `"authorization dependency unavailable"`, with a leak guard, because that endpoint is unauthenticated on the public gateway.
>
> Full re-validation, mutation table and findings: see the review comment on this PR.
>
> Deployment note: `deploy/docker/owui-patches/tenant_role_from_db.py` is spliced into the Open WebUI backend at image build time, so that half is inert until the chat image is rebuilt.

---

## Summary

This started as a database-review investigation of P0 pool-contention symptoms and grew, mid-task, into a confirmed count of **five distinct user-visible failure threads, at least eight distinct observed failure signatures**, all tracing to one root cause: the shared 15-client Supavisor session-mode pool. That count is the argument for fixing this structurally (raise the ceiling) rather than patching each symptom's call site, and it is the part the owner should read first.

### Every symptom traced to the same one cause

1. **Seeder write**: Cloudflare `522`, and the same job's log carried `(ECHECKOUTTIMEOUT) unable to check out connection from the pool after 15000ms in Session mode` — the ceiling named explicitly by the pooler itself.
2. **Gateway authorization**: `/v1/chat/completions` and `/v1/models` failed for every chat alias, including one routing to OpenRouter with no Groq involved (ruling out a provider-specific cause) — first a clean `503 upstream_unavailable`, then full timeouts, originating from `authz.Client.Resolve`'s `ErrUpstreamUnavailable` classification.
3. **OWUI login** (found via code audit + live pooler probe, this PR): every single login pays a session-mode connection acquisition, because `deploy/docker/owui-patches/tenant_role_from_db.py`'s `PGVECTOR_DB_URL` falls back to the raw session DSN — `SUPABASE_DB_POOL_URL_LIBPQ` was never set.
4. **Screenshot-capture agent**: 4 distinct failures in 5 attempts — a Supabase `504`, a Cloudflare `522`, a Caddy upstream timeout, and an auth bounce. Four different failure shapes from four different layers of the same request path, in one short window.
5. **A separate agent's API key**: lost mid-session because the revoke route it was calling was itself timing out against the same pool.

**Corroborating evidence that this is saturation, not a fault**: the gateway outage cleared on its own once activity dropped. A real defect does not self-heal when load falls; a shared, capped resource does. `scripts/derive-pooler-dsn.py`'s own docstring already proves the arithmetic doesn't fit even after prior mitigations (6 long-lived + 3x4 ephemeral CI = 18 > a ceiling of 15), and issue #841 independently measured the ceiling being hit with *zero* CI running at the time.

## What this PR fixes (code, verified, low risk)

1. **control-plane's `/health` was blind to runtime pool contention.** `RouterConfig.DBReady` was a `bool` computed once from `pool != nil` at boot and baked into the health handler closure. A `pgxpool.Pool` is never `nil` again after a successful boot, even when every checkout is timing out under runtime session-mode contention — so `/health` reported `200 {"status":"ok"}` throughout an active outage. Fixed with `platform/db.ResolveHealth`, a zero-cost tracker fed by real traffic on `/internal/apikeys/resolve` (no synthetic probe, no new connection, no added load on the pool this exists to report on). `DBReady` is now a per-request callback combining `pool != nil` with the tracker.
2. **edge-api's `/health` was fully static** — an unconditional `200`, checking nothing. `authz.Client` now tracks the outcome of its own resolve calls (a real verdict vs `ErrUpstreamUnavailable`) and exposes `Degraded()`; `/health` consults it.
3. **A verified-live correctness bug in the OWUI login-role lookup** (`deploy/docker/owui-patches/tenant_role_from_db.py`, runs on every OIDC login): it passed `statement_timeout`/`lock_timeout` via a psycopg2 `options=` startup string. Live-tested against the actual Supavisor transaction-mode pooler (not assumed from documentation, per explicit ask): the connection succeeds with no error, and `SHOW statement_timeout` reports the role's untouched 2-minute default, not the requested 3 seconds — a **silent** failure to bound this query. Replaced with `SET LOCAL statement_timeout` / `SET LOCAL lock_timeout` inside the existing implicit transaction, the same pattern every `set_config(..., true)` RLS call in this codebase already relies on. Re-verified live: `SHOW` now reports the requested 3s correctly.

## Why this PR does NOT move anything else to transaction mode

Moving a session-mode consumer to transaction mode requires per-call-site verification, not a category-level judgment call — getting it wrong breaks tenant isolation or reservation correctness, which is worse than the outage this PR is about. Before touching anything, I grepped every session-scoped primitive across both Go services, exhaustively, not by sampling:

- Every `set_config('app.current_tenant_id', $1, true)` call (control-plane: `role_pgx.go`, `egress/repository.go`, `agenttask/repository.go`, `rag/repository.go`, `marketplace/repository.go`; edge-api: `rag/repository.go`, `artifacts/repository.go`) already passes `is_local=true` inside an explicit `tx.Exec` — already transaction-scoped, already safe under transaction-mode pooling, everywhere it is set.
- Every advisory lock except one uses `pg_advisory_xact_lock` (transaction-scoped, safe): edge-api's `chat/audit.go`, control-plane's `audit/sync.go` and `rag/provision.go`. The one exception, `accounting/pglock.go`'s `PgxAccountLocker`, takes session-scoped `pg_advisory_lock`/`pg_advisory_unlock` across a whole credit reservation and must keep session mode.
- The one `LISTEN` in the codebase (`tenant/settings/listener.go`) needs one physical connection held for process life and must keep session mode.

Conclusion: edge-api has zero session-scoped dependencies anywhere (exhaustive, not sampled) — its existing transaction-mode assignment was already correct and safe before this audit. control-plane's two session-mode dependencies are real, narrow, and load-bearing enough (tenant-settings cache invalidation, credit-reservation correctness) that control-plane as a whole must stay on session mode. Nothing found here needs to move, and nothing in this PR moves it.

## What this PR recommends but does not execute (needs explicit sign-off — a Supabase project setting, not code)

**Raise Supavisor's session pool_size.** This is the only lever that adds headroom rather than redistributing an already-insufficient 15 across more claimants (the project's own tooling docstring says so explicitly). Postgres itself already provisions `max_connections=60` against a `pool_size` of 15, so there is very likely free room without any migration. Rejected: further cap redistribution alone (already tried once, proven insufficient by the project's own arithmetic); isolating CI onto separate credentials/project now (correct long-term direction, tracked in #631, a bigger lift than a same-day fix).

**Self-hosting Supabase, kept as two separate claims per explicit instruction not to collapse them:** it raises the pool_size ceiling but does not remove the CI/agent/live-traffic coupling — the same failure mode returns at a bigger number unless separately re-architected (#631's own two directions: a separate CI project, or a local Postgres for local/CI). This is orthogonal to the separately-measured slow-sign-in latency from browser-to-GoTrue calls against Supabase Cloud (3.5-9s, once 14.5s), which is a network-latency cost, not a pool-contention cost, and which self-hosting genuinely would fix since GoTrue would then run on the box. Two different problems, two different fixes — raising pool_size does nothing for the GoTrue latency, and self-hosting only helps the pool-contention symptoms by way of a bigger, not structurally different, ceiling.

## Test plan

- [x] `go build ./apps/control-plane/... ./apps/edge-api/...` clean
- [x] `go test ./apps/control-plane/... ./apps/edge-api/... -count=1 -short` — all packages pass, including new tests:
  - `platform/db`: `TestResolveHealth_DefaultsHealthy`, `TestResolveHealth_FlipsOnFailureThenClearsOnSuccess`
  - `apikeys`: `TestInternalResolveRecordsInfraFailureAsDegraded`, `TestInternalResolveRecordsNotFoundAsHealthy` (proves a genuine not-found verdict is never mistaken for a DB problem)
  - `platform/http`: `TestNewRouterHealthReactsToRuntimeChange` (same router instance, no restart, reacts to a runtime flip)
  - `edge-api/authz`: `TestDegraded_DefaultsHealthy`, `TestDegraded_NilClientReportsHealthy`, `TestDegraded_ClearsAfterSubsequentSuccess`
  - `edge-api/cmd/server`: `TestHealthReactsToRuntimeAuthzDegradation`, `TestHealthTreatsNilHealthyCallbackAsHealthy`
- [x] `gofmt -l` clean on every touched file
- [x] Live verification against the real Supavisor pooler for the `tenant_role_from_db.py` fix — two single-connection, sanitized, read-only probes (see commit message for the measured before/after: `options=` silently drops to a 2-minute default; `SET LOCAL` correctly measures 3s)
- [ ] Proof that the gateway keeps authorizing while the previously-fatal workload runs: **not attempted**, per the task's own constraint (would require live load generation against the shared pool this PR is about — explicitly gated on asking first, and the fleet was not quieted for it). No load test was run against the live pool at any point in this investigation; only two single, sanitized, read-only connection probes.

## Adversarial review

Ran as a single database-reviewer pass (self-review) given task scope; the full multi-stream pipeline (CodeRabbit, `ecc:code-review`, `security-reviewer`) was **not** run by this agent — declaring that explicitly rather than silently skipping it. Recommend the orchestrator run those streams before merge, given this touches the authorization hot path.

Buglog entries (JSON lines, for a future buglog-only PR per repo convention — not appended to `.wolf/buglog.jsonl` on this branch):

```json
{"id":"bug-2026-08-18-health-blind-to-runtime-pool-contention","date":"2026-08-18","title":"control-plane and edge-api /health both report 200 through a live pool-contention outage","error_message":"authz: key resolution failed err=authz: status 500; edge-api /v1/chat/completions and /v1/models return 503 upstream_unavailable then time out, while both /health endpoints answer 200 throughout","root_cause":"control-plane's RouterConfig.DBReady was a bool computed once from pool != nil at boot and baked into the health handler closure. A pgxpool.Pool is never nil again after a successful boot even when every checkout is timing out under runtime session-mode pool contention, so DBReady stayed true forever once set. edge-api's /health was a hardcoded 200 with no dependency on anything at all.","fix":"Added platform/db.ResolveHealth in control-plane, recording real resolve-path outcomes (infra failure vs genuine key verdict) with zero added connections; RouterConfig.DBReady is now a per-request callback combining pool!=nil with the tracker. Added authz.Client.Degraded() in edge-api, fed by the same ErrUpstreamUnavailable classification the request path already computes; /health now calls it. Both verified with unit tests that toggle the underlying signal against the same router/mux instance with no restart.","tags":["health-check","observability","connection-pool","supavisor","control-plane","edge-api","issue-816","issue-836"]}
{"id":"bug-2026-08-18-supavisor-txn-mode-drops-options-startup-param","date":"2026-08-18","title":"Supavisor transaction-mode pooler silently ignores libpq options= startup parameters","error_message":"psycopg2.connect(dsn, options=\"-c statement_timeout=3000 -c lock_timeout=3000\") succeeds with no error; SHOW statement_timeout then reports the role default (2min), not 3000ms","root_cause":"Startup-packet options parameters apply to whichever physical backend Supavisor hands the client at connection time in session mode, but transaction mode multiplexes many client sessions over a smaller set of backend connections and does not reliably apply or preserve those parameters per virtual client session. Verified live: the connection succeeds, no error or warning of any kind, and the requested timeouts are simply never in effect.","fix":"Replaced the options= startup string in deploy/docker/owui-patches/tenant_role_from_db.py with explicit SET LOCAL statement_timeout / SET LOCAL lock_timeout executed on the cursor inside the connection's existing implicit transaction, before the query. Verified live on the same transaction-mode DSN: SHOW reports the requested 3s for both.","tags":["postgres","supavisor","transaction-mode","psycopg2","open-webui","statement-timeout","silent-failure"]}
```

Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Health endpoints now reflect runtime database and authorization service degradation.
  * Health status recovers automatically after successful subsequent checks.
  * API-key resolution distinguishes infrastructure failures from valid not-found responses.

* **Bug Fixes**
  * Improved reporting of service availability when database or authorization dependencies become unavailable.
  * Tenant-role lookups now apply query and lock timeouts within transactions.

* **Tests**
  * Added coverage for degradation, recovery, healthy defaults, and dynamic health responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Buglog entry

Two further entries from the post-cutover rebase, in addition to the two above. Not appended to `.wolf/buglog.jsonl` on this branch, per repo policy; to be carried into a buglog-only PR off `main` once this merges.

```json
{"id":"bug-2026-08-22-authz-build-request-clears-degraded","date":"2026-08-22","title":"a malformed CONTROL_PLANE_BASE_URL cleared edge-api's degraded flag on every request and 401'd every valid key","error_message":"authz: build request: net/url: invalid control character in URL; the caller receives 401 Incorrect API key provided while /health keeps reporting 200","root_cause":"authz.Client.Resolve registers its deferred health-tracking store before http.NewRequestWithContext, and that store clears resolveDegraded for any error that is not ErrUpstreamUnavailable. The construction error was wrapped as a plain authz: build request, and on this path construction fails only for a malformed URL, which means a bad CONTROL_PLANE_BASE_URL and therefore a failure on every single call. So the flag was cleared on every call while no request could succeed. authorizer.go separately answers an unclassified resolve error with a permanent 401, so the same misconfiguration told every integrator their valid key was wrong.","fix":"Classify the construction failure as ErrUpstreamUnavailable, since a request that was never constructed never reached a control-plane verdict. That repairs the health signal and the caller-facing error class in one change, and is a smaller diff than reordering the defer while leaving the 401 in place. Guard: TestDegraded_RequestConstructionFailureDoesNotClearDegraded asserts the wrap and Degraded() together, and reverting the classification fails it.","tags":["edge-api","authz","health-check","silent-failure","error-classification","pr-975"]}
{"id":"bug-2026-08-22-rebase-silently-disarmed-a-health-test","date":"2026-08-22","title":"a health regression guard kept passing while testing nothing after an unrelated PR merged","error_message":"TestNewRouterHealthReactsToRuntimeChange asserted 200 on a router with no ProvisioningReady, and after #993 that path answers 503 for an unrelated reason","root_cause":"#993 made a nil ProvisioningReady degrade /health deliberately. PR #975's own regression guard built RouterConfig with only DBReady set, so after the rebase both of its 200 assertions were answered by the provisioning branch and the test stopped exercising DBReady at all. It failed loudly only because the rebase also changed DBReady's type; a change that had kept the type would have left it green and hollow. Mutation testing then found a second instance of the same shape: deleting the runtime term from the cmd/server wiring, leaving DBReady: func() bool { return pool != nil }, left the entire control-plane suite green.","fix":"Give the test a ready ProvisioningReady reporter so the two signals are moved one at a time from opposite sides, and extract dbReadyFunc out of the RouterConfig literal with TestDBReadyFuncCombinesBootAndRuntimeSignals covering no pool, pool plus fresh tracker, runtime degradation and recovery on one callback with no restart, and a nil tracker. Re-running the mutation now fails.","tags":["control-plane","health-check","test-quality","mutation-testing","rebase","pr-975","issue-993"]}
```


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR makes control-plane and edge-api health endpoints respond to runtime authorization/database degradation and moves the Open WebUI tenant-role query timeouts into its transaction.

- Adds atomic runtime health trackers driven by real API-key resolution traffic.
- Changes control-plane database readiness from a startup boolean to a per-request callback.
- Makes edge-api `/health` return a service-unavailable response after upstream authorization failures.
- Applies PostgreSQL statement and lock timeouts with `SET LOCAL` during Open WebUI login-role lookup.
- Adds regression coverage for degradation, recovery, callback polarity, nil callbacks, cache hits, and timeout-related wiring.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking defects identified.

The runtime health signals are wired with consistent polarity and safe nil handling, cache hits do not falsely claim upstream recovery, and the Open WebUI timeout statements execute within the existing implicit transaction.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/control-plane/internal/apikeys/http.go | Records successful key verdicts and infrastructure-class resolution failures in the control-plane runtime health tracker. |
| apps/control-plane/internal/platform/db/health.go | Introduces an atomic last-observed resolve-health signal with healthy startup semantics. |
| apps/control-plane/internal/platform/http/router.go | Evaluates database readiness dynamically for every health request and safely treats a nil callback as unavailable. |
| apps/edge-api/internal/authz/client.go | Tracks upstream authorization degradation across real control-plane round trips without letting Redis cache hits claim recovery. |
| apps/edge-api/cmd/server/main.go | Connects authorization degradation to the public health endpoint with fixed, topology-neutral error output. |
| deploy/docker/owui-patches/tenant_role_from_db.py | Replaces startup-option query limits with transaction-local statement and lock timeouts before the tenant-role lookup. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Request[API-key request] --> EdgeResolve[Edge authz Resolve]
  EdgeResolve --> Cache{Redis cache hit?}
  Cache -->|Yes| Verdict[Cached authorization verdict]
  Cache -->|No| CP[Control-plane resolve endpoint]
  CP --> DB[(Postgres)]
  DB --> CPHealth[Control-plane ResolveHealth]
  CP --> EdgeHealth[Edge resolveDegraded]
  CPHealth --> CPReady[Control-plane /health]
  EdgeHealth --> EdgeReady[Edge API /health]
  Login[Open WebUI login] --> Tx[Implicit transaction]
  Tx --> Timeouts[SET LOCAL timeouts]
  Timeouts --> RoleQuery[Tenant-role query]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: a malformed control-plane base URL ..."](https://github.com/sakibsadmanshajib/hive/commit/48c10483dfb26e912bde2dd21e8ab42c680a3a21) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54357132)</sub>

**Context used:**

- Knowledge Base — [Edge API security boundary](https://app.greptile.com/scubed/-/custom-context/knowledge-base/sakibsadmanshajib/hive/-/docs/edge-api-security-boundary.md)

<!-- /greptile_comment -->