### PR TITLE
ci: keep web-e2e diagnostics alive when the job hits its own cap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1312,12 +1312,20 @@ jobs:
     # job-level `concurrency:` group. That was reverted: GitHub Actions
     # only holds one job per concurrency group as pending, so a third
     # queued run cancels the second outright before it ever executes.
-    # web-e2e is not a required check, so a canceled result would surface
-    # nowhere and a PR could merge with no browser coverage at all, a
+    # web-e2e was not a required check then, so a canceled result would
+    # surface nowhere and a PR could merge with no browser coverage at all, a
     # silent gap of exactly the kind issue #659 exists to prevent (a
     # skipped test and a passing test are indistinguishable inside a green
     # check). Trading a noisy false-red failure for a silent absence is
     # not a fix.
+    #
+    # `Web E2E (full stack)` IS a required context on main today, read off the
+    # live branch protection on 2026-08-23 (.github/branch-protection-main.json
+    # still lists the older six and has not caught up). That strengthens the
+    # revert rather than reversing it: a queue-race cancellation would now
+    # block the merge outright instead of vanishing, and it is also why the
+    # diagnostic steps at the end of this job had to stop being skipped on a
+    # cancellation.
     #
     # What replaced it: gate this job on `needs.changes.outputs.web_e2e`
     # (see the `changes` job's decide step for the path reasoning),

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1708,14 +1708,31 @@ jobs:
         # as justified debt in tests/dark-spec-allowlist.json.
         run: npx playwright test --project=chromium
 
-      - name: Dump compose logs on failure
-        if: failure()
+      # The four diagnostic steps below run on `always()`, not `failure()`.
+      # This job carries `timeout-minutes: 35`, and GitHub reports a job killed
+      # by its own cap as cancelled rather than failed, so a plain `failure()`
+      # step is skipped in exactly the case that most needs explaining. That is
+      # observed here, not theoretical: runs that walked into the cap in August
+      # 2026 uploaded no compose log and no Next.js log, and the only artifact
+      # that survived was the Playwright report, which survived because its
+      # upload step already carried `always()`.
+      #
+      # Measured, not assumed, on a throwaway one minute job that slept past
+      # its own cap (run 32628384742, branch deleted after): the job concluded
+      # `cancelled`, its `if: failure()` step was skipped, and its `always()`,
+      # `cancelled()` and `failure() || cancelled()` steps all ran. So either
+      # condition would work. `always()` is the one used here because it is
+      # what the three sibling steps at the end of this job already carry and
+      # it does not depend on which flavour of cancellation arrives. The cost
+      # is a few seconds and one small log artifact on a green run.
+      - name: Dump compose logs
+        if: always()
         working-directory: deploy/docker
         # Piped through the redactor: see the sdk-tests dump step above.
         run: docker compose logs --no-color --timestamps --tail=500 2>&1 | python3 ../../scripts/redact-log-credentials.py > /tmp/compose-web-e2e-api.log || true
 
       - name: Upload compose logs
-        if: failure()
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: compose-logs-web-e2e-api
@@ -1723,8 +1740,8 @@ jobs:
           if-no-files-found: ignore
           retention-days: 5
 
-      - name: Redact the Next.js server log on failure
-        if: failure()
+      - name: Redact the Next.js server log
+        if: always()
         # The console renders an error boundary ("Something went wrong on this
         # page", plus a digest) when a server component throws, and the cause is
         # only ever in this log. On 2026-08-16 an invitation-acceptance spec
@@ -1742,7 +1759,7 @@ jobs:
           fi
 
       - name: Upload the redacted Next.js server log
-        if: failure()
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: nextjs-log-web-e2e

--- a/apps/web-console/tests/e2e/support/e2e-fixture-seed.mjs
+++ b/apps/web-console/tests/e2e/support/e2e-fixture-seed.mjs
@@ -220,7 +220,61 @@ export function createAdminClient() {
   }
   return createClient(url, serviceRoleKey, {
     auth: { persistSession: false, autoRefreshToken: false },
+    global: { fetch: timedFetch },
   });
+}
+
+// Ceiling for one admin API call. Node's fetch has no request deadline of its
+// own (only a 300s headers timeout), so a stalled call sits there until
+// fixture-reset.ts kills the whole seeder child at 120s with a bare signal,
+// which says nothing about which call was stuck. A full seed is roughly 40
+// calls at tens of milliseconds each, so 25s is far outside anything healthy
+// while still landing inside that outer kill. What it buys is one line naming
+// the endpoint that stalled.
+const ADMIN_CALL_TIMEOUT_MS = 25_000;
+
+function callTimeoutMs() {
+  // Overridable so the unit test can prove the message without waiting 25s,
+  // and so a run against a deliberately slow environment can be given room
+  // without editing this file.
+  const raw = Number(process.env.E2E_FIXTURE_CALL_TIMEOUT_MS);
+  return Number.isFinite(raw) && raw > 0 ? raw : ADMIN_CALL_TIMEOUT_MS;
+}
+
+export async function timedFetch(input, init = {}) {
+  // supabase-js passes a string today, but fetch takes a string, a URL or a
+  // Request, and the label must not be the thing that throws. A Request keeps
+  // its own method when init does not override it; a URL stringifies (reading
+  // `.url` off one yields undefined, which `new URL` rejects).
+  const request =
+    typeof Request !== "undefined" && input instanceof Request
+      ? input
+      : undefined;
+  const url = new URL(request?.url ?? String(input));
+  const method = init.method ?? request?.method ?? "GET";
+  // Path only. PostgREST puts filter values in the query string and some of
+  // them are fixture email addresses, so the query is deliberately dropped
+  // rather than redacted: this repository is public and CI logs are with it.
+  const label = `${method} ${url.pathname}`;
+  const startedAt = Date.now();
+  const timeoutMs = callTimeoutMs();
+  // gotrue-js passes its own signal on some admin calls, so compose rather
+  // than replace: dropping theirs would leave those calls unabortable.
+  const deadline = AbortSignal.timeout(timeoutMs);
+  const signal = init.signal
+    ? AbortSignal.any([init.signal, deadline])
+    : deadline;
+  try {
+    return await fetch(input, { ...init, signal });
+  } catch (err) {
+    if (deadline.aborted) {
+      throw new Error(
+        `[e2e-fixture-seed] admin API call stalled: ${label} did not answer ` +
+          `within ${timeoutMs}ms (waited ${Date.now() - startedAt}ms)`
+      );
+    }
+    throw err;
+  }
 }
 
 async function ensureUser(admin, opts) {

--- a/apps/web-console/tests/unit/e2e-fixture-call-timeout.test.ts
+++ b/apps/web-console/tests/unit/e2e-fixture-call-timeout.test.ts
@@ -1,0 +1,112 @@
+// @vitest-environment node
+//
+// Node, not the suite's default jsdom: the module under test is a Node-only
+// seeder, and jsdom's AbortSignal carries neither `timeout` nor `any`.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { timedFetch } from "../e2e/support/e2e-fixture-seed.mjs";
+
+// Without a per-call deadline the fixture seeder hangs for the full 120s that
+// fixture-reset.ts allows a reseed and then dies to a bare kill signal with
+// nothing on stderr, so the run says only that seeding took too long, never
+// which call was stuck. These are the guards on the deadline that replaced
+// that silence.
+
+const originalFetch = globalThis.fetch;
+
+/** A request that never settles until its own signal aborts. */
+function neverSettles() {
+  return ((_input: unknown, init: RequestInit = {}) =>
+    new Promise((_resolve, reject) => {
+      init.signal?.addEventListener("abort", () =>
+        reject(new DOMException("aborted", "AbortError"))
+      );
+    })) as typeof globalThis.fetch;
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  delete process.env.E2E_FIXTURE_CALL_TIMEOUT_MS;
+  vi.restoreAllMocks();
+});
+
+describe("timedFetch", () => {
+  it("names the endpoint that stalled, and drops the query string", async () => {
+    process.env.E2E_FIXTURE_CALL_TIMEOUT_MS = "25";
+    globalThis.fetch = neverSettles();
+
+    await expect(
+      timedFetch(
+        "https://project.supabase.co/rest/v1/account_profiles?login_email=like.%25%2B%25%40%25",
+        { method: "PATCH" }
+      )
+    ).rejects.toThrow(
+      /admin API call stalled: PATCH \/rest\/v1\/account_profiles did not answer within 25ms/
+    );
+
+    // The query string carries fixture email addresses, so it must not reach
+    // a CI log that is public on this repository.
+    let message = "";
+    try {
+      await timedFetch(
+        "https://project.supabase.co/rest/v1/x?email=eq.someone@example.com"
+      );
+    } catch (err) {
+      message = err instanceof Error ? err.message : String(err);
+    }
+    expect(message).toMatch(/admin API call stalled/);
+    expect(message).not.toContain("example.com");
+  });
+
+  it("labels a Request input with its own method, and accepts a URL input", async () => {
+    process.env.E2E_FIXTURE_CALL_TIMEOUT_MS = "25";
+    globalThis.fetch = neverSettles();
+
+    // fetch takes a string, a URL or a Request. Reading `.url` off a URL
+    // yields undefined and `new URL(undefined)` throws, which would replace
+    // the stall message with a TypeError from the diagnostic itself.
+    await expect(
+      timedFetch(
+        new Request("https://project.supabase.co/auth/v1/admin/users", {
+          method: "PATCH",
+        })
+      )
+    ).rejects.toThrow(
+      /admin API call stalled: PATCH \/auth\/v1\/admin\/users did not answer/
+    );
+
+    await expect(
+      timedFetch(new URL("https://project.supabase.co/rest/v1/accounts"))
+    ).rejects.toThrow(
+      /admin API call stalled: GET \/rest\/v1\/accounts did not answer/
+    );
+  });
+
+  it("passes a caller-supplied signal through instead of discarding it", async () => {
+    const seen: Array<AbortSignal | null | undefined> = [];
+    globalThis.fetch = ((_input: string, init: RequestInit = {}) => {
+      seen.push(init.signal);
+      return Promise.resolve(new Response("{}", { status: 200 }));
+    }) as typeof globalThis.fetch;
+
+    const caller = new AbortController();
+    await timedFetch("https://project.supabase.co/auth/v1/admin/users", {
+      signal: caller.signal,
+    });
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toBeInstanceOf(AbortSignal);
+    // Composed, so aborting the caller's controller still aborts the request.
+    caller.abort();
+    expect(seen[0]?.aborted).toBe(true);
+  });
+
+  it("lets a real response through untouched", async () => {
+    globalThis.fetch = (() =>
+      Promise.resolve(
+        new Response("ok", { status: 201 })
+      )) as typeof globalThis.fetch;
+
+    const res = await timedFetch("https://project.supabase.co/rest/v1/accounts");
+    expect(res.status).toBe(201);
+  });
+});


### PR DESCRIPTION
## The gap, as it exists on `main` today

`Web E2E (full stack)` is a required check. Its job in `.github/workflows/ci.yml` carries `timeout-minutes: 35`, and GitHub reports a job killed by its own cap as **cancelled**, not failed. Every `if: failure()` step is skipped on a cancellation.

Four of that job's diagnostic steps are `if: failure()`:

- `Dump compose logs on failure`
- `Upload compose logs`
- `Redact the Next.js server log on failure`
- `Upload the redacted Next.js server log`

So a `web-e2e` job that runs out of time uploads no compose log and no Next.js server log. The only artifact that survives is the Playwright report, and only because that one upload step already carries `always()`. The result is a red required check, with nothing attached to explain it, sitting on top of whichever pull request was unlucky enough to hit the cap.

This is a property of the harness, not of any one outage. It fires whenever the cap is reached, for any reason.

## Change

The four steps carry `always()`, and the two whose names said "on failure" are renamed to match what they now do. Nothing about what the suite asserts changes.

`always()` rather than `failure() || cancelled()`: both were measured to run on a cap kill (see below), so either would work. `always()` is what the three sibling steps at the end of this same job already carry, and it does not depend on which flavour of cancellation arrives. The cost is a few seconds and one small log artifact on a green run.

Second change, in the same job's fixture path and independent of the cap: the E2E fixture seeder's admin client now runs its calls through a 25 second deadline. Node's `fetch` has no request deadline of its own, only a 300 second headers timeout, so a stalled admin call sits there until `fixture-reset.ts` kills the seeder child at 120 seconds with a bare signal, and the run learns only that seeding was slow, never which call was stuck. A call that does not answer in time now throws naming the method and path it stalled on. The query string is dropped rather than redacted, because PostgREST puts fixture email addresses there and this repository is public. A caller supplied signal is composed with the deadline rather than replaced, so gotrue-js keeps its own aborts.

Third, one comment correction in the same job. Its history passage still said "web-e2e is not a required check", which is false today: `Web E2E (full stack)` is in the required contexts read off the live branch protection on 2026-08-23. The claim is corrected in place rather than deleted, because the passage explains why a job-level `concurrency:` group was reverted and being required strengthens that argument rather than reversing it. Noted there too: `.github/branch-protection-main.json` still lists the older six contexts and has not caught up with the live nine, which is a separate change and is not folded in here.

## Evidence that the new condition actually fires on a cap kill

Measured, not reasoned about. A throwaway workflow on a scratch branch (pushed, measured, branch deleted) with `timeout-minutes: 1`, a first step that sleeps 300 seconds, and one step per candidate condition. Run `32628384742`, job conclusion `cancelled`:

| step | condition | conclusion |
| --- | --- | --- |
| overrun the cap | none | `cancelled` |
| cond-failure | `failure()` | **`skipped`** |
| cond-cancelled | `cancelled()` | `success` |
| cond-always | `always()` | `success` |
| cond-failure-or-cancelled | `failure() \|\| cancelled()` | `success` |

That is the RED and the GREEN in one run. The condition on `main` today is skipped by a cap kill; the condition this pull request switches to runs. It also confirms the premise: a job killed by `timeout-minutes` concludes `cancelled`, not `failure`.

## Evidence for the seeder deadline

`apps/web-console`, in Docker (`docker compose run --rm --build --no-deps web-console npx vitest run tests/unit/e2e-fixture-call-timeout.test.ts`). Green first, then each guarded behaviour mutated, then restored:

| state | result |
| --- | --- |
| as pushed | 4 passed |
| deadline replaced with a signal that never fires | 2 failed (both stall tests, at the 5s vitest test timeout) |
| restored | 4 passed |
| label derivation reverted to `new URL(typeof input === "string" ? input : input.url)` with a hardcoded `GET` | 1 failed (the `Request` and `URL` test) |
| restored | 4 passed |

## What was removed from the earlier version of this pull request

The previous body diagnosed a shared Supabase fixture seeder degrading from 1.5s to past its 120s ceiling, and named the six pull requests it took down on 2026-08-17 and 2026-08-18. **That diagnosis is stale and has been deleted rather than carried forward.** PR #983 gave this job its own throwaway Postgres, GoTrue and PostgREST, so `web-e2e` no longer opens a connection to the shared project's session mode pooler at all. Leaving that text in place would have left the next reader chasing an outage that cannot recur in this job.

Removed from the diff for the same reason:

- `maxFailures: 5` in `playwright.config.ts`. Its whole purpose was to stop a wedged **shared** fixture from burning every spec's retries and walking the job into its cap. With a per job database there is no shared wedge to truncate, and a flat failure cap would only hide part of a genuine multi spec regression.
- The edit to the `Name a shared session-pool exhaustion on failure` step. That step no longer exists on `main`; #983 removed it along with the pooler it annotated.

What is kept is only the part that is still an open gap: the diagnostic steps surviving a cap kill, and the per call deadline in the seeder.

## Review

A fresh CodeRabbit pass was requested on the rebased head and came back **rate limited**, so that stream is SKIPPED rather than passed. Recording it explicitly: an unavailable review stream is not a clean review.

The one open thread (`e2e-fixture-seed.mjs`, label derivation on `Request` and `URL` inputs) is fixed and resolved, with the fix and its mutation check posted in the thread. `Request` inputs now keep their own method, `URL` inputs stringify instead of being read for a `.url` they do not have (that path called `new URL(undefined)`, so the diagnostic would have thrown a TypeError over the stall it exists to report), and both are covered by tests.

## Buglog entry

To be appended to `.wolf/buglog.jsonl` on `main` in a separate buglog only pull request after this merges, per `.claude/rules/openwolf.md`.

```json
{"id":"bug-web-e2e-cap-kill-diagnostics","timestamp":"2026-08-23T08:40:00.000Z","related_bugs":[],"occurrences":1,"last_seen":"2026-08-23T08:40:00.000Z","title":"web-e2e uploaded no diagnostics for exactly the runs that needed them","error_message":"A `web-e2e` run killed by its own `timeout-minutes` cap produced a red required check with no compose log and no Next.js server log attached, only the Playwright report","root_cause":"GitHub reports a job killed by `timeout-minutes` as cancelled rather than failed, and an `if: failure()` step is skipped on a cancellation. Four of the job's five diagnostic steps carried `if: failure()`; the fifth, the Playwright report upload, carried `always()`, which is why it was the only artifact that ever survived a capped out run","fix":"Switched the four steps to `always()`. Verified empirically on a throwaway one minute job that slept past its cap (run 32628384742): the job concluded cancelled, its `failure()` step was skipped, and its `always()`, `cancelled()` and `failure() || cancelled()` steps all ran","tags":["ci","github-actions","observability","web-e2e","timeout"]}
```
