### PR TITLE
chore: add security disclosure policy and dependabot baseline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,9 +11,9 @@
 # a flood of individual PRs. Major and security-only updates still get their
 # own PRs.
 #
-# Note on limits: Dependabot applies open-pull-requests-limit per configured
-# directory, not globally, so the Go and npm caps below bound each manifest at
-# 10 concurrent update PRs.
+# Note on limits: open-pull-requests-limit caps version-update pull requests
+# per configured directory. Security-update pull requests are separate and do
+# not count against the cap, so triage those as they arrive.
 version: 2
 
 updates:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,113 @@
+# Dependabot baseline.
+#
+# Cadence choice: GitHub Actions, Go modules, and npm packages move weekly, so
+# those ecosystems run every Monday in the early-morning UTC quiet hours,
+# keeping dependency churn predictable and away from working hours. Docker base
+# images change far less often, so a monthly pass is enough there.
+#
+# Grouping: minor and patch updates within each manifest are grouped into a
+# single pull request per ecosystem label ("actions", "go-minor-patch",
+# "npm-minor-patch") so routine bumps arrive as one reviewable diff instead of
+# a flood of individual PRs. Major and security-only updates still get their
+# own PRs.
+#
+# Note on limits: Dependabot applies open-pull-requests-limit per configured
+# directory, not globally, so the Go and npm caps below bound each manifest at
+# 10 concurrent update PRs.
+version: 2
+
+updates:
+  # GitHub Actions workflows at the repository root.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "04:00"
+      timezone: UTC
+    groups:
+      actions:
+        update-types:
+          - "minor"
+          - "patch"
+    open-pull-requests-limit: 5
+
+  # Go modules, one entry per module in the workspace.
+  - package-ecosystem: gomod
+    directory: /apps/control-plane
+    schedule:
+      interval: weekly
+      day: monday
+      time: "04:00"
+      timezone: UTC
+    groups:
+      go-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: gomod
+    directory: /apps/edge-api
+    schedule:
+      interval: weekly
+      day: monday
+      time: "04:00"
+      timezone: UTC
+    groups:
+      go-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: gomod
+    directory: /apps/agent-engine
+    schedule:
+      interval: weekly
+      day: monday
+      time: "04:00"
+      timezone: UTC
+    groups:
+      go-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    open-pull-requests-limit: 10
+
+  # npm frontends.
+  - package-ecosystem: npm
+    directory: /apps/web-console
+    schedule:
+      interval: weekly
+      day: monday
+      time: "04:00"
+      timezone: UTC
+    groups:
+      npm-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: npm
+    directory: /apps/agent-console
+    schedule:
+      interval: weekly
+      day: monday
+      time: "04:00"
+      timezone: UTC
+    groups:
+      npm-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    open-pull-requests-limit: 10
+
+  # Dockerfiles (control-plane, edge-api, web-console, agent services, etc).
+  - package-ecosystem: docker
+    directory: /deploy/docker
+    schedule:
+      interval: monthly
+      time: "04:00"
+      timezone: UTC

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,51 @@
+# Security Policy
+
+## Project Overview
+
+Hive is an OpenAI-compatible API gateway. The Go control-plane and edge-api handle routing, metering, and billing; the Next.js web-console is the developer console; the chat frontend is a heavily modified fork of Open WebUI; agent workloads run inside Apptainer sandboxes.
+
+## Supported Versions
+
+Hive is a pre-1.0 product with continuous deployment to the demo environment. Only the latest `main` branch of this repository is supported. We do not maintain security branches for older releases or tags; if you are running anything other than a recent build of `main`, upgrade before reporting or expecting a fix.
+
+## Reporting a Vulnerability
+
+Please do **not** open a public GitHub issue for a vulnerability.
+
+This repository has GitHub private vulnerability reporting enabled. Use it: go to the repository's **Security** tab and click **Report a vulnerability**. This keeps the details private while we triage and gives you a direct channel to the maintainers.
+
+**Expected response times:** every report is triaged within 5 business days. After triage, we will communicate an assessment and an expected fix timeline in the private thread.
+
+## Scope
+
+The following areas are in scope:
+
+- Authentication and session handling
+- Tenant isolation, including row level security boundaries between tenants
+- Money and billing paths (credits, reservations, settlement, payments)
+- Provider API key handling and any path where provider credentials could leak
+- Sandbox escape from the Apptainer-based agent execution environment
+- Injection flaws (SQL, command, template, prompt-adjacent injection with real impact)
+- Exposure of secrets, tokens, or internal configuration
+
+The following are out of scope:
+
+- Social engineering of staff, users, or support channels
+- Denial of wallet through paid load testing without prior coordination with us
+- Findings against `demo.scubed.co` endpoints that only demonstrate missing rate limits already tracked as known work
+
+## Safe Harbor
+
+We will not pursue action against good-faith security research that follows these rules:
+
+- Research only against your own accounts and your own data.
+- Never access, modify, or exfiltrate another tenant's data. Ever.
+- No destructive testing: no service degradation, no data deletion or corruption.
+- Report findings to us privately before any public disclosure.
+- We follow a 90 day coordinated disclosure window from first report.
+
+If you act in good faith within these bounds, we consider your activity authorized and will work with you on resolution and credit.
+
+## Priority Note
+
+Bugs in money-path handling (billing, credits, reservations, settlement) have standing priority per project decision D-034, which requires those paths to fail closed. Reports in this area will be treated as high severity.


### PR DESCRIPTION
## Summary

- Adds `SECURITY.md`: private vulnerability reporting instructions (GitHub Security tab > Report a vulnerability), supported-versions statement (latest main only, pre-1.0 with continuous demo deployment), in/out-of-scope guidance, safe harbor terms (own accounts/data only, report before disclosing, 90-day coordinated disclosure window), and a note that money-path bugs carry standing high-severity priority per project decision D-034 (fail closed).
- Adds `.github/dependabot.yml` (version 2) enabling Dependabot for the first time, tuned to manifests verified present in the repo:
  - github-actions: `/`, weekly Monday 04:00 UTC, patch+minor grouped as "actions", open PRs capped at 5.
  - gomod: `apps/control-plane`, `apps/edge-api`, `apps/agent-engine`, weekly Monday 04:00 UTC, minor+patch grouped as "go-minor-patch", cap 10 per manifest.
  - npm: `apps/web-console`, `apps/agent-console`, weekly Monday 04:00 UTC, minor+patch grouped as "npm-minor-patch", cap 10.
  - docker: `deploy/docker`, monthly 04:00 UTC.

## Why

Secret scanning is already enabled on this repo, but Dependabot was completely off and a public repository needs a documented vulnerability disclosure path. This PR closes both gaps: it gives security researchers a private reporting channel with explicit scope and safe-harbor rules, and turns on automated dependency updates across every ecosystem that actually exists here.

Docs-only change: no code paths touched.
