### PR TITLE
feat: scheduled encrypted backups for all four demo box data stores

### DIFF
--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -1534,7 +1534,15 @@ services:
     profiles:
       - monitoring
     ports:
-      - "9093:9093"
+      # Loopback only. The API is unauthenticated by design, and the box
+      # backup (scripts/backup-box.sh, issue #1000) now posts its failure
+      # alerts through this port as its failure channel, which makes the
+      # exposure load-bearing: anything on the LAN could forge a
+      # BackupFailed/Stale alert into the ops inbox or read firing alerts.
+      # Prometheus reaches alertmanager over the container network, and
+      # host-side callers use localhost, so nothing legitimate needed the
+      # LAN-reachable binding.
+      - "127.0.0.1:9093:9093"
     configs:
       - source: alertmanager_config
         target: /etc/alertmanager/alertmanager.yml

--- a/deploy/systemd-user/hive-box-backup.service
+++ b/deploy/systemd-user/hive-box-backup.service
@@ -1,0 +1,20 @@
+[Unit]
+# Runs the box backup as the sakib user via the user systemd manager. Linger
+# is already enabled for this user on the demo box, so user timers survive
+# reboot without root. The script is the installed copy under
+# /home/sakib/hive-backups/bin, not a repo checkout, so a deploy that resets
+# /home/sakib/hive can never take backups down with it.
+Description=Hive demo box backup (four production data stores)
+ConditionPathIsReadWrite=/home/sakib/hive-backups
+
+[Service]
+Type=oneshot
+ExecStart=/home/sakib/hive-backups/bin/backup-box.sh
+EnvironmentFile=/home/sakib/hive-backups/etc/backup.env
+
+# A run that hangs must not hold the flock forever: kill after one hour and
+# let the failure alert fire through the script's own error trap.
+TimeoutStartSec=3600
+
+[Install]
+WantedBy=default.target

--- a/deploy/systemd-user/hive-box-backup.service
+++ b/deploy/systemd-user/hive-box-backup.service
@@ -11,6 +11,10 @@ ConditionPathIsReadWrite=/home/sakib/hive-backups
 Type=oneshot
 ExecStart=/home/sakib/hive-backups/bin/backup-box.sh
 EnvironmentFile=/home/sakib/hive-backups/etc/backup.env
+# The run handles plaintext identity and ledger data: private temp handling
+# and no privilege gain, defense in depth on top of the script's own umask.
+UMask=0077
+NoNewPrivileges=true
 
 # A run that hangs must not hold the flock forever: kill after one hour and
 # let the failure alert fire through the script's own error trap.

--- a/deploy/systemd-user/hive-box-backup.timer
+++ b/deploy/systemd-user/hive-box-backup.timer
@@ -1,0 +1,13 @@
+[Unit]
+# Twice daily gives every missed slot a second chance the same day. Persistent
+# plus Linger means a box that was down at 03:15 catches up on boot.
+Description=Hive demo box backup schedule (twice daily, UTC)
+
+[Timer]
+OnCalendar=*-*-* 03,15:15:00 UTC
+Persistent=true
+RandomizedDelaySec=300
+Unit=hive-box-backup.service
+
+[Install]
+WantedBy=timers.target

--- a/docs/runbooks/box-backup-restore.md
+++ b/docs/runbooks/box-backup-restore.md
@@ -1,0 +1,201 @@
+# Demo box backup and restore runbook
+
+Closes the durability gap recorded in issue #1000: since the move off managed
+Supabase Cloud, every production store on the demo box was single-copy. This
+runbook documents the mechanism that now backs all four stores up on a
+schedule, encrypts them at rest, copies one set off the box, proves restorability
+into a throwaway target, and fails loudly when a run did not happen.
+
+## What is backed up
+
+| Store | How it is captured | Why this method |
+| --- | --- | --- |
+| Postgres (`postgres` database: identities in GoTrue's `auth` schema, tenants, api keys, credit ledger) | `pg_dump --format=custom`, streamed out of `hive-supabase-db-1` via `docker exec` stdout | Consistent snapshot of a running server, no stop or restart, custom format restores with `pg_restore` into any empty database |
+| Open WebUI relational state (`hive_owui-data` volume, `/data/webui.db`) | SQLite online backup API run inside the open-webui container, integrity-checked before leaving the container | Copying a SQLite file while its WAL is active is not safe; the backup API produces a consistent copy from a running writer |
+| Open WebUI uploads (`/data/uploads`) | `tar` streamed via `docker exec` | Plain files |
+| Supabase Storage object bytes (buckets `hive-files`, `hive-images`) | `tar` of `/var/lib/storage` streamed via `docker exec` | Object bytes live on the storage container's volume under a nested `stub/stub/` layout; metadata stays in Postgres and is covered by the DB dump |
+
+Measured sizes on 2026-08-23: db dump about 2.5 MB (custom format), webui.db
+about 1 MB, uploads under 100 KB, storage objects about 300 KB. A full daily
+set is under 5 MB.
+
+## Where artifacts live
+
+```
+/home/sakib/hive-backups/          # on the box, outside any git checkout
+├── bin/backup-box.sh              # installed copy of scripts/backup-box.sh
+├── etc/passphrase                 # chmod 600, openssl-compatible passphrase
+├── etc/backup.env                 # optional overrides for the units
+├── daily/YYYY-MM-DD/
+│   ├── db.pgdump.enc              # aes-256-cbc, pbkdf2 600000 iterations
+│   ├── webui.db.enc
+│   ├── uploads.tgz.enc
+│   ├── storage.tgz.enc
+│   ├── SHA256SUMS                 # over the four .enc artifacts
+│   └── MANIFEST.txt
+├── status/last-success-epoch      # unix epoch of last good run
+├── status/STATUS.txt              # one line per outcome, newest last
+└── logs/<ts>.log                  # full run log per invocation
+```
+
+Off-box copy: `/home/sakib/hive-backups/hive-demo/daily/...` on the dev
+machine, pulled encrypted only (scripts/pull-box-backups.sh). The passphrase
+also exists off-box at /home/sakib/hive-backups/etc/passphrase-hive-demo so a
+dead box does not take its own key down with it.
+
+## Schedule, retention, capacity
+
+- systemd USER timer `hive-box-backup.timer`: 03:15 and 15:15 UTC daily,
+  Persistent=true catches up after downtime; user-level because there is no
+  sudo on the box, reboot-surviving because Linger is enabled for sakib.
+- Watchdog cron entry runs `backup-box.sh --check` hourly. It is silent when
+  fresh, posts HiveBoxBackupStale when the last success is older than 26h.
+  It exists so that the death of the timer itself still surfaces within an hour.
+- Retention: 14 daily sets on the box. At measured size that is under 70 MB,
+  against roughly 34 GB free on the box root filesystem. Off-box accumulation
+  is about 150 MB/month if never pruned; prune by deleting whole day
+  directories.
+
+Numbers are chosen against measured reality, not guessed: dump 2.5 MB plus the
+other three artifacts keeps 14 days below the size of a single demo chat image.
+
+## Failure signal
+
+The script posts directly to Alertmanager's v2 API on the published host port
+(localhost:9093), reusing the existing routing tree and hive-ops email receiver
+(PR #998 made that chain work). No new component is deployed:
+
+- `HiveBoxBackupFailed`: posted immediately when any step errors. Auto-resolves
+  through resolve_timeout once a later run succeeds (success posts nothing).
+- `HiveBoxBackupStale`: posted by any `--check` invocation when the last
+  success exceeds 26 hours. Catches missed runs and dead schedulers.
+
+At-a-glance checks, newest line tells the story:
+
+```
+cat /home/sakib/hive-backups/status/STATUS.txt
+systemctl --user list-timers hive-box-backup.timer
+journalctl --user -u hive-box-backup -n 50
+```
+
+## Installing or reinstalling on the box
+
+Run as sakib on the box, from a checkout containing these files:
+
+```
+mkdir -p ~/hive-backups/bin ~/hive-backups/etc
+cp scripts/backup-box.sh ~/hive-backups/bin/backup-box.sh && chmod +x $_
+[ -f ~/hive-backups/etc/passphrase ] || { umask 077; openssl rand -base64 48 > ~/hive-backups/etc/passphrase; }
+chmod 600 ~/hive-backups/etc/passphrase
+mkdir -p ~/.config/systemd/user
+cp deploy/systemd-user/hive-box-backup.{service,timer} ~/.config/systemd/user/
+systemctl --user daemon-reload
+systemctl --user enable --now hive-box-backup.timer
+loginctl show-user "$USER" -p Linger   # must print Linger=yes
+(crontab -l 2>/dev/null; echo '17 * * * * /home/sakib/hive-backups/bin/backup-box.sh --check >> /home/sakib/hive-backups/logs/check.log 2>&1') | crontab -
+~/hive-backups/bin/backup-box.sh       # first run, watch it work
+```
+
+## Restore proof (safe, automated, no production contact)
+
+One command on the box:
+
+```
+/home/sakib/hive-backups/bin/restore-box-backup.sh
+```
+
+Decrypts today's db artifact to a private temp dir, stands up a throwaway
+Postgres from the same image production uses (`hive-supabase-db:pg16-cron`,
+network-isolated with `--network none`), restores, compares row counts for the
+ledger, tenant, api-key and identity tables plus storage metadata against the
+live database read-only, prints a verdict, destroys the throwaway. Extension
+DDL errors during restore are expected (pg_cron needs shared-preload config the
+vanilla entrypoint does not set); data row counts decide the verdict.
+
+Verified live 2026-08-23: all six compared tables matched (counts in PR body).
+
+Quick webui and storage verification commands (manual):
+
+```
+openssl enc -d -aes-256-cbc -pbkdf2 -iter 600000 -salt -pass file:~/hive-backups/etc/passphrase \
+  -in ~/hive-backups/daily/<day>/webui.db.enc -out /tmp/webui-check.db
+python3 -c "import sqlite3;print(sqlite3.connect('/tmp/webui-check.db').execute('PRAGMA integrity_check').fetchone()[0])"
+docker exec hive-open-webui-1 python3 -c "import sqlite3;print(sqlite3.connect('file:/data/webui.db?mode=ro',uri=True).execute('select count(*) from chat').fetchone()[0])"
+python3 -c "import sqlite3;print(sqlite3.connect('/tmp/webui-check.db').execute('select count(*) from chat').fetchone()[0])"
+
+openssl enc -d -aes-256-cbc -pbkdf2 -iter 600000 -salt -pass file:~/hive-backups/etc/passphrase \
+  -in ~/hive-backups/daily/<day>/storage.tgz.enc -out /tmp/storage-check.tgz
+tar tzf /tmp/storage-check.tgz | wc -l               # entry count vs live:
+docker exec hive-supabase-storage-1 find /var/lib/storage | wc -l
+```
+
+Always shred decrypted temps afterwards:
+
+```
+shred -u /tmp/webui-check.db /tmp/storage-check.tgz
+```
+
+## Real restore onto production (deliberately manual)
+
+No script automates writing over production. A human decides, then follows
+these steps. Assume the stack is stopped or the affected service recreated by
+whoever declares the disaster; this section covers data, not orchestration.
+
+### Database
+
+```
+# decrypt
+openssl enc -d -aes-256-cbc -pbkdf2 -iter 600000 -salt -pass file:~/hive-backups/etc/passphrase \
+  -in ~/hive-backups/daily/<day>/db.pgdump.enc -out /tmp/db.pgdump
+# restore into the existing postgres database (drop/create is destructive, do it consciously)
+docker exec hive-supabase-db-1 psql -U postgres -c 'DROP DATABASE postgres;'   # destructive by design
+docker exec hive-supabase-db-1 psql -U postgres -c 'CREATE DATABASE postgres;'
+docker exec -i hive-supabase-db-1 pg_restore -U postgres -d postgres --no-owner < /tmp/db.pgdump || true
+shred -u /tmp/db.pgdump
+```
+
+The trailing `|| true` swallows extension DDL failures exactly as the verify
+script documents; check the ledger and identity counts afterwards with the
+same comparison the verify script prints.
+
+### Open WebUI state
+
+```
+openssl enc -d -aes-256-cbc -pbkdf2 -iter 600000 -salt -pass file:~/hive-backups/etc/passphrase \
+  -in ~/hive-backups/daily/<day>/webui.db.enc -out /tmp/webui.db
+docker cp /tmp/webui.db hive-open-webui-1:/data/webui.db.restored
+# Open WebUI keeps webui.db open: coordinate a container restart with the
+# incident owner, then swap the restored file into place around that restart.
+docker exec hive-open-webui-1 mv /data/webui.db /data/webui.db.pre-restore
+docker restart hive-open-webui-1        # only together with the incident owner
+docker exec hive-open-webui-1 mv /data/webui.db.restored /data/webui.db
+docker restart hive-open-webui-1
+shred -u /tmp/webui.db
+```
+
+Open WebUI holds webui.db open, so replacing the live file requires restarting
+the open-webui container, which is out of scope for an automated path here.
+Coordinate the restart with whoever owns the incident, then move the restored
+file into place across the restart.
+
+### Storage objects
+
+```
+openssl enc -d -aes-256-cbc -pbkdf2 -iter 600000 -salt -pass file:~/hive-backups/etc/passphrase \
+  -in ~/hive-backups/daily/<day>/storage.tgz.enc -out /tmp/storage.tgz
+docker cp /tmp/storage.tgz hive-supabase-storage-1:/tmp/
+docker exec hive-supabase-storage-1 tar xzf /tmp/storage.tgz -C /
+docker exec hive-supabase-storage-1 rm -f /tmp/storage.tgz
+shred -u /tmp/storage.tgz
+```
+
+## Gaps this does not close
+
+- True offsite destination: one encrypted copy lives on the dev machine, which
+  stops the box-death scenario but not dev-machine-plus-box co-loss. Choosing
+  the real offsite/object-store destination is an owner decision, tracked in
+  the follow-up issue filed alongside this change.
+- Point-in-time recovery: pg_dump gives snapshots at run times, nothing finer.
+- Prometheus-scraped metric: would need node_exporter, which this deployment
+  does not run. The direct Alertmanager post reuses the transport that already
+  works; revisit if node_exporter lands later.

--- a/docs/runbooks/box-backup-restore.md
+++ b/docs/runbooks/box-backup-restore.md
@@ -88,7 +88,7 @@ cp scripts/backup-box.sh ~/hive-backups/bin/backup-box.sh
 cp scripts/restore-box-backup.sh ~/hive-backups/bin/restore-box-backup.sh
 chmod +x ~/hive-backups/bin/*.sh
 [ -f ~/hive-backups/etc/passphrase ] || { umask 077; openssl rand -base64 48 > ~/hive-backups/etc/passphrase; }
-chmod 600 ~/hive-backups/etc/passphrase
+chmod 600 ~/hive-backups/etc/passphrase ~/hive-backups/etc/backup.env
 mkdir -p ~/.config/systemd/user
 cp deploy/systemd-user/hive-box-backup.{service,timer} ~/.config/systemd/user/
 systemctl --user daemon-reload
@@ -223,8 +223,15 @@ The backup tar was created as `tar czf - -C / var/lib/storage`, so its entries c
 - True offsite destination: one encrypted copy lives on the dev machine, which
   stops the box-death scenario but not dev-machine-plus-box co-loss. Choosing
   the real offsite/object-store destination is an owner decision, tracked in
-  the follow-up issue filed alongside this change.
+  the follow-up issue filed alongside this change (#1100).
 - Point-in-time recovery: pg_dump gives snapshots at run times, nothing finer.
+- Encryption is aes-256-cbc with a per-file salt and PBKDF2 (600k iterations);
+  checksums detect corruption but are not signed, so an attacker who can write
+  inside /home/sakib/hive-backups could tamper with artifacts without
+  detection. Adequate for this box's threat model; if the threat model grows,
+  move to age or encrypt-then-HMAC before trusting these files in anger.
 - Prometheus-scraped metric: would need node_exporter, which this deployment
   does not run. The direct Alertmanager post reuses the transport that already
-  works; revisit if node_exporter lands later.
+  works; revisit if node_exporter lands later. Related hardening shipped with
+  this change: alertmanager now binds host port 9093 to loopback only, since
+  the backup failure channel made its unauthenticated API load-bearing.

--- a/docs/runbooks/box-backup-restore.md
+++ b/docs/runbooks/box-backup-restore.md
@@ -84,7 +84,9 @@ Run as sakib on the box, from a checkout containing these files:
 
 ```
 mkdir -p ~/hive-backups/bin ~/hive-backups/etc
-cp scripts/backup-box.sh ~/hive-backups/bin/backup-box.sh && chmod +x $_
+cp scripts/backup-box.sh ~/hive-backups/bin/backup-box.sh
+cp scripts/restore-box-backup.sh ~/hive-backups/bin/restore-box-backup.sh
+chmod +x ~/hive-backups/bin/*.sh
 [ -f ~/hive-backups/etc/passphrase ] || { umask 077; openssl rand -base64 48 > ~/hive-backups/etc/passphrase; }
 chmod 600 ~/hive-backups/etc/passphrase
 mkdir -p ~/.config/systemd/user
@@ -129,7 +131,7 @@ tar tzf /tmp/storage-check.tgz | wc -l               # entry count vs live:
 docker exec hive-supabase-storage-1 find /var/lib/storage | wc -l
 ```
 
-Always shred decrypted temps afterwards:
+Table names in the webui examples (chat, user, knowledge) are current Open WebUI schema and can drift across upstream upgrades; if a count query errors, list tables with `.tables` first. Always shred decrypted temps afterwards:
 
 ```
 shred -u /tmp/webui-check.db /tmp/storage-check.tgz
@@ -147,9 +149,12 @@ whoever declares the disaster; this section covers data, not orchestration.
 # decrypt
 openssl enc -d -aes-256-cbc -pbkdf2 -iter 600000 -salt -pass file:~/hive-backups/etc/passphrase \
   -in ~/hive-backups/daily/<day>/db.pgdump.enc -out /tmp/db.pgdump
-# restore into the existing postgres database (drop/create is destructive, do it consciously)
-docker exec hive-supabase-db-1 psql -U postgres -c 'DROP DATABASE postgres;'   # destructive by design
-docker exec hive-supabase-db-1 psql -U postgres -c 'CREATE DATABASE postgres;'
+# restore into the existing postgres database. Connect to template1 for both
+# administrative commands: Postgres refuses to drop the database the session
+# is connected to. drop/create is destructive by design, do it consciously,
+# and only once every client of this database is stopped.
+docker exec hive-supabase-db-1 psql -U postgres -d template1 -c 'DROP DATABASE postgres;'
+docker exec hive-supabase-db-1 psql -U postgres -d template1 -c 'CREATE DATABASE postgres;'
 docker exec -i hive-supabase-db-1 pg_restore -U postgres -d postgres --no-owner < /tmp/db.pgdump || true
 shred -u /tmp/db.pgdump
 ```
@@ -160,18 +165,28 @@ same comparison the verify script prints.
 
 ### Open WebUI state
 
+The restore REPLACES webui.db, it never merges. Open WebUI keeps the database open and its WAL files beside it, so a stale webui.db-wal replaying over a restored file would corrupt it: the -wal and -shm files must go with the old database, and every swap happens while the container is stopped.
+
 ```
+# 1. decrypt
 openssl enc -d -aes-256-cbc -pbkdf2 -iter 600000 -salt -pass file:~/hive-backups/etc/passphrase \
   -in ~/hive-backups/daily/<day>/webui.db.enc -out /tmp/webui.db
+# 2. copy the restored file into the volume under a staging name
 docker cp /tmp/webui.db hive-open-webui-1:/data/webui.db.restored
-# Open WebUI keeps webui.db open: coordinate a container restart with the
-# incident owner, then swap the restored file into place around that restart.
-docker exec hive-open-webui-1 mv /data/webui.db /data/webui.db.pre-restore
-docker restart hive-open-webui-1        # only together with the incident owner
-docker exec hive-open-webui-1 mv /data/webui.db.restored /data/webui.db
-docker restart hive-open-webui-1
+# 3. stop the writer (coordinate with whoever owns the incident)
+docker stop hive-open-webui-1
+# 4. swap files inside the volume using a throwaway helper on an image the box
+#    already has (no new pull), since a stopped container cannot exec
+docker run --rm -v hive_owui-data:/data --entrypoint sh hive-supabase-db:pg16-cron -c '
+  mv /data/webui.db /data/webui.db.pre-restore
+  rm -f /data/webui.db-wal /data/webui.db-shm
+  mv /data/webui.db.restored /data/webui.db'
+# 5. back up
+docker start hive-open-webui-1
 shred -u /tmp/webui.db
 ```
+
+Keep webui.db.pre-restore until chat history is confirmed intact.
 
 Open WebUI holds webui.db open, so replacing the live file requires restarting
 the open-webui container, which is out of scope for an automated path here.
@@ -180,14 +195,28 @@ file into place across the restart.
 
 ### Storage objects
 
+The restore REPLACES the object tree, it never merges. Extracting over the live tree would preserve objects created after the backup day while the restored Postgres metadata no longer knows about them, so the bucket bytes and the restored storage.objects rows must agree. Coordinate stopping the storage container with whoever owns the incident, replace the whole tree, then start again.
+
 ```
+# 1. decrypt
 openssl enc -d -aes-256-cbc -pbkdf2 -iter 600000 -salt -pass file:~/hive-backups/etc/passphrase \
   -in ~/hive-backups/daily/<day>/storage.tgz.enc -out /tmp/storage.tgz
-docker cp /tmp/storage.tgz hive-supabase-storage-1:/tmp/
-docker exec hive-supabase-storage-1 tar xzf /tmp/storage.tgz -C /
-docker exec hive-supabase-storage-1 rm -f /tmp/storage.tgz
+# 2. stop the writer (coordinate with whoever owns the incident)
+docker stop hive-supabase-storage-1
+# 3. replace the whole tree through a throwaway helper mounting the volume
+#    plus host /tmp read-only for the archive
+docker run --rm \
+  -v hive_supabase-storage-data:/storage \
+  -v /tmp:/host-tmp:ro \
+  --entrypoint bash hive-supabase-db:pg16-cron -c '
+  set -e
+  mkdir -p /storage/.pre-restore
+  find /storage -mindepth 1 -maxdepth 1 ! -name .pre-restore -exec mv {} /storage/.pre-restore/ +
+  tar xzf /host-tmp/storage.tgz --strip-components=2 -C /storage'
 shred -u /tmp/storage.tgz
 ```
+
+The backup tar was created as `tar czf - -C / var/lib/storage`, so its entries carry a `var/lib/storage/` prefix that `--strip-components=2` removes; the volume root becomes `/storage` inside the helper. The old tree is moved into `/storage/.pre-restore` inside the same volume: verify the extracted content, then delete `.pre-restore` (through a second helper run) and `docker start hive-supabase-storage-1`.
 
 ## Gaps this does not close
 

--- a/scripts/backup-box.sh
+++ b/scripts/backup-box.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# backup-box.sh -- encrypted, unattended backups of the demo box's four
+# production data stores, taken from a RUNNING stack (no stop/restart ever).
+#
+# Stores covered
+# --------------
+#   1. Postgres (identities, tenants, api keys, credit ledger): streamed
+#      pg_dump --format=custom out of the supabase-db container.
+#   2. Open WebUI relational state: webui.db snapshotted with SQLite's online
+#      backup API inside the open-webui container (copying webui.db while its
+#      WAL is active is NOT safe, which is why this is not a plain cp).
+#   3. Open WebUI uploads directory (/data/uploads).
+#   4. Supabase Storage object bytes (buckets hive-files and hive-images,
+#      including their nested stub/stub layout under /var/lib/storage).
+#
+# Why Alertmanager directly
+# -------------------------
+# The monitoring profile already runs Prometheus plus Alertmanager with working
+# email routing (PR #998). The backup script runs on the HOST, outside the
+# compose network where Prometheus scrapes, so a scraped metric would need a
+# new component (node_exporter is not deployed here). Posting alerts straight
+# to Alertmanager's v2 API on the published host port reuses the existing
+# transport end to end: same routing tree, same receiver, same email. A firing
+# alert resolves itself through resolve_timeout once a later successful run
+# stops posting it, so the success path sends nothing.
+#
+# Failure semantics are loud on both halves that can die:
+#   * a failed run posts HiveBoxBackupFailed immediately;
+#   * a missed run (dead timer, dead scheduler) is caught because every entry
+#     point calls --check first: any run older than STALE_AFTER seconds makes
+#     the next check post HiveBoxBackupStale. An hourly cron watchdog runs
+#     --check so the death of the systemd timer itself still surfaces within
+#     an hour.
+#
+# Secrets
+# -------
+# No secret value lives in this script or in the repository. The encryption
+# passphrase is read from PASSPHRASE_FILE (chmod 600, outside any git
+# checkout). Artifacts leave the box only in encrypted form.
+#
+# Usage
+# -----
+#   backup-box.sh            take one full backup set
+#   backup-box.sh --check    staleness watchdog only, no backup taken
+#
+# Environment (all defaulted, none required)
+# ------------------------------------------
+#   BACKUP_ROOT       /home/sakib/hive-backups
+#   DB_CONTAINER      hive-supabase-db-1        OWUI_CONTAINER hive-open-webui-1
+#   STORAGE_CONTAINER hive-supabase-storage-1
+#   PGUSER            postgres                  PGDATABASE     postgres
+#   KEEP_DAILY        14                        STALE_AFTER    93600 (26h)
+#   ALERTMANAGER_URL  http://localhost:9093
+#   PASSPHRASE_FILE   $BACKUP_ROOT/etc/passphrase
+set -euo pipefail
+
+BACKUP_ROOT="${BACKUP_ROOT:-/home/sakib/hive-backups}"
+DB_CONTAINER="${DB_CONTAINER:-hive-supabase-db-1}"
+OWUI_CONTAINER="${OWUI_CONTAINER:-hive-open-webui-1}"
+STORAGE_CONTAINER="${STORAGE_CONTAINER:-hive-supabase-storage-1}"
+PGUSER="${PGUSER:-postgres}"
+PGDATABASE="${PGDATABASE:-postgres}"
+KEEP_DAILY="${KEEP_DAILY:-14}"
+STALE_AFTER="${STALE_AFTER:-93600}"   # 26 hours: one missed daily slot of slack
+ALERTMANAGER_URL="${ALERTMANAGER_URL:-http://localhost:9093}"
+PASSPHRASE_FILE="${PASSPHRASE_FILE:-$BACKUP_ROOT/etc/passphrase}"
+
+MODE="run"
+if [[ "${1:-}" == "--check" ]]; then MODE="check"; fi
+
+TS="$(date -u +%Y%m%dT%H%M%SZ)"
+LOG_DIR="$BACKUP_ROOT/logs"
+mkdir -p "$LOG_DIR" "$BACKUP_ROOT/status" "$BACKUP_ROOT/tmp"
+LOG_FILE="$LOG_DIR/$TS.log"
+
+log()  { printf '%s %s\n' "$(date -u +%FT%TZ)" "$*" | tee -a "$LOG_FILE"; }
+warn() { log "WARN: $*"; }
+die()  { log "ERROR: $*"; exit 1; }
+
+# ---------------------------------------------------------------------------
+# Alertmanager direct post. Fixed literal strings only in labels and text, so
+# nothing user-controlled and nothing sensitive can reach the email body.
+# ---------------------------------------------------------------------------
+post_alert() {
+  local alertname="$1" description="$2" startsAt body
+  startsAt="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  body=$(printf '{"labels":{"alertname":"%s","severity":"critical","job":"box-backup","instance":"hive-demo"},"annotations":{"description":"%s"}}' \
+    "$alertname" "$description")
+  # Delivery failure must not fail the backup itself on the success path, and
+  # must not mask the underlying failure on the failure path. Log it either way.
+  curl -fsS -m 10 -XPOST "$ALERTMANAGER_URL/api/v2/alerts" \
+    -H 'Content-Type: application/json' -d "$body" \
+    >>"$LOG_FILE" 2>&1 || warn "alertmanager post failed for $alertname"
+}
+
+fail_run() {
+  log "backup FAILED at $1" || true
+  echo "FAILED $1 $(date -u +%FT%TZ)" >>"$BACKUP_ROOT/status/STATUS.txt"
+  post_alert "HiveBoxBackupFailed" "Backup run failed on the demo box at step $1. See /home/sakib/hive-backups/logs on the box."
+  exit 1
+}
+
+# Watchdog mode: fresh success means silence, anything else is loud.
+if [[ "$MODE" == "check" ]]; then
+  EPOCH_FILE="$BACKUP_ROOT/status/last-success-epoch"
+  NOW="$(date +%s)"
+  LAST="0"
+  [[ -f "$EPOCH_FILE" ]] && LAST="$(cat "$EPOCH_FILE")"
+  AGE=$(( NOW - LAST ))
+  if (( AGE > STALE_AFTER )); then
+    post_alert "HiveBoxBackupStale" "Last successful demo box backup is older than 26 hours (age ${AGE}s). A scheduled run did not happen."
+    die "stale: last success ${AGE}s ago exceeds threshold ${STALE_AFTER}s"
+  fi
+  log "check ok: last success ${AGE}s ago"
+  exit 0
+fi
+
+# ------------------------------- full run ----------------------------------
+# Serialize concurrent invocations (systemd timer and cron watchdog overlap).
+exec 9>"$BACKUP_ROOT/lock"
+flock -n 9 || { log "another backup run holds the lock, exiting"; exit 0; }
+
+[[ -r "$PASSPHRASE_FILE" ]] || fail_run "passphrase_missing"
+[[ "$(stat -c %a "$PASSPHRASE_FILE")" == "600" ]] \
+  || die "PASSPHRASE_FILE must be chmod 600, refusing to run"
+
+WORK="$BACKUP_ROOT/tmp/run-$TS"
+mkdir -p "$WORK"
+PUBLISH="$BACKUP_ROOT/daily/$(date -u +%F)"
+
+# Run the staleness check first so a half-dead schedule still alerts even when
+# this particular invocation succeeds.
+"$0" --check || true
+
+cleanup() {
+  rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+log "== backup run start ($TS) =="
+
+# 1. Database -------------------------------------------------------------
+# Custom format keeps pg_restore usable and compresses; the stream crosses
+# docker exec stdout only, it never touches the network in clear text.
+DB_DUMP="$WORK/db.pgdump"
+docker exec "$DB_CONTAINER" pg_dump -U "$PGUSER" -d "$PGDATABASE" -Fc > "$DB_DUMP" \
+  || fail_run "db_dump"
+[[ "$(head -c 5 "$DB_DUMP")" == "PGDMP" ]] || fail_run "db_dump_verify"
+log "db dump ok ($(du -h "$DB_DUMP" | cut -f1))"
+
+# 2. Open WebUI relational state (SQLite online snapshot) -----------------
+# The snapshot is written to the container's own /tmp (not the data volume),
+# integrity-checked, then streamed out. Never copied while WAL is hot.
+OWUI_SNAP="$WORK/webui.db"
+docker exec "$OWUI_CONTAINER" python3 -c '
+import os, sqlite3, sys, shutil
+src = sqlite3.connect("file:/data/webui.db?mode=ro", uri=True)
+dst_path = "/tmp/backup-webui-snapshot.db"
+dst = sqlite3.connect(dst_path)
+with dst:
+    src.backup(dst)
+dst.close(); src.close()
+check = sqlite3.connect(dst_path)
+result = check.execute("PRAGMA integrity_check").fetchone()[0]
+check.close()
+if result != "ok":
+    sys.exit("integrity_check said: " + result)
+with open(dst_path, "rb") as f:
+    shutil.copyfileobj(f, sys.stdout.buffer)
+os.remove("/tmp/backup-webui-snapshot.db")
+' > "$OWUI_SNAP" 2>>"$LOG_FILE" || fail_run "owui_snapshot"
+log "webui.db snapshot ok ($(du -h "$OWUI_SNAP" | cut -f1))"
+
+# 3. Open WebUI uploads ----------------------------------------------------
+UPLOADS_TGZ="$WORK/uploads.tgz"
+docker exec "$OWUI_CONTAINER" tar czf - -C /data uploads > "$UPLOADS_TGZ" \
+  || fail_run "owui_uploads"
+log "uploads tar ok ($(du -h "$UPLOADS_TGZ" | cut -f1))"
+
+# 4. Supabase Storage object bytes ----------------------------------------
+STORAGE_TGZ="$WORK/storage.tgz"
+docker exec "$STORAGE_CONTAINER" tar czf - -C / var/lib/storage > "$STORAGE_TGZ" \
+  || fail_run "storage_tar"
+log "storage tar ok ($(du -h "$STORAGE_TGZ" | cut -f1))"
+
+# 5. Encrypt every artifact -----------------------------------------------
+for f in "$DB_DUMP" "$OWUI_SNAP" "$UPLOADS_TGZ" "$STORAGE_TGZ"; do
+  openssl enc -aes-256-cbc -pbkdf2 -iter 600000 -salt \
+    -in "$f" -out "$f.enc" -pass file:"$PASSPHRASE_FILE" || fail_run "encrypt"
+done
+log "encryption ok"
+
+# 6. Publish the day directory atomically enough ---------------------------
+mkdir -p "$PUBLISH"
+for f in "$WORK"/*.enc; do
+  base="$(basename "$f" .enc)"
+  # Write-then-rename so a reader (or the off-box pull) never sees a torn file.
+  cp "$f" "$PUBLISH/$base.enc.partial" && mv -f "$PUBLISH/$base.enc.partial" "$PUBLISH/$base.enc"
+done
+(
+  cd "$PUBLISH"
+  # Regenerate checksums over exactly today's four artifacts.
+  ls | grep '\.enc$' | sort | xargs sha256sum > SHA256SUMS
+  {
+    echo "created $(date -u +%FT%TZ)"
+    ls -l --block-size=K *.enc | awk '{print $5, $9}'
+  } > MANIFEST.txt
+)
+log "published to $PUBLISH"
+
+# 7. Retention --------------------------------------------------------------
+cd "$BACKUP_ROOT/daily"
+ls -1 | sort -r | tail -n +$(( KEEP_DAILY + 1 )) | while read -r old; do
+  rm -rf "$old"
+  log "retention: removed $old"
+done
+
+# 8. Status + heartbeat ------------------------------------------------------
+NOW_EPOCH="$(date +%s)"
+echo "$NOW_EPOCH" > "$BACKUP_ROOT/status/last-success-epoch"
+{
+  echo "OK $(date -u +%FT%TZ) day=$(date -u +%F) files=$(ls "$PUBLISH" | grep -c '\.enc$')"
+} >> "$BACKUP_ROOT/status/STATUS.txt"
+
+log "== backup run complete =="
+
+# Success posts nothing to Alertmanager: resolve_timeout ends any earlier
+# firing alert on its own once the failures stop being posted.
+exit 0

--- a/scripts/backup-box.sh
+++ b/scripts/backup-box.sh
@@ -84,7 +84,8 @@ die()  { log "ERROR: $*"; exit 1; }
 post_alert() {
   local alertname="$1" description="$2" startsAt body
   startsAt="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-  body=$(printf '{"labels":{"alertname":"%s","severity":"critical","job":"box-backup","instance":"hive-demo"},"annotations":{"description":"%s"}}' \
+  # Alertmanager v2 expects an ARRAY of alerts; a bare object is a 400.
+  body=$(printf '[{"labels":{"alertname":"%s","severity":"critical","job":"box-backup","instance":"hive-demo"},"annotations":{"description":"%s"}}]' \
     "$alertname" "$description")
   # Delivery failure must not fail the backup itself on the success path, and
   # must not mask the underlying failure on the failure path. Log it either way.

--- a/scripts/backup-box.sh
+++ b/scripts/backup-box.sh
@@ -68,6 +68,14 @@ PASSPHRASE_FILE="${PASSPHRASE_FILE:-$BACKUP_ROOT/etc/passphrase}"
 MODE="run"
 if [[ "${1:-}" == "--check" ]]; then MODE="check"; fi
 
+# Validate required configuration up front so an empty environment value fails
+# here rather than halfway through a run. Defaults above are the
+# parameterization; this only rejects explicitly broken configuration.
+for var in BACKUP_ROOT DB_CONTAINER OWUI_CONTAINER STORAGE_CONTAINER \
+           PGUSER PGDATABASE KEEP_DAILY STALE_AFTER ALERTMANAGER_URL PASSPHRASE_FILE; do
+  [[ -n "${!var}" ]] || { echo "FATAL: $var is empty"; exit 1; }
+done
+
 TS="$(date -u +%Y%m%dT%H%M%SZ)"
 LOG_DIR="$BACKUP_ROOT/logs"
 mkdir -p "$LOG_DIR" "$BACKUP_ROOT/status" "$BACKUP_ROOT/tmp"
@@ -121,6 +129,11 @@ fi
 exec 9>"$BACKUP_ROOT/lock"
 flock -n 9 || { log "another backup run holds the lock, exiting"; exit 0; }
 
+# A systemd TimeoutStartSec kill must be as loud as any other failure: without
+# this trap the terminated script would die silently and only the staleness
+# watchdog would notice, hours later.
+trap 'fail_run "killed_by_signal"' TERM HUP INT
+
 [[ -r "$PASSPHRASE_FILE" ]] || fail_run "passphrase_missing"
 [[ "$(stat -c %a "$PASSPHRASE_FILE")" == "600" ]] \
   || die "PASSPHRASE_FILE must be chmod 600, refusing to run"
@@ -130,8 +143,9 @@ mkdir -p "$WORK"
 PUBLISH="$BACKUP_ROOT/daily/$(date -u +%F)"
 
 # Run the staleness check first so a half-dead schedule still alerts even when
-# this particular invocation succeeds.
-"$0" --check || true
+# this particular invocation succeeds. Output goes to THIS run's log, not the
+# journal, so two runs' lines never interleave.
+"$0" --check >>"$LOG_FILE" 2>&1 || true
 
 cleanup() {
   rm -rf "$WORK"
@@ -191,22 +205,32 @@ for f in "$DB_DUMP" "$OWUI_SNAP" "$UPLOADS_TGZ" "$STORAGE_TGZ"; do
 done
 log "encryption ok"
 
-# 6. Publish the day directory atomically enough ---------------------------
-mkdir -p "$PUBLISH"
+# 6. Publish the day directory as ONE committed unit -----------------------
+# Everything is assembled in a staging directory first; the published set is
+# then swapped in by rename. A failed run can never leave today's published
+# directory holding a mix of old and new artifacts, and the off-box pull can
+# treat the presence of SHA256SUMS as the commit marker for a complete set.
+STAGE="$WORK/stage"
+mkdir -p "$STAGE"
 for f in "$WORK"/*.enc; do
   base="$(basename "$f" .enc)"
-  # Write-then-rename so a reader (or the off-box pull) never sees a torn file.
-  cp "$f" "$PUBLISH/$base.enc.partial" && mv -f "$PUBLISH/$base.enc.partial" "$PUBLISH/$base.enc"
+  # Write-then-rename so a reader inside this script never sees a torn file.
+  cp "$f" "$STAGE/$base.enc.partial" && mv -f "$STAGE/$base.enc.partial" "$STAGE/$base.enc"
 done
 (
-  cd "$PUBLISH"
-  # Regenerate checksums over exactly today's four artifacts.
+  cd "$STAGE"
+  # Regenerate checksums over exactly this run's four artifacts.
   ls | grep '\.enc$' | sort | xargs sha256sum > SHA256SUMS
   {
     echo "created $(date -u +%FT%TZ)"
     ls -l --block-size=K *.enc | awk '{print $5, $9}'
   } > MANIFEST.txt
 )
+if [[ -d "$PUBLISH" ]]; then
+  mv "$PUBLISH" "$PUBLISH.old.$$"
+fi
+mv "$STAGE" "$PUBLISH"
+rm -rf "$PUBLISH.old.$$" 2>/dev/null || true
 log "published to $PUBLISH"
 
 # 7. Retention --------------------------------------------------------------

--- a/scripts/backup-box.sh
+++ b/scripts/backup-box.sh
@@ -54,6 +54,10 @@
 #   PASSPHRASE_FILE   $BACKUP_ROOT/etc/passphrase
 set -euo pipefail
 
+# Plaintext artifacts (identities, ledger, chat db) exist only inside
+# $BACKUP_ROOT while a run is in flight; keep them off other local users.
+umask 077
+
 BACKUP_ROOT="${BACKUP_ROOT:-/home/sakib/hive-backups}"
 DB_CONTAINER="${DB_CONTAINER:-hive-supabase-db-1}"
 OWUI_CONTAINER="${OWUI_CONTAINER:-hive-open-webui-1}"
@@ -90,11 +94,17 @@ die()  { log "ERROR: $*"; exit 1; }
 # nothing user-controlled and nothing sensitive can reach the email body.
 # ---------------------------------------------------------------------------
 post_alert() {
-  local alertname="$1" description="$2" startsAt body
+  local alertname="$1" description="$2" startsAt body safe_desc
   startsAt="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  # Escape JSON-significant characters so a description that ever gains
+  # interpolated content cannot produce malformed JSON. All current call
+  # sites are fixed literals; this is the latent foot-gun guard.
+  safe_desc="${2//\\/\\\\}"
+  safe_desc="${safe_desc//\"/\\\"}"
+  safe_desc="${safe_desc//$'\n'/ }"
   # Alertmanager v2 expects an ARRAY of alerts; a bare object is a 400.
   body=$(printf '[{"labels":{"alertname":"%s","severity":"critical","job":"box-backup","instance":"hive-demo"},"annotations":{"description":"%s"}}]' \
-    "$alertname" "$description")
+    "$alertname" "$safe_desc")
   # Delivery failure must not fail the backup itself on the success path, and
   # must not mask the underlying failure on the failure path. Log it either way.
   curl -fsS -m 10 -XPOST "$ALERTMANAGER_URL/api/v2/alerts" \
@@ -137,6 +147,11 @@ trap 'fail_run "killed_by_signal"' TERM HUP INT
 [[ -r "$PASSPHRASE_FILE" ]] || fail_run "passphrase_missing"
 [[ "$(stat -c %a "$PASSPHRASE_FILE")" == "600" ]] \
   || die "PASSPHRASE_FILE must be chmod 600, refusing to run"
+
+# Sweep work dirs abandoned by an untrappable death (SIGKILL, power loss):
+# they hold PLAINTEXT artifacts and nothing else removes them. Anything older
+# than a day cannot be a live run.
+find "$BACKUP_ROOT/tmp" -maxdepth 1 -name 'run-*' -mtime +0 -exec rm -rf {} + 2>/dev/null || true
 
 WORK="$BACKUP_ROOT/tmp/run-$TS"
 mkdir -p "$WORK"
@@ -239,6 +254,7 @@ ls -1 | sort -r | tail -n +$(( KEEP_DAILY + 1 )) | while read -r old; do
   rm -rf "$old"
   log "retention: removed $old"
 done
+find "$LOG_DIR" -name '*.log' -mtime "+$(( KEEP_DAILY - 1 ))" -delete 2>/dev/null || true
 
 # 8. Status + heartbeat ------------------------------------------------------
 NOW_EPOCH="$(date +%s)"

--- a/scripts/pull-box-backups.sh
+++ b/scripts/pull-box-backups.sh
@@ -9,6 +9,7 @@
 #
 # Usage:
 #   scripts/pull-box-backups.sh
+#   scripts/pull-box-backups.sh --prune     also delete local days the box dropped
 #   BOX=hive-demo DEST=/home/sakib/hive-backups scripts/pull-box-backups.sh
 #
 # Requires: rsync, and the ssh host alias $BOX (default hive-demo) in
@@ -19,13 +20,38 @@ BOX="${BOX:-hive-demo}"
 BACKUP_ROOT_ON_BOX="${BACKUP_ROOT_ON_BOX:-/home/sakib/hive-backups}"
 DEST="${DEST:-$HOME/hive-backups/$BOX}"
 
-mkdir -p "$DEST/daily"
-rsync -a "$BOX:$BACKUP_ROOT_ON_BOX/daily/" "$DEST/daily/"
+PRUNE=0
+for arg in "$@"; do
+  case "$arg" in
+    --prune) PRUNE=1 ;;
+    *) echo "unknown argument: $arg" >&2; exit 2 ;;
+  esac
+done
 
-echo "verifying checksums of pulled artifacts:"
+mkdir -p "$DEST/daily"
+if [[ "$PRUNE" == "1" ]]; then
+  rsync -a --delete "$BOX:$BACKUP_ROOT_ON_BOX/daily/" "$DEST/daily/"
+else
+  rsync -a "$BOX:$BACKUP_ROOT_ON_BOX/daily/" "$DEST/daily/"
+fi
+
+echo "verifying pulled artifacts:"
 STATUS=0
 for d in "$DEST"/daily/*/; do
-  [[ -f "$d/SHA256SUMS" ]] || continue
+  # A day directory without its full committed set means the pull raced the
+  # publisher or a transfer was truncated. That is a LOUD failure, never a
+  # silent skip: an incomplete off-box set must not read as protected.
+  ENCS=$(ls "$d" 2>/dev/null | grep -c '\.enc$' || true)
+  if [[ ! -f "$d/SHA256SUMS" || ! -f "$d/MANIFEST.txt" ]]; then
+    echo "FAIL: $d has no SHA256SUMS or MANIFEST.txt (incomplete set)" >&2
+    STATUS=1
+    continue
+  fi
+  if [[ "$ENCS" != "4" ]]; then
+    echo "FAIL: $d holds $ENCS encrypted artifacts, expected 4 (incomplete set)" >&2
+    STATUS=1
+    continue
+  fi
   (cd "$d" && sha256sum -c SHA256SUMS --quiet) || STATUS=1
 done
 if [[ "$STATUS" == "0" ]]; then

--- a/scripts/pull-box-backups.sh
+++ b/scripts/pull-box-backups.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# pull-box-backups.sh -- pull the box's encrypted backup artifacts to this
+# machine. Runs on the DEV machine, never on the box. Only encrypted artifacts
+# ever cross the network; decryption happens only where the passphrase lives.
+#
+# This is the stopgap off-box copy. A true offsite destination (object store,
+# separate physical location) remains an open owner decision, tracked in the
+# follow-up issue referenced from docs/runbooks/box-backup-restore.md.
+#
+# Usage:
+#   scripts/pull-box-backups.sh
+#   BOX=hive-demo DEST=/home/sakib/hive-backups scripts/pull-box-backups.sh
+#
+# Requires: rsync, and the ssh host alias $BOX (default hive-demo) in
+# ~/.ssh/config on this machine. Do not add one for this script's sake.
+set -euo pipefail
+
+BOX="${BOX:-hive-demo}"
+BACKUP_ROOT_ON_BOX="${BACKUP_ROOT_ON_BOX:-/home/sakib/hive-backups}"
+DEST="${DEST:-$HOME/hive-backups/$BOX}"
+
+mkdir -p "$DEST/daily"
+rsync -a "$BOX:$BACKUP_ROOT_ON_BOX/daily/" "$DEST/daily/"
+
+echo "verifying checksums of pulled artifacts:"
+STATUS=0
+for d in "$DEST"/daily/*/; do
+  [[ -f "$d/SHA256SUMS" ]] || continue
+  (cd "$d" && sha256sum -c SHA256SUMS --quiet) || STATUS=1
+done
+if [[ "$STATUS" == "0" ]]; then
+  echo "OK: all pulled days verified"
+else
+  echo "FAIL: checksum mismatch on at least one day" >&2
+fi
+exit "$STATUS"

--- a/scripts/restore-box-backup.sh
+++ b/scripts/restore-box-backup.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# restore-box-backup.sh -- prove a backup is restorable, into a THROWAWAY.
+#
+# Decrypts the newest (or a given) day's database dump, restores it into a
+# throwaway Postgres container built from the SAME image production runs,
+# compares row counts for the money and identity tables against the live
+# database, prints a table-by-table verdict, and destroys the throwaway. It
+# never writes to production: every write lands in its own throwaway container.
+#
+# The REAL restore onto production stays deliberately manual; see
+# docs/runbooks/box-backup-restore.md for that procedure.
+#
+# Usage (on the box):
+#   restore-box-backup.sh              verify the newest published day
+#   restore-box-backup.sh 2026-08-23   verify a specific day
+#   restore-box-backup.sh --keep       keep the throwaway container around
+#
+# Environment: same variables as backup-box.sh plus VERIFY_IMAGE (default
+# hive-supabase-db:pg16-cron, the exact production DB image).
+set -euo pipefail
+
+BACKUP_ROOT="${BACKUP_ROOT:-/tmp/hive-backups}"   # overridden on box to /home/sakib/hive-backups
+DB_CONTAINER="${DB_CONTAINER:-hive-supabase-db-1}"
+PGUSER="${PGUSER:-postgres}"
+VERIFY_IMAGE="${VERIFY_IMAGE:-hive-supabase-db:pg16-cron}"
+PASSPHRASE_FILE="${PASSPHRASE_FILE:-$BACKUP_ROOT/etc/passphrase}"
+
+DAY="latest"
+KEEP=0
+for arg in "$@"; do
+  case "$arg" in
+    --keep) KEEP=1 ;;
+    *) DAY="$arg" ;;
+  esac
+done
+
+[[ -r "$PASSPHRASE_FILE" ]] || { echo "FATAL: passphrase not readable"; exit 1; }
+
+if [[ "$DAY" == "latest" && -d "$BACKUP_ROOT/daily" ]]; then
+  DAY="$(ls -1 "$BACKUP_ROOT/daily" | sort | tail -1)"
+fi
+DIR="$BACKUP_ROOT/daily/$DAY"
+[[ -f "$DIR/db.pgdump.enc" ]] || { echo "FATAL: no db artifact under $DIR"; exit 1; }
+echo "== verifying $DAY =="
+
+WORK="$(mktemp -d /tmp/restore-verify.XXXXXX)"
+CNAME="hive-bk-verify-$$"
+cleanup() {
+  rm -rf "$WORK"
+  if [[ "$KEEP" == "0" ]]; then docker rm -f "$CNAME" >/dev/null 2>&1 || true; fi
+}
+trap cleanup EXIT
+
+# 1. Decrypt into a private temp dir on the box. Never crosses the network in
+#    the clear, never lands inside any git checkout.
+chmod 700 "$WORK"
+openssl enc -d -aes-256-cbc -pbkdf2 -iter 600000 -salt \
+  -in "$DIR/db.pgdump.enc" -out "$WORK/db.pgdump" \
+  -pass file:"$PASSPHRASE_FILE"
+
+# 2. Throwaway postgres from the production image: isolated network namespace
+#    (--network none), no published ports, random name, minutes of life.
+docker run -d --name "$CNAME" \
+  -e POSTGRES_HOST_AUTH_METHOD=trust \
+  --network none \
+  --restart no \
+  "$VERIFY_IMAGE" >/dev/null
+for _ in $(seq 1 60); do
+  docker exec "$CNAME" pg_isready -U postgres >/dev/null 2>&1 && break
+  sleep 1
+done
+docker exec "$CNAME" pg_isready -U postgres >/dev/null
+
+# 3. Restore. Extension DDL that needs shared-preload libraries the vanilla
+#    entrypoint does not set (pg_cron) fails here WITHOUT failing the data;
+#    pg_restore continues past individual object errors by default, and the
+#    row-count comparison below decides pass or fail, not pg_restore's exit code.
+echo "-- restoring (extension DDL errors are expected here, data errors are not)"
+docker exec -i "$CNAME" pg_restore -U postgres -d postgres --no-owner --role=postgres \
+  < "$WORK/db.pgdump" || true
+
+# 4. Compare counts. Live side is read-only SELECT count(*).
+TABLES=(public.credit_ledger_entries public.tenants public.api_keys auth.users auth.identities storage.objects)
+FAIL=0
+printf '%-32s %12s %12s\n' TABLE LIVE RESTORED
+for t in "${TABLES[@]}"; do
+  LIVE="$(docker exec "$DB_CONTAINER" psql -U "$PGUSER" -Atc "SELECT count(*) FROM $t")"
+  GOT="$(docker exec "$CNAME" psql -U "$PGUSER" -Atc "SELECT count(*) FROM $t" 2>/dev/null || echo ERR)"
+  VERDICT=ok
+  [[ "$LIVE" == "$GOT" ]] || { VERDICT=MISMATCH; FAIL=1; }
+  printf '%-32s %12s %12s  %s\n' "$t" "$LIVE" "$GOT" "$VERDICT"
+done
+
+echo ""
+if [[ "$FAIL" == "0" ]]; then
+  echo "PASS: all compared tables match between live and restored throwaway."
+else
+  echo "FAIL: at least one table count differs. Keep with --keep and inspect."
+fi
+
+if [[ "$KEEP" == "1" ]]; then
+  echo "throwaway container kept as $CNAME"
+fi
+exit "$FAIL"

--- a/scripts/restore-box-backup.sh
+++ b/scripts/restore-box-backup.sh
@@ -34,6 +34,11 @@ for arg in "$@"; do
   esac
 done
 
+# Only a real date string may reach file paths.
+if [[ "$DAY" != "latest" ]]; then
+  [[ "$DAY" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] || { echo "FATAL: day must be YYYY-MM-DD"; exit 2; }
+fi
+
 [[ -r "$PASSPHRASE_FILE" ]] || { echo "FATAL: passphrase not readable"; exit 1; }
 
 if [[ "$DAY" == "latest" && -d "$BACKUP_ROOT/daily" ]]; then

--- a/scripts/restore-box-backup.sh
+++ b/scripts/restore-box-backup.sh
@@ -97,14 +97,28 @@ RESTORE_LOG="$WORK/restore.log"
 docker exec -i "$CNAME" pg_restore -U postgres -d postgres --no-owner --role=postgres \
   < "$WORK/db.pgdump" > "$RESTORE_LOG" 2>&1 || true
 
-ALLOWED='pg_cron|cron\.|unrecognized configuration parameter|role "(service_role|authenticated|anon|supabase_auth_admin)"'
-UNEXPECTED="$(grep -i 'error' "$RESTORE_LOG" | grep -Ev "$ALLOWED" || true)"
+# Known-expected restore error categories, each justified:
+#   pg_cron / schema "cron" / its GUC: extension needs shared_preload_libraries
+#     the vanilla entrypoint does not set; DATA is unaffected.
+#   supabase + app roles (service_role, authenticated, anon, auth admin,
+#     hive_app, auditor_ro, ...): production roles do not exist in a bare
+#     container, so EVERY "role ... does not exist" grant or ownership error
+#     is expected; none of them touch row data.
+#   *_request_attempt_id_fkey: PRODUCTION ITSELF violates these three FKs
+#     (credit_reservations, usage_events and credit_reconciliation_jobs keep
+#     rows whose request_attempts were purged by retention: 2356, 483 and 161
+#     orphans counted live on 2026-08-23). Re-adding the constraint against a
+#     faithful copy of that data fails by design; every row itself restored.
+# Match actual error lines ("pg_restore: error: ..." possibly nested) while
+# excluding warning-summary lines like "pg_restore: warning: errors ignored".
+ALLOWED='pg_cron|cron\.|schema "cron"|unrecognized configuration parameter|role "[A-Za-z0-9_]+" does not exist|request_attempt_id_fkey'
+UNEXPECTED="$(grep -E ': ([Ee]rror|ERROR):' "$RESTORE_LOG" | grep -Ev "$ALLOWED" || true)"
 if [[ -n "$UNEXPECTED" ]]; then
   echo "-- UNEXPECTED restore errors (these are NOT in the allowed pg_cron/role set):"
   echo "$UNEXPECTED"
   FAIL=1
 else
-  echo "-- no unexpected restore errors ($(grep -ci 'error' "$RESTORE_LOG" || true) known-category lines suppressed)"
+  echo "-- no unexpected restore errors ($(grep -cE ': ([Ee]rror|ERROR):' "$RESTORE_LOG" || true) error lines, all in allowed categories)"
 fi
 
 # 4. Compare counts. Live side is read-only SELECT count(*).
@@ -122,7 +136,11 @@ echo ""
 if [[ "$FAIL" == "0" ]]; then
   echo "PASS: all compared tables match between live and restored throwaway."
 else
-  echo "FAIL: at least one table count differs. Keep with --keep and inspect."
+  echo "FAIL: at least one table count differs. Two known causes:"
+  echo "  1. LIVE DRIFT: production moved between the dump and this comparison"
+  echo "     (api_keys and ledger grow during live traffic). Take a fresh backup"
+  echo "     and rerun this script immediately; counts should settle equal."
+  echo "  2. REAL LOSS: the dump itself is short. Investigate before trusting it."
 fi
 
 if [[ "$KEEP" == "1" ]]; then

--- a/scripts/restore-box-backup.sh
+++ b/scripts/restore-box-backup.sh
@@ -19,7 +19,7 @@
 # hive-supabase-db:pg16-cron, the exact production DB image).
 set -euo pipefail
 
-BACKUP_ROOT="${BACKUP_ROOT:-/tmp/hive-backups}"   # overridden on box to /home/sakib/hive-backups
+BACKUP_ROOT="${BACKUP_ROOT:-/home/sakib/hive-backups}"
 DB_CONTAINER="${DB_CONTAINER:-hive-supabase-db-1}"
 PGUSER="${PGUSER:-postgres}"
 VERIFY_IMAGE="${VERIFY_IMAGE:-hive-supabase-db:pg16-cron}"

--- a/scripts/restore-box-backup.sh
+++ b/scripts/restore-box-backup.sh
@@ -50,10 +50,25 @@ cleanup() {
   if [[ "$KEEP" == "0" ]]; then docker rm -f "$CNAME" >/dev/null 2>&1 || true; fi
 }
 trap cleanup EXIT
+FAIL=0
+
+# 0. Verify the artifact set at its boundary BEFORE consuming anything: the
+#    published SHA256SUMS covers the encrypted files exactly as they were
+#    written, so corruption is caught here rather than as a confusing
+#    decrypt or restore failure.
+(
+  cd "$DIR"
+  ENCS=$(ls | grep '\.enc$' | wc -l)
+  if [[ "$ENCS" != "4" ]]; then
+    echo "FATAL: expected 4 encrypted artifacts in $DIR, found $ENCS (incomplete set?)"
+    exit 1
+  fi
+  sha256sum -c SHA256SUMS --quiet
+) || { echo "FATAL: checksum verification failed for $DAY"; exit 1; }
 
 # 1. Decrypt into a private temp dir on the box. Never crosses the network in
-#    the clear, never lands inside any git checkout.
-chmod 700 "$WORK"
+#    the clear, never lands inside any git checkout. mktemp already created
+#    this directory with 0700 permissions.
 openssl enc -d -aes-256-cbc -pbkdf2 -iter 600000 -salt \
   -in "$DIR/db.pgdump.enc" -out "$WORK/db.pgdump" \
   -pass file:"$PASSPHRASE_FILE"
@@ -72,16 +87,28 @@ done
 docker exec "$CNAME" pg_isready -U postgres >/dev/null
 
 # 3. Restore. Extension DDL that needs shared-preload libraries the vanilla
-#    entrypoint does not set (pg_cron) fails here WITHOUT failing the data;
-#    pg_restore continues past individual object errors by default, and the
-#    row-count comparison below decides pass or fail, not pg_restore's exit code.
-echo "-- restoring (extension DDL errors are expected here, data errors are not)"
+#    entrypoint does not set (pg_cron) fails here WITHOUT failing the data,
+#    and grants to Supabase roles that only exist in production fail too.
+#    pg_restore continues past individual errors by default. Those known
+#    categories are filtered out; ANY other error line fails verification even
+#    if the row counts below would have matched.
+echo "-- restoring (known pg_cron and role-grant errors are filtered, anything else fails)"
+RESTORE_LOG="$WORK/restore.log"
 docker exec -i "$CNAME" pg_restore -U postgres -d postgres --no-owner --role=postgres \
-  < "$WORK/db.pgdump" || true
+  < "$WORK/db.pgdump" > "$RESTORE_LOG" 2>&1 || true
+
+ALLOWED='pg_cron|cron\.|unrecognized configuration parameter|role "(service_role|authenticated|anon|supabase_auth_admin)"'
+UNEXPECTED="$(grep -i 'error' "$RESTORE_LOG" | grep -Ev "$ALLOWED" || true)"
+if [[ -n "$UNEXPECTED" ]]; then
+  echo "-- UNEXPECTED restore errors (these are NOT in the allowed pg_cron/role set):"
+  echo "$UNEXPECTED"
+  FAIL=1
+else
+  echo "-- no unexpected restore errors ($(grep -ci 'error' "$RESTORE_LOG" || true) known-category lines suppressed)"
+fi
 
 # 4. Compare counts. Live side is read-only SELECT count(*).
 TABLES=(public.credit_ledger_entries public.tenants public.api_keys auth.users auth.identities storage.objects)
-FAIL=0
 printf '%-32s %12s %12s\n' TABLE LIVE RESTORED
 for t in "${TABLES[@]}"; do
   LIVE="$(docker exec "$DB_CONTAINER" psql -U "$PGUSER" -Atc "SELECT count(*) FROM $t")"


### PR DESCRIPTION
# Demo box backups: all four production stores, scheduled, encrypted, restore-proven

Closes #1000. Since leaving managed Supabase, every production store on the demo box was single-copy on one physical machine. This change puts all four stores on a scheduled, unattended, reboot-surviving schedule with encryption at rest, an off-box encrypted copy, a verified throwaway restore proof executed against live production data, and a loud failure signal reusing the existing Alertmanager routing.

## What is backed up, and how

| Store | Capture method | Why this method |
| --- | --- | --- |
| Postgres (`postgres` DB: `auth.users` identities, tenants, api keys, credit ledger) | `pg_dump --format=custom` streamed out of `hive-supabase-db-1` over docker exec stdout | Consistent snapshot of the running server; no stop or restart of any service |
| Open WebUI relational state (`webui.db` on the `hive_owui-data` volume) | SQLite online backup API inside the open-webui container, integrity-checked before it leaves | Copying webui.db while its WAL is active is not safe; the backup API gives a consistent copy from a live writer |
| Open WebUI uploads (`/data/uploads`) | tar streamed via docker exec | Plain files |
| Supabase Storage object bytes (`hive-files`, `hive-images` buckets) | tar of `/var/lib/storage` streamed via docker exec | Object bytes sit under a nested `stub/stub/` layout; bucket metadata rides the DB dump |

## Retention sized to measured reality

Measured 2026-08-23: db dump 2.4 MB custom format, webui.db 1.0 MB, uploads under 8 KB compressed, storage 8 KB compressed. A full daily set is under 4 MB.

- On-box retention: 14 daily sets, under 70 MB total, against roughly 34 GB free on the box root filesystem.
- Off-box accumulation: about 120 MB per month if never pruned; `scripts/pull-box-backups.sh --prune` mirrors on-box retention.

## Schedule and watchdog

- systemd USER units (`deploy/systemd-user/hive-box-backup.{service,timer}`): fires 03:15 and 15:15 UTC daily, Persistent=true catches up missed slots after downtime. User-level because there is no sudo on the box; reboot-surviving because Linger=yes is enabled for sakib (verified live). Installed and live on the box since 2026-08-23 20:34 UTC, timer's first scheduled fire 03:16 UTC 2026-08-24.
- Hourly cron watchdog runs `backup-box.sh --check`: silent when fresh, alerts when the last success exceeds 26 hours, so the death of the timer itself surfaces within an hour.

## Failure signal

The script posts directly to Alertmanager's v2 API on the published host port (localhost:9093), riding the existing routing tree and hive-ops email receiver made working by #998. No new component deployed:

- `HiveBoxBackupFailed`: posted when any step errors, including a systemd timeout kill (signal trap), auto-resolves once a later run succeeds.
- `HiveBoxBackupStale`: posted by the watchdog on staleness.

Verified live: a forced-stale check posted successfully and appeared in Alertmanager's list addressed to receiver hive-ops. Success runs post nothing; resolve_timeout ends earlier failures on their own. At-a-glance state lives in `/home/sakib/hive-backups/status/STATUS.txt` on the box.

## Restore proof, executed live against production data

`scripts/restore-box-backup.sh` verifies SHA256SUMS before decrypting anything, stands up a throwaway Postgres from the exact production image (`hive-supabase-db:pg16-cron`, `--network none`, no published ports), restores with strict error filtering (any error outside a justified allowlist fails the proof even when counts match), compares row counts read-only against live, then destroys the throwaway. Final run 2026-08-23 21:05 UTC, exit 0:

| Table | Live | Restored | Verdict |
| --- | --- | --- | --- |
| public.credit_ledger_entries | 9791 | 9791 | ok |
| public.tenants | 970 | 970 | ok |
| public.api_keys | 90 | 90 | ok |
| auth.users | 166 | 166 | ok |
| auth.identities | 163 | 163 | ok |
| storage.objects | 15 | 15 | ok |

All six matched. The allowlist covers three verified categories: pg_cron DDL (needs shared_preload config a bare container does not set), grants to production roles that do not exist in a throwaway, and three foreign keys PRODUCTION ITSELF violates through its retention purge (2356 + 483 + 161 orphaned rows counted live, filed as #1102). Every row itself restores.

Open WebUI side verified too: decrypted webui.db passes integrity_check with chat 23=23, user 11=11, knowledge 2=2 vs live. Storage tar entry count matches live exactly (62=62). Decrypted temps shredded after verification.

## Off-box copy

One encrypted set pulled to the dev machine at `/home/sakib/hive-backups/hive-demo/daily/2026-08-23` via `scripts/pull-box-backups.sh`: rsync over ssh, encrypted artifacts only ever cross the network, checksums reverified after arrival. The passphrase also lives off-box at `/home/sakib/hive-backups/etc/passphrase-hive-demo`, mode 600, so a dead box does not take its only key down with it.

Stated plainly: a true offsite or object-store destination remains an owner decision and is NOT closed by this PR. It is tracked in #1100 with candidate options. Until it lands, box loss plus dev-machine co-loss takes every copy.

## Secrets posture

- No secret value appears in this repo, this PR, any workflow log, or any artifact. The passphrase was generated on the box, chmod 600, outside every git checkout.
- Artifacts contain identities and chat content: they exist only under `/home/sakib/hive-backups/` on the box and the same path on the dev machine, both outside git checkouts. Nothing uploaded anywhere; nothing crossed the network unencrypted.
- Alert payloads carry fixed literal strings only: alert name, host alias, generic step name.

## Review streams (D-038)

CodeRabbit CLI: ran, 10 findings, all dispositioned in the stream comment (7 adopted, 1 partially adopted with posted rebuttal, plus hardening beyond the ask on restore-error filtering). ecc:code-review plus plain adversarial pass: ran, 1 MEDIUM 3 LOW, all fixed. Security pass (mandatory for this diff): ran via a dedicated reviewer, no CRITICAL or HIGH, 3 MEDIUM and 4 LOW, all dispositioned in the security stream comment; the alertmanager loopback binding and artifact permission hardening came out of it. No stream skipped. Threads resolved as fixes landed.

## Buglog entry

```json
{"bug": "No backup of any production data store since leaving managed Supabase Cloud", "error_message": "single-copy ledger, identities and chat data on one physical box (issue #1000)", "root_cause": "the managed-Supabase exit (#982..#993) moved the data plane onto a bare pgvector container and replaced managed durability with nothing; no dump job, no timer, no off-box copy existed", "fix": "scripts/backup-box.sh plus systemd user timer twice daily, hourly cron staleness watchdog, aes-256-cbc encryption from a chmod 600 passphrase file outside all checkouts, 14-day retention against measured sizes, throwaway restore verification script, off-box encrypted pull helper, runbook at docs/runbooks/box-backup-restore.md", "tags": ["backup", "durability", "postgres", "sqlite", "supabase-storage"]}
```

```json
{"bug": "Alertmanager v2 alerts API rejected the backup script's failure posts with 400", "error_message": "curl: (22) The requested URL returned error: 400; server body: json: cannot unmarshal object into Go value of type models.PostableAlerts", "root_cause": "payload built as a single JSON object; /api/v2/alerts requires an array of alerts", "fix": "wrap payload in [ ] in scripts/backup-box.sh post_alert; verified live that stale-alert posts land and reach the hive-ops receiver", "tags": ["alertmanager", "monitoring", "json"]}
```

Second entry logged because it was found and fixed during this work's own debugging: the 400 reproduced byte-for-byte (a hand-written array posted fine while the printf-built object failed), which isolated the missing brackets.
