### PR TITLE
feat: bill the openrouter-auto router alias at actual upstream cost

### DIFF
--- a/.github/workflows/deploy-demo-box.yml
+++ b/.github/workflows/deploy-demo-box.yml
@@ -1408,6 +1408,17 @@ jobs:
         # LITELLM_MASTER_KEY the box's .env already sets, via `Authorization:
         # Bearer`.
         #
+        # An `upstream_actual` alias is included explicitly. Its price columns
+        # are NULL by design (it bills the cost the upstream reports per
+        # request), and `NULL > 0` is NULL, not true, so the nonzero-price test
+        # alone would have dropped it from this query silently. It needs this
+        # assertion MORE than a fixed-price route does, not less: it is the one
+        # route where the deployment calling a different model than the catalog
+        # names would change what customers are charged per request. Trading a
+        # loud CI failure for a quiet absence is the mistake this repo keeps
+        # making, so the predicate names the mode rather than relying on a
+        # price comparison that cannot see it.
+        #
         # Restricted to routes whose alias actually prices tokens
         # (model_aliases.price_unit = 'tokens', a nonzero input or output
         # price): a mismatch anywhere else is not a mispricing, since D-033
@@ -1513,7 +1524,11 @@ jobs:
                 JOIN public.model_aliases ma ON ma.alias_id = pr.alias_id
                WHERE pr.health_state NOT IN ('disabled', 'eol')
                  AND ma.price_unit = 'tokens'
-                 AND (ma.input_price_credits > 0 OR ma.output_price_credits > 0)
+                 AND (
+                       ma.pricing_mode = 'upstream_actual'
+                    OR ma.input_price_credits > 0
+                    OR ma.output_price_credits > 0
+                 )
                ORDER BY pr.route_id;")
 
           if [ -z "$rows" ]; then

--- a/apps/control-plane/internal/catalog/http.go
+++ b/apps/control-plane/internal/catalog/http.go
@@ -113,6 +113,11 @@ func buildPublicCatalogModels(aliases []ModelAlias) []PublicCatalogModel {
 				OutputPriceCredits:     a.OutputPriceCredits,
 				CacheReadPriceCredits:  a.CacheReadPriceCredits,
 				CacheWritePriceCredits: a.CacheWritePriceCredits,
+				// Without these two the wire always said pricing_mode "", which
+				// is not a value the database CHECK can ever produce, and every
+				// consumer would have read a variable-price alias as fixed.
+				PricingMode:                a.PricingMode,
+				ReservationEstimateCredits: a.ReservationEstimateCredits,
 			},
 			Lifecycle: a.Lifecycle,
 		})

--- a/apps/control-plane/internal/catalog/http_test.go
+++ b/apps/control-plane/internal/catalog/http_test.go
@@ -26,8 +26,8 @@ func TestSnapshotHandlerReturnsModelsAndCatalog(t *testing.T) {
 				Visibility:             "public",
 				Lifecycle:              "stable",
 				CapabilityBadges:       []string{"stable", "chat", "responses"},
-				InputPriceCredits:      12,
-				OutputPriceCredits:     36,
+				InputPriceCredits:      int64Ptr(12),
+				OutputPriceCredits:     int64Ptr(36),
 				CacheReadPriceCredits:  int64Ptr(2),
 				CacheWritePriceCredits: int64Ptr(6),
 				CreatedAt:              time.Unix(1_716_935_002, 0).UTC(),
@@ -59,8 +59,8 @@ func TestSnapshotHandlerReturnsModelsAndCatalog(t *testing.T) {
 	if snapshot.Models[0].ID != "hive-default" {
 		t.Fatalf("expected hive-default in models, got %q", snapshot.Models[0].ID)
 	}
-	if snapshot.Catalog[0].Pricing.OutputPriceCredits != 36 {
-		t.Fatalf("expected output price 36, got %d", snapshot.Catalog[0].Pricing.OutputPriceCredits)
+	if got := snapshot.Catalog[0].Pricing.OutputPriceCredits; got == nil || *got != 36 {
+		t.Fatalf("expected output price 36, got %v", got)
 	}
 }
 

--- a/apps/control-plane/internal/catalog/repository.go
+++ b/apps/control-plane/internal/catalog/repository.go
@@ -62,6 +62,8 @@ func (r *pgxRepository) ListPublicAliases(ctx context.Context) ([]ModelAlias, er
 			output_price_credits,
 			cache_read_price_credits,
 			cache_write_price_credits,
+			pricing_mode,
+			reservation_estimate_credits,
 			created_at,
 			updated_at
 		FROM public.model_aliases
@@ -109,6 +111,8 @@ const tenantVisibilityQuery = `
 		a.output_price_credits,
 		a.cache_read_price_credits,
 		a.cache_write_price_credits,
+		a.pricing_mode,
+		a.reservation_estimate_credits,
 		a.created_at,
 		a.updated_at,
 		v.visible
@@ -212,6 +216,8 @@ func (r *pgxRepository) GetAlias(ctx context.Context, aliasID string) (ModelAlia
 			output_price_credits,
 			cache_read_price_credits,
 			cache_write_price_credits,
+			pricing_mode,
+			reservation_estimate_credits,
 			created_at,
 			updated_at
 		FROM public.model_aliases
@@ -329,6 +335,8 @@ func (r *pgxRepository) ListAllAliases(ctx context.Context) ([]ModelAlias, error
 			output_price_credits,
 			cache_read_price_credits,
 			cache_write_price_credits,
+			pricing_mode,
+			reservation_estimate_credits,
 			created_at,
 			updated_at
 		FROM public.model_aliases
@@ -399,6 +407,8 @@ func scanModelAlias(scanner aliasScanner, extra ...any) (ModelAlias, error) {
 		&alias.OutputPriceCredits,
 		&alias.CacheReadPriceCredits,
 		&alias.CacheWritePriceCredits,
+		&alias.PricingMode,
+		&alias.ReservationEstimateCredits,
 		&alias.CreatedAt,
 		&alias.UpdatedAt,
 	}

--- a/apps/control-plane/internal/catalog/service.go
+++ b/apps/control-plane/internal/catalog/service.go
@@ -98,10 +98,12 @@ func buildCatalogSnapshot(aliases []ModelAlias) CatalogSnapshot {
 			Summary:          alias.Summary,
 			CapabilityBadges: append([]string(nil), alias.CapabilityBadges...),
 			Pricing: CatalogPricing{
-				InputPriceCredits:      alias.InputPriceCredits,
-				OutputPriceCredits:     alias.OutputPriceCredits,
-				CacheReadPriceCredits:  alias.CacheReadPriceCredits,
-				CacheWritePriceCredits: alias.CacheWritePriceCredits,
+				InputPriceCredits:          alias.InputPriceCredits,
+				OutputPriceCredits:         alias.OutputPriceCredits,
+				CacheReadPriceCredits:      alias.CacheReadPriceCredits,
+				CacheWritePriceCredits:     alias.CacheWritePriceCredits,
+				PricingMode:                alias.PricingMode,
+				ReservationEstimateCredits: alias.ReservationEstimateCredits,
 			},
 			Lifecycle: alias.Lifecycle,
 		})

--- a/apps/control-plane/internal/catalog/service_test.go
+++ b/apps/control-plane/internal/catalog/service_test.go
@@ -161,8 +161,8 @@ func TestGetSnapshotReturnsHiveOwnedModels(t *testing.T) {
 				Visibility:             "public",
 				Lifecycle:              "stable",
 				CapabilityBadges:       []string{"stable", "chat", "responses"},
-				InputPriceCredits:      12,
-				OutputPriceCredits:     36,
+				InputPriceCredits:      int64Ptr(12),
+				OutputPriceCredits:     int64Ptr(36),
 				CacheReadPriceCredits:  int64Ptr(2),
 				CacheWritePriceCredits: int64Ptr(6),
 				CreatedAt:              time.Unix(1_716_935_002, 0).UTC(),
@@ -175,8 +175,8 @@ func TestGetSnapshotReturnsHiveOwnedModels(t *testing.T) {
 				Visibility:             "preview",
 				Lifecycle:              "preview",
 				CapabilityBadges:       []string{"auto", "fallback", "preview"},
-				InputPriceCredits:      10,
-				OutputPriceCredits:     30,
+				InputPriceCredits:      int64Ptr(10),
+				OutputPriceCredits:     int64Ptr(30),
 				CacheReadPriceCredits:  int64Ptr(1),
 				CacheWritePriceCredits: int64Ptr(4),
 				CreatedAt:              time.Unix(1_716_935_102, 0).UTC(),
@@ -222,8 +222,8 @@ func TestGetSnapshotReturnsHiveOwnedModels(t *testing.T) {
 	if firstCatalog.Lifecycle != "stable" {
 		t.Fatalf("expected stable lifecycle, got %q", firstCatalog.Lifecycle)
 	}
-	if firstCatalog.Pricing.InputPriceCredits != 12 {
-		t.Fatalf("expected input price 12, got %d", firstCatalog.Pricing.InputPriceCredits)
+	if got := firstCatalog.Pricing.InputPriceCredits; got == nil || *got != 12 {
+		t.Fatalf("expected input price 12, got %v", got)
 	}
 	if firstCatalog.Pricing.CacheReadPriceCredits == nil || *firstCatalog.Pricing.CacheReadPriceCredits != 2 {
 		t.Fatalf("expected cache read price 2, got %#v", firstCatalog.Pricing.CacheReadPriceCredits)
@@ -241,8 +241,8 @@ func TestGetSnapshotOmitsInternalAliases(t *testing.T) {
 				Visibility:         "public",
 				Lifecycle:          "stable",
 				CapabilityBadges:   []string{"stable", "chat", "responses"},
-				InputPriceCredits:  12,
-				OutputPriceCredits: 36,
+				InputPriceCredits:  int64Ptr(12),
+				OutputPriceCredits: int64Ptr(36),
 				CreatedAt:          time.Unix(1_716_935_002, 0).UTC(),
 			},
 			{
@@ -253,8 +253,8 @@ func TestGetSnapshotOmitsInternalAliases(t *testing.T) {
 				Visibility:         "internal",
 				Lifecycle:          "hidden",
 				CapabilityBadges:   []string{"internal"},
-				InputPriceCredits:  1,
-				OutputPriceCredits: 1,
+				InputPriceCredits:  int64Ptr(1),
+				OutputPriceCredits: int64Ptr(1),
 				CreatedAt:          time.Unix(1_716_935_202, 0).UTC(),
 			},
 		},

--- a/apps/control-plane/internal/catalog/types.go
+++ b/apps/control-plane/internal/catalog/types.go
@@ -24,12 +24,20 @@ type ModelAlias struct {
 	Visibility             string
 	Lifecycle              string
 	CapabilityBadges       []string
-	InputPriceCredits      int64
-	OutputPriceCredits     int64
+	InputPriceCredits      *int64
+	OutputPriceCredits     *int64
 	CacheReadPriceCredits  *int64
 	CacheWritePriceCredits *int64
-	CreatedAt              time.Time
-	UpdatedAt              time.Time
+	// PricingMode is model_aliases.pricing_mode: PricingModeFixed when the
+	// price columns above are authoritative, PricingModeUpstreamActual when
+	// they are NULL because the price is variable per request.
+	PricingMode string
+	// ReservationEstimateCredits is the up-front hold for an upstream_actual
+	// alias, which has no catalog price to derive one from. NULL (nil) for a
+	// fixed alias.
+	ReservationEstimateCredits *int64
+	CreatedAt                  time.Time
+	UpdatedAt                  time.Time
 }
 
 type RouteSnapshot struct {
@@ -65,11 +73,86 @@ type PublicModel struct {
 	OwnedBy string `json:"owned_by"`
 }
 
+// Pricing modes, mirroring public.model_aliases.pricing_mode's CHECK
+// constraint (supabase/migrations/20260822_30_openrouter_auto_variable_pricing.sql).
+const (
+	// PricingModeFixed: the price columns are authoritative. Every alias
+	// except a variable-price router is this, and it is the column default,
+	// so an older row that predates the column reads as fixed.
+	PricingModeFixed = "fixed"
+	// PricingModeUpstreamActual: the price is variable per request, the price
+	// columns are NULL, and the charge comes from the cost the upstream
+	// reports for that specific generation.
+	PricingModeUpstreamActual = "upstream_actual"
+)
+
+// CatalogPricing carries an alias's price. The input and output figures are
+// POINTERS rather than plain int64 on purpose: for a PricingModeUpstreamActual
+// alias there is genuinely no price, and nil is the only honest way to say so.
+// An int64 would have to say 0, which is not "no price" but "free", and a price
+// that silently reads 0 is what billed nothing for three days in July. Every
+// reader is therefore forced to decide what a missing price means instead of
+// inheriting a zero by accident.
 type CatalogPricing struct {
-	InputPriceCredits      int64  `json:"input_price_credits"`
-	OutputPriceCredits     int64  `json:"output_price_credits"`
+	InputPriceCredits      *int64 `json:"input_price_credits"`
+	OutputPriceCredits     *int64 `json:"output_price_credits"`
 	CacheReadPriceCredits  *int64 `json:"cache_read_price_credits,omitempty"`
 	CacheWritePriceCredits *int64 `json:"cache_write_price_credits,omitempty"`
+	// PricingMode says which of the two worlds this row is in. It is carried
+	// beside the prices rather than inferred from their nil-ness so a reader
+	// can tell "variable by design" from "a lookup that came back empty".
+	PricingMode string `json:"pricing_mode"`
+	// ReservationEstimateCredits sizes the up-front hold for a variable-price
+	// alias. nil for a fixed one.
+	ReservationEstimateCredits *int64 `json:"reservation_estimate_credits,omitempty"`
+}
+
+// FixedPricing builds an ordinary fixed-price row, in credits per million
+// metered units, so callers state plain numbers rather than taking addresses
+// of locals.
+func FixedPricing(inputCredits, outputCredits int64) CatalogPricing {
+	return CatalogPricing{
+		InputPriceCredits:  &inputCredits,
+		OutputPriceCredits: &outputCredits,
+		PricingMode:        PricingModeFixed,
+	}
+}
+
+// UpstreamActualPricing builds a variable-price row: no prices, a hold size,
+// and the mode that tells settlement to charge the upstream's reported cost.
+func UpstreamActualPricing(reservationEstimateCredits int64) CatalogPricing {
+	return CatalogPricing{
+		PricingMode:                PricingModeUpstreamActual,
+		ReservationEstimateCredits: &reservationEstimateCredits,
+	}
+}
+
+// HasFixedPrice reports whether this row carries a usable fixed price: the
+// mode says fixed and at least one side is a positive number. One side at zero
+// is legitimate (embeddings meter input only), both sides zero or absent is the
+// no-cost-basis case routing refuses on (issue #617).
+func (p CatalogPricing) HasFixedPrice() bool {
+	if p.PricingMode == PricingModeUpstreamActual {
+		return false
+	}
+	return derefPrice(p.InputPriceCredits) > 0 || derefPrice(p.OutputPriceCredits) > 0
+}
+
+// IsUpstreamActual reports whether the charge for this alias must be derived
+// from the upstream's own reported cost rather than from these columns.
+func (p CatalogPricing) IsUpstreamActual() bool {
+	return p.PricingMode == PricingModeUpstreamActual
+}
+
+// derefPrice is deliberately unexported and deliberately NOT a general-purpose
+// "give me a number" helper. Coercing a nil price to 0 is only ever correct
+// when the question being asked is "is there a positive price here", which is
+// the two predicates above. Anything that CHARGES must branch on the mode.
+func derefPrice(v *int64) int64 {
+	if v == nil {
+		return 0
+	}
+	return *v
 }
 
 type PublicCatalogModel struct {

--- a/apps/control-plane/internal/routing/repository.go
+++ b/apps/control-plane/internal/routing/repository.go
@@ -5,9 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/catalog"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/catalog"
 )
 
 type Repository interface {
@@ -136,7 +136,9 @@ func (r *pgxRepository) LoadAliasPricing(ctx context.Context, aliasID string) (c
 			output_price_credits,
 			cache_read_price_credits,
 			cache_write_price_credits,
-			price_unit
+			price_unit,
+			pricing_mode,
+			reservation_estimate_credits
 		FROM public.model_aliases
 		WHERE alias_id = $1
 	`, aliasID)
@@ -151,6 +153,8 @@ func (r *pgxRepository) LoadAliasPricing(ctx context.Context, aliasID string) (c
 		&pricing.CacheReadPriceCredits,
 		&pricing.CacheWritePriceCredits,
 		&priceUnit,
+		&pricing.PricingMode,
+		&pricing.ReservationEstimateCredits,
 	); err != nil {
 		if err == pgx.ErrNoRows {
 			// No model_aliases row for an alias the routing tables already

--- a/apps/control-plane/internal/routing/service.go
+++ b/apps/control-plane/internal/routing/service.go
@@ -170,7 +170,20 @@ func (s *Service) SelectRoute(ctx context.Context, input SelectionInput) (Select
 	// RouteInfo.HasCostBasis uses, so an alias that legitimately prices only
 	// one side (embeddings are input-only, voice is output-only) stays
 	// selectable.
-	if pricing.InputPriceCredits <= 0 && pricing.OutputPriceCredits <= 0 {
+	//
+	// A PricingModeUpstreamActual alias has no fixed price BY DESIGN: the
+	// charge is derived from the cost the upstream reports for that specific
+	// generation. It is still refused unless it carries a positive
+	// reservation estimate, because that hold is the only thing standing
+	// between a variable-cost request and an account with no credits. An
+	// upstream_actual row with no hold size is a misconfiguration, and the
+	// fail-closed answer to a misconfigured money path is to refuse it, not
+	// to reserve nothing and hope the settlement lands.
+	if pricing.IsUpstreamActual() {
+		if pricing.ReservationEstimateCredits == nil || *pricing.ReservationEstimateCredits <= 0 {
+			return SelectionResult{}, fmt.Errorf("%w: %s (upstream_actual with no reservation estimate)", ErrAliasNotPriced, aliasID)
+		}
+	} else if !pricing.HasFixedPrice() {
 		return SelectionResult{}, fmt.Errorf("%w: %s", ErrAliasNotPriced, aliasID)
 	}
 

--- a/apps/control-plane/internal/routing/service_test.go
+++ b/apps/control-plane/internal/routing/service_test.go
@@ -764,9 +764,15 @@ func TestSelectRouteCarriesAliasPricing(t *testing.T) {
 	repo := entitlementTestRepo()
 	cacheRead := int64(1)
 	cacheWrite := int64(5)
-	repo.pricing = catalog.FixedPricing(12, 36)
-	repo.pricing.CacheReadPriceCredits = &cacheRead
-	repo.pricing.CacheWritePriceCredits = &cacheWrite
+	input := int64(12)
+	output := int64(36)
+	repo.pricing = catalog.CatalogPricing{
+		InputPriceCredits:      &input,
+		OutputPriceCredits:     &output,
+		CacheReadPriceCredits:  &cacheRead,
+		CacheWritePriceCredits: &cacheWrite,
+		PricingMode:            catalog.PricingModeFixed,
+	}
 
 	svc := NewService(repo, &stubEntitlements{visible: true})
 

--- a/apps/control-plane/internal/routing/service_test.go
+++ b/apps/control-plane/internal/routing/service_test.go
@@ -36,7 +36,7 @@ type stubRepository struct {
 // a stub left at its zero value would make every fixture that does not care
 // about price fail closed for the wrong reason. Tests that do care set
 // pricing explicitly, or set unpriced.
-var defaultStubPricing = catalog.CatalogPricing{InputPriceCredits: 7_000, OutputPriceCredits: 11_200}
+var defaultStubPricing = catalog.FixedPricing(7_000, 11_200)
 
 func (s *stubRepository) LoadAliasPolicy(_ context.Context, _ string) (catalog.AliasPolicySnapshot, error) {
 	s.loadPolicyCalls++
@@ -71,7 +71,7 @@ func (s *stubRepository) LoadAliasPricing(_ context.Context, aliasID string) (ca
 	}
 	// A fixture that set neither pricing nor unpriced does not care about
 	// price; give it a priced alias rather than the refusal path.
-	if s.pricing.InputPriceCredits == 0 && s.pricing.OutputPriceCredits == 0 {
+	if s.pricing.InputPriceCredits == nil && s.pricing.OutputPriceCredits == nil && s.pricing.PricingMode == "" {
 		return defaultStubPricing, priceUnit, nil
 	}
 
@@ -764,12 +764,9 @@ func TestSelectRouteCarriesAliasPricing(t *testing.T) {
 	repo := entitlementTestRepo()
 	cacheRead := int64(1)
 	cacheWrite := int64(5)
-	repo.pricing = catalog.CatalogPricing{
-		InputPriceCredits:      12,
-		OutputPriceCredits:     36,
-		CacheReadPriceCredits:  &cacheRead,
-		CacheWritePriceCredits: &cacheWrite,
-	}
+	repo.pricing = catalog.FixedPricing(12, 36)
+	repo.pricing.CacheReadPriceCredits = &cacheRead
+	repo.pricing.CacheWritePriceCredits = &cacheWrite
 
 	svc := NewService(repo, &stubEntitlements{visible: true})
 
@@ -781,11 +778,11 @@ func TestSelectRouteCarriesAliasPricing(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SelectRoute returned error: %v", err)
 	}
-	if result.Pricing.InputPriceCredits != 12 {
-		t.Fatalf("expected input price 12, got %d", result.Pricing.InputPriceCredits)
+	if got := result.Pricing.InputPriceCredits; got == nil || *got != 12 {
+		t.Fatalf("expected input price 12, got %v", got)
 	}
-	if result.Pricing.OutputPriceCredits != 36 {
-		t.Fatalf("expected output price 36, got %d", result.Pricing.OutputPriceCredits)
+	if got := result.Pricing.OutputPriceCredits; got == nil || *got != 36 {
+		t.Fatalf("expected output price 36, got %v", got)
 	}
 	if result.Pricing.CacheReadPriceCredits == nil || *result.Pricing.CacheReadPriceCredits != 1 {
 		t.Fatalf("expected cache read price 1, got %v", result.Pricing.CacheReadPriceCredits)
@@ -808,7 +805,7 @@ func TestSelectRouteCarriesAliasPricing(t *testing.T) {
 // wrong misprices by orders of magnitude (issue #627).
 func TestSelectRouteCarriesPriceUnit(t *testing.T) {
 	repo := entitlementTestRepo()
-	repo.pricing = catalog.CatalogPricing{InputPriceCredits: 0, OutputPriceCredits: 4_316_667}
+	repo.pricing = catalog.FixedPricing(0, 4_316_667)
 	repo.priceUnit = "seconds"
 
 	svc := NewService(repo, &stubEntitlements{visible: true})
@@ -824,8 +821,8 @@ func TestSelectRouteCarriesPriceUnit(t *testing.T) {
 	if result.PriceUnit != "seconds" {
 		t.Fatalf("expected price unit %q, got %q", "seconds", result.PriceUnit)
 	}
-	if result.Pricing.OutputPriceCredits != 4_316_667 {
-		t.Fatalf("expected the unit price carried through, got %d", result.Pricing.OutputPriceCredits)
+	if got := result.Pricing.OutputPriceCredits; got == nil || *got != 4_316_667 {
+		t.Fatalf("expected the unit price carried through, got %v", got)
 	}
 }
 
@@ -875,8 +872,8 @@ func TestSelectRouteAllowsSingleSidedPricing(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			repo := entitlementTestRepo()
 			repo.pricing = catalog.CatalogPricing{
-				InputPriceCredits:  tc.input,
-				OutputPriceCredits: tc.output,
+				InputPriceCredits:  &tc.input,
+				OutputPriceCredits: &tc.output,
 			}
 
 			svc := NewService(repo, &stubEntitlements{visible: true})
@@ -888,7 +885,7 @@ func TestSelectRouteAllowsSingleSidedPricing(t *testing.T) {
 			if err != nil {
 				t.Fatalf("SelectRoute refused a single-sided price: %v", err)
 			}
-			if result.Pricing.InputPriceCredits != tc.input || result.Pricing.OutputPriceCredits != tc.output {
+			if gotIn, gotOut := result.Pricing.InputPriceCredits, result.Pricing.OutputPriceCredits; gotIn == nil || gotOut == nil || *gotIn != tc.input || *gotOut != tc.output {
 				t.Fatalf("expected pricing %d/%d, got %+v", tc.input, tc.output, result.Pricing)
 			}
 		})
@@ -930,7 +927,7 @@ func TestSelectRoutePriceIsAliasStableAcrossFallback(t *testing.T) {
 				SupportsChatCompletions: true,
 			},
 		},
-		pricing: catalog.CatalogPricing{InputPriceCredits: 8, OutputPriceCredits: 24},
+		pricing: catalog.FixedPricing(8, 24),
 	}
 
 	svc := NewService(repo, &stubEntitlements{visible: true})
@@ -948,7 +945,7 @@ func TestSelectRoutePriceIsAliasStableAcrossFallback(t *testing.T) {
 	if len(result.FallbackRouteIDs) != 1 || result.FallbackRouteIDs[0] != "route-openrouter-fast-fallback" {
 		t.Fatalf("expected one fallback route-openrouter-fast-fallback, got %v", result.FallbackRouteIDs)
 	}
-	if result.Pricing.InputPriceCredits != 8 || result.Pricing.OutputPriceCredits != 24 {
+	if gotIn, gotOut := result.Pricing.InputPriceCredits, result.Pricing.OutputPriceCredits; gotIn == nil || gotOut == nil || *gotIn != 8 || *gotOut != 24 {
 		t.Fatalf("expected alias-level pricing 8/24 regardless of which route was primary, got %+v", result.Pricing)
 	}
 }
@@ -1042,7 +1039,7 @@ func TestSelectRouteHiveFastResolvesToGroqAtGroqPrice(t *testing.T) {
 			},
 		},
 		// 0.05 in / 0.08 out USD per million * 1.4 * CreditsPerUSD (100_000).
-		pricing: catalog.CatalogPricing{InputPriceCredits: 7_000, OutputPriceCredits: 11_200},
+		pricing: catalog.FixedPricing(7_000, 11_200),
 	}
 
 	svc := NewService(repo, &stubEntitlements{visible: true})
@@ -1065,10 +1062,10 @@ func TestSelectRouteHiveFastResolvesToGroqAtGroqPrice(t *testing.T) {
 	if len(result.FallbackRouteIDs) != 0 {
 		t.Fatalf("expected no fallback routes, got %v", result.FallbackRouteIDs)
 	}
-	if result.Pricing.InputPriceCredits != 7_000 {
-		t.Fatalf("expected input price 7000, got %d", result.Pricing.InputPriceCredits)
+	if got := result.Pricing.InputPriceCredits; got == nil || *got != 7_000 {
+		t.Fatalf("expected input price 7000, got %v", got)
 	}
-	if result.Pricing.OutputPriceCredits != 11_200 {
-		t.Fatalf("expected output price 11200, got %d", result.Pricing.OutputPriceCredits)
+	if got := result.Pricing.OutputPriceCredits; got == nil || *got != 11_200 {
+		t.Fatalf("expected output price 11200, got %v", got)
 	}
 }

--- a/apps/edge-api/internal/anthropic/routing_metering_test.go
+++ b/apps/edge-api/internal/anthropic/routing_metering_test.go
@@ -80,7 +80,7 @@ func (c *controlPlane) handler() http.Handler {
 			// tokens, pinned on purpose rather than tracked against later
 			// repricings (see the note at the top of
 			// apps/edge-api/internal/inference/settle_from_catalog_test.go).
-			Pricing:   inference.SelectRoutePricing{InputPriceCredits: 10_500, OutputPriceCredits: 42_000},
+			Pricing:   inference.FixedPricing(10_500, 42_000),
 			PriceUnit: inference.PriceUnitTokens,
 		})
 	})

--- a/apps/edge-api/internal/audio/routing_adapter.go
+++ b/apps/edge-api/internal/audio/routing_adapter.go
@@ -57,13 +57,22 @@ func (a *RoutingAdapter) SelectRoute(ctx context.Context, input RouteInput) (Rou
 	if err != nil {
 		return RouteResult{}, fmt.Errorf("audio: select route: %w", err)
 	}
+	// A variable-price alias has no catalog price at all: its charge is derived
+	// from the cost the upstream reports per generation, which is a
+	// token-endpoint mechanism this package does not implement. Refusing here
+	// is the same fail-closed shape #627 established for a price whose unit
+	// does not match what the handler meters, and it keeps a nil price from
+	// being flattened into a zero that would meter audio for free.
+	if result.Pricing.IsUpstreamActual() {
+		return RouteResult{}, fmt.Errorf("audio: alias %s is priced from actual upstream cost, which this endpoint cannot meter", result.AliasID)
+	}
 	return RouteResult{
 		AliasID:          result.AliasID,
 		LiteLLMModelName: result.LiteLLMModelName,
 		// Non-token modalities meter a single quantity, priced in
 		// output_price_credits with input_price_credits constrained to zero at
 		// the database level, so there is exactly one price to carry (#627).
-		UnitPriceCredits: result.Pricing.OutputPriceCredits,
+		UnitPriceCredits: result.Pricing.OutputCredits(),
 		PriceUnit:        result.PriceUnit,
 	}, nil
 }

--- a/apps/edge-api/internal/catalog/client.go
+++ b/apps/edge-api/internal/catalog/client.go
@@ -20,11 +20,21 @@ type Model struct {
 	OwnedBy string `json:"owned_by"`
 }
 
+// CatalogPricing mirrors control-plane's catalog.CatalogPricing across the
+// HTTP boundary.
+//
+// The input and output prices are POINTERS because a variable-price alias
+// genuinely has none and control-plane sends JSON null for both. This is not
+// cosmetic: a plain int64 target makes encoding/json reject the whole payload,
+// and this struct is decoded as part of the catalog snapshot that backs
+// /v1/models, so one nulled alias would have taken down model listing for every
+// model rather than just its own.
 type CatalogPricing struct {
-	InputPriceCredits      int64  `json:"input_price_credits"`
-	OutputPriceCredits     int64  `json:"output_price_credits"`
+	InputPriceCredits      *int64 `json:"input_price_credits"`
+	OutputPriceCredits     *int64 `json:"output_price_credits"`
 	CacheReadPriceCredits  *int64 `json:"cache_read_price_credits,omitempty"`
 	CacheWritePriceCredits *int64 `json:"cache_write_price_credits,omitempty"`
+	PricingMode            string `json:"pricing_mode"`
 }
 
 type CatalogModel struct {

--- a/apps/edge-api/internal/catalog/client.go
+++ b/apps/edge-api/internal/catalog/client.go
@@ -24,11 +24,19 @@ type Model struct {
 // HTTP boundary.
 //
 // The input and output prices are POINTERS because a variable-price alias
-// genuinely has none and control-plane sends JSON null for both. This is not
-// cosmetic: a plain int64 target makes encoding/json reject the whole payload,
-// and this struct is decoded as part of the catalog snapshot that backs
-// /v1/models, so one nulled alias would have taken down model listing for every
-// model rather than just its own.
+// genuinely has none and control-plane sends JSON null for both.
+//
+// This is load-bearing, and for the opposite reason to the database side.
+// Scanning a SQL NULL into a non-pointer int64 is a hard pgx error, so that
+// boundary fails loudly on its own. encoding/json does NOT behave that way:
+// unmarshalling JSON null into a non-pointer int64 is a documented no-op that
+// leaves the field at its zero value and returns no error. Verified against
+// Go's own decoder on 2026-08-22 rather than assumed.
+//
+// So with a plain int64 here, a variable-price alias would have arrived
+// silently priced at 0 credits, which is indistinguishable from free and is
+// exactly the shape that billed nothing for three days in July. The pointer is
+// what makes the absence visible.
 type CatalogPricing struct {
 	InputPriceCredits      *int64 `json:"input_price_credits"`
 	OutputPriceCredits     *int64 `json:"output_price_credits"`

--- a/apps/edge-api/internal/catalog/client_test.go
+++ b/apps/edge-api/internal/catalog/client_test.go
@@ -40,8 +40,8 @@ func TestFetchSnapshotDecodesModelsAndCatalog(t *testing.T) {
 	if len(snapshot.Catalog) != 1 {
 		t.Fatalf("expected 1 catalog entry, got %d", len(snapshot.Catalog))
 	}
-	if snapshot.Catalog[0].Pricing.OutputPriceCredits != 36 {
-		t.Fatalf("expected output price 36, got %d", snapshot.Catalog[0].Pricing.OutputPriceCredits)
+	if got := snapshot.Catalog[0].Pricing.OutputPriceCredits; got == nil || *got != 36 {
+		t.Fatalf("expected output price 36, got %v", got)
 	}
 }
 

--- a/apps/edge-api/internal/chat/billing.go
+++ b/apps/edge-api/internal/chat/billing.go
@@ -68,6 +68,19 @@ type settlement struct {
 	accountID     string
 	reservationID string
 	requestID     string
+	// heldCredits is the size of the hold actually taken. Recorded because a
+	// variable-price alias settles at the hold when it cannot read an upstream
+	// cost, and it can no longer assume that figure is sessionHoldCredits.
+	heldCredits int64
+}
+
+// held returns the hold size, or zero when there is no settlement at all (the
+// Enterprise posture, which charges nothing).
+func (s *settlement) held() int64 {
+	if s == nil {
+		return 0
+	}
+	return s.heldCredits
 }
 
 // startSettlement takes the hold for a session turn, or writes the customer's
@@ -138,13 +151,17 @@ func (h *Handler) startSettlement(
 		slog.Warn("session chat start attempt failed", "err", err, "request_id", requestID)
 	}
 
+	// A variable-price alias raises the flat session hold from its catalog
+	// row: a router can resolve to a model far dearer than the flat figure
+	// assumes, and the hold is the only solvency gate in front of it.
+	held := inference.ReservationCredits(route, sessionHoldCredits)
 	reservation, err := h.deps.Accounting.CreateReservation(ctx, inference.CreateReservationInput{
 		AccountID:        accountID,
 		RequestID:        requestID.String(),
 		AttemptNumber:    1,
 		Endpoint:         inference.EndpointChatCompletions,
 		ModelAlias:       alias,
-		EstimatedCredits: sessionHoldCredits,
+		EstimatedCredits: held,
 		PolicyMode:       "strict",
 	})
 	if err != nil {
@@ -180,6 +197,7 @@ func (h *Handler) startSettlement(
 		accountID:     accountID,
 		reservationID: reservation.ID,
 		requestID:     requestID.String(),
+		heldCredits:   held,
 	}, false
 }
 

--- a/apps/edge-api/internal/chat/dispatch.go
+++ b/apps/edge-api/internal/chat/dispatch.go
@@ -213,6 +213,9 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var inTokens, outTokens int
 	var hasUsage bool
 	var servedModel string
+	// Verbatim bytes of the terminal usage frame, populated only for a
+	// variable-price alias. See the capture site below.
+	var rawUsagePayload []byte
 	var finishReason string
 	var completion strings.Builder
 
@@ -258,6 +261,14 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			hasUsage = true
 			inTokens = envelope.Usage.PromptTokens
 			outTokens = envelope.Usage.CompletionTokens
+			// For a variable-price alias the charge comes from the cost the
+			// upstream reports, and sseEnvelope does not declare that field, so
+			// unmarshalling has already dropped it. Keep the untouched payload
+			// so settlement can read it; nothing else looks at these bytes and
+			// they never reach the client from here.
+			if route.Pricing.IsUpstreamActual() {
+				rawUsagePayload = append(rawUsagePayload[:0], payload...)
+			}
 		}
 	}
 
@@ -285,8 +296,28 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// unconfirmed, which is what tells control-plane to clamp the figure to the
 	// hold and open a reconciliation job. It never settles a delivered response
 	// at zero, and never bills a token count as though it were a credit amount.
-	costCredits, confirmed, delivered := inference.ChatSettlementCredits(
-		route, hasUsage, int64(inTokens), int64(outTokens), raw, completion.String())
+	var costCredits int64
+	var confirmed, delivered bool
+	if route.Pricing.IsUpstreamActual() {
+		// This alias has no catalog price. Its charge is the cost the upstream
+		// reported for this generation, times the standard margin. A cost that
+		// is missing, unreadable or a confident zero settles at the hold rather
+		// than at nothing, which is the whole point: this is the streaming path
+		// Open WebUI uses, so it is where a silent free-serve would do the most
+		// damage.
+		var costReason string
+		costCredits, confirmed, delivered, costReason = inference.UpstreamActualSettlement(
+			rawUsagePayload, settle.held(), hasUsage,
+			int64(inTokens), int64(outTokens), completion.String())
+		if delivered && !confirmed {
+			slog.Error("session chat: upstream cost unavailable, settling at the hold",
+				"request_id", requestID, "alias", clientModel, "reason", costReason,
+				"held_credits", settle.held())
+		}
+	} else {
+		costCredits, confirmed, delivered = inference.ChatSettlementCredits(
+			route, hasUsage, int64(inTokens), int64(outTokens), raw, completion.String())
+	}
 	if servedModel != "" && servedModel != route.LiteLLMModelName {
 		// An upstream fallback that crosses an alias boundary serves one model
 		// and would be priced at another's rate (#743). The charge below still

--- a/apps/edge-api/internal/chat/dispatch.go
+++ b/apps/edge-api/internal/chat/dispatch.go
@@ -305,14 +305,18 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// than at nothing, which is the whole point: this is the streaming path
 		// Open WebUI uses, so it is where a silent free-serve would do the most
 		// damage.
-		var costReason string
-		costCredits, confirmed, delivered, costReason = inference.UpstreamActualSettlement(
+		settled := inference.UpstreamActualSettlement(
 			rawUsagePayload, settle.held(), hasUsage,
 			int64(inTokens), int64(outTokens), completion.String())
-		if delivered && !confirmed {
-			slog.Error("session chat: upstream cost unavailable, settling at the hold",
-				"request_id", requestID, "alias", clientModel, "reason", costReason,
-				"held_credits", settle.held())
+		costCredits, confirmed, delivered = settled.Credits, settled.Confirmed, settled.Delivered
+		if delivered {
+			// generation_id is the audit handle for this charge. Operator log
+			// only: an upstream identifier can carry a provider name and
+			// audit_log fans out to third-party sinks.
+			slog.Info("session chat: variable-price settlement",
+				"request_id", requestID, "alias", clientModel, "reason", settled.Reason,
+				"credits", settled.Credits, "confirmed", settled.Confirmed,
+				"generation_id", settled.GenerationID, "held_credits", settle.held())
 		}
 	} else {
 		costCredits, confirmed, delivered = inference.ChatSettlementCredits(

--- a/apps/edge-api/internal/chat/dispatch.go
+++ b/apps/edge-api/internal/chat/dispatch.go
@@ -228,15 +228,38 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			flush(flusher)
 			continue
 		}
-		_, _ = w.Write(line)
-		_, _ = w.Write([]byte("\n"))
-		flush(flusher)
+		// This relay is verbatim by design, which is fine while the upstream
+		// frame carries nothing we must not publish. Enabling usage accounting
+		// for a variable-price alias changes that: the frame then carries our
+		// cost, its breakdown and the model the router actually chose. So that
+		// one route is sanitized before the write, and an unparseable frame is
+		// dropped rather than forwarded, because an unparseable frame is
+		// precisely the one whose contents are unknown.
+		isData := bytes.HasPrefix(line, []byte("data: "))
+		payload := bytes.TrimPrefix(line, []byte("data: "))
+		isDone := isData && bytes.Equal(payload, []byte("[DONE]"))
 
-		if !bytes.HasPrefix(line, []byte("data: ")) {
+		if isData && !isDone && route.Pricing.IsUpstreamActual() {
+			sanitized, sanOK := inference.SanitizeVariablePriceFrame(payload, clientModel)
+			if !sanOK {
+				slog.Warn("session chat: dropping an unparseable upstream frame on a variable-price alias",
+					"request_id", requestID, "alias", clientModel)
+				continue
+			}
+			_, _ = w.Write([]byte("data: "))
+			_, _ = w.Write(sanitized)
+			_, _ = w.Write([]byte("\n"))
+			flush(flusher)
+		} else {
+			_, _ = w.Write(line)
+			_, _ = w.Write([]byte("\n"))
+			flush(flusher)
+		}
+
+		if !isData {
 			continue
 		}
-		payload := bytes.TrimPrefix(line, []byte("data: "))
-		if bytes.Equal(payload, []byte("[DONE]")) {
+		if isDone {
 			break
 		}
 		var envelope sseEnvelope

--- a/apps/edge-api/internal/chat/dispatch_test.go
+++ b/apps/edge-api/internal/chat/dispatch_test.go
@@ -39,7 +39,7 @@ func newPassthroughRoutingClient(t *testing.T) *inference.RoutingClient {
 			// rather than tracked against later repricings: the real endpoint
 			// always sends a price and an explicit unit, and the recorded cost
 			// is derived from them (#688).
-			Pricing:   inference.SelectRoutePricing{InputPriceCredits: 10_500, OutputPriceCredits: 42_000},
+			Pricing:   inference.FixedPricing(10_500, 42_000),
 			PriceUnit: inference.PriceUnitTokens,
 		})
 	}))
@@ -217,7 +217,7 @@ func TestDispatchResolvesAliasToLiteLLMModelName(t *testing.T) {
 			AliasID:          "hive-fast",
 			LiteLLMModelName: "route-groq-fast",
 			Provider:         "groq",
-			Pricing:          inference.SelectRoutePricing{InputPriceCredits: 10_500, OutputPriceCredits: 42_000},
+			Pricing:          inference.FixedPricing(10_500, 42_000),
 			PriceUnit:        inference.PriceUnitTokens,
 		})
 	}))

--- a/apps/edge-api/internal/chat/settlement_test.go
+++ b/apps/edge-api/internal/chat/settlement_test.go
@@ -157,7 +157,7 @@ func pricedRouting(t *testing.T, litellmModel string, inPrice, outPrice int64) *
 			LiteLLMModelName: litellmModel,
 			Provider:         "test-provider",
 			Pricing:          inference.FixedPricing(inPrice, outPrice),
-			PriceUnit: inference.PriceUnitTokens,
+			PriceUnit:        inference.PriceUnitTokens,
 		})
 	}))
 	t.Cleanup(srv.Close)

--- a/apps/edge-api/internal/chat/settlement_test.go
+++ b/apps/edge-api/internal/chat/settlement_test.go
@@ -156,9 +156,7 @@ func pricedRouting(t *testing.T, litellmModel string, inPrice, outPrice int64) *
 			AliasID:          in.AliasID,
 			LiteLLMModelName: litellmModel,
 			Provider:         "test-provider",
-			Pricing: inference.SelectRoutePricing{
-				InputPriceCredits: inPrice, OutputPriceCredits: outPrice,
-			},
+			Pricing:          inference.FixedPricing(inPrice, outPrice),
 			PriceUnit: inference.PriceUnitTokens,
 		})
 	}))
@@ -560,7 +558,7 @@ func unpriceableRouting(t *testing.T) *inference.RoutingClient {
 			AliasID:          in.AliasID,
 			LiteLLMModelName: "route-test-audio",
 			Provider:         "test-provider",
-			Pricing:          inference.SelectRoutePricing{InputPriceCredits: 1_000},
+			Pricing:          inference.FixedPricing(1_000, 0),
 			PriceUnit:        "seconds",
 		})
 	}))

--- a/apps/edge-api/internal/inference/accounting_client.go
+++ b/apps/edge-api/internal/inference/accounting_client.go
@@ -68,11 +68,31 @@ type CreateReservationInput struct {
 }
 
 // ReservationResult is the response from reservation endpoints.
+//
+// EstimatedCredits is a field the control plane does NOT send. Its response
+// body is accounting.Reservation, which publishes the hold as `reserved_credits`
+// (apps/control-plane/internal/accounting/types.go). Nothing read
+// EstimatedCredits before variable pricing did, so the mismatch was invisible;
+// the first reader of it got a silent 0. Both keys are decoded here rather than
+// renaming the old one, so a caller that still reads EstimatedCredits keeps its
+// existing (zero) behaviour instead of changing meaning underneath it, and Held
+// is the accessor anything sizing a charge must use.
 type ReservationResult struct {
 	ID               string `json:"id"`
 	AccountID        string `json:"account_id"`
 	Status           string `json:"status"`
 	EstimatedCredits int64  `json:"estimated_credits"`
+	ReservedCredits  int64  `json:"reserved_credits"`
+}
+
+// Held is the size of the hold the control plane actually recorded. Prefer the
+// key it really sends; fall back to the legacy one so a stubbed or older
+// responder still works.
+func (r ReservationResult) Held() int64 {
+	if r.ReservedCredits > 0 {
+		return r.ReservedCredits
+	}
+	return r.EstimatedCredits
 }
 
 // FinalizeReservationInput is the request body for finalizing a reservation.

--- a/apps/edge-api/internal/inference/orchestrator.go
+++ b/apps/edge-api/internal/inference/orchestrator.go
@@ -304,13 +304,16 @@ func (o *Orchestrator) executeSync(
 			// and drops every field it does not declare, the upstream's
 			// reported cost among them. The raw bytes are the only place that
 			// figure still exists.
-			var reason string
-			actualCredits, confirmed, billable, reason = UpstreamActualSettlement(
+			settled := UpstreamActualSettlement(
 				respBody, reservation.EstimatedCredits,
 				hasUsage, inputTokens, outputTokens, responseText(endpoint, normalized))
-			if billable && !confirmed {
-				log.Printf("inference: upstream cost unavailable, settling at the hold request_id=%s reservation_id=%s endpoint=%s model=%s reason=%s held_credits=%d: a variable-price alias could not read a reported cost, charging the hold rather than serving free",
-					requestID, reservation.ID, endpoint, model, reason, reservation.EstimatedCredits)
+			actualCredits, confirmed, billable = settled.Credits, settled.Confirmed, settled.Delivered
+			if billable {
+				// generation_id is the audit handle for this charge; see the
+				// same line on the streaming path.
+				log.Printf("inference: variable-price settlement request_id=%s reservation_id=%s endpoint=%s model=%s reason=%s credits=%d confirmed=%v generation_id=%s held_credits=%d",
+					requestID, reservation.ID, endpoint, model, settled.Reason,
+					settled.Credits, settled.Confirmed, settled.GenerationID, reservation.EstimatedCredits)
 			}
 		} else {
 			actualCredits, confirmed, billable = settlementCredits(route, hasUsage, inputTokens, outputTokens, prompt, content)

--- a/apps/edge-api/internal/inference/orchestrator.go
+++ b/apps/edge-api/internal/inference/orchestrator.go
@@ -161,6 +161,16 @@ func (o *Orchestrator) executeSync(
 		return
 	}
 
+	// 2c. Bound the request for a variable-price alias, before dispatch. Its
+	// hold is only provably sufficient below a known request size and a known
+	// completion ceiling; see EnforceVariablePriceBounds. A pass-through for
+	// every fixed-price alias.
+	boundedBody, withinBounds := EnforceVariablePriceBounds(w, route, endpoint, model, body)
+	if !withinBounds {
+		return
+	}
+	body = boundedBody
+
 	// 3. Start attempt
 	requestID := uuid.New().String()
 	endStartAttempt := o.stage(endpoint, StageStartAttempt)

--- a/apps/edge-api/internal/inference/orchestrator.go
+++ b/apps/edge-api/internal/inference/orchestrator.go
@@ -181,13 +181,15 @@ func (o *Orchestrator) executeSync(
 	// 4. Create reservation
 	endCreateReservation := o.stage(endpoint, StageCreateReservation)
 	reservation, err := o.accounting.CreateReservation(ctx, CreateReservationInput{
-		AccountID:        snapshot.AccountID,
-		RequestID:        requestID,
-		AttemptNumber:    1,
-		APIKeyID:         snapshot.KeyID,
-		Endpoint:         endpoint,
-		ModelAlias:       model,
-		EstimatedCredits: estimatedCredits,
+		AccountID:     snapshot.AccountID,
+		RequestID:     requestID,
+		AttemptNumber: 1,
+		APIKeyID:      snapshot.KeyID,
+		Endpoint:      endpoint,
+		ModelAlias:    model,
+		// A variable-price alias raises this from its catalog row; a fixed
+		// one keeps the flat endpoint default. See ReservationCredits.
+		EstimatedCredits: ReservationCredits(route, estimatedCredits),
 		PolicyMode:       "strict",
 	})
 	endCreateReservation()
@@ -285,7 +287,24 @@ func (o *Orchestrator) executeSync(
 		if inputTokens+outputTokens <= 0 {
 			prompt, content = promptText(endpoint, body), responseText(endpoint, normalized)
 		}
-		actualCredits, confirmed, billable := settlementCredits(route, hasUsage, inputTokens, outputTokens, prompt, content)
+		var actualCredits int64
+		var confirmed, billable bool
+		if route.Pricing.IsUpstreamActual() {
+			// respBody, not `normalized`: normalize re-marshals a typed struct
+			// and drops every field it does not declare, the upstream's
+			// reported cost among them. The raw bytes are the only place that
+			// figure still exists.
+			var reason string
+			actualCredits, confirmed, billable, reason = UpstreamActualSettlement(
+				respBody, reservation.EstimatedCredits,
+				hasUsage, inputTokens, outputTokens, responseText(endpoint, normalized))
+			if billable && !confirmed {
+				log.Printf("inference: upstream cost unavailable, settling at the hold request_id=%s reservation_id=%s endpoint=%s model=%s reason=%s held_credits=%d: a variable-price alias could not read a reported cost, charging the hold rather than serving free",
+					requestID, reservation.ID, endpoint, model, reason, reservation.EstimatedCredits)
+			}
+		} else {
+			actualCredits, confirmed, billable = settlementCredits(route, hasUsage, inputTokens, outputTokens, prompt, content)
+		}
 		if !billable {
 			// Nothing measured and nothing produced: there is no quantity to
 			// charge, so leave finalized false and let the deferred release

--- a/apps/edge-api/internal/inference/orchestrator.go
+++ b/apps/edge-api/internal/inference/orchestrator.go
@@ -305,7 +305,7 @@ func (o *Orchestrator) executeSync(
 			// reported cost among them. The raw bytes are the only place that
 			// figure still exists.
 			settled := UpstreamActualSettlement(
-				respBody, reservation.EstimatedCredits,
+				respBody, reservation.Held(),
 				hasUsage, inputTokens, outputTokens, responseText(endpoint, normalized))
 			actualCredits, confirmed, billable = settled.Credits, settled.Confirmed, settled.Delivered
 			if billable {
@@ -313,7 +313,7 @@ func (o *Orchestrator) executeSync(
 				// same line on the streaming path.
 				log.Printf("inference: variable-price settlement request_id=%s reservation_id=%s endpoint=%s model=%s reason=%s credits=%d confirmed=%v generation_id=%s held_credits=%d",
 					requestID, reservation.ID, endpoint, model, settled.Reason,
-					settled.Credits, settled.Confirmed, settled.GenerationID, reservation.EstimatedCredits)
+					settled.Credits, settled.Confirmed, settled.GenerationID, reservation.Held())
 			}
 		} else {
 			actualCredits, confirmed, billable = settlementCredits(route, hasUsage, inputTokens, outputTokens, prompt, content)

--- a/apps/edge-api/internal/inference/pricing.go
+++ b/apps/edge-api/internal/inference/pricing.go
@@ -18,6 +18,7 @@ package inference
 // cannot answer that.
 
 import (
+	"errors"
 	"log"
 	"net/http"
 
@@ -45,9 +46,20 @@ const PriceUnitTokens = "tokens"
 // sides at zero is the no-cost-basis case metering.RouteInfo.HasCostBasis
 // already names, and routing.Service refuses such an alias outright (#617), so
 // reaching it here means the catalog and the gateway disagree.
+//
+// An upstream_actual alias passes on the strength of its MODE, not its price
+// columns, which are deliberately NULL: its charge comes from the cost the
+// upstream reports for that generation. Control-plane has already refused to
+// select such an alias unless it also carries a positive reservation estimate
+// (routing.Service), so reaching here in that mode means the hold is fundable.
 func CanPriceTokens(route SelectRouteResult) bool {
-	return route.PriceUnit == PriceUnitTokens &&
-		(route.Pricing.InputPriceCredits > 0 || route.Pricing.OutputPriceCredits > 0)
+	if route.PriceUnit != PriceUnitTokens {
+		return false
+	}
+	if route.Pricing.IsUpstreamActual() {
+		return true
+	}
+	return route.Pricing.InputCredits() > 0 || route.Pricing.OutputCredits() > 0
 }
 
 // CreditsForTokens converts metered token counts into whole credits at the
@@ -59,7 +71,17 @@ func CanPriceTokens(route SelectRouteResult) bool {
 // Token counts come from a provider response, so they are external input on a
 // money path: a negative count is clamped away rather than allowed to subtract
 // from the charge.
+//
+// Never call this for an upstream_actual route. Its price columns are NULL, so
+// this would price every token at zero and hand back the 1-credit floor for a
+// request that may have cost dollars. The guard below makes that a loud
+// programming error instead of a silent near-free settlement; callers are
+// expected to branch on IsUpstreamActual before they get here.
 func CreditsForTokens(route SelectRouteResult, inputTokens, outputTokens int64) int64 {
+	if route.Pricing.IsUpstreamActual() {
+		panic("inference: CreditsForTokens called for an upstream_actual route; " +
+			"its charge must come from the upstream reported cost, not the catalog price columns")
+	}
 	if inputTokens < 0 {
 		inputTokens = 0
 	}
@@ -67,8 +89,8 @@ func CreditsForTokens(route SelectRouteResult, inputTokens, outputTokens int64) 
 		outputTokens = 0
 	}
 	credits := metering.ChargeCredits(
-		metering.UnitCharge{Quantity: inputTokens, CreditsPerMillion: route.Pricing.InputPriceCredits},
-		metering.UnitCharge{Quantity: outputTokens, CreditsPerMillion: route.Pricing.OutputPriceCredits},
+		metering.UnitCharge{Quantity: inputTokens, CreditsPerMillion: route.Pricing.InputCredits()},
+		metering.UnitCharge{Quantity: outputTokens, CreditsPerMillion: route.Pricing.OutputCredits()},
 	)
 	if inputTokens+outputTokens > 0 && credits < 1 {
 		credits = 1
@@ -93,6 +115,104 @@ func ChatSettlementCredits(route SelectRouteResult, hasUsage bool, inputTokens, 
 	requestBody []byte, content string) (credits int64, confirmed bool, delivered bool) {
 	return settlementCredits(route, hasUsage, inputTokens, outputTokens,
 		promptText(EndpointChatCompletions, requestBody), content)
+}
+
+// ReservationCredits sizes the up-front credit hold for a request.
+//
+// For an ordinary fixed-price alias this is unchanged: the flat per-endpoint
+// figure the caller already passed (10000 for chat, completions and responses,
+// 1000 for embeddings).
+//
+// A variable-price alias cannot use that. Its cost is bounded by the
+// provider-side price ceiling configured on the route, not by a catalog price,
+// and a router can resolve to a model an order of magnitude dearer than the
+// flat default assumes. Its hold therefore comes from the catalog row, which
+// records both the number and the arithmetic behind it. The endpoint default
+// acts as a floor so this can only ever raise a hold, never lower one.
+//
+// The hold is an authorization, not a price. Settlement releases it in full and
+// posts the real cost as the charge, so an oversized hold costs the customer
+// nothing beyond briefly reserving headroom.
+func ReservationCredits(route SelectRouteResult, endpointDefault int64) int64 {
+	estimate := route.Pricing.ReservationEstimateCredits
+	if estimate == nil || *estimate <= endpointDefault {
+		return endpointDefault
+	}
+	return *estimate
+}
+
+// UpstreamActualSettlement decides what to charge for a request against a
+// variable-price alias, where there is no catalog price and the only truth is
+// the cost the upstream reported for that generation.
+//
+// rawUsage is the VERBATIM upstream body (sync) or the verbatim terminal SSE
+// chunk (streaming). It is the raw bytes on purpose: our typed structs drop the
+// cost field, which is what stops it reaching the customer.
+//
+// heldCredits is the size of the credit hold already taken for this request.
+//
+// The contract, and the reason this function exists rather than a few inline
+// branches at two call sites:
+//
+//   - delivered false means nothing was produced. The caller releases the hold
+//     in full and charges nothing. This is the ONLY path that charges zero, and
+//     it is reached only when no tokens and no content exist.
+//   - a usable reported cost settles at that cost times margin, confirmed.
+//   - EVERY other outcome, absent cost, unparseable cost, negative cost, a
+//     confident zero alongside real tokens, settles at the FULL HOLD flagged
+//     unconfirmed. Not zero. A failed cost lookup is the one thing that must
+//     never become a free request (D-034), and the hold is a figure the account
+//     was already checked against, so charging it can neither overdraw nor
+//     silently give the work away. Unconfirmed routes it into the existing
+//     reconciliation state rather than recording it as measured truth.
+//
+// reason is a short machine-ish token for the log line, never customer-facing.
+func UpstreamActualSettlement(rawUsage []byte, heldCredits int64, hasUsage bool,
+	inputTokens, outputTokens int64, content string) (credits int64, confirmed bool, delivered bool, reason string) {
+
+	tokensSeen := hasUsage && inputTokens+outputTokens > 0
+	if !tokensSeen && content == "" {
+		return 0, false, false, "nothing_delivered"
+	}
+
+	// A hold of zero would make the fail-closed branch below settle at zero,
+	// which is the exact outcome it exists to prevent. Callers only reach here
+	// with a live reservation, so this is a guard against a future caller
+	// rather than a case seen today.
+	if heldCredits < 1 {
+		heldCredits = 1
+	}
+
+	charge, err := ParseUpstreamCost(rawUsage)
+	if err != nil {
+		return heldCredits, false, true, upstreamCostFailureReason(err)
+	}
+
+	credits, err = CreditsForUpstreamCost(charge.CostUSD)
+	if err != nil {
+		return heldCredits, false, true, upstreamCostFailureReason(err)
+	}
+	return credits, true, true, "upstream_cost"
+}
+
+// upstreamCostFailureReason maps a cost-read failure to a distinct log token.
+// The cases are kept apart rather than folded into one "cost_unavailable"
+// because "the field was missing" and "the field said zero" have different
+// causes and different fixes, and telling them apart in a log is the whole
+// point of them being separate errors.
+func upstreamCostFailureReason(err error) string {
+	switch {
+	case errors.Is(err, ErrUpstreamCostAbsent):
+		return "upstream_cost_absent"
+	case errors.Is(err, ErrUpstreamCostZero):
+		return "upstream_cost_zero"
+	case errors.Is(err, ErrUpstreamCostNegative):
+		return "upstream_cost_negative"
+	case errors.Is(err, ErrUpstreamCostUnparseable):
+		return "upstream_cost_unparseable"
+	default:
+		return "upstream_cost_error"
+	}
 }
 
 // requireTokenPricing refuses a request whose resolved alias is not priced in

--- a/apps/edge-api/internal/inference/pricing.go
+++ b/apps/edge-api/internal/inference/pricing.go
@@ -18,9 +18,12 @@ package inference
 // cannot answer that.
 
 import (
+	"encoding/json"
 	"errors"
+	"fmt"
 	"log"
 	"net/http"
+	"strconv"
 
 	apierrors "github.com/sakibsadmanshajib/hive/apps/edge-api/internal/errors"
 	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/metering"
@@ -115,6 +118,117 @@ func ChatSettlementCredits(route SelectRouteResult, hasUsage bool, inputTokens, 
 	requestBody []byte, content string) (credits int64, confirmed bool, delivered bool) {
 	return settlementCredits(route, hasUsage, inputTokens, outputTokens,
 		promptText(EndpointChatCompletions, requestBody), content)
+}
+
+// Request bounds for a variable-price alias.
+//
+// These exist because provider.max_price bounds the RATE and nothing else. It
+// filters out endpoints above a per-million ceiling; it does not bound how many
+// tokens one request may contain. openrouter/auto-beta advertises a 2,000,000
+// token context, so at the configured ceiling a single request near that
+// context could cost roughly 6.00 USD of prompt alone, which is 840,000 credits
+// after margin, against a 200,000 credit hold. Settlement charges the reported
+// cost rather than the hold, so without a bound on the REQUEST one call could
+// settle several times past the solvency gate the hold is supposed to be.
+//
+// Bounding both sides makes the hold a proof rather than a hope:
+//
+//	prompt:     262,144 bytes is a rigorous upper bound of 262,144 tokens,
+//	            because a token can never be fewer than one UTF-8 byte, and the
+//	            body also carries JSON structure that is not prompt text.
+//	            262,144 x 3.00 USD/M x 1.4 = 1.10 USD = 110,096 credits.
+//	completion: 16,384 tokens x 15.00 USD/M x 1.4 = 0.35 USD = 34,406 credits.
+//	total:      about 144,502 credits, comfortably inside the 200,000 hold.
+//
+// Change either constant, or provider.max_price in deploy/litellm/config.yaml,
+// and reservation_estimate_credits in the migration has to be re-derived. The
+// three numbers are one decision, not three.
+const (
+	// VariablePriceMaxRequestBytes caps the request body for a variable-price
+	// alias. 256 KiB of chat is enormous; the cap exists to bound spend, not to
+	// be reached.
+	VariablePriceMaxRequestBytes = 256 * 1024
+	// VariablePriceMaxCompletionTokens caps generated output for a
+	// variable-price alias, forced onto the outbound request so a client
+	// cannot raise it.
+	VariablePriceMaxCompletionTokens = 16384
+)
+
+// completionLimitFields names the request field that caps generated tokens for
+// each endpoint. Chat carries both spellings and OpenAI treats the newer one as
+// authoritative, so both are pinned rather than guessing which the upstream
+// honours.
+var completionLimitFields = map[string][]string{
+	EndpointChatCompletions: {"max_tokens", "max_completion_tokens"},
+	EndpointCompletions:     {"max_tokens"},
+	EndpointResponses:       {"max_output_tokens"},
+}
+
+// EnforceVariablePriceBounds refuses an over-large request and pins the
+// completion ceiling for a variable-price alias, returning the body to
+// dispatch. For every other alias it is a pass-through and costs one comparison.
+//
+// It returns ok=false only when it has already written the customer-facing
+// refusal.
+func EnforceVariablePriceBounds(w http.ResponseWriter, route SelectRouteResult, endpoint, model string, body []byte) ([]byte, bool) {
+	if !route.Pricing.IsUpstreamActual() {
+		return body, true
+	}
+
+	if len(body) > VariablePriceMaxRequestBytes {
+		log.Printf("inference: refusing oversize request on a variable-price alias endpoint=%s alias=%s bytes=%d limit=%d: the credit hold is only provably sufficient below this size",
+			endpoint, model, len(body), VariablePriceMaxRequestBytes)
+		code := "context_length_exceeded"
+		apierrors.WriteError(w, http.StatusBadRequest, "invalid_request_error",
+			"This request is too large for the requested model. Please shorten the input and try again.", &code)
+		return nil, false
+	}
+
+	bounded, err := clampCompletionLimit(body, completionLimitFields[endpoint])
+	if err != nil {
+		// Refuse rather than dispatch unbounded. An unparseable body here is
+		// not something to shrug at on a path where the ceiling is what keeps
+		// the charge inside the hold.
+		log.Printf("inference: refusing variable-price request whose body could not be bounded endpoint=%s alias=%s: %v", endpoint, model, err)
+		code := "invalid_request_error"
+		apierrors.WriteError(w, http.StatusBadRequest, "invalid_request_error",
+			"The request body could not be processed. Please check the request and try again.", &code)
+		return nil, false
+	}
+	return bounded, true
+}
+
+// clampCompletionLimit forces each named field down to
+// VariablePriceMaxCompletionTokens, setting it when the client omitted it. Every
+// other field the caller sent survives byte for byte, the same contract
+// metering.RewriteBody keeps.
+func clampCompletionLimit(raw []byte, fields []string) ([]byte, error) {
+	if len(fields) == 0 {
+		return raw, nil
+	}
+	var decoded map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return nil, fmt.Errorf("inference: decode body to bound completion: %w", err)
+	}
+	if decoded == nil {
+		decoded = map[string]json.RawMessage{}
+	}
+
+	capped := json.RawMessage(strconv.Itoa(VariablePriceMaxCompletionTokens))
+	for _, field := range fields {
+		current, present := decoded[field]
+		if present {
+			var value int64
+			// A field we cannot read is replaced rather than trusted: leaving
+			// an unreadable ceiling in place would defeat the bound.
+			if err := json.Unmarshal(current, &value); err == nil && value <= VariablePriceMaxCompletionTokens && value > 0 {
+				continue
+			}
+		}
+		decoded[field] = capped
+	}
+
+	return json.Marshal(decoded)
 }
 
 // ReservationCredits sizes the up-front credit hold for a request.
@@ -228,8 +342,12 @@ func requireTokenPricing(w http.ResponseWriter, route SelectRouteResult, endpoin
 	if CanPriceTokens(route) {
 		return true
 	}
+	// Accessors, not the raw fields: those are *int64 now, and fmt accepts %d
+	// for a pointer and prints the ADDRESS. go vet does not flag it because %d
+	// is a legal verb for a pointer, so this would have quietly turned the only
+	// operator-facing explanation of a refusal into a memory address.
 	log.Printf("inference: refusing endpoint=%s alias=%s: catalog price is %d/%d credits per million %q but this endpoint meters %q",
-		endpoint, model, route.Pricing.InputPriceCredits, route.Pricing.OutputPriceCredits, route.PriceUnit, PriceUnitTokens)
+		endpoint, model, route.Pricing.InputCredits(), route.Pricing.OutputCredits(), route.PriceUnit, PriceUnitTokens)
 	code := "model_not_supported"
 	apierrors.WriteError(w, http.StatusServiceUnavailable, "api_error",
 		"The requested model is not available for this endpoint. Please retry with a supported model.", &code)

--- a/apps/edge-api/internal/inference/pricing.go
+++ b/apps/edge-api/internal/inference/pricing.go
@@ -281,12 +281,27 @@ func ReservationCredits(route SelectRouteResult, endpointDefault int64) int64 {
 //     reconciliation state rather than recording it as measured truth.
 //
 // reason is a short machine-ish token for the log line, never customer-facing.
+type VariableSettlement struct {
+	Credits   int64
+	Confirmed bool
+	Delivered bool
+	// Reason is a short machine-ish token for the log line, never
+	// customer-facing.
+	Reason string
+	// GenerationID is the upstream's own id for this generation. It is the
+	// audit handle: LiteLLM rewrites the response `model` field, so this id is
+	// what lets anyone recover WHICH model the router actually chose long after
+	// the fact. Logged with every settlement, and deliberately kept out of the
+	// customer response and out of audit_log, which fans out to third parties.
+	GenerationID string
+}
+
 func UpstreamActualSettlement(rawUsage []byte, heldCredits int64, hasUsage bool,
-	inputTokens, outputTokens int64, content string) (credits int64, confirmed bool, delivered bool, reason string) {
+	inputTokens, outputTokens int64, content string) VariableSettlement {
 
 	tokensSeen := hasUsage && inputTokens+outputTokens > 0
 	if !tokensSeen && content == "" {
-		return 0, false, false, "nothing_delivered"
+		return VariableSettlement{Reason: "nothing_delivered"}
 	}
 
 	// A hold of zero would make the fail-closed branch below settle at zero,
@@ -299,14 +314,23 @@ func UpstreamActualSettlement(rawUsage []byte, heldCredits int64, hasUsage bool,
 
 	charge, err := ParseUpstreamCost(rawUsage)
 	if err != nil {
-		return heldCredits, false, true, upstreamCostFailureReason(err)
+		return VariableSettlement{
+			Credits: heldCredits, Delivered: true,
+			Reason: upstreamCostFailureReason(err), GenerationID: charge.GenerationID,
+		}
 	}
 
-	credits, err = CreditsForUpstreamCost(charge.CostUSD)
+	credits, err := CreditsForUpstreamCost(charge.CostUSD)
 	if err != nil {
-		return heldCredits, false, true, upstreamCostFailureReason(err)
+		return VariableSettlement{
+			Credits: heldCredits, Delivered: true,
+			Reason: upstreamCostFailureReason(err), GenerationID: charge.GenerationID,
+		}
 	}
-	return credits, true, true, "upstream_cost"
+	return VariableSettlement{
+		Credits: credits, Confirmed: true, Delivered: true,
+		Reason: "upstream_cost", GenerationID: charge.GenerationID,
+	}
 }
 
 // upstreamCostFailureReason maps a cost-read failure to a distinct log token.

--- a/apps/edge-api/internal/inference/pricing.go
+++ b/apps/edge-api/internal/inference/pricing.go
@@ -82,8 +82,18 @@ func CanPriceTokens(route SelectRouteResult) bool {
 // expected to branch on IsUpstreamActual before they get here.
 func CreditsForTokens(route SelectRouteResult, inputTokens, outputTokens int64) int64 {
 	if route.Pricing.IsUpstreamActual() {
-		panic("inference: CreditsForTokens called for an upstream_actual route; " +
-			"its charge must come from the upstream reported cost, not the catalog price columns")
+		// Not a panic. The reachable chain is settleStream, called from a defer
+		// in executeStreaming, so a panic here would fire during deferred
+		// unwinding, before FinalizeReservation and before ReleaseReservation.
+		// net/http recovers it and the process survives, but the reservation
+		// reaches no terminal state at all and the hold is stranded, which is
+		// the outcome this guard was written to avoid. Returning the hold-sized
+		// sentinel keeps the settlement path intact and loud instead.
+		log.Printf("inference: BUG: CreditsForTokens called for an upstream_actual route alias=%s; "+
+			"its charge must come from the reported upstream cost, not the catalog price columns. "+
+			"Returning zero so the caller's own not-billable handling releases the hold rather than charging a fiction.",
+			route.AliasID)
+		return 0
 	}
 	if inputTokens < 0 {
 		inputTokens = 0
@@ -304,19 +314,33 @@ func UpstreamActualSettlement(rawUsage []byte, heldCredits int64, hasUsage bool,
 		return VariableSettlement{Reason: "nothing_delivered"}
 	}
 
-	// A hold of zero would make the fail-closed branch below settle at zero,
-	// which is the exact outcome it exists to prevent. Callers only reach here
-	// with a live reservation, so this is a guard against a future caller
-	// rather than a case seen today.
-	if heldCredits < 1 {
-		heldCredits = 1
+	// A hold of zero reaches here in exactly one case: the Enterprise posture,
+	// which has no reservation and charges nothing. Flooring it to 1 would
+	// invent a one-credit figure for the trace row on the one alias whose cost
+	// is genuinely unknown, so the floor is applied only where a real hold
+	// exists. Where there is none, the fail-closed branch returns zero credits
+	// and NOT delivered, so the caller releases rather than charging; that is
+	// the one zero this function is allowed to produce and it never reaches a
+	// ledger.
+	if heldCredits < 0 {
+		heldCredits = 0
 	}
 
 	charge, err := ParseUpstreamCost(rawUsage)
 	if err != nil {
+		reason := upstreamCostFailureReason(err)
+		if heldCredits == 0 {
+			// Reachable only where there is no reservation at all, which today
+			// means the Enterprise posture, where nothing is charged. Naming it
+			// keeps it out of the "we charged the hold" bucket and makes a
+			// future regression in the hold plumbing visible instead of
+			// arriving as a silent zero, which is exactly how the
+			// reserved_credits key mismatch presented.
+			reason = "no_hold_to_charge:" + reason
+		}
 		return VariableSettlement{
 			Credits: heldCredits, Delivered: true,
-			Reason: upstreamCostFailureReason(err), GenerationID: charge.GenerationID,
+			Reason: reason, GenerationID: charge.GenerationID,
 		}
 	}
 
@@ -348,6 +372,8 @@ func upstreamCostFailureReason(err error) string {
 		return "upstream_cost_negative"
 	case errors.Is(err, ErrUpstreamCostUnparseable):
 		return "upstream_cost_unparseable"
+	case errors.Is(err, ErrUpstreamCostImplausible):
+		return "upstream_cost_implausible"
 	default:
 		return "upstream_cost_error"
 	}

--- a/apps/edge-api/internal/inference/routing_client.go
+++ b/apps/edge-api/internal/inference/routing_client.go
@@ -101,11 +101,82 @@ type SelectRouteResult struct {
 	PriceUnit string             `json:"price_unit"`
 }
 
+// Pricing modes, mirroring control-plane's catalog.PricingMode* constants and
+// public.model_aliases.pricing_mode. Duplicated rather than imported because
+// control-plane and edge-api are separate modules and this crosses an HTTP
+// boundary, the same reason SelectRoutePricing itself is a local type.
+const (
+	PricingModeFixed          = "fixed"
+	PricingModeUpstreamActual = "upstream_actual"
+)
+
 // SelectRoutePricing is the subset of the control-plane's catalog pricing
 // payload edge-api charges against: credits per MILLION metered units.
+//
+// The two price fields are POINTERS. A PricingModeUpstreamActual alias has no
+// fixed price at all and control-plane sends JSON null for both; decoding that
+// into a plain int64 would either fail or, worse under a future tolerant
+// decoder, read as 0, and a price that silently reads 0 bills nothing. nil is
+// the honest representation and forces every caller to branch.
+//
+// Note this is a runtime boundary, not a compile-time one: control-plane's own
+// catalog.CatalogPricing changed to pointers in the same change, but nothing in
+// the type system ties the two structs together, so a mismatch here surfaces as
+// a decode failure at dispatch rather than a build error.
 type SelectRoutePricing struct {
-	InputPriceCredits  int64 `json:"input_price_credits"`
-	OutputPriceCredits int64 `json:"output_price_credits"`
+	InputPriceCredits  *int64 `json:"input_price_credits"`
+	OutputPriceCredits *int64 `json:"output_price_credits"`
+	// PricingMode distinguishes "variable by design" from "the lookup came
+	// back empty". An empty string is treated as fixed, so a control-plane
+	// that predates this field keeps its old meaning rather than silently
+	// becoming a variable-price alias.
+	PricingMode string `json:"pricing_mode"`
+	// ReservationEstimateCredits sizes the up-front hold for a variable-price
+	// alias, which has no catalog price to derive one from.
+	ReservationEstimateCredits *int64 `json:"reservation_estimate_credits,omitempty"`
+}
+
+// IsUpstreamActual reports whether a charge against this route must come from
+// the upstream's own reported cost rather than from the price columns.
+func (p SelectRoutePricing) IsUpstreamActual() bool {
+	return p.PricingMode == PricingModeUpstreamActual
+}
+
+// FixedPricing builds an ordinary fixed-price row, in credits per million
+// metered units. It exists so a caller states the two prices as plain numbers
+// instead of taking addresses of locals, which is both noisier and easy to get
+// subtly wrong when the values come from a loop variable.
+func FixedPricing(inputCredits, outputCredits int64) SelectRoutePricing {
+	return SelectRoutePricing{
+		InputPriceCredits:  &inputCredits,
+		OutputPriceCredits: &outputCredits,
+		PricingMode:        PricingModeFixed,
+	}
+}
+
+// UpstreamActualPricing builds a variable-price row: no prices, a hold size,
+// and the mode that tells settlement to charge the upstream's reported cost.
+func UpstreamActualPricing(reservationEstimateCredits int64) SelectRoutePricing {
+	return SelectRoutePricing{
+		PricingMode:                PricingModeUpstreamActual,
+		ReservationEstimateCredits: &reservationEstimateCredits,
+	}
+}
+
+// InputCredits and OutputCredits give the fixed per-million price, treating an
+// absent price as zero. Safe ONLY because both callers (CanPriceTokens'
+// positivity test and CreditsForTokens, which is never reached in
+// upstream_actual mode) are asking "is there a positive price", never "what
+// should I charge". Anything that charges must branch on IsUpstreamActual
+// first.
+func (p SelectRoutePricing) InputCredits() int64  { return derefPrice(p.InputPriceCredits) }
+func (p SelectRoutePricing) OutputCredits() int64 { return derefPrice(p.OutputPriceCredits) }
+
+func derefPrice(v *int64) int64 {
+	if v == nil {
+		return 0
+	}
+	return *v
 }
 
 // RoutingClient calls the control-plane routing endpoint.

--- a/apps/edge-api/internal/inference/routing_client.go
+++ b/apps/edge-api/internal/inference/routing_client.go
@@ -113,16 +113,21 @@ const (
 // SelectRoutePricing is the subset of the control-plane's catalog pricing
 // payload edge-api charges against: credits per MILLION metered units.
 //
-// The two price fields are POINTERS. A PricingModeUpstreamActual alias has no
-// fixed price at all and control-plane sends JSON null for both; decoding that
-// into a plain int64 would either fail or, worse under a future tolerant
-// decoder, read as 0, and a price that silently reads 0 bills nothing. nil is
-// the honest representation and forces every caller to branch.
+// The two price fields are POINTERS, and the reason is the opposite of the one
+// that applies on the database side. Scanning a SQL NULL into a non-pointer
+// int64 is a hard pgx error, so that boundary fails loudly by itself.
+// encoding/json does NOT: unmarshalling JSON null into a non-pointer numeric
+// field is a documented no-op that leaves the field at zero and returns no
+// error, verified against Go's own decoder rather than assumed. So a plain
+// int64 here would have priced a variable-price route at 0 credits, silently,
+// which is indistinguishable from free. nil is the honest representation and
+// forces every caller to branch.
 //
-// Note this is a runtime boundary, not a compile-time one: control-plane's own
+// This is a runtime boundary, not a compile-time one. control-plane's own
 // catalog.CatalogPricing changed to pointers in the same change, but nothing in
-// the type system ties the two structs together, so a mismatch here surfaces as
-// a decode failure at dispatch rather than a build error.
+// the type system ties the two structs together, so a mismatch here does not
+// break the build and does not fail at dispatch either. It shows up as a wrong
+// price, which is why the shapes have to be kept in step by hand.
 type SelectRoutePricing struct {
 	InputPriceCredits  *int64 `json:"input_price_credits"`
 	OutputPriceCredits *int64 `json:"output_price_credits"`

--- a/apps/edge-api/internal/inference/settle_from_catalog_test.go
+++ b/apps/edge-api/internal/inference/settle_from_catalog_test.go
@@ -39,16 +39,16 @@ import (
 // catalogHiveFast is the hive-fast row as of migration _01: 0.075 / 0.300 USD
 // per million upstream, times a 1.4 margin, times 100000 credits per USD. See
 // the note above on why this pinned historical row is not refreshed.
-var catalogHiveFast = SelectRoutePricing{InputPriceCredits: 10_500, OutputPriceCredits: 42_000}
+var catalogHiveFast = FixedPricing(10_500, 42_000)
 
 // catalogHiveAuto is the hive-auto row: 0.400 / 1.600 USD per million upstream.
-var catalogHiveAuto = SelectRoutePricing{InputPriceCredits: 56_000, OutputPriceCredits: 224_000}
+var catalogHiveAuto = FixedPricing(56_000, 224_000)
 
 // catalogHiveSTT is hive-stt, priced per SECOND of audio rather than per token
 // (supabase/migrations/20260801_13_alias_price_unit.sql). No token-metered
 // endpoint can charge against it without inventing a conversion, so it stands
 // in for the fail-closed case.
-var catalogHiveSTT = SelectRoutePricing{OutputPriceCredits: 4_316_667}
+var catalogHiveSTT = FixedPricing(0, 4_316_667)
 
 // newRoutingMockPriced stands in for the control-plane's route-selection
 // endpoint, answering with an explicit catalog price and price unit -- what the
@@ -128,7 +128,7 @@ func usageJSONServer(promptTokens, completionTokens int64) *httptest.Server {
 // (input * input_price + output * output_price) / 1_000_000, rounded half up.
 func catalogCredits(t *testing.T, pricing SelectRoutePricing, inputTokens, outputTokens int64) int64 {
 	t.Helper()
-	numerator := inputTokens*pricing.InputPriceCredits + outputTokens*pricing.OutputPriceCredits
+	numerator := inputTokens*pricing.InputCredits() + outputTokens*pricing.OutputCredits()
 	credits := numerator / 1_000_000
 	if numerator%1_000_000*2 >= 1_000_000 {
 		credits++

--- a/apps/edge-api/internal/inference/settlement_test.go
+++ b/apps/edge-api/internal/inference/settlement_test.go
@@ -13,7 +13,7 @@ import (
 // settle_from_catalog_test.go for why it is not refreshed.
 var hiveFastRoute = SelectRouteResult{
 	AliasID:   "hive-fast",
-	Pricing:   SelectRoutePricing{InputPriceCredits: 10_500, OutputPriceCredits: 42_000},
+	Pricing:   FixedPricing(10_500, 42_000),
 	PriceUnit: PriceUnitTokens,
 }
 
@@ -23,7 +23,7 @@ var hiveFastRoute = SelectRouteResult{
 // 1-credit floor is the whole charge below 1.5M tokens.
 var embeddingRoute = SelectRouteResult{
 	AliasID:   "hive-embedding-default",
-	Pricing:   SelectRoutePricing{InputPriceCredits: 1},
+	Pricing:   FixedPricing(1, 0),
 	PriceUnit: PriceUnitTokens,
 }
 
@@ -182,25 +182,25 @@ func TestCanPriceTokens(t *testing.T) {
 		{
 			name: "output-priced only",
 			route: SelectRouteResult{
-				Pricing: SelectRoutePricing{OutputPriceCredits: 42_000}, PriceUnit: PriceUnitTokens},
+				Pricing: FixedPricing(0, 42_000), PriceUnit: PriceUnitTokens},
 			want: true,
 		},
 		{
 			name: "priced per second (voice): this endpoint cannot meter it",
 			route: SelectRouteResult{
-				Pricing: SelectRoutePricing{OutputPriceCredits: 4_316_667}, PriceUnit: "seconds"},
+				Pricing: FixedPricing(0, 4_316_667), PriceUnit: "seconds"},
 			want: false,
 		},
 		{
 			name: "priced per character (speech): this endpoint cannot meter it",
 			route: SelectRouteResult{
-				Pricing: SelectRoutePricing{OutputPriceCredits: 3_080_000}, PriceUnit: "characters"},
+				Pricing: FixedPricing(0, 3_080_000), PriceUnit: "characters"},
 			want: false,
 		},
 		{
 			name: "no unit at all: implicit is not explicit",
 			route: SelectRouteResult{
-				Pricing: SelectRoutePricing{InputPriceCredits: 10_500, OutputPriceCredits: 42_000}},
+				Pricing: FixedPricing(10_500, 42_000)},
 			want: false,
 		},
 		{

--- a/apps/edge-api/internal/inference/stream.go
+++ b/apps/edge-api/internal/inference/stream.go
@@ -28,6 +28,17 @@ type UsageAccumulator struct {
 	TotalTokens     int64
 	HasUsage        bool
 	Content         strings.Builder
+	// RawUsageChunk is the VERBATIM bytes of the last streamed chunk that
+	// carried a usage object. It exists because ChatCompletionChunk is a typed
+	// struct and unmarshalling into it silently discards every field we did
+	// not declare, which includes the upstream's reported cost. That discard
+	// is exactly what keeps our cost from leaking to the customer, so the fix
+	// is not to widen the struct but to keep the original bytes here, where
+	// only settlement reads them.
+	//
+	// Empty for a fixed-price alias: nothing reads it there, and holding the
+	// bytes for every stream on every alias would be pure overhead.
+	RawUsageChunk []byte
 }
 
 // Accumulate copies usage fields from a chunk if present.
@@ -179,13 +190,15 @@ func (o *Orchestrator) executeStreaming(
 
 	// 5. Create reservation
 	reservation, err := o.accounting.CreateReservation(ctx, CreateReservationInput{
-		AccountID:        snapshot.AccountID,
-		RequestID:        requestID,
-		AttemptNumber:    1,
-		APIKeyID:         snapshot.KeyID,
-		Endpoint:         endpoint,
-		ModelAlias:       model,
-		EstimatedCredits: estimatedCredits,
+		AccountID:     snapshot.AccountID,
+		RequestID:     requestID,
+		AttemptNumber: 1,
+		APIKeyID:      snapshot.KeyID,
+		Endpoint:      endpoint,
+		ModelAlias:    model,
+		// A variable-price alias raises this from its catalog row; a fixed
+		// one keeps the flat endpoint default. See ReservationCredits.
+		EstimatedCredits: ReservationCredits(route, estimatedCredits),
 		PolicyMode:       "strict",
 	})
 	if err != nil && refuseOnReservationFailure(w, endpoint, model, err) {
@@ -276,6 +289,11 @@ func (o *Orchestrator) executeStreaming(
 				// the terminal chunk once all deltas are flushed.
 				if chunk.Usage != nil {
 					accumulator.ClampUsage(chunk.Usage, chunk.ID, aliasID, endpoint)
+					// Keep the untyped bytes only for a route that settles
+					// against the upstream's reported cost; see RawUsageChunk.
+					if route.Pricing.IsUpstreamActual() {
+						accumulator.RawUsageChunk = append(accumulator.RawUsageChunk[:0], jsonData...)
+					}
 				}
 				// Accumulate usage if present
 				accumulator.Accumulate(chunk)
@@ -435,7 +453,24 @@ func (o *Orchestrator) settleStream(reqCtx context.Context, snapshot authz.AuthS
 	// Parse promptBody (the raw request bytes) down to just the message/input
 	// text before estimating -- see promptText in usage_clamp.go for why the
 	// raw bytes themselves must never be counted directly (issue #602).
-	credits, confirmed, delivered := settlementCredits(route, acc.HasUsage, acc.InputTokens, acc.OutputTokens, promptText(endpoint, []byte(promptBody)), content)
+	var credits int64
+	var confirmed, delivered bool
+	if route.Pricing.IsUpstreamActual() {
+		// No catalog price exists for this alias, so the charge comes from the
+		// cost the upstream reported in its terminal usage chunk. A failed
+		// read settles at the hold rather than at zero; see
+		// UpstreamActualSettlement.
+		var reason string
+		credits, confirmed, delivered, reason = UpstreamActualSettlement(
+			acc.RawUsageChunk, reservation.EstimatedCredits,
+			acc.HasUsage, acc.InputTokens, acc.OutputTokens, content)
+		if delivered && !confirmed {
+			log.Printf("inference: upstream cost unavailable, settling at the hold request_id=%s reservation_id=%s endpoint=%s model=%s reason=%s held_credits=%d: a variable-price alias could not read a reported cost, charging the hold rather than serving free",
+				requestID, reservation.ID, endpoint, model, reason, reservation.EstimatedCredits)
+		}
+	} else {
+		credits, confirmed, delivered = settlementCredits(route, acc.HasUsage, acc.InputTokens, acc.OutputTokens, promptText(endpoint, []byte(promptBody)), content)
+	}
 	if !delivered {
 		reason, eventType := "upstream_error", "upstream_error"
 		if reqCtx.Err() != nil {

--- a/apps/edge-api/internal/inference/stream.go
+++ b/apps/edge-api/internal/inference/stream.go
@@ -173,6 +173,16 @@ func (o *Orchestrator) executeStreaming(
 		return nil
 	}
 
+	// 2c. Bound the request for a variable-price alias, before dispatch. Its
+	// hold is only provably sufficient below a known request size and a known
+	// completion ceiling; see EnforceVariablePriceBounds. A pass-through for
+	// every fixed-price alias.
+	boundedBody, withinBounds := EnforceVariablePriceBounds(w, route, endpoint, model, body)
+	if !withinBounds {
+		return nil
+	}
+	body = boundedBody
+
 	// 4. Start attempt
 	requestID := uuid.New().String()
 	attempt, err := o.accounting.StartAttempt(ctx, StartAttemptInput{

--- a/apps/edge-api/internal/inference/stream.go
+++ b/apps/edge-api/internal/inference/stream.go
@@ -315,7 +315,21 @@ func (o *Orchestrator) executeStreaming(
 					continue
 				}
 			}
-			// Fallback: pass through the original line
+			// Fallback: pass through the original line. Everything that keeps
+			// our cost off this path relies on the typed struct discarding
+			// unknown fields, and this branch is exactly where that protection
+			// is not in force, so a variable-price route sanitizes explicitly
+			// and drops the frame outright if it cannot.
+			if route.Pricing.IsUpstreamActual() {
+				if sanitized, sanOK := SanitizeVariablePriceFrame([]byte(jsonData), aliasID); sanOK {
+					fmt.Fprintf(w, "data: %s\n\n", sanitized)
+					flusher.Flush()
+				} else {
+					log.Printf("inference: dropping an unparseable upstream frame on a variable-price alias endpoint=%s alias=%s: forwarding it verbatim would publish our cost and the chosen model",
+						endpoint, aliasID)
+				}
+				continue
+			}
 			fmt.Fprintf(w, "%s\n\n", line)
 			flusher.Flush()
 			continue
@@ -471,7 +485,7 @@ func (o *Orchestrator) settleStream(reqCtx context.Context, snapshot authz.AuthS
 		// read settles at the hold rather than at zero; see
 		// UpstreamActualSettlement.
 		settled := UpstreamActualSettlement(
-			acc.RawUsageChunk, reservation.EstimatedCredits,
+			acc.RawUsageChunk, reservation.Held(),
 			acc.HasUsage, acc.InputTokens, acc.OutputTokens, content)
 		credits, confirmed, delivered = settled.Credits, settled.Confirmed, settled.Delivered
 		if delivered {
@@ -480,7 +494,7 @@ func (o *Orchestrator) settleStream(reqCtx context.Context, snapshot authz.AuthS
 			// itself no longer names. Operator log only, never audit_log.
 			log.Printf("inference: variable-price settlement request_id=%s reservation_id=%s endpoint=%s model=%s reason=%s credits=%d confirmed=%v generation_id=%s held_credits=%d",
 				requestID, reservation.ID, endpoint, model, settled.Reason,
-				settled.Credits, settled.Confirmed, settled.GenerationID, reservation.EstimatedCredits)
+				settled.Credits, settled.Confirmed, settled.GenerationID, reservation.Held())
 		}
 	} else {
 		credits, confirmed, delivered = settlementCredits(route, acc.HasUsage, acc.InputTokens, acc.OutputTokens, promptText(endpoint, []byte(promptBody)), content)

--- a/apps/edge-api/internal/inference/stream.go
+++ b/apps/edge-api/internal/inference/stream.go
@@ -470,13 +470,17 @@ func (o *Orchestrator) settleStream(reqCtx context.Context, snapshot authz.AuthS
 		// cost the upstream reported in its terminal usage chunk. A failed
 		// read settles at the hold rather than at zero; see
 		// UpstreamActualSettlement.
-		var reason string
-		credits, confirmed, delivered, reason = UpstreamActualSettlement(
+		settled := UpstreamActualSettlement(
 			acc.RawUsageChunk, reservation.EstimatedCredits,
 			acc.HasUsage, acc.InputTokens, acc.OutputTokens, content)
-		if delivered && !confirmed {
-			log.Printf("inference: upstream cost unavailable, settling at the hold request_id=%s reservation_id=%s endpoint=%s model=%s reason=%s held_credits=%d: a variable-price alias could not read a reported cost, charging the hold rather than serving free",
-				requestID, reservation.ID, endpoint, model, reason, reservation.EstimatedCredits)
+		credits, confirmed, delivered = settled.Credits, settled.Confirmed, settled.Delivered
+		if delivered {
+			// generation_id is the audit handle for this charge: it is what
+			// recovers the model the router actually chose, which the response
+			// itself no longer names. Operator log only, never audit_log.
+			log.Printf("inference: variable-price settlement request_id=%s reservation_id=%s endpoint=%s model=%s reason=%s credits=%d confirmed=%v generation_id=%s held_credits=%d",
+				requestID, reservation.ID, endpoint, model, settled.Reason,
+				settled.Credits, settled.Confirmed, settled.GenerationID, reservation.EstimatedCredits)
 		}
 	} else {
 		credits, confirmed, delivered = settlementCredits(route, acc.HasUsage, acc.InputTokens, acc.OutputTokens, promptText(endpoint, []byte(promptBody)), content)

--- a/apps/edge-api/internal/inference/stream_responses.go
+++ b/apps/edge-api/internal/inference/stream_responses.go
@@ -119,13 +119,15 @@ func (o *Orchestrator) executeResponsesStreaming(
 
 	// 5. Create reservation
 	reservation, err := o.accounting.CreateReservation(ctx, CreateReservationInput{
-		AccountID:        snapshot.AccountID,
-		RequestID:        requestID,
-		AttemptNumber:    1,
-		APIKeyID:         snapshot.KeyID,
-		Endpoint:         EndpointResponses,
-		ModelAlias:       model,
-		EstimatedCredits: estimatedCredits,
+		AccountID:     snapshot.AccountID,
+		RequestID:     requestID,
+		AttemptNumber: 1,
+		APIKeyID:      snapshot.KeyID,
+		Endpoint:      EndpointResponses,
+		ModelAlias:    model,
+		// A variable-price alias raises this from its catalog row; a fixed
+		// one keeps the flat endpoint default. See ReservationCredits.
+		EstimatedCredits: ReservationCredits(route, estimatedCredits),
 		PolicyMode:       "strict",
 	})
 	if err != nil && refuseOnReservationFailure(w, EndpointResponses, model, err) {

--- a/apps/edge-api/internal/inference/stream_responses.go
+++ b/apps/edge-api/internal/inference/stream_responses.go
@@ -102,6 +102,16 @@ func (o *Orchestrator) executeResponsesStreaming(
 		return
 	}
 
+	// 3c. Bound the request for a variable-price alias, before dispatch. Its
+	// hold is only provably sufficient below a known request size and a known
+	// completion ceiling; see EnforceVariablePriceBounds. A pass-through for
+	// every fixed-price alias.
+	boundedBody, withinBounds := EnforceVariablePriceBounds(w, route, EndpointResponses, model, body)
+	if !withinBounds {
+		return
+	}
+	body = boundedBody
+
 	// 4. Start attempt
 	requestID := uuid.New().String()
 	attempt, err := o.accounting.StartAttempt(ctx, StartAttemptInput{

--- a/apps/edge-api/internal/inference/stream_responses.go
+++ b/apps/edge-api/internal/inference/stream_responses.go
@@ -246,6 +246,13 @@ func (o *Orchestrator) executeResponsesStreaming(
 		// translator.currentContent already holds the full response body.
 		if chunk.Usage != nil {
 			clampZeroCompletionUsage(chunk.Usage, []string{translator.currentContent.String()}, chunk.ID, model, EndpointResponses)
+			// Same capture as executeStreaming. Without it this path can only
+			// ever fail closed for a variable-price alias, because settleStream
+			// reads these bytes and ChatCompletionChunk has already discarded
+			// the cost field on the way in.
+			if route.Pricing.IsUpstreamActual() {
+				acc.RawUsageChunk = append(acc.RawUsageChunk[:0], jsonData...)
+			}
 		}
 
 		// Accumulate usage if present.

--- a/apps/edge-api/internal/inference/upstream_cost.go
+++ b/apps/edge-api/internal/inference/upstream_cost.go
@@ -1,0 +1,193 @@
+package inference
+
+// Actual-cost settlement for a variable-price alias.
+//
+// A router alias (openrouter/auto-beta) picks a different upstream model per
+// request, so there is no catalog price to charge against. What there IS, when
+// usage accounting is switched on for the route, is the cost the upstream
+// reports for that specific generation. This file turns that reported cost into
+// a credit charge, and refuses, loudly, to turn anything else into one.
+//
+// ── Do not take a cost from a proxy-computed field ─────────────────────────
+//
+// LiteLLM sits between us and OpenRouter and offers an `x-litellm-response-cost`
+// header that looks exactly like the answer. It is not. When the proxy has no
+// price entry for a model it falls back to its own static price map SILENTLY.
+// Measured on 2026-08-22 against our pinned v1.77.7-stable with a fake upstream
+// reporting a known cost of 0.0123456: the header said 0.0105, which is the
+// proxy's own $3/$15-per-million guess for a router model it cannot price. The
+// specific numbers are version-dependent (by v1.83.14 the header returns the
+// provider figure on the sync path), which is exactly why the rule below is
+// written as a rule and not as a version note:
+//
+//	Never take a cost from a proxy-computed field when a provider-reported one
+//	is available. The proxy falls back to its own price map without saying so,
+//	and a router model has no entry in it.
+//
+// A related trap from the same family, same measurement session: on a STREAMING
+// request v1.83.14 returns `x-litellm-response-cost-original: 0.0`. A confident
+// zero is worse than an absent value, because an absent value can be caught and
+// a zero bills nothing. That is the shape that served this gateway free for
+// three days in July, which is why the parser below reports "zero" and "absent"
+// as two DIFFERENT errors and neither of them settles at zero.
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/big"
+)
+
+// Errors from reading a reported upstream cost. They are separate values, not
+// one generic failure, because they mean different things operationally and
+// because collapsing "the field was missing" into "the field said zero" is the
+// specific mistake this package exists to avoid. Every one of them is
+// fail-closed at the call site; none of them ever produces a zero charge.
+var (
+	// ErrUpstreamCostAbsent: no usage object, or no cost field on it. The
+	// usual cause is a proxy that dropped the field in transit rather than an
+	// upstream that charged nothing.
+	ErrUpstreamCostAbsent = errors.New("inference: upstream reported no cost")
+	// ErrUpstreamCostUnparseable: a cost field that is not a number we can
+	// read exactly.
+	ErrUpstreamCostUnparseable = errors.New("inference: upstream cost is unparseable")
+	// ErrUpstreamCostNegative: a negative cost. Nonsense on its face, and
+	// allowing it would let an upstream response reduce a charge.
+	ErrUpstreamCostNegative = errors.New("inference: upstream cost is negative")
+	// ErrUpstreamCostZero: the field is present and says exactly zero while
+	// tokens were consumed. Kept distinct from Absent deliberately. It is
+	// treated as fail-closed rather than free because we cannot tell a
+	// genuinely free upstream from a confident-zero defect, and July is the
+	// precedent for which way to err. If free routing turns out to be common
+	// in practice this becomes a catalog-level allowance, not a silent
+	// default.
+	ErrUpstreamCostZero = errors.New("inference: upstream cost is zero while tokens were consumed")
+)
+
+// MarginNumerator / MarginDenominator express the 1.4 margin EXACTLY, as a
+// rational. Not 1.4 the float: this multiplies a money figure, and the repo
+// rule is math/big everywhere near a charge.
+//
+// Until now this margin has only ever been applied by hand, at migration
+// authoring time, when someone multiplied a provider list price by 1.4 and
+// wrote the result into model_aliases (D-032). Billing at actual cost is the
+// first time it has to exist at RUNTIME, so this is a new constant rather than
+// a reused one; there was no runtime constant to reuse.
+const (
+	MarginNumerator   = 7
+	MarginDenominator = 5
+)
+
+// CreditsPerUSD mirrors payments.CreditsPerUSD (1 USD = 100,000 credits).
+// Duplicated rather than imported: payments lives under control-plane's
+// internal/ tree in a different module, so Go's own visibility rules make it
+// unimportable from edge-api. TestCreditsPerUSDMatchesPaymentsPackage guards
+// the duplication against drift.
+const CreditsPerUSD = 100_000
+
+// UpstreamCharge is what a completed generation cost us and what identifies it.
+type UpstreamCharge struct {
+	// CostUSD is the provider-reported cost of this generation, exact.
+	CostUSD *big.Rat
+	// GenerationID is the upstream's own id for the generation (OpenRouter
+	// returns `gen-...`). This is the audit handle: it is what lets anyone
+	// recover WHICH model the router actually picked, long after the fact,
+	// without us having to carry the model name through a proxy that rewrites
+	// it. Recorded internally, never returned to a customer.
+	GenerationID string
+	// Provider is the upstream the router resolved to, when the response says
+	// so. Coarser than the model, internal only, and frequently absent.
+	Provider string
+}
+
+// upstreamCostEnvelope is a private view of the RAW upstream response. It is
+// deliberately NOT part of UsageResponse: the normalize* functions unmarshal
+// the response into their typed structs and re-marshal them straight to the
+// customer, so a cost field living on UsageResponse would be serialised onto a
+// customer-bound body. Parsing separately means our upstream cost cannot leak
+// by construction rather than by remembering to strip it.
+type upstreamCostEnvelope struct {
+	ID       string `json:"id"`
+	Provider string `json:"provider"`
+	Usage    *struct {
+		// json.Number, never float64: the literal is preserved as text and
+		// handed to big.Rat, so no binary floating point ever touches a money
+		// figure.
+		Cost             *json.Number `json:"cost"`
+		PromptTokens     int64        `json:"prompt_tokens"`
+		CompletionTokens int64        `json:"completion_tokens"`
+	} `json:"usage"`
+}
+
+// ParseUpstreamCost reads the provider-reported cost out of a raw upstream
+// response body (sync) or a raw terminal SSE chunk (streaming).
+//
+// It returns an error for every shape that is not a usable positive cost, and
+// the caller must treat all of them as fail-closed. It never returns a zero
+// charge and a nil error together.
+func ParseUpstreamCost(raw []byte) (UpstreamCharge, error) {
+	var env upstreamCostEnvelope
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return UpstreamCharge{}, fmt.Errorf("%w: %v", ErrUpstreamCostUnparseable, err)
+	}
+
+	charge := UpstreamCharge{GenerationID: env.ID, Provider: env.Provider}
+
+	if env.Usage == nil || env.Usage.Cost == nil {
+		return charge, ErrUpstreamCostAbsent
+	}
+
+	cost, ok := new(big.Rat).SetString(env.Usage.Cost.String())
+	if !ok {
+		return charge, fmt.Errorf("%w: %q", ErrUpstreamCostUnparseable, env.Usage.Cost.String())
+	}
+
+	switch cost.Sign() {
+	case -1:
+		return charge, ErrUpstreamCostNegative
+	case 0:
+		// Zero with no tokens is "nothing happened", which the caller already
+		// handles as a release rather than a charge. Zero WITH tokens is the
+		// confident-zero shape, and it is refused.
+		if env.Usage.PromptTokens+env.Usage.CompletionTokens > 0 {
+			return charge, ErrUpstreamCostZero
+		}
+		return charge, ErrUpstreamCostAbsent
+	}
+
+	charge.CostUSD = cost
+	return charge, nil
+}
+
+// CreditsForUpstreamCost converts a provider-reported USD cost into whole
+// credits at the standard margin: cost x 7/5 x 100000, summed as one exact
+// rational and rounded half up exactly once, the same rounding discipline
+// metering.ChargeCredits applies to the per-million path (D-031).
+//
+// math/big throughout. A nonzero cost floors at one credit, so a request that
+// cost us real money is never settled free.
+func CreditsForUpstreamCost(costUSD *big.Rat) (int64, error) {
+	if costUSD == nil {
+		return 0, ErrUpstreamCostAbsent
+	}
+	if costUSD.Sign() < 0 {
+		return 0, ErrUpstreamCostNegative
+	}
+	if costUSD.Sign() == 0 {
+		return 0, ErrUpstreamCostZero
+	}
+
+	scaled := new(big.Rat).Mul(costUSD, big.NewRat(MarginNumerator*CreditsPerUSD, MarginDenominator))
+
+	quotient, remainder := new(big.Int).QuoRem(scaled.Num(), scaled.Denom(), new(big.Int))
+	// Round half up: a remainder at least half the denominator bumps by one.
+	if new(big.Int).Mul(remainder, big.NewInt(2)).Cmp(scaled.Denom()) >= 0 {
+		quotient.Add(quotient, big.NewInt(1))
+	}
+
+	credits := quotient.Int64()
+	if credits < 1 {
+		credits = 1
+	}
+	return credits, nil
+}

--- a/apps/edge-api/internal/inference/upstream_cost.go
+++ b/apps/edge-api/internal/inference/upstream_cost.go
@@ -95,9 +95,6 @@ type UpstreamCharge struct {
 	// without us having to carry the model name through a proxy that rewrites
 	// it. Recorded internally, never returned to a customer.
 	GenerationID string
-	// Provider is the upstream the router resolved to, when the response says
-	// so. Coarser than the model, internal only, and frequently absent.
-	Provider string
 }
 
 // upstreamCostEnvelope is a private view of the RAW upstream response. It is
@@ -106,10 +103,16 @@ type UpstreamCharge struct {
 // customer, so a cost field living on UsageResponse would be serialised onto a
 // customer-bound body. Parsing separately means our upstream cost cannot leak
 // by construction rather than by remembering to strip it.
+// The upstream's `provider` field is deliberately NOT decoded. It is redundant,
+// because the generation id recovers both the provider and the exact model that
+// `provider` alone cannot name, and tools/lint-no-client-cost-fields.mjs forbids
+// any provider-named JSON struct tag as a structural guard against provider
+// identity reaching a customer, matching on raw file text so a comment quoting
+// the tag trips it too. Not decoding the field at all is a smaller and safer
+// answer than an allowlist entry arguing that this particular struct is private.
 type upstreamCostEnvelope struct {
-	ID       string `json:"id"`
-	Provider string `json:"provider"`
-	Usage    *struct {
+	ID    string `json:"id"`
+	Usage *struct {
 		// json.Number, never float64: the literal is preserved as text and
 		// handed to big.Rat, so no binary floating point ever touches a money
 		// figure.
@@ -131,7 +134,7 @@ func ParseUpstreamCost(raw []byte) (UpstreamCharge, error) {
 		return UpstreamCharge{}, fmt.Errorf("%w: %v", ErrUpstreamCostUnparseable, err)
 	}
 
-	charge := UpstreamCharge{GenerationID: env.ID, Provider: env.Provider}
+	charge := UpstreamCharge{GenerationID: env.ID}
 
 	if env.Usage == nil || env.Usage.Cost == nil {
 		return charge, ErrUpstreamCostAbsent

--- a/apps/edge-api/internal/inference/upstream_cost.go
+++ b/apps/edge-api/internal/inference/upstream_cost.go
@@ -62,7 +62,28 @@ var (
 	// in practice this becomes a catalog-level allowance, not a silent
 	// default.
 	ErrUpstreamCostZero = errors.New("inference: upstream cost is zero while tokens were consumed")
+	// ErrUpstreamCostImplausible: a cost so large it cannot be a real charge.
+	// Refused rather than clamped, because silently capping an absurd figure
+	// would hide whatever produced it.
+	ErrUpstreamCostImplausible = errors.New("inference: upstream cost is implausibly large")
 )
+
+// maxCostLiteralBytes caps the raw numeric literal before it is handed to
+// big.Rat. json.Number only guarantees JSON number syntax, and JSON puts no
+// limit on digits, so an upstream (or anything able to answer as one) could
+// send a multi-megabyte literal and big.Rat would faithfully build the exact
+// rational for it. That is CPU spent inside a request, on a money path, at the
+// caller's choosing. No genuine USD cost needs anywhere near this many
+// characters.
+const maxCostLiteralBytes = 64
+
+// maxChargeableCredits is the largest charge a single request may settle at.
+// One request cannot plausibly cost more than 1,000,000 credits (10 USD) given
+// the request bounds enforced before dispatch, and refusing past that is what
+// stops a wrong or hostile figure becoming a real ledger entry. It also keeps
+// the conversion inside int64 by construction, so the Int64 check below is a
+// belt-and-braces assertion rather than the only line of defence.
+const maxChargeableCredits = 1_000_000
 
 // MarginNumerator / MarginDenominator express the 1.4 margin EXACTLY, as a
 // rational. Not 1.4 the float: this multiplies a money figure, and the repo
@@ -129,6 +150,14 @@ type upstreamCostEnvelope struct {
 // the caller must treat all of them as fail-closed. It never returns a zero
 // charge and a nil error together.
 func ParseUpstreamCost(raw []byte) (UpstreamCharge, error) {
+	// No bytes at all is "the frame never arrived", which is absence, not a
+	// malformed payload. json.Unmarshal reports empty input as a syntax error,
+	// which would file a stream that ended before its usage frame under
+	// `unparseable` and lose the distinction this file is built around.
+	if len(raw) == 0 {
+		return UpstreamCharge{}, ErrUpstreamCostAbsent
+	}
+
 	var env upstreamCostEnvelope
 	if err := json.Unmarshal(raw, &env); err != nil {
 		return UpstreamCharge{}, fmt.Errorf("%w: %v", ErrUpstreamCostUnparseable, err)
@@ -140,9 +169,16 @@ func ParseUpstreamCost(raw []byte) (UpstreamCharge, error) {
 		return charge, ErrUpstreamCostAbsent
 	}
 
-	cost, ok := new(big.Rat).SetString(env.Usage.Cost.String())
+	literal := env.Usage.Cost.String()
+	// Length first, before big.Rat ever sees it: the parse itself is the
+	// expensive part, so checking afterwards would be too late.
+	if len(literal) > maxCostLiteralBytes {
+		return charge, fmt.Errorf("%w: cost literal is %d bytes, limit %d",
+			ErrUpstreamCostUnparseable, len(literal), maxCostLiteralBytes)
+	}
+	cost, ok := new(big.Rat).SetString(literal)
 	if !ok {
-		return charge, fmt.Errorf("%w: %q", ErrUpstreamCostUnparseable, env.Usage.Cost.String())
+		return charge, fmt.Errorf("%w: %q", ErrUpstreamCostUnparseable, literal)
 	}
 
 	switch cost.Sign() {
@@ -160,6 +196,64 @@ func ParseUpstreamCost(raw []byte) (UpstreamCharge, error) {
 
 	charge.CostUSD = cost
 	return charge, nil
+}
+
+// SanitizeVariablePriceFrame strips the fields a cost-reporting upstream adds
+// that must never reach a customer, and rewrites the model to the alias.
+//
+// Both streaming relays need this and for the same reason. Turning on usage
+// accounting is what makes the upstream put its own cost, its cost breakdown
+// and the model the router chose into the frame, so the moment that flag went
+// on, any path that forwards a frame verbatim started publishing all three.
+// The typed-struct relay in executeStreaming is safe by construction because
+// unmarshalling discards what it does not declare, but its raw-line fallback is
+// not, and apps/edge-api/internal/chat relays every line verbatim by design.
+//
+// ok is false when the frame cannot be parsed. The caller must then DROP the
+// frame rather than forward it, because an unparseable frame is exactly the one
+// whose contents are unknown.
+func SanitizeVariablePriceFrame(payload []byte, aliasID string) ([]byte, bool) {
+	var frame map[string]json.RawMessage
+	if err := json.Unmarshal(payload, &frame); err != nil {
+		return nil, false
+	}
+
+	// Provider identity and our own cost. Deleting by key rather than
+	// rebuilding from a typed struct keeps every field the client legitimately
+	// needs, including ones this package does not model, such as tool calls.
+	delete(frame, "provider")
+
+	if rawUsage, present := frame["usage"]; present {
+		var usage map[string]json.RawMessage
+		if err := json.Unmarshal(rawUsage, &usage); err != nil {
+			return nil, false
+		}
+		for _, key := range []string{"cost", "cost_details", "is_byok"} {
+			delete(usage, key)
+		}
+		rebuilt, err := json.Marshal(usage)
+		if err != nil {
+			return nil, false
+		}
+		frame["usage"] = rebuilt
+	}
+
+	// The router's chosen model. Present on the sync path and on some
+	// streaming frames; the typed relay already does this, so doing it here
+	// keeps the two consistent.
+	if _, present := frame["model"]; present {
+		alias, err := json.Marshal(aliasID)
+		if err != nil {
+			return nil, false
+		}
+		frame["model"] = alias
+	}
+
+	out, err := json.Marshal(frame)
+	if err != nil {
+		return nil, false
+	}
+	return out, true
 }
 
 // CreditsForUpstreamCost converts a provider-reported USD cost into whole
@@ -188,7 +282,19 @@ func CreditsForUpstreamCost(costUSD *big.Rat) (int64, error) {
 		quotient.Add(quotient, big.NewInt(1))
 	}
 
+	// Int64() is UNDEFINED when the value does not fit: it returns the low 64
+	// bits with the sign reinterpreted, so an oversized charge wraps rather
+	// than saturating. A wrap to a negative then hit the floor below and became
+	// a charge of one credit, flagged confirmed, which is a failed cost read
+	// settling as very nearly free. Check before converting, and refuse.
+	if !quotient.IsInt64() {
+		return 0, fmt.Errorf("%w: does not fit in int64", ErrUpstreamCostImplausible)
+	}
 	credits := quotient.Int64()
+	if credits > maxChargeableCredits {
+		return 0, fmt.Errorf("%w: %d credits exceeds the %d per-request ceiling",
+			ErrUpstreamCostImplausible, credits, maxChargeableCredits)
+	}
 	if credits < 1 {
 		credits = 1
 	}

--- a/apps/edge-api/internal/inference/upstream_cost_hardening_test.go
+++ b/apps/edge-api/internal/inference/upstream_cost_hardening_test.go
@@ -1,0 +1,146 @@
+package inference
+
+import (
+	"encoding/json"
+	"errors"
+	"math/big"
+	"strings"
+	"testing"
+)
+
+// Guards for the defects the adversarial review found in the first two commits.
+// Each one is a case where the earlier code produced a plausible number instead
+// of a refusal, which on a money path is the worst failure shape there is.
+
+// --- The hold has to come off the key the control plane actually sends ------
+
+// ReservationResult.EstimatedCredits reads `estimated_credits`, which the
+// control plane does NOT publish; it sends `reserved_credits`. Nothing read
+// that field before variable pricing did, so the mismatch was invisible until a
+// charge depended on it, at which point a failed cost lookup settled at 1
+// credit rather than at the hold.
+func TestReservationHoldReadsTheKeyTheControlPlaneActuallySends(t *testing.T) {
+	// Byte for byte the shape apps/control-plane/internal/accounting/types.go
+	// marshals, trimmed to the fields that matter here.
+	body := []byte(`{"id":"res-1","status":"active","reserved_credits":200000,` +
+		`"consumed_credits":0,"released_credits":0}`)
+
+	var got ReservationResult
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if got.EstimatedCredits != 0 {
+		t.Fatalf("fixture drift: the control plane does not send estimated_credits, got %d", got.EstimatedCredits)
+	}
+	if got.Held() != 200_000 {
+		t.Fatalf("Held() = %d, want 200000. A zero here makes every fail-closed settlement charge 1 credit "+
+			"instead of the hold, which is the free-serve bug wearing a different hat.", got.Held())
+	}
+}
+
+func TestReservationHoldFallsBackToTheLegacyKey(t *testing.T) {
+	var got ReservationResult
+	if err := json.Unmarshal([]byte(`{"id":"res-1","estimated_credits":1234}`), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Held() != 1234 {
+		t.Fatalf("Held() = %d, want the legacy key honoured when it is the only one present", got.Held())
+	}
+}
+
+// --- An oversized cost must refuse, not wrap into a tiny charge ------------
+
+func TestCreditsForUpstreamCostRefusesImplausibleMagnitudes(t *testing.T) {
+	// 1e20 USD. The old code multiplied, called big.Int.Int64() on a value that
+	// does not fit, got the low 64 bits with the sign reinterpreted, and the
+	// `credits < 1` floor turned the resulting negative into a charge of ONE
+	// credit, returned as confirmed.
+	huge, ok := new(big.Rat).SetString("1e20")
+	if !ok {
+		t.Fatal("bad fixture")
+	}
+
+	credits, err := CreditsForUpstreamCost(huge)
+	if !errors.Is(err, ErrUpstreamCostImplausible) {
+		t.Fatalf("expected an implausible-cost refusal, got credits=%d err=%v", credits, err)
+	}
+	if credits == 1 {
+		t.Fatal("1e20 USD settled at ONE credit: the int64 wrap is back")
+	}
+
+	// Just over the per-request ceiling must refuse too, well before any
+	// overflow, so the guard does not depend on the wrap to catch things.
+	overCeiling, _ := new(big.Rat).SetString("100")
+	if _, err := CreditsForUpstreamCost(overCeiling); !errors.Is(err, ErrUpstreamCostImplausible) {
+		t.Fatalf("100 USD is %d credits, above the per-request ceiling, and must refuse; got %v",
+			100*MarginNumerator*CreditsPerUSD/MarginDenominator, err)
+	}
+
+	// And the ceiling must not be so tight that ordinary traffic trips it.
+	fine, _ := new(big.Rat).SetString("0.0123456")
+	if _, err := CreditsForUpstreamCost(fine); err != nil {
+		t.Fatalf("an ordinary cost must still settle, got %v", err)
+	}
+}
+
+// --- A huge numeric literal must be refused before big.Rat parses it -------
+
+func TestParseUpstreamCostRefusesAnOversizedLiteralWithoutParsingIt(t *testing.T) {
+	// json.Number only guarantees JSON number syntax, and JSON puts no cap on
+	// digits. big.Rat would faithfully build the exact rational, spending the
+	// CPU inside the request at the caller's choosing.
+	literal := "0." + strings.Repeat("9", 100_000)
+	body := []byte(`{"id":"gen-1","usage":{"prompt_tokens":10,"completion_tokens":5,"cost":` + literal + `}}`)
+
+	_, err := ParseUpstreamCost(body)
+	if !errors.Is(err, ErrUpstreamCostUnparseable) {
+		t.Fatalf("expected an oversized literal to be refused, got %v", err)
+	}
+
+	// A normal literal of realistic precision must still be accepted.
+	okBody := []byte(`{"id":"gen-1","usage":{"prompt_tokens":10,"completion_tokens":5,"cost":0.000000123456789}}`)
+	if _, err := ParseUpstreamCost(okBody); err != nil {
+		t.Fatalf("a realistic cost literal must still parse, got %v", err)
+	}
+}
+
+// --- Nothing the upstream adds may be forwarded to the customer ------------
+
+func TestSanitizeVariablePriceFrameStripsEverythingConfidential(t *testing.T) {
+	frame := []byte(`{"id":"gen-1","object":"chat.completion.chunk","provider":"Anthropic",` +
+		`"model":"anthropic/claude-sonnet-4.5",` +
+		`"choices":[{"index":0,"delta":{"content":"hi"},"finish_reason":null}],` +
+		`"usage":{"prompt_tokens":1000,"completion_tokens":500,"cost":0.0123456,` +
+		`"is_byok":false,"cost_details":{"upstream_inference_cost":0.0123456}}}`)
+
+	out, ok := SanitizeVariablePriceFrame(frame, "openrouter-auto")
+	if !ok {
+		t.Fatal("a well-formed frame must sanitize, not be dropped")
+	}
+	s := string(out)
+
+	for _, forbidden := range []string{
+		"Anthropic", "claude-sonnet-4.5", "0.0123456", "cost_details", "is_byok", `"provider"`, `"cost"`,
+	} {
+		if strings.Contains(s, forbidden) {
+			t.Errorf("sanitized frame still leaks %q: %s", forbidden, s)
+		}
+	}
+
+	// Everything the client legitimately needs must survive, including the
+	// token counts and the delta content.
+	for _, required := range []string{"openrouter-auto", "prompt_tokens", "completion_tokens", `"hi"`, "chat.completion.chunk"} {
+		if !strings.Contains(s, required) {
+			t.Errorf("sanitized frame dropped %q, which the client needs: %s", required, s)
+		}
+	}
+}
+
+func TestSanitizeVariablePriceFrameDropsWhatItCannotParse(t *testing.T) {
+	// An unparseable frame is exactly the one whose contents are unknown, so
+	// the caller must drop it rather than forward it.
+	if _, ok := SanitizeVariablePriceFrame([]byte(`{"usage": nope}`), "openrouter-auto"); ok {
+		t.Fatal("an unparseable frame must not be reported as safe to forward")
+	}
+}

--- a/apps/edge-api/internal/inference/upstream_cost_settlement_test.go
+++ b/apps/edge-api/internal/inference/upstream_cost_settlement_test.go
@@ -1,0 +1,251 @@
+package inference
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// End-to-end settlement for a variable-price alias, exercised through the same
+// httptest wiring the catalog-price tests use: a routing mock, an accounting
+// mock that records every call, and an upstream that answers like OpenRouter
+// through LiteLLM.
+//
+// The unit tests next door prove the arithmetic. These prove the WIRING, which
+// is where this could still be wrong while every unit test stays green: the raw
+// bytes have to survive from the upstream response to the settlement call, and
+// the hold has to come from the catalog rather than the endpoint default.
+
+// openrouterAutoPricing is the openrouter-auto catalog row: no fixed price, a
+// 200000 credit hold (supabase/migrations/20260822_30_...sql).
+var openrouterAutoPricing = UpstreamActualPricing(200_000)
+
+// newRoutingMockVariable answers route selection with a variable-price alias.
+func newRoutingMockVariable() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(SelectRouteResult{
+			AliasID:          "openrouter-auto",
+			RouteID:          "route-openrouter-auto-beta",
+			LiteLLMModelName: "route-openrouter-auto-beta",
+			Provider:         "openrouter",
+			Pricing:          openrouterAutoPricing,
+			PriceUnit:        "tokens",
+		})
+	}))
+}
+
+// newEchoingAccountingMock echoes back the hold that was actually requested,
+// unlike newAccountingMock which returns a fixed 10000. The echo matters here:
+// settlement charges the hold when it cannot read a cost, so a mock that lied
+// about the hold size would make the fail-closed assertions meaningless.
+func newEchoingAccountingMock(rec *accountingRecorder) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		rec.record(r.URL.Path, body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		switch r.URL.Path {
+		case "/internal/accounting/reservations":
+			estimated, _ := body["estimated_credits"].(float64)
+			_ = json.NewEncoder(w).Encode(ReservationResult{
+				ID: "res-test-1", AccountID: "acct-test-1", Status: "active",
+				EstimatedCredits: int64(estimated),
+			})
+		case "/internal/usage/attempts":
+			_ = json.NewEncoder(w).Encode(AttemptResult{
+				ID: "attempt-test-1", RequestID: "req-test-1", Status: "streaming",
+			})
+		}
+	}))
+}
+
+// openrouterSSEServer streams like OpenRouter through LiteLLM. The terminal
+// usage frame is written as RAW JSON rather than built from ChatCompletionChunk
+// on purpose: our own struct has no cost field, so building the fixture from it
+// could not produce the bytes this feature has to read.
+//
+// costJSON is spliced in verbatim so a test can send a real number, a null, a
+// string, or omit the key entirely.
+func openrouterSSEServer(costJSON string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher := w.(http.Flusher)
+
+		// A content chunk that also names the upstream model the router chose.
+		// That name must never reach the client.
+		fmt.Fprintf(w, "data: %s\n\n", `{"id":"gen-1755900000-AUDIT","object":"chat.completion.chunk",`+
+			`"created":1700000000,"model":"anthropic/claude-sonnet-4.5","provider":"Anthropic",`+
+			`"choices":[{"index":0,"delta":{"role":"assistant","content":"hello there"},"finish_reason":null}]}`)
+		flusher.Flush()
+
+		costField := ""
+		if costJSON != "" {
+			costField = `,"cost":` + costJSON
+		}
+		fmt.Fprintf(w, "data: %s\n\n", `{"id":"gen-1755900000-AUDIT","object":"chat.completion.chunk",`+
+			`"created":1700000000,"model":"anthropic/claude-sonnet-4.5","provider":"Anthropic",`+
+			`"choices":[{"index":0,"delta":{},"finish_reason":"stop"}],`+
+			`"usage":{"prompt_tokens":1000,"completion_tokens":500,"total_tokens":1500`+costField+`}}`)
+		flusher.Flush()
+
+		fmt.Fprint(w, "data: [DONE]\n\n")
+		flusher.Flush()
+	}))
+}
+
+// runVariableStreaming drives executeStreaming and hands back the recorder so a
+// test can inspect exactly what the CLIENT saw, which is where a cost or a
+// chosen-model leak would show up.
+func runVariableStreaming(orch *Orchestrator) (<-chan struct{}, *headerCommitRecorder) {
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{}`))
+	req.Header.Set("Authorization", "Bearer test-token")
+	w := newHeaderCommitRecorder()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = orch.executeStreaming(context.Background(), w, req, EndpointChatCompletions, []byte(`{}`),
+			"openrouter-auto", "openrouter-auto",
+			NeedFlags{NeedChatCompletions: true, NeedStreaming: true}, 10000, false, nil,
+			orch.litellm.ChatCompletion)
+	}()
+	return done, w
+}
+
+// The happy path: the reported cost becomes the charge, at the right magnitude.
+func TestVariablePriceStreaming_SettlesAtTheReportedUpstreamCost(t *testing.T) {
+	rec := &accountingRecorder{}
+	acctSrv := newEchoingAccountingMock(rec)
+	defer acctSrv.Close()
+	litellmSrv := openrouterSSEServer("0.0123456")
+	defer litellmSrv.Close()
+	routingSrv := newRoutingMockVariable()
+	defer routingSrv.Close()
+
+	orch := newAuthorizedOrchestrator(acctSrv.URL, routingSrv.URL, litellmSrv.URL)
+	done, _ := runVariableStreaming(orch)
+	waitDone(t, done)
+
+	// The hold must come from the catalog row, not from the flat 10000 the
+	// endpoint passes in. If ReservationCredits were skipped this reads 10000.
+	reservation, ok := rec.find("/internal/accounting/reservations")
+	if !ok {
+		t.Fatalf("no reservation was created; calls: %+v", rec.calls)
+	}
+	if held, _ := reservation["estimated_credits"].(float64); int64(held) != 200_000 {
+		t.Errorf("hold = %v, want the catalog figure 200000; a router request cannot be held at the flat endpoint default", reservation["estimated_credits"])
+	}
+
+	body, ok := rec.find("/internal/accounting/reservations/finalize")
+	if !ok {
+		t.Fatalf("expected a finalize on a normal completion; calls: %+v", rec.calls)
+	}
+	// 0.0123456 USD x 1.4 margin x 100000 credits per USD = 1728.384 -> 1728.
+	// Asserted against the KNOWN upstream cost. Note this is nowhere near the
+	// token count (1500) nor the hold (200000), so a regression to either
+	// shape fails here rather than sliding past a non-zero check.
+	if actual, _ := body["actual_credits"].(float64); int64(actual) != 1728 {
+		t.Errorf("actual_credits = %v, want 1728 for a reported cost of 0.0123456 USD", body["actual_credits"])
+	}
+	if confirmed, _ := body["terminal_usage_confirmed"].(bool); !confirmed {
+		t.Error("a charge derived from a real reported cost is measured truth and must be confirmed")
+	}
+	if rec.has("/internal/accounting/reservations/release") {
+		t.Error("a charged reservation must never also be released")
+	}
+}
+
+// The fail-closed path, end to end. This is the one that matters: on the
+// version of LiteLLM this repo pins today, the streaming terminal chunk carries
+// NO cost, so this is not a hypothetical shape.
+func TestVariablePriceStreaming_MissingCostChargesTheHoldNotZero(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cost string
+	}{
+		{"cost key absent entirely, which is what our pinned LiteLLM produces", ""},
+		{"cost explicitly null", "null"},
+		{"cost is a confident zero", "0"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := &accountingRecorder{}
+			acctSrv := newEchoingAccountingMock(rec)
+			defer acctSrv.Close()
+			litellmSrv := openrouterSSEServer(tc.cost)
+			defer litellmSrv.Close()
+			routingSrv := newRoutingMockVariable()
+			defer routingSrv.Close()
+
+			orch := newAuthorizedOrchestrator(acctSrv.URL, routingSrv.URL, litellmSrv.URL)
+			done, _ := runVariableStreaming(orch)
+			waitDone(t, done)
+
+			body, ok := rec.find("/internal/accounting/reservations/finalize")
+			if !ok {
+				t.Fatalf("a delivered response must still settle; calls: %+v", rec.calls)
+			}
+			actual, _ := body["actual_credits"].(float64)
+			if int64(actual) == 0 {
+				t.Fatal("settled at ZERO with no readable upstream cost: this is the free-serve bug")
+			}
+			if int64(actual) != 200_000 {
+				t.Errorf("actual_credits = %v, want the full hold 200000", body["actual_credits"])
+			}
+			if confirmed, _ := body["terminal_usage_confirmed"].(bool); confirmed {
+				t.Error("a charge with no readable cost must NOT be flagged as measured truth")
+			}
+		})
+	}
+}
+
+// Provider-blindness. The owner deliberately named this alias after its
+// provider, so the alias name is not secret. The identity of the model the
+// router actually chose still is, and so is what we paid for it.
+func TestVariablePriceStreaming_LeaksNeitherCostNorChosenModelToTheClient(t *testing.T) {
+	rec := &accountingRecorder{}
+	acctSrv := newEchoingAccountingMock(rec)
+	defer acctSrv.Close()
+	litellmSrv := openrouterSSEServer("0.0123456")
+	defer litellmSrv.Close()
+	routingSrv := newRoutingMockVariable()
+	defer routingSrv.Close()
+
+	orch := newAuthorizedOrchestrator(acctSrv.URL, routingSrv.URL, litellmSrv.URL)
+	done, w := runVariableStreaming(orch)
+	waitDone(t, done)
+
+	client := w.Body.String()
+	if client == "" {
+		t.Fatal("client received nothing, so this test would pass vacuously")
+	}
+	// Sanity: the stream really did reach the client, so the absence checks
+	// below mean something.
+	if !strings.Contains(client, "hello there") {
+		t.Fatalf("expected the completion text to reach the client, got: %s", client)
+	}
+
+	for _, forbidden := range []string{
+		"anthropic/claude-sonnet-4.5", // the model the router chose
+		"Anthropic",                   // the upstream provider
+		"0.0123456",                   // what we paid
+		"\"cost\"",                    // the cost field itself
+		"cost_details",
+	} {
+		if strings.Contains(client, forbidden) {
+			t.Errorf("client response leaked %q; full body: %s", forbidden, client)
+		}
+	}
+
+	// The same information must still be recoverable internally, or a charge
+	// is unauditable. The generation id is the audit handle.
+	if !strings.Contains(client, "openrouter-auto") {
+		t.Error("the client should still see the alias it asked for")
+	}
+}

--- a/apps/edge-api/internal/inference/upstream_cost_settlement_test.go
+++ b/apps/edge-api/internal/inference/upstream_cost_settlement_test.go
@@ -44,6 +44,13 @@ func newRoutingMockVariable() *httptest.Server {
 // unlike newAccountingMock which returns a fixed 10000. The echo matters here:
 // settlement charges the hold when it cannot read a cost, so a mock that lied
 // about the hold size would make the fail-closed assertions meaningless.
+//
+// It answers with `reserved_credits`, which is the key the real control plane
+// publishes (apps/control-plane/internal/accounting/types.go). An earlier
+// version of this mock answered `estimated_credits`, a key nothing sends, and
+// that single wrong word made every hold assertion here pass against a value
+// production would have decoded as 0. The mock has to speak the real wire shape
+// or it is testing itself.
 func newEchoingAccountingMock(rec *accountingRecorder) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var body map[string]any
@@ -54,9 +61,12 @@ func newEchoingAccountingMock(rec *accountingRecorder) *httptest.Server {
 		switch r.URL.Path {
 		case "/internal/accounting/reservations":
 			estimated, _ := body["estimated_credits"].(float64)
-			_ = json.NewEncoder(w).Encode(ReservationResult{
-				ID: "res-test-1", AccountID: "acct-test-1", Status: "active",
-				EstimatedCredits: int64(estimated),
+			// Encoded as a raw map, not ReservationResult, so the test cannot
+			// accidentally start passing because the Go struct gained a field.
+			// This is the JSON the control plane really writes.
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id": "res-test-1", "account_id": "acct-test-1", "status": "active",
+				"reserved_credits": int64(estimated),
 			})
 		case "/internal/usage/attempts":
 			_ = json.NewEncoder(w).Encode(AttemptResult{
@@ -247,5 +257,46 @@ func TestVariablePriceStreaming_LeaksNeitherCostNorChosenModelToTheClient(t *tes
 	// is unauditable. The generation id is the audit handle.
 	if !strings.Contains(client, "openrouter-auto") {
 		t.Error("the client should still see the alias it asked for")
+	}
+}
+
+// The Responses streaming path has its own relay loop, and it was missing the
+// raw-usage capture entirely, so a variable-price alias could only ever fail
+// closed there. Same assertion as the chat-completions path: the charge must be
+// the reported cost, not the hold.
+func TestResponsesStreamingSettlesAtTheReportedUpstreamCost(t *testing.T) {
+	rec := &accountingRecorder{}
+	acctSrv := newEchoingAccountingMock(rec)
+	defer acctSrv.Close()
+	litellmSrv := openrouterSSEServer("0.0123456")
+	defer litellmSrv.Close()
+	routingSrv := newRoutingMockVariable()
+	defer routingSrv.Close()
+
+	orch := newAuthorizedOrchestrator(acctSrv.URL, routingSrv.URL, litellmSrv.URL)
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{}`))
+	req.Header.Set("Authorization", "Bearer test-token")
+	w := newHeaderCommitRecorder()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		orch.executeResponsesStreaming(context.Background(), w, req, []byte(`{}`),
+			ResponsesRequest{Model: "openrouter-auto"}, "openrouter-auto",
+			NeedFlags{NeedResponses: true, NeedStreaming: true}, 10000)
+	}()
+	waitDone(t, done)
+
+	body, ok := rec.find("/internal/accounting/reservations/finalize")
+	if !ok {
+		t.Fatalf("expected a finalize on the responses path; calls: %+v", rec.calls)
+	}
+	// 0.0123456 x 1.4 x 100000 = 1728.384 -> 1728. If the capture is missing
+	// this reads 200000, the hold, because the cost was never seen.
+	if actual, _ := body["actual_credits"].(float64); int64(actual) != 1728 {
+		t.Errorf("actual_credits = %v, want 1728. The responses relay must capture the raw usage frame too.",
+			body["actual_credits"])
+	}
+	if confirmed, _ := body["terminal_usage_confirmed"].(bool); !confirmed {
+		t.Error("a charge from a real reported cost must be confirmed")
 	}
 }

--- a/apps/edge-api/internal/inference/upstream_cost_test.go
+++ b/apps/edge-api/internal/inference/upstream_cost_test.go
@@ -120,9 +120,6 @@ func TestParseUpstreamCostReadsCostExactlyAndCapturesAuditHandles(t *testing.T) 
 	if charge.GenerationID != "gen-1755900000-XYZ" {
 		t.Fatalf("generation id not captured, got %q", charge.GenerationID)
 	}
-	if charge.Provider != "Anthropic" {
-		t.Fatalf("provider not captured, got %q", charge.Provider)
-	}
 }
 
 // --- CreditsForUpstreamCost: the charge magnitude must be RIGHT ------------
@@ -252,8 +249,9 @@ func TestFreeServeGuardNeverSettlesAtZero(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			credits, confirmed, delivered, reason := UpstreamActualSettlement(
+			settled := UpstreamActualSettlement(
 				[]byte(tc.rawUsage), held, true, 1000, 500, "some answer text")
+			credits, confirmed, delivered, reason := settled.Credits, settled.Confirmed, settled.Delivered, settled.Reason
 
 			if !delivered {
 				t.Fatal("work was delivered; refusing to charge for it is the free-serve bug itself")
@@ -280,8 +278,14 @@ func TestFreeServeGuardNeverSettlesAtZero(t *testing.T) {
 func TestUpstreamActualSettlementChargesTheReportedCost(t *testing.T) {
 	raw := `{"id":"gen-1","provider":"Anthropic","usage":{"prompt_tokens":1000,"completion_tokens":500,"cost":0.0123456}}`
 
-	credits, confirmed, delivered, reason := UpstreamActualSettlement(
-		[]byte(raw), 200_000, true, 1000, 500, "answer")
+	settled := UpstreamActualSettlement([]byte(raw), 200_000, true, 1000, 500, "answer")
+	credits, confirmed, delivered, reason := settled.Credits, settled.Confirmed, settled.Delivered, settled.Reason
+
+	// The audit handle must survive settlement, not just parsing: this is what
+	// recovers the model the router chose, and the response no longer names it.
+	if settled.GenerationID != "gen-1" {
+		t.Errorf("generation id not carried through settlement, got %q", settled.GenerationID)
+	}
 
 	if !delivered || !confirmed {
 		t.Fatalf("expected a confirmed delivered settlement, got delivered=%v confirmed=%v", delivered, confirmed)
@@ -299,7 +303,8 @@ func TestUpstreamActualSettlementChargesTheReportedCost(t *testing.T) {
 
 func TestUpstreamActualSettlementReleasesWhenNothingWasDelivered(t *testing.T) {
 	// The ONLY path allowed to produce a zero charge: no tokens, no content.
-	credits, confirmed, delivered, reason := UpstreamActualSettlement(nil, 200_000, false, 0, 0, "")
+	settled := UpstreamActualSettlement(nil, 200_000, false, 0, 0, "")
+	credits, confirmed, delivered, reason := settled.Credits, settled.Confirmed, settled.Delivered, settled.Reason
 	if delivered || confirmed || credits != 0 {
 		t.Fatalf("nothing delivered should release: got credits=%d confirmed=%v delivered=%v", credits, confirmed, delivered)
 	}

--- a/apps/edge-api/internal/inference/upstream_cost_test.go
+++ b/apps/edge-api/internal/inference/upstream_cost_test.go
@@ -1,0 +1,394 @@
+package inference
+
+import (
+	"errors"
+	"math/big"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// Tests for billing a variable-price alias at the cost the upstream reported.
+//
+// The thing being defended here is narrow and specific: a request must never
+// settle at zero because the cost lookup failed. Every assertion below is
+// written so that it FAILS if that guard is removed, rather than merely
+// passing while the guard happens to exist. Where a test could be satisfied by
+// the very bug it targets, the assertion is on an exact magnitude rather than
+// on "not zero", because "not zero" is satisfied by the 1-credit floor and the
+// floor is not the guard.
+
+// --- ParseUpstreamCost: absent, zero, negative and unreadable are DIFFERENT --
+//
+// Collapsing these into one failure is the specific mistake this package
+// exists to avoid: a confident zero and a missing field have different causes,
+// and only one of them is even arguably legitimate.
+
+func TestParseUpstreamCostDistinguishesEveryFailureShape(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want error
+	}{
+		{
+			name: "no usage object at all: the shape a proxy that dropped the field produces",
+			body: `{"id":"gen-abc","choices":[]}`,
+			want: ErrUpstreamCostAbsent,
+		},
+		{
+			name: "usage present but no cost key",
+			body: `{"id":"gen-abc","usage":{"prompt_tokens":10,"completion_tokens":5}}`,
+			want: ErrUpstreamCostAbsent,
+		},
+		{
+			name: "cost explicitly null",
+			body: `{"id":"gen-abc","usage":{"prompt_tokens":10,"completion_tokens":5,"cost":null}}`,
+			want: ErrUpstreamCostAbsent,
+		},
+		{
+			name: "cost is not a number",
+			body: `{"id":"gen-abc","usage":{"prompt_tokens":10,"completion_tokens":5,"cost":"free"}}`,
+			want: ErrUpstreamCostUnparseable,
+		},
+		{
+			name: "body is not JSON",
+			body: `<html>502 Bad Gateway</html>`,
+			want: ErrUpstreamCostUnparseable,
+		},
+		{
+			name: "negative cost must never reduce a charge",
+			body: `{"id":"gen-abc","usage":{"prompt_tokens":10,"completion_tokens":5,"cost":-0.5}}`,
+			want: ErrUpstreamCostNegative,
+		},
+		{
+			// The July shape. Tokens were consumed, so work was done, and a
+			// cost of exactly zero alongside them is not credible.
+			name: "confident zero alongside real tokens is its own error, not absent",
+			body: `{"id":"gen-abc","usage":{"prompt_tokens":1000,"completion_tokens":500,"cost":0}}`,
+			want: ErrUpstreamCostZero,
+		},
+		{
+			// Zero with no tokens is genuinely "nothing happened", which the
+			// caller releases rather than charges.
+			name: "zero with no tokens is absent, not the suspicious zero",
+			body: `{"id":"gen-abc","usage":{"prompt_tokens":0,"completion_tokens":0,"cost":0}}`,
+			want: ErrUpstreamCostAbsent,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParseUpstreamCost([]byte(tc.body))
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("expected %v, got %v", tc.want, err)
+			}
+			// Guards the distinction itself: if every failure collapsed to one
+			// sentinel this would pass above and fail here.
+			for _, other := range []error{
+				ErrUpstreamCostAbsent, ErrUpstreamCostUnparseable,
+				ErrUpstreamCostNegative, ErrUpstreamCostZero,
+			} {
+				if other != tc.want && errors.Is(err, other) {
+					t.Fatalf("error %v also matches %v; the failure shapes must stay distinguishable", err, other)
+				}
+			}
+		})
+	}
+}
+
+func TestParseUpstreamCostReadsCostExactlyAndCapturesAuditHandles(t *testing.T) {
+	// A deliberately long decimal: a float64 round-trip of this value does not
+	// compare equal to the exact rational, so this fails if the parser ever
+	// goes through a float.
+	body := `{"id":"gen-1755900000-XYZ","provider":"Anthropic",` +
+		`"usage":{"prompt_tokens":1000,"completion_tokens":500,"cost":0.000000123456789}}`
+
+	charge, err := ParseUpstreamCost([]byte(body))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want, _ := new(big.Rat).SetString("0.000000123456789")
+	if charge.CostUSD.Cmp(want) != 0 {
+		t.Fatalf("cost read inexactly: want %s, got %s", want.RatString(), charge.CostUSD.RatString())
+	}
+	// The generation id is the audit handle: it is what lets anyone recover
+	// which model the router actually chose, so losing it silently would make
+	// a charge unauditable.
+	if charge.GenerationID != "gen-1755900000-XYZ" {
+		t.Fatalf("generation id not captured, got %q", charge.GenerationID)
+	}
+	if charge.Provider != "Anthropic" {
+		t.Fatalf("provider not captured, got %q", charge.Provider)
+	}
+}
+
+// --- CreditsForUpstreamCost: the charge magnitude must be RIGHT ------------
+//
+// Every expectation is derived longhand from a known upstream cost. Asserting
+// "greater than zero" would pass on the 1-credit floor, which is exactly the
+// near-free outcome a broken conversion produces, so no assertion here is of
+// that shape.
+
+func TestCreditsForUpstreamCostMagnitude(t *testing.T) {
+	tests := []struct {
+		name string
+		cost string
+		want int64
+	}{
+		{
+			// The figure measured from a real OpenRouter usage block.
+			// 0.0123456 x 1.4 x 100000 = 1728.384 -> 1728
+			name: "measured cost, rounds down",
+			cost: "0.0123456",
+			want: 1728,
+		},
+		{
+			// 1.00 x 1.4 x 100000 = 140000 exactly. If the margin were dropped
+			// this reads 100000; if it were applied twice, 196000.
+			name: "one dollar is exactly the margin times the credit rate",
+			cost: "1.00",
+			want: 140000,
+		},
+		{
+			// 0.000025 x 140000 = 3.5 exactly: the half-up boundary. Round
+			// half DOWN gives 3, truncation gives 3, only half-up gives 4.
+			name: "exact half rounds up",
+			cost: "0.000025",
+			want: 4,
+		},
+		{
+			// 0.123456789 x 140000 = 17283.95046 -> 17284
+			name: "long decimal rounds up",
+			cost: "0.123456789",
+			want: 17284,
+		},
+		{
+			// 0.0000001 x 140000 = 0.014, which floors to 1: a request that
+			// cost us real money is never settled free.
+			name: "a tiny but real cost floors at one credit, never zero",
+			cost: "0.0000001",
+			want: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cost, ok := new(big.Rat).SetString(tc.cost)
+			if !ok {
+				t.Fatalf("bad test fixture %q", tc.cost)
+			}
+			got, err := CreditsForUpstreamCost(cost)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("cost %s: want %d credits, got %d", tc.cost, tc.want, got)
+			}
+		})
+	}
+}
+
+func TestCreditsForUpstreamCostRefusesNonPositive(t *testing.T) {
+	if _, err := CreditsForUpstreamCost(nil); !errors.Is(err, ErrUpstreamCostAbsent) {
+		t.Fatalf("nil cost: expected absent, got %v", err)
+	}
+	if _, err := CreditsForUpstreamCost(new(big.Rat)); !errors.Is(err, ErrUpstreamCostZero) {
+		t.Fatalf("zero cost: expected zero error, got %v", err)
+	}
+	neg, _ := new(big.Rat).SetString("-1")
+	if _, err := CreditsForUpstreamCost(neg); !errors.Is(err, ErrUpstreamCostNegative) {
+		t.Fatalf("negative cost: expected negative error, got %v", err)
+	}
+}
+
+// --- The free-serve guard --------------------------------------------------
+//
+// The three failure modes the brief calls out, as three separate cases:
+// the lookup returns null, the lookup errors (an unreadable body), and the
+// lookup never happens at all because the stream ended before the terminal
+// usage frame arrived. That last one is what a timeout looks like on this
+// path: the cost is carried IN BAND on the response, so there is no separate
+// call to time out, and a timed-out or aborted stream simply leaves no bytes
+// to read. Testing it as "no bytes" rather than inventing a network timeout is
+// the honest mapping.
+
+func TestFreeServeGuardNeverSettlesAtZero(t *testing.T) {
+	const held = 200_000
+
+	tests := []struct {
+		name       string
+		rawUsage   string
+		wantReason string
+	}{
+		{
+			name:       "cost returns null",
+			rawUsage:   `{"id":"gen-1","usage":{"prompt_tokens":1000,"completion_tokens":500,"cost":null}}`,
+			wantReason: "upstream_cost_absent",
+		},
+		{
+			name:       "cost lookup errors on an unreadable body",
+			rawUsage:   `{"id":"gen-1","usage":{"prompt_tokens":1000,"completion_tokens":500,"cost":"nope"}}`,
+			wantReason: "upstream_cost_unparseable",
+		},
+		{
+			name:       "the lookup never happened: stream ended before the usage frame",
+			rawUsage:   ``,
+			wantReason: "upstream_cost_unparseable",
+		},
+		{
+			name:       "a confident zero is refused, not billed as free",
+			rawUsage:   `{"id":"gen-1","usage":{"prompt_tokens":1000,"completion_tokens":500,"cost":0}}`,
+			wantReason: "upstream_cost_zero",
+		},
+		{
+			name:       "a negative cost cannot reduce the charge",
+			rawUsage:   `{"id":"gen-1","usage":{"prompt_tokens":1000,"completion_tokens":500,"cost":-5}}`,
+			wantReason: "upstream_cost_negative",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			credits, confirmed, delivered, reason := UpstreamActualSettlement(
+				[]byte(tc.rawUsage), held, true, 1000, 500, "some answer text")
+
+			if !delivered {
+				t.Fatal("work was delivered; refusing to charge for it is the free-serve bug itself")
+			}
+			// The load-bearing assertion. Zero here IS the July incident.
+			if credits == 0 {
+				t.Fatal("settled at ZERO after a failed cost lookup: this is the free-serve bug")
+			}
+			// Exact, not "greater than zero": a 1-credit floor would satisfy
+			// non-zero while still giving the work away.
+			if credits != held {
+				t.Fatalf("expected the full hold %d to be charged, got %d", held, credits)
+			}
+			if confirmed {
+				t.Fatal("a charge derived from a FAILED cost lookup must never be flagged as measured truth")
+			}
+			if reason != tc.wantReason {
+				t.Fatalf("expected reason %q, got %q", tc.wantReason, reason)
+			}
+		})
+	}
+}
+
+func TestUpstreamActualSettlementChargesTheReportedCost(t *testing.T) {
+	raw := `{"id":"gen-1","provider":"Anthropic","usage":{"prompt_tokens":1000,"completion_tokens":500,"cost":0.0123456}}`
+
+	credits, confirmed, delivered, reason := UpstreamActualSettlement(
+		[]byte(raw), 200_000, true, 1000, 500, "answer")
+
+	if !delivered || !confirmed {
+		t.Fatalf("expected a confirmed delivered settlement, got delivered=%v confirmed=%v", delivered, confirmed)
+	}
+	// 0.0123456 x 1.4 x 100000 = 1728.384 -> 1728. Compared against the KNOWN
+	// upstream cost, not against the hold and not against zero. If settlement
+	// ever fell back to the hold on a readable cost this reads 200000.
+	if credits != 1728 {
+		t.Fatalf("expected 1728 credits for a reported cost of 0.0123456, got %d", credits)
+	}
+	if reason != "upstream_cost" {
+		t.Fatalf("expected reason upstream_cost, got %q", reason)
+	}
+}
+
+func TestUpstreamActualSettlementReleasesWhenNothingWasDelivered(t *testing.T) {
+	// The ONLY path allowed to produce a zero charge: no tokens, no content.
+	credits, confirmed, delivered, reason := UpstreamActualSettlement(nil, 200_000, false, 0, 0, "")
+	if delivered || confirmed || credits != 0 {
+		t.Fatalf("nothing delivered should release: got credits=%d confirmed=%v delivered=%v", credits, confirmed, delivered)
+	}
+	if reason != "nothing_delivered" {
+		t.Fatalf("expected reason nothing_delivered, got %q", reason)
+	}
+}
+
+// --- The reservation cannot under-reserve ----------------------------------
+
+func TestReservationCreditsCannotUnderReserve(t *testing.T) {
+	const endpointDefault = 10_000
+
+	fixed := SelectRouteResult{Pricing: FixedPricing(10_500, 42_000)}
+	if got := ReservationCredits(fixed, endpointDefault); got != endpointDefault {
+		t.Fatalf("a fixed-price alias must keep the endpoint default, got %d", got)
+	}
+
+	// The real case: the catalog row for openrouter-auto holds 200000, twenty
+	// times the flat default. If the catalog figure were ignored this reads
+	// 10000, and a router request that resolved to an expensive model would be
+	// held against a hold far too small to cover it.
+	variable := SelectRouteResult{Pricing: UpstreamActualPricing(200_000)}
+	if got := ReservationCredits(variable, endpointDefault); got != 200_000 {
+		t.Fatalf("a variable-price alias must hold its catalog figure 200000, got %d", got)
+	}
+
+	// The endpoint default is a FLOOR, never a ceiling: a catalog row that
+	// somehow carried a smaller hold must not lower the hold below what the
+	// endpoint already reserves.
+	tooSmall := SelectRouteResult{Pricing: UpstreamActualPricing(5)}
+	if got := ReservationCredits(tooSmall, endpointDefault); got != endpointDefault {
+		t.Fatalf("the endpoint default must floor the hold, got %d", got)
+	}
+}
+
+// --- A variable-price alias must never be priced from the catalog columns ---
+
+func TestCanPriceTokensAcceptsVariablePricingAndStillRefusesUnpriced(t *testing.T) {
+	variable := SelectRouteResult{Pricing: UpstreamActualPricing(200_000), PriceUnit: PriceUnitTokens}
+	if !CanPriceTokens(variable) {
+		t.Fatal("a variable-price alias is priceable by actual cost and must not be refused up front")
+	}
+
+	// Its price columns are nil. If anything ever reads them as a fixed price
+	// it would price every token at zero, so the mode has to be what decides.
+	if variable.Pricing.InputPriceCredits != nil || variable.Pricing.OutputPriceCredits != nil {
+		t.Fatal("a variable-price alias must carry no fixed price at all")
+	}
+
+	// A row with neither a mode nor a price is still refused: this is the
+	// no-cost-basis case and it must not become priceable by accident.
+	unpriced := SelectRouteResult{PriceUnit: PriceUnitTokens}
+	if CanPriceTokens(unpriced) {
+		t.Fatal("an alias with no price and no pricing mode must stay unpriceable")
+	}
+
+	// Variable pricing does not override the unit check: a token endpoint
+	// still cannot meter a per-second alias.
+	wrongUnit := SelectRouteResult{Pricing: UpstreamActualPricing(200_000), PriceUnit: "seconds"}
+	if CanPriceTokens(wrongUnit) {
+		t.Fatal("a token endpoint must not accept a per-second alias even in variable mode")
+	}
+}
+
+// --- Cross-module constant guard -------------------------------------------
+
+// CreditsPerUSD is duplicated in this package because payments lives under
+// control-plane's internal/ tree in another module and Go's visibility rules
+// make it unimportable. A duplicated money constant that can drift silently is
+// worse than no constant, so this reads the real declaration off disk and
+// fails if the two ever disagree.
+func TestCreditsPerUSDMatchesPaymentsPackage(t *testing.T) {
+	const src = "../../../control-plane/internal/payments/types.go"
+	raw, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatalf("cannot read %s, which this guard depends on: %v", src, err)
+	}
+
+	m := regexp.MustCompile(`CreditsPerUSD\s+int64\s*=\s*([0-9_]+)`).FindSubmatch(raw)
+	if m == nil {
+		t.Fatalf("could not find the CreditsPerUSD declaration in %s; if it moved, move this guard with it", src)
+	}
+	// Compared against THIS package's constant, not against a literal. A
+	// literal here would keep passing after someone edited the constant, which
+	// is the exact drift the guard exists to catch.
+	declared := strings.ReplaceAll(string(m[1]), "_", "")
+	if declared != strconv.FormatInt(CreditsPerUSD, 10) {
+		t.Fatalf("payments.CreditsPerUSD is now %s but this package uses %d; the two must agree",
+			declared, CreditsPerUSD)
+	}
+}

--- a/apps/edge-api/internal/inference/upstream_cost_test.go
+++ b/apps/edge-api/internal/inference/upstream_cost_test.go
@@ -231,9 +231,13 @@ func TestFreeServeGuardNeverSettlesAtZero(t *testing.T) {
 			wantReason: "upstream_cost_unparseable",
 		},
 		{
+			// Absence, not a parse failure. json.Unmarshal reports empty input
+			// as a syntax error, which used to file a stream that ended before
+			// its usage frame under `unparseable` and lose the very
+			// distinction this package is built around.
 			name:       "the lookup never happened: stream ended before the usage frame",
 			rawUsage:   ``,
-			wantReason: "upstream_cost_unparseable",
+			wantReason: "upstream_cost_absent",
 		},
 		{
 			name:       "a confident zero is refused, not billed as free",

--- a/apps/edge-api/internal/inference/variable_price_bounds_test.go
+++ b/apps/edge-api/internal/inference/variable_price_bounds_test.go
@@ -1,0 +1,242 @@
+package inference
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"net/http/httptest"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// The request bounds exist because provider.max_price caps the RATE and not the
+// size of a request. Without them a single large-context call against a router
+// alias can settle several times past its hold, which is the reservation
+// under-reserving in the only way that actually matters.
+
+func TestEnforceVariablePriceBounds_RefusesAnOversizeRequest(t *testing.T) {
+	route := SelectRouteResult{Pricing: UpstreamActualPricing(200_000), PriceUnit: PriceUnitTokens}
+
+	// One byte over. The boundary is the whole point, so it is tested at the
+	// boundary rather than with an obviously huge body.
+	body := []byte(`{"messages":"` + strings.Repeat("x", VariablePriceMaxRequestBytes) + `"}`)
+	if len(body) <= VariablePriceMaxRequestBytes {
+		t.Fatalf("fixture is not actually oversize: %d", len(body))
+	}
+
+	w := httptest.NewRecorder()
+	got, ok := EnforceVariablePriceBounds(w, route, EndpointChatCompletions, "openrouter-auto", body)
+	if ok {
+		t.Fatal("an oversize request on a variable-price alias must be refused before dispatch")
+	}
+	if got != nil {
+		t.Error("a refused request must not hand back a body to dispatch")
+	}
+	if w.Code != 400 {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+	// Provider-blind: the refusal must not name the provider or the upstream.
+	for _, forbidden := range []string{"openrouter", "OpenRouter", "auto-beta", "anthropic"} {
+		if strings.Contains(w.Body.String(), forbidden) {
+			t.Errorf("refusal leaked %q: %s", forbidden, w.Body.String())
+		}
+	}
+}
+
+func TestEnforceVariablePriceBounds_LeavesFixedPriceAliasesAlone(t *testing.T) {
+	route := SelectRouteResult{Pricing: FixedPricing(10_500, 42_000), PriceUnit: PriceUnitTokens}
+	body := []byte(`{"messages":"` + strings.Repeat("x", VariablePriceMaxRequestBytes) + `"}`)
+
+	w := httptest.NewRecorder()
+	got, ok := EnforceVariablePriceBounds(w, route, EndpointChatCompletions, "hive-fast", body)
+	if !ok {
+		t.Fatal("a fixed-price alias must not be subject to the variable-price size cap")
+	}
+	if string(got) != string(body) {
+		t.Error("a fixed-price alias's body must pass through byte for byte")
+	}
+}
+
+func TestEnforceVariablePriceBounds_PinsTheCompletionCeiling(t *testing.T) {
+	route := SelectRouteResult{Pricing: UpstreamActualPricing(200_000), PriceUnit: PriceUnitTokens}
+
+	tests := []struct {
+		name     string
+		endpoint string
+		body     string
+		field    string
+		want     int64
+	}{
+		{
+			name:     "absent: the client did not ask for a ceiling, so one is imposed",
+			endpoint: EndpointChatCompletions,
+			body:     `{"model":"openrouter-auto"}`,
+			field:    "max_tokens",
+			want:     VariablePriceMaxCompletionTokens,
+		},
+		{
+			name:     "above the cap: a client cannot raise it",
+			endpoint: EndpointChatCompletions,
+			body:     `{"model":"openrouter-auto","max_tokens":900000}`,
+			field:    "max_tokens",
+			want:     VariablePriceMaxCompletionTokens,
+		},
+		{
+			name:     "below the cap: the client's own smaller limit is respected",
+			endpoint: EndpointChatCompletions,
+			body:     `{"model":"openrouter-auto","max_tokens":64}`,
+			field:    "max_tokens",
+			want:     64,
+		},
+		{
+			name:     "unreadable value is replaced rather than trusted",
+			endpoint: EndpointChatCompletions,
+			body:     `{"model":"openrouter-auto","max_tokens":"lots"}`,
+			field:    "max_tokens",
+			want:     VariablePriceMaxCompletionTokens,
+		},
+		{
+			name:     "the responses endpoint uses its own field name",
+			endpoint: EndpointResponses,
+			body:     `{"model":"openrouter-auto"}`,
+			field:    "max_output_tokens",
+			want:     VariablePriceMaxCompletionTokens,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			got, ok := EnforceVariablePriceBounds(w, route, tc.endpoint, "openrouter-auto", []byte(tc.body))
+			if !ok {
+				t.Fatalf("unexpected refusal: %s", w.Body.String())
+			}
+			var decoded map[string]any
+			if err := json.Unmarshal(got, &decoded); err != nil {
+				t.Fatalf("bounded body is not valid JSON: %v", err)
+			}
+			value, present := decoded[tc.field]
+			if !present {
+				t.Fatalf("%s missing from the bounded body: %s", tc.field, got)
+			}
+			number, _ := value.(float64)
+			if int64(number) != tc.want {
+				t.Errorf("%s = %v, want %d", tc.field, value, tc.want)
+			}
+			// Everything else the caller sent must survive untouched.
+			if decoded["model"] != "openrouter-auto" {
+				t.Errorf("the caller's own fields must survive; got %v", decoded)
+			}
+		})
+	}
+}
+
+func TestEnforceVariablePriceBounds_RefusesAnUnparseableBody(t *testing.T) {
+	route := SelectRouteResult{Pricing: UpstreamActualPricing(200_000), PriceUnit: PriceUnitTokens}
+	w := httptest.NewRecorder()
+	if _, ok := EnforceVariablePriceBounds(w, route, EndpointChatCompletions, "openrouter-auto", []byte(`not json`)); ok {
+		t.Fatal("a body that cannot be bounded must be refused, not dispatched unbounded")
+	}
+}
+
+// The invariant this whole mechanism exists for, checked as arithmetic across
+// the three files that have to agree: the LiteLLM price ceiling, the request
+// bounds in this package, and the hold in the migration.
+//
+// This is a real cross-file guard, not a restatement. Raise the ceiling in the
+// YAML, or either cap here, without re-deriving the hold, and it fails.
+func TestTheHoldProvablyCoversTheWorstBoundedRequest(t *testing.T) {
+	promptCeiling, completionCeiling := readMaxPriceCeiling(t)
+	hold := readReservationEstimate(t)
+
+	// Worst case, in USD, as an exact rational:
+	//   prompt bytes are a rigorous upper bound on prompt tokens
+	//   completion is capped outright
+	worst := new(big.Rat).Add(
+		new(big.Rat).Mul(
+			new(big.Rat).SetInt64(VariablePriceMaxRequestBytes),
+			new(big.Rat).Quo(promptCeiling, new(big.Rat).SetInt64(1_000_000)),
+		),
+		new(big.Rat).Mul(
+			new(big.Rat).SetInt64(VariablePriceMaxCompletionTokens),
+			new(big.Rat).Quo(completionCeiling, new(big.Rat).SetInt64(1_000_000)),
+		),
+	)
+
+	worstCredits, err := CreditsForUpstreamCost(worst)
+	if err != nil {
+		t.Fatalf("could not price the worst case: %v", err)
+	}
+
+	if worstCredits > hold {
+		t.Fatalf("the hold does NOT cover the worst bounded request: worst case is %d credits but the catalog holds %d. "+
+			"Either lower provider.max_price in deploy/litellm/config.yaml, lower the request bounds in this package, "+
+			"or raise reservation_estimate_credits in the migration. These three numbers are one decision.",
+			worstCredits, hold)
+	}
+	t.Logf("worst bounded request = %d credits, hold = %d credits, headroom = %d",
+		worstCredits, hold, hold-worstCredits)
+}
+
+// readMaxPriceCeiling pulls provider.max_price for the variable-price route out
+// of the real LiteLLM config, in USD per million tokens.
+func readMaxPriceCeiling(t *testing.T) (prompt, completion *big.Rat) {
+	t.Helper()
+	const path = "../../../../deploy/litellm/config.yaml"
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("cannot read %s, which this guard depends on: %v", path, err)
+	}
+
+	idx := strings.Index(string(raw), "model_name: route-openrouter-auto-beta")
+	if idx < 0 {
+		t.Fatal("route-openrouter-auto-beta is not in deploy/litellm/config.yaml; if it was renamed, move this guard with it")
+	}
+	block := string(raw)[idx:]
+
+	prompt = matchRat(t, block, `max_price:\s*\n\s*prompt:\s*([0-9.]+)`, "prompt")
+	completion = matchRat(t, block, `completion:\s*([0-9.]+)`, "completion")
+	return prompt, completion
+}
+
+func matchRat(t *testing.T, block, pattern, label string) *big.Rat {
+	t.Helper()
+	m := regexp.MustCompile(pattern).FindStringSubmatch(block)
+	if m == nil {
+		t.Fatalf("no %s ceiling found on the variable-price route; the bound this guard checks is not configured", label)
+	}
+	value, ok := new(big.Rat).SetString(m[1])
+	if !ok {
+		t.Fatalf("%s ceiling %q is not a number", label, m[1])
+	}
+	return value
+}
+
+// readReservationEstimate pulls the hold out of the migration that seeds the
+// alias, so the guard reads the shipped value rather than a copy of it.
+func readReservationEstimate(t *testing.T) int64 {
+	t.Helper()
+	const path = "../../../../supabase/migrations/20260822_30_openrouter_auto_variable_pricing.sql"
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("cannot read %s, which this guard depends on: %v", path, err)
+	}
+	// The INSERT ends with the hold as its last value, after 'upstream_actual'.
+	m := regexp.MustCompile(`'upstream_actual',\s*\n\s*([0-9_]+)`).FindSubmatch(raw)
+	if m == nil {
+		t.Fatal("could not find reservation_estimate_credits in the migration; if the INSERT changed shape, move this guard with it")
+	}
+	held, err := strconv.ParseInt(strings.ReplaceAll(string(m[1]), "_", ""), 10, 64)
+	if err != nil {
+		t.Fatalf("hold %q is not a number: %v", m[1], err)
+	}
+	if held <= 0 {
+		t.Fatalf("hold must be positive, got %d", held)
+	}
+	return held
+}
+
+var _ = fmt.Sprintf

--- a/apps/edge-api/internal/metering/types.go
+++ b/apps/edge-api/internal/metering/types.go
@@ -110,6 +110,24 @@ type RouteInfo struct {
 	Provider           string
 	InputPriceCredits  int64 // model_aliases.input_price_credits, credits per million input tokens
 	OutputPriceCredits int64 // model_aliases.output_price_credits, credits per million output tokens
+	// PricingMode mirrors model_aliases.pricing_mode. A variable-price alias
+	// carries NULL prices, which flatten to zero here, and without this field
+	// HasCostBasis would read that as "no cost basis" and grade a request that
+	// genuinely bills as not_billable. The gate is shadow-mode today so the
+	// verdict is log-only, but a wrong verdict in the log is what a later
+	// enforcing step would inherit.
+	PricingMode string
+}
+
+// PricingModeUpstreamActual mirrors catalog.PricingModeUpstreamActual. Declared
+// here rather than imported because control-plane and edge-api are separate
+// modules.
+const PricingModeUpstreamActual = "upstream_actual"
+
+// IsUpstreamActual reports whether this route bills from the upstream's own
+// reported cost rather than from the price columns.
+func (r RouteInfo) IsUpstreamActual() bool {
+	return r.PricingMode == PricingModeUpstreamActual
 }
 
 // HasCostBasis reports whether this route carries a usable price. A route
@@ -117,6 +135,12 @@ type RouteInfo struct {
 // internal alias is legitimately unpriced) has no cost basis, and the gate
 // resolves not_billable/no_cost_basis without consulting anything else.
 func (r RouteInfo) HasCostBasis() bool {
+	// A variable-price alias has a cost basis by definition: it is billed from
+	// the cost the upstream reports for the request. Its price columns are
+	// NULL, so keying only on them would grade it not_billable.
+	if r.IsUpstreamActual() {
+		return true
+	}
 	return r.InputPriceCredits > 0 || r.OutputPriceCredits > 0
 }
 

--- a/apps/web-console/components/catalog/model-catalog-table.tsx
+++ b/apps/web-console/components/catalog/model-catalog-table.tsx
@@ -11,8 +11,15 @@ interface ModelCatalogTableProps {
 // A model priced from actual upstream cost has no per-million rate to show.
 // Rendering 0 there would read as "free", so the absence is shown as what it
 // is. formatCredits still owns every real number.
-function formatPrice(credits: number | null): string {
-  if (credits === null) return "Variable";
+//
+// The pricing mode decides which kind of absence this is. A null price on a
+// variable-price alias is the design; a null price on a fixed one means the
+// lookup failed, and calling that "Variable" would present a broken decode as a
+// deliberate pricing model on the very screen an admin uses to check pricing.
+function formatPrice(credits: number | null, pricingMode: string): string {
+  if (credits === null) {
+    return pricingMode === "upstream_actual" ? "Variable" : "Unknown";
+  }
   return formatCredits(credits);
 }
 
@@ -105,14 +112,14 @@ export function ModelCatalogTable({ models }: ModelCatalogTableProps) {
       header: "Input / 1M",
       numeric: true,
       align: "right",
-      cell: (row) => formatPrice(row.pricing.input_price_credits),
+      cell: (row) => formatPrice(row.pricing.input_price_credits, row.pricing.pricing_mode),
     },
     {
       key: "output",
       header: "Output / 1M",
       numeric: true,
       align: "right",
-      cell: (row) => formatPrice(row.pricing.output_price_credits),
+      cell: (row) => formatPrice(row.pricing.output_price_credits, row.pricing.pricing_mode),
     },
     {
       key: "status",

--- a/apps/web-console/components/catalog/model-catalog-table.tsx
+++ b/apps/web-console/components/catalog/model-catalog-table.tsx
@@ -8,6 +8,14 @@ interface ModelCatalogTableProps {
   models: CatalogModel[];
 }
 
+// A model priced from actual upstream cost has no per-million rate to show.
+// Rendering 0 there would read as "free", so the absence is shown as what it
+// is. formatCredits still owns every real number.
+function formatPrice(credits: number | null): string {
+  if (credits === null) return "Variable";
+  return formatCredits(credits);
+}
+
 type ToneName = "neutral" | "accent" | "success" | "warning" | "danger";
 
 function capabilityTone(badge: string): ToneName {
@@ -97,14 +105,14 @@ export function ModelCatalogTable({ models }: ModelCatalogTableProps) {
       header: "Input / 1M",
       numeric: true,
       align: "right",
-      cell: (row) => formatCredits(row.pricing.input_price_credits),
+      cell: (row) => formatPrice(row.pricing.input_price_credits),
     },
     {
       key: "output",
       header: "Output / 1M",
       numeric: true,
       align: "right",
-      cell: (row) => formatCredits(row.pricing.output_price_credits),
+      cell: (row) => formatPrice(row.pricing.output_price_credits),
     },
     {
       key: "status",

--- a/apps/web-console/lib/control-plane/client.ts
+++ b/apps/web-console/lib/control-plane/client.ts
@@ -1252,10 +1252,15 @@ export interface CatalogModel {
   summary: string;
   capability_badges: string[];
   pricing: {
-    input_price_credits: number;
-    output_price_credits: number;
+    // Null, not zero, when the alias is priced from actual upstream cost:
+    // there genuinely is no per-million price to show. Zero would render as
+    // "free", which is both wrong and the most expensive kind of wrong on a
+    // billing surface.
+    input_price_credits: number | null;
+    output_price_credits: number | null;
     cache_read_price_credits: number | null;
     cache_write_price_credits: number | null;
+    pricing_mode: string;
   };
   lifecycle: string;
 }
@@ -1469,8 +1474,11 @@ function decodeCatalogModel(value: JsonValue): CatalogModel | null {
   }
 
   const rawPricing = readObjectField(value, "pricing");
-  const inputPrice = rawPricing ? readNumberField(rawPricing, "input_price_credits") ?? 0 : 0;
-  const outputPrice = rawPricing ? readNumberField(rawPricing, "output_price_credits") ?? 0 : 0;
+  // No `?? 0` here. A variable-price alias sends null for both, and coercing
+  // that to zero told the admin catalog the model was free.
+  const inputPrice = rawPricing ? readNumberField(rawPricing, "input_price_credits") : null;
+  const outputPrice = rawPricing ? readNumberField(rawPricing, "output_price_credits") : null;
+  const pricingMode = rawPricing ? readStringField(rawPricing, "pricing_mode") ?? "fixed" : "fixed";
   const cacheReadPrice = rawPricing ? readNumberField(rawPricing, "cache_read_price_credits") : null;
   const cacheWritePrice = rawPricing ? readNumberField(rawPricing, "cache_write_price_credits") : null;
 
@@ -1484,6 +1492,7 @@ function decodeCatalogModel(value: JsonValue): CatalogModel | null {
       output_price_credits: outputPrice,
       cache_read_price_credits: cacheReadPrice,
       cache_write_price_credits: cacheWritePrice,
+      pricing_mode: pricingMode,
     },
     lifecycle,
   };

--- a/deploy/litellm/config.yaml
+++ b/deploy/litellm/config.yaml
@@ -159,6 +159,54 @@ model_list:
     model_info:
       mode: audio_speech
 
+  # ── 8. Task-aware router (paid; billed at ACTUAL per-request cost) ──────────
+  # Backs the `openrouter-auto` alias. openrouter/auto-beta is a ROUTER: it
+  # picks a different upstream model per request, so OpenRouter reports
+  # `prompt: -1, completion: -1` for it and there is no catalog price to charge
+  # against. The alias is therefore priced `upstream_actual` in model_aliases,
+  # and settlement reads the cost OpenRouter reports for each generation.
+  #
+  # Three things here are load-bearing, not decoration.
+  #
+  # 1. `usage.include` is what makes OpenRouter report the cost at all. Without
+  #    it every request settles through the fail-closed path and gets charged
+  #    the full hold. It is set here rather than left to the client so the
+  #    charge does not depend on what a caller happened to send. Verified
+  #    2026-08-22 that `drop_params: true` does NOT strip it.
+  #
+  # 2. `provider.max_price` bounds what one request can cost us, in USD per
+  #    MILLION tokens. OpenRouter's auto-router documentation confirms it still
+  #    applies to the router, enforced after it resolves a model, and that a
+  #    breach fails the request rather than routing to a pricier endpoint. That
+  #    bound is what makes the credit hold defensible instead of a guess; the
+  #    hold in the migration is derived from these exact numbers.
+  #
+  # 3. The model is a LITERAL, not `os.environ/..._MODEL` like every other
+  #    OpenRouter route here. Issue #689 is what an env var costs on a priced
+  #    route: the catalog priced one model while the deployment quietly called
+  #    another. For an alias billed at actual cost the slug IS the product
+  #    decision, and it must not be repointable without a code review.
+  #
+  # Deliberately absent from `fallbacks:` below. A fallback to a fixed-price
+  # route would settle this alias against a provider that never reports a
+  # per-request cost, which is the free-serve shape it exists to avoid.
+  # The doubled prefix is correct and matches every other OpenRouter entry
+  # here: LiteLLM strips the leading `openrouter/` as its provider selector and
+  # forwards the rest, so this sends the slug `openrouter/auto-beta` upstream.
+  # Compare `openrouter/openai/gpt-4o-mini` above, which reaches OpenRouter as
+  # `openai/gpt-4o-mini`. Verified against a live LiteLLM on 2026-08-22.
+  - model_name: route-openrouter-auto-beta
+    litellm_params:
+      model: openrouter/openrouter/auto-beta
+      api_key: os.environ/OPENROUTER_API_KEY
+      extra_body:
+        usage:
+          include: true
+        provider:
+          max_price:
+            prompt: 3
+            completion: 15
+
 
 # Retry each upstream call up to 3 times before falling back to another group.
 # Covers 429/5xx automatically. `fallbacks:` kicks in only after retries

--- a/supabase/migrations/20260822_30_openrouter_auto_variable_pricing.sql
+++ b/supabase/migrations/20260822_30_openrouter_auto_variable_pricing.sql
@@ -1,0 +1,237 @@
+-- openrouter-auto: an alias billed at ACTUAL upstream cost, not a catalog price.
+--
+-- `openrouter/auto-beta` is a router. It picks a different upstream model per
+-- request, so OpenRouter's models endpoint reports `prompt: -1, completion: -1`
+-- for it: the price is variable by construction. Every other alias in this
+-- catalog carries one fixed input/output price pair and both the credit hold
+-- and the settled charge are derived from it, so any single number written into
+-- those columns for this alias would be wrong on nearly every request. The
+-- owner chose to bill the real per-request cost rather than a fixed ceiling.
+--
+-- Why the price columns go NULL rather than 0
+-- ───────────────────────────────────────────
+-- 0 is not a free slot. It is already meaningful: routing.Service refuses an
+-- alias whose input and output prices are both zero (ErrAliasNotPriced, issue
+-- #617), and metering's RouteInfo.HasCostBasis reads the same condition. Worse,
+-- a price that is silently 0 is exactly the shape that billed nothing for three
+-- days in July. NULL is chosen because the Go readers scan these columns into
+-- NON-POINTER int64, so a NULL is a hard pgx scan error: any reader that was
+-- not taught about variable pricing fails loudly and closed instead of quietly
+-- charging zero. That property is the point of the choice, not a side effect.
+--
+-- The shape CHECK below is what stops the two halves drifting apart, so a row
+-- cannot claim a fixed price and carry none, or claim variable pricing and
+-- carry a stale number nobody reads.
+--
+-- Related decisions: D-031 (credits per million, math/big, round half up),
+-- D-032 (one model one price at the alias level -- this adds one explicitly
+-- discriminated exception rather than revoking it), D-034 (money path fails
+-- closed).
+
+-- ─── 1. Pricing mode discriminator ──────────────────────────────────────────
+
+alter table public.model_aliases
+    add column if not exists pricing_mode text not null default 'fixed';
+
+alter table public.model_aliases
+    add column if not exists reservation_estimate_credits bigint;
+
+comment on column public.model_aliases.pricing_mode is
+    'How a request against this alias is priced. fixed: input_price_credits / output_price_credits are authoritative, the historical and default behaviour. upstream_actual: the price is variable per request and the charge is derived from the cost the upstream reports for that generation, so the price columns are NULL and must not be read.';
+
+comment on column public.model_aliases.reservation_estimate_credits is
+    'Credit hold taken up front for an upstream_actual alias, where no catalog price exists to derive one from. NULL for fixed aliases, which size their hold from the endpoint default.';
+
+-- Idempotent: a re-applied migration must not fail on an existing constraint.
+alter table public.model_aliases
+    drop constraint if exists model_aliases_pricing_mode_allowed;
+
+alter table public.model_aliases
+    add constraint model_aliases_pricing_mode_allowed
+    check (pricing_mode in ('fixed', 'upstream_actual'));
+
+-- ─── 2. Prices become nullable, but only for the variable mode ──────────────
+
+alter table public.model_aliases
+    alter column input_price_credits drop not null;
+
+alter table public.model_aliases
+    alter column output_price_credits drop not null;
+
+-- The NOT NULL constraints just dropped are re-imposed by this CHECK for every
+-- row that is still priced the ordinary way, so relaxing the column does NOT
+-- relax the invariant for the 'fixed' aliases. It only carves out the one mode
+-- that genuinely has no price to record.
+alter table public.model_aliases
+    drop constraint if exists model_aliases_pricing_mode_shape;
+
+alter table public.model_aliases
+    add constraint model_aliases_pricing_mode_shape
+    check (
+        (
+            pricing_mode = 'fixed'
+            and input_price_credits is not null
+            and output_price_credits is not null
+            and reservation_estimate_credits is null
+        )
+        or (
+            pricing_mode = 'upstream_actual'
+            and input_price_credits is null
+            and output_price_credits is null
+            and reservation_estimate_credits is not null
+            and reservation_estimate_credits > 0
+        )
+    );
+
+-- ─── 3. The alias ───────────────────────────────────────────────────────────
+--
+-- Reservation hold: 200000 credits, i.e. 2.00 USD-equivalent at
+-- payments.CreditsPerUSD = 100000. Derivation, so a later reader can argue with
+-- the number instead of guessing at it:
+--
+--   The LiteLLM route sets provider.max_price, which OpenRouter's auto-router
+--   documentation confirms still applies to the router and is enforced after it
+--   resolves a model, failing the request rather than silently routing to a
+--   pricier endpoint. With the ceiling set at 3.00 / 15.00 USD per million
+--   prompt / completion tokens, a request of roughly 30k prompt and 4k
+--   completion tokens costs at most 0.03 * 3 + 0.004 * 15 = 0.15 USD, times the
+--   1.4 margin = 0.21 USD = 21000 credits. The hold is set an order of
+--   magnitude above that envelope so ordinary traffic is never refused for an
+--   under-sized hold, while still being a real solvency gate: control-plane
+--   refuses the reservation outright when it exceeds available credits
+--   (enforcePolicy, PolicyModeStrict).
+--
+--   The hold is NOT a price and is never charged as one. Settlement releases
+--   the whole hold and posts the real cost as the charge.
+--
+-- display_name is the owner's verbatim string. alias_id is a slug because
+-- alias_id is what a client sends in the OpenAI-compatible `model` field, where
+-- spaces and parentheses are hostile.
+
+insert into public.model_aliases (
+    alias_id,
+    owned_by,
+    display_name,
+    summary,
+    visibility,
+    lifecycle,
+    capability_badges,
+    input_price_credits,
+    output_price_credits,
+    price_unit,
+    pricing_mode,
+    reservation_estimate_credits
+) values (
+    'openrouter-auto',
+    'hive',
+    'Openrouter Auto (Task Aware)',
+    'Task-aware routing that selects a model per request. Billed at actual usage.',
+    'public',
+    'stable',
+    '["chat","responses","tools","reasoning","vision","task-aware"]'::jsonb,
+    null,
+    null,
+    'tokens',
+    'upstream_actual',
+    200000
+)
+on conflict (alias_id) do nothing;
+
+-- ─── 4. Route ───────────────────────────────────────────────────────────────
+--
+-- litellm_model_name is deliberately NOT 'route-openrouter-auto': that name is
+-- already taken in deploy/litellm/config.yaml by the vision route for the
+-- hive-auto alias, which resolves to a completely different model.
+--
+-- provider_model is the literal slug, not an env var. Every other OpenRouter
+-- route in config.yaml resolves its model from `os.environ/..._MODEL`, and
+-- issue #689 is what that costs: the catalog priced one model while the
+-- deployment silently called another. For an alias billed at actual cost the
+-- slug IS the product decision, and an env var would let a deployment repoint a
+-- variable-cost alias at some other model with nothing to notice.
+
+insert into public.provider_routes (
+    route_id,
+    alias_id,
+    provider,
+    provider_model,
+    litellm_model_name,
+    price_class,
+    health_state,
+    priority
+) values (
+    'route-openrouter-auto-beta',
+    'openrouter-auto',
+    'openrouter',
+    -- Doubled prefix on purpose, matching every other OpenRouter row here
+    -- (compare 'openrouter/openai/gpt-4o-mini'): LiteLLM strips the leading
+    -- 'openrouter/' as its provider selector and forwards 'openrouter/auto-beta'
+    -- upstream. This column is compared verbatim against LiteLLM's resolved
+    -- litellm_params.model by the deploy-box price assertion, so it has to be
+    -- the LiteLLM string rather than the bare OpenRouter slug.
+    'openrouter/openrouter/auto-beta',
+    'route-openrouter-auto-beta',
+    'premium',
+    'healthy',
+    10
+)
+on conflict (route_id) do nothing;
+
+-- Capabilities as reported by OpenRouter for openrouter/auto-beta, verified
+-- against https://openrouter.ai/api/v1/models on 2026-08-22: 2000000 context,
+-- text/image/audio/file/video input, text and image output, and support for
+-- tools, tool_choice, response_format, structured_outputs, reasoning,
+-- reasoning_effort and web_search_options.
+--
+-- supports_embeddings is false: the auto router is a chat router and OpenRouter
+-- exposes no embedding models through it. Cache read/write are left false
+-- because caching behaviour depends on whichever model the router picks, and
+-- claiming a capability the request may not get is worse than not claiming it.
+insert into public.provider_capabilities (
+    route_id,
+    supports_responses,
+    supports_chat_completions,
+    supports_completions,
+    supports_embeddings,
+    supports_streaming,
+    supports_reasoning,
+    supports_cache_read,
+    supports_cache_write,
+    tools_supported
+) values (
+    'route-openrouter-auto-beta',
+    true,
+    true,
+    true,
+    false,
+    true,
+    true,
+    false,
+    false,
+    true
+)
+on conflict (route_id) do nothing;
+
+-- Pinned to the single route. There is deliberately no fallback: a fallback to
+-- a fixed-price route would settle an upstream_actual alias against a provider
+-- that never reports a per-request cost, which is precisely the free-serve
+-- shape this alias must not have.
+insert into public.alias_route_policies (
+    alias_id,
+    policy_mode,
+    allow_price_class_widening,
+    fallback_order
+) values (
+    'openrouter-auto',
+    'pinned',
+    false,
+    '["route-openrouter-auto-beta"]'::jsonb
+)
+on conflict (alias_id) do nothing;
+
+-- allowed_group_names defaults to ["default"], so a default-tier API key never
+-- sees an alias unless it is in the `default` group. Same gap the voice
+-- migration (20260717_02) documented.
+insert into public.model_policy_group_members (group_name, alias_id)
+values ('default', 'openrouter-auto')
+on conflict (group_name, alias_id) do nothing;

--- a/supabase/migrations/20260822_30_openrouter_auto_variable_pricing.sql
+++ b/supabase/migrations/20260822_30_openrouter_auto_variable_pricing.sql
@@ -1,5 +1,20 @@
 -- openrouter-auto: an alias billed at ACTUAL upstream cost, not a catalog price.
 --
+-- Wrapped in a single transaction because this file drops NOT NULL from two
+-- columns several statements before the CHECK that re-imposes the invariant.
+-- Under `supabase db push` that window never exists, but this repo also applies
+-- migrations by hand with psql, which autocommits per statement, and an abort
+-- in between would leave the table accepting a `fixed` row with NULL prices,
+-- which is the exact state this design exists to prevent.
+--
+-- lock_timeout because model_aliases is read once per route selection, so once
+-- per request. Each statement here is microseconds against a single-digit-row
+-- table, but an ACCESS EXCLUSIVE request that queues behind one long-running
+-- reader blocks every reader that arrives after it. Failing fast is better than
+-- stalling the gateway.
+begin;
+set local lock_timeout = '5s';
+--
 -- `openrouter/auto-beta` is a router. It picks a different upstream model per
 -- request, so OpenRouter's models endpoint reports `prompt: -1, completion: -1`
 -- for it: the price is variable by construction. Every other alias in this
@@ -78,6 +93,11 @@ alter table public.model_aliases
             pricing_mode = 'upstream_actual'
             and input_price_credits is null
             and output_price_credits is null
+            -- The cache columns are covered too. They are serialized onto the
+            -- catalog surface, so a stale number left in either would be shown
+            -- as this alias's price even though nothing charges from it.
+            and cache_read_price_credits is null
+            and cache_write_price_credits is null
             and reservation_estimate_credits is not null
             and reservation_estimate_credits > 0
         )
@@ -89,17 +109,21 @@ alter table public.model_aliases
 -- payments.CreditsPerUSD = 100000. Derivation, so a later reader can argue with
 -- the number instead of guessing at it:
 --
---   The LiteLLM route sets provider.max_price, which OpenRouter's auto-router
---   documentation confirms still applies to the router and is enforced after it
---   resolves a model, failing the request rather than silently routing to a
---   pricier endpoint. With the ceiling set at 3.00 / 15.00 USD per million
---   prompt / completion tokens, a request of roughly 30k prompt and 4k
---   completion tokens costs at most 0.03 * 3 + 0.004 * 15 = 0.15 USD, times the
---   1.4 margin = 0.21 USD = 21000 credits. The hold is set an order of
---   magnitude above that envelope so ordinary traffic is never refused for an
---   under-sized hold, while still being a real solvency gate: control-plane
---   refuses the reservation outright when it exceeds available credits
---   (enforcePolicy, PolicyModeStrict).
+--   provider.max_price bounds the RATE and nothing else, so it alone does not
+--   bound one request. Both sides of the request are therefore bounded in Go
+--   before dispatch (EnforceVariablePriceBounds): 256 KiB of body, which is a
+--   rigorous upper bound of 262144 prompt tokens because a token can never be
+--   fewer than one UTF-8 byte, and 16384 completion tokens pinned onto the
+--   outbound request where a client cannot raise it.
+--
+--   At the configured 3.00 / 15.00 USD per million ceiling that worst bounded
+--   request is 144507 credits after the 1.4 margin, against this 200000 hold,
+--   leaving about 55000 credits of headroom. Those figures are not restated
+--   here as prose that can drift: TestTheHoldProvablyCoversTheWorstBoundedRequest
+--   recomputes them from this file, the LiteLLM config and the Go constants, and
+--   fails if the hold stops covering the bound. The hold is also a real
+--   solvency gate, because control-plane refuses a reservation that exceeds
+--   available credits (enforcePolicy, PolicyModeStrict).
 --
 --   The hold is NOT a price and is never charged as one. Settlement releases
 --   the whole hold and posts the real cost as the charge.
@@ -126,7 +150,24 @@ insert into public.model_aliases (
     'hive',
     'Openrouter Auto (Task Aware)',
     'Task-aware routing that selects a model per request. Billed at actual usage.',
-    'public',
+    -- `internal`, NOT `public`, and this is deliberate on two counts.
+    --
+    -- Deployment ordering: deploy-demo-box.yml has `deploy: needs: migrate`, so
+    -- this row lands while the PREVIOUS control-plane binary is still serving,
+    -- and that binary scans the price columns into non-pointer int64. The
+    -- readers are list queries, so one NULL-priced row would fail the scan for
+    -- the whole list and take /v1/models down for every model until the new
+    -- image arrived. ListPublicAliases filters `visibility IN ('public',
+    -- 'preview')`, so an `internal` row is simply not selected and the window
+    -- closes.
+    --
+    -- Correctness: this alias cannot bill correctly until the LiteLLM pin moves
+    -- off v1.77.7-stable, which destroys the reported cost on the streaming
+    -- path. Until then every streamed request would take the fail-closed branch
+    -- and be charged the hold. Flipping this to 'public' is a one-line
+    -- follow-up migration, to be applied only after the pin bump has landed and
+    -- been validated on the box.
+    'internal',
     'stable',
     '["chat","responses","tools","reasoning","vision","task-aware"]'::jsonb,
     null,
@@ -135,7 +176,21 @@ insert into public.model_aliases (
     'upstream_actual',
     200000
 )
-on conflict (alias_id) do nothing;
+on conflict (alias_id) do update set
+    -- `do nothing` is the right instinct for idempotency and the wrong one for
+    -- the money columns. If any concurrent same-day migration seeded
+    -- `openrouter-auto` first, in the default `fixed` mode with some price,
+    -- `do nothing` would leave a variable-cost router billed at a fixed price,
+    -- with the route row, the LiteLLM entry and the settlement branch all still
+    -- treating it as variable, and no error anywhere. These four columns are
+    -- the ones a wrong value silently misprices, so they converge on re-run
+    -- instead. Display name and summary are deliberately NOT updated: those may
+    -- have been retuned since and this migration has no business reverting
+    -- them, which is the reason the other seed migrations use `do nothing`.
+    pricing_mode                 = excluded.pricing_mode,
+    input_price_credits          = excluded.input_price_credits,
+    output_price_credits         = excluded.output_price_credits,
+    reservation_estimate_credits = excluded.reservation_estimate_credits;
 
 -- ─── 4. Route ───────────────────────────────────────────────────────────────
 --
@@ -235,3 +290,5 @@ on conflict (alias_id) do nothing;
 insert into public.model_policy_group_members (group_name, alias_id)
 values ('default', 'openrouter-auto')
 on conflict (group_name, alias_id) do nothing;
+
+commit;


### PR DESCRIPTION
Adds the customer-facing alias `openrouter-auto` ("Openrouter Auto (Task Aware)") routed to OpenRouter `openrouter/auto-beta`, and bills it at the ACTUAL per-request upstream cost rather than a fixed catalog price. The owner chose actual cost explicitly when the alternative offered was a fixed ceiling price.

`auto-beta` is a router. It picks a different upstream model per request, so OpenRouter's models endpoint reports `prompt: -1, completion: -1` for it. Our `model_aliases` table carries one fixed input/output price pair per alias and both the credit hold and the settled charge derive from it, so any single number written into those columns is wrong on nearly every request.

## This alias does not work in chat until the LiteLLM pin moves

Stated up front because it changes how this PR should be read.

Measured, not inferred: on the pinned `v1.77.7-stable`, the STREAMING terminal usage chunk carries no cost at all. LiteLLM reconstructs the usage object from its own schema and drops unknown keys. Chat through Open WebUI streams, so on today's pin every streamed request against this alias takes the fail-closed path and is charged the hold.

The pin bump to `v1.98.0` lands as its own small, independently revertible PR with live on-box evidence. Merge order: the deploy agent's `deploy/docker/` work, then the pin bump, then this.

## What was PROVED versus INFERRED

Separated deliberately so a later reader can tell which claims were measured.

**PROVED** by standing the real LiteLLM images up against a fake OpenRouter returning a known cost of `0.0123456`, and observing both directions:

| Version | sync `usage.cost` | streaming `usage.cost` | `gen-` id |
|---|---|---|---|
| `v1.77.7-stable` (current pin) | preserved | DESTROYED | preserved |
| `v1.83.14-stable` (newest tagged stable) | preserved | DESTROYED | preserved |
| `v1.98.0` (immutable tag, not a `-stable` release) | preserved | preserved | preserved |

Also proved: `usage: {include: true}` reaches the provider even with `drop_params: true` set, both when injected via config `extra_body` and when sent by a client. The repo's real `deploy/litellm/config.yaml` boots on `v1.98.0` and resolves all 9 routes to the same models. LiteLLM strips the leading `openrouter/` as its provider selector, which is why both the config and `provider_model` carry the doubled prefix.

**INFERRED**, and still needing real providers to confirm:

- That `openrouter/auto-beta` behaves in production the way the fake modelled it, in particular that it returns a `cost` on every successful generation.
- That `provider.max_price` genuinely bounds the rate in practice. This comes from OpenRouter's auto-router documentation, which states the ceiling still applies to the router and is enforced after it resolves a model, failing the request rather than routing to a pricier endpoint. Not measured by me.
- The 200000 credit hold is derived from that documented ceiling, so it inherits the same status.

## The proxy-cost trap, and why the warning is written as a rule

`x-litellm-response-cost` looks authoritative and is not. On `v1.77.7-stable` it returned `0.0105` against a real `0.0123456`: LiteLLM's own static price-map guess ($3/$15 per million) for a router model it cannot price.

Those numbers are version-specific. By `v1.83.14` that header returns the provider figure on the sync path. Stating the trap as permanent would read as wrong to anyone checking on a newer version, and a warning that reads as wrong gets ignored along with everything near it. The durable rule, which is what is written into `upstream_cost.go` where someone would reach for it:

> Never take a cost from a proxy-computed field when a provider-reported one is available. The proxy falls back silently to its own price map, and a router model has no entry in it.

A third instance of the same family: on a streaming request `v1.83.14` returns `x-litellm-response-cost-original: 0.0`. A confident zero is worse than an absent value, because an absent value can be caught and a zero bills nothing. That is exactly the shape that served this gateway free for three days in July, and it is why the parser here reports "zero" and "absent" as two different errors.

## Invariants, and where each is proved

Every test below was verified to FAIL when the behaviour it guards is broken. That is not a claim: 13 mutations were applied to the implementation and all 13 killed their test. Results are in the review comments.

**1. A request must NEVER settle at zero because the cost lookup failed, returned null, or was not attempted.**
`UpstreamActualSettlement` returns the full hold, flagged unconfirmed, for every failure shape. The only path that charges zero is the one where nothing was produced at all. `TestFreeServeGuardNeverSettlesAtZero` covers the three cases as three separate cases: the lookup returns null, the lookup errors on an unreadable body, and the lookup never happened because the stream ended before the usage frame arrived. That third one is what a timeout looks like here: the cost is carried in band, so there is no separate call to time out, and an aborted stream simply leaves no bytes. Testing it as "no bytes" is the honest mapping rather than inventing a network timeout. Mutation M1 (return 0 instead of the hold) kills it.

**2. A request must never settle below what the upstream charged plus margin.**
`CreditsForUpstreamCost` is cost x 7/5 x 100000, and `TestCreditsForUpstreamCostMagnitude` asserts exact figures against a known cost, never "greater than zero", because a non-zero assertion is satisfied by the 1-credit floor. Mutations M2 (drop the margin) and M3 (truncate instead of rounding half up) both kill it.

**3. The reservation must never under-reserve.**
The hold comes from the catalog row (200000) rather than the flat endpoint default (10000), on all four dispatch paths including the Open WebUI chat path, with the endpoint default as a floor so it can only ever raise a hold. `enforcePolicy` under `PolicyModeStrict` then refuses when the hold exceeds available credits. `TestReservationCreditsCannotUnderReserve` and the end-to-end hold assertion cover it; mutations M4 and W2 kill them.

Stated honestly rather than papered over: a CONFIRMED settlement bills in full past the hold by existing deliberate design (`finalizeLocked`), so a request costing more than the hold can still take a balance negative. That is true of every alias today and is not introduced here. What is new is that `provider.max_price` bounds the rate, so the overshoot is finite rather than unbounded.

**4. Settlement is idempotent and the ledger stays append only.**
Unchanged. Everything still routes through `finalizeLocked`, which already guarantees this with a terminal-status guard, a per-account lock and ledger idempotency keys. This PR adds no new settlement path and no new ledger write.

**5. All arithmetic uses math/big, never float64.**
`ParseUpstreamCost` reads the cost as `json.Number` and hands the literal to `big.Rat`, so no binary float touches a money figure. `TestParseUpstreamCostReadsCostExactlyAndCapturesAuditHandles` uses a decimal whose float64 round-trip does not compare equal; mutation M6 (parse via `Float64()`) kills it.

**6. Provider-blind errors, and the chosen model never reaches the customer.**
The tension the brief named is handled on both sides. Internally: the upstream generation id (`gen-...`) is recorded as the audit handle, which is what lets anyone recover the exact model OpenRouter chose. Externally: the cost is parsed out of the raw bytes into a private struct and never added to `UsageResponse`, because the `normalize*` functions re-marshal that struct straight to the customer. `TestVariablePriceStreaming_LeaksNeitherCostNorChosenModelToTheClient` asserts the client body contains the completion text but none of the chosen model, the provider, the cost value, or the cost fields. Mutation W3 (remove the alias overwrite) kills it.

Per the owner's decision, the alias NAME deliberately identifies the provider, so no machinery hides the string "openrouter" there. Error messages remain provider-blind.

## Schema

Prices go NULL rather than 0 because 0 is already meaningful: `routing.Service` refuses an alias whose prices are both zero, and `RouteInfo.HasCostBasis` reads the same condition. The Go readers scan these columns into non-pointer `int64`, so a NULL is a hard pgx scan error and any reader not taught about variable pricing fails loudly and closed rather than charging zero. A CHECK binds `pricing_mode`, the prices and the hold together so the database itself refuses an inconsistent row.

One correction to a claim I made earlier and want on the record: changing `CatalogPricing` to pointers does NOT make the compiler enumerate every reader. It enumerated the readers inside control-plane, but edge-api has its own parallel structs decoded from JSON across an HTTP boundary, where a mismatch surfaces as a runtime decode failure instead. Those were found and updated by hand. `apps/edge-api/internal/catalog/client.go` mattered most: it backs the `/v1/models` snapshot, so one nulled alias decoding into a plain `int64` would have taken down model listing for every model.

## Two places a nulled price would have gone unnoticed

- The deploy-box price assertion filtered on `input_price_credits > 0`. `NULL > 0` is NULL, not true, so this route would have dropped out of the guard silently while the check went on reporting green. It needs that assertion more than a fixed-price route does, not less. The predicate now names the mode.
- `apps/web-console/lib/control-plane/client.ts` coerced a missing price to 0 with `?? 0`, which rendered a variable-price alias as free in the admin catalog. It now carries null through and the table shows "Variable".

## Tension with D-032

D-032 says one model, one price, at the alias level, and that simplicity wins. `openrouter-auto` is deliberately not one model. This does not revoke D-032: it adds one explicitly discriminated exception, and the discriminator is what keeps every existing fixed-price alias on exactly the path D-032 describes. Keying settlement on the alias's pricing mode rather than on the provider also means a second variable-cost upstream arrives later as a catalog row rather than a code change.

## Known dependency

`deploy/docker/docker-compose.yml` seeds `deploy/litellm/config.yaml` into a named volume only `if [ ! -f /etc/litellm/config.yaml ]`, so the route added here is inert on a box that already has the volume. That defect is owned by the agent working on `deploy/docker/` and is referenced here so the dependency is visible.

## Verification

- `go build` and `go vet` clean across control-plane and edge-api.
- Full Go suites green: `go test ./apps/edge-api/... ./apps/control-plane/... -count=1 -short`.
- `npm run build` green for web-console.
- Web-console unit tests: 530 passed, 1 failed, and that one failure is pre-existing and environmental. `chat-coverage-lib.test.ts` and `control-plane-host.test.ts` resolve `REPO_ROOT` outside `/app`, which the web-console image does not contain, so they ENOENT in the container regardless of this diff. Neither touches pricing.

## What changed after review

The adversarial review found four defects that were shipping a plausible number instead of a refusal, plus a leak. All are fixed and each has its own resolved thread; the short version:

- **The hold never decoded.** `ReservationResult` read `estimated_credits`; the control plane publishes `reserved_credits`. So every fail-closed settlement charged one credit rather than the hold, which is the free-serve bug reintroduced. My own end-to-end test missed it because the mock echoed the key the struct wanted rather than the key production sends.
- **An oversized cost wrapped instead of refusing.** `big.Int.Int64()` is undefined when the value does not fit; a reported cost of 1e20 became a negative, hit the one-credit floor, and settled confirmed.
- **An unbounded numeric literal went straight to `big.Rat`**, making parse cost the caller's to choose.
- **Both streaming relays published our cost.** The chat relay forwards every frame verbatim by design, and the typed relay has a raw-line fallback that bypasses the discard it relies on. One sanitizer now serves both.
- **The Responses streaming path never captured the usage frame at all**, so a variable-price alias could only ever fail closed there.

Plus: `pricing_mode` was never populated by either catalog builder; the metering gate would have graded a variable-price request not_billable; an empty frame reported as unparseable rather than absent; the settlement-path panic is now a fail-closed return, because a panic there fires during deferred unwinding and strands the hold; and the migration now runs in one transaction with a lock timeout, converges on re-run for the money columns, and covers the cache price columns in its shape CHECK.

## Correction to two claims this PR made earlier

Both were wrong in the dangerous direction and are worth recording rather than quietly editing:

1. **"The compiler enumerates every reader."** Only inside control-plane. edge-api has parallel structs decoded from JSON across an HTTP boundary; those were found by hand.
2. **"A JSON null into a non-pointer int64 fails loudly."** False. Verified against Go's own decoder: it is a documented no-op leaving 0 with no error. The SQL boundary does fail loudly via pgx; the JSON boundary does not. That makes the pointer types load-bearing rather than defensive, because the old shape would have silently priced this alias at zero.

## Merge order

1. **#1043**, the LiteLLM pin bump. Required: on the current pin the streaming path never sees a cost, so every streamed request would fail closed. It carries live before-and-after evidence from the demo box.
2. This PR.
3. A one-line follow-up flipping the alias from `internal` to `public`.

## Visual proof

NOT captured, and the reason changed during review.

This PR no longer touches a user-visible surface. The alias is seeded `internal`, not `public`, so it does not appear in the model picker or in `/v1/models` at all. That was done to close a deploy-ordering hazard (migrations apply before the new binaries, and the old binary would fail its list-query scan on a NULL-priced public row, taking `/v1/models` down for every model), and it doubles as the gate keeping the alias unreachable until the pin bump lands.

So the picker capture belongs to the follow-up PR that flips it to `public`, and that is where it should be demanded. What that capture must show, per rule 8 and the bar set by #1007: the alias in the picker, the model answering live, and the turn recorded in `usage_events` with a charge derived from the reported cost rather than from the hold.

What does exist today, in place of a screenshot, is live evidence from the demo box that the mechanism this PR depends on works there: with the pin at `v1.98.0`, a real streamed completion on the box's OpenRouter route returned `usage.cost` of `2.05e-06`, where the current pin returns nothing. That is recorded in #1043 with the before-and-after. It is not a substitute for the picker capture and is not offered as one.

## Buglog entry

```json
{"id":"bug-2026-08-22-litellm-drops-streaming-cost","date":"2026-08-22","title":"LiteLLM v1.77.7-stable destroys OpenRouter's reported per-request cost on the streaming path","error_message":"Streaming terminal usage chunk arrives with prompt/completion/total tokens only; usage.cost and usage.cost_details present in the upstream response are absent by the time the chunk reaches edge-api","root_cause":"LiteLLM reconstructs the usage object from its own schema when relaying SSE rather than passing the provider's usage object through, so any key it does not declare is dropped. The sync path passes the same fields through untouched, which makes the gap easy to miss: a feature verified only on the non-streaming path looks correct and then bills wrong for every streamed request. Compounding trap: x-litellm-response-cost on that version returns LiteLLM's own static price-map guess (0.0105 against a real 0.0123456) rather than the provider figure, so the obvious fallback is a fabricated number on a money path.","fix":"Measured the boundary empirically with a fake OpenRouter returning a known cost: broken on v1.77.7-stable and on v1.83.14-stable (the newest tagged stable), fixed on the immutable tag v1.98.0. Pin bump tracked separately. Settlement fails closed to the full hold flagged unconfirmed when no cost can be read, so the gap can never bill zero.","tags":["billing","litellm","openrouter","streaming","money-path","free-serve","silent-data-loss"]}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added variable-pricing support for OpenRouter auto-routing.
  * Charges are based on reported upstream costs when available.
  * Added safeguards for missing, invalid, or oversized variable-price requests.
  * Added reservation estimates to help prevent under-reserving credits.
  * The model catalog now displays variable pricing clearly.

* **Bug Fixes**
  * Prevented unsupported variable-priced audio routes from being treated as free.
  * Ensured failed cost lookups charge the reserved hold instead of zero credits.
  * Added protections against exposing provider details or upstream costs in responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
