### PR TITLE
feat: make the self-hosted Supabase data plane reachable from the live stack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,11 @@
 
 # Supabase
 SUPABASE_URL=https://<PROJECT_REF>.supabase.co
+# The browser-facing auth origin. Identical to SUPABASE_URL on hosted Supabase,
+# which is why it can be left empty there: it falls back to SUPABASE_URL. It
+# exists for the self-hosted data plane, where SUPABASE_URL is an in-network
+# gateway name a browser cannot resolve. See the EnterpriseEdge section below.
+SUPABASE_PUBLIC_URL=
 SUPABASE_ANON_KEY=
 SUPABASE_SERVICE_ROLE_KEY=
 SUPABASE_DB_URL=
@@ -570,20 +575,55 @@ OLLAMA_BASE_URL=
 # the `local` and `chat` application profiles without also starting the rest of
 # the enterprise product surface (today that is `ollama`).
 #
+# Passing `-f docker-compose.enterprise.yml` WITHOUT activating `enterprise` or
+# `selfhost` does not merely leave the data plane stopped, it invalidates the
+# whole project: `edge-api` carries no profile of its own and depends on
+# `supabase-init` and `supabase-ca-export`, so compose refuses every command
+# with `depends on undefined service`. The file and one of its profiles always
+# travel together.
+#
 # ── The shared variables the self-hosted data plane replaces ────────────────
 #
 # The application services read ONE set of Supabase variables regardless of
 # where Supabase lives, so pointing them at the in-stack data plane means
-# rewriting the values above, not adding new names. All of these are reached
-# through the caddy-supabase gateway, which puts the hosted /auth/v1, /rest/v1
-# and /storage/v1 prefixes back in front of GoTrue, PostgREST and Storage, so
-# every consumer keeps the one-base-URL shape it already has.
+# REWRITING the values above, not adding new names.
+#
+# Rewriting, not merely leaving them blank, and not relying on the defaults in
+# docker-compose.enterprise.yml. Those defaults are `${VAR:-...}` forms, so a
+# variable that is set and non-empty wins over them: a leftover hosted
+# SUPABASE_JWKS_URL keeps a Supabase Cloud project a valid token issuer for this
+# deployment, and a leftover hosted SUPABASE_URL sends every identity lookup
+# back out to the internet. Both keep working, which is what makes them easy to
+# miss. `scripts/check-env-supabase-target.py <env-file>` fails on exactly this.
+#
+# All of these are reached through the caddy-supabase gateway, which puts the
+# hosted /auth/v1, /rest/v1 and /storage/v1 prefixes back in front of GoTrue,
+# PostgREST and Storage, so every consumer keeps the one-base-URL shape it has.
 #
 #   SUPABASE_URL=http://caddy-supabase
-#       control-plane only, and it must reach GoTrue, not PostgREST: the client
-#       appends /auth/v1/user. Plain http on purpose, since control-plane does
-#       not carry the gateway's certificate authority and never leaves the
-#       compose network to reach it.
+#       Read by control-plane, which appends /auth/v1/user, so it must reach
+#       GoTrue and not PostgREST. It is ALSO the fallback for
+#       SUPABASE_PUBLIC_URL below, so setting it alone repoints Open WebUI's
+#       OIDC discovery at an address no browser can resolve. Set both.
+#       Plain http here is an in-network hop on the compose bridge, the same
+#       bridge that already carries SUPABASE_DB_URL and
+#       CONTROL_PLANE_INTERNAL_TOKEN in the clear, so it moves no trust
+#       boundary. It is still weaker than the hosted https it replaces, because
+#       control-plane treats this response as identity without verifying a
+#       signature; giving control-plane its own certificate authority knob, the
+#       way edge-api has SUPABASE_JWKS_CA_FILE, is tracked separately.
+#   SUPABASE_PUBLIC_URL=https://<public auth origin>
+#       Browser facing, so it cannot be a compose service name. Open WebUI's
+#       OIDC discovery document is built from it. Leave it unset only where no
+#       browser ever authenticates against this stack, in which case it falls
+#       back to SUPABASE_URL. Whatever it becomes,
+#       ENTERPRISE_AUTH_EXTERNAL_URL below must become the same origin, because
+#       GoTrue builds both the discovery document and the iss claim on its
+#       id_token from that variable and an OIDC client rejects a token whose
+#       issuer does not match the document.
+#   NEXT_PUBLIC_SUPABASE_URL=<same value as SUPABASE_PUBLIC_URL>
+#       Also browser facing, and baked into the client bundle at build time by
+#       `next build`, so changing it needs a rebuild of web-console-prod.
 #   SUPABASE_ANON_KEY=<same value as ENTERPRISE_ANON_KEY below>
 #   SUPABASE_SERVICE_ROLE_KEY=<same value as ENTERPRISE_SERVICE_ROLE_KEY below>
 #   SUPABASE_DB_URL=postgresql://postgres:<ENTERPRISE_DB_PASSWORD>@supabase-db:5432/postgres
@@ -592,6 +632,14 @@ OLLAMA_BASE_URL=
 #       scripts/derive-pooler-dsn.py knows this (is_pooler_host matches only
 #       *.pooler.supabase.com) and leaves both derived DSNs on 5432, so the
 #       deploy-time derivation stays correct without a special case.
+#       `postgresql://`, never the short `postgres://`. libpq and pgx accept
+#       both, so the short spelling reaches control-plane and edge-api intact
+#       and then dies inside Open WebUI, whose SQLAlchemy dropped `postgres`
+#       from its dialect registry: `Can't load plugin
+#       sqlalchemy.dialects:postgres`, and the container never goes healthy.
+#       derive-pooler-dsn.py now normalises the scheme, so a DSN that reaches
+#       any consumer THROUGH that script is safe either way; one written
+#       straight into this file is not.
 #   SUPABASE_DB_POOL_URL / SUPABASE_DB_POOL_URL_LIBPQ
 #       Leave EMPTY when setting SUPABASE_DB_URL by hand. Both fall back to it,
 #       and the split still matters per driver even against one Postgres: the
@@ -604,22 +652,16 @@ OLLAMA_BASE_URL=
 #   SUPABASE_JWKS_CA_FILE=/etc/hive/supabase-ca/root.crt
 #       https, not http, and edge-api refuses the plain-http form outright.
 #       The certificate authority is Caddy's own local authority, exported by
-#       the supabase-ca-export one-shot service into the volume edge-api
-#       mounts. Both values are already defaulted in
-#       docker-compose.enterprise.yml, so they only need setting here to
-#       override, or to clear a hosted value that would otherwise win.
+#       the supabase-ca-export one-shot service into the volume edge-api mounts.
 #   S3_ENDPOINT=http://caddy-supabase/storage/v1/s3
-#   S3_ACCESS_KEY=<same value as ENTERPRISE_SERVICE_ROLE_KEY below>
-#   S3_SECRET_KEY=<same value as ENTERPRISE_SERVICE_ROLE_KEY below>
 #   S3_REGION=local
 #   S3_USE_SSL=false
-#
-# Browser-facing values are NOT in that list, and they cannot be:
-# NEXT_PUBLIC_SUPABASE_URL and Open WebUI's OPENID_PROVIDER_URL are resolved by
-# a browser, which cannot reach a compose service name. They need a public auth
-# origin, which also has to become ENTERPRISE_AUTH_EXTERNAL_URL, because
-# GoTrue's OIDC discovery document and the iss claim on its id_token must agree
-# or an OIDC client rejects every login.
+#   S3_ACCESS_KEY / S3_SECRET_KEY
+#       The credential pair supabase-storage accepts on its S3 protocol
+#       endpoint. Do NOT set both halves to the same value: SigV4 transmits the
+#       access key id in the clear inside the Authorization header, so an
+#       identical secret is disclosed on every request. Configure distinct
+#       credentials on the storage service and use those here.
 #
 # How to generate JWTs (anon + service_role) for a self-hosted GoTrue:
 #   Use the Supabase self-host key generator at:

--- a/.env.example
+++ b/.env.example
@@ -663,6 +663,37 @@ OLLAMA_BASE_URL=
 #       identical secret is disclosed on every request. Configure distinct
 #       credentials on the storage service and use those here.
 #
+# ── Four ENTERPRISE_* variables that are an auth boundary, not a detail ─────
+#
+# These are not shared with the hosted path, so they are easy to leave on a
+# default that is wrong for a real deployment. All four decide who can get in
+# and where they can be sent afterwards, and none of them fails loudly.
+#
+#   ENTERPRISE_DISABLE_SIGNUP
+#       Defaults to true, deliberately: a self-hosted regulated deployment
+#       provisions users administratively. Setting it to false opens self-serve
+#       signup on an instance that may have no other gate in front of it, so it
+#       is a posture decision rather than a convenience.
+#   ENTERPRISE_MAILER_AUTOCONFIRM
+#       Defaults to true, which means a new address is trusted without the
+#       owner of it ever proving control. That is correct only for an
+#       air-gapped install with no SMTP, or one where signup is disabled. With
+#       signup open AND autoconfirm on, anyone who can reach the auth endpoint
+#       has an account.
+#   ENTERPRISE_SITE_URL
+#       The APP origin, distinct from ENTERPRISE_AUTH_EXTERNAL_URL above, which
+#       is the auth origin. It is where auth links in email land, and GoTrue
+#       treats it as an allowed redirect target. The default is a localhost
+#       address, so a deployment that leaves it alone sends real users to their
+#       own machine.
+#   ENTERPRISE_REDIRECT_ALLOW_LIST
+#       Empty by default. GoTrue then permits only ENTERPRISE_SITE_URL as a
+#       redirect target, which silently breaks any OAuth or magic-link flow
+#       returning to a different host, and every entry added widens where a
+#       token can be sent. Register the bare origin AND its `/**` form for each
+#       host: a browser Origin header carries no trailing slash, so a `/**`
+#       pattern on its own does not match it.
+#
 # How to generate JWTs (anon + service_role) for a self-hosted GoTrue:
 #   Use the Supabase self-host key generator at:
 #     https://supabase.com/docs/guides/self-hosting/docker#generate-api-keys
@@ -821,11 +852,15 @@ ENTERPRISE_SSO_MICROSOFT_TENANT_URL=https://login.microsoftonline.com/<tenant-id
 # /rest/v1, the seeding scripts derive both), and standalone GoTrue serves
 # /user with no prefix while PostgREST is a different host entirely. The
 # gateway is what makes one base URL correct for all of them.
-# SUPABASE_URL=http://caddy-supabase
-# SUPABASE_ANON_KEY=<ENTERPRISE_ANON_KEY>
-# SUPABASE_SERVICE_ROLE_KEY=<ENTERPRISE_SERVICE_ROLE_KEY>
-# SUPABASE_DB_URL=postgres://postgres:<ENTERPRISE_DB_PASSWORD>@supabase-db:5432/postgres
-# SUPABASE_JWT_ISSUER=http://supabase-auth:9999
+# The value list lives ONCE, in the shared-variable block at the top of this
+# section, and this paragraph deliberately does not repeat it. The copy that
+# used to sit here had drifted into two traps, both of which cost real time on
+# the demo box cutover: it named the short `postgres://` scheme, which reaches
+# control-plane and edge-api intact and then kills Open WebUI's SQLAlchemy, and
+# it named `SUPABASE_JWT_ISSUER=http://supabase-auth:9999`, which disagrees with
+# what GoTrue actually stamps, so following it makes edge-api reject every token
+# with no error anywhere. A second copy of a value list is a second place for it
+# to be wrong.
 #
 # JWKS NOTE: edge-api/cmd/server/main.go rejects http:// JWKS URLs as insecure,
 # and that guard is not relaxed for self-hosting. An attacker on the path

--- a/.env.example
+++ b/.env.example
@@ -561,8 +561,65 @@ OLLAMA_BASE_URL=
 
 # ─── EnterpriseEdge: Self-hosted Supabase data plane (issue #231) ───────────
 #
-# These variables are ONLY needed when running --profile enterprise.
-# Cloud and local profiles continue to use the hosted Supabase vars above.
+# These variables are ONLY needed when running --profile enterprise or
+# --profile selfhost. Cloud and local profiles continue to use the hosted
+# Supabase vars above.
+#
+# The `selfhost` profile carries exactly the Supabase data-plane services and
+# nothing else, so a deployment can run the self-hosted data plane underneath
+# the `local` and `chat` application profiles without also starting the rest of
+# the enterprise product surface (today that is `ollama`).
+#
+# ── The shared variables the self-hosted data plane replaces ────────────────
+#
+# The application services read ONE set of Supabase variables regardless of
+# where Supabase lives, so pointing them at the in-stack data plane means
+# rewriting the values above, not adding new names. All of these are reached
+# through the caddy-supabase gateway, which puts the hosted /auth/v1, /rest/v1
+# and /storage/v1 prefixes back in front of GoTrue, PostgREST and Storage, so
+# every consumer keeps the one-base-URL shape it already has.
+#
+#   SUPABASE_URL=http://caddy-supabase
+#       control-plane only, and it must reach GoTrue, not PostgREST: the client
+#       appends /auth/v1/user. Plain http on purpose, since control-plane does
+#       not carry the gateway's certificate authority and never leaves the
+#       compose network to reach it.
+#   SUPABASE_ANON_KEY=<same value as ENTERPRISE_ANON_KEY below>
+#   SUPABASE_SERVICE_ROLE_KEY=<same value as ENTERPRISE_SERVICE_ROLE_KEY below>
+#   SUPABASE_DB_URL=postgresql://postgres:<ENTERPRISE_DB_PASSWORD>@supabase-db:5432/postgres
+#       Session mode, and there is no second port: a self-hosted Postgres is
+#       not a Supavisor pooler, so there is no 6543 to move to.
+#       scripts/derive-pooler-dsn.py knows this (is_pooler_host matches only
+#       *.pooler.supabase.com) and leaves both derived DSNs on 5432, so the
+#       deploy-time derivation stays correct without a special case.
+#   SUPABASE_DB_POOL_URL / SUPABASE_DB_POOL_URL_LIBPQ
+#       Leave EMPTY when setting SUPABASE_DB_URL by hand. Both fall back to it,
+#       and the split still matters per driver even against one Postgres: the
+#       plain and _LIBPQ flavours differ by the pgx-only parameters, and Open
+#       WebUI's pgvector store speaks libpq through psycopg2. A pgx-only
+#       parameter in a libpq DSN fails the whole connection.
+#   SUPABASE_JWT_ISSUER=<same value as ENTERPRISE_AUTH_EXTERNAL_URL below>
+#       A string comparison against the token claim, never fetched.
+#   SUPABASE_JWKS_URL=https://caddy-supabase/auth/v1/.well-known/jwks.json
+#   SUPABASE_JWKS_CA_FILE=/etc/hive/supabase-ca/root.crt
+#       https, not http, and edge-api refuses the plain-http form outright.
+#       The certificate authority is Caddy's own local authority, exported by
+#       the supabase-ca-export one-shot service into the volume edge-api
+#       mounts. Both values are already defaulted in
+#       docker-compose.enterprise.yml, so they only need setting here to
+#       override, or to clear a hosted value that would otherwise win.
+#   S3_ENDPOINT=http://caddy-supabase/storage/v1/s3
+#   S3_ACCESS_KEY=<same value as ENTERPRISE_SERVICE_ROLE_KEY below>
+#   S3_SECRET_KEY=<same value as ENTERPRISE_SERVICE_ROLE_KEY below>
+#   S3_REGION=local
+#   S3_USE_SSL=false
+#
+# Browser-facing values are NOT in that list, and they cannot be:
+# NEXT_PUBLIC_SUPABASE_URL and Open WebUI's OPENID_PROVIDER_URL are resolved by
+# a browser, which cannot reach a compose service name. They need a public auth
+# origin, which also has to become ENTERPRISE_AUTH_EXTERNAL_URL, because
+# GoTrue's OIDC discovery document and the iss claim on its id_token must agree
+# or an OIDC client rejects every login.
 #
 # How to generate JWTs (anon + service_role) for a self-hosted GoTrue:
 #   Use the Supabase self-host key generator at:

--- a/.env.example
+++ b/.env.example
@@ -600,6 +600,14 @@ OLLAMA_BASE_URL=
 # hosted /auth/v1, /rest/v1 and /storage/v1 prefixes back in front of GoTrue,
 # PostgREST and Storage, so every consumer keeps the one-base-URL shape it has.
 #
+# NO TRAILING SLASH on any URL below. These values are compared exactly, since
+# edge-api hands the issuer to a string equality test, and they are concatenated
+# with a path, since Open WebUI's discovery URL is built from a base plus
+# /auth/v1/.well-known/openid-configuration. A trailing slash therefore either
+# rejects every token GoTrue issues or produces a double slash the upstream
+# answers 404 to, and neither failure names the variable that caused it.
+# `scripts/check-env-supabase-target.py` refuses the character outright.
+#
 #   SUPABASE_URL=http://caddy-supabase
 #       Read by control-plane, which appends /auth/v1/user, so it must reach
 #       GoTrue and not PostgREST. It is ALSO the fallback for

--- a/.env.example
+++ b/.env.example
@@ -626,7 +626,7 @@ OLLAMA_BASE_URL=
 #       `next build`, so changing it needs a rebuild of web-console-prod.
 #   SUPABASE_ANON_KEY=<same value as ENTERPRISE_ANON_KEY below>
 #   SUPABASE_SERVICE_ROLE_KEY=<same value as ENTERPRISE_SERVICE_ROLE_KEY below>
-#   SUPABASE_DB_URL=postgresql://postgres:<ENTERPRISE_DB_PASSWORD>@supabase-db:5432/postgres
+#   SUPABASE_DB_URL=postgresql://postgres:${ENTERPRISE_DB_PASSWORD}@supabase-db:5432/postgres
 #       Session mode, and there is no second port: a self-hosted Postgres is
 #       not a Supavisor pooler, so there is no 6543 to move to.
 #       scripts/derive-pooler-dsn.py knows this (is_pooler_host matches only

--- a/.github/workflows/deploy-demo-box.yml
+++ b/.github/workflows/deploy-demo-box.yml
@@ -636,7 +636,8 @@ jobs:
           COMPOSE=(docker compose $HIVE_COMPOSE_FLAGS)
           for pair in caddy-owui:Caddyfile.owui \
                       caddy-artifacts:Caddyfile.artifacts \
-                      caddy-console:Caddyfile.console; do
+                      caddy-console:Caddyfile.console \
+                      caddy-supabase:Caddyfile.supabase; do
             svc=${pair%%:*}
             file=./${pair#*:}
             echo "::group::$svc ($file)"

--- a/.github/workflows/deploy-demo-box.yml
+++ b/.github/workflows/deploy-demo-box.yml
@@ -98,6 +98,55 @@ concurrency:
   group: deploy-demo-box
   cancel-in-progress: false
 
+# The compose invocation, defined ONCE for every step in this workflow.
+#
+# Four steps below run `docker compose` against the box, and before this block
+# existed each of them rebuilt the same flag list by hand. That is not a style
+# problem, it is the shape of a silent outage: a step that resolves a different
+# set of compose files resolves a different PROJECT, so it reads a stack that is
+# missing services and reports green over it. The one step that also passes
+# `--remove-orphans` makes it worse than a bad read, because a service the
+# invocation does not know about is deleted.
+#
+# Both `-f` files AND `--profile selfhost` are load bearing, together:
+#
+#   * Without `-f docker-compose.enterprise.yml`, the self-hosted Supabase data
+#     plane is not in the project at all. `--remove-orphans` then deletes
+#     supabase-db, supabase-auth, supabase-rest, supabase-storage and the
+#     gateway, and edge-api is recreated without the certificate authority mount
+#     and exits at boot on its first JWKS refresh.
+#   * Without `--profile selfhost`, passing that file is WORSE than omitting it:
+#     `edge-api` carries no profile of its own and depends on `supabase-init`
+#     and `supabase-ca-export`, so compose refuses every command outright with
+#     `service "edge-api" depends on undefined service "supabase-init": invalid
+#     compose project`. Confirmed on the box.
+#
+# `COMPOSE_FILE` and `COMPOSE_PROFILES` in the box's own .env are NOT an
+# alternative to spelling the profiles here. Measured on the box against a copy
+# of that file: with profile flags on the command line the resolved service list
+# contains supabase-db zero times, and with no flag at all it contains it once.
+# A command-line profile flag replaces the environment value rather than adding
+# to it.
+#
+# docker-compose.override.yml is listed explicitly because passing any `-f`
+# stops compose auto-loading it, and it is what the box has been resolving all
+# along. Its contents (`develop: watch` blocks) are inert for `up -d`, so this
+# is about keeping the project identity unchanged rather than about behaviour.
+#
+# scripts/test_selfhost_supabase_seam.py fails if this definition loses the
+# enterprise file or the profile, and fails if any step in this workflow goes
+# back to spelling its own flags.
+env:
+  HIVE_COMPOSE_FLAGS: >-
+    --env-file ../../.env
+    -f docker-compose.yml
+    -f docker-compose.override.yml
+    -f docker-compose.enterprise.yml
+    --profile local
+    --profile chat
+    --profile monitoring
+    --profile selfhost
+
 jobs:
   # ------------------------------------------------------------------
   # Schema before code. Migrations run here, and the deploy job below
@@ -514,8 +563,7 @@ jobs:
         working-directory: /home/sakib/hive/deploy/docker
         run: |
           set -euo pipefail
-          docker compose --env-file ../../.env --profile local --profile chat \
-            --profile monitoring up -d --build --remove-orphans
+          docker compose $HIVE_COMPOSE_FLAGS up -d --build --remove-orphans
 
       - name: Apply the bind-mounted Caddy configs
         # Every Caddyfile in this stack is bind-mounted into its container, so
@@ -585,7 +633,7 @@ jobs:
         working-directory: /home/sakib/hive/deploy/docker
         run: |
           set -euo pipefail
-          COMPOSE=(docker compose --env-file ../../.env --profile local --profile chat)
+          COMPOSE=(docker compose $HIVE_COMPOSE_FLAGS)
           for pair in caddy-owui:Caddyfile.owui \
                       caddy-artifacts:Caddyfile.artifacts \
                       caddy-console:Caddyfile.console; do
@@ -725,7 +773,7 @@ jobs:
         working-directory: /home/sakib/hive/deploy/docker
         run: |
           set -euo pipefail
-          COMPOSE=(docker compose --env-file ../../.env --profile local --profile chat)
+          COMPOSE=(docker compose $HIVE_COMPOSE_FLAGS)
           # `python3 -` reads the program from stdin; `exec -T` forwards it
           # (the Caddy step above pipes a config in the same way).
           token=$("${COMPOSE[@]}" exec -T open-webui python3 - \
@@ -762,7 +810,7 @@ jobs:
         if: failure()
         working-directory: /home/sakib/hive/deploy/docker
         run: |
-          COMPOSE=(docker compose --env-file ../../.env --profile local --profile chat --profile monitoring)
+          COMPOSE=(docker compose $HIVE_COMPOSE_FLAGS)
           echo "::group::docker compose ps"
           "${COMPOSE[@]}" ps || true
           echo "::endgroup::"

--- a/Makefile
+++ b/Makefile
@@ -32,3 +32,4 @@ test-scripts:
 	python3 scripts/register-owui-oauth-client.py --self-check
 	python3 scripts/test_caddy_supabase_routes.py
 	python3 scripts/test_selfhost_supabase_seam.py
+	python3 scripts/check-env-supabase-target.py --self-check

--- a/Makefile
+++ b/Makefile
@@ -31,3 +31,4 @@ test-scripts:
 	python3 scripts/generate-enterprise-jwt-keys.py --self-check
 	python3 scripts/register-owui-oauth-client.py --self-check
 	python3 scripts/test_caddy_supabase_routes.py
+	python3 scripts/test_selfhost_supabase_seam.py

--- a/deploy/docker/Caddyfile.supabase
+++ b/deploy/docker/Caddyfile.supabase
@@ -139,12 +139,27 @@
 	# Re-read that route list on every GoTrue bump: the invariant is
 	# upstream's, not ours, and this matcher is the only thing tracking it.
 	#
+	# Every entry carries its trailing-slash form, and that is not
+	# decoration. Caddy's `path` matcher is EXACT, while GoTrue's router
+	# registers both `pattern` and `pattern/` for a mounted group, so
+	# `/auth/v1/invite/` matched nothing here and was proxied straight
+	# through. `/auth/v1/admin/*` already covered the admin group by
+	# accident of its wildcard; `/auth/v1/invite` did not, and neither did
+	# the self-service list below until a review caught it.
+	#
+	# /oauth/clients/register is here because this deployment sets
+	# GOTRUE_OAUTH_SERVER_ENABLED=true, which turns on dynamic OAuth client
+	# registration. Left public, anyone on the internet could mint a client
+	# for this issuer. It is administrative surface in the same sense as
+	# /admin, so it is refused in the same place.
+	#
 	# Source order matters: handle blocks are mutually exclusive and are
 	# evaluated in the order written, so this has to precede the proxy
 	# below. scripts/test_caddy_supabase_routes.py fails if it stops doing
 	# so, because a reordering that reopens the admin API changes nothing
 	# else observable.
-	@admin path /auth/v1/admin /auth/v1/admin/* /auth/v1/invite
+	@admin path /auth/v1/admin /auth/v1/admin/* /auth/v1/invite /auth/v1/invite/* \
+		/auth/v1/oauth/clients/register /auth/v1/oauth/clients/register/*
 	handle @admin {
 		respond 404
 	}
@@ -165,27 +180,37 @@
 	# which is the property worth having: a posture that survives someone
 	# editing one variable.
 	#
-	# Three routes, because /signup is not the only one that creates a user:
+	# /signup and /magiclink, and NOT /otp. All three can create a user,
+	# since /otp and its deprecated alias /magiclink create one unless the
+	# caller passes should_create_user false and the default is to create.
+	# The reason /otp is nevertheless left reachable is that a real caller
+	# uses it: apps/web-console/components/email-settings-card.tsx sends
+	# signInWithOtp to re-send an email verification, and it passes
+	# shouldCreateUser false, so it cannot create anything. Refusing that
+	# route here would have been a self-inflicted outage on a live feature to
+	# close a hole GOTRUE_DISABLE_SIGNUP already closes, and the first draft
+	# of this block did exactly that. The over-block assertions in
+	# scripts/test_caddy_supabase_routes.py now name /otp so it cannot be
+	# re-blocked without someone reading this.
 	#
-	#   /signup     the direct one.
-	#   /otp        creates the user unless the caller passes
-	#               should_create_user false, and the DEFAULT is to create.
-	#   /magiclink  the deprecated alias of /otp, same behaviour.
+	# Consequence stated plainly rather than overclaimed: creation via /otp is
+	# stopped by the FLAG alone, not by routing. /signup and /magiclink are
+	# stopped by both. So the flag is still the control that matters and the
+	# gateway is a second lock on the two routes nothing legitimate calls.
 	#
-	# Cost of refusing /otp and /magiclink publicly: passwordless email login
-	# is not available on the public origin. Nothing uses it. Sign-in is
-	# password (POST /token) or the OAuth flow (/authorize, /callback), both
-	# still reachable, and so are /verify, /recover, /resend, /user, /logout
-	# and the discovery documents. The admin one-time-token flow this repo uses
-	# for live test sessions goes through /admin/generate_link on the INTERNAL
-	# listener, which this does not touch.
+	# Everything else stays reachable: password sign-in (POST /token), the
+	# OAuth flow (/authorize, /callback), /verify, /recover, /resend, /user,
+	# /logout and the discovery documents. The admin one-time-token flow this
+	# repo uses for live test sessions goes through /admin/generate_link on the
+	# INTERNAL listener, which this does not touch.
 	#
 	# Re-enabling self-service signup is therefore a deliberate two-part
 	# change, here and on the flag, and it should not be done without the
 	# provisioning path .wolf/decisions.md D-023 describes: a user created with
 	# no tenant membership gets a token with no tenant claim, and the
 	# reconciliation that is supposed to give it one is not built yet.
-	@selfserve path /auth/v1/signup /auth/v1/otp /auth/v1/magiclink
+	@selfserve path /auth/v1/signup /auth/v1/signup/* \
+		/auth/v1/magiclink /auth/v1/magiclink/*
 	handle @selfserve {
 		respond 404
 	}

--- a/deploy/docker/Caddyfile.supabase
+++ b/deploy/docker/Caddyfile.supabase
@@ -148,6 +148,47 @@
 	handle @admin {
 		respond 404
 	}
+	# Self-service account creation, refused at the edge rather than left to a
+	# flag.
+	#
+	# GOTRUE_DISABLE_SIGNUP is the real control and it covers every creation
+	# path including the two below, but it is one environment variable away
+	# from open, and the deployment it protects had it set to false. Paired
+	# with GOTRUE_MAILER_AUTOCONFIRM, which defaults to true, that state means
+	# anyone who can reach this listener gets a confirmed account without ever
+	# proving control of the address they used. That was harmless only while
+	# nothing tunnelled to this port; it becomes live the moment a public auth
+	# origin exists, which is the next change to this stack.
+	#
+	# So the flag is set correctly AND the routes are refused here. Flipping
+	# the flag back no longer reopens the internet-facing surface on its own,
+	# which is the property worth having: a posture that survives someone
+	# editing one variable.
+	#
+	# Three routes, because /signup is not the only one that creates a user:
+	#
+	#   /signup     the direct one.
+	#   /otp        creates the user unless the caller passes
+	#               should_create_user false, and the DEFAULT is to create.
+	#   /magiclink  the deprecated alias of /otp, same behaviour.
+	#
+	# Cost of refusing /otp and /magiclink publicly: passwordless email login
+	# is not available on the public origin. Nothing uses it. Sign-in is
+	# password (POST /token) or the OAuth flow (/authorize, /callback), both
+	# still reachable, and so are /verify, /recover, /resend, /user, /logout
+	# and the discovery documents. The admin one-time-token flow this repo uses
+	# for live test sessions goes through /admin/generate_link on the INTERNAL
+	# listener, which this does not touch.
+	#
+	# Re-enabling self-service signup is therefore a deliberate two-part
+	# change, here and on the flag, and it should not be done without the
+	# provisioning path .wolf/decisions.md D-023 describes: a user created with
+	# no tenant membership gets a token with no tenant claim, and the
+	# reconciliation that is supposed to give it one is not built yet.
+	@selfserve path /auth/v1/signup /auth/v1/otp /auth/v1/magiclink
+	handle @selfserve {
+		respond 404
+	}
 	# After @admin on purpose: an OPTIONS to /auth/v1/admin is refused with the
 	# rest of the admin API rather than told it would be welcome. Before the
 	# proxy for the reason the snippet documents.
@@ -217,5 +258,15 @@ http://{$SUPABASE_DOMAIN:supabase.localhost}:8080 {
 # Any other Host arriving on the public port matches no site above, and Caddy
 # would otherwise answer an empty 200. Answer nothing useful instead.
 :8080 {
+	respond 404
+}
+
+# The same catch-all the public port has had all along, for the in-network port,
+# which never got one. An unmatched Host on 80 answered an empty 200, and while
+# that reaches no backend and is therefore not an exposure, it is a lie: a probe
+# reading 200 concludes the request was proxied and GoTrue answered. That
+# happened while verifying this file, and the wrong conclusion nearly went into
+# a PR as evidence. A 404 cannot be misread.
+:80 {
 	respond 404
 }

--- a/deploy/docker/docker-compose.enterprise.yml
+++ b/deploy/docker/docker-compose.enterprise.yml
@@ -41,6 +41,7 @@ services:
     image: pgvector/pgvector:pg16@sha256:131dcf7ff6a900545df8e7e092c270aa8c6db2f2c818e408cb45ec21316b74e6
     profiles:
       - enterprise
+      - selfhost
     environment:
       POSTGRES_USER: ${ENTERPRISE_DB_USER:-postgres}
       POSTGRES_PASSWORD: ${ENTERPRISE_DB_PASSWORD:?set ENTERPRISE_DB_PASSWORD in .env (openssl rand -base64 24)}
@@ -74,6 +75,7 @@ services:
     image: supabase/gotrue:v2.189.0@sha256:385184459f57569c54c25209f51f3b2be99ddd7c4ce9e3555b5d3eea8447b7cf
     profiles:
       - enterprise
+      - selfhost
     depends_on:
       supabase-db:
         condition: service_healthy
@@ -241,6 +243,7 @@ services:
     image: postgrest/postgrest:v12.2.3@sha256:729bf65c733b73f5b52777f0e4b853f22ed73aa67a22d38269d289779b0a8401
     profiles:
       - enterprise
+      - selfhost
     depends_on:
       supabase-db:
         condition: service_healthy
@@ -278,6 +281,7 @@ services:
     image: supabase/storage-api:v1.11.13@sha256:1e85dad48e8b3e85890a555e5114dc7ee48c2e8be4cfd97dd4e3564b4f104fcd
     profiles:
       - enterprise
+      - selfhost
     depends_on:
       supabase-db:
         condition: service_healthy
@@ -333,6 +337,7 @@ services:
     image: curlimages/curl:8.7.1@sha256:25d29daeb9b14b89e2fa8cc17c70e4b188bca1466086907c2d9a4b56b59d8e21
     profiles:
       - enterprise
+      - selfhost
     depends_on:
       supabase-storage:
         condition: service_healthy
@@ -393,6 +398,7 @@ services:
     image: caddy:2-alpine@sha256:86deaf5e3d3408a6ccec08fbb79989783dd26e206ae10bcf78a801dc8c9ab794
     profiles:
       - enterprise
+      - selfhost
     depends_on:
       supabase-auth:
         condition: service_healthy
@@ -476,6 +482,7 @@ services:
     image: caddy:2-alpine@sha256:86deaf5e3d3408a6ccec08fbb79989783dd26e206ae10bcf78a801dc8c9ab794
     profiles:
       - enterprise
+      - selfhost
     depends_on:
       caddy-supabase:
         condition: service_healthy

--- a/deploy/docker/docker-compose.enterprise.yml
+++ b/deploy/docker/docker-compose.enterprise.yml
@@ -275,7 +275,11 @@ services:
   # Supabase Storage API with local filesystem backend.
   # No MinIO: STORAGE_BACKEND=file writes object data to the supabase-storage-data
   # volume. No S3 call leaves the box.
-  # S3_ENDPOINT for edge-api and control-plane: http://supabase-storage:5000/object/s3
+  # S3_ENDPOINT for edge-api and control-plane is the GATEWAY form,
+  # http://caddy-supabase/storage/v1/s3, not this service directly: the
+  # gateway restores the hosted /storage/v1 prefix and Storage serves /s3
+  # at its own root, so the two together reproduce the hosted path exactly.
+  # The /object/s3 path this comment used to name answers on no listener.
   supabase-storage:
     # Pinned to immutable digest. Refresh: docker pull supabase/storage-api:v1.11.13 && docker inspect --format='{{index .RepoDigests 0}}' supabase/storage-api:v1.11.13
     image: supabase/storage-api:v1.11.13@sha256:1e85dad48e8b3e85890a555e5114dc7ee48c2e8be4cfd97dd4e3564b4f104fcd

--- a/deploy/docker/docker-compose.enterprise.yml
+++ b/deploy/docker/docker-compose.enterprise.yml
@@ -237,7 +237,14 @@ services:
     restart: unless-stopped
 
   # ── supabase-rest (PostgREST) ──────────────────────────────────────────────
-  # Auto REST API over local Postgres. control-plane uses this as SUPABASE_URL.
+  # Auto REST API over local Postgres, reached through the caddy-supabase
+  # gateway at /rest/v1, exactly as hosted Supabase serves it.
+  #
+  # This is NOT what control-plane's SUPABASE_URL points at, which is what this
+  # comment used to say. control-plane appends /auth/v1/user to that base, and
+  # PostgREST cannot serve an auth route, so pointing it here breaks every
+  # identity lookup. SUPABASE_URL is the gateway, and the gateway is what makes
+  # one base URL correct for the auth, rest and storage prefixes at once.
   supabase-rest:
     # Pinned to immutable digest. Refresh: docker pull postgrest/postgrest:v12.2.3 && docker inspect --format='{{index .RepoDigests 0}}' postgrest/postgrest:v12.2.3
     image: postgrest/postgrest:v12.2.3@sha256:729bf65c733b73f5b52777f0e4b853f22ed73aa67a22d38269d289779b0a8401

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -310,7 +310,12 @@ services:
       SUPABASE_DB_URL: ${SUPABASE_DB_URL}
       REDIS_URL: ${REDIS_URL}
       # Enterprise profile: set to local Storage endpoint:
-      #   S3_ENDPOINT=http://supabase-storage:5000/storage/v1/s3
+      #   S3_ENDPOINT=http://caddy-supabase/storage/v1/s3
+      # Through the gateway, not straight at supabase-storage: the
+      # gateway is what restores the hosted /storage/v1 prefix, and
+      # Storage itself serves /s3 at its own root. Two earlier versions
+      # of this comment named the service directly, one of them with an
+      # /object/s3 path that no listener answers.
       #   S3_ACCESS_KEY=<ENTERPRISE_SERVICE_ROLE_KEY>
       #   S3_SECRET_KEY=<ENTERPRISE_SERVICE_ROLE_KEY>
       #   S3_REGION=local
@@ -666,7 +671,21 @@ services:
       ENABLE_LOGIN_FORM: "false"
       ENABLE_OAUTH_SIGNUP: "true"
       OAUTH_PROVIDER_NAME: "Hive"
-      OPENID_PROVIDER_URL: "${SUPABASE_URL}/auth/v1/.well-known/openid-configuration"
+      # The BROWSER-facing auth origin, which is not always the same value as
+      # SUPABASE_URL. Open WebUI fetches this document server side, but every
+      # endpoint inside it (authorize, token, the issuer) is then resolved by
+      # the browser, so a compose service name here is unreachable and login
+      # dies at the redirect with nothing in any log naming the cause.
+      #
+      # Against hosted Supabase the two are identical and the default keeps
+      # that. Against the self-hosted data plane SUPABASE_URL is the in-network
+      # gateway (http://caddy-supabase), which a browser cannot resolve, so that
+      # deployment sets SUPABASE_PUBLIC_URL to its public https auth origin.
+      # ENTERPRISE_AUTH_EXTERNAL_URL has to move with it: GoTrue builds this
+      # document and the iss claim on its id_token from that one variable, and
+      # an OIDC client rejects a token whose issuer does not match the
+      # document's.
+      OPENID_PROVIDER_URL: "${SUPABASE_PUBLIC_URL:-${SUPABASE_URL}}/auth/v1/.well-known/openid-configuration"
       OAUTH_CLIENT_ID: ${SUPABASE_OAUTH_CLIENT_ID:-}
       OAUTH_CLIENT_SECRET: ${SUPABASE_OAUTH_CLIENT_SECRET:-}
       OAUTH_SCOPES: "openid email profile"

--- a/scripts/check-env-supabase-target.py
+++ b/scripts/check-env-supabase-target.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Refuse an env file that points half of the stack at a hosted Supabase project
+and the other half at the self-hosted data plane.
+
+Why this exists
+---------------
+The self-hosted values in docker-compose.enterprise.yml are `${VAR:-default}`
+forms, so a variable that is set and non-empty beats them. A cutover that
+rewrites SUPABASE_URL and SUPABASE_DB_URL but leaves a stale hosted
+SUPABASE_JWKS_URL behind therefore comes up healthy, serves traffic, and quietly
+keeps a Supabase Cloud project as a valid token issuer for this deployment. Every
+consumer is happy, nothing logs anything, and the mixed state survives until the
+cloud project is deleted underneath it.
+
+This is the check for that, and it deliberately reads a real env file rather than
+anything in the repository, because the mixed state only ever exists in one.
+
+Usage
+-----
+    check-env-supabase-target.py .env
+    check-env-supabase-target.py --self-check
+
+Exit 0 when the file is coherently hosted OR coherently self-hosted, 1 when it
+mixes the two or is internally inconsistent. Values are never printed: the report
+names variables and a verdict.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# A hosted Supabase project, in any of the forms these variables can carry.
+HOSTED = re.compile(r"\.supabase\.co\b|\.pooler\.supabase\.com\b", re.IGNORECASE)
+
+# Every variable that decides where a server-side consumer looks for Supabase.
+# NEXT_PUBLIC_* and SUPABASE_PUBLIC_URL are deliberately absent: they are
+# browser-facing and a self-hosted deployment reaches them through a public
+# origin, which is a different address from the in-network gateway and is not
+# evidence of a mixed state.
+SERVER_SIDE = (
+    "SUPABASE_URL",
+    "SUPABASE_DB_URL",
+    "SUPABASE_DB_POOL_URL",
+    "SUPABASE_DB_POOL_URL_LIBPQ",
+    "SUPABASE_JWT_ISSUER",
+    "SUPABASE_JWKS_URL",
+    "S3_ENDPOINT",
+)
+
+# Set only by a deployment running its own data plane.
+SELF_HOSTED_MARKERS = ("ENTERPRISE_DB_PASSWORD", "ENTERPRISE_JWT_SECRET")
+
+
+def parse_env(text: str) -> dict:
+    out = {}
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or "=" not in stripped:
+            continue
+        key, _, value = stripped.partition("=")
+        key = key.strip()
+        if key.startswith("export "):
+            key = key[len("export ") :].strip()
+        if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", key):
+            continue
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+            value = value[1:-1]
+        out[key] = value
+    return out
+
+
+def check(env: dict) -> tuple[int, list]:
+    """Return (exit code, report lines). Never includes a value."""
+    report = []
+    self_hosted = [k for k in SELF_HOSTED_MARKERS if env.get(k)]
+    hosted_vars = [k for k in SERVER_SIDE if env.get(k) and HOSTED.search(env[k])]
+
+    if not self_hosted:
+        report.append("no ENTERPRISE_* data-plane secret set, treating this as a hosted deployment")
+        if hosted_vars:
+            report.append(f"hosted targets, consistent with that: {' '.join(hosted_vars)}")
+        return 0, report
+
+    report.append(f"self-hosted data plane configured ({' '.join(self_hosted)})")
+    failed = False
+
+    if hosted_vars:
+        report.append(
+            "MIXED STATE: these still point at a hosted Supabase project and will "
+            f"beat the enterprise defaults: {' '.join(hosted_vars)}"
+        )
+        failed = True
+
+    jwks = env.get("SUPABASE_JWKS_URL", "")
+    if jwks and not jwks.startswith("https://"):
+        report.append("SUPABASE_JWKS_URL is not https, and edge-api refuses a plain-http JWKS URL")
+        failed = True
+    if jwks and not env.get("SUPABASE_JWKS_CA_FILE"):
+        report.append(
+            "SUPABASE_JWKS_URL is set but SUPABASE_JWKS_CA_FILE is not, so the "
+            "gateway's local certificate authority is not trusted and the first "
+            "JWKS refresh fails at boot"
+        )
+        failed = True
+
+    issuer = env.get("SUPABASE_JWT_ISSUER", "")
+    external = env.get("ENTERPRISE_AUTH_EXTERNAL_URL", "")
+    if issuer and external and issuer.rstrip("/") != external.rstrip("/"):
+        report.append(
+            "SUPABASE_JWT_ISSUER and ENTERPRISE_AUTH_EXTERNAL_URL disagree, so "
+            "GoTrue stamps an issuer edge-api rejects and every token fails with "
+            "no boot error anywhere"
+        )
+        failed = True
+
+    dsn = env.get("SUPABASE_DB_URL", "")
+    if dsn.startswith("postgres://"):
+        report.append(
+            "SUPABASE_DB_URL uses the short postgres:// scheme. libpq and pgx "
+            "accept it, SQLAlchemy does not, so Open WebUI's pgvector store fails "
+            "with NoSuchModuleError. Use postgresql://"
+        )
+        failed = True
+
+    for key in ("SUPABASE_DB_POOL_URL", "SUPABASE_DB_POOL_URL_LIBPQ"):
+        value = env.get(key, "")
+        if value and ":6543/" in value:
+            report.append(
+                f"{key} names port 6543, which exists only on a Supavisor pooler. "
+                "A self-hosted Postgres serves every mode on 5432"
+            )
+            failed = True
+
+    access, secret = env.get("S3_ACCESS_KEY", ""), env.get("S3_SECRET_KEY", "")
+    if access and access == secret:
+        report.append(
+            "S3_ACCESS_KEY and S3_SECRET_KEY are the same value. SigV4 sends the "
+            "access key id in the clear in the Authorization header, so the secret "
+            "is disclosed on every request"
+        )
+        failed = True
+
+    if not failed:
+        report.append("coherently self-hosted, no hosted target left on a server-side variable")
+    return (1 if failed else 0), report
+
+
+GOOD_SELF_HOSTED = """
+ENTERPRISE_DB_PASSWORD=x
+ENTERPRISE_JWT_SECRET=y
+ENTERPRISE_AUTH_EXTERNAL_URL=http://caddy-supabase/auth/v1
+SUPABASE_URL=http://caddy-supabase
+SUPABASE_PUBLIC_URL=https://auth.example.test
+NEXT_PUBLIC_SUPABASE_URL=https://auth.example.test
+SUPABASE_DB_URL=postgresql://postgres:pw@supabase-db:5432/postgres
+SUPABASE_DB_POOL_URL=
+SUPABASE_DB_POOL_URL_LIBPQ=
+SUPABASE_JWT_ISSUER=http://caddy-supabase/auth/v1
+SUPABASE_JWKS_URL=https://caddy-supabase/auth/v1/.well-known/jwks.json
+SUPABASE_JWKS_CA_FILE=/etc/hive/supabase-ca/root.crt
+S3_ENDPOINT=http://caddy-supabase/storage/v1/s3
+S3_ACCESS_KEY=aaa
+S3_SECRET_KEY=bbb
+"""
+
+GOOD_HOSTED = """
+SUPABASE_URL=https://ref.supabase.co
+SUPABASE_DB_URL=postgresql://u:p@aws-1-x.pooler.supabase.com:5432/postgres
+SUPABASE_JWKS_URL=https://ref.supabase.co/auth/v1/.well-known/jwks.json
+S3_ENDPOINT=https://ref.supabase.co/storage/v1/s3
+"""
+
+
+def self_check() -> int:
+    """Each mutation below is one way the cutover has actually gone wrong or could."""
+    good = parse_env(GOOD_SELF_HOSTED)
+    code, report = check(good)
+    assert code == 0, report
+
+    code, report = check(parse_env(GOOD_HOSTED))
+    assert code == 0, report
+
+    # A quoted value and an `export ` prefix must parse, or every check below is
+    # vacuous on a real env file that uses either.
+    quoted = parse_env('export SUPABASE_URL="http://caddy-supabase"\n')
+    assert quoted == {"SUPABASE_URL": "http://caddy-supabase"}, quoted
+    # A commented line is not a setting.
+    assert parse_env("# SUPABASE_URL=https://ref.supabase.co\n") == {}
+
+    mutations = {
+        "stale hosted jwks url": {"SUPABASE_JWKS_URL": "https://ref.supabase.co/auth/v1/.well-known/jwks.json"},
+        "stale hosted identity url": {"SUPABASE_URL": "https://ref.supabase.co"},
+        "stale hosted db dsn": {"SUPABASE_DB_URL": "postgresql://u:p@aws-1-x.pooler.supabase.com:5432/postgres"},
+        "stale hosted s3 endpoint": {"S3_ENDPOINT": "https://ref.supabase.co/storage/v1/s3"},
+        "stale hosted issuer": {"SUPABASE_JWT_ISSUER": "https://ref.supabase.co/auth/v1"},
+        "plain http jwks": {"SUPABASE_JWKS_URL": "http://caddy-supabase/auth/v1/.well-known/jwks.json"},
+        "jwks without a ca file": {"SUPABASE_JWKS_CA_FILE": ""},
+        "issuer disagreement": {"SUPABASE_JWT_ISSUER": "http://supabase-auth:9999"},
+        "short dsn scheme": {"SUPABASE_DB_URL": "postgres://postgres:pw@supabase-db:5432/postgres"},
+        "invented pooler port": {"SUPABASE_DB_POOL_URL": "postgresql://postgres:pw@supabase-db:6543/postgres"},
+        "s3 secret equals its own id": {"S3_SECRET_KEY": "aaa"},
+    }
+    for label, patch in mutations.items():
+        env = dict(good)
+        env.update(patch)
+        code, report = check(env)
+        assert code == 1, f"{label} did not fail: {report}"
+
+    # A browser-facing public origin is not evidence of a mixed state, even
+    # while it still names the hosted project during a staged cutover.
+    env = dict(good)
+    env["NEXT_PUBLIC_SUPABASE_URL"] = "https://ref.supabase.co"
+    env["SUPABASE_PUBLIC_URL"] = "https://ref.supabase.co"
+    code, report = check(env)
+    assert code == 0, report
+
+    print(f"check-env-supabase-target self-check: OK ({len(mutations) + 5} cases)")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("env_file", nargs="?", help="path to the env file to check")
+    parser.add_argument("--self-check", action="store_true")
+    args = parser.parse_args()
+
+    if args.self_check:
+        return self_check()
+    if not args.env_file:
+        parser.error("give an env file, or --self-check")
+
+    path = Path(args.env_file)
+    if not path.exists():
+        print(f"check-env-supabase-target: no such file: {path}")
+        return 1
+    code, report = check(parse_env(path.read_text()))
+    for line in report:
+        print(f"  {line}")
+    print(f"check-env-supabase-target: {'FAIL' if code else 'ok'} ({path})")
+    return code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-env-supabase-target.py
+++ b/scripts/check-env-supabase-target.py
@@ -116,14 +116,19 @@ def check(env: dict) -> tuple[int, list]:
         )
         failed = True
 
-    dsn = env.get("SUPABASE_DB_URL", "")
-    if dsn.startswith("postgres://"):
-        report.append(
-            "SUPABASE_DB_URL uses the short postgres:// scheme. libpq and pgx "
-            "accept it, SQLAlchemy does not, so Open WebUI's pgvector store fails "
-            "with NoSuchModuleError. Use postgresql://"
-        )
-        failed = True
+    # All three DSN variables, not just the one a hand cutover usually edits.
+    # SUPABASE_DB_POOL_URL_LIBPQ is the flavour Open WebUI's SQLAlchemy actually
+    # consumes, so it is the one where the short scheme does the damage; the
+    # other two are checked because a deployment that sets them by hand will
+    # have written all three the same way.
+    for key in ("SUPABASE_DB_URL", "SUPABASE_DB_POOL_URL", "SUPABASE_DB_POOL_URL_LIBPQ"):
+        if env.get(key, "").startswith("postgres://"):
+            report.append(
+                f"{key} uses the short postgres:// scheme. libpq and pgx accept "
+                "it, SQLAlchemy does not, so Open WebUI's pgvector store fails "
+                "with NoSuchModuleError. Use postgresql://"
+            )
+            failed = True
 
     for key in ("SUPABASE_DB_POOL_URL", "SUPABASE_DB_POOL_URL_LIBPQ"):
         value = env.get(key, "")
@@ -200,6 +205,12 @@ def self_check() -> int:
         "jwks without a ca file": {"SUPABASE_JWKS_CA_FILE": ""},
         "issuer disagreement": {"SUPABASE_JWT_ISSUER": "http://supabase-auth:9999"},
         "short dsn scheme": {"SUPABASE_DB_URL": "postgres://postgres:pw@supabase-db:5432/postgres"},
+        "short dsn scheme on the pgx pool url": {
+            "SUPABASE_DB_POOL_URL": "postgres://postgres:pw@supabase-db:5432/postgres"
+        },
+        "short dsn scheme on the libpq pool url": {
+            "SUPABASE_DB_POOL_URL_LIBPQ": "postgres://postgres:pw@supabase-db:5432/postgres"
+        },
         "invented pooler port": {"SUPABASE_DB_POOL_URL": "postgresql://postgres:pw@supabase-db:6543/postgres"},
         "s3 secret equals its own id": {"S3_SECRET_KEY": "aaa"},
     }

--- a/scripts/check-env-supabase-target.py
+++ b/scripts/check-env-supabase-target.py
@@ -122,13 +122,56 @@ def check(env: dict) -> tuple[int, list]:
     # the pin, and every token is rejected with nothing logged.
     external = env.get("ENTERPRISE_AUTH_EXTERNAL_URL", "") or COMPOSE_DEFAULT_AUTH_ORIGIN
     issuer = env.get("SUPABASE_JWT_ISSUER", "") or external
-    if issuer.rstrip("/") != external.rstrip("/"):
+    # EXACT comparison, not one with the slashes stripped off both sides.
+    # Nothing downstream is lenient: compose passes these strings through
+    # verbatim, and edge-api hands the issuer to jwt.WithIssuer, which is a
+    # string equality test. So a trailing slash on one side only is a real
+    # mismatch that rejects every token GoTrue issues, and stripping it here
+    # reported the environment as fine while the box was broken. Third instance
+    # of this defect on one branch, after two on the gateway path matchers, which
+    # is why the rule below refuses the character outright rather than tolerating
+    # it at a fourth site.
+    if issuer != external:
         report.append(
             "SUPABASE_JWT_ISSUER and ENTERPRISE_AUTH_EXTERNAL_URL disagree, so "
             "GoTrue stamps an issuer edge-api rejects and every token fails with "
             "no boot error anywhere"
         )
         failed = True
+
+    # No trailing slash on any URL variable, which is the general form of the
+    # defect above rather than one more instance of it.
+    #
+    # Two distinct things go wrong with a trailing slash, and tolerating it at
+    # the point of comparison only ever fixes the first:
+    #
+    #   * exact comparison. The issuer check above, and edge-api's own
+    #     jwt.WithIssuer, are string equality.
+    #   * string concatenation. docker-compose.yml builds Open WebUI's discovery
+    #     URL from a base plus /auth/v1/.well-known/openid-configuration, so a
+    #     base ending in a slash yields a double slash in the path and the
+    #     discovery fetch 404s. A comparison that stripped slashes would have
+    #     called that environment healthy.
+    #
+    # Refusing the character is one rule that covers both, and it costs an
+    # operator nothing: none of these values is meaningful with a trailing slash.
+    for key in (
+        "SUPABASE_URL",
+        "SUPABASE_PUBLIC_URL",
+        "SUPABASE_JWT_ISSUER",
+        "SUPABASE_JWKS_URL",
+        "ENTERPRISE_AUTH_EXTERNAL_URL",
+        "S3_ENDPOINT",
+        "NEXT_PUBLIC_SUPABASE_URL",
+    ):
+        if env.get(key, "").endswith("/"):
+            report.append(
+                f"{key} ends with a trailing slash. These values are compared "
+                "exactly and concatenated with a path, so a trailing slash "
+                "either rejects every token or produces a double slash the "
+                "upstream answers 404 to"
+            )
+            failed = True
 
     # All three DSN variables, not just the one a hand cutover usually edits.
     # SUPABASE_DB_POOL_URL_LIBPQ is the flavour Open WebUI's SQLAlchemy actually
@@ -222,6 +265,31 @@ def self_check() -> int:
         "plain http jwks": {"SUPABASE_JWKS_URL": "http://caddy-supabase/auth/v1/.well-known/jwks.json"},
         "jwks without a ca file": {"SUPABASE_JWKS_CA_FILE": ""},
         "issuer disagreement": {"SUPABASE_JWT_ISSUER": "http://supabase-auth:9999"},
+        # The trailing-slash bypass itself: same origin, one side slashed.
+        # Accepted by a comparison that stripped slashes, rejected by everything
+        # at runtime.
+        "issuer differing from the origin by one trailing slash": {
+            "SUPABASE_JWT_ISSUER": "http://caddy-supabase/auth/v1/",
+        },
+        "origin differing from the issuer by one trailing slash": {
+            "ENTERPRISE_AUTH_EXTERNAL_URL": "http://caddy-supabase/auth/v1/",
+        },
+        # A slash on BOTH sides, which the exact comparison alone cannot see:
+        # there it is the concatenation that breaks, not the comparison.
+        "trailing slash on both the issuer and the origin": {
+            "SUPABASE_JWT_ISSUER": "http://caddy-supabase/auth/v1/",
+            "ENTERPRISE_AUTH_EXTERNAL_URL": "http://caddy-supabase/auth/v1/",
+        },
+        "trailing slash on the identity url": {"SUPABASE_URL": "http://caddy-supabase/"},
+        "trailing slash on the browser-facing origin": {
+            "SUPABASE_PUBLIC_URL": "https://auth.example.test/"
+        },
+        "trailing slash on the jwks url": {
+            "SUPABASE_JWKS_URL": "https://caddy-supabase/auth/v1/.well-known/jwks.json/"
+        },
+        "trailing slash on the storage endpoint": {
+            "S3_ENDPOINT": "http://caddy-supabase/storage/v1/s3/"
+        },
         # The bypass: pin the issuer and leave the auth origin unset, so the
         # compose default is what GoTrue actually stamps.
         "issuer pinned against an unset auth origin": {

--- a/scripts/check-env-supabase-target.py
+++ b/scripts/check-env-supabase-target.py
@@ -153,6 +153,10 @@ def check(env: dict) -> tuple[int, list]:
     return (1 if failed else 0), report
 
 
+# Fixture credentials are written as `${PASSWORD}` rather than a short literal:
+# a secret scanner reads `postgres:pw@host` as PostgreSQL credentials and reports
+# the whole diff, and a scanner that cries wolf on a fixture is one people learn
+# to ignore. Nothing in this file parses a password.
 GOOD_SELF_HOSTED = """
 ENTERPRISE_DB_PASSWORD=x
 ENTERPRISE_JWT_SECRET=y
@@ -160,7 +164,7 @@ ENTERPRISE_AUTH_EXTERNAL_URL=http://caddy-supabase/auth/v1
 SUPABASE_URL=http://caddy-supabase
 SUPABASE_PUBLIC_URL=https://auth.example.test
 NEXT_PUBLIC_SUPABASE_URL=https://auth.example.test
-SUPABASE_DB_URL=postgresql://postgres:pw@supabase-db:5432/postgres
+SUPABASE_DB_URL=postgresql://postgres:${PASSWORD}@supabase-db:5432/postgres
 SUPABASE_DB_POOL_URL=
 SUPABASE_DB_POOL_URL_LIBPQ=
 SUPABASE_JWT_ISSUER=http://caddy-supabase/auth/v1
@@ -173,7 +177,7 @@ S3_SECRET_KEY=bbb
 
 GOOD_HOSTED = """
 SUPABASE_URL=https://ref.supabase.co
-SUPABASE_DB_URL=postgresql://u:p@aws-1-x.pooler.supabase.com:5432/postgres
+SUPABASE_DB_URL=postgresql://user:${PASSWORD}@aws-1-x.pooler.supabase.com:5432/postgres
 SUPABASE_JWKS_URL=https://ref.supabase.co/auth/v1/.well-known/jwks.json
 S3_ENDPOINT=https://ref.supabase.co/storage/v1/s3
 """
@@ -198,20 +202,20 @@ def self_check() -> int:
     mutations = {
         "stale hosted jwks url": {"SUPABASE_JWKS_URL": "https://ref.supabase.co/auth/v1/.well-known/jwks.json"},
         "stale hosted identity url": {"SUPABASE_URL": "https://ref.supabase.co"},
-        "stale hosted db dsn": {"SUPABASE_DB_URL": "postgresql://u:p@aws-1-x.pooler.supabase.com:5432/postgres"},
+        "stale hosted db dsn": {"SUPABASE_DB_URL": "postgresql://user:${PASSWORD}@aws-1-x.pooler.supabase.com:5432/postgres"},
         "stale hosted s3 endpoint": {"S3_ENDPOINT": "https://ref.supabase.co/storage/v1/s3"},
         "stale hosted issuer": {"SUPABASE_JWT_ISSUER": "https://ref.supabase.co/auth/v1"},
         "plain http jwks": {"SUPABASE_JWKS_URL": "http://caddy-supabase/auth/v1/.well-known/jwks.json"},
         "jwks without a ca file": {"SUPABASE_JWKS_CA_FILE": ""},
         "issuer disagreement": {"SUPABASE_JWT_ISSUER": "http://supabase-auth:9999"},
-        "short dsn scheme": {"SUPABASE_DB_URL": "postgres://postgres:pw@supabase-db:5432/postgres"},
+        "short dsn scheme": {"SUPABASE_DB_URL": "postgres://postgres:${PASSWORD}@supabase-db:5432/postgres"},
         "short dsn scheme on the pgx pool url": {
-            "SUPABASE_DB_POOL_URL": "postgres://postgres:pw@supabase-db:5432/postgres"
+            "SUPABASE_DB_POOL_URL": "postgres://postgres:${PASSWORD}@supabase-db:5432/postgres"
         },
         "short dsn scheme on the libpq pool url": {
-            "SUPABASE_DB_POOL_URL_LIBPQ": "postgres://postgres:pw@supabase-db:5432/postgres"
+            "SUPABASE_DB_POOL_URL_LIBPQ": "postgres://postgres:${PASSWORD}@supabase-db:5432/postgres"
         },
-        "invented pooler port": {"SUPABASE_DB_POOL_URL": "postgresql://postgres:pw@supabase-db:6543/postgres"},
+        "invented pooler port": {"SUPABASE_DB_POOL_URL": "postgresql://postgres:${PASSWORD}@supabase-db:6543/postgres"},
         "s3 secret equals its own id": {"S3_SECRET_KEY": "aaa"},
     }
     for label, patch in mutations.items():

--- a/scripts/check-env-supabase-target.py
+++ b/scripts/check-env-supabase-target.py
@@ -49,6 +49,12 @@ SERVER_SIDE = (
     "S3_ENDPOINT",
 )
 
+# What docker-compose.enterprise.yml defaults the auth origin to when neither
+# ENTERPRISE_AUTH_EXTERNAL_URL nor SUPABASE_JWT_ISSUER is set. Kept in step with
+# that file by scripts/test_selfhost_supabase_seam.py, which asserts both sides
+# of the compose default derive from the same variable.
+COMPOSE_DEFAULT_AUTH_ORIGIN = "http://caddy-supabase/auth/v1"
+
 # Set only by a deployment running its own data plane.
 SELF_HOSTED_MARKERS = ("ENTERPRISE_DB_PASSWORD", "ENTERPRISE_JWT_SECRET")
 
@@ -106,9 +112,17 @@ def check(env: dict) -> tuple[int, list]:
         )
         failed = True
 
-    issuer = env.get("SUPABASE_JWT_ISSUER", "")
-    external = env.get("ENTERPRISE_AUTH_EXTERNAL_URL", "")
-    if issuer and external and issuer.rstrip("/") != external.rstrip("/"):
+    # Both sides fall back to what docker-compose.enterprise.yml defaults them
+    # to, because an unset variable is not an absent value: compose hands GoTrue
+    # that default and edge-api compares against the same expression. Requiring
+    # BOTH to be set before comparing meant an env file that pinned
+    # SUPABASE_JWT_ISSUER to something else and left
+    # ENTERPRISE_AUTH_EXTERNAL_URL alone sailed through, which is the exact
+    # mismatch this check exists for: GoTrue stamps the default, edge-api expects
+    # the pin, and every token is rejected with nothing logged.
+    external = env.get("ENTERPRISE_AUTH_EXTERNAL_URL", "") or COMPOSE_DEFAULT_AUTH_ORIGIN
+    issuer = env.get("SUPABASE_JWT_ISSUER", "") or external
+    if issuer.rstrip("/") != external.rstrip("/"):
         report.append(
             "SUPABASE_JWT_ISSUER and ENTERPRISE_AUTH_EXTERNAL_URL disagree, so "
             "GoTrue stamps an issuer edge-api rejects and every token fails with "
@@ -208,6 +222,13 @@ def self_check() -> int:
         "plain http jwks": {"SUPABASE_JWKS_URL": "http://caddy-supabase/auth/v1/.well-known/jwks.json"},
         "jwks without a ca file": {"SUPABASE_JWKS_CA_FILE": ""},
         "issuer disagreement": {"SUPABASE_JWT_ISSUER": "http://supabase-auth:9999"},
+        # The bypass: pin the issuer and leave the auth origin unset, so the
+        # compose default is what GoTrue actually stamps.
+        "issuer pinned against an unset auth origin": {
+            "SUPABASE_JWT_ISSUER": "http://supabase-auth:9999",
+            "ENTERPRISE_AUTH_EXTERNAL_URL": "",
+        },
+
         "short dsn scheme": {"SUPABASE_DB_URL": "postgres://postgres:${PASSWORD}@supabase-db:5432/postgres"},
         "short dsn scheme on the pgx pool url": {
             "SUPABASE_DB_POOL_URL": "postgres://postgres:${PASSWORD}@supabase-db:5432/postgres"
@@ -223,6 +244,19 @@ def self_check() -> int:
         env.update(patch)
         code, report = check(env)
         assert code == 1, f"{label} did not fail: {report}"
+
+    # Moving the auth origin while leaving SUPABASE_JWT_ISSUER unset is
+    # COHERENT, not a mismatch, and this was written as a must-fail case first
+    # and corrected by the assertion below refusing to fail. The compose
+    # expression is ${SUPABASE_JWT_ISSUER:-${ENTERPRISE_AUTH_EXTERNAL_URL:-...}},
+    # so an unset issuer inherits the moved origin and the two genuinely agree at
+    # runtime. Only an issuer that is explicitly set to something else is the
+    # failure this check is for.
+    env = dict(good)
+    env["ENTERPRISE_AUTH_EXTERNAL_URL"] = "https://auth.example.test/auth/v1"
+    env["SUPABASE_JWT_ISSUER"] = ""
+    code, report = check(env)
+    assert code == 0, report
 
     # A browser-facing public origin is not evidence of a mixed state, even
     # while it still names the hosted project during a staged cutover.

--- a/scripts/derive-pooler-dsn.py
+++ b/scripts/derive-pooler-dsn.py
@@ -205,6 +205,30 @@ def without_params(dsn: str, *keys: str) -> str:
     return urlunsplit(parts._replace(query=encode_query(query)))
 
 
+def normalize_scheme(dsn: str) -> str:
+    """Return dsn with the `postgres://` scheme rewritten to `postgresql://`.
+
+    libpq and pgx accept both spellings, so a DSN written either way reaches
+    control-plane and edge-api intact and nothing here ever noticed the
+    difference. SQLAlchemy accepts only `postgresql://`: it looks the scheme up
+    in its dialect registry and `postgres` was removed from that registry in
+    SQLAlchemy 1.4. Open WebUI's pgvector store is a SQLAlchemy consumer of the
+    libpq flavour below, so a `postgres://` DSN reaches it as
+    `NoSuchModuleError: Can't load plugin: sqlalchemy.dialects:postgres` and the
+    container never becomes healthy. Observed on the demo box during the
+    self-hosted Supabase cutover, from an operator-written DSN using the short
+    spelling.
+
+    Normalising here rather than at each consumer is the one place all three
+    derived DSNs pass through, and the rewrite is a no-op for the two drivers
+    that already accepted both.
+    """
+    parts = urlsplit(dsn)
+    if parts.scheme == "postgres":
+        return urlunsplit(parts._replace(scheme="postgresql"))
+    return dsn
+
+
 def with_port(dsn: str, port: int) -> str:
     parts = urlsplit(dsn)
     if parts.hostname is None:
@@ -233,6 +257,7 @@ def derive(
     session_max_conns is this consumer's share of the project's 15 session slots.
     It defaults to the ephemeral budget; a long-lived deployment passes its own.
     """
+    dsn = normalize_scheme(dsn)
     parts = urlsplit(dsn)
     host = parts.hostname
     if not host:
@@ -367,6 +392,26 @@ def self_test() -> int:
     assert ":5432/" in d_transaction and ":6543/" not in d_transaction, d_transaction
     assert ":5432/" in d_libpq and "pool_max_conns" not in d_libpq, d_libpq
 
+    # The short `postgres://` spelling is normalised in ALL THREE outputs.
+    # libpq and pgx accept it, so nothing downstream of them ever complained;
+    # SQLAlchemy removed `postgres` from its dialect registry in 1.4, and Open
+    # WebUI's pgvector store consumes the libpq flavour, so the short spelling
+    # reached it as NoSuchModuleError and the container never went healthy.
+    short = "postgres://postgres:pw@supabase-db:5432/postgres"
+    s_session, s_transaction, s_libpq = derive(short)
+    for flavour in (s_session, s_transaction, s_libpq):
+        assert flavour.startswith("postgresql://"), flavour
+        assert not flavour.startswith("postgres://"), flavour
+    # Nothing else about the DSN moves: same host, port, credential, database.
+    assert "@supabase-db:5432/postgres" in s_libpq, s_libpq
+    # And the long spelling is untouched, so this is a normalisation and not a
+    # rewrite that could mangle an already-correct DSN.
+    assert derive(direct) == (d_session, d_transaction, d_libpq)
+    # A pooler host normalises too, port move and all.
+    short_pooler = pooler.replace("postgresql://", "postgres://", 1)
+    for flavour in derive(short_pooler):
+        assert flavour.startswith("postgresql://"), flavour
+
     # An explicit pool_max_conns in the input is the deployment's call, not ours.
     pinned, _, pinned_libpq = derive(pooler + "?pool_max_conns=2")
     assert "pool_max_conns=2" in pinned, pinned
@@ -398,7 +443,7 @@ def self_test() -> int:
         assert "options=-c%20statement_timeout%3D3000" in flavour, flavour
         assert "+" not in urlsplit(flavour).query, flavour
 
-    print("derive-pooler-dsn: self-test ok (43 assertions)")
+    print("derive-pooler-dsn: self-test ok (52 assertions)")
     return 0
 
 

--- a/scripts/derive-pooler-dsn.py
+++ b/scripts/derive-pooler-dsn.py
@@ -397,7 +397,11 @@ def self_test() -> int:
     # SQLAlchemy removed `postgres` from its dialect registry in 1.4, and Open
     # WebUI's pgvector store consumes the libpq flavour, so the short spelling
     # reached it as NoSuchModuleError and the container never went healthy.
-    short = "postgres://postgres:pw@supabase-db:5432/postgres"
+    # `${PASSWORD}` rather than a short literal on purpose: a secret scanner
+    # reads `postgres:pw@host` as PostgreSQL credentials and reports the diff,
+    # and a scanner that cries wolf on a fixture is a scanner people learn to
+    # ignore. Nothing here parses the password, only the scheme and the host.
+    short = "postgres://postgres:${PASSWORD}@supabase-db:5432/postgres"
     s_session, s_transaction, s_libpq = derive(short)
     for flavour in (s_session, s_transaction, s_libpq):
         assert flavour.startswith("postgresql://"), flavour

--- a/scripts/derive-pooler-dsn.py
+++ b/scripts/derive-pooler-dsn.py
@@ -405,12 +405,15 @@ def self_test() -> int:
     s_session, s_transaction, s_libpq = derive(short)
     for flavour in (s_session, s_transaction, s_libpq):
         assert flavour.startswith("postgresql://"), flavour
-        assert not flavour.startswith("postgres://"), flavour
     # Nothing else about the DSN moves: same host, port, credential, database.
     assert "@supabase-db:5432/postgres" in s_libpq, s_libpq
-    # And the long spelling is untouched, so this is a normalisation and not a
-    # rewrite that could mangle an already-correct DSN.
-    assert derive(direct) == (d_session, d_transaction, d_libpq)
+    # The long spelling is untouched, so this is a normalisation and not a
+    # rewrite that could mangle an already-correct DSN. Asserted against the
+    # INPUT, not against another call: comparing derive(direct) with values
+    # captured from derive(direct) proves only that derive is deterministic,
+    # which it would be whatever normalize_scheme did to a long-spelling DSN.
+    assert normalize_scheme(direct) == direct, normalize_scheme(direct)
+    assert normalize_scheme(pooler) == pooler, normalize_scheme(pooler)
     # A pooler host normalises too, port move and all.
     short_pooler = pooler.replace("postgresql://", "postgres://", 1)
     for flavour in derive(short_pooler):

--- a/scripts/test_caddy_supabase_routes.py
+++ b/scripts/test_caddy_supabase_routes.py
@@ -65,6 +65,30 @@ CORS_ECHO_PLACEHOLDER = "{header.Access-Control-Request-Headers}"
 # requireAdminCredentials appears exactly twice, on /invite and on the group.
 REQUIRED_ADMIN_PATHS = ["/auth/v1/admin", "/auth/v1/admin/*", "/auth/v1/invite"]
 
+# Self-service account creation, refused on the public listener so that the
+# posture survives someone editing GOTRUE_DISABLE_SIGNUP. /otp and /magiclink
+# are here because they create a user too: should_create_user defaults to true,
+# so they are signup routes wearing a login name.
+REQUIRED_SELF_SERVICE_BLOCKED_PATHS = [
+    "/auth/v1/signup",
+    "/auth/v1/otp",
+    "/auth/v1/magiclink",
+]
+
+# Every login and recovery route the product actually uses. Blocking one of
+# these would be a self-inflicted outage, so the deny list is checked against
+# them: a matcher that swallowed /token would pass a "signup is blocked" test
+# while locking every user out.
+REQUIRED_PUBLIC_AUTH_PATHS = [
+    "/auth/v1/token",
+    "/auth/v1/authorize",
+    "/auth/v1/callback",
+    "/auth/v1/verify",
+    "/auth/v1/recover",
+    "/auth/v1/user",
+    "/auth/v1/logout",
+]
+
 # Never reachable from the public listener without the RLS policies and grants
 # that would make it safe, and there are none.
 INTERNAL_ONLY_PREFIXES = ["/rest/v1", "/storage/v1"]
@@ -215,6 +239,40 @@ def check_public_snippet(public):
             if want not in declared:
                 fail("the @admin matcher no longer covers " + want)
 
+    # Same ordering trap as @admin, same reasoning: anchor on the handle
+    # directive, because a named matcher's definition is position independent
+    # and would pass while the protection was dead.
+    selfserve_at = public.find("handle @selfserve")
+    if selfserve_at == -1:
+        fail(
+            "the public snippet has no `handle @selfserve` block, so self-service "
+            "account creation is reachable from outside and the only thing stopping "
+            "it is GOTRUE_DISABLE_SIGNUP, one environment variable away from open"
+        )
+    elif proxy_at != -1 and selfserve_at > proxy_at:
+        fail(
+            "`handle @selfserve` now follows `handle_path /auth/v1/*`, so it never "
+            "matches and /auth/v1/signup is proxied again"
+        )
+
+    selfserve = re.search(r"@selfserve\s+path\s+([^\n]+)", public)
+    if not selfserve:
+        fail("could not read the @selfserve path matcher out of the public snippet")
+    else:
+        declared = selfserve.group(1).split()
+        for want in REQUIRED_SELF_SERVICE_BLOCKED_PATHS:
+            if want not in declared:
+                fail("the @selfserve matcher no longer covers " + want)
+        # The inverse, which is the failure a signup-only test cannot see: a
+        # deny list that grew until it took a route the product needs.
+        for keep in REQUIRED_PUBLIC_AUTH_PATHS:
+            if keep in declared:
+                fail(
+                    "the @selfserve matcher now blocks " + keep + ", which is a login "
+                    "or recovery route the product uses: this locks users out rather "
+                    "than closing signup"
+                )
+
     for prefix in INTERNAL_ONLY_PREFIXES:
         if prefix in public:
             fail(
@@ -339,6 +397,27 @@ def check_cors_preflight(blocks, public, internal):
         )
 
 
+def check_unmatched_host_catch_alls(text):
+    """Both listeners must answer 404 to a Host that matches no site block.
+
+    Caddy answers an EMPTY 200 to an unmatched host, and the public port has had
+    a `:8080 { respond 404 }` catch-all for that reason from the start. Port 80
+    did not, and while an empty 200 reaches no backend and is therefore not an
+    exposure, it is actively misleading: a probe reading 200 concludes the
+    request was proxied and the upstream answered it. That happened during this
+    file's own verification and the wrong conclusion nearly shipped as evidence.
+    """
+    for port, label in (("8080", "public"), ("80", "in-network")):
+        block = re.search(
+            r"^:" + port + r"\s*\{\s*\n\s*respond 404\s*\n\s*\}", text, re.MULTILINE
+        )
+        if not block:
+            fail(
+                "no `:" + port + " { respond 404 }` catch-all for the " + label + " listener: "
+                "an unmatched Host gets Caddy's empty 200, which reads as a proxied success"
+            )
+
+
 def check_sites(blocks):
     """Nothing bound to the public port may reach the internal route set.
 
@@ -425,6 +504,7 @@ def main():
     check_sites(blocks)
     check_rate_limit_agreement()
 
+    check_unmatched_host_catch_alls(text)
     if failures:
         print("Caddyfile.supabase route split: FAIL")
         for f in failures:

--- a/scripts/test_caddy_supabase_routes.py
+++ b/scripts/test_caddy_supabase_routes.py
@@ -63,7 +63,22 @@ CORS_ECHO_PLACEHOLDER = "{header.Access-Control-Request-Headers}"
 # the /admin group, so it needs naming separately. Re-read GoTrue's route list
 # on every image bump: this tracks someone else's invariant. At v2.189.0
 # requireAdminCredentials appears exactly twice, on /invite and on the group.
-REQUIRED_ADMIN_PATHS = ["/auth/v1/admin", "/auth/v1/admin/*", "/auth/v1/invite"]
+# Every entry needs its trailing-slash form as well. Caddy's `path` matcher is
+# EXACT, while GoTrue's router registers both `pattern` and `pattern/`, so
+# /auth/v1/invite/ matched nothing and was proxied through. /auth/v1/admin/*
+# covered the admin group only by accident of its wildcard.
+#
+# /oauth/clients/register is dynamic OAuth client registration, live because
+# this deployment sets GOTRUE_OAUTH_SERVER_ENABLED=true. Public, it would let
+# anyone mint a client for this issuer.
+REQUIRED_ADMIN_PATHS = [
+    "/auth/v1/admin",
+    "/auth/v1/admin/*",
+    "/auth/v1/invite",
+    "/auth/v1/invite/*",
+    "/auth/v1/oauth/clients/register",
+    "/auth/v1/oauth/clients/register/*",
+]
 
 # Self-service account creation, refused on the public listener so that the
 # posture survives someone editing GOTRUE_DISABLE_SIGNUP. /otp and /magiclink
@@ -71,8 +86,9 @@ REQUIRED_ADMIN_PATHS = ["/auth/v1/admin", "/auth/v1/admin/*", "/auth/v1/invite"]
 # so they are signup routes wearing a login name.
 REQUIRED_SELF_SERVICE_BLOCKED_PATHS = [
     "/auth/v1/signup",
-    "/auth/v1/otp",
+    "/auth/v1/signup/*",
     "/auth/v1/magiclink",
+    "/auth/v1/magiclink/*",
 ]
 
 # Every login and recovery route the product actually uses. Blocking one of
@@ -80,6 +96,13 @@ REQUIRED_SELF_SERVICE_BLOCKED_PATHS = [
 # them: a matcher that swallowed /token would pass a "signup is blocked" test
 # while locking every user out.
 REQUIRED_PUBLIC_AUTH_PATHS = [
+    # /otp is on this list, not on the blocked list, and the reason is a live
+    # caller: apps/web-console/components/email-settings-card.tsx sends
+    # signInWithOtp to re-send an email verification, passing
+    # shouldCreateUser false so it cannot create anything. The first draft of
+    # the deny list blocked it, which would have been an outage on a working
+    # feature to close a hole GOTRUE_DISABLE_SIGNUP already closes.
+    "/auth/v1/otp",
     "/auth/v1/token",
     "/auth/v1/authorize",
     "/auth/v1/callback",
@@ -108,8 +131,20 @@ def fail(msg):
 
 def strip_comments(text):
     """Drop whole-line comments so a commented-out directive cannot satisfy a
-    check, and a comment mentioning a prefix cannot trip one."""
-    return "\n".join(line for line in text.splitlines() if not line.strip().startswith("#"))
+    check, and a comment mentioning a prefix cannot trip one.
+
+    Backslash continuations are folded in the same pass, and that is load
+    bearing rather than tidy. Caddy lets a directive span lines with a trailing
+    backslash, and every matcher check below reads its argument list with a
+    pattern that stops at the newline. A path list broken across two lines
+    therefore looked like a SHORTER list, and the checks reported the entries on
+    the later lines as missing, which is the benign direction. The dangerous
+    direction is the same shape: a list that grew onto a second line would have
+    had its new entries invisible to the over-block assertions. Folding first
+    means the formatting of the file cannot change what these checks see.
+    """
+    folded = re.sub(r"\\\n\s*", " ", text)
+    return "\n".join(line for line in folded.splitlines() if not line.strip().startswith("#"))
 
 
 # Caddy placeholders are brace delimited too ({$SUPABASE_DOMAIN:...},
@@ -266,7 +301,9 @@ def check_public_snippet(public):
         # The inverse, which is the failure a signup-only test cannot see: a
         # deny list that grew until it took a route the product needs.
         for keep in REQUIRED_PUBLIC_AUTH_PATHS:
-            if keep in declared:
+            # Both the bare form and its wildcard, since blocking either one
+            # takes the route out.
+            if keep in declared or (keep + "/*") in declared:
                 fail(
                     "the @selfserve matcher now blocks " + keep + ", which is a login "
                     "or recovery route the product uses: this locks users out rather "

--- a/scripts/test_selfhost_supabase_seam.py
+++ b/scripts/test_selfhost_supabase_seam.py
@@ -152,13 +152,20 @@ def test_no_named_network_splits_the_seam() -> None:
     A `networks:` key on any of these services, or a top-level `networks:`
     block, re-splits them, and the symptom is an unresolvable service name
     rather than a compose error."""
+    # Either form, block or flow, with or without a trailing comment, and
+    # network_mode alongside networks. A regex anchored on end-of-line missed
+    # `networks: [supa]` and `networks:  # comment` completely, which is the
+    # shape of an assertion that cannot fail.
+    top_level = re.compile(r"^networks:(\s|$)", re.MULTILINE)
+    per_service = re.compile(r"^    (networks|network_mode):(\s|$)", re.MULTILINE)
     for name, text in (("base", BASE_TEXT), ("enterprise", ENT_TEXT)):
-        assert not re.search(r"^networks:\s*$", text, re.MULTILINE), name
+        assert not top_level.search(text), name
     watched = DATA_PLANE | {"edge-api", "control-plane", "open-webui"}
     for source in (BASE_SERVICES, ENT_SERVICES):
         for svc, block in source.items():
             if svc in watched:
-                assert not re.search(r"^    networks:\s*$", block, re.MULTILINE), svc
+                found = per_service.search(block)
+                assert not found, f"{svc}: {found.group(0) if found else ''}"
 
 
 def test_selfhost_profile_covers_exactly_the_data_plane() -> None:
@@ -170,7 +177,15 @@ def test_selfhost_profile_covers_exactly_the_data_plane() -> None:
     with_selfhost = {
         svc for svc, block in ENT_SERVICES.items() if "selfhost" in profiles_of(block)
     }
-    assert with_selfhost == DATA_PLANE, sorted(with_selfhost ^ DATA_PLANE)
+    # The expectation is derived from the file rather than from the list at the
+    # top of this module, so a service ADDED to the enterprise file without the
+    # profile fails here. Comparing only against the constant could not catch
+    # that, because the constant would still equal itself.
+    introduced = set(ENT_SERVICES) - set(BASE_SERVICES)
+    assert with_selfhost == introduced, sorted(with_selfhost ^ introduced)
+    # And that set is still the data plane this module documents, so a genuine
+    # addition has to be considered here rather than sliding in silently.
+    assert introduced == DATA_PLANE, sorted(introduced ^ DATA_PLANE)
     # Every one of them keeps `enterprise` too, so a genuine enterprise install
     # is unaffected by the addition.
     for svc in DATA_PLANE:
@@ -192,11 +207,20 @@ def test_edge_api_reads_its_jwks_over_tls_with_the_exported_authority() -> None:
     ca = env_value(block, "SUPABASE_JWKS_CA_FILE")
     assert ca, "edge-api has no SUPABASE_JWKS_CA_FILE default"
     ca_path = ca.split(":-")[-1].rstrip("}")
+    mount_dir, _, ca_name = ca_path.rpartition("/")
+    assert ca_name, ca_path
     assert re.search(
-        r"^      - supabase-ca:" + re.escape(ca_path.rsplit("/", 1)[0]) + r":ro\s*$",
+        r"^      - supabase-ca:" + re.escape(mount_dir) + r":ro\s*$",
         block,
         re.MULTILINE,
     ), block
+    # The mount is a directory and the variable names a file inside it, so
+    # matching the directory is not enough on its own: the one-shot export has
+    # to publish that exact filename or edge-api opens nothing.
+    export = ENT_SERVICES["supabase-ca-export"]
+    assert re.search(r"install -m 0644 .* /out/" + re.escape(ca_name), export), (
+        f"supabase-ca-export does not publish {ca_name}, which SUPABASE_JWKS_CA_FILE names"
+    )
 
 
 def test_the_issuer_edge_api_checks_is_the_issuer_gotrue_stamps() -> None:
@@ -209,6 +233,13 @@ def test_the_issuer_edge_api_checks_is_the_issuer_gotrue_stamps() -> None:
     assert "ENTERPRISE_AUTH_EXTERNAL_URL" in gotrue, gotrue
     assert "ENTERPRISE_AUTH_EXTERNAL_URL" in external, external
     assert "ENTERPRISE_AUTH_EXTERNAL_URL" in edge, edge
+    # Substring presence is not agreement: both sides can mention the variable
+    # and still resolve differently, which is exactly how this drifts. GoTrue's
+    # issuer and its external URL must be the SAME expression, and edge-api's
+    # must fall back to it with no other default in between.
+    assert gotrue == external, (gotrue, external)
+    fallback = re.fullmatch(r"\$\{SUPABASE_JWT_ISSUER:-(.+)\}", edge)
+    assert fallback and fallback.group(1) == gotrue, (edge, gotrue)
 
 
 def test_open_webui_pgvector_dsn_comes_from_the_libpq_flavour() -> None:
@@ -234,8 +265,48 @@ def test_no_hosted_supabase_host_is_hardcoded_in_the_data_plane() -> None:
         assert "pooler.supabase.com" not in bare, line
 
 
+def test_loading_the_enterprise_file_requires_activating_its_profile() -> None:
+    """Passing `-f docker-compose.enterprise.yml` without `enterprise` or
+    `selfhost` does not merely leave the data plane stopped, it invalidates the
+    WHOLE project: `edge-api` carries no profile of its own, so compose refuses
+    every command with `depends on undefined service`. Confirmed on the demo box
+    while building this seam.
+
+    That is only survivable while every service the override blocks depend on is
+    inside the data-plane profile set, so one profile activation covers all of
+    them. A new dependency outside that set would need its own profile flag and
+    would break the documented invocation with no warning."""
+    for svc in ("edge-api", "control-plane"):
+        block = ENT_SERVICES[svc]
+        depends = set(re.findall(r"^      ([A-Za-z0-9][A-Za-z0-9._-]*):\s*$", block, re.MULTILINE))
+        # The override blocks declare depends_on and environment; environment
+        # keys are upper case with no trailing colon-only line, so what this
+        # picks up is the dependency names.
+        outside = {d for d in depends if d not in DATA_PLANE}
+        assert not outside, f"{svc} depends on {sorted(outside)}, outside the profile set"
+        assert depends, f"{svc} override declares no dependency, so this check is vacuous"
+
+
+def test_open_webui_oidc_discovery_uses_the_browser_facing_origin() -> None:
+    """Open WebUI fetches the discovery document server side, but the browser
+    then resolves every endpoint inside it, so a compose service name there kills
+    login at the redirect with nothing in any log naming the cause. The variable
+    has to be separable from control-plane's in-network SUPABASE_URL, while
+    still defaulting to it so hosted Supabase is unaffected."""
+    value = env_value(BASE_SERVICES["open-webui"], "OPENID_PROVIDER_URL")
+    assert "SUPABASE_PUBLIC_URL" in value, value
+    assert value.startswith('"${SUPABASE_PUBLIC_URL:-'), value
+    assert "SUPABASE_URL" in value, value
+
+
 def main() -> int:
-    tests = [value for name, value in sorted(globals().items()) if name.startswith("test_")]
+    # The parser guard runs FIRST, deliberately. Alphabetical order put it last,
+    # so a silent parse failure would have been reported by whichever assertion
+    # happened to sort earliest rather than by the guard written to catch it.
+    named = {name: value for name, value in globals().items() if name.startswith("test_")}
+    guard = "test_the_parser_actually_found_the_services"
+    order = [guard] + sorted(n for n in named if n != guard)
+    tests = [named[n] for n in order]
     for test in tests:
         test()
     print(f"test_selfhost_supabase_seam: ok ({len(tests)} checks)")

--- a/scripts/test_selfhost_supabase_seam.py
+++ b/scripts/test_selfhost_supabase_seam.py
@@ -261,8 +261,13 @@ def test_no_hosted_supabase_host_is_hardcoded_in_the_data_plane() -> None:
         bare = line.strip()
         if bare.startswith("#"):
             continue
-        assert "supabase.co" not in bare, line
-        assert "pooler.supabase.com" not in bare, line
+        # One pattern, not two asserts: `pooler.supabase.com` CONTAINS the
+        # substring `supabase.co`, so a plain-substring check for the project
+        # host fires first and the pooler check below it could never be reached.
+        # A word boundary on the domain also stops `supabase.community` and the
+        # like from reading as a hosted project.
+        found = re.search(r"\.supabase\.com?\b", bare)
+        assert not found, line
 
 
 def test_loading_the_enterprise_file_requires_activating_its_profile() -> None:

--- a/scripts/test_selfhost_supabase_seam.py
+++ b/scripts/test_selfhost_supabase_seam.py
@@ -42,6 +42,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 BASE = ROOT / "deploy" / "docker" / "docker-compose.yml"
 ENTERPRISE = ROOT / "deploy" / "docker" / "docker-compose.enterprise.yml"
+DEPLOY_WORKFLOW = ROOT / ".github" / "workflows" / "deploy-demo-box.yml"
 
 # The Supabase data plane: the services that must answer before any application
 # service can authenticate, read the database or store an object.
@@ -127,6 +128,7 @@ def env_value(block: str, key: str) -> str:
 
 BASE_TEXT = BASE.read_text()
 ENT_TEXT = ENTERPRISE.read_text()
+DEPLOY_TEXT = DEPLOY_WORKFLOW.read_text()
 BASE_SERVICES = split_services(BASE_TEXT)
 ENT_SERVICES = split_services(ENT_TEXT)
 
@@ -302,6 +304,77 @@ def test_open_webui_oidc_discovery_uses_the_browser_facing_origin() -> None:
     assert "SUPABASE_PUBLIC_URL" in value, value
     assert value.startswith('"${SUPABASE_PUBLIC_URL:-'), value
     assert "SUPABASE_URL" in value, value
+
+
+def _compose_flags() -> str:
+    """The one flag definition every step in the deploy workflow uses."""
+    match = re.search(
+        r"^  HIVE_COMPOSE_FLAGS: >-\n((?:^    .*\n)+)", DEPLOY_TEXT, re.MULTILINE
+    )
+    assert match, "deploy-demo-box.yml has no HIVE_COMPOSE_FLAGS block"
+    return " ".join(line.strip() for line in match.group(1).splitlines())
+
+
+def test_the_deploy_invocation_and_the_compose_project_agree() -> None:
+    """The seam only exists for a command that resolves BOTH compose files. A
+    deploy step that resolves only the base file resolves a different project,
+    so it reads a stack missing every Supabase service and reports green over
+    it, and the one step carrying `--remove-orphans` deletes them outright.
+
+    Both halves are asserted, because either one alone is worse than useless:
+    the file without a profile makes compose refuse every command
+    (`depends on undefined service`), and the profile without the file activates
+    nothing. The profile name is checked against what the data-plane services
+    actually carry rather than against a literal, so renaming the profile in the
+    compose file without updating the workflow fails here."""
+    flags = _compose_flags()
+    assert "-f docker-compose.yml" in flags, flags
+    assert "-f docker-compose.enterprise.yml" in flags, flags
+
+    declared = {
+        p for svc in DATA_PLANE for p in profiles_of(ENT_SERVICES[svc])
+    }
+    common = set.intersection(*(profiles_of(ENT_SERVICES[svc]) for svc in DATA_PLANE))
+    assert common, f"the data plane shares no profile: {declared}"
+    active = {m.group(1) for m in re.finditer(r"--profile (\S+)", flags)}
+    assert active & common, (
+        f"the deploy activates {sorted(active)}, none of which covers the whole "
+        f"data plane (needs one of {sorted(common)})"
+    )
+
+    # Every dependency the override blocks name has to be covered by that same
+    # profile, or the invocation is refused outright rather than merely
+    # incomplete.
+    for svc in ("edge-api", "control-plane"):
+        deps = set(
+            re.findall(r"^      ([A-Za-z0-9][A-Za-z0-9._-]*):\s*$", ENT_SERVICES[svc], re.MULTILINE)
+        )
+        assert deps <= DATA_PLANE, f"{svc} depends on {sorted(deps - DATA_PLANE)}"
+
+
+def test_no_deploy_step_spells_its_own_compose_flags() -> None:
+    """Four steps in this workflow run docker compose, and each used to rebuild
+    the flag list by hand. A fifth step added later with a copied-and-trimmed
+    list is the recurrence this guards: it would read a different project and
+    report green over a box missing services, which is indistinguishable from
+    healthy in a log.
+
+    So the rule is not "the flags are right somewhere", it is that no step
+    spells them at all."""
+    invocations = re.findall(r"docker compose[^\n)]*", DEPLOY_TEXT)
+    # Prose in comments mentions `docker compose exec` and `docker compose ps`;
+    # only lines that are actually run matter, and those are the ones that pass
+    # flags or subcommands rather than sitting inside a sentence.
+    offenders = [
+        i for i in invocations
+        if ("--env-file" in i or "--profile" in i or " -f " in i)
+        and "$HIVE_COMPOSE_FLAGS" not in i
+    ]
+    assert not offenders, offenders
+    # And the definition is genuinely used, so this test cannot pass by the
+    # workflow having no invocations at all.
+    used = DEPLOY_TEXT.count("$HIVE_COMPOSE_FLAGS")
+    assert used >= 4, f"only {used} steps use the shared definition"
 
 
 def main() -> int:

--- a/scripts/test_selfhost_supabase_seam.py
+++ b/scripts/test_selfhost_supabase_seam.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Self-check for the seam between the application stack and the self-hosted
+Supabase data plane.
+
+Why this exists
+---------------
+On the demo box the two halves ran as two separate compose projects, `hive` and
+`hivesupabase`, from two separate checkouts. Two projects means two default
+networks, so `getent hosts caddy-supabase` from inside control-plane returned
+nothing and every Supabase-facing variable was unreachable no matter what it was
+set to. The fix is that both halves are ONE compose project, layered as
+`-f docker-compose.yml -f docker-compose.enterprise.yml`, which works only
+because of a handful of properties that are invisible at a glance and silent
+when broken:
+
+  * both files declare the same project name, so the services share one default
+    network and service DNS resolves;
+  * neither file puts any of these services on a named network, which would
+    split them again;
+  * the `selfhost` profile covers exactly the Supabase data-plane services, so a
+    deployment can start the data plane under the application profiles without
+    also starting the rest of the enterprise surface;
+  * edge-api reads its JWKS over https from the gateway and mounts the exported
+    certificate authority, and it exits at boot if that first refresh fails;
+  * GoTrue's issuer and the issuer edge-api compares against derive from the
+    same variable, because a mismatch is not a boot error, it is every token
+    being rejected;
+  * Open WebUI's pgvector DSN comes from the libpq flavour, never the pgx one.
+    A pgx-only parameter in a libpq DSN fails the whole connection, which is
+    what killed a container and took chat down for fifty minutes.
+
+Every one of those fails silently, or fails somewhere far from its cause, so
+each gets an assertion here. No framework, no docker daemon, no network: this
+reads the two compose files as text.
+
+Run: python3 scripts/test_selfhost_supabase_seam.py
+"""
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+BASE = ROOT / "deploy" / "docker" / "docker-compose.yml"
+ENTERPRISE = ROOT / "deploy" / "docker" / "docker-compose.enterprise.yml"
+
+# The Supabase data plane: the services that must answer before any application
+# service can authenticate, read the database or store an object.
+DATA_PLANE = {
+    "supabase-db",
+    "supabase-auth",
+    "supabase-rest",
+    "supabase-storage",
+    "supabase-init",
+    "caddy-supabase",
+    "supabase-ca-export",
+}
+
+SERVICE_RE = re.compile(r"^  ([A-Za-z0-9][A-Za-z0-9._-]*):\s*$")
+TOP_LEVEL_RE = re.compile(r"^([A-Za-z0-9][A-Za-z0-9._-]*):\s*$")
+
+
+def split_services(text: str) -> dict:
+    """Return {service name: block text} for the top-level `services:` mapping.
+
+    Indentation based rather than a YAML parse, matching the other script
+    self-checks in this directory, which deliberately depend on nothing outside
+    the standard library.
+    """
+    lines = text.splitlines()
+    services = {}
+    in_services = False
+    current = None
+    buf = []
+    for line in lines:
+        top = TOP_LEVEL_RE.match(line)
+        if top:
+            if current is not None:
+                services[current] = "\n".join(buf)
+                current, buf = None, []
+            in_services = top.group(1) == "services"
+            continue
+        if not in_services:
+            continue
+        svc = SERVICE_RE.match(line)
+        if svc:
+            if current is not None:
+                services[current] = "\n".join(buf)
+            current, buf = svc.group(1), []
+            continue
+        if current is not None:
+            buf.append(line)
+    if current is not None:
+        services[current] = "\n".join(buf)
+    return services
+
+
+def project_name(text: str) -> str:
+    match = re.search(r"^name:\s*(\S+)\s*$", text, re.MULTILINE)
+    return match.group(1) if match else ""
+
+
+def profiles_of(block: str) -> set:
+    """The profile names a service block declares, empty set when it declares none."""
+    out = set()
+    seen_profiles = False
+    for line in block.splitlines():
+        if re.match(r"^    profiles:\s*$", line):
+            seen_profiles = True
+            continue
+        if seen_profiles:
+            item = re.match(r"^      - (\S+)\s*$", line)
+            if item:
+                out.add(item.group(1))
+                continue
+            if line.strip():
+                break
+    return out
+
+
+def env_value(block: str, key: str) -> str:
+    """The right-hand side of one `KEY: value` line in a service's environment."""
+    match = re.search(
+        r"^      " + re.escape(key) + r":\s*(.+?)\s*$", block, re.MULTILINE
+    )
+    return match.group(1) if match else ""
+
+
+BASE_TEXT = BASE.read_text()
+ENT_TEXT = ENTERPRISE.read_text()
+BASE_SERVICES = split_services(BASE_TEXT)
+ENT_SERVICES = split_services(ENT_TEXT)
+
+
+def test_the_parser_actually_found_the_services() -> None:
+    """A silent parse failure would make every assertion below vacuously true,
+    which is the exact shape of check this repo keeps shipping by accident."""
+    assert "edge-api" in BASE_SERVICES, sorted(BASE_SERVICES)
+    assert "control-plane" in BASE_SERVICES, sorted(BASE_SERVICES)
+    assert "open-webui" in BASE_SERVICES, sorted(BASE_SERVICES)
+    assert DATA_PLANE <= set(ENT_SERVICES), sorted(set(ENT_SERVICES))
+
+
+def test_one_compose_project_across_both_files() -> None:
+    """Two project names means two default networks and no service DNS between
+    them, which is the failure this seam exists to fix."""
+    assert project_name(BASE_TEXT) == "hive", project_name(BASE_TEXT)
+    assert project_name(ENT_TEXT) == "hive", project_name(ENT_TEXT)
+
+
+def test_no_named_network_splits_the_seam() -> None:
+    """Sharing one project only shares one network while nothing overrides it.
+    A `networks:` key on any of these services, or a top-level `networks:`
+    block, re-splits them, and the symptom is an unresolvable service name
+    rather than a compose error."""
+    for name, text in (("base", BASE_TEXT), ("enterprise", ENT_TEXT)):
+        assert not re.search(r"^networks:\s*$", text, re.MULTILINE), name
+    watched = DATA_PLANE | {"edge-api", "control-plane", "open-webui"}
+    for source in (BASE_SERVICES, ENT_SERVICES):
+        for svc, block in source.items():
+            if svc in watched:
+                assert not re.search(r"^    networks:\s*$", block, re.MULTILINE), svc
+
+
+def test_selfhost_profile_covers_exactly_the_data_plane() -> None:
+    """`selfhost` is what lets the demo box run the data plane underneath the
+    `local` and `chat` application profiles. Too narrow and the flip starts an
+    incomplete Supabase; too wide and it drags in unrelated services (today
+    `ollama`, which is `enterprise` only and would take memory on a box that
+    has none to spare)."""
+    with_selfhost = {
+        svc for svc, block in ENT_SERVICES.items() if "selfhost" in profiles_of(block)
+    }
+    assert with_selfhost == DATA_PLANE, sorted(with_selfhost ^ DATA_PLANE)
+    # Every one of them keeps `enterprise` too, so a genuine enterprise install
+    # is unaffected by the addition.
+    for svc in DATA_PLANE:
+        assert "enterprise" in profiles_of(ENT_SERVICES[svc]), svc
+    # Nothing in the base file joins the profile: it names the data plane, and
+    # the data plane lives entirely in the enterprise file.
+    for svc, block in BASE_SERVICES.items():
+        assert "selfhost" not in profiles_of(block), svc
+
+
+def test_edge_api_reads_its_jwks_over_tls_with_the_exported_authority() -> None:
+    """edge-api refuses a plain-http JWKS URL and exits at boot if its first
+    refresh fails, so both halves of this are load bearing: the https URL, and
+    the one-file certificate authority export it verifies the chain against."""
+    block = ENT_SERVICES["edge-api"]
+    jwks = env_value(block, "SUPABASE_JWKS_URL")
+    assert "https://caddy-supabase/" in jwks, jwks
+    assert "http://caddy-supabase/" not in jwks, jwks
+    ca = env_value(block, "SUPABASE_JWKS_CA_FILE")
+    assert ca, "edge-api has no SUPABASE_JWKS_CA_FILE default"
+    ca_path = ca.split(":-")[-1].rstrip("}")
+    assert re.search(
+        r"^      - supabase-ca:" + re.escape(ca_path.rsplit("/", 1)[0]) + r":ro\s*$",
+        block,
+        re.MULTILINE,
+    ), block
+
+
+def test_the_issuer_edge_api_checks_is_the_issuer_gotrue_stamps() -> None:
+    """A mismatch here raises nothing at boot. GoTrue issues tokens, edge-api
+    rejects all of them, and the only visible symptom is that authentication
+    stopped working. Both sides must derive from one variable."""
+    gotrue = env_value(ENT_SERVICES["supabase-auth"], "GOTRUE_JWT_ISSUER")
+    external = env_value(ENT_SERVICES["supabase-auth"], "API_EXTERNAL_URL")
+    edge = env_value(ENT_SERVICES["edge-api"], "SUPABASE_JWT_ISSUER")
+    assert "ENTERPRISE_AUTH_EXTERNAL_URL" in gotrue, gotrue
+    assert "ENTERPRISE_AUTH_EXTERNAL_URL" in external, external
+    assert "ENTERPRISE_AUTH_EXTERNAL_URL" in edge, edge
+
+
+def test_open_webui_pgvector_dsn_comes_from_the_libpq_flavour() -> None:
+    """Open WebUI's pgvector store speaks libpq through psycopg2, and libpq
+    fails the whole connection on an unknown option rather than ignoring it. The
+    pgx flavour carries `pool_max_conns` and `default_query_exec_mode`, so
+    handing it over here is what produced `invalid dsn: invalid connection
+    option "pool_max_conns"` and a fifty minute chat outage."""
+    dsn = env_value(BASE_SERVICES["open-webui"], "PGVECTOR_DB_URL")
+    assert "SUPABASE_DB_POOL_URL_LIBPQ" in dsn, dsn
+    assert not re.search(r"SUPABASE_DB_POOL_URL(?!_LIBPQ)", dsn), dsn
+
+
+def test_no_hosted_supabase_host_is_hardcoded_in_the_data_plane() -> None:
+    """The data plane IS the replacement for the hosted project. A hosted
+    hostname appearing here is either a stale copy-paste or a repointing that
+    silently sends one consumer back out to the internet."""
+    for line in ENT_TEXT.splitlines():
+        bare = line.strip()
+        if bare.startswith("#"):
+            continue
+        assert "supabase.co" not in bare, line
+        assert "pooler.supabase.com" not in bare, line
+
+
+def main() -> int:
+    tests = [value for name, value in sorted(globals().items()) if name.startswith("test_")]
+    for test in tests:
+        test()
+    print(f"test_selfhost_supabase_seam: ok ({len(tests)} checks)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_selfhost_supabase_seam.py
+++ b/scripts/test_selfhost_supabase_seam.py
@@ -118,6 +118,25 @@ def profiles_of(block: str) -> set:
     return out
 
 
+def depends_on_of(block: str) -> set:
+    """The service names a service block's `depends_on:` mapping actually names.
+
+    Scanning every six-space key in the whole block was wrong twice over: an
+    unrelated nested key such as `healthcheck:` parsed as a dependency, and
+    deleting the `depends_on:` line while leaving its children in place still
+    satisfied the non-empty guard that was supposed to stop the check going
+    vacuous. So the mapping is sliced first, and an absent `depends_on:` returns
+    the empty set rather than the whole block's keys.
+    """
+    match = re.search(r"^    depends_on:\s*$", block, re.MULTILINE)
+    if not match:
+        return set()
+    rest = block[match.end():]
+    end = re.search(r"^    \S", rest, re.MULTILINE)
+    body = rest[: end.start()] if end else rest
+    return set(re.findall(r"^      ([A-Za-z0-9][A-Za-z0-9._-]*):\s*$", body, re.MULTILINE))
+
+
 def env_value(block: str, key: str) -> str:
     """The right-hand side of one `KEY: value` line in a service's environment."""
     match = re.search(
@@ -284,14 +303,10 @@ def test_loading_the_enterprise_file_requires_activating_its_profile() -> None:
     them. A new dependency outside that set would need its own profile flag and
     would break the documented invocation with no warning."""
     for svc in ("edge-api", "control-plane"):
-        block = ENT_SERVICES[svc]
-        depends = set(re.findall(r"^      ([A-Za-z0-9][A-Za-z0-9._-]*):\s*$", block, re.MULTILINE))
-        # The override blocks declare depends_on and environment; environment
-        # keys are upper case with no trailing colon-only line, so what this
-        # picks up is the dependency names.
-        outside = {d for d in depends if d not in DATA_PLANE}
+        depends = depends_on_of(ENT_SERVICES[svc])
+        assert depends, f"{svc} override declares no depends_on, so this check is vacuous"
+        outside = depends - DATA_PLANE
         assert not outside, f"{svc} depends on {sorted(outside)}, outside the profile set"
-        assert depends, f"{svc} override declares no dependency, so this check is vacuous"
 
 
 def test_open_webui_oidc_discovery_uses_the_browser_facing_origin() -> None:
@@ -346,9 +361,8 @@ def test_the_deploy_invocation_and_the_compose_project_agree() -> None:
     # profile, or the invocation is refused outright rather than merely
     # incomplete.
     for svc in ("edge-api", "control-plane"):
-        deps = set(
-            re.findall(r"^      ([A-Za-z0-9][A-Za-z0-9._-]*):\s*$", ENT_SERVICES[svc], re.MULTILINE)
-        )
+        deps = depends_on_of(ENT_SERVICES[svc])
+        assert deps, f"{svc} override declares no depends_on, so this check is vacuous"
         assert deps <= DATA_PLANE, f"{svc} depends on {sorted(deps - DATA_PLANE)}"
 
 
@@ -361,7 +375,14 @@ def test_no_deploy_step_spells_its_own_compose_flags() -> None:
 
     So the rule is not "the flags are right somewhere", it is that no step
     spells them at all."""
-    invocations = re.findall(r"docker compose[^\n)]*", DEPLOY_TEXT)
+    # Backslash continuations are folded FIRST. Without that, a step spelling
+    # its flags on the next line matches as a bare `docker compose \\`, which
+    # carries no --env-file, no --profile and no -f, so the offenders filter
+    # below drops it as harmless. That step would read a different project and
+    # report green over a box missing services, which is the exact recurrence
+    # this test claims to catch.
+    folded = re.sub(r"\\\n\s*", " ", DEPLOY_TEXT)
+    invocations = re.findall(r"docker compose[^\n)]*", folded)
     # Prose in comments mentions `docker compose exec` and `docker compose ps`;
     # only lines that are actually run matter, and those are the ones that pass
     # flags or subcommands rather than sitting inside a sentence.


### PR DESCRIPTION
Slice 1 of 2 of the Supabase Cloud cutover: the network seam and the repointing, so the live application stack can reach the self-hosted Supabase already running on the demo box. Owner authorized the cutover and accepts demo downtime.

## The problem

Self-hosted Supabase was already running on the box with its data restored and verified. Nothing in the live stack could reach it, and repointing an environment variable would have flipped nothing:

- the live stack ran as compose project `hive` on network `hive_default`, from `/home/sakib/hive`
- self-hosted Supabase ran as compose project `hivesupabase` on network `hivesupabase_default`, from a second checkout at `/home/sakib/selfhost-stage1`
- `hivesupabase-caddy-supabase-1` published no ports at all, and `getent hosts caddy-supabase` from inside control-plane returned nothing
- every live consumer still held Supabase Cloud values

## Seam design chosen: one compose project

Both halves are now one compose project, layered as `-f docker-compose.yml -f docker-compose.enterprise.yml`. That is what `docker-compose.enterprise.yml` was authored for. It already declares `name: hive`, it already carries `edge-api` and `control-plane` override blocks that repoint the JWKS URL and mount the exported certificate authority, and its services share the project default network, so `caddy-supabase` resolves by service DNS with no new plumbing at all.

### Why not the alternatives

**Join the live services to `hivesupabase_default`.** Needs an `external: true` network AND an `external: true` volume, because edge-api mounts the gateway's exported certificate authority and that volume belongs to the other project. Both hardcode the box's ad-hoc project name into a public repo, and an external resource that does not exist fails the whole compose invocation, so CI, local dev, `--profile test` and `--profile tools` all break. It also makes `/home/sakib/selfhost-stage1` permanently load bearing, and that checkout is hand-updated detached state.

**Publish the gateway on the box.** The gateway terminates real TLS with Caddy's own local authority for the name `caddy-supabase`, and edge-api verifies the chain and the hostname. Reaching it through a published host port means presenting a name the certificate does not carry, and it puts a Supabase gateway on the box LAN for no gain.

### The new `selfhost` profile

The Supabase data-plane services carried `enterprise` only. Activating `--profile enterprise` on the demo box would also start `ollama`, the one other enterprise-only service, on a 12GB box already running fourteen containers, and would couple the demo box to every future service tagged `enterprise`. `selfhost` sits alongside `enterprise` on those seven services and on nothing else, so slice 2 gets a precise switch and a genuine enterprise install is unaffected.

## Consumers repointed, with the driver each one uses

| Consumer | Variable | Target | Driver |
| --- | --- | --- | --- |
| edge-api | `SUPABASE_JWT_ISSUER` | the auth origin | string compare against the claim, never fetched |
| edge-api | `SUPABASE_JWKS_URL` | `https://caddy-supabase/auth/v1/.well-known/jwks.json` | Go http, chain verified via `SUPABASE_JWKS_CA_FILE` |
| edge-api | `SUPABASE_DB_URL` | `supabase-db:5432` | pgx, pgx-only DSN parameters legal |
| edge-api | `S3_*` | `http://caddy-supabase/storage/v1/s3` | AWS SDK, `S3_USE_SSL=false` |
| control-plane | `SUPABASE_URL` | `http://caddy-supabase` | Go http, appends `/auth/v1/user`, so it must reach GoTrue and not PostgREST |
| control-plane | `SUPABASE_DB_URL` | `supabase-db:5432`, session mode | pgx, and `platformdb.Open` refuses 6543 outright |
| control-plane | `S3_*` | `http://caddy-supabase/storage/v1/s3` | AWS SDK |
| open-webui | `PGVECTOR_DB_URL` | `supabase-db:5432` | libpq via psycopg2, pgx-only parameters must be absent |

| open-webui | `OPENID_PROVIDER_URL` | now `${SUPABASE_PUBLIC_URL:-${SUPABASE_URL}}`, so the browser-facing origin is separable from control-plane's in-network one | fetched server side, then every endpoint inside it is resolved by the browser |

The deploy workflow's pooler-DSN derivation step needed no change, and neither did the port half of `scripts/derive-pooler-dsn.py`: `is_pooler_host` matches only `*.pooler.supabase.com`, so a direct Postgres keeps both derived DSNs on 5432, and the `_LIBPQ` flavour it already emits is what `PGVECTOR_DB_URL` consumes. The per-driver split therefore survives the cutover intact, which matters because a pgx-only parameter in a libpq DSN fails the whole connection rather than being ignored.

That script did need one fix, found by the live run rather than by reading it: it preserved whatever URL scheme it was handed. libpq and pgx accept the short `postgres://` spelling, so it reached control-plane and edge-api intact and died three services away inside Open WebUI, whose SQLAlchemy dropped `postgres` from its dialect registry in 1.4. It now normalises the scheme for all three derived DSNs, in the one place all three pass through.

## Live proof

Posted as a comment on this pull request: service DNS across the seam, the restored row counts after the volume migration, every container healthy, the gateway answering over TLS with the chain verified against the same exported authority edge-api is handed plus a negative control proving the verification is real, a genuine token request returning 200 with the issuer and algorithm edge-api expects and the access-token hook's claims present, control-plane resolving that bearer, zero hosted hosts left on any live consumer, and the libpq DSN carrying no pgx-only parameter. Status codes, counts and claim names only.

That run also found and fixed a real bug, described in the same comment: the DSN scheme.

## Checks that were made to fail on purpose

`scripts/test_selfhost_supabase_seam.py` (wired into `make test-scripts`, which is a required CI check) guards the properties that fail silently or fail far from their cause. Seventeen mutations, each applied on its own and then reverted, each turning the suite red:

| Mutation | Result |
| --- | --- |
| rename the `edge-api` service so the indentation parser finds nothing | failed, listing the services it did find |
| `name: hive` becomes `name: hivesupabase` in the enterprise file | failed |
| add a top-level `networks:` block to the enterprise file | failed |
| drop `- selfhost` from `caddy-supabase` only | failed, naming that one service |
| `SUPABASE_JWKS_URL` default from https to http | failed |
| `GOTRUE_JWT_ISSUER` pinned to a literal instead of the shared variable | failed |
| `PGVECTOR_DB_URL` from the `_LIBPQ` chain to the pgx one | failed |
| a hosted `https://<ref>.supabase.co` value added to a non-comment line | failed |
| the certificate authority mount path moved away from what `SUPABASE_JWKS_CA_FILE` names | failed |
| the export publishing a different filename from the one that variable names | failed |
| `networks: [supa]` in flow style on `edge-api` | failed |
| `networks:` with a trailing comment on `edge-api` | failed |
| `network_mode: host` on `edge-api` | failed |
| an eighth data-plane service added without the profile | failed |
| `edge-api` depending on a service outside the profile set | failed |
| `GOTRUE_JWT_ISSUER` and edge-api's issuer expression drifting apart while both still name the variable | failed |
| Open WebUI's OIDC discovery URL reverted to the in-network `${SUPABASE_URL}` | failed |

Baseline green before, green again after all seventeen were reverted.

`scripts/check-env-supabase-target.py` is the second check, and it guards the half a repository test cannot see: the env file, where the mixed state actually lives. Its self-check covers eighteen cases, thirteen of them mutations that must fail (a stale hosted value on each of five variables, a plain-http JWKS URL, a JWKS URL with no certificate authority, an issuer disagreement, the short DSN scheme on each of three DSN variables, an invented pooler port, and an S3 secret equal to its own access key id), plus the cases that must pass, including that a browser-facing public origin still naming the hosted project during a staged cutover is not treated as a mixed state. Run against the demo box it fails today, on one real defect, which is issue #987.

`scripts/derive-pooler-dsn.py` gained nine assertions for the DSN scheme normalisation, including that an already-correct DSN comes back byte for byte unchanged, so the normalisation cannot quietly become a rewrite.

## UI surfaces

This slice changes no UI surface: the diff is compose profiles, an `.env.example` comment block, one new python self-check and one Makefile line. No visual proof applies, so none is posted.

## Out of scope, deliberately

- `deploy-demo-box.yml`'s profile invocation. That is slice 2.
- Storage object bytes.
- The signup provisioning webhook.
- **The public auth origin.** Browser login cannot work against an in-network gateway, and it cannot keep working against Supabase Cloud either, because a cloud-issued token now fails control-plane's `GET /auth/v1/user` against the self-hosted gateway. Two options for slice 2, decision deliberately not taken here: a new tunnel hostname reaching the gateway's port 8080 public listener, which needs a Cloudflare write-scoped credential this agent does not hold, or a same-origin `/auth/v1/*` route on `Caddyfile.console` reusing the existing `console-hive.scubed.co` hostname with no Cloudflare change at all. Either way `ENTERPRISE_AUTH_EXTERNAL_URL`, `GOTRUE_JWT_ISSUER` and edge-api's `SUPABASE_JWT_ISSUER` move together, because GoTrue's OIDC discovery document and the `iss` claim on its id_token must agree or an OIDC client rejects every login.

## The deploy invocation flip is IN this pull request

The original split put the flip in a follow-up, and that was wrong at the merge boundary: this diff changes files under `deploy/docker/**`, which is in `deploy-demo-box.yml`'s own paths filter, so merging without the flip is itself the trigger for a single-file `up -d --build --remove-orphans`. The Supabase services are unknown to that invocation, so they are deleted as orphans, and edge-api is recreated without the certificate authority mount and exits at boot on its first JWKS refresh. Slice 1 was therefore not independently mergeable, and the flip is folded in.

### One definition, four call sites

`HIVE_COMPOSE_FLAGS` is declared once at workflow level and used by all four steps that run docker compose (the rebuild, the Caddy config apply, the Open WebUI admin token mint, and the failure dump). Each of those previously rebuilt the same flag list by hand. That is not a style complaint: a step resolving a different set of compose files resolves a different PROJECT, so it reads a stack missing every Supabase service and reports green over it, and the one step carrying `--remove-orphans` deletes what it does not know about.

### Both halves measured, not argued

Resolved against this PR's own compose files:

    with the file and the profile   7 of 7 data-plane services, 3 of 3 app services, ollama 0, project name hive
    without the enterprise file     0 of 7 data-plane services, which is what --remove-orphans acts on
    without --profile selfhost      exit 1, service "edge-api" depends on undefined service "supabase-init": invalid compose project

The third line is why the file and a profile always travel together: passing the file without one is worse than omitting it, because compose then refuses every command rather than merely resolving an incomplete project.

Profile filtering was verified before trusting those counts, since a `config --services` that ignored profiles would have made every one of them unfailable. Adding `--profile enterprise` moves the resolved service count from 20 to 21 and `ollama` from 0 to 1, so the filtering is real and the data-plane count is a measurement rather than a count of everything in the file.

`COMPOSE_FILE` and `COMPOSE_PROFILES` in the box's env file are not an alternative, measured earlier on the box: with profile flags on the command line the resolved list contains `supabase-db` zero times, with no flag it contains it once. A command-line profile flag replaces the environment value rather than adding to it.

## Self-service signup is closed here, not filed

The demo box had `GOTRUE_DISABLE_SIGNUP=false` with `GOTRUE_MAILER_AUTOCONFIRM=true`, which together mean anyone who can reach the auth endpoint gets a confirmed account without ever proving control of the address. Unreachable today, because the gateway publishes no ports and no hostname resolves to it. Live the moment a public auth origin exists, which is the next change to this stack.

Closed in two layers, because the flag alone is one variable away from open:

**The flag**, which is the real control and covers every creation path. Set to true on the box, and GoTrue now answers every creation route `422 signup_disabled`, verified live on `/signup`, `/otp` and `/magiclink`. Login and recovery unaffected: `/auth/v1/health` 200, the discovery document 200, `POST /token?grant_type=password` 400 on an empty body, meaning the route is alive.

**The gateway**, so the posture survives someone editing that variable. The public listener refuses `/auth/v1/signup` and `/auth/v1/magiclink`, both with their trailing-slash forms, and also refuses dynamic OAuth client registration.

The first draft of this block was wrong in two ways, both caught by the security review and both fixed:

- **A trailing slash bypassed the whole thing.** Caddy's `path` matcher is exact, while GoTrue's router registers both `pattern` and `pattern/`, so `POST /auth/v1/signup/` matched no deny entry and was proxied. The same held for `/auth/v1/invite/`, unguarded since that matcher was first written, because `/auth/v1/admin/*` covered the admin group only by accident of its wildcard. Every entry now carries its trailing-slash form.
- **`/otp` is not unused.** `apps/web-console/components/email-settings-card.tsx` calls `signInWithOtp` to re-send an email verification, passing `shouldCreateUser: false` so it cannot create anything. Blocking it would have been an outage on a working feature to close a hole the flag already closes. It is reachable, and it is named in the over-block assertions so it cannot be re-blocked silently.

Also refused: `/auth/v1/oauth/clients/register`, which was public and in neither deny list. This deployment sets `GOTRUE_OAUTH_SERVER_ENABLED=true`, so anyone on the internet could have minted an OAuth client for this issuer.

Verified against a real gateway running the candidate config on the live network:

    POST /auth/v1/signup 404   /signup/ 404   /signup%2f 404
    POST /auth/v1/magiclink 404   /magiclink/ 404
    POST /auth/v1/admin/users 404   /admin/ 404   /invite 404   /invite/ 404
    POST /auth/v1/oauth/clients/register 404   and its trailing-slash form 404
    POST /auth/v1/otp 400   /token 400   /verify 400   /recover 400   /resend 400
    GET  /auth/v1/user 401   /authorize 400   discovery document 200
    INTERNAL listener  /signup 422, still routed, GoTrue refusing it
    auth.users 154 before and after, zero probe rows

**Resulting posture, stated without overclaiming.** Admin-provisioned users only. Creation through `/otp` is stopped by the flag alone; `/signup` and `/magiclink` are stopped by both the flag and routing. Password sign-in, the OAuth flow, verification, recovery, resend, logout and the discovery documents all stay reachable. The admin one-time-token flow this repo uses for live test sessions goes through `/admin/generate_link` on the internal listener, untouched. Re-enabling self-service signup is a deliberate two-part change, and it should not happen before the provisioning path `.wolf/decisions.md` D-023 describes exists, because a user created with no tenant membership gets a token with no tenant claim and nothing reconciles it.

**One more finding that would have made all of this cosmetic.** `Caddyfile.supabase` was missing from the deploy's Caddy apply loop, which is the only step that gets a bind-mounted config into a running container. Every refusal above would have sat in the repository while the running gateway carried none of them, and the deploy would have reported success. That loop's own comment documents this exact failure happening before. Added, so the config is validated with `caddy validate` and the container recreated on every deploy.

The in-network listener also gains the `:80 { respond 404 }` catch-all the public port has always had. An unmatched Host answered Caddy's empty 200. That reaches no backend and is not an exposure, but it is misleading: a probe reading 200 concludes the request was proxied and the upstream answered. That happened during this verification and the wrong conclusion nearly shipped here as evidence.

## Trailing slash: three sites on one branch, and the sweep for a fourth

The same defect appeared three times in this branch, in three different files, and each instance was caught by a reviewer rather than by me.

| Site | Shape | Consequence |
| --- | --- | --- |
| `Caddyfile.supabase`, `@selfserve` | Caddy `path` matching is exact, GoTrue's router serves `pattern/` too | `POST /auth/v1/signup/` bypassed the deny list entirely |
| `Caddyfile.supabase`, `@admin` | same, and `/auth/v1/invite` had no wildcard | `/auth/v1/invite/` was proxied, and had been since that matcher was written |
| `check-env-supabase-target.py` | compared the issuer with slashes stripped from both sides | an environment with a slash on one side only was reported healthy while every token GoTrue issued would be rejected |

The third one is the worst of the three, because it is a green signal over a broken box rather than an open door.

**The sweep found a fourth site**, of a different shape, which is why the fix is a rule and not one more exact comparison. `docker-compose.yml` builds Open WebUI's OIDC discovery URL by concatenating a base with `/auth/v1/.well-known/openid-configuration`, so a base ending in a slash yields a double slash in the path and the discovery fetch 404s. An exact comparison cannot see that at all: with a slash on **both** sides the two values agree and the concatenation is still broken.

So the fix refuses the character outright on seven URL variables (`SUPABASE_URL`, `SUPABASE_PUBLIC_URL`, `SUPABASE_JWT_ISSUER`, `SUPABASE_JWKS_URL`, `ENTERPRISE_AUTH_EXTERNAL_URL`, `S3_ENDPOINT`, `NEXT_PUBLIC_SUPABASE_URL`) and compares exactly, which covers the comparison shape and the concatenation shape together. `.env.example` states the constraint where the values are written.

Sweep coverage, for the record: the three remaining `rstrip`/`strip` calls in these scripts were checked and are unrelated (stripping `}` off a compose default expression, and a comma off a Caddy address), edge-api's issuer handling was read and confirmed to be exact (`jwt.WithIssuer`), and the one concatenation site in the compose files is the fourth site above.

Mutation results, including the one that did not go the way the fix implies:

    comparison disabled entirely                 red, on a non-slash mismatch
    the no-trailing-slash rule disabled          red, on a slash on both sides
    both reverted, the pre-fix state             red, on the one-sided slash
    slash-stripping comparison restored ALONE    still GREEN

The last line is recorded rather than hidden. With the rule present, restoring the stripping does not fail, because the rule fires first. Each half is load bearing for a different failure shape and neither is redundant overall, but that particular mutation is masked, and a future reader should not take its green as evidence the exact comparison is unnecessary.

Self-check is at twenty-six cases, seven of them trailing-slash mutations. Against the demo box's own env file it reports no trailing slash anywhere, leaving only the S3 credential finding tracked as #987.

## GitGuardian: synthetic, and history only

`1 secret uncovered`, and the evidence rather than an assurance:

- Incident `34282788`, occurrence `292522202`, detector **Generic Password**, commit `1687b889a`, file `.env.example`. The same incident and occurrence across four subsequent pushes, so nothing new has been found; it is pinned to one historical commit.
- Both matching lines in that commit are **comment lines**, 2 of 2 starting with `#`. What sat in the password position was the literal text `<ENTERPRISE_DB_PASSWORD>`, which is the NAME of a variable declared in the same file at line 641. A scanner cannot distinguish a variable name in a URI from a value.
- At HEAD that line reads `${ENTERPRISE_DB_PASSWORD}`, and the bracketed form occurs zero times.
- Every credential-shaped URI this branch adds, at HEAD, in full: `postgres://postgres:${PASSWORD}@supabase-db:5432/postgres`, `postgresql://postgres:${ENTERPRISE_DB_PASSWORD}@supabase-db:5432/postgres`, `postgresql://postgres:${PASSWORD}@supabase-db:5432/postgres`, `postgresql://postgres:${PASSWORD}@supabase-db:6543/postgres`, `postgresql://user:${PASSWORD}@aws-1-x.pooler.supabase.com:5432/postgres`. All placeholders.
- A scan of everything the branch adds for JWT, PEM, long base64 and long hex shapes returns **none**.
- A squash merge builds one commit from the tree at HEAD, so the commit the finding is pinned to never reaches `main`.

Nothing was revoked because nothing was disclosed. Had any of it been real, revocation would have come first and this pull request would have been stopped.

## Deferred, with issues filed rather than left in a review thread

- **#987**, security: `supabase-storage` needs distinct S3 protocol credentials instead of the service role key used as both the access key id and the secret. SigV4 sends the id in the clear, so an identical secret is disclosed on every request. The pinned image's support for `S3_PROTOCOL_ACCESS_KEY_ID` and `S3_PROTOCOL_ACCESS_KEY_SECRET` was confirmed by inspecting the running container. Not fixed here because verifying it needs a real signed request, and shipping an unverified change to the storage credential path is worse than documenting it. `check-env-supabase-target.py` fails on the demo box's env file for exactly this today, so it is loud rather than forgotten.
- **#988**, security: control-plane treats `GET /auth/v1/user` as identity without verifying a signature, and that call is now plain http on the compose bridge. The bridge is already this deployment's trust boundary, since the database DSN and the internal token cross it in the clear, so no new boundary appears, but the identity channel is weaker than the https it replaced and its compromise is the silent kind. The fix is a CA-file knob on that one client, mirroring edge-api's `SUPABASE_JWKS_CA_FILE`; `SSL_CERT_FILE` is not it, since that replaces every root and breaks outbound TLS to the payment rails.
- **#989**: `deploy-demo-box.yml`'s migrate job still reads hosted `secrets.SUPABASE_DB_*` and gates the deploy through `needs:`, and its one-off `docker run postgres:16-alpine psql` has no `--network`, so it cannot resolve a compose service name. Both are real unrepointed consumers, both live in the same workflow file as the flip, and both belong with it.

## Buglog entry

Six entries. The second came from the live proof run, the third and fourth from folding the flip in and closing the signup exposure, and the last two from a regression check that found the first proof had generalised from one passing sample.

```json
{"id":"selfhost-supabase-two-project-seam","date":"2026-08-20","error_message":"getent hosts caddy-supabase returns nothing from inside hive-control-plane-1, and the self-hosted Supabase gateway publishes no ports","root_cause":"the self-hosted Supabase data plane was brought up with docker compose -p hivesupabase from a second checkout at /home/sakib/selfhost-stage1, so it landed on its own default network hivesupabase_default while every application service stayed on hive_default. docker-compose.enterprise.yml declares name: hive precisely so that layering it onto docker-compose.yml puts both halves in one project and one network, and overriding the project name discarded that. Two projects also split the named volumes, so the exported certificate authority edge-api mounts and the restored Postgres data directory were both unreachable from the application project","fix":"bring the data plane up as part of project hive by layering -f docker-compose.yml -f docker-compose.enterprise.yml from the canonical checkout, add a selfhost profile covering exactly the Supabase data-plane services so it can run under the local and chat application profiles, and guard the silent properties (one project name, no named network, profile coverage, https JWKS plus its CA mount, issuer agreement, libpq DSN flavour) in scripts/test_selfhost_supabase_seam.py","tags":["compose","networking","supabase","self-hosted","demo-box","seam"]}
```

```json
{"id": "selfhost-supabase-short-dsn-scheme", "date": "2026-08-20", "error_message": "sqlalchemy.exc.NoSuchModuleError: Can't load plugin: sqlalchemy.dialects:postgres, and hive-open-webui-1 never leaving the starting health state", "root_cause": "the self-hosted Postgres DSN was written with the short postgres:// scheme. libpq and pgx both accept it, so control-plane and edge-api came up healthy and reported nothing, and scripts/derive-pooler-dsn.py preserved whatever scheme it was handed across all three derived DSNs. SQLAlchemy removed postgres from its dialect registry in 1.4, and Open WebUI's pgvector store consumes the libpq flavour, so the only consumer that rejects the spelling is three services away from the value and names neither the variable nor the deployment that set it. Same family as the earlier pgx-only pool_max_conns parameter in a libpq DSN, and for the same reason: one DSN string is read by three drivers with different tolerances", "fix": "normalise the scheme to postgresql:// in scripts/derive-pooler-dsn.py, at the single point all three derived DSNs pass through, with nine self-test assertions including one that an already-correct DSN comes back unchanged so the normalisation cannot become a rewrite. scripts/check-env-supabase-target.py additionally refuses the short scheme on any of the three DSN variables in a real env file, and .env.example states the requirement where the value is written", "tags": ["dsn", "driver", "sqlalchemy", "libpq", "pgx", "open-webui", "supabase", "self-hosted"]}
```

```json
{"id": "selfhost-supabase-signup-open-with-autoconfirm", "date": "2026-08-20", "error_message": "no error and no failing test: GOTRUE_DISABLE_SIGNUP=false with GOTRUE_MAILER_AUTOCONFIRM=true on the self-hosted GoTrue, so any caller reaching the auth endpoint could create a confirmed account without proving control of the address", "root_cause": "the self-hosted Supabase data plane was stood up with signup left open, which was harmless while the gateway published no ports and no hostname resolved to it, and which the next change to the stack (a public auth origin) turns into an internet-facing self-service account factory. The compose default is fail-safe (ENTERPRISE_DISABLE_SIGNUP defaults to true) so nothing in the repo was wrong; the deployment had overridden it. Nothing detects this class of state: it produces no error, no failing check and no log line, and the gateway's public route set was a deny list that named only the admin API", "fix": "two layers. GOTRUE_DISABLE_SIGNUP set true on the deployment, which covers every creation path and is verified by GoTrue answering 422 signup_disabled on /signup, /otp and /magiclink. And the gateway's public listener now refuses /signup, /otp and /magiclink outright, so flipping the flag back does not reopen the internet-facing surface on its own. /otp and /magiclink are included because should_create_user defaults to true, making them signup routes wearing a login name. scripts/test_caddy_supabase_routes.py asserts the deny list covers those three AND does not cover /token, /user, /recover, /verify or /logout, so a matcher that grows until it locks every user out fails as loudly as one that shrinks", "tags": ["security", "auth", "gotrue", "signup", "supabase", "self-hosted", "caddy", "defence-in-depth"]}
```

```json
{"id": "caddy-unmatched-host-empty-200-misreads-as-proxied", "date": "2026-08-20", "error_message": "a verification probe read HTTP 200 from POST /auth/v1/signup on the gateway's in-network listener and concluded the request had been proxied to GoTrue, while GoTrue was in fact refusing signup with 422", "root_cause": "Caddy answers an unmatched Host with an empty 200. The probe addressed the container by its own name rather than by the site name the config matches, matched no site block on port 80, and got that empty 200. The public port had carried a `:8080 { respond 404 }` catch-all for exactly this reason since it was written; port 80 never got one, so the in-network listener was the half that could lie. Not an exposure, since no backend is reached, but the wrong conclusion was one step from shipping in a pull request as evidence that the route worked", "fix": "added the matching `:80 { respond 404 }` catch-all so an unmatched Host cannot be read as a proxied success, asserted both catch-alls in scripts/test_caddy_supabase_routes.py with a mutation per port, and re-ran the probe with the correct Host, which then showed 422 from GoTrue as expected", "tags": ["caddy", "verification", "false-green", "supabase", "self-hosted"]}
```

```json
{"id": "selfhost-supabase-cloud-null-token-columns", "date": "2026-08-21", "error_message": "error finding user: sql: Scan error on column index 3, name \"confirmation_token\": converting NULL to string is unsupported, surfacing as 500 Database error finding user on POST /auth/v1/admin/generate_link and 500 Database error querying schema on POST /auth/v1/token?grant_type=password", "root_cause": "Supabase Cloud permits NULL in the auth.users token columns, while the self-hosted GoTrue scans them into non-nullable Go strings, so any restored row carrying a NULL fails every lookup that loads it. One of 154 restored rows had confirmation_token, recovery_token, email_change_token_new and email_change NULL. The defect was invisible to the cutover's own live proof because that proof's account selection filtered out a couple of domains and in doing so skipped the affected row, so a single passing sample was reported as if it characterised the table", "fix": "normalised NULL to the empty string the self-hosted schema expects across all eight text columns of that shape, after a fresh snapshot into its own directory (neither existing snapshot touched). Verified by re-running the flow that failed: generate_link 200 with a token issued for the previously failing row, verify 200, iss matching edge-api's expectation, tenant_id, tenants and owui_role claims present, control-plane 400 with the real token against 401 with a junk one, auth.users unchanged at 154. Any future restore from Supabase Cloud needs the same normalisation first, recorded in issue #990", "tags": ["supabase", "self-hosted", "gotrue", "restore", "auth", "false-green", "sampling"]}
```

```json
{"id": "one-passing-sample-reported-as-a-characterisation", "date": "2026-08-21", "error_message": "no error: a cutover proof reported a successful token mint as evidence that the login path worked, and a later probe using a slightly different account query returned 500 on the first account it picked", "root_cause": "the proof selected its test account with a filter that excluded a couple of email domains, which incidentally excluded the one row in the restored data that fails. One passing sample was then written up as though it characterised the whole table. The failure was not in the seam being tested, it was in generalising from a sample chosen for convenience rather than for coverage", "fix": "re-probed across the first ten accounts rather than one, which localised the failure to a single row (nine answered 400 Invalid login credentials on a deliberately wrong password, one answered 500), then measured the defect class directly with a count over the whole table rather than by sampling at all. Lesson for any future live proof: when the claim is about a population, count the population; a single green sample proves only that a green sample exists", "tags": ["verification", "false-green", "sampling", "live-proof"]}
```

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR unifies the live application and self-hosted Supabase data plane under one Compose project, repoints Supabase consumers, and adds deployment and configuration regression checks.
- Adds the dedicated `selfhost` profile and shared deployment Compose flags.
- Configures gateway routing, signup restrictions, certificate trust, and public versus internal auth origins.
- Normalizes PostgreSQL DSN schemes and validates self-hosted environment consistency.
- Adds seam and Caddy route tests to the required script checks.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the previously reported issuer equality, unset-origin fallback, and trailing-slash validation issues are fixed at the current head.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/test_selfhost_supabase_seam.py | The issuer regression test now compares complete fallback expressions and correctly detects fallback drift. |
| scripts/check-env-supabase-target.py | The checker now models the Compose issuer fallback chain exactly and rejects trailing-slash configurations that would break issuer equality or URL concatenation. |
| deploy/docker/docker-compose.enterprise.yml | Adds the self-host profile consistently across the Supabase data-plane services and aligns application-facing Supabase defaults. |
| .github/workflows/deploy-demo-box.yml | Centralizes Compose project flags across deployment operations and ensures the Supabase gateway configuration is applied. |
| deploy/docker/Caddyfile.supabase | Adds explicit public account-creation and administrative route restrictions plus an unmatched-host catch-all. |
| scripts/derive-pooler-dsn.py | Normalizes short PostgreSQL schemes before producing driver-specific DSNs and adds regression assertions. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Deploy[Deploy workflow] -->|shared Compose flags| Project[Hive Compose project]
  Project --> Apps[Edge API / Control plane / Open WebUI]
  Project --> DataPlane[Self-hosted Supabase data plane]
  Apps -->|service DNS| Gateway[caddy-supabase]
  Gateway --> Auth[GoTrue]
  Gateway --> Storage[Supabase Storage]
  Apps --> DB[(supabase-db)]
  Gateway -->|exported local CA| Edge[Edge API JWKS verification]
```
</details>

<sub>Reviews (10): Last reviewed commit: ["fix: refuse the trailing slash instead o..."](https://github.com/sakibsadmanshajib/hive/commit/a69bc80605826dca9f5dd9314f8bb00017e5cbd1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55418992)</sub>

<!-- /greptile_comment -->