### PR TITLE
fix: migrate the database the stack actually uses, and reach it from the right network

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,14 @@
+# actionlint configuration.
+#
+# actionlint is not run by this repository's own CI. This file exists so that a
+# local run, a pre-commit hook, or a third-party reviewer that runs actionlint
+# does not report a false positive on the demo box's runner label and bury real
+# findings underneath it.
+#
+# `hive-demo` is the custom label on the self-hosted runner on the owner's demo
+# box, used by the `migrate` and `deploy` jobs in deploy-demo-box.yml. Its other
+# labels (self-hosted, Linux, X64) are all in actionlint's built-in list, so
+# only this one needs declaring.
+self-hosted-runner:
+  labels:
+    - hive-demo

--- a/.github/workflows/deploy-demo-box.yml
+++ b/.github/workflows/deploy-demo-box.yml
@@ -82,6 +82,12 @@ on:
       # script would merge and never redeploy to pick the fix up.
       - 'scripts/check-retention-schedule.sh'
       - 'scripts/derive-pooler-dsn.py'
+      # The single answer to "how does a command on the box reach the stack's
+      # database". Both the migrate job and the deploy job's price assertion go
+      # through it, so a fix to it that never deployed would leave both of them
+      # running the broken version, which is the same blind spot every other
+      # script listed here exists for.
+      - 'scripts/stack-psql.sh'
       # Installs and restarts the host-side agent-engine launch daemon in the
       # deploy job below. Same blind spot as every other script listed here:
       # without an entry, a fix to it would merge and never deploy.
@@ -170,50 +176,161 @@ jobs:
   #     and self-contained. Nothing pending narrows a constraint or drops a
   #     column, so this window is safe.
   #
-  # Runs on a GitHub-hosted runner rather than the box: it needs psql, and the
-  # demo box has no passwordless sudo to install it (same limitation as the
-  # runner-as-a-service note below). It reaches Postgres over the same pooler
-  # secrets the PR cleanup job already uses, so no new secret is introduced and
-  # the box is not touched at all.
+  # Runs ON THE BOX, and the reason is the whole point of this job's shape.
+  #
+  # It used to run on ubuntu-latest and connect over the SUPABASE_DB_* secrets.
+  # That worked for exactly as long as the database was a hosted Supavisor
+  # pooler on a public hostname. After the self-hosted cutover (PR #986) the
+  # database the stack uses has no published port at all and exists only inside
+  # the compose network, which no GitHub-hosted runner can reach. This job did
+  # not go red for that. Those secrets still named a reachable Supabase Cloud
+  # project, so it applied every pending migration there, reported that nightly
+  # retention was scheduled, and finished green, while the database the
+  # application actually reads received no schema change whatsoever. There was
+  # no signal of any kind: success is what the job printed in both worlds.
+  #
+  # So the target is no longer a separate secret set. It is derived from
+  # SUPABASE_DB_URL in the box's own .env, which is the value control-plane
+  # itself connects with, and it is then asserted to BE that database by
+  # comparing pg_control_system().system_identifier against what the running
+  # supabase-db container reports over its own local socket. The two sides
+  # reach the server by unrelated routes and are named by unrelated inputs, so
+  # the comparison can genuinely fail, and when it fails it fails this job and
+  # stops the deploy.
+  #
+  # psql on the box: still not installed, and there is still no passwordless
+  # sudo to install it. That is not worked around by wishing, it is worked
+  # around by running psql in a throwaway container on the stack's own network
+  # (scripts/stack-psql.sh), which the deploy job's price assertion uses too.
+  # bash, python3 and sha256sum, the other things scripts/apply-migrations.sh
+  # needs, are all present on the host already.
   # ------------------------------------------------------------------
   migrate:
     name: Apply pending database migrations
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, hive-demo]
     permissions:
       contents: read
     timeout-minutes: 10
+    env:
+      # Every psql call in this job goes through the wrapper, so no step gets
+      # to invent its own docker invocation. A bare `psql` here would at least
+      # be loud (there is none on the host); a `docker run` that forgot
+      # --network would connect to nothing and read like a broken database,
+      # which is exactly how this broke the first time.
+      PSQL_BIN: ${{ github.workspace }}/scripts/stack-psql.sh
     steps:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-
-      - name: Install psql
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq postgresql-client
 
       - name: Validate the migration baseline file
         # Cheap, no database: catches a typo'd or stale baseline entry before
         # anything connects.
         run: scripts/apply-migrations.sh --check
 
-      - name: Pick the transaction-mode pooler port
-        # A migration run needs no session state, so it has no business holding
-        # one of the project's 15 session-mode client slots -- those are shared
-        # with the live demo stack, and exhausting them has taken chat down.
-        # Only a Supavisor pooler host gets the 6543 override; a direct
-        # Postgres serves every mode on its single port.
-        env:
-          PGHOST: ${{ secrets.SUPABASE_DB_HOST }}
-          PGPORT: ${{ secrets.SUPABASE_DB_PORT }}
+      - name: Make sure the stack's database is up
+        # Schema before code needs a database to talk to, and this job is now
+        # the first thing in the run. Without this a box whose stack is down
+        # cannot deploy the fix for its stack being down: migrate would fail on
+        # an unreachable database and the `needs:` edge would stop the deploy.
+        #
+        # Deliberately NOT --remove-orphans, and deliberately only this one
+        # service. Recreating the whole stack is the deploy job's work, and a
+        # compose invocation carrying --remove-orphans is the one that deletes
+        # the data plane when it resolves a different project (see the
+        # HIVE_COMPOSE_FLAGS block at the top of this file).
+        working-directory: /home/sakib/hive/deploy/docker
+        run: docker compose $HIVE_COMPOSE_FLAGS up -d supabase-db
+
+      - name: Derive the migration connection from the box's own .env
+        # One source of truth for what to migrate: the same SUPABASE_DB_URL the
+        # stack's own services connect with. A separate secret set is what made
+        # the silent-success failure above possible, so there is no longer one.
+        #
+        # scripts/derive-pooler-dsn.py --emit-libpq-env hands back libpq
+        # variables rather than a DSN, because apply-migrations.sh and
+        # check-retention-schedule.sh take libpq variables and deliberately
+        # never parse a DSN (parameters are per-driver, and a pgx-only one in a
+        # libpq value is rejected outright, which has already crash-looped a
+        # container). It also lands a pooler host on the transaction-mode port,
+        # which is why the old port-picking step is gone rather than kept: a
+        # migration needs no session state and must not hold one of the
+        # project's 15 session slots.
         run: |
           set -euo pipefail
-          port="$PGPORT"
-          case "$PGHOST" in
-            *.pooler.supabase.com) port=6543 ;;
-          esac
-          echo "PG_POOL_PORT=$port" >> "$GITHUB_ENV"
-          echo "migrations will connect to $PGHOST:$port"
+          env_file=/home/sakib/hive/.env
+          raw=$(grep -E '^SUPABASE_DB_URL=' "$env_file" | head -1 | cut -d= -f2-)
+          # A hand-edited .env may quote the value; the DSN parser must not see
+          # the quotes.
+          raw="${raw%\"}"; raw="${raw#\"}"
+          raw="${raw%\'}"; raw="${raw#\'}"
+          if [ -z "$raw" ]; then
+            echo "::error::SUPABASE_DB_URL is missing or empty in $env_file, so there is no migration target"
+            exit 1
+          fi
+          # The DSN and the password it carries are not repository secrets, so
+          # nothing masks them automatically. Register both before anything
+          # else in this job can echo one.
+          echo "::add-mask::$raw"
+          python3 scripts/derive-pooler-dsn.py --self-test
+          creds=$(python3 scripts/derive-pooler-dsn.py --dsn "$raw" --emit-libpq-env)
+          while IFS= read -r line; do
+            case "$line" in
+              PGPASSWORD=*) echo "::add-mask::${line#PGPASSWORD=}" ;;
+            esac
+            printf '%s\n' "$line" >> "$GITHUB_ENV"
+          done <<< "$creds"
+
+      - name: Assert the migration target is the database this stack uses
+        # The identity assertion. Not a comment, not a hostname pattern match:
+        # pg_control_system().system_identifier is generated by initdb and is
+        # unique per cluster, so two connections agreeing on it agree on the
+        # server.
+        #
+        # The two sides are independent on purpose, which is what lets this
+        # fail. The target side is a libpq connection over the compose network,
+        # named entirely by SUPABASE_DB_URL from the box's .env. The stack side
+        # is a local socket inside the running supabase-db container, named
+        # entirely by compose project resolution, with the role and database
+        # read out of the container's own environment rather than out of that
+        # DSN. Point the DSN at any other database, hosted or otherwise, and
+        # the identifiers differ and this step fails.
+        #
+        # Both sides being empty is treated as failure too. A check whose only
+        # failure mode is "the strings differ" passes when neither side
+        # produced a string at all, which is the shape that has bitten this
+        # repository repeatedly.
+        working-directory: /home/sakib/hive/deploy/docker
+        run: |
+          set -euo pipefail
+          identity_sql='SELECT system_identifier FROM pg_control_system()'
+
+          target=$("$PSQL_BIN" -tAXq -v ON_ERROR_STOP=1 -c "$identity_sql" | tr -d '[:space:]')
+          if [ -z "$target" ]; then
+            echo "::error::the migration connection returned no system_identifier, so the target database could not be identified at all"
+            exit 1
+          fi
+
+          db_user=$(docker compose $HIVE_COMPOSE_FLAGS exec -T supabase-db printenv POSTGRES_USER | tr -d '[:space:]')
+          db_name=$(docker compose $HIVE_COMPOSE_FLAGS exec -T supabase-db printenv POSTGRES_DB | tr -d '[:space:]')
+          if [ -z "$db_user" ] || [ -z "$db_name" ]; then
+            echo "::error::could not read POSTGRES_USER/POSTGRES_DB out of the running supabase-db container, so the stack's own database could not be identified"
+            exit 1
+          fi
+
+          stack=$(docker compose $HIVE_COMPOSE_FLAGS exec -T supabase-db \
+            psql -U "$db_user" -d "$db_name" --no-psqlrc -tAXq -v ON_ERROR_STOP=1 \
+              -c "$identity_sql" | tr -d '[:space:]')
+          if [ -z "$stack" ]; then
+            echo "::error::the running supabase-db container returned no system_identifier, so the stack's own database could not be identified"
+            exit 1
+          fi
+
+          if [ "$target" != "$stack" ]; then
+            echo "::error::migration target mismatch: the connection derived from SUPABASE_DB_URL is cluster $target, but the database this stack runs is cluster $stack. Refusing to migrate a database the application does not use. Fix SUPABASE_DB_URL in the box's .env, or the stack, so the two agree."
+            exit 1
+          fi
+          echo "migration target confirmed: cluster $target is the database this stack runs"
 
       - name: Apply pending migrations
         # No `|| true`, no continue-on-error, no swallowed exit code: the script
@@ -222,7 +339,8 @@ jobs:
         # edge below stops the deploy. Silent failure is the entire defect class
         # this job exists to remove.
         #
-        # Only libpq variables are exported. This path never builds a DSN
+        # Only libpq variables are used, and they come from the derive step
+        # above rather than from this step. This path never builds a DSN
         # string, because DSN parameters are per-driver and a pgx-only parameter
         # in a libpq value is rejected outright (that mistake has already
         # crash-looped a container and cost ~50 minutes of chat downtime).
@@ -234,12 +352,6 @@ jobs:
         # state that is neither aborts this step and prints what it needs. That
         # abort is the intended outcome, not a flake: the alternative is a green
         # deploy over schema that was never created.
-        env:
-          PGHOST: ${{ secrets.SUPABASE_DB_HOST }}
-          PGPORT: ${{ env.PG_POOL_PORT }}
-          PGUSER: ${{ secrets.SUPABASE_DB_USER }}
-          PGDATABASE: ${{ secrets.SUPABASE_DB_NAME }}
-          PGPASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
         run: scripts/apply-migrations.sh
 
       - name: Report whether nightly metering retention is scheduled
@@ -255,12 +367,6 @@ jobs:
         # mistake the guards already avoid. Absence surfaces as a ::warning::
         # annotation on the run summary. The migration step above is unchanged
         # and still fails the deploy on a real migration error.
-        env:
-          PGHOST: ${{ secrets.SUPABASE_DB_HOST }}
-          PGPORT: ${{ env.PG_POOL_PORT }}
-          PGUSER: ${{ secrets.SUPABASE_DB_USER }}
-          PGDATABASE: ${{ secrets.SUPABASE_DB_NAME }}
-          PGPASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
         run: scripts/check-retention-schedule.sh
 
   deploy:
@@ -1057,8 +1163,15 @@ jobs:
             exit 1
           fi
 
-          rows=$(docker run --rm "postgres:16-alpine" \
-            psql "$SUPABASE_DB_POOL_URL_LIBPQ" -At -F'|' -v ON_ERROR_STOP=1 -c "
+          # ../../scripts/stack-psql.sh, not a bare `docker run`. This step
+          # already ran psql in a container, but on the default bridge
+          # network, where the self-hosted database's compose-network hostname
+          # does not resolve: the first deploy after PR #986 failed here with
+          # `could not translate host name "supabase-db" to address`. The
+          # wrapper attaches the container to the stack's network, and is the
+          # single place that answers this for the whole repository.
+          rows=$(../../scripts/stack-psql.sh \
+            "$SUPABASE_DB_POOL_URL_LIBPQ" -At -F'|' -v ON_ERROR_STOP=1 -c "
               SELECT pr.route_id, pr.litellm_model_name, pr.provider_model
                 FROM public.provider_routes pr
                 JOIN public.model_aliases ma ON ma.alias_id = pr.alias_id

--- a/.github/workflows/deploy-demo-box.yml
+++ b/.github/workflows/deploy-demo-box.yml
@@ -210,7 +210,10 @@ jobs:
     runs-on: [self-hosted, hive-demo]
     permissions:
       contents: read
-    timeout-minutes: 10
+    # 20, not 10. This job now checks the repository out on the box, and the
+    # very first run on a fresh runner workspace pays for that in full. A
+    # timeout here does not just fail this job, it stops the deploy.
+    timeout-minutes: 20
     env:
       # Every psql call in this job goes through the wrapper, so no step gets
       # to invent its own docker invocation. A bare `psql` here would at least
@@ -259,7 +262,11 @@ jobs:
         run: |
           set -euo pipefail
           env_file=/home/sakib/hive/.env
-          raw=$(grep -E '^SUPABASE_DB_URL=' "$env_file" | head -1 | cut -d= -f2-)
+          # `|| true` matters: under `set -o pipefail` a grep that matches
+          # nothing fails the whole pipeline, so `set -e` would kill this step
+          # before the explanatory error below could ever print. The failure
+          # would still be loud, but it would name nothing.
+          raw=$(grep -E '^SUPABASE_DB_URL=' "$env_file" | head -1 | cut -d= -f2- || true)
           # A hand-edited .env may quote the value; the DSN parser must not see
           # the quotes.
           raw="${raw%\"}"; raw="${raw#\"}"
@@ -305,22 +312,41 @@ jobs:
           set -euo pipefail
           identity_sql='SELECT system_identifier FROM pg_control_system()'
 
-          target=$("$PSQL_BIN" -tAXq -v ON_ERROR_STOP=1 -c "$identity_sql" | tr -d '[:space:]')
+          # Each command's exit status is handled before its output is
+          # trimmed, and both are checked. Piping straight into `tr` would put
+          # a failing psql inside a pipeline, where `set -o pipefail` plus
+          # `set -e` kill the step before the explanatory error runs: the
+          # emptiness guards below would then be code that cannot execute,
+          # which is the shape this whole change exists to stop shipping.
+          if ! target=$("$PSQL_BIN" -tAXq -v ON_ERROR_STOP=1 -c "$identity_sql"); then
+            echo "::error::the migration connection could not be opened, so the target database could not be identified at all"
+            exit 1
+          fi
+          target=$(printf '%s' "$target" | tr -d '[:space:]')
           if [ -z "$target" ]; then
             echo "::error::the migration connection returned no system_identifier, so the target database could not be identified at all"
             exit 1
           fi
 
-          db_user=$(docker compose $HIVE_COMPOSE_FLAGS exec -T supabase-db printenv POSTGRES_USER | tr -d '[:space:]')
-          db_name=$(docker compose $HIVE_COMPOSE_FLAGS exec -T supabase-db printenv POSTGRES_DB | tr -d '[:space:]')
+          if ! db_user=$(docker compose $HIVE_COMPOSE_FLAGS exec -T supabase-db printenv POSTGRES_USER) \
+            || ! db_name=$(docker compose $HIVE_COMPOSE_FLAGS exec -T supabase-db printenv POSTGRES_DB); then
+            echo "::error::could not reach the running supabase-db container, so the stack's own database could not be identified"
+            exit 1
+          fi
+          db_user=$(printf '%s' "$db_user" | tr -d '[:space:]')
+          db_name=$(printf '%s' "$db_name" | tr -d '[:space:]')
           if [ -z "$db_user" ] || [ -z "$db_name" ]; then
-            echo "::error::could not read POSTGRES_USER/POSTGRES_DB out of the running supabase-db container, so the stack's own database could not be identified"
+            echo "::error::the supabase-db container reported no POSTGRES_USER/POSTGRES_DB, so the stack's own database could not be identified"
             exit 1
           fi
 
-          stack=$(docker compose $HIVE_COMPOSE_FLAGS exec -T supabase-db \
+          if ! stack=$(docker compose $HIVE_COMPOSE_FLAGS exec -T supabase-db \
             psql -U "$db_user" -d "$db_name" --no-psqlrc -tAXq -v ON_ERROR_STOP=1 \
-              -c "$identity_sql" | tr -d '[:space:]')
+              -c "$identity_sql"); then
+            echo "::error::the supabase-db container refused the identity query, so the stack's own database could not be identified"
+            exit 1
+          fi
+          stack=$(printf '%s' "$stack" | tr -d '[:space:]')
           if [ -z "$stack" ]; then
             echo "::error::the running supabase-db container returned no system_identifier, so the stack's own database could not be identified"
             exit 1
@@ -618,7 +644,10 @@ jobs:
         working-directory: /home/sakib/hive
         run: |
           set -euo pipefail
-          existing=$(grep -E '^SUPABASE_DB_URL=' .env | head -1 | cut -d= -f2-)
+          # `|| true` for the same reason as the migrate job's copy of this:
+          # pipefail turns "no match" into a step that dies before the error
+          # message below can name what is missing.
+          existing=$(grep -E '^SUPABASE_DB_URL=' .env | head -1 | cut -d= -f2- || true)
           # A hand-edited .env may quote the value; the DSN parser must not see
           # the quotes.
           existing="${existing%\"}"; existing="${existing#\"}"

--- a/Makefile
+++ b/Makefile
@@ -33,3 +33,4 @@ test-scripts:
 	python3 scripts/test_caddy_supabase_routes.py
 	python3 scripts/test_selfhost_supabase_seam.py
 	python3 scripts/check-env-supabase-target.py --self-check
+	python3 scripts/derive-pooler-dsn.py --self-test

--- a/scripts/apply-migrations.sh
+++ b/scripts/apply-migrations.sh
@@ -45,6 +45,13 @@
 # surface down for ~50 minutes). psql is a libpq client, so libpq variables are
 # the only thing passed here.
 #
+# PSQL_BIN names the client to run, defaulting to plain `psql` on PATH. It
+# exists because the self-hosted data plane publishes no host port and its
+# hostname is a compose-network name, so a host-side psql cannot resolve it at
+# all: the demo box sets PSQL_BIN=scripts/stack-psql.sh, which runs the same
+# client inside the stack's network. The libpq variables above are the only
+# interface either way, so nothing else here changes.
+#
 # Point PGPORT at the pooler's transaction-mode port (6543) rather than session
 # mode (5432). Session-mode clients are 1:1 with server connections and capped
 # at the project's pool_size of 15, shared with the live demo stack and every CI
@@ -236,7 +243,11 @@ fi
 # ---------------------------------------------------------------------------
 # Ledger
 # ---------------------------------------------------------------------------
-psql_q() { psql --no-psqlrc -qtAX -v ON_ERROR_STOP=1 "$@"; }
+# Every psql invocation in this script goes through PSQL_BIN. See the
+# "Connection" note in the header for why it is indirect.
+PSQL_BIN="${PSQL_BIN:-psql}"
+
+psql_q() { "$PSQL_BIN" --no-psqlrc -qtAX -v ON_ERROR_STOP=1 "$@"; }
 
 # ---------------------------------------------------------------------------
 # Does the baseline describe THIS database?
@@ -411,7 +422,7 @@ fi
 
 for name in "${pending[@]}"; do
   echo "::group::applying $name"
-  psql --no-psqlrc -X -v ON_ERROR_STOP=1 -f "$migrations_dir/$name"
+  "$PSQL_BIN" --no-psqlrc -X -v ON_ERROR_STOP=1 -f "$migrations_dir/$name"
   sha="$(sha256sum "$migrations_dir/$name" | cut -d' ' -f1)"
   psql_q -c "INSERT INTO public.hive_schema_migrations (filename, sha256, source)
              VALUES ('$name', '$sha', 'applied')"

--- a/scripts/check-retention-schedule.sh
+++ b/scripts/check-retention-schedule.sh
@@ -37,12 +37,19 @@
 # Connection settings come from libpq environment variables (PGHOST, PGPORT,
 # PGUSER, PGDATABASE, PGPASSWORD), same as apply-migrations.sh. No DSN is built
 # here, because DSN parameters are per driver and psql is a libpq client.
+#
+# PSQL_BIN names the client, same as apply-migrations.sh, and for the same
+# reason: on the demo box the database has no published port and only exists
+# inside the stack's compose network, so the caller points this at
+# scripts/stack-psql.sh.
 
 set -euo pipefail
 
 JOB_NAME='metering-shadow-verdicts-purge'
 
-psql_q() { psql --no-psqlrc -qtAX -v ON_ERROR_STOP=1 "$@"; }
+PSQL_BIN="${PSQL_BIN:-psql}"
+
+psql_q() { "$PSQL_BIN" --no-psqlrc -qtAX -v ON_ERROR_STOP=1 "$@"; }
 
 # pg_extension has to be checked separately and first: when pg_cron is not
 # installed the cron schema does not exist either, and a single query

--- a/scripts/derive-pooler-dsn.py
+++ b/scripts/derive-pooler-dsn.py
@@ -311,6 +311,19 @@ def derive(
 # connection from these variables and deliberately never parse a DSN.
 LIBPQ_ENV_ORDER = ("PGHOST", "PGPORT", "PGUSER", "PGDATABASE", "PGPASSWORD")
 
+# Query parameters libpq itself also reads from the environment, so they can be
+# carried across rather than refused. Refusing them would be loud but wrong: a
+# hosted DSN routinely carries sslmode=require, and failing the migration run
+# over a parameter that has a perfectly good environment equivalent trades one
+# quiet defect for a noisy one. scripts/stack-psql.sh forwards exactly these
+# four into the container, so anything added here has to be added there too.
+QUERY_PARAM_ENV = {
+    "sslmode": "PGSSLMODE",
+    "options": "PGOPTIONS",
+    "connect_timeout": "PGCONNECT_TIMEOUT",
+    "application_name": "PGAPPNAME",
+}
+
 
 def libpq_env(libpq_dsn: str) -> dict[str, str]:
     """Split a libpq-safe DSN into the libpq environment variables.
@@ -322,9 +335,10 @@ def libpq_env(libpq_dsn: str) -> dict[str, str]:
     separate set of secrets, which after the self-hosted cutover pointed at a
     different database than the stack, and reported success either way.
 
-    A query parameter with no libpq environment equivalent is refused rather
-    than dropped. Silently losing, say, sslmode from a migration connection is
-    the same class of quiet difference this function exists to remove.
+    A query parameter that libpq also reads from the environment is carried
+    across as that variable. One with no equivalent is refused rather than
+    dropped: silently losing a connection parameter is the same class of quiet
+    difference this function exists to remove.
     """
     parts = urlsplit(normalize_scheme(libpq_dsn))
     host = parts.hostname
@@ -333,11 +347,14 @@ def libpq_env(libpq_dsn: str) -> dict[str, str]:
     dbname = parts.path.lstrip("/")
     if not dbname:
         raise ValueError(f"DSN has no database name: {libpq_dsn!r}")
-    leftover = [name for name, _ in parse_qsl(parts.query)]
+    # keep_blank_values, because `options=` is a real (if odd) instruction to
+    # send no options and dropping it would change the connection.
+    query = parse_qsl(parts.query, keep_blank_values=True)
+    leftover = sorted({name for name, _ in query if name not in QUERY_PARAM_ENV})
     if leftover:
         raise ValueError(
             f"DSN carries parameters with no libpq environment equivalent: "
-            f"{', '.join(sorted(leftover))}. Export the matching PG* variable "
+            f"{', '.join(leftover)}. Export the matching PG* variable "
             "explicitly instead of relying on this conversion, which would "
             "otherwise drop them silently"
         )
@@ -345,13 +362,27 @@ def libpq_env(libpq_dsn: str) -> dict[str, str]:
     # variables are raw values. Handing psql `p%40ss` as PGPASSWORD
     # authenticates as the literal string, which fails with a password error
     # that says nothing about encoding.
-    return {
+    env = {
         "PGHOST": host,
         "PGPORT": str(parts.port or SESSION_PORT),
         "PGUSER": unquote(parts.username or ""),
-        "PGDATABASE": dbname,
+        "PGDATABASE": unquote(dbname),
         "PGPASSWORD": unquote(parts.password or ""),
     }
+    # parse_qsl has already decoded these, so they are raw values like the rest.
+    for name, value in query:
+        env[QUERY_PARAM_ENV[name]] = value
+    # The caller appends these to $GITHUB_ENV, which is a line-oriented file, so
+    # a value carrying a newline would inject arbitrary variables into every
+    # later step of the job. A percent-encoded newline in a DSN decodes to a
+    # real one here, so this is reachable from the input rather than theoretical.
+    for name, value in sorted(env.items()):
+        if "\n" in value or "\r" in value:
+            raise ValueError(
+                f"{name} contains a newline, which cannot be exported safely "
+                "through a line-oriented environment file"
+            )
+    return env
 
 
 def build_dsn(host: str, port: str, user: str, dbname: str, password: str) -> str:
@@ -512,15 +543,34 @@ def self_test() -> int:
     # migrate job no longer needs a port-picking step of its own.
     assert libpq_env(derive(pooler)[2])["PGPORT"] == "6543", pooler
 
+    # A parameter libpq reads from the environment is carried across, not
+    # refused: a hosted DSN routinely carries sslmode, and failing the whole
+    # migration run over it would be loud and wrong.
+    ssl_env = libpq_env("postgresql://u:p@h:5432/postgres?sslmode=require")
+    assert ssl_env["PGSSLMODE"] == "require", ssl_env
+    opt_env = libpq_env(
+        "postgresql://u:p@h:5432/postgres?options=-c%20statement_timeout%3D3000"
+    )
+    assert opt_env["PGOPTIONS"] == "-c statement_timeout=3000", opt_env
+
     # A parameter with no libpq environment equivalent is refused, not dropped.
     try:
-        libpq_env("postgresql://u:p@h:5432/postgres?sslmode=require")
+        libpq_env("postgresql://u:p@h:5432/postgres?target_session_attrs=rw")
     except ValueError as err:
-        assert "sslmode" in str(err), err
+        assert "target_session_attrs" in str(err), err
     else:
         raise AssertionError("libpq_env silently dropped an unmapped parameter")
 
-    print("derive-pooler-dsn: self-test ok (59 assertions)")
+    # A newline anywhere in an emitted value is refused, because the caller
+    # appends these to a line-oriented environment file.
+    try:
+        libpq_env("postgresql://u:p%0aPGHOST%3Devil@h:5432/postgres")
+    except ValueError as err:
+        assert "newline" in str(err), err
+    else:
+        raise AssertionError("libpq_env emitted a value carrying a newline")
+
+    print("derive-pooler-dsn: self-test ok (64 assertions)")
     return 0
 
 

--- a/scripts/derive-pooler-dsn.py
+++ b/scripts/derive-pooler-dsn.py
@@ -90,7 +90,7 @@ from __future__ import annotations
 
 import argparse
 import sys
-from urllib.parse import parse_qsl, quote, urlencode, urlsplit, urlunsplit
+from urllib.parse import parse_qsl, quote, unquote, urlencode, urlsplit, urlunsplit
 
 # Supavisor's fixed port pair. Session mode is 5432 only: Supabase deprecated
 # session mode on 6543 in February 2025, so 6543 is unambiguously transaction
@@ -306,6 +306,54 @@ def derive(
     return session, transaction, without_params(transaction, *PGX_ONLY_PARAMS)
 
 
+# libpq's own names for what a DSN carries. psql is a libpq client and so are
+# apply-migrations.sh and check-retention-schedule.sh, both of which take their
+# connection from these variables and deliberately never parse a DSN.
+LIBPQ_ENV_ORDER = ("PGHOST", "PGPORT", "PGUSER", "PGDATABASE", "PGPASSWORD")
+
+
+def libpq_env(libpq_dsn: str) -> dict[str, str]:
+    """Split a libpq-safe DSN into the libpq environment variables.
+
+    This exists so a caller that must hand a script libpq variables, rather
+    than a DSN, still derives them from the one DSN the deployment actually
+    uses instead of assembling its own host and port from somewhere else. That
+    "somewhere else" is the whole defect: the migrate job used to read a
+    separate set of secrets, which after the self-hosted cutover pointed at a
+    different database than the stack, and reported success either way.
+
+    A query parameter with no libpq environment equivalent is refused rather
+    than dropped. Silently losing, say, sslmode from a migration connection is
+    the same class of quiet difference this function exists to remove.
+    """
+    parts = urlsplit(normalize_scheme(libpq_dsn))
+    host = parts.hostname
+    if not host:
+        raise ValueError(f"DSN has no host: {libpq_dsn!r}")
+    dbname = parts.path.lstrip("/")
+    if not dbname:
+        raise ValueError(f"DSN has no database name: {libpq_dsn!r}")
+    leftover = [name for name, _ in parse_qsl(parts.query)]
+    if leftover:
+        raise ValueError(
+            f"DSN carries parameters with no libpq environment equivalent: "
+            f"{', '.join(sorted(leftover))}. Export the matching PG* variable "
+            "explicitly instead of relying on this conversion, which would "
+            "otherwise drop them silently"
+        )
+    # urlsplit leaves the userinfo percent-encoded, and libpq environment
+    # variables are raw values. Handing psql `p%40ss` as PGPASSWORD
+    # authenticates as the literal string, which fails with a password error
+    # that says nothing about encoding.
+    return {
+        "PGHOST": host,
+        "PGPORT": str(parts.port or SESSION_PORT),
+        "PGUSER": unquote(parts.username or ""),
+        "PGDATABASE": dbname,
+        "PGPASSWORD": unquote(parts.password or ""),
+    }
+
+
 def build_dsn(host: str, port: str, user: str, dbname: str, password: str) -> str:
     return f"postgresql://{quote(user, safe='')}:{quote(password, safe='')}@{host}:{port}/{dbname}"
 
@@ -450,7 +498,29 @@ def self_test() -> int:
         assert "options=-c%20statement_timeout%3D3000" in flavour, flavour
         assert "+" not in urlsplit(flavour).query, flavour
 
-    print("derive-pooler-dsn: self-test ok (52 assertions)")
+    # --emit-libpq-env carries every component through, and decodes the
+    # password rather than handing psql a percent-encoded one.
+    _, _, direct_libpq = derive("postgres://postgres:p%40ss@supabase-db:5432/postgres")
+    env = libpq_env(direct_libpq)
+    assert env["PGHOST"] == "supabase-db", env
+    assert env["PGPORT"] == "5432", env
+    assert env["PGUSER"] == "postgres", env
+    assert env["PGDATABASE"] == "postgres", env
+    assert env["PGPASSWORD"] == "p@ss", env
+
+    # A pooler input lands on the transaction-mode port, which is why the
+    # migrate job no longer needs a port-picking step of its own.
+    assert libpq_env(derive(pooler)[2])["PGPORT"] == "6543", pooler
+
+    # A parameter with no libpq environment equivalent is refused, not dropped.
+    try:
+        libpq_env("postgresql://u:p@h:5432/postgres?sslmode=require")
+    except ValueError as err:
+        assert "sslmode" in str(err), err
+    else:
+        raise AssertionError("libpq_env silently dropped an unmapped parameter")
+
+    print("derive-pooler-dsn: self-test ok (59 assertions)")
     return 0
 
 
@@ -470,6 +540,15 @@ def main(argv: list[str]) -> int:
             "this consumer's share of the project's 15 session-mode slots "
             f"(default {DEFAULT_SESSION_MAX_CONNS}, the ephemeral budget; a "
             "long-lived deployment passes a larger one explicitly)"
+        ),
+    )
+    ap.add_argument(
+        "--emit-libpq-env",
+        action="store_true",
+        help=(
+            "print PGHOST/PGPORT/PGUSER/PGDATABASE/PGPASSWORD for the "
+            "transaction-mode libpq DSN instead of the three DSN lines, for a "
+            "caller that has to hand libpq variables to psql"
         ),
     )
     ap.add_argument("--self-test", action="store_true")
@@ -493,6 +572,23 @@ def main(argv: list[str]) -> int:
         session, transaction, libpq = derive(dsn, session_max_conns=args.session_max_conns)
     except ValueError as err:
         ap.error(str(err))
+    if args.emit_libpq_env:
+        try:
+            env = libpq_env(libpq)
+        except ValueError as err:
+            ap.error(str(err))
+        for name in LIBPQ_ENV_ORDER:
+            print(f"{name}={env[name]}")
+        # Host, port, user and database on stderr; never the password. Same
+        # split as the DSN path below, and for the same reason: a caller
+        # redirects stdout into $GITHUB_ENV and still wants a readable log.
+        print(
+            f"libpq env: PGHOST={env['PGHOST']} PGPORT={env['PGPORT']} "
+            f"PGUSER={env['PGUSER']} PGDATABASE={env['PGDATABASE']}",
+            file=sys.stderr,
+        )
+        return 0
+
     print(f"SUPABASE_DB_URL={session}")
     print(f"SUPABASE_DB_POOL_URL={transaction}")
     print(f"SUPABASE_DB_POOL_URL_LIBPQ={libpq}")

--- a/scripts/derive-pooler-dsn.py
+++ b/scripts/derive-pooler-dsn.py
@@ -89,6 +89,8 @@ values keep it. The cap still applies.
 from __future__ import annotations
 
 import argparse
+import contextlib
+import io
 import sys
 from urllib.parse import parse_qsl, quote, unquote, urlencode, urlsplit, urlunsplit
 
@@ -570,7 +572,30 @@ def self_test() -> int:
     else:
         raise AssertionError("libpq_env emitted a value carrying a newline")
 
-    print("derive-pooler-dsn: self-test ok (64 assertions)")
+    # The CLI, not just the function. libpq_env mapping a parameter is useless
+    # if main() does not print it: that gap shipped once in this very branch,
+    # because every assertion above stopped at the function boundary.
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        rc = main(
+            [
+                "--dsn",
+                "postgresql://u:pw@h.pooler.supabase.com:5432/postgres?sslmode=require",
+                "--emit-libpq-env",
+            ]
+        )
+    assert rc == 0, rc
+    emitted = dict(
+        line.split("=", 1) for line in buf.getvalue().splitlines() if "=" in line
+    )
+    for name in LIBPQ_ENV_ORDER:
+        assert name in emitted, emitted
+    assert emitted["PGSSLMODE"] == "require", emitted
+    # A pooler DSN must come out on the transaction-mode port through the CLI
+    # too, not only through derive().
+    assert emitted["PGPORT"] == "6543", emitted
+
+    print("derive-pooler-dsn: self-test ok (69 assertions)")
     return 0
 
 
@@ -628,6 +653,14 @@ def main(argv: list[str]) -> int:
         except ValueError as err:
             ap.error(str(err))
         for name in LIBPQ_ENV_ORDER:
+            print(f"{name}={env[name]}")
+        # Whatever libpq_env mapped out of the query string, which is not in the
+        # fixed five above. A set difference rather than a second literal list:
+        # printing only LIBPQ_ENV_ORDER was a real bug caught in review, where
+        # the mapping existed and the printer did not know about it, so a DSN
+        # carrying sslmode=require connected without it. Derived this way, a
+        # mapping added to QUERY_PARAM_ENV cannot be forgotten here.
+        for name in sorted(set(env) - set(LIBPQ_ENV_ORDER)):
             print(f"{name}={env[name]}")
         # Host, port, user and database on stderr; never the password. Same
         # split as the DSN path below, and for the same reason: a caller

--- a/scripts/stack-psql.sh
+++ b/scripts/stack-psql.sh
@@ -41,6 +41,13 @@
 # and fails loudly with "No such file or directory" rather than silently
 # reading the wrong file.
 #
+# `docker run -i` is required, because scripts/apply-migrations.sh pipes the
+# ledger DDL into psql on stdin. The cost is that this consumes the caller's
+# stdin, so a caller whose own stdin is something it still needs (a script fed
+# to `bash -s`, a `while read` loop reading a stream) must redirect it:
+# `scripts/stack-psql.sh ... </dev/null`. A GitHub Actions `run:` step gets
+# /dev/null already, which is why every caller in this repository is safe.
+#
 # Usage
 # -----
 #   scripts/stack-psql.sh -tAc 'SELECT 1'                 # libpq env vars

--- a/scripts/stack-psql.sh
+++ b/scripts/stack-psql.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# stack-psql.sh -- run psql against the database the demo box's stack actually
+# uses, from a host that cannot reach it directly.
+#
+# Why this exists
+# ---------------
+# Until the self-hosted Supabase cutover (PR #986) every database this repo's
+# workflows touched was a hosted Supavisor pooler on a public hostname, so
+# `psql` on the runner's own host resolved it and connected. The self-hosted
+# data plane has no published port at all (see docker-compose.enterprise.yml:
+# "No host port binding: all access is via the internal compose network"), and
+# its hostname `supabase-db` is a compose-network name. A host-side psql
+# therefore fails with
+#
+#     could not translate host name "supabase-db" to address: Name has no
+#     usable address
+#
+# which is exactly how the deploy job's model-catalog price assertion broke on
+# the first deploy after the cutover. That step already ran psql in a container
+# (`docker run --rm postgres:16-alpine psql ...`), but on the default bridge
+# network, where the name does not resolve either.
+#
+# This is the single place that answers "how does a command on the box reach
+# that database". Every caller goes through it rather than inventing its own
+# docker invocation, because a second invocation is a second answer, and the
+# one that is wrong fails in a way that reads like a broken database.
+#
+# What it does
+# ------------
+# Runs the official psql client in a throwaway container attached to the
+# stack's compose network, with the repository bind-mounted read-only at its
+# own absolute path so an absolute `-f /path/to/migration.sql` resolves to the
+# same file inside. libpq environment variables are passed through, so callers
+# keep using PGHOST/PGPORT/PGUSER/PGDATABASE/PGPASSWORD and no DSN is built
+# here (DSN parameters are per-driver, and a pgx-only parameter in a libpq
+# value is rejected outright; that mistake has already crash-looped a
+# container).
+#
+# The container's working directory is the repository root, not the caller's.
+# Pass absolute paths to `-f`. A relative one resolves against the repo root
+# and fails loudly with "No such file or directory" rather than silently
+# reading the wrong file.
+#
+# Usage
+# -----
+#   scripts/stack-psql.sh -tAc 'SELECT 1'                 # libpq env vars
+#   scripts/stack-psql.sh "$SUPABASE_DB_POOL_URL_LIBPQ" -tAc 'SELECT 1'
+#   PSQL_BIN=scripts/stack-psql.sh scripts/apply-migrations.sh
+#
+# HIVE_STACK_NETWORK overrides the network. Its default is derived, not
+# guessed: docker-compose.enterprise.yml pins `name: hive`, and compose names
+# a project's implicit network `<project>_default`. scripts/
+# test_selfhost_supabase_seam.py fails if that project name changes without
+# this default following it.
+
+set -euo pipefail
+
+network="${HIVE_STACK_NETWORK:-hive_default}"
+# Same client the deploy job has been using for this query all along. Not
+# pinned by digest deliberately: it is a throwaway client that reads nothing
+# from the image but the psql binary, and a stale pin here would be one more
+# thing to chase when the server moves.
+image="${HIVE_PSQL_IMAGE:-postgres:16-alpine}"
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if ! docker network inspect "$network" >/dev/null 2>&1; then
+  echo "stack-psql: docker network '$network' does not exist, so there is no stack to reach." >&2
+  echo "stack-psql: bring the stack up first, or set HIVE_STACK_NETWORK to the right network." >&2
+  docker network ls --format '  {{.Name}}' >&2
+  exit 1
+fi
+
+# Unset variables are simply not forwarded by `-e NAME`, so listing them all is
+# safe whether or not the caller exported them.
+exec docker run --rm -i \
+  --network "$network" \
+  --volume "$repo_root:$repo_root:ro" \
+  --workdir "$repo_root" \
+  -e PGHOST -e PGPORT -e PGUSER -e PGDATABASE -e PGPASSWORD \
+  -e PGSSLMODE -e PGOPTIONS -e PGCONNECT_TIMEOUT -e PGAPPNAME \
+  "$image" psql "$@"

--- a/scripts/test_selfhost_supabase_seam.py
+++ b/scripts/test_selfhost_supabase_seam.py
@@ -28,6 +28,16 @@ when broken:
   * Open WebUI's pgvector DSN comes from the libpq flavour, never the pgx one.
     A pgx-only parameter in a libpq DSN fails the whole connection, which is
     what killed a container and took chat down for fifty minutes.
+  * migrations run somewhere that can actually reach the stack's database, and
+    prove they reached THAT database. The data plane publishes no host port, so
+    a GitHub-hosted runner cannot reach it at all, yet the migrate job reported
+    success anyway by connecting to the hosted project the old secrets still
+    named. Nothing went red; the database the application reads simply stopped
+    receiving schema changes.
+  * every psql in the deploy workflow goes through scripts/stack-psql.sh, whose
+    default network is the compose project's own. A second, hand-rolled
+    `docker run` lands on the default bridge network, where the data plane's
+    hostname does not resolve, and the failure reads as a broken database.
 
 Every one of those fails silently, or fails somewhere far from its cause, so
 each gets an assertion here. No framework, no docker daemon, no network: this
@@ -396,6 +406,135 @@ def test_no_deploy_step_spells_its_own_compose_flags() -> None:
     # workflow having no invocations at all.
     used = DEPLOY_TEXT.count("$HIVE_COMPOSE_FLAGS")
     assert used >= 4, f"only {used} steps use the shared definition"
+
+
+def _job_block(name: str) -> str:
+    """The text of one job in the deploy workflow.
+
+    Job keys sit at two-space indent and every line inside a job is deeper than
+    that, so the next two-space key is the end of this job.
+    """
+    match = re.search(
+        rf"^  {re.escape(name)}:\n(.*?)(?=^  [A-Za-z0-9_-]+:\s*$|\Z)",
+        DEPLOY_TEXT,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert match, f"deploy-demo-box.yml has no job named {name}"
+    return match.group(1)
+
+
+def _step_block(job_text: str, step_name: str) -> str:
+    """The text of one step, by its `name:`."""
+    match = re.search(
+        rf"^      - name: {re.escape(step_name)}\n(.*?)(?=^      - (?:name|uses):|\Z)",
+        job_text,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert match, f"no step named {step_name!r}"
+    return match.group(1)
+
+
+def test_migrations_run_where_the_stacks_database_is_reachable() -> None:
+    """The data plane binds no host port, so nothing outside the compose network
+    can reach it. A migrate job on a GitHub-hosted runner therefore cannot
+    apply anything to the database this deployment uses, and the failure is
+    invisible: the SUPABASE_DB_* secrets still named a reachable hosted project,
+    so the job applied every migration there and reported success while the
+    live database drifted.
+
+    Both halves are asserted. Running on the box is not enough on its own if the
+    old secret set is still what names the target, and dropping the secrets is
+    not enough if the job still runs where it cannot connect."""
+    block = _job_block("migrate")
+    assert "runs-on: [self-hosted, hive-demo]" in block, block[:200]
+    assert "ubuntu-latest" not in block, "the migrate job cannot reach the data plane from a hosted runner"
+    for name in (
+        "SUPABASE_DB_HOST",
+        "SUPABASE_DB_PORT",
+        "SUPABASE_DB_USER",
+        "SUPABASE_DB_NAME",
+        "SUPABASE_DB_PASSWORD",
+    ):
+        assert f"secrets.{name}" not in block, (
+            f"the migrate job reads secrets.{name}, which names a database "
+            "independently of the one the stack uses"
+        )
+    assert "SUPABASE_DB_URL" in block, (
+        "the migrate job must derive its target from the value the stack itself "
+        "connects with"
+    )
+
+
+def test_the_migration_target_is_asserted_to_be_the_stacks_database() -> None:
+    """An identity assertion, not a comment. system_identifier comes from initdb
+    and is unique per cluster, so two connections that agree on it are talking
+    to the same server.
+
+    What makes it able to fail is that the two sides are named by unrelated
+    inputs: the target by SUPABASE_DB_URL out of the box's .env, the stack by
+    compose project resolution of the running container. Assert both sides are
+    still independent, and that an empty answer from either fails rather than
+    comparing equal to the other empty answer."""
+    block = _job_block("migrate")
+    step = _step_block(block, "Assert the migration target is the database this stack uses")
+    assert "pg_control_system()" in step, step
+    assert '"$PSQL_BIN"' in step, "the target side must connect the way the migration does"
+    assert "exec -T supabase-db" in step, "the stack side must come from the running container"
+    assert 'if [ "$target" != "$stack" ]' in step, step
+    # One exit for the mismatch and one for each way a side can come back empty.
+    assert step.count("exit 1") >= 4, (
+        "an empty result on either side must fail too, not compare equal to the "
+        "other empty result"
+    )
+    live = [
+        line for line in block.splitlines() if not line.strip().startswith("#")
+    ]
+    assert not any("continue-on-error:" in line for line in live), (
+        "the assertion cannot be advisory"
+    )
+
+
+def test_no_deploy_step_reaches_the_database_without_the_wrapper() -> None:
+    """scripts/stack-psql.sh is the single answer to "how does a command on the
+    box reach the stack's database". The deploy job's price assertion already
+    ran psql in a container and still broke, because that container was on the
+    default bridge network where `supabase-db` does not resolve. A second
+    hand-rolled invocation is that failure again, and it reads as a broken
+    database rather than as a wiring mistake.
+
+    The one exemption is psql run INSIDE the database container itself, which
+    needs no network at all."""
+    folded = re.sub(r"\\\n\s*", " ", DEPLOY_TEXT)
+    offenders = []
+    for line in folded.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#") or "psql" not in stripped:
+            continue
+        if "stack-psql.sh" in stripped or "PSQL_BIN" in stripped:
+            continue
+        if "docker compose" in stripped and "exec -T supabase-db" in stripped:
+            continue
+        offenders.append(stripped)
+    assert not offenders, offenders
+    # And the wrapper is genuinely reached, so this cannot pass by the workflow
+    # having stopped talking to the database at all.
+    assert DEPLOY_TEXT.count("stack-psql.sh") >= 2, DEPLOY_TEXT.count("stack-psql.sh")
+
+
+def test_the_wrapper_default_network_is_the_compose_project_network() -> None:
+    """The wrapper's default network is derived, not guessed: compose names a
+    project's implicit network `<project>_default`. Renaming the project without
+    following it here would put every psql on a network with no database on it,
+    and the error would name a hostname rather than a project."""
+    wrapper = (ROOT / "scripts" / "stack-psql.sh").read_text()
+    match = re.search(r"HIVE_STACK_NETWORK:-([A-Za-z0-9_.-]+)", wrapper)
+    assert match, "stack-psql.sh has no HIVE_STACK_NETWORK default"
+    project = project_name(ENT_TEXT)
+    assert project, "docker-compose.enterprise.yml declares no project name"
+    assert match.group(1) == f"{project}_default", (
+        f"wrapper defaults to {match.group(1)!r} but the compose project is "
+        f"{project!r}, whose default network is {project}_default"
+    )
 
 
 def main() -> int:

--- a/scripts/test_selfhost_supabase_seam.py
+++ b/scripts/test_selfhost_supabase_seam.py
@@ -481,11 +481,23 @@ def test_the_migration_target_is_asserted_to_be_the_stacks_database() -> None:
     assert '"$PSQL_BIN"' in step, "the target side must connect the way the migration does"
     assert "exec -T supabase-db" in step, "the stack side must come from the running container"
     assert 'if [ "$target" != "$stack" ]' in step, step
-    # One exit for the mismatch and one for each way a side can come back empty.
-    assert step.count("exit 1") >= 4, (
-        "an empty result on either side must fail too, not compare equal to the "
-        "other empty result"
+    # Not a count of `exit 1`, which a later change that adds guards inflates
+    # until turning one guard advisory no longer trips it. That is exactly what
+    # happened here once: the threshold version of this assertion passed with
+    # the empty-target guard mutated to `exit 0`. The invariant is per message:
+    # every ::error:: in this step aborts.
+    messages = re.findall(r"::error::", step)
+    aborting = re.findall(r'echo "::error::[^\n]*"\n\s*exit 1\n', step)
+    assert messages, step
+    assert len(aborting) == len(messages), (
+        f"{len(messages) - len(aborting)} of the {len(messages)} error messages "
+        "in the identity step do not abort, so the step reports a mispointed "
+        "database and carries on"
     )
+    # And both sides still have an emptiness guard of their own, so the step
+    # cannot be reduced to the mismatch comparison alone, where two empty
+    # answers compare equal.
+    assert len(re.findall(r"returned no system_identifier", step)) >= 2, step
     live = [
         line for line in block.splitlines() if not line.strip().startswith("#")
     ]
@@ -516,9 +528,24 @@ def test_no_deploy_step_reaches_the_database_without_the_wrapper() -> None:
             continue
         offenders.append(stripped)
     assert not offenders, offenders
-    # And the wrapper is genuinely reached, so this cannot pass by the workflow
-    # having stopped talking to the database at all.
-    assert DEPLOY_TEXT.count("stack-psql.sh") >= 2, DEPLOY_TEXT.count("stack-psql.sh")
+    # And the wrapper is genuinely EXECUTED, not merely mentioned. Counting
+    # occurrences in the whole file counts the comments explaining it, so that
+    # count stays high while both real invocations are deleted.
+    migrate = _job_block("migrate")
+    assert re.search(
+        r"^      PSQL_BIN: \$\{\{ github\.workspace \}\}/scripts/stack-psql\.sh\s*$",
+        migrate,
+        re.MULTILINE,
+    ), "the migrate job does not point PSQL_BIN at the wrapper"
+    price = _step_block(
+        _job_block("deploy"),
+        "Assert model catalog prices agree with the model LiteLLM will call",
+    )
+    assert re.search(
+        r"^\s*rows=\$\(\.\./\.\./scripts/stack-psql\.sh\b",
+        price,
+        re.MULTILINE,
+    ), "the price assertion does not run the wrapper"
 
 
 def test_the_wrapper_default_network_is_the_compose_project_network() -> None:
@@ -535,6 +562,23 @@ def test_the_wrapper_default_network_is_the_compose_project_network() -> None:
         f"wrapper defaults to {match.group(1)!r} but the compose project is "
         f"{project!r}, whose default network is {project}_default"
     )
+
+
+def test_the_wrapper_forwards_every_parameter_the_deriver_maps() -> None:
+    """derive-pooler-dsn.py turns a DSN query parameter into a PG* variable, and
+    scripts/stack-psql.sh is what carries PG* variables into the container. A
+    variable mapped by one and not forwarded by the other is dropped in
+    silence: the connection still opens, just without the sslmode or the
+    statement timeout the DSN asked for."""
+    deriver = (ROOT / "scripts" / "derive-pooler-dsn.py").read_text()
+    block = re.search(r"QUERY_PARAM_ENV = \{(.*?)\}", deriver, re.DOTALL)
+    assert block, "derive-pooler-dsn.py has no QUERY_PARAM_ENV mapping"
+    mapped = set(re.findall(r'"(PG[A-Z_]+)"', block.group(1)))
+    assert mapped, block.group(1)
+    wrapper = (ROOT / "scripts" / "stack-psql.sh").read_text()
+    forwarded = set(re.findall(r"-e (PG[A-Z_]+)", wrapper))
+    missing = mapped - forwarded
+    assert not missing, f"stack-psql.sh does not forward {sorted(missing)}"
 
 
 def main() -> int:


### PR DESCRIPTION
Fixes the two ways `deploy-demo-box.yml` was talking to the wrong database after the self-hosted Supabase cutover (#986). One of them was loud. The other reported success.

## The loud one: nothing on the box could reach the data plane

`deploy` step "Assert model catalog prices agree with the model LiteLLM will call" failed with

```
psql: error: could not translate host name "supabase-db" to address: Name has no usable address
```

That step already ran psql in a container, but with a bare `docker run --rm postgres:16-alpine`, so the container landed on the default bridge network. `docker-compose.enterprise.yml` says it in its own comment: "No host port binding: all access is via the internal compose network". The hostname is a compose-network name and resolves nowhere else.

Treated as a class, not as one step. Every command on the box that needs the stack's database now goes through `scripts/stack-psql.sh`, which runs the same client in a throwaway container attached to the stack's network, bind-mounts the repository read-only at its own absolute path so an absolute `-f /path/migration.sql` still resolves, and passes libpq variables through. One mechanism, three call sites, and `test_no_deploy_step_reaches_the_database_without_the_wrapper` fails the build if a fourth invents its own.

Host-side steps audited across the whole workflow, and what each turned out to be:

| Step | Reaches | Verdict |
| --- | --- | --- |
| `deploy` / Assert model catalog prices | `supabase-db` via `docker run` psql | **Broken. Fixed** by routing through the wrapper. |
| `deploy` / Derive the pooler DSN split | nothing, it only parses a string | No connection, unaffected. |
| `deploy` / Verify the chat-origin Caddy config, Install hive_jwt_forward | `http://localhost:3003` | caddy-owui publishes `3003:80`. Reachable from the host. |
| `deploy` / Sync LiteLLM model list | `http://localhost:8081` | edge-api publishes `8081:8081`. Reachable. |
| `deploy` / Assert model catalog prices (LiteLLM half) | `http://localhost:4000` | litellm publishes `4000:4000`. Reachable. |
| `deploy` / Smoke test public hostnames | `https://*-hive.scubed.co` | Public, through the tunnel. Reachable. |
| `deploy` / Caddy admin API | `127.0.0.1:2019` inside the container, via `compose exec` | Already in-network. |
| `migrate` / everything | see below | **Wrong database entirely. Fixed.** |

`supabase-db` is the only service in the stack with no published port, which is why it is the only one that broke.

## The silent one: `migrate` was applying to Supabase Cloud

`migrate` ran on `ubuntu-latest` against the `SUPABASE_DB_*` secrets. The self-hosted database is unreachable from any GitHub-hosted runner, so it cannot have been the target, and the job still reported success and printed that nightly metering retention was scheduled and active. Those secrets still name a reachable Supabase Cloud project, so that is where every pending migration went. Nothing was red in either world; success was the only output the job had.

Three consequences, all silent: future migrations land on the project that is about to be deleted, the live database drifts, and no signal exists for either.

What changed:

* `migrate` now runs on `[self-hosted, hive-demo]`, so it is on the network the database exists on.
* psql is still not installed on the box and there is still no passwordless sudo to install it. Solved rather than wished away: the job sets `PSQL_BIN=scripts/stack-psql.sh` and every psql call in `apply-migrations.sh` and `check-retention-schedule.sh` goes through it. `bash`, `python3` and `sha256sum`, the other things those scripts need, are already on the host.
* The target is no longer a parallel secret set. It comes from the same `SUPABASE_DB_URL` in the box's `.env` that control-plane connects with, converted to libpq variables by a new `scripts/derive-pooler-dsn.py --emit-libpq-env`. That mode maps the four query parameters libpq also reads from the environment, refuses any other rather than dropping it, refuses a value carrying a newline (which would inject variables into `$GITHUB_ENV`), and lands a pooler host on the transaction-mode port, which is why the old port-picking step is deleted rather than kept.
* A new step **asserts identity before anything is applied**. `pg_control_system().system_identifier` is generated by initdb and unique per cluster. The migration connection's value must equal what the running `supabase-db` container reports over its own local socket. The two sides are named by unrelated inputs (a DSN out of `.env` versus compose project resolution, with the role and database read out of the container's own environment), so the comparison can genuinely fail. A failure to connect, a failure to reach the container, and an empty answer from either side are three separate reported outcomes, none of which compares equal to the other empty answer.
* `migrate` starts `supabase-db` first, with no `--remove-orphans` and no other service. Without it, a box whose stack is down could not deploy the fix for its stack being down: migrate would fail on an unreachable database and the `needs:` edge would stop the deploy.

## Mutation testing

Every check here was made to fail on purpose. Nineteen structural mutations against the guards, nine runtime proofs on the box itself. All three rounds are listed, including the one that came back green and the bug the third round's reviewers found in the second round's fix.

Structural, against `scripts/test_selfhost_supabase_seam.py` and `scripts/derive-pooler-dsn.py --self-test`:

| # | Mutation | Result |
| --- | --- | --- |
| M1 | `migrate` back to `runs-on: ubuntu-latest` | RED |
| M2 | reintroduce `secrets.SUPABASE_DB_HOST` in `migrate` | RED, "names a database independently of the one the stack uses" |
| M3 | delete the identity-assertion step | RED, "no step named ..." |
| M4 | let an empty `system_identifier` pass (`exit 1` becomes `exit 0`) | **GREEN on the first attempt.** See below. RED after the guard was rewritten. |
| M5 | price step back to a hand-rolled `docker run ... psql` | RED, offender listed |
| M6 | wrapper default network drifts to `hive-default` | RED, names the project and the network it should be |
| M7 | boundary probe, not a mutation: does `_job_block("migrate")` swallow the `deploy` job? | It does not. 189 lines, containing neither "Pull latest main" nor "Prune build cache". Stated rather than omitted: this one stayed green because the regex is correct, which is a defensible green rather than a hidden one. |
| M8 | `libpq_env` stops URL-decoding the password | RED, `PGPASSWORD` came back `p%40ss` |
| M9 | `libpq_env` silently drops an unmapped parameter | RED |
| M10 | `sslmode` removed from the parameter mapping | RED, refusal message names it |
| M11 | the `$GITHUB_ENV` newline guard replaced with `if False` | RED |
| M12 | `migrate` stops pointing `PSQL_BIN` at the wrapper | RED |
| M13 | price step stops executing the wrapper while the comments still mention it | RED |
| M14 | wrapper stops forwarding `-e PGSSLMODE` while the deriver still maps it | RED, "stack-psql.sh does not forward ['PGSSLMODE']" |
| M15 | the mismatch guard itself made advisory (`exit 0`) | RED, "1 of the 7 error messages ... do not abort" |
| M16 | the stack-side emptiness guard deleted outright | RED |
| M17 | `libpq_env`'s newline guard replaced with `if False`, then `make test-scripts` run the way the required CI job runs it | RED, `make: *** [Makefile:36: test-scripts] Error 1` |
| M18 | the CLI's second print loop deleted, reintroducing the parameter-drop bug Greptile found | RED, `KeyError: 'PGSSLMODE'` |
| M19 | the pooler branch made unreachable so a pooler DSN keeps port 5432 through the CLI | RED |

**Where these guards actually run, since a guard nothing invokes is the same as no guard.** `scripts/test_selfhost_supabase_seam.py` is already run on every non-docs pull request by `make test-scripts` in ci.yml's `repo-policy-lints` job, which is a required check, so the five structural guards added here do gate a PR. `scripts/derive-pooler-dsn.py --self-test` did **not**: it was invoked only from `deploy-demo-box.yml`, `owui-nightly.yml` and `agent-visual-proof.yml`, all of which run after a merge or on a schedule. Its 64 assertions cover the parsing that now decides which database the migration connects to, so a PR could have broken the password decoding, the parameter mapping or the `$GITHUB_ENV` newline guard with nothing red until the change was already on main and deploying. It is now in the same target, and M17 proves that target goes red.

**M4 is the one worth reading.** Its first version asserted `step.count("exit 1") >= 4`. Fixing an unrelated `pipefail` problem in the same step (see the review threads) added guards, which inflated that count until turning the empty-target guard into `exit 0` no longer tripped the threshold. The mutation was run and it passed. The assertion is now per message: every `::error::` in the step must be immediately followed by `exit 1`, plus a floor of two emptiness guards so the step cannot be reduced to the mismatch comparison alone. M4, M15 and M16 all go red against the rewritten version. A threshold on a count of a thing that a later change adds more of is not a check; it is a check with an expiry date.

Runtime, on the demo box against the live stack, read-only, nothing applied and nothing restarted, re-run against the final commit:

| # | Check | Result |
| --- | --- | --- |
| R1 | wrapper on the stack network | `rc=0`, cluster `7675489800166150182` |
| R2 | wrapper forced onto the default bridge network | `rc=2`, and the error is verbatim the original failure: `could not translate host name "supabase-db" to address: Name has no usable address`. The `--network` flag is load bearing, proven rather than asserted. |
| R3 | wrapper pointed at a network that does not exist | `rc=1`, names the variable and lists the networks that do exist |
| R4 | `apply-migrations.sh --dry-run` through `PSQL_BIN` | `rc=0`, "no pending migrations (88 files, all recorded)" |
| R5 | same with no `PSQL_BIN`, so plain host psql | `rc=1`, `psql: command not found`. Loud, not silent. |
| R6 | `check-retention-schedule.sh` through `PSQL_BIN` | `rc=0`, and see the finding below |
| R7 | identity assertion, matching case | `target=stack=7675489800166150182`, pass |
| R8 | identity assertion with the migration connection pointed at a different cluster on the same network | `target=7676343025276125224` against `stack=7675489800166150182`, mismatch, would refuse the deploy |
| R9 | does `up -d supabase-db` disturb the live container? | `--dry-run` reports only "Container hive-supabase-db-1 Running". No recreate, no restart. |

## Review rounds, and the bug the second round introduced

Three rounds, eight findings, all real, all fixed, all threads resolved.

Round one, before the PR was marked ready: CodeRabbit CLI (1 major, 1 minor) plus a plain adversarial pass (1 high security, 2 high correctness, 1 low). `ecc:code-review`'s checklist produced nothing unique to itself and is folded into that pass. `/codex:adversarial-review` was **SKIPPED**, stated rather than quietly omitted: the diff is CI wiring plus two shell scripts and one Python helper, touching no auth, money or input-parsing path in the product, so the mandatory-security-review trigger does not fire.

Round two, after ready, from the PR's own bots: Greptile P1 and CodeRabbit major.

**Greptile's P1 was a bug I introduced in round one's own fix**, which is the most useful thing to come out of this review. Round one taught `libpq_env` to map `sslmode`, `options`, `connect_timeout` and `application_name` into `PG*` variables instead of refusing them. It did not teach `main()` to print them: that loop iterated a fixed five-name tuple, so the four were computed and then dropped before reaching `$GITHUB_ENV`. A DSN carrying `sslmode=require` would have connected without it. The same silent drop the refusal logic existed to prevent, moved one function along. It shipped because every assertion in the self-test stopped at the `libpq_env` function boundary and the CLI path had no coverage at all; the self-test now drives `main()` itself. Fixed as a set difference against the fixed five rather than a second literal list, so the next mapping cannot be forgotten there either.

CodeRabbit's major was the missing `.github/actionlint.yaml` entry for the `hive-demo` runner label. Added, with one correction recorded in the thread: this repository runs no actionlint job, so nothing in CI was failing. The `migrate` job's new `runs-on` simply gave the same unknown-label false positive a second home, and a linter that always reports one finding is a linter whose real findings get skipped.

Process note, recorded in both threads rather than hidden: my batch resolver auto-resolved those two threads before I had read them. That was wrong. Both were read, both were valid, both are fixed, and each thread carries the reply saying so.

## Two findings this immediately surfaced

**Nightly metering retention is not scheduled on the self-hosted database.** R6 returns "the pg_cron extension is not installed on this database, so 20260729_02 skipped `cron.schedule`". The old job printed "scheduled and active" because it was reading the cloud project, where the extension exists. This is the fix working as intended: a false green becomes a true warning on the first run. `pgvector/pgvector:pg16` ships no pg_cron and it is not in `shared_preload_libraries`. Issue #615 already tracks this; the step is deliberately advisory and does not block the deploy.

**`scripts/check-env-supabase-target.py` exists and is wired into nothing.** Deliberately left unwired here, because running it against the box's current `.env` exits non-zero: it reports the data plane as coherently self-hosted, then fails on an unrelated finding, that `S3_ACCESS_KEY` and `S3_SECRET_KEY` hold the same value, which discloses the secret in every SigV4 `Authorization` header. Wiring it as a gate today would block every deploy on that. Worth its own issue and its own fix; not this PR.

## Latent state of the other two jobs

Both were `skipped` in the failing run because `deploy` failed, so neither had been exercised since the cutover.

**`sdk-replay`** (`ubuntu-latest`): clean. It talks only to `https://api-hive.scubed.co/v1` with `HIVE_API_KEY`, so its target is the box by construction and it touches no database and no Supabase credential. No change needed.

**`agent-workspace-coverage`** (`ubuntu-latest`): latently mispointed, but it fails loudly rather than silently, and it is `workflow_dispatch`-only pending #881 and #886. It mints a session through `live-auth.mjs` against `secrets.SUPABASE_URL` with `secrets.SUPABASE_SERVICE_ROLE_KEY`, which is the Supabase Cloud project. The box's `SUPABASE_JWT_ISSUER` and `SUPABASE_JWKS_URL` are now self-hosted values, so control-plane will reject a cloud-issued token outright and the probe fails at sign-in. A real break to fix before the job is re-enabled, but a visible one, gated behind two open issues, so it is left out of this PR rather than half-fixed inside it. Same shape and worth noting while it is in view: `owui-nightly.yml` and `agent-visual-proof.yml` both reconstruct a DSN from `secrets.SUPABASE_DB_*` and would query or migrate the cloud project too.

## Buglog entry

```json
{"id":"BUG-2026-08-21-01","date":"2026-08-21","title":"deploy-demo-box migrated Supabase Cloud while the box ran self-hosted, and reported success","error_message":"psql: error: could not translate host name \"supabase-db\" to address: Name has no usable address (deploy job); migrate job green while applying nothing to the live database","root_cause":"Two host-side assumptions survived the self-hosted Supabase cutover. The deploy job's price assertion ran psql in a container on the default bridge network, where the data plane's compose-network hostname does not resolve. The migrate job ran on a GitHub-hosted runner against an independent SUPABASE_DB_* secret set, which still named a reachable Supabase Cloud project, so it applied migrations there and reported success while the database the application reads received nothing. Neither job had any way to notice which database it was talking to.","fix":"Added scripts/stack-psql.sh as the single way a command on the box reaches the stack's database, a throwaway psql container on the compose network with the repo bind-mounted at its own path. Routed the price assertion and both migration scripts through it via PSQL_BIN. Moved the migrate job onto the self-hosted runner, derived its connection from the same SUPABASE_DB_URL the stack uses via a new derive-pooler-dsn.py --emit-libpq-env, and added an identity assertion comparing pg_control_system().system_identifier against the running supabase-db container before anything is applied. Five structural guards in test_selfhost_supabase_seam.py keep the wiring from regressing.","tags":["ci","deploy","supabase","selfhost","silent-failure","migrations","docker-network"]}
```

## Test plan

- [x] `python3 scripts/test_selfhost_supabase_seam.py` (17 checks, was 12)
- [x] `python3 scripts/derive-pooler-dsn.py --self-test` (69 assertions, was 52), now also run on pull requests through `make test-scripts`
- [x] `bash -n` on every `run:` block in the workflow, and on all three shell scripts
- [x] YAML parses, five jobs resolve, `migrate` has the expected seven steps
- [x] nineteen structural mutations, nine runtime proofs on the box (tables above)
- [x] adversarial review, three streams plus two PR bots, eight findings, all fixed, all threads resolved
- [x] `Migration applier tests` on this PR, which exercises `apply-migrations.sh` with `PSQL_BIN` unset against a throwaway Postgres, proving the default path is unchanged. Passed on this PR
- [ ] the deploy run on merge, the only thing that can exercise `migrate` on the self-hosted runner end to end

No UI surface is touched, so no visual proof applies.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR moves database migration work onto the demo box and routes host-side PostgreSQL access through the stack’s Docker network, ensuring migrations and deployment checks target the self-hosted database.
- Derives migration credentials from the stack’s own `SUPABASE_DB_URL`.
- Verifies the migration connection and running container share the same PostgreSQL cluster identity.
- Adds a reusable network-aware `psql` wrapper and routes migration, retention, and catalog checks through it.
- Preserves mapped libpq query parameters through environment emission and container forwarding.
- Adds structural and parser tests to guard the deployment seam.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

The previously reported libpq emission failure is fixed, and no blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/deploy-demo-box.yml | Moves migration execution to the self-hosted runner, derives the live stack connection, verifies cluster identity, and consistently uses the network-aware PostgreSQL wrapper. |
| scripts/derive-pooler-dsn.py | Adds libpq environment emission that preserves all supported query parameters and rejects unsupported or newline-bearing values. |
| scripts/stack-psql.sh | Provides the shared PostgreSQL client path on the compose network while forwarding core and optional libpq environment variables. |
| scripts/apply-migrations.sh | Supports the configurable PostgreSQL executable used by the self-hosted migration workflow without changing the default client path. |
| scripts/check-retention-schedule.sh | Uses the same configurable PostgreSQL executable so retention checks query the database actually migrated. |
| scripts/test_selfhost_supabase_seam.py | Adds structural checks for runner placement, target identity verification, wrapper use, and mapped libpq variable forwarding. |
| Makefile | Adds the DSN parser’s self-test to the repository script-test target. |
| .github/actionlint.yaml | Declares the repository’s custom self-hosted runner label for local and third-party actionlint runs. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix: emit the libpq parameters libpq\_env..."](https://github.com/sakibsadmanshajib/hive/commit/06903d43d5592e3c053926f060146d58ba89e22b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55445651)</sub>

<!-- /greptile_comment -->