### PR TITLE
fix: serve the file size cap to chat clients

### DIFF
--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -1146,6 +1146,9 @@ services:
       # per-user JWT: OWUI_SHIM_KEY must be a real minted "hk_" Hive API key for
       # this path to authenticate at all (see scripts/seed-owui-e2e-user.py).
       RAG_EMBEDDING_MODEL: ${OWUI_RAG_EMBEDDING_ALIAS:-hive-embedding-default}
+      # Serves rag.file.max_size to clients as file.max_size so MessageInput's
+      # size guard fires client-side instead of failing opaquely server-side (#1108 follow-up).
+      RAG_FILE_MAX_SIZE: ${RAG_FILE_MAX_SIZE:-}
       # Chat dictation. These four are persistent config as well, reconciled by
       # the same owui-patches/hive_rag_env_config.py for the same
       # first-boot-wins reason as the RAG keys above.


### PR DESCRIPTION
Follow-up to #1108. RAG_FILE_MAX_SIZE was never passed into the open-webui container, so /api/config served file.max_size as null and the client-side upload guard in MessageInput.svelte never fired; oversized attachments failed opaquely server-side instead of being refused with a visible message naming the limit. PR #1112 fixed the guard enforcement paths and raised the shim unwrap cap; this closes the loop by letting the box serve a cap at all. One passthrough line in the open-webui environment block plus a comment; setting RAG_FILE_MAX_SIZE=100 in the box .env makes every chat client refuse oversized attachments with the existing toast. YAML parses clean, idiom matches neighbors. Box-side env set and live toast verification happen at deploy time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for exposing the maximum allowed RAG file size to clients.
  * Enables client-side validation before uploading files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->