### PR TITLE
ci: stop demo-box deploys waiting on a manual approval gate

### DIFF
--- a/.github/workflows/deploy-demo-box.yml
+++ b/.github/workflows/deploy-demo-box.yml
@@ -211,7 +211,6 @@ jobs:
   # ------------------------------------------------------------------
   migrate:
     name: Apply pending database migrations
-    environment: demo-box
     runs-on: [self-hosted, hive-demo]
     permissions:
       contents: read
@@ -618,7 +617,6 @@ jobs:
   deploy:
     name: Pull + recreate stack on the demo box
     needs: migrate
-    environment: demo-box
     runs-on: [self-hosted, hive-demo]
     # This job never checks out the repo, and it no longer pulls either. The
     # box's clone at /home/sakib/hive is advanced by the migrate job above,


### PR DESCRIPTION
## Summary

Removes the two job-level `environment: demo-box` keys from `.github/workflows/deploy-demo-box.yml`. Nothing else changes.

## Why

The `demo-box` environment carries a `required_reviewers` protection rule naming the repository owner. A job-level `environment:` key makes GitHub hold that job in `waiting` until a human approves it in the UI. Both self-hosted jobs referenced it, and `deploy` has `needs: migrate`, so the gate stopped the workflow at its very first job and the demo box stopped receiving `main` at all.

This is observed, not predicted. Run [32633210460](https://github.com/sakibsadmanshajib/hive/actions/runs/32633210460) for commit `7cfc460e` is sitting in status `waiting` right now, with its only started job `Apply pending database migrations` also `waiting`, and a pending deployment on environment `demo-box` listing the owner as the required reviewer. Every later merge queues behind it.

Deploys on this repository are autonomous by owner ruling. The intended gating in front of a deploy is machine checks that fail loudly, not a human click. Stronger automated post-deploy verification is being built separately; this PR only removes the human gate that is currently blocking everything.

## What changed

- `.github/workflows/deploy-demo-box.yml`: deleted `environment: demo-box` from the `migrate` job and from the `deploy` job. Two lines, no other edits.

## What is deliberately NOT changed

- **The `demo-box` environment itself stays.** It is repository configuration that may be wanted for something else, and deleting an environment is not undone by reverting a PR. Only the workflow's dependency on it is removed.
- **`.github/CODEOWNERS` stays.** It routes review to the owner for visibility and cannot block an autonomous merge. Verified against live branch protection on `main` rather than assumed:

  | setting | live value | effect on merge |
  |---|---|---|
  | `required_pull_request_reviews` | present (not null) | object exists, so the fields below decide |
  | `require_code_owner_reviews` | `false` | CODEOWNERS review is **not** required |
  | `required_approving_review_count` | `0` | no human approval needed to merge |

  Worth stating precisely because the working assumption had been that `required_pull_request_reviews` was null. It is not null; it is present but non-blocking. The conclusion is the same, CODEOWNERS is inert as a gate, but it rests on those two fields rather than on the object's absence, and a future change to either would silently turn CODEOWNERS into a merge blocker.

- **The pending approval on the waiting run was not actioned.** An agent clicking through an owner-approval control is not something that should become normal, even when the control is one the owner has ruled should not exist. Removing the gate by pull request is the legitimate route; satisfying it on the owner's behalf is not. The waiting run may need re-running once this lands.

## Verification

The failure mode is already demonstrated live by the waiting run linked above: with the keys present, the workflow does not start the migration. Confirmed before this change that both keys were present at lines 214 and 621, and after it that the file still parses as valid workflow YAML with all five jobs intact and no `environment` key on any of them:

```
jobs parsed: ['migrate', 'deploy', 'sdk-replay', 'agent-workspace-coverage', 'report-failure']
  migrate                  | environment: None | needs: None      | runs-on: ['self-hosted', 'hive-demo']
  deploy                   | environment: None | needs: migrate   | runs-on: ['self-hosted', 'hive-demo']
  sdk-replay               | environment: None | needs: deploy    | runs-on: ubuntu-latest
  agent-workspace-coverage | environment: None | needs: deploy    | runs-on: ubuntu-latest
  report-failure           | environment: None | needs: ['migrate', 'deploy', 'sdk-replay'] | runs-on: ubuntu-latest
```

The confirming signal after merge is a `deploy-demo-box` run on `main` that goes straight to `in_progress` instead of `waiting`.

## Rollback

Reverting restores both keys and re-freezes demo-box deploys behind a manual approval.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the demo-box deployment workflow configuration.
  * Deployment and migration jobs no longer explicitly assign a deployment environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->