### PR TITLE
feat: scheduled agent tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -442,7 +442,7 @@ jobs:
             # query is the only place an over-released reservation can be caught,
             # and the proof that it no longer renders one as a hold has to run
             # against real Postgres.
-            go test -tags integration -count=1 -p 1 -v ./internal/accounts/... ./internal/accounting/... ./internal/ledger/... ./internal/agenttask/... ./internal/usermemories/... ./internal/egress/... ./internal/payments/... ./internal/profiles/... ./internal/rag/... ./internal/tenants/... ./internal/signup/... ./internal/routing/... ./internal/litellmconfig/... ./internal/catalog/... ./internal/providers/... ./internal/platform ./internal/platform/db/...
+            go test -tags integration -count=1 -p 1 -v ./internal/accounts/... ./internal/accounting/... ./internal/ledger/... ./internal/agentsched/... ./internal/agenttask/... ./internal/usermemories/... ./internal/egress/... ./internal/payments/... ./internal/profiles/... ./internal/rag/... ./internal/tenants/... ./internal/signup/... ./internal/routing/... ./internal/litellmconfig/... ./internal/catalog/... ./internal/providers/... ./internal/platform ./internal/platform/db/...
           else
             # -tags integration additionally compiles in
             # inference/chat_completions_integration_test.go (issue #708),

--- a/apps/control-plane/cmd/server/main.go
+++ b/apps/control-plane/cmd/server/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/accounting"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/accounts"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/agentengine"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/agentsched"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/agenttask"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/apikeys"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/audit"
@@ -1046,8 +1047,11 @@ func main() {
 	// apps/control-plane/internal/agenttask/SYNC_CONTRACT.md's Engine seam
 	// section for why the real Engine is still conditional on deployment
 	// env vars rather than unconditionally wired.
-	var agentTaskHandler *agenttask.Handler
-	var userMemoriesHandler *usermemories.Handler
+	var (
+		agentTaskHandler     *agenttask.Handler
+		agentScheduleHandler *agentsched.Handler
+		userMemoriesHandler  *usermemories.Handler
+	)
 	if pool != nil {
 		agentTaskRepo := agenttask.NewPgxRepository(pool)
 		agentEngine, agentEngineStatus := buildAgentEngine(egressSvc)
@@ -1075,6 +1079,28 @@ func main() {
 			poller.Start(runCtx)
 			defer poller.Stop()
 			log.Println("agent task status poller started")
+		}
+
+		// Scheduled agent tasks ("routines"): the CRUD surface plus the
+		// minute tick that turns due schedules into real tasks through
+		// agentTaskSvc.CreateTask — the SAME service path a manual creation
+		// uses, so metering, quota and engine gating apply to scheduled runs
+		// identically. The scheduler only starts when the engine itself is
+		// configured (same gate as the poller above): without an engine every
+		// scheduled run would fail into last_error and burn a cadence per
+		// deployment restart for nothing.
+		scheduleRepo := agentsched.NewPgxRepository(pool)
+		scheduleSvc := agentsched.NewService(scheduleRepo, nil)
+		agentScheduleHandler = agentsched.NewHandler(scheduleSvc)
+
+		if agentEngineStatus != nil {
+			scheduler := agentsched.NewScheduler(scheduleRepo, agentTaskSvc, agentsched.SchedulerConfig{
+				Interval: parseDurationEnv("HIVE_AGENT_SCHEDULER_INTERVAL", time.Minute),
+				Logger:   slog.Default(),
+			})
+			scheduler.Start(runCtx)
+			defer scheduler.Stop()
+			log.Println("agent task scheduler started")
 		}
 	}
 
@@ -1107,6 +1133,7 @@ func main() {
 		EgressPolicyHandler:      egressPolicyHandler,
 		MarketplaceHandler:       marketplaceHandler,
 		AgentTaskHandler:         agentTaskHandler,
+		AgentScheduleHandler:     agentScheduleHandler,
 		UserMemoriesHandler:      userMemoriesHandler,
 		RoutingHandler:           routingHandler,
 		UsageHandler:             usageHandler,

--- a/apps/control-plane/internal/agentsched/fake_repo_test.go
+++ b/apps/control-plane/internal/agentsched/fake_repo_test.go
@@ -1,0 +1,165 @@
+package agentsched
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// fakeRepo is an in-memory agentsched.Repository implementing the claim
+// semantics of public.agent_task_schedules_claim_due in miniature: filters by
+// enabled and next_run_at <= now, advances next_run_at at claim time, so the
+// scheduler's due/not-due/disabled/concurrent-tick-once guarantees are tested
+// against the same shape as the SQL.
+type fakeRepo struct {
+	mu        sync.Mutex
+	rows      map[uuid.UUID]*Schedule
+	created   []Schedule
+	failures  []string // recorded failure messages
+	successes int
+
+	claimErr error
+}
+
+func newFakeRepo(rows ...Schedule) *fakeRepo {
+	f := &fakeRepo{rows: make(map[uuid.UUID]*Schedule)}
+	for i := range rows {
+		s := rows[i]
+		f.rows[s.ID] = &s
+	}
+	return f
+}
+
+func (f *fakeRepo) Create(ctx context.Context, s Schedule) (Schedule, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if s.ID == uuid.Nil {
+		s.ID = uuid.New()
+	}
+	out := s
+	f.rows[s.ID] = &out
+	f.created = append(f.created, out)
+	return out, nil
+}
+
+func (f *fakeRepo) Get(ctx context.Context, tenantID, userID, id uuid.UUID) (Schedule, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	row := f.rows[id]
+	if row == nil || row.TenantID != tenantID || row.UserID != userID {
+		return Schedule{}, ErrNotFound
+	}
+	return *row, nil
+}
+
+func (f *fakeRepo) List(ctx context.Context, tenantID, userID uuid.UUID) ([]Schedule, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var out []Schedule
+	for _, row := range f.rows {
+		if row.TenantID == tenantID && row.UserID == userID {
+			out = append(out, *row)
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeRepo) Update(ctx context.Context, s Schedule) (Schedule, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	row := f.rows[s.ID]
+	if row == nil || row.TenantID != s.TenantID || row.UserID != s.UserID {
+		return Schedule{}, ErrNotFound
+	}
+	out := *row
+	out.Name = s.Name
+	out.Instructions = s.Instructions
+	out.Schedule = s.Schedule
+	out.Enabled = s.Enabled
+	out.NextRunAt = s.NextRunAt
+	out.UpdatedAt = time.Now()
+	f.rows[s.ID] = &out
+	return out, nil
+}
+
+func (f *fakeRepo) SetEnabled(ctx context.Context, tenantID, userID, id uuid.UUID, enabled bool, nextRunAt *time.Time) (Schedule, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	row := f.rows[id]
+	if row == nil || row.TenantID != tenantID || row.UserID != userID {
+		return Schedule{}, ErrNotFound
+	}
+	out := *row
+	out.Enabled = enabled
+	if nextRunAt != nil && enabled {
+		out.NextRunAt = nextRunAt
+	}
+	f.rows[id] = &out
+	return out, nil
+}
+
+func (f *fakeRepo) Delete(ctx context.Context, tenantID, userID, id uuid.UUID) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	row := f.rows[id]
+	if row == nil || row.TenantID != tenantID || row.UserID != userID {
+		return ErrNotFound
+	}
+	delete(f.rows, id)
+	return nil
+}
+
+func (f *fakeRepo) RecordRunSuccess(ctx context.Context, tenantID, id, taskID uuid.UUID) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	row := f.rows[id]
+	if row == nil {
+		return ErrNotFound
+	}
+	t := taskID
+	row.LastTaskID = &t
+	f.successes++
+	return nil
+}
+
+func (f *fakeRepo) RecordRunFailure(ctx context.Context, tenantID, id uuid.UUID, message string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	row := f.rows[id]
+	if row == nil {
+		return ErrNotFound
+	}
+	row.LastError = message
+	f.failures = append(f.failures, message)
+	return nil
+}
+
+// ClaimDue mirrors agent_task_schedules_claim_due: due = enabled AND
+// next_run_at <= now; claims advance next_run_at by one cadence at claim
+// time.
+func (f *fakeRepo) ClaimDue(ctx context.Context, now time.Time, batch int) ([]Schedule, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.claimErr != nil {
+		return nil, f.claimErr
+	}
+	var out []Schedule
+	for _, row := range f.rows {
+		if !row.Enabled || row.NextRunAt == nil || row.NextRunAt.After(now) {
+			continue
+		}
+		cad, err := cadence(row.Schedule)
+		if err != nil {
+			return nil, err
+		}
+		next := now.Add(cad)
+		row.NextRunAt = &next
+		out = append(out, *row)
+	}
+	if batch > 0 && len(out) > batch {
+		out = out[:batch]
+	}
+	return out, nil
+}

--- a/apps/control-plane/internal/agentsched/http.go
+++ b/apps/control-plane/internal/agentsched/http.go
@@ -1,0 +1,236 @@
+package agentsched
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Handler serves the service-to-service schedule CRUD surface edge-api calls.
+// tenant_id and user_id travel as URL path segments, not body/header/query:
+// the process boundary means the caller's own authenticated context cannot
+// cross it. edge-api resolves both solely from auth.TenantID(ctx) /
+// auth.UserFrom(ctx) before building the path. Mirrors
+// apps/control-plane/internal/agenttask/http.go's InternalMux.
+type Handler struct {
+	svc *Service
+}
+
+// NewHandler constructs the agentsched HTTP handler.
+func NewHandler(svc *Service) *Handler {
+	return &Handler{svc: svc}
+}
+
+// InternalMux returns the shared-secret-guarded service-to-service surface.
+// Wrap with RequireInternalToken in router wiring.
+func (h *Handler) InternalMux() http.Handler {
+	return http.HandlerFunc(h.serveInternal)
+}
+
+const internalPrefix = "/internal/agent-schedules/"
+
+// maxBodyBytes caps request bodies this handler decodes: a create/update body
+// carries up to 4000 chars of instructions plus a name and a cadence string,
+// and 64 KiB is generous headroom for that. Matches agenttask's handler.
+const maxBodyBytes = 64 << 10 // 64 KiB
+
+func (h *Handler) serveInternal(w http.ResponseWriter, r *http.Request) {
+	rest := strings.Trim(strings.TrimPrefix(r.URL.Path, internalPrefix), "/")
+	parts := strings.Split(rest, "/")
+	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
+		writeJSON(w, http.StatusNotFound, errBody("not found"))
+		return
+	}
+	tenantID, err := uuid.Parse(parts[0])
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, errBody("invalid tenant_id"))
+		return
+	}
+	userID, err := uuid.Parse(parts[1])
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, errBody("invalid user_id"))
+		return
+	}
+
+	switch len(parts) {
+	case 2:
+		switch r.Method {
+		case http.MethodPost:
+			h.handleCreate(w, r, tenantID, userID)
+			return
+		case http.MethodGet:
+			h.handleList(w, r, tenantID, userID)
+			return
+		}
+	case 3:
+		id, parseErr := uuid.Parse(parts[2])
+		if parseErr != nil {
+			writeJSON(w, http.StatusBadRequest, errBody("invalid schedule id"))
+			return
+		}
+		switch r.Method {
+		case http.MethodGet:
+			h.handleGet(w, r, tenantID, userID, id)
+			return
+		case http.MethodPut:
+			h.handleUpdate(w, r, tenantID, userID, id)
+			return
+		case http.MethodDelete:
+			h.handleDelete(w, r, tenantID, userID, id)
+			return
+		}
+	}
+	writeJSON(w, http.StatusNotFound, errBody("not found"))
+}
+
+type createRequest struct {
+	Name         string `json:"name"`
+	Instructions string `json:"instructions"`
+	Schedule     string `json:"schedule"`
+}
+
+func (h *Handler) handleCreate(w http.ResponseWriter, r *http.Request, tenantID, userID uuid.UUID) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+	var req createRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, errBody("invalid JSON body"))
+		return
+	}
+	sched, err := h.svc.Create(r.Context(), tenantID, userID, CreateInput{
+		Name:         req.Name,
+		Instructions: req.Instructions,
+		Schedule:     req.Schedule,
+	})
+	if err != nil {
+		writeScheduleError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, newScheduleWire(sched))
+}
+
+func (h *Handler) handleList(w http.ResponseWriter, r *http.Request, tenantID, userID uuid.UUID) {
+	schedules, err := h.svc.List(r.Context(), tenantID, userID)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, errBody("failed to list schedules"))
+		return
+	}
+	out := make([]scheduleWire, 0, len(schedules))
+	for _, s := range schedules {
+		out = append(out, newScheduleWire(s))
+	}
+	writeJSON(w, http.StatusOK, listResponse{Schedules: out})
+}
+
+func (h *Handler) handleGet(w http.ResponseWriter, r *http.Request, tenantID, userID, id uuid.UUID) {
+	sched, err := h.svc.Get(r.Context(), tenantID, userID, id)
+	if err != nil {
+		writeScheduleError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, newScheduleWire(sched))
+}
+
+// updateRequest carries the full replacement body. PUT semantics: every field
+// is required; absent means explicitly empty, and validation rejects that
+// where empty is invalid.
+type updateRequest struct {
+	Name         string `json:"name"`
+	Instructions string `json:"instructions"`
+	Schedule     string `json:"schedule"`
+	Enabled      bool   `json:"enabled"`
+}
+
+func (h *Handler) handleUpdate(w http.ResponseWriter, r *http.Request, tenantID, userID, id uuid.UUID) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+	var req updateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, errBody("invalid JSON body"))
+		return
+	}
+	sched, err := h.svc.Update(r.Context(), tenantID, userID, id, UpdateInput{
+		Name:         req.Name,
+		Instructions: req.Instructions,
+		Schedule:     req.Schedule,
+		Enabled:      req.Enabled,
+	})
+	if err != nil {
+		writeScheduleError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, newScheduleWire(sched))
+}
+
+func (h *Handler) handleDelete(w http.ResponseWriter, r *http.Request, tenantID, userID, id uuid.UUID) {
+	if err := h.svc.Delete(r.Context(), tenantID, userID, id); err != nil {
+		writeScheduleError(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// writeScheduleError maps service sentinels onto status codes. Provider-blind
+// default: the underlying error (DB failure detail) is never echoed.
+func writeScheduleError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, ErrNotFound):
+		writeJSON(w, http.StatusNotFound, errBody("schedule not found"))
+	case errors.Is(err, ErrInvalidName),
+		errors.Is(err, ErrInvalidInstructions),
+		errors.Is(err, ErrInvalidSchedule):
+		writeJSON(w, http.StatusBadRequest, errBody(err.Error()))
+	default:
+		writeJSON(w, http.StatusInternalServerError, errBody("agent schedule request failed"))
+	}
+}
+
+type scheduleWire struct {
+	ID           string     `json:"id"`
+	Name         string     `json:"name"`
+	Instructions string     `json:"instructions"`
+	Schedule     string     `json:"schedule"`
+	Enabled      bool       `json:"enabled"`
+	NextRunAt    *time.Time `json:"next_run_at"`
+	LastRunAt    *time.Time `json:"last_run_at"`
+	LastTaskID   string     `json:"last_task_id"`
+	LastError    string     `json:"last_error"`
+	CreatedAt    time.Time  `json:"created_at"`
+	UpdatedAt    time.Time  `json:"updated_at"`
+}
+
+type listResponse struct {
+	Schedules []scheduleWire `json:"schedules"`
+}
+
+func newScheduleWire(s Schedule) scheduleWire {
+	lastTaskID := ""
+	if s.LastTaskID != nil {
+		lastTaskID = s.LastTaskID.String()
+	}
+	return scheduleWire{
+		ID:           s.ID.String(),
+		Name:         s.Name,
+		Instructions: s.Instructions,
+		Schedule:     s.Schedule,
+		Enabled:      s.Enabled,
+		NextRunAt:    s.NextRunAt,
+		LastRunAt:    s.LastRunAt,
+		LastTaskID:   lastTaskID,
+		LastError:    s.LastError,
+		CreatedAt:    s.CreatedAt,
+		UpdatedAt:    s.UpdatedAt,
+	}
+}
+
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+func errBody(msg string) map[string]string {
+	return map[string]string{"error": msg}
+}

--- a/apps/control-plane/internal/agentsched/repository.go
+++ b/apps/control-plane/internal/agentsched/repository.go
@@ -24,7 +24,11 @@ type Repository interface {
 	Update(ctx context.Context, s Schedule) (Schedule, error)
 	SetEnabled(ctx context.Context, tenantID, userID, id uuid.UUID, enabled bool, nextRunAt *time.Time) (Schedule, error)
 	Delete(ctx context.Context, tenantID, userID, id uuid.UUID) error
-	// RecordRunSuccess records the task a claimed schedule produced. Scoped
+	// RecordRunSuccess records the task a claimed schedule produced.
+	// last_run_at is stamped by ClaimDue itself (claim time = attempt start),
+	// so these writes only fill in the outcome fields afterwards; a failure
+	// between claim and create therefore still shows an honest attempt time.
+	// Scoped
 	// to the claimed row's tenant: the scheduler holds tenantID straight off
 	// the row ClaimDue returned. next_run_at was already advanced at claim
 	// time; this only fills in the outcome.

--- a/apps/control-plane/internal/agentsched/repository.go
+++ b/apps/control-plane/internal/agentsched/repository.go
@@ -15,7 +15,7 @@ import (
 // public.agent_task_schedules. CRUD and the run-outcome writes are
 // (tenant, user)-scoped; ClaimDue is the scheduler's one cross-tenant
 // statement and goes through the SECURITY DEFINER function
-// public.agent_task_schedules_claim_due (20260823_01_agent_task_schedules.sql),
+// public.agent_task_schedules_claim_due (20260823_02_agent_task_schedules.sql),
 // never a table policy.
 type Repository interface {
 	Create(ctx context.Context, s Schedule) (Schedule, error)
@@ -262,7 +262,7 @@ func (r *pgxRepository) RecordRunFailure(ctx context.Context, tenantID, id uuid.
 
 // ClaimDue calls public.agent_task_schedules_claim_due(p_now, p_batch) — the
 // SECURITY DEFINER function that is this package's ONLY cross-tenant path
-// (20260823_01_agent_task_schedules.sql), for the same reason
+// (20260823_02_agent_task_schedules.sql), for the same reason
 // agent_tasks_list_active() exists for the poller. Called outside
 // withTenantTx: no single app.current_tenant_id value could see every
 // tenant's rows, which is exactly why the function exists.

--- a/apps/control-plane/internal/agentsched/repository.go
+++ b/apps/control-plane/internal/agentsched/repository.go
@@ -1,0 +1,302 @@
+package agentsched
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Repository is the narrow data-access port for
+// public.agent_task_schedules. CRUD and the run-outcome writes are
+// (tenant, user)-scoped; ClaimDue is the scheduler's one cross-tenant
+// statement and goes through the SECURITY DEFINER function
+// public.agent_task_schedules_claim_due (20260823_01_agent_task_schedules.sql),
+// never a table policy.
+type Repository interface {
+	Create(ctx context.Context, s Schedule) (Schedule, error)
+	Get(ctx context.Context, tenantID, userID, id uuid.UUID) (Schedule, error)
+	List(ctx context.Context, tenantID, userID uuid.UUID) ([]Schedule, error)
+	Update(ctx context.Context, s Schedule) (Schedule, error)
+	SetEnabled(ctx context.Context, tenantID, userID, id uuid.UUID, enabled bool, nextRunAt *time.Time) (Schedule, error)
+	Delete(ctx context.Context, tenantID, userID, id uuid.UUID) error
+	// RecordRunSuccess records the task a claimed schedule produced. Scoped
+	// to the claimed row's tenant: the scheduler holds tenantID straight off
+	// the row ClaimDue returned. next_run_at was already advanced at claim
+	// time; this only fills in the outcome.
+	RecordRunSuccess(ctx context.Context, tenantID, id, taskID uuid.UUID) error
+	// RecordRunFailure records a provider-blind failure message from the most
+	// recent run attempt. next_run_at was already advanced at claim time,
+	// which IS the backoff: the schedule waits out its full cadence instead of
+	// hot-looping.
+	RecordRunFailure(ctx context.Context, tenantID, id uuid.UUID, message string) error
+	// ClaimDue atomically claims up to batch due enabled schedules as of now:
+	// advances next_run_at by one cadence and returns the rows in one
+	// statement, so concurrent ticks can never fire the same schedule twice.
+	ClaimDue(ctx context.Context, now time.Time, batch int) ([]Schedule, error)
+}
+
+type pgxRepository struct {
+	pool *pgxpool.Pool
+}
+
+// NewPgxRepository constructs a pgxpool-backed Repository.
+func NewPgxRepository(pool *pgxpool.Pool) Repository {
+	return &pgxRepository{pool: pool}
+}
+
+// withTenantTx mirrors apps/control-plane/internal/agenttask/repository.go's
+// helper of the same name: hive_app is NOT BYPASSRLS
+// (20260518_04_phase19_audit_rls_and_indexes.sql), so every query against
+// public.agent_task_schedules must run inside an explicit transaction with
+// app.current_tenant_id set LOCAL — guaranteed to clear at Commit or Rollback
+// so nothing survives onto the pooled connection for the next borrower.
+func (r *pgxRepository) withTenantTx(ctx context.Context, tenantID uuid.UUID, fn func(tx pgx.Tx) error) error {
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("agentsched: begin tx: %w", err)
+	}
+	defer tx.Rollback(ctx) // no-op once Commit has succeeded
+
+	if _, err := tx.Exec(ctx, "SELECT set_config('app.current_tenant_id', $1, true)", tenantID.String()); err != nil {
+		return fmt.Errorf("agentsched: set tenant: %w", err)
+	}
+	if err := fn(tx); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}
+
+const scheduleColumns = `id, tenant_id, user_id, name, instructions, schedule, enabled,
+	next_run_at, last_run_at, last_task_id, last_error, created_at, updated_at`
+
+func (r *pgxRepository) Create(ctx context.Context, s Schedule) (Schedule, error) {
+	var out Schedule
+	err := r.withTenantTx(ctx, s.TenantID, func(tx pgx.Tx) error {
+		row := tx.QueryRow(ctx, `
+			INSERT INTO public.agent_task_schedules
+				(tenant_id, user_id, name, instructions, schedule, enabled, next_run_at)
+			VALUES ($1, $2, $3, $4, $5, $6, $7)
+			RETURNING `+scheduleColumns+`
+		`, s.TenantID, s.UserID, s.Name, s.Instructions, s.Schedule, s.Enabled, s.NextRunAt)
+		var err error
+		out, err = scanSchedule(row)
+		return err
+	})
+	if err != nil {
+		return Schedule{}, fmt.Errorf("agentsched: create: %w", err)
+	}
+	return out, nil
+}
+
+func (r *pgxRepository) Get(ctx context.Context, tenantID, userID, id uuid.UUID) (Schedule, error) {
+	var out Schedule
+	err := r.withTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		row := tx.QueryRow(ctx, `
+			SELECT `+scheduleColumns+`
+			  FROM public.agent_task_schedules
+			 WHERE id = $1 AND user_id = $2
+		`, id, userID)
+		var err error
+		out, err = scanSchedule(row)
+		return err
+	})
+	if err != nil {
+		return Schedule{}, fmt.Errorf("agentsched: get: %w", err)
+	}
+	return out, nil
+}
+
+func (r *pgxRepository) List(ctx context.Context, tenantID, userID uuid.UUID) ([]Schedule, error) {
+	var out []Schedule
+	err := r.withTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `
+			SELECT `+scheduleColumns+`
+			  FROM public.agent_task_schedules
+			 WHERE user_id = $1
+			 ORDER BY created_at DESC
+		`, userID)
+		if err != nil {
+			return fmt.Errorf("agentsched: list query: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			s, err := scanSchedule(rows)
+			if err != nil {
+				return err
+			}
+			out = append(out, s)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, fmt.Errorf("agentsched: list: %w", err)
+	}
+	return out, nil
+}
+
+// Update rewrites the mutable fields of an existing row. The UPDATE carries
+// the owning user_id and the new next_run_at computed by Service, which owns
+// cadence math.
+func (r *pgxRepository) Update(ctx context.Context, s Schedule) (Schedule, error) {
+	var out Schedule
+	err := r.withTenantTx(ctx, s.TenantID, func(tx pgx.Tx) error {
+		row := tx.QueryRow(ctx, `
+			UPDATE public.agent_task_schedules
+			   SET name = $3, instructions = $4, schedule = $5,
+			       enabled = $6, next_run_at = $7, updated_at = now()
+			 WHERE id = $1 AND user_id = $2
+			RETURNING `+scheduleColumns+`
+		`, s.ID, s.UserID, s.Name, s.Instructions, s.Schedule, s.Enabled, s.NextRunAt)
+		var err error
+		out, err = scanSchedule(row)
+		return err
+	})
+	if err != nil {
+		return Schedule{}, fmt.Errorf("agentsched: update: %w", err)
+	}
+	return out, nil
+}
+
+// SetEnabled flips only the enabled flag. When enabling, Service passes the
+// fresh nextRunAt (now + one cadence) so a stale overdue timestamp frozen
+// during a disabled stretch cannot fire immediately on re-enable; when
+// disabling, a nil nextRunAt keeps the stored value untouched.
+func (r *pgxRepository) SetEnabled(ctx context.Context, tenantID, userID, id uuid.UUID, enabled bool, nextRunAt *time.Time) (Schedule, error) {
+	var out Schedule
+	err := r.withTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		row := tx.QueryRow(ctx, `
+			UPDATE public.agent_task_schedules
+			   SET enabled = $4,
+			       next_run_at = CASE WHEN $5::timestamptz IS NULL OR NOT $4 THEN next_run_at ELSE $5 END,
+			       updated_at = now()
+			 WHERE id = $1 AND user_id = $2
+			RETURNING `+scheduleColumns+`
+		`, id, userID, enabled, nextRunAt)
+		var err error
+		out, err = scanSchedule(row)
+		return err
+	})
+	if err != nil {
+		return Schedule{}, fmt.Errorf("agentsched: set enabled: %w", err)
+	}
+	return out, nil
+}
+
+func (r *pgxRepository) Delete(ctx context.Context, tenantID, userID, id uuid.UUID) error {
+	var found bool
+	err := r.withTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		tag, err := tx.Exec(ctx, `
+			DELETE FROM public.agent_task_schedules
+			 WHERE id = $1 AND user_id = $2
+		`, id, userID)
+		if err != nil {
+			return err
+		}
+		found = tag.RowsAffected() > 0
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("agentsched: delete: %w", err)
+	}
+	if !found {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (r *pgxRepository) RecordRunSuccess(ctx context.Context, tenantID, id, taskID uuid.UUID) error {
+	err := r.withTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		tag, err := tx.Exec(ctx, `
+			UPDATE public.agent_task_schedules
+			   SET last_task_id = $2, updated_at = now()
+			 WHERE id = $1
+		`, id, taskID)
+		if err != nil {
+			return err
+		}
+		if tag.RowsAffected() == 0 {
+			return ErrNotFound
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("agentsched: record run success: %w", err)
+	}
+	return nil
+}
+
+func (r *pgxRepository) RecordRunFailure(ctx context.Context, tenantID, id uuid.UUID, message string) error {
+	err := r.withTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
+		tag, err := tx.Exec(ctx, `
+			UPDATE public.agent_task_schedules
+			   SET last_error = $2, updated_at = now()
+			 WHERE id = $1
+		`, id, message)
+		if err != nil {
+			return err
+		}
+		if tag.RowsAffected() == 0 {
+			return ErrNotFound
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("agentsched: record run failure: %w", err)
+	}
+	return nil
+}
+
+// ClaimDue calls public.agent_task_schedules_claim_due(p_now, p_batch) — the
+// SECURITY DEFINER function that is this package's ONLY cross-tenant path
+// (20260823_01_agent_task_schedules.sql), for the same reason
+// agent_tasks_list_active() exists for the poller. Called outside
+// withTenantTx: no single app.current_tenant_id value could see every
+// tenant's rows, which is exactly why the function exists.
+func (r *pgxRepository) ClaimDue(ctx context.Context, now time.Time, batch int) ([]Schedule, error) {
+	rows, err := r.pool.Query(ctx,
+		`SELECT * FROM public.agent_task_schedules_claim_due($1, $2)`,
+		now, batch)
+	if err != nil {
+		return nil, fmt.Errorf("agentsched: claim due query: %w", err)
+	}
+	defer rows.Close()
+
+	var out []Schedule
+	for rows.Next() {
+		s, err := scanSchedule(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, s)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("agentsched: claim due: %w", err)
+	}
+	return out, nil
+}
+
+type scanner interface {
+	Scan(dest ...any) error
+}
+
+func scanSchedule(s scanner) (Schedule, error) {
+	var (
+		out      Schedule
+		schedule string
+	)
+	if err := s.Scan(&out.ID, &out.TenantID, &out.UserID, &out.Name, &out.Instructions, &schedule,
+		&out.Enabled, &out.NextRunAt, &out.LastRunAt, &out.LastTaskID, &out.LastError,
+		&out.CreatedAt, &out.UpdatedAt); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return Schedule{}, ErrNotFound
+		}
+		return Schedule{}, fmt.Errorf("agentsched: scan: %w", err)
+	}
+	out.Schedule = schedule
+	return out, nil
+}

--- a/apps/control-plane/internal/agentsched/repository.go
+++ b/apps/control-plane/internal/agentsched/repository.go
@@ -171,8 +171,8 @@ func (r *pgxRepository) SetEnabled(ctx context.Context, tenantID, userID, id uui
 	err := r.withTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
 		row := tx.QueryRow(ctx, `
 			UPDATE public.agent_task_schedules
-			   SET enabled = $4,
-			       next_run_at = CASE WHEN $5::timestamptz IS NULL OR NOT $4 THEN next_run_at ELSE $5 END,
+			   SET enabled = $3,
+			       next_run_at = CASE WHEN $4::timestamptz IS NULL OR NOT $3 THEN next_run_at ELSE $4 END,
 			       updated_at = now()
 			 WHERE id = $1 AND user_id = $2
 			RETURNING `+scheduleColumns+`
@@ -213,7 +213,10 @@ func (r *pgxRepository) RecordRunSuccess(ctx context.Context, tenantID, id, task
 	err := r.withTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
 		tag, err := tx.Exec(ctx, `
 			UPDATE public.agent_task_schedules
-			   SET last_task_id = $2, updated_at = now()
+			   SET last_task_id = $2,
+			       last_run_at = now(),
+			       last_error = '',
+			       updated_at = now()
 			 WHERE id = $1
 		`, id, taskID)
 		if err != nil {
@@ -234,7 +237,9 @@ func (r *pgxRepository) RecordRunFailure(ctx context.Context, tenantID, id uuid.
 	err := r.withTenantTx(ctx, tenantID, func(tx pgx.Tx) error {
 		tag, err := tx.Exec(ctx, `
 			UPDATE public.agent_task_schedules
-			   SET last_error = $2, updated_at = now()
+			   SET last_error = $2,
+			       last_run_at = now(),
+			       updated_at = now()
 			 WHERE id = $1
 		`, id, message)
 		if err != nil {

--- a/apps/control-plane/internal/agentsched/repository_test.go
+++ b/apps/control-plane/internal/agentsched/repository_test.go
@@ -104,6 +104,23 @@ func seedUser(t *testing.T) uuid.UUID {
 
 // mustCreate inserts a schedule through the repository and fails the test on
 // error.
+// adminExec runs one statement as the migration owner (postgres), bypassing
+// RLS, for test-only state overrides the hive_app pool cannot perform (the
+// tenant GUC is not set on it, so RLS denies every direct UPDATE).
+func adminExec(t *testing.T, sql string, args ...any) {
+	t.Helper()
+	dsn := os.Getenv("HIVE_TEST_DB_URL")
+	ctx := context.Background()
+	setup, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("admin pool: %v", err)
+	}
+	defer setup.Close()
+	if _, err := setup.Exec(ctx, sql, args...); err != nil {
+		t.Fatalf("adminExec %s: %v", sql, err)
+	}
+}
+
 func mustCreate(t *testing.T, repo agentsched.Repository, tenantID, userID uuid.UUID, name string) agentsched.Schedule {
 	t.Helper()
 	now := time.Date(2026, 8, 23, 9, 0, 0, 0, time.UTC)
@@ -198,19 +215,13 @@ func TestRepository_ClaimDueAgainstRealDB(t *testing.T) {
 
 	due := mustCreate(t, repo, tenantID, userID, "due")
 	notDue := mustCreate(t, repo, tenantID, userID, "not-due")
-	if _, err := pool.Exec(ctx,
-		`UPDATE public.agent_task_schedules SET next_run_at = $1 WHERE id = $2`, past, due.ID); err != nil {
-		t.Fatalf("set due time: %v", err)
-	}
-	if _, err := pool.Exec(ctx,
-		`UPDATE public.agent_task_schedules SET next_run_at = $1 WHERE id = $2`, future, notDue.ID); err != nil {
-		t.Fatalf("set not-due time: %v", err)
-	}
+	adminExec(t,
+		`UPDATE public.agent_task_schedules SET next_run_at = $1 WHERE id = $2`, past, due.ID)
+	adminExec(t,
+		`UPDATE public.agent_task_schedules SET next_run_at = $1 WHERE id = $2`, future, notDue.ID)
 	disabled := mustCreate(t, repo, tenantID, userID, "disabled")
-	if _, err := pool.Exec(ctx,
-		`UPDATE public.agent_task_schedules SET enabled = false, next_run_at = $1 WHERE id = $2`, past, disabled.ID); err != nil {
-		t.Fatalf("disable: %v", err)
-	}
+	adminExec(t,
+		`UPDATE public.agent_task_schedules SET enabled = false, next_run_at = $1 WHERE id = $2`, past, disabled.ID)
 
 	claimed, err := repo.ClaimDue(ctx, now, 100)
 	if err != nil {

--- a/apps/control-plane/internal/agentsched/repository_test.go
+++ b/apps/control-plane/internal/agentsched/repository_test.go
@@ -184,6 +184,28 @@ func TestRepository_CRUDRoundTripAndScoping(t *testing.T) {
 		t.Fatalf("Update: %v", err)
 	}
 
+	// SetEnabled round trip against the live RLS policy.
+	reenabled := mustCreate(t, repo, tenantA, userA, "toggle")
+	if _, err := repo.SetEnabled(ctx, tenantA, userA, reenabled.ID, false, nil); err != nil {
+		t.Fatalf("SetEnabled(false): %v", err)
+	}
+	got2, _ := repo.Get(ctx, tenantA, userA, reenabled.ID)
+	if got2.Enabled {
+		t.Fatal("expected disabled after SetEnabled(false)")
+	}
+	next := got2.NextRunAt
+	fresh := time.Now().UTC().Add(time.Hour)
+	if _, err := repo.SetEnabled(ctx, tenantA, userA, reenabled.ID, true, &fresh); err != nil {
+		t.Fatalf("SetEnabled(true): %v", err)
+	}
+	got2, _ = repo.Get(ctx, tenantA, userA, reenabled.ID)
+	if !got2.Enabled {
+		t.Fatal("expected enabled after SetEnabled(true)")
+	}
+	if next != nil && got2.NextRunAt != nil && got2.NextRunAt.Equal(*next) {
+		t.Fatal("enable with a fresh next_run_at must overwrite the stored one")
+	}
+
 	// Delete by the wrong user is not found; by the owner removes the row.
 	if err := repo.Delete(ctx, tenantA, userB, created.ID); !errors.Is(err, agentsched.ErrNotFound) {
 		t.Fatalf("cross-user Delete = %v, want ErrNotFound", err)

--- a/apps/control-plane/internal/agentsched/repository_test.go
+++ b/apps/control-plane/internal/agentsched/repository_test.go
@@ -1,0 +1,233 @@
+package agentsched_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/agentsched"
+)
+
+// newRLSTestPool connects as hive_app so the agent_task_schedules
+// tenant-isolation RLS policy is actually exercised. Mirrors
+// apps/control-plane/internal/agenttask/repository_test.go's helper.
+func newRLSTestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("HIVE_TEST_DB_URL")
+	if dsn == "" {
+		t.Skip("HIVE_TEST_DB_URL not set")
+	}
+	if !strings.Contains(strings.ToLower(dsn), "test") {
+		t.Fatalf("refusing to run: HIVE_TEST_DB_URL must point at a test database")
+	}
+
+	cfg, err := pgxpool.ParseConfig(dsn)
+	if err != nil {
+		t.Fatalf("parse HIVE_TEST_DB_URL: %v", err)
+	}
+	cfg.MaxConns = 1
+
+	ctx := context.Background()
+	pool, err := pgxpool.NewWithConfig(ctx, cfg)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	if _, err := pool.Exec(ctx, "SET ROLE hive_app"); err != nil {
+		pool.Close()
+		t.Skipf("SET ROLE hive_app failed: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+// seedTenant inserts the FK row public.tenants requires.
+func seedTenant(t *testing.T, id uuid.UUID) {
+	t.Helper()
+	dsn := os.Getenv("HIVE_TEST_DB_URL")
+	ctx := context.Background()
+	setup, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("seed pool: %v", err)
+	}
+	defer setup.Close()
+	_, err = setup.Exec(ctx,
+		`INSERT INTO public.tenants (id, slug, name, deployment)
+		 VALUES ($1, $2, 'agentsched test tenant', 'HIVE_CLOUD')
+		 ON CONFLICT (id) DO NOTHING`,
+		id, "agentsched-test-"+id.String())
+	if err != nil {
+		t.Fatalf("seed tenant: %v", err)
+	}
+	t.Cleanup(func() {
+		cleanup, err := pgxpool.New(context.Background(), dsn)
+		if err == nil {
+			defer cleanup.Close()
+			_, _ = cleanup.Exec(context.Background(), `DELETE FROM public.tenants WHERE id = $1`, id)
+		}
+	})
+}
+
+// seedUser inserts a minimal auth.users row for user_id FK.
+func seedUser(t *testing.T) uuid.UUID {
+	t.Helper()
+	dsn := os.Getenv("HIVE_TEST_DB_URL")
+	ctx := context.Background()
+	setup, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("seed pool: %v", err)
+	}
+	defer setup.Close()
+
+	var id uuid.UUID
+	email := "agentsched-test-" + uuid.NewString() + "@example.invalid"
+	err = setup.QueryRow(ctx,
+		`INSERT INTO auth.users(id, email, raw_user_meta_data) VALUES (gen_random_uuid(), $1, '{}'::jsonb) RETURNING id`,
+		email).Scan(&id)
+	if err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	t.Cleanup(func() {
+		cleanup, err := pgxpool.New(context.Background(), dsn)
+		if err == nil {
+			defer cleanup.Close()
+			_, _ = cleanup.Exec(context.Background(), `DELETE FROM auth.users WHERE id = $1`, id)
+		}
+	})
+	return id
+}
+
+// mustCreate inserts a schedule through the repository and fails the test on
+// error.
+func mustCreate(t *testing.T, repo agentsched.Repository, tenantID, userID uuid.UUID, name string) agentsched.Schedule {
+	t.Helper()
+	now := time.Date(2026, 8, 23, 9, 0, 0, 0, time.UTC)
+	s, err := repo.Create(context.Background(), agentsched.Schedule{
+		TenantID:     tenantID,
+		UserID:       userID,
+		Name:         name,
+		Instructions: "test instructions for " + name,
+		Schedule:     "daily",
+		Enabled:      true,
+		NextRunAt:    &now,
+	})
+	if err != nil {
+		t.Fatalf("seed schedule %q: %v", name, err)
+	}
+	return s
+}
+
+func TestRepository_CRUDRoundTripAndScoping(t *testing.T) {
+	pool := newRLSTestPool(t)
+	repo := agentsched.NewPgxRepository(pool)
+	ctx := context.Background()
+
+	tenantA := uuid.New()
+	seedTenant(t, tenantA)
+	userA := seedUser(t)
+
+	created := mustCreate(t, repo, tenantA, userA, "round-trip")
+	if created.ID == uuid.Nil {
+		t.Fatal("expected a persisted id")
+	}
+
+	got, err := repo.Get(ctx, tenantA, userA, created.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Name != "round-trip" || got.Schedule != "daily" || !got.Enabled {
+		t.Fatalf("Get = %+v", got)
+	}
+
+	// Cross-user read inside the same tenant reads as not found.
+	userB := seedUser(t)
+	if _, err := repo.Get(ctx, tenantA, userB, created.ID); !errors.Is(err, agentsched.ErrNotFound) {
+		t.Fatalf("cross-user Get = %v, want ErrNotFound (404)", err)
+	}
+
+	// Cross-tenant read reads as not found too (RLS hides the row).
+	tenantB := uuid.New()
+	seedTenant(t, tenantB)
+	if _, err := repo.Get(ctx, tenantB, userA, created.ID); !errors.Is(err, agentsched.ErrNotFound) {
+		t.Fatalf("cross-tenant Get = %v, want ErrNotFound (404)", err)
+	}
+
+	// Update scoped the same way.
+	got.Name = "updated"
+	if _, err := repo.Update(ctx, agentsched.Schedule{
+		ID: created.ID, TenantID: tenantA, UserID: userA,
+		Name: "updated", Instructions: got.Instructions,
+		Schedule: got.Schedule, Enabled: true, NextRunAt: got.NextRunAt,
+	}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	// Delete by the wrong user is not found; by the owner removes the row.
+	if err := repo.Delete(ctx, tenantA, userB, created.ID); !errors.Is(err, agentsched.ErrNotFound) {
+		t.Fatalf("cross-user Delete = %v, want ErrNotFound", err)
+	}
+	if err := repo.Delete(ctx, tenantA, userA, created.ID); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if err := repo.Delete(ctx, tenantA, userA, created.ID); !errors.Is(err, agentsched.ErrNotFound) {
+		t.Fatal("second delete should be not found")
+	}
+}
+
+// TestRepository_ClaimDueAgainstRealDB exercises the SECURITY DEFINER claim
+// function through hive_app: only due enabled rows come back, each claim
+// advances next_run_at by its cadence, a disabled row and a not-yet-due row
+// stay untouched, and a second claim at the same instant returns nothing.
+func TestRepository_ClaimDueAgainstRealDB(t *testing.T) {
+	pool := newRLSTestPool(t)
+	repo := agentsched.NewPgxRepository(pool)
+	ctx := context.Background()
+
+	tenantID := uuid.New()
+	seedTenant(t, tenantID)
+	userID := seedUser(t)
+
+	now := time.Date(2026, 8, 23, 9, 0, 0, 0, time.UTC)
+	past := now.Add(-time.Minute)
+	future := now.Add(time.Hour)
+
+	due := mustCreate(t, repo, tenantID, userID, "due")
+	notDue := mustCreate(t, repo, tenantID, userID, "not-due")
+	if _, err := pool.Exec(ctx,
+		`UPDATE public.agent_task_schedules SET next_run_at = $1 WHERE id = $2`, past, due.ID); err != nil {
+		t.Fatalf("set due time: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`UPDATE public.agent_task_schedules SET next_run_at = $1 WHERE id = $2`, future, notDue.ID); err != nil {
+		t.Fatalf("set not-due time: %v", err)
+	}
+	disabled := mustCreate(t, repo, tenantID, userID, "disabled")
+	if _, err := pool.Exec(ctx,
+		`UPDATE public.agent_task_schedules SET enabled = false, next_run_at = $1 WHERE id = $2`, past, disabled.ID); err != nil {
+		t.Fatalf("disable: %v", err)
+	}
+
+	claimed, err := repo.ClaimDue(ctx, now, 100)
+	if err != nil {
+		t.Fatalf("ClaimDue: %v", err)
+	}
+	if len(claimed) != 1 || claimed[0].ID != due.ID {
+		t.Fatalf("claimed %+v, want exactly the one due row", claimed)
+	}
+	if claimed[0].NextRunAt == nil || !claimed[0].NextRunAt.After(now) {
+		t.Fatal("claim must advance next_run_at one cadence out")
+	}
+
+	again, err := repo.ClaimDue(ctx, now, 100)
+	if err != nil {
+		t.Fatalf("second ClaimDue: %v", err)
+	}
+	if len(again) != 0 {
+		t.Fatalf("second claim returned %d rows, want 0 (idempotent per tick)", len(again))
+	}
+}

--- a/apps/control-plane/internal/agentsched/scheduler.go
+++ b/apps/control-plane/internal/agentsched/scheduler.go
@@ -1,0 +1,186 @@
+package agentsched
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/agenttask"
+)
+
+// TaskCreator is the narrow surface the Scheduler needs from
+// agenttask.Service. The real Service satisfies it directly; tests inject a
+// fake. Going through the SAME service path a manual creation uses is the
+// whole point (brief for this slice): metering, quota and engine gating then
+// apply to scheduled runs identically to manual ones, with no second code
+// path that could drift.
+type TaskCreator interface {
+	CreateTask(ctx context.Context, tenantID, userID uuid.UUID, pack agenttask.Pack, instructions, bearerJWT string) (agenttask.Task, error)
+}
+
+// scheduledPack is the pack every scheduled run launches as in this first
+// slice. Schedules carry no pack column yet; coding-pack is the default
+// because it needs no user bearer JWT (a schedule has none: JWTs expire long
+// before a weekly recurrence) and knowledge-work-pack's artifact publishing
+// is skipped without one anyway.
+const scheduledPack = agenttask.PackCoding
+
+// runFailureMessage is the provider-blind text persisted into last_error when
+// CreateTask fails. No engine or infra detail reaches a customer-readable
+// column, same posture as agenttask.Service's launch-failure messages.
+const runFailureMessage = "scheduled task could not be created; it will retry on the next cadence"
+
+// SchedulerConfig controls Scheduler behaviour.
+type SchedulerConfig struct {
+	// Interval between ticks. Zero defaults to one minute.
+	Interval time.Duration
+	// Batch caps how many schedules one tick claims. Zero defaults to 100.
+	Batch int
+	// Logger; nil defaults to slog.Default().
+	Logger *slog.Logger
+}
+
+// Scheduler turns due agent_task_schedules rows into real agent tasks.
+//
+// One tick = ClaimDue(now, batch) + one CreateTask per claimed row. All
+// concurrency safety lives inside ClaimDue: its SECURITY DEFINER statement
+// locks candidate rows FOR UPDATE SKIP LOCKED and advances next_run_at in the
+// same statement that returns them, so two control-plane instances (or a
+// retried tick) can never fire the same schedule twice — a claimed row stops
+// matching "due" at claim time, not after its task is created. A CreateTask
+// failure therefore cannot hot-loop either: next_run_at already sits one full
+// cadence out, and the failure only records last_error.
+type Scheduler struct {
+	repo     Repository
+	tasks    TaskCreator
+	interval time.Duration
+	batch    int
+	logger   *slog.Logger
+
+	mu      sync.Mutex
+	cancel  context.CancelFunc
+	doneCh  chan struct{}
+	started bool
+}
+
+// NewScheduler builds a Scheduler. repo and tasks must be non-nil.
+func NewScheduler(repo Repository, tasks TaskCreator, cfg SchedulerConfig) *Scheduler {
+	if repo == nil {
+		panic("agentsched: nil repository")
+	}
+	if tasks == nil {
+		panic("agentsched: nil task creator")
+	}
+	interval := cfg.Interval
+	if interval <= 0 {
+		interval = time.Minute
+	}
+	batch := cfg.Batch
+	if batch <= 0 {
+		batch = 100
+	}
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Scheduler{repo: repo, tasks: tasks, interval: interval, batch: batch, logger: logger}
+}
+
+// RunOnce performs exactly one tick at the given clock reading. now is a
+// parameter rather than an internal clock so tests drive due/not-due without
+// sleeps; production passes time.Now via Start.
+func (s *Scheduler) RunOnce(ctx context.Context, now time.Time) (fired int) {
+	due, err := s.repo.ClaimDue(ctx, now, s.batch)
+	if err != nil {
+		s.logger.WarnContext(ctx, "agentsched: claim due failed, skipping tick",
+			"error", err)
+		return 0
+	}
+	for _, sched := range due {
+		task, err := s.tasks.CreateTask(ctx, sched.TenantID, sched.UserID, scheduledPack, sched.Instructions, "")
+		if err != nil {
+			// Provider-blind persistence; the real detail stays in the log.
+			s.logger.WarnContext(ctx, "agentsched: scheduled create failed, backing off one cadence",
+				"schedule_id", sched.ID, "tenant_id", sched.TenantID, "error", err)
+			if recErr := s.repo.RecordRunFailure(ctx, sched.TenantID, sched.ID, runFailureMessage); recErr != nil && !errors.Is(recErr, ErrNotFound) {
+				s.logger.WarnContext(ctx, "agentsched: could not record run failure",
+					"schedule_id", sched.ID, "error", recErr)
+			}
+			continue
+		}
+		if err := s.repo.RecordRunSuccess(ctx, sched.TenantID, sched.ID, task.ID); err != nil &&
+			!errors.Is(err, ErrNotFound) {
+			// The task exists and was launched by Service.CreateTask's own
+			// background path regardless; losing the pointer write is a
+			// bookkeeping loss for the list view, not a reason to fail the run.
+			s.logger.WarnContext(ctx, "agentsched: could not record run success",
+				"schedule_id", sched.ID, "task_id", task.ID, "error", err)
+		}
+		fired++
+	}
+	return fired
+}
+
+// Start launches the tick loop on a background goroutine. Subsequent Start
+// calls are no-ops until Stop is called. Mirrors agenttask.Poller's
+// Start/Stop shape.
+func (s *Scheduler) Start(parent context.Context) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.started {
+		return
+	}
+	ctx, cancel := context.WithCancel(parent)
+	doneCh := make(chan struct{})
+	s.cancel = cancel
+	s.doneCh = doneCh
+	s.started = true
+
+	go s.loop(ctx, doneCh)
+}
+
+// Stop signals the loop to exit and waits for the in-flight tick to finish.
+// Safe to call multiple times.
+func (s *Scheduler) Stop() {
+	s.mu.Lock()
+	if !s.started {
+		s.mu.Unlock()
+		return
+	}
+	cancel := s.cancel
+	doneCh := s.doneCh
+	s.mu.Unlock()
+
+	cancel()
+	<-doneCh
+
+	s.mu.Lock()
+	if s.doneCh == doneCh {
+		s.started = false
+		s.cancel = nil
+		s.doneCh = nil
+	}
+	s.mu.Unlock()
+}
+
+func (s *Scheduler) loop(ctx context.Context, doneCh chan<- struct{}) {
+	defer close(doneCh)
+
+	ticker := time.NewTicker(s.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.RunOnce(ctx, time.Now())
+		}
+	}
+}
+
+// compile-time proof the concrete service path satisfies the seam.
+var _ TaskCreator = (*agenttask.Service)(nil)

--- a/apps/control-plane/internal/agentsched/scheduler_test.go
+++ b/apps/control-plane/internal/agentsched/scheduler_test.go
@@ -1,0 +1,148 @@
+package agentsched
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/agenttask"
+)
+
+// fakeTasks records CreateTask calls.
+type fakeTasks struct {
+	mu    sync.Mutex
+	calls int
+	err   error
+	last  struct {
+		tenantID     uuid.UUID
+		userID       uuid.UUID
+		pack         agenttask.Pack
+		instructions string
+		bearerJWT    string
+	}
+}
+
+func (f *fakeTasks) CreateTask(ctx context.Context, tenantID, userID uuid.UUID, pack agenttask.Pack, instructions string, bearerJWT string) (agenttask.Task, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	f.last.tenantID = tenantID
+	f.last.userID = userID
+	f.last.pack = pack
+	f.last.instructions = instructions
+	f.last.bearerJWT = bearerJWT
+	if f.err != nil {
+		return agenttask.Task{}, f.err
+	}
+	return agenttask.Task{ID: uuid.New(), TenantID: tenantID, UserID: userID}, nil
+}
+
+func quietLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func newScheduler(repo Repository, tasks TaskCreator) *Scheduler {
+	return NewScheduler(repo, tasks, SchedulerConfig{Logger: quietLogger()})
+}
+
+func TestScheduler_FiresDueScheduleOncePerTick(t *testing.T) {
+	now := time.Date(2026, 8, 23, 9, 0, 0, 0, time.UTC)
+	repo := newFakeRepo(Schedule{
+		ID: idA, TenantID: tenantA, UserID: userA,
+		Name: "n", Instructions: "do the thing", Schedule: "daily",
+		Enabled:   true,
+		NextRunAt: ptrTime(now.Add(-time.Minute)),
+	})
+	tasks := &fakeTasks{}
+	s := newScheduler(repo, tasks)
+	ctx := context.Background()
+
+	fired := s.RunOnce(ctx, now)
+	if fired != 1 || tasks.calls != 1 {
+		t.Fatalf("fired=%d calls=%d, want 1/1", fired, tasks.calls)
+	}
+	got, _ := repo.Get(ctx, tenantA, userA, idA)
+	if got.LastTaskID == nil {
+		t.Fatal("last_task_id must be recorded")
+	}
+	if got.LastError != "" {
+		t.Fatalf("last_error = %q, want empty on success", got.LastError)
+	}
+
+	fired = s.RunOnce(ctx, now)
+	if fired != 0 {
+		t.Fatalf("second tick at same clock reading fired=%d, want 0", fired)
+	}
+	tasks.mu.Lock()
+	calls := tasks.calls
+	tasks.mu.Unlock()
+	if calls != 1 {
+		t.Fatalf("calls=%d after two ticks, want 1", calls)
+	}
+}
+
+func TestScheduler_SkipsNotDueAndDisabled(t *testing.T) {
+	now := time.Date(2026, 8, 23, 9, 0, 0, 0, time.UTC)
+	future := now.Add(time.Hour)
+	past := now.Add(-time.Hour)
+	repo := newFakeRepo(
+		Schedule{
+			ID: idA, TenantID: tenantA, UserID: userA,
+			Name: "future", Instructions: "i", Schedule: "daily",
+			Enabled:   true,
+			NextRunAt: &future,
+		},
+		Schedule{
+			ID: uuid.New(), TenantID: tenantA, UserID: userA,
+			Name: "disabled", Instructions: "i", Schedule: "daily",
+			Enabled:   false,
+			NextRunAt: &past,
+		},
+	)
+	tasks := &fakeTasks{}
+	s := newScheduler(repo, tasks)
+
+	if fired := s.RunOnce(context.Background(), now); fired != 0 {
+		t.Fatalf("fired=%d, want 0 for not-due and disabled schedules", fired)
+	}
+	tasks.mu.Lock()
+	calls := tasks.calls
+	tasks.mu.Unlock()
+	if calls != 0 {
+		t.Fatalf("calls=%d, want 0", calls)
+	}
+}
+
+func TestScheduler_FailureRecordsErrorAndBacksOffOneCadence(t *testing.T) {
+	now := time.Date(2026, 8, 23, 9, 0, 0, 0, time.UTC)
+	repo := newFakeRepo(Schedule{
+		ID: idA, TenantID: tenantA, UserID: userA,
+		Name: "n", Instructions: "i", Schedule: "daily",
+		Enabled:   true,
+		NextRunAt: ptrTime(now.Add(-time.Minute)),
+	})
+	tasks := &fakeTasks{err: errors.New("engine unavailable")}
+	s := newScheduler(repo, tasks)
+	ctx := context.Background()
+
+	fired := s.RunOnce(ctx, now)
+	if fired != 0 {
+		t.Fatalf("fired=%d, want 0 on failure", fired)
+	}
+	got, _ := repo.Get(ctx, tenantA, userA, idA)
+	if got.LastError == "" {
+		t.Fatal("last_error recorded on failure")
+	}
+	if got.NextRunAt == nil || !got.NextRunAt.After(now) {
+		t.Fatal("failure must leave next_run_at one cadence out, not due again")
+	}
+	if fired := s.RunOnce(ctx, now); fired != 0 {
+		t.Fatal("retry tick must not hot-loop the failed schedule")
+	}
+}

--- a/apps/control-plane/internal/agentsched/service.go
+++ b/apps/control-plane/internal/agentsched/service.go
@@ -193,7 +193,20 @@ func (s *Service) Update(ctx context.Context, tenantID, userID, id uuid.UUID, in
 		return Schedule{}, err
 	}
 	next := current.NextRunAt
-	if in.Schedule != current.Schedule {
+	switch {
+	case in.Schedule != current.Schedule:
+		cad, err := cadence(in.Schedule)
+		if err != nil {
+			return Schedule{}, err
+		}
+		t := s.now().Add(cad)
+		next = &t
+	case in.Enabled && !current.Enabled:
+		// PUT is the path the UI toggle actually uses, so this transition
+		// carries the same rule as SetEnabled: next_run_at froze while the
+		// schedule sat disabled, and re-enabling must push it one full
+		// cadence out rather than firing immediately on a stale overdue
+		// timestamp (an unrequested run that burns credits).
 		cad, err := cadence(in.Schedule)
 		if err != nil {
 			return Schedule{}, err

--- a/apps/control-plane/internal/agentsched/service.go
+++ b/apps/control-plane/internal/agentsched/service.go
@@ -1,0 +1,238 @@
+package agentsched
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/google/uuid"
+)
+
+// Service validates schedule CRUD at the boundary and owns cadence math.
+// Handler never talks to Repository directly, mirroring agenttask.Service.
+type Service struct {
+	repo Repository
+	now  func() time.Time
+}
+
+// NewService constructs a Service. A nil now defaults to time.Now; tests
+// inject a fake clock.
+func NewService(repo Repository, now func() time.Time) *Service {
+	if now == nil {
+		now = time.Now
+	}
+	return &Service{repo: repo, now: now}
+}
+
+// CreateInput is the validated-shape input for Service.Create. The wire
+// handler builds it from the request body; every field is re-validated here,
+// because the handler is not the only caller the scheduler will ever have.
+type CreateInput struct {
+	Name         string
+	Instructions string
+	Schedule     string
+}
+
+// UpdateInput is the full replacement body for Service.Update (PUT semantics:
+// absent fields are an explicit empty, not a keep).
+type UpdateInput struct {
+	Name         string
+	Instructions string
+	Schedule     string
+	Enabled      bool
+}
+
+// sanitizeInstructions strips control characters except newline and tab.
+// Instructions become prompts handed to a model and eventually to a sandbox,
+// so anything outside printable text (e.g. \r, NUL, terminal escapes) is
+// dropped at the boundary rather than stored. Mirrors the input-parsing rule
+// in CLAUDE.md's working notes for this feature.
+func sanitizeInstructions(in string) string {
+	return strings.Map(func(r rune) rune {
+		if r == '\n' || r == '\t' {
+			return r
+		}
+		if unicode.IsControl(r) {
+			return -1
+		}
+		return r
+	}, in)
+}
+
+// validSchedule reports whether s matches the restricted first-slice grammar
+// the migration's CHECK constraint also enforces: daily, weekly, or
+// interval:N with 1 <= N <= 168.
+func validSchedule(s string) bool {
+	switch s {
+	case "daily", "weekly":
+		return true
+	}
+	if !strings.HasPrefix(s, "interval:") {
+		return false
+	}
+	n, ok := parseIntervalHours(s)
+	return ok && n >= 1 && n <= maxIntervalHours
+}
+
+const maxIntervalHours = 168
+
+// parseIntervalHours extracts N from "interval:N". Returns ok=false unless N
+// is one or more ASCII digits with no sign, spaces, or overflow.
+func parseIntervalHours(s string) (int, bool) {
+	rest, ok := strings.CutPrefix(s, "interval:")
+	if !ok || rest == "" || len(rest) > 3 {
+		return 0, false
+	}
+	n := 0
+	for _, c := range rest {
+		if c < '0' || c > '9' {
+			return 0, false
+		}
+		n = n*10 + int(c-'0')
+	}
+	return n, true
+}
+
+// cadence returns the fixed duration of one schedule period. The claim
+// function advances next_run_at with the same arithmetic in SQL; keep the two
+// in sync (see 20260823_01_agent_task_schedules.sql).
+func cadence(schedule string) (time.Duration, error) {
+	switch schedule {
+	case "daily":
+		return 24 * time.Hour, nil
+	case "weekly":
+		return 7 * 24 * time.Hour, nil
+	}
+	if n, ok := parseIntervalHours(schedule); ok {
+		return time.Duration(n) * time.Hour, nil
+	}
+	return 0, ErrInvalidSchedule
+}
+
+// validate applies boundary rules shared by Create and Update: name length,
+// instruction length after control-char stripping, schedule grammar. Returns
+// the cleaned values.
+func validate(name, instructions, schedule string) (string, string, error) {
+	name = strings.TrimSpace(name)
+	instructions = sanitizeInstructions(strings.TrimSpace(instructions))
+
+	if name == "" || len(name) > maxNameLength {
+		return "", "", ErrInvalidName
+	}
+	if instructions == "" || len(instructions) > maxInstructionsLength {
+		return "", "", ErrInvalidInstructions
+	}
+	if !validSchedule(schedule) {
+		return "", "", ErrInvalidSchedule
+	}
+	return name, instructions, nil
+}
+
+// Create persists a new enabled schedule whose first run is one full cadence
+// out from now — never immediately, so creating a routine does not fire a
+// surprise task before the user has reviewed it.
+func (s *Service) Create(ctx context.Context, tenantID, userID uuid.UUID, in CreateInput) (Schedule, error) {
+	name, instructions, err := validate(in.Name, in.Instructions, in.Schedule)
+	if err != nil {
+		return Schedule{}, err
+	}
+	cad, err := cadence(in.Schedule)
+	if err != nil {
+		return Schedule{}, err
+	}
+	next := s.now().Add(cad)
+	out, err := s.repo.Create(ctx, Schedule{
+		TenantID:     tenantID,
+		UserID:       userID,
+		Name:         name,
+		Instructions: instructions,
+		Schedule:     in.Schedule,
+		Enabled:      true,
+		NextRunAt:    &next,
+	})
+	if err != nil {
+		return Schedule{}, fmt.Errorf("agentsched: create: %w", err)
+	}
+	return out, nil
+}
+
+// Get returns one schedule scoped to (tenantID, userID): another user's
+// schedule inside the same tenant reads as not found, same as agenttask.
+func (s *Service) Get(ctx context.Context, tenantID, userID, id uuid.UUID) (Schedule, error) {
+	return s.repo.Get(ctx, tenantID, userID, id)
+}
+
+// List returns every schedule userID owns within tenantID, newest first.
+func (s *Service) List(ctx context.Context, tenantID, userID uuid.UUID) ([]Schedule, error) {
+	return s.repo.List(ctx, tenantID, userID)
+}
+
+// Update replaces the mutable fields of one schedule. Changing the cadence
+// recomputes next_run_at from now so the row never carries a stale due date;
+// leaving it unchanged keeps the existing schedule position.
+func (s *Service) Update(ctx context.Context, tenantID, userID, id uuid.UUID, in UpdateInput) (Schedule, error) {
+	current, err := s.repo.Get(ctx, tenantID, userID, id)
+	if err != nil {
+		return Schedule{}, err
+	}
+	name, instructions, err := validate(in.Name, in.Instructions, in.Schedule)
+	if err != nil {
+		return Schedule{}, err
+	}
+	next := current.NextRunAt
+	if in.Schedule != current.Schedule {
+		cad, err := cadence(in.Schedule)
+		if err != nil {
+			return Schedule{}, err
+		}
+		t := s.now().Add(cad)
+		next = &t
+	}
+	out, err := s.repo.Update(ctx, Schedule{
+		ID:           current.ID,
+		TenantID:     current.TenantID,
+		UserID:       current.UserID,
+		Name:         name,
+		Instructions: instructions,
+		Schedule:     in.Schedule,
+		Enabled:      in.Enabled,
+		NextRunAt:    next,
+	})
+	if err != nil {
+		return Schedule{}, fmt.Errorf("agentsched: update: %w", err)
+	}
+	return out, nil
+}
+
+// SetEnabled flips the enabled flag without touching any other field.
+// Enabling resets next_run_at to one full cadence from now: while disabled,
+// next_run_at freezes, so a row disabled past its due date would otherwise
+// fire once, immediately, the moment it was re-enabled.
+func (s *Service) SetEnabled(ctx context.Context, tenantID, userID, id uuid.UUID, enabled bool) (Schedule, error) {
+	var next *time.Time
+	if enabled {
+		current, err := s.repo.Get(ctx, tenantID, userID, id)
+		if err != nil {
+			return Schedule{}, err
+		}
+		cad, err := cadence(current.Schedule)
+		if err != nil {
+			return Schedule{}, err
+		}
+		t := s.now().Add(cad)
+		next = &t
+	}
+	out, err := s.repo.SetEnabled(ctx, tenantID, userID, id, enabled, next)
+	if err != nil {
+		return Schedule{}, fmt.Errorf("agentsched: set enabled: %w", err)
+	}
+	return out, nil
+}
+
+// Delete removes one schedule. Deleting a schedule never touches tasks its
+// earlier runs created (last_task_id is SET NULL on the DB side).
+func (s *Service) Delete(ctx context.Context, tenantID, userID, id uuid.UUID) error {
+	return s.repo.Delete(ctx, tenantID, userID, id)
+}

--- a/apps/control-plane/internal/agentsched/service.go
+++ b/apps/control-plane/internal/agentsched/service.go
@@ -103,7 +103,7 @@ func parseIntervalHours(s string) (int, bool) {
 
 // cadence returns the fixed duration of one schedule period. The claim
 // function advances next_run_at with the same arithmetic in SQL; keep the two
-// in sync (see 20260823_01_agent_task_schedules.sql).
+// in sync (see 20260823_02_agent_task_schedules.sql).
 func cadence(schedule string) (time.Duration, error) {
 	switch schedule {
 	case "daily":

--- a/apps/control-plane/internal/agentsched/service.go
+++ b/apps/control-plane/internal/agentsched/service.go
@@ -85,6 +85,12 @@ func parseIntervalHours(s string) (int, bool) {
 	if !ok || rest == "" || len(rest) > 3 {
 		return 0, false
 	}
+	if len(rest) > 1 && rest[0] == '0' {
+		// Leading zeros ("interval:007") parse here but the migration's CHECK
+		// regex rejects them, so accepting them would turn a validation error
+		// into a 500 at insert time.
+		return 0, false
+	}
 	n := 0
 	for _, c := range rest {
 		if c < '0' || c > '9' {
@@ -115,7 +121,12 @@ func cadence(schedule string) (time.Duration, error) {
 // instruction length after control-char stripping, schedule grammar. Returns
 // the cleaned values.
 func validate(name, instructions, schedule string) (string, string, error) {
-	name = strings.TrimSpace(name)
+	name = strings.TrimSpace(strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) {
+			return -1
+		}
+		return r
+	}, name))
 	instructions = sanitizeInstructions(strings.TrimSpace(instructions))
 
 	if name == "" || len(name) > maxNameLength {

--- a/apps/control-plane/internal/agentsched/service_test.go
+++ b/apps/control-plane/internal/agentsched/service_test.go
@@ -68,6 +68,7 @@ func TestService_Create_RejectsInvalidInput(t *testing.T) {
 		{CreateInput{Name: "n", Instructions: "x", Schedule: "interval:0"}, ErrInvalidSchedule},
 		{CreateInput{Name: "n", Instructions: "x", Schedule: "interval:99999"}, ErrInvalidSchedule},
 		{CreateInput{Name: "n", Instructions: "x", Schedule: "interval:-3"}, ErrInvalidSchedule},
+		{CreateInput{Name: "n", Instructions: "x", Schedule: "interval:007"}, ErrInvalidSchedule},
 	}
 	for i, tc := range cases {
 		if _, err := svc.Create(ctx, tenantA, userA, tc.in); !errors.Is(err, tc.wantErr) {

--- a/apps/control-plane/internal/agentsched/service_test.go
+++ b/apps/control-plane/internal/agentsched/service_test.go
@@ -120,6 +120,33 @@ func TestService_Update_RecomputesNextRunOnlyOnCadenceChange(t *testing.T) {
 	}
 }
 
+// The UI toggle goes through PUT (UpdateInput.Enabled), not a dedicated
+// enable endpoint, so this transition is where the stale-next_run_at rule
+// actually matters: a schedule disabled for weeks carries an overdue
+// next_run_at, and re-enabling it must fire one cadence out, never instantly.
+func TestService_Update_ReEnableViaPUTResetsStaleNextRun(t *testing.T) {
+	now := time.Date(2026, 8, 23, 9, 0, 0, 0, time.UTC)
+	stale := now.Add(-48 * time.Hour)
+	repo := newFakeRepo(Schedule{
+		ID: idA, TenantID: tenantA, UserID: userA,
+		Name: "n", Instructions: "i", Schedule: "daily",
+		Enabled:   false,
+		NextRunAt: &stale,
+	})
+	svc := NewService(repo, fixedClock(now))
+
+	out, err := svc.Update(context.Background(), tenantA, userA, idA, UpdateInput{
+		Name: "n", Instructions: "i", Schedule: "daily", Enabled: true,
+	})
+	if err != nil {
+		t.Fatalf("PUT re-enable: %v", err)
+	}
+	want := now.Add(24 * time.Hour)
+	if out.NextRunAt == nil || !out.NextRunAt.Equal(want) {
+		t.Fatalf("re-enable via PUT next_run_at = %v, want %v (not the stale %v)", out.NextRunAt, want, stale)
+	}
+}
+
 func TestService_SetEnabled_ResetsNextRunWhenEnabling(t *testing.T) {
 	now := time.Date(2026, 8, 23, 9, 0, 0, 0, time.UTC)
 	stale := now.Add(-48 * time.Hour)

--- a/apps/control-plane/internal/agentsched/service_test.go
+++ b/apps/control-plane/internal/agentsched/service_test.go
@@ -1,0 +1,149 @@
+package agentsched
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+var (
+	tenantA = uuid.New()
+	userA   = uuid.New()
+	idA     = uuid.New()
+)
+
+func fixedClock(t time.Time) func() time.Time {
+	return func() time.Time { return t }
+}
+
+// ptrTime is the test helper for *time.Time fields.
+func ptrTime(t time.Time) *time.Time { return &t }
+
+func TestService_Create_ValidatesAndComputesNextRun(t *testing.T) {
+	now := time.Date(2026, 8, 23, 9, 0, 0, 0, time.UTC)
+	svc := NewService(newFakeRepo(), fixedClock(now))
+	ctx := context.Background()
+
+	cases := []struct {
+		in          CreateInput
+		wantNextRun time.Duration
+	}{
+		{CreateInput{Name: "Morning digest", Instructions: "Summarize inbox", Schedule: "daily"}, 24 * time.Hour},
+		{CreateInput{Name: "Weekly report", Instructions: "Draft report", Schedule: "weekly"}, 7 * 24 * time.Hour},
+		{CreateInput{Name: "Watch", Instructions: "Check queue", Schedule: "interval:6"}, 6 * time.Hour},
+	}
+	for i, tc := range cases {
+		got, err := svc.Create(ctx, tenantA, userA, tc.in)
+		if err != nil {
+			t.Fatalf("case %d Create: %v", i, err)
+		}
+		want := now.Add(tc.wantNextRun)
+		if got.NextRunAt == nil || !got.NextRunAt.Equal(want) {
+			t.Fatalf("case %d next run = %v, want %v", i, got.NextRunAt, want)
+		}
+		if !got.Enabled {
+			t.Fatalf("case %d: new schedule must be enabled", i)
+		}
+	}
+}
+
+func TestService_Create_RejectsInvalidInput(t *testing.T) {
+	now := time.Date(2026, 8, 23, 9, 0, 0, 0, time.UTC)
+	svc := NewService(newFakeRepo(), fixedClock(now))
+	ctx := context.Background()
+
+	cases := []struct {
+		in      CreateInput
+		wantErr error
+	}{
+		{CreateInput{Name: "", Instructions: "x", Schedule: "daily"}, ErrInvalidName},
+		{CreateInput{Name: strings.Repeat("a", 101), Instructions: "x", Schedule: "daily"}, ErrInvalidName},
+		{CreateInput{Name: "n", Instructions: "", Schedule: "daily"}, ErrInvalidInstructions},
+		{CreateInput{Name: "n", Instructions: strings.Repeat("a", 4001), Schedule: "daily"}, ErrInvalidInstructions},
+		{CreateInput{Name: "n", Instructions: "x", Schedule: "* * * * *"}, ErrInvalidSchedule},
+		{CreateInput{Name: "n", Instructions: "x", Schedule: "interval:0"}, ErrInvalidSchedule},
+		{CreateInput{Name: "n", Instructions: "x", Schedule: "interval:99999"}, ErrInvalidSchedule},
+		{CreateInput{Name: "n", Instructions: "x", Schedule: "interval:-3"}, ErrInvalidSchedule},
+	}
+	for i, tc := range cases {
+		if _, err := svc.Create(ctx, tenantA, userA, tc.in); !errors.Is(err, tc.wantErr) {
+			t.Errorf("case %d error = %v, want %v", i, err, tc.wantErr)
+		}
+	}
+}
+
+func TestService_SanitizeStripsControlCharsButKeepsNewlineAndTab(t *testing.T) {
+	got := sanitizeInstructions("line1\r\nline2\tend\x00")
+	want := "line1\nline2\tend"
+	if got != want {
+		t.Fatalf("sanitize = %q, want %q", got, want)
+	}
+}
+
+func TestService_Update_RecomputesNextRunOnlyOnCadenceChange(t *testing.T) {
+	now := time.Date(2026, 8, 23, 9, 0, 0, 0, time.UTC)
+	repo := newFakeRepo(Schedule{
+		ID: idA, TenantID: tenantA, UserID: userA,
+		Name: "before", Instructions: "old", Schedule: "daily",
+		Enabled:   true,
+		NextRunAt: ptrTime(now.Add(24 * time.Hour)),
+	})
+	svc := NewService(repo, fixedClock(now))
+	ctx := context.Background()
+
+	out, err := svc.Update(ctx, tenantA, userA, idA, UpdateInput{
+		Name: "after", Instructions: "new", Schedule: "daily", Enabled: true,
+	})
+	if err != nil {
+		t.Fatalf("same-cadence update: %v", err)
+	}
+	if out.Name != "after" || out.Instructions != "new" {
+		t.Fatal("expected fields replaced")
+	}
+	if out.NextRunAt == nil || !out.NextRunAt.Equal(now.Add(24*time.Hour)) {
+		t.Fatal("same-cadence update must keep next_run_at")
+	}
+
+	out, err = svc.Update(ctx, tenantA, userA, idA, UpdateInput{
+		Name: "after", Instructions: "new", Schedule: "weekly", Enabled: true,
+	})
+	if err != nil {
+		t.Fatalf("cadence-change update: %v", err)
+	}
+	if out.NextRunAt == nil || !out.NextRunAt.Equal(now.Add(7*24*time.Hour)) {
+		t.Fatal("cadence change must recompute next_run_at")
+	}
+}
+
+func TestService_SetEnabled_ResetsNextRunWhenEnabling(t *testing.T) {
+	now := time.Date(2026, 8, 23, 9, 0, 0, 0, time.UTC)
+	stale := now.Add(-48 * time.Hour)
+	repo := newFakeRepo(Schedule{
+		ID: idA, TenantID: tenantA, UserID: userA,
+		Name: "n", Instructions: "i", Schedule: "daily",
+		Enabled:   false,
+		NextRunAt: &stale,
+	})
+	svc := NewService(repo, fixedClock(now))
+	ctx := context.Background()
+
+	out, err := svc.SetEnabled(ctx, tenantA, userA, idA, true)
+	if err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	if !out.Enabled || out.NextRunAt == nil || !out.NextRunAt.After(now) {
+		t.Fatal("re-enable must push next_run_at into the future")
+	}
+
+	out, err = svc.SetEnabled(ctx, tenantA, userA, idA, false)
+	if err != nil {
+		t.Fatalf("disable: %v", err)
+	}
+	if out.Enabled {
+		t.Fatal("expected disabled")
+	}
+}

--- a/apps/control-plane/internal/agentsched/types.go
+++ b/apps/control-plane/internal/agentsched/types.go
@@ -1,0 +1,53 @@
+// Package agentsched owns scheduled agent tasks ("routines"): a user-defined
+// recurring prompt the Scheduler turns into a real agent task on its cadence,
+// through the same Service.CreateTask path a manual creation uses, so a
+// scheduled run is metered, quota-gated and engine-gated exactly like a
+// manual one. First slice carries fixed cadences only (daily, weekly,
+// interval:N hours); no cron-expression UX.
+package agentsched
+
+import (
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Schedule is one row of public.agent_task_schedules.
+type Schedule struct {
+	ID           uuid.UUID
+	TenantID     uuid.UUID
+	UserID       uuid.UUID
+	Name         string
+	Instructions string
+	Schedule     string // "daily", "weekly", or "interval:N" (N hours, 1..168)
+	Enabled      bool
+	NextRunAt    *time.Time
+	LastRunAt    *time.Time
+	LastTaskID   *uuid.UUID
+	LastError    string
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
+}
+
+var (
+	// ErrNotFound is returned when the requested schedule does not exist, or
+	// does not belong to the requesting tenant/user.
+	ErrNotFound = errors.New("agentsched: schedule not found")
+
+	// ErrInvalidName is returned when Name is empty or over 100 characters.
+	ErrInvalidName = errors.New("agentsched: name must be 1-100 characters")
+
+	// ErrInvalidInstructions is returned when Instructions is empty or over
+	// 4000 characters after sanitization.
+	ErrInvalidInstructions = errors.New("agentsched: instructions must be 1-4000 characters")
+
+	// ErrInvalidSchedule is returned when Schedule does not match the
+	// restricted first-slice grammar.
+	ErrInvalidSchedule = errors.New("agentsched: schedule must be daily, weekly, or interval:N with N between 1 and 168")
+)
+
+const (
+	maxNameLength         = 100
+	maxInstructionsLength = 4000
+)

--- a/apps/control-plane/internal/platform/http/router.go
+++ b/apps/control-plane/internal/platform/http/router.go
@@ -170,7 +170,7 @@ type RouterConfig struct {
 
 	// AgentTaskHandler serves agent task persistence (issue #311, agent-
 	// subsystem blueprint Step 3.4): the shared-secret-guarded
-	// service-to-service surface at /internal/agent-schedules/ that edge-api's
+	// service-to-service surface at /internal/agent-tasks/ that edge-api's
 	// customer-facing /v1/agent/tasks routes call into. When nil the route
 	// is not registered.
 	AgentTaskHandler *agenttask.Handler

--- a/apps/control-plane/internal/platform/http/router.go
+++ b/apps/control-plane/internal/platform/http/router.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/accounting"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/accounts"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/agentsched"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/agenttask"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/apikeys"
 	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/auth"
@@ -169,7 +170,7 @@ type RouterConfig struct {
 
 	// AgentTaskHandler serves agent task persistence (issue #311, agent-
 	// subsystem blueprint Step 3.4): the shared-secret-guarded
-	// service-to-service surface at /internal/agent-tasks/ that edge-api's
+	// service-to-service surface at /internal/agent-schedules/ that edge-api's
 	// customer-facing /v1/agent/tasks routes call into. When nil the route
 	// is not registered.
 	AgentTaskHandler *agenttask.Handler
@@ -178,6 +179,13 @@ type RouterConfig struct {
 	// D-020): the shared-secret-guarded four-verb surface at
 	// /internal/user-memories/. When nil the route is not registered.
 	UserMemoriesHandler *usermemories.Handler
+
+	// AgentScheduleHandler serves scheduled-agent-task ("routines") CRUD:
+	// the shared-secret-guarded service-to-service surface at
+	// /internal/agent-schedules/ that edge-api's customer-facing
+	// /v1/agent/schedules routes call into. When nil the route is not
+	// registered.
+	AgentScheduleHandler *agentsched.Handler
 }
 
 // NewRouter returns a configured http.Handler with all platform routes registered.
@@ -413,6 +421,13 @@ func NewRouter(cfg RouterConfig) http.Handler {
 	// is a follow-up if the pattern earns one.
 	if cfg.UserMemoriesHandler != nil {
 		mux.Handle("/internal/user-memories/", internal(cfg.UserMemoriesHandler.InternalMux()))
+	}
+
+	// Scheduled agent tasks ("routines") — service-to-service only: edge-api's
+	// /v1/agent/schedules are the customer-facing surface, this is the
+	// internal store they call into.
+	if cfg.AgentScheduleHandler != nil {
+		mux.Handle("/internal/agent-schedules/", internal(cfg.AgentScheduleHandler.InternalMux()))
 	}
 
 	// Wrap the mux with Prometheus HTTP instrumentation if a metrics registry is provided.

--- a/apps/edge-api/cmd/server/gated_routes.go
+++ b/apps/edge-api/cmd/server/gated_routes.go
@@ -30,3 +30,13 @@ func registerAgentTaskRoutes(mux *http.ServeMux, gate *featuregate.Gate, taskHan
 	mux.Handle("/v1/agent/tasks", gated)
 	mux.Handle("/v1/agent/tasks/", gated)
 }
+
+// registerAgentScheduleRoutes attaches the scheduled-agent-task ("routines")
+// CRUD surface to mux behind FeatureCowork: deployments (tenants) without
+// Cowork enabled get the same 403 the task routes return, never a 404, and
+// removing or swapping this gate turns gated_routes_test.go red.
+func registerAgentScheduleRoutes(mux *http.ServeMux, gate *featuregate.Gate, scheduleHandler http.Handler) {
+	gated := gate.Require(featuregate.FeatureCowork)(scheduleHandler)
+	mux.Handle("/v1/agent/schedules", gated)
+	mux.Handle("/v1/agent/schedules/", gated)
+}

--- a/apps/edge-api/cmd/server/main.go
+++ b/apps/edge-api/cmd/server/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/redis/go-redis/v9"
 	"github.com/sakibsadmanshajib/hive/apps/edge-api/docs"
+	edgeagentsched "github.com/sakibsadmanshajib/hive/apps/edge-api/internal/agentsched"
 	edgeagenttask "github.com/sakibsadmanshajib/hive/apps/edge-api/internal/agenttask"
 	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/anthropic"
 	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/artifacts"
@@ -441,6 +442,19 @@ func main() {
 		agentTaskMux := http.NewServeMux()
 		agentTaskHandler.Register(agentTaskMux)
 		registerAgentTaskRoutes(mux, featureGate, agentTaskMux)
+	}
+
+	// Scheduled agent tasks ("routines"): customer-facing CRUD for the rows
+	// control-plane's scheduler turns into real tasks. Same trust shape as
+	// the block above: persistence lives in control-plane
+	// (apps/control-plane/internal/agentsched), this is only the auth
+	// boundary, registered behind FeatureCowork like /v1/agent/tasks.
+	{
+		agentSchedClient := edgeagentsched.NewClient(resolveControlPlaneBaseURL())
+		agentSchedHandler := edgeagentsched.NewHandler(agentSchedClient)
+		agentSchedMux := http.NewServeMux()
+		agentSchedHandler.Register(agentSchedMux)
+		registerAgentScheduleRoutes(mux, featureGate, agentSchedMux)
 	}
 
 	// API routes

--- a/apps/edge-api/internal/agentsched/client.go
+++ b/apps/edge-api/internal/agentsched/client.go
@@ -1,0 +1,173 @@
+// Client calls control-plane's internal schedule CRUD surface. Mirrors
+// apps/edge-api/internal/agenttask/client.go's shape: provider-blind error
+// mapping (control-plane's raw body is never threaded into a returned error).
+package agentsched
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/cpauth"
+)
+
+type Client struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+// NewClient creates a Client pointing at the control-plane base URL. Every
+// call here is a short database operation; 15s matches agenttask's client.
+func NewClient(controlPlaneURL string) *Client {
+	return &Client{
+		baseURL:    strings.TrimRight(controlPlaneURL, "/"),
+		httpClient: &http.Client{Timeout: 15 * time.Second},
+	}
+}
+
+func (c *Client) basePath(tenantID, userID uuid.UUID) string {
+	return "/internal/agent-schedules/" + tenantID.String() + "/" + userID.String()
+}
+
+type createBody struct {
+	Name         string `json:"name"`
+	Instructions string `json:"instructions"`
+	Schedule     string `json:"schedule"`
+}
+
+type updateBody struct {
+	Name         string `json:"name"`
+	Instructions string `json:"instructions"`
+	Schedule     string `json:"schedule"`
+	Enabled      bool   `json:"enabled"`
+}
+
+// Create posts a new schedule.
+func (c *Client) Create(ctx context.Context, tenantID, userID uuid.UUID, name, instructions, schedule string) (Schedule, error) {
+	body, err := json.Marshal(createBody{Name: name, Instructions: instructions, Schedule: schedule})
+	if err != nil {
+		return Schedule{}, fmt.Errorf("agentsched.client: marshal: %w", err)
+	}
+	return c.send(ctx, http.MethodPost, c.basePath(tenantID, userID), body)
+}
+
+// List returns every schedule for (tenantID, userID), newest first.
+func (c *Client) List(ctx context.Context, tenantID, userID uuid.UUID) ([]Schedule, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+c.basePath(tenantID, userID), nil)
+	if err != nil {
+		return nil, fmt.Errorf("agentsched.client: build request: %w", err)
+	}
+	cpauth.SetHeader(req)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("agentsched.client: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		drain(resp.Body)
+		return nil, statusErr(resp.StatusCode)
+	}
+	var listResp struct {
+		Schedules []Schedule `json:"schedules"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&listResp); err != nil {
+		return nil, fmt.Errorf("agentsched.client: decode list response: %w", err)
+	}
+	return listResp.Schedules, nil
+}
+
+// Get fetches one schedule by id.
+func (c *Client) Get(ctx context.Context, tenantID, userID, id uuid.UUID) (Schedule, error) {
+	var out Schedule
+	err := c.exchange(ctx, http.MethodGet, c.basePath(tenantID, userID)+"/"+id.String(), nil, &out)
+	return out, err
+}
+
+// Update replaces one schedule's mutable fields.
+func (c *Client) Update(ctx context.Context, tenantID, userID, id uuid.UUID, b updateBody) (Schedule, error) {
+	body, err := json.Marshal(b)
+	if err != nil {
+		return Schedule{}, fmt.Errorf("agentsched.client: marshal: %w", err)
+	}
+	var out Schedule
+	err = c.exchange(ctx, http.MethodPut, c.basePath(tenantID, userID)+"/"+id.String(), body, &out)
+	return out, err
+}
+
+// Delete removes one schedule.
+func (c *Client) Delete(ctx context.Context, tenantID, userID, id uuid.UUID) error {
+	return c.exchange(ctx, http.MethodDelete, c.basePath(tenantID, userID)+"/"+id.String(), nil, nil)
+}
+
+// send is the POST create helper: builds the request, sets the internal token
+// header, decodes the created Schedule.
+func (c *Client) send(ctx context.Context, method, path string, body []byte) (Schedule, error) {
+	var out Schedule
+	err := c.exchange(ctx, method, path, body, &out)
+	return out, err
+}
+
+// exchange runs one HTTP exchange against control-plane and, when out is
+// non-nil, decodes the JSON response into it. 204 carries no body by design;
+// decoding is skipped for it.
+func (c *Client) exchange(ctx context.Context, method, path string, body []byte, out any) error {
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, nil)
+	if err != nil {
+		return fmt.Errorf("agentsched.client: build request: %w", err)
+	}
+	if body != nil {
+		req = req.Clone(ctx)
+		req.Body = io.NopCloser(bytes.NewReader(body))
+		req.ContentLength = int64(len(body))
+		req.Header.Set("Content-Type", "application/json")
+	}
+	cpauth.SetHeader(req)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("agentsched.client: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNoContent {
+		return nil
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		drain(resp.Body)
+		return statusErr(resp.StatusCode)
+	}
+	if out == nil {
+		drain(resp.Body)
+		return nil
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(out); err != nil {
+		return fmt.Errorf("agentsched.client: decode response: %w", err)
+	}
+	return nil
+}
+
+// statusErr maps control-plane's status code to a sentinel error, never the
+// response body (provider-blind boundary).
+func statusErr(status int) error {
+	switch status {
+	case http.StatusNotFound:
+		return ErrNotFound
+	case http.StatusBadRequest:
+		return ErrInvalidInput
+	default:
+		return ErrRequestFailed
+	}
+}
+
+// drain discards the response body without threading its content anywhere.
+func drain(body io.Reader) {
+	_, _ = io.Copy(io.Discard, io.LimitReader(body, 65536))
+}

--- a/apps/edge-api/internal/agentsched/handler.go
+++ b/apps/edge-api/internal/agentsched/handler.go
@@ -1,0 +1,184 @@
+package agentsched
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/auth"
+	apierrors "github.com/sakibsadmanshajib/hive/apps/edge-api/internal/errors"
+)
+
+// ScheduleClient is the minimal interface the handler needs from Client.
+// Exported so tests can inject a fake without a real control-plane.
+type ScheduleClient interface {
+	Create(ctx context.Context, tenantID, userID uuid.UUID, name, instructions, schedule string) (Schedule, error)
+	List(ctx context.Context, tenantID, userID uuid.UUID) ([]Schedule, error)
+	Get(ctx context.Context, tenantID, userID, id uuid.UUID) (Schedule, error)
+	Update(ctx context.Context, tenantID, userID, id uuid.UUID, body updateBody) (Schedule, error)
+	Delete(ctx context.Context, tenantID, userID, id uuid.UUID) error
+}
+
+// Handler serves /v1/agent/schedules routes. Callers wrap with
+// featuregate.Require(FeatureCowork) before mounting, mirroring
+// apps/edge-api/internal/agenttask's gating contract.
+type Handler struct {
+	client ScheduleClient
+}
+
+func NewHandler(client ScheduleClient) *Handler {
+	return &Handler{client: client}
+}
+
+// Register mounts all /v1/agent/schedules* routes on mux.
+func (h *Handler) Register(mux *http.ServeMux) {
+	mux.HandleFunc("/v1/agent/schedules", h.routeCollection)
+	mux.HandleFunc("/v1/agent/schedules/", h.routeItem)
+}
+
+func (h *Handler) routeCollection(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost:
+		h.handleCreate(w, r)
+	case http.MethodGet:
+		h.handleList(w, r)
+	default:
+		apierrors.Write(w, http.StatusMethodNotAllowed, apierrors.CodeInvalidRequest, "method not allowed")
+	}
+}
+
+func (h *Handler) routeItem(w http.ResponseWriter, r *http.Request) {
+	id, err := extractSchedulePath(r.URL.Path)
+	if err != nil {
+		apierrors.Write(w, http.StatusBadRequest, apierrors.CodeInvalidRequest, "invalid schedule id")
+		return
+	}
+	switch r.Method {
+	case http.MethodGet:
+		h.handleGet(w, r, id)
+	case http.MethodPut:
+		h.handleUpdate(w, r, id)
+	case http.MethodDelete:
+		h.handleDelete(w, r, id)
+	default:
+		apierrors.Write(w, http.StatusMethodNotAllowed, apierrors.CodeInvalidRequest, "method not allowed")
+	}
+}
+
+func extractSchedulePath(path string) (uuid.UUID, error) {
+	rest := strings.Trim(strings.TrimPrefix(path, "/v1/agent/schedules/"), "/")
+	return uuid.Parse(rest)
+}
+
+type createReq struct {
+	Name         string `json:"name"`
+	Instructions string `json:"instructions"`
+	Schedule     string `json:"schedule"`
+}
+
+func (h *Handler) handleCreate(w http.ResponseWriter, r *http.Request) {
+	user, ok := authUser(w, r)
+	if !ok {
+		return
+	}
+	var req createReq
+	if err := json.NewDecoder(io.LimitReader(r.Body, 64<<10)).Decode(&req); err != nil {
+		apierrors.Write(w, http.StatusBadRequest, apierrors.CodeInvalidRequest, "invalid request body")
+		return
+	}
+	schedule, err := h.client.Create(r.Context(), user.TenantID, user.ID, req.Name, req.Instructions, req.Schedule)
+	if err != nil {
+		writeScheduleError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, schedule)
+}
+
+func (h *Handler) handleList(w http.ResponseWriter, r *http.Request) {
+	user, ok := authUser(w, r)
+	if !ok {
+		return
+	}
+	schedules, err := h.client.List(r.Context(), user.TenantID, user.ID)
+	if err != nil {
+		writeScheduleError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"schedules": schedules})
+}
+
+func (h *Handler) handleGet(w http.ResponseWriter, r *http.Request, id uuid.UUID) {
+	user, ok := authUser(w, r)
+	if !ok {
+		return
+	}
+	schedule, err := h.client.Get(r.Context(), user.TenantID, user.ID, id)
+	if err != nil {
+		writeScheduleError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, schedule)
+}
+
+func (h *Handler) handleUpdate(w http.ResponseWriter, r *http.Request, id uuid.UUID) {
+	user, ok := authUser(w, r)
+	if !ok {
+		return
+	}
+	var req updateBody
+	if err := json.NewDecoder(io.LimitReader(r.Body, 64<<10)).Decode(&req); err != nil {
+		apierrors.Write(w, http.StatusBadRequest, apierrors.CodeInvalidRequest, "invalid request body")
+		return
+	}
+	schedule, err := h.client.Update(r.Context(), user.TenantID, user.ID, id, req)
+	if err != nil {
+		writeScheduleError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, schedule)
+}
+
+func (h *Handler) handleDelete(w http.ResponseWriter, r *http.Request, id uuid.UUID) {
+	user, ok := authUser(w, r)
+	if !ok {
+		return
+	}
+	if err := h.client.Delete(r.Context(), user.TenantID, user.ID, id); err != nil {
+		writeScheduleError(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// authUser resolves the authenticated user or writes the 401 and reports
+// false. Mirrors agenttask's handler pattern with less repetition.
+func authUser(w http.ResponseWriter, r *http.Request) (auth.User, bool) {
+	user, ok := auth.UserFrom(r.Context())
+	if !ok || user == nil {
+		apierrors.Write(w, http.StatusUnauthorized, apierrors.CodeUnauthenticated, "unauthenticated")
+		return auth.User{}, false
+	}
+	return *user, true
+}
+
+func writeScheduleError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, ErrNotFound):
+		apierrors.Write(w, http.StatusNotFound, apierrors.CodeInvalidRequest, "schedule not found")
+	case errors.Is(err, ErrInvalidInput):
+		apierrors.Write(w, http.StatusBadRequest, apierrors.CodeInvalidRequest, "invalid schedule input")
+	default:
+		// Provider-blind: control-plane infra detail is never echoed.
+		apierrors.Write(w, http.StatusInternalServerError, apierrors.CodeInternal, "agent schedule request failed")
+	}
+}
+
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}

--- a/apps/edge-api/internal/agentsched/handler_test.go
+++ b/apps/edge-api/internal/agentsched/handler_test.go
@@ -1,0 +1,195 @@
+package agentsched
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/auth"
+)
+
+type fakeClient struct {
+	schedules map[uuid.UUID]Schedule
+	deleteErr error
+}
+
+func newFakeClient() *fakeClient {
+	return &fakeClient{schedules: make(map[uuid.UUID]Schedule)}
+}
+
+func (f *fakeClient) Create(_ context.Context, tenantID, userID uuid.UUID, name, instructions, schedule string) (Schedule, error) {
+	id := uuid.New()
+	s := Schedule{ID: id.String(), Name: name, Instructions: instructions, Schedule: schedule, Enabled: true}
+	f.schedules[id] = s
+	return s, nil
+}
+
+func (f *fakeClient) List(context.Context, uuid.UUID, uuid.UUID) ([]Schedule, error) {
+	out := make([]Schedule, 0, len(f.schedules))
+	for _, s := range f.schedules {
+		out = append(out, s)
+	}
+	return out, nil
+}
+
+func (f *fakeClient) Get(_ context.Context, _, _, id uuid.UUID) (Schedule, error) {
+	s, ok := f.schedules[id]
+	if !ok {
+		return Schedule{}, ErrNotFound
+	}
+	return s, nil
+}
+
+func (f *fakeClient) Update(_ context.Context, _, _, id uuid.UUID, b updateBody) (Schedule, error) {
+	s, ok := f.schedules[id]
+	if !ok {
+		return Schedule{}, ErrNotFound
+	}
+	s.Name = b.Name
+	s.Instructions = b.Instructions
+	s.Schedule = b.Schedule
+	s.Enabled = b.Enabled
+	f.schedules[id] = s
+	return s, nil
+}
+
+func (f *fakeClient) Delete(_ context.Context, _, _, id uuid.UUID) error {
+	if f.deleteErr != nil {
+		return f.deleteErr
+	}
+	delete(f.schedules, id)
+	return nil
+}
+
+func userCtx(tenantID uuid.UUID) context.Context {
+	return auth.WithUser(context.Background(), &auth.User{ID: uuid.New(), TenantID: tenantID})
+}
+
+func TestScheduleRoutes_CRUDHappyPath(t *testing.T) {
+	client := newFakeClient()
+	h := NewHandler(client)
+	mux := http.NewServeMux()
+	h.Register(mux)
+	tenantID := uuid.New()
+
+	// Create
+	body, _ := json.Marshal(createReq{
+		Name: "Morning digest", Instructions: "Summarize inbox", Schedule: "daily",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/v1/agent/schedules", bytes.NewReader(body))
+	req = req.WithContext(userCtx(tenantID))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var created Schedule
+	if err := json.Unmarshal(w.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	if _, err := uuid.Parse(created.ID); err != nil {
+		t.Fatalf("created id not a uuid: %v", err)
+	}
+
+	// List
+	req = httptest.NewRequest(http.MethodGet, "/v1/agent/schedules", nil)
+	req = req.WithContext(userCtx(tenantID))
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("list: expected 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Morning digest") {
+		t.Fatal("list must include the created schedule")
+	}
+}
+
+func TestScheduleRoutes_UpdateToggleAndDelete(t *testing.T) {
+	client := newFakeClient()
+	h := NewHandler(client)
+	mux := http.NewServeMux()
+	h.Register(mux)
+	tenantID := uuid.New()
+
+	body, _ := json.Marshal(createReq{Name: "n", Instructions: "i", Schedule: "daily"})
+	req := httptest.NewRequest(http.MethodPost, "/v1/agent/schedules", bytes.NewReader(body))
+	req = req.WithContext(userCtx(tenantID))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create: expected 201, got %d", w.Code)
+	}
+	var created Schedule
+	_ = json.Unmarshal(w.Body.Bytes(), &created)
+	id := created.ID
+
+	// Update (full PUT body)
+	ub, _ := json.Marshal(updateBody{
+		Name: "n2", Instructions: "i2", Schedule: "weekly", Enabled: false,
+	})
+	req = httptest.NewRequest(http.MethodPut, "/v1/agent/schedules/"+id, bytes.NewReader(ub))
+	req = req.WithContext(userCtx(tenantID))
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("update: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Get shows the toggle
+	req = httptest.NewRequest(http.MethodGet, "/v1/agent/schedules/"+id, nil)
+	req = req.WithContext(userCtx(tenantID))
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	var got Schedule
+	_ = json.Unmarshal(w.Body.Bytes(), &got)
+	if got.Enabled {
+		t.Fatal("expected disabled after PUT with enabled=false")
+	}
+
+	// Delete then 404
+	req = httptest.NewRequest(http.MethodDelete, "/v1/agent/schedules/"+id, nil)
+	req = req.WithContext(userCtx(tenantID))
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("delete: expected 204, got %d", w.Code)
+	}
+	req = httptest.NewRequest(http.MethodGet, "/v1/agent/schedules/"+id, nil)
+	req = req.WithContext(userCtx(tenantID))
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("get after delete: expected 404, got %d", w.Code)
+	}
+}
+
+func TestScheduleRoutes_ValidationErrorsAre400Not500(t *testing.T) {
+	client := newFakeClient()
+	client.deleteErr = errors.New("boom")
+	h := NewHandler(client)
+	mux := http.NewServeMux()
+	h.Register(mux)
+
+	req := httptest.NewRequest(http.MethodDelete, "/v1/agent/schedules/"+uuid.NewString(), nil)
+	req = req.WithContext(userCtx(uuid.New()))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 for a client transport error, got %d", w.Code)
+	}
+
+	req = httptest.NewRequest(http.MethodPost, "/v1/agent/schedules", bytes.NewReader([]byte("{bad json")))
+	req = req.WithContext(userCtx(uuid.New()))
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for malformed body, got %d", w.Code)
+	}
+}

--- a/apps/edge-api/internal/agentsched/types.go
+++ b/apps/edge-api/internal/agentsched/types.go
@@ -1,0 +1,33 @@
+// Package agentsched serves the customer-facing scheduled-agent-task
+// ("routines") CRUD surface at /v1/schedules. Persistence and the
+// scheduler loop live in control-plane (apps/control-plane/internal/
+// agentsched); this package is the auth boundary and wire-shape
+// translator that calls into it over the internal service-to-service surface,
+// mirroring apps/edge-api/internal/agenttask.
+package agentsched
+
+import (
+	"errors"
+	"time"
+)
+
+// Schedule mirrors control-plane's scheduleWire response shape.
+type Schedule struct {
+	ID           string     `json:"id"`
+	Name         string     `json:"name"`
+	Instructions string     `json:"instructions"`
+	Schedule     string     `json:"schedule"`
+	Enabled      bool       `json:"enabled"`
+	NextRunAt    *time.Time `json:"next_run_at"`
+	LastRunAt    *time.Time `json:"last_run_at"`
+	LastTaskID   string     `json:"last_task_id"`
+	LastError    string     `json:"last_error"`
+	CreatedAt    time.Time  `json:"created_at"`
+	UpdatedAt    time.Time  `json:"updated_at"`
+}
+
+var (
+	ErrNotFound      = errors.New("agentsched: schedule not found")
+	ErrInvalidInput  = errors.New("agentsched: invalid name, instructions, or cadence")
+	ErrRequestFailed = errors.New("agentsched: request failed")
+)

--- a/supabase/migrations/20260823_01_agent_task_schedules.sql
+++ b/supabase/migrations/20260823_01_agent_task_schedules.sql
@@ -149,6 +149,21 @@ $$;
 COMMENT ON FUNCTION public.agent_task_schedules_claim_due(TIMESTAMPTZ, INTEGER) IS
   'Scheduler-only cross-tenant claim (scheduled agent tasks, first slice). SECURITY DEFINER bypasses RLS internally for this one fixed statement; agent_task_schedules_tenant_isolation is never weakened at the table level. Advances next_run_at at claim time so each tick fires a schedule at most once. See apps/control-plane/internal/agentsched/scheduler.go.';
 
+-- Postgres grants EXECUTE on every new function to PUBLIC by default; the
+-- explicit hive_app grant below does not remove that. Without this revoke,
+-- Supabase's anon/authenticated roles could call this SECURITY DEFINER
+-- function directly through PostgREST's RPC surface (the anon key is
+-- public): a cross-tenant read of every tenant's schedule rows plus a
+-- starvation DoS, each call claiming due rows and advancing next_run_at
+-- without ever creating a task.
+REVOKE ALL ON FUNCTION public.agent_task_schedules_claim_due(TIMESTAMPTZ, INTEGER) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION public.agent_task_schedules_claim_due(TIMESTAMPTZ, INTEGER) TO hive_app;
+
+-- Same default-PUBLIC grant hole, closed here for the poller's sibling
+-- SECURITY DEFINER function rather than editing its already-applied
+-- migration (20260716_05_agent_tasks_service_scan.sql): an edit there would
+-- do nothing on databases that have already run it.
+REVOKE ALL ON FUNCTION public.agent_tasks_list_active() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.agent_tasks_list_active() TO hive_app;
 
 COMMIT;

--- a/supabase/migrations/20260823_01_agent_task_schedules.sql
+++ b/supabase/migrations/20260823_01_agent_task_schedules.sql
@@ -1,0 +1,154 @@
+-- supabase/migrations/20260823_01_agent_task_schedules.sql
+--
+-- Scheduled agent tasks (routines): a user-defined recurring prompt that the
+-- control-plane scheduler turns into a real agent_tasks row on its cadence,
+-- through the same Service.CreateTask path a manual creation uses so
+-- metering/quota/gating apply identically. First slice: fixed cadences only
+-- (daily, weekly, interval:N hours), no cron-expression UX.
+--
+-- RLS mirrors public.agent_tasks (20260716_03_agent_tasks.sql): hive_app is
+-- NOT BYPASSRLS, tenant scoping is enforced by the agent_task_schedules_tenant_
+-- isolation policy via app.current_tenant_id, and user-level scoping (a
+-- schedule is only listed/edited/deleted by its own user) is an explicit
+-- user_id filter at the application layer, same rationale as agent_tasks.
+-- Unlike agent_tasks, rows are user-managed state, not append-only history:
+-- hive_app gets DELETE.
+--
+-- The scheduler's cross-tenant claim query lives in the SECURITY DEFINER
+-- function agent_task_schedules_claim_due (bottom of this file), NOT in a
+-- table policy, for exactly the reason 20260716_05_agent_tasks_service_scan.sql
+-- documents: a blanket cross-tenant policy would OR-combine with the tenant
+-- isolation policy and cancel it for every ordinary hive_app read.
+--
+-- Depends on: 20260516_01_phase19_tenants.sql (public.tenants),
+-- 20260716_03_agent_tasks.sql (public.agent_tasks).
+
+BEGIN;
+
+CREATE TABLE public.agent_task_schedules (
+    id           UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id    UUID        NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+    user_id      UUID        NOT NULL REFERENCES auth.users(id),
+    name         TEXT        NOT NULL CHECK (char_length(name) BETWEEN 1 AND 100),
+    instructions TEXT        NOT NULL CHECK (char_length(instructions) BETWEEN 1 AND 4000),
+    -- Restricted cadence grammar, first slice: two presets plus a bounded
+    -- hourly interval. The regex bounds N to 1..168 (one hour to one week)
+    -- so a typo like interval:0 or interval:99999 can neither hot-loop the
+    -- scheduler nor silently park a schedule forever.
+    schedule     TEXT        NOT NULL
+                             CHECK (schedule ~ '^(daily|weekly|interval:(16[0-8]|1[0-5][0-9]|[1-9][0-9]|[1-9]))$'),
+    enabled      BOOLEAN     NOT NULL DEFAULT true,
+    next_run_at  TIMESTAMPTZ,
+    last_run_at  TIMESTAMPTZ,
+    last_task_id UUID        REFERENCES public.agent_tasks(id) ON DELETE SET NULL,
+    last_error   TEXT        NOT NULL DEFAULT '',
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE public.agent_task_schedules IS
+  'Scheduled agent tasks (routines), first slice. schedule holds a fixed cadence: daily, weekly, or interval:N (N hours, 1..168). The control-plane scheduler claims due rows through agent_task_schedules_claim_due (FOR UPDATE SKIP LOCKED, next_run_at advanced at claim time so a tick can never double-fire) and creates one agent_tasks row per run through the same service path as a manual task, so scheduled runs consume credits exactly like manual ones. last_error carries a provider-blind message from the most recent failed run attempt.';
+
+CREATE INDEX agent_task_schedules_due_idx
+    ON public.agent_task_schedules (next_run_at)
+    WHERE enabled;
+
+ALTER TABLE public.agent_task_schedules ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public' AND tablename = 'agent_task_schedules'
+          AND policyname = 'agent_task_schedules_tenant_isolation'
+    ) THEN
+        -- NULLIF(..., '') guards the Postgres GUC placeholder quirk documented
+        -- in 20260716_03_agent_tasks.sql: a pooled connection can return ''
+        -- from current_setting(name, true) after the LOCAL scope ends, and
+        -- casting '' to ::uuid raises instead of denying. NULLIF folds it to
+        -- NULL, which compares false: deny by default.
+        CREATE POLICY agent_task_schedules_tenant_isolation
+            ON public.agent_task_schedules AS PERMISSIVE FOR ALL TO hive_app
+            USING      (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::uuid)
+            WITH CHECK (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::uuid);
+    END IF;
+END$$;
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.agent_task_schedules TO hive_app;
+GRANT SELECT ON public.agent_task_schedules TO auditor_ro;
+
+-- The scheduler loop's one cross-tenant statement. Claims up to p_batch due
+-- enabled schedules atomically: the data-modifying CTE locks the matched rows
+-- (FOR UPDATE SKIP LOCKED, so two concurrent control-plane instances claim
+-- disjoint sets) and advances next_run_at in the SAME statement that returns
+-- the rows, which is what makes a tick idempotent — once claimed, the row no
+-- longer matches "due" and a concurrent or retried tick cannot fire it again.
+-- The advance happens at claim time even if the task create that follows
+-- fails; the failure path records last_error and the schedule simply waits
+-- out its (already advanced) next cadence instead of hot-looping.
+--
+-- SECURITY DEFINER for the same reason agent_tasks_list_active() is
+-- (20260716_05): this must see every tenant's rows and a table-level policy
+-- granting that would cancel agent_task_schedules_tenant_isolation. The
+-- function is the ONLY cross-tenant path; the returned column list and order
+-- is exactly what apps/control-plane/internal/agentsched's scanSchedule
+-- expects.
+CREATE OR REPLACE FUNCTION public.agent_task_schedules_claim_due(
+    p_now   TIMESTAMPTZ,
+    p_batch INTEGER
+)
+RETURNS TABLE (
+    id           UUID,
+    tenant_id    UUID,
+    user_id      UUID,
+    name         TEXT,
+    instructions TEXT,
+    schedule     TEXT,
+    enabled      BOOLEAN,
+    next_run_at  TIMESTAMPTZ,
+    last_run_at  TIMESTAMPTZ,
+    last_task_id UUID,
+    last_error   TEXT,
+    created_at   TIMESTAMPTZ,
+    updated_at   TIMESTAMPTZ
+)
+LANGUAGE sql VOLATILE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+    WITH due AS (
+        SELECT s.id
+          FROM public.agent_task_schedules s
+         WHERE s.enabled AND s.next_run_at <= p_now
+         ORDER BY s.next_run_at ASC
+         LIMIT GREATEST(COALESCE(p_batch, 1), 1)
+         FOR UPDATE SKIP LOCKED
+    ),
+    claimed AS (
+        UPDATE public.agent_task_schedules s
+           SET next_run_at = CASE s.schedule
+                                 WHEN 'daily'   THEN p_now + INTERVAL '24 hours'
+                                 WHEN 'weekly'  THEN p_now + INTERVAL '7 days'
+                                 ELSE p_now + make_interval(hours => substring(s.schedule FROM 'interval:(\d+)')::int)
+                             END,
+               last_run_at = p_now,
+               last_error  = '',
+               updated_at  = p_now
+          FROM due
+         WHERE s.id = due.id
+        RETURNING s.id, s.tenant_id, s.user_id, s.name, s.instructions, s.schedule,
+                  s.enabled, s.next_run_at, s.last_run_at, s.last_task_id, s.last_error,
+                  s.created_at, s.updated_at
+    )
+    SELECT c.id, c.tenant_id, c.user_id, c.name, c.instructions, c.schedule,
+           c.enabled, c.next_run_at, c.last_run_at, c.last_task_id, c.last_error,
+           c.created_at, c.updated_at
+      FROM claimed c;
+$$;
+
+COMMENT ON FUNCTION public.agent_task_schedules_claim_due(TIMESTAMPTZ, INTEGER) IS
+  'Scheduler-only cross-tenant claim (scheduled agent tasks, first slice). SECURITY DEFINER bypasses RLS internally for this one fixed statement; agent_task_schedules_tenant_isolation is never weakened at the table level. Advances next_run_at at claim time so each tick fires a schedule at most once. See apps/control-plane/internal/agentsched/scheduler.go.';
+
+GRANT EXECUTE ON FUNCTION public.agent_task_schedules_claim_due(TIMESTAMPTZ, INTEGER) TO hive_app;
+
+COMMIT;

--- a/supabase/migrations/20260823_02_agent_task_schedules.sql
+++ b/supabase/migrations/20260823_02_agent_task_schedules.sql
@@ -1,4 +1,4 @@
--- supabase/migrations/20260823_01_agent_task_schedules.sql
+-- supabase/migrations/20260823_02_agent_task_schedules.sql
 --
 -- Scheduled agent tasks (routines): a user-defined recurring prompt that the
 -- control-plane scheduler turns into a real agent_tasks row on its cadence,

--- a/vendor/open-webui/src/lib/hive/AgentSchedules.svelte
+++ b/vendor/open-webui/src/lib/hive/AgentSchedules.svelte
@@ -115,10 +115,6 @@
 	}
 </script>
 
-<svelte:head>
-	<title>Scheduled tasks • Hive</title>
-</svelte:head>
-
 <div class="hv-panel flex flex-col w-full h-screen max-h-[100dvh] max-w-full">
 	<div class="px-6 py-4 border-b border-gray-100 dark:border-gray-850">
 		<h2 class="text-lg font-medium">Scheduled tasks</h2>
@@ -176,9 +172,10 @@
 
 		<!-- Delete confirmation (#866) -->
 		{#if pendingDelete}
+			<svelte:window on:keydown={(e) => e.key === 'Escape' && (pendingDelete = null)} />
 			<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
-				<div class="bg-white dark:bg-gray-900 rounded-xl p-5 max-w-sm space-y-3 mx-4">
-					<p class="font-medium">Delete "{$pendingDelete.name}"?</p>
+				<div role="dialog" aria-modal="true" class="bg-white dark:bg-gray-900 rounded-xl p-5 max-w-sm space-y-3 mx-4">
+					<p class="font-medium">Delete "{pendingDelete.name}"?</p>
 					<p class="text-sm text-gray-500">Future runs stop immediately. Already created tasks stay.</p>
 					<div class="flex justify-end gap-2">
 						<button class="px-3 py-1.5 text-sm rounded-lg border" on:click={() => (pendingDelete = null)}>Cancel</button>

--- a/vendor/open-webui/src/lib/hive/AgentSchedules.svelte
+++ b/vendor/open-webui/src/lib/hive/AgentSchedules.svelte
@@ -1,0 +1,191 @@
+<script lang="ts">
+	/*
+	 * Scheduled agent tasks ("routines") panel, first slice.
+	 *
+	 * The backend (control-plane scheduler + edge-api CRUD) is real and tested;
+	 * what is missing is the credential bridge. hive_agent_proxy.py forwards
+	 * only task operations to /v1/agent/*, so this page cannot reach
+	 * /v1/agent/schedules from the browser yet. Until that bridge wave lands,
+	 * everything renders behind SCHEDULES_BRIDGE_READY=false with an explicit
+	 * notice, per the slice brief's "say so plainly" requirement.
+	 */
+	import { getContext } from 'svelte';
+	import { toast } from 'svelte-sonner';
+
+	import {
+		SCHEDULES_API_BASE,
+		SCHEDULES_BRIDGE_READY,
+		cadenceLabel,
+		validateScheduleInput,
+		type AgentSchedule
+	} from './agentSchedules';
+
+	const i18n: any = getContext('i18n');
+
+	let schedules: AgentSchedule[] = [];
+	let name = '';
+	let instructions = '';
+	let cadence = 'daily';
+	let busy = false;
+	let pendingDelete: AgentSchedule | null = null;
+
+	async function load() {
+		try {
+			const res = await fetch(SCHEDULES_API_BASE);
+			if (!res.ok) throw new Error(String(res.status));
+			const data = await res.json();
+			schedules = data.schedules ?? [];
+		} catch (e) {
+			toast.error($i18n.t('Could not load schedules'));
+			console.log('agent schedules load failed', e);
+		}
+	}
+
+	async function create() {
+		const problem = validateScheduleInput(name, instructions, cadence);
+		if (problem) {
+			toast.error($i18n.t(problem));
+			return;
+		}
+		busy = true;
+		try {
+			const res = await fetch(SCHEDULES_API_BASE, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ name, instructions, schedule: cadence })
+			});
+			if (!res.ok) throw new Error(String(res.status));
+			name = '';
+				instructions = '';
+			await load();
+		} catch {
+			toast.error($i18n.t('Could not create schedule'));
+		} finally {
+			busy = false;
+		}
+	}
+
+	async function toggle(s: AgentSchedule) {
+		busy = true;
+		try {
+			const res = await fetch(`${SCHEDULES_API_BASE}/${s.id}`, {
+				method: 'PUT',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					name: s.name,
+					instructions: s.instructions,
+					schedule: s.schedule,
+					enabled: !s.enabled
+				})
+			});
+			if (!res.ok) throw new Error(String(res.status));
+			await load();
+		} catch {
+			toast.error($i18n.t('Could not update schedule'));
+		} finally {
+			busy = false;
+		}
+	}
+
+	function confirmDelete(s: AgentSchedule) {
+		// #866 lesson: destructive actions need confirmation before firing.
+		pendingDelete = s;
+	}
+
+	async function doDelete() {
+		if (!pendingDelete) return;
+		const target = pendingDelete;
+		pendingDelete = null;
+		busy = true;
+		try {
+			const res = await fetch(`${SCHEDULES_API_BASE}/${target.id}`, { method: 'DELETE' });
+			if (!res.ok) throw new Error(String(res.status));
+			await load();
+		} catch {
+			toast.error($i18n.t('Could not delete schedule'));
+		} finally {
+			busy = false;
+		}
+	}
+
+	// The flag is a compile-time constant today; this guard keeps the list
+	// load off the wire while the bridge is pending.
+	if (SCHEDULES_BRIDGE_READY) {
+		void load();
+	}
+</script>
+
+<svelte:head>
+	<title>Scheduled tasks • Hive</title>
+</svelte:head>
+
+<div class="hv-panel flex flex-col w-full h-screen max-h-[100dvh] max-w-full">
+	<div class="px-6 py-4 border-b border-gray-100 dark:border-gray-850">
+		<h2 class="text-lg font-medium">Scheduled tasks</h2>
+	</div>
+
+	{#if !SCHEDULES_BRIDGE_READY}
+		<div class="flex-1 flex items-center items-center justify-center px-6">
+			<div class="max-w-md text-center space-y-2 text-sm text-gray-500 dark:text-gray-400">
+				<p class="font-medium text-gray-700 dark:text-gray-300">Not available yet</p>
+				<p>
+					Scheduled task management has not been bridged into the chat backend on this
+					deployment yet. The scheduling engine runs server side; this panel lights up once its
+					routes are reachable from here.
+				</p>
+			</div>
+		</div>
+	{:else}
+		<div class="flex-1 overflow-y-auto px-6 py-4 space-y-4">
+			<!-- Create form -->
+			<div class="rounded-xl border border-gray-100 dark:border-gray-850 p-4 space-y-3">
+				<input class="w-full rounded-lg px-3 py-2 text-sm bg-transparent border border-gray-200 dark:border-gray-800" bind:value={name} placeholder="Name" />
+				<textarea rows="4" class="w-full rounded-lg px-3 py-2 text-sm bg-transparent border border-gray-200 dark:border-gray-800" bind:value={instructions} placeholder={$i18n.t('Instructions (these become the prompt each run)')} />
+				<select class="w-full rounded-lg px-3 py-2 text-sm bg-transparent border border-gray-200 dark:border-gray-800" bind:value={cadence}>
+					<option value="daily">Daily</option>
+					<option value="weekly">Weekly</option>
+					<option value="interval:1">Every hour</option>
+					<option value="interval:6">Every 6 hours</option>
+				</select>
+				<button disabled={busy} class="px-3 py-1.5 text-sm rounded-lg bg-black text-white dark:bg-white dark:text-black" on:click={create}>
+					{$i18n.t('Create schedule')}
+				</button>
+			</div>
+
+			<!-- List -->
+			{#each schedules as s (s.id)}
+				<div class="flex items-start justify-between rounded-xl border border-gray-100 dark:border-gray-850 p-3">
+					<div class="min-w-0">
+						<p class="font-medium truncate">{s.name}</p>
+						<p class="text-xs text-gray-500">{cadenceLabel(s.schedule)}</p>
+						{#if s.last_error}
+							<p class="text-xs text-red-500">Last run failed: {s.last_error}</p>
+						{/if}
+					</div>
+					<div class="flex gap-2 flex-none">
+						<button disabled={busy} class="text-sm px-2 py-1 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-850" on:click={() => toggle(s)}>
+							{s.enabled ? $i18n.t('Disable') : $i18n.t('Enable')}
+						</button>
+						<button disabled={busy} class="text-sm px-2 py-1 rounded-lg text-red-500 hover:bg-red-50" on:click={() => confirmDelete(s)}>
+							{$i18n.t('Delete')}
+						</button>
+					</div>
+				</div>
+			{/each}
+		</div>
+
+		<!-- Delete confirmation (#866) -->
+		{#if pendingDelete}
+			<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+				<div class="bg-white dark:bg-gray-900 rounded-xl p-5 max-w-sm space-y-3 mx-4">
+					<p class="font-medium">Delete "{$pendingDelete.name}"?</p>
+					<p class="text-sm text-gray-500">Future runs stop immediately. Already created tasks stay.</p>
+					<div class="flex justify-end gap-2">
+						<button class="px-3 py-1.5 text-sm rounded-lg border" on:click={() => (pendingDelete = null)}>Cancel</button>
+						<button class="px-3 py-1.5 text-sm rounded-lg bg-red-600 text-white" on:click={doDelete}>Delete</button>
+					</div>
+				</div>
+			</div>
+		{/if}
+	{/if}
+</div>

--- a/vendor/open-webui/src/lib/hive/agentSchedules.test.ts
+++ b/vendor/open-webui/src/lib/hive/agentSchedules.test.ts
@@ -19,6 +19,9 @@ describe('agentSchedules', () => {
 		expect(validateScheduleInput('n', '', 'daily')).not.toBeNull();
 		expect(validateScheduleInput('n', 'i', '* * * * *')).not.toBeNull();
 		expect(validateScheduleInput('n', 'i', 'interval:99999')).not.toBeNull();
+		expect(validateScheduleInput('n', 'i', 'interval:109')).toBeNull();
+		expect(validateScheduleInput('n', 'i', 'interval:168')).toBeNull();
+		expect(validateScheduleInput('n', 'i', 'interval:169')).not.toBeNull();
 		expect(validateScheduleInput('n', 'i', 'daily')).toBeNull();
 	});
 });

--- a/vendor/open-webui/src/lib/hive/agentSchedules.test.ts
+++ b/vendor/open-webui/src/lib/hive/agentSchedules.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { SCHEDULES_BRIDGE_READY, cadenceLabel, validateScheduleInput } from './agentSchedules';
+
+describe('agentSchedules', () => {
+	it('exposes the honest bridge state for this slice', () => {
+		expect(SCHEDULES_BRIDGE_READY).toBe(false);
+	});
+
+	it('labels cadences readably', () => {
+		expect(cadenceLabel('daily')).toBe('Daily');
+		expect(cadenceLabel('weekly')).toBe('Weekly');
+		expect(cadenceLabel('interval:6')).toBe('Every 6 hours');
+		expect(cadenceLabel('interval:1')).toBe('Every 1 hour');
+	});
+
+	it('validates input at the boundary', () => {
+		expect(validateScheduleInput('', 'x', 'daily')).not.toBeNull();
+		expect(validateScheduleInput('n', '', 'daily')).not.toBeNull();
+		expect(validateScheduleInput('n', 'i', '* * * * *')).not.toBeNull();
+		expect(validateScheduleInput('n', 'i', 'interval:99999')).not.toBeNull();
+		expect(validateScheduleInput('n', 'i', 'daily')).toBeNull();
+	});
+});

--- a/vendor/open-webui/src/lib/hive/agentSchedules.ts
+++ b/vendor/open-webui/src/lib/hive/agentSchedules.ts
@@ -68,7 +68,7 @@ export function validateScheduleInput(name: string, instructions: string, schedu
 	if (!stripped.trim() || stripped.length > 4000) {
 		return 'Instructions must be 1-4000 characters.';
 	}
-	if (!['daily', 'weekly'].includes(schedule) && !/^interval:([1-9]|[1-9][0-9]|1[0-6][0-8])$/.test(schedule)) {
+	if (!['daily', 'weekly'].includes(schedule) && !/^interval:([1-9]|[1-9][0-9]|1[0-5][0-9]|16[0-8])$/.test(schedule)) {
 		return 'Pick daily, weekly, or an hourly interval between 1 and 168.';
 	}
 	return null;

--- a/vendor/open-webui/src/lib/hive/agentSchedules.ts
+++ b/vendor/open-webui/src/lib/hive/agentSchedules.ts
@@ -1,0 +1,75 @@
+/*
+ * Scheduled agent tasks ("routines"), from the chat frontend.
+ *
+ * Hive authored. Everything under src/lib/hive/ is ours, so a rebase against
+ * a future upstream tag reads as a file list rather than an archaeology
+ * exercise.
+ *
+ * Bridge status, first slice: NOT bridged. The server-side proxy in the chat
+ * container (deploy/docker/owui-patches/hive_agent_proxy.py) forwards a FIXED
+ * set of four task operations to /v1/agent/* on edge-api and has no schedule
+ * routes yet. The browser holds Open WebUI's session token, which edge-api
+ * does not accept, so until the proxy gains schedule routes this page cannot
+ * reach the backend at all from here. The page therefore renders behind
+ * SCHEDULES_BRIDGE_READY=false with an explicit notice instead of shipping a
+ * form whose every call 404s. Next wave: add schedule routes to the proxy,
+ * then flip this one boolean.
+ */
+
+// Same shape rationale as agentTasks.ts's DEFAULT_AGENT_API_BASE_URL comment:
+// the default must survive the scratch-dir vitest runner without $lib alias
+// resolution, and callers pass the dev-aware base.
+export const SCHEDULES_API_BASE = '/api/v1/hive/agent/schedules';
+
+/**
+ * Whether the chat-container proxy bridges /v1/agent/schedules today.
+ *
+ * False in this first slice, deliberately exported as a const rather than
+ * read from config: the honest state of the deployment is "not reachable",
+ * and a config knob would invite flipping it before the bridge exists.
+ */
+export const SCHEDULES_BRIDGE_READY = false;
+
+/** Cadence presets the first slice supports. */
+export type ScheduleCadence = 'daily' | 'weekly' | 'interval:N';
+
+export interface AgentSchedule {
+	id: string;
+	name: string;
+	instructions: string;
+	schedule: string;
+	enabled: boolean;
+	next_run_at: string | null;
+	last_run_at: string | null;
+	last_task_id: string | null;
+	last_error: string;
+	created_at: string;
+	updated_at: string;
+}
+
+/** Human label for a cadence string; unknown shapes pass through verbatim. */
+export function cadenceLabel(schedule: string): string {
+	if (schedule === 'daily' || schedule === 'weekly') {
+		return schedule.charAt(0).toUpperCase() + schedule.slice(1);
+	}
+	const match = schedule.match(/^interval:(\d+)$/);
+	if (match) {
+		return `Every ${match[1]} hour${Number(match[1]) === 1 ? '' : 's'}`;
+	}
+	return schedule;
+}
+
+/** Client-side mirror of the boundary validation the backend applies. */
+export function validateScheduleInput(name: string, instructions: string, schedule: string): string | null {
+	if (!name.trim() || name.length > 100) {
+		return 'Name must be 1-100 characters.';
+	}
+	const stripped = instructions.replace(/\r/g, '');
+	if (!stripped.trim() || stripped.length > 4000) {
+		return 'Instructions must be 1-4000 characters.';
+	}
+	if (!['daily', 'weekly'].includes(schedule) && !/^interval:([1-9]|[1-9][0-9]|1[0-6][0-8])$/.test(schedule)) {
+		return 'Pick daily, weekly, or an hourly interval between 1 and 168.';
+	}
+	return null;
+}

--- a/vendor/open-webui/src/routes/(app)/agents/schedules/+page.svelte
+++ b/vendor/open-webui/src/routes/(app)/agents/schedules/+page.svelte
@@ -47,8 +47,8 @@
 								<SidebarIcon />
 							</div>
 						</button>
-						</div>
-					</div>
+					</Tooltip>
+				</div>
 			</div>
 		</nav>
 	{/if}

--- a/vendor/open-webui/src/routes/(app)/agents/schedules/+page.svelte
+++ b/vendor/open-webui/src/routes/(app)/agents/schedules/+page.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+	/*
+	 * Scheduled tasks route, first slice.
+	 *
+	 * Its own route file per the slice brief: nav.ts is untouched, a later
+	 * wave owns adding the nav row. The panel is the same hv-panel shell the
+	 * agents page uses.
+	 */
+	import { getContext } from 'svelte';
+	import { WEBUI_NAME, showSidebar, mobile } from '$lib/stores';
+
+	import Tooltip from '$lib/components/common/Tooltip.svelte';
+	import SidebarIcon from '$lib/components/icons/Sidebar.svelte';
+	import AgentSchedules from '$lib/hive/AgentSchedules.svelte';
+
+	const i18n: any = getContext('i18n');
+</script>
+
+<svelte:head>
+	<title>
+		{$i18n.t('Scheduled')} {$i18n.t('Tasks')} • {$WEBUI_NAME}
+	</title>
+</svelte:head>
+
+<div
+	class="hv-panel flex flex-col w-full h-screen max-h-[100dvh] transition-width duration-200 ease-in-out {$showSidebar
+		? 'md:max-w-[calc(100%-var(--sidebar-width))]'
+		: ''} max-w-full"
+>
+	{#if $mobile}
+		<nav class="px-2.5 pt-1.5 w-full drag-region select-none">
+			<div class="flex items-center">
+				<div class="{$showSidebar ? 'md:hidden' : ''} flex flex-none items-center self-end">
+					<Tooltip
+						content={$showSidebar ? $i18n.t('Close Sidebar') : $i18n.t('Open Sidebar')}
+						interactive={true}
+					>
+						<button
+							id="sidebar-toggle-button"
+							class="cursor-pointer flex rounded-lg hover:bg-gray-100 dark:hover:bg-gray-850 transition"
+							on:click={() => {
+								showSidebar.set(!$showSidebar);
+							}}
+							aria-label={$showSidebar ? $i18n.t('Close Sidebar') : $i18n.t('Open Sidebar')}
+						>
+							<div class="self-center p-1.5">
+								<SidebarIcon />
+							</div>
+						</button>
+						</div>
+					</div>
+			</div>
+		</nav>
+	{/if}
+
+	<div class="hv-panel-region">
+		<AgentSchedules />
+	</div>
+</div>


### PR DESCRIPTION
## What

First slice of server-side scheduled agent tasks (routines), closing the Claude-parity gap where competitors run scheduled prompts server side. Smallest credible demo slice; no cron-expression UX.

**Money-path invariant (noted, not modified):** scheduled runs consume credits exactly like manual ones because the scheduler creates each run through `agenttask.Service.CreateTask`, the same service path a manual creation uses, so metering, quota and engine gating apply identically. This PR does not touch metering code.

**Input parsing (security-relevant):** schedule instructions become model prompts and eventually reach the sandbox path. They are validated at the boundary: name capped at 100 chars, instructions stripped of control characters (keeping newline and tab) and capped at 4000, cadence grammar restricted to `daily`, `weekly`, or `interval:N` with N bounded 1..168 by a CHECK constraint plus validation on both sides (Go service, edge handler mapping, frontend mirror). Security-reviewer stream mandatory per brief; see review section below.

## Scope

1. **Migration** `20260823_01_agent_task_schedules.sql`: `public.agent_task_schedules` with the full column set from the brief (last_error included), RLS mirroring 20260716_03's tenant-isolation policy with the NULLIF GUC guard, partial index on next_run_at WHERE enabled, and the SECURITY DEFINER claim function `agent_task_schedules_claim_due(p_now, p_batch)`.
2. **Control-plane package** `apps/control-plane/internal/agentsched`: repository (withTenantTx mirroring agenttask), boundary-validating service owning cadence math, internal HTTP surface at `/internal/agent-schedules/{tenant_id}/{user_id}[/...]` mirroring agenttask's InternalMux structure, and the Scheduler worker.
3. **edge-api package** `apps/edge-api/internal/agentsched`: client to control-plane plus customer-facing `/v1/agent/schedules` CRUD routes registered behind `featuregate.Require(FeatureCowork)` via `registerAgentScheduleRoutes` in gated_routes.go, so deployments without Cowork get 403 not 404.
4. **Scheduler design one-liner:** every minute (HIVE_AGENT_SCHEDULER_INTERVAL, default 1m) claim due enabled rows FOR UPDATE SKIP LOCKED via the SECURITY DEFINER function; next_run_at advances in the same statement that returns the rows, which is what makes a tick idempotent and makes failure backoff automatic: a failed create leaves next_run_at one full cadence out and only records last_error, so nothing hot-loops. Runs are created through agenttask.Service.CreateTask with an empty bearer JWT (none exists for a scheduled run; knowledge-work artifact publishing skips without one, coding-pack needs none). Scheduled runs launch as coding-pack in this slice since schedules carry no pack column yet.
5. **UI slice:** page at `/agents/schedules` as its own new route file, nav.ts untouched per brief. **Reachability verdict, plainly: NOT reachable from the browser in this slice.** The chat shell's server-side bridge (hive_agent_proxy.py) forwards a fixed set of task operations only and has no schedule routes, and the browser holds no credential edge-api accepts, so the panel renders an explicit "not available yet" notice behind SCHEDULES_BRIDGE_READY=false (a compile-time const, deliberately not config). The full list/create/toggle/delete-with-confirm UI is built and dormant behind the flag for the bridge wave to light up by flipping one boolean after adding five proxy routes. Delete carries the #866 confirmation dialog.

## Tests

- Control-plane agentsched unit suite (fake repo + fake clock): create cadence math for all three presets, boundary validation including interval bounds, sanitize control-char behavior, update recomputes next_run_at only on cadence change, re-enable resets stale next_run_at, scheduler due/not-due/disabled/failure-backoff/concurrent-tick-once.
- Repository RLS suite (HIVE_TEST_DB_URL-gated, runs against the ephemeral Postgres in CI): CRUD round trip, cross-user read/update/delete reads as 404 inside the same tenant, cross-tenant read is 404 under RLS, and ClaimDue against the real SECURITY DEFINER function proves due/not-due/disabled/advance-on-claim/idempotent-second-tick.
- edge-api agentsched handler suite: fake-client CRUD happy path, PUT toggle reflected in Get, delete then 404, transport error maps 500, malformed body maps 400.
- Frontend vitest suite (scripts/test-owui-hive-frontend.sh): bridge flag honesty + cadence labels + boundary validation mirror. 6 files, 60 tests green locally.
- Full module sweeps: go test ./apps/control-plane/... -short: 54 packages ok, 0 fail. ./apps/edge-api/... -short: 26 ok, 0 fail. gofmt clean.

## Review

Adversarial review streams post inline here. The security stream on input parsing is mandatory for this diff shape and will be addressed before merge; merge is intentionally withheld from this PR's scope.

## Accepted limitations and follow-ups (independent review)

- **Blocking fix applied (c5b1b33e9):** Update kept the frozen next_run_at when the cadence was unchanged, so re-enabling a long-disabled schedule via the UI's PUT toggle fired an unrequested run immediately. The disabled-to-enabled transition now recomputes next_run_at one cadence out; unit test covers exactly that transition.
- **State retention: accepted, tracked in #1082.** Schedule rows and the agent_tasks rows each run spawns accumulate with no TTL or cap; a retention policy is follow-up work once real usage exists.
- **Fire-time Cowork gate / user-active recheck: accepted, tracked in #1082.** The scheduler fires due schedules without re-checking the tenant's ENABLE_COWORK gate or the user's active state, so a tenant that loses access keeps firing until the schedule is deleted manually.
- **last_run_at semantics, noted in code:** the claim stamps last_run_at at attempt start (claim time), before the create outcome is known; RecordRunSuccess/Failure fill in the outcome fields afterwards.

The security stream verified the SECURITY DEFINER surface clean otherwise (empty search_path, single fixed statement, PUBLIC execute revoked).