### PR TITLE
ci: move workflows to node 24 and current action majors

### DIFF
--- a/.github/workflows/agent-engine-sif.yml
+++ b/.github/workflows/agent-engine-sif.yml
@@ -45,7 +45,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Apptainer ${{ env.APPTAINER_VERSION }}
         run: |
@@ -90,7 +90,7 @@ jobs:
           apptainer inspect agent-engine.sif
 
       - name: Upload agent-engine.sif artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: agent-engine-sif
           path: deploy/apptainer/agent-engine.sif

--- a/.github/workflows/agent-stream-delta-proof.yml
+++ b/.github/workflows/agent-stream-delta-proof.yml
@@ -51,9 +51,9 @@ jobs:
       actions: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.work
           cache-dependency-path: apps/agent-engine/go.sum
@@ -177,7 +177,7 @@ jobs:
 
       - name: Upload the captured log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: stream-delta-proof-${{ github.run_id }}
           path: /tmp/proof-redacted.log

--- a/.github/workflows/agent-visual-proof.yml
+++ b/.github/workflows/agent-visual-proof.yml
@@ -209,7 +209,7 @@ jobs:
           gh pr view "$pr" -R "$GITHUB_REPOSITORY" --json number,title,headRefOid \
             --jq '"proving PR #\(.number): \(.title) at head \(.headRefOid)"'
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ steps.target.outputs.ref }}
 
@@ -233,13 +233,13 @@ jobs:
           sudo chown "$(id -un):$(id -gn)" /mnt/ms-playwright
           df -h / /mnt
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: apps/web-console/package-lock.json
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
       - name: Mint this run's internal service token
         # Random per run and masked. It authenticates control-plane to the
@@ -764,7 +764,7 @@ jobs:
         # not a silent absence either, because the lint step itself is red
         # and names the file it found.
         if: always() && steps.capture.conclusion != 'skipped' && steps.lint.conclusion != 'failure'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: agent-visual-proof-${{ github.run_id }}
           path: ${{ env.CAPTURE_DIR }}
@@ -840,7 +840,7 @@ jobs:
 
       - name: Upload the failure logs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: agent-visual-proof-logs-${{ github.run_id }}
           path: |

--- a/.github/workflows/chat-coverage.yml
+++ b/.github/workflows/chat-coverage.yml
@@ -47,14 +47,14 @@ jobs:
       run:
         working-directory: apps/web-console
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           # Leave no usable git credential in the runner's config for the rest
           # of the job, which runs a browser against a live deployment.
           persist-credentials: false
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: apps/web-console/package-lock.json
       - name: Install dependencies
@@ -107,14 +107,14 @@ jobs:
       SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
       COV_SURFACES: ${{ inputs.surfaces }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           # Leave no usable git credential in the runner's config for the rest
           # of the job, which runs a browser against a live deployment.
           persist-credentials: false
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: apps/web-console/package-lock.json
       - name: Check the inputs the sweep cannot run without
@@ -138,7 +138,7 @@ jobs:
         run: npm run e2e:chat-coverage
       - name: Upload the coverage ledger
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: chat-coverage-ledger
           # Two named files, never a directory. Everything this suite writes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,10 +318,10 @@ jobs:
           - module: agent-engine
             path: ./apps/agent-engine
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         if: needs.changes.outputs.run != 'false'
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         if: needs.changes.outputs.run != 'false'
         with:
           go-version: '1.24'
@@ -474,13 +474,13 @@ jobs:
       run:
         working-directory: apps/desktop-sandbox
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install libcap headers
         # codex-bwrap's build.rs compiles vendored bubblewrap against libcap.
         run: sudo apt-get update && sudo apt-get install -y libcap-dev pkg-config
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
@@ -533,7 +533,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.run == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install GTK/WebKit headers
         run: |
@@ -542,7 +542,7 @@ jobs:
             libwebkit2gtk-4.1-dev libgtk-3-dev librsvg2-dev \
             libayatana-appindicator3-dev libssl-dev
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
@@ -562,9 +562,9 @@ jobs:
         working-directory: apps/desktop/src-tauri
         run: cargo test
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: apps/desktop/package-lock.json
 
@@ -602,13 +602,13 @@ jobs:
     needs: changes
     if: always()
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         if: needs.changes.outputs.run != 'false'
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         if: needs.changes.outputs.run != 'false'
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Install repo-level dev deps
         if: needs.changes.outputs.run != 'false'
@@ -742,11 +742,11 @@ jobs:
       run:
         working-directory: apps/agent-console
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: apps/agent-console/package-lock.json
 
@@ -777,13 +777,13 @@ jobs:
       run:
         working-directory: apps/web-console
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         if: needs.changes.outputs.run != 'false'
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         if: needs.changes.outputs.run != 'false'
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: apps/web-console/package-lock.json
 
@@ -873,12 +873,12 @@ jobs:
       github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name != github.repository
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
+      - uses: actions/checkout@v7
+      - uses: docker/setup-buildx-action@v4
       - name: Build all service images (cached)
-        uses: docker/bake-action@v6
+        uses: docker/bake-action@v7
         with:
-          workdir: .
+          source: .
           files: |
             ./deploy/docker/docker-bake.hcl
           targets: edge-api,control-plane,web-console
@@ -978,9 +978,9 @@ jobs:
       # writes to $GITHUB_ENV and silently point the SDK suites back at the
       # shared account.
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
       - name: Start a throwaway Postgres and apply the real schema
         shell: bash
@@ -1091,7 +1091,7 @@ jobs:
 
       - name: Cache third-party images (redis, litellm)
         id: img-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: /tmp/docker-images
           # Keyed on the pinned tags so tag bumps invalidate the cache.
@@ -1115,9 +1115,9 @@ jobs:
           fi
 
       - name: Build stack images (buildx + GHA cache)
-        uses: docker/bake-action@v6
+        uses: docker/bake-action@v7
         with:
-          workdir: .
+          source: .
           files: |
             ./deploy/docker/docker-bake.hcl
           targets: edge-api,control-plane,sdk-tests-js,sdk-tests-py,sdk-tests-java
@@ -1231,7 +1231,7 @@ jobs:
 
       - name: Upload compose logs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: compose-logs
           path: /tmp/compose.log
@@ -1253,7 +1253,7 @@ jobs:
         # via the PR checks, no need to also file a repo issue. Dedupe on an
         # open issue with the label below instead of filing one per red run.
         if: failure() && (github.event_name == 'push' || github.event_name == 'schedule')
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const label = 'ci-failure:live-integration';
@@ -1403,13 +1403,13 @@ jobs:
       # and was already skipping here because this job has never set
       # EDGE_BASE_URL. Removing it changes no spec's outcome.
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: apps/web-console/package-lock.json
 
@@ -1507,7 +1507,7 @@ jobs:
 
       - name: Cache third-party images (redis, litellm)
         id: img-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: /tmp/docker-images
           key: docker-images-redis-8.4-alpine-litellm-v1.77.7-stable
@@ -1528,9 +1528,9 @@ jobs:
           fi
 
       - name: Build stack images (reuse GHA cache from live-integration)
-        uses: docker/bake-action@v6
+        uses: docker/bake-action@v7
         with:
-          workdir: .
+          source: .
           files: |
             ./deploy/docker/docker-bake.hcl
           targets: edge-api,control-plane
@@ -1587,7 +1587,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: pw-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}
@@ -1751,7 +1751,7 @@ jobs:
 
       - name: Upload compose logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: compose-logs-web-e2e-api
           path: /tmp/compose-web-e2e-api.log
@@ -1778,7 +1778,7 @@ jobs:
 
       - name: Upload the redacted Next.js server log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: nextjs-log-web-e2e
           path: /tmp/nextjs-redacted.log
@@ -1787,7 +1787,7 @@ jobs:
 
       - name: Upload Playwright report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report-api
           # Traces (.zip), videos (.webm) and index.html are excluded. This
@@ -1850,7 +1850,7 @@ jobs:
       run:
         working-directory: apps/desktop-sandbox
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install libcap headers + build deps
         # codex-bwrap's build.rs compiles vendored bubblewrap against libcap.
@@ -1863,7 +1863,7 @@ jobs:
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
           sudo sysctl -w kernel.unprivileged_userns_clone=1 || true
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/demo-chat-settings-check.yml
+++ b/.github/workflows/demo-chat-settings-check.yml
@@ -56,12 +56,12 @@ jobs:
     outputs:
       kind: ${{ steps.check.outputs.kind }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: apps/web-console/package-lock.json
       - name: Check the inputs this job cannot run without
@@ -114,7 +114,7 @@ jobs:
         run: |
           mkdir -p /tmp/proof
           node ../../docs/proof/issue-855-enter-key/capture.mjs manual-repair /tmp/proof "$DEMO_ACCOUNT_EMAIL"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: github.event_name == 'workflow_dispatch' && inputs.repair == 'true'
         with:
           name: enter-key-proof
@@ -137,7 +137,7 @@ jobs:
       issues: write
     timeout-minutes: 5
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v9
         env:
           KIND: ${{ needs.check.outputs.kind }}
         with:

--- a/.github/workflows/deploy-demo-box.yml
+++ b/.github/workflows/deploy-demo-box.yml
@@ -226,7 +226,7 @@ jobs:
       # which is exactly how this broke the first time.
       PSQL_BIN: ${{ github.workspace }}/scripts/stack-psql.sh
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -1749,15 +1749,15 @@ jobs:
       HIVE_TEST_MODEL: hive-default
       HIVE_EMBEDDING_MODEL: hive-embedding-default
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
-          node-version: '22'
+          node-version: '24'
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.12'
 
@@ -1864,13 +1864,13 @@ jobs:
       run:
         working-directory: apps/web-console
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: apps/web-console/package-lock.json
 
@@ -1885,7 +1885,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: pw-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}
@@ -1952,7 +1952,7 @@ jobs:
         # token today, so that was a posture gap rather than a live leak, but
         # naming the files means a future log line cannot widen the artifact.
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: agent-workspace-coverage
           path: |
@@ -1981,7 +1981,7 @@ jobs:
       issues: write
     timeout-minutes: 5
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v9
         env:
           MIGRATE_RESULT: ${{ needs.migrate.result }}
           DEPLOY_RESULT: ${{ needs.deploy.result }}

--- a/.github/workflows/deploy-web-console-workers.yml
+++ b/.github/workflows/deploy-web-console-workers.yml
@@ -44,13 +44,13 @@ jobs:
       run:
         working-directory: apps/web-console
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
-          node-version: '22'
+          node-version: '24'
         # No npm cache here: apps/web-console/package-lock.json is also
         # cached by pull_request workflows that run on fork PRs (e.g.
         # license-gate), so restoring that cache in this trusted deploy job

--- a/.github/workflows/license-gate.yml
+++ b/.github/workflows/license-gate.yml
@@ -46,9 +46,9 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version: '1.24'
           cache-dependency-path: |
@@ -57,14 +57,14 @@ jobs:
             packages/storage/go.sum
 
       - name: Cache go-licenses binary
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/go/bin/go-licenses
           key: go-licenses-v1.6.0-${{ runner.os }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: apps/web-console/package-lock.json
 
@@ -85,7 +85,7 @@ jobs:
 
       - name: Upload SBOM artefacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: sbom-${{ github.sha }}
           path: |

--- a/.github/workflows/migration-applier-tests.yml
+++ b/.github/workflows/migration-applier-tests.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/oauth-scope-gate.yml
+++ b/.github/workflows/oauth-scope-gate.yml
@@ -81,7 +81,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/owui-nightly.yml
+++ b/.github/workflows/owui-nightly.yml
@@ -29,10 +29,10 @@ jobs:
       LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
       LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '24'
       - name: Reconstruct SUPABASE_DB_URL
         # HIVE_TEST_DB_URL secret does not exist (phantom -- 2026-07-04 run
         # 28643196239 failed on it). Reconstruct from the same DB part
@@ -330,7 +330,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: pw-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}
@@ -447,7 +447,7 @@ jobs:
         run: |
           npm i --no-save yaml pg
           node tools/soc2-coverage-report.mjs || true
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: owui-playwright-report
@@ -469,7 +469,7 @@ jobs:
             !apps/web-console/playwright-report-owui/**/*.webm
             !apps/web-console/playwright-report-owui/index.html
           retention-days: 5
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           # Proof captures, kept out of the HTML report's own folder because
@@ -481,7 +481,7 @@ jobs:
           if-no-files-found: warn
           retention-days: 5
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: owui-compose-logs


### PR DESCRIPTION
Batch 2 of the approved dependency sweep: mechanical workflow runtime bumps.

## What changed

- **node-version `'20'`/`'22'` → `'24'`** in all 14 setup-node steps across 12 workflow files. Node 20 is EOL since April 2026; 24 is the active LTS (26 reaches LTS in October).
- **Action majors**, each latest stable verified on its GitHub releases page before bumping:
  - actions/checkout v4 → v7
  - actions/setup-node v4 → v7
  - actions/upload-artifact v4 → v7
  - actions/cache v4 → v6
  - actions/setup-go v5 → v7
  - actions/setup-python v5 → v7
  - docker/setup-buildx-action v3 → v4
  - docker/bake-action v6 → v7
  - actions/github-script v7 → v9
- **Migration-note adjustments, not blind bumps:**
  - bake-action v7 merges `workdir` into `source`: three ci.yml steps switched from `workdir: .` to `source: .`
  - github-script v9 makes `@actions/github` ESM-only and rejects scripts declaring their own `getOctokit`; all three of our scripts grepped clean for both patterns
  - upload-artifact v6+ and all node24 actions require Actions Runner ≥ 2.327.1; GitHub-hosted runners qualify, and the hive-demo-box runner was installed August 2026 so it is newer than that floor
  - setup-node v5+ auto-enables package-manager caching when package.json has a `packageManager` field; harmless if absent, cache restore failures are warnings only

## Deliberately not bumped

- cloudflare/wrangler-action stays at v3: its v4 changes the default wrangler CLI from v3 to v4, which is a behavioral deploy change rather than a mechanical bump.

## Supersedes Dependabot PRs

This PR supersedes #1019, #1022, #1023, #1025, and #1027; close those as superseded when this merges.

## Verification

The PR's own ci.yml run is the test: it executes the bumped checkout, cache, setup-go, setup-node (node 24), buildx, bake-action, upload-artifact, and github-script steps end to end. Required checks are watched to completion.