### PR TITLE
fix: cut redundant login redirects and dead terminal probe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ test-scripts:
 	python3 scripts/restore-storage-objects.py --self-check
 	python3 scripts/test_owui_oauth_client_auth.py
 	python3 scripts/test_owui_agent_proxy.py
+	python3 scripts/test_owui_oauth_callback_landing.py
 
 # Node, not python, and it downloads a pinned vitest, so it is deliberately not
 # folded into test-scripts, which is pure python with no network.

--- a/deploy/docker/Dockerfile.open-webui
+++ b/deploy/docker/Dockerfile.open-webui
@@ -263,6 +263,20 @@ COPY deploy/docker/owui-patches/apply_oauth_client_auth_patch.py /tmp/apply_oaut
 RUN python3 /tmp/apply_oauth_client_auth_patch.py \
     && test "$(grep -c '\*\*hive_refresh_request(client, refresh_data),' /app/backend/open_webui/utils/oauth.py)" = "2" \
     && python3 -c "import ast, pathlib; ast.parse(pathlib.Path('/app/backend/open_webui/utils/oauth.py').read_text())"
+# A repeat sign-in paid one extra full HTML document for nothing: the OAuth
+# callback redirected to /auth, whose only job was converting the token cookie
+# into a stored session before client-side navigating to / anyway. The root
+# layout in the frontend source now performs that conversion itself (the
+# `token=` recovery block in vendor/open-webui/src/routes/+layout.svelte), so
+# the success leg lands directly on `/`. The error leg is deliberately left
+# alone: its display lives on the sign-in page, and the patch asserts that leg
+# keeps targeting /auth?error=.
+COPY deploy/docker/owui-patches/apply_oauth_callback_landing_patch.py /tmp/apply_oauth_callback_landing_patch.py
+RUN python3 /tmp/apply_oauth_callback_landing_patch.py \
+    && grep -q "redirect_base_url}/'" /app/backend/open_webui/utils/oauth.py \
+    && ! grep -q "redirect_base_url}/auth'" /app/backend/open_webui/utils/oauth.py \
+    && grep -q 'redirect_url}?error=' /app/backend/open_webui/utils/oauth.py \
+    && python3 -c "import ast, pathlib; ast.parse(pathlib.Path('/app/backend/open_webui/utils/oauth.py').read_text())"
 # Chat was broken on every route because Open WebUI attached tool schemas that
 # no route in this deployment can serve.
 #

--- a/deploy/docker/owui-patches/apply_oauth_callback_landing_patch.py
+++ b/deploy/docker/owui-patches/apply_oauth_callback_landing_patch.py
@@ -1,0 +1,51 @@
+"""Build-time splice: send the OAuth callback's success redirect straight to
+the application root instead of /auth.
+
+Upstream redirects every OAuth callback to `/auth`, which converts the token
+cookie into a stored session and then client-side navigates to `/` anyway, so
+a repeat sign-in pays one extra full HTML document for nothing. The frontend
+root layout now recovers the session from that cookie itself (see the
+`token=` recovery block in vendor/open-webui/src/routes/+layout.svelte), so
+the success leg can land directly on `/`.
+
+The error leg is deliberately untouched: it keeps targeting /auth with
+`?error=`, because the error display lives on the sign-in page. The assert
+below pins that, so a future upstream change that reroutes errors cannot slip
+past this patch.
+
+Asserts its own effect and fails the build otherwise, the same posture as
+this Dockerfile's other patches: a future open-webui digest bump whose OAuth
+callback shifted breaks the build loudly rather than silently reintroducing
+the bounce. Running this script twice fails on purpose: after the first run
+the anchor is gone, and a second application would be a silent no-op.
+"""
+
+import ast
+import pathlib
+
+TARGET = pathlib.Path("/app/backend/open_webui/utils/oauth.py")
+ANCHOR = "        redirect_url = f'{redirect_base_url}/auth'\n"
+REPLACEMENT = "        redirect_url = f'{redirect_base_url}/'\n"
+# The error leg must keep landing on the sign-in page where its display lives.
+ERROR_LEG = "redirect_url}?error="
+
+text = TARGET.read_text()
+
+assert text.count(ANCHOR) == 1, (
+    "the OAuth callback success redirect to '/auth' is not present exactly "
+    "once -- upstream open-webui source shifted, patch needs updating"
+)
+assert ERROR_LEG in text, (
+    "the OAuth callback error leg (?error= back to /auth) is missing -- "
+    "upstream open-webui source shifted, patch needs updating"
+)
+
+patched = text.replace(ANCHOR, REPLACEMENT, 1)
+ast.parse(patched)  # never write an oauth.py that cannot be imported
+TARGET.write_text(patched)
+
+# Assert-after: prove the splice landed and the error leg survived it.
+final = TARGET.read_text()
+assert final.count(REPLACEMENT) == 1, "success redirect replacement did not land"
+assert final.count(ANCHOR) == 0, "stale '/auth' success target still present"
+assert ERROR_LEG in final, "error leg was disturbed by the patch"

--- a/docs/proof/login-hop-slimming/README.md
+++ b/docs/proof/login-hop-slimming/README.md
@@ -1,0 +1,112 @@
+# Proof: fix/login-hop-slimming (PR #1078)
+
+No URL in this capture carries a credential, code, state, or token value in
+its query string (the screenshots below never show a browser address bar at
+all, and the only cookie value used is a locally-minted throwaway JWT signed
+with a fixed local test secret that exists nowhere outside this harness), so
+no redaction step applied. Confirmed before writing this file, not assumed.
+
+## Substrate
+
+Not the live scubed.co demo box: no path to it was available in this session.
+Instead, two Docker images built from this repo's own
+`deploy/docker/Dockerfile.open-webui`, the same Dockerfile the demo box
+builds from:
+
+- **AFTER** = `hive-open-webui:login-hop-slimming`, built from this PR's head
+  commit `603a343f71068a4f7aee7c598bb6a874af6f616b`. Confirmed live: the
+  running container's own `/app/backend/open_webui/utils/oauth.py` contains
+  `redirect_url = f'{redirect_base_url}/'` on the success leg.
+- **BEFORE** = `hive-open-webui:mergebase-baseline`, built from `369c07c0`,
+  the merge-base of `fix/login-hop-slimming` and `origin/main`. Built from the
+  merge-base rather than current `main` HEAD because current `main` fails
+  this exact Docker build with a pre-existing, unrelated Svelte error
+  (`<svelte:window>` placement in `src/lib/hive/AgentSchedules.svelte`,
+  introduced by PR #1081 after this branch diverged). Not fixed here, out of
+  this PR's scope; the merge-base predates that commit
+  (`git merge-base --is-ancestor` confirms it), so it is a clean pre-fix
+  baseline. Frontend unit tests passed on both builds during the image build
+  (60/60, including `sso-redirect.test.ts`).
+
+Harness: a real Postgres, a real OWUI backend, and a stub OIDC discovery
+document (a static JSON file, not a real external IdP — none was reachable
+from this environment), driven by real Playwright/Chromium with a
+`history.pushState`/`replaceState` hook injected at document-start so
+SvelteKit's client-side route changes are visible even when they never touch
+the network. No mocking of any OWUI backend endpoint.
+
+## Fix 1: anonymous visitor no longer mounts /auth before the provider redirect
+
+3 runs each, fresh browser context per run:
+
+| run | visited `/auth` (client-side route) | time to `GET /oauth/oidc/login` |
+|---|---|---|
+| BEFORE 1 | yes | 6649ms |
+| BEFORE 2 | yes | 2723ms |
+| BEFORE 3 | yes | 3131ms |
+| AFTER 1 | no | 4291ms |
+| AFTER 2 | no | 3564ms |
+| AFTER 3 | no | 3803ms |
+
+BEFORE visited `/auth` as a client-side route in 3/3 runs before ever
+requesting `/oauth/oidc/login`; AFTER did so in 0/3. This machine runs several
+dozen other concurrent containers during this session, so the absolute-time
+column is noisy (BEFORE's own range spans 2.7s-6.6s); the route-visited column
+is the clean, 100%-consistent signal and is exactly the hop this fix removes.
+
+## Fix 2: OAuth callback lands on / directly instead of bouncing through /auth
+
+Reproduced the exact browser state the instant after a real callback exchange
+(a real, valid `token` cookie set, no `localStorage` token, no prior page
+load), then loaded each build's actual real landing target:
+
+- **BEFORE**, landing on its real target `/auth`: 1 full HTML document load
+  (of `/auth`, a page whose only remaining job here is converting the
+  cookie), then a client-side route change to `/` at t=3400ms once the
+  conversion finishes. See `before-landing-auth-intermediate.png`.
+- **AFTER**, landing on its real target `/`: 1 full HTML document load (of
+  `/`, the actual destination), session recovered from the cookie in place,
+  0 further navigation. See `after-landing-root-signed-in.png`.
+
+Both end up signed in on `/`; BEFORE pays for a full mount-and-render cycle of
+a page that is not the destination, AFTER does not.
+
+Also checked, for completeness, not because it happens in production: what
+BEFORE's *root layout* does if handed a cookie-only session on `/` directly
+(proving the two fixes are correctly yoked together). It does not recognize
+the cookie at all — no cookie-recovery code exists there pre-fix — so it
+takes the anonymous branch, client-routes to `/auth` at t=2964ms, and only
+there does the pre-existing (unrelated to this PR) cookie recovery fire,
+landing back on `/` at t=3187ms. Confirms the callback-target change alone,
+without the frontend cookie-recovery half this PR also ships, would have
+stranded users on an anonymous `/`.
+
+## Fix 3: dead terminals probe
+
+Same authenticated session (a real JWT minted via the real
+`/api/v1/auths/signin` against a real bootstrapped admin user in this
+harness's own Postgres), same backend, only the frontend image swapped:
+
+- BEFORE: `GET /api/v1/terminals/` observed once on chat-layout mount.
+- AFTER: `GET /api/v1/terminals/` observed zero times.
+
+## What this does not cover
+
+This harness never completed a real external IdP code exchange (state/PKCE
+round trip against a live GoTrue instance); none was reachable from this
+environment. That code path (`oauth.py` state validation around line 282,
+PKCE/`code_challenge_method` around line 805) was reviewed directly and
+confirmed both untouched and physically distant from this patch's anchor line
+at ~1966, not exercised end-to-end here. The
+`apply_oauth_callback_landing_patch.py` self-check
+(`scripts/test_owui_oauth_callback_landing.py`) already exercises the real
+patch against the real vendored file and is green in this PR's CI.
+
+## Screenshots
+
+- `before-landing-auth-intermediate.png`: the pre-fix `/auth` page rendered
+  mid-conversion (the "You're now logged in" toast visible, page not yet
+  navigated to `/`) — the wasted document this PR removes from the return
+  leg.
+- `after-landing-root-signed-in.png`: the post-fix landing directly on `/`,
+  already signed in, no intermediate page ever rendered.

--- a/scripts/test_owui_oauth_callback_landing.py
+++ b/scripts/test_owui_oauth_callback_landing.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Self-check for the Open WebUI OAuth callback landing patch.
+
+The callback's success redirect used to hardcode `/auth`, whose only job was
+converting the token cookie into a stored session before client-side
+navigating to `/` anyway; one extra full HTML document per sign-in for
+nothing. apply_oauth_callback_landing_patch.py retargets that leg to `/`,
+leaving the error leg (?error= back to the sign-in page) untouched.
+
+This file runs the real patch script against a throwaway copy of the real
+vendored oauth.py, so a future open-webui digest bump that shifts the callback
+fails here in CI instead of failing an image build on a demo box. It also pins
+the pairing invariant: the frontend half (the token-cookie recovery block in
+the root layout) must exist for the backend retarget to be safe.
+No framework, no network, no Open WebUI import.
+Run: python3 scripts/test_owui_oauth_callback_landing.py
+"""
+import ast
+import pathlib
+import shutil
+import tempfile
+
+REPO = pathlib.Path(__file__).resolve().parents[1]
+PATCH = REPO / "deploy" / "docker" / "owui-patches" / "apply_oauth_callback_landing_patch.py"
+VENDOR_OAUTH = REPO / "vendor" / "open-webui" / "backend" / "open_webui" / "utils" / "oauth.py"
+ROOT_LAYOUT = REPO / "vendor" / "open-webui" / "src" / "routes" / "+layout.svelte"
+
+ANCHOR = "        redirect_url = f'{redirect_base_url}/auth'\n"
+REPLACEMENT = "        redirect_url = f'{redirect_base_url}/'\n"
+ERROR_LEG = "redirect_url}?error="
+RECOVERY_MARK = "rawCookie"
+
+
+def run_patch_against(target_path: pathlib.Path) -> None:
+    """Execute the build-time patch script with its TARGET pointed at a
+    temporary copy instead of the image's /app path."""
+    source = PATCH.read_text()
+    image_path = "/app/backend/open_webui/utils/oauth.py"
+    assert image_path in source, "patch script no longer names its image target"
+    source = source.replace(image_path, str(target_path))
+    exec(compile(source, str(PATCH), "exec"), {"__name__": "__main__"})  # noqa: S102
+
+
+def test_patch_retargets_success_leg_only():
+    with tempfile.TemporaryDirectory() as tmp:
+        target = pathlib.Path(tmp) / "oauth.py"
+        shutil.copy(VENDOR_OAUTH, target)
+
+        run_patch_against(target)
+
+        patched = target.read_text()
+        assert ANCHOR not in patched, "stale '/auth' success target survived"
+        assert patched.count(REPLACEMENT) == 1, "success leg was not retargeted to '/'"
+        assert ERROR_LEG in patched, "error leg must keep landing on the sign-in page"
+        ast.parse(patched), "patched oauth.py does not parse"
+
+
+def test_second_run_fails_loudly():
+    """Idempotence posture: re-application is a silent no-op risk, so it must
+    fail the assertion rather than pass quietly."""
+    with tempfile.TemporaryDirectory() as tmp:
+        target = pathlib.Path(tmp) / "oauth.py"
+        shutil.copy(VENDOR_OAUTH, target)
+        run_patch_against(target)
+        try:
+            run_patch_against(target)
+        except AssertionError:
+            return
+        raise AssertionError("running the patch twice did not fail loudly")
+
+
+def test_shifted_upstream_fails_the_asserts():
+    """A vendor bump that removes or renames the redirect line must trip the
+    patch's own assertion, never silently skip."""
+    with tempfile.TemporaryDirectory() as tmp:
+        target = pathlib.Path(tmp) / "oauth.py"
+        shutil.copy(VENDOR_OAUTH, target)
+        drifted = target.read_text().replace(ANCHOR, "")
+        assert drifted != target.read_text()
+        target.write_text(drifted)
+        try:
+            run_patch_against(target)
+        except AssertionError:
+            return
+        raise AssertionError("drifted upstream passed the patch without its anchor")
+
+
+def test_frontend_half_is_present():
+    """The backend retarget is only safe because the root layout converts the
+    token cookie into a session itself. If that block disappears (an upstream
+    layout rewrite, a bad merge) this check fails before the pair ships
+    half-applied."""
+    layout = ROOT_LAYOUT.read_text()
+    assert RECOVERY_MARK in layout, (
+        "root layout no longer recovers the OAuth token cookie; the callback "
+        "landing patch would strand users on an anonymous page"
+    )
+    assert "ssoAutoRedirectDecision" in layout, (
+        "root layout no longer consults the tested SSO decision function"
+    )
+
+
+def main() -> int:
+    test_patch_retargets_success_leg_only()
+    test_second_run_fails_loudly()
+    test_shifted_upstream_fails_the_asserts()
+    test_frontend_half_is_present()
+    print("ok: oauth callback landing patch retargets '/', keeps ?error= leg, "
+          "fails loudly on drift and reapplication")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/vendor/open-webui/src/routes/(app)/+layout.svelte
+++ b/vendor/open-webui/src/routes/(app)/+layout.svelte
@@ -12,12 +12,11 @@
 	import { getModels, getToolServersData, getVersionUpdates } from '$lib/apis';
 	import { getTools } from '$lib/apis/tools';
 	import { getBanners } from '$lib/apis/configs';
-	import { getTerminalServers } from '$lib/apis/terminal';
 	import { getUserSettings } from '$lib/apis/users';
 	import { setTextScale } from '$lib/utils/text-scale';
 	import { consumeModelPrefetch } from '$lib/hive/model-prefetch';
 
-	import { WEBUI_VERSION, WEBUI_API_BASE_URL } from '$lib/constants';
+	import { WEBUI_VERSION } from '$lib/constants';
 	import { compareVersion } from '$lib/utils';
 
 	import {
@@ -183,18 +182,12 @@
 			terminalServers.set([]);
 		}
 
-		// Fetch terminal servers the user has access to (for FileNav + terminal_id)
-		const systemTerminals = await getTerminalServers(localStorage.token);
-		if (systemTerminals.length > 0) {
-			// Store with proxy URL and session key for FileNav file browsing
-			const terminalEntries = systemTerminals.map((t) => ({
-				id: t.id,
-				url: `${WEBUI_API_BASE_URL}/terminals/${t.id}`,
-				name: t.name,
-				key: localStorage.token
-			}));
-			terminalServers.update((existing) => [...existing, ...terminalEntries]);
-		}
+		// The per-user system terminal probe (`GET /api/v1/terminals/`) was
+		// removed: this deployment runs no terminal service, Caddy blocks the
+		// path outright, and the probe fired on every chat layout mount only to
+		// come back empty. The admin Settings page and the model workspace's
+		// terminal selector keep calling the API on demand for deployments
+		// that do have one.
 	};
 
 	const setBanners = async () => {

--- a/vendor/open-webui/src/routes/+layout.svelte
+++ b/vendor/open-webui/src/routes/+layout.svelte
@@ -58,6 +58,14 @@
 	import { executeToolServer, getBackendConfig, getModels, getVersion } from '$lib/apis';
 	import { getSessionUser, updateUserTimezone, userSignOut } from '$lib/apis/auths';
 	import { isAuthenticatedConfig, prefetchModels } from '$lib/hive/model-prefetch';
+	import {
+		clearSignedOut,
+		clearSsoAttempt,
+		markSsoAttempt,
+		readSsoAttemptAt,
+		readSignedOut,
+		ssoAutoRedirectDecision
+	} from '$lib/hive/sso-redirect';
 	import { getAllTags, getChatList } from '$lib/apis/chats';
 	import { chatCompletion } from '$lib/apis/openai';
 	import {
@@ -1103,7 +1111,29 @@
 		// the deployment, so the depth of the chain, rather than any single
 		// slow call, is what kept the composer off screen. Start all three
 		// here and await each result at the point it is first needed.
-		const startupToken = localStorage.token;
+		let startupToken = localStorage.token;
+		// An OAuth round trip lands directly on this application now: the
+		// callback's success redirect targets `/` rather than `/auth` (see the
+		// apply_oauth_callback_landing_patch.py splice in Dockerfile.open-webui).
+		// The round trip's only artifact is the `token` cookie, so recover the
+		// session here instead of bouncing through /auth to do it. The cookie is
+		// only trusted after the server validates it; an invalid or stale cookie
+		// falls through to the anonymous path below unchanged.
+		if (!startupToken) {
+			const rawCookie = document.cookie
+				.split('; ')
+				.find((cookie) => cookie.startsWith('token='));
+			if (rawCookie) {
+				const cookieToken = decodeURIComponent(rawCookie.split('=')[1] ?? '');
+				const cookieSession = await getSessionUser(cookieToken).catch(() => null);
+				if (cookieSession) {
+					clearSsoAttempt();
+					clearSignedOut();
+					localStorage.token = cookieToken;
+					startupToken = cookieToken;
+				}
+			}
+		}
 		const sessionUserRequest = startupToken
 			? getSessionUser(startupToken).catch((error) => {
 					toast.error(`${error}`);
@@ -1214,6 +1244,28 @@
 					// Don't redirect if we're already on the auth page
 					// Needed because we pass in tokens from OAuth logins via URL fragments
 					if ($page.url.pathname !== '/auth') {
+						// On an SSO-only deployment the /auth intermediate state is a
+						// wasted full-page hop: the sign-in page would immediately hand
+						// this visitor to the single configured provider anyway. Decide
+						// that here with the same tested decision function the sign-in
+						// page uses, so every guard (auto_redirect off, an error landing,
+						// the signed-out marker, a recent failed attempt, any second
+						// auth mode, onboarding) keeps the old route. The attempt stamp
+						// is written before leaving for the same reason it is there:
+						// an unrecorded attempt is how an endless bounce starts.
+						const decision = ssoAutoRedirectDecision($config, {
+							lastAttemptAt: readSsoAttemptAt(),
+							now: Date.now(),
+							signedOut: readSignedOut(),
+							hasSession: false
+						});
+						if (decision.redirect && markSsoAttempt()) {
+							if (currentUrl !== '/') {
+								localStorage.setItem('redirectPath', currentUrl);
+							}
+							window.location.href = `${WEBUI_BASE_URL}/oauth/${decision.provider}/login`;
+							return;
+						}
 						await goto(`/auth?redirect=${encodedUrl}`);
 					}
 				}


### PR DESCRIPTION
## Summary

A measured repeat sign-in cost 3 full HTML loads plus 3 redirects across two origins for one session grant. Two of those hops are removable code, not network physics, and a third request is pure waste:

1. **Root layout /auth intermediate state** (vendor/open-webui/src/routes/+layout.svelte). Every anonymous visitor was pushed into `/auth` before the automatic SSO-only redirect fired. The layout now consults the same tested `ssoAutoRedirectDecision` function the sign-in page uses, and when it says redirect, the layout jumps straight to the provider login endpoint, marking the attempt stamp first (an unrecorded attempt is how an endless bounce starts).
2. **OAuth callback success leg** (backend/open_webui/utils/oauth.py:1966). Upstream hardcodes `{base}/auth`, whose only job was converting the token cookie into a stored session before client-side navigating to `/` anyway. Backend edits are inert in this image build unless shipped as source surgery, so this lands as an asserted patch in `deploy/docker/owui-patches/apply_oauth_callback_landing_patch.py` following the `apply_rag_env_config_patch.py` posture: assert-before, splice, ast.parse, assert-after. The error leg is deliberately untouched and pinned by assertion: it keeps landing on `/auth?error=` where the error display lives. The frontend counterpart lives in the root layout: with no stored token but a `token` cookie present, it validates the cookie server-side via `getSessionUser` and adopts the session, so the callback can land directly on `/`.
3. **Dead terminals probe** ((app)/+layout.svelte). `GET /api/v1/terminals/` fired on every chat layout mount although no terminal service exists in this deployment and Caddy blocks the path outright (#770). Probe removed. The admin Settings page and the model workspace terminal selector keep their on-demand calls.

## Guards preserved

- `/auth` stays reachable whenever `auto_redirect` is false, an OAuth error lands (`?error=`), the signed-out marker is set, a recent attempt is within the 15s retry window, a second auth mode exists (login form on, LDAP, trusted header), or onboarding has not finished. All decided by the unchanged, already-tested `ssoAutoRedirectDecision`.
- Cookie recovery validates against the server before trusting anything; an invalid or stale cookie falls through to the anonymous path exactly as before.
- No auth guard weakened: the cookie is never trusted without a successful `getSessionUser`.
- Independently re-verified in review (see Security review below): the callback's redirect-base-url computation, the OAuth state/PKCE validation, and the error leg are all untouched by and physically distant from the patched line.

## Tests

- New self-check `scripts/test_owui_oauth_callback_landing.py` (wired into `make test-scripts`): runs the real patch script against a copy of the real vendored oauth.py, asserts the retarget, that reapplication fails loudly, that upstream drift trips the asserts, and that the frontend half still exists so the pair cannot ship half-applied.
- Existing suites green: `make test-owui-frontend` 57/57 (includes the sso-redirect decision suite).

## Verification: live measurement (not reasoning)

Full methodology and results: `docs/proof/login-hop-slimming/README.md`, and posted as a PR review comment. Substrate: a local harness built from this PR's own `deploy/docker/Dockerfile.open-webui` (real Postgres, real OWUI backend, stub OIDC discovery, real Playwright/Chromium), not the live demo box (no path to it in this session). BEFORE image built from the merge-base with `main` (`369c07c0`), since current `main` HEAD fails this same Docker build on an unrelated, pre-existing Svelte error introduced after this branch diverged (see "Found during this review" below).

- **Fix 1** (root-layout skip): 3/3 BEFORE runs client-routed through `/auth` before requesting `/oauth/oidc/login`; 0/3 AFTER runs did.
- **Fix 2** (callback landing): BEFORE's real landing target `/auth` costs one full document load of a page whose only job is converting the cookie, then a client-side bounce to `/`; AFTER's real landing target `/` recovers the session in the same one document load with zero further navigation.
- **Fix 3** (terminals probe): BEFORE fires `GET /api/v1/terminals/` once per chat-layout mount; AFTER fires it zero times, same authenticated session, same backend.

## Review

- **CodeRabbit CLI**: attempted twice (`coderabbit review --committed --base main`), both times hit the account's review-limit rate cap. **SKIPPED**, not counted as a clean pass.
- **`ecc:code-review`**: this review pass's toolset had no Skill/Agent dispatch capability to invoke it directly. **SKIPPED** (structural capability gap); substance covered by the plain adversarial pass.
- **Security review (mandatory, auth path)**: performed directly, posted in full as a PR review comment. Verdict: no security regression. Redirect target, cookie trust boundary, redirect-path guard, and state/nonce/PKCE validation all confirmed unweakened, confirmed live where possible rather than only read from source.
- **Plain adversarial pass**: performed directly, posted in full as a PR review comment. No blocking findings.

## Found during this review (informational, not fixed here)

`origin/main` HEAD currently fails `docker build -f deploy/docker/Dockerfile.open-webui`: a `<svelte:window>` tag placed inside a conditional block in `src/lib/hive/AgentSchedules.svelte` (landed via PR #1081, after this branch diverged) is invalid Svelte and fails the frontend build stage. No CI job builds this Docker image for a non-fork PR, so this went undetected. Not fixed in this PR (out of scope, unrelated file). Filed as #1090.

## Buglog entry

```json
{"id":"bug-2026-08-23-owui-login-hop-waste","date":"2026-08-23","title":"Repeat OWUI sign-in paid three full HTML document loads and three redirects for one session grant","error_message":"Anonymous visit to / always rendered /auth before an SSO-only auto-redirect fired, and the OAuth callback's success leg always landed back on /auth (whose only job was converting the token cookie) before a second navigation to /","root_cause":"The root layout had no auto-redirect decision of its own and no cookie-recovery logic, so every anonymous visitor was pushed through the sign-in page's own SPA route even on a single-provider SSO-only deployment where that page always immediately hands off to the provider anyway; the OAuth callback's backend redirect target was hardcoded to /auth for the same reason, one full document load whose only purpose was to run that same conversion before bouncing to / regardless of outcome.","fix":"Root layout now consults the existing, already-tested ssoAutoRedirectDecision (the same function the sign-in page uses) before falling through to /auth, and recovers a session from the token cookie itself (via a real getSessionUser server round trip) so the callback's success leg can target / directly. Backend retarget shipped as an asserted source-surgery patch (deploy/docker/owui-patches/apply_oauth_callback_landing_patch.py) since backend edits under vendor/open-webui are otherwise inert in this image build; error leg pinned untouched by the same patch's assertions. A dead GET /api/v1/terminals/ probe on every chat-layout mount was removed in the same pass. Verified live: a local harness built from this PR's own Dockerfile showed 0/3 post-fix runs visiting /auth on an anonymous SSO redirect versus 3/3 pre-fix, and a cookie-only landing on / settling signed in with zero further navigation post-fix versus one full /auth document load plus a client-side bounce pre-fix.","tags":["owui","oauth","sso","redirect","login-latency","open-webui","pr-1078"],"pr":1078}
```

## Proof plan

Playwright journey against a stack built from this branch, counting HTML document loads and 3xx across one full unauthenticated sign-in through to first chat view. BEFORE baseline: 3 loads / 3 redirects (measured live pre-change). AFTER must be strictly lower with zero behavior loss; error path must render the sign-in UI. Captures + redacted logs under docs/proof/login-hop-slimming/, key screenshot posted via scripts/post-pr-visual-proof.sh.

Auth-path adjacent: adversarial review mandatory per pipeline.
