### PR TITLE
fix: add missing vendor/open-webui path to deploy-demo-box.yml filter

### DIFF
--- a/.github/ci/lint-deploy-paths-filter.mjs
+++ b/.github/ci/lint-deploy-paths-filter.mjs
@@ -21,15 +21,25 @@
 // It does not (and cannot, without executing the compose profile logic)
 // check docker-compose.yml's own inputs (env files, bind mounts, image
 // digests) or the workflow's own script/scripts: entries -- those are listed
-// by hand in the paths filter today and are not COPY sources. It also only
-// understands the two glob shapes this filter actually uses: an exact
-// literal ('go.work') and a directory wildcard ('apps/edge-api/**'). A third
-// shape showing up in the filter would need this matcher extended.
+// by hand in the paths filter today and are not COPY sources. On the filter
+// side it only understands the two glob shapes this filter actually uses: an
+// exact literal ('go.work') and a directory wildcard ('apps/edge-api/**'). A
+// third shape showing up in the filter would need this matcher extended.
+//
+// A Docker COPY source can itself carry a `*` (`go.work.sum*`, meaning "copy
+// this file if it exists"). Docker resolves that against the real build
+// context, so this script does the same rather than string-matching the
+// glob literally: it expands the wildcard against the actual files on disk
+// and checks each real match. Comparing the un-expanded glob text against
+// the filter would have made `go.work.sum*` equal to the literal filter
+// entry `go.work.sum` by construction, silently approving a future
+// `go.work.sum.bak` that the real Docker build would also pick up and that
+// the filter does not cover (CodeRabbit review, PR #976).
 //
 // Run: node .github/ci/lint-deploy-paths-filter.mjs
 
 import { readFileSync, readdirSync } from 'node:fs';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { parse } from 'yaml';
 
 const WORKFLOW_FILE = '.github/workflows/deploy-demo-box.yml';
@@ -57,6 +67,35 @@ function isCovered(source, filters) {
   });
 }
 
+function escapeRegExpLiteral(text) {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// Expands one COPY/ADD source token against the real repository tree. A
+// plain path (no `*`) is returned as-is, trailing slash stripped so a
+// directory copy compares equal to the filter's `/**`-stripped prefix. A
+// wildcard is resolved the way Docker resolves it: only within the final
+// path segment, against whatever actually exists in that directory today. A
+// wildcard matching nothing (the "copy if present" idiom, and the file is
+// not present) expands to nothing, same as Docker would copy nothing.
+function expandSource(rawSrc) {
+  const src = rawSrc.replace(/\/+$/, '');
+  if (!src.includes('*')) return [src];
+
+  const dir = dirname(src);
+  const base = dir === '.' ? src : src.slice(dir.length + 1);
+  const pattern = new RegExp(`^${base.split('*').map(escapeRegExpLiteral).join('.*')}$`);
+  const prefix = dir === '.' ? '' : `${dir}/`;
+
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return [];
+  }
+  return entries.filter((e) => pattern.test(e)).map((e) => `${prefix}${e}`);
+}
+
 // Extracts COPY/ADD host-filesystem sources from one Dockerfile's text.
 // Joins backslash line continuations first, then reads instruction lines.
 // Skips `--from=<stage>` copies: those read a previous build stage's
@@ -75,13 +114,7 @@ function copySources(text) {
     const args = tokens.filter((t) => !t.startsWith('--'));
     // COPY/ADD needs at least one source and one destination.
     if (args.length < 2) continue;
-    for (const src of args.slice(0, -1)) {
-      // Docker allows a trailing `*` for "copy if present"; strip it so
-      // `go.work.sum*` compares equal to the filter's literal `go.work.sum`.
-      // Strip a trailing `/` the same way so a directory COPY compares
-      // equal to the `/**`-stripped filter prefix.
-      sources.push(src.replace(/\*+$/, '').replace(/\/+$/, ''));
-    }
+    for (const src of args.slice(0, -1)) sources.push(...expandSource(src));
   }
   return sources;
 }

--- a/.github/ci/lint-deploy-paths-filter.mjs
+++ b/.github/ci/lint-deploy-paths-filter.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+// Deploy path-filter coverage guard.
+//
+// deploy-demo-box.yml's `on.push.paths` is a hand-maintained allowlist that
+// decides whether a merge to main triggers a real deploy. Twice now a real
+// build input had no entry: apps/web-console (issue behind PR #786, its own
+// comment block in that workflow) and vendor/open-webui (the fork's source
+// tree, added by PR #938). Both times the merge was green, the change sat on
+// main, and nothing outside a manual audit noticed it never shipped -- a
+// paths filter with a missing entry does not fail loud, it just never runs.
+//
+// This script closes the class rather than the one instance: it reads every
+// COPY/ADD source in every deploy/docker/Dockerfile.* and checks it against
+// the paths filter. Deliberately scoped to deploy/docker/Dockerfile.* rather
+// than only the Dockerfiles the demo-box deploy job actually builds: every
+// Dockerfile in that directory COPYs exclusively from apps/**, packages/**,
+// deploy/docker/** or go.work(.sum) today, so checking the wider set costs
+// nothing extra and still catches the next vendored tree the moment its
+// Dockerfile lands, before anyone wires it into a compose profile.
+//
+// It does not (and cannot, without executing the compose profile logic)
+// check docker-compose.yml's own inputs (env files, bind mounts, image
+// digests) or the workflow's own script/scripts: entries -- those are listed
+// by hand in the paths filter today and are not COPY sources. It also only
+// understands the two glob shapes this filter actually uses: an exact
+// literal ('go.work') and a directory wildcard ('apps/edge-api/**'). A third
+// shape showing up in the filter would need this matcher extended.
+//
+// Run: node .github/ci/lint-deploy-paths-filter.mjs
+
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { parse } from 'yaml';
+
+const WORKFLOW_FILE = '.github/workflows/deploy-demo-box.yml';
+const DOCKER_DIR = 'deploy/docker';
+
+// Same YAML-1.1-boolean-key dodge as lint-workflow-check-names.mjs: `on:`
+// parses to the boolean `true` under the default schema.
+function onBlock(workflow) {
+  return workflow?.on ?? workflow?.[true] ?? workflow?.True;
+}
+
+function pushPaths(workflow) {
+  const on = onBlock(workflow);
+  const paths = on?.push?.paths;
+  return Array.isArray(paths) ? paths : [];
+}
+
+function isCovered(source, filters) {
+  return filters.some((pattern) => {
+    if (pattern.endsWith('/**')) {
+      const prefix = pattern.slice(0, -3);
+      return source === prefix || source.startsWith(`${prefix}/`);
+    }
+    return source === pattern;
+  });
+}
+
+// Extracts COPY/ADD host-filesystem sources from one Dockerfile's text.
+// Joins backslash line continuations first, then reads instruction lines.
+// Skips `--from=<stage>` copies: those read a previous build stage's
+// filesystem, not the host, so they carry no path-filter obligation of
+// their own (their ultimate host source, if any, is COPYed into that
+// earlier stage and is covered by this same scan).
+function copySources(text) {
+  const joined = text.replace(/\\\r?\n/g, ' ');
+  const sources = [];
+  for (const rawLine of joined.split('\n')) {
+    const line = rawLine.trim();
+    const match = /^(?:COPY|ADD)\s+(.*)$/i.exec(line);
+    if (!match) continue;
+    const tokens = match[1].split(/\s+/).filter(Boolean);
+    if (tokens.some((t) => t.startsWith('--from='))) continue;
+    const args = tokens.filter((t) => !t.startsWith('--'));
+    // COPY/ADD needs at least one source and one destination.
+    if (args.length < 2) continue;
+    for (const src of args.slice(0, -1)) {
+      // Docker allows a trailing `*` for "copy if present"; strip it so
+      // `go.work.sum*` compares equal to the filter's literal `go.work.sum`.
+      // Strip a trailing `/` the same way so a directory COPY compares
+      // equal to the `/**`-stripped filter prefix.
+      sources.push(src.replace(/\*+$/, '').replace(/\/+$/, ''));
+    }
+  }
+  return sources;
+}
+
+const workflow = parse(readFileSync(WORKFLOW_FILE, 'utf8'));
+const filters = pushPaths(workflow);
+
+if (filters.length === 0) {
+  console.error(`${WORKFLOW_FILE}: could not find on.push.paths -- refusing to pass silently.`);
+  process.exit(1);
+}
+
+const dockerfiles = readdirSync(DOCKER_DIR).filter((f) => f.startsWith('Dockerfile.'));
+const uncovered = new Map(); // source -> Set of dockerfiles
+
+for (const file of dockerfiles) {
+  const path = join(DOCKER_DIR, file);
+  const sources = copySources(readFileSync(path, 'utf8'));
+  for (const source of sources) {
+    if (isCovered(source, filters)) continue;
+    if (!uncovered.has(source)) uncovered.set(source, new Set());
+    uncovered.get(source).add(path);
+  }
+}
+
+if (uncovered.size > 0) {
+  console.error(`${WORKFLOW_FILE} paths filter is missing entries:`);
+  for (const [source, files] of uncovered) {
+    console.error(`  - ${source} (COPYed by ${[...files].join(', ')})`);
+  }
+  console.error(
+    'Add a paths entry for each (a literal for an exact file, or "<dir>/**" for a directory) so a ' +
+      'change here still triggers a demo-box deploy. See this file\'s own header comment for why this ' +
+      'has already happened twice silently.',
+  );
+  process.exit(1);
+}
+
+console.log(
+  `Deploy path-filter coverage OK: every COPY/ADD source across ${dockerfiles.length} Dockerfiles ` +
+    `under ${DOCKER_DIR}/ is covered by ${WORKFLOW_FILE}'s push.paths.`,
+);

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -619,6 +619,16 @@ jobs:
       - if: needs.changes.outputs.run != 'false'
         run: node .github/ci/lint-workflow-check-names.mjs
 
+      # Deploy path-filter coverage: every COPY/ADD source in every
+      # deploy/docker/Dockerfile.* must have a matching entry in
+      # deploy-demo-box.yml's push.paths, or a merge to main that only
+      # touches that source ships silently to nowhere. Lives here for the
+      # same reason lint-workflow-check-names.mjs does: this job is a
+      # required check, so the guard cannot be bypassed by a change that
+      # only touches workflows or Dockerfiles.
+      - if: needs.changes.outputs.run != 'false'
+        run: node .github/ci/lint-deploy-paths-filter.mjs
+
       - if: needs.changes.outputs.run != 'false'
         run: npm run lint:tenant-setting
       - if: needs.changes.outputs.run != 'false'

--- a/.github/workflows/deploy-demo-box.yml
+++ b/.github/workflows/deploy-demo-box.yml
@@ -34,6 +34,19 @@ on:
       # supabase/migrations and hive_jwt_forward gaps below: a paths filter
       # with a missing entry does not fail loud, it just never runs.
       - 'apps/web-console/**'
+      # deploy/docker/Dockerfile.open-webui's frontend build stage COPYs this
+      # tree directly (`COPY vendor/open-webui ./`) to compile the forked chat
+      # frontend from source (see that Dockerfile's own header comment and the
+      # `deploy` job's timeout-minutes comment below, both of which already
+      # documented this as a real build input). It had no entry here, so PR
+      # #971 (nav fixes touching only this tree) merged and triggered no
+      # deploy at all, until an audit against every deploy/docker/Dockerfile.*
+      # COPY source (2026-08-18) found the gap. Same failure class as
+      # apps/web-console above: `.github/ci/lint-deploy-paths-filter.mjs`
+      # (wired into ci.yml's repo-policy-lints job) now checks every
+      # Dockerfile in deploy/docker/ against this list so the next missing
+      # entry fails a PR check instead of silently never deploying.
+      - 'vendor/open-webui/**'
       - 'packages/**'
       - 'deploy/docker/**'
       - 'deploy/litellm/**'


### PR DESCRIPTION
## Summary

`deploy-demo-box.yml`'s `push.paths` filter had no entry for `vendor/open-webui`, the forked chat frontend's source tree that `Dockerfile.open-webui` compiles directly from (`COPY vendor/open-webui ./`). A change under that tree merges to `main` and triggers no deploy at all. PR #971 (nav fixes, merged clean) is the live example: it touched only `vendor/open-webui`, and no deploy run followed. The fork build in PR #938 deployed only because it also touched `deploy/docker/Dockerfile.open-webui`, which the filter does cover, so past deploys were incidental rather than evidence the path worked.

The workflow's own comment already documents this exact failure class for `apps/web-console` (PR #786) and `supabase/migrations`. This is the same defect recurring a second time in the same file.

I audited every other Dockerfile the deploy job builds (`edge-api`, `control-plane`, `agent-console`, `web-console.prod`, `agent-engine`) plus the ones it does not (`sdk-tests-*`, `toolchain`, `desktop-linux`, non-prod `web-console`). Every COPY/ADD source across all of them falls under `apps/**`, `packages/**`, `deploy/docker/**`, or `go.work(.sum)`, all already present in the filter. `vendor/open-webui` was the only gap.

## Changes

- `.github/workflows/deploy-demo-box.yml`: add `vendor/open-webui/**` to `push.paths`, with a comment pointing at the new guard below.
- New `.github/ci/lint-deploy-paths-filter.mjs`: parses the deploy workflow's `push.paths` and every `deploy/docker/Dockerfile.*`'s COPY/ADD sources, fails if any source is not covered by the filter. Skips `--from=` stage copies, which read a prior build stage rather than the host filesystem.
- Wired into `.github/workflows/ci.yml`'s existing `repo-policy-lints` job (already a required check, already installs `node`+`yaml`), right after the sibling `lint-workflow-check-names.mjs` step. No new CI job.

Deliberately not added to `.github/branch-protection-main.json`'s required-checks list: `repo-policy-lints` is already required, so this step riding inside it already fails the PR loudly on a gap. Promoting it to its own named required check is a separate, more sensitive branch-protection change and out of scope here.

## Verification

Ran the new guard locally (`npm ci --ignore-scripts && node .github/ci/lint-deploy-paths-filter.mjs`):
- Passes after this fix: `Deploy path-filter coverage OK: every COPY/ADD source across 14 Dockerfiles under deploy/docker/ is covered...`
- Stashed only the `deploy-demo-box.yml` change and reran: fails loud, naming `vendor/open-webui/package.json`, `vendor/open-webui/package-lock.json`, and `vendor/open-webui` itself as uncovered. Confirms the guard would have caught the original bug.
- Re-ran the sibling `lint-workflow-check-names.mjs`: still passes, no regression (23 check names, 6 required contexts).
- Both edited workflow YAMLs parse cleanly.

## Deploy note

Merging this PR changes `.github/workflows/deploy-demo-box.yml` itself, which is already in its own filter, so the merge will trigger a real deploy to the demo box. That deploy will also carry every other merged-but-undeployed change currently sitting on `main` (including PR #971). Given the open P0 on the shared Supabase connection pool, hold this merge for explicit go-ahead rather than merging on green CI alone.

## Buglog entry

Second instance of the same defect class in the same file (first: PR #786, `apps/web-console`).

```json
{"error_message":"vendor/open-webui had no entry in deploy-demo-box.yml's push.paths filter; a change under that tree merged to main and triggered no deploy","root_cause":"the paths filter is a hand-maintained allowlist and the fork's frontend source tree (added when the chat frontend was forked to compile from source) was never added to it, so PR #971 (nav fixes touching only vendor/open-webui) merged clean with zero deploy run","fix":"added vendor/open-webui/** to the filter; added .github/ci/lint-deploy-paths-filter.mjs (wired into ci.yml's repo-policy-lints required check) which parses every deploy/docker/Dockerfile.*'s COPY/ADD sources against the filter and fails loud on the next missing entry instead of silently never deploying","tags":["ci","deploy","paths-filter","open-webui","recurring"]}
```
