### PR TITLE
ci: gate demo-box deploys behind owner review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners
+*       @sakibsadmanshajib

--- a/.github/workflows/deploy-demo-box.yml
+++ b/.github/workflows/deploy-demo-box.yml
@@ -211,6 +211,7 @@ jobs:
   # ------------------------------------------------------------------
   migrate:
     name: Apply pending database migrations
+    environment: demo-box
     runs-on: [self-hosted, hive-demo]
     permissions:
       contents: read
@@ -617,6 +618,7 @@ jobs:
   deploy:
     name: Pull + recreate stack on the demo box
     needs: migrate
+    environment: demo-box
     runs-on: [self-hosted, hive-demo]
     # This job never checks out the repo, and it no longer pulls either. The
     # box's clone at /home/sakib/hive is advanced by the migrate job above,


### PR DESCRIPTION
## Summary

Environment wiring makes GitHub enforce the required-reviewer gate before any job targeting the demo box starts. CODEOWNERS routes all files to the owner for review.

## Why

Approved follow-up from the 2026-08-22 github-operating-model plan.

## What changed

- `.github/CODEOWNERS` (new): default owner `@sakibsadmanshajib` for all paths.
- `.github/workflows/deploy-demo-box.yml`: `environment: demo-box` added at job level on both `hive-demo` self-hosted jobs (`migrate`, `deploy`). Nothing else changed; `ubuntu-latest` jobs untouched.

## Test evidence

CI will validate the workflow YAML parses (verified locally with a YAML load of all five jobs). Environment `demo-box` pre-exists on the repo with required reviewer and protected-branches-only policy, so no environment provisioning needed.

## Rollback

Reverting this PR removes both changes: the job-level `environment:` keys drop out of the two demo jobs and CODEOWNERS is deleted. No other state to unwind.