### PR TITLE
chore: raise Go toolchain to 1.26 across workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,7 +324,7 @@ jobs:
       - uses: actions/setup-go@v5
         if: needs.changes.outputs.run != 'false'
         with:
-          go-version: '1.24'
+          go-version: '1.26'
           cache-dependency-path: |
             apps/edge-api/go.sum
             apps/control-plane/go.sum

--- a/.github/workflows/license-gate.yml
+++ b/.github/workflows/license-gate.yml
@@ -50,7 +50,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.26'
           cache-dependency-path: |
             apps/edge-api/go.sum
             apps/control-plane/go.sum

--- a/apps/agent-engine/go.mod
+++ b/apps/agent-engine/go.mod
@@ -1,8 +1,8 @@
 module github.com/sakibsadmanshajib/hive/apps/agent-engine
 
-go 1.24.0
+go 1.26.0
 
-toolchain go1.24.13
+toolchain go1.26.7
 
 require (
 	github.com/google/uuid v1.6.0

--- a/apps/control-plane/go.mod
+++ b/apps/control-plane/go.mod
@@ -1,8 +1,8 @@
 module github.com/sakibsadmanshajib/hive/apps/control-plane
 
-go 1.24.0
+go 1.26.0
 
-toolchain go1.24.13
+toolchain go1.26.7
 
 require (
 	github.com/google/uuid v1.6.0

--- a/apps/edge-api/go.mod
+++ b/apps/edge-api/go.mod
@@ -1,8 +1,8 @@
 module github.com/sakibsadmanshajib/hive/apps/edge-api
 
-go 1.24.0
+go 1.26.0
 
-toolchain go1.24.13
+toolchain go1.26.7
 
 require (
 	github.com/jackc/pgerrcode v0.0.0-20250907135507-afb5586c32a6

--- a/deploy/docker/Dockerfile.agent-engine
+++ b/deploy/docker/Dockerfile.agent-engine
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine AS base
+FROM golang:1.26-alpine AS base
 RUN apk add --no-cache git
 WORKDIR /app
 COPY go.work go.work.sum* ./

--- a/deploy/docker/Dockerfile.control-plane
+++ b/deploy/docker/Dockerfile.control-plane
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine
+FROM golang:1.26-alpine
 
 RUN apk add --no-cache git
 

--- a/deploy/docker/Dockerfile.control-plane
+++ b/deploy/docker/Dockerfile.control-plane
@@ -2,7 +2,8 @@ FROM golang:1.26-alpine
 
 RUN apk add --no-cache git
 
-# Install air for hot reload (requires GOTOOLCHAIN=auto for Go 1.24 base)
+# Install air for hot reload (GOTOOLCHAIN=auto lets this step self-upgrade
+# if air's own go.mod ever outpaces the base image's native Go version)
 ENV GOTOOLCHAIN=auto
 RUN go install github.com/air-verse/air@v1.64.5
 

--- a/deploy/docker/Dockerfile.control-plane.prod
+++ b/deploy/docker/Dockerfile.control-plane.prod
@@ -7,7 +7,7 @@
 
 # Build stage: pinned to the BUILD host's native arch so the Go toolchain
 # itself runs fast (no qemu overhead for the compiler).
-FROM --platform=$BUILDPLATFORM golang:1.24-alpine AS build
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS build
 
 # TARGETARCH is injected by buildx (value: amd64 or arm64).
 # When empty (plain docker build) Go uses the host GOARCH.

--- a/deploy/docker/Dockerfile.edge-api
+++ b/deploy/docker/Dockerfile.edge-api
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine AS base
+FROM golang:1.26-alpine AS base
 RUN apk add --no-cache git
 RUN GOTOOLCHAIN=auto go install github.com/air-verse/air@v1.64.5
 WORKDIR /app

--- a/deploy/docker/Dockerfile.edge-api.prod
+++ b/deploy/docker/Dockerfile.edge-api.prod
@@ -7,7 +7,7 @@
 
 # Build stage: pinned to the BUILD host's native arch so the Go toolchain
 # itself runs fast (no qemu overhead for the compiler).
-FROM --platform=$BUILDPLATFORM golang:1.24-alpine AS build
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS build
 
 # TARGETARCH is injected by buildx (value: amd64 or arm64).
 # When empty (plain docker build) Go uses the host GOARCH.

--- a/deploy/docker/Dockerfile.toolchain
+++ b/deploy/docker/Dockerfile.toolchain
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine AS base
+FROM golang:1.26-alpine AS base
 RUN apk add --no-cache git curl nodejs npm python3 py3-pip py3-yaml
 RUN GOTOOLCHAIN=auto go install github.com/ogen-go/ogen/cmd/ogen@v1.20.2
 RUN GOTOOLCHAIN=auto go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@v2.6.0

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -439,7 +439,7 @@ services:
       # buildAgentEngine ignores every HIVE_AGENT_ENGINE_* path variable
       # below and forwards launches to that daemon.
       #
-      # Why: this service runs inside a golang:1.24-alpine container, which
+      # Why: this service runs inside a golang:1.26-alpine container, which
       # cannot exec the host's Apptainer directly (glibc-linked binary, no
       # musl dynamic loader; no /dev/fuse; would need real CAP_SYS_ADMIN-class
       # privilege on the service holding Stripe/Supabase/payment secrets).

--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
-go 1.24.0
+go 1.26.0
 
-toolchain go1.24.13
+toolchain go1.26.7
 
 use ./apps/edge-api
 

--- a/packages/audit-canonical/go.mod
+++ b/packages/audit-canonical/go.mod
@@ -1,7 +1,7 @@
 module github.com/sakibsadmanshajib/hive/packages/audit-canonical
 
-go 1.24.0
+go 1.26.0
 
-toolchain go1.24.13
+toolchain go1.26.7
 
 require github.com/google/uuid v1.6.0

--- a/packages/embedmodel/go.mod
+++ b/packages/embedmodel/go.mod
@@ -1,5 +1,5 @@
 module github.com/sakibsadmanshajib/hive/packages/embedmodel
 
-go 1.24.0
+go 1.26.0
 
-toolchain go1.24.13
+toolchain go1.26.7

--- a/packages/storage/go.mod
+++ b/packages/storage/go.mod
@@ -1,8 +1,8 @@
 module github.com/sakibsadmanshajib/hive/packages/storage
 
-go 1.24.0
+go 1.26.0
 
-toolchain go1.24.13
+toolchain go1.26.7
 
 require github.com/aws/aws-sdk-go-v2 v1.41.5
 

--- a/scripts/install-agent-engine-host.sh
+++ b/scripts/install-agent-engine-host.sh
@@ -88,7 +88,7 @@ docker run --rm \
   -v hive_gomodcache:/go/pkg/mod \
   -w /workspace \
   -e CGO_ENABLED=0 \
-  golang:1.24-alpine \
+  golang:1.26-alpine \
   go build -o /out/agent-engine ./apps/agent-engine/cmd/agent-engine
 # `go build` already emits 0755, so this is belt and braces for an odd umask.
 # It is allowed to fail: under rootful Docker (every GitHub-hosted runner) the


### PR DESCRIPTION
## Summary
Raises the Go toolchain across the workspace so the module bumps in #1013 and #1015 stop failing every Go job (go.work currently pins go 1.24.0).

## Changes
- go.work: go directive to 1.26.0, toolchain go1.26.7
- all six go.mod files: go 1.26.0 plus toolchain go1.26.7, matching the existing convention
- five application Dockerfiles moved from golang:1.24-alpine to golang:1.26-alpine (agent-engine, control-plane, edge-api, and their prod variants)
- Dockerfile.toolchain base moved to golang:1.26-alpine, its installed Go is now 1.26.7 native (GOTOOLCHAIN=local), so 1.26 modules compile without auto-download
- ci.yml and license-gate.yml setup-go pins moved from '1.24' to '1.26' (review finding); agent-stream-delta-proof.yml already follows go.work via go-version-file
- one stale compose comment and the agent-engine host install script updated to match the new image tag
- Dockerfile.control-plane's air-install comment no longer hardcodes a Go version (adversarial-review finding, see below)
- no module dependencies are bumped here; those arrive via the #1013/#1015 rebases after this merges

## Verification
Toolchain image rebuilt from scratch (`docker compose --profile tools build toolchain`) to confirm it actually picks up golang:1.26-alpine rather than reusing a cached 1.24 layer; `go version` inside the rebuilt container reports `go1.26.7 linux/amd64` natively, no auto-download needed.

All six Go modules run green against that rebuilt image, using full module-relative paths (`./apps/control-plane/...` etc., required under go.work):
- control-plane: 51 packages, all ok
- edge-api: 25 packages, all ok
- agent-engine: 12 packages (2 no-test-files), all ok
- storage: 1 package, ok
- audit-canonical: 1 package, ok
- embedmodel: 1 package, ok

`go vet ./apps/control-plane/... ./apps/edge-api/... ./apps/agent-engine/... ./packages/storage/... ./packages/audit-canonical/... ./packages/embedmodel/...` exits 0 with no output (the earlier `./apps/... ./packages/...` wildcard form does not resolve under go.work and was corrected here). No Go source files changed in this PR.

Full CI is green on the pushed head, including live-Postgres RLS suites, Web E2E, and the Cowork Apptainer proof job.

## Adversarial review
- CodeRabbit CLI (`coderabbit review --base origin/main --agent`): 0 findings across all 17 changed files. Real run, not a skip (the GitHub-App CodeRabbit check reports "skipped: draft pull request" separately, which is expected while draft).
- ecc:code-review / go-reviewer / plain adversarial pass: performed directly by the builder in this session (no separate Agent-dispatch tool available); one real finding, fixed: `Dockerfile.control-plane`'s air-install comment named "Go 1.24 base" and would have gone stale again on the next raise, reworded to describe the `GOTOOLCHAIN=auto` mechanism generically. Repo-wide grep confirms zero remaining `1.24`/`1.27` golang references outside an unrelated synthetic fixture string in `tools/lint-go-db-test-wiring.test.mjs`.

## Follow-up
After merge, comment `@dependabot rebase` on #1013 and #1015 so their branches pick up the new toolchain. Note: a literal `git merge` of this branch's head into either dependabot branch conflicts on the `go`/`toolchain` lines in `apps/control-plane/go.mod` and `apps/edge-api/go.mod` (dependabot's own diffs there already bump `go 1.24.0` to `go 1.25.0` with no toolchain line, to satisfy one of the updated packages' own minimum). `@dependabot rebase` regenerates the update fresh against the new base rather than doing a textual merge, so it should resolve cleanly by keeping this PR's `go 1.26.0`/`toolchain go1.26.7` and reapplying just the dependency bumps, but that is dependabot's behavior to verify live after this merges, not something proven by the conflict test alone.
