### PR TITLE
fix: stop a required check spending the live demo's provider budget, and make an exhausted budget say so

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1019,12 +1019,21 @@ jobs:
       # and a required check on main went red for a reason no commit caused,
       # while the demo answered nothing.
       #
-      # deepseek-v4-flash is an existing public alias pinned to
-      # route-deepseek-v4-flash on OpenRouter, a DIFFERENT provider account
-      # whose limit is prepaid credit rather than a daily token cliff. Measured
-      # 2026-08-23 against the live provider with this suite's own request
-      # shapes: about USD 0.000017 per completion, so a whole run is a fraction
-      # of a cent. A second Groq key would not have helped: the limit is per
+      # deepseek-v4-pro is an existing public alias pinned to
+      # route-deepseek-v4-pro on OpenRouter, a DIFFERENT provider account
+      # whose limit is prepaid credit rather than a daily token cliff.
+      # deepseek-v4-flash was tried first and rejected on evidence: its slug
+      # (~deepseek/deepseek-v4-flash-latest) is an unpinned OpenRouter router
+      # whose upstreams disagree about the OpenAI contract under
+      # response_format json_object. Across probes and the CI run of this
+      # branch it returned message.content as a parsed JSON object (run
+      # 32665985618), as null, and as string on different calls, so no strict
+      # assertion can survive it. deepseek-v4-pro-0813 is date-pinned, returns
+      # content as a string every time, and answers forced tool_choice with a
+      # real tool_calls shape (probed live 2026-08-23 through the demo box's
+      # LiteLLM). It costs more per completion than flash but a whole suite
+      # run stays in single-digit cents, bounded by the token ceiling below. A
+      # second Groq key would not have helped: the limit is per
       # organization, not per key.
       #
       # Fidelity consequence, stated rather than buried: this check no longer
@@ -1038,7 +1047,7 @@ jobs:
       # Set the CI_LIVE_INTEGRATION_MODEL repository variable to point this
       # back at hive-default (say, once a CI-only Groq organization exists)
       # without touching this file.
-      HIVE_TEST_MODEL: ${{ vars.CI_LIVE_INTEGRATION_MODEL || 'deepseek-v4-flash' }}
+      HIVE_TEST_MODEL: ${{ vars.CI_LIVE_INTEGRATION_MODEL || 'deepseek-v4-pro' }}
       # The suites' own default, named here rather than left implicit, because
       # the spend meter below asserts that no alias outside these two is ever
       # billed by this job.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,12 @@ on:
   push:
     branches: [main]
   schedule:
-    # Daily fidelity run on main: exercises paid hive-default model to catch
-    # provider regressions that a free-tier model might silently swallow.
+    # Daily run on main. It used to be described as the "paid hive-default
+    # fidelity run", which stopped being true when the 2026-08-22 catalog
+    # restructure moved hive-default onto Groq, and stopped being desirable
+    # when that shared free-tier daily budget ran out and reddened a required
+    # check (issue #1088). It now exercises the same alias every other trigger
+    # does; see live-integration's HIVE_TEST_MODEL below for which one and why.
     - cron: '0 4 * * *'
   workflow_dispatch:
 
@@ -660,6 +664,14 @@ jobs:
       # paste, which is how there came to be six.
       - if: needs.changes.outputs.run != 'false'
         run: npm run lint:dead-supabase-secrets
+      # Issue #1088. The live-integration job set HIVE_TEST_MODEL, the SDK
+      # suites read it, and the compose services forwarded nothing, so the knob
+      # meant to keep a merge-gate check off the live demo's provider budget
+      # was wired to nothing for a month while every run reported green. This
+      # fails when a suite reads a HIVE_* variable that neither its compose
+      # service nor its image provides.
+      - if: needs.changes.outputs.run != 'false'
+        run: npm run lint:sdk-test-env
       # A synchronous child process in a Playwright spec freezes the worker's
       # event loop, so no test timeout in that file can fire while it runs.
       # PR #838 found a test recorded as passed at 30194 ms under a 30000 ms
@@ -933,11 +945,10 @@ jobs:
     # that pays for real provider completions is also the one that gets
     # cancelled first on a degraded runner, with an empty step log to read.
     timeout-minutes: 35
-    # Run on push to main (post-merge gate) or on PRs that carry the
-    # run-live-integration label. The label gate lets contributors
-    # explicitly opt in without running paid completions on every PR.
-    # The daily cron variant (schedule) also runs here to exercise the
-    # paid hive-default model for fidelity checks.
+    # Run on push to main (post-merge gate), on the daily cron, or on PRs that
+    # carry the run-live-integration label. The label gate lets contributors
+    # explicitly opt in without spending a provider allowance on every PR.
+    # Every trigger now calls the same alias; see HIVE_TEST_MODEL below.
     # Fork PRs are excluded: GitHub does not expose secrets to fork
     # runners on pull_request events, so no secret can leak.
     if: >-
@@ -987,19 +998,56 @@ jobs:
       OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
       GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
       NVIDIA_NIM_API_KEY: ${{ secrets.NVIDIA_NIM_API_KEY }}
-      # Routine PR runs use a free OpenRouter model to avoid per-token
-      # charges on every merge-gate check. The daily cron run (schedule)
-      # and post-merge push runs use the paid hive-default model for
-      # full fidelity. HIVE_TEST_MODEL propagates into sdk-tests
-      # containers via docker compose env interpolation.
-      OPENROUTER_DEFAULT_MODEL: >-
-        ${{ (github.event_name == 'schedule' || github.event_name == 'push')
-            && vars.OPENROUTER_DEFAULT_MODEL
-            || 'openrouter/mistralai/mistral-7b-instruct:free' }}
-      HIVE_TEST_MODEL: >-
-        ${{ (github.event_name == 'schedule' || github.event_name == 'push')
-            && 'hive-default'
-            || 'hive-default' }}
+      # Which alias the token-consuming SDK suites call, and therefore which
+      # provider account this job bills. Issue #1088.
+      #
+      # What was here before was a per-event ternary that read as "free model
+      # on pull requests, paid fidelity on push and cron" and was dead three
+      # times over. Both branches of the HIVE_TEST_MODEL ternary evaluated to
+      # hive-default; the value never reached the suites at all, because the
+      # sdk-tests compose services forwarded nothing (fixed in
+      # deploy/docker/docker-compose.yml, guarded by
+      # tools/lint-sdk-test-env-propagation.mjs); and the variable the ternary
+      # actually switched, OPENROUTER_DEFAULT_MODEL, is documented UNUSED in
+      # .env.example after its consumer route-openrouter-default was deleted by
+      # the 2026-08-22 catalog restructure.
+      #
+      # That restructure is what made it matter: it moved hive-default from
+      # OpenRouter onto Groq, so every run of this job since then has spent the
+      # live demo box's Groq free-tier DAILY token budget (limit 200000, shared
+      # across the organization, hard cliff). On 2026-08-23 that budget ran out
+      # and a required check on main went red for a reason no commit caused,
+      # while the demo answered nothing.
+      #
+      # deepseek-v4-flash is an existing public alias pinned to
+      # route-deepseek-v4-flash on OpenRouter, a DIFFERENT provider account
+      # whose limit is prepaid credit rather than a daily token cliff. Measured
+      # 2026-08-23 against the live provider with this suite's own request
+      # shapes: about USD 0.000017 per completion, so a whole run is a fraction
+      # of a cent. A second Groq key would not have helped: the limit is per
+      # organization, not per key.
+      #
+      # Fidelity consequence, stated rather than buried: this check no longer
+      # exercises the Groq gpt-oss-20b route the demo serves chat from. A
+      # Groq-specific regression is caught by the sdk-replay job in
+      # deploy-demo-box.yml, which runs these same suites against the live box
+      # on hive-default after every deploy and is deliberately left alone. The
+      # "Declare which provider account this run bills" step below prints this
+      # every run so it is never an unstated assumption.
+      #
+      # Set the CI_LIVE_INTEGRATION_MODEL repository variable to point this
+      # back at hive-default (say, once a CI-only Groq organization exists)
+      # without touching this file.
+      HIVE_TEST_MODEL: ${{ vars.CI_LIVE_INTEGRATION_MODEL || 'hive-default' }}
+      # The suites' own default, named here rather than left implicit, because
+      # the spend meter below asserts that no alias outside these two is ever
+      # billed by this job.
+      HIVE_EMBEDDING_MODEL: hive-embedding-default
+      # Nothing reads this. It is passed only because docker-compose.yml
+      # interpolates it into the litellm service's environment, and an unset
+      # variable there is a compose warning on every invocation. See
+      # .env.example, which documents it as UNUSED.
+      OPENROUTER_DEFAULT_MODEL: ${{ vars.OPENROUTER_DEFAULT_MODEL }}
       OPENROUTER_AUTO_MODEL: ${{ vars.OPENROUTER_AUTO_MODEL }}
       OPENROUTER_FAST_FALLBACK_MODEL: ${{ vars.OPENROUTER_FAST_FALLBACK_MODEL }}
       OPENROUTER_EMBEDDING_MODEL: ${{ vars.OPENROUTER_EMBEDDING_MODEL }}
@@ -1029,6 +1077,28 @@ jobs:
       - uses: actions/checkout@v7
 
       - uses: docker/setup-buildx-action@v4
+
+      # Say which provider allowance this run spends, and what it therefore
+      # does NOT cover, before it spends any of it. Issue #1088: for a month
+      # this job silently drove the same Groq daily token budget the live demo
+      # answers customers from, while its own comments described a cheaper
+      # path it was not taking. A reduced-fidelity check has to announce
+      # itself, every run, or it reads as coverage it does not have.
+      - name: Declare which provider account this run bills
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "SDK suites will call alias: $HIVE_TEST_MODEL"
+          echo "embedding suites will call: $HIVE_EMBEDDING_MODEL"
+          if [ "$HIVE_TEST_MODEL" = "hive-default" ] \
+            || [ "$HIVE_TEST_MODEL" = "hive-small" ] \
+            || [ "$HIVE_TEST_MODEL" = "hive-medium" ] \
+            || [ "$HIVE_TEST_MODEL" = "hive-auto" ] \
+            || [ "$HIVE_TEST_MODEL" = "hive-fast" ]; then
+            echo "::warning::this run bills the SHARED Groq free-tier daily token budget, the same allowance the live demo box serves chat from. Exhausting it takes the demo down and reddens this required check for reasons no commit caused (issue #1088)."
+          else
+            echo "::notice::this run bills '$HIVE_TEST_MODEL', which is NOT the Groq route the live demo serves chat from. Groq-specific regressions are not covered here; the sdk-replay job in deploy-demo-box.yml covers them against the live box on hive-default after each deploy."
+          fi
 
       - name: Start a throwaway Postgres and apply the real schema
         shell: bash
@@ -1245,6 +1315,10 @@ jobs:
           jq -r '.data[0:3] | .[] | .id' /tmp/models.json
 
       - name: Run SDK suites in parallel (JS + Python + Java)
+        # id, because the spend meter below runs on always() and needs to tell
+        # "the suites failed, so the database may not exist" from "the suites
+        # passed and the meter is unreadable", which is a defect.
+        id: sdk-suites
         working-directory: deploy/docker
         shell: bash
         run: |
@@ -1278,6 +1352,133 @@ jobs:
           done
           exit $fail
 
+      # Issue #1088. A provider allowance this job spends was invisible until
+      # it ran out. This reads what the gateway actually metered on its own
+      # throwaway database, so the spend of a run is a number in the log every
+      # time rather than something reconstructed from a provider console after
+      # a red check.
+      #
+      # It also asserts the alias the suites called, which is the check that
+      # would have caught the original defect: HIVE_TEST_MODEL was set here,
+      # the suites read it, and nothing forwarded it, so the workflow's stated
+      # model and the model actually billed disagreed for a month with every
+      # run green.
+      - name: Report and bound this run's metered provider spend
+        if: always()
+        shell: bash
+        env:
+          PGHOST: 127.0.0.1
+          PGPORT: '5432'
+          PGUSER: postgres
+          PGPASSWORD: postgres
+          PGDATABASE: hive_ci
+          SUITES_OUTCOME: ${{ steps.sdk-suites.outcome }}
+          # Circuit breaker, not coverage: it is meant to sit dormant and to
+          # fire on a runaway loop or a suite that starts generating long
+          # completions, before a provider allowance is drained rather than
+          # after. Set at roughly four times the measured spend of a passing
+          # run (see the PR for issue #1088 for the measurement), which leaves
+          # room for a suite being added without a false alarm.
+          RUN_TOKEN_CEILING: '80000'
+        run: |
+          set -uo pipefail
+          q() { psql --no-psqlrc -qtAX -v ON_ERROR_STOP=1 -c "$1"; }
+
+          if ! total=$(q "select coalesce(sum(input_tokens + output_tokens), 0)
+                            from public.usage_events where event_type = 'completed'"); then
+            # A job that already failed may have failed before this database
+            # existed, which is not a second defect. A job that PASSED and
+            # cannot be metered is: the ceiling silently did not run, and a
+            # check that quietly stops checking is worse than one that fails.
+            if [ "$SUITES_OUTCOME" = "success" ]; then
+              echo "::error::the SDK suites passed but the usage meter could not be read, so this run's provider spend is unknown and the token ceiling did not run"
+              exit 1
+            fi
+            echo "::warning::usage meter unreadable, and the suites had already failed, so no spend figure for this run"
+            exit 0
+          fi
+
+          echo "metered provider spend for this run, by alias:"
+          psql --no-psqlrc -qX -v ON_ERROR_STOP=1 -c "
+            select model_alias,
+                   event_type,
+                   count(*)            as events,
+                   sum(input_tokens)   as input_tokens,
+                   sum(output_tokens)  as output_tokens
+              from public.usage_events
+             group by 1, 2
+             order by 1, 2"
+
+          echo "::notice::live-integration metered ${total} tokens on alias '${HIVE_TEST_MODEL}' (ceiling ${RUN_TOKEN_CEILING})"
+
+          if [ "$total" -gt "$RUN_TOKEN_CEILING" ]; then
+            echo "::error::this run metered ${total} tokens, over the ${RUN_TOKEN_CEILING} ceiling. Something is generating far more than the suites should. Find it before raising the ceiling: a provider allowance is shared with the live demo."
+            exit 1
+          fi
+
+          # The alias assertion. Only two aliases can legitimately appear: the
+          # chat/completions/responses suites use HIVE_TEST_MODEL and the
+          # embedding suites use HIVE_EMBEDDING_MODEL. Anything else means the
+          # value this workflow sets is not the value being billed.
+          unexpected=$(q "select string_agg(distinct model_alias, ', ')
+                            from public.usage_events
+                           where event_type = 'completed'
+                             and model_alias not in ('${HIVE_TEST_MODEL}', '${HIVE_EMBEDDING_MODEL}')")
+          if [ -n "$unexpected" ]; then
+            echo "::error::this run billed alias(es) '${unexpected}', which is not what HIVE_TEST_MODEL ('${HIVE_TEST_MODEL}') or HIVE_EMBEDDING_MODEL ('${HIVE_EMBEDDING_MODEL}') selects. The model knob is not reaching the suites (issue #1088), so this job is spending an allowance it did not choose."
+            exit 1
+          fi
+
+          if [ "$SUITES_OUTCOME" = "success" ]; then
+            served=$(q "select count(*) from public.usage_events
+                         where event_type = 'completed'
+                           and model_alias = '${HIVE_TEST_MODEL}'")
+            if [ "$served" = "0" ]; then
+              echo "::error::the suites passed without a single metered completion on '${HIVE_TEST_MODEL}'. This job's whole purpose is a real provider round trip, so a pass with no completion is a pass over nothing."
+              exit 1
+            fi
+            echo "${served} completion(s) served by '${HIVE_TEST_MODEL}'"
+          fi
+
+      # Issue #1088 again, the half that cost a full diagnosis cycle. On
+      # 2026-08-23 this job went red with `Test timed out in 60000ms` as the
+      # only visible fact, because LiteLLM retried a rate-limited deployment
+      # three times at up to 45 seconds each while the suites time out at 60.
+      # The actual 429, naming an exhausted daily token budget, existed only
+      # inside a container-log artifact nobody reads first. A red check that
+      # misreports its own cause is worse than a slow one.
+      - name: Name the real cause when the upstream refused
+        if: failure()
+        working-directory: deploy/docker
+        shell: bash
+        run: |
+          set -uo pipefail
+          # Redacted because this output is public: container logs carry bearer
+          # headers and provider keys verbatim. Same redactor the artifact
+          # upload below uses.
+          logs=$(docker compose logs --no-color --tail=2000 litellm edge-api 2>&1 \
+            | python3 ../../scripts/redact-log-credentials.py || true)
+
+          class=""
+          if printf '%s' "$logs" | grep -qiE 'tokens per day|per day \(TPD\)|TPD\b'; then
+            class="the provider refused on a DAILY token budget (TPD). It resets on the provider's own schedule, so retrying or re-running will not fix it; the allowance is gone until then. This is shared with the live demo box, which is answering nothing right now for the same reason."
+          elif printf '%s' "$logs" | grep -qiE 'rate.?limit|RateLimitError|rate_limit_exceeded|HTTP/1.1" 429|status_code=429|status=429'; then
+            class="the provider rate limited us (429). Check whether the window is per minute (transient, retry) or per day (an allowance that is spent)."
+          elif printf '%s' "$logs" | grep -qiE 'insufficient.?credit|402 Payment Required|quota'; then
+            class="the provider account is out of credit or quota (402). No retry fixes this; it needs funding."
+          fi
+
+          if [ -n "$class" ]; then
+            echo "::error::UPSTREAM REFUSAL, not a performance regression: $class"
+            echo "matching lines (redacted, first 5):"
+            printf '%s' "$logs" \
+              | grep -iE 'tokens per day|rate.?limit|RateLimitError|rate_limit_exceeded|429|insufficient.?credit|402 Payment Required' \
+              | head -5
+            echo "UPSTREAM_FAILURE_CLASS=$class" >> "$GITHUB_ENV"
+          else
+            echo "no upstream refusal signature in the litellm or edge-api logs, so this failure is something else. The compose-logs artifact below is the next place to look."
+          fi
+
       - name: Dump compose logs on failure
         if: failure()
         working-directory: deploy/docker
@@ -1310,11 +1511,20 @@ jobs:
         # open issue with the label below instead of filing one per red run.
         if: failure() && (github.event_name == 'push' || github.event_name == 'schedule')
         uses: actions/github-script@v9
+        env:
+          # Written by the "Name the real cause" step above when it recognises
+          # an upstream refusal. Carried into the issue body so the first thing
+          # a reader sees is the cause, not a link to a run whose test output
+          # says "timed out" (issue #1088).
+          UPSTREAM_FAILURE_CLASS: ${{ env.UPSTREAM_FAILURE_CLASS }}
         with:
           script: |
             const label = 'ci-failure:live-integration';
             const title = 'Live integration (SDK tests + smoke) is failing on main';
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const cause = process.env.UPSTREAM_FAILURE_CLASS
+              ? `**Cause identified from the container logs:** ${process.env.UPSTREAM_FAILURE_CLASS}\n\n`
+              : '';
             const { data: open } = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -1326,7 +1536,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: open[0].number,
-                body: `Still failing: ${runUrl}`,
+                body: `Still failing: ${runUrl}\n\n${cause}`,
               });
             } else {
               await github.rest.issues.create({
@@ -1335,6 +1545,7 @@ jobs:
                 title,
                 labels: [label],
                 body: `Live integration failed on ${context.eventName === 'schedule' ? 'the daily cron' : 'push to main'}.\n\n` +
+                  cause +
                   `First detected: ${runUrl}\n\n` +
                   'Filed automatically. Close it once a run goes green; it will be refiled if it fails again.',
               });

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1376,10 +1376,17 @@ jobs:
           # Circuit breaker, not coverage: it is meant to sit dormant and to
           # fire on a runaway loop or a suite that starts generating long
           # completions, before a provider allowance is drained rather than
-          # after. Set at roughly four times the measured spend of a passing
-          # run (see the PR for issue #1088 for the measurement), which leaves
-          # room for a suite being added without a false alarm.
-          RUN_TOKEN_CEILING: '80000'
+          # after.
+          #
+          # Derived from two measured runs of this job rather than picked: 1348
+          # tokens across 22 completions on hive-default (run 32660770153) and
+          # 1434 across the same 22 on deepseek-v4-flash, which spends more per
+          # completion because it is a reasoning model (run 32661219454). About
+          # four times the larger of the two leaves room for a few new tests and
+          # for reasoning variance while still catching an order-of-magnitude
+          # runaway. Raise it only alongside a measurement, and only after
+          # finding out what grew.
+          RUN_TOKEN_CEILING: '6000'
         run: |
           set -uo pipefail
           q() { psql --no-psqlrc -qtAX -v ON_ERROR_STOP=1 -c "$1"; }
@@ -1409,6 +1416,16 @@ jobs:
              group by 1, 2
              order by 1, 2"
 
+          # A non-numeric total means the query answered something this step
+          # cannot compare, and every assertion below would then quietly
+          # evaluate to "fine". Refuse instead.
+          case "$total" in
+            ''|*[!0-9]*)
+              echo "::error::the usage meter returned '${total}', which is not a token count, so nothing below actually checked anything"
+              exit 1
+              ;;
+          esac
+
           echo "::notice::live-integration metered ${total} tokens on alias '${HIVE_TEST_MODEL}' (ceiling ${RUN_TOKEN_CEILING})"
 
           if [ "$total" -gt "$RUN_TOKEN_CEILING" ]; then
@@ -1420,19 +1437,30 @@ jobs:
           # chat/completions/responses suites use HIVE_TEST_MODEL and the
           # embedding suites use HIVE_EMBEDDING_MODEL. Anything else means the
           # value this workflow sets is not the value being billed.
-          unexpected=$(q "select string_agg(distinct model_alias, ', ')
-                            from public.usage_events
-                           where event_type = 'completed'
-                             and model_alias not in ('${HIVE_TEST_MODEL}', '${HIVE_EMBEDDING_MODEL}')")
+          #
+          # The query's own failure is checked, not just its result: a psql
+          # error returns an EMPTY string here, which reads exactly like "no
+          # unexpected alias" and would turn this into an assertion that cannot
+          # fail.
+          if ! unexpected=$(q "select string_agg(distinct model_alias, ', ')
+                                 from public.usage_events
+                                where event_type = 'completed'
+                                  and model_alias not in ('${HIVE_TEST_MODEL}', '${HIVE_EMBEDDING_MODEL}')"); then
+            echo "::error::the alias assertion query failed, so this run's billed alias is unverified"
+            exit 1
+          fi
           if [ -n "$unexpected" ]; then
             echo "::error::this run billed alias(es) '${unexpected}', which is not what HIVE_TEST_MODEL ('${HIVE_TEST_MODEL}') or HIVE_EMBEDDING_MODEL ('${HIVE_EMBEDDING_MODEL}') selects. The model knob is not reaching the suites (issue #1088), so this job is spending an allowance it did not choose."
             exit 1
           fi
 
           if [ "$SUITES_OUTCOME" = "success" ]; then
-            served=$(q "select count(*) from public.usage_events
-                         where event_type = 'completed'
-                           and model_alias = '${HIVE_TEST_MODEL}'")
+            if ! served=$(q "select count(*) from public.usage_events
+                              where event_type = 'completed'
+                                and model_alias = '${HIVE_TEST_MODEL}'"); then
+              echo "::error::the completion-count query failed, so it is unknown whether this passing run served a single real completion"
+              exit 1
+            fi
             if [ "$served" = "0" ]; then
               echo "::error::the suites passed without a single metered completion on '${HIVE_TEST_MODEL}'. This job's whole purpose is a real provider round trip, so a pass with no completion is a pass over nothing."
               exit 1
@@ -1456,24 +1484,30 @@ jobs:
           # Redacted because this output is public: container logs carry bearer
           # headers and provider keys verbatim. Same redactor the artifact
           # upload below uses.
-          logs=$(docker compose logs --no-color --tail=2000 litellm edge-api 2>&1 \
-            | python3 ../../scripts/redact-log-credentials.py || true)
+          docker compose logs --no-color --tail=2000 litellm edge-api 2>&1 \
+            | python3 ../../scripts/redact-log-credentials.py > /tmp/upstream.log || true
 
+          # Grep a FILE, deliberately, never `printf '%s' "$logs" | grep -q`.
+          # grep -q exits at its first match, the writer then takes SIGPIPE, and
+          # under `set -o pipefail` the pipeline reports FAILURE even though it
+          # matched. That is not theoretical: the first draft of this step was
+          # run over the real 2026-08-23 compose-logs artifact, whose log says
+          # "on tokens per day (TPD)" eighteen times, and the daily-budget
+          # branch below silently lost to exactly that.
           class=""
-          if printf '%s' "$logs" | grep -qiE 'tokens per day|per day \(TPD\)|TPD\b'; then
-            class="the provider refused on a DAILY token budget (TPD). It resets on the provider's own schedule, so retrying or re-running will not fix it; the allowance is gone until then. This is shared with the live demo box, which is answering nothing right now for the same reason."
-          elif printf '%s' "$logs" | grep -qiE 'rate.?limit|RateLimitError|rate_limit_exceeded|HTTP/1.1" 429|status_code=429|status=429'; then
-            class="the provider rate limited us (429). Check whether the window is per minute (transient, retry) or per day (an allowance that is spent)."
-          elif printf '%s' "$logs" | grep -qiE 'insufficient.?credit|402 Payment Required|quota'; then
-            class="the provider account is out of credit or quota (402). No retry fixes this; it needs funding."
+          if grep -qiE 'tokens per day|per day \(TPD\)|TPD\b' /tmp/upstream.log; then
+            class="the provider refused on a DAILY token budget (TPD). It resets on the provider's own schedule, so retrying or re-running will not fix it; the allowance is gone until then. If that provider is also the live demo's, the demo is answering nothing right now for the same reason."
+          elif grep -qiE 'rate.?limit|RateLimitError|rate_limit_exceeded|status_code=429|status=429' /tmp/upstream.log; then
+            class="the provider rate limited us (429). Check whether the window is per minute (transient, so a rerun may pass) or per day (an allowance that is spent)."
+          elif grep -qiE 'insufficient.?credit|402 Payment Required' /tmp/upstream.log; then
+            class="the provider account is out of credit (402). No retry fixes this; it needs funding."
           fi
 
           if [ -n "$class" ]; then
             echo "::error::UPSTREAM REFUSAL, not a performance regression: $class"
             echo "matching lines (redacted, first 5):"
-            printf '%s' "$logs" \
-              | grep -iE 'tokens per day|rate.?limit|RateLimitError|rate_limit_exceeded|429|insufficient.?credit|402 Payment Required' \
-              | head -5
+            grep -iE 'tokens per day|rate.?limit|RateLimitError|rate_limit_exceeded|insufficient.?credit|402 Payment Required' \
+              /tmp/upstream.log | head -5
             echo "UPSTREAM_FAILURE_CLASS=$class" >> "$GITHUB_ENV"
           else
             echo "no upstream refusal signature in the litellm or edge-api logs, so this failure is something else. The compose-logs artifact below is the next place to look."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1038,7 +1038,7 @@ jobs:
       # Set the CI_LIVE_INTEGRATION_MODEL repository variable to point this
       # back at hive-default (say, once a CI-only Groq organization exists)
       # without touching this file.
-      HIVE_TEST_MODEL: ${{ vars.CI_LIVE_INTEGRATION_MODEL || 'hive-default' }}
+      HIVE_TEST_MODEL: ${{ vars.CI_LIVE_INTEGRATION_MODEL || 'deepseek-v4-flash' }}
       # The suites' own default, named here rather than left implicit, because
       # the spend meter below asserts that no alias outside these two is ever
       # billed by this job.

--- a/apps/control-plane/internal/litellmconfig/generator_test.go
+++ b/apps/control-plane/internal/litellmconfig/generator_test.go
@@ -357,6 +357,56 @@ model_list:
 	assert.Contains(t, content, "gpt-4o")
 }
 
+// Issue #1089's fix is one top-level key in deploy/litellm/config.yaml,
+// router_settings.retry_policy, and control-plane rewrites that file on every
+// catalog sync. If the merge dropped an unrecognised top-level key, the fix
+// would work exactly until the first sync and then silently stop, which is the
+// shape of defect that has cost this project real time (a repository change
+// that looks applied and is inert on the running box). This asserts the merge
+// keeps it, by name and by value, rather than trusting the comment that says it
+// keeps "all other top-level keys".
+func TestWriteAndRestartPreservesRouterSettings(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+
+	existing := `
+router_settings:
+  retry_policy:
+    RateLimitErrorRetries: 0
+litellm_settings:
+  num_retries: 3
+general_settings:
+  master_key: old-key
+model_list:
+  - model_name: old-model
+    litellm_params:
+      model: openrouter/old
+`
+	require.NoError(t, os.WriteFile(configPath, []byte(existing), 0o600))
+
+	cfg := litellmconfig.Config{
+		Models:             twoModels(),
+		GeneralSettings:    litellmconfig.GeneralSettings{MasterKey: "new-key"},
+		ExistingConfigPath: configPath,
+	}
+
+	require.NoError(t, litellmconfig.WriteAndRestart(context.Background(), configPath, cfg, &mockRestarter{}))
+
+	data, readErr := os.ReadFile(configPath)
+	require.NoError(t, readErr)
+
+	var got struct {
+		RouterSettings struct {
+			RetryPolicy map[string]int `yaml:"retry_policy"`
+		} `yaml:"router_settings"`
+	}
+	require.NoError(t, yaml.Unmarshal(data, &got))
+
+	retries, ok := got.RouterSettings.RetryPolicy["RateLimitErrorRetries"]
+	require.True(t, ok, "router_settings.retry_policy.RateLimitErrorRetries must survive a catalog sync, or the rate-limit fix for issue #1089 is inert after the first sync")
+	assert.Equal(t, 0, retries, "the preserved value must be the operator's 0, not a re-defaulted one")
+}
+
 func TestWriteAndRestartSkipsRestarterOnGenerateFailure(t *testing.T) {
 	// To trigger a Generate failure we rely on the fact that nil Models slice
 	// with a bad config path combination never happens in normal flow.

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -306,6 +306,19 @@ services:
     environment:
       HIVE_BASE_URL: http://edge-api:8080/v1
       HIVE_API_KEY: ${HIVE_API_KEY:-}
+      # Issue #1088. These two are read by the suites
+      # (packages/sdk-tests/js/tests/**), and until this line existed nothing
+      # forwarded them: `docker compose run` gives a service only its own
+      # declared environment, so the caller's HIVE_TEST_MODEL never crossed
+      # into the container and every suite fell back to its literal default.
+      # ci.yml set it, the comment there claimed it propagated, and the check
+      # went on driving the live demo's provider budget on every run.
+      # tools/lint-sdk-test-env-propagation.mjs now fails on that shape.
+      #
+      # The defaults are the suites' own in-code fallbacks, restated so the
+      # value is visible here rather than only in the test file.
+      HIVE_TEST_MODEL: ${HIVE_TEST_MODEL:-hive-default}
+      HIVE_EMBEDDING_MODEL: ${HIVE_EMBEDDING_MODEL:-hive-embedding-default}
 
   sdk-tests-py:
     image: hive-sdk-tests-py:ci
@@ -320,6 +333,10 @@ services:
     environment:
       HIVE_BASE_URL: http://edge-api:8080/v1
       HIVE_API_KEY: ${HIVE_API_KEY:-}
+      # Same pair, same reason as sdk-tests-js above (issue #1088). Read by
+      # packages/sdk-tests/python/tests/**.
+      HIVE_TEST_MODEL: ${HIVE_TEST_MODEL:-hive-default}
+      HIVE_EMBEDDING_MODEL: ${HIVE_EMBEDDING_MODEL:-hive-embedding-default}
 
   sdk-tests-java:
     image: hive-sdk-tests-java:ci

--- a/deploy/litellm/config.yaml
+++ b/deploy/litellm/config.yaml
@@ -395,11 +395,48 @@ model_list:
 # before consulting drop_params, so callers must not send that field at all
 # (see apps/edge-api/internal/rag/embed.go and
 # apps/control-plane/internal/rag/ingest.go, which reduce client-side instead).
+# Per-exception-class retry counts, which override num_retries below for the
+# classes named here. Issue #1089.
+#
+# A rate limit gets ZERO retries. The limit that actually fired on 2026-08-23
+# was Groq's tokens-per-DAY budget, and retrying a window that resets tomorrow
+# cannot succeed: it only converts a fast, correct, actionable 429 into a slow
+# wrong one. LiteLLM cannot tell a per-day budget from a per-second burst, so a
+# blanket retry on rate limits is a bet that every rate limit is transient, and
+# the one we hit was not.
+#
+# Measured on the image this stack runs (v1.98.0), against a stub upstream that
+# returns 429 on demand, rather than read off a doc page:
+#
+#   without this block   4 upstream attempts, 11.47s, client sees 429
+#   with this block      1 upstream attempt,   1.79s, client sees 429
+#   with this block, upstream 500 instead
+#                        4 upstream attempts, 13.27s, client sees 500
+#
+# The third line is the one that makes this safe: every other error class still
+# retries num_retries times. And the absorption for a genuine per-minute burst
+# is not lost, it moves one layer out: edge-api retries 429 itself, four
+# attempts inside about 2.9 seconds, and returns the final 429 verbatim
+# (apps/edge-api/internal/inference/retry.go). Fast absorption stays, the slow
+# multi-minute kind goes.
+#
+# One caution found while measuring: LiteLLM classifies partly on message
+# CONTENT, not only on status code. A stub returning HTTP 500 whose body
+# mentioned "limits" was mapped to RateLimitError and therefore not retried. So
+# a provider whose 5xx text talks about limits will now fail fast rather than
+# retry. That is the correct trade for the case this fixes and is written down
+# so the next reader does not rediscover it from a strange log line.
+router_settings:
+  retry_policy:
+    RateLimitErrorRetries: 0
+
 litellm_settings:
   # Sovereign edge: disable all LiteLLM telemetry so no call metadata is
   # sent to LiteLLM's hosted services. Must be set to False (string form)
   # per the LiteLLM docs; the Python bool False is also accepted at runtime.
   telemetry: False
+  # Applies to every error class EXCEPT the ones router_settings.retry_policy
+  # above names.
   num_retries: 3
   request_timeout: 45
   allowed_fails: 3

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lint:model-visibility": "node tools/lint-tenant-model-visibility-single-source.mjs",
     "lint:litellm-routing": "node tools/lint-litellm-dispatch-requires-routing.mjs",
     "lint:litellm-config": "node tools/lint-litellm-config-fallbacks.mjs",
+    "lint:sdk-test-env": "node tools/lint-sdk-test-env-propagation.mjs",
     "lint:proof-tokens": "node tools/lint-no-token-in-proof-captures.mjs",
     "lint:pgx-dsn": "node tools/lint-no-pgx-dsn-for-libpq.mjs",
     "lint:dead-supabase-secrets": "node tools/lint-no-dead-supabase-secrets.mjs",

--- a/packages/sdk-tests/js/tests/responses/responses.test.ts
+++ b/packages/sdk-tests/js/tests/responses/responses.test.ts
@@ -10,9 +10,13 @@ const MODEL = process.env.HIVE_TEST_MODEL ?? "hive-default";
 // provider_capabilities.supports_reasoning and these aliases have it true, so
 // there is no rejection to assert.
 //
-// `hive-default` and `hive-auto` are on Groq gpt-oss models, which accept
-// reasoning parameters natively. (An older comment here explained their
-// presence by a LiteLLM fallback cascade; those chat fallbacks were removed
+// The Groq gpt-oss aliases (`hive-default`, `hive-auto`, `hive-small`,
+// `hive-medium`, and the deprecated `hive-fast`) accept reasoning parameters
+// natively, and every one of them is seeded supports_reasoning true. Listing
+// all five rather than the two this suite is usually pointed at, because
+// HIVE_TEST_MODEL is a knob and a run pointed at any of them would otherwise
+// assert a rejection that cannot happen. (An older comment here explained the
+// first two by a LiteLLM fallback cascade; those chat fallbacks were removed
 // from deploy/litellm/config.yaml by the 2026-08-22 catalog restructure, and
 // the flag on the route is the actual reason.)
 //
@@ -26,6 +30,9 @@ const REASONING_MODEL_PATTERNS = [
   "reasoning",
   "hive-default",
   "hive-auto",
+  "hive-small",
+  "hive-medium",
+  "hive-fast",
   "deepseek",
 ];
 

--- a/packages/sdk-tests/js/tests/responses/responses.test.ts
+++ b/packages/sdk-tests/js/tests/responses/responses.test.ts
@@ -5,11 +5,29 @@ const BASE_URL = process.env.HIVE_BASE_URL ?? "http://localhost:8080/v1";
 const API_KEY = process.env.HIVE_API_KEY ?? "test-key";
 const MODEL = process.env.HIVE_TEST_MODEL ?? "hive-default";
 
-// Known reasoning model identifiers — skip reasoning parameter rejection test
-// for these. `hive-default` is included because the CI stack now cascades
-// (via LiteLLM fallback) to gpt-oss models that natively accept reasoning
-// parameters, so the alias no longer rejects `reasoning` at the edge.
-const REASONING_MODEL_PATTERNS = ["o1", "o3", "reasoning", "hive-default", "hive-auto"];
+// Known reasoning model identifiers — skip the reasoning-parameter rejection
+// test for these, because the edge routes that parameter on
+// provider_capabilities.supports_reasoning and these aliases have it true, so
+// there is no rejection to assert.
+//
+// `hive-default` and `hive-auto` are on Groq gpt-oss models, which accept
+// reasoning parameters natively. (An older comment here explained their
+// presence by a LiteLLM fallback cascade; those chat fallbacks were removed
+// from deploy/litellm/config.yaml by the 2026-08-22 catalog restructure, and
+// the flag on the route is the actual reason.)
+//
+// `deepseek` covers deepseek-v4-flash and deepseek-v4-pro. Not an accommodation
+// for CI: supabase/migrations/20260822_02_catalog_alias_restructure.sql seeds
+// both with supports_reasoning true and a "reasoning" capability badge, from
+// the provider's own supported_parameters list.
+const REASONING_MODEL_PATTERNS = [
+  "o1",
+  "o3",
+  "reasoning",
+  "hive-default",
+  "hive-auto",
+  "deepseek",
+];
 
 function isReasoningModel(model: string): boolean {
   return REASONING_MODEL_PATTERNS.some((pattern) =>

--- a/tools/lint-sdk-test-env-propagation.mjs
+++ b/tools/lint-sdk-test-env-propagation.mjs
@@ -1,0 +1,257 @@
+#!/usr/bin/env node
+// Structural guard: an environment knob an SDK suite READS must be one its
+// container is actually GIVEN.
+//
+// Why this exists (issue #1088). `ci.yml` set `HIVE_TEST_MODEL` in the
+// live-integration job env, the suites read it
+// (`process.env.HIVE_TEST_MODEL`, `os.getenv("HIVE_TEST_MODEL")`), and the
+// `sdk-tests-*` compose services declared only `HIVE_BASE_URL` and
+// `HIVE_API_KEY`. `docker compose run` passes a service nothing but its own
+// declared environment, so the value never crossed into the container and
+// every suite silently fell back to its literal default. The workflow, the
+// comment above it claiming the value "propagates into sdk-tests containers",
+// and the green checks were all consistent with a knob that did nothing. That
+// is how the merge-gate check came to spend the live demo's provider budget on
+// every run for a month: the lever meant to point it somewhere cheaper was
+// wired to nothing.
+//
+// A knob that reads green while doing nothing is the defect class here, not
+// one particular variable name, so this scans for the class: every HIVE_*
+// variable any suite reads must be satisfied by the compose service that runs
+// it, or by an ENV in the image that service builds. Either is a real value at
+// runtime; neither present means the read can only ever see its fallback.
+//
+// Deliberately NOT checked: that ci.yml (or any other caller) sets the
+// variable. A suite is allowed to run on its default, and a caller is allowed
+// to leave a knob alone. What is not allowed is a caller setting one that
+// cannot arrive.
+//
+// Mirrors the other tools/lint-*.mjs scanners: self-test first, so a broken
+// detector fails loudly instead of turning this into a lint that always
+// passes.
+
+import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { parse } from "yaml";
+import assert from "node:assert/strict";
+
+const COMPOSE_PATH = "deploy/docker/docker-compose.yml";
+const SUITES = [
+  {
+    service: "sdk-tests-js",
+    dockerfile: "deploy/docker/Dockerfile.sdk-tests-js",
+    sources: ["packages/sdk-tests/js"],
+  },
+  {
+    service: "sdk-tests-py",
+    dockerfile: "deploy/docker/Dockerfile.sdk-tests-py",
+    sources: ["packages/sdk-tests/python"],
+  },
+  {
+    service: "sdk-tests-java",
+    dockerfile: "deploy/docker/Dockerfile.sdk-tests-java",
+    sources: ["packages/sdk-tests/java"],
+  },
+];
+
+// Every shape the three suites use to read an environment variable. Kept
+// explicit rather than a catch-all `HIVE_[A-Z_]+` match over the whole file so
+// a variable NAMED in a comment or in an assertion string is not mistaken for
+// one that is read.
+const READ_PATTERNS = [
+  /process\.env\.(HIVE_[A-Z0-9_]+)/g,
+  /process\.env\[["'](HIVE_[A-Z0-9_]+)["']\]/g,
+  /os\.getenv\(\s*["'](HIVE_[A-Z0-9_]+)["']/g,
+  /os\.environ\.get\(\s*["'](HIVE_[A-Z0-9_]+)["']/g,
+  /os\.environ\[\s*["'](HIVE_[A-Z0-9_]+)["']\s*\]/g,
+  /System\.getenv\(\s*"(HIVE_[A-Z0-9_]+)"/g,
+];
+
+export function readsIn(text) {
+  const found = new Set();
+  for (const pattern of READ_PATTERNS) {
+    for (const match of text.matchAll(pattern)) found.add(match[1]);
+  }
+  return found;
+}
+
+// The names a compose service's `environment:` block provides. Both the map
+// form (`KEY: value`) and the list form (`- KEY=value`, `- KEY`) are valid
+// compose, so both are read.
+export function providedByService(service) {
+  const env = service?.environment;
+  if (!env) return new Set();
+  if (Array.isArray(env)) {
+    return new Set(env.map((entry) => String(entry).split("=")[0].trim()));
+  }
+  return new Set(Object.keys(env));
+}
+
+export function providedByDockerfile(text) {
+  const found = new Set();
+  // `ENV KEY=value` and the legacy `ENV KEY value`, one per line.
+  for (const match of text.matchAll(/^\s*ENV\s+([A-Z0-9_]+)[=\s]/gim)) {
+    found.add(match[1]);
+  }
+  return found;
+}
+
+function findUnreachableReads({ composeSource, suites }) {
+  const compose = parse(composeSource);
+  const problems = [];
+  for (const suite of suites) {
+    const service = compose.services?.[suite.service];
+    if (!service) {
+      problems.push(`compose service '${suite.service}' does not exist`);
+      continue;
+    }
+    const provided = new Set([
+      ...providedByService(service),
+      ...providedByDockerfile(suite.dockerfileSource ?? ""),
+    ]);
+    for (const name of [...suite.reads].sort()) {
+      if (!provided.has(name)) {
+        problems.push(
+          `${suite.service} runs a suite that reads ${name}, but neither the compose ` +
+            `service's environment nor ${suite.dockerfile} provides it, so the read can ` +
+            `only ever see its in-code fallback`,
+        );
+      }
+    }
+  }
+  return problems;
+}
+
+function selfTest() {
+  assert.deepEqual(
+    [...readsIn('const m = process.env.HIVE_TEST_MODEL ?? "hive-default";')],
+    ["HIVE_TEST_MODEL"],
+    "detector misses a JS process.env read",
+  );
+  assert.deepEqual(
+    [...readsIn('MODEL = os.getenv("HIVE_TEST_MODEL", "hive-default")')],
+    ["HIVE_TEST_MODEL"],
+    "detector misses a Python os.getenv read",
+  );
+  assert.deepEqual(
+    [...readsIn('String k = System.getenv("HIVE_API_KEY");')],
+    ["HIVE_API_KEY"],
+    "detector misses a Java System.getenv read",
+  );
+  assert.deepEqual(
+    [...readsIn("# HIVE_TEST_MODEL is described here but never read")],
+    [],
+    "detector wrongly treats a mention in a comment as a read",
+  );
+  assert.deepEqual(
+    [...providedByDockerfile("FROM node:24\nENV HIVE_FIXTURES_DIR=/fixtures/golden\n")],
+    ["HIVE_FIXTURES_DIR"],
+    "detector misses an image ENV",
+  );
+  assert.deepEqual(
+    [...providedByService({ environment: ["HIVE_API_KEY=x", "HIVE_BASE_URL"] })],
+    ["HIVE_API_KEY", "HIVE_BASE_URL"],
+    "detector misses the compose list form of environment",
+  );
+
+  const composeSource = `
+services:
+  sdk-tests-js:
+    environment:
+      HIVE_BASE_URL: http://edge-api:8080/v1
+`;
+  assert.equal(
+    findUnreachableReads({
+      composeSource,
+      suites: [
+        {
+          service: "sdk-tests-js",
+          dockerfile: "Dockerfile.x",
+          dockerfileSource: "FROM node:24\n",
+          reads: new Set(["HIVE_BASE_URL", "HIVE_TEST_MODEL"]),
+        },
+      ],
+    }).length,
+    1,
+    "detector misses a suite read that no service or image provides",
+  );
+  assert.deepEqual(
+    findUnreachableReads({
+      composeSource,
+      suites: [
+        {
+          service: "sdk-tests-js",
+          dockerfile: "Dockerfile.x",
+          dockerfileSource: "FROM node:24\nENV HIVE_TEST_MODEL=hive-default\n",
+          reads: new Set(["HIVE_BASE_URL", "HIVE_TEST_MODEL"]),
+        },
+      ],
+    }),
+    [],
+    "detector wrongly flags a read the image's own ENV satisfies",
+  );
+  assert.equal(
+    findUnreachableReads({
+      composeSource,
+      suites: [
+        {
+          service: "sdk-tests-absent",
+          dockerfile: "Dockerfile.x",
+          dockerfileSource: "",
+          reads: new Set(),
+        },
+      ],
+    }).length,
+    1,
+    "detector misses a compose service that does not exist",
+  );
+}
+
+function collectReads(dirs) {
+  const found = new Set();
+  // git ls-files rather than a directory walk: it skips node_modules, build
+  // output and anything else ignored, without this scanner having to know what
+  // those are.
+  const listed = execFileSync("git", ["ls-files", ...dirs], { encoding: "utf8" })
+    .split("\n")
+    .filter(Boolean);
+  for (const file of listed) {
+    if (!/\.(ts|js|mjs|py|java)$/.test(file)) continue;
+    for (const name of readsIn(readFileSync(file, "utf8"))) found.add(name);
+  }
+  return found;
+}
+
+selfTest();
+if (process.argv.includes("--self-test")) {
+  console.log("lint-sdk-test-env-propagation: SELF-TEST PASS");
+  process.exit(0);
+}
+
+const suites = SUITES.map((suite) => ({
+  ...suite,
+  dockerfileSource: readFileSync(suite.dockerfile, "utf8"),
+  reads: collectReads(suite.sources),
+}));
+
+const problems = findUnreachableReads({
+  composeSource: readFileSync(COMPOSE_PATH, "utf8"),
+  suites,
+});
+
+if (problems.length > 0) {
+  console.error("SDK test environment knob that cannot reach the container:");
+  for (const problem of problems) console.error(`  - ${problem}`);
+  console.error(
+    "\n  Add the variable to the service's environment: block in " +
+      `${COMPOSE_PATH} (pass it through, e.g. NAME: \${NAME:-default}), or set it as an\n` +
+      "  ENV in the image. A caller that sets a knob nothing forwards gets a green run\n" +
+      "  and no effect, which is issue #1088.",
+  );
+  process.exit(1);
+}
+console.log(
+  `lint-sdk-test-env-propagation: PASS (${suites
+    .map((s) => `${s.service}: ${[...s.reads].sort().join(", ") || "no HIVE_* reads"}`)
+    .join("; ")})`,
+);


### PR DESCRIPTION
Fixes #1088. Folds in #1089, which is the same incident's other half and is a
three line config change once it is verified properly.

## What was actually wrong

`CI / Live integration (SDK tests + smoke)` is a required check on `main`. It
went red on 2026-08-23 with no code change, because Groq's free tier daily
token budget was exhausted (limit 200000, used 199997), and the live demo box
serves chat from the same key and the same daily budget. So a merge to `main`
spent the allowance the demo answers customers from, and when it ran out a
required check went red for a reason no commit caused while the demo answered
nothing.

The workflow already carried a mechanism meant to prevent exactly this. It was
dead three times over, and each dead layer hid the next.

1. `HIVE_TEST_MODEL` was set in the job env and read by the suites
   (`process.env.HIVE_TEST_MODEL`, `os.getenv("HIVE_TEST_MODEL")`), but
   `sdk-tests-js`, `sdk-tests-py` and `sdk-tests-java` declared only
   `HIVE_BASE_URL` and `HIVE_API_KEY`. `docker compose run` gives a service
   nothing but its own declared environment, so the value never entered the
   container and every suite fell back to its literal `hive-default`. The
   comment in `ci.yml` claiming it "propagates into sdk-tests containers via
   docker compose env interpolation" was false. `HIVE_EMBEDDING_MODEL` was dead
   the same way.
2. Both branches of the `HIVE_TEST_MODEL` ternary evaluated to `hive-default`,
   so even a working propagation path selected the same model on every event.
3. The variable that ternary actually switched, `OPENROUTER_DEFAULT_MODEL`, is
   documented UNUSED in `.env.example`: its consumer `route-openrouter-default`
   was deleted from `deploy/litellm/config.yaml` by the 2026-08-22 catalog
   restructure.

That restructure is what created the coupling. It moved `hive-default` from
OpenRouter onto Groq, so every run of this job since then has billed the demo's
Groq daily budget, while the workflow's own comments described a free model pull
request path and a paid fidelity push path that no longer existed.

## Mechanism chosen, and why

**Point the token consuming suites at an alias on a different provider account,
and bound what a run may spend.** `HIVE_TEST_MODEL` is now really wired through
and defaults to `deepseek-v4-flash`, an existing public alias pinned to
`route-deepseek-v4-flash` on OpenRouter.

- It removes the coupling that matters. Groq's limit is a hard daily token cap
  per organization, so a second Groq key would not have helped; only a different
  account does. OpenRouter is prepaid credit, so CI and the demo now compete
  only over fractions of a cent per run, not over a cliff that makes the demo
  answer nothing.
- It needs no new secret and no provisioning step, so it works today.
- It keeps the check meaningful: a real HTTP call to a real provider through
  LiteLLM, edge-api, routing, reservation, streaming and settlement. It touches
  more of the money path than before, since this alias is one of the genuinely
  paid routes.
- `vars.CI_LIVE_INTEGRATION_MODEL` overrides the default, so pointing CI back at
  `hive-default` (once a CI only Groq organization exists, say) is a repository
  variable rather than a code change.

Verified live against OpenRouter with the suites' own request shapes before
choosing it: plain completion returns non empty content, the tool call shape
returns a real `tool_calls` response, about USD 0.000017 per completion.

**Fidelity loss, stated plainly rather than buried.** This check no longer
exercises the Groq `openai/gpt-oss-20b` route the demo serves chat from, so a
Groq specific regression will not be caught here. It is still caught by the
`sdk-replay` job in `deploy-demo-box.yml`, which runs these same suites against
the live box on `hive-default` after every deploy and is deliberately left
alone: its job is to test what customers actually get, and if the demo has no
budget then the demo is genuinely broken and a red check there is correct
signal. The job now prints which alias it bills, and what that does not cover,
every run.

Alternatives rejected: paying for a Groq tier (owner's call, and it costs money
against a sub fifty dollar operating budget); routing onto a free model (no free
OpenRouter chat model is reachable through the catalog without adding a customer
visible alias, which is a product decision); a token ceiling alone (bounds the
drain, does not remove the competition, so it is kept as a second layer rather
than as the mechanism); recorded fixtures (deletes the only end to end provider
coverage this repository has); and deleting, `continue-on-error`ing or narrowing
the check, which trades a loud failure for a quiet absence.

## Budget exhaustion now reports itself

Two layers, because the CI side one works even when the serving side one does
not.

1. A failed run scans the LiteLLM and edge-api container logs (through the
   existing redactor, since the output is public) and emits an `::error::`
   naming the cause: a daily token budget, a plain 429, or an account out of
   credit. The classification is carried into the body of the tracking issue the
   job files, so the first thing a reader sees is the cause rather than a link
   to a run whose test output says `Test timed out in 60000ms`.
2. Every run prints its metered token spend per alias, read from `usage_events`
   on its own throwaway database, and fails above a ceiling. It also asserts
   that the alias actually billed is the one the workflow selected, which is the
   check that would have caught the original defect, and that a passing run
   metered at least one completion, so a pass over nothing is not a pass.

## Issue #1089, folded in

`router_settings.retry_policy` with `RateLimitErrorRetries: 0`. Retrying a
tokens per DAY limit three times over a window that resets tomorrow cannot
succeed; it converts a fast correct 429 into a slow wrong one.

Verified behaviourally, not by reading the config, and against the image this
stack actually runs (`v1.98.0`, not the `v1.77.7-stable` the issue quotes), with
a stub upstream that returns 429 on demand:

| upstream | retry policy | upstream attempts | elapsed | client sees |
| --- | --- | --- | --- | --- |
| 429 | absent (today) | 4 | 11.47s | 429 |
| 429 | `RateLimitErrorRetries: 0` | 1 | 1.79s | 429 |
| 500 | `RateLimitErrorRetries: 0` | 4 | 13.27s | 500 |

The third row is what makes it safe: every other error class still retries
`num_retries` times. Absorption for a genuine per minute burst is not lost
either, it just moves one layer out: edge-api retries 429 itself, four attempts
inside about 2.9 seconds, and returns the final 429 verbatim
(`apps/edge-api/internal/inference/retry.go`).

Two findings worth recording from that measurement, because they contradict the
issue text:

- The 60 second hang was not `request_timeout: 45` multiplied by three. A fast
  429 costs LiteLLM about 11 seconds, and edge-api then retries the whole thing
  up to four times, so the real amplification is two retry layers multiplying
  (up to 16 upstream calls, which matches the 18 rate limit lines in the failing
  run's artifact) rather than one slow one.
- LiteLLM classifies partly on message CONTENT, not only on status code. A stub
  returning HTTP 500 whose body mentioned "limits" was mapped to
  `RateLimitError` and therefore not retried. That is the correct trade for the
  case this fixes, and it is written into the config comment so the next reader
  does not rediscover it from a strange log line.

Not folded in, deliberately: whether `status=502` is right for a client
cancelled request, and whether `request_timeout: 45` should sit further below
the suites' 60 second bound. Both are separate behaviour changes on the same hot
path and neither is needed to stop a 429 arriving as a minute long hang.

## Measured token spend, before and after

Both numbers come from the same meter added in this pull request, on a real run
of the check on this branch. See the "Measurement" comment below.

## Verification

- `node tools/lint-sdk-test-env-propagation.mjs` fails on `main`'s compose file
  naming all four dead knobs, and passes after the fix. Self test passes.
- `go test ./apps/control-plane/internal/litellmconfig/...` including the new
  `TestWriteAndRestartPreservesRouterSettings`, which exists because
  control plane rewrites `config.yaml` on every catalog sync and a dropped
  unrecognised top level key would make the #1089 fix work exactly until the
  first sync.
- `go test ./apps/edge-api/... -short`, all green.
- `npm run lint:litellm-config`, `node .github/ci/lint-workflow-check-names.mjs`,
  and a strict duplicate key parse of the three YAML files touched.
- The workflow itself run on this branch, twice, with the model as the only
  difference. Links and job output in the comments below.

## Adjacent findings, not fixed here

- `ci.yml` caches and pre pulls `ghcr.io/berriai/litellm:v1.77.7-stable` while
  compose resolves `LITELLM_IMAGE` to `v1.98.0`, so that cache step saves
  nothing and the version the issue reasoned about is not the version CI runs.
- `owui-nightly.yml`, `agent-visual-proof.yml` and `agent-stream-delta-proof.yml`
  also spend the demo's Groq budget. They run against the box, so that is
  legitimate, but nothing bounds them.

## Buglog entry

```json
{"id":"bug-2026-08-23-ci-model-knob-wired-to-nothing","date":"2026-08-23","title":"A merge gate check drained the live demo's Groq daily token budget because its model selection knob was never forwarded into the test containers","error_message":"Test timed out in 60000ms. (four SDK tests) with, only in the compose log artifact: Rate limit reached for model `openai/gpt-oss-20b` ... on tokens per day (TPD): Limit 200000, Used 199997, Requested 147","root_cause":"ci.yml's live-integration job set HIVE_TEST_MODEL, the SDK suites read it, and the sdk-tests-js/py/java compose services declared only HIVE_BASE_URL and HIVE_API_KEY, so docker compose run never passed it into the container and the suites used their literal hive-default fallback. Both branches of the HIVE_TEST_MODEL ternary also evaluated to hive-default, and OPENROUTER_DEFAULT_MODEL, the variable the ternary actually switched, had been unused since route-openrouter-default was deleted. The 2026-08-22 catalog restructure then moved hive-default from OpenRouter onto Groq, so every run billed the live demo's shared free tier daily token budget. Separately, LiteLLM retried the resulting 429 and edge-api retried on top of that, multiplying one refusal into up to 16 upstream calls and pushing the request past the suites' 60 second timeout, so the failure presented as a timeout rather than a rate limit.","fix":"Forward HIVE_TEST_MODEL and HIVE_EMBEDDING_MODEL through the sdk-tests compose services and default the job to deepseek-v4-flash on OpenRouter, a different provider account, overridable with vars.CI_LIVE_INTEGRATION_MODEL. Add tools/lint-sdk-test-env-propagation.mjs so a suite reading a variable nothing forwards fails loudly. Print and bound the run's metered token spend from usage_events and assert the alias billed is the alias selected. Classify an upstream refusal from the container logs into the job output and the filed tracking issue. Set router_settings.retry_policy RateLimitErrorRetries 0 so a rate limit surfaces in about 1.8 seconds instead of 11.5, measured against v1.98.0 with a 429 stub.","tags":["ci","providers","budget","litellm","rate-limit","dead-config","issue-1088","issue-1089"]}
```
