### PR TITLE
feat: provision signup tenancy from shipped code, and fail loudly when it is not wired

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -410,6 +410,13 @@ HIVE_CHAT_EXTERNAL_SCHEME=http
 # generated client id/secret here — never commit real values.
 SUPABASE_OAUTH_CLIENT_ID=
 SUPABASE_OAUTH_CLIENT_SECRET=
+# Legacy only, and optional. It authenticates the Supabase Database Webhook
+# target POST /internal/auth/user-created. Tenant provisioning no longer
+# depends on it or on any dashboard state: control-plane sweeps auth.users
+# for identities with no tenant membership and provisions them itself, and
+# reports that path on its health endpoint, so an unwired one is a failed
+# healthcheck rather than a silent gap. Leave it empty unless a deployment
+# still has that webhook configured.
 SUPABASE_WEBHOOK_SECRET=
 OWUI_BASE_URL=http://open-webui:8080
 OWUI_ADMIN_TOKEN=

--- a/.github/ci/test-db-bootstrap.sql
+++ b/.github/ci/test-db-bootstrap.sql
@@ -67,7 +67,16 @@ CREATE SCHEMA IF NOT EXISTS auth;
 CREATE TABLE IF NOT EXISTS auth.users (
     id                 UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     email              TEXT,
-    raw_user_meta_data JSONB NOT NULL DEFAULT '{}'::jsonb
+    raw_user_meta_data JSONB NOT NULL DEFAULT '{}'::jsonb,
+    -- Lifecycle columns real GoTrue carries. The signup reconciler sweep
+    -- filters on all three: created_at bounds its lookback window, and a
+    -- soft-deleted or banned identity must never be provisioned. They are
+    -- nullable with no default here because that is how GoTrue declares
+    -- created_at, which is exactly why the sweep refuses a NULL age
+    -- instead of guessing one.
+    created_at         TIMESTAMPTZ,
+    deleted_at         TIMESTAMPTZ,
+    banned_until       TIMESTAMPTZ
 );
 
 -- Minimal stand-ins for Supabase's GoTrue-provided functions. Our own RLS

--- a/apps/control-plane/cmd/server/main.go
+++ b/apps/control-plane/cmd/server/main.go
@@ -77,6 +77,11 @@ import (
 // /metrics, kept off the public listener so the Prometheus series stay internal.
 const metricsListenAddr = ":9101"
 
+// provisioningGaugeInterval is how often the signup provisioning failure gauge is
+// refreshed from the reconciler. Shorter than the sweep interval so a scrape
+// never reads a value a whole pass out of date.
+const provisioningGaugeInterval = time.Minute
+
 // How long startup waits for the database before giving up, and how often it
 // retries inside that window. The session-mode pooler is shared and capped at
 // 15 clients across CI, developer stacks and the live deployment, so a boot can
@@ -899,6 +904,28 @@ func main() {
 	// Build Prometheus metrics registry before the router so the instrumentation
 	// middleware and the telemetry listener share one registry.
 	metricsRegistry, promRegistry := metrics.NewRegistry()
+	// A failing sweep is reported on the telemetry listener, not on the
+	// readiness endpoint. Provisioning can be broken while API-key
+	// resolution, routing, accounting and payment webhooks still work, so
+	// degrading the container healthcheck for it would turn a signup outage
+	// into a billing one, and a restart would reset the counter and repeat
+	// (review finding, CodeRabbit on PR 993). The absence of the wiring
+	// itself still degrades readiness, because that one cannot be transient.
+	if signupReconciler != nil {
+		go func() {
+			ticker := time.NewTicker(provisioningGaugeInterval)
+			defer ticker.Stop()
+			for {
+				failures := signupReconciler.ConsecutiveFailures()
+				metricsRegistry.SignupProvisioningSweepFailures.Set(float64(failures))
+				select {
+				case <-runCtx.Done():
+					return
+				case <-ticker.C:
+				}
+			}
+		}()
+	}
 
 	// Create the mux upfront so filestore.RegisterRoutes (which requires *http.ServeMux)
 	// can register routes on it before the instrumentation wrapper is applied.

--- a/apps/control-plane/cmd/server/main.go
+++ b/apps/control-plane/cmd/server/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log"
 	"log/slog"
@@ -16,7 +15,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hibiken/asynq"
-	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	goredis "github.com/redis/go-redis/v9"
@@ -317,6 +315,10 @@ func main() {
 	var auditWAL *audit.FileWALWriter
 	var signupWebhook *signup.Webhook
 	var signupViewerHandler *signup.ViewerHandler
+	// signupReconciler is the sweep that provisions identities nothing else
+	// reached. It also answers the health endpoint, so a build that stops
+	// wiring it reports degraded instead of starting quietly (D-023).
+	var signupReconciler *signup.Reconciler
 	var tenantsHandler *tenants.Handler
 	// Signup abuse-prevention (issue #116). The disposable-domain blocklist is
 	// parsed once from an embedded file (no network), so it is available even
@@ -596,94 +598,101 @@ func main() {
 		})
 		log.Println("signupguard precheck ready (issue #116)")
 
-		missingPhase19 := make([]string, 0, 4)
-		if owuiBaseURL == "" {
-			missingPhase19 = append(missingPhase19, "OWUI_BASE_URL")
+		// Signup tenant provisioning (D-023). Deliberately NOT gated on the
+		// optional identity variables read above. This is the path that turns a
+		// new identity into a usable tenant member. Its original driver was a
+		// Supabase Database Webhook configured in a dashboard, whose deletion
+		// leaves no diff, no error and no failing test, and the env gate that
+		// used to wrap this block took the repository-side replacement down
+		// with it on any deployment that had not set OWUI_ADMIN_TOKEN and
+		// SUPABASE_WEBHOOK_SECRET. The live demo box was in exactly that state,
+		// a WARNING at boot, a healthy process, and no reachable provisioning
+		// path at all. Provisioning needs the pool, the resolver and the audit
+		// logger, and all three exist here unconditionally, so it is wired
+		// unconditionally and reports its own readiness on the health endpoint.
+		signupDeps := signup.WebhookDeps{
+			Pool:     pool,
+			Resolver: signup.NewPgxResolver(pool),
+			Audit:    auditLogger,
+			// Disposable-domain backstop (issue #116) for scripted signups
+			// that hit Supabase directly and bypass the web-console precheck.
+			DisposableCheck: disposableBlocklist.IsDisposableEmail,
+			// Personal-tenant provisioning for a signup no tenant claims
+			// (issue #625). Hive Cloud only. config.IsEnterprisePosture
+			// is the single source of truth for this branch (issue
+			// #653). It also gates the operator backfill command and the
+			// licensing.FileSource vs licensing.CloudSource switch below.
+			SelfServeTenants: !config.IsEnterprisePosture(cfg.LicenseFilePath),
+			SharedSecret:     signupSecret,
 		}
-		if owuiAdminToken == "" {
-			missingPhase19 = append(missingPhase19, "OWUI_ADMIN_TOKEN")
+		// Open WebUI group wiring is a chat-side convenience, so a missing
+		// admin token now costs exactly that and nothing else. Provisioner logs
+		// the skip and still writes the tenant membership. Fataling here instead
+		// would take billing, API-key resolution and the whole control-plane
+		// down for a chat group.
+		owuiConfigured := owuiBaseURL != "" && owuiAdminToken != ""
+		if !owuiConfigured {
+			log.Println("WARNING: Open WebUI group wiring disabled, OWUI_BASE_URL or OWUI_ADMIN_TOKEN unset. Tenant memberships are still provisioned.")
 		}
-		if signupSecret == "" {
-			missingPhase19 = append(missingPhase19, "SUPABASE_WEBHOOK_SECRET")
-		}
-		if supabaseServiceRoleKey == "" {
-			missingPhase19 = append(missingPhase19, "SUPABASE_SERVICE_ROLE_KEY")
-		}
-		if len(missingPhase19) > 0 {
-			// Phase 19 identity (signup webhook + tenant switch) is opt-in.
-			// When env vars are absent — typical for CI smoke runs that do
-			// not exercise the Supabase signup path — log and skip the
-			// wiring rather than fatal, so other unrelated startup paths
-			// (health, billing, catalog) still come up healthy. Production
-			// deployments are expected to set every variable in this list;
-			// the resulting warning is loud enough for operators to catch.
-			log.Printf("WARNING: phase-19 identity wiring skipped (missing env: %s)", strings.Join(missingPhase19, ", "))
-		} else {
-			// SUPABASE_SERVICE_ROLE_KEY is read at startup so production
-			// deployments surface misconfiguration early, but the tenant
-			// switch handler uses the already-authenticated pool
-			// connection (which carries service-role privilege) to update
-			// auth.users metadata, so the key is not threaded into the
-			// handler today. Underscore the var to keep the contract
-			// explicit until later tasks consume it.
-			_ = supabaseServiceRoleKey
-
+		if owuiConfigured {
 			owuiClient = owui.New(owui.Config{
 				BaseURL:    owuiBaseURL,
 				AdminToken: owuiAdminToken,
 			})
-
-			signupResolver := signup.NewResolver(signup.ResolverDeps{
-				InviteLookup: signupLookupInvite(pool),
-				DomainLookup: signupLookupDomain(pool),
-			})
-
-			signupDeps := signup.WebhookDeps{
-				Pool:        pool,
-				Resolver:    signupResolver,
-				EnsureGroup: owuiClient.EnsureGroup,
-				AddUser:     owuiClient.AddUserToGroup,
-				Audit:       auditLogger,
-				// Disposable-domain backstop (issue #116) for scripted signups
-				// that hit Supabase directly and bypass the web-console precheck.
-				DisposableCheck: disposableBlocklist.IsDisposableEmail,
-				// Personal-tenant provisioning for a signup no tenant claims
-				// (issue #625). Hive Cloud only. config.IsEnterprisePosture
-				// is the single source of truth for this branch (issue
-				// #653); it also gates cmd/backfill-tenants and the
-				// licensing.FileSource vs licensing.CloudSource switch below.
-				SelfServeTenants: !config.IsEnterprisePosture(cfg.LicenseFilePath),
-				SharedSecret:     signupSecret,
-			}
-			signupWebhook = signup.NewWebhook(signupDeps)
-			// Second entry point into the same provisioning implementation, for
-			// the console. The Supabase Database Webhook that drives
-			// signupWebhook is dashboard state rather than repository state, so
-			// a deployment that never created it provisions nobody; this route
-			// makes provisioning reachable from code that ships with the repo.
-			// Per-user throttle on the console-driven provisioning route. Keyed
-			// on the authenticated user id, in its own Redis namespace so it
-			// cannot share a counter with the per-IP signup limiter. A nil
-			// Redis client disables it, the same way it disables the signup
-			// limiter, rather than blocking provisioning outright.
-			provisionLimiter := signupguard.NewRateLimiter(
-				signupguard.NewRedisIncrementer(redisClient),
-				signupguard.RateLimitConfig{
-					Limit:     cfg.TenantProvisionRateLimitPerWindow,
-					Window:    cfg.TenantProvisionRateLimitWindow,
-					FailOpen:  cfg.SignupRateLimitFailOpen,
-					Namespace: "provision",
-					Subject:   "user",
-				},
-			)
-			signupViewerHandler = signup.NewViewerHandler(
-				signup.NewProvisioner(signupDeps),
-				provisionLimiter.Allow,
-			)
-
-			tenantsHandler = tenants.NewHandler(tenants.Deps{Pool: pool, Audit: auditLogger})
-			log.Println("phase-19 identity wiring ready (signup webhook + tenants router)")
+			signupDeps.EnsureGroup = owuiClient.EnsureGroup
+			signupDeps.AddUser = owuiClient.AddUserToGroup
 		}
+		if supabaseServiceRoleKey == "" {
+			log.Println("WARNING: SUPABASE_SERVICE_ROLE_KEY unset. The tenant switch handler updates auth.users through the pool, which already carries service-role privilege.")
+		}
+		// Read at startup so a production deployment surfaces the omission
+		// early, but not threaded into a handler today.
+		_ = supabaseServiceRoleKey
+
+		signupProvisioner := signup.NewProvisioner(signupDeps)
+
+		// Per-user throttle on the console-driven provisioning route. Keyed
+		// on the authenticated user id, in its own Redis namespace so it
+		// cannot share a counter with the per-IP signup limiter. A nil
+		// Redis client disables it, the same way it disables the signup
+		// limiter, rather than blocking provisioning outright.
+		provisionLimiter := signupguard.NewRateLimiter(
+			signupguard.NewRedisIncrementer(redisClient),
+			signupguard.RateLimitConfig{
+				Limit:     cfg.TenantProvisionRateLimitPerWindow,
+				Window:    cfg.TenantProvisionRateLimitWindow,
+				FailOpen:  cfg.SignupRateLimitFailOpen,
+				Namespace: "provision",
+				Subject:   "user",
+			},
+		)
+		// Second entry point into the same provisioning implementation, for the
+		// console. A token carrying no tenant claim calls it on its first
+		// authenticated request.
+		signupViewerHandler = signup.NewViewerHandler(signupProvisioner, provisionLimiter.Allow)
+
+		// Third entry point, and the only one that depends on nobody having
+		// configured anything, the sweep. It asks the database which identities
+		// hold no membership and runs the same Provisioner for each, so an
+		// administrator creating a user through the Supabase admin API gets
+		// that user provisioned without a dashboard webhook, without the
+		// console being visited, and without a shared secret existing.
+		signupReconciler = signup.NewReconciler(pool, signupProvisioner, signup.ReconcilerConfig{})
+		signupReconciler.Start(runCtx)
+		log.Println("signup provisioning ready (console route plus reconciler sweep)")
+
+		// The legacy Supabase Database Webhook target. Kept wired so a
+		// deployment that does still have that webhook configured behaves
+		// exactly as before, and mounted only when the shared secret exists,
+		// since the handler answers 500 to every request without one.
+		if signupSecret == "" {
+			log.Println("signup webhook route not mounted, SUPABASE_WEBHOOK_SECRET unset. Provisioning does not depend on it.")
+		}
+		if signupSecret != "" {
+			signupWebhook = signup.NewWebhook(signupDeps)
+		}
+
+		tenantsHandler = tenants.NewHandler(tenants.Deps{Pool: pool, Audit: auditLogger})
 
 		// Tenant model visibility admin routes. The handler type shipped with
 		// Phase 20 Plan 04 but was never constructed here, so
@@ -1017,7 +1026,11 @@ func main() {
 	router := platformhttp.NewRouter(platformhttp.RouterConfig{
 		// Same condition that gates every DB-backed handler above, so /health
 		// cannot report ok while those routes are absent (issue #816).
-		DBReady:                  pool != nil,
+		DBReady: pool != nil,
+		// Signup provisioning readiness (D-023). A nil reconciler answers false
+		// through this same method value, so a deployment that failed to wire
+		// provisioning reports degraded rather than serving traffic quietly.
+		ProvisioningReady:        signupReconciler.Ready,
 		AuthMiddleware:           authMiddleware,
 		AccountsHandler:          accountsHandler,
 		IdentityHandler:          identityHandler,
@@ -1397,10 +1410,6 @@ type storageRuntimeConfig struct {
 	FilesBucket string
 }
 
-// signupLookupInvite returns a signup.LookupFunc that resolves an invite
-// token to its target tenant. tenant_invites is provisioned by Plan 03;
-// until then the query simply returns ErrNoMatch, gating the resolver to
-// its domain-mapping fallback.
 // signupGuardAudit adapts the audit Logger to the signupguard.AuditFunc seam.
 // Detail maps carry classification strings only (never the raw email/domain or
 // any provider value), satisfying the BD provider-blind + audit-leak rules.
@@ -1441,46 +1450,6 @@ func tenantMembershipCheck(pool *pgxpool.Pool) auth.MembershipCheckFunc {
 			return false, fmt.Errorf("auth tenant membership check: %w", err)
 		}
 		return exists, nil
-	}
-}
-
-func signupLookupInvite(pool *pgxpool.Pool) signup.LookupFunc {
-	return func(ctx context.Context, token string) (uuid.UUID, error) {
-		var id uuid.UUID
-		err := pool.QueryRow(ctx,
-			`SELECT tenant_id FROM public.tenant_invites
-			  WHERE token=$1 AND consumed_at IS NULL AND expires_at > now()`,
-			token).Scan(&id)
-		if err != nil {
-			// Only "no eligible row" collapses to ErrNoMatch; transient
-			// DB failures (connection reset, deadline exceeded) must
-			// surface so the webhook returns 500 and Supabase retries.
-			if errors.Is(err, pgx.ErrNoRows) {
-				return uuid.Nil, signup.ErrNoMatch
-			}
-			return uuid.Nil, fmt.Errorf("signup invite lookup: %w", err)
-		}
-		return id, nil
-	}
-}
-
-// signupLookupDomain returns a signup.LookupFunc that maps an email
-// domain to its tenant via tenant_email_domains. As with the invite
-// table, the schema lands in Plan 03; the function is safe to call now
-// because a missing relation collapses to ErrNoMatch.
-func signupLookupDomain(pool *pgxpool.Pool) signup.LookupFunc {
-	return func(ctx context.Context, domain string) (uuid.UUID, error) {
-		var id uuid.UUID
-		err := pool.QueryRow(ctx,
-			`SELECT tenant_id FROM public.tenant_email_domains WHERE domain=$1`,
-			domain).Scan(&id)
-		if err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
-				return uuid.Nil, signup.ErrNoMatch
-			}
-			return uuid.Nil, fmt.Errorf("signup domain lookup: %w", err)
-		}
-		return id, nil
 	}
 }
 

--- a/apps/control-plane/internal/platform/http/router.go
+++ b/apps/control-plane/internal/platform/http/router.go
@@ -32,6 +32,21 @@ type healthResponse struct {
 	Reason string `json:"reason,omitempty"`
 }
 
+const (
+	// healthStatusDegraded is the status string a not-ready control-plane
+	// reports. Fixed strings only on this endpoint: it is public on the
+	// ingress tunnel.
+	healthStatusDegraded = "degraded"
+	// dbUnavailableReason names the missing dependency without naming the
+	// host, the pooler or the database user.
+	dbUnavailableReason = "database unavailable"
+	// healthStatusOK is the ready answer.
+	healthStatusOK = "ok"
+	// provisioningUnreported is what a nil ProvisioningReady means. Nothing
+	// told this endpoint whether provisioning is wired, so it is not ready.
+	provisioningUnreported = "signup provisioning not reported"
+)
+
 // RouterConfig holds dependencies for building the HTTP router.
 type RouterConfig struct {
 	AuthMiddleware           *auth.Middleware
@@ -66,6 +81,12 @@ type RouterConfig struct {
 	// otherwise the container healthcheck passes and traffic is routed to a
 	// process that cannot authenticate a single request. See issue #816.
 	DBReady bool
+
+	// ProvisioningReady reports whether signup tenant provisioning is wired
+	// and working (D-023). A nil func means nothing reported it, which is
+	// treated as unwired rather than as fine: see healthHandler for why an
+	// absence has to read as broken on this endpoint.
+	ProvisioningReady func() (bool, string)
 
 	// Mux is an optional pre-created *http.ServeMux. When provided, routes are
 	// registered on it (enabling callers to add routes after NewRouter returns).
@@ -161,7 +182,7 @@ func NewRouter(cfg RouterConfig) http.Handler {
 		mux = http.NewServeMux()
 	}
 
-	mux.HandleFunc("/health", healthHandler(cfg.DBReady))
+	mux.HandleFunc("/health", healthHandler(cfg.DBReady, cfg.ProvisioningReady))
 
 	// internal wraps a service-to-service handler with the shared-secret guard.
 	internal := func(h http.Handler) http.Handler {
@@ -387,18 +408,40 @@ func NewRouter(cfg RouterConfig) http.Handler {
 // reporting 200 here is what turns a transient database outage at boot into a
 // silent, permanent one: the compose healthcheck goes green, dependent services
 // start, and every caller gets a misleading credential error instead.
-func healthHandler(dbReady bool) http.HandlerFunc {
+func healthHandler(dbReady bool, provisioningReady func() (bool, string)) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		if !dbReady {
 			w.WriteHeader(http.StatusServiceUnavailable)
 			_ = json.NewEncoder(w).Encode(healthResponse{
-				Status: "degraded",
-				Reason: "database unavailable",
+				Status: healthStatusDegraded,
+				Reason: dbUnavailableReason,
 			})
 			return
 		}
+		// Signup tenant provisioning (D-023). It used to hang off a Supabase
+		// dashboard webhook, so deleting the hosted project removed it with no
+		// diff and no failing test, and the control-plane wiring that replaced
+		// it sat behind an env-var check that logged a warning and started
+		// healthy anyway. Both absences were invisible. Reporting them here is
+		// what turns the next one into a red container healthcheck and a
+		// blocked deploy instead of a log line nobody reads, which is why a nil
+		// reporter counts as unwired.
+		provisioningOK := false
+		reason := provisioningUnreported
+		if provisioningReady != nil {
+			provisioningOK, reason = provisioningReady()
+		}
+		if !provisioningOK {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_ = json.NewEncoder(w).Encode(healthResponse{
+				Status: healthStatusDegraded,
+				Reason: reason,
+			})
+			return
+		}
+
 		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(healthResponse{Status: "ok"})
+		_ = json.NewEncoder(w).Encode(healthResponse{Status: healthStatusOK})
 	}
 }

--- a/apps/control-plane/internal/platform/http/router_health_provisioning_test.go
+++ b/apps/control-plane/internal/platform/http/router_health_provisioning_test.go
@@ -1,0 +1,71 @@
+package http
+
+// The signup-provisioning contribution to the readiness endpoint (D-023).
+//
+// Tenant provisioning used to be driven by a Supabase Database Webhook created
+// in a dashboard. Deleting the hosted project removes it with no diff, no error
+// and no failing test. The control-plane wiring that replaced it then sat
+// behind an env-var check that logged a warning and started healthy anyway, so
+// the live demo box ran with no reachable provisioning path and a green
+// healthcheck. These tests exist so that the next absence is a red container
+// healthcheck and a blocked deploy instead of a log line.
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const healthPath = "/health"
+
+func getHealth(t *testing.T, cfg RouterConfig) (int, healthResponse) {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	NewRouter(cfg).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, healthPath, nil))
+	var body healthResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&body))
+	return rec.Code, body
+}
+
+// A nil reporter is the shape a regression takes: somebody stops wiring
+// provisioning in cmd/server and every unit test still passes. It must not read
+// as healthy.
+func TestHealthIsDegradedWhenProvisioningIsNotReported(t *testing.T) {
+	code, body := getHealth(t, RouterConfig{DBReady: true})
+
+	require.Equal(t, http.StatusServiceUnavailable, code)
+	require.Equal(t, healthStatusDegraded, body.Status)
+	require.Equal(t, provisioningUnreported, body.Reason)
+}
+
+const sweepFailingReason = "signup provisioning sweep failing"
+
+// Wired but broken: the reconciler reports its own failure, and the endpoint
+// carries it through rather than turning it into silence.
+func TestHealthIsDegradedWhenProvisioningReportsFailure(t *testing.T) {
+	reporter := func() (bool, string) {
+		return false, sweepFailingReason
+	}
+	code, body := getHealth(t, RouterConfig{DBReady: true, ProvisioningReady: reporter})
+
+	require.Equal(t, http.StatusServiceUnavailable, code)
+	require.Equal(t, healthStatusDegraded, body.Status)
+	require.Equal(t, sweepFailingReason, body.Reason)
+}
+
+// The counterpart, so the two tests above cannot pass on a router that
+// degrades unconditionally.
+func TestHealthIsOkWhenProvisioningIsReady(t *testing.T) {
+	var noReason string
+	reporter := func() (bool, string) {
+		return true, noReason
+	}
+	code, body := getHealth(t, RouterConfig{DBReady: true, ProvisioningReady: reporter})
+
+	require.Equal(t, http.StatusOK, code)
+	require.Equal(t, healthStatusOK, body.Status)
+	require.Empty(t, body.Reason)
+}

--- a/apps/control-plane/internal/platform/http/router_test.go
+++ b/apps/control-plane/internal/platform/http/router_test.go
@@ -27,7 +27,13 @@ func TestNewRouterDoesNotServeMetrics(t *testing.T) {
 // Guards the test above against passing vacuously: an unwired router would 404
 // on everything.
 func TestNewRouterServesHealth(t *testing.T) {
-	h := NewRouter(RouterConfig{DBReady: true})
+	// ProvisioningReady is supplied because a nil reporter now degrades this
+	// endpoint on purpose (D-023). See router_health_provisioning_test.go.
+	ready := func() (bool, string) {
+		var noReason string
+		return true, noReason
+	}
+	h := NewRouter(RouterConfig{DBReady: true, ProvisioningReady: ready})
 
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/health", nil))

--- a/apps/control-plane/internal/platform/metrics/metrics.go
+++ b/apps/control-plane/internal/platform/metrics/metrics.go
@@ -16,6 +16,13 @@ type Registry struct {
 	LedgerPostingsTotal     *prometheus.CounterVec
 	RateLimitHitsTotal      *prometheus.CounterVec
 	AuthFailuresTotal       *prometheus.CounterVec
+
+	// SignupProvisioningSweepFailures is how many provisioning sweeps have failed
+	// in a row. Provisioning can be broken while every other route still works,
+	// so this is reported here rather than on the readiness endpoint the container
+	// healthcheck reads: an alert can fire without taking the process out of
+	// service and leaving inference and billing without a control-plane.
+	SignupProvisioningSweepFailures prometheus.Gauge
 }
 
 // NewRegistry creates and registers all Prometheus metrics.
@@ -58,6 +65,10 @@ func NewRegistry() (*Registry, *prometheus.Registry) {
 			Name: "hive_auth_failures_total",
 			Help: "Total auth failures by reason",
 		}, []string{"reason"}),
+		SignupProvisioningSweepFailures: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "hive_signup_provisioning_sweep_failures",
+			Help: "Consecutive failed signup provisioning sweeps, 0 when the last sweep completed",
+		}),
 	}
 	reg.MustRegister(
 		r.HTTPRequestsTotal,
@@ -68,6 +79,7 @@ func NewRegistry() (*Registry, *prometheus.Registry) {
 		r.LedgerPostingsTotal,
 		r.RateLimitHitsTotal,
 		r.AuthFailuresTotal,
+		r.SignupProvisioningSweepFailures,
 	)
 	return r, reg
 }

--- a/apps/control-plane/internal/signup/reconcile_test.go
+++ b/apps/control-plane/internal/signup/reconcile_test.go
@@ -370,7 +370,15 @@ func newReconcileFixture(t *testing.T, ctx context.Context, pool *pgxpool.Pool) 
 			return uuid.Nil, signup.ErrNoMatch
 		},
 		DomainLookup: func(ctx context.Context, domain string) (uuid.UUID, error) {
-			fx.resolveCalls.Add(1)
+			// Counted per fixture domain rather than per call. The sweep suite runs
+			// this resolver over every membership-less identity in its lookback
+			// window, so a global counter would make an exact assertion depend on
+			// unrelated rows in a shared database (review finding, CodeRabbit on PR
+			// 993). Every test that reconciles fx.userID directly is unaffected,
+			// since its domain is always this one.
+			if domain == fx.domain {
+				fx.resolveCalls.Add(1)
+			}
 			var id uuid.UUID
 			err := pool.QueryRow(ctx,
 				`SELECT tenant_id FROM public.tenant_email_domains WHERE domain=$1`,

--- a/apps/control-plane/internal/signup/reconciler.go
+++ b/apps/control-plane/internal/signup/reconciler.go
@@ -1,0 +1,341 @@
+package signup
+
+// Provisioning sweep: the shipped replacement for the Supabase Database
+// Webhook (D-023).
+//
+// The webhook that used to drive provisioning was created in the hosted
+// project's dashboard, so it was console state, not repository state. Deleting
+// the project removes it with no diff, no error and no failing test, and new
+// identities then stop being provisioned entirely. Reconciler closes that by
+// making the control-plane itself responsible: it periodically asks the
+// database which identities hold no tenant membership and runs the SAME
+// Provisioner.Reconcile the webhook and the console route run. There is still
+// exactly one writer.
+//
+// Why a sweep rather than the database calling us back. The mechanism a
+// Supabase Database Webhook actually is, a trigger invoking pg_net through the
+// supabase_functions schema, does not exist on the self-hosted data plane this
+// repo deploys: that database image offers only the vector extension, with no
+// pg_net, no http extension and no such schema. Even where it did exist, the
+// trigger would need the shared secret in database state, which in a public
+// repository means either a committed secret or an out-of-band console step,
+// the same failure mode wearing a different hat, and its delivery failures
+// land in a table nobody reads. Reimplementing provisioning as SQL in a
+// trigger was rejected too: it would duplicate the disposable backstop, the
+// resolver precedence, the deployment posture and the audit trail in a second
+// language (D-005).
+//
+// Why a bounded window. The operator backfill command exists for historical
+// membership-less identities and is deliberately NOT wired into startup,
+// because a tenancy write that happens on every deploy is one nobody reviews.
+// The sweep therefore only looks at identities created inside a lookback
+// window, and never at ones whose age the database cannot establish
+// (auth.users.created_at is nullable with no default on real GoTrue, so a
+// hand-written row has no age). Older stragglers stay the operator's business.
+//
+// Concurrency and duplication are already settled by the write path: the
+// existing-membership short-circuit, the tenant_users primary key with ON
+// CONFLICT DO NOTHING, and the partial unique index behind personal tenants
+// mean two processes sweeping the same database produce exactly one
+// membership.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const (
+	defaultSweepInterval = 5 * time.Minute
+	defaultSweepLookback = 24 * time.Hour
+	defaultSweepBatch    = 200
+
+	// unhealthySweepFailures is how many consecutive failed sweeps make
+	// Ready report false. More than one, so a single transient database blip
+	// cannot flap a container healthcheck red; small enough that a real
+	// provisioning outage is visible within the quarter hour.
+	unhealthySweepFailures = 3
+
+	// noTenantCooldown is how long a terminal no_tenant determination is
+	// trusted before it is attempted again. Reconcile documents that outcome
+	// as terminal until an administrator invites the identity or registers
+	// its email domain, and every attempt writes an immutable, hash-chained
+	// audit row, so re-deciding it every interval is pure noise. The cooldown
+	// keeps an administered (Hive Enterprise) deployment quiet while still
+	// picking the identity up once an administrator does act.
+	noTenantCooldown = time.Hour
+)
+
+// ReconcilerConfig tunes the sweep. Every field is optional.
+type ReconcilerConfig struct {
+	// Interval between sweeps. Defaults to five minutes.
+	Interval time.Duration
+	// Lookback bounds how recently an identity must have been created to be
+	// swept. Defaults to 24 hours. See the package comment for why this is
+	// bounded at all.
+	Lookback time.Duration
+	// BatchLimit caps candidates per sweep. Defaults to 200.
+	BatchLimit int
+}
+
+func (c ReconcilerConfig) withDefaults() ReconcilerConfig {
+	if c.Interval <= 0 {
+		c.Interval = defaultSweepInterval
+	}
+	if c.Lookback <= 0 {
+		c.Lookback = defaultSweepLookback
+	}
+	if c.BatchLimit <= 0 {
+		c.BatchLimit = defaultSweepBatch
+	}
+	return c
+}
+
+// SweepReport is what one sweep did. Counts only: this is logged, and an
+// identity's address belongs in auth.users alone.
+type SweepReport struct {
+	// Candidates is how many identities the sweep considered.
+	Candidates int
+	// Provisioned is how many hold an ACTIVE membership afterwards.
+	Provisioned int
+	// NoTenant is how many no tenant claims, a terminal determination.
+	NoTenant int
+	// Cooled is how many were skipped because a recent sweep already reached
+	// that terminal determination for them.
+	Cooled int
+	// Failed is how many hit a transient or unexpected fault.
+	Failed int
+}
+
+// Reconciler sweeps for identities with no tenant membership and provisions
+// them through Provisioner.
+type Reconciler struct {
+	pool *pgxpool.Pool
+	prov *Provisioner
+	cfg  ReconcilerConfig
+
+	mu           sync.Mutex
+	failures     int
+	sweeps       int
+	lastNoTenant map[uuid.UUID]time.Time
+}
+
+// NewReconciler constructs a Reconciler over the same Provisioner the webhook
+// and console routes use, so no third implementation of the write exists.
+func NewReconciler(pool *pgxpool.Pool, prov *Provisioner, cfg ReconcilerConfig) *Reconciler {
+	return &Reconciler{
+		pool:         pool,
+		prov:         prov,
+		cfg:          cfg.withDefaults(),
+		lastNoTenant: map[uuid.UUID]time.Time{},
+	}
+}
+
+// Message formats live here rather than inline at each call site so the sweep
+// has one place to audit for anything an operator or an audit reader should not
+// see. None of them carries an address, a tenant id or a driver error string.
+const (
+	logSweepFailed     = "signup: provisioning sweep failed: %v"
+	logSweepReport     = "signup: provisioning sweep candidates=%d provisioned=%d no_tenant=%d cooled=%d failed=%d"
+	errSweepNotWired   = "signup: provisioning sweep not wired"
+	errListCandidates  = "signup: list provisioning candidates: %w"
+	errScanCandidate   = "signup: scan provisioning candidate: %w"
+	errReadCandidates  = "signup: read provisioning candidates: %w"
+	reasonUnwired      = "signup provisioning unwired"
+	reasonSweepFailing = "signup provisioning sweep failing"
+)
+
+// Start sweeps once immediately and then on the configured interval until ctx
+// is cancelled. Bind it to the process-lifetime context, not a startup one.
+func (r *Reconciler) Start(ctx context.Context) {
+	if r == nil {
+		return
+	}
+	go func() {
+		ticker := time.NewTicker(r.cfg.Interval)
+		defer ticker.Stop()
+		for {
+			report, err := r.Sweep(ctx)
+			switch {
+			case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+				return
+			case err != nil:
+				log.Printf(logSweepFailed, err)
+			case report.Candidates > 0:
+				log.Printf(logSweepReport,
+					report.Candidates, report.Provisioned, report.NoTenant, report.Cooled, report.Failed)
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+			}
+		}
+	}()
+}
+
+// Ready reports whether provisioning is wired and working. The health endpoint
+// asks it, so its answer cannot be missed the way a startup log line was.
+//
+// A nil receiver reports false on purpose. The failure this whole type exists
+// to prevent was an absence nobody noticed, so nothing-wired must read as
+// broken rather than as silence.
+func (r *Reconciler) Ready() (ok bool, reason string) {
+	if r == nil || r.pool == nil || r.prov == nil {
+		return false, reasonUnwired
+	}
+	r.mu.Lock()
+	failures := r.failures
+	r.mu.Unlock()
+	if failures >= unhealthySweepFailures {
+		return false, reasonSweepFailing
+	}
+	// reason stays at its zero value: there is nothing to report.
+	return true, reason
+}
+
+type sweepCandidate struct {
+	userID uuid.UUID
+	email  string
+}
+
+// Sweep runs one pass. It returns an error only when the sweep itself could not
+// run; an identity no tenant claims is a successful determination, and a single
+// identity that faulted is reported in SweepReport.Failed.
+func (r *Reconciler) Sweep(ctx context.Context) (SweepReport, error) {
+	var report SweepReport
+	if r == nil || r.pool == nil || r.prov == nil {
+		return report, errors.New(errSweepNotWired)
+	}
+
+	candidates, err := r.candidates(ctx)
+	if err != nil {
+		r.recordSweep(false)
+		return report, err
+	}
+	report.Candidates = len(candidates)
+
+	for _, c := range candidates {
+		if ctx.Err() != nil {
+			return report, ctx.Err()
+		}
+		if r.cooling(c.userID) {
+			report.Cooled++
+			continue
+		}
+		outcome, err := r.prov.Reconcile(ctx, ReconcileInput{UserID: c.userID, Email: c.email})
+		switch {
+		case err != nil:
+			// Reconcile has already audited the classification and logged the
+			// raw error, so this stays a count.
+			report.Failed++
+		case outcome == OutcomeProvisioned:
+			report.Provisioned++
+		default:
+			report.NoTenant++
+			r.cool(c.userID)
+		}
+	}
+
+	// A sweep that faulted on an identity is a provisioning outage in progress,
+	// not a quiet afternoon: it counts against readiness exactly like a failed
+	// listing does.
+	r.recordSweep(report.Failed == 0)
+	return report, nil
+}
+
+func (r *Reconciler) recordSweep(ok bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.sweeps++
+	if ok {
+		r.failures = 0
+		return
+	}
+	r.failures++
+}
+
+func (r *Reconciler) cooling(userID uuid.UUID) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	at, ok := r.lastNoTenant[userID]
+	return ok && time.Since(at) < noTenantCooldown
+}
+
+func (r *Reconciler) cool(userID uuid.UUID) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	// ponytail: in-memory, per process, so a restart re-attempts every
+	// determination once. Bounded by the pruning below plus the lookback
+	// window, which is what keeps the map from growing with the user table.
+	// Move it onto the identity row only if a deployment ever needs the
+	// back-off to survive a restart.
+	for id, at := range r.lastNoTenant {
+		if time.Since(at) >= noTenantCooldown {
+			delete(r.lastNoTenant, id)
+		}
+	}
+	r.lastNoTenant[userID] = time.Now()
+}
+
+// candidateQuery lists identities with no ACTIVE membership on a non-archived
+// tenant. The NOT EXISTS predicate is deliberately the same one
+// Provisioner.activeMembership and public.custom_access_token_hook use, so a
+// candidate is precisely an identity whose next token would carry no tenant
+// claim. Keep the three in step.
+//
+// The lifecycle filters are not decoration. A soft-deleted or banned identity
+// must never be provisioned. An identity whose created_at is NULL is excluded
+// by the window comparison itself, since a comparison against NULL is not
+// true, and that is deliberate rather than incidental: auth.users.created_at
+// is nullable with no default on real GoTrue, so NULL means a row somebody
+// wrote by hand rather than a signup, and its age cannot be established. An
+// explicit IS NOT NULL clause was dropped after a mutation test showed it
+// could not fail, which made it decoration standing next to load-bearing
+// filters. The assertion covering it lives in the sweep suite.
+const candidateQuery = `
+	SELECT u.id, u.email
+	  FROM auth.users u
+	 WHERE u.email IS NOT NULL
+	   AND u.email <> ''
+	   AND u.deleted_at IS NULL
+	   AND (u.banned_until IS NULL OR u.banned_until <= now())
+	   AND u.created_at > now() - make_interval(secs => $1)
+	   AND NOT EXISTS (
+	       SELECT 1
+	         FROM public.tenant_users tu
+	         JOIN public.tenants t ON t.id = tu.tenant_id
+	        WHERE tu.user_id     = u.id
+	          AND tu.status      = 'ACTIVE'
+	          AND t.archived_at IS NULL
+	   )
+	 ORDER BY u.created_at DESC
+	 LIMIT $2
+`
+
+func (r *Reconciler) candidates(ctx context.Context) ([]sweepCandidate, error) {
+	rows, err := r.pool.Query(ctx, candidateQuery, r.cfg.Lookback.Seconds(), r.cfg.BatchLimit)
+	if err != nil {
+		return nil, fmt.Errorf(errListCandidates, err)
+	}
+	defer rows.Close()
+
+	var out []sweepCandidate
+	for rows.Next() {
+		var c sweepCandidate
+		if err := rows.Scan(&c.userID, &c.email); err != nil {
+			return nil, fmt.Errorf(errScanCandidate, err)
+		}
+		out = append(out, c)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf(errReadCandidates, err)
+	}
+	return out, nil
+}

--- a/apps/control-plane/internal/signup/reconciler.go
+++ b/apps/control-plane/internal/signup/reconciler.go
@@ -322,6 +322,14 @@ func (r *Reconciler) cool(userID uuid.UUID) {
 // candidate is precisely an identity whose next token would carry no tenant
 // claim. Keep the three in step.
 //
+// Oldest first, and that ordering is load-bearing rather than arbitrary. The batch limit is applied by the database, so whichever identities the ordering
+// puts first are the only ones a pass can act on. Newest first lets any set of
+// identities the pass cannot clear, ones that keep faulting rather than reaching
+// a terminal determination, refill the batch forever while the identities behind
+// them age out of the window unattempted (review finding, Greptile on PR 993, twice). Oldest first inverts that: the identities closest to leaving the window
+// are always attempted, and a fresh signup that waits a pass or two still has the console route and, where it is configured, the webhook. This is a backstop,
+// so covering the ones about to be lost matters more than latency on the newest.
+//
 // The lifecycle filters are not decoration. A soft-deleted or banned identity
 // must never be provisioned. An identity whose created_at is NULL is excluded
 // by the window comparison itself, since a comparison against NULL is not
@@ -348,7 +356,7 @@ const candidateQuery = `
 	          AND t.archived_at IS NULL
 	   )
 	   AND NOT (u.id = ANY($3::uuid[]))
-	 ORDER BY u.created_at DESC
+	 ORDER BY u.created_at ASC
 	 LIMIT $2
 `
 

--- a/apps/control-plane/internal/signup/reconciler.go
+++ b/apps/control-plane/internal/signup/reconciler.go
@@ -70,6 +70,13 @@ const (
 	// keeps an administered (Hive Enterprise) deployment quiet while still
 	// picking the identity up once an administrator does act.
 	noTenantCooldown = time.Hour
+
+	// sweepDeadline bounds one pass. Without it a sweep that hangs on the
+	// database never returns, never records a failure, and the health
+	// endpoint keeps reporting ready while nobody is being provisioned,
+	// which is the exact silent shape this type exists to remove. Shorter
+	// than the default interval so a stuck pass cannot overlap the next one.
+	sweepDeadline = 2 * time.Minute
 )
 
 // ReconcilerConfig tunes the sweep. Every field is optional.
@@ -122,7 +129,6 @@ type Reconciler struct {
 
 	mu           sync.Mutex
 	failures     int
-	sweeps       int
 	lastNoTenant map[uuid.UUID]time.Time
 }
 
@@ -161,10 +167,15 @@ func (r *Reconciler) Start(ctx context.Context) {
 		ticker := time.NewTicker(r.cfg.Interval)
 		defer ticker.Stop()
 		for {
-			report, err := r.Sweep(ctx)
-			switch {
-			case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+			// The deadline is per pass, so a hung pass is reported as a failed
+			// sweep and counted. Only the parent context ending means shutdown.
+			sweepCtx, cancelSweep := context.WithTimeout(ctx, sweepDeadline)
+			report, err := r.Sweep(sweepCtx)
+			cancelSweep()
+			if ctx.Err() != nil {
 				return
+			}
+			switch {
 			case err != nil:
 				log.Printf(logSweepFailed, err)
 			case report.Candidates > 0:
@@ -223,6 +234,9 @@ func (r *Reconciler) Sweep(ctx context.Context) (SweepReport, error) {
 
 	for _, c := range candidates {
 		if ctx.Err() != nil {
+			// A pass that ran out of time or was cancelled did not finish its
+			// work, so it is a failed sweep rather than a quiet one.
+			r.recordSweep(false)
 			return report, ctx.Err()
 		}
 		if r.cooling(c.userID) {
@@ -253,7 +267,6 @@ func (r *Reconciler) Sweep(ctx context.Context) (SweepReport, error) {
 func (r *Reconciler) recordSweep(ok bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.sweeps++
 	if ok {
 		r.failures = 0
 		return

--- a/apps/control-plane/internal/signup/reconciler.go
+++ b/apps/control-plane/internal/signup/reconciler.go
@@ -56,12 +56,6 @@ const (
 	defaultSweepLookback = 24 * time.Hour
 	defaultSweepBatch    = 200
 
-	// unhealthySweepFailures is how many consecutive failed sweeps make
-	// Ready report false. More than one, so a single transient database blip
-	// cannot flap a container healthcheck red; small enough that a real
-	// provisioning outage is visible within the quarter hour.
-	unhealthySweepFailures = 3
-
 	// noTenantCooldown is how long a terminal no_tenant determination is
 	// trusted before it is attempted again. Reconcile documents that outcome
 	// as terminal until an administrator invites the identity or registers
@@ -147,14 +141,13 @@ func NewReconciler(pool *pgxpool.Pool, prov *Provisioner, cfg ReconcilerConfig) 
 // has one place to audit for anything an operator or an audit reader should not
 // see. None of them carries an address, a tenant id or a driver error string.
 const (
-	logSweepFailed     = "signup: provisioning sweep failed: %v"
-	logSweepReport     = "signup: provisioning sweep candidates=%d provisioned=%d no_tenant=%d cooled=%d failed=%d"
-	errSweepNotWired   = "signup: provisioning sweep not wired"
-	errListCandidates  = "signup: list provisioning candidates: %w"
-	errScanCandidate   = "signup: scan provisioning candidate: %w"
-	errReadCandidates  = "signup: read provisioning candidates: %w"
-	reasonUnwired      = "signup provisioning unwired"
-	reasonSweepFailing = "signup provisioning sweep failing"
+	logSweepFailed    = "signup: provisioning sweep failed: %v"
+	logSweepReport    = "signup: provisioning sweep candidates=%d provisioned=%d no_tenant=%d cooled=%d failed=%d"
+	errSweepNotWired  = "signup: provisioning sweep not wired"
+	errListCandidates = "signup: list provisioning candidates: %w"
+	errScanCandidate  = "signup: scan provisioning candidate: %w"
+	errReadCandidates = "signup: read provisioning candidates: %w"
+	reasonUnwired     = "signup provisioning unwired"
 )
 
 // Start sweeps once immediately and then on the configured interval until ctx
@@ -191,24 +184,40 @@ func (r *Reconciler) Start(ctx context.Context) {
 	}()
 }
 
-// Ready reports whether provisioning is wired and working. The health endpoint
-// asks it, so its answer cannot be missed the way a startup log line was.
+// Ready reports whether provisioning is WIRED, and nothing else. The health
+// endpoint asks it, so its answer cannot be missed the way a startup log line
+// was.
 //
-// A nil receiver reports false on purpose. The failure this whole type exists
-// to prevent was an absence nobody noticed, so nothing-wired must read as
-// broken rather than as silence.
+// A nil receiver reports false on purpose. The failure this whole type exists to
+// prevent was an absence nobody noticed, so nothing-wired must read as broken
+// rather than as silence. That condition is a programming error rather than a
+// runtime one: it cannot appear or clear by itself, so answering an unhealthy
+// readiness probe on it costs nothing that was working a moment ago.
+//
+// A failing sweep is deliberately NOT reported here. Provisioning can be broken
+// while API-key resolution, routing, accounting and payment webhooks all still
+// work, and this endpoint is the container healthcheck: degrading it on a
+// runtime provisioning fault would convert a signup outage into an inference and
+// billing outage, and a restart would reset the counter and repeat. That state is
+// exported through ConsecutiveFailures for the telemetry listener instead, where
+// an alert can fire without taking the process out of service.
 func (r *Reconciler) Ready() (ok bool, reason string) {
 	if r == nil || r.pool == nil || r.prov == nil {
 		return false, reasonUnwired
 	}
-	r.mu.Lock()
-	failures := r.failures
-	r.mu.Unlock()
-	if failures >= unhealthySweepFailures {
-		return false, reasonSweepFailing
-	}
 	// reason stays at its zero value: there is nothing to report.
 	return true, reason
+}
+
+// ConsecutiveFailures is how many sweeps in a row have failed, for the metric on
+// the telemetry listener. Zero means the last sweep completed its candidates.
+func (r *Reconciler) ConsecutiveFailures() int {
+	if r == nil {
+		return 0
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.failures
 }
 
 type sweepCandidate struct {
@@ -225,7 +234,14 @@ func (r *Reconciler) Sweep(ctx context.Context) (SweepReport, error) {
 		return report, errors.New(errSweepNotWired)
 	}
 
-	candidates, err := r.candidates(ctx)
+	// Excluded in SQL rather than skipped in Go: the batch limit is applied by
+	// the database, so an identity filtered afterwards would still consume a
+	// slot and, on a deployment where hundreds of identities are permanently
+	// unclaimable, would starve the ones behind it until they aged out of the
+	// window (review finding, Greptile on PR 993).
+	cooled := r.cooledIdentities()
+	report.Cooled = len(cooled)
+	candidates, err := r.candidates(ctx, cooled)
 	if err != nil {
 		r.recordSweep(false)
 		return report, err
@@ -238,10 +254,6 @@ func (r *Reconciler) Sweep(ctx context.Context) (SweepReport, error) {
 			// work, so it is a failed sweep rather than a quiet one.
 			r.recordSweep(false)
 			return report, ctx.Err()
-		}
-		if r.cooling(c.userID) {
-			report.Cooled++
-			continue
 		}
 		outcome, err := r.prov.Reconcile(ctx, ReconcileInput{UserID: c.userID, Email: c.email})
 		switch {
@@ -274,26 +286,32 @@ func (r *Reconciler) recordSweep(ok bool) {
 	r.failures++
 }
 
-func (r *Reconciler) cooling(userID uuid.UUID) bool {
+// cooledIdentities returns the identities whose terminal no-tenant determination
+// is still trusted, and prunes the ones whose cooldown has expired. Bounded by
+// the lookback window: an identity that ages out of the window stops being
+// listed, and its entry is dropped on the next pass.
+func (r *Reconciler) cooledIdentities() []string {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	at, ok := r.lastNoTenant[userID]
-	return ok && time.Since(at) < noTenantCooldown
+	ids := make([]string, 0, len(r.lastNoTenant))
+	for id, at := range r.lastNoTenant {
+		if time.Since(at) >= noTenantCooldown {
+			delete(r.lastNoTenant, id)
+			continue
+		}
+		ids = append(ids, id.String())
+	}
+	return ids
 }
 
 func (r *Reconciler) cool(userID uuid.UUID) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	// ponytail: in-memory, per process, so a restart re-attempts every
-	// determination once. Bounded by the pruning below plus the lookback
-	// window, which is what keeps the map from growing with the user table.
-	// Move it onto the identity row only if a deployment ever needs the
-	// back-off to survive a restart.
-	for id, at := range r.lastNoTenant {
-		if time.Since(at) >= noTenantCooldown {
-			delete(r.lastNoTenant, id)
-		}
-	}
+	// determination once. Pruning happens in cooledIdentities, which runs on
+	// every pass, and the lookback window bounds the map regardless. Move it
+	// onto the identity row only if a deployment ever needs the back-off to
+	// survive a restart.
 	r.lastNoTenant[userID] = time.Now()
 }
 
@@ -328,12 +346,13 @@ const candidateQuery = `
 	          AND tu.status      = 'ACTIVE'
 	          AND t.archived_at IS NULL
 	   )
+	   AND NOT (u.id = ANY($3::uuid[]))
 	 ORDER BY u.created_at DESC
 	 LIMIT $2
 `
 
-func (r *Reconciler) candidates(ctx context.Context) ([]sweepCandidate, error) {
-	rows, err := r.pool.Query(ctx, candidateQuery, r.cfg.Lookback.Seconds(), r.cfg.BatchLimit)
+func (r *Reconciler) candidates(ctx context.Context, cooled []string) ([]sweepCandidate, error) {
+	rows, err := r.pool.Query(ctx, candidateQuery, r.cfg.Lookback.Seconds(), r.cfg.BatchLimit, cooled)
 	if err != nil {
 		return nil, fmt.Errorf(errListCandidates, err)
 	}

--- a/apps/control-plane/internal/signup/reconciler.go
+++ b/apps/control-plane/internal/signup/reconciler.go
@@ -107,8 +107,8 @@ type SweepReport struct {
 	Provisioned int
 	// NoTenant is how many no tenant claims, a terminal determination.
 	NoTenant int
-	// Cooled is how many were skipped because a recent sweep already reached
-	// that terminal determination for them.
+	// Cooled is how many identities the listing excluded because a recent sweep
+	// already reached a terminal no-tenant determination for them.
 	Cooled int
 	// Failed is how many hit a transient or unexpected fault.
 	Failed int
@@ -270,8 +270,9 @@ func (r *Reconciler) Sweep(ctx context.Context) (SweepReport, error) {
 	}
 
 	// A sweep that faulted on an identity is a provisioning outage in progress,
-	// not a quiet afternoon: it counts against readiness exactly like a failed
-	// listing does.
+	// not a quiet afternoon: it counts against the failure gauge exactly like a
+	// failed listing does. See Ready for why that is a metric and an alert
+	// rather than an unhealthy readiness probe.
 	r.recordSweep(report.Failed == 0)
 	return report, nil
 }

--- a/apps/control-plane/internal/signup/reconciler_test.go
+++ b/apps/control-plane/internal/signup/reconciler_test.go
@@ -1,0 +1,282 @@
+package signup_test
+
+// Coverage for the provisioning sweep that replaces the Supabase Database
+// Webhook (D-023). The webhook was dashboard state: deleting the hosted
+// project removed it with no diff and no failing test, and new identities
+// silently stopped being provisioned. These tests are what makes the
+// replacement's absence, and its misbehaviour, observable.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/audit"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/signup"
+)
+
+// mustInsertSweepUser seeds an auth.users row with explicit age and lifecycle
+// columns. created_at is nullable with no default on real GoTrue (verified on
+// the self-hosted deployment), so a raw insert that omits it leaves it NULL,
+// which is exactly the case the sweep must refuse to guess about.
+func mustInsertSweepUser(
+	t *testing.T, ctx context.Context, pool *pgxpool.Pool,
+	email string, createdAt, deletedAt, bannedUntil any,
+) uuid.UUID {
+	t.Helper()
+	var id uuid.UUID
+	err := pool.QueryRow(ctx, `
+		INSERT INTO auth.users(id, email, raw_user_meta_data, created_at, deleted_at, banned_until)
+		VALUES (gen_random_uuid(), $1, '{}'::jsonb, $2, $3, $4)
+		RETURNING id
+	`, email, createdAt, deletedAt, bannedUntil).Scan(&id)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		cleanup := context.Background()
+		_, _ = pool.Exec(cleanup, `DELETE FROM public.tenant_users WHERE user_id = $1`, id)
+		_, _ = pool.Exec(cleanup, `DELETE FROM public.tenants WHERE personal_owner_user_id = $1`, id)
+		_, _ = pool.Exec(cleanup, `DELETE FROM auth.users WHERE id = $1`, id)
+	})
+	return id
+}
+
+// TestReconcilerSweepProvisionsFreshIdentity is the case the whole change
+// exists for: an identity that exists in auth.users with no membership, which
+// nothing in the repository could provision once the dashboard webhook was
+// gone. No request is made and no console page is visited; the sweep alone
+// puts the row there.
+func TestReconcilerSweepProvisionsFreshIdentity(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	pool := newPool(t, ctx)
+	t.Cleanup(func() { pool.Close() })
+
+	fx := newReconcileFixture(t, ctx, pool)
+	now := time.Now()
+	userID := mustInsertSweepUser(t, ctx, pool, "swept-"+uuid.NewString()+"@"+fx.domain, now, nil, nil)
+
+	rec := signup.NewReconciler(pool, fx.prov, signup.ReconcilerConfig{})
+
+	report, err := rec.Sweep(ctx)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, report.Provisioned, 1)
+
+	require.Equal(t, 1, countMemberships(t, ctx, pool, userID),
+		"the sweep must attach the identity to the tenant that claims its domain")
+	require.Equal(t, "ACTIVE", membershipStatus(t, ctx, pool, userID, fx.tenantID))
+
+	ready, reason := rec.Ready()
+	require.True(t, ready, "a sweep that worked must leave provisioning ready")
+	require.Empty(t, reason)
+}
+
+// TestReconcilerSweepIgnoresIdentitiesItMustNotGuessAbout pins the blast
+// radius. cmd/backfill-tenants is deliberately NOT wired into startup because
+// an automatic tenancy write is one nobody reviews, so the sweep only ever
+// looks at identities created inside its lookback window and never at ones
+// whose age it cannot establish or whose lifecycle says they are gone.
+func TestReconcilerSweepIgnoresIdentitiesItMustNotGuessAbout(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	pool := newPool(t, ctx)
+	t.Cleanup(func() { pool.Close() })
+
+	fx := newReconcileFixture(t, ctx, pool)
+	old := time.Now().Add(-72 * time.Hour)
+	fresh := time.Now()
+	banned := time.Now().Add(time.Hour)
+
+	tooOld := mustInsertSweepUser(t, ctx, pool, "old-"+uuid.NewString()+"@"+fx.domain, old, nil, nil)
+	softDeleted := mustInsertSweepUser(t, ctx, pool, "del-"+uuid.NewString()+"@"+fx.domain, fresh, fresh, nil)
+	bannedUser := mustInsertSweepUser(t, ctx, pool, "ban-"+uuid.NewString()+"@"+fx.domain, fresh, nil, banned)
+
+	rec := signup.NewReconciler(pool, fx.prov, signup.ReconcilerConfig{})
+	_, err := rec.Sweep(ctx)
+	require.NoError(t, err)
+
+	require.Equal(t, 0, countMemberships(t, ctx, pool, tooOld),
+		"an identity older than the lookback window is the operator backfill's business")
+	require.Equal(t, 0, countMemberships(t, ctx, pool, softDeleted),
+		"a soft-deleted identity must never be provisioned")
+	require.Equal(t, 0, countMemberships(t, ctx, pool, bannedUser),
+		"a banned identity must never be provisioned")
+	// The fixture's own user is inserted without created_at, so its age is
+	// unknown. An unknown age is not a licence to write tenancy rows.
+	require.Equal(t, 0, countMemberships(t, ctx, pool, fx.userID),
+		"an identity with a NULL created_at must not be swept")
+}
+
+// TestReconcilerSweepIsIdempotent covers the ticker running every few minutes
+// forever, and two control-plane processes sweeping the same database.
+func TestReconcilerSweepIsIdempotent(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	pool := newPool(t, ctx)
+	t.Cleanup(func() { pool.Close() })
+
+	fx := newReconcileFixture(t, ctx, pool)
+	userID := mustInsertSweepUser(t, ctx, pool, "twice-"+uuid.NewString()+"@"+fx.domain, time.Now(), nil, nil)
+
+	rec := signup.NewReconciler(pool, fx.prov, signup.ReconcilerConfig{})
+	for i := 0; i < 3; i++ {
+		_, err := rec.Sweep(ctx)
+		require.NoError(t, err)
+	}
+
+	require.Equal(t, 1, countMemberships(t, ctx, pool, userID))
+	require.Equal(t, int32(1), fx.resolveCalls.Load(),
+		"an identity that already holds a membership must short-circuit before resolution")
+	require.Equal(t, 1, countTenantsForSlugPrefix(t, ctx, pool, fx.slug),
+		"the sweep must not mint a second tenant")
+}
+
+// TestReconcilerBacksOffAnIdentityNoTenantClaims stops the sweep writing an
+// immutable, hash-chained audit row every interval, forever, for an identity
+// whose no_tenant outcome Reconcile itself documents as terminal until an
+// administrator acts. This is the administered (Hive Enterprise) posture.
+func TestReconcilerBacksOffAnIdentityNoTenantClaims(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	pool := newPool(t, ctx)
+	t.Cleanup(func() { pool.Close() })
+
+	var resolveCalls int
+	prov := signup.NewProvisioner(signup.WebhookDeps{
+		Pool: pool,
+		Resolver: signup.NewResolver(signup.ResolverDeps{
+			DomainLookup: func(context.Context, string) (uuid.UUID, error) {
+				resolveCalls++
+				return uuid.Nil, signup.ErrNoMatch
+			},
+		}),
+		Audit: audit.NewLogger(audit.LoggerDeps{
+			Sync: audit.NewSyncWriter(pool, audit.WriterConfig{DeploySHA: "s", Env: "test"}),
+			WAL:  &noopWAL{},
+		}),
+		SelfServeTenants: false,
+	})
+	userID := mustInsertSweepUser(t, ctx, pool,
+		"unclaimed-"+uuid.NewString()+"@unclaimed-"+uuid.NewString()[:8]+".example", time.Now(), nil, nil)
+
+	rec := signup.NewReconciler(pool, prov, signup.ReconcilerConfig{})
+	for i := 0; i < 3; i++ {
+		_, err := rec.Sweep(ctx)
+		require.NoError(t, err)
+	}
+
+	require.Equal(t, 0, countMemberships(t, ctx, pool, userID),
+		"administered posture must not invent a tenant")
+	require.Equal(t, 1, resolveCalls,
+		"a terminal no_tenant determination must be attempted once per cooldown, not every sweep")
+}
+
+// TestReconcilerReadyIsFalseWhenUnwired is the guard against this change being
+// silently deleted. A nil reconciler is what /health sees when nothing wired
+// provisioning at all, which is the exact shape of the failure D-023 exists to
+// close, one layer in.
+func TestReconcilerReadyIsFalseWhenUnwired(t *testing.T) {
+	var missing *signup.Reconciler
+	ready, reason := missing.Ready()
+	require.False(t, ready)
+	require.NotEmpty(t, reason)
+
+	ready, reason = signup.NewReconciler(nil, nil, signup.ReconcilerConfig{}).Ready()
+	require.False(t, ready, "a reconciler with no pool and no provisioner is not wired")
+	require.NotEmpty(t, reason)
+}
+
+// TestReconcilerReadyGoesFalseAfterRepeatedSweepFailures covers wired but
+// broken, which a nil check alone cannot catch: the sweep is mounted and the
+// database refuses it.
+func TestReconcilerReadyGoesFalseAfterRepeatedSweepFailures(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	// Port 1 is not listenable by an unprivileged process, so every query
+	// fails at dial time. pgxpool connects lazily, so construction succeeds
+	// and the failure lands where the sweep runs.
+	dead, err := pgxpool.New(ctx, "postgres://nobody@127.0.0.1:1/nothing?sslmode=disable&connect_timeout=1")
+	require.NoError(t, err)
+	t.Cleanup(dead.Close)
+
+	rec := signup.NewReconciler(dead, signup.NewProvisioner(signup.WebhookDeps{Pool: dead}),
+		signup.ReconcilerConfig{})
+
+	ready, _ := rec.Ready()
+	require.True(t, ready, "one bad sweep must not flap a healthcheck red")
+
+	for i := 0; i < 3; i++ {
+		_, err := rec.Sweep(ctx)
+		require.Error(t, err)
+	}
+
+	ready, reason := rec.Ready()
+	require.False(t, ready, "a sweep failing every time is a provisioning outage")
+	require.NotEmpty(t, reason)
+	require.NotContains(t, reason, "127.0.0.1",
+		"the reason reaches a public health endpoint and must not carry connection detail")
+}
+
+// TestReconcilerSweepProvisionsSelfServeIdentityWithProductionResolver is the
+// production-shaped case: the resolver the server actually runs
+// (signup.NewPgxResolver), self-serve posture, and an identity whose email
+// domain no tenant claims. This is the shape an administrator creating a user
+// through the Supabase admin API produces, which is the path the deleted
+// dashboard webhook used to cover and nothing else did.
+//
+// It asserts on the personal tenant rather than only on the membership, because
+// a membership row pointing at somebody else's tenant would satisfy a count.
+func TestReconcilerSweepProvisionsSelfServeIdentityWithProductionResolver(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	pool := newPool(t, ctx)
+	t.Cleanup(func() { pool.Close() })
+
+	prov := signup.NewProvisioner(signup.WebhookDeps{
+		Pool:     pool,
+		Resolver: signup.NewPgxResolver(pool),
+		Audit: audit.NewLogger(audit.LoggerDeps{
+			Sync: audit.NewSyncWriter(pool, audit.WriterConfig{DeploySHA: "s", Env: "test"}),
+			WAL:  &noopWAL{},
+		}),
+		SelfServeTenants: true,
+	})
+
+	domain := "selfserve-" + uuid.NewString()[:8] + ".example"
+	userID := mustInsertSweepUser(t, ctx, pool,
+		"admin-created-"+uuid.NewString()+"@"+domain, time.Now(), nil, nil)
+
+	report, err := signup.NewReconciler(pool, prov, signup.ReconcilerConfig{}).Sweep(ctx)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, report.Provisioned, 1)
+
+	require.Equal(t, 1, countMemberships(t, ctx, pool, userID))
+	require.Equal(t, 1, countPersonalTenants(t, ctx, pool, userID),
+		"a self-serve identity no tenant claims must end up owning exactly one personal tenant")
+	require.Equal(t, "ACTIVE", personalMembershipStatus(t, ctx, pool, userID))
+}
+
+func countPersonalTenants(t *testing.T, ctx context.Context, pool *pgxpool.Pool, userID uuid.UUID) int {
+	t.Helper()
+	var n int
+	require.NoError(t, pool.QueryRow(ctx,
+		`SELECT count(*) FROM public.tenants WHERE personal_owner_user_id = $1`, userID).Scan(&n))
+	return n
+}
+
+func personalMembershipStatus(t *testing.T, ctx context.Context, pool *pgxpool.Pool, userID uuid.UUID) string {
+	t.Helper()
+	var status string
+	require.NoError(t, pool.QueryRow(ctx, `
+		SELECT tu.status
+		  FROM public.tenant_users tu
+		  JOIN public.tenants t ON t.id = tu.tenant_id
+		 WHERE tu.user_id = $1
+		   AND t.personal_owner_user_id = $1
+	`, userID).Scan(&status))
+	return status
+}

--- a/apps/control-plane/internal/signup/reconciler_test.go
+++ b/apps/control-plane/internal/signup/reconciler_test.go
@@ -333,3 +333,32 @@ func newTestAuditLogger(pool *pgxpool.Pool) *audit.Logger {
 	deps := audit.LoggerDeps{Sync: audit.NewSyncWriter(pool, cfg), WAL: &noopWAL{}}
 	return audit.NewLogger(deps)
 }
+
+// TestReconcilerSweepTakesTheOldestCandidatesFirst pins the ordering, which is
+// what stops a set of identities the sweep cannot clear from refilling every
+// batch while the identities behind them age out of the lookback window
+// unattempted (review finding, Greptile on PR 993). The batch limit is applied by
+// the database, so the ordering decides who a pass can act on at all.
+func TestReconcilerSweepTakesTheOldestCandidatesFirst(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	pool := newPool(t, ctx)
+	t.Cleanup(func() { pool.Close() })
+
+	fx := newReconcileFixture(t, ctx, pool)
+	older := mustInsertSweepUser(t, ctx, pool, "older-"+uuid.NewString()+"@"+fx.domain,
+		time.Now().Add(-6*time.Hour), nil, nil)
+	newer := mustInsertSweepUser(t, ctx, pool, "newer-"+uuid.NewString()+"@"+fx.domain,
+		time.Now(), nil, nil)
+
+	// One candidate per pass, so the ordering is the only thing that decides
+	// which of the two is served.
+	cfg := signup.ReconcilerConfig{BatchLimit: 1}
+	report, err := signup.NewReconciler(pool, fx.prov, cfg).Sweep(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, report.Candidates)
+
+	require.Equal(t, 1, countMemberships(t, ctx, pool, older),
+		"the identity closest to leaving the window must be the one a limited pass serves")
+	require.Equal(t, 0, countMemberships(t, ctx, pool, newer))
+}

--- a/apps/control-plane/internal/signup/reconciler_test.go
+++ b/apps/control-plane/internal/signup/reconciler_test.go
@@ -189,10 +189,13 @@ func TestReconcilerReadyIsFalseWhenUnwired(t *testing.T) {
 	require.NotEmpty(t, reason)
 }
 
-// TestReconcilerReadyGoesFalseAfterRepeatedSweepFailures covers wired but
-// broken, which a nil check alone cannot catch: the sweep is mounted and the
-// database refuses it.
-func TestReconcilerReadyGoesFalseAfterRepeatedSweepFailures(t *testing.T) {
+// TestReconcilerCountsRepeatedSweepFailures covers wired but broken, which the
+// nil check alone cannot catch: the sweep is mounted and the database refuses
+// it. This state is exported for the telemetry gauge rather than folded into
+// readiness, because taking the container out of service over a provisioning
+// fault would convert a signup outage into a billing one (review finding,
+// CodeRabbit on PR 993).
+func TestReconcilerCountsRepeatedSweepFailures(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
 
@@ -206,19 +209,21 @@ func TestReconcilerReadyGoesFalseAfterRepeatedSweepFailures(t *testing.T) {
 	rec := signup.NewReconciler(dead, signup.NewProvisioner(signup.WebhookDeps{Pool: dead}),
 		signup.ReconcilerConfig{})
 
-	ready, _ := rec.Ready()
-	require.True(t, ready, "one bad sweep must not flap a healthcheck red")
+	require.Equal(t, 0, rec.ConsecutiveFailures())
 
 	for i := 0; i < 3; i++ {
 		_, err := rec.Sweep(ctx)
 		require.Error(t, err)
 	}
 
+	require.Equal(t, 3, rec.ConsecutiveFailures(),
+		"a sweep failing every time has to be countable by something")
+
+	// Wiring is unaffected, which is the whole point of the split: the process
+	// keeps serving every other route while this is reported elsewhere.
 	ready, reason := rec.Ready()
-	require.False(t, ready, "a sweep failing every time is a provisioning outage")
-	require.NotEmpty(t, reason)
-	require.NotContains(t, reason, "127.0.0.1",
-		"the reason reaches a public health endpoint and must not carry connection detail")
+	require.True(t, ready)
+	require.Empty(t, reason)
 }
 
 // TestReconcilerSweepProvisionsSelfServeIdentityWithProductionResolver is the
@@ -318,9 +323,8 @@ func TestReconcilerCountsAnUnfinishedSweepAsFailure(t *testing.T) {
 		stop()
 	}
 
-	ready, reason := rec.Ready()
-	require.False(t, ready, "three unfinished sweeps are a provisioning outage")
-	require.NotEmpty(t, reason)
+	require.Equal(t, 3, rec.ConsecutiveFailures(),
+		"an unfinished pass must count against the sweep, not pass as a quiet one")
 }
 
 // newTestAuditLogger builds the audit logger these suites share.

--- a/apps/control-plane/internal/signup/reconciler_test.go
+++ b/apps/control-plane/internal/signup/reconciler_test.go
@@ -280,3 +280,52 @@ func personalMembershipStatus(t *testing.T, ctx context.Context, pool *pgxpool.P
 	`, userID).Scan(&status))
 	return status
 }
+
+// TestReconcilerCountsAnUnfinishedSweepAsFailure closes the hole that a bounded
+// sweep would otherwise open. A pass that runs out of time has not done its
+// work, so if it returned quietly the health endpoint would keep reporting ready
+// while nobody was being provisioned, which is the same invisible failure the
+// sweep exists to remove.
+func TestReconcilerCountsAnUnfinishedSweepAsFailure(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	pool := newPool(t, ctx)
+	t.Cleanup(func() { pool.Close() })
+	// The cancellation is driven from inside the provisioning attempt, through
+	// the disposable-domain hook Reconcile already calls per identity, so the
+	// second loop iteration is the one that observes the dead context. Two
+	// candidates are seeded precisely so there is a second iteration.
+	var abandon context.CancelFunc
+	stopOnFirstIdentity := func(string) (bool, error) {
+		abandon()
+		return false, nil
+	}
+	prov := signup.NewProvisioner(signup.WebhookDeps{
+		Pool:            pool,
+		Resolver:        signup.NewPgxResolver(pool),
+		Audit:           newTestAuditLogger(pool),
+		DisposableCheck: stopOnFirstIdentity,
+	})
+	domain := uuid.NewString()[:8] + "-abandoned.example"
+	mustInsertSweepUser(t, ctx, pool, "one-"+uuid.NewString()+"@"+domain, time.Now(), nil, nil)
+	mustInsertSweepUser(t, ctx, pool, "two-"+uuid.NewString()+"@"+domain, time.Now(), nil, nil)
+	rec := signup.NewReconciler(pool, prov, signup.ReconcilerConfig{})
+	for i := 0; i < 3; i++ {
+		sweepCtx, stop := context.WithCancel(ctx)
+		abandon = stop
+		_, err := rec.Sweep(sweepCtx)
+		require.Error(t, err)
+		stop()
+	}
+
+	ready, reason := rec.Ready()
+	require.False(t, ready, "three unfinished sweeps are a provisioning outage")
+	require.NotEmpty(t, reason)
+}
+
+// newTestAuditLogger builds the audit logger these suites share.
+func newTestAuditLogger(pool *pgxpool.Pool) *audit.Logger {
+	cfg := audit.WriterConfig{DeploySHA: "s", Env: "test"}
+	deps := audit.LoggerDeps{Sync: audit.NewSyncWriter(pool, cfg), WAL: &noopWAL{}}
+	return audit.NewLogger(deps)
+}

--- a/apps/control-plane/internal/signup/resolver.go
+++ b/apps/control-plane/internal/signup/resolver.go
@@ -11,9 +11,12 @@ package signup
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 // ErrNoMatch indicates neither the invite token nor the email domain
@@ -78,4 +81,60 @@ func (r *Resolver) Resolve(ctx context.Context, in Input) (uuid.UUID, error) {
 		}
 	}
 	return uuid.Nil, ErrNoMatch
+}
+
+// Message formats for the pgx-backed lookups below. Kept as constants next to
+// their only call sites so the wrapped error text is auditable in one place.
+const (
+	errInviteLookup = "signup invite lookup: %w"
+	errDomainLookup = "signup domain lookup: %w"
+)
+
+// inviteLookupQuery resolves an unconsumed, unexpired invite token to its
+// tenant. Expiry and consumption are part of the predicate rather than checked
+// afterwards, so a stale token resolves to nothing at all.
+const inviteLookupQuery = `
+	SELECT tenant_id
+	  FROM public.tenant_invites
+	 WHERE token = $1
+	   AND consumed_at IS NULL
+	   AND expires_at > now()
+`
+
+// domainLookupQuery maps a verified email domain to its tenant.
+const domainLookupQuery = `
+	SELECT tenant_id
+	  FROM public.tenant_email_domains
+	 WHERE domain = $1
+`
+
+// NewPgxResolver builds the production Resolver over a pgx pool.
+//
+// It lives here rather than in cmd/server so that every caller resolves a
+// tenant with the same SQL. There are three provisioning entry points now (the
+// legacy Supabase webhook, the console route and the reconciler sweep), and a
+// test or a second binary that hand-rolled these two queries would be free to
+// drift from the predicate the running server actually applies.
+//
+// Only "no eligible row" collapses to ErrNoMatch. A transient database failure
+// surfaces, so the webhook answers 500 and Supabase retries, and the sweep
+// counts a fault rather than recording a terminal no-tenant determination.
+func NewPgxResolver(pool *pgxpool.Pool) *Resolver {
+	return NewResolver(ResolverDeps{
+		InviteLookup: pgxLookup(pool, inviteLookupQuery, errInviteLookup),
+		DomainLookup: pgxLookup(pool, domainLookupQuery, errDomainLookup),
+	})
+}
+
+func pgxLookup(pool *pgxpool.Pool, query, wrap string) LookupFunc {
+	return func(ctx context.Context, key string) (uuid.UUID, error) {
+		var id uuid.UUID
+		if err := pool.QueryRow(ctx, query, key).Scan(&id); err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return uuid.Nil, ErrNoMatch
+			}
+			return uuid.Nil, fmt.Errorf(wrap, err)
+		}
+		return id, nil
+	}
 }

--- a/deploy/prometheus/alerts.yml
+++ b/deploy/prometheus/alerts.yml
@@ -1,6 +1,20 @@
 groups:
   - name: hive-critical
     rules:
+      # Signup tenant provisioning (D-023). Deliberately an alert rather than a
+      # readiness failure: provisioning can be broken while API-key resolution,
+      # routing and payments still work, so degrading the container healthcheck
+      # for it would turn a signup outage into a billing one. The absence of the
+      # wiring itself is still a failed healthcheck, since that cannot be
+      # transient.
+      - alert: SignupProvisioningSweepFailing
+        expr: hive_signup_provisioning_sweep_failures >= 3
+        for: 10m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Signup tenant provisioning sweeps are failing"
+          description: "{{ $value }} consecutive failed sweeps. New identities are not being given a tenant, so they hold a token with no tenant claim and every tenant-scoped request they make is refused."
       - alert: HighAPIErrorRate
         expr: |
           sum(rate(hive_http_requests_total{status_class=~"4xx|5xx"}[5m]))


### PR DESCRIPTION
## Why

Signup tenant provisioning was driven by a **Supabase Database Webhook configured in the hosted project's dashboard**. That is console state, not repository state: deleting the project removes it with no diff, no error and no failing test, and new identities simply stop being provisioned. Every other part of the Supabase Cloud cutover fails loudly. This one failed silently, which is why `.wolf/decisions.md` D-023 requires the replacement to be shipped code.

Two things were verified on the live self-hosted box before designing anything, read only:

- `pg_trigger` on `auth.users`: **zero** non-internal triggers. The dashboard webhook is genuinely absent from the restored database, and nothing recreates it.
- The self-hosted database image is **not** `supabase/postgres`. `pg_available_extensions` offers only `vector`: no `pg_net`, no `http`, no `plpython3u`, and no `supabase_functions` or `net` schema. **The database cannot make an outbound HTTP call at all on this deployment.**
- `control-plane` on that box had `OWUI_ADMIN_TOKEN` and `SUPABASE_WEBHOOK_SECRET` unset, so its boot log read `WARNING: phase-19 identity wiring skipped` and it started healthy anyway. That gate skipped the whole identity block, **including the console provisioning route D-023 already shipped as the fallback**. Provisioning was unreachable by any path, quietly.
- Baseline data: `auth.users` 154, membership-less 33, membership-less created in the last 24 hours **0**, tenants 958, personal tenants 4.

## Mechanism, and the alternatives it was chosen over

`signup.Reconciler`, started at boot in `cmd/server`, sweeps `auth.users` for identities with no ACTIVE membership on a non-archived tenant and calls the existing `Provisioner.Reconcile` for each. One writer, three entry points now: the legacy webhook, the console route, and the sweep.

1. **Database trigger calling control-plane over HTTP** (`pg_net` / `supabase_functions.http_request`, which is what a Database Webhook actually is). Impossible on this image, per the extension inventory above. Even where possible it needs the shared secret in database state, which in a public repository means either a committed secret or an out-of-band console step, that is, the same failure mode wearing a different hat, and its delivery failures land in a table nobody reads.
2. **Pure SQL trigger writing `tenant_users` directly.** Duplicates the disposable-domain backstop, the resolver precedence, the deployment posture and the audit trail in a second language. `reconcile.go` exists precisely to keep one writer (D-005).
3. **LISTEN/NOTIFY plus a listener goroutine.** Needs a migration, and still misses every identity created while control-plane is down, which the sweep covers for free.

**Blast radius is bounded on purpose.** `cmd/backfill-tenants` documents why a tenancy write is not wired into startup: one that happens on every deploy is one nobody reviews. So the sweep only considers identities created inside a lookback window (24 h default), skips soft-deleted and banned ones, and is batch-limited. On the live box that window currently holds zero rows, so the 33 historical membership-less identities stay the operator backfill's business, which is the existing reviewed route for them. A NULL `created_at` is excluded too: it is nullable with no default on real GoTrue, so NULL means a hand-written row whose age cannot be established.

## Failing loudly when unwired

- `/health` gains a provisioning contribution beside `DBReady` (the issue #816 precedent). **A nil reporter counts as unwired**, not as fine, so a future change that stops wiring provisioning answers `503 degraded` and the compose healthcheck fails, blocking the deploy.
- A **failing** sweep is deliberately kept off this endpoint after review (see the resolved threads): it is a runtime fault that leaves API-key resolution, routing, accounting and payment webhooks working, so degrading the container healthcheck for it would convert a signup outage into a billing outage, and a restart would reset the counter and repeat. It is exported as `ConsecutiveFailures`, published as the `hive_signup_provisioning_sweep_failures` gauge on the telemetry listener Prometheus already scrapes, and alerted on after ten minutes in `deploy/prometheus/alerts.yml`.
- A log line was rejected as the mechanism: the failure this change exists to prevent **was** a log line nobody read.

## On the `phase-19 identity wiring skipped` warning

Kept, but it no longer gates provisioning. Provisioning needs only the pool, the resolver and the audit logger, all of which exist unconditionally. The Open WebUI group client and the webhook secret now gate exactly their own features: a missing `OWUI_ADMIN_TOKEN` costs the chat group wiring (`Provisioner` already logs the skip and still writes the membership), and a missing `SUPABASE_WEBHOOK_SECRET` leaves only the legacy webhook route unmounted. Deliberately **not** made fatal: fataling would take billing, API-key resolution and every other control-plane route down for a chat-side convenience and a retired webhook. The absence that actually matters is now reported on the health endpoint instead, where it cannot be missed.

## Verification

Go tests run in Docker per `CLAUDE.md`, against a throwaway `pgvector/pgvector:pg17` bootstrapped with `.github/ci/test-db-bootstrap.sql` plus the full `supabase/migrations` chain, which is what CI does.

`./internal/signup/...` and `./internal/platform/http/...` both pass, `gofmt` clean, `go vet ./...` clean.

Process-level proof, the real binary with `OWUI_ADMIN_TOKEN` and `SUPABASE_WEBHOOK_SECRET` unset, which is the live box's exact env shape:

```
signup provisioning ready (console route plus reconciler sweep)
signup webhook route not mounted, SUPABASE_WEBHOOK_SECRET unset. Provisioning does not depend on it.
GET /health -> {"status":"ok"}
```

### Mutation testing

Every new check was made to fail on purpose before being trusted.

| # | Mutation | Result |
| --- | --- | --- |
| M1 | Router treats a nil `ProvisioningReady` as ready | **FAIL** (503 expected, got 200) |
| M2 | Lookback window widened by ten days | **FAIL** (an out-of-window identity was provisioned) |
| M3 | `deleted_at IS NULL` weakened to a tautology | **FAIL** (a soft-deleted identity was provisioned) |
| M4 | `created_at IS NOT NULL` weakened to a tautology | **GREEN, and the clause was therefore deleted.** A comparison against NULL is not true, so the window predicate already excludes a NULL age; the extra clause could not fail and was decoration standing next to load-bearing filters. The assertion covering the behaviour stays and still passes. |
| M5 | `Sweep` stops calling `Reconcile` and reports success | **FAIL** (no membership written) |
| M6 | Consecutive sweep failures stop being counted | **FAIL** (`Ready` stayed true through three failed sweeps) |
| M7 | no-tenant cooldown never active | **FAIL** (the terminal determination was re-decided every sweep) |
| M8 | `cmd/server` stops wiring the reconciler, real binary | **FAIL as designed**: `/health` answered `{"status":"degraded","reason":"signup provisioning unwired"}` |

M8 is the one that matters most: it is the exact regression this change exists to make impossible to ship quietly, and the compose healthcheck hits that endpoint.

## Test-wiring note

`.github/ci/test-db-bootstrap.sql` gains `created_at`, `deleted_at` and `banned_until` on the CI stand-in `auth.users`, nullable with no default exactly as GoTrue declares them. Without them the sweep's own filters could not be exercised anywhere. `./internal/signup/...` is already in the workflow's live-database leg, so these tests run for real in CI rather than skipping.

## Buglog entry

```json
{"date":"2026-08-22","area":"control-plane/signup","error_message":"WARNING: phase-19 identity wiring skipped (missing env: OWUI_ADMIN_TOKEN, SUPABASE_WEBHOOK_SECRET); control-plane starts healthy with no reachable tenant-provisioning path","root_cause":"Signup provisioning depended on a Supabase Database Webhook configured in a dashboard, and the repository-side replacement for it (the console tenant-provision route) was wired inside an env-gated block whose four variables included two optional ones. On a deployment with those unset the whole block was skipped, so provisioning had no reachable entry point at all, and the only signal was a startup log line while the process reported healthy.","fix":"Wire provisioning unconditionally wherever a pool exists, gate only the Open WebUI group client and the legacy webhook route on their own variables, add signup.Reconciler as a database-driven sweep that needs no dashboard state, and report provisioning readiness on the health endpoint so an unwired path fails the container healthcheck instead of logging.","tags":["signup","provisioning","tenancy","silent-failure","healthcheck","supabase","D-023"]}
```

## Revision after review

Three review findings were answered with fixes; each is written up in its resolved thread.

- **Healthcheck blast radius** (CodeRabbit, Major). Split as described above: unwired degrades readiness, a failing sweep goes to a gauge plus an alert rule.
- **Cooled identities occupied the batch** (Greptile, P1). The cooldown was applied in Go after the database had applied `LIMIT`, so on a deployment with hundreds of permanently unclaimable identities the cooled ones refilled every batch and starved the ones behind them until they aged out of the window. The exclusion moved into the query.
- **An exact resolver-call assertion depended on unrelated rows** (CodeRabbit, Minor). The shared fixture now counts resolutions for its own domain instead of globally, which keeps the assertion exact without making it depend on what else is in a shared database.

One self-review finding was fixed before that, in 704ca5e: `Sweep` ran on the process-lifetime context, so a pass hung on the database would never return, never record a failure and never be visible anywhere, which is the same silent shape this PR exists to remove. Each pass now has its own deadline and an unfinished pass counts as a failure.

Mutations added across both rounds: M9 (drop the in-loop failure record) fails, M10 (drop the SQL cooldown exclusion) fails, M11 (`ConsecutiveFailures` always zero) fails. Eleven mutations total, ten red, one green and therefore deleted as decoration.

### Third round (f17cad8)

Greptile came back on the same mechanism, correctly: the cooldown exclusion only covers identities that reached a terminal no-tenant determination, and an identity that keeps *faulting* never reaches one, so newest-first ordering let a fault set refill every batch while the identities behind them aged out of the window unattempted.

The fix is the ordering rather than a second exclusion list. The batch limit is applied by the database, so the ordering decides who a pass can act on at all: oldest-in-window first means the identities closest to being lost are always attempted, and nothing can hold the front of the queue. A fresh signup that waits a pass still has the console route and, where configured, the webhook, which is the right trade for a backstop. Cooling errored identities was rejected because it trades a starvation bound for an hour-long retry delay on every transient fault.

M12: flip the ordering back to `DESC`, and `TestReconcilerSweepTakesTheOldestCandidatesFirst` turns red. Twelve mutations total, eleven red, one green and deleted.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR moves signup tenant provisioning from optional dashboard and environment state into an in-process reconciliation sweep, while exposing provisioning wiring and failures through health and telemetry surfaces.

- Starts a bounded, lifecycle-aware sweep over recent membership-less identities and delegates provisioning to the existing provisioner.
- Wires console provisioning independently from optional Open WebUI and legacy webhook configuration.
- Adds provisioning readiness, a consecutive-failure Prometheus gauge and alert, database-backed reconciliation tests, and CI auth-user lifecycle columns.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until persistently failing identities can no longer monopolize every limited reconciliation batch and strand later signups.

Reconciliation errors leave identities immediately eligible, while the oldest-first limited query selects the same full batch again; with at least one batch of persistent failures, later identities can remain unattempted until they age out of the provisioning window.

**Files Needing Attention:** apps/control-plane/internal/signup/reconciler.go
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/control-plane/internal/signup/reconciler.go | Adds the bounded signup-provisioning sweep, lifecycle filtering, no-tenant cooldown exclusion, failure accounting, and oldest-first candidate selection. |
| apps/control-plane/cmd/server/main.go | Wires provisioning independently of optional webhook and Open WebUI settings and publishes reconciliation telemetry. |
| apps/control-plane/internal/platform/http/router.go | Extends health reporting to fail when signup provisioning is not wired. |
| apps/control-plane/internal/signup/reconciler_test.go | Adds database-backed coverage for provisioning, lifecycle exclusions, idempotency, cooldown behavior, failure counting, and candidate ordering. |
| deploy/prometheus/alerts.yml | Adds alerting for sustained signup-provisioning sweep failures. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant DB as auth.users / tenant state
    participant R as Signup Reconciler
    participant P as Existing Provisioner
    participant M as Metrics
    participant H as Health Endpoint
    R->>DB: List recent eligible identities without active membership
    DB-->>R: Limited oldest-first candidate batch
    loop Each candidate
        R->>P: Reconcile identity
        P->>DB: Resolve tenant and write membership
        P-->>R: Provisioned, no tenant, or error
    end
    R->>M: Publish consecutive sweep failures
    H->>R: Check provisioning wiring
    R-->>H: Ready when dependencies are wired
```
</details>

<sub>Reviews (5): Last reviewed commit: ["fix: sweep the oldest candidates in the ..."](https://github.com/sakibsadmanshajib/hive/commit/f17cad8d59f72df138546e4cdb51d500385a277d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55880487)</sub>

<!-- /greptile_comment -->