### PR TITLE
fix: break the migrate/deploy deadlock that made the demo box undeployable

### DIFF
--- a/.github/workflows/deploy-demo-box.yml
+++ b/.github/workflows/deploy-demo-box.yml
@@ -1326,6 +1326,62 @@ jobs:
           echo "SMOKE FAIL"
           exit 1
 
+      - name: Reconcile LiteLLM's config volume with the repo seed
+        # Ordering, and that is the whole job of this step.
+        #
+        # The litellm service reconciles its config volume against the repo's
+        # seed on start, keyed on the seed's checksum (see its entrypoint in
+        # docker-compose.yml). But `up -d` above only recreates a service whose
+        # DEFINITION changed, and editing deploy/litellm/config.yaml changes no
+        # service definition, so a deploy that only changes that file never
+        # restarts this container and the entrypoint never runs.
+        #
+        # Something does restart it: the catalog sync in the next step, after
+        # it has written its merged config. That is the wrong order. The sync
+        # would merge the DB over the STALE config, write it, restart, and the
+        # entrypoint would then notice the seed changed and overwrite that
+        # merged result with the raw seed, leaving the proxy with no DB-managed
+        # routes at all. So the reconcile has to happen before the sync, not as
+        # a side effect after it.
+        #
+        # Restarting only on drift, rather than every deploy, because a LiteLLM
+        # restart is a real if brief chat interruption and the sync below
+        # already performs one whenever it has something to apply.
+        working-directory: /home/sakib/hive/deploy/docker
+        run: |
+          set -euo pipefail
+          COMPOSE=(docker compose $HIVE_COMPOSE_FLAGS)
+
+          seed_sha=$(sha256sum ../../deploy/litellm/config.yaml | cut -d' ' -f1)
+          # `|| true`: a missing marker file is the normal state on a volume
+          # seeded before this mechanism existed, and on a fresh volume. Both
+          # are drift, which is exactly what the comparison below concludes.
+          applied_sha=$("${COMPOSE[@]}" exec -T litellm \
+            cat /etc/litellm/.seed.sha256 2>/dev/null </dev/null | tr -d '\r\n' || true)
+
+          if [ "$seed_sha" = "$applied_sha" ]; then
+            echo "LiteLLM config volume already carries this seed ($seed_sha); no restart needed."
+            exit 0
+          fi
+
+          echo "LiteLLM seed drifted (repo=$seed_sha applied=${applied_sha:-none}); restarting so its entrypoint reseeds."
+          "${COMPOSE[@]}" restart litellm
+
+          # Prove the reseed actually happened rather than assuming the restart
+          # implies it. A container that came back up still carrying the old
+          # marker means the entrypoint did not reconcile, and continuing would
+          # hand the sync below the same stale base this step exists to
+          # replace.
+          for i in $(seq 1 12); do
+            applied_sha=$("${COMPOSE[@]}" exec -T litellm \
+              cat /etc/litellm/.seed.sha256 2>/dev/null </dev/null | tr -d '\r\n' || true)
+            [ "$seed_sha" = "$applied_sha" ] && { echo "reseeded to $seed_sha"; exit 0; }
+            echo "attempt $i: marker is ${applied_sha:-none}, waiting"
+            sleep 5
+          done
+          echo "::error::LiteLLM restarted but its config volume still does not carry the repo seed ($seed_sha). Its entrypoint did not reconcile, so the catalog sync below would merge onto a stale base." >&2
+          exit 1
+
       - name: Sync LiteLLM model list from the DB catalog (issue #713)
         # control-plane's litellmconfig service (Phase 20 Plan 03) already
         # generates deploy/litellm/config.yaml's model_list directly from

--- a/.github/workflows/deploy-demo-box.yml
+++ b/.github/workflows/deploy-demo-box.yml
@@ -230,6 +230,188 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Pull latest main
+        # In migrate, and first, because of the 2026-08-22 deadlock.
+        #
+        # This step used to be the deploy job's first step. That put the only
+        # thing that advances the box's clone AFTER the only thing that
+        # reconciles the box's database, and the two are not independent: the
+        # reconcile step below runs `docker compose ... up -d --build
+        # supabase-db` with working-directory /home/sakib/hive/deploy/docker,
+        # so it reads THIS clone's compose file, not the runner workspace's.
+        #
+        # So a change to how supabase-db is built could not reach the job that
+        # depends on it. PR #994 moved supabase-db onto a locally built image
+        # carrying pg_cron, and 20260822_01 needs that extension. migrate ran
+        # the old compose file, left the container on the old image, applied a
+        # migration that wanted pg_cron, and failed; deploy `needs: migrate`,
+        # so the job that would have pulled the fixed compose file was skipped.
+        # Three runs (32605288283, 32605296549, 32607780396) burned on that
+        # circle and the demo box could not deploy at all, chat sign-in
+        # included, until the image was recreated by hand.
+        #
+        # Pulling here breaks the circle by ordering it correctly: update the
+        # tree, reconcile the database service from the tree, then migrate
+        # against it, then deploy the rest. scripts/test_selfhost_supabase_seam.py
+        # fails if these three steps ever go back out of order, or if the pull
+        # and the reconcile stop naming the same directory.
+        #
+        # Root cause of the 2026-08-13 outage (every deploy since failing
+        # `fatal: could not read Username for 'https://github.com': No such
+        # device or address`, exit 128): the box's persistent clone at
+        # /home/sakib/hive authenticates its HTTPS remote from some
+        # credential external to this workflow (a stored PAT or a git
+        # credential helper on the box; this runner has no shell access to
+        # inspect which). That credential worked through the 2026-08-12
+        # 20:04 UTC run (confirmed from that run's own log: `git fetch`
+        # printed a real ref listing, not an error) and was gone by the next
+        # deploy 17 hours later, with the workflow file byte-identical
+        # across that gap (`git log -- .github/workflows/deploy-demo-box.yml`
+        # between those two commits is empty). That is an expired or rotated
+        # credential, not a missing config line: nothing in this repo
+        # changed to cause it.
+        #
+        # Fix: stop depending on any credential that lives on the box at
+        # all. `github.token` is this job's own ephemeral, auto-rotated
+        # GITHUB_TOKEN (scoped read-only by `contents: read` above, minted
+        # fresh per run), the same mechanism actions/checkout uses
+        # internally. It is supplied as per-invocation `GIT_CONFIG_*`
+        # environment variables rather than `.git/config`, so there is
+        # nothing here to expire or rotate again. Two things a first pass
+        # of this comment got wrong, corrected after security review on
+        # this PR: the interpolated value IS written to disk, in the
+        # runner's own materialized step script under $RUNNER_TEMP (this
+        # runner is not ephemeral, see the box-reboot note below, so that
+        # file is not on a fresh tmpfs); and GitHub only auto-masks the
+        # literal token, not the base64 Basic-auth blob derived from it, so
+        # that blob is masked explicitly below instead. The token itself
+        # now reaches the script only via the `GH_TOKEN` env var, never
+        # interpolated into the script text, matching the pattern the
+        # agent-engine step below already uses.
+        #
+        # actions/checkout itself was considered instead of fixing the pull
+        # in place, letting the runner's own already-authenticated checkout
+        # do the fetch. Rejected: every step below assumes /home/sakib/hive is
+        # a long-lived directory carrying the box's own untracked .env
+        # (every secret this stack runs on) and Docker build cache.
+        # actions/checkout's default `clean: true` runs `git clean -ffdx`,
+        # which would delete that untracked .env on first use, a bigger
+        # and riskier change than fixing the credential the persistent
+        # clone already uses.
+        #
+        # GIT_TERMINAL_PROMPT=0 makes a still-bad credential fail in one
+        # git-native line instead of the opaque "could not read Username /
+        # No such device or address" this outage actually produced (that
+        # message is itself just what a denied non-interactive prompt looks
+        # like on a runner with no tty).
+        env:
+          GIT_TERMINAL_PROMPT: "0"
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          cd /home/sakib/hive
+
+          # A leftover .git/index.lock from a prior run killed mid checkout
+          # (the timeout-minutes below, a manual cancel, or a box reboot
+          # this file's own header says the runner does not survive) would
+          # fail this line with a lock message instead of the real problem.
+          # Age-gated, not unconditional: this clone is the box's shared
+          # checkout, other writers (git gc --auto, a human on the box) can
+          # legitimately hold this lock, and the workflow-level concurrency
+          # group only serializes this workflow's own runs against each
+          # other. 30 minutes matches this job's own timeout-minutes above,
+          # so a lock younger than that is still someone's live operation.
+          # Both moved together when the chat frontend build landed; they are
+          # one invariant and must not drift apart.
+          find .git -maxdepth 1 -name index.lock -mmin +30 -delete
+          git checkout main
+
+          # The token below authenticates ANY public github.com repo, not
+          # just this one, so it would fetch happily from a repointed
+          # origin. Check first, or a repointed remote pulls the wrong
+          # content while reporting the same green this whole fix exists to
+          # make honest.
+          # Redacted unconditionally, not just when a mismatch is found:
+          # origin can embed a credential (https://user:token@github.com/...)
+          # and this value reaches both the error branch below and the
+          # diagnostic dump after it, so redacting once here keeps every
+          # later use safe by construction instead of relying on each print
+          # site to remember.
+          expected_url="https://github.com/${{ github.repository }}"
+          actual_url=$(git remote get-url origin)
+          # Greedy up to the LAST @, not the first: a credential whose
+          # secret half itself contains an unencoded @ would otherwise
+          # leave part of it printed after a first-@ match.
+          redacted_url=$(printf '%s' "$actual_url" | sed -E 's#//.*@#//REDACTED@#')
+          case "$actual_url" in
+            "$expected_url"|"$expected_url.git") ;;
+            *)
+              echo "::error::box remote 'origin' is $redacted_url, expected $expected_url(.git). Refusing to pull: this job's GITHUB_TOKEN would authenticate a fetch from any public github.com repo, so a repointed remote would silently deploy the wrong source. Fix with: git -C /home/sakib/hive remote set-url origin $expected_url.git" >&2
+              exit 1
+              ;;
+          esac
+
+          # Secret-free, and answers exactly what this PR could not verify
+          # without box access: whether a credential path older than this
+          # fix could still shadow or rescue it. --name-only reports THAT a
+          # helper is configured, never its value: a helper can be an
+          # inline shell snippet with a PAT embedded in it, and that value
+          # is exactly the on-box credential this whole PR suspects.
+          git config --show-origin --name-only --get-regexp '^credential\.helper$' \
+            && echo "credential.helper is configured (value withheld)" \
+            || echo "no credential helper configured"
+          echo "origin: $redacted_url"
+          [ -f "$HOME/.git-credentials" ] && echo "a stored credential file exists on the box" || true
+          [ -f "$HOME/.netrc" ] && echo "a .netrc file exists on the box" || true
+
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error::GH_TOKEN is empty. This job's permissions block (needs contents: read) or the runner's token minting is the problem, not the box." >&2
+            exit 1
+          fi
+
+          # GIT_CONFIG_* env vars, not `git -c` on argv: argv is world
+          # readable via /proc/<pid>/cmdline on a stock box with no
+          # hidepid, env is readable only by the same uid or root. Slot 1
+          # empties credential.helper for this invocation so a stored PAT
+          # or netrc on the box cannot shadow or rescue the header in slot
+          # 0: a failure below is unambiguously this token's failure.
+          b64=$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 -w0)
+          echo "::add-mask::$b64"
+          export GIT_CONFIG_COUNT=2
+          export GIT_CONFIG_KEY_0="http.https://github.com/.extraheader"
+          export GIT_CONFIG_VALUE_0="AUTHORIZATION: basic $b64"
+          export GIT_CONFIG_KEY_1="credential.helper"
+          export GIT_CONFIG_VALUE_1=""
+
+          if ! git fetch origin main; then
+            echo "::error::git fetch origin main failed. See the git error above for the actual cause. If it names the username/credential, check the deploy job's permissions block (needs contents: read)." >&2
+            exit 1
+          fi
+          if ! git pull --ff-only origin main; then
+            echo "::error::git pull --ff-only origin main failed after a successful fetch, so this is a fast-forward divergence (a stray local commit on the box, or main force-pushed), not a credential problem. See the git error above; git -C /home/sakib/hive log --oneline -5 origin/main on the box will show what diverged." >&2
+            exit 1
+          fi
+
+          # pull --ff-only moves the ref and writes the worktree as two
+          # separate steps, not one atomic operation. A run killed in
+          # between (this job's own timeout, a cancel, or a box reboot)
+          # leaves HEAD advanced over a half-written tree; the next run's
+          # fetch/pull then reports "Already up to date" over that same
+          # half-written tree and goes green. This catches either case:
+          # this run's own interruption never reaches this line anyway, so
+          # only a genuinely dirty tree (this run's or a leftover one) fails
+          # it.
+          if [ -n "$(git status --porcelain -uno)" ]; then
+            echo "::error::working tree at /home/sakib/hive has tracked-file changes against HEAD after the pull, consistent with a previous deploy interrupted mid checkout. Recover with: git -C /home/sakib/hive reset --hard origin/main (safe: reset --hard does not remove untracked files, so the box's .env is not touched)." >&2
+            exit 1
+          fi
+
+          # --ff-only means this line only runs after a real advance or a
+          # no-op "Already up to date.", never after a silent partial pull,
+          # but nothing upstream of this could tell the two apart without
+          # reading raw git output. Record the outcome explicitly instead.
+          echo "deployed commit: $(git rev-parse HEAD)"
+
       - name: Validate the migration baseline file
         # Cheap, no database: catches a typo'd or stale baseline entry before
         # anything connects.
@@ -436,15 +618,19 @@ jobs:
     name: Pull + recreate stack on the demo box
     needs: migrate
     runs-on: [self-hosted, hive-demo]
-    # This job never checks out the repo (the box already has its own clone).
+    # This job never checks out the repo, and it no longer pulls either. The
+    # box's clone at /home/sakib/hive is advanced by the migrate job above,
+    # which `needs:` guarantees has already run, so every step here reads a
+    # tree that is already at this run's commit. See the Pull latest main step
+    # in migrate for why the pull has to happen that early.
+    #
     # Failure reporting lives in the report-failure job at the end of this
     # file, so that a failed migrate is reported too rather than vanishing
     # when this job is skipped. actions:read exists for one reason: the
     # agent-engine step below downloads the CI-built Apptainer image when the
     # box has none, since that image is linux/amd64 only and cannot be built
-    # on the dev machine. contents:read is for the Pull latest main step
-    # below: it authenticates the box's own HTTPS remote with this job's own
-    # ephemeral github.token instead of a credential stored on the box.
+    # on the dev machine. contents:read is still required: the agent-engine
+    # step's own GH_TOKEN is job-scoped and needs it.
     permissions:
       actions: read
       contents: read
@@ -458,163 +644,6 @@ jobs:
     # vendored tree alone hit the cache and cost nothing extra.
     timeout-minutes: 30
     steps:
-      - name: Pull latest main
-        # Root cause of the 2026-08-13 outage (every deploy since failing
-        # `fatal: could not read Username for 'https://github.com': No such
-        # device or address`, exit 128): the box's persistent clone at
-        # /home/sakib/hive authenticates its HTTPS remote from some
-        # credential external to this workflow (a stored PAT or a git
-        # credential helper on the box; this runner has no shell access to
-        # inspect which). That credential worked through the 2026-08-12
-        # 20:04 UTC run (confirmed from that run's own log: `git fetch`
-        # printed a real ref listing, not an error) and was gone by the next
-        # deploy 17 hours later, with the workflow file byte-identical
-        # across that gap (`git log -- .github/workflows/deploy-demo-box.yml`
-        # between those two commits is empty). That is an expired or rotated
-        # credential, not a missing config line: nothing in this repo
-        # changed to cause it.
-        #
-        # Fix: stop depending on any credential that lives on the box at
-        # all. `github.token` is this job's own ephemeral, auto-rotated
-        # GITHUB_TOKEN (scoped read-only by `contents: read` above, minted
-        # fresh per run), the same mechanism actions/checkout uses
-        # internally. It is supplied as per-invocation `GIT_CONFIG_*`
-        # environment variables rather than `.git/config`, so there is
-        # nothing here to expire or rotate again. Two things a first pass
-        # of this comment got wrong, corrected after security review on
-        # this PR: the interpolated value IS written to disk, in the
-        # runner's own materialized step script under $RUNNER_TEMP (this
-        # runner is not ephemeral, see the box-reboot note below, so that
-        # file is not on a fresh tmpfs); and GitHub only auto-masks the
-        # literal token, not the base64 Basic-auth blob derived from it, so
-        # that blob is masked explicitly below instead. The token itself
-        # now reaches the script only via the `GH_TOKEN` env var, never
-        # interpolated into the script text, matching the pattern the
-        # agent-engine step below already uses.
-        #
-        # actions/checkout itself was considered instead of fixing the pull
-        # in place, letting the runner's own already-authenticated checkout
-        # do the fetch. Rejected: every step below assumes /home/sakib/hive is
-        # a long-lived directory carrying the box's own untracked .env
-        # (every secret this stack runs on) and Docker build cache.
-        # actions/checkout's default `clean: true` runs `git clean -ffdx`,
-        # which would delete that untracked .env on first use, a bigger
-        # and riskier change than fixing the credential the persistent
-        # clone already uses.
-        #
-        # GIT_TERMINAL_PROMPT=0 makes a still-bad credential fail in one
-        # git-native line instead of the opaque "could not read Username /
-        # No such device or address" this outage actually produced (that
-        # message is itself just what a denied non-interactive prompt looks
-        # like on a runner with no tty).
-        env:
-          GIT_TERMINAL_PROMPT: "0"
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          cd /home/sakib/hive
-
-          # A leftover .git/index.lock from a prior run killed mid checkout
-          # (the timeout-minutes below, a manual cancel, or a box reboot
-          # this file's own header says the runner does not survive) would
-          # fail this line with a lock message instead of the real problem.
-          # Age-gated, not unconditional: this clone is the box's shared
-          # checkout, other writers (git gc --auto, a human on the box) can
-          # legitimately hold this lock, and the workflow-level concurrency
-          # group only serializes this workflow's own runs against each
-          # other. 30 minutes matches this job's own timeout-minutes above,
-          # so a lock younger than that is still someone's live operation.
-          # Both moved together when the chat frontend build landed; they are
-          # one invariant and must not drift apart.
-          find .git -maxdepth 1 -name index.lock -mmin +30 -delete
-          git checkout main
-
-          # The token below authenticates ANY public github.com repo, not
-          # just this one, so it would fetch happily from a repointed
-          # origin. Check first, or a repointed remote pulls the wrong
-          # content while reporting the same green this whole fix exists to
-          # make honest.
-          # Redacted unconditionally, not just when a mismatch is found:
-          # origin can embed a credential (https://user:token@github.com/...)
-          # and this value reaches both the error branch below and the
-          # diagnostic dump after it, so redacting once here keeps every
-          # later use safe by construction instead of relying on each print
-          # site to remember.
-          expected_url="https://github.com/${{ github.repository }}"
-          actual_url=$(git remote get-url origin)
-          # Greedy up to the LAST @, not the first: a credential whose
-          # secret half itself contains an unencoded @ would otherwise
-          # leave part of it printed after a first-@ match.
-          redacted_url=$(printf '%s' "$actual_url" | sed -E 's#//.*@#//REDACTED@#')
-          case "$actual_url" in
-            "$expected_url"|"$expected_url.git") ;;
-            *)
-              echo "::error::box remote 'origin' is $redacted_url, expected $expected_url(.git). Refusing to pull: this job's GITHUB_TOKEN would authenticate a fetch from any public github.com repo, so a repointed remote would silently deploy the wrong source. Fix with: git -C /home/sakib/hive remote set-url origin $expected_url.git" >&2
-              exit 1
-              ;;
-          esac
-
-          # Secret-free, and answers exactly what this PR could not verify
-          # without box access: whether a credential path older than this
-          # fix could still shadow or rescue it. --name-only reports THAT a
-          # helper is configured, never its value: a helper can be an
-          # inline shell snippet with a PAT embedded in it, and that value
-          # is exactly the on-box credential this whole PR suspects.
-          git config --show-origin --name-only --get-regexp '^credential\.helper$' \
-            && echo "credential.helper is configured (value withheld)" \
-            || echo "no credential helper configured"
-          echo "origin: $redacted_url"
-          [ -f "$HOME/.git-credentials" ] && echo "a stored credential file exists on the box" || true
-          [ -f "$HOME/.netrc" ] && echo "a .netrc file exists on the box" || true
-
-          if [ -z "${GH_TOKEN:-}" ]; then
-            echo "::error::GH_TOKEN is empty. This job's permissions block (needs contents: read) or the runner's token minting is the problem, not the box." >&2
-            exit 1
-          fi
-
-          # GIT_CONFIG_* env vars, not `git -c` on argv: argv is world
-          # readable via /proc/<pid>/cmdline on a stock box with no
-          # hidepid, env is readable only by the same uid or root. Slot 1
-          # empties credential.helper for this invocation so a stored PAT
-          # or netrc on the box cannot shadow or rescue the header in slot
-          # 0: a failure below is unambiguously this token's failure.
-          b64=$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 -w0)
-          echo "::add-mask::$b64"
-          export GIT_CONFIG_COUNT=2
-          export GIT_CONFIG_KEY_0="http.https://github.com/.extraheader"
-          export GIT_CONFIG_VALUE_0="AUTHORIZATION: basic $b64"
-          export GIT_CONFIG_KEY_1="credential.helper"
-          export GIT_CONFIG_VALUE_1=""
-
-          if ! git fetch origin main; then
-            echo "::error::git fetch origin main failed. See the git error above for the actual cause. If it names the username/credential, check the deploy job's permissions block (needs contents: read)." >&2
-            exit 1
-          fi
-          if ! git pull --ff-only origin main; then
-            echo "::error::git pull --ff-only origin main failed after a successful fetch, so this is a fast-forward divergence (a stray local commit on the box, or main force-pushed), not a credential problem. See the git error above; git -C /home/sakib/hive log --oneline -5 origin/main on the box will show what diverged." >&2
-            exit 1
-          fi
-
-          # pull --ff-only moves the ref and writes the worktree as two
-          # separate steps, not one atomic operation. A run killed in
-          # between (this job's own timeout, a cancel, or a box reboot)
-          # leaves HEAD advanced over a half-written tree; the next run's
-          # fetch/pull then reports "Already up to date" over that same
-          # half-written tree and goes green. This catches either case:
-          # this run's own interruption never reaches this line anyway, so
-          # only a genuinely dirty tree (this run's or a leftover one) fails
-          # it.
-          if [ -n "$(git status --porcelain -uno)" ]; then
-            echo "::error::working tree at /home/sakib/hive has tracked-file changes against HEAD after the pull, consistent with a previous deploy interrupted mid checkout. Recover with: git -C /home/sakib/hive reset --hard origin/main (safe: reset --hard does not remove untracked files, so the box's .env is not touched)." >&2
-            exit 1
-          fi
-
-          # --ff-only means this line only runs after a real advance or a
-          # no-op "Already up to date.", never after a silent partial pull,
-          # but nothing upstream of this could tell the two apart without
-          # reading raw git output. Record the outcome explicitly instead.
-          echo "deployed commit: $(git rev-parse HEAD)"
-
       - name: Install and restart the agent-engine launch daemon
         # Issue #780. Cowork tasks need an Apptainer sandbox per task, and
         # control-plane's own container cannot exec Apptainer. The launcher

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ test-scripts:
 	python3 scripts/test_check_oauth_scopes.py
 	python3 scripts/test_caddy_supabase_routes.py
 	python3 scripts/test_selfhost_supabase_seam.py
+	python3 scripts/test_litellm_config_seam.py
 	python3 scripts/check-env-supabase-target.py --self-check
 	python3 scripts/derive-pooler-dsn.py --self-test
 	python3 scripts/test_caddy_console_auth_origin.py --self-check

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -191,17 +191,48 @@ services:
       # LiteLLM reads from it. The volume persists generated config across
       # container recreates; the seed file is copied in on first start.
       - litellm-config:/etc/litellm
-      # Mount the repo seed config read-only so the entrypoint can copy it
-      # into the shared volume when the volume is empty (first boot).
-      - ../../deploy/litellm/config.yaml:/seed/config.yaml:ro
-    # On first boot the shared volume is empty; copy the seed config so LiteLLM
-    # has a valid config.yaml before control-plane pushes its first sync.
+      # The DIRECTORY, read-only, not the single file it used to be.
+      #
+      # A single-file bind mount resolves to one inode at container start and
+      # keeps it. git checkout does not edit a file in place, it writes a
+      # replacement and renames over the old name, so a `git pull` that changes
+      # this config gives the host a NEW inode while the container goes on
+      # showing the old one until it is recreated. Measured on the demo box,
+      # replacing a file the same way git does: the file-mounted container
+      # still read the old content, the directory-mounted one read the new
+      # content. Mounting the directory means /seed/config.yaml is resolved per
+      # open, so the container always reads what the repository currently says.
+      - ../../deploy/litellm:/seed:ro
+    # Reconcile the shared volume against the repo's seed on every start.
+    #
+    # This used to be `if [ ! -f /etc/litellm/config.yaml ]`, which copies the
+    # seed exactly once in the lifetime of the volume. The volume outlives
+    # container recreates by design, so on any box that had already booted once
+    # (the demo box included) an edit to deploy/litellm/config.yaml never
+    # reached the running proxy again: routes added or repointed there were
+    # inert, silently, while the repository, the pull request and CI all looked
+    # correct. Deleting the volume by hand was the only cure, and nothing said
+    # so.
+    #
+    # Keyed on a checksum of the seed rather than on the config's existence,
+    # and that distinction is what makes it safe. control-plane owns
+    # /etc/litellm/config.yaml at runtime: it merges the DB's model catalog
+    # over this seed and RESTARTS this container to apply it. An unconditional
+    # copy here would therefore overwrite, on that very restart, the config
+    # control-plane just wrote and restarted for. Comparing the seed against
+    # the checksum recorded when it was last copied means a control-plane
+    # restart is a no-op (the seed did not change) while a genuine repository
+    # change is applied (it did).
     entrypoint:
       - /bin/sh
       - -c
       - |
-        if [ ! -f /etc/litellm/config.yaml ]; then
+        seed_sha="$$(sha256sum /seed/config.yaml | cut -d" " -f1)"
+        if [ ! -f /etc/litellm/config.yaml ] \
+          || [ "$$seed_sha" != "$$(cat /etc/litellm/.seed.sha256 2>/dev/null)" ]; then
+          echo "litellm: seeding /etc/litellm/config.yaml from the repo config ($$seed_sha)"
           cp /seed/config.yaml /etc/litellm/config.yaml
+          printf '%s' "$$seed_sha" > /etc/litellm/.seed.sha256
         fi
         exec litellm --config=/etc/litellm/config.yaml
     command: []

--- a/scripts/test_litellm_config_seam.py
+++ b/scripts/test_litellm_config_seam.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""The repo's LiteLLM config must reach the running proxy.
+
+Two independent mechanisms used to stop it, both measured on the demo box
+rather than reasoned about:
+
+  1. The shared config volume was seeded `if [ ! -f /etc/litellm/config.yaml ]`,
+     so exactly once in the lifetime of the volume. The volume outlives
+     container recreates by design, so on any box that had booted once, an
+     edit to deploy/litellm/config.yaml never reached the proxy again. Routes
+     added or repointed there were inert, silently, while the repository, the
+     pull request and CI all looked correct. Observed live: the container's
+     config carried a top-level general_settings key the repo's seed does not
+     have, so the running file demonstrably was not the repo's file.
+
+  2. The seed was bind-mounted as a single FILE. A single-file bind mount
+     resolves to one inode at container start and keeps it, and git checkout
+     replaces a file rather than editing it in place. Measured on the box by
+     replacing a file the way git does: the file-mounted container still read
+     the old content, a directory-mounted one read the new content. So even a
+     forced reseed would have copied the pre-pull file.
+
+The interesting part of the fix is what it must NOT do. control-plane owns
+/etc/litellm/config.yaml at runtime: it merges the DB's model catalog over the
+seed and restarts the container to apply it. So an unconditional copy on start
+would overwrite, on that very restart, the config control-plane just wrote and
+restarted for. The reconcile is therefore keyed on a checksum of the seed.
+
+This file checks the wiring statically AND runs the entrypoint's real shell
+logic against temporary directories, because the wiring assertions alone would
+pass against a script that does the wrong thing.
+"""
+
+import hashlib
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPOSE = ROOT / "deploy" / "docker" / "docker-compose.yml"
+DEPLOY_WORKFLOW = ROOT / ".github" / "workflows" / "deploy-demo-box.yml"
+SEED = ROOT / "deploy" / "litellm" / "config.yaml"
+
+COMPOSE_TEXT = COMPOSE.read_text()
+DEPLOY_TEXT = DEPLOY_WORKFLOW.read_text()
+
+
+def _service_block(name: str) -> str:
+    match = re.search(
+        rf"^  {re.escape(name)}:\n(.*?)(?=^  [A-Za-z0-9._-]+:\s*$|\Z)",
+        COMPOSE_TEXT,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert match, f"docker-compose.yml has no service named {name}"
+    return match.group(1)
+
+
+LITELLM = _service_block("litellm")
+
+
+def _entrypoint_script() -> str:
+    """The shell body of the litellm entrypoint, unescaped as compose hands it
+    to the container: compose turns `$$` into a literal `$`."""
+    match = re.search(
+        r"^    entrypoint:\n"
+        r"      - /bin/sh\n"
+        r"      - -c\n"
+        r"      - \|\n"
+        r"(.*?)(?=^    [a-z]|\Z)",
+        LITELLM,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert match, "could not find the litellm entrypoint script in docker-compose.yml"
+    body = "\n".join(line[8:] for line in match.group(1).splitlines())
+    return body.replace("$$", "$")
+
+
+def test_the_seed_is_mounted_as_a_directory_not_a_single_file() -> None:
+    """A single-file bind mount is pinned to the inode it resolved at start,
+    and git replaces files rather than editing them, so a pull that changes the
+    seed would not be visible inside the container at all."""
+    assert "- ../../deploy/litellm:/seed:ro" in LITELLM, (
+        "the litellm service does not mount deploy/litellm as a read-only "
+        "DIRECTORY at /seed"
+    )
+    assert "/config.yaml:/seed/config.yaml" not in LITELLM, (
+        "the litellm service bind-mounts the seed as a single file, which goes "
+        "stale the moment a git checkout replaces it on the host"
+    )
+
+
+def test_the_entrypoint_reconciles_on_a_checksum_not_on_mere_existence() -> None:
+    """Keyed on existence, the seed is copied once per volume and every later
+    repository change is inert. Keyed on a checksum, a repository change is
+    applied and a control-plane restart is not mistaken for one."""
+    script = _entrypoint_script()
+    assert "sha256sum /seed/config.yaml" in script, script
+    assert ".seed.sha256" in script, (
+        "the entrypoint does not record which seed it applied, so it cannot "
+        "tell a changed seed from a control-plane restart"
+    )
+    # Recording the marker is what stops the copy from being unconditional.
+    assert re.search(r">\s*/etc/litellm/\.seed\.sha256", script), script
+
+
+def _run_entrypoint(root: Path) -> str:
+    """Run the real entrypoint logic with /seed and /etc/litellm redirected
+    into a temp tree, and `exec litellm ...` replaced by a marker echo."""
+    script = _entrypoint_script()
+    script = script.replace("/etc/litellm", str(root / "etc"))
+    script = script.replace("/seed", str(root / "seed"))
+    script = re.sub(r"^exec litellm .*$", "echo STARTED", script, flags=re.MULTILINE)
+    assert "STARTED" in script, "the entrypoint no longer execs litellm"
+    proc = subprocess.run(
+        ["/bin/sh", "-c", script], capture_output=True, text=True, timeout=30
+    )
+    assert proc.returncode == 0, f"entrypoint failed: {proc.stderr}"
+    return proc.stdout
+
+
+def _fixture(tmp: Path, seed_text: str) -> Path:
+    root = tmp / "root"
+    (root / "seed").mkdir(parents=True, exist_ok=True)
+    (root / "etc").mkdir(parents=True, exist_ok=True)
+    (root / "seed" / "config.yaml").write_text(seed_text)
+    return root
+
+
+def test_the_entrypoint_seeds_an_empty_volume() -> None:
+    """A fresh volume, a fresh box, or a recreated volume has to end up with a
+    valid config before anything syncs, or LiteLLM cannot boot at all."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = _fixture(Path(tmp), "model_list: [seed-v1]\n")
+        _run_entrypoint(root)
+        live = root / "etc" / "config.yaml"
+        assert live.exists(), "an empty volume was not seeded"
+        assert live.read_text() == "model_list: [seed-v1]\n"
+
+
+def test_a_changed_seed_reaches_the_volume() -> None:
+    """The reported defect. A repository edit must land on a volume that was
+    already seeded by an earlier boot."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = _fixture(Path(tmp), "model_list: [seed-v1]\n")
+        _run_entrypoint(root)
+
+        (root / "seed" / "config.yaml").write_text("model_list: [seed-v2]\n")
+        _run_entrypoint(root)
+
+        live = (root / "etc" / "config.yaml").read_text()
+        assert live == "model_list: [seed-v2]\n", (
+            "a changed repo seed did not reach the config volume, which is the "
+            f"whole defect: {live!r}"
+        )
+
+
+def test_an_unchanged_seed_does_not_clobber_control_planes_merged_config() -> None:
+    """The half an unconditional copy gets wrong.
+
+    control-plane merges the DB's catalog over the seed, writes the result to
+    this same path, and restarts the container to apply it. That restart runs
+    this entrypoint again. If it copied unconditionally it would immediately
+    destroy the merged config it was restarted to load, and the proxy would
+    come up with no DB-managed routes."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = _fixture(Path(tmp), "model_list: [seed-v1]\n")
+        _run_entrypoint(root)
+
+        merged = "model_list: [seed-v1, from-the-database]\n"
+        (root / "etc" / "config.yaml").write_text(merged)
+        _run_entrypoint(root)  # stands in for control-plane's restart
+
+        live = (root / "etc" / "config.yaml").read_text()
+        assert live == merged, (
+            "the entrypoint overwrote control-plane's merged config on a "
+            f"restart where the seed had not changed: {live!r}"
+        )
+
+
+def test_the_recorded_marker_matches_the_seed_actually_applied() -> None:
+    """The marker is the whole basis of the decision, so a marker that does not
+    match the file that was copied would make the next boot either clobber
+    forever or never reconcile again."""
+    with tempfile.TemporaryDirectory() as tmp:
+        text = "model_list: [seed-v1]\n"
+        root = _fixture(Path(tmp), text)
+        _run_entrypoint(root)
+        marker = (root / "etc" / ".seed.sha256").read_text().strip()
+        assert marker == hashlib.sha256(text.encode()).hexdigest(), marker
+
+
+def _step_pos(job_text: str, step_name: str) -> int:
+    match = re.search(
+        rf"^      - name: {re.escape(step_name)}\s*$", job_text, re.MULTILINE
+    )
+    assert match, f"the deploy job has no step named {step_name!r}"
+    return match.start()
+
+
+def test_the_deploy_reconciles_the_seed_before_it_syncs_the_catalog() -> None:
+    """`up -d` only recreates a service whose DEFINITION changed, and editing
+    deploy/litellm/config.yaml changes no service definition, so a deploy that
+    only changes that file never restarts the container and the entrypoint
+    never runs.
+
+    The catalog sync does restart it, after writing its merged config, which is
+    the wrong order: the sync would merge the DB over the stale config, and the
+    entrypoint would then notice the changed seed and overwrite that merged
+    result with the raw seed, leaving the proxy with no DB-managed routes.
+
+    Asserted as an order, because both steps being present is exactly the
+    arrangement that gets this wrong."""
+    match = re.search(
+        r"^  deploy:\n(.*?)(?=^  [A-Za-z0-9_-]+:\s*$|\Z)",
+        DEPLOY_TEXT,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert match, "deploy-demo-box.yml has no deploy job"
+    deploy = match.group(1)
+
+    reconcile = _step_pos(deploy, "Reconcile LiteLLM's config volume with the repo seed")
+    sync = _step_pos(deploy, "Sync LiteLLM model list from the DB catalog (issue #713)")
+    assert reconcile < sync, (
+        "the deploy syncs the model catalog before reconciling the config "
+        "volume with the repo seed, so the sync merges onto a stale base and "
+        "the reseed then discards the merge"
+    )
+
+
+def test_the_seed_the_tests_describe_is_the_file_the_service_mounts() -> None:
+    """Cheap guard against this whole file drifting onto a path that no longer
+    exists, which would turn every assertion above into a check of nothing."""
+    assert SEED.is_file(), f"{SEED} does not exist"
+    assert "model_list" in SEED.read_text(), "the seed config has no model_list"
+
+
+def main() -> int:
+    assert shutil.which("sha256sum"), "these tests need coreutils sha256sum"
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    for test in tests:
+        test()
+    print(f"test_litellm_config_seam: ok ({len(tests)} checks)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_selfhost_supabase_seam.py
+++ b/scripts/test_selfhost_supabase_seam.py
@@ -841,6 +841,144 @@ def test_the_retention_check_demands_evidence_of_execution() -> None:
     )
 
 
+def _step_pos(job_text: str, step_name: str) -> int:
+    """Character offset of a step's `- name:` line within a job, for ordering
+    assertions. Ordering is the whole point of the deadlock below, so it is
+    asserted on positions rather than on mere presence."""
+    match = re.search(
+        rf"^      - name: {re.escape(step_name)}\s*$", job_text, re.MULTILINE
+    )
+    assert match, f"the migrate job has no step named {step_name!r}"
+    return match.start()
+
+
+def test_migrations_run_against_a_reconciled_database_container() -> None:
+    """The 2026-08-22 deadlock, which cost three deploy runs and took chat
+    sign-in down while its fix sat merged on main.
+
+    The shape: migrate reconciles the database service by running
+    `docker compose ... up -d --build supabase-db` with a working-directory of
+    /home/sakib/hive/deploy/docker, so it reads the BOX's clone, not the
+    runner workspace this job checks out. Nothing in migrate advanced that
+    clone. The only step that did was deploy's Pull latest main, and deploy
+    `needs: migrate`.
+
+    So the moment a migration depended on something only a newer compose file
+    provides, the run could not converge: PR #994 moved supabase-db onto a
+    locally built image carrying pg_cron, 20260822_01 needed pg_cron, migrate
+    rebuilt from the pre-#994 compose file, got the old image, failed on the
+    missing extension, and skipped the job that would have pulled the fix.
+
+    The fix is ordering, so the assertions are on order. Presence alone would
+    pass against the exact arrangement that deadlocked."""
+    migrate = _job_block("migrate")
+
+    pull = _step_pos(migrate, "Pull latest main")
+    reconcile = _step_pos(migrate, "Make sure the stack's database is up")
+    apply_ = _step_pos(migrate, "Apply pending migrations")
+
+    assert pull < reconcile, (
+        "the migrate job reconciles the database container before it updates "
+        "the box's clone, so the compose file it builds from is whatever the "
+        "last successful deploy left behind. A migration that needs a change "
+        "to that file can then never be satisfied."
+    )
+    assert reconcile < apply_, (
+        "migrations are applied before the database service is reconciled to "
+        "the compose file, so they run against yesterday's server"
+    )
+
+    # The coupling that makes the order matter: the pull and the reconcile must
+    # act on the SAME directory. A pull that updated some other clone would
+    # satisfy the ordering assertions above and change nothing.
+    pull_step = _step_block(migrate, "Pull latest main")
+    reconcile_step = _step_block(migrate, "Make sure the stack's database is up")
+    clone = "/home/sakib/hive"
+    assert f"cd {clone}\n" in pull_step, (
+        f"the Pull latest main step does not update {clone}, which is the "
+        "clone the reconcile step below builds from"
+    )
+    assert "git pull --ff-only origin main" in pull_step, pull_step[:200]
+    assert f"working-directory: {clone}/deploy/docker" in reconcile_step, (
+        "the reconcile step does not build from the clone the pull updates, "
+        f"so updating {clone} would not change what it builds"
+    )
+    assert "--build supabase-db" in reconcile_step, (
+        "the reconcile step does not pass --build, so a change to "
+        "Dockerfile.supabase-db never reaches the running container: compose "
+        "builds a locally built image only when it is absent entirely"
+    )
+
+    # Exactly one pull, and it is this one. Leaving a second copy behind in
+    # deploy would be harmless today and would rot into two sources of truth
+    # for which commit the box is on.
+    deploy = _job_block("deploy")
+    assert "- name: Pull latest main" not in deploy, (
+        "the deploy job still pulls as well; the box's clone must be advanced "
+        "in exactly one place, and that place has to be upstream of migrate"
+    )
+
+
+def _do_blocks(sql: str) -> list:
+    """Every `DO $tag$ ... $tag$;` body in a migration, in file order."""
+    return [m.group(2) for m in re.finditer(r"DO \$(\w+)\$(.*?)\$\1\$;", sql, re.DOTALL)]
+
+
+def _strip_sql_comments(sql: str) -> str:
+    """`-- ...` comments removed, so an assertion about code cannot be
+    satisfied by prose.
+
+    Written because it happened: the first version of the guard test below
+    passed against a deliberately reverted guard, because the comment
+    explaining the guard mentions pg_available_extensions by name and the
+    assertion was reading the comment. A check that cannot go red is worse
+    than no check, since it also reports that the thing is covered."""
+    return "\n".join(re.sub(r"--.*$", "", line) for line in sql.splitlines())
+
+
+def test_the_retention_migration_skips_a_pg_cron_that_is_only_a_catalog_row() -> None:
+    """pg_extension is a catalog row. pg_available_extensions is what is on
+    disk. The migration gated its CREATE EXTENSION block on the second and its
+    cron.schedule block on the first, which is fine right up until the two
+    disagree.
+
+    They disagreed on the demo box. The restored production dump carried a
+    pg_cron row (and the cron schema, and cron.schedule) into a server whose
+    image had never shipped the library, so the first block correctly announced
+    that pg_cron was unavailable and skipped, and the second block then saw the
+    catalog row, resolved cron.schedule by name, and died calling it:
+    `could not access file "$libdir/pg_cron"`. The migration runs as a
+    superuser on the box, so its handler re-raised, the migration aborted, and
+    the deploy that would have supplied the library was skipped behind
+    `needs: migrate`.
+
+    Both blocks must ask the same question. The file's own NOTICE already
+    promises this file is a clean no-op where pg_cron is genuinely absent."""
+    migrations = sorted((ROOT / "supabase" / "migrations").glob("*.sql"))
+    schedulers = [
+        p for p in migrations
+        if "cron.schedule" in p.read_text() and RETENTION_JOB in p.read_text()
+    ]
+    assert schedulers, "no migration schedules the retention job at all"
+    latest = schedulers[-1]
+
+    blocks = [_strip_sql_comments(b) for b in _do_blocks(latest.read_text())]
+    calling = [b for b in blocks if "cron.schedule(" in b]
+    assert calling, (
+        f"{latest.name} names cron.schedule but not inside a DO block this "
+        "test can read; if the file was restructured, restate the guard "
+        "assertion below against the new shape rather than deleting it"
+    )
+    for block in calling:
+        guard = block[: block.index("cron.schedule(")]
+        assert "pg_available_extensions" in guard, (
+            f"{latest.name} calls cron.schedule guarded only by the catalog "
+            "row. A database that carries a pg_cron row from a restored dump "
+            "but has no pg_cron library on disk reaches the call and aborts "
+            "the migration, which is the 2026-08-22 deadlock."
+        )
+
+
 def main() -> int:
     # The parser guard runs FIRST, deliberately. Alphabetical order put it last,
     # so a silent parse failure would have been reported by whichever assertion

--- a/supabase/migrations/20260822_01_metering_retention_pg_cron_schedule.sql
+++ b/supabase/migrations/20260822_01_metering_retention_pg_cron_schedule.sql
@@ -115,7 +115,25 @@ DECLARE
 BEGIN
   SELECT rolsuper INTO is_super FROM pg_roles WHERE rolname = current_user;
 
-  IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_cron') THEN
+  -- Both halves, and the second one is not redundant.
+  --
+  -- pg_extension is a catalog row. pg_available_extensions is what is on disk.
+  -- Those two normally agree, and this block gated on the catalog row alone
+  -- until they disagreed on the demo box: the restored production dump carried
+  -- a pg_extension row for pg_cron (and the cron schema and cron.schedule
+  -- alongside it) into a server whose image never shipped the library. So the
+  -- block above correctly reported the extension unavailable and skipped, and
+  -- then this block saw the catalog row, resolved cron.schedule by name, and
+  -- died on `could not access file "$libdir/pg_cron"` at the point of actually
+  -- calling it. As a superuser, which the box migrates as, the handler below
+  -- re-raises, so the migration aborted, the deploy job `needs:` it, and the
+  -- box could not deploy the very image that would have supplied the library.
+  --
+  -- Availability means the files are present, not that a row survived a
+  -- restore. Asking the same question the block above asks is what makes this
+  -- file the clean no-op its own NOTICE already promises it is.
+  IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_cron')
+     AND EXISTS (SELECT 1 FROM pg_available_extensions WHERE name = 'pg_cron') THEN
     -- Same name, schedule and command as 20260729_02. cron.schedule upserts on
     -- (jobname, username), so re-running this against a database that already
     -- has the job is a no-op rather than a duplicate.


### PR DESCRIPTION
Fixes #1002.

The demo box could not deploy at all from 2026-08-22, chat sign-in included, and the fix for it was already merged on main the entire time. Three runs burned on the same circle: 32605288283 (#994), 32605296549 (#998), 32607780396 (#1003), the last of which carried the P0 chat sign-in fix.

## The circle

`deploy` declares `needs: migrate`, so a failed `migrate` skips `deploy`, `sdk-replay` and `agent-workspace-coverage`.

`migrate` failed applying `20260822_01_metering_retention_pg_cron_schedule.sql`:

```
NOTICE:  pg_cron is not available on this Postgres install, so no nightly retention job is scheduled here. ...
ERROR:  could not access file "$libdir/pg_cron": No such file or directory
CONTEXT:  SQL statement "SELECT cron.schedule(
        'metering-shadow-verdicts-purge', ...
```

pg_cron was absent because the container was still on `pgvector/pgvector:pg16`. `docker-compose.enterprise.yml` had already been changed to build `hive-supabase-db:pg16-cron`, which supplies it. That change could not be applied, because the only job that applies it is `deploy`, and `deploy` was skipped behind the failing `migrate`.

## Defect A: the migration aborted where it promised to skip

The two guards in that file do not ask the same question. The `CREATE EXTENSION` block checks `pg_available_extensions`, which is what is on disk. The `cron.schedule` block checked `pg_extension`, which is a catalog row.

Those normally agree. On the demo box they did not, and this is the part worth recording: the restored production dump carried a `pg_cron` row, and the `cron` schema and `cron.schedule` with it, into a server whose image had never shipped the library. Verified live before the fix:

| probe | value |
| --- | --- |
| `select count(*) from pg_available_extensions where name='pg_cron'` | `0` |
| `select extname from pg_extension` | includes `pg_cron` |
| `show shared_preload_libraries` | empty |

So the first block correctly announced pg_cron unavailable and skipped, and the second block then saw the catalog row, resolved `cron.schedule` by name, and died calling it. The migration runs as a superuser on the box, so its handler re-raised rather than degrading to a notice, which is correct behaviour for a superuser and is why the whole chain stopped.

Both blocks now ask the same question. A pg_cron that is only a catalog row is not available, and the file becomes the clean no-op its own NOTICE already promises.

`scripts/check-retention-schedule.sh` is deliberately untouched and still fails the deploy when the nightly job is missing on the box. That division is the point: a migration must not abort a deploy over an absent extension, and the check must still abort it over an absent job. Softening both is how retention went unscheduled and unnoticed in the first place.

## Defect B: migrations ran against a container nothing had reconciled

`migrate` reconciles the database service with `docker compose ... up -d --build supabase-db`, at `working-directory: /home/sakib/hive/deploy/docker`. That is the box's own long-lived clone, not the runner workspace the job checks out with `actions/checkout`.

Nothing in `migrate` advanced that clone. The only step that did was `deploy`'s `Pull latest main`, and `deploy` needs `migrate`. So the reconcile step read a compose file frozen at the last successful deploy, and a change to how `supabase-db` is built could never reach the job that depends on it. Confirmed on the box: its clone was still at `851003b7b`, and its `docker-compose.enterprise.yml` still pinned the plain pgvector digest with no `command:` and no cron image.

`Pull latest main` moves into `migrate`, ahead of the reconcile step, and out of `deploy`. The order is now: update the tree, reconcile the database service from that tree, migrate against it, then deploy the rest.

The step text itself is unchanged, so the 2026-08-13 credential fix and its reasoning move intact. It is still exactly one pull, so the box's clone still has one writer, and `deploy` still reads a tree already at this run's commit because `needs:` guarantees `migrate` ran.

A new job that only reconciles the database was considered and rejected as larger: the reconcile step already lives in the right job and only ever needed a current tree to read.

## Regression coverage

Both new tests are in `scripts/test_selfhost_supabase_seam.py`, which `make test-scripts` already runs as a required CI check, so they can actually block a merge.

`test_migrations_run_against_a_reconciled_database_container` asserts positions, not presence. Presence alone passes against the exact arrangement that deadlocked. It also pins the coupling that makes order matter: the pull and the reconcile must name the same directory, the reconcile must keep `--build`, and `deploy` must not grow a second pull.

`test_the_retention_migration_skips_a_pg_cron_that_is_only_a_catalog_row` asserts the `cron.schedule` guard covers on-disk availability.

Every assertion was mutation-tested rather than assumed. Seven mutations, each run against the suite and then reverted:

| mutation | result |
| --- | --- |
| guard reverted to catalog-row-only | red |
| pull step removed from migrate | red |
| pull moved after the reconcile, all steps still present | red |
| `--build` dropped from the reconcile step | red |
| reconcile pointed at a clone the pull does not update | red |
| duplicate pull left in deploy | red |
| unmutated tree | green, 25 checks |

The guard test was green on its first attempt against a deliberately reverted guard, because the comment explaining the guard mentions `pg_available_extensions` by name and the assertion was reading the comment rather than the code. `_strip_sql_comments` exists because of that, and the docstring says so. A check that cannot go red is worse than no check, because it also reports the thing as covered.

## Box state

The box was unblocked by hand before this PR, because the deadlock could not be broken by merging anything. A fresh `pg_dumpall` snapshot was taken first to a new timestamped path, leaving the two existing snapshots untouched, then the clone was fast-forwarded and only `supabase-db` was recreated with the repository's canonical compose flags. No `--remove-orphans`, no other service touched.

Verified after the recreate, from inside the container:

| probe | before | after |
| --- | --- | --- |
| `Config.Image` | `pgvector/pgvector:pg16` | `hive-supabase-db:pg16-cron` |
| `server_version` | 16.14 | 16.14 |
| `shared_preload_libraries` | empty | `pg_cron` |
| `pg_cron` in `pg_available_extensions` | absent | `1.6` |
| `vector` | 0.8.3 | 0.8.3 |
| `auth.users` | 154 | 154 |
| `credit_ledger_entries` | 9072 | 9072 |
| `credit_reservations` | 2404 | 2404 |
| `tenants` | 958 | 958 |
| `api_keys` | 83 | 83 |
| `pg_control_system().system_identifier` | 7675489800166150182 | 7675489800166150182 |

The identifier matching is what rules out a recreate onto an empty volume, which row counts alone would not.

Run 32607780396 was then re-run and the whole chain went green, `deploy` included. Chat sign-in is back: `chat-hive.scubed.co` serves the sign-in page with no console errors, `/oauth/oidc/login` now requests `openid email profile`, and the authorization endpoint accepts it with a 302 to consent rather than the rejection #1003 fixed.

## Buglog entry

```json
{"id":"bug-2026-08-22-pgcron-migrate-deploy-deadlock","date":"2026-08-22","title":"deploy-demo-box deadlocked: migrations needed an extension only the skipped deploy job could install","error_message":"ERROR: could not access file \"$libdir/pg_cron\": No such file or directory, CONTEXT: SQL statement \"SELECT cron.schedule('metering-shadow-verdicts-purge', ...)\" in 20260822_01_metering_retention_pg_cron_schedule.sql","root_cause":"Two defects compounding. First, the migration gated its CREATE EXTENSION block on pg_available_extensions (files on disk) but its cron.schedule block on pg_extension (a catalog row); a restored production dump carried a pg_cron catalog row into a server whose image lacked the library, so the first block skipped and the second called cron.schedule anyway and aborted as superuser. Second, the migrate job reconciles supabase-db from the box's own clone at /home/sakib/hive, but only the deploy job pulls into that clone, and deploy needs migrate. So the compose change that supplies pg_cron could never reach the job that required it, and every merge re-ran the same circle for three runs.","fix":"Gate the cron.schedule block on pg_available_extensions as well as pg_extension, so the migration is a genuine no-op where pg_cron is not on disk. Move the Pull latest main step from deploy into migrate, ahead of the supabase-db reconcile step, so the tree is updated before anything builds from it. Regression tests in scripts/test_selfhost_supabase_seam.py assert step ORDER plus the pull/reconcile directory coupling, and the guard test strips SQL comments so it cannot pass on prose.","tags":["deploy","ci","migrations","pg_cron","postgres","deadlock","demo-box","job-ordering","restored-dump"]}
```

---

# Second commit: the LiteLLM config never reached the running proxy

Folded in at the coordinator's request because it is the same defect class, the repo diverging from the running system behind a green deploy, and because `deploy/docker/docker-compose.yml` should have exactly one editor this cycle.

`docker-compose.yml` seeded `deploy/litellm/config.yaml` into a named volume behind `if [ ! -f /etc/litellm/config.yaml ]`. The volume outlives container recreates by design, so on any box that had booted once, and the demo box had, an edit to that config never reached the proxy again. Deleting the volume by hand was the only cure and nothing said so.

Measured, not inferred. On the box:

| probe | result |
| --- | --- |
| top-level keys in the repo seed | `files_settings`, `litellm_settings`, `model_list` |
| top-level keys in the live container config | the same three plus `general_settings` |

The live file is provably not the repository's file.

## A second staleness bug underneath it

The seed was bind-mounted as a single **file**, and a single-file bind mount resolves to one inode at container start and keeps it. `git checkout` does not edit a file in place, it writes a replacement and renames over the old name. So a pull that changed this config would leave the container reading the pre-pull file until it was recreated, and a forced reseed would have copied stale bytes.

Verified on the box by replacing a file exactly the way git does:

```
before: file-mount=v1 dir-mount=v1
after : file-mount=v1 dir-mount=v2
```

## Why not a read-only bind mount

Because something writes that path at runtime. control-plane's `litellmconfig` service merges the DB's model catalog over this seed, writes the result to `/etc/litellm/config.yaml`, and restarts the container to apply it (`WriteAndRestart`, `generator.go`). A read-only mount over the live path breaks the catalog sync outright.

That same fact rules out the other obvious fix. An unconditional copy on start would overwrite, on that very restart, the config control-plane just wrote and restarted for, and the proxy would come up with no DB-managed routes at all.

## The fix

- The seed is mounted as a read-only **directory**, so `/seed/config.yaml` resolves per open and always reads what the repository currently says.
- The entrypoint reconciles against a **checksum** of the seed, recorded in the volume when applied. A control-plane restart leaves the seed unchanged and is a no-op; a genuine repository change is applied. This survives a container recreate, a fresh volume and a rebuilt box, which is the standard `Dockerfile.supabase-db` sets for pg_cron.
- The deploy reconciles **before** it syncs the catalog. `up -d` only recreates a service whose definition changed, and editing the config changes no service definition, so nothing else restarts the container. The catalog sync does restart it, after writing its merged config, which is the wrong order.

Verified end to end in a real container under real compose interpolation:

```
--- boot 1 (empty volume)
litellm: seeding /etc/litellm/config.yaml from the repo config (70d6faf3...)
STARTED with: model_list: [seed-v1]
--- control-plane writes a merged config, then restarts the container
STARTED with: model_list: [seed-v1, from-the-database]
--- repo seed changed the way git does (replace, not edit)
litellm: seeding /etc/litellm/config.yaml from the repo config (defc1c45...)
STARTED with: model_list: [seed-v2]
```

## Regression coverage

`scripts/test_litellm_config_seam.py`, wired into `make test-scripts`. It runs the entrypoint's actual shell against temporary directories rather than pattern-matching its text, so it fails for the naive over-correction as well as for the original defect. Mutation-tested:

| mutation | result |
| --- | --- |
| entrypoint reverted to first-boot-only seeding | red |
| entrypoint copies unconditionally, clobbering the merged config | red |
| marker records a constant instead of the applied seed | red |
| seed back to a single-file bind mount | red |
| reconcile step moved after the catalog sync | red |
| unmutated tree | green, 8 checks |

## Note for the LiteLLM image pin bump

The entrypoint needs `/bin/sh`, `sha256sum`, `cut`, `cat` and `printf` in the image. All five are present in `v1.77.7-stable` (confirmed by running `sha256sum` inside the live container). If the pending bump to `1.98.0` moves to a distroless or busybox-less base, this entrypoint fails closed at container start rather than silently, but it would need adjusting. Worth one check when that pin lands. Nothing else in this change interacts with the pin.

## Buglog entry, second defect

```json
{"id":"bug-2026-08-22-litellm-config-volume-seeded-once","date":"2026-08-22","title":"LiteLLM config edits in the repo never reached the running proxy","error_message":"No error surfaced. Routes added or repointed in deploy/litellm/config.yaml were silently inert on the demo box; the running container's config carried a top-level general_settings key absent from the repo seed, proving the live file was not the repo file.","root_cause":"Two compounding staleness bugs. First, docker-compose.yml seeded deploy/litellm/config.yaml into the litellm-config named volume behind `if [ ! -f /etc/litellm/config.yaml ]`, so the copy happened exactly once per volume, and the volume outlives container recreates by design. Second, the seed was bind-mounted as a single FILE, which pins one inode at container start, and git checkout replaces files rather than editing them in place, so even a forced reseed would have copied the pre-pull content. Measured on the box: after a git-style replace, a file-mounted container still read v1 while a directory-mounted one read v2.","fix":"Mount deploy/litellm as a read-only DIRECTORY at /seed so the path resolves per open. Reconcile the volume in the entrypoint against a sha256 of the seed recorded in the volume, not against the config's mere existence, so a control-plane restart (control-plane merges the DB catalog over the seed, writes the same path, and restarts the container) is a no-op while a genuine repo change is applied. Add a deploy step that restarts litellm on seed drift BEFORE the catalog sync, since `up -d` never recreates a service whose definition did not change and the sync's own restart would otherwise reseed after the merge and discard it. Regression test scripts/test_litellm_config_seam.py executes the real entrypoint shell against temp dirs, wired into make test-scripts.","tags":["deploy","docker-compose","litellm","volume","bind-mount","inode","stale-config","demo-box","first-boot-seed"]}
```
