### PR TITLE
fix: stand the Cowork proof job up on its own Supabase, not the deleted one

### DIFF
--- a/.github/workflows/agent-visual-proof.yml
+++ b/.github/workflows/agent-visual-proof.yml
@@ -78,7 +78,15 @@ on:
       - 'apps/edge-api/internal/agenttask/**'
       - 'deploy/apptainer/**'
       - 'deploy/docker/Caddyfile.agent-proof'
+      - 'deploy/docker/docker-compose.agent-proof.yml'
       - 'scripts/install-agent-engine-host.sh'
+      # The job stands its own Supabase up with these, so a change to any of
+      # them can break it. Without them here that break would land on main and
+      # only surface on the next unrelated pull request that happens to touch
+      # an agent path, which is the shape of the outage this job just had.
+      - 'scripts/ci-supabase-stack.sh'
+      - 'scripts/ci-throwaway-db.sh'
+      - 'scripts/generate-enterprise-jwt-keys.py'
       - '.github/workflows/agent-visual-proof.yml'
 
 # No concurrency group on purpose. GitHub holds only one run per group as
@@ -458,17 +466,43 @@ jobs:
           while IFS= read -r line; do
             [ -n "$line" ] || continue
             case "$line" in
+              # Dropped, and rewritten below to the bridge form. The script
+              # prints the localhost form, which is correct for the caller that
+              # runs everything on the runner and wrong for this job. Matching
+              # SUPABASE_URL= exactly, so SUPABASE_URL_FROM_CONTAINER= is left
+              # alone.
+              SUPABASE_URL=*) continue ;;
               *_KEY=*) echo "::add-mask::${line#*=}" ;;
             esac
             echo "$line" >> "$GITHUB_ENV"
           done < /tmp/supabase-env
 
-          # The mirrors the agent-console bundle is BUILT with. They must equal
-          # what the harness mints sessions against: @supabase/ssr names its
-          # cookie after the project ref in the URL it is given, so a bundle
-          # built with one origin cannot read a cookie written for another, and
-          # the browser lands on sign-in with a valid session in hand.
-          sed -n 's/^SUPABASE_URL=/NEXT_PUBLIC_SUPABASE_URL=/p'           /tmp/supabase-env >> "$GITHUB_ENV"
+          # ONE origin, and it has to be one, reached by three different
+          # things that do not share a network namespace:
+          #
+          #   * the Playwright browser and the seeder, on the runner
+          #   * agent-console's SERVER side, inside a container. middleware.ts
+          #     and lib/supabase/server.ts both build a client from
+          #     NEXT_PUBLIC_SUPABASE_URL and run in the container, where
+          #     localhost is the container itself. This is the difference from
+          #     ci.yml's web-e2e job, where the console is a host process and
+          #     the localhost form is right for every caller.
+          #   * agent-console's BROWSER bundle, which bakes the value at build
+          #     time, so it cannot be a per-caller override anyway.
+          #
+          # The docker bridge gateway address satisfies all three: containers
+          # route to it, and it is an interface on the runner itself, so a host
+          # process reaches the published port through it too. It also has to
+          # be a single value rather than a per-caller one because @supabase/ssr
+          # names its cookie after the project ref in the URL it is given: a
+          # bundle built with one origin cannot read a cookie written for
+          # another, and the browser then lands on sign-in holding a valid
+          # session.
+          container_url=$(sed -n 's/^SUPABASE_URL_FROM_CONTAINER=//p' /tmp/supabase-env)
+          {
+            echo "SUPABASE_URL=$container_url"
+            echo "NEXT_PUBLIC_SUPABASE_URL=$container_url"
+          } >> "$GITHUB_ENV"
           sed -n 's/^SUPABASE_ANON_KEY=/NEXT_PUBLIC_SUPABASE_ANON_KEY=/p' /tmp/supabase-env >> "$GITHUB_ENV"
 
           # What docker-compose.agent-proof.yml reads to give edge-api the one
@@ -507,11 +541,10 @@ jobs:
       - name: Start the stack with the launcher socket wired in
         working-directory: deploy/docker
         env:
-          # control-plane calls GET /auth/v1/user on SUPABASE_URL from inside a
-          # container, where localhost is the container itself. The throwaway
-          # stack publishes its gateway on the runner, so the service gets the
-          # docker bridge form of the same URL the browser uses.
-          SUPABASE_URL: ${{ env.SUPABASE_URL_FROM_CONTAINER }}
+          # SUPABASE_URL is NOT set here. It is already the docker bridge form
+          # in $GITHUB_ENV, which is what control-plane needs for its
+          # GET /auth/v1/user call from inside a container, and a second source
+          # of truth for one value is how the two drift.
           # SUPABASE_SERVICE_ROLE_KEY is NOT repeated here. It comes from
           # $GITHUB_ENV, written by the throwaway stack step, and a step-level
           # entry would override that with the deleted hosted project's key.

--- a/.github/workflows/agent-visual-proof.yml
+++ b/.github/workflows/agent-visual-proof.yml
@@ -117,17 +117,30 @@ jobs:
       pull-requests: write
     env:
       COMPOSE_PROFILES: local
-      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-      SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
-      # Without both of these edge-api logs "phase-19 JWT auth wiring
-      # skipped" at boot and then answers 403 to every Supabase-JWT caller,
-      # which the console renders as "the agent workspace is turned off for
-      # your organization": a real page, and proof of nothing. Measured in
-      # run 31819555736, where the token carried the right tenant and
-      # control-plane reported the gate on. Derived from SUPABASE_URL rather
-      # than added as two more secrets, since both are public URLs.
-      SUPABASE_JWT_ISSUER: ${{ secrets.SUPABASE_URL }}/auth/v1
-      SUPABASE_JWKS_URL: ${{ secrets.SUPABASE_URL }}/auth/v1/.well-known/jwks.json
+      # Every compose call in this job has to resolve the SAME project, and
+      # there are nine of them. A step that resolves a different file set
+      # resolves a different project, reads a stack missing services and
+      # reports on it; the teardown step, which also passes --remove-orphans,
+      # would delete what it does not know about. One environment variable is
+      # what keeps them identical, rather than nine hand-copied flag lists.
+      # docker-compose.override.yml is named explicitly because setting
+      # COMPOSE_FILE stops compose auto-loading it, and it is what every
+      # previous run of this job resolved.
+      COMPOSE_FILE: docker-compose.yml:docker-compose.override.yml:docker-compose.agent-proof.yml
+      # SUPABASE_URL, SUPABASE_ANON_KEY, SUPABASE_SERVICE_ROLE_KEY, the two
+      # NEXT_PUBLIC_ mirrors, SUPABASE_JWT_ISSUER and SUPABASE_JWKS_URL are
+      # deliberately NOT job-level entries.
+      #
+      # They used to name the hosted Supabase project, and that project is
+      # gone: it was deleted during the move to the self-hosted data plane, so
+      # from 2026-08-19 every run of this job on every branch failed with
+      # control-plane's "database unreachable" after the pooler answered
+      # "tenant or user not found". The job now stands up its own Postgres,
+      # GoTrue and PostgREST and writes all seven values to $GITHUB_ENV, and a
+      # job-level entry TAKES PRECEDENCE over what a step writes there, so
+      # naming one here would silently point the stack, the browser and the
+      # fixture seeder back at a project that no longer exists. Same reasoning,
+      # and the same trap, as ci.yml's web-e2e job.
       REDIS_URL: redis://redis:6379/0
       CONTROL_PLANE_PORT: '8081'
       CONTROL_PLANE_BASE_URL: http://localhost:8081
@@ -154,8 +167,6 @@ jobs:
       S3_USE_SSL: 'true'
       S3_BUCKET_FILES: ${{ secrets.S3_BUCKET_FILES }}
       S3_BUCKET_IMAGES: ${{ secrets.S3_BUCKET_IMAGES }}
-      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
-      NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
       # The console's browser fetches must stay same-origin: edge-api serves
       # no CORS headers. Empty means relative, which is what the shipped
       # image is built with; Caddyfile.agent-proof is the same-origin front.
@@ -368,32 +379,117 @@ jobs:
           apptainer exec "$sif" /bin/true
           echo "rootless apptainer exec of the shipped image: ok"
 
-      - name: Reconstruct SUPABASE_DB_URL
-        env:
-          SUPABASE_DB_HOST: ${{ secrets.SUPABASE_DB_HOST }}
-          SUPABASE_DB_PORT: ${{ secrets.SUPABASE_DB_PORT }}
-          SUPABASE_DB_USER: ${{ secrets.SUPABASE_DB_USER }}
-          SUPABASE_DB_NAME: ${{ secrets.SUPABASE_DB_NAME }}
-          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+      - name: Stand up this run's own Supabase (Postgres, GoTrue, PostgREST)
+        shell: bash
         run: |
           set -euo pipefail
-          # Session-mode clients are capped at the shared project's pool_size
-          # of 15 and shared with the live demo stack, so a job that booted a
-          # stack on session mode alone could take chat-hive offline.
-          python3 scripts/derive-pooler-dsn.py --self-test
-          # Masked before it is exported. Actions masks the secrets it knows,
-          # but a DSN is a derived value it has never seen, and it carries the
-          # password inside it, so a later step that echoes the variable would
-          # print the credential in clear.
-          dsns=$(python3 scripts/derive-pooler-dsn.py \
-            --host "$SUPABASE_DB_HOST" --port "$SUPABASE_DB_PORT" \
-            --user "$SUPABASE_DB_USER" --dbname "$SUPABASE_DB_NAME" \
-            --password "$SUPABASE_DB_PASSWORD")
+          # The hosted runner image already ships psql, so the usual case is a
+          # no-op. apt is the bounded fallback, for the same reason ci.yml's
+          # web-e2e job bounds it: an unbounded apt hung there for a whole job
+          # budget and emitted nothing, and a hang that produces no evidence is
+          # worse than a failure that does.
+          if ! command -v psql >/dev/null; then
+            for attempt in 1 2 3; do
+              if sudo timeout 180 apt-get update -qq \
+                 && sudo timeout 180 apt-get install -y -qq postgresql-client; then
+                break
+              fi
+              echo "::warning::apt attempt $attempt failed or timed out, retrying"
+              sleep 10
+            done
+          fi
+          if ! command -v psql >/dev/null; then
+            echo "::error::psql is unavailable and apt could not install it"
+            exit 1
+          fi
+
+          # Same image and tag ci.yml's go-tests and web-e2e jobs already use,
+          # so there is one throwaway-Postgres approach in this repository
+          # rather than a third.
+          docker run -d --name hive-ci-db -p 5432:5432 \
+            -e POSTGRES_PASSWORD=postgres \
+            -e POSTGRES_DB=hive_ci \
+            pgvector/pgvector:pg17
+          for _ in $(seq 1 90); do
+            if docker exec hive-ci-db pg_isready -U postgres -h 127.0.0.1 >/dev/null 2>&1; then
+              break
+            fi
+            sleep 2
+          done
+          if ! docker exec hive-ci-db pg_isready -U postgres -h 127.0.0.1; then
+            echo "::error::the throwaway Postgres never became ready"
+            docker logs hive-ci-db | tail -40
+            exit 1
+          fi
+
+          export PGHOST=127.0.0.1 PGPORT=5432 PGUSER=postgres \
+                 PGPASSWORD=postgres PGDATABASE=hive_ci
+
+          # A database alone is not enough, and the coupling is not separable.
+          # The fixture seeder below talks supabase-js (auth.admin.createUser
+          # against /auth/v1, .from(table) against /rest/v1), the harness signs
+          # a browser in through @supabase/ssr, and GoTrue's custom access
+          # token hook (20260516_07) runs INSIDE the database holding the user
+          # rows and raises no_active_membership for a user with no tenant_users
+          # row. Cloud auth over a local database therefore fails every login;
+          # it is all or nothing per job.
+          #
+          # --jwks-tls-ca is what this job needs beyond web-e2e: edge-api
+          # validates browser tokens against a JWKS document and refuses both a
+          # plain http URL and an empty key set, so the stack script signs with
+          # an EC key and fronts the endpoint with real TLS. See the "JWKS over
+          # TLS" section in that script.
+          ca_dir="$RUNNER_TEMP/supabase-ca"
+          scripts/ci-supabase-stack.sh --port 9000 \
+            --jwks-tls-ca "$ca_dir/root.crt" > /tmp/supabase-env
+
+          # set -e covers a non-zero exit and nothing covers a zero exit with
+          # truncated stdout: the loop below succeeds on an empty file and the
+          # job then dies inside the stack boot with an unset SUPABASE_URL,
+          # several steps from the cause.
+          for v in SUPABASE_URL SUPABASE_ANON_KEY SUPABASE_SERVICE_ROLE_KEY \
+                   SUPABASE_URL_FROM_CONTAINER SUPABASE_JWT_ISSUER \
+                   SUPABASE_JWKS_URL SUPABASE_JWKS_HOST SUPABASE_JWKS_HOST_IP; do
+            if ! grep -q "^$v=." /tmp/supabase-env; then
+              echo "::error::the throwaway Supabase stack printed no $v line"
+              exit 1
+            fi
+          done
           while IFS= read -r line; do
-            [ -z "$line" ] && continue
-            echo "::add-mask::${line#*=}"
+            [ -n "$line" ] || continue
+            case "$line" in
+              *_KEY=*) echo "::add-mask::${line#*=}" ;;
+            esac
             echo "$line" >> "$GITHUB_ENV"
-          done <<<"$dsns"
+          done < /tmp/supabase-env
+
+          # The mirrors the agent-console bundle is BUILT with. They must equal
+          # what the harness mints sessions against: @supabase/ssr names its
+          # cookie after the project ref in the URL it is given, so a bundle
+          # built with one origin cannot read a cookie written for another, and
+          # the browser lands on sign-in with a valid session in hand.
+          sed -n 's/^SUPABASE_URL=/NEXT_PUBLIC_SUPABASE_URL=/p'           /tmp/supabase-env >> "$GITHUB_ENV"
+          sed -n 's/^SUPABASE_ANON_KEY=/NEXT_PUBLIC_SUPABASE_ANON_KEY=/p' /tmp/supabase-env >> "$GITHUB_ENV"
+
+          # What docker-compose.agent-proof.yml reads to give edge-api the one
+          # certificate it needs and the name to reach the TLS front by.
+          {
+            echo "PROOF_SUPABASE_CA_DIR=$ca_dir"
+            sed -n 's/^SUPABASE_JWKS_HOST=/PROOF_JWKS_HOST=/p'       /tmp/supabase-env
+            sed -n 's/^SUPABASE_JWKS_HOST_IP=/PROOF_JWKS_HOST_IP=/p' /tmp/supabase-env
+          } >> "$GITHUB_ENV"
+
+          # The address a compose container reaches this database on. localhost
+          # inside those containers is the container itself; the docker0
+          # gateway is routable from every bridge network compose creates.
+          gw=$(docker network inspect bridge -f '{{ (index .IPAM.Config 0).Gateway }}')
+          dsn="postgres://postgres:postgres@${gw}:5432/hive_ci?sslmode=disable"
+          echo "SUPABASE_DB_URL=$dsn" >> "$GITHUB_ENV"
+          # There is no pooler here and none is wanted. The transaction-mode
+          # DSN existed to keep this job off the shared project's 15
+          # session-mode client slots, and the job no longer touches that
+          # project at all.
+          echo "SUPABASE_DB_POOL_URL=$dsn" >> "$GITHUB_ENV"
 
       - name: Build the stack images
         run: |
@@ -411,7 +507,14 @@ jobs:
       - name: Start the stack with the launcher socket wired in
         working-directory: deploy/docker
         env:
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          # control-plane calls GET /auth/v1/user on SUPABASE_URL from inside a
+          # container, where localhost is the container itself. The throwaway
+          # stack publishes its gateway on the runner, so the service gets the
+          # docker bridge form of the same URL the browser uses.
+          SUPABASE_URL: ${{ env.SUPABASE_URL_FROM_CONTAINER }}
+          # SUPABASE_SERVICE_ROLE_KEY is NOT repeated here. It comes from
+          # $GITHUB_ENV, written by the throwaway stack step, and a step-level
+          # entry would override that with the deleted hosted project's key.
           # THE variable that matters: with it set, buildAgentEngine forwards
           # every launch to the host daemon and reads none of the path
           # variables. The directory is bind-mounted into control-plane; the
@@ -503,7 +606,9 @@ jobs:
       - name: Seed this run's fixture tenant
         working-directory: apps/web-console
         env:
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          # SUPABASE_SERVICE_ROLE_KEY is NOT repeated here. It comes from
+          # $GITHUB_ENV, written by the throwaway stack step, and a step-level
+          # entry would override that with the deleted hosted project's key.
           E2E_VERIFIED_EMAIL: e2e-verified+${{ github.run_id }}-${{ github.run_attempt }}@scubed.com.bd
           E2E_VERIFIED_PASSWORD: ${{ secrets.E2E_VERIFIED_PASSWORD }}
           E2E_UNVERIFIED_EMAIL: e2e-unverified+${{ github.run_id }}-${{ github.run_attempt }}@scubed.com.bd
@@ -570,7 +675,9 @@ jobs:
       - name: Capture the proof
         id: capture
         env:
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          # SUPABASE_SERVICE_ROLE_KEY is NOT repeated here. It comes from
+          # $GITHUB_ENV, written by the throwaway stack step, and a step-level
+          # entry would override that with the deleted hosted project's key.
           PROOF_BASE_URL: ${{ env.PROOF_ORIGIN }}
           PROOF_EMAIL: e2e-verified+${{ github.run_id }}-${{ github.run_attempt }}@scubed.com.bd
           PROOF_RUNTIME_DIR: ${{ env.RUNTIME_DIR }}

--- a/.github/workflows/agent-visual-proof.yml
+++ b/.github/workflows/agent-visual-proof.yml
@@ -123,6 +123,9 @@ jobs:
       contents: write
       actions: read
       pull-requests: write
+      # For the failure notifier at the end of this job, which is the only
+      # thing here that touches an issue.
+      issues: write
     env:
       COMPOSE_PROFILES: local
       # Every compose call in this job has to resolve the SAME project, and
@@ -845,6 +848,62 @@ jobs:
             /tmp/compose.log
           if-no-files-found: ignore
           retention-days: 5
+
+      - name: Announce a red run on the tracking issue
+        # WHY THIS EXISTS, and why this job is still not a required check.
+        #
+        # This job failed on every branch for four days and nothing said so,
+        # which is how the deleted Supabase project went unnoticed while
+        # orchestrator rule 8 still depended on the proof it produces. The
+        # property actually needed is that a red run ANNOUNCES itself, not
+        # that it gates: this is a path-gated job that boots a real sandbox,
+        # so making it required would block unrelated pull requests and turn
+        # a flaky sandbox into a merge stopper. Announcing is the cheap half
+        # of the value; gating is the expensive half nobody asked for.
+        #
+        # Excluded on a sabotage dispatch on purpose. That arm is the job's
+        # own negative control and is SUPPOSED to go red, so paging on it
+        # would train everyone to ignore this issue, which is the same
+        # failure as the silence it replaces.
+        if: failure() && github.event.inputs.sabotage != 'true'
+        # Never let the notifier change the job's verdict. `if: failure()`
+        # already means it cannot turn a green run red, and this plus the
+        # `|| true` below mean a GitHub API hiccup cannot turn a red run into
+        # a differently-red run that hides the real failing step.
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TITLE: agent visual proof is failing
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -uo pipefail
+          body=$(printf '%s\n' \
+            "Run [\`${GITHUB_RUN_ID}\`](${RUN_URL}) failed on \`${GITHUB_REF_NAME}\` at commit \`${GITHUB_SHA}\`." \
+            "" \
+            "This job is deliberately not a required check, so nothing else will" \
+            "surface this. Read the run log and the uploaded failure artifacts" \
+            "before assuming it is the branch under test: when this job breaks" \
+            "repo-wide it is usually its own environment, not the change." \
+            "" \
+            "Close this by hand once a green run confirms the fix. It is not" \
+            "closed automatically, because a green run on one branch does not" \
+            "prove the job is healthy on main.")
+          # ONE issue, reused, or a bad week produces fifty and the signal
+          # drowns exactly the way the silence did.
+          #
+          # The list API rather than the search API on purpose: search is
+          # eventually consistent, and two failures minutes apart could both
+          # miss the issue the other just opened and file a duplicate.
+          num=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --limit 200 \
+                  --json number,title -q '.[] | [.number, .title] | @tsv' 2>/dev/null \
+                | awk -F'\t' -v t="$TITLE" '$2 == t { print $1; exit }')
+          if [ -n "${num:-}" ]; then
+            gh issue comment "$num" --repo "$GITHUB_REPOSITORY" --body "$body" || true
+            echo "commented on existing tracking issue #$num"
+          else
+            gh issue create --repo "$GITHUB_REPOSITORY" --title "$TITLE" --body "$body" || true
+            echo "opened the tracking issue"
+          fi
 
       - name: Tear down
         if: always()

--- a/deploy/docker/docker-compose.agent-proof.yml
+++ b/deploy/docker/docker-compose.agent-proof.yml
@@ -1,0 +1,39 @@
+# CI-only overlay for the Cowork visual proof job
+# (.github/workflows/agent-visual-proof.yml). Never deployed, and named in
+# COMPOSE_FILE by that workflow alone.
+#
+# It exists for one reason: that job now stands up its own Supabase rather than
+# borrowing a hosted project, and edge-api is the one service that needs more
+# than a URL to accept a token from it. edge-api validates every browser JWT
+# against SUPABASE_JWKS_URL and refuses a plain http one, deliberately, so the
+# throwaway stack serves its JWKS through a TLS front holding a certificate
+# from Caddy's own local authority. Trusting that authority means mounting one
+# file, and reaching the front means resolving one name, and neither can be
+# expressed as an environment variable alone.
+#
+# This lives in its own file rather than in docker-compose.yml because it is
+# meaningless anywhere else: the paths below are runner paths, created by
+# scripts/ci-supabase-stack.sh minutes earlier and destroyed with the runner.
+# Same reasoning, and the same scope, as Caddyfile.agent-proof next to it.
+#
+# The three variables are all `:?`. A missing one would otherwise mount an
+# empty path or write a hosts entry pointing nowhere, and edge-api would fail
+# its first JWKS refresh with a connection error naming none of this.
+services:
+  edge-api:
+    # The TLS front runs on the runner and is reached on a published port, so
+    # the hostname its certificate carries has to resolve to the docker bridge
+    # gateway from inside this container. A container name would not do it:
+    # the front is not part of this compose project.
+    extra_hosts:
+      - "${PROOF_JWKS_HOST:?set by the agent visual proof workflow}:${PROOF_JWKS_HOST_IP:?set by the agent visual proof workflow}"
+    environment:
+      # Narrows which authority is acceptable for the JWKS fetch, replacing the
+      # system roots for that one request rather than extending them. Chain and
+      # hostname verification still happen; this never turns them off.
+      SUPABASE_JWKS_CA_FILE: /etc/hive/supabase-ca/root.crt
+    volumes:
+      # Read only, and one directory holding one public certificate. Caddy's
+      # data directory is deliberately NOT mounted: it holds the authority's
+      # private key.
+      - ${PROOF_SUPABASE_CA_DIR:?set by the agent visual proof workflow}:/etc/hive/supabase-ca:ro

--- a/scripts/ci-supabase-stack.sh
+++ b/scripts/ci-supabase-stack.sh
@@ -63,12 +63,21 @@ db_user="${PGUSER:-postgres}"
 db_password=${PGPASSWORD:-postgres}
 network="hive-ci-supabase"
 gateway_port="9000"
+# Opt-in, and off by default so the callers that only need a browser login are
+# byte-for-byte unaffected. See the "JWKS over TLS" section further down for
+# why a second front exists and why the signing key changes shape with it.
+jwks_tls_ca=""
+jwks_tls_host="supabase-tls"
+jwks_tls_port="9443"
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --db-container) db_container="$2"; shift 2 ;;
     --db-name) db_name="$2"; shift 2 ;;
     --port) gateway_port="$2"; shift 2 ;;
+    --jwks-tls-ca) jwks_tls_ca="$2"; shift 2 ;;
+    --jwks-tls-host) jwks_tls_host="$2"; shift 2 ;;
+    --jwks-tls-port) jwks_tls_port="$2"; shift 2 ;;
     *) echo "unknown argument: $1" >&2; exit 2 ;;
   esac
 done
@@ -109,6 +118,64 @@ anon_key="$(mint_key anon)"
 service_role_key="$(mint_key service_role)"
 
 # ---------------------------------------------------------------------------
+# JWKS over TLS. Opt-in, requested with --jwks-tls-ca.
+#
+# Why a caller would want it: edge-api does not take a shared secret. It
+# validates every browser token with jwt.WithKeySet against SUPABASE_JWKS_URL
+# and refuses to boot when the first refresh yields no usable key
+# (apps/edge-api/internal/auth/jwt_supabase.go). Two separate properties of the
+# default stack above defeat that, and fixing either one alone changes nothing:
+#
+#   * HS256 alone publishes NOTHING. GoTrue's internal/api/jwks.go skips every
+#     key whose public half is nil or of type jwa.OctetSeq, so with only
+#     GOTRUE_JWT_SECRET the endpoint answers {"keys":[]}. Measured against the
+#     pin above rather than inferred. The fix is upstream-supported and
+#     config-only: hand GoTrue an EC P-256 key through GOTRUE_JWT_KEYS and it
+#     signs user tokens ES256 and publishes the public half, while still
+#     accepting the legacy HS256 anon and service_role keys through the
+#     GOTRUE_JWT_SECRET fallback. Both halves come from
+#     scripts/generate-enterprise-jwt-keys.py, which the enterprise profile
+#     already uses for exactly this.
+#   * edge-api refuses a plain http JWKS URL, deliberately, because anything on
+#     the path to one can swap the key set and mint tokens it would then accept
+#     (loadJWTAuthEnv in apps/edge-api/cmd/server/main.go, guarded by
+#     jwt_env_test.go). That guard is NOT relaxed here. Caddy terminates real
+#     TLS with its own local authority and the caller is handed that authority
+#     to trust, so the chain and the hostname are still verified. It is the
+#     same arrangement docker-compose.enterprise.yml runs on the demo box.
+#
+# PostgREST moves to the verification key set at the same time, because the
+# user tokens it now sees are ES256 while the anon and service_role keys stay
+# HS256, and it has to accept both.
+# ---------------------------------------------------------------------------
+gotrue_key_args=()
+pgrst_jwt="${jwt_secret}"
+if [ -n "$jwks_tls_ca" ]; then
+  log "==> asymmetric signing key, so the JWKS endpoint is not empty"
+  keys_out="$(ENTERPRISE_JWT_SECRET="$jwt_secret" \
+    python3 "$repo_root/scripts/generate-enterprise-jwt-keys.py")"
+  jwt_keys="$(printf '%s\n' "$keys_out" | sed -n 's/^ENTERPRISE_JWT_KEYS=//p')"
+  jwt_verify_keys="$(printf '%s\n' "$keys_out" | sed -n 's/^ENTERPRISE_JWT_VERIFY_KEYS=//p')"
+  # Both, not either. A truncated generator run would otherwise leave GoTrue
+  # signing HS256 again, and that surfaces as edge-api refusing to boot, three
+  # components away from the cause.
+  if [ -z "$jwt_keys" ] || [ -z "$jwt_verify_keys" ]; then
+    log "::error::generate-enterprise-jwt-keys.py printed no ENTERPRISE_JWT_KEYS / ENTERPRISE_JWT_VERIFY_KEYS pair"
+    exit 1
+  fi
+  jwks_issuer="https://${jwks_tls_host}:${jwks_tls_port}/auth/v1"
+  gotrue_key_args=(
+    -e "GOTRUE_JWT_KEYS=${jwt_keys}"
+    # Set explicitly, and emitted verbatim below as SUPABASE_JWT_ISSUER. The
+    # issuer is a string comparison against the token claim and is never
+    # fetched, so the only way it goes wrong is by drifting from what GoTrue
+    # stamps. One variable feeding both is what stops that.
+    -e "GOTRUE_JWT_ISSUER=${jwks_issuer}"
+  )
+  pgrst_jwt="${jwt_verify_keys}"
+fi
+
+# ---------------------------------------------------------------------------
 # Network. The database container is already running and published on the host;
 # it is attached to a user-defined network here so GoTrue and PostgREST can
 # resolve it by name.
@@ -147,6 +214,7 @@ docker run -d --name supabase-auth --network "$network" \
   -e "GOTRUE_SITE_URL=http://localhost:3000" \
   -e "GOTRUE_URI_ALLOW_LIST=http://localhost:3000/**,http://127.0.0.1:3000/**" \
   -e "GOTRUE_JWT_SECRET=${jwt_secret}" \
+  ${gotrue_key_args[@]+"${gotrue_key_args[@]}"} \
   -e GOTRUE_JWT_AUD=authenticated \
   -e GOTRUE_JWT_ADMIN_ROLES=service_role \
   -e GOTRUE_JWT_EXP=3600 \
@@ -199,7 +267,7 @@ docker run -d --name supabase-rest --network "$network" \
   -e "PGRST_DB_URI=${db_url}" \
   -e "PGRST_DB_SCHEMAS=public,storage,graphql_public" \
   -e PGRST_DB_ANON_ROLE=anon \
-  -e "PGRST_JWT_SECRET=${jwt_secret}" \
+  -e "PGRST_JWT_SECRET=${pgrst_jwt}" \
   -e PGRST_DB_USE_LEGACY_GUCS=false \
   postgrest/postgrest:v12.2.3 >/dev/null
 
@@ -411,6 +479,76 @@ if [ "$preflight_failures" -ne 0 ]; then
   exit 1
 fi
 
+# ---------------------------------------------------------------------------
+# The TLS front, when --jwks-tls-ca asked for one.
+#
+# It proxies the nginx gateway rather than replacing it, so the CORS handling
+# and prefix routing asserted above stay the one implementation. All this adds
+# is a verified-TLS listener for the single consumer that requires one.
+#
+# The listener carries a HOSTNAME, not the bridge IP, because the certificate
+# has to match what the consumer asks for and a name survives a runner whose
+# docker0 address differs. The consumer maps that name onto the published port
+# itself: for a compose service that is an extra_hosts entry pointing at the
+# bridge gateway address emitted below.
+# ---------------------------------------------------------------------------
+if [ -n "$jwks_tls_ca" ]; then
+  log "==> TLS front for the JWKS endpoint"
+  read -r -d '' tls_conf <<CADDY || true
+{
+	auto_https disable_redirects
+}
+https://${jwks_tls_host}:${jwks_tls_port} {
+	tls internal
+	reverse_proxy supabase-gw:80
+}
+CADDY
+  docker rm -f supabase-tls >/dev/null 2>&1 || true
+  # Same pinned Caddy digest deploy/docker/docker-compose.enterprise.yml runs,
+  # so this pulls nothing a stack boot has not already pulled.
+  docker run -d --name supabase-tls --network "$network" \
+    --network-alias "$jwks_tls_host" \
+    -p "${jwks_tls_port}:${jwks_tls_port}" \
+    -e "TLS_CONF=$tls_conf" \
+    --entrypoint /bin/sh \
+    caddy:2-alpine@sha256:86deaf5e3d3408a6ccec08fbb79989783dd26e206ae10bcf78a801dc8c9ab794 \
+    -c 'printf "%s\n" "$TLS_CONF" > /etc/caddy/Caddyfile && exec caddy run --config /etc/caddy/Caddyfile' >/dev/null
+
+  ca_src="/data/caddy/pki/authorities/local/root.crt"
+  for _ in $(seq 1 60); do
+    if docker exec supabase-tls test -s "$ca_src" 2>/dev/null; then break; fi
+    sleep 2
+  done
+  if ! docker exec supabase-tls test -s "$ca_src" 2>/dev/null; then
+    log "::error::the TLS front never wrote its local authority certificate"
+    docker logs supabase-tls 2>&1 | tail -30 >&2
+    exit 1
+  fi
+  mkdir -p "$(dirname "$jwks_tls_ca")"
+  docker cp "supabase-tls:${ca_src}" "$jwks_tls_ca" >/dev/null
+  # Caddy writes root.crt 0600 root. The published edge-api image runs as uid
+  # 10001, so an unreadable file means SUPABASE_JWKS_CA_FILE fails with
+  # permission denied and the process exits at boot. Same reason
+  # docker-compose.enterprise.yml exports the certificate through a one-shot
+  # service instead of mounting Caddy's data directory.
+  chmod 0644 "$jwks_tls_ca"
+
+  # The whole point of the two changes above, asserted end to end rather than
+  # assumed: real TLS, verified against that authority, returning a key set
+  # with at least one key in it. An empty "keys" array is the exact shape
+  # HS256-only GoTrue returns, and it is what makes edge-api refuse to boot, so
+  # it fails here by name instead of there by symptom.
+  jwks_body="$(curl -sS --cacert "$jwks_tls_ca" \
+    --resolve "${jwks_tls_host}:${jwks_tls_port}:127.0.0.1" \
+    "https://${jwks_tls_host}:${jwks_tls_port}/auth/v1/.well-known/jwks.json" || true)"
+  if ! printf '%s' "$jwks_body" | python3 -c 'import json,sys; sys.exit(0 if json.load(sys.stdin).get("keys") else 1)' 2>/dev/null; then
+    log "::error::the JWKS endpoint served no usable key over TLS. edge-api validates every browser token against this document and refuses to boot on an empty key set."
+    docker logs supabase-tls 2>&1 | tail -20 >&2
+    exit 1
+  fi
+  log "JWKS is served over verified TLS and carries at least one key"
+fi
+
 # The gateway address a container on another docker network reaches. Not
 # localhost: inside those containers that is the container itself.
 gw_ip="$(docker network inspect bridge -f '{{ (index .IPAM.Config 0).Gateway }}')"
@@ -419,3 +557,13 @@ echo "SUPABASE_URL=${base}"
 echo "SUPABASE_ANON_KEY=${anon_key}"
 echo "SUPABASE_SERVICE_ROLE_KEY=${service_role_key}"
 echo "SUPABASE_URL_FROM_CONTAINER=http://${gw_ip}:${gateway_port}"
+if [ -n "$jwks_tls_ca" ]; then
+  # The issuer GoTrue was told to stamp, the https document edge-api fetches,
+  # the authority that makes it verifiable, and the address the hostname has to
+  # resolve to from inside a container. A consumer needs all four or none.
+  echo "SUPABASE_JWT_ISSUER=${jwks_issuer}"
+  echo "SUPABASE_JWKS_URL=https://${jwks_tls_host}:${jwks_tls_port}/auth/v1/.well-known/jwks.json"
+  echo "SUPABASE_JWKS_CA_PATH=${jwks_tls_ca}"
+  echo "SUPABASE_JWKS_HOST=${jwks_tls_host}"
+  echo "SUPABASE_JWKS_HOST_IP=${gw_ip}"
+fi


### PR DESCRIPTION
Fixes #1050.

## Root cause

**Nothing was done to this job. Something was deleted underneath it.**

`agent-visual-proof.yml` and `owui-nightly.yml` reconstruct their Supabase URL and DSN from the `SUPABASE_*` repository secrets. Those secrets name the hosted Supabase project that was **deleted** during the move to the self-hosted data plane. PR #983 migrated `ci.yml` onto a throwaway Postgres and left these two behind. Every one of those secrets still carries an April 2026 timestamp; none was repointed after the cutover.

The result: the `agent visual proof` job concluded `failure` on **every** branch from 2026-08-19 onward, including unrelated dependabot branches. It is not a required check, so nothing surfaced it, while orchestrator rule 8 went on treating it as the only mechanism that can produce Cowork visual proof before merge.

Evidence, taken from the runs rather than inferred:

* `owui-nightly` run 32623212748, which uses the same secrets, prints both halves in clear text: `socket.gaierror: [Errno -2] Name or service not known` for the project host, and `error: (ENOTFOUND) tenant/user *** not found` from the pooler. **A pooler reporting that the tenant does not exist is not contention and not a bad credential — it is a project that is gone.**
* `agent visual proof` run 32630605062: `dependency failed to start: container hive-control-plane-1 is unhealthy`, behind control-plane's `database unreachable after 13 attempt(s)`.
* Last green run of this job was 32143173133 on 2026-08-18, immediately before the cutover.

Consistent with `deploy-demo-box` staying green and the demo box being healthy: this was the job's own data plane, never a code regression.

### Which other workflows read those dead secrets

Asked and answered, because a third silent victim would be worse than the first two. Six workflows reference them. Beyond this one and `owui-nightly` (now tracked in #1055):

| Workflow | State | Assessment |
| --- | --- | --- |
| `deploy-web-console-workers.yml` | green, deploying | Bakes `NEXT_PUBLIC_SUPABASE_URL` / `ANON_KEY` into the shipped Cloudflare Workers bundle. Both secrets predate the cutover, so this may be shipping a dead auth origin while CI reports green. Not diagnosed here; flagged for the web-console owner. |
| `chat-coverage.yml` | green | Uses them only in the live sweep, which is path-gated off. Dormant. |
| `deploy-demo-box.yml` | green | Usage is inside an `if: workflow_dispatch` QA job, not the deploy path. Would fail if dispatched. |
| `demo-chat-settings-check.yml` | never run | Dormant. |

So no third workflow is actively failing, but one is green while possibly shipping a broken artifact, which is the more dangerous shape. Once nothing reads these secrets they should be deleted rather than left for the next workflow that assumes they are live.

## The fix

PR #983 already moved ci.yml onto a throwaway Postgres, GoTrue and PostgREST booted per job. This job now does the same, calling the same `scripts/ci-supabase-stack.sh` that `web-e2e` calls, rather than adding a second approach.

`web-e2e` does not exercise edge-api's Supabase-JWT path. This job does, and asserts on it. Two properties of the throwaway stack defeated that, and fixing either one alone changes nothing.

### 1. An HS256 GoTrue publishes an empty JWKS

GoTrue's `internal/api/jwks.go` skips every key whose public half is nil or of type `jwa.OctetSeq`. With only `GOTRUE_JWT_SECRET` set, `/auth/v1/.well-known/jwks.json` answers exactly:

```json
{"keys":[]}
```

**Measured against the pinned `supabase/gotrue:v2.170.0` image, not inferred.** edge-api validates with `jwt.WithKeySet` and refuses to boot when the initial refresh yields no usable key, so a stack configured that way cannot authenticate a single request.

The fix is upstream-supported and config-only: hand GoTrue an EC P-256 key through `GOTRUE_JWT_KEYS`. It then signs user tokens ES256 and publishes the public half, while still accepting the legacy HS256 anon and service_role keys through the `GOTRUE_JWT_SECRET` fallback. The key pair comes from `scripts/generate-enterprise-jwt-keys.py`, which the enterprise profile already uses for exactly this. PostgREST moves to the matching verification set at the same time, because the user tokens it now sees are ES256 while the anon and service_role keys stay HS256 and it has to accept both.

This finding is written into `scripts/ci-supabase-stack.sh` beside the code that fixes it, not only here, so the next person meets it where they would hit the problem.

### 2. edge-api refuses a plain http JWKS URL

Deliberately, because anything on the path to an http JWKS can swap the key set and mint tokens the service would then accept (`loadJWTAuthEnv`, guarded by `jwt_env_test.go`).

**That guard is not relaxed.** A Caddy front terminates real TLS with its own local authority, and edge-api is pointed at that authority through `SUPABASE_JWKS_CA_FILE`, so chain and hostname verification still happen. It is the same arrangement `docker-compose.enterprise.yml` runs on the demo box. Weakening a guard so CI can pass is how a real protection gets deleted for a test's convenience.

Both are **opt-in behind `--jwks-tls-ca`**. The only edit on the shared script's default path is `PGRST_JWT_SECRET=${jwt_secret}` becoming `${pgrst_jwt}`, which is assigned `${jwt_secret}` unless the flag is passed, so `web-e2e` is unaffected. Confirmed by `Web E2E (full stack)` passing on this PR.

### One Supabase origin for three callers

`agent-console` builds its Supabase client from `NEXT_PUBLIC_SUPABASE_URL` in `middleware.ts` and `lib/supabase/server.ts`, and both run **inside the container**, where localhost is the container itself. `web-e2e` never hits this because its console is a host process. The value also cannot be a per-caller override, because the browser bundle bakes it at build time and `@supabase/ssr` derives its cookie name from it. The docker bridge gateway address satisfies the browser, the seeder and the container alike.

Caught before CI did, but the earlier run 32632619269 confirms the symptom exactly: signed in successfully, edge-api answered `/v1/featuregate` with `ENABLE_COWORK: true`, and the browser still landed on `/agent-workspace/auth/sign-in`.

## Files outside the workflow

Two, both deliberate:

* `scripts/ci-supabase-stack.sh` — the opt-in flag above. Shared with `web-e2e`, hence the care to keep the default path equivalent.
* `deploy/docker/docker-compose.agent-proof.yml` — **new, proof-job-only**, named in `COMPOSE_FILE` by this workflow alone. edge-api needs one certificate mounted and one hostname resolvable, and neither can be an environment variable. It sits beside `Caddyfile.agent-proof`, same scope, same reasoning.

`deploy/docker/docker-compose.yml` is **not** touched.

The workflow also pins `COMPOSE_FILE`. There are nine compose invocations in this job and they must resolve one project; the teardown passes `--remove-orphans`, so a step resolving a different file set would delete services it did not know about.

## Making a red run announce itself

This job failed for four days in silence. That silence was as much the defect as the breakage, so a `failure`-only notifier now posts to a single tracking issue.

Deliberately **not** solved by making the job a required check. It is a path-gated job that boots a real Apptainer sandbox; gating merges on it would block unrelated pull requests and turn a flaky sandbox into a merge stopper. The property needed is that a red run announces itself, not that it gates.

Three properties, each built for a specific failure mode:

* **One issue, reused.** Found by exact title through the **list** API, not the eventually consistent search API, so two failures minutes apart cannot both miss the issue the other just filed. A new issue per failure would drown the signal exactly as the silence did.
* **It can never change the job's verdict.** `if: failure()` means it cannot turn a green run red; `continue-on-error` plus `|| true` on every call mean a GitHub hiccup cannot mask the real failing step.
* **Silent on a sabotage dispatch.** That arm is supposed to go red, and paging on it would train everyone to ignore the issue.

Verified end to end rather than assumed: three simulated red runs produced **one** issue plus two comments, not three issues, and the lookup matches exact titles only (a prefix does not collide). Test issue was closed as cleanup.

## Proof, in both directions

Green was confirmed **before** anything was mutated, so the red cannot be a pre-existing failure wearing a mutation's name.

| Direction | Mechanism | Run | Result |
| --- | --- | --- | --- |
| **Green** | ordinary `pull_request` run on `2f538f7c1` | [`32633641207`](https://github.com/sakibsadmanshajib/hive/actions/runs/32633641207) | **passed**: every step green through capture, empty-capture refusal, credential lint, and posting the captures on this pull request |
| **Red** | `sabotage=true` dispatch on `2f538f7c1`, the job's own negative control, which stops the launcher so nothing can launch | [`32633878650`](https://github.com/sakibsadmanshajib/hive/actions/runs/32633878650) | **failed as designed**: the sabotage step stopped the launcher, the harness signed in and created the task (HTTP 201) but `launch-liveness` failed on `launcher never reached 1 live session(s), saw 0`, and **Post the captures on the pull request was skipped**, so a red run publishes no proof rather than publishing something misleading |

Corroborating, on the previous commit `4ac2ed874`:

* Green run 32632790459 passed, posting two screenshots and a log showing a real sandbox: `create answered HTTP 201 in 85ms, status=queued`, task reached a terminal state, `scenario launch-liveness: ok`.
* Red run 32633216332 failed for the right reason, and this is the part that matters: it signed in, rendered the console and created the task (`HTTP 201`), then failed on `launcher never reached 1 live session(s), saw 0`. **"Post the captures on the pull request" was skipped**, so a broken run publishes no proof at all rather than publishing something misleading.

Component-level measurements taken on real containers before any of this was written, because the fix turns on two claims that would be embarrassing to assume:

* HS256-only GoTrue on the pinned image returns exactly `{"keys":[]}`.
* The same GoTrue with `GOTRUE_JWT_KEYS` returns a populated ES256 key set, fetchable through the Caddy front over TLS **verified against the exported authority**, while the identical fetch **without** that authority is refused. The TLS is real, not disabled.

## Buglog entry

```json
{"id":"BUG-1050","date":"2026-08-23","title":"Cowork visual-proof job failed repo-wide after the hosted Supabase project was deleted","error_message":"database not available at startup: database unreachable after 13 attempt(s); pooler answered ENOTFOUND tenant/user not found; getaddrinfo returned Name or service not known for the project host","root_cause":"agent-visual-proof.yml and owui-nightly.yml reconstructed their stack's Supabase URL and DSN from the SUPABASE_* repository secrets, which name the hosted project deleted during the move to the self-hosted data plane. PR #983 moved ci.yml onto a throwaway Postgres but these two workflows were not migrated, so control-plane never became healthy and the job died before capturing anything. Because the job is not a required check, every branch failed silently for four days while orchestrator rule 8 still depended on it. Two further traps sat behind the obvious one: an HS256-only GoTrue publishes an empty JWKS because internal/api/jwks.go skips keys with no public half, and edge-api refuses a plain http JWKS URL by design.","fix":"Boot a throwaway Postgres, GoTrue and PostgREST per run via scripts/ci-supabase-stack.sh, as ci.yml already does. Added an opt-in --jwks-tls-ca mode giving GoTrue an EC signing key so its JWKS is non-empty, fronted by Caddy tls internal so edge-api's https-only guard is satisfied without being relaxed. Pinned NEXT_PUBLIC_SUPABASE_URL to the docker bridge address so the browser and the in-container agent-console agree on one origin. Removed every hosted-project secret from the job env, since a job-level entry overrides what a step writes to GITHUB_ENV. Added a failure-only notifier that reuses one tracking issue, so the next repo-wide break is not silent.","tags":["ci","supabase","jwks","gotrue","visual-proof","silent-failure","agent-visual-proof"]}
```
