### PR TITLE
fix: launch Cowork on every workspace by default via a registry-declared gate default

### DIFF
--- a/apps/control-plane/internal/tenant/settings/resolver.go
+++ b/apps/control-plane/internal/tenant/settings/resolver.go
@@ -39,7 +39,10 @@ func NewResolver(pool *pgxpool.Pool, ttl time.Duration) *Resolver {
 
 // IsEnabled returns true only when the row exists and enabled = true.
 // An unset key returns false; callers that need to distinguish "off" from
-// "unset" should use ValueRaw.
+// "unset" should use ValueRaw. Note this per-key path does NOT apply the
+// feature_gate_keys.default_enabled fallback (issue #1107); the registry
+// reads AllEnabled and ClientVisibleEnabled do. No production caller gates a
+// registry key through IsEnabled today, so the two cannot disagree.
 func (r *Resolver) IsEnabled(ctx context.Context, tenantID uuid.UUID, key Key) bool {
 	e, ok := r.lookup(ctx, tenantID, key)
 	if !ok {
@@ -141,9 +144,15 @@ func (r *Resolver) ClientVisibleEnabled(ctx context.Context, tenantID uuid.UUID)
 // always issues one fresh, indexed (tenant_id) query and bypasses the per-key
 // cache (the edge-api Gate already caches the whole response per tenant for
 // 30s with singleflight dedup on cold misses).
+//
+// Unset keys read their registry-declared default (feature_gate_keys.
+// default_enabled, issue #1107): an explicit tenant_settings row still wins,
+// so an admin can turn a default-on key off per workspace by writing an
+// enabled=false row through Set. Keys whose registry row keeps the false
+// default behave exactly as before.
 func (r *Resolver) gateMap(ctx context.Context, tenantID uuid.UUID, categories []string) (map[Key]bool, error) {
 	rows, err := r.pool.Query(ctx, `
-		SELECT k.key, COALESCE(s.enabled, false) AS enabled
+		SELECT k.key, COALESCE(s.enabled, k.default_enabled) AS enabled
 		  FROM public.feature_gate_keys k
 		  LEFT JOIN public.tenant_settings s
 		    ON s.tenant_id = $1 AND s.key = k.key

--- a/apps/control-plane/internal/tenant/settings/resolver_test.go
+++ b/apps/control-plane/internal/tenant/settings/resolver_test.go
@@ -136,6 +136,64 @@ func TestResolver_AllEnabled_ReturnsFullSet(t *testing.T) {
 	}
 }
 
+// TestResolver_GateDefaults_UnsetKeyReadsDeclaredDefault is the #1107 guard:
+// a workspace with no explicit tenant_settings row for a key whose registry
+// row declares default_enabled = true must resolve that gate as enabled. This
+// is what makes Cowork launchable on every workspace by default instead of
+// only on tenants hand-seeded by scripts/seed-demo-owner.py, and it must hold
+// through BOTH read surfaces (AllEnabled backs the admin console toggle UI,
+// ClientVisibleEnabled backs the featuregate endpoint edge-api gates /v1/agent
+// routes on).
+func TestResolver_GateDefaults_UnsetKeyReadsDeclaredDefault(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	pool, teardown := newTestPool(t, ctx)
+	defer teardown()
+
+	r := settings.NewResolver(pool, 30*time.Second)
+	tid := mustTenant(t, ctx, pool, "t-fg-default-on", "HIVE_CLOUD")
+
+	clientVisible, err := r.ClientVisibleEnabled(ctx, tid)
+	require.NoError(t, err)
+	require.Truef(t, clientVisible[settings.EnableCowork],
+		"ENABLE_COWORK has default_enabled = true and no explicit row, so ClientVisibleEnabled must report it enabled")
+	require.Falsef(t, clientVisible[settings.EnableRAG],
+		"keys without a declared default keep opt-in behavior: ENABLE_RAG unset must stay false")
+
+	all, err := r.AllEnabled(ctx, tid)
+	require.NoError(t, err)
+	require.Truef(t, all[settings.EnableCowork],
+		"AllEnabled must apply the declared default so the admin toggle UI shows the real state")
+}
+
+// TestResolver_GateDefaults_ExplicitRowOverridesDefault proves the default is
+// only a fallback: an admin who turns the gate off per workspace writes an
+// enabled=false row through Resolver.Set, and that row must win over the
+// declared default on every read surface.
+func TestResolver_GateDefaults_ExplicitRowOverridesDefault(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	pool, teardown := newTestPool(t, ctx)
+	defer teardown()
+
+	r := settings.NewResolver(pool, 30*time.Second)
+	tid := mustTenant(t, ctx, pool, "t-fg-default-off", "HIVE_CLOUD")
+
+	require.NoError(t, r.Set(ctx, tid, settings.EnableCowork, false, uuid.Nil))
+
+	clientVisible, err := r.ClientVisibleEnabled(ctx, tid)
+	require.NoError(t, err)
+	require.Falsef(t, clientVisible[settings.EnableCowork],
+		"an explicit enabled=false tenant_settings row must override the declared default")
+
+	all, err := r.AllEnabled(ctx, tid)
+	require.NoError(t, err)
+	require.Falsef(t, all[settings.EnableCowork],
+		"an explicit enabled=false tenant_settings row must override the declared default in the full set too")
+}
+
 func TestResolver_CacheInvalidatesOnNotify(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/docs/proof/cowork-launch-1107/capture.log
+++ b/docs/proof/cowork-launch-1107/capture.log
@@ -1,0 +1,25 @@
+[2026-08-24T01:45:58.818Z] goto https://chat-hive.scubed.co/agents
+[2026-08-24T01:46:02.834Z] round 0: at https://chat-hive.scubed.co/
+[2026-08-24T01:46:11.895Z] api GET /api/v1/hive/agent/tasks -> 200
+[2026-08-24T01:46:14.432Z] round 1: at https://chat-hive.scubed.co/agents
+[2026-08-24T01:46:17.050Z] screenshot 01-agents-composer.png
+[2026-08-24T01:46:17.085Z] textarea placeholder="Describe the task in your own words"
+[2026-08-24T01:46:17.152Z] filled task instructions
+[2026-08-24T01:46:17.229Z] screenshot 02-task-typed.png
+[2026-08-24T01:46:17.466Z] api POST /api/v1/hive/agent/tasks -> 201
+[2026-08-24T01:46:17.468Z] submit POST /v1/agent/tasks -> 201
+[2026-08-24T01:46:20.599Z] api GET /api/v1/hive/agent/tasks -> 200
+[2026-08-24T01:46:23.782Z] api GET /api/v1/hive/agent/tasks -> 200
+[2026-08-24T01:46:24.077Z] terminal status=Done; screenshot 04-task-final.png
+[2026-08-24T01:46:24.077Z] final row text: Run this single shell command and then finish: echo "hello from PR 1111 cowork verification" Queued Waiting for a sandbox to pick it up. Coding · less than a minute Cancel || Run this single shell command and then finish: echo "hello from PR 1111 cowork verification" Done Finished. The result reference is below. Result: The command was executed successfully. The output was: hello from PR 1111 cowo
+[2026-08-24T01:46:24.077Z] tasks api snapshot: 2401b1af queued | 523d9a4e succeeded :: The command was executed successfully. The output was:
+
+hello from PR 1111 cowork verification
+
+The command completed with exit code 0. | 5675a653 succeeded :: The command executed successfully. Output: "hello from PR 1111 cowork verification" (exit code 0).
+[2026-08-24T01:46:24.078Z] wrote capture.log
+[2026-08-24T01:48:34.249Z] 05 rows: 
+[2026-08-24T01:49:20.109Z] round 0: at https://chat-hive.scubed.co/
+[2026-08-24T01:49:31.556Z] round 1: at https://chat-hive.scubed.co/agents
+[2026-08-24T01:49:35.703Z] newest row: Run this single shell command and then finish: echo "hello from PR 1111 cowork verification" Done Finished. The result reference is below. Result: The command executed successfully. Output: "hello from PR 1111 cowork verification" (exit code 0). Coding · 13m
+[2026-08-24T01:49:36.791Z] screenshot 05-task-done.png (Done row painted)

--- a/supabase/migrations/20260824_01_cowork_gate_default_enabled.sql
+++ b/supabase/migrations/20260824_01_cowork_gate_default_enabled.sql
@@ -1,0 +1,28 @@
+-- Issue #1107: Cowork is unlaunchable on every workspace that has no explicit
+-- ENABLE_COWORK tenant_settings row. The gate registry had no concept of a
+-- default state, so "unset" read as false everywhere: only tenants hand-seeded
+-- by scripts/seed-demo-owner.py could launch agent tasks, which is why the
+-- demo workspace worked while the parity-audit user's workspace answered 403
+-- ("The agent service is not enabled for this organization").
+--
+-- This is the defaults layer the 20260715_04_featuregate_dynamic_keys.sql
+-- header anticipated: a per-key default carried ON the registry itself, so
+-- the resolution rule becomes "explicit tenant_settings row wins; otherwise
+-- the key's declared default". No per-tenant backfill is needed: existing and
+-- future workspaces both pick the default up at read time.
+--
+-- Scope is deliberately one key: ENABLE_COWORK only. RAG, voice, relay, SSO,
+-- billing, and audit keys keep their current opt-in behavior because their
+-- default stays false, and an admin can still turn Cowork off per workspace
+-- by writing an enabled=false tenant_settings row through the existing
+-- feature-gate admin surface, which overrides any default.
+
+ALTER TABLE public.feature_gate_keys
+  ADD COLUMN IF NOT EXISTS default_enabled boolean NOT NULL DEFAULT false;
+
+UPDATE public.feature_gate_keys
+   SET default_enabled = true
+ WHERE key = 'ENABLE_COWORK';
+
+COMMENT ON COLUMN public.feature_gate_keys.default_enabled IS
+  'State reported for this gate when the tenant has no explicit tenant_settings row. Explicit rows always win over the declared default.';


### PR DESCRIPTION
Closes #1107.

## What gated it

Nothing was wrong with the agent infrastructure. The box runs the socket-arm launcher (hive-agent-engine systemd user service, active; SIF present; sessions and workspaces directories live). The gate in front of every agent-task route is the per-tenant `ENABLE_COWORK` tenant setting:

- `apps/edge-api/cmd/server/gated_routes.go` wraps /v1/agent routes in `featuregate.Require(featuregate.FeatureCowork)`.
- edge-api resolves flags from control-plane `GET /internal/featuregate/{tenant_id}`, which reads `feature_gate_keys LEFT JOIN tenant_settings` with `COALESCE(s.enabled, false)`: an unset key read as **false**.
- Only tenants hand-seeded by scripts/seed-demo-owner.py had rows. Verified live on the box: `hive-demo` has `ENABLE_COWORK = true` (seeded 2026-08-10), while the parity-audit user's workspace `e2e-verified-tenant` has zero gate rows, so it 403'd on every task call. Every fresh workspace would do the same.

## The fix

A defaults layer on the registry itself, exactly the extension point the 20260715_04_featuregate_dynamic_keys.sql header anticipated:

1. Migration adds `feature_gate_keys.default_enabled boolean NOT NULL DEFAULT false` and sets it true for `ENABLE_COWORK` only.
2. Resolver's shared registry query becomes `COALESCE(s.enabled, k.default_enabled)`: explicit tenant_settings row wins, otherwise the declared default applies.
3. Effect is immediate for existing and future workspaces with no data backfill. RAG, voice, relay, SSO, billing and audit keys keep opt-in behavior because their defaults stay false, and an admin can still turn Cowork off per workspace via the existing feature-gate admin PUT, which writes a row that overrides the default.

Per D-044 this keeps the knob control-plane owned: one reviewed migration plus one resolver line instead of runtime database rows invisible to git.

## Tests

TDD against a throwaway pgvector/pgvector:pg17 loaded with .github/ci/test-db-bootstrap.sql plus the full supabase/migrations chain including the new migration:

- RED: new `TestResolver_GateDefaults_UnsetKeyReadsDeclaredDefault` fails on the old query (unset ENABLE_COWORK read false).
- GREEN: both new tests (`UnsetKeyReadsDeclaredDefault`, `ExplicitRowOverridesDefault`) pass with the fix; full internal/tenant/settings suite ok. go vet clean.
- Other packages' intermittent failures on my dirty shared throwaway DB were reproduced identically with the change stashed, so they are pre-existing local interference, not this diff. CI's clean ephemeral DB is authoritative.

## Live launch evidence

Captured against https://chat-hive.scubed.co as a dedicated proof identity (uiux-proof@hive-demo.invalid, hive-uiux-proof workspace, gates on since 2026-07-26), not the demo account, per docs/live-test-auth.md: a real Cowork task reached a sandbox and returned output. Screenshots posted via scripts/post-pr-visual-proof.sh; capture log under docs/proof/.

## Buglog entry

{"ts":"2026-08-24","error_message":"403 'The agent service is not enabled for this organization' on every Cowork task submission outside hand-seeded tenants","root_cause":"feature_gate_keys carried no default state, so unset ENABLE_COWORK read false everywhere; only seed-demo-owner.py tenants had rows","fix":"registry-declared default_enabled column applied when no explicit tenant_settings row exists; ENABLE_COWORK default flipped on by migration 20260824_01","tags":"featuregate,cowork,tenant-settings"}


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cowork is now enabled by default for tenants without an explicit setting.
  * Tenant-specific settings can still disable Cowork.

* **Bug Fixes**
  * Feature availability now consistently respects registry defaults when tenant settings are unset.

* **Documentation**
  * Clarified how registry defaults and explicit tenant settings are applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->