### PR TITLE
fix: drop the OAuth scope the self-hosted auth server rejects, and check capability against it

### DIFF
--- a/.github/workflows/deploy-demo-box.yml
+++ b/.github/workflows/deploy-demo-box.yml
@@ -867,47 +867,6 @@ jobs:
           head -c 400 "$body" || true
           exit 1
 
-      - name: Verify the OAuth scopes the chat container asks for are supported
-        # Issue #787. The scope list Open WebUI sends on its authorize request
-        # has to be a subset of what the deployed authorization server
-        # advertises, and nothing in this repository can know that on its own.
-        # #787 added `offline_access` after validating against hosted Supabase,
-        # which advertised it. The self-hosted GoTrue does not, and GoTrue
-        # rejects an unknown scope outright instead of ignoring it, so the
-        # authorize request 302'd back to the callback with
-        # error=invalid_request and chat sign-in was dead for every user, with
-        # a fully green deploy sitting on top of it.
-        #
-        # .github/workflows/oauth-scope-gate.yml runs the same check on pull
-        # requests, and catches a scope this repository adds. This one catches
-        # the other direction, which is the one that actually happened: the
-        # server dropping a capability while the repository stands still. No
-        # pull request exists at that moment for a pull-request gate to fire
-        # on, so only a post-deploy check can see it.
-        #
-        # The discovery URL is read out of the running container rather than
-        # written here, so the check interrogates exactly the document Open
-        # WebUI itself resolves. A second URL spelled by hand would be a second
-        # thing that can drift, and drift is the whole defect.
-        #
-        # Placed after the recreate above, so the container being asked is the
-        # one this deploy just shipped, and before the Function install below,
-        # which is a slower step whose failure would otherwise mask this one.
-        working-directory: /home/sakib/hive/deploy/docker
-        run: |
-          set -euo pipefail
-          # `|| true` on purpose: printenv exits 1 when the variable is absent,
-          # and under `set -e` that aborts the step here, before the branch
-          # below that explains what is wrong. The explanation is the point, so
-          # the failure has to reach it.
-          url=$(docker compose $HIVE_COMPOSE_FLAGS exec -T open-webui \
-            printenv OPENID_PROVIDER_URL </dev/null | tr -d '\r' || true)
-          if [ -z "$url" ]; then
-            echo "::error::open-webui has no OPENID_PROVIDER_URL, so its OIDC login is not configured at all. That is a deploy failure, not a reason to skip this check." >&2
-            exit 1
-          fi
-          python3 /home/sakib/hive/scripts/check-oauth-scopes.py --discovery "$url"
-
       - name: Install the hive_jwt_forward Open WebUI Function
         # Issue #556. Per-user chat attribution depends on an Open WebUI
         # Function that no deployment has ever had. Open WebUI offers no mount
@@ -1290,6 +1249,75 @@ jobs:
             exit 1
           fi
           echo "model catalog matches every priced route LiteLLM will actually call"
+
+      - name: Verify the OAuth scopes the chat container asks for are supported
+        # Issue #787. The scope list Open WebUI sends on its authorize request
+        # has to be a subset of what the deployed authorization server
+        # advertises, and nothing in this repository can know that on its own.
+        # #787 added `offline_access` after validating against hosted Supabase,
+        # which advertised it. The self-hosted GoTrue does not, and GoTrue
+        # rejects an unknown scope outright instead of ignoring it, so the
+        # authorize request 302'd back to the callback with
+        # error=invalid_request and chat sign-in was dead for every user, with
+        # a fully green deploy sitting on top of it.
+        #
+        # .github/workflows/oauth-scope-gate.yml runs the same check on pull
+        # requests, and catches a scope this repository adds. This one catches
+        # the other direction, which is the one that actually happened: the
+        # server dropping a capability while the repository stands still. No
+        # pull request exists at that moment for a pull-request gate to fire
+        # on, so only a post-deploy check can see it.
+        #
+        # The discovery URL is read out of the running container rather than
+        # written here, so the check interrogates exactly the document Open
+        # WebUI itself resolves. A second URL spelled by hand would be a second
+        # thing that can drift, and drift is the whole defect.
+        #
+        # Which is why this step also compares that URL against the one the
+        # pull-request gate uses. That gate runs on a cloud runner with no
+        # stack to interrogate, so it has to spell the origin by hand, from
+        # CONSOLE_URL. Open WebUI resolves SUPABASE_PUBLIC_URL instead: a
+        # different variable with a different owner, agreeing today by hand
+        # rather than by construction. Repoint one and the gate would go on
+        # interrogating the old host and go on reporting green, which is #787
+        # one level up. The comparison costs nothing here because this step
+        # already holds the deployed value, and it turns that agreement into
+        # something a deploy fails over once, loudly, instead of a silence.
+        #
+        # Placed at the END of the job, deliberately. This is an audit, it
+        # changes no deployment state, and it is the only step here that
+        # depends on reaching a host over the internet. Earlier in the job, a
+        # momentary DNS or tunnel blip would abort the deploy before the
+        # hive_jwt_forward install, leaving the box without the attribution
+        # Function, which is the #556 failure that step exists to prevent.
+        # Failing last still fails the run.
+        env:
+          # The same expression oauth-scope-gate.yml uses, so the two cannot
+          # drift apart without one of them saying so.
+          CONSOLE_URL: ${{ vars.CONSOLE_URL || 'https://console-hive.scubed.co' }}
+        working-directory: /home/sakib/hive/deploy/docker
+        run: |
+          set -euo pipefail
+          # `if ! url=$(...)` rather than a bare assignment, matching the
+          # supabase-db probe earlier in this job: printenv exits 1 when the
+          # variable is absent, and under `set -e` a failed command
+          # substitution ends the step right there, before the branch that
+          # explains what is wrong can print. The two cases a reader expects
+          # that message to cover, an unset variable and a container that is
+          # not running, are exactly the two it would never have reached.
+          if ! url=$(docker compose $HIVE_COMPOSE_FLAGS exec -T open-webui \
+               printenv OPENID_PROVIDER_URL </dev/null | tr -d '\r') || [ -z "$url" ]; then
+            echo "::error::open-webui has no OPENID_PROVIDER_URL, or the container is not running, so its OIDC login is not configured at all. That is a deploy failure, not a reason to skip this check." >&2
+            exit 1
+          fi
+
+          expected="${CONSOLE_URL}/auth/v1/.well-known/openid-configuration"
+          if [ "$url" != "$expected" ]; then
+            echo "::error::the chat container resolves its OIDC discovery document at $url, but .github/workflows/oauth-scope-gate.yml checks $expected. The pull-request gate is therefore interrogating a different authorization server than the deployment uses, and would report green over a scope this one rejects (#787). Point the CONSOLE_URL repository variable at the deployment's auth origin, or fix SUPABASE_PUBLIC_URL." >&2
+            exit 1
+          fi
+
+          python3 /home/sakib/hive/scripts/check-oauth-scopes.py --discovery "$url"
 
       - name: Prune build cache older than 24h
         # Measured on the demo box 2026-07-29: `docker system df` showed

--- a/.github/workflows/deploy-demo-box.yml
+++ b/.github/workflows/deploy-demo-box.yml
@@ -97,6 +97,10 @@ on:
       # the same blind spot the supabase/migrations entry above exists for.
       - 'scripts/install-owui-jwt-forward.py'
       - 'scripts/owui-mint-admin-token.py'
+      # Invoked by the deploy job's OAuth scope verification step below. Same
+      # blind spot as every other script listed here: without an entry, a fix
+      # to the check itself would merge and never reach the box.
+      - 'scripts/check-oauth-scopes.py'
       - '.github/workflows/deploy-demo-box.yml'
   workflow_dispatch:
 
@@ -862,6 +866,43 @@ jobs:
           echo "::error::/v1/featuregate on caddy-owui is not answering as edge-api JSON. The running Caddy config does not match deploy/docker/Caddyfile.owui (issue #619). Last status $code, content-type ${ctype:-none}."
           head -c 400 "$body" || true
           exit 1
+
+      - name: Verify the OAuth scopes the chat container asks for are supported
+        # Issue #787. The scope list Open WebUI sends on its authorize request
+        # has to be a subset of what the deployed authorization server
+        # advertises, and nothing in this repository can know that on its own.
+        # #787 added `offline_access` after validating against hosted Supabase,
+        # which advertised it. The self-hosted GoTrue does not, and GoTrue
+        # rejects an unknown scope outright instead of ignoring it, so the
+        # authorize request 302'd back to the callback with
+        # error=invalid_request and chat sign-in was dead for every user, with
+        # a fully green deploy sitting on top of it.
+        #
+        # .github/workflows/oauth-scope-gate.yml runs the same check on pull
+        # requests, and catches a scope this repository adds. This one catches
+        # the other direction, which is the one that actually happened: the
+        # server dropping a capability while the repository stands still. No
+        # pull request exists at that moment for a pull-request gate to fire
+        # on, so only a post-deploy check can see it.
+        #
+        # The discovery URL is read out of the running container rather than
+        # written here, so the check interrogates exactly the document Open
+        # WebUI itself resolves. A second URL spelled by hand would be a second
+        # thing that can drift, and drift is the whole defect.
+        #
+        # Placed after the recreate above, so the container being asked is the
+        # one this deploy just shipped, and before the Function install below,
+        # which is a slower step whose failure would otherwise mask this one.
+        working-directory: /home/sakib/hive/deploy/docker
+        run: |
+          set -euo pipefail
+          url=$(docker compose $HIVE_COMPOSE_FLAGS exec -T open-webui \
+            printenv OPENID_PROVIDER_URL </dev/null | tr -d '\r')
+          if [ -z "$url" ]; then
+            echo "::error::open-webui has no OPENID_PROVIDER_URL, so its OIDC login is not configured at all. That is a deploy failure, not a reason to skip this check." >&2
+            exit 1
+          fi
+          python3 /home/sakib/hive/scripts/check-oauth-scopes.py --discovery "$url"
 
       - name: Install the hive_jwt_forward Open WebUI Function
         # Issue #556. Per-user chat attribution depends on an Open WebUI

--- a/.github/workflows/deploy-demo-box.yml
+++ b/.github/workflows/deploy-demo-box.yml
@@ -896,8 +896,12 @@ jobs:
         working-directory: /home/sakib/hive/deploy/docker
         run: |
           set -euo pipefail
+          # `|| true` on purpose: printenv exits 1 when the variable is absent,
+          # and under `set -e` that aborts the step here, before the branch
+          # below that explains what is wrong. The explanation is the point, so
+          # the failure has to reach it.
           url=$(docker compose $HIVE_COMPOSE_FLAGS exec -T open-webui \
-            printenv OPENID_PROVIDER_URL </dev/null | tr -d '\r')
+            printenv OPENID_PROVIDER_URL </dev/null | tr -d '\r' || true)
           if [ -z "$url" ]; then
             echo "::error::open-webui has no OPENID_PROVIDER_URL, so its OIDC login is not configured at all. That is a deploy failure, not a reason to skip this check." >&2
             exit 1

--- a/.github/workflows/oauth-scope-gate.yml
+++ b/.github/workflows/oauth-scope-gate.yml
@@ -21,10 +21,17 @@ name: OAuth scope gate
 # the box, and refusing to merge a deploy configuration change while its target
 # is unreachable is the correct answer anyway.
 #
-# Not a required status check, for the same reason. The repository's merge
-# policy is all checks green plus zero unresolved threads, so a red run here
-# still blocks a merge in practice, without wedging every unrelated pull
-# request behind a home lab machine's uptime.
+# Not a required status check, for the same reason, and it is worth being
+# precise about what that costs rather than talking it away.
+# .github/branch-protection-main.json lists six required contexts and this is
+# not one of them, `strict` is false and `required_pull_request_reviews` is
+# null, so GitHub will merge a pull request with this run red. Since this
+# repository merges autonomously through the merge API, nothing sits between a
+# red run here and a merge except the merging agent reading it. This is an
+# advisory signal, not an enforced gate. If it should genuinely gate, the
+# honest change is adding the context to branch protection and accepting that
+# box downtime blocks deploy YAML merges, which the paragraph above argues is
+# acceptable anyway.
 #
 # The paths filter is deploy/docker rather than all of deploy/ for that same
 # reason, narrowed after review. `deploy/**.yml` also matched Prometheus

--- a/.github/workflows/oauth-scope-gate.yml
+++ b/.github/workflows/oauth-scope-gate.yml
@@ -25,19 +25,34 @@ name: OAuth scope gate
 # policy is all checks green plus zero unresolved threads, so a red run here
 # still blocks a merge in practice, without wedging every unrelated pull
 # request behind a home lab machine's uptime.
+#
+# The paths filter is deploy/docker rather than all of deploy/ for that same
+# reason, narrowed after review. `deploy/**.yml` also matched Prometheus
+# alerts, the Alertmanager config, Grafana provisioning, the LiteLLM model list
+# and the headscale config, none of which can carry an OAUTH_SCOPES
+# declaration in any realistic sense, and the justification above does not
+# stretch to parking a Grafana datasource change behind a home lab machine.
+# Nothing is lost by narrowing: the script still scans all of deploy/ on the
+# runs that do happen, and `make test-scripts` in the required repo-policy
+# lints job scans all of deploy/ offline on EVERY pull request, so a scope
+# added anywhere else still fails a required check without waiting on the box.
+#
+# One more reason to keep it narrow, from the same review: the wider this
+# filter is, the more motive someone has to quietly stop the gate firing, and
+# that is the one change TestOWUIOAuthScopeGateIsWired cannot see.
 
 on:
   pull_request:
     paths:
-      - 'deploy/**.yml'
-      - 'deploy/**.yaml'
+      - 'deploy/docker/**.yml'
+      - 'deploy/docker/**.yaml'
       - 'scripts/check-oauth-scopes.py'
       - '.github/workflows/oauth-scope-gate.yml'
   push:
     branches: [main]
     paths:
-      - 'deploy/**.yml'
-      - 'deploy/**.yaml'
+      - 'deploy/docker/**.yml'
+      - 'deploy/docker/**.yaml'
       - 'scripts/check-oauth-scopes.py'
       - '.github/workflows/oauth-scope-gate.yml'
   workflow_dispatch:

--- a/.github/workflows/oauth-scope-gate.yml
+++ b/.github/workflows/oauth-scope-gate.yml
@@ -1,0 +1,80 @@
+name: OAuth scope gate
+
+# Asks the deployed authorization server what it supports, and fails when the
+# scopes this repository configures are not a subset of that.
+#
+# Why this workflow exists, in one incident: PR #787 added `offline_access` to
+# OAUTH_SCOPES in deploy/docker/docker-compose.yml. It was validated against
+# hosted Supabase, whose discovery document advertised that scope. The
+# self-hosted GoTrue this stack had already cut over to does not advertise it,
+# and GoTrue rejects an unknown scope outright rather than ignoring it, so the
+# authorize request 302'd straight back to the callback with
+# error=invalid_request. No consent screen, no code, no session. Chat sign-in
+# was dead for every user, and every check in this repository was green,
+# because no check in this repository had ever asked the server anything.
+#
+# Deliberately its own workflow rather than a step in ci.yml's required
+# repo-policy-lints job. That job runs on every pull request, and putting a
+# call to a live host inside it would make an unrelated documentation change
+# unmergeable whenever the demo box is down. Here the paths filter below means
+# only a pull request that actually touches deploy YAML or this check waits on
+# the box, and refusing to merge a deploy configuration change while its target
+# is unreachable is the correct answer anyway.
+#
+# Not a required status check, for the same reason. The repository's merge
+# policy is all checks green plus zero unresolved threads, so a red run here
+# still blocks a merge in practice, without wedging every unrelated pull
+# request behind a home lab machine's uptime.
+
+on:
+  pull_request:
+    paths:
+      - 'deploy/**.yml'
+      - 'deploy/**.yaml'
+      - 'scripts/check-oauth-scopes.py'
+      - '.github/workflows/oauth-scope-gate.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'deploy/**.yml'
+      - 'deploy/**.yaml'
+      - 'scripts/check-oauth-scopes.py'
+      - '.github/workflows/oauth-scope-gate.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: oauth-scope-gate-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  scopes-are-supported:
+    name: Configured OAuth scopes are advertised by the auth server
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      # The comparator's own tests first. A subset check that can no longer go
+      # red is indistinguishable from one that returns 0 unconditionally, and
+      # running it against a corpus it agrees with proves nothing. These cases
+      # replay #787's exact scope string against the deployed server's exact
+      # capability list and require exit 1.
+      - name: The check can still fail
+        run: python3 scripts/test_check_oauth_scopes.py
+
+      # CONSOLE_URL is the public auth origin (Caddy fronts GoTrue at
+      # /auth/v1 there), the same variable and default chat-coverage.yml
+      # already uses. No secret is involved: a discovery document is public by
+      # specification, and this request carries no credential.
+      - name: Configured scopes are a subset of scopes_supported
+        env:
+          CONSOLE_URL: ${{ vars.CONSOLE_URL || 'https://console-hive.scubed.co' }}
+        run: |
+          set -euo pipefail
+          python3 scripts/check-oauth-scopes.py \
+            --discovery "${CONSOLE_URL}/auth/v1/.well-known/openid-configuration"

--- a/.github/workflows/oauth-scope-gate.yml
+++ b/.github/workflows/oauth-scope-gate.yml
@@ -44,7 +44,11 @@ on:
 
 concurrency:
   group: oauth-scope-gate-${{ github.ref }}
-  cancel-in-progress: true
+  # Superseded pull-request pushes are worth cancelling. Commits on main are
+  # not: two landing close together would cancel the earlier one's run, and
+  # that commit then has no verdict at all. An absent check reads exactly like
+  # a passing one, which is the failure mode this repository keeps paying for.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ test-scripts:
 	python3 scripts/test_owui_model_picker_filter.py
 	python3 scripts/generate-enterprise-jwt-keys.py --self-check
 	python3 scripts/register-owui-oauth-client.py --self-check
+	python3 scripts/test_check_oauth_scopes.py
 	python3 scripts/test_caddy_supabase_routes.py
 	python3 scripts/test_selfhost_supabase_seam.py
 	python3 scripts/check-env-supabase-target.py --self-check

--- a/apps/edge-api/internal/auth/owui_oauth_scope_test.go
+++ b/apps/edge-api/internal/auth/owui_oauth_scope_test.go
@@ -144,6 +144,10 @@ func TestOWUIOAuthScopeGateIsWired(t *testing.T) {
 			"requested OAuth scope against what the deployed authorization "+
 			"server actually advertises (#787). It must exist.")
 
+	// Each needle is an INVOCATION, not a filename. A bare filename match
+	// would be satisfied by the commented-out remains of a step, or by a
+	// sentence in a comment explaining why the check was removed, which is
+	// precisely the moment this guard has to fire.
 	for _, wiring := range []struct {
 		file   string
 		needle string
@@ -151,14 +155,14 @@ func TestOWUIOAuthScopeGateIsWired(t *testing.T) {
 	}{
 		{
 			file:   filepath.Join(".github", "workflows", "oauth-scope-gate.yml"),
-			needle: "scripts/check-oauth-scopes.py",
+			needle: "python3 scripts/check-oauth-scopes.py",
 			why: "the pull-request gate is what catches an unadvertised scope " +
 				"BEFORE it is merged and deployed, which is the whole gap #787 " +
 				"went through",
 		},
 		{
 			file:   filepath.Join(".github", "workflows", "deploy-demo-box.yml"),
-			needle: "scripts/check-oauth-scopes.py",
+			needle: "scripts/check-oauth-scopes.py --discovery",
 			why: "the post-deploy step is what catches the authorization server " +
 				"dropping a capability while this repository stands still, which " +
 				"is the direction the self-hosted cutover broke and which no " +
@@ -166,7 +170,7 @@ func TestOWUIOAuthScopeGateIsWired(t *testing.T) {
 		},
 		{
 			file:   "Makefile",
-			needle: "test_check_oauth_scopes.py",
+			needle: "python3 scripts/test_check_oauth_scopes.py",
 			why: "the comparator's own tests must run in a required check, or a " +
 				"subset check that can no longer go red is indistinguishable " +
 				"from one that passes unconditionally",
@@ -176,9 +180,54 @@ func TestOWUIOAuthScopeGateIsWired(t *testing.T) {
 		require.NoError(t, readErr, "%s must exist: %s", wiring.file, wiring.why)
 		// require.True rather than require.Contains: a failed Contains prints
 		// the entire file into the test log and buries the explanation.
-		require.True(t, strings.Contains(string(body), wiring.needle),
-			"%s no longer references %q, so %s", wiring.file, wiring.needle, wiring.why)
+		require.True(t, containsUncommented(string(body), wiring.needle),
+			"%s no longer invokes %q outside a comment, so %s",
+			wiring.file, wiring.needle, wiring.why)
 	}
+}
+
+// TestContainsUncommentedRejectsCommentedInvocations is the self-check for the
+// matcher above, and it exists because the matcher is the only thing standing
+// between "the gate is wired" and "the gate is mentioned". Without these cases
+// a regression to plain strings.Contains would keep every assertion above
+// green while the step it checks sat commented out.
+func TestContainsUncommentedRejectsCommentedInvocations(t *testing.T) {
+	const needle = "python3 scripts/check-oauth-scopes.py"
+
+	for _, tc := range []struct {
+		name string
+		body string
+		want bool
+	}{
+		{"a real step", "      run: |\n        python3 scripts/check-oauth-scopes.py --discovery x\n", true},
+		{"commented out whole line", "      # python3 scripts/check-oauth-scopes.py --discovery x\n", false},
+		{"named in prose", "      # we removed python3 scripts/check-oauth-scopes.py because reasons\n", false},
+		{"trailing comment after a real call", "        python3 scripts/check-oauth-scopes.py # why\n", true},
+		{"absent entirely", "      run: echo nothing\n", false},
+	} {
+		require.Equal(t, tc.want, containsUncommented(tc.body, needle), tc.name)
+	}
+}
+
+// containsUncommented reports whether needle appears on a line that is not
+// commented out, in either YAML or make syntax (both use #).
+//
+// Plain strings.Contains would accept a step that had been commented out, or a
+// comment describing the invocation that used to be there. Those are the exact
+// states this guard exists to catch, so matching them would make it decorative.
+func containsUncommented(body, needle string) bool {
+	for _, line := range strings.Split(body, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "#") {
+			continue
+		}
+		if index := strings.Index(line, needle); index >= 0 {
+			// The needle itself must not sit after a # on the same line.
+			if hash := strings.Index(line, "#"); hash == -1 || hash > index {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // TestOWUIImageAppliesOAuthRefreshClientAuthPatch asserts the Open WebUI image
@@ -266,8 +315,27 @@ func envDeclarations(t *testing.T, key string) []scopeDeclaration {
 			if strings.HasPrefix(trimmed, "#") {
 				continue
 			}
-			prefix, rawValue, ok := strings.Cut(trimmed, key+":")
-			if !ok || prefix != "" {
+			// Both Compose environment spellings, mapping and list:
+			//
+			//   environment:
+			//     OAUTH_SCOPES: "openid email profile"
+			//
+			//   environment:
+			//     - OAUTH_SCOPES=openid email profile
+			//
+			// Reading only the mapping form is the same defect in a new
+			// place. Compose accepts either, so a declaration written the
+			// other way would satisfy this guard by being invisible to it,
+			// and an invisible declaration reports a clean pass over a
+			// corpus of nothing. scripts/check-oauth-scopes.py reads both
+			// for the same reason.
+			var rawValue string
+			switch {
+			case strings.HasPrefix(trimmed, key+":"):
+				rawValue = strings.TrimPrefix(trimmed, key+":")
+			case strings.HasPrefix(trimmed, "- "+key+"="), strings.HasPrefix(trimmed, "-"+key+"="):
+				_, rawValue, _ = strings.Cut(trimmed, "=")
+			default:
 				continue
 			}
 			found = append(found, scopeDeclaration{

--- a/apps/edge-api/internal/auth/owui_oauth_scope_test.go
+++ b/apps/edge-api/internal/auth/owui_oauth_scope_test.go
@@ -86,20 +86,34 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestOWUIOAuthScopesRequestOpenID asserts that every Open WebUI OIDC scope
-// declaration under deploy/ still asks for an identity.
+// TestOWUIOAuthScopesRequestAnIdentity asserts that every Open WebUI OIDC
+// scope declaration under deploy/ still asks for enough to identify a user.
 //
-// This is the only thing about the scope value that is knowable offline.
-// `openid` is what makes the exchange OIDC rather than a bare OAuth grant, and
-// without it the server issues no id_token at all (GoTrue gates GenerateIDToken
-// on exactly this scope), so the unwrap middleware has nobody to attribute a
-// request to. Whether every OTHER scope in the list is one the deployed server
-// will accept is checked against the live discovery document, not from here.
+// This guards the direction the live gate cannot: the live gate fails when the
+// list gains a scope the server rejects, and would be perfectly happy with a
+// list trimmed down to nothing but `openid`, since a smaller set is still a
+// subset. Losing a scope this deployment needs is a different outage with the
+// same shape, so it is asserted here, where it can be checked offline.
+//
+// Both entries are read from the pinned supabase/gotrue v2.189.0 rather than
+// from OAuth convention, which is what caused #787:
+//
+//   - openid. handleAuthorizationCodeGrant generates an id_token only under
+//     `if models.HasScope(scopeList, models.ScopeOpenID)`, so without it the
+//     exchange is a bare OAuth grant and the unwrap middleware has no identity
+//     to attribute a request to.
+//   - email. The email and email_verified claims are gated on
+//     `hasEmailScope` (internal/api/oauthserver/handlers.go). Open WebUI
+//     provisions and matches its account from the email claim, so a token
+//     without it signs nobody in.
+//
+// `profile` is deliberately not required. It only carries name and picture,
+// and their absence degrades an avatar rather than breaking sign-in.
 //
 // It scans all deploy YAML rather than one known line so a second compose
 // file, override, or profile cannot reintroduce a defect by copying a value
 // into a new place.
-func TestOWUIOAuthScopesRequestOpenID(t *testing.T) {
+func TestOWUIOAuthScopesRequestAnIdentity(t *testing.T) {
 	declarations := envDeclarations(t, "OAUTH_SCOPES")
 	require.NotEmpty(t, declarations,
 		"expected at least one OAUTH_SCOPES declaration under deploy/; if Open "+
@@ -111,6 +125,12 @@ func TestOWUIOAuthScopesRequestOpenID(t *testing.T) {
 		require.Contains(t, scopes, "openid",
 			"%s:%d declares OAUTH_SCOPES %q without openid; the unwrap middleware "+
 				"needs an OIDC identity token exchange, not a bare OAuth grant",
+			d.path, d.line, d.value)
+		require.Contains(t, scopes, "email",
+			"%s:%d declares OAUTH_SCOPES %q without email. GoTrue gates the email "+
+				"and email_verified claims on that scope, and Open WebUI matches "+
+				"its account on the email claim, so every sign-in fails with an "+
+				"id_token that has no email in it",
 			d.path, d.line, d.value)
 	}
 }

--- a/apps/edge-api/internal/auth/owui_oauth_scope_test.go
+++ b/apps/edge-api/internal/auth/owui_oauth_scope_test.go
@@ -1,13 +1,14 @@
 package auth_test
 
-// Regression guard for #782.
+// Regression guards for #782 and for the outage its own fix caused, #787.
 //
 // OWUIUnwrap fails closed when a shim-key /v1/chat/completions request carries
 // no `__metadata.upstream_auth`, which is the correct response to a missing
 // per-user token. What made that fail-closed catastrophic in production was
 // upstream Open WebUI destroying the token supply on a schedule:
 //
-//   - Supabase issues OAuth access tokens with a 3600 second lifetime.
+//   - The authorization server issues OAuth access tokens with a 3600 second
+//     lifetime.
 //   - OAuthManager.get_oauth_token refreshes once `now + 5 minutes` reaches
 //     `expires_at`, so the refresh path is first entered roughly 55 minutes
 //     into a signed-in session.
@@ -16,33 +17,50 @@ package auth_test
 //     gone. `__oauth_token__` is empty from then on, hive_jwt_forward injects
 //     nothing, and every completion 401s until the user signs in again.
 //
-// Two independent inputs to that chain, and both were broken.
+// #787 read that chain as two broken inputs and fixed both. Only one of them
+// was ever broken, and the other "fix" took chat sign-in down outright.
 //
-// First, the scope on the authorize request, which this file guards. Supabase
-// advertises `offline_access` in scopes_supported and `refresh_token` in
-// grant_types_supported, so asking for it is what makes a refresh possible at
-// all. Without it Supabase issues no refresh token, _perform_token_refresh
-// returns None on its very first guard, and the deployment locks every user
-// out roughly 55 minutes after they sign in.
+// The half that was never broken: the scope on the authorize request. #787
+// added `offline_access` to OAUTH_SCOPES because hosted Supabase advertised it
+// and OAuth convention says a refresh token needs it. The self-hosted GoTrue
+// this stack cut over to does not advertise it, and does not need it either.
+// Read at the pinned supabase/gotrue v2.189.0 rather than assumed:
+// SupportedOAuthScopes in internal/models/oauth_scope.go is openid, profile,
+// email, phone; and the authorization code grant in
+// internal/api/oauthserver/handlers.go calls tokenService.IssueRefreshToken
+// unconditionally and always puts refresh_token in the token response. So the
+// refresh token exists with or without the scope, and asking for the scope is
+// fatal: GoTrue 302s the authorize request straight back to the callback with
+// error=invalid_request, no consent screen, no code, no session. Every user
+// locked out at the front door instead of 55 minutes in.
 //
-// Second, the client authentication on the refresh request. That one cannot be
-// guarded from here because it is not configuration: Open WebUI hand builds
-// the refresh POST with the client credentials in the form body, which is
+// Which is why there is no assertion here that any particular scope is
+// requested. That question cannot be answered from inside this repository at
+// all, and answering it from convention is precisely what shipped #787: the
+// set of legal scopes is a property of the deployed authorization server, and
+// it changed underneath a compose file that did not. It is checked against the
+// live discovery document instead, by scripts/check-oauth-scopes.py, on every
+// pull request touching deploy YAML and again after every deploy.
+// TestOWUIOAuthScopeGateIsWired below asserts that wiring still exists, since
+// a gate that lives outside this test binary is a gate that can be deleted
+// without turning anything in here red.
+//
+// The half that was genuinely broken, and that stays fixed: the client
+// authentication on the refresh request. Open WebUI hand builds the refresh
+// POST with the client credentials in the form body, which is
 // client_secret_post, while authlib performs the authorization code exchange
-// with client_secret_basic. Supabase enforces the registered method exactly,
+// with client_secret_basic. The server enforces the registered method exactly,
 // so a refresh token that exists is still refused and the session destroyed
-// anyway. That half is fixed inside the image, by the patch this file asserts
-// is still wired into Dockerfile.open-webui, and its behaviour is covered by
+// anyway. That is fixed inside the image, by the patch
+// TestOWUIImageAppliesOAuthRefreshClientAuthPatch asserts is still wired into
+// Dockerfile.open-webui, and its behaviour is covered by
 // scripts/test_owui_oauth_client_auth.py.
 //
-// Fixing only one of the two leaves the defect in place, which is why both are
-// asserted here.
-//
 // This lives here, next to the middleware that emits the customer-facing
-// error, because that middleware is where the defect surfaces and where the
-// next person will start reading.
+// error, because that middleware is where the #782 defect surfaces and where
+// the next person will start reading.
 //
-// Why no e2e test catches this, and why these are configuration invariants
+// Why no e2e test catches #782, and why these are configuration invariants
 // instead of another chat spec: every phase-19 chat spec runs all of its turns
 // inside one short session. The multi-turn one at
 // apps/web-console/e2e/phase-19/owui/02-chat-multi-turn.spec.ts budgets 360
@@ -52,6 +70,12 @@ package auth_test
 // one message, or several messages inside a minute, passes against a build
 // that locks every user out an hour later. That is the shape of defect that
 // ships.
+//
+// And why no e2e test caught #787 either, which is the harder one: the suite
+// does exercise sign-in, but only against a deployment that already exists.
+// Nothing runs between "the compose file changed" and "the deployment is
+// rebuilt from it", so a scope the server rejects is not observable until the
+// change is already live. That gap is what the live gate closes.
 
 import (
 	"os"
@@ -62,16 +86,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// requiredOAuthScope is the scope whose absence caused #782.
-const requiredOAuthScope = "offline_access"
-
-// TestOWUIOAuthScopesRequestOfflineAccess asserts that every Open WebUI OIDC
-// scope declaration under deploy/ asks for a refresh token.
+// TestOWUIOAuthScopesRequestOpenID asserts that every Open WebUI OIDC scope
+// declaration under deploy/ still asks for an identity.
+//
+// This is the only thing about the scope value that is knowable offline.
+// `openid` is what makes the exchange OIDC rather than a bare OAuth grant, and
+// without it the server issues no id_token at all (GoTrue gates GenerateIDToken
+// on exactly this scope), so the unwrap middleware has nobody to attribute a
+// request to. Whether every OTHER scope in the list is one the deployed server
+// will accept is checked against the live discovery document, not from here.
 //
 // It scans all deploy YAML rather than one known line so a second compose
-// file, override, or profile cannot reintroduce the defect by copying the old
-// value into a new place.
-func TestOWUIOAuthScopesRequestOfflineAccess(t *testing.T) {
+// file, override, or profile cannot reintroduce a defect by copying a value
+// into a new place.
+func TestOWUIOAuthScopesRequestOpenID(t *testing.T) {
 	declarations := envDeclarations(t, "OAUTH_SCOPES")
 	require.NotEmpty(t, declarations,
 		"expected at least one OAUTH_SCOPES declaration under deploy/; if Open "+
@@ -80,18 +108,76 @@ func TestOWUIOAuthScopesRequestOfflineAccess(t *testing.T) {
 
 	for _, d := range declarations {
 		scopes := strings.Fields(d.value)
-		require.Contains(t, scopes, requiredOAuthScope,
-			"%s:%d declares OAUTH_SCOPES %q without %q. Without it Supabase "+
-				"returns no refresh token, Open WebUI deletes the OAuth session at "+
-				"its first refresh attempt, and every chat completion 401s about "+
-				"55 minutes after sign-in until the user signs in again (#782)",
-			d.path, d.line, d.value, requiredOAuthScope)
-
-		// A refresh token with no identity scope would authenticate nobody.
 		require.Contains(t, scopes, "openid",
 			"%s:%d declares OAUTH_SCOPES %q without openid; the unwrap middleware "+
 				"needs an OIDC identity token exchange, not a bare OAuth grant",
 			d.path, d.line, d.value)
+	}
+}
+
+// TestOWUIOAuthScopeGateIsWired asserts the live capability check still exists
+// and is still invoked from every place that is supposed to invoke it.
+//
+// Without this, the gate that catches #787 is three files nothing in this test
+// binary references. Deleting the workflow step, or dropping the self-check
+// from `make test-scripts`, would leave every Go test green while the only
+// thing that can compare a requested scope against a real authorization
+// server quietly stops running. That is the same failure shape as #787 itself:
+// a repository fully in agreement with itself and wrong about the deployment.
+//
+// Three call sites, because they catch different directions of the same
+// mismatch and no one of them subsumes another:
+//
+//   - the pull-request gate catches a scope added here that the server does
+//     not advertise, which is #787;
+//   - the deploy step catches a capability the server stops advertising while
+//     this repository stands still, which is what the self-hosted cutover did;
+//   - `make test-scripts` runs the comparator's own tests in a required check,
+//     so the comparator cannot rot into something that returns 0 regardless.
+func TestOWUIOAuthScopeGateIsWired(t *testing.T) {
+	root := repoRootForAuth(t)
+
+	script := filepath.Join(root, "scripts", "check-oauth-scopes.py")
+	_, err := os.Stat(script)
+	require.NoError(t, err,
+		"scripts/check-oauth-scopes.py is the only check that compares a "+
+			"requested OAuth scope against what the deployed authorization "+
+			"server actually advertises (#787). It must exist.")
+
+	for _, wiring := range []struct {
+		file   string
+		needle string
+		why    string
+	}{
+		{
+			file:   filepath.Join(".github", "workflows", "oauth-scope-gate.yml"),
+			needle: "scripts/check-oauth-scopes.py",
+			why: "the pull-request gate is what catches an unadvertised scope " +
+				"BEFORE it is merged and deployed, which is the whole gap #787 " +
+				"went through",
+		},
+		{
+			file:   filepath.Join(".github", "workflows", "deploy-demo-box.yml"),
+			needle: "scripts/check-oauth-scopes.py",
+			why: "the post-deploy step is what catches the authorization server " +
+				"dropping a capability while this repository stands still, which " +
+				"is the direction the self-hosted cutover broke and which no " +
+				"repository-only check can ever see",
+		},
+		{
+			file:   "Makefile",
+			needle: "test_check_oauth_scopes.py",
+			why: "the comparator's own tests must run in a required check, or a " +
+				"subset check that can no longer go red is indistinguishable " +
+				"from one that passes unconditionally",
+		},
+	} {
+		body, readErr := os.ReadFile(filepath.Join(root, wiring.file))
+		require.NoError(t, readErr, "%s must exist: %s", wiring.file, wiring.why)
+		// require.True rather than require.Contains: a failed Contains prints
+		// the entire file into the test log and buries the explanation.
+		require.True(t, strings.Contains(string(body), wiring.needle),
+			"%s no longer references %q, so %s", wiring.file, wiring.needle, wiring.why)
 	}
 }
 

--- a/apps/edge-api/internal/auth/owui_oauth_scope_test.go
+++ b/apps/edge-api/internal/auth/owui_oauth_scope_test.go
@@ -195,6 +195,20 @@ func TestOWUIOAuthScopeGateIsWired(t *testing.T) {
 				"subset check that can no longer go red is indistinguishable " +
 				"from one that passes unconditionally",
 		},
+		{
+			// Deleting `pull_request:` and leaving `workflow_dispatch:` keeps
+			// every invocation above on an uncommented line while the gate
+			// stops firing on pull requests entirely. Of the ways to disable
+			// this quietly it is the most likely one to be reached for, since
+			// it looks like trimming a noisy trigger rather than removing a
+			// check.
+			file:   filepath.Join(".github", "workflows", "oauth-scope-gate.yml"),
+			needle: "pull_request:",
+			why: "without a pull_request trigger the gate runs only on main and " +
+				"on demand, so an unadvertised scope is caught after it is " +
+				"merged rather than before, which is the whole gap #787 " +
+				"went through",
+		},
 	} {
 		body, readErr := os.ReadFile(filepath.Join(root, wiring.file))
 		require.NoError(t, readErr, "%s must exist: %s", wiring.file, wiring.why)
@@ -204,6 +218,42 @@ func TestOWUIOAuthScopeGateIsWired(t *testing.T) {
 			"%s no longer invokes %q outside a comment, so %s",
 			wiring.file, wiring.needle, wiring.why)
 	}
+
+	// The Makefile check above reads the whole file, so moving the line out of
+	// `test-scripts` into a target nothing calls would satisfy it while the
+	// comparator's tests stopped running. ci.yml runs `make test-scripts` and
+	// nothing else, so the recipe is the thing that matters.
+	makefile, err := os.ReadFile(filepath.Join(root, "Makefile"))
+	require.NoError(t, err)
+	require.True(t, inMakeRecipe(string(makefile), "test-scripts", "python3 scripts/test_check_oauth_scopes.py"),
+		"scripts/test_check_oauth_scopes.py is somewhere in the Makefile but not inside "+
+			"the test-scripts recipe, which is the only target CI invokes "+
+			"(.github/workflows/ci.yml, repo-policy-lints). A target nobody calls runs "+
+			"nothing, and the comparator is then unguarded.")
+}
+
+// inMakeRecipe reports whether needle appears in the recipe lines of target.
+//
+// A make recipe is the tab-indented run of lines under `target:`, ending at
+// the first line that is neither indented nor blank.
+func inMakeRecipe(makefile, target, needle string) bool {
+	inTarget := false
+	for _, line := range strings.Split(makefile, "\n") {
+		switch {
+		case strings.HasPrefix(line, target+":"):
+			inTarget = true
+		case inTarget && strings.TrimSpace(line) == "":
+			continue
+		case inTarget && !strings.HasPrefix(line, "\t") && !strings.HasPrefix(line, " "):
+			inTarget = false
+		}
+		if inTarget && strings.HasPrefix(line, "\t") &&
+			!strings.HasPrefix(strings.TrimSpace(line), "#") &&
+			strings.Contains(line, needle) {
+			return true
+		}
+	}
+	return false
 }
 
 // TestContainsUncommentedRejectsCommentedInvocations is the self-check for the
@@ -227,6 +277,23 @@ func TestContainsUncommentedRejectsCommentedInvocations(t *testing.T) {
 	} {
 		require.Equal(t, tc.want, containsUncommented(tc.body, needle), tc.name)
 	}
+
+	// The Makefile recipe matcher, same idea: being in the file is not being
+	// in the target CI runs.
+	const call = "python3 scripts/test_check_oauth_scopes.py"
+	for _, tc := range []struct {
+		name string
+		body string
+		want bool
+	}{
+		{"inside the recipe", "test-scripts:\n\tpython3 a.py\n\t" + call + "\n", true},
+		{"in another target", "test-scripts:\n\tpython3 a.py\n\nsomething-else:\n\t" + call + "\n", false},
+		{"after the recipe ends", "test-scripts:\n\tpython3 a.py\n\nnotes = " + call + "\n", false},
+		{"commented inside the recipe", "test-scripts:\n\t# " + call + "\n", false},
+		{"absent entirely", "test-scripts:\n\tpython3 a.py\n", false},
+	} {
+		require.Equal(t, tc.want, inMakeRecipe(tc.body, "test-scripts", call), tc.name)
+	}
 }
 
 // containsUncommented reports whether needle appears on a line that is not
@@ -235,6 +302,14 @@ func TestContainsUncommentedRejectsCommentedInvocations(t *testing.T) {
 // Plain strings.Contains would accept a step that had been commented out, or a
 // comment describing the invocation that used to be there. Those are the exact
 // states this guard exists to catch, so matching them would make it decorative.
+//
+// The edge of what this can see, stated so the next reader does not assume
+// more of it: `if: false`, or any never-true `if:` expression, on the deploy
+// step or on the gate's job leaves the invocation on an uncommented line and
+// reads as wired here. Catching that needs a YAML parse and an expression
+// evaluator, which is a bigger dependency than the risk justifies. The two
+// disabling moves that ARE caught are a commented-out invocation and a removed
+// pull_request trigger, plus the recipe check below for the Makefile.
 func containsUncommented(body, needle string) bool {
 	for _, line := range strings.Split(body, "\n") {
 		if strings.HasPrefix(strings.TrimSpace(line), "#") {

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -703,22 +703,40 @@ services:
       OPENID_PROVIDER_URL: "${SUPABASE_PUBLIC_URL:-${SUPABASE_URL}}/auth/v1/.well-known/openid-configuration"
       OAUTH_CLIENT_ID: ${SUPABASE_OAUTH_CLIENT_ID:-}
       OAUTH_CLIENT_SECRET: ${SUPABASE_OAUTH_CLIENT_SECRET:-}
-      # offline_access is load-bearing, not decoration (#782). Supabase issues
-      # access tokens with a 3600 second lifetime, and Open WebUI refreshes at
-      # 5 minutes before expiry (OAuthManager.get_oauth_token). When that
-      # refresh runs, _perform_token_refresh returns None on its very first
-      # guard if the stored session has no refresh_token, and the caller then
-      # DELETES the OAuth session outright. From that moment __oauth_token__ is
-      # empty forever, hive_jwt_forward injects no upstream_auth, and every
-      # chat completion 401s with missingUserTokenMessage until the user signs
-      # in again through SSO. Without offline_access on the authorize request
-      # Supabase returns no refresh token at all, so that destruction was
-      # guaranteed roughly 55 minutes into every signed-in session.
+      # Every scope here has to be one the deployed authorization server
+      # advertises. An unknown scope is fatal rather than ignored: GoTrue
+      # answers the authorize request with a 302 straight back to the callback
+      # carrying error=invalid_request and "unsupported scope: <name>", so
+      # there is no consent screen, no authorization code and no session at
+      # all. Sign-in is simply dead for every user.
       #
-      # Supabase's own discovery document advertises offline_access in
-      # scopes_supported and refresh_token in grant_types_supported, so this
-      # asks for something the provider already offers. Guarded by
-      # TestOWUIOAuthScopesRequestOfflineAccess in apps/edge-api/internal/auth.
+      # That is exactly what #787 shipped on 2026-08-20. It added
+      # offline_access after validating against hosted Supabase, whose
+      # discovery document advertised it. The self-hosted GoTrue this stack cut
+      # over to does not: its scopes_supported is openid, profile, email,
+      # phone, and SupportedOAuthScopes in internal/models/oauth_scope.go at
+      # the pinned v2.189.0 is that same four value list. Chat sign-in stayed
+      # dead until the scope came back out.
+      #
+      # offline_access buys nothing here even where it is accepted, which is
+      # the part #787 got wrong on both sides. GoTrue's authorization code
+      # grant calls tokenService.IssueRefreshToken unconditionally and always
+      # puts refresh_token in the token response (internal/api/oauthserver/
+      # handlers.go at v2.189.0), so the refresh token #782 needs is issued
+      # whether or not the scope is requested. Read from the pinned source and
+      # then confirmed live against the box rather than inferred, since
+      # inferring a capability is what caused this in the first place:
+      # docs/proof/oauth-scope-selfhost-2026-08-22/.
+      #
+      # Guarded on both sides, because the two halves of this mismatch drift
+      # independently. scripts/check-oauth-scopes.py reads the live
+      # scopes_supported and fails when this value is not a subset of it. It
+      # runs on every pull request that touches deploy YAML
+      # (.github/workflows/oauth-scope-gate.yml) and again after every deploy
+      # (deploy-demo-box.yml). The first catches a scope added here that the
+      # backend does not know; the second catches a capability the backend
+      # stops advertising while this file stands still, which is the direction
+      # the self-hosted cutover actually broke.
       #
       # This one is NOT shadowable by a persisted row, which is the question
       # every Open WebUI setting in this file has to answer since #722. Traced
@@ -731,10 +749,11 @@ services:
       # reconciler is needed here, unlike OAUTH_AUTO_REDIRECT and the feature
       # flags that do go through one.
       #
-      # The scope is only half of #782. A refresh token that exists is still
-      # refused, because Open WebUI's refresh POST authenticates the client in
-      # a different dialect than the authorization code exchange does. That
-      # half is fixed inside the image by Dockerfile.open-webui's
+      # The surviving half of #787, and the only half #782 ever needed. A
+      # refresh token that exists is still refused, because Open WebUI's
+      # refresh POST authenticates the client in a different dialect than the
+      # authorization code exchange does. That half is fixed inside the image
+      # by Dockerfile.open-webui's
       # apply_oauth_client_auth_patch.py, deliberately NOT by setting
       # OAUTH_TOKEN_ENDPOINT_AUTH_METHOD here: pinning that to
       # client_secret_post would also force every Supabase OAuth client to be
@@ -742,7 +761,7 @@ services:
       # manual ops with no script behind it. Every client this project has
       # registered so far is client_secret_basic, so that value would break
       # sign-in outright on each of them.
-      OAUTH_SCOPES: "openid email profile offline_access"
+      OAUTH_SCOPES: "openid email profile"
       # Supabase's OAuth 2.1 authorization server requires PKCE on every
       # authorize request. authlib (OWUI's OAuth client) only sends
       # code_challenge/code_challenge_method when this is set, so without it

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -718,15 +718,26 @@ services:
       # the pinned v2.189.0 is that same four value list. Chat sign-in stayed
       # dead until the scope came back out.
       #
-      # offline_access buys nothing here even where it is accepted, which is
-      # the part #787 got wrong on both sides. GoTrue's authorization code
-      # grant calls tokenService.IssueRefreshToken unconditionally and always
-      # puts refresh_token in the token response (internal/api/oauthserver/
+      # Against GoTrue specifically, offline_access also buys nothing even
+      # where it is accepted, which is the part #787 got wrong on both sides.
+      # GoTrue's authorization code grant calls
+      # tokenService.IssueRefreshToken unconditionally and always puts
+      # refresh_token in the token response (internal/api/oauthserver/
       # handlers.go at v2.189.0), so the refresh token #782 needs is issued
       # whether or not the scope is requested. Read from the pinned source and
       # then confirmed live against the box rather than inferred, since
       # inferring a capability is what caused this in the first place:
       # docs/proof/oauth-scope-selfhost-2026-08-22/.
+      #
+      # Scoped to GoTrue on purpose, and not a general claim about OAuth. On
+      # most authorization servers offline_access is exactly the switch that
+      # gates a durable refresh credential, and OPENID_PROVIDER_URL above is
+      # built from SUPABASE_PUBLIC_URL, so a deployment pointed at a different
+      # server would need this value revisited or #782 returns as a silent
+      # 55 minute lockout. TestOWUIOAuthScopesRequestAnIdentity guards the
+      # scopes whose absence breaks sign-in outright (openid and email); it
+      # cannot guard this one, because whether it is needed is a property of
+      # the server rather than of this file.
       #
       # Guarded on both sides, because the two halves of this mismatch drift
       # independently. scripts/check-oauth-scopes.py reads the live

--- a/docs/proof/oauth-scope-selfhost-2026-08-22/capture.log
+++ b/docs/proof/oauth-scope-selfhost-2026-08-22/capture.log
@@ -237,10 +237,10 @@ CodeRabbit's local review raised two blind spots, both real, both fixed:
 
   Restored, green:
 
-    --- PASS: TestOWUIOAuthScopesRequestOpenID (0.00s)
+    --- PASS: TestOWUIOAuthScopesRequestAnIdentity (0.00s)
     --- PASS: TestOWUIOAuthScopeGateIsWired (0.00s)
     --- PASS: TestContainsUncommentedRejectsCommentedInvocations (0.00s)
-    $ python3 scripts/test_check_oauth_scopes.py   -> 19 checks, all passed
+    $ python3 scripts/test_check_oauth_scopes.py   -> all checks passed
 
   Also confirmed in CI on the first commit: the new pull-request gate
   ("Configured OAuth scopes are advertised by the auth server") passed in 8
@@ -313,3 +313,48 @@ asserted offline instead, from the pinned source rather than from convention:
     FAIL
 
   Restored to "openid email profile", green.
+
+
+10. Security review round, and the box left clean
+-------------------------------------------------
+
+An independent security pass on the pull request returned no blocker (nothing
+critical, high or medium) and four low findings, all applied:
+
+  * the discovery fetch now refuses any scheme but http and https, so a local
+    file cannot decide whether the gate passes, and it reads the body with a
+    256 KiB cap so a slow drip cannot stall the deploy job while it holds the
+    deploy-demo-box concurrency group. Redirect targets are re-checked. Fixture
+    cases cover file://, ftp:// and gopher://.
+  * oauth-scope-gate no longer cancels in-progress runs on main, only on pull
+    requests. Two commits landing close together would otherwise cancel the
+    earlier one's run, leaving that commit with no verdict, which reads exactly
+    like a pass.
+  * the deploy step's `printenv` now tolerates a missing variable, because
+    under `set -e` its exit 1 aborted the step before the branch that explains
+    what is wrong could print.
+  * the compose comment's claim about offline_access is scoped to GoTrue rather
+    than stated of OAuth in general, since on most authorization servers that
+    scope IS the switch gating a durable refresh credential.
+
+Nothing in this capture was found to be a real credential: every
+credential-bearing parameter is a placeholder and every token is reported as
+presence and length. The reviewer's one housekeeping note is closed too: the
+temporary /tmp/hive-owui-scope-hotfix.yml on the box has been deleted, and the
+running container still carries the fixed value independently of it:
+
+  $ docker inspect hive-open-webui-1 --format '{{range .Config.Env}}...'
+    OAUTH_SCOPES=openid email profile
+
+  $ (sign-in chain, re-run after the cleanup)
+    [3] GET https://console-hive.scubed.co/oauth/consent?authorization_id=<REDACTED>
+        -> 200 text/html
+        VERDICT: reached a rendered page (consent screen)
+
+Also recorded from that review, for whoever next opens an admin surface: the
+socat tap used here published GoTrue's admin API on the box's loopback for the
+tap's lifetime, which put it in reach of every local process, outside the
+boundary Caddy defines for /auth/v1. The better pattern was already used in
+section 5 of this capture and needs no published port at all: run the admin
+calls from a throwaway container attached to the stack's own network
+(`docker run --rm --network hive_default ...`). Do that next time instead.

--- a/docs/proof/oauth-scope-selfhost-2026-08-22/capture.log
+++ b/docs/proof/oauth-scope-selfhost-2026-08-22/capture.log
@@ -11,6 +11,15 @@ Every credential-bearing query parameter is redacted below (client_id, state,
 nonce, code_challenge, code, authorization_id). Token values are never printed:
 presence and length only.
 
+Two registers in this document, kept apart on purpose, because the whole
+incident came from confusing them. MEASURED means a request was made against
+the deployment and the response is transcribed. READ means a file was read in
+supabase/auth at tag v2.189.0, the tag this stack pins by digest; GoTrue is not
+vendored in this repository, so those attributions are a reading of an external
+source, not an observation of this server. Every conclusion below rests on the
+measured half; the read half explains why the measurement comes out the way it
+does. Where a line names a GoTrue file or function, it is READ.
+
 
 1. What the authorization server actually advertises
 ---------------------------------------------------
@@ -379,6 +388,26 @@ Four medium findings, all applied, none of them cosmetic:
     model-catalog work. No coverage lost: the script still scans all of deploy/
     on the runs that happen, and `make test-scripts` scans all of deploy/
     offline on every pull request inside a required check.
+
+Two further findings from the same review were applied beyond that list, and
+they are the ones that changed behaviour rather than placement:
+
+  * nothing noticed a scope being LOST, only one being added, because every
+    subset passes a subset check. Two restorations: the offline guard now
+    requires email as well as openid (section 9), and check-oauth-scopes.py now
+    fails when the server ADVERTISES offline_access while the configuration
+    omits it. That second one is the important one. It turns the assertion #787
+    deleted from a convention-derived claim into a server-derived one: a no-op
+    against the self-hosted GoTrue, which does not advertise the scope, and an
+    automatic return of #782's guard if this stack ever moves to a server that
+    does.
+  * two legal YAML spellings got the wrong verdict. A trailing comment
+    (`OAUTH_SCOPES: "openid email profile"  # note`) was split into scopes
+    named `profile"`, `#` and `keep`, failing a legal edit with an
+    outage-flavoured message, which is how a check teaches people to route
+    around it. An interpolated value now says it cannot be resolved rather than
+    naming a brace as an unsupported scope. A folded multi-line value is named
+    as a known boundary in the docstring rather than parsed.
 
 Re-rehearsed on the box after those edits, still against its unfixed checkout:
 

--- a/docs/proof/oauth-scope-selfhost-2026-08-22/capture.log
+++ b/docs/proof/oauth-scope-selfhost-2026-08-22/capture.log
@@ -199,3 +199,50 @@ The temporary in-network tap used to reach GoTrue's admin API (a socat
 container publishing on 127.0.0.1 only, plus an ssh local forward) was removed
 afterwards, and its absence confirmed: the container is gone and the forwarded
 port answers nothing.
+
+
+7. Review-round mutations (CodeRabbit findings, second commit)
+--------------------------------------------------------------
+
+CodeRabbit's local review raised two blind spots, both real, both fixed:
+
+  major  the scope scanner read only Compose's mapping form
+         (`OAUTH_SCOPES: "..."`), not its list form
+         (`- OAUTH_SCOPES=...`). Compose accepts either, so a declaration
+         written the other way would not fail the check, it would be invisible
+         to it, and the check would report a clean run over a corpus of zero.
+         Both scripts/check-oauth-scopes.py and envDeclarations in
+         owui_oauth_scope_test.go now read both spellings.
+
+  minor  the wiring guard matched a bare filename, so a commented-out step, or
+         a comment explaining that the check had been removed, would satisfy
+         it. It now matches invocations and ignores comment lines
+         (containsUncommented), with its own table test.
+
+  Mutation, list form: `- OAUTH_SCOPES=openid email profile offline_access`
+
+    ok   list-form `- OAUTH_SCOPES=...` with a bad scope fails
+    ok   list-form with a good scope passes
+    ok   list form is seen as one declaration
+
+  Mutation, the Makefile invocation commented out rather than deleted:
+
+    $ go test ./apps/edge-api/internal/auth/... -run OWUIOAuthScopeGateIsWired
+    --- FAIL: TestOWUIOAuthScopeGateIsWired (0.00s)
+        Messages: Makefile no longer invokes
+                  "python3 scripts/test_check_oauth_scopes.py" outside a
+                  comment, so the comparator's own tests must run in a required
+                  check [...]
+    FAIL
+
+  Restored, green:
+
+    --- PASS: TestOWUIOAuthScopesRequestOpenID (0.00s)
+    --- PASS: TestOWUIOAuthScopeGateIsWired (0.00s)
+    --- PASS: TestContainsUncommentedRejectsCommentedInvocations (0.00s)
+    $ python3 scripts/test_check_oauth_scopes.py   -> 19 checks, all passed
+
+  Also confirmed in CI on the first commit: the new pull-request gate
+  ("Configured OAuth scopes are advertised by the auth server") passed in 8
+  seconds against the live discovery document from a GitHub-hosted runner, so
+  the gate genuinely reaches the deployed authorization server.

--- a/docs/proof/oauth-scope-selfhost-2026-08-22/capture.log
+++ b/docs/proof/oauth-scope-selfhost-2026-08-22/capture.log
@@ -1,0 +1,201 @@
+OAuth scope capability mismatch (#787): live capture against the demo box
+=========================================================================
+
+Date:     2026-08-22
+Surfaces: https://chat-hive.scubed.co  (Open WebUI, OIDC client)
+          https://console-hive.scubed.co/auth/v1  (self-hosted GoTrue, issuer)
+Identity: rag-verify-e2e@hive-e2e.invalid, session minted through the admin
+          one-time-token flow. No password was read and none was changed.
+
+Every credential-bearing query parameter is redacted below (client_id, state,
+nonce, code_challenge, code, authorization_id). Token values are never printed:
+presence and length only.
+
+
+1. What the authorization server actually advertises
+---------------------------------------------------
+
+  GET https://console-hive.scubed.co/auth/v1/.well-known/openid-configuration
+
+  issuer                              https://console-hive.scubed.co/auth/v1
+  scopes_supported                    openid profile email phone
+  grant_types_supported               authorization_code refresh_token
+  response_types_supported            code
+  token_endpoint_auth_methods         client_secret_basic client_secret_post none
+
+  GET http://supabase-auth:9999/health   (in-network, direct)
+  {"version":"v2.189.0","name":"GoTrue",...}
+
+  offline_access is absent, and it is not merely undeclared. At the pinned
+  supabase/gotrue v2.189.0, internal/models/oauth_scope.go declares
+  SupportedOAuthScopes as exactly openid, profile, email, phone, and
+  internal/api/oauthserver/authorize.go rejects anything outside that set.
+
+
+2. The outage, reproduced before the fix
+----------------------------------------
+
+  [1] GET https://chat-hive.scubed.co/oauth/oidc/login
+      -> 302
+      -> Location: https://console-hive.scubed.co/auth/v1/oauth/authorize
+                     ?response_type=code&client_id=<REDACTED>
+                     &redirect_uri=https://chat-hive.scubed.co/oauth/oidc/callback
+                     &scope=openid+email+profile+offline_access
+                     &state=<REDACTED>&nonce=<REDACTED>
+                     &code_challenge=<REDACTED>&code_challenge_method=S256
+      scope requested: openid email profile offline_access
+
+  [2] GET (that authorize URL)
+      -> 302 text/html
+      -> Location: https://chat-hive.scubed.co/oauth/oidc/callback
+                     ?error=invalid_request
+                     &error_description=unsupported+scope%3A+offline_access
+                     &state=<REDACTED>
+      VERDICT: FAILED at the authorization server. No consent screen, no
+               authorization code, no session. Sign-in dead for every user.
+
+
+3. The same chain after the fix
+-------------------------------
+
+  open-webui recreated with OAUTH_SCOPES="openid email profile", container
+  reported healthy, then:
+
+  [1] GET https://chat-hive.scubed.co/oauth/oidc/login
+      -> 302
+      -> Location: https://console-hive.scubed.co/auth/v1/oauth/authorize
+                     ?response_type=code&client_id=<REDACTED>
+                     &redirect_uri=https://chat-hive.scubed.co/oauth/oidc/callback
+                     &scope=openid+email+profile
+                     &state=<REDACTED>&nonce=<REDACTED>
+                     &code_challenge=<REDACTED>&code_challenge_method=S256
+      scope requested: openid email profile
+
+  [2] GET (that authorize URL)
+      -> 302 text/html
+      -> Location: https://console-hive.scubed.co/oauth/consent
+                     ?authorization_id=<REDACTED>
+
+  [3] GET https://console-hive.scubed.co/oauth/consent?authorization_id=<REDACTED>
+      -> 200 text/html
+      VERDICT: reached the consent page. No error parameter anywhere in the
+               chain.
+
+
+4. End to end in a real browser, signed in
+------------------------------------------
+
+  Chromium, cookies from a minted session for rag-verify-e2e@hive-e2e.invalid:
+
+    302 https://chat-hive.scubed.co/oauth/oidc/login
+    302 https://console-hive.scubed.co/auth/v1/oauth/authorize?...&scope=openid+email+profile&...
+    307 https://chat-hive.scubed.co/oauth/oidc/callback?code=<REDACTED>&state=<REDACTED>
+    landed on: https://chat-hive.scubed.co/
+    title:     Hive
+
+  Screenshot: the chat surface, signed in, account chip reading
+  rag-verify-e2e@hive-e2e.inva... in the sidebar. Posted on the pull request as
+  an inline image through scripts/post-pr-visual-proof.sh.
+
+  Unauthenticated, the same chain lands on the console sign-in page AT the
+  consent URL (https://console-hive.scubed.co/oauth/consent?authorization_id=
+  <REDACTED>), which is the correct behaviour and still not an error redirect.
+
+
+5. Does GoTrue issue a refresh token WITHOUT offline_access?
+-----------------------------------------------------------
+
+  This is the question that decides whether #787 retains any value. Answered
+  by walking a complete authorization code flow with the fix's scope set, from
+  a throwaway container on the stack's own network:
+
+  scope requested:      openid email profile   (deliberately no offline_access)
+  authorize:            HTTP 302 -> consent page, handle length 32 <REDACTED>
+  load authorization:   HTTP 200
+  consent approve:      HTTP 200 -> authorization code issued, length 36 <REDACTED>
+  token exchange:       HTTP 200
+    keys returned:      access_token expires_in id_token refresh_token token_type
+    access_token        present, 1236 chars
+    refresh_token       present, 12 chars
+    id_token            present, 724 chars
+    expires_in          3600
+
+  VERDICT: a refresh token IS issued with no offline_access in the request.
+  Consistent with the source: handleAuthorizationCodeGrant calls
+  tokenService.IssueRefreshToken unconditionally and always puts refresh_token
+  in the response map.
+
+  Consequence for #787: its scope half was never necessary and was fatal here.
+  Its other half, the client-authentication dialect on the refresh POST
+  (Dockerfile.open-webui's apply_oauth_client_auth_patch.py), is still
+  load bearing, because a refresh token that exists is still refused when the
+  refresh request authenticates the client in the wrong dialect. So this is a
+  partial revert, not a full one.
+
+
+6. The check that would have caught this, shown failing
+------------------------------------------------------
+
+  scripts/check-oauth-scopes.py reads the live scopes_supported and fails when
+  a configured scope is not in it.
+
+  Mutation: OAUTH_SCOPES in deploy/docker/docker-compose.yml put back to
+  "openid email profile offline_access", the exact #787 value, then run against
+  the real deployed discovery document:
+
+    $ python3 scripts/check-oauth-scopes.py --discovery \
+        https://console-hive.scubed.co/auth/v1/.well-known/openid-configuration
+    ::error file=deploy/docker/docker-compose.yml,line=764::
+      deploy/docker/docker-compose.yml:764 requests offline_access, which
+      https://console-hive.scubed.co/auth/v1/.well-known/openid-configuration
+      does not advertise. [...] chat sign-in is dead for every user (#787).
+      Advertised scopes are openid profile email phone.
+    authorization server: https://console-hive.scubed.co/auth/v1/.well-known/openid-configuration
+    scopes_supported:     openid profile email phone
+    EXIT=1
+
+  Mutation reverted, same command:
+
+    authorization server: https://console-hive.scubed.co/auth/v1/.well-known/openid-configuration
+    scopes_supported:     openid profile email phone
+    ok deploy/docker/docker-compose.yml:764 OAUTH_SCOPES='openid email profile'
+    EXIT=0
+
+  Mutation: scripts/check-oauth-scopes.py moved out of the tree, so the gate
+  is gone while the repository still claims it:
+
+    $ go test ./apps/edge-api/internal/auth/... -run OWUIOAuthScopeGateIsWired
+    --- FAIL: TestOWUIOAuthScopeGateIsWired (0.00s)
+        Error: stat /workspace/scripts/check-oauth-scopes.py: no such file or directory
+        Messages: scripts/check-oauth-scopes.py is the only check that compares
+                  a requested OAuth scope against what the deployed
+                  authorization server actually advertises (#787). It must exist.
+    FAIL
+
+  Script restored, both green:
+
+    $ python3 scripts/test_check_oauth_scopes.py
+    ... 16 checks, all passed
+    $ go test ./apps/edge-api/internal/auth/... -run OWUIOAuth -v
+    --- PASS: TestOWUIOAuthScopesRequestOpenID (0.00s)
+    --- PASS: TestOWUIOAuthScopeGateIsWired (0.00s)
+    ok
+
+
+Notes on how the box was restored ahead of the merge
+----------------------------------------------------
+
+Sign-in was dead on the live box while this pull request was still open, and
+the deploy that ships the repository fix only runs on merge. So the running
+open-webui container was recreated with the corrected scope supplied through a
+one-service compose override at /tmp/hive-owui-scope-hotfix.yml on the box,
+with --no-deps and no --remove-orphans, and nothing in the box's git checkout
+touched (a dirty tracked file there would break the deploy job's
+`git pull --ff-only`). The merge supersedes it: deploy-demo-box recreates
+open-webui from deploy/docker/docker-compose.yml, which now carries the same
+value.
+
+The temporary in-network tap used to reach GoTrue's admin API (a socat
+container publishing on 127.0.0.1 only, plus an ssh local forward) was removed
+afterwards, and its absence confirmed: the container is gone and the forwarded
+port answers nothing.

--- a/docs/proof/oauth-scope-selfhost-2026-08-22/capture.log
+++ b/docs/proof/oauth-scope-selfhost-2026-08-22/capture.log
@@ -246,3 +246,41 @@ CodeRabbit's local review raised two blind spots, both real, both fixed:
   ("Configured OAuth scopes are advertised by the auth server") passed in 8
   seconds against the live discovery document from a GitHub-hosted runner, so
   the gate genuinely reaches the deployed authorization server.
+
+
+8. The post-deploy step, rehearsed on the box before the merge
+-------------------------------------------------------------
+
+A step that only ever runs after a merge is a step nobody has run. So the exact
+command from deploy-demo-box.yml was executed by hand on the box, against the
+box's own still-unfixed checkout of main (851003b7b, OAUTH_SCOPES with
+offline_access at line 745), with the same HIVE_COMPOSE_FLAGS:
+
+  discovery URL read from the running container:
+    https://console-hive.scubed.co/auth/v1/.well-known/openid-configuration
+  authorization server: https://console-hive.scubed.co/auth/v1/.well-known/openid-configuration
+  scopes_supported:     openid profile email phone
+  ::error file=deploy/docker/docker-compose.yml,line=745::
+    deploy/docker/docker-compose.yml:745 requests offline_access, which [...]
+    does not advertise. [...] chat sign-in is dead for every user (#787).
+    Advertised scopes are openid profile email phone.
+
+So the step works mechanically on the box (compose exec resolves, printenv
+returns the concrete URL, python3 is present, the public discovery document is
+reachable from the box), and it goes RED on the exact commit that caused the
+outage, naming the exact line. After the merge it reads the fixed value and
+passes.
+
+One thing found by rehearsing rather than reasoning: the check resolves its
+corpus relative to its own path, so a copy of the script run from /tmp reported
+"no OAUTH_SCOPES declaration found under /deploy" and exited 1. That is correct
+behaviour and correctly loud, but the message did not name the likely cause, so
+it now does. The rehearsal was then redone with the script staged next to a
+deploy/ tree.
+
+The script was deliberately NOT copied into /home/sakib/hive/scripts/ for this
+rehearsal: an untracked file at a path the incoming merge also creates makes
+`git pull --ff-only` refuse, which would have broken the deploy this was
+rehearsing. Only /tmp paths and a symlink there were used, and both are removed.
+The box's checkout carries no tracked modification (`git status --porcelain`
+shows only pre-existing .env backups), so the deploy's fast-forward is clear.

--- a/docs/proof/oauth-scope-selfhost-2026-08-22/capture.log
+++ b/docs/proof/oauth-scope-selfhost-2026-08-22/capture.log
@@ -284,3 +284,32 @@ rehearsal: an untracked file at a path the incoming merge also creates makes
 rehearsing. Only /tmp paths and a symlink there were used, and both are removed.
 The box's checkout carries no tracked modification (`git status --porcelain`
 shows only pre-existing .env backups), so the deploy's fast-forward is clear.
+
+
+9. The other direction: losing a scope this deployment needs
+------------------------------------------------------------
+
+The live gate fails when the list GAINS a scope the server rejects. It is
+perfectly happy with a list trimmed to nothing but `openid`, because a smaller
+set is still a subset. That is a different outage with the same shape, so it is
+asserted offline instead, from the pinned source rather than from convention:
+
+  openid  handleAuthorizationCodeGrant generates an id_token only under
+          `if models.HasScope(scopeList, models.ScopeOpenID)`.
+  email   the email and email_verified claims are gated on `hasEmailScope`
+          (internal/api/oauthserver/handlers.go), and Open WebUI matches its
+          account on the email claim.
+
+  profile is deliberately not required: it carries only name and picture, whose
+  absence degrades an avatar rather than breaking sign-in.
+
+  Mutation: OAUTH_SCOPES set to "openid profile".
+
+    --- FAIL: TestOWUIOAuthScopesRequestAnIdentity (0.00s)
+        Error: []string{"openid", "profile"} does not contain "email"
+        Messages: deploy/docker/docker-compose.yml:764 declares OAUTH_SCOPES
+                  "openid profile" without email. GoTrue gates the email and
+                  email_verified claims on that scope [...]
+    FAIL
+
+  Restored to "openid email profile", green.

--- a/docs/proof/oauth-scope-selfhost-2026-08-22/capture.log
+++ b/docs/proof/oauth-scope-selfhost-2026-08-22/capture.log
@@ -351,7 +351,49 @@ running container still carries the fixed value independently of it:
         -> 200 text/html
         VERDICT: reached a rendered page (consent screen)
 
-Also recorded from that review, for whoever next opens an admin surface: the
+11. Adversarial review round, and the step re-rehearsed after it
+----------------------------------------------------------------
+
+Four medium findings, all applied, none of them cosmetic:
+
+  * the audit step sat before the hive_jwt_forward install, so a momentary DNS
+    or tunnel blip reaching the discovery document would abort the deploy
+    before that Function was installed, which is the #556 failure the Function
+    step exists to prevent. It is an audit and changes no state, so it moved to
+    the END of the job. Failing last still fails the run.
+  * `printenv` under `set -e` ended the step before the friendly diagnostic
+    could print, so the two cases a reader expects that message to cover, an
+    unset variable and a container that is not running, were exactly the two it
+    could never reach. Now `if ! url=$(...) || [ -z "$url" ]`, the shape the
+    supabase-db probe in the same job already uses.
+  * the pull-request gate spells its origin by hand from CONSOLE_URL while Open
+    WebUI resolves SUPABASE_PUBLIC_URL. They agree today by hand, not by
+    construction, and a repoint would leave the gate interrogating the old host
+    and reporting green, which is #787 one level up. The deploy step now
+    compares the two and fails on a mismatch, which costs nothing because it
+    already holds the deployed value.
+  * the gate's paths filter was `deploy/**.yml`, matching Prometheus alerts,
+    Alertmanager, Grafana provisioning, the LiteLLM model list and headscale,
+    none of which can carry an OAUTH_SCOPES declaration. Narrowed to
+    `deploy/docker/**`, so a home lab outage cannot park monitoring or
+    model-catalog work. No coverage lost: the script still scans all of deploy/
+    on the runs that happen, and `make test-scripts` scans all of deploy/
+    offline on every pull request inside a required check.
+
+Re-rehearsed on the box after those edits, still against its unfixed checkout:
+
+  discovery URL read from the running container:
+    https://console-hive.scubed.co/auth/v1/.well-known/openid-configuration
+  matches the URL the pull-request gate checks
+  ::error file=deploy/docker/docker-compose.yml,line=745:: [...] requests
+    offline_access, which [...] does not advertise. [...] (#787).
+
+So the new mismatch comparison passes on the real deployment, and the check
+still goes red on the commit that caused the outage. Box left clean again:
+`git status --porcelain` shows no tracked modification, and the /tmp staging is
+removed.
+
+Also recorded from the security review, for whoever next opens an admin surface: the
 socat tap used here published GoTrue's admin API on the box's loopback for the
 tap's lifetime, which put it in reach of every local process, outside the
 boundary Caddy defines for /auth/v1. The better pattern was already used in

--- a/scripts/check-oauth-scopes.py
+++ b/scripts/check-oauth-scopes.py
@@ -61,6 +61,19 @@ def declarations(deploy_dir: Path) -> list[tuple[Path, int, str]]:
     mirrors envDeclarations in apps/edge-api/internal/auth/owui_oauth_scope_test.go
     on purpose: same corpus, one side checked offline and one side checked
     against the live server.
+
+    Both Compose environment spellings are recognized, mapping and list:
+
+        environment:
+          OAUTH_SCOPES: "openid email profile"
+
+        environment:
+          - OAUTH_SCOPES=openid email profile
+
+    Reading only the first would be the same defect in a new place. Compose
+    accepts either, so a declaration written the other way would sail past a
+    check whose entire job is to have no blind spot, and it would do it
+    silently, reporting a clean run over a corpus of zero.
     """
     found: list[tuple[Path, int, str]] = []
     for path in sorted(deploy_dir.rglob("*")):
@@ -68,10 +81,15 @@ def declarations(deploy_dir: Path) -> list[tuple[Path, int, str]]:
             continue
         for number, line in enumerate(path.read_text().splitlines(), start=1):
             stripped = line.strip()
-            if stripped.startswith("#") or not stripped.startswith(ENV_KEY + ":"):
+            if stripped.startswith("#"):
                 continue
-            value = stripped[len(ENV_KEY) + 1 :].strip().strip("\"'")
-            found.append((path, number, value))
+            if stripped.startswith(ENV_KEY + ":"):
+                raw = stripped[len(ENV_KEY) + 1 :]
+            elif stripped.startswith("- " + ENV_KEY + "=") or stripped.startswith("-" + ENV_KEY + "="):
+                raw = stripped.split("=", 1)[1]
+            else:
+                continue
+            found.append((path, number, raw.strip().strip("\"'")))
     return found
 
 

--- a/scripts/check-oauth-scopes.py
+++ b/scripts/check-oauth-scopes.py
@@ -75,6 +75,18 @@ def declarations(deploy_dir: Path) -> list[tuple[Path, int, str]]:
     accepts either, so a declaration written the other way would sail past a
     check whose entire job is to have no blind spot, and it would do it
     silently, reporting a clean run over a corpus of zero.
+
+    Known boundary, named rather than parsed: this reads the key's own line, so
+    a value folded across two lines is seen only as its first line, and the
+    continuation is invisible.
+
+        OAUTH_SCOPES: openid email
+          profile offline_access
+
+    YAML folds that into four scopes; this sees two, and passes. Nothing in
+    this repository is written that way and a real YAML parse is a bigger
+    dependency than the risk justifies, but a reader adding a scope should
+    keep the value on one line. Both call sites already do.
     """
     found: list[tuple[Path, int, str]] = []
     for path in sorted(deploy_dir.rglob("*")):
@@ -90,6 +102,15 @@ def declarations(deploy_dir: Path) -> list[tuple[Path, int, str]]:
                 raw = stripped.split("=", 1)[1]
             else:
                 continue
+            # A trailing YAML comment is not part of the value. Without this,
+            # `OAUTH_SCOPES: "openid email profile"  # keep in sync` is split
+            # into scopes named `profile"`, `#`, `keep` and `in`, and the check
+            # fails an entirely legal edit with an outage-flavoured message
+            # naming `#` as an unsupported scope. Failing closed is the right
+            # direction, but a check that cries wolf on legal style is one
+            # people learn to route around, and this repository's own Go
+            # matcher already treats a trailing comment as legitimate.
+            raw = raw.split(" #", 1)[0]
             found.append((path, number, raw.strip().strip("\"'")))
     return found
 
@@ -185,6 +206,44 @@ def report(
         except ValueError:
             relative = path
         requested = value.split()
+
+        if "${" in value:
+            failures += 1
+            print(
+                f"::error file={relative},line={number}::{relative}:{number} declares "
+                f"{ENV_KEY} as {value!r}, which this check cannot resolve: the value that "
+                "reaches the container is decided by an environment file it cannot read. "
+                "Spell the scopes literally here, or the gate is guessing.",
+                file=sys.stderr,
+            )
+            continue
+
+        # The direction a subset check cannot see on its own. If the server
+        # advertises offline_access and this configuration does not ask for
+        # it, that is #782 waiting to happen: on an authorization server that
+        # gates refresh issuance on the scope, Open WebUI destroys the OAuth
+        # session at its first refresh and every user is locked out roughly 55
+        # minutes after signing in.
+        #
+        # Server-derived rather than convention-derived, which is the whole
+        # point. Against the self-hosted GoTrue this is a no-op, because that
+        # server does not advertise the scope and does not need it. If this
+        # stack ever moves to a server that does, the guard #787 deleted comes
+        # back by itself instead of being rediscovered through another outage.
+        if "offline_access" in advertised and "offline_access" not in requested:
+            failures += 1
+            print(
+                f"::error file={relative},line={number}::{relative}:{number} declares "
+                f"{ENV_KEY} {value!r} while {origin} advertises offline_access. On a server "
+                "that gates refresh issuance on that scope, Open WebUI's first token "
+                "refresh finds no refresh_token, deletes the OAuth session, and every chat "
+                "completion 401s about 55 minutes after sign-in (#782). Ask for it, or "
+                "establish that this server issues a refresh token without it the way "
+                "docs/proof/oauth-scope-selfhost-2026-08-22/ did for GoTrue.",
+                file=sys.stderr,
+            )
+            continue
+
         unknown = [scope for scope in requested if scope not in advertised]
         if unknown:
             failures += 1

--- a/scripts/check-oauth-scopes.py
+++ b/scripts/check-oauth-scopes.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Refuse an OAUTH_SCOPES value the deployed authorization server does not
+advertise.
+
+Why this exists
+---------------
+PR #787 added `offline_access` to OAUTH_SCOPES in deploy/docker/docker-compose.yml
+after validating against hosted Supabase, whose discovery document advertised
+that scope. The self-hosted GoTrue this stack cut over to does not advertise it:
+scopes_supported is openid, profile, email, phone. GoTrue rejects an unknown
+scope outright rather than ignoring it, so the authorize request 302'd straight
+back to the callback with `error=invalid_request&error_description=unsupported
+scope: offline_access`. No consent screen, no authorization code, no session.
+Chat sign-in was dead for every user, and every test in the repository was green,
+because nothing in the repository knew what the backend could do.
+
+Two sides of one mismatch, and they drift independently:
+
+  * a scope added to the repository that the backend does not know, which is
+    #787, caught when this runs on a pull request that touches deploy YAML;
+  * a capability the backend stops advertising while the repository stands
+    still, which is what the self-hosted cutover actually did, caught when this
+    runs after a deploy.
+
+So this reads the live document rather than any checked-in snapshot of it. A
+snapshot would have been written from hosted Supabase and would have agreed with
+#787 all the way into the outage.
+
+Usage
+-----
+    check-oauth-scopes.py --discovery https://host/auth/v1/.well-known/openid-configuration
+    check-oauth-scopes.py --discovery-file fixture.json    # offline, for tests
+    check-oauth-scopes.py --self-check
+
+Exit 0 when every declared scope is advertised, 1 otherwise. An unreachable or
+malformed discovery document is also exit 1: this check has nothing useful to
+say without one, and saying nothing quietly is the failure mode it exists to
+remove.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEPLOY_DIR = REPO_ROOT / "deploy"
+ENV_KEY = "OAUTH_SCOPES"
+TIMEOUT_SECONDS = 30
+
+
+def declarations(deploy_dir: Path) -> list[tuple[Path, int, str]]:
+    """Every OAUTH_SCOPES assignment in deploy YAML, with file and line.
+
+    Scans all deploy YAML rather than one known line, so a second compose file,
+    an override or a profile cannot reintroduce the defect somewhere new. This
+    mirrors envDeclarations in apps/edge-api/internal/auth/owui_oauth_scope_test.go
+    on purpose: same corpus, one side checked offline and one side checked
+    against the live server.
+    """
+    found: list[tuple[Path, int, str]] = []
+    for path in sorted(deploy_dir.rglob("*")):
+        if path.suffix not in (".yml", ".yaml") or not path.is_file():
+            continue
+        for number, line in enumerate(path.read_text().splitlines(), start=1):
+            stripped = line.strip()
+            if stripped.startswith("#") or not stripped.startswith(ENV_KEY + ":"):
+                continue
+            value = stripped[len(ENV_KEY) + 1 :].strip().strip("\"'")
+            found.append((path, number, value))
+    return found
+
+
+def fetch_supported(url: str) -> list[str]:
+    """scopes_supported from a live discovery document.
+
+    Raises RuntimeError with a legible cause. Never returns a default: a
+    default here would let an unreachable server read as a pass, which is the
+    silent absence this check exists to replace with a loud failure.
+    """
+    request = urllib.request.Request(url, headers={"User-Agent": "hive-oauth-scope-check"})
+    try:
+        with urllib.request.urlopen(request, timeout=TIMEOUT_SECONDS) as response:
+            document = json.load(response)
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        raise RuntimeError(f"could not fetch {url}: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"{url} did not return JSON: {exc}") from exc
+    return read_supported(document, url)
+
+
+def read_supported(document: object, origin: str) -> list[str]:
+    if not isinstance(document, dict):
+        raise RuntimeError(f"{origin} is not an OpenID discovery document")
+    supported = document.get("scopes_supported")
+    if not isinstance(supported, list) or not supported:
+        raise RuntimeError(
+            f"{origin} declares no usable scopes_supported. An authorization "
+            "server that advertises nothing cannot be checked against, and "
+            "treating that as a pass is how an unsupported scope ships."
+        )
+    return [str(scope) for scope in supported]
+
+
+def report(
+    found: list[tuple[Path, int, str]],
+    supported: list[str],
+    origin: str,
+    scanned: Path = DEPLOY_DIR,
+) -> int:
+    """Print the verdict and return the process exit code."""
+    print(f"authorization server: {origin}")
+    print(f"scopes_supported:     {' '.join(supported)}")
+
+    if not found:
+        print(
+            f"::error::no {ENV_KEY} declaration found under {scanned}. If the "
+            "Open WebUI OIDC wiring moved, move this check with it rather than "
+            "letting it pass over an empty corpus.",
+            file=sys.stderr,
+        )
+        return 1
+
+    advertised = set(supported)
+    failures = 0
+    for path, number, value in found:
+        try:
+            relative = path.relative_to(REPO_ROOT)
+        except ValueError:
+            relative = path
+        requested = value.split()
+        unknown = [scope for scope in requested if scope not in advertised]
+        if unknown:
+            failures += 1
+            print(
+                f"::error file={relative},line={number}::{relative}:{number} requests "
+                f"{' '.join(unknown)}, which {origin} does not advertise. GoTrue "
+                "rejects an unknown scope outright, so this 302s the authorize "
+                "request back to the callback with error=invalid_request and no "
+                "session is ever created: chat sign-in is dead for every user "
+                f"(#787). Advertised scopes are {' '.join(supported)}.",
+                file=sys.stderr,
+            )
+        else:
+            print(f"ok {relative}:{number} {ENV_KEY}={value!r}")
+    return 1 if failures else 0
+
+
+def self_check() -> int:
+    """Run the unit tests next to this script, so `--self-check` cannot pass
+    over a comparator nobody exercised."""
+    test = Path(__file__).with_name("test_check_oauth_scopes.py")
+    return subprocess.call([sys.executable, str(test)])
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    source = parser.add_mutually_exclusive_group()
+    source.add_argument("--discovery", help="URL of the OpenID discovery document")
+    source.add_argument(
+        "--discovery-file",
+        help="a discovery document on disk, for tests and offline runs",
+    )
+    parser.add_argument("--self-check", action="store_true", help="run this script's own tests")
+    args = parser.parse_args()
+
+    if args.self_check:
+        return self_check()
+
+    try:
+        if args.discovery_file:
+            origin = args.discovery_file
+            supported = read_supported(json.loads(Path(origin).read_text()), origin)
+        elif args.discovery:
+            origin = args.discovery
+            supported = fetch_supported(origin)
+        else:
+            parser.error("one of --discovery, --discovery-file or --self-check is required")
+    except (RuntimeError, OSError, json.JSONDecodeError) as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        return 1
+
+    return report(declarations(DEPLOY_DIR), supported, origin, DEPLOY_DIR)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check-oauth-scopes.py
+++ b/scripts/check-oauth-scopes.py
@@ -51,6 +51,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 DEPLOY_DIR = REPO_ROOT / "deploy"
 ENV_KEY = "OAUTH_SCOPES"
 TIMEOUT_SECONDS = 30
+MAX_DOCUMENT_BYTES = 256 * 1024
 
 
 def declarations(deploy_dir: Path) -> list[tuple[Path, int, str]]:
@@ -99,11 +100,41 @@ def fetch_supported(url: str) -> list[str]:
     Raises RuntimeError with a legible cause. Never returns a default: a
     default here would let an unreachable server read as a pass, which is the
     silent absence this check exists to replace with a loud failure.
+
+    Three deliberate narrowings, none of them theoretical for a helper that
+    fetches a URL read out of a deployment's own configuration:
+
+      * http and https only. The stdlib opener also speaks file:// and ftp://,
+        so `--discovery file:///tmp/anything.json` would otherwise let a local
+        file decide whether the gate passes. Same check and same reason as
+        scripts/install-owui-jwt-forward.py.
+      * the body is read with a cap rather than streamed into the JSON parser.
+        A slow drip or an endless body would otherwise stall until the
+        enclosing job's timeout, which on the deploy job is thirty minutes
+        while it holds the deploy-demo-box concurrency group.
+      * the redirect target is checked too, because a redirect can move the
+        answer to a host the configuration never named.
     """
+    if urllib.parse.urlsplit(url).scheme not in ("http", "https"):
+        raise RuntimeError(
+            f"refusing to read a discovery document from {url!r}: only http and "
+            "https are accepted, so a local file or an ftp target cannot decide "
+            "whether this gate passes"
+        )
     request = urllib.request.Request(url, headers={"User-Agent": "hive-oauth-scope-check"})
     try:
         with urllib.request.urlopen(request, timeout=TIMEOUT_SECONDS) as response:
-            document = json.load(response)
+            if urllib.parse.urlsplit(response.geturl()).scheme not in ("http", "https"):
+                raise RuntimeError(
+                    f"{url} redirected to {response.geturl()!r}, which is not http or https"
+                )
+            body = response.read(MAX_DOCUMENT_BYTES + 1)
+        if len(body) > MAX_DOCUMENT_BYTES:
+            raise RuntimeError(
+                f"{url} returned more than {MAX_DOCUMENT_BYTES} bytes; a discovery "
+                "document is a small JSON object, so this is not one"
+            )
+        document = json.loads(body)
     except (urllib.error.URLError, TimeoutError, OSError) as exc:
         raise RuntimeError(f"could not fetch {url}: {exc}") from exc
     except json.JSONDecodeError as exc:

--- a/scripts/check-oauth-scopes.py
+++ b/scripts/check-oauth-scopes.py
@@ -136,9 +136,12 @@ def report(
 
     if not found:
         print(
-            f"::error::no {ENV_KEY} declaration found under {scanned}. If the "
-            "Open WebUI OIDC wiring moved, move this check with it rather than "
-            "letting it pass over an empty corpus.",
+            f"::error::no {ENV_KEY} declaration found under {scanned}. Two "
+            "causes, and neither is a reason to exit 0: the Open WebUI OIDC "
+            "wiring moved, in which case move this check with it; or this "
+            "script is being run from a copy outside the repository, since the "
+            "corpus is resolved relative to the script's own path and a copy "
+            "elsewhere sees an empty one.",
             file=sys.stderr,
         )
         return 1

--- a/scripts/test_check_oauth_scopes.py
+++ b/scripts/test_check_oauth_scopes.py
@@ -119,6 +119,16 @@ def main() -> int:
         # server that advertises it.
         expect(verdict(red, HOSTED)[0] == 0, "#787's scope string passes against hosted Supabase")
 
+        # And the direction a plain subset check cannot see: against a server
+        # that DOES advertise offline_access, omitting it is #782 waiting to
+        # happen, so it fails. This is what turns the assertion #787's revert
+        # deleted into a server-derived one instead of a convention-derived
+        # one. Against the self-hosted GoTrue it is a no-op, which the
+        # "fixed scope string passes" case above already proves.
+        code, output = verdict(green, HOSTED)
+        expect(code == 1, "omitting offline_access fails against a server that advertises it")
+        expect("#782" in output, "that failure cites the incident it prevents")
+
         # A second file cannot smuggle the bad value back in past a first file
         # that is clean, which is the whole reason the corpus is every deploy
         # YAML rather than one known line.
@@ -134,6 +144,33 @@ def main() -> int:
         list_green = list_corpus(tmp / "list-ok", "openid email profile")
         expect(verdict(list_green, SELF_HOSTED)[0] == 0, "list-form with a good scope passes")
         expect(len(check.declarations(list_green)) == 1, "list form is seen as one declaration")
+
+        # A trailing YAML comment is legal style and must not become scopes.
+        # Without stripping it the comparator is handed `profile"`, `#`, `keep`
+        # and `in` as scope names and fails a perfectly good edit, which is how
+        # a check teaches people to route around it.
+        commented = tmp / "trailing" / "deploy" / "docker"
+        commented.mkdir(parents=True)
+        (commented / "docker-compose.yml").write_text(
+            "services:\n  open-webui:\n    environment:\n"
+            '      OAUTH_SCOPES: "openid email profile"  # keep in sync with the gate\n'
+        )
+        code, output = verdict(tmp / "trailing" / "deploy", SELF_HOSTED)
+        expect(code == 0, "a trailing YAML comment is not read as scopes")
+        expect("#" not in output.split("OAUTH_SCOPES=")[-1].split("\n")[0],
+               "the parsed value excludes the comment")
+
+        # An interpolated value cannot be resolved from here, and saying so
+        # beats naming a brace as an unsupported scope.
+        interpolated = tmp / "interp" / "deploy" / "docker"
+        interpolated.mkdir(parents=True)
+        (interpolated / "docker-compose.yml").write_text(
+            "services:\n  open-webui:\n    environment:\n"
+            '      OAUTH_SCOPES: "${OWUI_OAUTH_SCOPES:-openid email profile}"\n'
+        )
+        code, output = verdict(tmp / "interp" / "deploy", SELF_HOSTED)
+        expect(code == 1, "an interpolated value fails rather than being guessed at")
+        expect("cannot resolve" in output, "and says why, rather than naming a brace as a scope")
 
         # A commented-out declaration is not a declaration. Every fixture file
         # above carries one, so this asserts the scanner ignored it rather than
@@ -204,6 +241,16 @@ def main() -> int:
     # This is what makes the check part of the build rather than a library: if
     # someone adds an unadvertised scope to deploy YAML, this fails offline,
     # without waiting for the live gate to reach the box.
+    #
+    # Note the asymmetry, so its failure mode is understood before it happens
+    # rather than after: this assertion runs against the SELF_HOSTED fixture
+    # above, not against the server. check-oauth-scopes.py's own docstring
+    # argues against snapshots, and it is right about the live gate; this is
+    # deliberately the other thing, a fast offline backstop. So if this stack
+    # moves to an authorization server that advertises offline_access and the
+    # scope is added legitimately, this required check goes red while the live
+    # gate stays green, and the correct fix is to update SELF_HOSTED at the top
+    # of this file rather than to argue with the deployment.
     expect(
         verdict(check.DEPLOY_DIR, SELF_HOSTED)[0] == 0,
         "this repository's own deploy YAML passes against self-hosted GoTrue",

--- a/scripts/test_check_oauth_scopes.py
+++ b/scripts/test_check_oauth_scopes.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Self-checks for scripts/check-oauth-scopes.py.
+
+No framework, no network, matching the other scripts/test_*.py in this repo.
+
+The point of this file is narrow and specific: prove the comparator can go RED.
+A subset check that only ever runs against a corpus it agrees with is
+indistinguishable from a check that returns 0 unconditionally, and this
+repository has shipped that shape before. So every assertion below that matters
+is a negative one, and the headline case is #787 itself, replayed: the exact
+scope string that killed sign-in, against the exact scopes_supported the
+self-hosted GoTrue answers with, must exit 1.
+"""
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+SPEC = importlib.util.spec_from_file_location("check_oauth_scopes", HERE / "check-oauth-scopes.py")
+assert SPEC and SPEC.loader
+check = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(check)
+
+# What the deployed self-hosted GoTrue actually answers with. Copied from
+# https://console-hive.scubed.co/auth/v1/.well-known/openid-configuration on
+# 2026-08-22, and identical to SupportedOAuthScopes in
+# internal/models/oauth_scope.go at the pinned supabase/gotrue v2.189.0.
+SELF_HOSTED = ["openid", "profile", "email", "phone"]
+
+# What hosted Supabase advertised, which is the document #787 was validated
+# against. Kept so the fixture corpus contains a server where offline_access is
+# legitimate: a check that says no to everything is as useless as one that says
+# yes to everything.
+HOSTED = ["openid", "profile", "email", "phone", "offline_access"]
+
+failures: list[str] = []
+
+
+def expect(condition: bool, what: str) -> None:
+    if condition:
+        print(f"ok   {what}")
+    else:
+        failures.append(what)
+        print(f"FAIL {what}")
+
+
+def corpus(tmp: Path, *scope_values: str) -> Path:
+    """A throwaway deploy/ tree declaring the given OAUTH_SCOPES values."""
+    deploy = tmp / "deploy" / "docker"
+    deploy.mkdir(parents=True, exist_ok=True)
+    for index, value in enumerate(scope_values):
+        (deploy / f"docker-compose.{index}.yml").write_text(
+            "services:\n"
+            "  open-webui:\n"
+            "    environment:\n"
+            "      # OAUTH_SCOPES: \"openid commented_out\"\n"
+            f'      OAUTH_SCOPES: "{value}"\n'
+        )
+    return tmp / "deploy"
+
+
+def verdict(deploy: Path, supported: list[str]) -> tuple[int, str]:
+    """Exit code plus everything the check printed.
+
+    Output is captured rather than let through, for two reasons. The failure
+    messages are GitHub `::error` annotations, and a passing test that emits a
+    dozen of them into a CI log trains people to ignore real ones. And having
+    the text in hand lets a case assert WHICH scope was named, not merely that
+    something failed.
+    """
+    out, err = io.StringIO(), io.StringIO()
+    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+        code = check.report(check.declarations(deploy), supported, "fixture", deploy)
+    return code, out.getvalue() + err.getvalue()
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as raw:
+        tmp = Path(raw)
+
+        # The regression itself. #787's exact value against the deployed
+        # server's exact capability list.
+        red = corpus(tmp / "787", "openid email profile offline_access")
+        code, output = verdict(red, SELF_HOSTED)
+        expect(code == 1, "#787's scope string fails against self-hosted GoTrue")
+        expect("offline_access" in output, "the failure names the offending scope")
+        expect("#787" in output, "the failure cites the incident")
+
+        # The fix. Same corpus shape, offline_access removed.
+        green = corpus(tmp / "fixed", "openid email profile")
+        expect(verdict(green, SELF_HOSTED)[0] == 0, "the fixed scope string passes")
+
+        # Not a check that refuses everything: offline_access is fine against a
+        # server that advertises it.
+        expect(verdict(red, HOSTED)[0] == 0, "#787's scope string passes against hosted Supabase")
+
+        # A second file cannot smuggle the bad value back in past a first file
+        # that is clean, which is the whole reason the corpus is every deploy
+        # YAML rather than one known line.
+        both = corpus(tmp / "both", "openid email profile", "openid offline_access")
+        expect(verdict(both, SELF_HOSTED)[0] == 1, "a bad value in a second deploy file fails")
+
+        # A commented-out declaration is not a declaration. Every fixture file
+        # above carries one, so this asserts the scanner ignored it rather than
+        # counting it, and the fixed corpus passing at all is that proof.
+        expect(
+            len(check.declarations(corpus(tmp / "comment", "openid email profile"))) == 1,
+            "a commented OAUTH_SCOPES line is not counted as a declaration",
+        )
+
+        # An empty corpus fails rather than passing over nothing. This is the
+        # shape that turns a moved config into a permanently green check.
+        empty = tmp / "empty" / "deploy"
+        empty.mkdir(parents=True)
+        expect(verdict(empty, SELF_HOSTED)[0] == 1, "an empty deploy corpus fails")
+
+        # A discovery document that advertises no scopes is an error, not a
+        # server that permits everything.
+        for broken, why in (
+            ({}, "no scopes_supported key"),
+            ({"scopes_supported": []}, "an empty scopes_supported"),
+            ({"scopes_supported": "openid"}, "a non-list scopes_supported"),
+            ("not a document", "a non-object document"),
+        ):
+            try:
+                check.read_supported(broken, "fixture")
+                expect(False, f"{why} is rejected")
+            except RuntimeError:
+                expect(True, f"{why} is rejected")
+
+        # An unreachable server is exit 1, never a quiet pass.
+        try:
+            check.fetch_supported("http://127.0.0.1:1/nothing-here")
+            expect(False, "an unreachable discovery URL raises")
+        except RuntimeError:
+            expect(True, "an unreachable discovery URL raises")
+
+        # End to end through main(), against a discovery document on disk, so
+        # the argument plumbing is exercised and not just the internals.
+        document = tmp / "discovery.json"
+        document.write_text(json.dumps({"scopes_supported": SELF_HOSTED}))
+        saved_deploy, saved_root = check.DEPLOY_DIR, check.REPO_ROOT
+        try:
+            check.DEPLOY_DIR, check.REPO_ROOT = red, tmp / "787"
+            sys.argv = ["check-oauth-scopes.py", "--discovery-file", str(document)]
+            out, err = io.StringIO(), io.StringIO()
+            with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+                bad = check.main()
+                check.DEPLOY_DIR, check.REPO_ROOT = green, tmp / "fixed"
+                good = check.main()
+            expect(bad == 1, "main() exits 1 on the #787 corpus")
+            expect(good == 0, "main() exits 0 on the fixed corpus")
+        finally:
+            check.DEPLOY_DIR, check.REPO_ROOT = saved_deploy, saved_root
+
+    # The real repository must pass against the real deployed capability list.
+    # This is what makes the check part of the build rather than a library: if
+    # someone adds an unadvertised scope to deploy YAML, this fails offline,
+    # without waiting for the live gate to reach the box.
+    expect(
+        verdict(check.DEPLOY_DIR, SELF_HOSTED)[0] == 0,
+        "this repository's own deploy YAML passes against self-hosted GoTrue",
+    )
+
+    if failures:
+        print(f"\n{len(failures)} check(s) failed:")
+        for item in failures:
+            print(f"  - {item}")
+        return 1
+    print("\nall checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_check_oauth_scopes.py
+++ b/scripts/test_check_oauth_scopes.py
@@ -65,6 +65,25 @@ def corpus(tmp: Path, *scope_values: str) -> Path:
     return tmp / "deploy"
 
 
+def list_corpus(tmp: Path, value: str) -> Path:
+    """The same declaration in Compose's OTHER environment spelling.
+
+    Compose accepts a list of `NAME=value` strings as readily as a mapping. A
+    checker that reads only the mapping form reports a clean run over a corpus
+    of zero when someone writes the list form, which is the original defect
+    wearing a different hat.
+    """
+    deploy = tmp / "deploy" / "docker"
+    deploy.mkdir(parents=True, exist_ok=True)
+    (deploy / "docker-compose.list.yml").write_text(
+        "services:\n"
+        "  open-webui:\n"
+        "    environment:\n"
+        f"      - OAUTH_SCOPES={value}\n"
+    )
+    return tmp / "deploy"
+
+
 def verdict(deploy: Path, supported: list[str]) -> tuple[int, str]:
     """Exit code plus everything the check printed.
 
@@ -105,6 +124,16 @@ def main() -> int:
         # YAML rather than one known line.
         both = corpus(tmp / "both", "openid email profile", "openid offline_access")
         expect(verdict(both, SELF_HOSTED)[0] == 1, "a bad value in a second deploy file fails")
+
+        # Compose's list spelling is checked too, or it is a hole the size of
+        # the whole defect: not merely a missed failure but a silent pass over
+        # zero declarations.
+        list_red = list_corpus(tmp / "list-bad", "openid email profile offline_access")
+        expect(verdict(list_red, SELF_HOSTED)[0] == 1,
+               "list-form `- OAUTH_SCOPES=...` with a bad scope fails")
+        list_green = list_corpus(tmp / "list-ok", "openid email profile")
+        expect(verdict(list_green, SELF_HOSTED)[0] == 0, "list-form with a good scope passes")
+        expect(len(check.declarations(list_green)) == 1, "list form is seen as one declaration")
 
         # A commented-out declaration is not a declaration. Every fixture file
         # above carries one, so this asserts the scanner ignored it rather than

--- a/scripts/test_check_oauth_scopes.py
+++ b/scripts/test_check_oauth_scopes.py
@@ -170,6 +170,18 @@ def main() -> int:
         except RuntimeError:
             expect(True, "an unreachable discovery URL raises")
 
+        # A non-http scheme is refused rather than fetched. Without this, a
+        # local file could decide whether the gate passes, and the URL comes
+        # out of a deployment's own configuration.
+        local = tmp / "local-discovery.json"
+        local.write_text(json.dumps({"scopes_supported": ["openid", "offline_access"]}))
+        for hostile in (f"file://{local}", "ftp://example.invalid/d.json", "gopher://x/"):
+            try:
+                check.fetch_supported(hostile)
+                expect(False, f"{hostile.split(':')[0]}:// is refused")
+            except RuntimeError:
+                expect(True, f"{hostile.split(':')[0]}:// is refused")
+
         # End to end through main(), against a discovery document on disk, so
         # the argument plumbing is exercised and not just the internals.
         document = tmp / "discovery.json"


### PR DESCRIPTION
## P0: chat sign-in was dead on the demo box

`main` at 851003b7b (#787) set `OAUTH_SCOPES` to `openid email profile offline_access`. The self-hosted GoTrue does not advertise `offline_access` and rejects an unknown scope outright, so every authorize request 302'd back to the callback with `error=invalid_request&error_description=unsupported scope: offline_access`. No consent screen, no code, no session, for every user.

Measured before the fix:

```
[1] GET https://chat-hive.scubed.co/oauth/oidc/login
    -> 302 .../auth/v1/oauth/authorize?...&scope=openid+email+profile+offline_access&...
[2] GET (that authorize URL)
    -> 302 .../oauth/oidc/callback?error=invalid_request
            &error_description=unsupported+scope%3A+offline_access
```

Measured after:

```
[2] GET (same URL, scope=openid+email+profile)
    -> 302 https://console-hive.scubed.co/oauth/consent?authorization_id=<REDACTED>
[3] GET that consent URL
    -> 200 text/html    consent page reached, no error parameter anywhere
```

And end to end in a real browser, signed in as `rag-verify-e2e@hive-e2e.invalid` (session minted through the admin one-time-token flow, no password read or changed): authorize, callback with a code, landed signed in on `https://chat-hive.scubed.co/`. Screenshot posted below as an inline image.

The live box was restored ahead of this merge with a one-service compose override applied to the running `open-webui` container (`--no-deps`, no `--remove-orphans`, nothing in the box's git checkout touched, so the deploy job's `git pull --ff-only` still fast-forwards). Merging supersedes it; the override file has since been deleted from the box and the container still carries the fixed value independently of it.

## Why a partial revert of #787 and not a full one

Determined empirically rather than from OAuth convention, since convention is what caused this.

Read at the pinned `supabase/gotrue v2.189.0`: `handleAuthorizationCodeGrant` calls `tokenService.IssueRefreshToken` unconditionally and always puts `refresh_token` in the token response, and `SupportedOAuthScopes` is exactly `openid, profile, email, phone`. Measured against the deployed server by walking a complete authorization code flow with no `offline_access` in the request:

```
scope requested:      openid email profile   (deliberately no offline_access)
token exchange:       HTTP 200
  keys returned:      access_token expires_in id_token refresh_token token_type
  refresh_token       present, 12 chars
  expires_in          3600
```

So #787's scope half was never needed here, and was fatal. Its other half is still load bearing and stays: `Dockerfile.open-webui`'s `apply_oauth_client_auth_patch.py`, because a refresh token that exists is still refused when the refresh POST authenticates the client in the dialect it is not registered for. `TestOWUIImageAppliesOAuthRefreshClientAuthPatch` is unchanged.

## The check that would have caught this

`scripts/check-oauth-scopes.py` reads the live `scopes_supported` and fails when the configured scopes disagree with it, in both directions. Nothing in this repository had ever asked the authorization server anything, which is why #787 was green everywhere.

| Where | Catches |
| --- | --- |
| `.github/workflows/oauth-scope-gate.yml`, on pull requests touching `deploy/docker` YAML | a scope added here that the server does not advertise, which is #787 |
| `deploy-demo-box.yml`, at the end of every deploy, reading the URL out of the running container | a capability the server stops advertising while this repository stands still, which is what the self-hosted cutover did and what no pull-request gate can see |
| `make test-scripts`, inside the required repo-policy-lints job | the comparator itself rotting into something that returns 0 regardless |

It also fails when the server **advertises** `offline_access` and the configuration omits it. That restores #787's deleted assertion as a server-derived rule rather than a convention-derived one: a no-op against the self-hosted GoTrue, and an automatic return of #782's guard if this stack ever moves to a server that gates refresh issuance on the scope.

The pull-request gate is deliberately its own workflow rather than a step in the required lints job: a live call inside that job would make an unrelated docs change unmergeable whenever the box is down. It is **advisory, not enforced**: it is not one of the six required contexts, so GitHub will merge with it red and only the merging agent reading it stands in the way. The header says so plainly rather than overclaiming.

Because the two call sites necessarily spell the auth origin differently (a cloud runner has no stack to interrogate), the deploy step compares the URL it reads out of the container against the one the gate uses and fails the deploy on a mismatch. The agreement is an enforced invariant, not a convention.

### Shown failing on purpose

Every check added here was mutated and observed red before being restored. Full transcripts in the capture log.

| Mutation | Result |
| --- | --- |
| `offline_access` put back, run against the real deployed discovery document | exit 1, names `docker-compose.yml:764` and the advertised set |
| the gate script moved out of the tree | `TestOWUIOAuthScopeGateIsWired` fails |
| the Makefile invocation commented out rather than deleted | same test fails, on the invocation matcher |
| `OAUTH_SCOPES` set to `openid profile` | `TestOWUIOAuthScopesRequestAnIdentity` fails on the missing `email` |
| list form `- OAUTH_SCOPES=...openid offline_access` | exit 1 |
| omitting `offline_access` against a server that advertises it | exit 1, cites #782 |
| the whole deploy step, rehearsed on the box against its unfixed checkout | exit 1, names `docker-compose.yml:745` |

That last one is the strongest: the post-deploy step was run by hand on the box before the merge, so it is not a step nobody has executed. It reads the discovery URL out of the running container, agrees with the gate's URL, and goes red on the exact commit that caused the outage.

## The replaced guard

`TestOWUIOAuthScopesRequestOfflineAccess` asserted that `offline_access` was present. That assertion came from OAuth convention and from hosted Supabase's document, which is exactly the reasoning that shipped this outage, so it is replaced rather than kept:

- `TestOWUIOAuthScopesRequestAnIdentity` requires `openid` and `email`, both cited to GoTrue source (id_token generation is gated on the first, the email claims on the second, and Open WebUI keys its account on the email claim). `profile` is deliberately not required.
- `TestOWUIOAuthScopeGateIsWired` asserts the live gate is still invoked from all three call sites, that oauth-scope-gate.yml still has a `pull_request` trigger, and that the comparator's invocation lives inside the `test-scripts` recipe rather than anywhere in the Makefile. Comment lines do not satisfy any of it. A never-true `if:` is named in the comment as the edge of what a text matcher can see.

## Review

Three streams, all findings addressed, all threads resolved.

- **CodeRabbit CLI**: 2 findings (1 major, 1 minor), both fixed. Compose list-form parsing, and invocation-vs-filename matching.
- **Security review**: 0 critical, 0 high, 0 medium, 4 low, 2 informational. Scheme allowlist and a body cap on the discovery fetch, `cancel-in-progress` scoped to pull requests, the `printenv` diagnostic made reachable, the compose claim scoped to GoTrue. Confirmed no real credential anywhere in the capture.
- **Adversarial review**: 0 critical, 0 high, 8 medium, 2 low. Step moved to the end of the deploy so a network blip cannot abort before the hive_jwt_forward install, the two-URL drift closed, the paths filter narrowed off `deploy/**`, scope-loss detection added, trailing-comment and interpolated values handled, the merge-gate claim corrected, and MEASURED separated from READ in the capture.

## Test plan

- [x] `go test ./apps/edge-api/internal/auth/... -run 'OWUIOAuthScope|ContainsUncommented' -v` in the toolchain container, `go vet` and `gofmt` clean
- [x] `make test-scripts`: green, including the new `test_check_oauth_scopes.py` (28 assertions, mostly negative)
- [x] `npm run lint:proof-tokens`, `lint-deploy-paths-filter.mjs`, `lint-workflow-check-names.mjs`: all ok
- [x] Live: failing chain reproduced, fix applied to the running container, chain re-run to the consent page, full browser sign-in completed
- [x] Live: refresh token confirmed issued without `offline_access`
- [x] Live: the pull-request gate passed in CI in 8 seconds against the real discovery document
- [x] Live: the post-deploy step rehearsed on the box, red on the unfixed checkout, URL comparison green
- [x] Every added check mutated and observed red, then restored

Full capture: `docs/proof/oauth-scope-selfhost-2026-08-22/capture.log`.

## Buglog entry

```json
{"id":"bug-2026-08-22-oauth-scope-offline-access","date":"2026-08-22","severity":"critical","area":"auth/oauth","error_message":"error=invalid_request&error_description=unsupported scope: offline_access on every https://chat-hive.scubed.co/oauth/oidc/login attempt; no consent screen, no authorization code, no session","root_cause":"PR #787 added offline_access to OAUTH_SCOPES in deploy/docker/docker-compose.yml, validated against hosted Supabase whose discovery document advertised that scope. The self-hosted GoTrue v2.189.0 the stack cut over to lists only openid, profile, email, phone in SupportedOAuthScopes and rejects an unknown scope outright instead of ignoring it. Nothing in the repository compared the configured scopes against the authorization server's advertised capability, so every check stayed green while sign-in was dead. The scope was also unnecessary: handleAuthorizationCodeGrant calls IssueRefreshToken unconditionally, so a refresh token is issued without it, confirmed live by a full authorization code flow.","fix":"Set OAUTH_SCOPES to \"openid email profile\" (partial revert of #787, keeping its client-auth-dialect patch). Added scripts/check-oauth-scopes.py, which reads the live scopes_supported and fails when a configured scope is not advertised, and also when the server advertises offline_access while the config omits it. Wired into a pull-request gate (.github/workflows/oauth-scope-gate.yml), a post-deploy step in deploy-demo-box.yml that also asserts the two call sites resolve the same auth origin, and make test-scripts. Replaced the offline_access assertion in owui_oauth_scope_test.go with an openid-plus-email guard and a wiring guard for the gate.","tags":["oauth","gotrue","self-hosted-supabase","open-webui","sign-in","capability-mismatch","p0","787"],"pr":"#1003"}
```

Closes the outage introduced by #787.
