### PR TITLE
fix: make the sandbox browser binary lookup HOME-independent

### DIFF
--- a/deploy/apptainer/agent-engine.def
+++ b/deploy/apptainer/agent-engine.def
@@ -81,13 +81,34 @@ From: nikolaik/python-nodejs:python3.12-nodejs22-bookworm
     # x86-64 only, so Playwright's own bundled Chromium download works
     # normally: no distro-Chromium workaround needed (that was only ever
     # required for arm64, which this box does not target).
+    #
+    # PLAYWRIGHT_BROWSERS_PATH pins the browser install to /opt/ms-playwright
+    # instead of the default $HOME/.cache/ms-playwright. The sandbox launches
+    # with --containall (apps/agent-engine/internal/sandbox), which replaces
+    # HOME with a per-session temp dir, so a browser cached under the image's
+    # root home is unreachable at runtime. /opt is part of the image and
+    # survives containment.
+    export PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright
     python3 -m playwright install --with-deps chromium
+
+    # openhands-tools' browser tool resolves the binary itself
+    # (vendor/openhands/openhands-tools/openhands/tools/browser_use/impl.py,
+    # check_chromium_available) and that scan checks standard install paths
+    # and PATH but not PLAYWRIGHT_BROWSERS_PATH, so expose the downloaded
+    # Chromium at a location that scan already covers. set -eu makes an empty
+    # find result fail the build loud instead of shipping a dangling link.
+    ln -sfn \
+        "$(find /opt/ms-playwright -type f -name chrome -path '*chrome-linux*' | head -n1)" \
+        /usr/bin/chromium
 
     mkdir -p /workspace
     chmod 0777 /workspace
 
 %environment
     export RUNTIME=process
+    # Same path the %post install above pinned; keeps any Playwright-API
+    # consumer (and future tool code) pointed at the HOME-independent cache.
+    export PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright
 
 %runscript
     # The sandbox launches with --net --network none

--- a/docs/proof/sandbox-browser-path/static-proof.log
+++ b/docs/proof/sandbox-browser-path/static-proof.log
@@ -1,0 +1,60 @@
+# Static proof: PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright lands browsers outside HOME
+Date: 2026-08-23T12:48:47Z
+Base image: nikolaik/python-nodejs:python3.12-nodejs22-bookworm (same as agent-engine.def From)
+Commands mirror deploy/apptainer/agent-engine.def %post browser block.
+---
+Unable to find image 'nikolaik/python-nodejs:python3.12-nodejs22-bookworm' locally
+python3.12-nodejs22-bookworm: Pulling from nikolaik/python-nodejs
+34e7f1cb7a29: Pulling fs layer
+957d7edbe91a: Pulling fs layer
+2dd2dd4f152b: Pulling fs layer
+478b71b3aa44: Pulling fs layer
+70d6fabcd00c: Pulling fs layer
+4e52cc066ec8: Pulling fs layer
+cc836a4a4441: Pulling fs layer
+bd0ec93c9c52: Pulling fs layer
+c4013e1e3834: Pulling fs layer
+071836a5e5d5: Pulling fs layer
+4b6bf4040e90: Pulling fs layer
+8c25b52dcbc8: Pulling fs layer
+f28fcf489c65: Download complete
+071836a5e5d5: Download complete
+957d7edbe91a: Download complete
+4e52cc066ec8: Download complete
+cc836a4a4441: Download complete
+4b6bf4040e90: Download complete
+bd0ec93c9c52: Download complete
+70d6fabcd00c: Download complete
+c4013e1e3834: Download complete
+c4013e1e3834: Pull complete
+8c25b52dcbc8: Download complete
+bd0ec93c9c52: Pull complete
+2dd2dd4f152b: Download complete
+478b71b3aa44: Download complete
+2dd2dd4f152b: Pull complete
+34e7f1cb7a29: Download complete
+34e7f1cb7a29: Pull complete
+4e52cc066ec8: Pull complete
+70d6fabcd00c: Pull complete
+071836a5e5d5: Pull complete
+957d7edbe91a: Pull complete
+4b6bf4040e90: Pull complete
+8c25b52dcbc8: Pull complete
+cc836a4a4441: Pull complete
+478b71b3aa44: Pull complete
+Digest: sha256:c0d1856945dd471fe29666957a13ac3880e8b348086632c179cb4d0eb61da92a
+Status: Downloaded newer image for nikolaik/python-nodejs:python3.12-nodejs22-bookworm
+WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.
+
+[notice] A new release of pip is available: 26.1.2 -> 26.2.1
+[notice] To update, run: pip install --upgrade pip
+[1] dirs under /opt/ms-playwright:
+chromium-1234
+chromium_headless_shell-1234
+ffmpeg-1011
+[2] found binary: /opt/ms-playwright/chromium-1234/chrome-linux64/chrome
+[3] readlink /usr/bin/chromium -> /opt/ms-playwright/chromium-1234/chrome-linux64/chrome
+[4] launch under simulated --containall HOME (per-session temp dir):
+Google Chrome for Testing 151.0.7922.34 
+[5] default-HOME cache absent as expected:
+ls: cannot access '/root/.cache/ms-playwright': No such file or directory


### PR DESCRIPTION
Fixes the sandbox browser capability being unreachable despite Chromium shipping in the image.

## Mechanism (why it fails)

`apps/agent-engine/internal/sandbox.BuildArgv` launches every session with `--containall`. Apptainer's `--containall` implies `--contain`, which replaces `HOME` with a fresh per-session temp directory. `%post` installed Playwright's Chromium under the image root's `$HOME/.cache/ms-playwright`, which stays inside the image but is invisible to every runtime lookup that resolves through `Path.home()`.

The vendored browser tool resolves its binary itself (`vendor/openhands/openhands-tools/openhands/tools/browser_use/impl.py`, `check_chromium_available()`): it scans standard install paths (`/usr/bin/chromium` etc.), then `Path.home()/.cache/ms-playwright`, then `PATH`. It does **not** read `PLAYWRIGHT_BROWSERS_PATH`.

## Change

`deploy/apptainer/agent-engine.def` only:

1. `%post`: pin the install with `PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright` so browsers land in a HOME-independent image path, then symlink the downloaded chrome binary to `/usr/bin/chromium`, a location the vendored scan already covers.
2. `%environment`: export `PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright` so any Playwright-API consumer agrees with the install location.

No Go change: grep over `apps/` found zero references to `ms-playwright` or browser paths in Go code; binary resolution lives entirely in the vendored Python tool. Egress proxy, allowlists, and timeout config untouched (verified correct as-is).

## Static proof

Captured in `docs/proof/sandbox-browser-path/static-proof.log`: same base image as the def's `From:` line, running the exact `%post` browser block. Browsers land under `/opt/ms-playwright`, `/usr/bin/chromium` resolves to the downloaded binary, and the binary launches under a simulated containment HOME (`env HOME=/tmp/per-session-home ...`). The default-HOME cache does not exist afterward, proving the old layout was indeed HOME-bound. No credentials involved.

## SIF rebuild path

The `agent-engine SIF` workflow triggers on `pull_request` for changes under `deploy/apptainer/**`, so CI builds the SIF on this PR branch; the artifact is downloadable from the run. After merge, the push to `main` triggers the workflow again, and the demo host must download and install the rebuilt artifact (`gh run download -n agent-engine-sif -D /opt/hive`) before any live behavior changes. Deploy is out of scope for this PR.

## Live proof

Live BEFORE evidence could not be captured by this branch: submitting an agent task to the box requires an authenticated user JWT against edge-api `/v1/agent/tasks`, and this session holds none. Marked pending-live-capture honestly.

Post-merge AFTER capture steps (whoever deploys):

1. Install the rebuilt SIF on the host (`gh run download -n agent-engine-sif -D /opt/hive`, then follow `deploy/apptainer/README.md`).
2. Submit one agent task whose instructions ask the agent to open https://example.com through its browser tool and report the page title.
3. Expect success: title "Example Domain". On the pre-fix image the same task fails with "Chromium is required for browser operations but is not installed".
4. Capture the task transcript and save the redacted log under `docs/proof/sandbox-browser-path/live-proof.log`.

## CI on this PR

`Build agent-engine.sif` passes on this branch (4m17s) and publishes the artifact. `Capture Cowork proof (real Apptainer launch)` initially failed on a startup race (it resolves the SIF artifact before the SIF run finishes on a fresh branch); the failed-step rerun passed, launching this exact image end to end through a real rootless Apptainer start plus the full proof stack.

## Buglog entry

```json
{"ts":"2026-08-23","error_message":"Chromium is required for browser operations but is not installed","root_cause":"the agent-engine launcher starts every session with --containall, which replaces HOME with a per-session temp dir, while playwright installed Chromium under /root/.cache/ms-playwright at build time; the vendored check_chromium_available scan covers standard install paths, the HOME cache and PATH but never reads PLAYWRIGHT_BROWSERS_PATH","fix":"pin PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright in deploy/apptainer/agent-engine.def %post and %environment and symlink the downloaded chrome binary to /usr/bin/chromium so the vendored scan finds it regardless of HOME","tags":["agent-engine","apptainer","playwright","containment"]}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Chromium availability in packaged environments by standardizing the browser installation location.
  * Added a system-level Chromium link to support browser-based functionality reliably.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->