### PR TITLE
chore: pin LiteLLM to v1.98.0, which does not drop the provider's reported cost

### DIFF
--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -161,7 +161,24 @@ services:
       - gomodcache:/go/pkg/mod
 
   litellm:
-    image: ${LITELLM_IMAGE:-ghcr.io/berriai/litellm:v1.77.7-stable}
+    # Pinned by tag AND digest, matching the convention the enterprise compose
+    # file already uses. The tag is readable at review time; the digest is what
+    # makes it reproducible if the tag is ever moved.
+    #
+    # v1.98.0 is newer than v1.83.14-stable but is NOT one of LiteLLM's
+    # `-stable` releases, so it has had less soak time on the component that
+    # fronts every request. That is a real tradeoff and it is taken knowingly.
+    # The reason it is taken: on both v1.77.7-stable and v1.83.14-stable,
+    # LiteLLM reconstructs the usage object when relaying SSE and drops the
+    # provider's reported cost, so no variable-cost alias can be billed
+    # correctly on a streaming request, which is every chat turn. Measured, not
+    # read off release notes; see the PR for the matrix.
+    #
+    # Recoverable two ways if it misbehaves: it is validated on the box by
+    # setting LITELLM_IMAGE before this default moves, and LITELLM_IMAGE remains
+    # the one-variable revert afterwards, needing no PR and no redeploy of
+    # anything else.
+    image: ${LITELLM_IMAGE:-ghcr.io/berriai/litellm:v1.98.0@sha256:20b5044b619055374061a6d5b7b08754cad75aeabbf82ddf4f69cc0cf80ddaf4}
     # Fixed container name so the control-plane Docker restart API can locate
     # this container by name regardless of the Compose project name.
     container_name: litellm


### PR DESCRIPTION
One line of `deploy/docker/docker-compose.yml`: the LiteLLM image pin moves from `v1.77.7-stable` to `v1.98.0`, pinned by tag and digest together.

## Why

On the currently pinned version, LiteLLM reconstructs the usage object when relaying SSE and keeps only the keys it declares, so the provider's reported per-request cost never reaches the gateway on a streaming request. The sync path passes the same field through untouched, which is what makes this easy to miss: anything verified only on the non-streaming path looks correct and then bills wrong for every streamed turn, and every chat turn is streamed.

This blocks PR #1012, which bills a router alias at actual upstream cost. It is landing separately and first, because a proxy upgrade in front of every request deserves to be revertible on its own.

## Measured, not read off release notes

### On the live demo box, with real provider keys

The strongest evidence available, and it is a genuine before-and-after rather than a single reading. Same probe, same route (`route-deepseek-v4-flash`, the OpenRouter-backed route the box actually has), issued from inside the litellm container so no key crossed a boundary. Only the litellm container was recreated; nothing else on the box was touched.

| pin | routes resolved | sync `usage.cost` | streaming `usage.cost` |
|---|---|---|---|
| `v1.77.7-stable` (current) | 13 | 8.064e-06, present | **missing** |
| `v1.98.0` | 13 | 7.896e-06, present | **2.05e-06, present** |

All 13 routes resolved to identical models on both images. The box was restored to the repo default immediately afterwards and `chat-hive.scubed.co` answers 200; it is not sitting on an unmerged image.

### In a lab, against a fake OpenRouter returning a known cost

Run first, to establish the version boundary without spending real tokens. Fake upstream reporting exactly `0.0123456`:

| version | sync | streaming |
|---|---|---|
| `v1.77.7-stable` | preserved | DESTROYED |
| `v1.83.14-stable` (newest tagged stable) | preserved | DESTROYED |
| `v1.98.0` | preserved | preserved |

The middle row is why this is not "upgrade to the newest stable". The newest tagged stable does not carry the fix.

Also established there: `usage: {include: true}` reaches the provider even with `drop_params: true` set, both via config `extra_body` and when a client sends it; and the repo's real `deploy/litellm/config.yaml` boots on `v1.98.0` resolving all nine of its routes to the same models.

## The tradeoff, stated plainly

`v1.98.0` is newer than `v1.83.14-stable` but is **not** one of LiteLLM's `-stable` releases. It has had less soak time on the component that fronts every request. That is real and it is taken knowingly.

What makes it recoverable:

1. **On-box validation before the default moves.** Done, above: swapped, probed, restored, chat verified.
2. **`LITELLM_IMAGE` is a one-variable revert.** Setting it on the box overrides this default with no PR, no redeploy of anything else, and no code change. That is the same mechanism used to run this experiment.

## Alternatives I checked and rejected

- **Recover the cost from a response header instead, avoiding the upgrade.** Cannot work. On a streaming request `v1.83.14` returns `x-litellm-response-cost-original: 0.0`, because headers are written before the stream completes.
- **Use `x-litellm-response-cost` on the current pin.** Actively dangerous. It returns LiteLLM's own static price-map guess when it has no price for a model: `0.0105` against a real `0.0123456` in the lab. That is a fabricated number on a money path, and it looks exactly like the right answer.

## Pin format

Tag and digest together, matching the convention `docker-compose.enterprise.yml` already uses for `supabase/gotrue`, `postgrest` and `storage-api`. The tag stays readable at review time; the digest is what makes it reproducible if the tag is ever moved. The digest was read back off the image that produced the measurements above, not transcribed.

## Risk

Config-compatible: the repo config boots unchanged and resolves every route identically, verified on both the lab config and the box's live config. The blast radius is nonetheless every request through the gateway, which is why this is one line in its own PR rather than a hunk inside a pricing change.
