### PR TITLE
perf: serve compressed responses from caddy

### DIFF
--- a/deploy/docker/Caddyfile.console
+++ b/deploy/docker/Caddyfile.console
@@ -19,6 +19,11 @@
 # upstream that derives an absolute URL from request scheme sees the scheme
 # users actually arrive on, same pattern as Caddyfile.owui.
 http://{$CONSOLE_DOMAIN:console.localhost} {
+  # Compress compressible responses for every route in this block (directives
+  # are sorted, so encode wraps the handle and reverse_proxy blocks below).
+  # Already-compressed content types (images, video, archives) are excluded by
+  # Caddy's default compression filter.
+  encode zstd gzip
   # The public auth origin, served from this app's OWN origin rather than a
   # second public hostname.
   #

--- a/deploy/docker/Caddyfile.owui
+++ b/deploy/docker/Caddyfile.owui
@@ -12,6 +12,11 @@
 # on purpose: this listener is published on a host port, so an incoming
 # X-Forwarded-Proto is attacker-controlled and must not be believed.
 :80 {
+  # Compress compressible responses for every route in this block (directives
+  # are sorted, so encode wraps the matchers, respond and reverse_proxy below).
+  # Already-compressed content types (images, video, archives) are excluded by
+  # Caddy's default compression filter.
+  encode zstd gzip
   # Defence-in-depth admin block. Open WebUI's env flags can regress across
   # releases (admin panel re-enabled by a misconfigured chart), so the proxy
   # answers 404 on every variant of the admin and signup paths regardless of


### PR DESCRIPTION
## What

Adds a site level `encode zstd gzip` directive to the two app Caddyfiles:

- `deploy/docker/Caddyfile.owui`: right after the `:80 {` site block opening
- ` deploy/docker/Caddyfile.console`: right after the `http://{$CONSOLE_DOMAIN:console.localhost} {` opening

Caddy sorts directives, so `encode` wraps every route in each block (matchers, respond, reverse_proxy, handle groups). Compressible responses (JS, CSS, JSON, HTML) now leave Caddy compressed; already-compressed content types are excluded by Caddy's default filter.

## Why brotli is not in the list

The pinned image `caddy:2-alpine@sha256:86deaf5e...794` ships only the gzip and zstd encoders. `encode zstd br gzip` fails `caddy validate` on it with `module not registered: http.encoders.br`, and the deploy workflow validates with that same pinned binary, so brotli would have blocked the deploy. zstd and gzip cover every current browser.

## Deploy pickup

`.github/workflows/deploy-demo-box.yml` lines 736 to 836 validate the host files with the pinned image and then reload or recreate `caddy-owui` and `caddy-console` when the mounted file differs by inode, so this reaches both proxies automatically after merge.

## Proof

Pending live capture by design: there is no local running stack to capture against, so `docs/proof/caddy-encode/` is intentionally not created.

Post-merge check on the deployed box (expecting `content-encoding: gzip`, since brotli is unavailable in the pinned image):

```
curl -H 'Accept-Encoding: gzip' -sI https://chat-hive.scubed.co/_app/immutable/<chunk>.js
# expect: content-encoding: gzip
```