### PR TITLE
fix: surface composer size failures instead of silently no-oping the send (#1108)

### DIFF
--- a/apps/edge-api/internal/auth/owui_unwrap.go
+++ b/apps/edge-api/internal/auth/owui_unwrap.go
@@ -52,10 +52,13 @@ func IsOWUIUnwrapped(ctx context.Context) bool {
 }
 
 // maxOWUIUnwrapBody caps the body we buffer for metadata extraction.
-// OWUI chat-completions bodies are typically small (~kilobytes); a 2 MiB
-// ceiling is well past the largest realistic prompt + attachments
-// without giving an attacker a memory-amplification primitive.
-const maxOWUIUnwrapBody = 2 << 20 // 2 MiB
+// Chat messages carry inlined attachment text (#1108): a pasted document
+// or extracted file content lands whole inside the JSON completion body,
+// so realistic signed-in-user sends reach multiple MiB. A 16 MiB ceiling
+// keeps that traffic flowing while staying far below anything that could
+// act as a memory-amplification primitive. Over-limit requests with a
+// declared Content-Length are rejected before a byte is buffered.
+const maxOWUIUnwrapBody = 16 << 20 // 16 MiB
 
 // maxOWUIBearerToken caps the token length extracted from
 // `__metadata.upstream_auth`. A Supabase JWT is typically ~1 KB; 8 KiB
@@ -113,7 +116,8 @@ type OWUIUnwrapConfig struct {
 //     such a request can never be legitimate, and passing it
 //     through would be a way around the fail-closed check below.
 //   - Body unreadable                                          → 400 (fail closed).
-//   - Body > maxOWUIUnwrapBody                                 → 413.
+//   - Body > maxOWUIUnwrapBody (declared Content-Length or
+//     buffered read)                                          → 413.
 //   - Body is JSON but missing __metadata.upstream_auth        → 401 on a
 //     path requiring a per-user token, otherwise pass through
 //     with shim Authorization intact. Either way emit a
@@ -200,6 +204,16 @@ func OWUIUnwrap(cfg OWUIUnwrapConfig) func(http.Handler) http.Handler {
 				// Non-JSON shim requests (multipart uploads for audio
 				// or images) cannot carry __metadata; pass through.
 				next.ServeHTTP(w, r)
+				return
+			}
+			// Reject a declared oversize body before reading anything.
+			// Buffering first then answering 413 makes the client upload
+			// megabytes we already know we will refuse (#1108): the
+			// stalled-upload shape users reported as a silent hang.
+			// ContentLength is -1 when unknown (chunked), which fails this
+			// comparison and falls through to the LimitReader below.
+			if r.ContentLength > maxOWUIUnwrapBody {
+				writeAuthError(w, http.StatusRequestEntityTooLarge, "PAYLOAD_TOO_LARGE", "request body too large")
 				return
 			}
 			// Cap the read at maxOWUIUnwrapBody+1 so we can detect

--- a/apps/edge-api/internal/auth/owui_unwrap_test.go
+++ b/apps/edge-api/internal/auth/owui_unwrap_test.go
@@ -297,12 +297,52 @@ func TestOWUIUnwrap_ChatCompletionsWithNonJSONBody_StillRejects(t *testing.T) {
 func TestOWUIUnwrap_OverLimitBody_413(t *testing.T) {
 	mw := auth.OWUIUnwrap(auth.OWUIUnwrapConfig{ShimKey: testShimKey})
 	next, _ := newCaptureHandler()
-	big := bytes.Repeat([]byte("a"), (2<<20)+10) // 2 MiB + 10
+	big := bytes.Repeat([]byte("a"), (16<<20)+10) // 16 MiB + 10
 	req := wrap(t, big, "Bearer "+testShimKey)
 	rr := httptest.NewRecorder()
 	mw(next).ServeHTTP(rr, req)
 	if rr.Code != http.StatusRequestEntityTooLarge {
 		t.Fatalf("expected 413, got %d", rr.Code)
+	}
+}
+
+// A chat body carrying inlined attachment text (#1108) is legitimately
+// multiple MiB. Just under the new cap it must flow through with the
+// per-user token still unwrapped from __metadata.
+func TestOWUIUnwrap_LargeInlinedBodyWithinCap_Unwraps(t *testing.T) {
+	mw := auth.OWUIUnwrap(auth.OWUIUnwrapConfig{ShimKey: testShimKey})
+	next, captured := newCaptureHandler()
+	filler := string(bytes.Repeat([]byte("a"), (12<<20)-1024))
+	raw := `{"model":"hive-default","messages":[{"role":"user","content":"` + filler + `"}],"__metadata":{"upstream_auth":"user-jwt"}}`
+	req := wrap(t, []byte(raw), "Bearer "+testShimKey)
+	rr := httptest.NewRecorder()
+	mw(next).ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("unexpected status %d: %s", rr.Code, rr.Body.String())
+	}
+	if captured.authorization != "Bearer user-jwt" {
+		t.Fatalf("expected per-user token on a ~12 MiB body, got %q", captured.authorization)
+	}
+}
+
+// A declared oversize Content-Length is refused before the body is read,
+// so the client learns immediately instead of uploading megabytes into a
+// request that was already doomed (#1108 silent-hang shape).
+func TestOWUIUnwrap_ContentLengthOverLimit_RejectedWithoutReading(t *testing.T) {
+	mw := auth.OWUIUnwrap(auth.OWUIUnwrapConfig{ShimKey: testShimKey})
+	next, captured := newCaptureHandler()
+	body := strings.NewReader(`{"model":"hive-default"}`)
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", body)
+	req.Header.Set("Authorization", "Bearer "+testShimKey)
+	req.Header.Set("Content-Type", "application/json")
+	req.ContentLength = (16 << 20) + 1
+	rr := httptest.NewRecorder()
+	mw(next).ServeHTTP(rr, req)
+	if rr.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected 413, got %d", rr.Code)
+	}
+	if captured.authorization != "" {
+		t.Fatalf("handler must not run, got authorization %q", captured.authorization)
 	}
 }
 

--- a/scripts/test-owui-hive-frontend.sh
+++ b/scripts/test-owui-hive-frontend.sh
@@ -44,7 +44,9 @@ for rel in \
 	chat/SettingsModal.svelte \
 	chat/ModelSelector/Selector.svelte \
 	chat/Settings/Account.svelte \
-	chat/Settings/Advanced/AdvancedParams.svelte
+	chat/Settings/Advanced/AdvancedParams.svelte \
+	chat/MessageInput.svelte \
+	chat/Chat.svelte
 do
 	mkdir -p "$WORK/lib/components/${rel%/*}"
 	cp "$COMPONENT_SRC/$rel" "$WORK/lib/components/$rel"

--- a/vendor/open-webui/src/lib/components/chat/Chat.svelte
+++ b/vendor/open-webui/src/lib/components/chat/Chat.svelte
@@ -656,14 +656,17 @@
 					message.error = data.error;
 					// A completion failure must be visible even when the failing
 					// message is scrolled off-screen (#1108): state alone read
-					// as a silently no-op send.
+					// as a silently no-op send. The bubble keeps the full detail;
+					// the toast carries a bounded version, and anything that is
+					// not already a display string falls back to the generic
+					// completion-failure wording rather than dumping an object.
 					const errorContent =
 						data?.error?.content ?? data?.error?.message ?? data?.error ?? '';
 					if (errorContent) {
 						toast.error(
 							typeof errorContent === 'string'
-								? errorContent
-								: JSON.stringify(errorContent)
+								? errorContent.slice(0, 300)
+								: $i18n.t('Uh-oh! There was an issue with the response.')
 						);
 					}
 				} else if (type === 'chat:message:follow_ups') {

--- a/vendor/open-webui/src/lib/components/chat/Chat.svelte
+++ b/vendor/open-webui/src/lib/components/chat/Chat.svelte
@@ -654,6 +654,18 @@
 					}, 100);
 				} else if (type === 'chat:message:error') {
 					message.error = data.error;
+					// A completion failure must be visible even when the failing
+					// message is scrolled off-screen (#1108): state alone read
+					// as a silently no-op send.
+					const errorContent =
+						data?.error?.content ?? data?.error?.message ?? data?.error ?? '';
+					if (errorContent) {
+						toast.error(
+							typeof errorContent === 'string'
+								? errorContent
+								: JSON.stringify(errorContent)
+						);
+					}
 				} else if (type === 'chat:message:follow_ups') {
 					message.followUps = data.follow_ups;
 

--- a/vendor/open-webui/src/lib/components/chat/MessageInput.svelte
+++ b/vendor/open-webui/src/lib/components/chat/MessageInput.svelte
@@ -631,6 +631,22 @@
 			return null;
 		}
 
+		// Enforce the configured size cap here rather than only in
+		// inputFilesHandler (#1108): large pasted text and drag-dropped files
+		// reach this handler directly, skipping that guard, and an oversized
+		// attachment used to land as a chip that could never send.
+		if (
+			($config?.file?.max_size ?? null) !== null &&
+			file.size > ($config?.file?.max_size ?? 0) * 1024 * 1024
+		) {
+			toast.error(
+				$i18n.t(`File size should not exceed {{maxSize}} MB.`, {
+					maxSize: $config?.file?.max_size
+				})
+			);
+			return null;
+		}
+
 		const tempItemId = uuidv4();
 		const fileItem = {
 			type: 'file',

--- a/vendor/open-webui/src/lib/hive/composer-size-guard.test.ts
+++ b/vendor/open-webui/src/lib/hive/composer-size-guard.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+// Regression guard for #1108 (composer submit silently no-ops on large
+// pastes / attachments). The repo has no component-test harness for the chat
+// frontend, so like settings-declutter.test.ts this pins behavior at source
+// level:
+//
+//   1. uploadFileHandler must enforce $config.file.max_size itself. Large
+//      pasted text and drag-dropped files reach it directly, bypassing
+//      inputFilesHandler's guard, so an oversized attachment used to land as
+//      a chip that could never send.
+//   2. The chat:message:error socket handler must toast the error content.
+//      Setting message state alone read as a silently no-op send.
+
+const component = (rel: string): string =>
+	readFileSync(fileURLToPath(new URL(rel, import.meta.url)), 'utf8');
+
+const between = (src: string, startMarker: string, endMarker: string): string => {
+	const start = src.indexOf(startMarker);
+	const end = src.indexOf(endMarker, start);
+	if (start === -1 || end === -1) {
+		throw new Error(`markers not found: ${startMarker}, ${endMarker}`);
+	}
+	return src.slice(start, end);
+};
+
+describe('attachment size guard (#1108)', () => {
+	it('uploadFileHandler enforces the configured max_size before a chip is created', () => {
+		const handler = between(
+			component('../components/chat/MessageInput.svelte'),
+			'const uploadFileHandler',
+			'const inputFilesHandler'
+		);
+
+		expect(handler).toContain('$config?.file?.max_size');
+		expect(handler).toContain('file.size > ($config?.file?.max_size ?? 0) * 1024 * 1024');
+		expect(handler).toContain('toast.error');
+	});
+
+	it('the paste path routes through uploadFileHandler, which now carries the guard', () => {
+		const src = component('../components/chat/MessageInput.svelte');
+		expect(src).toContain('await uploadFileHandler(file, true, { context: \'full\' })');
+	});
+});
+
+describe('completion errors are visible (#1108)', () => {
+	it('chat:message:error toasts the error content instead of only setting state', () => {
+		const branch = between(
+			component('../components/chat/Chat.svelte'),
+			"type === 'chat:message:error'",
+			"chat:message:follow_ups"
+		);
+
+		expect(branch).toContain('message.error = data.error;');
+		expect(branch).toContain('toast.error');
+	});
+});


### PR DESCRIPTION
Fixes #1108.

## Problem

Composer submit silently no-ops on large pastes and large attachments: the message never sends, no toast, no error. Two independent gaps combine into that silence.

### 1. Edge unwrap cap answered 413 to legitimate sends

`maxOWUIUnwrapBody` (`apps/edge-api/internal/auth/owui_unwrap.go`) buffered at most **2 MiB** of the JSON completion body while extracting `__metadata.upstream_auth`. Chat messages carry inlined attachment text (a pasted document or extracted file content lands whole inside `messages[].content`), so realistic signed-in-user bodies exceed 2 MiB and got a bare 413.

**Choice made: raise the bounded buffer to 16 MiB plus a fast-fail on declared oversize, not the skip-buffering arm.** The alternative arm (skip metadata buffering when Content-Length exceeds the cap and pass through unbuffered) is unsafe here: chat completions are a per-user path, so the user token only arrives inside the buffered JSON. Passing through unbuffered either forwards with the shim key still on Authorization (billing and audit misattribution, fail-open) or blanket-rejects every oversized legitimate chat with 401 (fail-closed but breaks the feature). Raising to a bounded 16 MiB keeps per-user auth intact; memory stays bounded at 16 MiB per in-flight request, and a declared Content-Length over the cap is now refused before a single byte is read, which removes the slow upload-then-refuse shape users saw as a hang.

### 2. Frontend swallowed every downstream error signal

- The `chat:message:error` socket handler in `Chat.svelte` set `message.error` but never toasted, so any backend-surfaced upstream failure was invisible unless the exact bubble was on screen.
- The config-based size guard lived only in `inputFilesHandler`. Large pasted text and drag-dropped files reach `uploadFileHandler` by direct call, bypassing it, so an oversized attachment landed as a chip that could never send.

## Repro shapes against this fix

- **100KB paste**: text over the character limit becomes a pasted-text attachment routed through `uploadFileHandler`; if its content inflates the completion body past 2 MiB, edge previously answered 413 and the composer showed nothing. Now bodies up to 16 MiB flow through unwrapped as before (Go test `TestOWUIUnwrap_LargeInlinedBodyWithinCap_Unwraps`), and any failure that still occurs surfaces as a toast via the `chat:message:error` handler.
- **50MB attachment**: rejected client-side with a visible toast when `$config.file.max_size` is served, now from `uploadFileHandler` itself so the paste and drag-drop entry points are covered too (vitest guard pins this). If one still reaches the server, the declared Content-Length is refused immediately with 413 before buffering, and that failure now reaches the composer as a visible toast instead of a 45s silent stall.

## Tests

- Go: updated `TestOWUIUnwrap_OverLimitBody_413` to the new ceiling; added `TestOWUIUnwrap_LargeInlinedBodyWithinCap_Unwraps` (~12 MiB body unwraps with per-user token) and `TestOWUIUnwrap_ContentLengthOverLimit_RejectedWithoutReading` (handler never runs). `go test ./apps/edge-api/internal/auth/... -count=1` green in the toolchain container.
- Frontend: new `vendor/open-webui/src/lib/hive/composer-size-guard.test.ts` (3 tests) run by `scripts/test-owui-hive-frontend.sh`: `uploadFileHandler` must carry the max_size guard, paste must route through it, and `chat:message:error` must toast. Suite green: 8 files, 73 tests.

## Visual proof

Pending live verification: no stack was running in this worktree during the change, so no fresh screenshot against the actually-running stack yet. Per fleet rules this PR does not merge without it; capture against the deployed result after deploy or against a live local stack.


## Buglog entry

```json
{"error_message":"Composer submit on a large paste or attachment silently no-ops: no send, no error, no size guardrail (#1108)","root_cause":"apps/edge-api/internal/auth/owui_unwrap.go capped buffered metadata extraction at 2 MiB and answered 413 above it while chat bodies carry inlined attachment text; frontend chat:message:error handler set message state without any toast so upstream failures were invisible; the config-based size guard lived only in inputFilesHandler so paste and drag-drop paths calling uploadFileHandler directly bypassed it","fix":"raised maxOWUIUnwrapBody to 16 MiB with declared Content-Length rejected before reading; uploadFileHandler now enforces $config.file.max_size at attach time on every entry path; chat:message:error toasts bounded error content","tags":["composer","owui-unwrap","413","silent-failure","chat-frontend"]}
```
