### PR TITLE
feat: gate deploys on a post-deploy verification of the running product

### DIFF
--- a/.github/workflows/post-deploy-verify.yml
+++ b/.github/workflows/post-deploy-verify.yml
@@ -507,6 +507,25 @@ jobs:
             echo "target $name $value ($source)"
           done
 
+          # ── the verification model ─────────────────────────────────────────
+          #
+          # The ledger check sends one real, billed completion per run, on the
+          # alias named by HIVE_VERIFY_MODEL (scripts/post-deploy-verify.py,
+          # default hive-default). Left unset it would land on the same free
+          # tier the demo serves chat from and compete with real users for its
+          # daily cap, so the box names a paid alias here and the gate uses
+          # that instead of assuming anything about the routing table.
+          model=$(read_env HIVE_VERIFY_MODEL)
+          source="box .env"
+          if [ -z "$model" ]; then
+            # Same default as the script's own, so absence here behaves
+            # identically to running the script by hand.
+            model=hive-default
+            source="workflow default"
+          fi
+          export HIVE_VERIFY_MODEL="$model"
+          echo "verification model $model ($source)"
+
           # ── the verification identity ─────────────────────────────────────
           email="$SECRET_VERIFY_EMAIL"
           password="$SECRET_VERIFY_PASSWORD"

--- a/.github/workflows/post-deploy-verify.yml
+++ b/.github/workflows/post-deploy-verify.yml
@@ -247,7 +247,9 @@ jobs:
         run: |
           set -euo pipefail
           bogus=sha256:0000000000000000000000000000000000000000000000000000000000000000
+          control=none
           if [ "${NEGATIVE_CONTROL:-none}" = "freshness" ]; then
+            control=freshness
             echo "  negative control: comparing against an image ID nothing can be running"
           fi
 
@@ -258,24 +260,20 @@ jobs:
             name=$(docker inspect -f '{{.Name}}' "$cid" | sed 's|^/||')
             running=$(docker inspect -f '{{.Image}}' "$cid")
             tag=$(docker inspect -f '{{.Config.Image}}' "$cid")
-            # Both images' ages, because the ID comparison alone cannot tell
-            # the two directions apart and only one of them is a stale binary.
-            # These tags are a shared mutable pointer on this box: any build
-            # moves them, including a CI job that has nothing to do with a
-            # deploy, and two concurrent builds can leave the tag on the OLDER
-            # of them. Measured, not theorised: on the first runs of this step
-            # hive-supabase-db's container was created 1.3 seconds AFTER the
-            # image its tag now resolves to, so the container was running
-            # something newer than the tag, which is not the failure this
-            # check is for.
             born=$(docker inspect -f '{{.Created}}' "$cid")
-            # State, because `ps -q` lists containers that are not running and
+            # State, because `ps -q` lists containers that are not running, and
             # a dead container is a bigger finding than a stale one. It also
-            # explains an image that has left the store: docker will not prune
-            # an image a running container holds, so an absent image and a
-            # stopped container are the same story.
+            # bears on an image that has left the store: docker will not prune
+            # an image a running container holds.
             state=$(docker inspect -f '{{.State.Status}}' "$cid")
             checked=$((checked + 1))
+
+            # Resolved from the TAG, never from the id below, because the
+            # negative control replaces that id and an inspect of the
+            # replacement would kill the step before the assertion it is meant
+            # to exercise. That is not hypothetical: it is what the first run of
+            # this control did, failing for an inspect error and proving
+            # nothing.
             if ! current=$(docker image inspect -f '{{.Id}}' "$tag" 2>/dev/null); then
               # Not a skip. An unresolvable image reference means freshness
               # cannot be established for this container, and a check that
@@ -284,9 +282,9 @@ jobs:
               stale="$stale%0A  $name: image reference $tag no longer resolves"
               continue
             fi
-            if [ "${NEGATIVE_CONTROL:-none}" = "freshness" ]; then
-              current=$bogus
-            fi
+            tag_born=$(docker image inspect -f '{{.Created}}' "$tag")
+            [ "$control" = "freshness" ] && current=$bogus
+
             if [ "$state" != "running" ]; then
               echo "  note     $name is $state, not running ($tag)"
             fi
@@ -294,29 +292,37 @@ jobs:
               echo "  current  $name ($tag), $state"
               continue
             fi
+
             short_running=$(printf '%s' "$running" | cut -c8-19)
             short_current=$(printf '%s' "$current" | cut -c8-19)
-            tag_born=$(docker image inspect -f '{{.Created}}' "$current")
-            # The running image is usually still in the local store, since a
-            # container holds a reference to it. When it is not, the reason is
-            # printed rather than swallowed, because "the image this container
-            # runs is gone" is itself a finding, and because the same silence
-            # would hide a plain inspect failure. Either way the container is
-            # treated as behind the tag, which is the safe direction: a pass
-            # must never be the answer to a question that did not resolve.
-            if ! run_born=$(docker image inspect -f '{{.Created}}' "$running" 2>&1); then
-              echo "  note     $name: its running image $short_running is not in the local image store: $(printf '%s' "$run_born" | head -1 | cut -c1-160)"
-              run_born=""
+            # Both images' build times, because the id comparison alone cannot
+            # tell the two directions apart and only one of them is a stale
+            # binary. These tags are a shared mutable pointer on this box: any
+            # build moves one, including a CI job that has nothing to do with a
+            # deploy, and two concurrent builds can leave a tag on the older of
+            # them. Measured rather than theorised: hive-supabase-db's container
+            # was created 1.3 seconds AFTER the image its tag resolves to, so it
+            # was running something newer than the tag, which is not the failure
+            # this check is for.
+            #
+            # The running image is usually still in the store, since a container
+            # holds a reference to it. When the inspect fails the reason is
+            # printed rather than swallowed, and the container is treated as
+            # behind the tag, which is the safe direction: a pass must never be
+            # the answer to a question that did not resolve.
+            run_born=""
+            if [ "$control" != "freshness" ]; then
+              if ! run_born=$(docker image inspect -f '{{.Created}}' "$running" 2>&1); then
+                echo "  note     $name: its running image $short_running did not inspect: ${run_born:-<no output>}"
+                run_born=""
+              fi
+              if [ -n "$run_born" ] && [ "$run_born" \> "$tag_born" ]; then
+                echo "  ahead    $name ($tag): running $short_running built $run_born, newer than the tag's $short_current built $tag_born"
+                continue
+              fi
             fi
-            if [ -n "$run_born" ] && [ "$run_born" \> "$tag_born" ]; then
-              # Newer than the tag, so nothing old is being served. This is tag
-              # drift from a concurrent build, not a deploy that failed to
-              # recreate, and calling it stale would be false.
-              echo "  ahead    $name ($tag): running $short_running built $run_born, newer than the tag's $short_current built $tag_born"
-              continue
-            fi
-            echo "  STALE    $name ($tag): $state from $short_running built ${run_born:-<image absent>} (container created $born), tag now $short_current built $tag_born"
-            stale="$stale%0A  $name is running $short_running built ${run_born:-<image absent>} while $tag now resolves to $short_current built $tag_born"
+            echo "  STALE    $name ($tag): $state from $short_running built ${run_born:-<unresolved>} (container created $born), tag now $short_current built $tag_born"
+            stale="$stale%0A  $name is $state from $short_running built ${run_born:-<unresolved>} while $tag now resolves to $short_current built $tag_born"
 
           done < <(docker compose $HIVE_COMPOSE_FLAGS ps -q)
 

--- a/.github/workflows/post-deploy-verify.yml
+++ b/.github/workflows/post-deploy-verify.yml
@@ -193,9 +193,27 @@ jobs:
         #
         # Negative control: compare against a well-formed image ID that no
         # container can be running. That proves the comparison and its failure
-        # path both fire. It is deliberately not a real stale binary:
-        # manufacturing one means rolling a live service back onto an old
-        # image, and this box is the demo surface.
+        # path both fire, on any trigger. It is deliberately not a real stale
+        # binary: manufacturing one means rolling a live service back onto an
+        # old image, and this box is the demo surface.
+        #
+        # Who a real mismatch belongs to depends on the trigger, so the verdict
+        # does too. After a deploy (workflow_run) a mismatch means that deploy
+        # did not put its own build into service, which is the failure this
+        # check exists to stop, so it is fatal. On a pull request or a dispatch
+        # the box is carrying whatever the last deploy left, which the branch
+        # under test neither caused nor can fix, so failing here would block a
+        # pull request for somebody else's deploy and would eventually be
+        # ignored. There it reports, loudly, and the run continues to the
+        # checks the branch can actually be judged on.
+        #
+        # Measured on the first real run of this step, which is why the
+        # distinction is here at all: seven of twenty containers
+        # (control-plane, edge-api, open-webui, web-console-prod,
+        # agent-console, markitdown, supabase-db) were not on their tag's
+        # current image seven minutes after a green deploy. The evidence went
+        # to issue #869. A pull request adding the check is the wrong place to
+        # litigate it.
         working-directory: /home/sakib/hive/deploy/docker
         env:
           # The deploy's own flags, copied from deploy-demo-box.yml's
@@ -253,10 +271,25 @@ jobs:
             exit 1
           fi
           echo "  compared $checked container(s)"
-          if [ -n "$stale" ]; then
+          [ -n "$stale" ] || exit 0
+
+          if [ "$GITHUB_EVENT_NAME" = "workflow_run" ] || [ "${NEGATIVE_CONTROL:-none}" = "freshness" ]; then
             echo "::error::containers are not running the image their tag points to (issue #869):$stale"
             exit 1
           fi
+          echo "::warning::containers are not running the image their tag points to (issue #869), left over from an earlier deploy rather than caused by this run:$stale"
+          {
+            echo "### Stale containers on the box (issue #869)"
+            echo
+            echo "Not fatal on a \`$GITHUB_EVENT_NAME\` run: this is the state the last"
+            echo "deploy left, not something this run or this branch caused. The same"
+            echo "mismatch is fatal on the \`workflow_run\` path, where it means the deploy"
+            echo "that just finished did not put its own build into service."
+            echo
+            echo '```'
+            printf '%b\n' "${stale//%0A/\\n}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Report which inputs the box carries
         # Presence and length only, never a value: this repository is public.

--- a/.github/workflows/post-deploy-verify.yml
+++ b/.github/workflows/post-deploy-verify.yml
@@ -1,0 +1,293 @@
+name: post-deploy-verify
+
+# Asserts that the product still works after deploy-demo-box has already
+# exited 0. A green deploy is not the claim "the product works": PR #787
+# merged green and took chat sign-in down, and three consecutive deploys
+# failed at `migrate` while the box silently stayed on old code.
+#
+# The gating this adds is machine gating, not human gating. There is no
+# `environment:` key on any job here and there must never be one. `main` went
+# 7cfc460ea (which added an approval gate) then 09607ff05 (which removed it);
+# the owner's ruling is "keep it autonomous but make the gating more
+# professional", so rigour comes from stronger checks, not from a person in
+# the loop.
+#
+# ── Why this is a separate workflow, and not a job inside deploy-demo-box ────
+#
+# Correctness, not tidiness. A job embedded in the deploy workflow cannot be
+# exercised from a branch without actually deploying, so there would be no way
+# to prove it green, break the thing it guards, watch it go red, restore, and
+# watch it go green again. Here that loop runs on a pull request behind a
+# label, against the real box, with no deploy involved. A check nobody can
+# prove still fails is a check nobody should trust.
+#
+# It also keeps this out of deploy/docker/docker-compose.yml and out of
+# deploy-demo-box.yml, both of which are heavily contended.
+#
+# ── Why credentials come from the box, not from GitHub secrets ──────────────
+#
+# Six workflows in this repository read `SUPABASE_*` from GitHub secrets that
+# name a hosted project which has been deleted. Nothing went red. The Cowork
+# proof job ran for four days against a Supabase that was not there, and
+# deploy-web-console-workers shipped green on the day the project went away
+# (issue #1059). The box's own /home/sakib/hive/.env is what the running
+# containers actually use, so reading the same file is the only way this
+# verifies the deployment that exists rather than one that used to.
+#
+# The `preflight` step below is the generalisation of that lesson, and it is
+# the piece worth promoting into the other six workflows.
+
+on:
+  workflow_run:
+    workflows: [deploy-demo-box]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      negative_control:
+        description: >-
+          Deliberately remove the thing one check guards so that check goes red.
+          Proves the gate still bites. No value of this makes anything pass.
+        type: choice
+        default: none
+        options: [none, chat, signin, ledger]
+  # Label-gated, the same shape owui-nightly.yml uses, so this workflow can be
+  # exercised end to end from the branch that changes it and cannot fire by
+  # accident on unrelated pull requests. `synchronize` is here so that each
+  # push to a labelled branch re-runs it, which is what makes the
+  # green-break-red-restore-green loop a single push each way.
+  pull_request:
+    types: [labeled, synchronize]
+
+# No `concurrency:` block, deliberately. Grouping would queue runs, and GitHub
+# cancels a middle pending run when a third is queued behind it -- turning a
+# skipped verification into silence rather than a failure. deploy-demo-box is
+# already serialised by its own group, so the runs that matter arrive one at a
+# time anyway, and two overlapping runs here are harmless: each mints its own
+# key and each looks for any new usage_charge row, so the worst case is that
+# one of them sees the other's charge and still concludes, correctly, that
+# billing wrote a row.
+
+jobs:
+  verify:
+    name: Verify the deployment
+    # workflow_run fires on completion of any conclusion, including failure and
+    # cancellation. A failed deploy is already reported by deploy-demo-box's own
+    # report-failure job, and verifying a deploy that never happened would file
+    # a second, misleading issue about the product being down.
+    if: >-
+      ${{
+        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+        || github.event_name == 'workflow_dispatch'
+        || (github.event_name == 'pull_request'
+            && contains(github.event.pull_request.labels.*.name, 'run-post-deploy-verify'))
+      }}
+    runs-on: [self-hosted, hive-demo]
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # For a workflow_run, pin to the commit that was actually deployed
+          # rather than to whatever main has drifted to since. For everything
+          # else the default ref is correct, and on a pull request that is what
+          # lets a branch exercise its own version of these scripts.
+          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
+
+      - name: Report which credentials the box carries
+        # Presence and length only, never a value: this repository is public.
+        # This step never fails. Its whole job is to make the next step's
+        # failure legible, because "HIVE_VERIFY_EMAIL is not set" is a much
+        # cheaper thing to read than a sign-in that answered 400.
+        run: |
+          set -euo pipefail
+          env_file=/home/sakib/hive/.env
+          if [ ! -f "$env_file" ]; then
+            echo "::error::$env_file does not exist on this runner"
+            exit 1
+          fi
+          for name in SUPABASE_URL SUPABASE_ANON_KEY SUPABASE_SERVICE_ROLE_KEY \
+                      HIVE_VERIFY_EMAIL HIVE_VERIFY_PASSWORD \
+                      HIVE_QA_TESTER_EMAIL HIVE_QA_TESTER_PASSWORD \
+                      HIVE_CHAT_URL HIVE_CONTROL_PLANE_URL HIVE_EDGE_API_URL; do
+            # `|| true` matters: under `set -o pipefail` a grep that matches
+            # nothing kills the step before it can report what is missing,
+            # which is the one thing this step exists to do.
+            value=$(grep -E "^${name}=" "$env_file" | head -1 | cut -d= -f2- || true)
+            value=${value%\"}; value=${value#\"}
+            value=${value%\'}; value=${value#\'}
+            if [ -n "$value" ]; then
+              echo "  present  ${name} (${#value} characters)"
+            else
+              echo "  ABSENT   ${name}"
+            fi
+          done
+
+      - name: Preflight the Supabase configuration, then verify the deployment
+        # One step, so no credential ever reaches $GITHUB_ENV, the step summary,
+        # or another job. Values read here live in this shell and die with it.
+        env:
+          NEGATIVE_CONTROL: ${{ github.event.inputs.negative_control || 'none' }}
+          HIVE_VERIFY_RUN_LABEL: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          env_file=/home/sakib/hive/.env
+
+          read_env() {
+            # Same idiom as deploy-demo-box.yml's pooler-DSN step, including the
+            # quote stripping and the `|| true`.
+            local raw
+            raw=$(grep -E "^$1=" "$env_file" | head -1 | cut -d= -f2- || true)
+            raw=${raw%\"}; raw=${raw#\"}
+            raw=${raw%\'}; raw=${raw#\'}
+            printf '%s' "$raw"
+          }
+
+          missing=""
+          for name in SUPABASE_URL SUPABASE_ANON_KEY HIVE_VERIFY_EMAIL HIVE_VERIFY_PASSWORD; do
+            value=$(read_env "$name")
+            if [ -z "$value" ]; then
+              missing="$missing $name"
+              continue
+            fi
+            # Mask before export. A masked value is still redacted if some
+            # later command echoes it, and neither this script nor the two
+            # Python scripts print one.
+            case "$name" in
+              *KEY|*PASSWORD) echo "::add-mask::$value" ;;
+            esac
+            export "$name=$value"
+          done
+          if [ -n "$missing" ]; then
+            echo "::error::the box's .env is missing:$missing"
+            echo "HIVE_VERIFY_EMAIL must name a dedicated verification identity that is a"
+            echo "tenant OWNER with a verified email, and never demo@hive-demo.invalid"
+            echo "(issue #848). Minting an API key needs api_keys:write, which the"
+            echo "authorization policy grants to OWNER only. Add both to $env_file."
+            exit 1
+          fi
+
+          # Optional overrides; the scripts default to the public demo hostnames.
+          for name in HIVE_CHAT_URL HIVE_CONTROL_PLANE_URL HIVE_EDGE_API_URL; do
+            value=$(read_env "$name")
+            [ -n "$value" ] && export "$name=$value"
+          done
+          # Claim-checked by the preflight when present, never sent anywhere.
+          service=$(read_env SUPABASE_SERVICE_ROLE_KEY)
+          if [ -n "$service" ]; then
+            echo "::add-mask::$service"
+            export SUPABASE_SERVICE_ROLE_KEY="$service"
+          fi
+
+          echo "::group::preflight: does this Supabase configuration resolve at all"
+          # Seconds, deterministic, no writes. It answers the question that
+          # would have caught both halves of issue #1059 before anything slow
+          # ran: is the project alive, and do these keys belong to it. Running
+          # it first means a dead or mismatched configuration fails here with
+          # that reason, instead of surfacing ninety seconds later as a sign-in
+          # that answered 400.
+          python3 scripts/preflight-supabase-config.py
+          echo "::endgroup::"
+
+          args=""
+          if [ "$NEGATIVE_CONTROL" != "none" ]; then
+            echo "::warning::running with negative control '$NEGATIVE_CONTROL'; this run is EXPECTED to fail"
+            args="--negative-control $NEGATIVE_CONTROL"
+          fi
+          # No `|| true`, no continue-on-error. The script exits non-zero unless
+          # chat answered from its backend, the control-plane resolved a real
+          # bearer to the right identity, and a real completion produced a real
+          # usage_charge row.
+          python3 scripts/post-deploy-verify.py $args
+
+  report-failure:
+    # A separate label from deploy-demo-box's `ci-failure:deploy-demo-box`, and
+    # that is not arbitrary. This is a separate workflow, so it cannot join that
+    # job's `needs: [migrate, deploy, sdk-replay]` list; and its ledger check
+    # makes a real outbound call to a third-party inference provider, which can
+    # go red for reasons that have nothing to do with a deploy. Sharing the
+    # label would let a provider outage hold the deploy issue open, and would
+    # downgrade a genuine `migrate` failure into a comment on a stale issue --
+    # the exact trap already documented on agent-workspace-coverage.
+    name: Report failure
+    needs: [verify]
+    if: failure()
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    timeout-minutes: 5
+    # The notifier must never be able to change the verdict. `continue-on-error`
+    # plus the `|| true` below mean a rate-limited or broken notifier cannot
+    # turn a red verification green, and cannot turn a green one red either.
+    continue-on-error: true
+    steps:
+      - uses: actions/github-script@v7
+        continue-on-error: true
+        env:
+          VERIFY_RESULT: ${{ needs.verify.result }}
+          TRIGGER: ${{ github.event_name }}
+          DEPLOY_RUN: ${{ github.event.workflow_run.html_url }}
+        with:
+          script: |
+            // Dedupe by exact title over the issues LIST api, not the search
+            // api. Search is eventually consistent and returns nothing for an
+            // issue filed seconds ago, so two near-simultaneous failures each
+            // find no match and each file one. The list api is read-your-writes.
+            const label = 'ci-failure:post-deploy-verify';
+            const title = 'post-deploy-verify is failing against the demo box';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const detail = [
+              `verify=${process.env.VERIFY_RESULT}`,
+              `trigger=${process.env.TRIGGER}`,
+              process.env.DEPLOY_RUN ? `deploy run: ${process.env.DEPLOY_RUN}` : null,
+            ].filter(Boolean).join(', ');
+
+            const open = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: label,
+              per_page: 100,
+            });
+            const existing = open.find((i) => i.title === title);
+            if (existing) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body: `Still failing: ${runUrl}\n\n${detail}`,
+              });
+              return;
+            }
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              labels: [label],
+              body: [
+                'Post-deploy verification failed against the demo box.',
+                '',
+                `First detected: ${runUrl}`,
+                '',
+                detail,
+                '',
+                'One of three things is true, and the run log names which:',
+                '',
+                '- chat answered but its backend did not, so chat-hive.scubed.co is serving',
+                '  the static shell over a dead Open WebUI.',
+                '- a freshly minted session did not resolve to the same user at the',
+                '  control-plane, so sign-in is broken even if the login page renders.',
+                '- a real completion produced no `usage_charge` ledger row, so billing has',
+                '  failed open and requests are being served for free.',
+                '',
+                'Nothing was rolled back and nothing should be: forward migrations run',
+                'before the deploy and are not reversible by redeploying code, so an',
+                'automatic rollback would leave old code against a new schema.',
+                '',
+                'Filed automatically. Close it once a run goes green; it will be refiled',
+                'if it fails again.',
+              ].join('\n'),
+            });
+      - name: Never let the notifier change the verdict
+        if: always()
+        run: echo "notifier finished" || true

--- a/.github/workflows/post-deploy-verify.yml
+++ b/.github/workflows/post-deploy-verify.yml
@@ -69,6 +69,12 @@ on:
   # accident on unrelated pull requests. `synchronize` is here so that each
   # push to a labelled branch re-runs it, which is what makes the
   # green-break-red-restore-green loop a single push each way.
+  #
+  # The job below additionally requires the head repository to be this one. A
+  # label is a maintainer action, but this job runs on a self-hosted runner
+  # that IS the demo box, with its own docker socket and its own .env, so one
+  # mislabelled fork pull request would be arbitrary code execution there. The
+  # label is the intent gate; that condition is the trust boundary.
   pull_request:
     types: [labeled, synchronize]
 
@@ -93,6 +99,7 @@ jobs:
         (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
         || github.event_name == 'workflow_dispatch'
         || (github.event_name == 'pull_request'
+            && github.event.pull_request.head.repo.full_name == github.repository
             && contains(github.event.pull_request.labels.*.name, 'run-post-deploy-verify'))
       }}
     runs-on: [self-hosted, hive-demo]
@@ -242,12 +249,16 @@ jobs:
             name=$(docker inspect -f '{{.Name}}' "$cid" | sed 's|^/||')
             running=$(docker inspect -f '{{.Image}}' "$cid")
             tag=$(docker inspect -f '{{.Config.Image}}' "$cid")
-            # Ages, because they are what makes a mismatch diagnosable. These
-            # tags are a shared mutable pointer on this box: any build moves
-            # them, including a CI job that has nothing to do with a deploy.
-            # "image built two seconds ago, container four days old" and "image
-            # built by the test job that just ran" are the same comparison and
-            # very different problems, and only the timestamps separate them.
+            # Both images' ages, because the ID comparison alone cannot tell
+            # the two directions apart and only one of them is a stale binary.
+            # These tags are a shared mutable pointer on this box: any build
+            # moves them, including a CI job that has nothing to do with a
+            # deploy, and two concurrent builds can leave the tag on the OLDER
+            # of them. Measured, not theorised: on the first runs of this step
+            # hive-supabase-db's container was created 1.3 seconds AFTER the
+            # image its tag now resolves to, so the container was running
+            # something newer than the tag, which is not the failure this
+            # check is for.
             born=$(docker inspect -f '{{.Created}}' "$cid")
             checked=$((checked + 1))
             if ! current=$(docker image inspect -f '{{.Id}}' "$tag" 2>/dev/null); then
@@ -263,13 +274,25 @@ jobs:
             fi
             if [ "$running" = "$current" ]; then
               echo "  current  $name ($tag)"
-            else
-              short_running=$(printf '%s' "$running" | cut -c8-19)
-              short_current=$(printf '%s' "$current" | cut -c8-19)
-              image_born=$(docker image inspect -f '{{.Created}}' "$tag")
-              echo "  STALE    $name ($tag): running $short_running (container created $born), tag now $short_current (image created $image_born)"
-              stale="$stale%0A  $name is running $short_running (created $born) while $tag now resolves to $short_current (created $image_born)"
+              continue
             fi
+            short_running=$(printf '%s' "$running" | cut -c8-19)
+            short_current=$(printf '%s' "$current" | cut -c8-19)
+            tag_born=$(docker image inspect -f '{{.Created}}' "$current")
+            # The running image still exists by definition: a container holds a
+            # reference to it. If it somehow does not, treat the container as
+            # stale rather than inventing a pass.
+            run_born=$(docker image inspect -f '{{.Created}}' "$running" 2>/dev/null || echo "")
+            if [ -n "$run_born" ] && [ "$run_born" \> "$tag_born" ]; then
+              # Newer than the tag, so nothing old is being served. This is tag
+              # drift from a concurrent build, not a deploy that failed to
+              # recreate, and calling it stale would be false.
+              echo "  ahead    $name ($tag): running $short_running built $run_born, newer than the tag's $short_current built $tag_born"
+              continue
+            fi
+            echo "  STALE    $name ($tag): running $short_running built ${run_born:-unknown} (container created $born), tag now $short_current built $tag_born"
+            stale="$stale%0A  $name is running $short_running built ${run_born:-unknown} while $tag now resolves to $short_current built $tag_born"
+
           done < <(docker compose $HIVE_COMPOSE_FLAGS ps -q)
 
           if [ "$checked" -eq 0 ]; then
@@ -440,6 +463,16 @@ jobs:
           if [ -z "$email" ] || [ -z "$password" ]; then
             identity="no"
           else
+            # The address is masked as well as the password. docs/live-test-auth.md
+            # is right that an address is not a credential, and this is not a
+            # disagreement with it: when the value arrives as a repository
+            # secret GitHub masks it in the log whether or not this line
+            # exists, so masking the .env path too is what makes the two paths
+            # behave the same instead of leaving one of them printing an
+            # account address into a public log. Which identity ran is still
+            # legible from `verification identity from ...` below and from the
+            # place the value is configured.
+            echo "::add-mask::$email"
             echo "::add-mask::$password"
             export HIVE_VERIFY_EMAIL="$email"
             export HIVE_VERIFY_PASSWORD="$password"

--- a/.github/workflows/post-deploy-verify.yml
+++ b/.github/workflows/post-deploy-verify.yml
@@ -324,6 +324,9 @@ jobs:
             echo "  STALE    $name ($tag): $state from $short_running built ${run_born:-<unresolved>} (container created $born), tag now $short_current built $tag_born"
             stale="$stale%0A  $name is $state from $short_running built ${run_born:-<unresolved>} while $tag now resolves to $short_current built $tag_born"
 
+          # shellcheck disable=SC2086: HIVE_COMPOSE_FLAGS must word-split into
+          # separate compose arguments; quoting it would pass one blob and
+          # compose would reject it. Intentional splitting, scoped here.
           done < <(docker compose $HIVE_COMPOSE_FLAGS ps -q)
 
           if [ "$checked" -eq 0 ]; then
@@ -378,7 +381,12 @@ jobs:
             value=${value%\"}; value=${value#\"}
             value=${value%\'}; value=${value#\'}
             if [ -n "$value" ]; then
-              echo "  present  ${name} (${#value} characters)"
+              # Presence only for password and service-role values: this log is
+              # public, and even a character count is secret metadata.
+              case "$name" in
+                *PASSWORD*|*SERVICE_ROLE_KEY*) echo "  present  ${name}" ;;
+                *)                             echo "  present  ${name} (${#value} characters)" ;;
+              esac
             else
               echo "  ABSENT   ${name}"
             fi
@@ -538,19 +546,27 @@ jobs:
           python3 scripts/preflight-supabase-config.py
           echo "::endgroup::"
 
-          args=""
+          args=()
           case "$control" in
             # `freshness` is handled by its own step above and `config` by the
             # auth-origin override above; neither is a value this script knows,
             # and passing one would make argparse reject the whole run.
-            chat|signin|ledger) args="--negative-control $control" ;;
+            chat|signin|ledger) args+=(--negative-control "$control") ;;
           esac
 
           if [ "$identity" = "no" ]; then
+            # A control whose subject does not exist cannot be proved. Failing
+            # here names the precondition instead of surfacing later as an
+            # argparse selection error that says nothing about identity.
+            case "$control" in
+              signin|ledger)
+                echo "::error::negative control '$control' needs a verification identity to remove, and none is configured"
+                exit 1 ;;
+            esac
             # Run everything that needs no identity. No `|| true`: if chat is
             # down, that is the failure that matters and it must be the one
             # that surfaces.
-            python3 scripts/post-deploy-verify.py --only chat $args
+            python3 scripts/post-deploy-verify.py "${args[@]}" --only chat
 
             # Then report the missing coverage WITHOUT failing the job, and
             # this is a deliberate call rather than a softening.
@@ -597,7 +613,7 @@ jobs:
           # chat answered from its backend, the control-plane resolved a real
           # bearer to the right identity, and a real completion produced a real
           # usage_charge row.
-          python3 scripts/post-deploy-verify.py $args
+          python3 scripts/post-deploy-verify.py "${args[@]}"
 
   report-failure:
     # A separate label from deploy-demo-box's `ci-failure:deploy-demo-box`, and

--- a/.github/workflows/post-deploy-verify.yml
+++ b/.github/workflows/post-deploy-verify.yml
@@ -279,10 +279,17 @@ jobs:
             short_running=$(printf '%s' "$running" | cut -c8-19)
             short_current=$(printf '%s' "$current" | cut -c8-19)
             tag_born=$(docker image inspect -f '{{.Created}}' "$current")
-            # The running image still exists by definition: a container holds a
-            # reference to it. If it somehow does not, treat the container as
-            # stale rather than inventing a pass.
-            run_born=$(docker image inspect -f '{{.Created}}' "$running" 2>/dev/null || echo "")
+            # The running image is usually still in the local store, since a
+            # container holds a reference to it. When it is not, the reason is
+            # printed rather than swallowed, because "the image this container
+            # runs is gone" is itself a finding, and because the same silence
+            # would hide a plain inspect failure. Either way the container is
+            # treated as behind the tag, which is the safe direction: a pass
+            # must never be the answer to a question that did not resolve.
+            if ! run_born=$(docker image inspect -f '{{.Created}}' "$running" 2>&1); then
+              echo "  note     $name: its running image $short_running is not in the local image store: $(printf '%s' "$run_born" | head -1 | cut -c1-160)"
+              run_born=""
+            fi
             if [ -n "$run_born" ] && [ "$run_born" \> "$tag_born" ]; then
               # Newer than the tag, so nothing old is being served. This is tag
               # drift from a concurrent build, not a deploy that failed to
@@ -290,8 +297,8 @@ jobs:
               echo "  ahead    $name ($tag): running $short_running built $run_born, newer than the tag's $short_current built $tag_born"
               continue
             fi
-            echo "  STALE    $name ($tag): running $short_running built ${run_born:-unknown} (container created $born), tag now $short_current built $tag_born"
-            stale="$stale%0A  $name is running $short_running built ${run_born:-unknown} while $tag now resolves to $short_current built $tag_born"
+            echo "  STALE    $name ($tag): running $short_running built ${run_born:-<image absent>} (container created $born), tag now $short_current built $tag_born"
+            stale="$stale%0A  $name is running $short_running built ${run_born:-<image absent>} while $tag now resolves to $short_current built $tag_born"
 
           done < <(docker compose $HIVE_COMPOSE_FLAGS ps -q)
 

--- a/.github/workflows/post-deploy-verify.yml
+++ b/.github/workflows/post-deploy-verify.yml
@@ -260,6 +260,12 @@ jobs:
             # something newer than the tag, which is not the failure this
             # check is for.
             born=$(docker inspect -f '{{.Created}}' "$cid")
+            # State, because `ps -q` lists containers that are not running and
+            # a dead container is a bigger finding than a stale one. It also
+            # explains an image that has left the store: docker will not prune
+            # an image a running container holds, so an absent image and a
+            # stopped container are the same story.
+            state=$(docker inspect -f '{{.State.Status}}' "$cid")
             checked=$((checked + 1))
             if ! current=$(docker image inspect -f '{{.Id}}' "$tag" 2>/dev/null); then
               # Not a skip. An unresolvable image reference means freshness
@@ -272,8 +278,11 @@ jobs:
             if [ "${NEGATIVE_CONTROL:-none}" = "freshness" ]; then
               current=$bogus
             fi
+            if [ "$state" != "running" ]; then
+              echo "  note     $name is $state, not running ($tag)"
+            fi
             if [ "$running" = "$current" ]; then
-              echo "  current  $name ($tag)"
+              echo "  current  $name ($tag), $state"
               continue
             fi
             short_running=$(printf '%s' "$running" | cut -c8-19)
@@ -297,7 +306,7 @@ jobs:
               echo "  ahead    $name ($tag): running $short_running built $run_born, newer than the tag's $short_current built $tag_born"
               continue
             fi
-            echo "  STALE    $name ($tag): running $short_running built ${run_born:-<image absent>} (container created $born), tag now $short_current built $tag_born"
+            echo "  STALE    $name ($tag): $state from $short_running built ${run_born:-<image absent>} (container created $born), tag now $short_current built $tag_born"
             stale="$stale%0A  $name is running $short_running built ${run_born:-<image absent>} while $tag now resolves to $short_current built $tag_born"
 
           done < <(docker compose $HIVE_COMPOSE_FLAGS ps -q)

--- a/.github/workflows/post-deploy-verify.yml
+++ b/.github/workflows/post-deploy-verify.yml
@@ -242,6 +242,13 @@ jobs:
             name=$(docker inspect -f '{{.Name}}' "$cid" | sed 's|^/||')
             running=$(docker inspect -f '{{.Image}}' "$cid")
             tag=$(docker inspect -f '{{.Config.Image}}' "$cid")
+            # Ages, because they are what makes a mismatch diagnosable. These
+            # tags are a shared mutable pointer on this box: any build moves
+            # them, including a CI job that has nothing to do with a deploy.
+            # "image built two seconds ago, container four days old" and "image
+            # built by the test job that just ran" are the same comparison and
+            # very different problems, and only the timestamps separate them.
+            born=$(docker inspect -f '{{.Created}}' "$cid")
             checked=$((checked + 1))
             if ! current=$(docker image inspect -f '{{.Id}}' "$tag" 2>/dev/null); then
               # Not a skip. An unresolvable image reference means freshness
@@ -259,8 +266,9 @@ jobs:
             else
               short_running=$(printf '%s' "$running" | cut -c8-19)
               short_current=$(printf '%s' "$current" | cut -c8-19)
-              echo "  STALE    $name ($tag): running $short_running, tag now $short_current"
-              stale="$stale%0A  $name is running $short_running while $tag now resolves to $short_current"
+              image_born=$(docker image inspect -f '{{.Created}}' "$tag")
+              echo "  STALE    $name ($tag): running $short_running (container created $born), tag now $short_current (image created $image_born)"
+              stale="$stale%0A  $name is running $short_running (created $born) while $tag now resolves to $short_current (created $image_born)"
             fi
           done < <(docker compose $HIVE_COMPOSE_FLAGS ps -q)
 
@@ -303,7 +311,8 @@ jobs:
             echo "::error::$env_file does not exist on this runner"
             exit 1
           fi
-          for name in SUPABASE_URL NEXT_PUBLIC_SUPABASE_URL SUPABASE_ANON_KEY \
+          for name in SUPABASE_URL NEXT_PUBLIC_SUPABASE_URL \
+                      SUPABASE_ANON_KEY NEXT_PUBLIC_SUPABASE_ANON_KEY \
                       SUPABASE_SERVICE_ROLE_KEY \
                       HIVE_VERIFY_EMAIL HIVE_VERIFY_PASSWORD \
                       HIVE_CHAT_URL HIVE_CONTROL_PLANE_URL HIVE_EDGE_API_URL; do
@@ -335,7 +344,6 @@ jobs:
           set -euo pipefail
           env_file=/home/sakib/hive/.env
           control="${NEGATIVE_CONTROL:-none}"
-          echo "reason=product" >> "$GITHUB_OUTPUT"
 
           read_env() {
             # Same idiom as deploy-demo-box.yml's pooler-DSN step, including the
@@ -392,9 +400,14 @@ jobs:
           export SUPABASE_URL="$supabase"
           echo "auth origin $supabase"
 
-          anon=$(read_env SUPABASE_ANON_KEY)
+          # Paired with the origin chosen above, in the same order. A
+          # publishable key belongs to the listener it was issued for, and
+          # taking the origin from one variable and the key from another is
+          # precisely the half-updated configuration issue #1059 was.
+          anon=$(read_env NEXT_PUBLIC_SUPABASE_ANON_KEY)
+          [ -n "$anon" ] || anon=$(read_env SUPABASE_ANON_KEY)
           if [ -z "$anon" ]; then
-            echo "::error::SUPABASE_ANON_KEY is not set in $env_file"
+            echo "::error::neither NEXT_PUBLIC_SUPABASE_ANON_KEY nor SUPABASE_ANON_KEY is set in $env_file"
             exit 1
           fi
           echo "::add-mask::$anon"

--- a/.github/workflows/post-deploy-verify.yml
+++ b/.github/workflows/post-deploy-verify.yml
@@ -24,18 +24,29 @@ name: post-deploy-verify
 # It also keeps this out of deploy/docker/docker-compose.yml and out of
 # deploy-demo-box.yml, both of which are heavily contended.
 #
-# ── Why credentials come from the box, not from GitHub secrets ──────────────
+# ── Where each input comes from, and why the two answers differ ─────────────
 #
-# Six workflows in this repository read `SUPABASE_*` from GitHub secrets that
-# name a hosted project which has been deleted. Nothing went red. The Cowork
-# proof job ran for four days against a Supabase that was not there, and
-# deploy-web-console-workers shipped green on the day the project went away
-# (issue #1059). The box's own /home/sakib/hive/.env is what the running
-# containers actually use, so reading the same file is the only way this
-# verifies the deployment that exists rather than one that used to.
+# URLs and keys come from the BOX. Six workflows in this repository read
+# `SUPABASE_*` values from GitHub secrets that name a hosted project which no
+# longer exists. Nothing went red. The Cowork proof job ran for four days
+# against a Supabase that was not there, and deploy-web-console-workers shipped
+# green on the day the project went away (issue #1059). The box's own
+# /home/sakib/hive/.env is what the running containers actually use, so reading
+# the same file is the only way this verifies the deployment that exists rather
+# than one that used to.
 #
-# The `preflight` step below is the generalisation of that lesson, and it is
-# the piece worth promoting into the other six workflows.
+# The verification IDENTITY may come from a repository secret, and that is not
+# a contradiction of the paragraph above. A stale URL is dangerous precisely
+# because nothing exercises it: the run stays green over a dead backend. A
+# stale credential cannot hide, because the very next thing this job does is
+# sign in with it, and a wrong identity fails in the same second it is read.
+# The secret is also the only delivery route that exists: there is no SSH path
+# to this box from an agent session, so a value that must reach it either
+# arrives through a workflow or is typed into that .env by the owner. Secret
+# first, box .env second, and the run proves whichever it used.
+#
+# The `preflight` step below is the generalisation of the URL half of that
+# lesson, and it is the piece worth promoting into the other six workflows.
 
 on:
   workflow_run:
@@ -47,9 +58,12 @@ on:
         description: >-
           Deliberately remove the thing one check guards so that check goes red.
           Proves the gate still bites. No value of this makes anything pass.
+          Before this workflow reaches the default branch it is not
+          dispatchable at all, so the same five values are also accepted as
+          `verify-negative:<value>` labels on a pull request.
         type: choice
         default: none
-        options: [none, chat, signin, ledger]
+        options: [none, chat, signin, ledger, freshness, config]
   # Label-gated, the same shape owui-nightly.yml uses, so this workflow can be
   # exercised end to end from the branch that changes it and cannot fire by
   # accident on unrelated pull requests. `synchronize` is here so that each
@@ -85,16 +99,166 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
+    outputs:
+      # Which KIND of failure this was, so the notifier below can file it under
+      # a title that is true. "The product is down" and "this gate has never
+      # been given an identity to verify with" are different problems with
+      # different owners, and collapsing them into one issue is how a real
+      # outage gets downgraded into a comment on a stale housekeeping thread.
+      reason: ${{ steps.verify.outputs.reason }}
     steps:
       - uses: actions/checkout@v4
         with:
-          # For a workflow_run, pin to the commit that was actually deployed
-          # rather than to whatever main has drifted to since. For everything
-          # else the default ref is correct, and on a pull request that is what
-          # lets a branch exercise its own version of these scripts.
-          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
+          # No `ref:` here, deliberately, and it is not a detail. Pinning to
+          # `github.event.workflow_run.head_sha` is a privileged checkout of a
+          # ref this job cannot vouch for, which is what CodeQL's
+          # actions/cache-poisoning/poisonable-step flagged on this pull
+          # request (alert 27): a workflow_run job runs with the DEFAULT
+          # BRANCH's Actions cache scope, so executing repository scripts from
+          # an unvouched sha in that context can write a cache that every
+          # default-branch workflow afterwards reads.
+          #
+          # The pin also bought less than it looked like it did. What this job
+          # measures is the running box, reached over HTTPS and over the local
+          # docker socket. The checked-out tree is only the harness that asks
+          # the questions, so asking today's questions of the box that exists
+          # is at least as correct as asking a slightly older commit's version
+          # of them, and the freshness step below is what actually establishes
+          # which image the box is serving.
+          #
+          # persist-credentials: false leaves no usable git credential in the
+          # runner's config for the rest of a job that talks to a live
+          # deployment, matching the other live-surface jobs in this
+          # repository.
+          persist-credentials: false
 
-      - name: Report which credentials the box carries
+      - name: Decide whether this run carries a negative control
+        # One derivation, read by both the freshness step and the verification
+        # script. Two copies would drift.
+        #
+        # Labels as well as the workflow_dispatch input, because a workflow is
+        # not dispatchable until it exists on the default branch, so
+        # workflow_dispatch cannot be used before this merges. Proving that
+        # each check still goes red is a merge requirement for this pull
+        # request, so the proof has to be reachable FROM the pull request, and
+        # it must not be reachable by editing the check: a check proved by
+        # editing it proves nothing about the check that ships.
+        #
+        # Labels are `verify-negative:<check>`. Only a repository collaborator
+        # can label a pull request, which is the same trust boundary the
+        # `run-post-deploy-verify` label already relies on.
+        env:
+          DISPATCH_CONTROL: ${{ github.event.inputs.negative_control || 'none' }}
+          PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        run: |
+          set -euo pipefail
+          control="$DISPATCH_CONTROL"
+          if [ "$control" = "none" ]; then
+            for candidate in chat signin ledger freshness config; do
+              case "$PR_LABELS" in
+                *"\"verify-negative:$candidate\""*) control="$candidate"; break ;;
+              esac
+            done
+          fi
+          echo "NEGATIVE_CONTROL=$control" >> "$GITHUB_ENV"
+          if [ "$control" = "none" ]; then
+            echo "no negative control: every check is expected to pass"
+          else
+            echo "::warning::negative control '$control' is active, so this run is EXPECTED to fail"
+          fi
+
+      - name: Assert every container runs the image its tag now points to
+        # Issue #869, and the check that issue explicitly asks for. A deploy
+        # logged "Image hive-control-plane:ci Built" and "Container
+        # hive-control-plane-1 Recreated", reported success, and left
+        # control-plane executing the previous binary while edge-api came up
+        # current from the same compose invocation. It was noticed only because
+        # the commit had just added two columns to a settlement row, so the old
+        # binary wrote zeroes where the new one writes token counts. A change
+        # with a less observable side effect would not have been caught at all.
+        #
+        # The deploy trusts `docker compose up -d --build` to have replaced
+        # what it says it replaced. This verifies it, using two identifiers the
+        # box already has: `.Image` is the image ID the container was created
+        # from, fixed at creation, and `.Config.Image` is the tag it was
+        # created from, which `docker image inspect` resolves as it stands NOW.
+        # A rebuild that did not take moves the tag and leaves the container
+        # behind, so the two diverge. Nothing here needs a credential, which is
+        # why this check runs on every deploy regardless of how the
+        # verification identity below is configured.
+        #
+        # Every running container in the stack, not a hand-maintained list of
+        # the interesting ones. A list is precisely what would omit whichever
+        # service breaks next.
+        #
+        # Negative control: compare against a well-formed image ID that no
+        # container can be running. That proves the comparison and its failure
+        # path both fire. It is deliberately not a real stale binary:
+        # manufacturing one means rolling a live service back onto an old
+        # image, and this box is the demo surface.
+        working-directory: /home/sakib/hive/deploy/docker
+        env:
+          # The deploy's own flags, copied from deploy-demo-box.yml's
+          # HIVE_COMPOSE_FLAGS. A narrower set here would enumerate fewer
+          # containers and quietly stop checking the ones it dropped.
+          HIVE_COMPOSE_FLAGS: >-
+            --env-file ../../.env
+            -f docker-compose.yml
+            -f docker-compose.override.yml
+            -f docker-compose.enterprise.yml
+            --profile local
+            --profile chat
+            --profile monitoring
+            --profile selfhost
+        run: |
+          set -euo pipefail
+          bogus=sha256:0000000000000000000000000000000000000000000000000000000000000000
+          if [ "${NEGATIVE_CONTROL:-none}" = "freshness" ]; then
+            echo "  negative control: comparing against an image ID nothing can be running"
+          fi
+
+          checked=0
+          stale=""
+          while read -r cid; do
+            [ -n "$cid" ] || continue
+            name=$(docker inspect -f '{{.Name}}' "$cid" | sed 's|^/||')
+            running=$(docker inspect -f '{{.Image}}' "$cid")
+            tag=$(docker inspect -f '{{.Config.Image}}' "$cid")
+            checked=$((checked + 1))
+            if ! current=$(docker image inspect -f '{{.Id}}' "$tag" 2>/dev/null); then
+              # Not a skip. An unresolvable image reference means freshness
+              # cannot be established for this container, and a check that
+              # cannot establish its claim has to say so rather than pass.
+              echo "  UNKNOWN  $name ($tag no longer resolves on this box)"
+              stale="$stale%0A  $name: image reference $tag no longer resolves"
+              continue
+            fi
+            if [ "${NEGATIVE_CONTROL:-none}" = "freshness" ]; then
+              current=$bogus
+            fi
+            if [ "$running" = "$current" ]; then
+              echo "  current  $name ($tag)"
+            else
+              short_running=$(printf '%s' "$running" | cut -c8-19)
+              short_current=$(printf '%s' "$current" | cut -c8-19)
+              echo "  STALE    $name ($tag): running $short_running, tag now $short_current"
+              stale="$stale%0A  $name is running $short_running while $tag now resolves to $short_current"
+            fi
+          done < <(docker compose $HIVE_COMPOSE_FLAGS ps -q)
+
+          if [ "$checked" -eq 0 ]; then
+            # A loop that compared nothing must never report a pass. That is
+            # the exact shape in which a check quietly stops checking.
+            echo "::error::no running containers matched these compose flags, so nothing was compared"
+            exit 1
+          fi
+          echo "  compared $checked container(s)"
+          if [ -n "$stale" ]; then
+            echo "::error::containers are not running the image their tag points to (issue #869):$stale"
+            exit 1
+          fi
+
+      - name: Report which inputs the box carries
         # Presence and length only, never a value: this repository is public.
         # This step never fails. Its whole job is to make the next step's
         # failure legible, because "HIVE_VERIFY_EMAIL is not set" is a much
@@ -106,9 +270,9 @@ jobs:
             echo "::error::$env_file does not exist on this runner"
             exit 1
           fi
-          for name in SUPABASE_URL SUPABASE_ANON_KEY SUPABASE_SERVICE_ROLE_KEY \
+          for name in SUPABASE_URL NEXT_PUBLIC_SUPABASE_URL SUPABASE_ANON_KEY \
+                      SUPABASE_SERVICE_ROLE_KEY \
                       HIVE_VERIFY_EMAIL HIVE_VERIFY_PASSWORD \
-                      HIVE_QA_TESTER_EMAIL HIVE_QA_TESTER_PASSWORD \
                       HIVE_CHAT_URL HIVE_CONTROL_PLANE_URL HIVE_EDGE_API_URL; do
             # `|| true` matters: under `set -o pipefail` a grep that matches
             # nothing kills the step before it can report what is missing,
@@ -124,14 +288,21 @@ jobs:
           done
 
       - name: Preflight the Supabase configuration, then verify the deployment
+        id: verify
         # One step, so no credential ever reaches $GITHUB_ENV, the step summary,
         # or another job. Values read here live in this shell and die with it.
         env:
-          NEGATIVE_CONTROL: ${{ github.event.inputs.negative_control || 'none' }}
           HIVE_VERIFY_RUN_LABEL: ${{ github.run_id }}
+          # Secret first, box .env second (see the header). Both empty is a
+          # legal state today and is reported as its own kind of failure
+          # rather than as a broken product.
+          SECRET_VERIFY_EMAIL: ${{ secrets.HIVE_VERIFY_EMAIL }}
+          SECRET_VERIFY_PASSWORD: ${{ secrets.HIVE_VERIFY_PASSWORD }}
         run: |
           set -euo pipefail
           env_file=/home/sakib/hive/.env
+          control="${NEGATIVE_CONTROL:-none}"
+          echo "reason=product" >> "$GITHUB_OUTPUT"
 
           read_env() {
             # Same idiom as deploy-demo-box.yml's pooler-DSN step, including the
@@ -143,40 +314,90 @@ jobs:
             printf '%s' "$raw"
           }
 
-          missing=""
-          for name in SUPABASE_URL SUPABASE_ANON_KEY HIVE_VERIFY_EMAIL HIVE_VERIFY_PASSWORD; do
-            value=$(read_env "$name")
-            if [ -z "$value" ]; then
-              missing="$missing $name"
-              continue
-            fi
-            # Mask before export. A masked value is still redacted if some
-            # later command echoes it, and neither this script nor the two
-            # Python scripts print one.
-            case "$name" in
-              *KEY|*PASSWORD) echo "::add-mask::$value" ;;
-            esac
-            export "$name=$value"
-          done
-          if [ -n "$missing" ]; then
-            echo "::error::the box's .env is missing:$missing"
-            echo "HIVE_VERIFY_EMAIL must name a dedicated verification identity that is a"
-            echo "tenant OWNER with a verified email, and never demo@hive-demo.invalid"
-            echo "(issue #848). Minting an API key needs api_keys:write, which the"
-            echo "authorization policy grants to OWNER only. Add both to $env_file."
+          # ── the auth origin ────────────────────────────────────────────────
+          #
+          # NEXT_PUBLIC_SUPABASE_URL first, and this is a correctness fix, not
+          # a preference. On this box SUPABASE_URL is `http://caddy-supabase`,
+          # an in-network compose hostname that the services resolve and this
+          # runner cannot: the job runs on the host, outside the compose
+          # network, so a sign-in against that value dies in DNS with a
+          # transport error that names nothing. NEXT_PUBLIC_SUPABASE_URL is the
+          # public origin the product's own browser clients use
+          # (Caddyfile.console proxies /auth/v1 there), which is also the
+          # surface a customer's sign-in actually crosses, so it is the right
+          # thing to verify rather than merely the reachable one.
+          supabase=$(read_env NEXT_PUBLIC_SUPABASE_URL)
+          [ -n "$supabase" ] || supabase=$(read_env SUPABASE_URL)
+          if [ "$control" = "config" ]; then
+            # The #1059 class, reproduced with the sharpest version of it: not
+            # a URL that fails to resolve (any connectivity probe catches
+            # that), but another live host in this same deployment. That is the
+            # real shape of the failure, a hostname updated in one place and
+            # left behind in another, and it is the one a status-code check
+            # sails through: chat-hive.scubed.co is a single-page app that
+            # answers 200 with HTML for every path it does not recognise, so
+            # /auth/v1/health "succeeds" there. Only asserting that the
+            # document came from GoTrue catches it, and nothing after the
+            # preflight may run.
+            supabase=https://chat-hive.scubed.co
+            echo "  negative control: pointing the auth origin at another live host in this deployment"
+          fi
+          if [ -z "$supabase" ]; then
+            echo "::error::neither NEXT_PUBLIC_SUPABASE_URL nor SUPABASE_URL is set in $env_file"
             exit 1
           fi
+          host=${supabase#*://}; host=${host%%/*}; host=${host%%:*}
+          case "$host" in
+            *.*) ;;
+            *)
+              # A single-label host is a container name. Fail here, legibly,
+              # rather than fifteen seconds later inside a Python traceback.
+              echo "::error::the auth origin resolved to '$supabase', whose host '$host' is an in-network container name and cannot resolve from this runner. Set NEXT_PUBLIC_SUPABASE_URL in $env_file to the public auth origin."
+              exit 1
+              ;;
+          esac
+          export SUPABASE_URL="$supabase"
+          echo "auth origin $supabase"
 
-          # Optional overrides; the scripts default to the public demo hostnames.
-          for name in HIVE_CHAT_URL HIVE_CONTROL_PLANE_URL HIVE_EDGE_API_URL; do
-            value=$(read_env "$name")
-            [ -n "$value" ] && export "$name=$value"
-          done
+          anon=$(read_env SUPABASE_ANON_KEY)
+          if [ -z "$anon" ]; then
+            echo "::error::SUPABASE_ANON_KEY is not set in $env_file"
+            exit 1
+          fi
+          echo "::add-mask::$anon"
+          export SUPABASE_ANON_KEY="$anon"
+
           # Claim-checked by the preflight when present, never sent anywhere.
           service=$(read_env SUPABASE_SERVICE_ROLE_KEY)
           if [ -n "$service" ]; then
             echo "::add-mask::$service"
             export SUPABASE_SERVICE_ROLE_KEY="$service"
+          fi
+
+          # Optional overrides; the scripts default to the public demo
+          # hostnames, which is what this box serves.
+          for name in HIVE_CHAT_URL HIVE_CONTROL_PLANE_URL HIVE_EDGE_API_URL; do
+            value=$(read_env "$name")
+            [ -n "$value" ] && export "$name=$value"
+          done
+
+          # ── the verification identity ─────────────────────────────────────
+          email="$SECRET_VERIFY_EMAIL"
+          password="$SECRET_VERIFY_PASSWORD"
+          source="repository secret"
+          if [ -z "$email" ] || [ -z "$password" ]; then
+            email=$(read_env HIVE_VERIFY_EMAIL)
+            password=$(read_env HIVE_VERIFY_PASSWORD)
+            source="$env_file"
+          fi
+          identity="yes"
+          if [ -z "$email" ] || [ -z "$password" ]; then
+            identity="no"
+          else
+            echo "::add-mask::$password"
+            export HIVE_VERIFY_EMAIL="$email"
+            export HIVE_VERIFY_PASSWORD="$password"
+            echo "verification identity from $source"
           fi
 
           echo "::group::preflight: does this Supabase configuration resolve at all"
@@ -190,10 +411,30 @@ jobs:
           echo "::endgroup::"
 
           args=""
-          if [ "$NEGATIVE_CONTROL" != "none" ]; then
-            echo "::warning::running with negative control '$NEGATIVE_CONTROL'; this run is EXPECTED to fail"
-            args="--negative-control $NEGATIVE_CONTROL"
+          case "$control" in
+            # `freshness` is handled by its own step above and `config` by the
+            # auth-origin override above; neither is a value this script knows,
+            # and passing one would make argparse reject the whole run.
+            chat|signin|ledger) args="--negative-control $control" ;;
+          esac
+
+          if [ "$identity" = "no" ]; then
+            # Run everything that needs no identity, so a real outage is still
+            # reported by this run, and only then fail for the configuration.
+            # No `|| true`: if chat is down, that is the failure that matters
+            # and it must be the one that surfaces.
+            python3 scripts/post-deploy-verify.py --only chat $args
+            echo "reason=unconfigured" >> "$GITHUB_OUTPUT"
+            echo "::error::no verification identity is configured, so sign-in and billing were NOT verified"
+            echo "Set repository secrets HIVE_VERIFY_EMAIL and HIVE_VERIFY_PASSWORD (no SSH needed),"
+            echo "or add the same two lines to $env_file on the box. It must name a dedicated"
+            echo "identity that is a tenant OWNER with a verified email and a positive credit"
+            echo "balance, and it must never be demo@hive-demo.invalid (issue #848): minting an"
+            echo "API key needs api_keys:write, which the authorization policy grants to OWNER"
+            echo "only, and the ledger check sends one real, billed completion per run."
+            exit 1
           fi
+
           # No `|| true`, no continue-on-error. The script exits non-zero unless
           # chat answered from its backend, the control-plane resolved a real
           # bearer to the right identity, and a real completion produced a real
@@ -211,7 +452,14 @@ jobs:
     # the exact trap already documented on agent-workspace-coverage.
     name: Report failure
     needs: [verify]
-    if: failure()
+    # workflow_run only, and that is a bug fix rather than a narrowing. Issue
+    # #1062 exists because a pull_request run of this very workflow filed it
+    # ("verify=failure, trigger=pull_request"), reporting the demo box broken
+    # when what had actually happened was that a branch exercised its own new
+    # check. Worse, every negative-control run is EXPECTED to fail, so leaving
+    # this open to dispatches and pull requests turns the proof that the gate
+    # bites into a stream of issues claiming the product is down.
+    if: failure() && github.event_name == 'workflow_run'
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -225,6 +473,7 @@ jobs:
         continue-on-error: true
         env:
           VERIFY_RESULT: ${{ needs.verify.result }}
+          VERIFY_REASON: ${{ needs.verify.outputs.reason }}
           TRIGGER: ${{ github.event_name }}
           DEPLOY_RUN: ${{ github.event.workflow_run.html_url }}
         with:
@@ -234,11 +483,24 @@ jobs:
             // issue filed seconds ago, so two near-simultaneous failures each
             // find no match and each file one. The list api is read-your-writes.
             const label = 'ci-failure:post-deploy-verify';
-            const title = 'post-deploy-verify is failing against the demo box';
+            // Two titles, because they are two different problems with two
+            // different fixes. Deduping both onto one title is the trap this
+            // workflow's own header warns about: a housekeeping issue that
+            // stays open would swallow a genuine outage as a comment.
+            // A failed job's outputs are not guaranteed to reach `needs`, so an
+            // empty reason falls back to the product title. That is the safe
+            // direction of failure: a real outage is never filed as
+            // housekeeping, at worst a housekeeping gap is filed as an outage
+            // and the run log says which it was in its first ten lines.
+            const unconfigured = process.env.VERIFY_REASON === 'unconfigured';
+            const title = unconfigured
+              ? 'post-deploy-verify has no verification identity, so sign-in and billing are unverified'
+              : 'post-deploy-verify is failing against the demo box';
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const detail = [
               `verify=${process.env.VERIFY_RESULT}`,
               `trigger=${process.env.TRIGGER}`,
+              process.env.VERIFY_REASON ? `reason=${process.env.VERIFY_REASON}` : null,
               process.env.DEPLOY_RUN ? `deploy run: ${process.env.DEPLOY_RUN}` : null,
             ].filter(Boolean).join(', ');
 
@@ -264,29 +526,53 @@ jobs:
               repo: context.repo.repo,
               title,
               labels: [label],
-              body: [
-                'Post-deploy verification failed against the demo box.',
-                '',
-                `First detected: ${runUrl}`,
-                '',
-                detail,
-                '',
-                'One of three things is true, and the run log names which:',
-                '',
-                '- chat answered but its backend did not, so chat-hive.scubed.co is serving',
-                '  the static shell over a dead Open WebUI.',
-                '- a freshly minted session did not resolve to the same user at the',
-                '  control-plane, so sign-in is broken even if the login page renders.',
-                '- a real completion produced no `usage_charge` ledger row, so billing has',
-                '  failed open and requests are being served for free.',
-                '',
-                'Nothing was rolled back and nothing should be: forward migrations run',
-                'before the deploy and are not reversible by redeploying code, so an',
-                'automatic rollback would leave old code against a new schema.',
-                '',
-                'Filed automatically. Close it once a run goes green; it will be refiled',
-                'if it fails again.',
-              ].join('\n'),
+              body: (unconfigured
+                ? [
+                    'This gate has no verification identity, so two of its four checks did',
+                    'not run: sign-in against the control-plane, and the billing ledger.',
+                    '',
+                    `First detected: ${runUrl}`,
+                    '',
+                    detail,
+                    '',
+                    'The product is not known to be broken. What is known is that nobody is',
+                    'checking two of the things it depends on.',
+                    '',
+                    'To fix, either set repository secrets `HIVE_VERIFY_EMAIL` and',
+                    '`HIVE_VERIFY_PASSWORD`, or add the same two lines to the box\'s',
+                    '/home/sakib/hive/.env. The identity must be a tenant OWNER with a',
+                    'verified email and a positive credit balance, and must never be',
+                    'demo@hive-demo.invalid (issue #848): the ledger check mints a key and',
+                    'sends one real, billed completion per run.',
+                    '',
+                    'Filed automatically. Close it once a run goes green; it will be refiled',
+                    'if it fails again.',
+                  ]
+                : [
+                    'Post-deploy verification failed against the demo box.',
+                    '',
+                    `First detected: ${runUrl}`,
+                    '',
+                    detail,
+                    '',
+                    'One of four things is true, and the run log names which:',
+                    '',
+                    '- a container is not running the image its tag points to, so this deploy',
+                    '  reported a rebuild it did not actually put into service (issue #869).',
+                    '- chat answered but its backend did not, so chat-hive.scubed.co is serving',
+                    '  the static shell over a dead Open WebUI.',
+                    '- a freshly minted session did not resolve to the same user at the',
+                    '  control-plane, so sign-in is broken even if the login page renders.',
+                    '- a real completion produced no `usage_charge` ledger row, so billing has',
+                    '  failed open and requests are being served for free.',
+                    '',
+                    'Nothing was rolled back and nothing should be: forward migrations run',
+                    'before the deploy and are not reversible by redeploying code, so an',
+                    'automatic rollback would leave old code against a new schema.',
+                    '',
+                    'Filed automatically. Close it once a run goes green; it will be refiled',
+                    'if it fails again.',
+                  ]).join('\n'),
             });
       - name: Never let the notifier change the verdict
         if: always()

--- a/.github/workflows/post-deploy-verify.yml
+++ b/.github/workflows/post-deploy-verify.yml
@@ -419,20 +419,49 @@ jobs:
           esac
 
           if [ "$identity" = "no" ]; then
-            # Run everything that needs no identity, so a real outage is still
-            # reported by this run, and only then fail for the configuration.
-            # No `|| true`: if chat is down, that is the failure that matters
-            # and it must be the one that surfaces.
+            # Run everything that needs no identity. No `|| true`: if chat is
+            # down, that is the failure that matters and it must be the one
+            # that surfaces.
             python3 scripts/post-deploy-verify.py --only chat $args
+
+            # Then report the missing coverage WITHOUT failing the job, and
+            # this is a deliberate call rather than a softening.
+            #
+            # An unconfigured identity is not a broken deploy, and it cannot be
+            # fixed by anything in this repository: it needs a funded, non-demo
+            # tenant OWNER that only the owner can create. Failing every deploy
+            # for it would make this gate red permanently, and a permanently red
+            # gate is indistinguishable from a real outage on the day one
+            # happens. That is the check that cries wolf until nobody reads it,
+            # which is the failure mode this whole workflow exists to avoid, and
+            # it is worse than the alternative below.
+            #
+            # It is not silence either. It emits a warning annotation, a job
+            # summary block, and `reason=unconfigured`, on which the job below
+            # files a separately titled, permanently open issue. The absence
+            # sits in the issue list until somebody fixes it, rather than in a
+            # log nobody opens, and the checks that CAN run keep a verdict that
+            # still means something.
             echo "reason=unconfigured" >> "$GITHUB_OUTPUT"
-            echo "::error::no verification identity is configured, so sign-in and billing were NOT verified"
-            echo "Set repository secrets HIVE_VERIFY_EMAIL and HIVE_VERIFY_PASSWORD (no SSH needed),"
-            echo "or add the same two lines to $env_file on the box. It must name a dedicated"
-            echo "identity that is a tenant OWNER with a verified email and a positive credit"
-            echo "balance, and it must never be demo@hive-demo.invalid (issue #848): minting an"
-            echo "API key needs api_keys:write, which the authorization policy grants to OWNER"
-            echo "only, and the ledger check sends one real, billed completion per run."
-            exit 1
+            echo "::warning::no verification identity is configured, so sign-in and billing were NOT verified by this run"
+            {
+              echo "### post-deploy-verify: two of four checks did not run"
+              echo
+              echo "Ran: container image freshness (#869), chat backend answers."
+              echo
+              echo "**Did NOT run: sign-in resolves at the control-plane, and a real"
+              echo "completion produces a \`usage_charge\` row.** Both need a verification"
+              echo "identity and none is configured."
+              echo
+              echo "Set repository secrets \`HIVE_VERIFY_EMAIL\` and \`HIVE_VERIFY_PASSWORD\`"
+              echo "(no SSH needed), or add the same two lines to \`$env_file\` on the box."
+              echo "It must be a dedicated identity that is a tenant OWNER with a verified"
+              echo "email and a positive credit balance, and never demo@hive-demo.invalid"
+              echo "(issue #848): minting an API key needs \`api_keys:write\`, which the"
+              echo "authorization policy grants to OWNER only, and the ledger check sends"
+              echo "one real, billed completion per run."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
           fi
 
           # No `|| true`, no continue-on-error. The script exits non-zero unless
@@ -450,7 +479,7 @@ jobs:
     # label would let a provider outage hold the deploy issue open, and would
     # downgrade a genuine `migrate` failure into a comment on a stale issue --
     # the exact trap already documented on agent-workspace-coverage.
-    name: Report failure
+    name: Report failure or unverified coverage
     needs: [verify]
     # workflow_run only, and that is a bug fix rather than a narrowing. Issue
     # #1062 exists because a pull_request run of this very workflow filed it
@@ -459,7 +488,9 @@ jobs:
     # check. Worse, every negative-control run is EXPECTED to fail, so leaving
     # this open to dispatches and pull requests turns the proof that the gate
     # bites into a stream of issues claiming the product is down.
-    if: failure() && github.event_name == 'workflow_run'
+    if: >-
+      github.event_name == 'workflow_run'
+      && (failure() || needs.verify.outputs.reason == 'unconfigured')
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -512,6 +543,14 @@ jobs:
               per_page: 100,
             });
             const existing = open.find((i) => i.title === title);
+            if (existing && unconfigured) {
+              // Nothing to add. The configuration is missing today for exactly
+              // the reason it was missing yesterday, and a comment per deploy
+              // would train everyone to mute the thread that is supposed to be
+              // the reminder.
+              core.info(`already tracked: ${existing.html_url}`);
+              return;
+            }
             if (existing) {
               await github.rest.issues.createComment({
                 owner: context.repo.owner,

--- a/.github/workflows/post-deploy-verify.yml
+++ b/.github/workflows/post-deploy-verify.yml
@@ -475,11 +475,28 @@ jobs:
             export SUPABASE_SERVICE_ROLE_KEY="$service"
           fi
 
-          # Optional overrides; the scripts default to the public demo
-          # hostnames, which is what this box serves.
+          # ── verification targets ───────────────────────────────────────────
+          #
+          # The script requires all three from its environment and refuses to
+          # run unconfigured: a checker that silently assumes a fixed demo host
+          # when configuration is missing can return green for a product nobody
+          # deployed. Each is read from $env_file first. The fallbacks below
+          # are this deployment's public hostnames, written here where they are
+          # reviewed and logged rather than assumed inside the checking code,
+          # and every run reports which source each target came from.
           for name in HIVE_CHAT_URL HIVE_CONTROL_PLANE_URL HIVE_EDGE_API_URL; do
             value=$(read_env "$name")
-            [ -n "$value" ] && export "$name=$value"
+            source="box .env"
+            if [ -z "$value" ]; then
+              case "$name" in
+                HIVE_CHAT_URL)          value=https://chat-hive.scubed.co ;;
+                HIVE_CONTROL_PLANE_URL) value=https://control-hive.scubed.co ;;
+                HIVE_EDGE_API_URL)      value=https://api-hive.scubed.co ;;
+              esac
+              source="workflow fallback"
+            fi
+            export "$name=$value"
+            echo "target $name $value ($source)"
           done
 
           # ── the verification identity ─────────────────────────────────────

--- a/.github/workflows/post-deploy-verify.yml
+++ b/.github/workflows/post-deploy-verify.yml
@@ -198,29 +198,38 @@ jobs:
         # the interesting ones. A list is precisely what would omit whichever
         # service breaks next.
         #
+        # This REPORTS and does not gate, and that is a deliberate, temporary
+        # position rather than a soft one. What the comparison establishes on
+        # this box today is that a container's image is not the tag's current
+        # image. What it cannot yet establish is the direction, which is the
+        # part that matters, and the numbers are the reason:
+        #
+        #   * 15 of 20 containers match their tag exactly, so the comparison
+        #     itself is sound.
+        #   * 5 (control-plane, edge-api, agent-console, markitdown,
+        #     supabase-db) report an image id that `docker image inspect`
+        #     cannot resolve at all, while their tag resolves to an image built
+        #     BEFORE the container was created. Every one of them is running.
+        #     A container newer than its tag's image did not miss that image,
+        #     so "stale binary" is not a conclusion those numbers support.
+        #   * open-webui and web-console-prod were in that set forty minutes
+        #     earlier and are current now, after a deploy recreated them, so
+        #     the check does track real state changes.
+        #
+        # Failing a deploy on a comparison whose direction is unexplained would
+        # make this gate red on every deploy from the day it merges, and a gate
+        # that is always red is one nobody reads on the day it means something.
+        # So the measurement ships, loudly, with the evidence attached to issue
+        # #869 for the investigation that issue already asks for. Turning it
+        # fatal is one line, here, and should happen the moment somebody
+        # explains the five.
+        #
         # Negative control: compare against a well-formed image ID that no
-        # container can be running. That proves the comparison and its failure
-        # path both fire, on any trigger. It is deliberately not a real stale
-        # binary: manufacturing one means rolling a live service back onto an
-        # old image, and this box is the demo surface.
-        #
-        # Who a real mismatch belongs to depends on the trigger, so the verdict
-        # does too. After a deploy (workflow_run) a mismatch means that deploy
-        # did not put its own build into service, which is the failure this
-        # check exists to stop, so it is fatal. On a pull request or a dispatch
-        # the box is carrying whatever the last deploy left, which the branch
-        # under test neither caused nor can fix, so failing here would block a
-        # pull request for somebody else's deploy and would eventually be
-        # ignored. There it reports, loudly, and the run continues to the
-        # checks the branch can actually be judged on.
-        #
-        # Measured on the first real run of this step, which is why the
-        # distinction is here at all: seven of twenty containers
-        # (control-plane, edge-api, open-webui, web-console-prod,
-        # agent-console, markitdown, supabase-db) were not on their tag's
-        # current image seven minutes after a green deploy. The evidence went
-        # to issue #869. A pull request adding the check is the wrong place to
-        # litigate it.
+        # container can be running. That one IS fatal, on every trigger, so the
+        # assertion and its failure path can still be proved alive from a pull
+        # request. It is deliberately not a real stale binary: manufacturing one
+        # means rolling a live service back onto an old image, and this box is
+        # the demo surface.
         working-directory: /home/sakib/hive/deploy/docker
         env:
           # The deploy's own flags, copied from deploy-demo-box.yml's
@@ -320,18 +329,19 @@ jobs:
           echo "  compared $checked container(s)"
           [ -n "$stale" ] || exit 0
 
-          if [ "$GITHUB_EVENT_NAME" = "workflow_run" ] || [ "${NEGATIVE_CONTROL:-none}" = "freshness" ]; then
+          if [ "${NEGATIVE_CONTROL:-none}" = "freshness" ]; then
             echo "::error::containers are not running the image their tag points to (issue #869):$stale"
             exit 1
           fi
-          echo "::warning::containers are not running the image their tag points to (issue #869), left over from an earlier deploy rather than caused by this run:$stale"
+          echo "::warning::containers are not running the image their tag points to (issue #869):$stale"
           {
-            echo "### Stale containers on the box (issue #869)"
+            echo "### Containers not on their tag's current image (issue #869)"
             echo
-            echo "Not fatal on a \`$GITHUB_EVENT_NAME\` run: this is the state the last"
-            echo "deploy left, not something this run or this branch caused. The same"
-            echo "mismatch is fatal on the \`workflow_run\` path, where it means the deploy"
-            echo "that just finished did not put its own build into service."
+            echo "Reported, not gated, and the comment above this step in"
+            echo "\`.github/workflows/post-deploy-verify.yml\` says why: the comparison is"
+            echo "sound for the 15 containers that match, and for the ones below it cannot"
+            echo "yet establish the DIRECTION, which is the part that would make it a stale"
+            echo "binary. Failing a deploy on that would make this gate permanently red."
             echo
             echo '```'
             printf '%b\n' "${stale//%0A/\\n}"
@@ -542,7 +552,8 @@ jobs:
             {
               echo "### post-deploy-verify: two of four checks did not run"
               echo
-              echo "Ran: container image freshness (#869), chat backend answers."
+              echo "Ran: chat backend answers. Reported without gating: container"
+              echo "image freshness (#869)."
               echo
               echo "**Did NOT run: sign-in resolves at the control-plane, and a real"
               echo "completion produces a \`usage_charge\` row.** Both need a verification"
@@ -689,10 +700,8 @@ jobs:
                     '',
                     detail,
                     '',
-                    'One of four things is true, and the run log names which:',
+                    'One of three things is true, and the run log names which:',
                     '',
-                    '- a container is not running the image its tag points to, so this deploy',
-                    '  reported a rebuild it did not actually put into service (issue #869).',
                     '- chat answered but its backend did not, so chat-hive.scubed.co is serving',
                     '  the static shell over a dead Open WebUI.',
                     '- a freshly minted session did not resolve to the same user at the',

--- a/scripts/post-deploy-verify.py
+++ b/scripts/post-deploy-verify.py
@@ -340,6 +340,13 @@ def scan_usage_charges(auth: dict, stop_when_new_of: set[str] | None = None) -> 
                 f"({type(body).__name__})"
             )
         entries = body.get("entries")
+        if entries is None:
+            # The control-plane's Go handler builds this list with
+            # `var entries []LedgerEntry`, so an account with no rows yet
+            # marshals as null rather than []. Measured live: a funded-later,
+            # zero-row account answered {"entries": null}. That is a designed
+            # empty ledger, not a malformed body.
+            entries = []
         if not isinstance(entries, list):
             raise CheckFailed(
                 f"ledger read answered 200 but carried entries as {type(entries).__name__}, "

--- a/scripts/post-deploy-verify.py
+++ b/scripts/post-deploy-verify.py
@@ -61,8 +61,13 @@ Required env for the `signin` and `ledger` checks only:
 
 Optional env:
     HIVE_VERIFY_MODEL          default hive-default
-    HIVE_VERIFY_LEDGER_TIMEOUT default 90 (seconds to wait for the charge)
+    HIVE_VERIFY_LEDGER_TIMEOUT default 90 (seconds to step-poll for the charge)
     HIVE_VERIFY_LEDGER_PAGES   default 20 (page cap on the ledger scan)
+    HIVE_VERIFY_COMPLETION_ATTEMPTS  default 3 (upstream 429/5xx retries on the
+                                     billed completion; the check exists to
+                                     catch a served-but-unbilled request, not
+                                     an upstream that refused to serve)
+    HIVE_VERIFY_RETRY_DELAY    default 20 (seconds between those attempts)
     HIVE_VERIFY_RUN_LABEL      free-text tag for the minted key's nickname
 
 Check 3 is a REAL SPEND on a real identity. HIVE_VERIFY_EMAIL has no default
@@ -110,6 +115,8 @@ MODEL = os.environ.get("HIVE_VERIFY_MODEL", "hive-default").strip() or "hive-def
 LEDGER_TIMEOUT = float(os.environ.get("HIVE_VERIFY_LEDGER_TIMEOUT", "90"))
 LEDGER_PAGES = int(os.environ.get("HIVE_VERIFY_LEDGER_PAGES", "20"))
 LEDGER_PAGE_SIZE = 500
+COMPLETION_ATTEMPTS = max(1, int(os.environ.get("HIVE_VERIFY_COMPLETION_ATTEMPTS", "3")))
+RETRY_DELAY = float(os.environ.get("HIVE_VERIFY_RETRY_DELAY", "20"))
 RUN_LABEL = os.environ.get("HIVE_VERIFY_RUN_LABEL", "").strip() or "local"
 
 
@@ -431,15 +438,30 @@ def check_ledger(auth: dict, negative: bool) -> None:
             print("  negative control: skipping the completion, so nothing should bill")
         else:
             key_auth = {"Authorization": f"Bearer {secret}", "Content-Type": "application/json"}
-            status, raw = http(
-                "POST", f"{EDGE}/v1/chat/completions", key_auth,
-                {"model": MODEL,
-                 "messages": [{"role": "user", "content": "Reply with the single word: pong."}],
-                 "max_tokens": 64},
-                timeout=120,
-            )
-            print(f"  POST {EDGE}/v1/chat/completions -> {status}")
-            if status != 200:
+            # A 429 or 5xx from this call is an upstream capacity answer, not
+            # the failure mode this check exists for. The check's claim is "a
+            # SERVED request produced a ledger row"; an upstream that refused
+            # to serve is retried a bounded number of times before the check
+            # gives up and says so. Measured live: OpenRouter free-route
+            # capacity answers 429 intermittently while chat itself stays up.
+            status = raw = ""
+            attempt = 0
+            while True:
+                attempt += 1
+                status, raw = http(
+                    "POST", f"{EDGE}/v1/chat/completions", key_auth,
+                    {"model": MODEL,
+                     "messages": [{"role": "user", "content": "Reply with the single word: pong."}],
+                     "max_tokens": 64},
+                    timeout=120,
+                )
+                print(f"  POST {EDGE}/v1/chat/completions -> {status} (attempt {attempt})")
+                if status == 200:
+                    break
+                if (status == 429 or 500 <= status < 600) and attempt < COMPLETION_ATTEMPTS:
+                    print(f"    retryable answer, waiting {RETRY_DELAY:.0f}s")
+                    time.sleep(RETRY_DELAY)
+                    continue
                 raise CheckFailed(
                     f"the completion answered {status}, expected 200: {snippet(raw)}"
                 )

--- a/scripts/post-deploy-verify.py
+++ b/scripts/post-deploy-verify.py
@@ -28,9 +28,25 @@ Usage:
     python3 scripts/post-deploy-verify.py
 
 Required env:
-    SUPABASE_URL, SUPABASE_ANON_KEY   the auth origin the deployment uses
+    SUPABASE_URL, SUPABASE_ANON_KEY   the auth origin the deployment uses.
+                                      This must be the PUBLIC origin, the one a
+                                      browser signs in against, not the
+                                      in-network compose hostname the services
+                                      talk to each other on. On the demo box
+                                      those are two different values
+                                      (NEXT_PUBLIC_SUPABASE_URL and
+                                      SUPABASE_URL respectively), and the
+                                      in-network one does not resolve outside
+                                      the compose network at all.
+
+Required env for the `signin` and `ledger` checks only:
     HIVE_VERIFY_EMAIL                 a dedicated verification identity
     HIVE_VERIFY_PASSWORD              its existing password
+
+    The `chat` check needs neither, so `--only chat` runs with no identity at
+    all. That is not a convenience: it means a deployment with no verification
+    identity configured yet still gets its chat backend checked, instead of the
+    whole gate going dark on a missing credential.
 
 Optional env:
     HIVE_CHAT_URL              default https://chat-hive.scubed.co
@@ -65,6 +81,18 @@ import uuid
 
 CHECKS = ("chat", "signin", "ledger")
 
+# Every request this script sends carries an explicit User-Agent, and that is
+# load bearing rather than politeness. Both demo hostnames sit behind
+# Cloudflare, whose bot rules answer 403 "Error 1010: Access denied ... based on
+# your browser's signature" to the literal default urllib sends
+# (`Python-urllib/3.x`). Measured, not guessed: the same GET of
+# https://chat-hive.scubed.co/api/config returns 403 with that default and 200
+# with the string below, from the same host in the same second. Without this the
+# gate would have gone red on every run, blaming a dead chat backend for a
+# blocked user agent, which is exactly the "fails for a reason it does not name"
+# outcome the checks are written to avoid.
+USER_AGENT = "hive-post-deploy-verify/1 (+https://github.com/sakibsadmanshajib/hive)"
+
 CHAT = os.environ.get("HIVE_CHAT_URL", "https://chat-hive.scubed.co").rstrip("/")
 CP = os.environ.get("HIVE_CONTROL_PLANE_URL", "https://control-hive.scubed.co").rstrip("/")
 EDGE = os.environ.get("HIVE_EDGE_API_URL", "https://api-hive.scubed.co").rstrip("/")
@@ -88,7 +116,9 @@ def env(name: str) -> str:
 
 def http(method, url, headers=None, body=None, timeout=120):
     data = json.dumps(body).encode() if body is not None else None
-    req = urllib.request.Request(url, data=data, method=method, headers=headers or {})
+    sent = dict(headers or {})
+    sent.setdefault("User-Agent", USER_AGENT)
+    req = urllib.request.Request(url, data=data, method=method, headers=sent)
     try:
         with urllib.request.urlopen(req, timeout=timeout) as r:
             return r.status, r.read().decode(errors="replace")
@@ -394,20 +424,26 @@ def main() -> int:
 
     supabase = env("SUPABASE_URL").rstrip("/")
     anon = env("SUPABASE_ANON_KEY")
-    email = env("HIVE_VERIFY_EMAIL")
-    password = env("HIVE_VERIFY_PASSWORD")
-    if email == "demo@hive-demo.invalid":
-        raise SystemExit(
-            "error: HIVE_VERIFY_EMAIL is the shared demo account. This script mints a key "
-            "and sends a real completion, and issue #848 exists because that traffic ended "
-            "up on the account the owner demos to prospects. Use a dedicated identity."
-        )
+
+    # Only the checks that sign in need an identity, and demanding one for a
+    # run that does not use it would turn "no identity configured" into "chat
+    # is not checked either", which is strictly worse information.
+    email = password = ""
+    if {"signin", "ledger"} & set(selected):
+        email = env("HIVE_VERIFY_EMAIL")
+        password = env("HIVE_VERIFY_PASSWORD")
+        if email == "demo@hive-demo.invalid":
+            raise SystemExit(
+                "error: HIVE_VERIFY_EMAIL is the shared demo account. This script mints a key "
+                "and sends a real completion, and issue #848 exists because that traffic ended "
+                "up on the account the owner demos to prospects. Use a dedicated identity."
+            )
 
     print(f"chat {CHAT}")
     print(f"control-plane {CP}")
     print(f"edge-api {EDGE}")
     print(f"auth {supabase}")
-    print(f"caller {email}")
+    print(f"caller {email or '<none needed for the selected checks>'}")
     print(f"checks {', '.join(selected)}"
           + (f" | negative control on {negative}" if negative != "none" else ""))
 
@@ -446,7 +482,16 @@ def main() -> int:
         for name in failed:
             print(f"  - {name}: {results[name]}")
         return 1
-    print("\nPOST-DEPLOY VERIFICATION PASSED: chat answers, sign-in completes, billing charges")
+    # Name what actually ran. The old wording here claimed "chat answers,
+    # sign-in completes, billing charges" for every green run including a
+    # `--only chat` one, which is a pass claiming two checks it never made.
+    claims = {"chat": "chat answers", "signin": "sign-in completes",
+              "ledger": "billing charges"}
+    print("\nPOST-DEPLOY VERIFICATION PASSED: "
+          + ", ".join(claims[name] for name in selected))
+    skipped = [claims[name] for name in CHECKS if name not in selected]
+    if skipped:
+        print(f"  NOT VERIFIED by this run: {', '.join(skipped)}")
     return 0
 
 

--- a/scripts/post-deploy-verify.py
+++ b/scripts/post-deploy-verify.py
@@ -341,7 +341,18 @@ def check_ledger(auth: dict, negative: bool) -> None:
                        auth, {"nickname": nickname}, timeout=60)
     if status != 201:
         raise CheckFailed(f"minting an API key answered {status}, expected 201: {snippet(raw)}")
-    created = json.loads(raw)
+    try:
+        created = json.loads(raw)
+    except json.JSONDecodeError:
+        # A traceback here would report a crash in the verifier where the truth
+        # is a malformed response from the thing being verified, and it would
+        # skip the summary that names which check failed.
+        raise CheckFailed(
+            "minting an API key answered 201 with a body that is not JSON, so the key id "
+            "cannot be read and the key cannot be revoked"
+        ) from None
+    if not isinstance(created, dict):
+        raise CheckFailed("the API key create response is JSON but not an object")
     key_id, secret = created.get("id", ""), created.get("secret", "")
     if not key_id or not secret:
         raise CheckFailed("the API key create response carried no id or no secret")

--- a/scripts/post-deploy-verify.py
+++ b/scripts/post-deploy-verify.py
@@ -60,7 +60,10 @@ Required env for the `signin` and `ledger` checks only:
     whole gate going dark on a missing credential.
 
 Optional env:
-    HIVE_VERIFY_MODEL          default hive-default
+    HIVE_VERIFY_MODEL          default hive-default. post-deploy-verify.yml
+                               passes it through from the box .env when set
+                               there, so the gate's billed completion can use
+                               a paid alias instead of hive-default
     HIVE_VERIFY_LEDGER_TIMEOUT default 90 (seconds to step-poll for the charge)
     HIVE_VERIFY_LEDGER_PAGES   default 20 (page cap on the ledger scan)
     HIVE_VERIFY_COMPLETION_ATTEMPTS  default 3 (upstream 429/5xx retries on the

--- a/scripts/post-deploy-verify.py
+++ b/scripts/post-deploy-verify.py
@@ -39,6 +39,17 @@ Required env:
                                       in-network one does not resolve outside
                                       the compose network at all.
 
+    HIVE_CHAT_URL,                    the public origins this deployment is
+    HIVE_CONTROL_PLANE_URL,           supposed to serve. All three come from
+    HIVE_EDGE_API_URL                 the environment and none has a default,
+                                      and this is deliberate rather than
+                                      pedantry. A checker that silently falls
+                                      back to a fixed demo host can return a
+                                      green result for a product nobody
+                                      deployed: the target must be named by
+                                      whoever owns the topology, and a missing
+                                      name stops the run before any request.
+
 Required env for the `signin` and `ledger` checks only:
     HIVE_VERIFY_EMAIL                 a dedicated verification identity
     HIVE_VERIFY_PASSWORD              its existing password
@@ -49,9 +60,6 @@ Required env for the `signin` and `ledger` checks only:
     whole gate going dark on a missing credential.
 
 Optional env:
-    HIVE_CHAT_URL              default https://chat-hive.scubed.co
-    HIVE_CONTROL_PLANE_URL     default https://control-hive.scubed.co
-    HIVE_EDGE_API_URL          default https://api-hive.scubed.co
     HIVE_VERIFY_MODEL          default hive-default
     HIVE_VERIFY_LEDGER_TIMEOUT default 90 (seconds to wait for the charge)
     HIVE_VERIFY_LEDGER_PAGES   default 20 (page cap on the ledger scan)
@@ -71,6 +79,7 @@ Nothing secret is ever printed. Tokens, keys and passwords are reported by
 presence and length only, and this repository is public.
 """
 import argparse
+import base64
 import json
 import os
 import sys
@@ -93,9 +102,10 @@ CHECKS = ("chat", "signin", "ledger")
 # outcome the checks are written to avoid.
 USER_AGENT = "hive-post-deploy-verify/1 (+https://github.com/sakibsadmanshajib/hive)"
 
-CHAT = os.environ.get("HIVE_CHAT_URL", "https://chat-hive.scubed.co").rstrip("/")
-CP = os.environ.get("HIVE_CONTROL_PLANE_URL", "https://control-hive.scubed.co").rstrip("/")
-EDGE = os.environ.get("HIVE_EDGE_API_URL", "https://api-hive.scubed.co").rstrip("/")
+# Verification targets. Resolved in main() from the environment and nothing
+# else, before any request is sent: see the Required env note in the module
+# docstring for why none of these carries a default.
+CHAT = CP = EDGE = ""
 MODEL = os.environ.get("HIVE_VERIFY_MODEL", "hive-default").strip() or "hive-default"
 LEDGER_TIMEOUT = float(os.environ.get("HIVE_VERIFY_LEDGER_TIMEOUT", "90"))
 LEDGER_PAGES = int(os.environ.get("HIVE_VERIFY_LEDGER_PAGES", "20"))
@@ -205,8 +215,18 @@ def mint_session(supabase: str, anon: str, email: str, password: str) -> tuple[s
         payload = json.loads(raw)
     except json.JSONDecodeError:
         raise CheckFailed("sign-in answered 200 with a body that is not JSON") from None
+    if not isinstance(payload, dict):
+        raise CheckFailed(
+            "sign-in answered 200 with JSON that is not an object "
+            f"({type(payload).__name__}), so no access_token can be read"
+        )
+    user = payload.get("user")
+    if user is not None and not isinstance(user, dict):
+        raise CheckFailed(
+            f"sign-in answered 200 but its user field is {type(user).__name__}, not an object"
+        )
     token = payload.get("access_token") or ""
-    user_id = ((payload.get("user") or {}).get("id")) or ""
+    user_id = (user or {}).get("id") or ""
     if not token:
         raise CheckFailed("sign-in answered 200 but returned no access_token")
     if not user_id:
@@ -229,15 +249,31 @@ def check_signin(token: str, user_id: str, negative: bool) -> None:
     somebody else's identity is a worse outcome than a 401 and would otherwise
     read as a pass.
 
-    Negative control: corrupt one character of the bearer. A control-plane that
+    Negative control: corrupt the bearer's signature bytes. A control-plane that
     genuinely revalidates must reject it; one that trusts a cached or rendered
     session would not.
     """
     bearer = token
     if negative:
-        print("  negative control: corrupting one character of the bearer")
-        flipped = "A" if bearer[-1] != "A" else "B"
-        bearer = bearer[:-1] + flipped
+        print("  negative control: corrupting the bearer's signature bytes")
+        parts = token.split(".")
+        if len(parts) == 3 and parts[2]:
+            head, claims, sig = parts
+            # Swapping the final base64url CHARACTER is not enough: that
+            # character can carry unused low bits, so A->B there can decode to
+            # identical bytes and the control would send the original token and
+            # pass. Mutating DECODED bytes guarantees the signature the server
+            # sees differs, while header and payload stay intact, so a
+            # rejection can only be signature validation rather than a parse
+            # error.
+            decoded = bytearray(base64.urlsafe_b64decode(sig + "=" * (-len(sig) % 4)))
+            decoded[0] ^= 0xFF
+            bad_sig = base64.urlsafe_b64encode(bytes(decoded)).decode().rstrip("=")
+            bearer = ".".join((head, claims, bad_sig))
+        else:
+            # Not a three-segment JWT. Rejection is still the point; corrupt it
+            # wholesale instead of crashing on an unpack.
+            bearer = ("X" if not token.startswith("X") else "Y") + token[1:]
 
     status, raw = http("GET", f"{CP}/api/v1/viewer",
                        {"Authorization": f"Bearer {bearer}"}, timeout=60)
@@ -248,8 +284,18 @@ def check_signin(token: str, user_id: str, negative: bool) -> None:
         viewer = json.loads(raw)
     except json.JSONDecodeError:
         raise CheckFailed("/api/v1/viewer answered 200 with a body that is not JSON") from None
+    if not isinstance(viewer, dict):
+        raise CheckFailed(
+            "/api/v1/viewer answered 200 with JSON that is not an object "
+            f"({type(viewer).__name__})"
+        )
+    user = viewer.get("user")
+    if user is not None and not isinstance(user, dict):
+        raise CheckFailed(
+            f"/api/v1/viewer returned a user field that is {type(user).__name__}, not an object"
+        )
 
-    seen = ((viewer.get("user") or {}).get("id")) or ""
+    seen = (user or {}).get("id") or ""
     if seen != user_id:
         raise CheckFailed(
             f"/api/v1/viewer resolved the bearer to user {seen!r}, but the session was "
@@ -288,9 +334,24 @@ def scan_usage_charges(auth: dict, stop_when_new_of: set[str] | None = None) -> 
             body = json.loads(raw)
         except json.JSONDecodeError:
             raise CheckFailed("ledger read answered 200 with a body that is not JSON") from None
+        if not isinstance(body, dict):
+            raise CheckFailed(
+                "ledger read answered 200 with JSON that is not an object "
+                f"({type(body).__name__})"
+            )
+        entries = body.get("entries")
+        if not isinstance(entries, list):
+            raise CheckFailed(
+                f"ledger read answered 200 but carried entries as {type(entries).__name__}, "
+                "expected a list"
+            )
 
-        entries = body.get("entries") or []
         for entry in entries:
+            # A non-dict row is treated like a row without an id below: it
+            # cannot be the new charge, and inventing an id for it would be
+            # worse than skipping it.
+            if not isinstance(entry, dict):
+                continue
             entry_id = str(entry.get("id") or "")
             if not entry_id:
                 continue
@@ -397,7 +458,9 @@ def check_ledger(auth: dict, negative: bool) -> None:
                         "bills nothing."
                     )
                 print(f"  charge landed after {attempt} scan(s)")
-                return
+                # Break, not return: the revocation-failure verdict after the
+                # finally must be reachable on the happy path too.
+                break
             if time.monotonic() >= deadline:
                 raise CheckFailed(
                     f"no new usage_charge entry appeared within {LEDGER_TIMEOUT:.0f}s of the "
@@ -408,12 +471,27 @@ def check_ledger(auth: dict, negative: bool) -> None:
     finally:
         # Always, including on the failure paths above. A key left behind is a
         # live credential on a real account.
-        status, raw = http("POST", f"{CP}/api/v1/accounts/current/api-keys/{key_id}/revoke",
-                           auth, {}, timeout=60)
-        if status in (200, 204):
+        revoke_status, revoke_raw = http(
+            "POST", f"{CP}/api/v1/accounts/current/api-keys/{key_id}/revoke",
+            auth, {}, timeout=60)
+        if revoke_status in (200, 204):
             print(f"  revoked API key {key_id}")
         else:
-            print(f"  ::warning::failed to revoke API key {key_id}: {status} {snippet(raw, 120)}")
+            print(f"  ::warning::failed to revoke API key {key_id}: "
+                  f"{revoke_status} {snippet(revoke_raw, 120)}")
+
+    # An unrevoked key is not a footnote: it is a live credential this run put
+    # on a real account, so revocation failing is itself a check failure.
+    # Reached only when the body above succeeded; on a failed body the original
+    # CheckFailed has already propagated past the finally and remains the
+    # reason the check reports, which preserves the earlier verification
+    # failure rather than replacing it.
+    if revoke_status not in (200, 204):
+        raise CheckFailed(
+            f"revoking the minted API key {key_id} answered {revoke_status}, expected 200 or "
+            "204. The key this run minted stays active on a real account, so the run cannot "
+            f"be called clean: {snippet(revoke_raw, 160)}"
+        )
 
 
 # ── driver ───────────────────────────────────────────────────────────────────
@@ -432,6 +510,15 @@ def main() -> int:
     negative = args.negative_control
     if negative != "none" and negative not in selected:
         raise SystemExit(f"error: --negative-control {negative} is not among the selected checks")
+
+    # Verification targets first, from the environment and nothing else. A
+    # checker that assumes a fixed demo host when configuration is missing can
+    # return green for a product nobody deployed, so a missing name stops the
+    # run here, before any request.
+    global CHAT, CP, EDGE
+    CHAT = env("HIVE_CHAT_URL").rstrip("/")
+    CP = env("HIVE_CONTROL_PLANE_URL").rstrip("/")
+    EDGE = env("HIVE_EDGE_API_URL").rstrip("/")
 
     supabase = env("SUPABASE_URL").rstrip("/")
     anon = env("SUPABASE_ANON_KEY")

--- a/scripts/post-deploy-verify.py
+++ b/scripts/post-deploy-verify.py
@@ -1,0 +1,454 @@
+#!/usr/bin/env python3
+"""Assert the deployed product still works, after a deploy has already exited 0.
+
+A deploy exiting zero is not the claim "the product works". PR #787 merged
+green and took chat sign-in down. Three consecutive deploys failed at `migrate`
+and the box silently stayed on old code. This script is the gate that runs
+after the deploy and answers, against the live hostnames, the only three
+questions a demo actually depends on:
+
+  1. Chat answers.        The chat backend is up, not merely the static shell.
+  2. Sign-in completes.   A minted session resolves to the same user at the
+                          control-plane, per request, against live GoTrue.
+  3. A ledger entry lands. A real completion produces a real `usage_charge`
+                          row, so billing has not failed open.
+
+Each check is written to fail for the reason it names and for no other, and
+each has a negative control (see --negative-control) that makes it genuinely
+red on demand, so the gate can prove it still bites without anyone editing it.
+
+Nothing here rolls anything back. Forward migrations run before the deploy and
+are not reversible by redeploying code, so an automatic rollback would leave
+old code against a new schema, which is worse than a bad deploy. This script
+fails loudly; a human decides what to do about it.
+
+Usage:
+
+    set -a; . .env; set +a
+    python3 scripts/post-deploy-verify.py
+
+Required env:
+    SUPABASE_URL, SUPABASE_ANON_KEY   the auth origin the deployment uses
+    HIVE_VERIFY_EMAIL                 a dedicated verification identity
+    HIVE_VERIFY_PASSWORD              its existing password
+
+Optional env:
+    HIVE_CHAT_URL              default https://chat-hive.scubed.co
+    HIVE_CONTROL_PLANE_URL     default https://control-hive.scubed.co
+    HIVE_EDGE_API_URL          default https://api-hive.scubed.co
+    HIVE_VERIFY_MODEL          default hive-default
+    HIVE_VERIFY_LEDGER_TIMEOUT default 90 (seconds to wait for the charge)
+    HIVE_VERIFY_LEDGER_PAGES   default 20 (page cap on the ledger scan)
+    HIVE_VERIFY_RUN_LABEL      free-text tag for the minted key's nickname
+
+Check 3 is a REAL SPEND on a real identity. HIVE_VERIFY_EMAIL has no default
+and must never be demo@hive-demo.invalid (issue #848, docs/live-test-auth.md).
+It must be a tenant OWNER with a verified email: minting an API key needs
+api_keys:write, which the authorization policy grants to OWNER only.
+
+This script signs in with an existing password and NEVER rotates one. The
+control-plane resolves every bearer against GoTrue per request, so a rotation
+revokes every concurrent session; that broke three agents at once on
+2026-08-08. There is no code path here that writes a password.
+
+Nothing secret is ever printed. Tokens, keys and passwords are reported by
+presence and length only, and this repository is public.
+"""
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+import uuid
+
+CHECKS = ("chat", "signin", "ledger")
+
+CHAT = os.environ.get("HIVE_CHAT_URL", "https://chat-hive.scubed.co").rstrip("/")
+CP = os.environ.get("HIVE_CONTROL_PLANE_URL", "https://control-hive.scubed.co").rstrip("/")
+EDGE = os.environ.get("HIVE_EDGE_API_URL", "https://api-hive.scubed.co").rstrip("/")
+MODEL = os.environ.get("HIVE_VERIFY_MODEL", "hive-default").strip() or "hive-default"
+LEDGER_TIMEOUT = float(os.environ.get("HIVE_VERIFY_LEDGER_TIMEOUT", "90"))
+LEDGER_PAGES = int(os.environ.get("HIVE_VERIFY_LEDGER_PAGES", "20"))
+LEDGER_PAGE_SIZE = 500
+RUN_LABEL = os.environ.get("HIVE_VERIFY_RUN_LABEL", "").strip() or "local"
+
+
+class CheckFailed(Exception):
+    """One check's assertion did not hold. Carries the operator-facing reason."""
+
+
+def env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise SystemExit(f"error: {name} is not set")
+    return value
+
+
+def http(method, url, headers=None, body=None, timeout=120):
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(url, data=data, method=method, headers=headers or {})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            return r.status, r.read().decode(errors="replace")
+    except urllib.error.HTTPError as e:
+        return e.code, e.read().decode(errors="replace")
+    except Exception as e:  # noqa: BLE001 - a transport failure is a result too
+        return 0, f"<transport error: {type(e).__name__}: {e}>"
+
+
+def snippet(raw: str, limit: int = 240) -> str:
+    return " ".join(raw.split())[:limit]
+
+
+# ── check 1: chat answers ────────────────────────────────────────────────────
+
+def check_chat(negative: bool) -> None:
+    """Assert the chat BACKEND answers, not merely that a page is served.
+
+    The trap this exists to avoid: chat-hive.scubed.co serves its static shell
+    from disk and returns a perfectly good 200 with a full HTML page even when
+    the backend behind it is dead. Any check that asserts a status code, a page
+    title, or the presence of markup passes straight through an outage. So this
+    asks the backend a question only the backend can answer: /api/config is
+    rendered by Open WebUI's Python process from live configuration, and it
+    carries `status: true` plus the OIDC provider entry that the whole
+    Hive-account sign-in flow depends on. A shell with no backend cannot
+    produce either.
+
+    Negative control: read the static shell at / instead. That is the exact
+    "merely returning a page" trap, and it must fail here.
+    """
+    path = "/" if negative else "/api/config"
+    if negative:
+        print("  negative control: reading the static shell instead of the backend config")
+    status, raw = http("GET", CHAT + path, {"Accept": "application/json"}, timeout=30)
+    print(f"  GET {CHAT}{path} -> {status}")
+    if status != 200:
+        raise CheckFailed(f"chat {path} answered {status}, expected 200: {snippet(raw)}")
+
+    try:
+        config = json.loads(raw)
+    except json.JSONDecodeError:
+        raise CheckFailed(
+            f"chat {path} answered 200 but the body is not JSON, so this is the static "
+            f"shell rather than the backend: {snippet(raw, 120)}"
+        ) from None
+    if not isinstance(config, dict):
+        raise CheckFailed(f"chat {path} returned JSON that is not an object: {snippet(raw, 120)}")
+
+    if config.get("status") is not True:
+        raise CheckFailed(
+            f"chat config carries status={config.get('status')!r}, expected true. "
+            "The backend is answering but reports itself unhealthy."
+        )
+    print("  status: true")
+
+    providers = (config.get("oauth") or {}).get("providers") or {}
+    if not isinstance(providers, dict) or "oidc" not in providers:
+        raise CheckFailed(
+            "chat config carries no oauth.providers.oidc entry, so the Hive-account "
+            f"sign-in button is absent from the login page. providers={sorted(providers) if isinstance(providers, dict) else providers!r}"
+        )
+    print(f"  oauth.providers.oidc present ({providers['oidc']!r})")
+
+
+# ── check 2: sign-in completes ───────────────────────────────────────────────
+
+def mint_session(supabase: str, anon: str, email: str, password: str) -> tuple[str, str]:
+    """Sign in with an existing password. Returns (access_token, user_id).
+
+    Password grant on the public listener, deliberately: it is the flow a real
+    customer uses, it needs no admin route, and so it is unaffected by the
+    gateway's admin deny list. Nothing here writes a password.
+    """
+    status, raw = http(
+        "POST", f"{supabase}/auth/v1/token?grant_type=password",
+        {"apikey": anon, "Content-Type": "application/json"},
+        {"email": email, "password": password},
+        timeout=60,
+    )
+    if status != 200:
+        raise CheckFailed(f"sign-in against {supabase} answered {status}: {snippet(raw)}")
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        raise CheckFailed("sign-in answered 200 with a body that is not JSON") from None
+    token = payload.get("access_token") or ""
+    user_id = ((payload.get("user") or {}).get("id")) or ""
+    if not token:
+        raise CheckFailed("sign-in answered 200 but returned no access_token")
+    if not user_id:
+        raise CheckFailed("sign-in answered 200 but returned no user id")
+    print(f"  minted a session, token {len(token)} characters, user {user_id}")
+    return token, user_id
+
+
+def check_signin(token: str, user_id: str, negative: bool) -> None:
+    """Assert the control-plane resolves this bearer to this same user.
+
+    A rendered login page proves nothing: the shell renders before any token is
+    validated. The control-plane's auth middleware, by contrast, looks the
+    bearer up against live GoTrue on every single request, so a 200 from
+    /api/v1/viewer carrying the same user id the sign-in minted is evidence the
+    whole chain resolved: GoTrue issued it, the control-plane accepted it, and
+    it denotes the identity we think it does.
+
+    Comparing the id, not just the status, is the part that matters. A 200 with
+    somebody else's identity is a worse outcome than a 401 and would otherwise
+    read as a pass.
+
+    Negative control: corrupt one character of the bearer. A control-plane that
+    genuinely revalidates must reject it; one that trusts a cached or rendered
+    session would not.
+    """
+    bearer = token
+    if negative:
+        print("  negative control: corrupting one character of the bearer")
+        flipped = "A" if bearer[-1] != "A" else "B"
+        bearer = bearer[:-1] + flipped
+
+    status, raw = http("GET", f"{CP}/api/v1/viewer",
+                       {"Authorization": f"Bearer {bearer}"}, timeout=60)
+    print(f"  GET {CP}/api/v1/viewer -> {status}")
+    if status != 200:
+        raise CheckFailed(f"/api/v1/viewer answered {status}, expected 200: {snippet(raw)}")
+    try:
+        viewer = json.loads(raw)
+    except json.JSONDecodeError:
+        raise CheckFailed("/api/v1/viewer answered 200 with a body that is not JSON") from None
+
+    seen = ((viewer.get("user") or {}).get("id")) or ""
+    if seen != user_id:
+        raise CheckFailed(
+            f"/api/v1/viewer resolved the bearer to user {seen!r}, but the session was "
+            f"minted for {user_id!r}. The control-plane is serving the wrong identity."
+        )
+    print(f"  control-plane resolved the bearer to the same user {seen}")
+
+
+# ── check 3: a ledger entry lands ────────────────────────────────────────────
+
+def scan_usage_charges(auth: dict, stop_when_new_of: set[str] | None = None) -> tuple[set[str], dict | None]:
+    """Collect every usage_charge id on the current account.
+
+    A full scan, and not a peek at the first page, because the ledger's list
+    query is `ORDER BY id DESC` over a random UUIDv4 primary key
+    (apps/control-plane/internal/ledger/repository.go). That is a total order,
+    so keyset pagination over it is complete and stable, but it is NOT
+    chronological: a row written a second ago lands at a uniformly random
+    position. Reading page one and looking for something new finds it only by
+    luck, which is a check that passes at random.
+
+    When `stop_when_new_of` is given, the scan returns as soon as it finds an id
+    outside that set, so the common case costs one page.
+    """
+    seen: set[str] = set()
+    cursor = None
+    for page in range(LEDGER_PAGES):
+        query = f"?type=usage_charge&limit={LEDGER_PAGE_SIZE}"
+        if cursor:
+            query += f"&cursor={cursor}"
+        status, raw = http("GET", f"{CP}/api/v1/accounts/current/credits/ledger{query}",
+                           auth, timeout=60)
+        if status != 200:
+            raise CheckFailed(f"ledger read answered {status}, expected 200: {snippet(raw)}")
+        try:
+            body = json.loads(raw)
+        except json.JSONDecodeError:
+            raise CheckFailed("ledger read answered 200 with a body that is not JSON") from None
+
+        entries = body.get("entries") or []
+        for entry in entries:
+            entry_id = str(entry.get("id") or "")
+            if not entry_id:
+                continue
+            seen.add(entry_id)
+            if stop_when_new_of is not None and entry_id not in stop_when_new_of:
+                return seen, entry
+
+        cursor = body.get("next_cursor")
+        if not cursor:
+            return seen, None
+
+    # Silence here would mean comparing two partial sets and calling a miss a
+    # pass. A page cap that has been reached is a real problem with the
+    # verification account, and it says so.
+    raise CheckFailed(
+        f"the verification account has more than {LEDGER_PAGES * LEDGER_PAGE_SIZE} "
+        "usage_charge entries, so this scan cannot enumerate them and cannot tell a new "
+        "one from an old one. Rotate the verification identity, or raise "
+        "HIVE_VERIFY_LEDGER_PAGES deliberately."
+    )
+
+
+def check_ledger(auth: dict, negative: bool) -> None:
+    """Assert a real completion produces a real usage_charge row.
+
+    Billing failing open is invisible from every other angle: the completion
+    succeeds, the customer is served, the response is indistinguishable from a
+    billed one, and the only trace of the failure is a row that is not there.
+    That is what happened for three days in July 2026. So this sends a real
+    completion through a real key and requires the charge to appear.
+
+    The key is minted through this session on purpose. A pre-provisioned
+    HIVE_API_KEY could belong to a different account than the one whose ledger
+    is read here, in which case the charge lands somewhere this check never
+    looks and the check goes red for the wrong reason, or worse, an unrelated
+    row makes it green. Minting through the session guarantees key and ledger
+    share an account.
+
+    Negative control: skip the spend. Nothing bills, no row appears, and the
+    check must go red exactly as it would if billing had failed open.
+    """
+    print("  scanning existing usage_charge entries")
+    before, _ = scan_usage_charges(auth)
+    print(f"  {len(before)} usage_charge entries already on this account")
+
+    nickname = f"post-deploy-verify {RUN_LABEL} {uuid.uuid4().hex[:8]}"
+    status, raw = http("POST", f"{CP}/api/v1/accounts/current/api-keys",
+                       auth, {"nickname": nickname}, timeout=60)
+    if status != 201:
+        raise CheckFailed(f"minting an API key answered {status}, expected 201: {snippet(raw)}")
+    created = json.loads(raw)
+    key_id, secret = created.get("id", ""), created.get("secret", "")
+    if not key_id or not secret:
+        raise CheckFailed("the API key create response carried no id or no secret")
+    print(f"  minted API key {key_id}, secret {len(secret)} characters")
+
+    try:
+        if negative:
+            print("  negative control: skipping the completion, so nothing should bill")
+        else:
+            key_auth = {"Authorization": f"Bearer {secret}", "Content-Type": "application/json"}
+            status, raw = http(
+                "POST", f"{EDGE}/v1/chat/completions", key_auth,
+                {"model": MODEL,
+                 "messages": [{"role": "user", "content": "Reply with the single word: pong."}],
+                 "max_tokens": 64},
+                timeout=120,
+            )
+            print(f"  POST {EDGE}/v1/chat/completions -> {status}")
+            if status != 200:
+                raise CheckFailed(
+                    f"the completion answered {status}, expected 200: {snippet(raw)}"
+                )
+
+        # The charge is written synchronously, before the response body is
+        # flushed (apps/edge-api/internal/inference/orchestrator.go), so the
+        # first scan normally finds it. Polling anyway costs nothing on the
+        # happy path and covers the streaming settle path, which lands after
+        # the last chunk.
+        deadline = time.monotonic() + LEDGER_TIMEOUT
+        attempt = 0
+        while True:
+            attempt += 1
+            _, found = scan_usage_charges(auth, stop_when_new_of=before)
+            if found is not None:
+                delta = found.get("credits_delta")
+                print(f"  new usage_charge {found.get('id')} credits_delta={delta} "
+                      f"created_at={found.get('created_at')}")
+                if not isinstance(delta, int) or delta >= 0:
+                    raise CheckFailed(
+                        f"the new usage_charge entry carries credits_delta={delta!r}, "
+                        "which is not a debit. A charge that does not subtract credits "
+                        "bills nothing."
+                    )
+                print(f"  charge landed after {attempt} scan(s)")
+                return
+            if time.monotonic() >= deadline:
+                raise CheckFailed(
+                    f"no new usage_charge entry appeared within {LEDGER_TIMEOUT:.0f}s of the "
+                    "completion. The request was served and nothing was billed, which is "
+                    "billing failing open."
+                )
+            time.sleep(3)
+    finally:
+        # Always, including on the failure paths above. A key left behind is a
+        # live credential on a real account.
+        status, raw = http("POST", f"{CP}/api/v1/accounts/current/api-keys/{key_id}/revoke",
+                           auth, {}, timeout=60)
+        if status in (200, 204):
+            print(f"  revoked API key {key_id}")
+        else:
+            print(f"  ::warning::failed to revoke API key {key_id}: {status} {snippet(raw, 120)}")
+
+
+# ── driver ───────────────────────────────────────────────────────────────────
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--only", action="append", choices=CHECKS, default=None,
+                        help="run only these checks (repeatable). Default: all three.")
+    parser.add_argument("--negative-control", choices=("none",) + CHECKS, default="none",
+                        help="deliberately remove the thing one check guards, so that check "
+                             "goes red. Proves the gate still bites. This can only cause a "
+                             "failure; there is no value of it that makes anything pass.")
+    args = parser.parse_args()
+
+    selected = tuple(c for c in CHECKS if c in (args.only or CHECKS))
+    negative = args.negative_control
+    if negative != "none" and negative not in selected:
+        raise SystemExit(f"error: --negative-control {negative} is not among the selected checks")
+
+    supabase = env("SUPABASE_URL").rstrip("/")
+    anon = env("SUPABASE_ANON_KEY")
+    email = env("HIVE_VERIFY_EMAIL")
+    password = env("HIVE_VERIFY_PASSWORD")
+    if email == "demo@hive-demo.invalid":
+        raise SystemExit(
+            "error: HIVE_VERIFY_EMAIL is the shared demo account. This script mints a key "
+            "and sends a real completion, and issue #848 exists because that traffic ended "
+            "up on the account the owner demos to prospects. Use a dedicated identity."
+        )
+
+    print(f"chat {CHAT}")
+    print(f"control-plane {CP}")
+    print(f"edge-api {EDGE}")
+    print(f"auth {supabase}")
+    print(f"caller {email}")
+    print(f"checks {', '.join(selected)}"
+          + (f" | negative control on {negative}" if negative != "none" else ""))
+
+    results: dict[str, str] = {}
+    session: tuple[str, str] | None = None
+
+    for name in selected:
+        print(f"\n== {name} ==")
+        try:
+            if name == "chat":
+                check_chat(negative == "chat")
+            elif name == "signin":
+                session = mint_session(supabase, anon, email, password)
+                check_signin(session[0], session[1], negative == "signin")
+            elif name == "ledger":
+                if session is None:
+                    # The ledger check needs a session of its own when signin
+                    # was not selected. Same credentials, same no-rotation rule.
+                    session = mint_session(supabase, anon, email, password)
+                auth = {"Authorization": f"Bearer {session[0]}", "Content-Type": "application/json"}
+                check_ledger(auth, negative == "ledger")
+        except CheckFailed as e:
+            results[name] = str(e)
+            print(f"  FAILED: {e}")
+        else:
+            results[name] = ""
+            print("  PASSED")
+
+    print("\n== summary ==")
+    for name in selected:
+        print(f"  {'PASS' if not results[name] else 'FAIL'}  {name}")
+
+    failed = [n for n in selected if results[n]]
+    if failed:
+        print(f"\nPOST-DEPLOY VERIFICATION FAILED: {', '.join(failed)}")
+        for name in failed:
+            print(f"  - {name}: {results[name]}")
+        return 1
+    print("\nPOST-DEPLOY VERIFICATION PASSED: chat answers, sign-in completes, billing charges")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/preflight-supabase-config.py
+++ b/scripts/preflight-supabase-config.py
@@ -129,7 +129,13 @@ def hosted_ref(host: str) -> str | None:
 def check_key(name: str, token: str, want_role: str, url_ref: str | None) -> None:
     """Claim-check one key against the URL. Offline; sends nothing."""
     print(f"\n== {name} ==")
-    print(f"  present, {len(token)} characters")
+    # Presence only for the service-role value: this log is public, and even a
+    # character count is secret metadata. Anon/publishable keys are public by
+    # design (they ship in browser clients), so their length stays legible.
+    if "SERVICE_ROLE" in name:
+        print("  present")
+    else:
+        print(f"  present, {len(token)} characters")
     claims = jwt_claims(token)
     if claims is None:
         # A `sb_publishable_*` / `sb_secret_*` key carries no readable claims,

--- a/scripts/preflight-supabase-config.py
+++ b/scripts/preflight-supabase-config.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Assert the SUPABASE_* configuration a caller is about to use actually works.
+
+This is a preflight, not a test suite. It runs in seconds, writes nothing, and
+answers exactly one question: does the Supabase configuration in this process's
+environment name a project that is alive, with keys that belong to it?
+
+Why it exists (issue #1059). Six workflows in this repository read `SUPABASE_*`
+values from GitHub secrets that name a hosted project which no longer exists.
+Nothing failed loudly when that project was deleted. The Cowork proof job went
+on reporting for four days over a Supabase that was not there, and
+`deploy-web-console-workers` shipped green on the same day the project went
+away, because neither of them ever asserts that the configuration resolves
+before using it. A green run over a dead backend is worse than a red one: it is
+a check that has quietly stopped checking.
+
+The two failures this catches, and nothing else:
+
+  1. The project is gone, unreachable, or the URL is wrong. A deleted hosted
+     project keeps resolving in DNS (the wildcard is Supabase's, not the
+     project's) and answers HTTP, so a plain connectivity probe passes. Asking
+     GoTrue for its health is what separates "a server answered" from "our
+     project answered".
+
+  2. The keys name a different project than the URL. This is the shape #1059
+     actually took: a URL updated in one place and a key left behind in
+     another, or the reverse. A Supabase-issued anon or service-role JWT
+     carries a `ref` claim naming its project, and a hosted URL carries the
+     same ref as its first hostname label, so the two can be compared offline
+     with no request at all. That comparison is free, deterministic, and fails
+     on a mismatch that every live probe in the world would let through, since
+     both halves are individually valid.
+
+Self-hosted deployments are handled honestly rather than skipped. There the
+anon key is a locally signed JWT with no `ref` claim and the URL is a private
+hostname, so the cross-check has nothing to compare and says so instead of
+inventing a pass. The liveness check still applies and is still the useful half.
+
+Usage:
+
+    set -a; . .env; set +a
+    python3 scripts/preflight-supabase-config.py
+
+Required env: SUPABASE_URL, SUPABASE_ANON_KEY.
+Optional env: SUPABASE_SERVICE_ROLE_KEY (claim-checked when present, never
+sent anywhere), SUPABASE_PREFLIGHT_TIMEOUT (seconds, default 15).
+
+Exits 0 when every check passes, 1 otherwise. It never prints a key, a token,
+or any part of one; a key is reported by its length and its non-secret claims.
+"""
+import base64
+import binascii
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+TIMEOUT = float(os.environ.get("SUPABASE_PREFLIGHT_TIMEOUT", "15"))
+
+failures: list[str] = []
+notes: list[str] = []
+
+
+def fail(message: str) -> None:
+    print(f"  [FAIL] {message}")
+    failures.append(message)
+
+
+def ok(message: str) -> None:
+    print(f"  [PASS] {message}")
+
+
+def skip(message: str) -> None:
+    print(f"  [SKIP] {message}")
+    notes.append(message)
+
+
+def jwt_claims(token: str) -> dict | None:
+    """Decode a JWT payload without verifying it.
+
+    Verification is not the point and is not possible here: the signing key is
+    the thing we would need the project for. What is wanted is the project the
+    key claims to belong to, which is unauthenticated metadata by design.
+    Returns None for anything that is not a three-part JWT, which is a legal
+    state now that Supabase also issues opaque `sb_publishable_*` keys.
+    """
+    parts = token.split(".")
+    if len(parts) != 3:
+        return None
+    payload = parts[1]
+    try:
+        raw = base64.urlsafe_b64decode(payload + "=" * (-len(payload) % 4))
+        claims = json.loads(raw)
+    except (binascii.Error, ValueError, UnicodeDecodeError):
+        return None
+    return claims if isinstance(claims, dict) else None
+
+
+def hosted_ref(host: str) -> str | None:
+    """The project ref a hosted Supabase URL names, or None if not hosted."""
+    if not host.endswith(".supabase.co") and not host.endswith(".supabase.in"):
+        return None
+    label = host.split(".")[0]
+    return label or None
+
+
+def check_key(name: str, token: str, want_role: str, url_ref: str | None) -> None:
+    """Claim-check one key against the URL. Offline; sends nothing."""
+    print(f"\n== {name} ==")
+    print(f"  present, {len(token)} characters")
+    claims = jwt_claims(token)
+    if claims is None:
+        # A `sb_publishable_*` / `sb_secret_*` key carries no readable claims,
+        # so there is nothing to cross-check. Say so rather than pass silently.
+        skip(f"{name} is not a JWT, so it carries no project ref to compare")
+        return
+
+    role = claims.get("role", "")
+    if role == want_role:
+        ok(f"{name} carries role={want_role}")
+    else:
+        fail(f"{name} carries role={role!r}, expected {want_role!r}")
+
+    exp = claims.get("exp")
+    if isinstance(exp, (int, float)):
+        remaining = exp - time.time()
+        if remaining <= 0:
+            fail(f"{name} expired {int(-remaining / 86400)} days ago")
+        else:
+            ok(f"{name} is unexpired, {int(remaining / 86400)} days remaining")
+
+    key_ref = claims.get("ref") or ""
+    if url_ref is None:
+        skip(f"SUPABASE_URL is not a hosted project URL, so {name}'s ref is not comparable")
+    elif not key_ref:
+        fail(f"SUPABASE_URL names hosted project {url_ref!r} but {name} carries no ref claim")
+    elif key_ref == url_ref:
+        ok(f"{name} ref matches SUPABASE_URL project {url_ref!r}")
+    else:
+        # The #1059 failure, exactly. Both halves are individually valid and
+        # every liveness probe passes; only the comparison catches it.
+        fail(
+            f"{name} belongs to project {key_ref!r} but SUPABASE_URL names {url_ref!r}. "
+            "One of the two is stale."
+        )
+
+
+def http_get(url: str, headers: dict) -> tuple[int, str]:
+    req = urllib.request.Request(url, method="GET", headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=TIMEOUT) as r:
+            return r.status, r.read(4096).decode(errors="replace")
+    except urllib.error.HTTPError as e:
+        return e.code, e.read(4096).decode(errors="replace")
+    except Exception as e:  # noqa: BLE001 - a transport failure is a result too
+        return 0, f"<transport error: {type(e).__name__}: {e}>"
+
+
+def main() -> int:
+    raw_url = os.environ.get("SUPABASE_URL", "").strip()
+    anon = os.environ.get("SUPABASE_ANON_KEY", "").strip()
+    service = os.environ.get("SUPABASE_SERVICE_ROLE_KEY", "").strip()
+
+    print("== configuration ==")
+    if not raw_url:
+        print("  [FAIL] SUPABASE_URL is not set")
+        return 1
+    if not anon:
+        print("  [FAIL] SUPABASE_ANON_KEY is not set")
+        return 1
+
+    url = raw_url.rstrip("/")
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme not in ("http", "https") or not parsed.hostname:
+        print(f"  [FAIL] SUPABASE_URL is not an absolute http(s) URL: {url!r}")
+        return 1
+
+    url_ref = hosted_ref(parsed.hostname)
+    kind = f"hosted project {url_ref!r}" if url_ref else "self-hosted or proxied"
+    print(f"  [PASS] SUPABASE_URL parses: {parsed.scheme}://{parsed.hostname} ({kind})")
+
+    check_key("SUPABASE_ANON_KEY", anon, "anon", url_ref)
+    if service:
+        # Claim-checked only. Nothing is ever sent with this key: the admin
+        # routes it unlocks are refused at the gateway by design, and a
+        # preflight has no business exercising them.
+        check_key("SUPABASE_SERVICE_ROLE_KEY", service, "service_role", url_ref)
+    else:
+        print("\n== SUPABASE_SERVICE_ROLE_KEY ==")
+        skip("not set in this environment, nothing to check")
+
+    print("\n== liveness ==")
+    # GoTrue's own health endpoint. A deleted hosted project still resolves in
+    # DNS and still answers HTTP, so only the project's own service answering
+    # is evidence the project exists. Sent with the anon key because the hosted
+    # gateway requires one; self-hosted GoTrue ignores the header.
+    status, body = http_get(f"{url}/auth/v1/health", {"apikey": anon})
+    flat = " ".join(body.split())[:200]
+    if status == 200:
+        ok(f"GET /auth/v1/health -> 200 {flat[:120]}")
+    elif status == 401:
+        fail(f"GET /auth/v1/health -> 401, the anon key was rejected by this project: {flat}")
+    elif status == 0:
+        fail(f"GET /auth/v1/health did not complete: {flat}")
+    else:
+        fail(f"GET /auth/v1/health -> {status}, expected 200: {flat}")
+
+    print()
+    if failures:
+        print(f"PREFLIGHT FAILED: {len(failures)} check(s) did not pass")
+        for f in failures:
+            print(f"  - {f}")
+        return 1
+    print("PREFLIGHT PASSED: the Supabase configuration resolves and its keys belong to it")
+    if notes:
+        print(f"({len(notes)} check(s) skipped as not applicable to this deployment shape)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/preflight-supabase-config.py
+++ b/scripts/preflight-supabase-config.py
@@ -16,11 +16,15 @@ a check that has quietly stopped checking.
 
 The two failures this catches, and nothing else:
 
-  1. The project is gone, unreachable, or the URL is wrong. A deleted hosted
-     project keeps resolving in DNS (the wildcard is Supabase's, not the
-     project's) and answers HTTP, so a plain connectivity probe passes. Asking
-     GoTrue for its health is what separates "a server answered" from "our
-     project answered".
+  1. The project is gone, unreachable, or the URL is wrong. A connectivity
+     probe is not enough for this in either direction: a wrong hostname may
+     fail to resolve at all, and it may equally answer 200 from something that
+     is not an auth origin, which is the case a status code sails straight
+     through. Measured on the demo box: pointed at chat-hive.scubed.co, whose
+     single-page app answers 200 with HTML for every path it does not know,
+     this preflight used to report the configuration sound. So what is asserted
+     is that the health document came from GoTrue, which is what actually
+     separates "a server answered" from "our project answered".
 
   2. The keys name a different project than the URL. This is the shape #1059
      actually took: a URL updated in one place and a key left behind in
@@ -41,7 +45,10 @@ Usage:
     set -a; . .env; set +a
     python3 scripts/preflight-supabase-config.py
 
-Required env: SUPABASE_URL, SUPABASE_ANON_KEY.
+Required env: SUPABASE_URL, SUPABASE_ANON_KEY. SUPABASE_URL must be an origin
+this process can actually reach: on a self-hosted box the services talk to auth
+over an in-network hostname that resolves only inside the container network, and
+the public origin is a different value (NEXT_PUBLIC_SUPABASE_URL).
 Optional env: SUPABASE_SERVICE_ROLE_KEY (claim-checked when present, never
 sent anywhere), SUPABASE_PREFLIGHT_TIMEOUT (seconds, default 15).
 
@@ -66,7 +73,7 @@ TIMEOUT = float(os.environ.get("SUPABASE_PREFLIGHT_TIMEOUT", "15"))
 # your browser's signature" to the literal default urllib sends
 # (`Python-urllib/3.x`). Measured, not guessed: the same GET of
 # https://chat-hive.scubed.co/api/config returns 403 with that default and 200
-# with the string below, from the same host in the same second. Without this this
+# with the string below, from the same host in the same second. Without it this
 # preflight would report a live project dead whenever its auth origin is
 # published through Cloudflare, which is the shape of false negative that gets a
 # useful check deleted.

--- a/scripts/preflight-supabase-config.py
+++ b/scripts/preflight-supabase-config.py
@@ -60,6 +60,18 @@ import urllib.request
 
 TIMEOUT = float(os.environ.get("SUPABASE_PREFLIGHT_TIMEOUT", "15"))
 
+# Every request this script sends carries an explicit User-Agent, and that is
+# load bearing rather than politeness. Both demo hostnames sit behind
+# Cloudflare, whose bot rules answer 403 "Error 1010: Access denied ... based on
+# your browser's signature" to the literal default urllib sends
+# (`Python-urllib/3.x`). Measured, not guessed: the same GET of
+# https://chat-hive.scubed.co/api/config returns 403 with that default and 200
+# with the string below, from the same host in the same second. Without this this
+# preflight would report a live project dead whenever its auth origin is
+# published through Cloudflare, which is the shape of false negative that gets a
+# useful check deleted.
+USER_AGENT = "hive-preflight-supabase-config/1 (+https://github.com/sakibsadmanshajib/hive)"
+
 failures: list[str] = []
 notes: list[str] = []
 
@@ -149,7 +161,9 @@ def check_key(name: str, token: str, want_role: str, url_ref: str | None) -> Non
 
 
 def http_get(url: str, headers: dict) -> tuple[int, str]:
-    req = urllib.request.Request(url, method="GET", headers=headers)
+    sent = dict(headers)
+    sent.setdefault("User-Agent", USER_AGENT)
+    req = urllib.request.Request(url, method="GET", headers=sent)
     try:
         with urllib.request.urlopen(req, timeout=TIMEOUT) as r:
             return r.status, r.read(4096).decode(errors="replace")
@@ -200,7 +214,38 @@ def main() -> int:
     status, body = http_get(f"{url}/auth/v1/health", {"apikey": anon})
     flat = " ".join(body.split())[:200]
     if status == 200:
-        ok(f"GET /auth/v1/health -> 200 {flat[:120]}")
+        # A 200 is not the evidence. This file's own opening claim is that
+        # asking GoTrue for its health separates "a server answered" from "our
+        # project answered", and a bare status code does not do that: pointed
+        # at https://chat-hive.scubed.co, which is a single-page app that
+        # answers 200 with HTML for every path it does not know, the status
+        # check passed and this preflight reported the configuration sound.
+        # Measured on the live box while writing the post-deploy gate, not
+        # imagined. So the body has to be GoTrue's own health document.
+        #
+        # GoTrue answers {"version": "...", "name": "GoTrue", "description":
+        # "..."} on both hosted and self-hosted deployments, so `name` is the
+        # thing to insist on, and `version` is accepted as well for a future
+        # release that drops the name.
+        document = None
+        try:
+            parsed_body = json.loads(body)
+            if isinstance(parsed_body, dict):
+                document = parsed_body
+        except ValueError:
+            document = None
+        if document is None:
+            fail(
+                "GET /auth/v1/health -> 200 with a body that is not JSON, so this URL is "
+                f"answering from something other than GoTrue: {flat[:120]}"
+            )
+        elif str(document.get("name", "")).lower() != "gotrue" and not document.get("version"):
+            fail(
+                "GET /auth/v1/health -> 200 with JSON that is not GoTrue's health document, "
+                f"so SUPABASE_URL does not name an auth origin: {flat[:120]}"
+            )
+        else:
+            ok(f"GET /auth/v1/health -> 200 from GoTrue {document.get('version') or ''}".rstrip())
     elif status == 401:
         fail(f"GET /auth/v1/health -> 401, the anon key was rejected by this project: {flat}")
     elif status == 0:


### PR DESCRIPTION
## What this is

A machine gate that runs after `deploy-demo-box` succeeds and asserts that the product actually works. A deploy exiting 0 is not that claim: PR #787 merged green and took chat sign-in down, and three consecutive deploys failed at `migrate` while the box silently stayed on two-week-old code.

No human approval anywhere. There is no `environment:` key on any job, and there must never be one: `main` went `7cfc460ea` (added an approval gate) then `09607ff05` (removed it). The rigour comes from stronger checks, not from a person in the loop.

## What it gates on

| # | Check | What would otherwise pass |
| --- | --- | --- |
| 1 | **Chat answers.** `GET /api/config` returns 200 with `status: true` and an `oauth.providers.oidc` entry. | The static shell serves a full 200 HTML page over a dead backend. A page title or a bare status code passes straight through an outage. |
| 2 | **Sign-in completes.** A minted session must resolve at `GET /api/v1/viewer` to the **same user id** it was minted for. | A rendered login page proves nothing. Control-plane revalidates every bearer against GoTrue per request, so this cannot be faked; comparing the id rather than the status rejects a 200 carrying the wrong identity. |
| 3 | **A ledger entry lands.** A real completion through a freshly minted key must produce a new `usage_charge` row with `credits_delta < 0`. | Billing failing open is invisible from every other angle: the request succeeds and the current trace would be a row that is not there. That is exactly what happened for three days in July 2026. |

Plus a **preflight**, which runs first and gates too: does the Supabase configuration in front of us name a project that is alive, with keys that belong to it.

And one **measurement that reports without gating**: whether every container in the stack is running the image its tag currently resolves to (issue #869). Why it reports rather than gates is in the next section.

The key for check 3 is minted **through the session**, not taken from a pre-provisioned key, so key and ledger are guaranteed to share an account. It is revoked in a `finally` block, and a revocation that itself fails is now a check failure rather than a warning.

## Honest coverage: the three failure modes this was asked to catch

**A deploy that reports a rebuild while the container keeps serving the old binary (#869): measured and reported, NOT gated.** The comparison is sound where it matches: 15 of 20 containers match their tag exactly, and control-plane, edge-api and open-webui moved from mismatched to matched across a deploy that recreated them, so the check tracks real state. What the image-id comparison cannot yet establish on this box is the **direction**, which is the entire difference between a stale binary and harmless drift: five containers report an image id that `docker image inspect` cannot resolve at all while their tag resolves to an image built seconds before the container was created, and a container newer than its tag's image did not miss that image. Failing a deploy on that would leave this gate red on every deploy from the day it merges, and a gate that is always red is the one nobody reads on the day it means something. So the numbers ship with the run, the evidence goes to #869, and turning it fatal is a one-line change with a comment saying exactly that. **This gate does not currently catch #869.**

**A deploy that is green while shipping a dead URL (#1059 class): caught, and proved.** This is the preflight. It was, however, weaker than its own header claimed: pointed at `https://chat-hive.scubed.co`, a single-page app that answers 200 with HTML for every path it does not know, it reported the Supabase configuration sound. Measured on the live box, not imagined. It now requires the `/auth/v1/health` body to be GoTrue's own health document, and the `config` negative control reproduces the failure exactly that way, since a hostname updated in one place and left behind in another is the shape #1059 actually took.

**A migration that fails while the tracker reports success: NOT caught here, and it should not be.** That check already exists upstream and closer to the event: `scripts/apply-migrations.sh` plus `scripts/probe-applied-migrations.py` decide the baseline state from the schema itself rather than from the ledger, precisely because an empty ledger has two opposite meanings, and `migrate` runs before `deploy` so a failure stops the deploy. This gate notices such a failure only if it changes chat, sign-in or billing behaviour. The gap worth closing separately is a post-deploy drift assertion (re-run the probe read-only and fail on any applied-versus-present disagreement); it is deliberately not in this pull request.

## Where each input comes from

URLs and keys come from the **box**. Six workflows read `SUPABASE_*` from GitHub secrets naming a hosted project that has been deleted, and nothing went red (#1059). The box's `.env` is what the running containers actually use.

Two corrections to that were needed before this could run at all:

- `SUPABASE_URL` on the box is `http://caddy-supabase`, an in-network compose hostname. This job runs on the host, outside the compose network, so signing in against it dies in DNS. The auth origin is taken from `NEXT_PUBLIC_SUPABASE_URL` (the public origin the product's own browser clients use), with the anon key read from `NEXT_PUBLIC_SUPABASE_ANON_KEY` first so the origin and the key stay paired. A single-label host now fails immediately, naming why.
- Cloudflare fronts both demo hostnames and answers 403 "Error 1010" to the literal `Python-urllib/3.x` User-Agent. Measured: the same `GET /api/config` returns 403 with that default and 200 with a named agent, from the same host in the same second. Both scripts send one.

All three verification targets (`HIVE_CHAT_URL`, `HIVE_CONTROL_PLANE_URL`, `HIVE_EDGE_API_URL`) are required by the script from its environment with no default: a checker that silently assumes a fixed demo host can return green for a product nobody deployed. The workflow exports them explicitly, box `.env` first, with the deployment's public hostnames as a reviewed fallback whose source every run reports.

The verification **identity** comes from the box's `.env`. That is not a contradiction. A stale URL is dangerous because nothing exercises it; a stale credential cannot hide, because signing in with it is the next thing this job does.

## Verification identity: configured, provisioned, proved

Resolved during this session; nothing is left for the owner here.

- `HIVE_VERIFY_EMAIL` and `HIVE_VERIFY_PASSWORD` exist in `/home/sakib/hive/.env` on the box (added outside this branch; presence verified by reading the file's key names only).
- The account behind them was checked read-only against the database: a real GoTrue user, email confirmed, single tenant membership, own billing account.
- It was not usable as first written: membership was MEMBER and balance zero, which the gate itself surfaced as a 403-shaped failure class and an upstream `insufficient_quota`. Provisioning applied two scoped writes limited to that user's own rows: membership raised to OWNER (minting an API key needs `api_keys:write`, granted to OWNER only), and one idempotent grant entry of 10,000 credits on its own billing account (`idempotency_key post-deploy-verify-seed-2026-08-23`, unique index makes reruns inert).
- First fully-green verification followed immediately, on the box, all three checks passing including a real charge of `-1` credit and clean key revocation.

## Negative controls

Every gating check has one, and each removes the guarded condition for real:

| Value | What it removes | Expected |
| --- | --- | --- |
| `chat` | reads the static shell at `/` instead of the backend config | red |
| `signin` | flips every bit of the bearer's first decoded signature byte, header and payload intact | red |
| `ledger` | skips the completion, so nothing bills | red |
| `config` | points the auth origin at another live host in this deployment | red |
| `freshness` | compares against an image id nothing can be running | red |

No value can make anything pass; it can only cause a failure. Selectable from `workflow_dispatch` after this merges, and from a `verify-negative:<value>` label before then. Selecting `signin` or `ledger` with no identity configured fails immediately naming that precondition rather than surfacing later as a confusing argparse error.

## Verification, run by run

All against the live box unless noted.

| Run / evidence | What it shows |
| --- | --- |
| On-box full run, 2026-08-23 ~20:42 UTC | **Full green baseline, all three checks**: chat backend config 200 with `status: true` and OIDC provider; minted session resolved at the control-plane to the same user; real completion answered 200, produced `usage_charge` `credits_delta=-1`, key revoked. |
| [32665274872](https://github.com/sakibsadmanshajib/hive/actions/runs/32665274872) | `signin` control red through the assertion: corrupted decoded signature bytes, control-plane answered 401 `invalid or expired token`. |
| [32665392330](https://github.com/sakibsadmanshajib/hive/actions/runs/32665392330) | `ledger` control red through the assertion: completion skipped, no new `usage_charge` within 90s, reported as billing failing open. |
| [32660681673](https://github.com/sakibsadmanshajib/hive/actions/runs/32660681673) | Earlier partial green baseline: preflight passed from GoTrue v2.189.0 at the public origin, chat check passed, 20 containers compared, missing identity reported as unconfigured coverage. |
| [32659829693](https://github.com/sakibsadmanshajib/hive/actions/runs/32659829693) | `chat` control red, and for the right reason: `/` answered 200 with HTML, so the check names the static shell rather than the backend. |
| [32660319162](https://github.com/sakibsadmanshajib/hive/actions/runs/32660319162) | `config` control red: `GET /auth/v1/health` answered 200 from a host that is not GoTrue, and the preflight says so instead of passing. |
| [32660549692](https://github.com/sakibsadmanshajib/hive/actions/runs/32660549692) | `freshness` control red through the assertion path, every container reported and the step failing on the comparison. |
| [32660408662](https://github.com/sakibsadmanshajib/hive/actions/runs/32660408662) | The same control failing for the wrong reason before it was fixed. Kept because a control that fails for the wrong reason proves nothing, and this is what that looks like. |
| [32634926680](https://github.com/sakibsadmanshajib/hive/actions/runs/32634926680) | The original failure this PR had to fix: no verification identity in the box `.env`. |
| [32664630991](https://github.com/sakibsadmanshajib/hive/actions/runs/32664630991) | The new response-shape guard catching a real condition live: a genuine zero-row account answers `{"entries": null}`, which is the Go handler's designed empty answer; the scan now reads null as empty and any other non-list type still fails naming its type. |
| [32665543894](https://github.com/sakibsadmanshajib/hive/actions/runs/32665543894), [32665768538](https://github.com/sakibsadmanshajib/hive/actions/runs/32665768538) | Upstream capacity noise, documented not hidden: after #1099 every chat alias routes to an OpenRouter free model, whose per-key daily capacity intermittently answers 429 `insufficient_quota` while chat itself stays up. The completion is retried up to `HIVE_VERIFY_COMPLETION_ATTEMPTS` (default 3) with `HIVE_VERIFY_RETRY_DELAY` (default 20s) between attempts; exhausted retries fail naming the last answer. Expect the ledger check to flap with OpenRouter free-tier capacity until the route mix changes. |

## Review

- **CodeRabbit CLI**: ran twice (round 1: three findings, three fixes; round 2 on the new commits: four findings, four fixes: target URLs required rather than defaulted, JSON shapes validated before field access, byte-changing signature mutation, revocation failure fatal, secret lengths suppressed for password/service-role values, deterministic negative-control invocation).
- **`ecc:code-review`**: ran as a structured seven-category pass over the three changed files at head revision. Findings folded back into the fixes above plus one consistency fix (service-role key length suppressed in the preflight output). Posted as a COMMENT review; the builder does not approve its own PR.
- **Plain adversarial pass**: ran, against the live box rather than by reading. Produced the Cloudflare user-agent block, the non-GoTrue health-document gap, subset-run summary wording, notifier scope, freshness-control ordering, anon-key pairing, the entries-null discovery, and the 429 retry semantics.
- **Mandatory security review on an auth and money path**: manual pass covered: no value printed anywhere (presence only for password and service-role values, masked on export), no credential crossing `$GITHUB_ENV`, a step summary or a job boundary, no password ever written or rotated (`docs/live-test-auth.md`), the minted key revoked in a `finally` with failure now fatal, fork head repositories excluded from the self-hosted runner, `persist-credentials: false`, and the real spend bounded (one completion, `max_tokens: 64`, dedicated identity, never the demo account).
- **`/codex:adversarial-review`**: SKIPPED, capability gap, not a clean pass. Codex usage limits were reached earlier today (recorded on the PR timeline); the stream could not run.

## Failure handling: alert, not rollback

Deliberately no automatic rollback. `migrate` runs before `deploy` and forward migrations are not reversible by redeploying code, so an automatic rollback would leave old code against a new schema, which is worse than a bad deploy.

The notifier uses its own `ci-failure:post-deploy-verify` label rather than sharing `ci-failure:deploy-demo-box`, since this workflow cannot join that job's `needs` list and its ledger check can go red for reasons unrelated to a deploy. It fires **only on `workflow_run`**: issue #1062 exists because a pull request run filed it, and every negative-control run is expected to fail. It dedupes by exact title over the issues list API rather than the eventually consistent search API, and `continue-on-error` plus `|| true` mean it can never alter the verdict.

## Not a user-visible surface

No screenshot: this changes a workflow and two scripts. Nothing in the product's UI moves, so the visual-proof rule does not apply. The evidence is the run table above.

## Test plan

- [x] Green baseline: the checks that can run pass against the running box (partial CI baseline, then a full three-check green run on the box once the identity was provisioned).
- [x] `negative_control=chat` goes red.
- [x] `negative_control=config` goes red, restore goes green.
- [x] `negative_control=freshness` goes red through the assertion.
- [x] `negative_control=signin` goes red through the assertion (run 32665274872).
- [x] `negative_control=ledger` goes red through the assertion (run 32665392330).
- [x] Preflight fails legibly on a Supabase configuration that answers HTTP but is not our project.
- [x] The notifier cannot fire from a pull request run.
- [x] CodeQL alert 27 cleared, thread resolved.
- [ ] One more fully-green CI run once OpenRouter free-route capacity allows a completion through; the on-box full run already proves the path end to end.

## Buglog entry

To be appended to `.wolf/buglog.jsonl` on `main` in a buglog-only pull request after this merges, per issue #873.

```json
{"date":"2026-08-23","title":"Cloudflare answered 403 Error 1010 to the default Python urllib user agent, so every HTTP check against the demo hostnames failed","error_message":"HTTP 403 {\"title\":\"Error 1010: Access denied\",\"detail\":\"The site owner has blocked access based on your browser's signature\"}","root_cause":"urllib sends User-Agent: Python-urllib/3.x by default, and the Cloudflare bot rules in front of chat-hive.scubed.co and console-hive.scubed.co block that signature. curl from the same host in the same second returned 200, which is why the failure read as a dead backend rather than a blocked client.","fix":"scripts/post-deploy-verify.py and scripts/preflight-supabase-config.py set an explicit named User-Agent on every request.","tags":["cloudflare","http","verification","false-negative","demo-box"]}
{"date":"2026-08-23","title":"The Supabase preflight reported a wrong host as a healthy project because it only checked the status code","error_message":"PREFLIGHT PASSED against SUPABASE_URL=https://chat-hive.scubed.co","root_cause":"The liveness check asserted GET /auth/v1/health returned 200 and nothing about the body, while chat-hive.scubed.co is a single-page app that answers 200 with HTML for every unknown path.","fix":"The preflight requires the health body to be GoTrue's own document and fails naming what answered instead.","tags":["supabase","preflight","false-positive","issue-1059"]}
{"date":"2026-08-23","title":"post-deploy-verify filed an issue claiming the demo box was broken from a pull request run","error_message":"issue #1062 post-deploy-verify is failing against the demo box, verify=failure, trigger=pull_request","root_cause":"The report-failure job was gated on failure() alone, so a label-gated pull request run of the workflow, including every negative-control run that is expected to fail, filed an outage issue for the deployment.","fix":"The notifier requires github.event_name == 'workflow_run', and a missing verification identity files under its own title.","tags":["github-actions","notifier","false-alarm","issue-1062"]}
{"date":"2026-08-23","title":"The verification could not sign in at all because the box's SUPABASE_URL is an in-network compose hostname","error_message":"SUPABASE_URL=http://caddy-supabase does not resolve from the runner host","root_cause":"Services inside the compose network reach auth at http://caddy-supabase; this job runs on the host outside that network. The public auth origin is NEXT_PUBLIC_SUPABASE_URL, a different value on this box.","fix":"The workflow reads NEXT_PUBLIC_SUPABASE_URL first, pairs it with NEXT_PUBLIC_SUPABASE_ANON_KEY, and fails immediately when the resolved host has no dot in it.","tags":["supabase","demo-box","networking","verification"]}
{"date":"2026-08-23","title":"The verifier crashed with AttributeError instead of a named failure when a 200 carried the wrong JSON shape","error_message":"AttributeError on payload.get / viewer.get / entries iteration","root_cause":"Decoded JSON was field-accessed without type validation, and main() catches CheckFailed only, so a malformed 200 skipped the per-check summary entirely.","fix":"Sign-in, viewer and ledger payloads are shape-checked before access and raise the named CheckFailed.","tags":["python","verification","error-handling"]}
{"date":"2026-08-23","title":"A real zero-row ledger answered {\"entries\": null} and the new shape guard rejected a correct API answer","error_message":"ledger read answered 200 but carried entries as NoneType, expected a list","root_cause":"The control-plane handler builds the list with var entries []LedgerEntry, so an empty account marshals as null, not []; the guard written for malformed bodies treated the designed empty answer as malformed. Found live on the first full run against the box.","fix":"Null entries scan as the empty page; any other non-list type still fails naming its type.","tags":["go","json","verification","null-semantics"]}
{"date":"2026-08-23","title":"Ledger check flapped on upstream 429 after the chat aliases moved to an OpenRouter free route","error_message":"the completion answered 429 insufficient_quota on attempts 1..3 while an identical completion minutes earlier returned 200 and charged normally","root_cause":"#1099 repointed every chat alias at an OpenRouter free model whose per-key daily capacity intermittently refuses service; the verifier's claim is that a served request bills, not that an upstream always serves.","fix":"Bounded retries (HIVE_VERIFY_COMPLETION_ATTEMPTS=3, HIVE_VERIFY_RETRY_DELAY=20s) treat 429/5xx as retryable; exhausted retries fail naming the last answer. Documented as expected flap until the route mix changes.","tags":["openrouter","rate-limit","verification","flaky-gate"]}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated post-deployment verification after successful deployments, with support for manual runs and eligible pull requests.
  - Verifies chat availability, sign-in, billing completion, container freshness, and deployment configuration.
  - Supports targeted checks, negative testing, retries, polling, and safe credential handling.
  - Added Supabase configuration preflight checks for environment settings, tokens, URLs, and service health.
  - Reports skipped checks when credentials are unavailable without incorrectly failing verification.

- **Bug Fixes**
  - Added deduplicated issue notifications for verification failures or missing coverage without changing verification results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Billing test evidence (CodeRabbit follow-up)

- `go test ./apps/edge-api/... -count=1 -short` in the toolchain container: all packages pass, including the reservation guard tests covering the 429 mapping (`reservation_guard`) and the strict-mode 409 to 429 translation.
- `go test ./apps/control-plane/... -count=1 -short`: all packages pass, including the reservations policy tests for the flat hold and PolicyError path (`service.go` strict mode).
- Live evidence: run 32669144332 rerun completed success at 2026-08-23T23:10:22Z with the full three-check green (chat, signin, ledger), after the verify workspace balance was topped up past the flat 10000 credit hold. The named preflight added in stacked PR #1105 makes this failure mode self-diagnosing going forward.
