### PR TITLE
fix: preflight verify workspace balance before the billed completion

### DIFF
--- a/scripts/post-deploy-verify.py
+++ b/scripts/post-deploy-verify.py
@@ -122,6 +122,10 @@ COMPLETION_ATTEMPTS = max(1, int(os.environ.get("HIVE_VERIFY_COMPLETION_ATTEMPTS
 RETRY_DELAY = float(os.environ.get("HIVE_VERIFY_RETRY_DELAY", "20"))
 RUN_LABEL = os.environ.get("HIVE_VERIFY_RUN_LABEL", "").strip() or "local"
 
+# The flat credit hold every chat completion takes before dispatch (see the
+# preflight in check_ledger for why this number lives here).
+LEDGER_CHAT_HOLD_CREDITS = 10_000
+
 
 class CheckFailed(Exception):
     """One check's assertion did not hold. Carries the operator-facing reason."""
@@ -410,6 +414,48 @@ def check_ledger(auth: dict, negative: bool) -> None:
     Negative control: skip the spend. Nothing bills, no row appears, and the
     check must go red exactly as it would if billing had failed open.
     """
+    if not negative:
+        # Preflight the account's spendable balance against the flat credit
+        # hold every chat completion takes. A fixed-price alias reserves a
+        # flat 10000 credits per request regardless of model or price
+        # (apps/edge-api/internal/inference/chat_completions.go passes that
+        # endpoint default to ReservationCredits, which falls back to it
+        # whenever reservation_estimate_credits is null on the alias), and
+        # control-plane refuses the reservation with a 409 when available
+        # credits are below it. Edge maps that 409 to a 429 whose message
+        # reads like an upstream provider quota error, which sent a real
+        # incident (2026-08-23) chasing OpenRouter, AtlasCloud and Google
+        # theories before the ledger said the verify workspace held 9999
+        # credits against the 10000 hold. Name that condition here instead:
+        # fail for THIS reason, before any upstream retry is burned.
+        status, raw = http("GET", f"{CP}/api/v1/accounts/current/credits/balance",
+                           auth, timeout=60)
+        if status != 200:
+            # The preflight is diagnostic, not load-bearing for correctness:
+            # if the balance cannot be read, let the completion attempt speak
+            # for itself rather than redacting its answer behind a read error.
+            print(f"  ::warning::could not read balance ({status}), "
+                  "skipping the headroom preflight")
+        else:
+            try:
+                summary = json.loads(raw)
+                available = int(summary.get("available_credits"))
+            except (json.JSONDecodeError, TypeError, ValueError):
+                raise CheckFailed(
+                    "the balance endpoint answered 200 with a body this script cannot "
+                    f"read: {snippet(raw)}"
+                ) from None
+            if available < LEDGER_CHAT_HOLD_CREDITS:
+                raise CheckFailed(
+                    f"workspace has {available} available credits, below the flat "
+                    f"{LEDGER_CHAT_HOLD_CREDITS}-credit hold every chat completion "
+                    "reserves. Control-plane refuses the reservation and edge surfaces "
+                    "it as a 429 insufficient_quota that looks like an upstream quota "
+                    "error but is not one. Top up the verify workspace's ledger "
+                    "(credit_ledger_entries grant row) and rerun."
+                )
+            print(f"  balance preflight ok ({available} available credits)")
+
     print("  scanning existing usage_charge entries")
     before, _ = scan_usage_charges(auth)
     print(f"  {len(before)} usage_charge entries already on this account")

--- a/scripts/post-deploy-verify.py
+++ b/scripts/post-deploy-verify.py
@@ -123,8 +123,10 @@ RETRY_DELAY = float(os.environ.get("HIVE_VERIFY_RETRY_DELAY", "20"))
 RUN_LABEL = os.environ.get("HIVE_VERIFY_RUN_LABEL", "").strip() or "local"
 
 # The flat credit hold every chat completion takes before dispatch (see the
-# preflight in check_ledger for why this number lives here).
-LEDGER_CHAT_HOLD_CREDITS = 10_000
+# preflight in check_ledger for why this number lives here). Optional
+# override for a deployment where that endpoint default has moved.
+LEDGER_CHAT_HOLD_CREDITS = int(
+    os.environ.get("HIVE_VERIFY_CHAT_HOLD_CREDITS", "10000"))
 
 
 class CheckFailed(Exception):
@@ -439,8 +441,19 @@ def check_ledger(auth: dict, negative: bool) -> None:
         else:
             try:
                 summary = json.loads(raw)
+            except json.JSONDecodeError:
+                raise CheckFailed(
+                    "the balance endpoint answered 200 with a body that is not JSON, "
+                    f"so the headroom preflight cannot run: {snippet(raw)}"
+                ) from None
+            if not isinstance(summary, dict):
+                raise CheckFailed(
+                    "the balance endpoint answered 200 with JSON that is not an object "
+                    f"({type(summary).__name__})"
+                )
+            try:
                 available = int(summary.get("available_credits"))
-            except (json.JSONDecodeError, TypeError, ValueError):
+            except (TypeError, ValueError):
                 raise CheckFailed(
                     "the balance endpoint answered 200 with a body this script cannot "
                     f"read: {snippet(raw)}"


### PR DESCRIPTION
Stacked on #1061 (targets its branch, since scripts/post-deploy-verify.py exists only there). Not for merge until #1061 lands, then rebase or retarget to main.

## What happened live (2026-08-23)

The post-deploy-verify ledger check failed every run with:

```
HTTP 429 {"error":{"message":"You exceeded your current quota, please check your plan and billing details.","type":"insufficient_quota","code":"insufficient_quota"}}
```

The wording reads like an upstream provider quota error. It is not. Every upstream layer tested clean: direct OpenRouter 200, LiteLLM route-deepseek-v4-flash 200, catalog alias mapping correct, zero requests reaching litellm during the failures.

## Root cause

1. The verify workspace was seeded with exactly 10000 credits (`post-deploy-verify-seed-2026-08-23` grant).
2. The first passing run consumed 1 credit, leaving 9999.
3. Every chat completion reserves a flat **10000 credit hold** before dispatch (`apps/edge-api/internal/inference/chat_completions.go` passes that endpoint default to `ReservationCredits`, which falls back to it because `reservation_estimate_credits` is null on every fixed-price alias).
4. Control-plane refuses the reservation with a strict-mode PolicyError 409 (`reservation exceeds available credits`, `apps/control-plane/internal/accounting/service.go`).
5. Edge maps that 409 to HTTP 429 `insufficient_quota` with the OpenAI-style message text (`apps/edge-api/internal/inference/reservation_guard.go`). No usage_events row is written because nothing was ever dispatched.

Refused requests consume nothing, so the balance never recovers and every rerun fails identically. The timing correlation with #1099's deploy was coincidence.

## What this PR changes

A named preflight in `check_ledger` before any spend: read `GET /api/v1/accounts/current/credits/balance` and fail with the real reason plus remediation when available credits are below the flat hold. A non-200 read warns and proceeds so the completion attempt still speaks for itself; the negative control skips both spend and preflight.

## Evidence

- Reproduced through the public edge with a key on the verify workspace at balance 9999: exact 429 body above.
- Fixed operationally by a +10000 grant ledger row (`post-deploy-verify-topup-2026-08-23`); same call then answered 200.
- Rerun of post-deploy-verify run 32669144332 completed success after the top-up.

## Buglog entry

{"error_message":"post-deploy-verify ledger check fails with HTTP 429 insufficient_quota from /v1/chat/completions","root_cause":"verify workspace balance 9999 credits fell below the flat 10000 credit chat reservation hold after the first passing run consumed one credit; control-plane answers 409 policy rejection and edge maps it to a 429 whose message mimics an upstream provider quota error","fix":"operational +10000 credit grant to the verify workspace ledger; PR adds a named balance preflight so the gate reports this condition instead of an upstream-looking 429","tags":"billing,reservation,fail-closed,post-deploy-verify,misleading-error"}

## Test plan

- [x] py_compile passes
- [x] Live reproduction of the 429 at balance 9999 and 200 after top-up
- [x] Gate rerun green against the topped-up box
- [ ] Negative path: balance below hold produces the new named CheckFailed (exercisable by draining the workspace again)