### PR TITLE
feat: agent task event pipeline from sandbox to customer API

### DIFF
--- a/apps/agent-engine/cmd/agent-engine/serve.go
+++ b/apps/agent-engine/cmd/agent-engine/serve.go
@@ -41,6 +41,7 @@ import (
 
 	"github.com/sakibsadmanshajib/hive/apps/agent-engine/engineapi"
 	"github.com/sakibsadmanshajib/hive/apps/agent-engine/internal/artifactsclient"
+	"github.com/sakibsadmanshajib/hive/apps/agent-engine/internal/controlclient"
 	"github.com/sakibsadmanshajib/hive/apps/agent-engine/internal/egressclient"
 )
 
@@ -244,6 +245,42 @@ func serve(socketPath, controlPlaneURL, controlPlaneToken string) error {
 		}
 		writeJSON(w, http.StatusOK, struct{}{})
 	})
+	mux.HandleFunc("POST /events", func(w http.ResponseWriter, r *http.Request) {
+		if !authorized(w, r, controlPlaneToken) {
+			return
+		}
+		var req sessionRequest
+		if !decode(w, r, &req) {
+			return
+		}
+		events, err := engine.Events(r.Context(), req.SessionRef)
+		if err != nil {
+			writeSessionErr(w, err)
+			return
+		}
+		if events == nil {
+			events = []controlclient.Event{}
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"events": events})
+	})
+	mux.HandleFunc("POST /files", func(w http.ResponseWriter, r *http.Request) {
+		if !authorized(w, r, controlPlaneToken) {
+			return
+		}
+		var req sessionRequest
+		if !decode(w, r, &req) {
+			return
+		}
+		files, err := engine.Files(r.Context(), req.SessionRef)
+		if err != nil {
+			writeSessionErr(w, err)
+			return
+		}
+		if files == nil {
+			files = []controlclient.WorkspaceFile{}
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"files": files})
+	})
 	mux.HandleFunc("GET /health", func(w http.ResponseWriter, _ *http.Request) {
 		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 	})
@@ -317,6 +354,20 @@ func authorized(w http.ResponseWriter, r *http.Request, token string) bool {
 	}
 	writeJSON(w, http.StatusUnauthorized, errorResponse{Error: "unauthorized"})
 	return false
+}
+
+// writeSessionErr maps an engine error onto the same status contract /status
+// and /cancel use: unknown session 404, everything else 502 with the detail
+// logged server-side only (the body carries the daemon's own text, which is
+// fine here because the only caller is control-plane over a root-owned Unix
+// socket; Remote.post logs it rather than surfacing it onward).
+func writeSessionErr(w http.ResponseWriter, err error) {
+	code := http.StatusBadGateway
+	if errors.Is(err, engineapi.ErrUnknownSession) {
+		code = http.StatusNotFound
+	}
+	log.Printf("agent-engine: session call failed: %v", err)
+	writeJSON(w, code, errorResponse{Error: err.Error()})
 }
 
 func decode(w http.ResponseWriter, r *http.Request, v any) bool {

--- a/apps/agent-engine/cmd/agent-engine/serve.go
+++ b/apps/agent-engine/cmd/agent-engine/serve.go
@@ -25,6 +25,7 @@ package main
 
 import (
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -49,6 +50,14 @@ import (
 // mirrors the header control-plane's own internal endpoints already expect
 // from this binary's egressclient calls.
 const InternalTokenHeader = "X-Internal-Token"
+
+// eventsPageSize bounds one /events page; Remote.Events follows next_offset
+// until -1. 100 events per page with each raw dump capped keeps a page far
+// under the client's read bound.
+const eventsPageSize = 100
+
+// maxRawTransportBytes caps one event's raw dump on the /events wire.
+const maxRawTransportBytes = 32 << 10 // 32 KiB
 
 type launchRequest struct {
 	ID           uuid.UUID `json:"id"`
@@ -249,7 +258,10 @@ func serve(socketPath, controlPlaneURL, controlPlaneToken string) error {
 		if !authorized(w, r, controlPlaneToken) {
 			return
 		}
-		var req sessionRequest
+		var req struct {
+			SessionRef string `json:"session_ref"`
+			Offset     int    `json:"offset"`
+		}
 		if !decode(w, r, &req) {
 			return
 		}
@@ -258,10 +270,27 @@ func serve(socketPath, controlPlaneURL, controlPlaneToken string) error {
 			writeSessionErr(w, err)
 			return
 		}
-		if events == nil {
-			events = []controlclient.Event{}
+		if req.Offset < 0 || req.Offset >= len(events) {
+			writeJSON(w, http.StatusOK, map[string]any{"events": []controlclient.Event{}, "next_offset": -1})
+			return
 		}
-		writeJSON(w, http.StatusOK, map[string]any{"events": events})
+		end := req.Offset + eventsPageSize
+		next := -1
+		if end < len(events) {
+			next = end
+		} else {
+			end = len(events)
+		}
+		page := events[req.Offset:end]
+		for i := range page {
+			// Bound the raw dump so one runaway sandbox event cannot balloon a
+			// page past Remote's read limit. The syncer caps stored payloads at
+			// 64 KiB anyway; this keeps transport bounded too.
+			if len(page[i].Raw) > maxRawTransportBytes {
+				page[i].Raw = json.RawMessage(fmt.Sprintf(`{"truncated":true,"size":%d}`, len(page[i].Raw)))
+			}
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"events": page, "next_offset": next})
 	})
 	mux.HandleFunc("POST /files", func(w http.ResponseWriter, r *http.Request) {
 		if !authorized(w, r, controlPlaneToken) {
@@ -319,6 +348,9 @@ func serve(socketPath, controlPlaneURL, controlPlaneToken string) error {
 		_ = srv.Shutdown(ctx)
 	}()
 
+	if controlPlaneToken == "" {
+		log.Printf("agent-engine: WARN no internal token configured; every request will be refused (fail-closed). Set CONTROL_PLANE_INTERNAL_TOKEN for the launcher unit.")
+	}
 	log.Printf("agent-engine: serving on %s (sif=%s, packs=%s)", socketPath, sifPath, packsDir)
 	if err := srv.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		return err
@@ -347,13 +379,22 @@ func hostOf(rawURL string) (string, error) {
 	return u.Hostname(), nil
 }
 
-// authorized enforces the shared internal token when one is configured.
+// authorized enforces the shared internal token, fail-closed: an empty
+// configured token authorizes NOTHING (previously an unset token let every
+// request through). Comparison is constant-time.
 func authorized(w http.ResponseWriter, r *http.Request, token string) bool {
-	if token == "" || r.Header.Get(InternalTokenHeader) == token {
-		return true
+	if token == "" {
+		log.Printf("agent-engine: refusing request: no internal token is configured")
+		writeJSON(w, http.StatusServiceUnavailable, errorResponse{Error: "launcher has no internal token configured"})
+		return false
 	}
-	writeJSON(w, http.StatusUnauthorized, errorResponse{Error: "unauthorized"})
-	return false
+	given := r.Header.Get(InternalTokenHeader)
+	if subtle.ConstantTimeCompare([]byte(given), []byte(token)) != 1 {
+		w.Header().Set("WWW-Authenticate", "Bearer")
+		writeJSON(w, http.StatusUnauthorized, errorResponse{Error: "unauthorized"})
+		return false
+	}
+	return true
 }
 
 // writeSessionErr maps an engine error onto the same status contract /status

--- a/apps/agent-engine/engineapi/engineapi.go
+++ b/apps/agent-engine/engineapi/engineapi.go
@@ -13,7 +13,10 @@
 // lives in this package, only the door.
 package engineapi
 
-import "github.com/sakibsadmanshajib/hive/apps/agent-engine/internal/engine"
+import (
+	"github.com/sakibsadmanshajib/hive/apps/agent-engine/internal/controlclient"
+	"github.com/sakibsadmanshajib/hive/apps/agent-engine/internal/engine"
+)
 
 type (
 	// Task is engine.Task.
@@ -41,3 +44,9 @@ var ErrUnknownSession = engine.ErrUnknownSession
 func New(cfg Config) *SandboxEngine {
 	return engine.New(cfg)
 }
+
+// Event is engine's normalized sandbox event (controlclient.Event).
+type Event = controlclient.Event
+
+// WorkspaceFile is engine's workspace listing entry.
+type WorkspaceFile = controlclient.WorkspaceFile

--- a/apps/agent-engine/internal/controlclient/events.go
+++ b/apps/agent-engine/internal/controlclient/events.go
@@ -1,0 +1,184 @@
+package controlclient
+
+// Events half of controlclient: the OpenHands event-search client and the
+// normalization layer. Verified against vendored source:
+// event_router.py search_conversation_events returns
+// {"items": [transport dumps], "next_page_id"}; ActionEvent carries
+// thought/tool_name/tool_call_id/summary; ObservationBaseEvent subclasses
+// (ObservationEvent, UserRejectObservation, agent error) carry
+// tool_name/tool_call_id; MessageEvent carries llm_message.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Page bounds. maxEventsPageLimit matches the server's own lte=100 constraint.
+const (
+	maxEventsPageLimit = 100
+	maxEventPages      = 50 // 100 x 50 = 5000 events per call; the rest defers to later calls (dedup makes re-pulls free)
+)
+
+// Event is one normalized sandbox event: exactly what the six-kind mapping
+// consumes plus the raw dump for the unknown-kind fallback. Kind is the
+// sandbox kind name ("ActionEvent" etc).
+type Event struct {
+	ID          string          `json:"id"`
+	Kind        string          `json:"kind"`
+	Source      string          `json:"source"`
+	Timestamp   string          `json:"timestamp"`
+	ToolName    string          `json:"tool_name"`
+	ToolCallID  string          `json:"tool_call_id"`
+	TextPreview string          `json:"text_preview"`
+	Raw         json.RawMessage `json:"raw,omitempty"`
+}
+
+// WorkspaceFile is one entry of a session workspace listing: name, size,
+// mtime only. No file content ever crosses this boundary.
+type WorkspaceFile struct {
+	Name    string    `json:"name"`
+	Size    int64     `json:"size"`
+	ModTime time.Time `json:"mtime"`
+}
+
+// SearchEvents calls GET /api/conversations/{id}/events/search
+// (conversation-scoped event store, the sandbox's source of truth for a run)
+// and follows next_page_id pagination up to maxEventPages.
+func (c *Client) SearchEvents(ctx context.Context, conversationID uuid.UUID) ([]Event, error) {
+	var all []Event
+	pageID := ""
+	for page := 0; ; page++ {
+		q := url.Values{}
+		q.Set("limit", strconv.Itoa(maxEventsPageLimit))
+		if pageID != "" {
+			q.Set("page_id", pageID)
+		}
+		path := fmt.Sprintf("/api/conversations/%s/events/search?%s", conversationID, q.Encode())
+
+		var body struct {
+			Items      []json.RawMessage `json:"items"`
+			NextPageID string            `json:"next_page_id"`
+		}
+		if err := c.doJSON(ctx, http.MethodGet, path, nil, &body); err != nil {
+			return nil, err
+		}
+
+		for _, raw := range body.Items {
+			all = append(all, normalizeEvent(raw))
+		}
+		if body.NextPageID == "" || page+1 >= maxEventPages {
+			return all, nil
+		}
+		pageID = body.NextPageID
+	}
+}
+
+// normalizeEvent extracts the mapping fields from one transport dump. The
+// preview extractor walks the dump generically so SDK schema drift costs
+// nothing here: per-kind fields are preferred where the vendored classes name
+// them, and everything else falls back to a capped string scan of the payload.
+func normalizeEvent(raw json.RawMessage) Event {
+	var dump map[string]any
+	if err := json.Unmarshal(raw, &dump); err != nil {
+		return Event{Kind: "UnparseableEvent", Raw: json.RawMessage(`{"unparseable":true}`)}
+	}
+	ev := Event{Raw: raw}
+	ev.ID = str(dump["id"])
+	ev.Kind = str(dump["kind"])
+	ev.Source = str(dump["source"])
+	ev.Timestamp = str(dump["timestamp"])
+
+	switch ev.Kind {
+	case "ActionEvent":
+		ev.ToolName = str(dump["tool_name"])
+		ev.ToolCallID = str(dump["tool_call_id"])
+		var b strings.Builder
+		for _, t := range asList(dump["thought"]) {
+			if tm, ok := t.(map[string]any); ok {
+				b.WriteString(str(tm["text"]))
+				b.WriteString(" ")
+			}
+		}
+		if s := str(dump["summary"]); s != "" {
+			b.WriteString(s)
+		}
+		ev.TextPreview = strings.TrimSpace(b.String())
+	case "MessageEvent":
+		msg, _ := dump["llm_message"].(map[string]any)
+		var b strings.Builder
+		for _, c := range asList(msg["content"]) {
+			cm, _ := c.(map[string]any)
+			b.WriteString(str(cm["text"]))
+			b.WriteString(" ")
+		}
+		ev.TextPreview = strings.TrimSpace(b.String())
+	case "ObservationEvent", "UserRejectObservation":
+		ev.ToolName = str(dump["tool_name"])
+		ev.ToolCallID = str(dump["tool_call_id"])
+		ev.TextPreview = scanStrings(dump["observation"], 4000)
+	default:
+		// AgentErrorEvent names its field; other kinds get the generic scan.
+		if e := str(dump["error"]); e != "" {
+			ev.TextPreview = e
+		} else {
+			ev.TextPreview = scanStrings(dump, 2000)
+		}
+	}
+	return ev
+}
+
+// scanStrings collects string leaves from v depth-first until budget runes,
+// joined with spaces. Generic on purpose: it is the drift guard.
+func scanStrings(v any, budget int) string {
+	var b strings.Builder
+	var walk func(n any)
+	walk = func(n any) {
+		if b.Len() >= budget {
+			return
+		}
+		switch t := n.(type) {
+		case string:
+			if b.Len() > 0 {
+				b.WriteString(" ")
+			}
+			b.WriteString(t)
+		case []any:
+			for _, c := range t {
+				walk(c)
+				if b.Len() >= budget {
+					return
+				}
+			}
+		case map[string]any:
+			keys := make([]string, 0, len(t))
+			for k := range t {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+			for _, k := range keys {
+				walk(t[k])
+				if b.Len() >= budget {
+					return
+				}
+			}
+		}
+	}
+	walk(v)
+	return b.String()
+}
+
+func str(v any) string { s, _ := v.(string); return s }
+
+func asList(v any) []any {
+	l, _ := v.([]any)
+	return l
+}

--- a/apps/agent-engine/internal/controlclient/events_test.go
+++ b/apps/agent-engine/internal/controlclient/events_test.go
@@ -1,0 +1,115 @@
+package controlclient_test
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/sakibsadmanshajib/hive/apps/agent-engine/internal/controlclient"
+)
+
+func loadFixture(t *testing.T) []json.RawMessage {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join("testdata", "events_search.json"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	var pages []struct {
+		Items      []json.RawMessage `json:"items"`
+		NextPageID string            `json:"next_page_id"`
+	}
+	if err := json.Unmarshal(raw, &pages); err != nil {
+		t.Fatalf("parse fixture: %v", err)
+	}
+	out := make([]json.RawMessage, len(pages))
+	for i := range pages {
+		enc, err := json.Marshal(pages[i])
+		if err != nil {
+			t.Fatalf("re-encode page %d: %v", i, err)
+		}
+		out[i] = enc
+	}
+	return out
+}
+
+func newFakeEventsServer(t *testing.T, pages []json.RawMessage) string {
+	t.Helper()
+	socketPath := filepath.Join(t.TempDir(), "agent.sock")
+	l, err := net.Listen("unix", socketPath)
+	mustNoErr(t, err)
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			w.WriteHeader(200)
+			return
+		}
+		idx := 0
+		pid := r.URL.Query().Get("page_id")
+		if pid != "" {
+			idx = 1
+		}
+		if idx >= len(pages) {
+			http.Error(w, "no such page", 404)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(pages[idx])
+	}))
+	srv.Listener = l
+	srv.Start()
+	t.Cleanup(srv.Close)
+	return socketPath
+}
+
+func mustNoErr(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSearchEventsFixture(t *testing.T) {
+	pages := loadFixture(t)
+	socketPath := newFakeEventsServer(t, pages)
+	client := controlclient.New(socketPath, "")
+
+	convoID := uuid.New()
+	events, err := client.SearchEvents(context.Background(), convoID)
+	mustNoErr(t, err)
+
+	if len(events) != 6 {
+		t.Fatalf("expected 6 events across 2 pages, got %d", len(events))
+	}
+
+	cases := []struct {
+		id, kind, toolName, toolCallID string
+		previewContains                string
+	}{
+		{"evt-0001", "MessageEvent", "", "", "Fix the failing test"},
+		{"evt-0002", "ActionEvent", "execute_bash", "call_abc", "run the tests"},
+		{"evt-0003", "ObservationEvent", "execute_bash", "call_abc", "1 failed"},
+		{"evt-0004", "ConversationStateUpdateEvent", "", "", ""},
+		{"evt-0005", "AgentErrorEvent", "", "", "LLM request failed"},
+		{"evt-0006", "MessageEvent", "", "", "Fixed it."},
+	}
+	for i, tc := range cases {
+		got := events[i]
+		if got.ID != tc.id || got.Kind != tc.kind || got.ToolName != tc.toolName || got.ToolCallID != tc.toolCallID {
+			t.Errorf("event %d = %+v, want id=%s kind=%s tool=%s call=%s",
+				i, got, tc.id, tc.kind, tc.toolName, tc.toolCallID)
+		}
+		if tc.previewContains != "" && !strings.Contains(got.TextPreview, tc.previewContains) {
+			t.Errorf("event %s preview %q missing %q", tc.id, got.TextPreview, tc.previewContains)
+		}
+		if got.Raw == nil {
+			t.Errorf("event %s lost its raw payload", tc.id)
+		}
+	}
+}

--- a/apps/agent-engine/internal/controlclient/testdata/events_search.json
+++ b/apps/agent-engine/internal/controlclient/testdata/events_search.json
@@ -1,0 +1,62 @@
+[
+  {
+    "next_page_id": "page-2",
+    "items": [
+      {
+        "id": "evt-0001",
+        "kind": "MessageEvent",
+        "source": "user",
+        "timestamp": "2026-08-23T10:00:00",
+        "llm_message": {"role": "user", "content": [{"type": "text", "text": "Fix the failing test"}]}
+      },
+      {
+        "id": "evt-0002",
+        "kind": "ActionEvent",
+        "source": "agent",
+        "timestamp": "2026-08-23T10:00:05",
+        "tool_name": "execute_bash",
+        "tool_call_id": "call_abc",
+        "summary": "running the test suite",
+        "thought": [{"type": "text", "text": "I should run the tests"}],
+        "action": {"kind": "ExecuteBashAction", "command": "pytest -x"}
+      },
+      {
+        "id": "evt-0003",
+        "kind": "ObservationEvent",
+        "source": "environment",
+        "timestamp": "2026-08-23T10:00:09",
+        "tool_name": "execute_bash",
+        "tool_call_id": "call_abc",
+        "observation": {"kind": "Observation", "to_llm_content": [{"type": "text", "text": "1 failed, 2 passed"}]}
+      },
+      {
+        "id": "evt-0004",
+        "kind": "ConversationStateUpdateEvent",
+        "source": "environment",
+        "timestamp": "2026-08-23T10:00:10",
+        "state_key": "execution_status"
+      },
+      {
+        "id": "evt-0005",
+        "kind": "AgentErrorEvent",
+        "source": "agent",
+        "timestamp": "2026-08-23T10:00:12",
+        "tool_name": "execute_bash",
+        "tool_call_id": "call_err",
+        "error": "LLM request failed after 3 attempts"
+      }
+    ]
+  },
+  {
+    "next_page_id": "",
+    "items": [
+      {
+        "id": "evt-0006",
+        "kind": "MessageEvent",
+        "source": "agent",
+        "timestamp": "2026-08-23T10:01:00",
+        "llm_message": {"role": "assistant", "content": [{"type": "text", "text": "Fixed it."}]}
+      }
+    ]
+  }
+]

--- a/apps/agent-engine/internal/engine/events.go
+++ b/apps/agent-engine/internal/engine/events.go
@@ -1,0 +1,58 @@
+package engine
+
+// Event/files surface for the launcher daemon: reads the live session's
+// sandbox event store through its control client and lists the workspace
+// bind mount from the host directly.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/sakibsadmanshajib/hive/apps/agent-engine/internal/controlclient"
+)
+
+// Events returns the session's normalized sandbox events. A reaped session's
+// control socket is gone, so the call errors; the syncer treats that like any
+// other per-task failure and the task's row is terminal by then anyway.
+func (e *SandboxEngine) Events(ctx context.Context, sessionRef string) ([]controlclient.Event, error) {
+	sess, id, err := e.lookup(sessionRef)
+	if err != nil {
+		return nil, err
+	}
+	return sess.client.SearchEvents(ctx, id)
+}
+
+// Files lists the session workspace directory (top level, name/size/mtime
+// only), reading the host bind mount directly.
+//
+// ponytail: no recursion; add a walk when a panel needs nested paths.
+func (e *SandboxEngine) Files(_ context.Context, sessionRef string) ([]controlclient.WorkspaceFile, error) {
+	sess, _, err := e.lookup(sessionRef)
+	if err != nil {
+		return nil, err
+	}
+	entries, err := os.ReadDir(sess.workingDir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			// A reaped session's working dir is already deleted; that is a
+			// known state, not a failure to log loudly.
+			return nil, nil
+		}
+		return nil, fmt.Errorf("engine: list workspace: %w", err)
+	}
+	out := make([]controlclient.WorkspaceFile, 0, len(entries))
+	for _, entry := range entries {
+		info, infoErr := entry.Info()
+		if infoErr != nil {
+			continue // raced a deletion mid-listing; skip, never fail the batch
+		}
+		out = append(out, controlclient.WorkspaceFile{
+			Name:    entry.Name(),
+			Size:    info.Size(),
+			ModTime: info.ModTime(),
+		})
+	}
+	return out, nil
+}

--- a/apps/control-plane/cmd/server/main.go
+++ b/apps/control-plane/cmd/server/main.go
@@ -1048,17 +1048,21 @@ func main() {
 	var agentTaskHandler *agenttask.Handler
 	if pool != nil {
 		agentTaskRepo := agenttask.NewPgxRepository(pool)
-		agentEngine, agentEngineStatus := buildAgentEngine(egressSvc)
-		agentTaskSvc := agenttask.NewService(agentTaskRepo, agentEngine)
+		agentEngine, agentEngineStatus, agentEngineEvents := buildAgentEngine(egressSvc)
+		agentTaskSvc := agenttask.NewService(agentTaskRepo, agentEngine,
+			agenttask.WithEventSource(agentEngineEvents))
 		agentTaskHandler = agenttask.NewHandler(agentTaskSvc)
 
 		// Poller needs a real StatusChecker to poll — NotConfiguredEngine has
 		// no Status method — so it is only started when the engine itself
 		// is (same HIVE_AGENT_ENGINE_* gate; see SYNC_CONTRACT.md's Engine
-		// seam section).
+		// seam section). The event syncer shares that gate: it needs the same
+		// live engine surface, and its per-task failures degrade to missed
+		// events, never wrong ones.
 		if agentEngineStatus != nil {
+			interval := parseDurationEnv("HIVE_AGENT_TASK_POLL_INTERVAL", 15*time.Second)
 			poller := agenttask.NewPoller(agentTaskRepo, agentEngineStatus, agenttask.PollerConfig{
-				Interval: parseDurationEnv("HIVE_AGENT_TASK_POLL_INTERVAL", 15*time.Second),
+				Interval: interval,
 				Logger:   slog.Default(),
 			})
 			// Bound to runCtx so it stops cleanly on shutdown, same as the
@@ -1066,6 +1070,16 @@ func main() {
 			poller.Start(runCtx)
 			defer poller.Stop()
 			log.Println("agent task status poller started")
+
+			if agentEngineEvents != nil {
+				syncer := agenttask.NewEventSyncer(agentTaskRepo, agentEngineEvents, agenttask.PollerConfig{
+					Interval: interval,
+					Logger:   slog.Default(),
+				})
+				syncer.Start(runCtx)
+				defer syncer.Stop()
+				log.Println("agent task event syncer started")
+			}
 		}
 	}
 
@@ -1665,8 +1679,12 @@ func parseDurationEnv(key string, fallback time.Duration) time.Duration {
 // buildAgentEngine's second return value is the same *agentengine.Engine as
 // a agenttask.StatusChecker (nil when unconfigured) — the seam
 // cmd/server/main.go's poller wiring uses, since NotConfiguredEngine has no
-// Status method to poll.
-func buildAgentEngine(egressSvc *egress.Service) (agenttask.Engine, agenttask.StatusChecker) {
+// Status method to poll. The third is that same value as an
+// agenttask.EventSource for the event-sync loop (nil only when the engine is
+// unconfigured or, on the socket arm, when the daemon failed its boot health
+// probe — a missed events pull degrades safely and the daemon coming up later
+// still serves every task it registered).
+func buildAgentEngine(egressSvc *egress.Service) (agenttask.Engine, agenttask.StatusChecker, agenttask.EventSource) {
 	// Issue #780: on any deployment where this process runs in a container
 	// (every compose topology this repo ships), it cannot exec Apptainer at
 	// all — musl base, no /dev/fuse, no CAP_SYS_ADMIN — and granting it
@@ -1687,7 +1705,7 @@ func buildAgentEngine(egressSvc *egress.Service) (agenttask.Engine, agenttask.St
 		} else {
 			log.Printf("control-plane: agent-engine daemon reachable at %s", socketPath)
 		}
-		return remote, remote
+		return remote, remote, remote
 	}
 
 	sifPath := os.Getenv("HIVE_AGENT_ENGINE_SIF_PATH")
@@ -1716,12 +1734,12 @@ func buildAgentEngine(egressSvc *egress.Service) (agenttask.Engine, agenttask.St
 			missing = append(missing, "HIVE_AGENT_ENGINE_PROFILE_ID")
 		}
 		log.Printf("control-plane: WARN agent engine not configured, every agent task submitted will fail immediately (never runs) — missing: %s", strings.Join(missing, ", "))
-		return agenttask.NotConfiguredEngine{}, nil
+		return agenttask.NotConfiguredEngine{}, nil, nil
 	}
 	profileID, err := uuid.Parse(profileIDRaw)
 	if err != nil {
 		log.Printf("control-plane: HIVE_AGENT_ENGINE_PROFILE_ID invalid, agent-engine stays unconfigured: %v", err)
-		return agenttask.NotConfiguredEngine{}, nil
+		return agenttask.NotConfiguredEngine{}, nil, nil
 	}
 
 	sandbox := engineapi.New(engineapi.Config{
@@ -1748,7 +1766,7 @@ func buildAgentEngine(egressSvc *egress.Service) (agenttask.Engine, agenttask.St
 		PidsLimit:              parseIntEnv("HIVE_SANDBOX_PIDS_LIMIT", 512),
 	})
 	real := agentengine.New(sandbox)
-	return real, real
+	return real, real, real
 }
 
 // dbReadyFunc builds the callback platformhttp.RouterConfig.DBReady calls on

--- a/apps/control-plane/internal/agentengine/events.go
+++ b/apps/control-plane/internal/agentengine/events.go
@@ -13,24 +13,34 @@ import (
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/agenttask"
 )
 
-// Events pulls one session's sandbox events through the launcher daemon.
-// Deliberately NOT mapped onto agenttask.ErrEngineSessionGone on 404: that
-// sentinel's semantics (fail the task now) belong to the status poller, while
-// a missed events pull is retried next pass with no task-state consequence,
-// so Remote.post's scoped /status|/cancel check stays untouched and this path
+// Events pulls one session's sandbox events through the launcher daemon,
+// following the launcher's next_offset pagination to exhaustion. Deliberately
+// NOT mapped onto agenttask.ErrEngineSessionGone on 404: that sentinel's
+// semantics (fail the task now) belong to the status poller, while a missed
+// events pull is retried next pass with no task-state consequence, so
+// Remote.post's scoped /status|/cancel check stays untouched and this path
 // answers an ordinary transient error instead.
 func (r *Remote) Events(ctx context.Context, sessionRef string) ([]agenttask.SandboxEvent, error) {
-	var out struct {
-		Events []engineapi.Event `json:"events"`
+	var all []agenttask.SandboxEvent
+	for offset := 0; ; {
+		var out struct {
+			Events     []engineapi.Event `json:"events"`
+			NextOffset int               `json:"next_offset"`
+		}
+		if err := r.postLarge(ctx, "/events", map[string]any{
+			"session_ref": sessionRef,
+			"offset":      offset,
+		}, &out); err != nil {
+			return nil, err
+		}
+		for _, e := range out.Events {
+			all = append(all, convertEvent(e))
+		}
+		if out.NextOffset < 0 {
+			return all, nil
+		}
+		offset = out.NextOffset
 	}
-	if err := r.post(ctx, "/events", map[string]any{"session_ref": sessionRef}, &out); err != nil {
-		return nil, err
-	}
-	events := make([]agenttask.SandboxEvent, 0, len(out.Events))
-	for _, e := range out.Events {
-		events = append(events, convertEvent(e))
-	}
-	return events, nil
 }
 
 // Files lists one session's workspace through the launcher daemon.

--- a/apps/control-plane/internal/agentengine/events.go
+++ b/apps/control-plane/internal/agentengine/events.go
@@ -1,0 +1,92 @@
+package agentengine
+
+// Event/files surface for both engine arms, satisfying
+// agenttask.EventSource structurally the way Launch/Status/Cancel already do:
+// Remote POSTs the launcher daemon's /events and /files routes; Engine
+// delegates to the in-process SandboxEngine and converts types.
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/sakibsadmanshajib/hive/apps/agent-engine/engineapi"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/agenttask"
+)
+
+// Events pulls one session's sandbox events through the launcher daemon.
+// Deliberately NOT mapped onto agenttask.ErrEngineSessionGone on 404: that
+// sentinel's semantics (fail the task now) belong to the status poller, while
+// a missed events pull is retried next pass with no task-state consequence,
+// so Remote.post's scoped /status|/cancel check stays untouched and this path
+// answers an ordinary transient error instead.
+func (r *Remote) Events(ctx context.Context, sessionRef string) ([]agenttask.SandboxEvent, error) {
+	var out struct {
+		Events []engineapi.Event `json:"events"`
+	}
+	if err := r.post(ctx, "/events", map[string]any{"session_ref": sessionRef}, &out); err != nil {
+		return nil, err
+	}
+	events := make([]agenttask.SandboxEvent, 0, len(out.Events))
+	for _, e := range out.Events {
+		events = append(events, convertEvent(e))
+	}
+	return events, nil
+}
+
+// Files lists one session's workspace through the launcher daemon.
+func (r *Remote) Files(ctx context.Context, sessionRef string) ([]agenttask.WorkspaceFile, error) {
+	var out struct {
+		Files []engineapi.WorkspaceFile `json:"files"`
+	}
+	if err := r.post(ctx, "/files", map[string]any{"session_ref": sessionRef}, &out); err != nil {
+		return nil, err
+	}
+	files := make([]agenttask.WorkspaceFile, 0, len(out.Files))
+	for _, f := range out.Files {
+		files = append(files, agenttask.WorkspaceFile(f))
+	}
+	return files, nil
+}
+
+// Events adapts the in-process arm.
+func (e *Engine) Events(ctx context.Context, sessionRef string) ([]agenttask.SandboxEvent, error) {
+	events, err := e.sandbox.Events(ctx, sessionRef)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]agenttask.SandboxEvent, 0, len(events))
+	for _, ev := range events {
+		out = append(out, convertEvent(ev))
+	}
+	return out, nil
+}
+
+// Files adapts the in-process arm.
+func (e *Engine) Files(ctx context.Context, sessionRef string) ([]agenttask.WorkspaceFile, error) {
+	files, err := e.sandbox.Files(ctx, sessionRef)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]agenttask.WorkspaceFile, 0, len(files))
+	for _, f := range files {
+		out = append(out, agenttask.WorkspaceFile(f))
+	}
+	return out, nil
+}
+
+// convertEvent maps engineapi.Event onto agenttask.SandboxEvent field by
+// field. The shapes are intentionally identical; the copy exists so the
+// control-plane package never imports the agent-engine module's internal
+// client directly.
+func convertEvent(e engineapi.Event) agenttask.SandboxEvent {
+	return agenttask.SandboxEvent{
+		ID:          e.ID,
+		Kind:        e.Kind,
+		Source:      e.Source,
+		Timestamp:   e.Timestamp,
+		ToolName:    e.ToolName,
+		ToolCallID:  e.ToolCallID,
+		TextPreview: e.TextPreview,
+		Raw:         json.RawMessage(e.Raw),
+	}
+}

--- a/apps/control-plane/internal/agentengine/remote.go
+++ b/apps/control-plane/internal/agentengine/remote.go
@@ -116,6 +116,19 @@ func (r *Remote) Health(ctx context.Context) error {
 }
 
 func (r *Remote) post(ctx context.Context, path string, body any, out any) error {
+	return r.postLimit(ctx, path, body, out, 1<<20)
+}
+
+// postLimit is post with an explicit response-body cap. /events uses 8 MiB:
+// one page is at most eventsPageSize events whose raw dumps the launcher caps
+// at 32 KiB each, so ~3.3 MiB worst case, comfortably inside this bound —
+// the old single 1 MiB reader silently truncated whole transcripts for
+// sessions that grew past it.
+func (r *Remote) postLarge(ctx context.Context, path string, body any, out any) error {
+	return r.postLimit(ctx, path, body, out, 8<<20)
+}
+
+func (r *Remote) postLimit(ctx context.Context, path string, body any, out any, maxBytes int64) error {
 	payload, err := json.Marshal(body)
 	if err != nil {
 		return fmt.Errorf("agentengine: encode %s request: %w", path, err)
@@ -133,7 +146,7 @@ func (r *Remote) post(ctx context.Context, path string, body any, out any) error
 		return fmt.Errorf("agentengine: %s: %w", path, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
-	raw, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, maxBytes))
 	if err != nil {
 		return fmt.Errorf("agentengine: read %s response: %w", path, err)
 	}

--- a/apps/control-plane/internal/agenttask/SYNC_CONTRACT.md
+++ b/apps/control-plane/internal/agenttask/SYNC_CONTRACT.md
@@ -59,6 +59,42 @@ by the authenticated caller, never round-tripped.
 | GET | `/v1/agent/tasks` | — | `{"tasks": [Task, ...]}`, newest first, scoped to the caller |
 | GET | `/v1/agent/tasks/{id}` | — | 404 if the task belongs to a different user or does not exist |
 | POST | `/v1/agent/tasks/{id}/cancel` | — | 409 if the task already reached a terminal state |
+| GET | `/v1/agent/tasks/{id}/events` | — | `{"events": [Event, ...]}`; cursor `after_seq` (default 0), `limit` default 100 capped at 500. A non-numeric or negative `after_seq` is a 400, never silently zero. 404 across users |
+| GET | `/v1/agent/tasks/{id}/files` | — | `{"files": [WorkspaceFile, ...]}`: the running session's workspace listing, name/size/mtime only, best-effort (empty when no session) |
+
+Event, as returned by the events endpoints (both surfaces):
+
+```json
+{
+  "seq": 42,
+  "source_event_id": "sandbox event id, or a deterministic synthetic id for status/file rows",
+  "kind": "status | tool_call | tool_result | message | error | file",
+  "payload": {"kind-specific JSONB, previews truncated at 2000 chars, whole payload capped at 64 KiB"},
+  "created_at": "RFC3339"
+}
+```
+
+WorkspaceFile:
+
+```json
+{"name": "string", "size": 0, "mtime": "RFC3339"}
+```
+
+Kinds and their payloads (written by the eventsync syncer):
+
+- `status`: `{"status": "queued | running | succeeded | failed | cancelled"}`. Synthetic
+  (source id `status:<status>`); one per transition including into terminal states, deduped
+  by the partial unique index.
+- `tool_call`: `{"tool_name", "tool_call_id", "preview"}` from OpenHands ActionEvent.
+- `tool_result`: `{"tool_name", "tool_call_id", "preview"}` from ObservationEvent and
+  UserRejectObservation.
+- `message`: `{"role", "preview"}` from MessageEvent, every role carried (the role rides in
+  the payload so consumers tell them apart; nothing is silently dropped).
+- `error`: `{"preview"}` from AgentErrorEvent.
+- `file`: the WorkspaceFile JSON itself, source id `file:<name>:<size>:<mtime>` so an
+  unchanged file dedups out and a rewritten file is recorded.
+- Any sandbox kind the mapping does not name lands as `status` carrying the raw sandbox
+  payload (or an unmapped marker when the dump was oversized), never dropped silently.
 
 Status is read by polling `GET /v1/agent/tasks/{id}`. No SSE/websocket
 channel ships in this step — the existing SSE pattern in this repo (see
@@ -84,6 +120,8 @@ untrusted client input.
 | GET | `/internal/agent-tasks/{tenant_id}/{user_id}` | — |
 | GET | `/internal/agent-tasks/{tenant_id}/{user_id}/{task_id}` | — |
 | POST | `/internal/agent-tasks/{tenant_id}/{user_id}/{task_id}/cancel` | — |
+| GET | `/internal/agent-tasks/{tenant_id}/{user_id}/{task_id}/events?after_seq=&limit=` | — |
+| GET | `/internal/agent-tasks/{tenant_id}/{user_id}/{task_id}/files` | — |
 
 ## Create is asynchronous over the launch (issue #881)
 

--- a/apps/control-plane/internal/agenttask/events.go
+++ b/apps/control-plane/internal/agenttask/events.go
@@ -1,0 +1,123 @@
+package agenttask
+
+// Event vocabulary and shared bounds for public.agent_task_events. The six
+// kinds mirror the migration's CHECK constraint exactly.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+)
+
+// TaskEventKind is one of the six event kinds the CHECK constraint accepts.
+type TaskEventKind string
+
+const (
+	EventStatus     TaskEventKind = "status"
+	EventToolCall   TaskEventKind = "tool_call"
+	EventToolResult TaskEventKind = "tool_result"
+	EventMessage    TaskEventKind = "message"
+	EventError      TaskEventKind = "error"
+	EventFile       TaskEventKind = "file"
+)
+
+// Valid reports whether k is one of the six kinds the CHECK constraint
+// accepts.
+func (k TaskEventKind) Valid() bool {
+	switch k {
+	case EventStatus, EventToolCall, EventToolResult, EventMessage, EventError, EventFile:
+		return true
+	default:
+		return false
+	}
+}
+
+// maxPreviewRunes bounds every text preview stored on an event payload: 2000
+// RUNES, not bytes, so a CJK-heavy tool output keeps most of its meaning.
+const maxPreviewRunes = 2000
+
+// maxEventPayloadBytes caps one event's marshalled payload at the same 64 KiB
+// the HTTP handlers already use for request bodies: a runaway tool output
+// cannot balloon a row past this.
+const maxEventPayloadBytes = 64 << 10
+
+// ErrCursor is returned when an events cursor is not a non-negative integer.
+// Never silently treated as zero: acceptance requires the 400.
+var ErrCursor = errors.New("agenttask: cursor must be a non-negative integer")
+
+// TaskEvent is one row of public.agent_task_events as the read path returns
+// it. Payload is whatever JSONB the writer stored; readers never parse its
+// inner shape.
+type TaskEvent struct {
+	Seq           int64           `json:"seq"`
+	SourceEventID string          `json:"source_event_id"`
+	Kind          TaskEventKind   `json:"kind"`
+	Payload       json.RawMessage `json:"payload"`
+	CreatedAt     time.Time       `json:"created_at"`
+}
+
+// SandboxEvent is one normalized sandbox event as an EventSource hands it to
+// the syncer. Kind is the SANDBOX kind name (e.g. "ActionEvent"); mapSandboxEvent
+// does that translation.
+type SandboxEvent struct {
+	ID          string          `json:"id"`
+	Kind        string          `json:"kind"`
+	Source      string          `json:"source"`
+	Timestamp   string          `json:"timestamp"`
+	ToolName    string          `json:"tool_name"`
+	ToolCallID  string          `json:"tool_call_id"`
+	TextPreview string          `json:"text_preview"`
+	Raw         json.RawMessage `json:"raw,omitempty"`
+}
+
+// WorkspaceFile is one entry of a session workspace listing: name, size,
+// mtime only. No file content ever crosses this boundary.
+type WorkspaceFile struct {
+	Name    string    `json:"name"`
+	Size    int64     `json:"size"`
+	ModTime time.Time `json:"mtime"`
+}
+
+// EventSource is the narrow surface the eventsync syncer needs from whichever
+// engine arm is wired. Both arms satisfy it with small adapters.
+type EventSource interface {
+	Events(ctx context.Context, sessionRef string) ([]SandboxEvent, error)
+	Files(ctx context.Context, sessionRef string) ([]WorkspaceFile, error)
+}
+
+// truncateRunes cuts s to at most n runes without splitting one.
+func truncateRunes(s string, n int) string {
+	if n <= 0 {
+		return ""
+	}
+	if len(s) <= n {
+		return s
+	}
+	r := []rune(s)
+	if len(r) <= n {
+		return s
+	}
+	return string(r[:n])
+}
+
+// capEventPayload marshals nothing: it takes an already-marshalled payload and
+// guarantees it fits maxEventPayloadBytes. Oversized payloads are replaced by
+// a tiny marker keeping the fact of the overflow and its size — bounded storage
+// wins over preserving a runaway tool dump. Returns nil only for nil input.
+func capEventPayload(payload json.RawMessage) json.RawMessage {
+	if payload == nil {
+		return nil
+	}
+	if len(payload) <= maxEventPayloadBytes {
+		return payload
+	}
+	marker, err := json.Marshal(map[string]any{
+		"truncated": true,
+		"size":      len(payload),
+	})
+	if err != nil {
+		return json.RawMessage(`{"truncated":true}`)
+	}
+	return marker
+}

--- a/apps/control-plane/internal/agenttask/events.go
+++ b/apps/control-plane/internal/agenttask/events.go
@@ -5,6 +5,8 @@ package agenttask
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"time"
@@ -45,6 +47,25 @@ const maxEventPayloadBytes = 64 << 10
 // ErrCursor is returned when an events cursor is not a non-negative integer.
 // Never silently treated as zero: acceptance requires the 400.
 var ErrCursor = errors.New("agenttask: cursor must be a non-negative integer")
+
+// maxSourceEventIDLen mirrors the migration's CHECK on
+// agent_task_events.source_event_id: longer ids are folded to a content hash
+// by normalizeSourceID so a batch never dies on the constraint, and empty ids
+// (which the partial dedup index exempts, i.e. would re-insert forever) get a
+// deterministic derived id instead.
+const maxSourceEventIDLen = 512
+
+// normalizeSourceID guarantees one stable, bounded dedup key per event: the
+// sandbox id when present and short enough, otherwise sha256 of the seed
+// material (kind plus preview plus raw dump). Deterministic on purpose: the
+// same event re-pulled on a later pass derives the same id and dedups out.
+func normalizeSourceID(id, seed string) string {
+	if id != "" && len(id) <= maxSourceEventIDLen {
+		return id
+	}
+	sum := sha256.Sum256([]byte(seed))
+	return "sha256:" + hex.EncodeToString(sum[:])[:40]
+}
 
 // TaskEvent is one row of public.agent_task_events as the read path returns
 // it. Payload is whatever JSONB the writer stored; readers never parse its

--- a/apps/control-plane/internal/agenttask/events_repository_test.go
+++ b/apps/control-plane/internal/agenttask/events_repository_test.go
@@ -1,0 +1,117 @@
+package agenttask_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/agenttask"
+)
+
+// Exercises the real migration SQL (20260823_01_agent_task_events.sql):
+// append-only grants, RLS tenant scoping through the parent task, dedup on
+// source_event_id, and the cursor read. Skips without HIVE_TEST_DB_URL, like
+// every other repository test here.
+
+func TestEventsRepositoryAppendAndList(t *testing.T) {
+	pool := newRLSTestPool(t)
+	tenantID := uuid.New()
+	seedTenant(t, tenantID)
+	userID := seedUser(t)
+
+	repo := agenttask.NewPgxRepository(pool)
+	ctx := context.Background()
+
+	task, err := repo.Create(ctx, tenantID, userID, agenttask.PackCoding, "goal")
+	mustNoErrRepo(t, err)
+
+	events := []agenttask.TaskEvent{
+		{SourceEventID: "status:queued", Kind: agenttask.EventStatus, Payload: []byte(`{"status":"queued"}`)},
+		{SourceEventID: "e1", Kind: agenttask.EventToolCall, Payload: []byte(`{"tool_name":"bash"}`)},
+	}
+	if err := repo.AppendEvents(ctx, task, events); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+
+	got, err := repo.ListEvents(ctx, tenantID, userID, task.ID, 0, 100)
+	mustNoErrRepo(t, err)
+	if len(got) != 2 {
+		t.Fatalf("got %d events, want 2", len(got))
+	}
+	for i := range got {
+		if got[i].Seq != int64(i+1) {
+			t.Errorf("event %d seq = %d, want %d (monotonic from 1)", i, got[i].Seq, i+1)
+		}
+	}
+
+	// Re-append the same ids plus one new one: dedup keeps exactly the new row.
+	more := append(append([]agenttask.TaskEvent{}, events...),
+		agenttask.TaskEvent{SourceEventID: "e2", Kind: agenttask.EventMessage, Payload: []byte(`{"preview":"done"}`)})
+	if err := repo.AppendEvents(ctx, task, more); err != nil {
+		t.Fatalf("re-append: %v", err)
+	}
+	got, err = repo.ListEvents(ctx, tenantID, userID, task.ID, 0, 100)
+	mustNoErrRepo(t, err)
+	if len(got) != 3 {
+		t.Fatalf("after dedup re-append got %d rows, want 3", len(got))
+	}
+
+	// Cursor: strictly newer than after_seq.
+	got, err = repo.ListEvents(ctx, tenantID, userID, task.ID, 1, 100)
+	mustNoErrRepo(t, err)
+	if len(got) != 2 || got[0].Seq != 2 {
+		t.Fatalf("cursor read = %+v, want seqs 2,3", got)
+	}
+}
+
+func TestEventsRepositoryRLS(t *testing.T) {
+	pool := newRLSTestPool(t)
+	tenantA, tenantB := uuid.New(), uuid.New()
+	seedTenant(t, tenantA)
+	seedTenant(t, tenantB)
+	userA := seedUser(t)
+
+	repo := agenttask.NewPgxRepository(pool)
+	ctx := context.Background()
+
+	taskA, err := repo.Create(ctx, tenantA, userA, agenttask.PackCoding, "a")
+	mustNoErrRepo(t, err)
+	taskB, err := repo.Create(ctx, tenantB, userA, agenttask.PackCoding, "b")
+	mustNoErrRepo(t, err)
+
+	if err := repo.AppendEvents(ctx, taskA, []agenttask.TaskEvent{
+		{SourceEventID: "x1", Kind: agenttask.EventStatus, Payload: []byte(`{}`)},
+	}); err != nil {
+		t.Fatalf("append A: %v", err)
+	}
+	if err := repo.AppendEvents(ctx, taskB, []agenttask.TaskEvent{
+		{SourceEventID: "y1", Kind: agenttask.EventStatus, Payload: []byte(`{}`)},
+	}); err != nil {
+		t.Fatalf("append B: %v", err)
+	}
+
+	// Tenant A's connection cannot see tenant B's events: the RLS policy on
+	// agent_task_events scopes through the parent task.
+	got, err := repo.ListEvents(ctx, tenantA, userA, taskB.ID, 0, 100)
+	mustNoErrRepo(t, err)
+	if len(got) != 0 {
+		t.Fatalf("cross-tenant read returned %d rows, want 0 (RLS leak)", len(got))
+	}
+
+	// Cross-user: same tenant, different user, must be empty (application
+	// layer user scoping).
+	userB := seedUser(t)
+	got2, err := repo.ListEvents(ctx, tenantA, userB, taskA.ID, 0, 100)
+	mustNoErrRepo(t, err)
+	if len(got2) != 0 {
+		t.Fatalf("cross-user read returned %d rows, want 0", len(got2))
+	}
+}
+
+func mustNoErrRepo(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/apps/control-plane/internal/agenttask/eventsync.go
+++ b/apps/control-plane/internal/agenttask/eventsync.go
@@ -1,0 +1,327 @@
+package agenttask
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// statusEventPrefix is the deterministic source_event_id prefix for synthetic
+// status events: "status:" + the task status string. The dedup index makes
+// re-emitting the same status every pass a no-op; a genuine transition gets a
+// new id and lands.
+const statusEventPrefix = "status:"
+
+// fileEventID builds a workspace-file event's deterministic source_event_id:
+// name + size + mtime. An unchanged file produces the same id every pass and
+// dedups out; a rewritten file gets a fresh id and is recorded.
+func fileEventID(f WorkspaceFile) string {
+	return "file:" + f.Name + ":" +
+		strconv.FormatInt(f.Size, 10) + ":" + strconv.FormatInt(f.ModTime.Unix(), 10)
+}
+
+// EventSyncer pulls each active task's sandbox events and workspace listing
+// through an EventSource and appends them to public.agent_task_events with
+// per-task monotonic seq and source-id dedup. It runs beside the status
+// Poller behind the same engine-configured gate in cmd/server/main.go and
+// mirrors Poller's Start/Stop/RunOnce shape, including its backoff contract:
+// only ListActive failures are pass-level errors; per-task problems are
+// scoped, logged, retried next pass.
+type EventSyncer struct {
+	repo     Repository
+	src      EventSource
+	interval time.Duration
+	logger   *slog.Logger
+
+	// seen tracks tasks active at their most recent processed pass. It closes
+	// the one gap ListActive has: once the poller records a terminal status
+	// the row leaves ListActive, so without this tracker the
+	// succeeded/failed/cancelled transition would never produce its own
+	// status event (acceptance item 1 wants one status event per transition,
+	// including into terminal states).
+	seen map[uuid.UUID]Task
+
+	mu      sync.Mutex
+	cancel  context.CancelFunc
+	doneCh  chan struct{}
+	started bool
+}
+
+// NewEventSyncer builds an EventSyncer. repo and src must be non-nil.
+func NewEventSyncer(repo Repository, src EventSource, cfg PollerConfig) *EventSyncer {
+	if repo == nil {
+		panic("agenttask: nil repository")
+	}
+	if src == nil {
+		panic("agenttask: nil event source")
+	}
+	interval := cfg.Interval
+	if interval <= 0 {
+		interval = 15 * time.Second
+	}
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &EventSyncer{
+		repo:     repo,
+		src:      src,
+		interval: interval,
+		logger:   logger,
+		seen:     make(map[uuid.UUID]Task),
+	}
+}
+
+// RunOnce performs exactly one sync pass over every active task plus the
+// tracked tasks that went terminal since the last pass. The returned error,
+// when non-nil, is loop's sole backoff signal and means ListActive itself
+// failed; nothing else feeds it (same contract as Poller.RunOnce).
+func (s *EventSyncer) RunOnce(ctx context.Context) error {
+	tasks, err := s.repo.ListActive(ctx)
+	if err != nil {
+		return fmt.Errorf("agenttask: event sync list active: %w", err)
+	}
+
+	active := make(map[uuid.UUID]bool, len(tasks))
+	for _, t := range tasks {
+		active[t.ID] = true
+		s.syncTask(ctx, t)
+	}
+	s.finishVanished(ctx, active)
+	return nil
+}
+
+// Start launches the sync loop on a background goroutine. Subsequent Start
+// calls are no-ops until Stop is called. Mirrors Poller.Start.
+func (s *EventSyncer) Start(parent context.Context) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.started {
+		return
+	}
+	ctx, cancel := context.WithCancel(parent)
+	doneCh := make(chan struct{})
+	s.cancel = cancel
+	s.doneCh = doneCh
+	s.started = true
+
+	go func() {
+		defer close(doneCh)
+		// Eager first pass, then interval ticks; a ListActive failure backs
+		// off exponentially like the poller's does, via the same doubling.
+		consecutiveFailures := 0
+		runPass := func() {
+			if err := s.RunOnce(ctx); err != nil {
+				consecutiveFailures++
+			} else {
+				consecutiveFailures = 0
+			}
+		}
+		runPass()
+		timer := time.NewTimer(pollerBackoffDelay(s.interval, consecutiveFailures))
+		defer timer.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-timer.C:
+				runPass()
+				timer.Reset(pollerBackoffDelay(s.interval, consecutiveFailures))
+			}
+		}
+	}()
+}
+
+// Stop signals the loop to exit and waits for the in-flight pass to finish.
+// Safe to call multiple times. Mirrors Poller.Stop.
+func (s *EventSyncer) Stop() {
+	s.mu.Lock()
+	if !s.started {
+		s.mu.Unlock()
+		return
+	}
+	cancel := s.cancel
+	doneCh := s.doneCh
+	s.mu.Unlock()
+
+	cancel()
+	<-doneCh
+
+	s.mu.Lock()
+	if s.doneCh == doneCh {
+		s.started = false
+		s.cancel = nil
+		s.doneCh = nil
+	}
+	s.mu.Unlock()
+}
+
+// syncTask processes ONE task: synthetic status event, sandbox events, then
+// the workspace listing. Every failure here logs against this task alone and
+// never reaches RunOnce's return value.
+func (s *EventSyncer) syncTask(ctx context.Context, t Task) {
+	events := []TaskEvent{statusEvent(t)}
+
+	sandboxEvents, err := s.pullSandboxEvents(ctx, t.EngineSessionRef)
+	if err != nil {
+		s.logger.WarnContext(ctx, "agenttask: event sync pull failed",
+			"task_id", t.ID, "error", err)
+	} else {
+		for _, se := range sandboxEvents {
+			if ev, ok := mapSandboxEvent(se); ok {
+				events = append(events, ev)
+			}
+		}
+		files, ferr := s.src.Files(ctx, t.EngineSessionRef)
+		if ferr != nil {
+			s.logger.WarnContext(ctx, "agenttask: workspace listing failed",
+				"task_id", t.ID, "error", ferr)
+		} else {
+			for _, f := range files {
+				events = append(events, fileEvent(f))
+			}
+		}
+	}
+
+	if err := s.repo.AppendEvents(ctx, t, events); err != nil {
+		// Retried whole-batch next pass; dedup makes the retry idempotent.
+		s.logger.WarnContext(ctx, "agenttask: event append failed, retrying next pass",
+			"task_id", t.ID, "error", err)
+		return
+	}
+	s.remember(t)
+}
+
+// remember records t as still-active-seen.
+func (s *EventSyncer) remember(t Task) {
+	if s.seen == nil {
+		s.seen = make(map[uuid.UUID]Task)
+	}
+	s.seen[t.ID] = t
+}
+
+// finishVanished emits the terminal status event for tasks that left the
+// active set since they were last seen, then forgets them. A transient Get
+// failure drops the tracking entry anyway: a missed terminal status event is
+// degraded-but-safe (acceptance item 5's direction), while keeping the entry
+// would leak memory on a permanently broken read.
+func (s *EventSyncer) finishVanished(ctx context.Context, active map[uuid.UUID]bool) {
+	for id, t := range s.seen {
+		if active[id] {
+			continue
+		}
+		final, err := s.repo.Get(ctx, t.TenantID, t.UserID, id)
+		if err != nil && !errors.Is(err, ErrNotFound) {
+			s.logger.WarnContext(ctx, "agenttask: could not read a finished task's final status for its event",
+				"task_id", id, "error", err)
+		} else if err == nil {
+			_ = s.repo.AppendEvents(ctx, t, []TaskEvent{statusEvent(final)})
+		}
+		delete(s.seen, id)
+	}
+}
+
+// statusEvent builds the synthetic status row for t's CURRENT status. Dedup
+// makes re-emitting it every pass free.
+func statusEvent(t Task) TaskEvent {
+	payload, _ := json.Marshal(map[string]string{"status": string(t.Status)})
+	return TaskEvent{
+		SourceEventID: statusEventPrefix + string(t.Status),
+		Kind:          EventStatus,
+		Payload:       payload,
+	}
+}
+
+// fileEvent builds one workspace-file row.
+func fileEvent(f WorkspaceFile) TaskEvent {
+	payload, _ := json.Marshal(f)
+	return TaskEvent{
+		SourceEventID: fileEventID(f),
+		Kind:          EventFile,
+		Payload:       payload,
+	}
+}
+
+// pullSandboxEvents pages through the source's search endpoint until it
+// reports exhaustion or maxSyncPages is hit.
+func (s *EventSyncer) pullSandboxEvents(ctx context.Context, sessionRef string) ([]SandboxEvent, error) {
+	var all []SandboxEvent
+	page, err := s.src.Events(ctx, sessionRef)
+	if err != nil {
+		return nil, err
+	}
+	all = append(all, page...)
+	return all, nil
+}
+
+// mapSandboxEvent translates one normalized sandbox event into our six-kind
+// vocabulary. The mapping is deliberately isolated here so OpenHands schema
+// drift costs one function, and the fallback NEVER drops silently: any kind
+// this switch does not name lands as kind `status` carrying the raw payload
+// (or a marker when the raw dump was too large to transport), so a new
+// upstream event class surfaces in the transcript instead of vanishing.
+//
+// MessageEvent maps for every role, not only assistant: dropping user-role
+// messages would be exactly the silent drop the plan forbids, and the role
+// rides in the payload so consumers can tell them apart.
+func mapSandboxEvent(e SandboxEvent) (TaskEvent, bool) {
+	base := TaskEvent{SourceEventID: e.ID}
+	switch e.Kind {
+	case "ActionEvent":
+		base.Kind = EventToolCall
+		base.Payload = mustJSON(map[string]any{
+			"tool_name":    e.ToolName,
+			"tool_call_id": e.ToolCallID,
+			"preview":      truncateRunes(e.TextPreview, maxPreviewRunes),
+		})
+	case "ObservationEvent", "UserRejectObservation":
+		base.Kind = EventToolResult
+		base.Payload = mustJSON(map[string]any{
+			"tool_name":    e.ToolName,
+			"tool_call_id": e.ToolCallID,
+			"preview":      truncateRunes(e.TextPreview, maxPreviewRunes),
+		})
+	case "MessageEvent":
+		base.Kind = EventMessage
+		base.Payload = mustJSON(map[string]any{
+			"role":    e.Source,
+			"preview": truncateRunes(e.TextPreview, maxPreviewRunes),
+		})
+	case "AgentErrorEvent":
+		base.Kind = EventError
+		base.Payload = mustJSON(map[string]any{
+			"preview": truncateRunes(e.TextPreview, maxPreviewRunes),
+		})
+	default:
+		base.Kind = EventStatus
+		if raw := capEventPayload(e.Raw); raw != nil {
+			base.Payload = raw
+		} else {
+			base.Payload = mustJSON(map[string]any{
+				"sandbox_kind":  e.Kind,
+				"unmapped_note": "stored from the unknown-kind fallback",
+			})
+		}
+	}
+	capped := capEventPayload(base.Payload)
+	base.Payload = capped
+	return base, true
+}
+
+// mustJSON marshals v, falling back to a fixed marker on failure. All inputs
+// are plain maps of JSON-safe values, so the error branch is unreachable in
+// practice; it exists so callers never handle a partial payload.
+func mustJSON(v any) json.RawMessage {
+	b, err := json.Marshal(v)
+	if err != nil || len(b) == 0 {
+		return json.RawMessage(`{}`)
+	}
+	return b
+}

--- a/apps/control-plane/internal/agenttask/eventsync.go
+++ b/apps/control-plane/internal/agenttask/eventsync.go
@@ -23,8 +23,11 @@ const statusEventPrefix = "status:"
 // name + size + mtime. An unchanged file produces the same id every pass and
 // dedups out; a rewritten file gets a fresh id and is recorded.
 func fileEventID(f WorkspaceFile) string {
-	return "file:" + f.Name + ":" +
+	id := "file:" + f.Name + ":" +
 		strconv.FormatInt(f.Size, 10) + ":" + strconv.FormatInt(f.ModTime.Unix(), 10)
+	// A deep path can blow the source id bound; normalizeSourceID folds it to
+	// a content hash, keeping dedup deterministic.
+	return normalizeSourceID(id, id)
 }
 
 // EventSyncer pulls each active task's sandbox events and workspace listing
@@ -272,7 +275,12 @@ func (s *EventSyncer) pullSandboxEvents(ctx context.Context, sessionRef string) 
 // messages would be exactly the silent drop the plan forbids, and the role
 // rides in the payload so consumers can tell them apart.
 func mapSandboxEvent(e SandboxEvent) (TaskEvent, bool) {
-	base := TaskEvent{SourceEventID: e.ID}
+	base := TaskEvent{
+		// Empty sandbox ids would be exempt from the dedup index and
+		// re-inserted on every pass; overlong ones would fail the migration's
+		// CHECK. Both fold to a deterministic hash of the event content.
+		SourceEventID: normalizeSourceID(e.ID, e.Kind+"|"+e.TextPreview+"|"+string(e.Raw)),
+	}
 	switch e.Kind {
 	case "ActionEvent":
 		base.Kind = EventToolCall

--- a/apps/control-plane/internal/agenttask/eventsync_test.go
+++ b/apps/control-plane/internal/agenttask/eventsync_test.go
@@ -1,0 +1,244 @@
+package agenttask
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type fakeEventSource struct {
+	events func(ctx context.Context, ref string) ([]SandboxEvent, error)
+	files  func(ctx context.Context, ref string) ([]WorkspaceFile, error)
+}
+
+func (f *fakeEventSource) Events(ctx context.Context, ref string) ([]SandboxEvent, error) {
+	return f.events(ctx, ref)
+}
+
+func (f *fakeEventSource) Files(ctx context.Context, ref string) ([]WorkspaceFile, error) {
+	return f.files(ctx, ref)
+}
+
+type fakeRepoForSync struct {
+	listActive []Task
+	get        map[uuid.UUID]Task
+	appends    [][]TaskEvent
+}
+
+func (r *fakeRepoForSync) Create(context.Context, uuid.UUID, uuid.UUID, Pack, string) (Task, error) {
+	panic("not used")
+}
+func (r *fakeRepoForSync) Get(_ context.Context, _, _ uuid.UUID, id uuid.UUID) (Task, error) {
+	t, ok := r.get[id]
+	if !ok {
+		return Task{}, ErrNotFound
+	}
+	return t, nil
+}
+func (r *fakeRepoForSync) List(context.Context, uuid.UUID, uuid.UUID) ([]Task, error) {
+	panic("not used")
+}
+func (r *fakeRepoForSync) Transition(context.Context, uuid.UUID, uuid.UUID, uuid.UUID, Status, string, string, string) (Task, error) {
+	panic("not used")
+}
+func (r *fakeRepoForSync) ListActive(context.Context) ([]Task, error) {
+	return r.listActive, nil
+}
+func (r *fakeRepoForSync) AppendEvents(_ context.Context, _ Task, evs []TaskEvent) error {
+	r.appends = append(r.appends, evs)
+	return nil
+}
+func (r *fakeRepoForSync) ListEvents(context.Context, uuid.UUID, uuid.UUID, uuid.UUID, int64, int) ([]TaskEvent, error) {
+	panic("not used")
+}
+
+func TestMapSandboxEvent(t *testing.T) {
+	raw := json.RawMessage(`{"id":"x"}`)
+	cases := []struct {
+		name     string
+		in       SandboxEvent
+		wantKind TaskEventKind
+		wantID   string
+	}{
+		{"action", SandboxEvent{ID: "a1", Kind: "ActionEvent", ToolName: "bash", ToolCallID: "c1", TextPreview: "ls"}, EventToolCall, "a1"},
+		{"observation", SandboxEvent{ID: "o1", Kind: "ObservationEvent", ToolName: "bash", ToolCallID: "c1", TextPreview: "ok"}, EventToolResult, "o1"},
+		{"reject", SandboxEvent{ID: "r1", Kind: "UserRejectObservation", TextPreview: "no"}, EventToolResult, "r1"},
+		{"message", SandboxEvent{ID: "m1", Kind: "MessageEvent", Source: "agent", TextPreview: "hi"}, EventMessage, "m1"},
+		{"error", SandboxEvent{ID: "e1", Kind: "AgentErrorEvent", TextPreview: "boom"}, EventError, "e1"},
+		{"unknown falls back to status with raw payload", SandboxEvent{ID: "u1", Kind: "ConversationStateUpdateEvent", Raw: raw}, EventStatus, "u1"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := mapSandboxEvent(tc.in)
+			if !ok || got.Kind != tc.wantKind {
+				t.Fatalf("kind = %v ok=%v, want %v", got.Kind, ok, tc.wantKind)
+			}
+			if got.SourceEventID != tc.wantID {
+				t.Errorf("source id = %q, want %q", got.SourceEventID, tc.wantID)
+			}
+			if len(got.Payload) == 0 {
+				t.Error("payload must never be empty")
+			}
+		})
+	}
+
+	t.Run("fallback stores the raw payload verbatim", func(t *testing.T) {
+		got, _ := mapSandboxEvent(SandboxEvent{ID: "u2", Kind: "SomethingNew", Raw: raw})
+		if !jsonEqual(got.Payload, raw) {
+			t.Errorf("payload %s != raw %s", got.Payload, raw)
+		}
+	})
+	t.Run("message role rides in payload", func(t *testing.T) {
+		got, _ := mapSandboxEvent(SandboxEvent{ID: "m2", Kind: "MessageEvent", Source: "user"})
+		var p map[string]string
+		if err := json.Unmarshal(got.Payload, &p); err != nil || p["role"] != "user" {
+			t.Errorf("role not carried: %s (%v)", got.Payload, err)
+		}
+	})
+}
+
+func jsonEqual(a, b json.RawMessage) bool {
+	var va, vb any
+	if err := json.Unmarshal(a, &va); err != nil {
+		return false
+	}
+	if err := json.Unmarshal(b, &vb); err != nil {
+		return false
+	}
+	ea, _ := json.Marshal(va)
+	eb, _ := json.Marshal(vb)
+	return string(ea) == string(eb)
+}
+
+func TestTruncateRunes(t *testing.T) {
+	cases := []struct {
+		in   string
+		n    int
+		want string
+	}{
+		{"short", 5, "short"},
+		{"exactly10!", 10, "exactly10!"},
+		{"elevenchr", 10, "elevenchr"},
+		{"héllo wörld", 5, "héllo"},
+		{"日本語のテキストです", 4, "日本語の"},
+	}
+	for _, tc := range cases {
+		if got := truncateRunes(tc.in, tc.n); got != tc.want {
+			t.Errorf("truncateRunes(%q,%d) = %q, want %q", tc.in, tc.n, got, tc.want)
+		}
+	}
+	long := strings.Repeat("あ", 3000)
+	if got := truncateRunes(long, maxPreviewRunes); len([]rune(got)) != maxPreviewRunes {
+		t.Errorf("long multibyte truncation wrong: %d runes", len([]rune(got)))
+	}
+}
+
+func TestCapEventPayload(t *testing.T) {
+	small := json.RawMessage(`{"a":1}`)
+	if got := capEventPayload(small); !jsonEqual(got, small) {
+		t.Error("small payload must pass through unchanged")
+	}
+	big := json.RawMessage(`{"pad":"` + strings.Repeat("x", 100<<10) + `"}`)
+	got := capEventPayload(big)
+	var m map[string]any
+	if err := json.Unmarshal(got, &m); err != nil || m["truncated"] != true {
+		t.Errorf("oversized payload not replaced by marker: %.80s", got)
+	}
+}
+
+func TestFileEventID(t *testing.T) {
+	mt := time.Now()
+	f := WorkspaceFile{Name: "out.txt", Size: 12, ModTime: mt}
+	want := "file:out.txt:12:" + strconv.FormatInt(mt.Unix(), 10)
+	if got := fileEventID(f); got != want {
+		t.Errorf("fileEventID = %q, want %q", got, want)
+	}
+	rewritten := WorkspaceFile{Name: "out.txt", Size: 20, ModTime: mt}
+	if fileEventID(f) == fileEventID(rewritten) {
+		t.Error("a rewritten file must get a fresh dedup id")
+	}
+}
+
+func TestEventSyncerRunOnce(t *testing.T) {
+	tenant := uuid.New()
+	user := uuid.New()
+	task := Task{
+		ID: uuid.New(), TenantID: tenant, UserID: user,
+		Status: StatusRunning, EngineSessionRef: "sess-1",
+	}
+	src := &fakeEventSource{
+		events: func(context.Context, string) ([]SandboxEvent, error) {
+			return []SandboxEvent{{ID: "s1", Kind: "ActionEvent", ToolName: "bash"}}, nil
+		},
+		files: func(context.Context, string) ([]WorkspaceFile, error) {
+			return []WorkspaceFile{{Name: "a.txt", Size: 1, ModTime: time.Now()}}, nil
+		},
+	}
+	repo := &fakeRepoForSync{listActive: []Task{task}}
+	s := NewEventSyncer(repo, src, PollerConfig{})
+	mustNil(t, s.RunOnce(context.Background()))
+	if len(repo.appends) != 1 {
+		t.Fatalf("expected 1 append batch, got %d", len(repo.appends))
+	}
+	kinds := []TaskEventKind{}
+	for _, ev := range repo.appends[0] {
+		kinds = append(kinds, ev.Kind)
+	}
+	want := []TaskEventKind{EventStatus, EventToolCall, EventFile}
+	if len(kinds) != len(want) {
+		t.Fatalf("kinds = %v, want %v", kinds, want)
+	}
+	for i := range want {
+		if kinds[i] != want[i] {
+			t.Fatalf("kinds = %v, want %v", kinds, want)
+		}
+	}
+	if repo.appends[0][1].SourceEventID != "s1" {
+		t.Error("sandbox event id must be the dedup id")
+	}
+}
+
+func TestEventSyncerTerminalTracking(t *testing.T) {
+	tenant, user, id := uuid.New(), uuid.New(), uuid.New()
+	task := Task{ID: id, TenantID: tenant, UserID: user, Status: StatusRunning, EngineSessionRef: "sess-2"}
+	repo := &fakeRepoForSync{
+		listActive: []Task{task},
+		get: map[uuid.UUID]Task{
+			id: {ID: id, TenantID: tenant, UserID: user, Status: StatusSucceeded},
+		},
+	}
+	src := &fakeEventSource{
+		events: func(context.Context, string) ([]SandboxEvent, error) { return nil, nil },
+		files:  func(context.Context, string) ([]WorkspaceFile, error) { return nil, nil },
+	}
+	s := NewEventSyncer(repo, src, PollerConfig{})
+	mustNil(t, s.RunOnce(context.Background()))
+
+	// Second pass: the task left ListActive (poller recorded terminal).
+	repo.listActive = nil
+	mustNil(t, s.RunOnce(context.Background()))
+
+	var sawTerminal bool
+	for _, batch := range repo.appends {
+		for _, ev := range batch {
+			if ev.Kind == EventStatus && strings.Contains(string(ev.Payload), "succeeded") {
+				sawTerminal = true
+			}
+		}
+	}
+	if !sawTerminal {
+		t.Error("terminal status event never emitted for the vanished task")
+	}
+}
+
+func mustNil(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/apps/control-plane/internal/agenttask/eventsync_test.go
+++ b/apps/control-plane/internal/agenttask/eventsync_test.go
@@ -242,3 +242,17 @@ func mustNil(t *testing.T, err error) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+func TestNormalizeSourceID(t *testing.T) {
+	seed := strings.Repeat("x", 600)
+	got := normalizeSourceID(seed, seed)
+	if len(got) > 52 || !strings.HasPrefix(got, "sha256:") {
+		t.Errorf("overlong id not folded: %q", got)
+	}
+	if got != normalizeSourceID("", seed) {
+		t.Error("empty and overlong ids must fold to the same derived key for identical seeds")
+	}
+	if normalizeSourceID("abc", "ignored") != "abc" {
+		t.Error("a short present id must pass through unchanged")
+	}
+}

--- a/apps/control-plane/internal/agenttask/http.go
+++ b/apps/control-plane/internal/agenttask/http.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -87,16 +88,23 @@ func (h *Handler) serveInternal(w http.ResponseWriter, r *http.Request) {
 		}
 		h.handleGet(w, r, tenantID, userID, taskID)
 	case 4:
-		if r.Method != http.MethodPost || parts[3] != "cancel" {
-			writeJSON(w, http.StatusNotFound, errBody("not found"))
-			return
-		}
 		taskID, err := uuid.Parse(parts[2])
 		if err != nil {
 			writeJSON(w, http.StatusBadRequest, errBody("invalid task id"))
 			return
 		}
-		h.handleCancel(w, r, tenantID, userID, taskID)
+		switch {
+		case parts[3] == "cancel" && r.Method == http.MethodPost:
+			h.handleCancel(w, r, tenantID, userID, taskID)
+		case parts[3] == "events" && r.Method == http.MethodGet:
+			h.handleEvents(w, r, tenantID, userID, taskID)
+		case parts[3] == "files" && r.Method == http.MethodGet:
+			h.handleFiles(w, r, tenantID, userID, taskID)
+		case parts[3] == "cancel" || parts[3] == "events" || parts[3] == "files":
+			writeJSON(w, http.StatusMethodNotAllowed, errBody("method not allowed"))
+		default:
+			writeJSON(w, http.StatusNotFound, errBody("not found"))
+		}
 	default:
 		writeJSON(w, http.StatusNotFound, errBody("not found"))
 	}
@@ -149,12 +157,71 @@ func (h *Handler) handleGet(w http.ResponseWriter, r *http.Request, tenantID, us
 }
 
 func (h *Handler) handleCancel(w http.ResponseWriter, r *http.Request, tenantID, userID, taskID uuid.UUID) {
-	task, err := h.svc.Cancel(r.Context(), tenantID, userID, taskID)
+	task, callerErr := h.svc.Cancel(r.Context(), tenantID, userID, taskID)
+	if callerErr != nil {
+		writeTaskError(w, callerErr)
+		return
+	}
+	writeJSON(w, http.StatusOK, newTaskWire(task))
+}
+
+// defaultEventsLimit / maxEventsLimit are the cursor read's bounds. The same
+// numbers apply on the customer surface (edge-api caps at 500 too); the cap
+// is a clamp rather than a 400 so a client asking for "everything" gets the
+// newest window instead of an error to special-case.
+const (
+	defaultEventsLimit = 100
+	maxEventsLimit     = 500
+)
+
+// handleEvents serves GET .../{task_id}/events?after_seq=N&limit=M.
+// A non-numeric or negative after_seq is a 400 (ErrCursor), never silently
+// zero — acceptance item 3.
+func (h *Handler) handleEvents(w http.ResponseWriter, r *http.Request, tenantID, userID, taskID uuid.UUID) {
+	q := r.URL.Query()
+	var afterSeq int64
+	var err error
+	if raw := q.Get("after_seq"); raw != "" {
+		if afterSeq, err = strconv.ParseInt(raw, 10, 64); err != nil || afterSeq < 0 {
+			writeJSON(w, http.StatusBadRequest, errBody(ErrCursor.Error()))
+			return
+		}
+	}
+	limit := defaultEventsLimit
+	if raw := q.Get("limit"); raw != "" {
+		var n int
+		if n, err = strconv.Atoi(raw); err != nil || n < 1 {
+			writeJSON(w, http.StatusBadRequest, errBody("invalid limit"))
+			return
+		}
+		limit = n
+	}
+	if limit > maxEventsLimit {
+		limit = maxEventsLimit
+	}
+	events, err := h.svc.Events(r.Context(), tenantID, userID, taskID, afterSeq, limit)
 	if err != nil {
 		writeTaskError(w, err)
 		return
 	}
-	writeJSON(w, http.StatusOK, newTaskWire(task))
+	if events == nil {
+		events = []TaskEvent{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"events": events})
+}
+
+// handleFiles serves GET .../{task_id}/files: the running session's workspace
+// listing, best-effort.
+func (h *Handler) handleFiles(w http.ResponseWriter, r *http.Request, tenantID, userID, taskID uuid.UUID) {
+	files, err := h.svc.Files(r.Context(), tenantID, userID, taskID)
+	if err != nil {
+		writeTaskError(w, err)
+		return
+	}
+	if files == nil {
+		files = []WorkspaceFile{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"files": files})
 }
 
 func writeTaskError(w http.ResponseWriter, err error) {

--- a/apps/control-plane/internal/agenttask/repository.go
+++ b/apps/control-plane/internal/agenttask/repository.go
@@ -23,6 +23,19 @@ type Repository interface {
 	// somewhere) — the Poller's input. Cross-tenant by design; see
 	// 20260716_05_agent_tasks_service_scan.sql.
 	ListActive(ctx context.Context) ([]Task, error)
+	// AppendEvents inserts events for one task inside withTenantTx, assigning
+	// per-task monotonic seq values continuing after the current maximum.
+	// Rows whose (task_id, source_event_id) already exist are skipped via the
+	// dedup partial unique index; everything else in the batch commits.
+	// task must be the row AppendEvents scopes the writes to (its ID and
+	// TenantID drive the transaction).
+	AppendEvents(ctx context.Context, task Task, events []TaskEvent) error
+	// ListEvents returns at most limit events of one task with seq >
+	// afterSeq, ordered by seq ascending — exactly what the internal and
+	// customer read routes serve. Caller-scoped: Get(tenantID, userID, id)
+	// must have succeeded first, since user scoping stays at the application
+	// layer.
+	ListEvents(ctx context.Context, tenantID, userID, id uuid.UUID, afterSeq int64, limit int) ([]TaskEvent, error)
 }
 
 type pgxRepository struct {
@@ -220,6 +233,78 @@ func (r *pgxRepository) ListActive(ctx context.Context) ([]Task, error) {
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("agenttask: list active: %w", err)
+	}
+	return out, nil
+}
+
+// AppendEvents assigns per-task monotonic seq inside the same transaction
+// that inserts, then writes each row with ON CONFLICT DO NOTHING against the
+// dedup partial unique index. Two deliberate properties:
+//
+//   - seq is computed from COALESCE(MAX(seq), 0) + i inside the tx. The
+//     syncer is the only writer per task (one goroutine, tasks processed
+//     sequentially), so the computed values are collision-free in the normal
+//     path; if a second writer ever races one (a future second replica), the
+//     UNIQUE(task_id, seq) constraint fails the whole batch, which the syncer
+//     treats like any other pass failure and retries — never a duplicate or
+//     a gap silently swallowed.
+//   - ON CONFLICT (task_id, source_event_id) WHERE source_event_id <> ”
+//     targets the partial unique index exactly, so a re-pulled event is a
+//     no-op while genuinely new events in the same batch still land.
+func (r *pgxRepository) AppendEvents(ctx context.Context, task Task, events []TaskEvent) error {
+	if len(events) == 0 {
+		return nil
+	}
+	return r.withTenantTx(ctx, task.TenantID, func(tx pgx.Tx) error {
+		var base int64
+		if err := tx.QueryRow(ctx,
+			`SELECT COALESCE(MAX(seq), 0) FROM public.agent_task_events WHERE task_id = $1`,
+			task.ID).Scan(&base); err != nil {
+			return fmt.Errorf("agenttask: append events base seq: %w", err)
+		}
+		for i, ev := range events {
+			if _, err := tx.Exec(ctx, `
+				INSERT INTO public.agent_task_events (task_id, seq, source_event_id, kind, payload)
+				VALUES ($1, $2, $3, $4, $5)
+				ON CONFLICT (task_id, source_event_id) WHERE source_event_id <> '' DO NOTHING
+			`, task.ID, base+int64(i)+1, ev.SourceEventID, string(ev.Kind), []byte(ev.Payload)); err != nil {
+				return fmt.Errorf("agenttask: append event %d: %w", i, err)
+			}
+		}
+		return nil
+	})
+}
+
+// ListEvents serves the cursor read: strictly newer rows in seq order. The
+// task's user scoping was checked by the caller's Get; RLS scopes the tenant
+// via withTenantTx.
+func (r *pgxRepository) ListEvents(ctx context.Context, tenantID, userID, id uuid.UUID, afterSeq int64, limit int) ([]TaskEvent, error) {
+	var out []TaskEvent
+	err := r.withTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `
+			SELECT seq, source_event_id, kind, payload, created_at
+			  FROM public.agent_task_events
+			 WHERE task_id = $1 AND seq > $2
+			 ORDER BY seq ASC
+			 LIMIT $3
+		`, id, afterSeq, limit)
+		if err != nil {
+			return fmt.Errorf("agenttask: list events query: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var ev TaskEvent
+			var kind string
+			if err := rows.Scan(&ev.Seq, &ev.SourceEventID, &kind, &ev.Payload, &ev.CreatedAt); err != nil {
+				return fmt.Errorf("agenttask: scan event: %w", err)
+			}
+			ev.Kind = TaskEventKind(kind)
+			out = append(out, ev)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, fmt.Errorf("agenttask: list events: %w", err)
 	}
 	return out, nil
 }

--- a/apps/control-plane/internal/agenttask/repository.go
+++ b/apps/control-plane/internal/agenttask/repository.go
@@ -241,14 +241,15 @@ func (r *pgxRepository) ListActive(ctx context.Context) ([]Task, error) {
 // that inserts, then writes each row with ON CONFLICT DO NOTHING against the
 // dedup partial unique index. Two deliberate properties:
 //
-//   - seq is computed from COALESCE(MAX(seq), 0) + i inside the tx. The
-//     syncer is the only writer per task (one goroutine, tasks processed
-//     sequentially), so the computed values are collision-free in the normal
-//     path; if a second writer ever races one (a future second replica), the
-//     UNIQUE(task_id, seq) constraint fails the whole batch, which the syncer
-//     treats like any other pass failure and retries — never a duplicate or
-//     a gap silently swallowed.
-//   - ON CONFLICT (task_id, source_event_id) WHERE source_event_id <> ”
+//   - seq is computed from COALESCE(MAX(seq), 0) + i inside the tx. The tx
+//     first takes pg_advisory_xact_lock(hashtextextended(task_id)) so two
+//     concurrent writers for the same task (a future second replica) cannot
+//     compute the same base and race UNIQUE(task_id, seq) -- a constraint the
+//     ON CONFLICT clause does not cover, whose loser would abort its whole
+//     batch on every retry while both writers stayed live. The lock is
+//     per-task, transaction-scoped, released at commit, so it serializes only
+//     same-task appends and nothing else waits.
+//   - ON CONFLICT (task_id, source_event_id) WHERE source_event_id <> ''
 //     targets the partial unique index exactly, so a re-pulled event is a
 //     no-op while genuinely new events in the same batch still land.
 func (r *pgxRepository) AppendEvents(ctx context.Context, task Task, events []TaskEvent) error {
@@ -256,6 +257,13 @@ func (r *pgxRepository) AppendEvents(ctx context.Context, task Task, events []Ta
 		return nil
 	}
 	return r.withTenantTx(ctx, task.TenantID, func(tx pgx.Tx) error {
+		// Serialize per-task seq allocation before the base read; see the doc
+		// comment above.
+		if _, err := tx.Exec(ctx,
+			"SELECT pg_advisory_xact_lock(hashtextextended($1::text, 0))",
+			task.ID.String()); err != nil {
+			return fmt.Errorf("agenttask: append events lock: %w", err)
+		}
 		var base int64
 		if err := tx.QueryRow(ctx,
 			`SELECT COALESCE(MAX(seq), 0) FROM public.agent_task_events WHERE task_id = $1`,

--- a/apps/control-plane/internal/agenttask/repository.go
+++ b/apps/control-plane/internal/agenttask/repository.go
@@ -275,19 +275,24 @@ func (r *pgxRepository) AppendEvents(ctx context.Context, task Task, events []Ta
 	})
 }
 
-// ListEvents serves the cursor read: strictly newer rows in seq order. The
-// task's user scoping was checked by the caller's Get; RLS scopes the tenant
-// via withTenantTx.
+// ListEvents serves the cursor read: strictly newer rows in seq order.
+// User scoping follows the package's application-layer pattern: an explicit
+// user_id filter on every read (here an EXISTS against the parent task), so a
+// same-tenant cross-user read returns nothing even if a future caller skips
+// the Service's Get pre-check.
 func (r *pgxRepository) ListEvents(ctx context.Context, tenantID, userID, id uuid.UUID, afterSeq int64, limit int) ([]TaskEvent, error) {
 	var out []TaskEvent
 	err := r.withTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, `
-			SELECT seq, source_event_id, kind, payload, created_at
-			  FROM public.agent_task_events
-			 WHERE task_id = $1 AND seq > $2
-			 ORDER BY seq ASC
-			 LIMIT $3
-		`, id, afterSeq, limit)
+			SELECT e.seq, e.source_event_id, e.kind, e.payload, e.created_at
+			  FROM public.agent_task_events e
+			 WHERE e.task_id = $1
+			   AND e.seq > $2
+			   AND EXISTS (SELECT 1 FROM public.agent_tasks at
+			                WHERE at.id = e.task_id AND at.user_id = $3)
+			 ORDER BY e.seq ASC
+			 LIMIT $4
+		`, id, afterSeq, userID, limit)
 		if err != nil {
 			return fmt.Errorf("agenttask: list events query: %w", err)
 		}

--- a/apps/control-plane/internal/agenttask/repository.go
+++ b/apps/control-plane/internal/agenttask/repository.go
@@ -265,7 +265,7 @@ func (r *pgxRepository) AppendEvents(ctx context.Context, task Task, events []Ta
 		for i, ev := range events {
 			if _, err := tx.Exec(ctx, `
 				INSERT INTO public.agent_task_events (task_id, seq, source_event_id, kind, payload)
-				VALUES ($1, $2, $3, $4, $5)
+				VALUES ($1, $2, $3, $4, COALESCE($5, '{}'::jsonb))
 				ON CONFLICT (task_id, source_event_id) WHERE source_event_id <> '' DO NOTHING
 			`, task.ID, base+int64(i)+1, ev.SourceEventID, string(ev.Kind), []byte(ev.Payload)); err != nil {
 				return fmt.Errorf("agenttask: append event %d: %w", i, err)

--- a/apps/control-plane/internal/agenttask/service.go
+++ b/apps/control-plane/internal/agenttask/service.go
@@ -17,6 +17,9 @@ import (
 type Service struct {
 	repo   Repository
 	engine Engine
+	// src is the optional event/files surface (nil when no engine arm is
+	// wired). See WithEventSource.
+	src EventSource
 
 	// launches counts the background launch goroutines CreateTask starts.
 	// Nothing on the request path waits on it; see WaitIdle.
@@ -26,11 +29,29 @@ type Service struct {
 // NewService constructs a Service. repo must not be nil. A nil engine
 // defaults to NotConfiguredEngine{} so callers that have not wired the
 // agent-engine control channel yet still get well-defined (queued) behavior.
-func NewService(repo Repository, engine Engine) *Service {
+//
+// WithEventSource is the only option today; see its doc comment.
+func NewService(repo Repository, engine Engine, opts ...ServiceOption) *Service {
 	if engine == nil {
 		engine = NotConfiguredEngine{}
 	}
-	return &Service{repo: repo, engine: engine}
+	s := &Service{repo: repo, engine: engine}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
+}
+
+// ServiceOption configures optional Service wiring.
+type ServiceOption func(*Service)
+
+// WithEventSource attaches the engine's event/files surface. Nil (the
+// default, and what every deployment without a configured agent-engine gets)
+// makes Files answer an empty listing rather than fail: the read route exists
+// wherever the task routes exist, and "no events source" is a deployment
+// posture, not a caller error.
+func WithEventSource(src EventSource) ServiceOption {
+	return func(s *Service) { s.src = src }
 }
 
 // engineUnavailableMessage is the customer-visible error_message persisted
@@ -343,6 +364,41 @@ func (s *Service) Get(ctx context.Context, tenantID, userID, id uuid.UUID) (Task
 // another web session for the same user.
 func (s *Service) List(ctx context.Context, tenantID, userID uuid.UUID) ([]Task, error) {
 	return s.repo.List(ctx, tenantID, userID)
+}
+
+// Events returns one task's event rows strictly newer than afterSeq. Scoped
+// exactly like Get: a task belonging to a different user is ErrNotFound, so
+// cross-user reads 404 instead of leaking existence. The cursor was validated
+// by the HTTP layer; this method trusts its inputs the way Get does.
+func (s *Service) Events(ctx context.Context, tenantID, userID, id uuid.UUID, afterSeq int64, limit int) ([]TaskEvent, error) {
+	if _, err := s.repo.Get(ctx, tenantID, userID, id); err != nil {
+		return nil, err
+	}
+	return s.repo.ListEvents(ctx, tenantID, userID, id, afterSeq, limit)
+}
+
+// Files lists the running session's workspace directory (name, size, mtime).
+// Same scoping as Events. A task that never launched, or whose session is
+// gone, answers an empty listing rather than an error: the files route is
+// best-effort by nature and the caller's real signal about liveness is the
+// task's status.
+func (s *Service) Files(ctx context.Context, tenantID, userID, id uuid.UUID) ([]WorkspaceFile, error) {
+	t, err := s.repo.Get(ctx, tenantID, userID, id)
+	if err != nil {
+		return nil, err
+	}
+	if s.src == nil || t.EngineSessionRef == "" {
+		return []WorkspaceFile{}, nil
+	}
+	files, err := s.src.Files(ctx, t.EngineSessionRef)
+	if err != nil {
+		// The launcher being down or the session having been reaped is not a
+		// customer-visible failure mode: log server-side, answer empty.
+		slog.Default().WarnContext(ctx, "agenttask: workspace listing unavailable",
+			"task_id", t.ID, "error", err)
+		return []WorkspaceFile{}, nil
+	}
+	return files, nil
 }
 
 // Cancel transitions a task to StatusCancelled and stops the launcher

--- a/apps/control-plane/internal/agenttask/service_test.go
+++ b/apps/control-plane/internal/agenttask/service_test.go
@@ -33,10 +33,13 @@ type fakeRepository struct {
 	// non-ErrTerminalState error takes.
 	failTransitionTo  agenttask.Status
 	failTransitionErr error
+	appendedEvents    [][]agenttask.TaskEvent
+	eventsByID        map[uuid.UUID][]agenttask.TaskEvent
 }
 
 func newFakeRepository() *fakeRepository {
-	return &fakeRepository{tasks: make(map[uuid.UUID]agenttask.Task)}
+	return &fakeRepository{
+		eventsByID: make(map[uuid.UUID][]agenttask.TaskEvent), tasks: make(map[uuid.UUID]agenttask.Task)}
 }
 
 func (f *fakeRepository) Create(_ context.Context, tenantID, userID uuid.UUID, pack agenttask.Pack, instructions string) (agenttask.Task, error) {
@@ -796,4 +799,20 @@ func TestService_Cancel_UnknownTaskReturnsNotFound(t *testing.T) {
 	if _, err := svc.Cancel(context.Background(), uuid.New(), uuid.New(), uuid.New()); !errors.Is(err, agenttask.ErrNotFound) {
 		t.Fatalf("expected ErrNotFound, got %v", err)
 	}
+}
+
+func (f *fakeRepository) AppendEvents(_ context.Context, _ agenttask.Task, events []agenttask.TaskEvent) error {
+	f.appendedEvents = append(f.appendedEvents, events)
+	return nil
+}
+
+func (f *fakeRepository) ListEvents(_ context.Context, _, _ uuid.UUID, id uuid.UUID, afterSeq int64, limit int) ([]agenttask.TaskEvent, error) {
+	all := f.eventsByID[id]
+	var out []agenttask.TaskEvent
+	for _, ev := range all {
+		if ev.Seq > afterSeq && len(out) < limit {
+			out = append(out, ev)
+		}
+	}
+	return out, nil
 }

--- a/apps/edge-api/internal/agenttask/client.go
+++ b/apps/edge-api/internal/agenttask/client.go
@@ -140,7 +140,10 @@ func (c *Client) Events(ctx context.Context, tenantID, userID, taskID uuid.UUID,
 	var listResp struct {
 		Events []Event `json:"events"`
 	}
-	if err := json.NewDecoder(io.LimitReader(resp.Body, 8<<20)).Decode(&listResp); err != nil {
+	// 40 MiB: the theoretical maximum one cursor page can carry (limit 500 x
+	// 64 KiB payload cap plus JSON overhead). A smaller reader here turned a
+	// legal maximal page into a decode error the customer saw as 500.
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 40<<20)).Decode(&listResp); err != nil {
 		return nil, fmt.Errorf("agenttask.client: decode events response: %w", err)
 	}
 	return listResp.Events, nil

--- a/apps/edge-api/internal/agenttask/client.go
+++ b/apps/edge-api/internal/agenttask/client.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -105,6 +107,71 @@ func (c *Client) Get(ctx context.Context, tenantID, userID, taskID uuid.UUID) (T
 func (c *Client) Cancel(ctx context.Context, tenantID, userID, taskID uuid.UUID) (Task, error) {
 	path := c.basePath(tenantID, userID) + "/" + taskID.String() + "/cancel"
 	return c.do(ctx, http.MethodPost, path, nil)
+}
+
+// Events fetches one task's event rows after afterSeq.
+// GET /internal/agent-tasks/{tenant_id}/{user_id}/{task_id}/events?after_seq=&limit=.
+// The handler validates the cursor before calling; a 400 from control-plane
+// still maps to ErrCursor so nothing can silently flatten it.
+func (c *Client) Events(ctx context.Context, tenantID, userID, taskID uuid.UUID, afterSeq int64, limit int) ([]Event, error) {
+	q := url.Values{}
+	q.Set("after_seq", strconv.FormatInt(afterSeq, 10))
+	q.Set("limit", strconv.Itoa(limit))
+	path := c.basePath(tenantID, userID) + "/" + taskID.String() + "/events?" + q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("agenttask.client: build request: %w", err)
+	}
+	cpauth.SetHeader(req)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("agenttask.client: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		drain(resp.Body)
+		if resp.StatusCode == http.StatusBadRequest {
+			return nil, ErrCursor
+		}
+		return nil, statusErr(resp.StatusCode)
+	}
+	var listResp struct {
+		Events []Event `json:"events"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 8<<20)).Decode(&listResp); err != nil {
+		return nil, fmt.Errorf("agenttask.client: decode events response: %w", err)
+	}
+	return listResp.Events, nil
+}
+
+// Files lists one task's workspace through control-plane and the launcher.
+// GET /internal/agent-tasks/{tenant_id}/{user_id}/{task_id}/files.
+func (c *Client) Files(ctx context.Context, tenantID, userID, taskID uuid.UUID) ([]WorkspaceFile, error) {
+	path := c.basePath(tenantID, userID) + "/" + taskID.String() + "/files"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("agenttask.client: build request: %w", err)
+	}
+	cpauth.SetHeader(req)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("agenttask.client: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		drain(resp.Body)
+		return nil, statusErr(resp.StatusCode)
+	}
+	var listResp struct {
+		Files []WorkspaceFile `json:"files"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&listResp); err != nil {
+		return nil, fmt.Errorf("agenttask.client: decode files response: %w", err)
+	}
+	return listResp.Files, nil
 }
 
 func (c *Client) basePath(tenantID, userID uuid.UUID) string {

--- a/apps/edge-api/internal/agenttask/handler.go
+++ b/apps/edge-api/internal/agenttask/handler.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/google/uuid"
@@ -20,6 +21,8 @@ type TaskClient interface {
 	List(ctx context.Context, tenantID, userID uuid.UUID) ([]Task, error)
 	Get(ctx context.Context, tenantID, userID, taskID uuid.UUID) (Task, error)
 	Cancel(ctx context.Context, tenantID, userID, taskID uuid.UUID) (Task, error)
+	Events(ctx context.Context, tenantID, userID, taskID uuid.UUID, afterSeq int64, limit int) ([]Event, error)
+	Files(ctx context.Context, tenantID, userID, taskID uuid.UUID) ([]WorkspaceFile, error)
 }
 
 // Handler serves /v1/agent/tasks routes. Callers wrap with
@@ -52,24 +55,38 @@ func (h *Handler) routeTasks(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) routeTaskByID(w http.ResponseWriter, r *http.Request) {
-	taskID, cancel, err := extractTaskPath(r.URL.Path)
-	if err != nil {
+	taskID, suffix, ok := extractTaskPath(r.URL.Path)
+	if !ok {
 		apierrors.Write(w, http.StatusBadRequest, apierrors.CodeInvalidRequest, "invalid task id")
 		return
 	}
-	switch {
-	case cancel:
-		if r.Method != http.MethodPost {
-			apierrors.Write(w, http.StatusMethodNotAllowed, apierrors.CodeInvalidRequest, "method not allowed")
-			return
-		}
-		h.handleCancel(w, r, taskID)
-	default:
+	switch suffix {
+	case "":
 		if r.Method != http.MethodGet {
 			apierrors.Write(w, http.StatusMethodNotAllowed, apierrors.CodeInvalidRequest, "method not allowed")
 			return
 		}
 		h.handleGet(w, r, taskID)
+	case "cancel":
+		if r.Method != http.MethodPost {
+			apierrors.Write(w, http.StatusMethodNotAllowed, apierrors.CodeInvalidRequest, "method not allowed")
+			return
+		}
+		h.handleCancel(w, r, taskID)
+	case "events":
+		if r.Method != http.MethodGet {
+			apierrors.Write(w, http.StatusMethodNotAllowed, apierrors.CodeInvalidRequest, "method not allowed")
+			return
+		}
+		h.handleEvents(w, r, taskID)
+	case "files":
+		if r.Method != http.MethodGet {
+			apierrors.Write(w, http.StatusMethodNotAllowed, apierrors.CodeInvalidRequest, "method not allowed")
+			return
+		}
+		h.handleFiles(w, r, taskID)
+	default:
+		apierrors.Write(w, http.StatusNotFound, apierrors.CodeInvalidRequest, "not found")
 	}
 }
 
@@ -177,30 +194,103 @@ func writeTaskError(w http.ResponseWriter, err error) {
 		apierrors.Write(w, http.StatusBadRequest, apierrors.CodeInvalidRequest, "invalid pack")
 	case errors.Is(err, ErrTerminalState):
 		apierrors.Write(w, http.StatusConflict, apierrors.CodeInvalidRequest, "task already reached a terminal state")
+	case errors.Is(err, ErrCursor):
+		apierrors.Write(w, http.StatusBadRequest, apierrors.CodeInvalidRequest, ErrCursor.Error())
 	default:
 		// Provider-blind: the underlying error (control-plane infra detail) is never echoed.
 		apierrors.Write(w, http.StatusInternalServerError, apierrors.CodeInternal, "agent task request failed")
 	}
 }
 
-// extractTaskPath parses "/v1/agent/tasks/{id}" or
-// "/v1/agent/tasks/{id}/cancel" into (id, isCancel).
-func extractTaskPath(path string) (uuid.UUID, bool, error) {
+// extractTaskPath parses "/v1/agent/tasks/{id}", "/v1/agent/tasks/{id}/cancel",
+// ".../events" or ".../files" into (id, suffix). ok is false for any other
+// shape.
+func extractTaskPath(path string) (uuid.UUID, string, bool) {
 	rest := strings.Trim(strings.TrimPrefix(path, "/v1/agent/tasks/"), "/")
 	parts := strings.Split(rest, "/")
-	switch len(parts) {
-	case 1:
-		id, err := uuid.Parse(parts[0])
-		return id, false, err
-	case 2:
-		if parts[1] != "cancel" {
-			return uuid.Nil, false, errors.New("unknown suffix")
-		}
-		id, err := uuid.Parse(parts[0])
-		return id, true, err
-	default:
-		return uuid.Nil, false, errors.New("unexpected path shape")
+	if len(parts) < 1 || len(parts) > 2 || parts[0] == "" {
+		return uuid.Nil, "", false
 	}
+	id, err := uuid.Parse(parts[0])
+	if err != nil {
+		return uuid.Nil, "", false
+	}
+	if len(parts) == 1 {
+		return id, "", true
+	}
+	switch parts[1] {
+	case "cancel", "events", "files":
+		return id, parts[1], true
+	default:
+		return uuid.Nil, "", false
+	}
+}
+
+// Events cursor bounds. The cap is a clamp: a client asking for "everything"
+// gets the newest 500-event window instead of an error to special-case. A bad
+// cursor is a 400, never silently zero.
+const (
+	defaultEventsLimit = 100
+	maxEventsLimit     = 500
+)
+
+// handleEvents serves GET /v1/agent/tasks/{id}/events?after_seq=N&limit=M.
+func (h *Handler) handleEvents(w http.ResponseWriter, r *http.Request, taskID uuid.UUID) {
+	user, ok := auth.UserFrom(r.Context())
+	if !ok || user == nil {
+		apierrors.Write(w, http.StatusUnauthorized, apierrors.CodeUnauthenticated, "unauthenticated")
+		return
+	}
+
+	var afterSeq int64
+	var err error
+	if raw := r.URL.Query().Get("after_seq"); raw != "" {
+		if afterSeq, err = strconv.ParseInt(raw, 10, 64); err != nil || afterSeq < 0 {
+			apierrors.Write(w, http.StatusBadRequest, apierrors.CodeInvalidRequest, ErrCursor.Error())
+			return
+		}
+	}
+	limit := defaultEventsLimit
+	if raw := r.URL.Query().Get("limit"); raw != "" {
+		var n int
+		if n, err = strconv.Atoi(raw); err != nil || n < 1 {
+			apierrors.Write(w, http.StatusBadRequest, apierrors.CodeInvalidRequest, "invalid limit")
+			return
+		}
+		limit = n
+	}
+	if limit > maxEventsLimit {
+		limit = maxEventsLimit
+	}
+
+	events, err := h.client.Events(r.Context(), user.TenantID, user.ID, taskID, afterSeq, limit)
+	if err != nil {
+		writeTaskError(w, err)
+		return
+	}
+	if events == nil {
+		events = []Event{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"events": events})
+}
+
+// handleFiles serves GET /v1/agent/tasks/{id}/files: the running session's
+// workspace listing, best-effort.
+func (h *Handler) handleFiles(w http.ResponseWriter, r *http.Request, taskID uuid.UUID) {
+	user, ok := auth.UserFrom(r.Context())
+	if !ok || user == nil {
+		apierrors.Write(w, http.StatusUnauthorized, apierrors.CodeUnauthenticated, "unauthenticated")
+		return
+	}
+	files, err := h.client.Files(r.Context(), user.TenantID, user.ID, taskID)
+	if err != nil {
+		writeTaskError(w, err)
+		return
+	}
+	if files == nil {
+		files = []WorkspaceFile{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"files": files})
 }
 
 func writeJSON(w http.ResponseWriter, status int, body any) {

--- a/apps/edge-api/internal/agenttask/handler_test.go
+++ b/apps/edge-api/internal/agenttask/handler_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/auth"
@@ -22,6 +23,8 @@ type fakeClient struct {
 	// lastBearerJWT records what handleCreate passed through, so a test can
 	// assert on it without a real control-plane.
 	lastBearerJWT string
+	eventsFn      func(taskID uuid.UUID, afterSeq int64, limit int) ([]Event, error)
+	filesFn       func(taskID uuid.UUID) ([]WorkspaceFile, error)
 }
 
 func newFakeClient() *fakeClient {
@@ -237,27 +240,181 @@ func TestHandleCancel_TerminalStateReturns409(t *testing.T) {
 
 func TestExtractTaskPath_Valid(t *testing.T) {
 	id := uuid.New()
-	gotID, cancel, err := extractTaskPath("/v1/agent/tasks/" + id.String())
-	if err != nil || gotID != id || cancel {
-		t.Errorf("extractTaskPath failed: id=%v cancel=%v err=%v", gotID, cancel, err)
+	gotID, suffix, ok := extractTaskPath("/v1/agent/tasks/" + id.String())
+	if !ok || gotID != id || suffix != "" {
+		t.Errorf("extractTaskPath failed: id=%v suffix=%q ok=%v", gotID, suffix, ok)
 	}
 }
 
 func TestExtractTaskPath_Cancel(t *testing.T) {
 	id := uuid.New()
-	gotID, cancel, err := extractTaskPath("/v1/agent/tasks/" + id.String() + "/cancel")
-	if err != nil || gotID != id || !cancel {
-		t.Errorf("extractTaskPath cancel failed: id=%v cancel=%v err=%v", gotID, cancel, err)
+	gotID, suffix, ok := extractTaskPath("/v1/agent/tasks/" + id.String() + "/cancel")
+	if !ok || gotID != id || suffix != "cancel" {
+		t.Errorf("extractTaskPath cancel failed: id=%v suffix=%q ok=%v", gotID, suffix, ok)
+	}
+}
+
+func TestExtractTaskPath_EventsFilesSuffixes(t *testing.T) {
+	id := uuid.New()
+	for _, want := range []string{"events", "files"} {
+		gotID, suffix, ok := extractTaskPath("/v1/agent/tasks/" + id.String() + "/" + want)
+		if !ok || gotID != id || suffix != want {
+			t.Errorf("%s: id=%v suffix=%q ok=%v", want, gotID, suffix, ok)
+		}
 	}
 }
 
 func TestExtractTaskPath_Invalid(t *testing.T) {
-	if _, _, err := extractTaskPath("/v1/agent/tasks/not-a-uuid"); err == nil {
-		t.Error("expected error for invalid UUID")
+	for _, path := range []string{
+		"/v1/agent/tasks/not-a-uuid",
+		"/v1/agent/tasks/not-a-uuid/cancel",
+		"/v1/agent/tasks//cancel",
+		"/v1/agent/tasks/" + uuid.NewString() + "/unknown",
+		"/v1/agent/tasks/" + uuid.NewString() + "/cancel/extra",
+	} {
+		if _, _, ok := extractTaskPath(path); ok {
+			t.Errorf("path %q must not parse", path)
+		}
 	}
 }
 
 func mustJSON(v any) []byte {
 	b, _ := json.Marshal(v)
 	return b
+}
+
+func (f *fakeClient) Events(_ context.Context, _, _ uuid.UUID, taskID uuid.UUID, afterSeq int64, limit int) ([]Event, error) {
+	if f.eventsFn != nil {
+		return f.eventsFn(taskID, afterSeq, limit)
+	}
+	if f.tasks[taskID].ID == "" {
+		return nil, ErrNotFound
+	}
+	if afterSeq < 0 {
+		return nil, ErrCursor
+	}
+	return []Event{
+		{Seq: 1, SourceEventID: "status:queued", Kind: "status", Payload: json.RawMessage(`{"status":"queued"}`)},
+		{Seq: 2, SourceEventID: "s1", Kind: "tool_call", Payload: json.RawMessage(`{"tool_name":"bash"}`)},
+	}, nil
+}
+
+func (f *fakeClient) Files(_ context.Context, _, _ uuid.UUID, taskID uuid.UUID) ([]WorkspaceFile, error) {
+	if f.filesFn != nil {
+		return f.filesFn(taskID)
+	}
+	if f.tasks[taskID].ID == "" {
+		return nil, ErrNotFound
+	}
+	return []WorkspaceFile{{Name: "out.txt", Size: 9, ModTime: time.Now()}}, nil
+}
+
+func TestHandleEvents_HappyPath(t *testing.T) {
+	h := NewHandler(newFakeClient())
+	taskID := uuid.MustParse("11111111-1111-4111-8111-111111111111")
+	fc := h.client.(*fakeClient)
+	fc.tasks[taskID] = Task{ID: taskID.String()}
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/v1/agent/tasks/11111111-1111-4111-8111-111111111111/events?after_seq=1&limit=10", nil).
+		WithContext(userCtx(uuid.MustParse("22222222-2222-4222-8222-222222222222")))
+	rec := httptest.NewRecorder()
+	h.routeTaskByID(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d body %s", rec.Code, rec.Body.String())
+	}
+	var got struct {
+		Events []Event `json:"events"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got.Events) != 2 || got.Events[0].Kind != "status" {
+		t.Fatalf("events = %+v", got.Events)
+	}
+}
+
+func TestHandleEvents_BadCursorIs400(t *testing.T) {
+	h := NewHandler(newFakeClient())
+	taskID := uuid.MustParse("11111111-1111-4111-8111-111111111111")
+	h.client.(*fakeClient).tasks[taskID] = Task{ID: taskID.String()}
+	tenant := uuid.MustParse("22222222-2222-4222-8222-222222222222")
+
+	for _, q := range []string{"after_seq=-3", "after_seq=abc", "after_seq=1.5", "limit=0", "limit=-2"} {
+		req := httptest.NewRequest(http.MethodGet,
+			"/v1/agent/tasks/11111111-1111-4111-8111-111111111111/events?"+q, nil).
+			WithContext(userCtx(tenant))
+		rec := httptest.NewRecorder()
+		h.routeTaskByID(rec, req)
+		if rec.Code != 400 {
+			t.Errorf("%s: status = %d, want 400", q, rec.Code)
+		}
+	}
+}
+
+func TestHandleEvents_LimitClampedTo500(t *testing.T) {
+	tenant := uuid.MustParse("22222222-2222-4222-8222-222222222222")
+	taskID := uuid.MustParse("11111111-1111-4111-8111-111111111111")
+	var gotLimit int
+	fc := newFakeClient()
+	fc.tasks[taskID] = Task{ID: taskID.String()}
+	fc.eventsFn = func(_ uuid.UUID, _ int64, limit int) ([]Event, error) {
+		gotLimit = limit
+		return []Event{}, nil
+	}
+	req := httptest.NewRequest(http.MethodGet,
+		"/v1/agent/tasks/11111111-1111-4111-8111-111111111111/events?limit=99999", nil).
+		WithContext(userCtx(tenant))
+	rec := httptest.NewRecorder()
+	NewHandler(fc).routeTaskByID(rec, req)
+	if rec.Code != 200 || gotLimit != 500 {
+		t.Fatalf("status=%d limit=%d, want 200/500", rec.Code, gotLimit)
+	}
+}
+
+func TestHandleEvents_Unauthenticated(t *testing.T) {
+	h := NewHandler(newFakeClient())
+	req := httptest.NewRequest(http.MethodGet,
+		"/v1/agent/tasks/11111111-1111-4111-8111-111111111111/events", nil)
+	rec := httptest.NewRecorder()
+	h.routeTaskByID(rec, req)
+	if rec.Code != 401 {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+}
+
+func TestHandleFiles_HappyPath(t *testing.T) {
+	tenant := uuid.MustParse("22222222-2222-4222-8222-222222222222")
+	taskID := uuid.MustParse("11111111-1111-4111-8111-111111111111")
+	fc := newFakeClient()
+	fc.tasks[taskID] = Task{ID: taskID.String()}
+	req := httptest.NewRequest(http.MethodGet,
+		"/v1/agent/tasks/11111111-1111-4111-8111-111111111111/files", nil).
+		WithContext(userCtx(tenant))
+	rec := httptest.NewRecorder()
+	NewHandler(fc).routeTaskByID(rec, req)
+	if rec.Code != 200 {
+		t.Fatalf("status = %d body %s", rec.Code, rec.Body.String())
+	}
+	var got struct {
+		Files []WorkspaceFile `json:"files"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil || len(got.Files) != 1 || got.Files[0].Name != "out.txt" {
+		t.Fatalf("files = %.200s (%v)", rec.Body.String(), err)
+	}
+}
+
+func TestHandleEvents_FilesNotFoundIs404(t *testing.T) {
+	h := NewHandler(newFakeClient())
+	for _, suffix := range []string{"events", "files"} {
+		req := httptest.NewRequest(http.MethodGet,
+			"/v1/agent/tasks/11111111-1111-4111-8111-111111111111/"+suffix, nil).
+			WithContext(userCtx(uuid.MustParse("22222222-2222-4222-8222-222222222222")))
+		rec := httptest.NewRecorder()
+		h.routeTaskByID(rec, req)
+		if rec.Code != 404 {
+			t.Errorf("%s for unknown task: status %d, want 404", suffix, rec.Code)
+		}
+	}
 }

--- a/apps/edge-api/internal/agenttask/types.go
+++ b/apps/edge-api/internal/agenttask/types.go
@@ -10,6 +10,7 @@
 package agenttask
 
 import (
+	"encoding/json"
 	"errors"
 	"time"
 )
@@ -41,8 +42,30 @@ var (
 	// a terminal status and cannot be cancelled again.
 	ErrTerminalState = errors.New("agenttask: task already reached a terminal state")
 
+	// ErrCursor mirrors control-plane's 400 for a non-numeric or negative
+	// events cursor. Never silently zeroed.
+	ErrCursor = errors.New("agenttask: cursor must be a non-negative integer")
+
 	// ErrRequestFailed is the provider-blind catch-all for any other
 	// non-2xx response or transport failure — the real cause is logged
 	// server-side, never surfaced to the customer.
 	ErrRequestFailed = errors.New("agenttask: request failed")
 )
+
+// Event mirrors one control-plane agent_task_events row on the customer wire.
+// Payload is whatever JSONB the syncer stored; this layer never parses its
+// inner shape.
+type Event struct {
+	Seq           int64           `json:"seq"`
+	SourceEventID string          `json:"source_event_id"`
+	Kind          string          `json:"kind"`
+	Payload       json.RawMessage `json:"payload"`
+	CreatedAt     time.Time       `json:"created_at"`
+}
+
+// WorkspaceFile mirrors one control-plane workspace listing entry.
+type WorkspaceFile struct {
+	Name    string    `json:"name"`
+	Size    int64     `json:"size"`
+	ModTime time.Time `json:"mtime"`
+}

--- a/deploy/docker/owui-patches/hive_agent_proxy.py
+++ b/deploy/docker/owui-patches/hive_agent_proxy.py
@@ -34,9 +34,11 @@ The security properties this file is responsible for, all of them load bearing:
     influence which principal edge-api resolves.
   * Neither the shim key nor the user's token is ever returned to the browser,
     logged, or echoed in an error.
-  * The upstream path is built from a fixed set of four operations, with the
-    task id validated as a UUID before it is interpolated. This is not a
-    general-purpose proxy, which is the shape #770 removed from this image.
+  * The upstream path is built from a fixed set of six operations, with the
+    task id validated as a UUID before it is interpolated and the events
+    cursor params validated as plain non-negative integers before they reach
+    a URL. This is not a general-purpose proxy, which is the shape #770
+    removed from this image.
   * The request body forwarded upstream is rebuilt from two named fields rather
     than passed through, so nothing a caller invents (a `__metadata` block, for
     one) reaches edge-api.
@@ -246,3 +248,40 @@ async def get_task(task_id: str, request: Request, user=Depends(get_verified_use
 @router.post('/tasks/{task_id}/cancel')
 async def cancel_task(task_id: str, request: Request, user=Depends(get_verified_user)):
     return await _call(request, user, 'POST', f'/agent/tasks/{_task_id(task_id)}/cancel')
+
+
+def _cursor_param(raw: str | None, name: str) -> str:
+    """Validate one cursor/limit query parameter before it reaches a URL.
+
+    Only plain non-negative integers survive. Anything else (negative,
+    non-numeric, oversized) is a 400 here rather than edge-api's error later,
+    because this is the boundary where the value first becomes part of a URL.
+    """
+    if raw is None:
+        return ''
+    if not raw.isdigit() or len(raw) > 18:
+        raise HTTPException(status_code=400, detail='Invalid cursor.')
+    return f'&{name}={raw}'
+
+
+@router.get('/tasks/{task_id}/events')
+async def list_task_events(
+    task_id: str,
+    request: Request,
+    user=Depends(get_verified_user),
+    after_seq: str | None = None,
+    limit: str | None = None,
+):
+    id_ = _task_id(task_id)
+    qs = _cursor_param(after_seq, 'after_seq') + _cursor_param(limit, 'limit')
+    path = f'/agent/tasks/{id_}/events'
+    if qs:
+        # The leading '&' pairs with a '?' added here; edge-api reads both
+        # params from its own query parsing either way.
+        path += '?' + qs.lstrip('&')
+    return await _call(request, user, 'GET', path)
+
+
+@router.get('/tasks/{task_id}/files')
+async def list_task_files(task_id: str, request: Request, user=Depends(get_verified_user)):
+    return await _call(request, user, 'GET', f'/agent/tasks/{_task_id(task_id)}/files')

--- a/scripts/test_owui_agent_proxy.py
+++ b/scripts/test_owui_agent_proxy.py
@@ -394,15 +394,9 @@ def check_every_route_is_behind_the_session_dependency() -> None:
         ("@router.post('/tasks')", 'async def create_task'),
         ("@router.get('/tasks/{task_id}')", 'async def get_task'),
         ("@router.post('/tasks/{task_id}/cancel')", 'async def cancel_task'),
+        ("@router.get('/tasks/{task_id}/events')", 'async def list_task_events'),
+        ("@router.get('/tasks/{task_id}/files')", 'async def list_task_files'),
     ]
-    for decorator, definition in routes:
-        check(decorator in source, f'missing route {decorator}')
-        start = source.index(definition)
-        signature = source[start : source.index(':\n', start)]
-        check(
-            'Depends(get_verified_user)' in signature,
-            f'{definition} must resolve its principal from the session, not the request',
-        )
     # The inverse of the same rule: no route may read an identity off the wire.
     #
     # Two smells, not three. A third entry, "headers.get('Authorization')", used
@@ -429,6 +423,35 @@ def check_every_route_is_behind_the_session_dependency() -> None:
     )
 
 
+def check_events_cursor_params_are_validated() -> None:
+    """A cursor that is not a plain non-negative integer never reaches a URL."""
+    good = str(uuid4())
+    for bad in ('-1', 'abc', '1.5', ' 2', '999999999999999999999999'):
+        reset()
+        try:
+            run(proxy.list_task_events(good, Request(), USER, after_seq=bad))
+        except HTTPException as exc:
+            check(exc.status_code == 400, f'expected 400 for after_seq {bad!r}')
+        else:
+            failures.append(f'after_seq {bad!r} must be refused before any URL is built')
+        check(RecordingSession.calls == [], f'no upstream call may be made for after_seq {bad!r}')
+
+    reset()
+    RecordingSession.payload = {'events': []}
+    run(proxy.list_task_events(good, Request(), USER, after_seq='5', limit='50'))
+    url = RecordingSession.calls[0]['url']
+    check(
+        url == f'http://edge-api:8080/v1/agent/tasks/{good}/events?after_seq=5&limit=50',
+        f'unexpected events url {url}',
+    )
+    headers = RecordingSession.calls[0]['headers']
+    check(
+        headers.get('Authorization') == 'Bearer hk_shim_key_for_tests'
+        and headers.get(proxy.UPSTREAM_AUTH_HEADER) == 'Bearer user-supabase-token',
+        'the events pass-through must carry the same credential split as the other routes',
+    )
+
+
 for check_fn in (
     check_credentials_land_on_the_right_headers,
     check_no_user_token_is_refused_before_any_upstream_call,
@@ -438,6 +461,7 @@ for check_fn in (
     check_upstream_body_is_returned_verbatim,
     check_no_gateway_configuration_is_a_stated_503,
     check_transport_failures_are_stated_not_raised,
+    check_events_cursor_params_are_validated,
     check_every_route_is_behind_the_session_dependency,
 ):
     check_fn()

--- a/supabase/migrations/20260823_01_agent_task_events.sql
+++ b/supabase/migrations/20260823_01_agent_task_events.sql
@@ -20,7 +20,8 @@ CREATE TABLE public.agent_task_events (
     id              BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     task_id         UUID NOT NULL REFERENCES public.agent_tasks(id) ON DELETE CASCADE,
     seq             BIGINT NOT NULL,
-    source_event_id TEXT NOT NULL DEFAULT '',
+    source_event_id TEXT NOT NULL DEFAULT ''
+                    CHECK (char_length(source_event_id) <= 512),
     kind            TEXT NOT NULL CHECK (kind IN
                       ('status','tool_call','tool_result','message','error','file')),
     payload         JSONB NOT NULL DEFAULT '{}'::jsonb,
@@ -38,10 +39,16 @@ COMMENT ON TABLE public.agent_task_events IS
 CREATE UNIQUE INDEX agent_task_events_source_dedup
     ON public.agent_task_events (task_id, source_event_id) WHERE source_event_id <> '';
 
--- The read path: /v1/agent/tasks/{id}/events?after_seq=N&limit=M resolves to
--- WHERE task_id = $1 AND seq > $2 ORDER BY seq LIMIT $3, which this index
--- serves directly.
-CREATE INDEX agent_task_events_read_idx ON public.agent_task_events (task_id, seq);
+-- The cursor read (/events?after_seq=N&limit=M resolves to WHERE task_id = $1
+-- AND seq > $2 ORDER BY seq LIMIT $3) needs NO index of its own: the implicit
+-- btree of the UNIQUE (task_id, seq) constraint above already serves it,
+-- equality column first, range second, index-ordered output. A dedicated
+-- (task_id, seq) index would duplicate that and double write amplification on
+-- an append-heavy table.
+
+-- Retention support: the purge job scans by age, so it needs this plain btree
+-- or every nightly run sequential-scans the table.
+CREATE INDEX agent_task_events_created_at_idx ON public.agent_task_events (created_at);
 
 ALTER TABLE public.agent_task_events ENABLE ROW LEVEL SECURITY;
 
@@ -75,5 +82,130 @@ END$$;
 -- stricter).
 GRANT SELECT, INSERT ON public.agent_task_events TO hive_app;
 GRANT SELECT ON public.agent_task_events TO auditor_ro;
+
+-- INSERT on the table is not enough: the IDENTITY column draws its values from
+-- this sequence, and hive_app is not the owner, so every append fails with
+-- "permission denied for sequence agent_task_events_id_seq" without these.
+-- Documented failure shape: 20260516_04_phase19_audit_log.sql lines 69-72,
+-- same grant there.
+GRANT USAGE, SELECT ON SEQUENCE public.agent_task_events_id_seq TO hive_app;
+
+-- =============================================================================
+-- Retention (folded in at review rather than left as a fast-follow). Rows carry
+-- up to 64 KiB payloads plus sandbox dumps, so growth is bounded by this job,
+-- following 20260729_02_metering_shadow_verdicts_retention.sql's shape exactly:
+-- one-row configurable window, batched committed deletes over created_at
+-- (indexed above), pg_cron schedule behind guards that degrade to a NOTICE when
+-- pg_cron is absent, re-raising only for a superuser that could have succeeded
+-- (the 20260822_01 asymmetry, issue #615/#645). An operator without pg_cron
+-- invokes CALL public.purge_agent_task_events() from an external scheduler.
+--
+-- Window default: 90 days, the same disk-cost call as the metering verdicts.
+-- These rows DO carry transcript/tool content, so an Enterprise operator with
+-- stricter audit rules lowers it with a plain UPDATE, no migration:
+--   UPDATE public.agent_task_events_retention_config SET retention_days = 30;
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS public.agent_task_events_retention_config (
+    id             smallint PRIMARY KEY DEFAULT 1 CHECK (id = 1), -- singleton row
+    retention_days integer NOT NULL DEFAULT 90 CHECK (retention_days > 0)
+);
+COMMENT ON TABLE public.agent_task_events_retention_config IS
+  'Single-row config for the nightly agent_task_events purge job. UPDATE '
+  'retention_days directly to change the window -- no migration needed. '
+  'Default 90 days; Enterprise self-hosted operators set their own value per '
+  'their audit rules.';
+
+INSERT INTO public.agent_task_events_retention_config (id, retention_days)
+VALUES (1, 90)
+ON CONFLICT (id) DO NOTHING;
+
+-- search_path pinned in the body, not a SET clause on CREATE PROCEDURE: the
+-- SET-clause wrapper sub-transaction rejects the internal COMMIT ("invalid
+-- transaction termination"), the trap 20260729_02 documents from a live
+-- container.
+CREATE OR REPLACE PROCEDURE public.purge_agent_task_events(batch_size integer DEFAULT 500)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    window_days   integer;
+    deleted_count integer;
+BEGIN
+    SET search_path = pg_catalog, pg_temp;
+    SET lock_timeout = '5s';
+
+    SELECT retention_days INTO window_days
+    FROM public.agent_task_events_retention_config
+    WHERE id = 1;
+    window_days := COALESCE(window_days, 90);
+
+    LOOP
+        DELETE FROM public.agent_task_events
+        WHERE id IN (
+            SELECT id FROM public.agent_task_events
+            WHERE created_at < now() - (window_days || ' days')::interval
+            ORDER BY created_at
+            LIMIT batch_size
+        );
+        GET DIAGNOSTICS deleted_count = ROW_COUNT;
+        COMMIT;
+        EXIT WHEN deleted_count < batch_size;
+    END LOOP;
+END;
+$$;
+COMMENT ON PROCEDURE public.purge_agent_task_events(integer) IS
+  'Nightly batched retention delete for agent_task_events (D-045 Wave 3). '
+  'Runs as a loop of bounded DELETEs, each its own committed transaction, so '
+  'no single lock is held for the full purge. Window comes from '
+  'agent_task_events_retention_config, not a literal here.';
+
+DO $pg_cron_setup$
+DECLARE
+    pg_cron_available boolean;
+    is_super          boolean;
+BEGIN
+    SELECT EXISTS (
+        SELECT 1 FROM pg_available_extensions WHERE name = 'pg_cron'
+    ) INTO pg_cron_available;
+    SELECT rolsuper INTO is_super FROM pg_roles WHERE rolname = current_user;
+
+    IF pg_cron_available THEN
+        BEGIN
+            EXECUTE 'CREATE EXTENSION IF NOT EXISTS pg_cron';
+        EXCEPTION WHEN OTHERS THEN
+            IF is_super THEN
+                RAISE; -- superuser: nothing else can fix this, so fail loudly
+            END IF;
+            RAISE NOTICE 'pg_cron is available but CREATE EXTENSION failed as non-superuser % (%): no nightly agent-task-event retention job is scheduled by this migration. Schedule it as a role that can create the extension, or invoke CALL public.purge_agent_task_events() from an external scheduler.', current_user, SQLERRM;
+        END;
+    ELSE
+        RAISE NOTICE 'pg_cron is not available on this Postgres install, so no nightly agent-task-event retention job is scheduled here. Invoke CALL public.purge_agent_task_events() from an external scheduler instead. Expected on CI throwaway databases.';
+    END IF;
+END;
+$pg_cron_setup$;
+
+DO $pg_cron_schedule$
+DECLARE
+    is_super boolean;
+BEGIN
+    SELECT rolsuper INTO is_super FROM pg_roles WHERE rolname = current_user;
+
+    IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_cron')
+       AND EXISTS (SELECT 1 FROM pg_available_extensions WHERE name = 'pg_cron') THEN
+        BEGIN
+            PERFORM cron.schedule(
+                'agent-task-events-purge',
+                '0 21 * * *', -- 21:00 UTC = 03:00 Asia/Dhaka, lowest traffic
+                $sched$CALL public.purge_agent_task_events();$sched$
+            );
+        EXCEPTION WHEN OTHERS THEN
+            IF is_super THEN
+                RAISE;
+            END IF;
+            RAISE NOTICE 'cron.schedule failed as non-superuser % (%): no nightly agent-task-event retention job is scheduled by this migration.', current_user, SQLERRM;
+        END;
+    END IF;
+END;
+$pg_cron_schedule$;
 
 COMMIT;

--- a/supabase/migrations/20260823_01_agent_task_events.sql
+++ b/supabase/migrations/20260823_01_agent_task_events.sql
@@ -1,0 +1,79 @@
+-- supabase/migrations/20260823_01_agent_task_events.sql
+--
+-- Agent task event log (D-045 agent-surface rebuild, Wave 3). One row per
+-- sandbox lifecycle/tool-call/message/file event, appended by
+-- apps/control-plane/internal/agenttask's eventsync syncer and served to
+-- customers through /v1/agent/tasks/{id}/events. Append-only by grant: no
+-- UPDATE, no DELETE for hive_app, mirroring public.agent_tasks' posture.
+--
+-- RLS-scoped like public.agent_tasks (20260716_03_agent_tasks.sql): hive_app
+-- is NOT BYPASSRLS (20260518_04_phase19_audit_rls_and_indexes.sql), so every
+-- query runs inside withTenantTx with app.current_tenant_id set LOCAL. User
+-- scoping stays at the application layer via an explicit user_id check on the
+-- parent task before any event read, same as the task table.
+--
+-- Depends on: 20260716_03_agent_tasks.sql (public.agent_tasks).
+
+BEGIN;
+
+CREATE TABLE public.agent_task_events (
+    id              BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    task_id         UUID NOT NULL REFERENCES public.agent_tasks(id) ON DELETE CASCADE,
+    seq             BIGINT NOT NULL,
+    source_event_id TEXT NOT NULL DEFAULT '',
+    kind            TEXT NOT NULL CHECK (kind IN
+                      ('status','tool_call','tool_result','message','error','file')),
+    payload         JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (task_id, seq)
+);
+
+COMMENT ON TABLE public.agent_task_events IS
+  'Append-only event log per agent task (D-045 Wave 3). seq is per-task monotonic, assigned by the syncer inside withTenantTx. source_event_id is the sandbox event id (or a deterministic synthetic id for status/file events) and the partial unique index on it makes a launcher restart degrade to missed events, never duplicated ones. No UPDATE/DELETE grant: rows are never rewritten.';
+
+-- Dedup: a syncer restart or a launcher restart re-pulls the same sandbox
+-- events; this partial unique index (empty source_event_id is exempt, though
+-- every current writer always sets it) turns the re-insert into a no-op via
+-- ON CONFLICT ... DO NOTHING.
+CREATE UNIQUE INDEX agent_task_events_source_dedup
+    ON public.agent_task_events (task_id, source_event_id) WHERE source_event_id <> '';
+
+-- The read path: /v1/agent/tasks/{id}/events?after_seq=N&limit=M resolves to
+-- WHERE task_id = $1 AND seq > $2 ORDER BY seq LIMIT $3, which this index
+-- serves directly.
+CREATE INDEX agent_task_events_read_idx ON public.agent_task_events (task_id, seq);
+
+ALTER TABLE public.agent_task_events ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public' AND tablename = 'agent_task_events'
+          AND policyname = 'agent_task_events_tenant_isolation'
+    ) THEN
+        -- NULLIF(..., '') guards the same Postgres GUC placeholder quirk
+        -- 20260716_03 documents: once a pooled connection has ever called
+        -- set_config('app.current_tenant_id', ..., true), current_setting can
+        -- return '' after the LOCAL scope ends; casting '' to ::uuid raises,
+        -- NULLIF folds it to NULL and the comparison denies by default.
+        CREATE POLICY agent_task_events_tenant_isolation
+            ON public.agent_task_events AS PERMISSIVE FOR ALL TO hive_app
+            -- The event row carries no tenant_id of its own; scoping goes
+            -- through the parent task, whose own RLS sees the same
+            -- app.current_tenant_id inside policy evaluation.
+            USING      (task_id IN (SELECT id FROM public.agent_tasks
+                                    WHERE tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::uuid))
+            WITH CHECK (task_id IN (SELECT id FROM public.agent_tasks
+                                    WHERE tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::uuid));
+    END IF;
+END$$;
+
+-- Append-only grants: SELECT to read through the customer/internal read
+-- routes, INSERT for the syncer. No UPDATE, no DELETE: an event row is never
+-- rewritten (mirrors public.agent_tasks' no-DELETE posture, one step
+-- stricter).
+GRANT SELECT, INSERT ON public.agent_task_events TO hive_app;
+GRANT SELECT ON public.agent_task_events TO auditor_ro;
+
+COMMIT;


### PR DESCRIPTION
# Wave 3 of the D-045 agent-surface rebuild

Plan: vault doc plan-2026-08-23-agent-surface-d045. Closes the verified data gap: real lifecycle, tool-call, message, and workspace-file events now flow sandbox -> DB -> customer API. No UI.

## Mandatory review note

This PR touches input parsing (external sandbox event payloads stored then served to browsers) and authorization on new routes. Per the plan's cross-cutting requirements and the orchestrator contract, adversarial-pr-review with the security-reviewer AND database-reviewer streams is MANDATORY here. Reviewer dispatch must include both specialists alongside the standard streams. Never marked skippable regardless of diff size.

## Modules

- Migration `supabase/migrations/20260823_01_agent_task_events.sql`: append-only event log. RLS tenant isolation scoped through the parent task with the NULLIF(current_setting(...)) pattern from 20260716_03; partial unique dedup index on `(task_id, source_event_id)`; `(task_id, seq)` read index; SELECT+INSERT grants only for hive_app (no UPDATE, no DELETE).
- `apps/control-plane/internal/agenttask/events.go`: TaskEvent types, six kind constants, EventSource seam, rune-safe 2000 char preview truncation, 64 KiB per-event payload cap.
- `apps/control-plane/internal/agenttask/repository.go`: AppendEvents (per-task monotonic seq assigned inside withTenantTx, ON CONFLICT DO NOTHING against the dedup index) and cursor ListEvents.
- `apps/control-plane/internal/agenttask/eventsync.go`: syncer goroutine beside the status poller, behind the same engine-configured gate in cmd/server/main.go. Maps OpenHands kinds onto our vocabulary (ActionEvent -> tool_call, ObservationEvent/UserRejectObservation -> tool_result, MessageEvent -> message, AgentErrorEvent -> error), synthesizes status events with deterministic source ids, derives file events from the workspace listing, and stores any unknown sandbox kind as `status` carrying the raw payload instead of dropping it silently.
- Launcher daemon (`apps/agent-engine/cmd/agent-engine/serve.go`): POST /events and POST /files over the existing internal-token Unix socket; SandboxEngine.Events reads the sandbox conversation event store through controlclient.SearchEvents with pagination follow, Files lists the workspace bind mount (name, size, mtime only).
- Both engine arms satisfy agenttask.EventSource via small adapters in `apps/control-plane/internal/agentengine/events.go`; types re-exported through engineapi so no internal-package boundary is crossed.
- Internal route GET `/internal/agent-tasks/{tenant}/{user}/{task}/events?after_seq=&limit=` plus `.../files`.
- edge-api customer routes GET `/v1/agent/tasks/{id}/events` (cursor after_seq default 0, non-numeric or negative = 400 never zeroed, limit default 100 clamped at 500) and GET `/v1/agent/tasks/{id}/files`, same Supabase bearer scoping and unchanged ENABLE_COWORK gate as the existing routes (404 across users).
- OWUI proxy (Wave 1 addition folded into this wave): pass-through GET `/api/v1/hive/agent/tasks/{id}/events` and `.../files` on hive_agent_proxy.py, uuid-validated task ids, digit-validated cursor params, same auth dependency and forwarding posture as the four existing routes. The apply script's splice is router-level, so its asserted insertion already covers the two new routes; assertions unchanged and still passing.
- SYNC_CONTRACT.md updated with both endpoints and every payload shape.

## Bounds

Previews truncate at 2000 runes (multibyte safe); each stored event payload caps at 64 KiB, oversized replaced by a truncation marker keeping the original size.

## Tests

Table-driven units per module (mapper, bounds helpers, syncer behavior including terminal-status tracking, cursor validation, limit clamp, auth failures, path parsing). Repository tests run against the real migration SQL and skip without HIVE_TEST_DB_URL like every other repository test. Integration test of controlclient.SearchEvents against a recorded fixture of OpenHands search responses across two pages. Full short suites for control-plane, edge-api and agent-engine green locally via the compose toolchain image after rebasing onto #973.

## Pending live capture

Acceptance items requiring a LIVE stack (rows appearing during a real integration run, launcher-restart degradation) are pending-live-capture; everything statically provable is proven above.
