### PR TITLE
feat: free pool router with load-balanced failover across our own free keys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -132,7 +132,9 @@ CONTROL_PLANE_PUBLIC_URL=
 LITELLM_MASTER_KEY=litellm-dev-key
 # Provider keys (FREE tier used in CI)
 OPENROUTER_API_KEY=            # OpenRouter free router (primary)
-GROQ_API_KEY=                  # Groq free (chat fallback + reasoning)
+GROQ_API_KEY=                  # Groq free (audio + free pool member #1)
+GROQ_API_KEY_2=                # Groq key slot 2 (free pool member; same endpoint, separate quota)
+GEMINI_API_KEY=                # Google Gemini (free pool member via the OpenAI-compatible endpoint)
 
 # OpenRouter routing. These MUST match provider_routes.provider_model for
 # route-openrouter-default / route-openrouter-auto (supabase/migrations/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -997,6 +997,11 @@ jobs:
       LITELLM_MASTER_KEY: ${{ secrets.LITELLM_MASTER_KEY }}
       OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
       GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+      # Free pool key slots; hive-free (the default HIVE_TEST_MODEL) fails over
+      # across all four deployments, so each slot must reach the litellm
+      # container.
+      GROQ_API_KEY_2: ${{ secrets.GROQ_API_KEY_2 }}
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
       NVIDIA_NIM_API_KEY: ${{ secrets.NVIDIA_NIM_API_KEY }}
       # Which alias the token-consuming SDK suites call, and therefore which
       # provider account this job bills. Issue #1088.
@@ -1692,6 +1697,8 @@ jobs:
       # without exposing paid API keys to a job that never needs them.
       OPENROUTER_API_KEY: 'ci-stub-not-used'
       GROQ_API_KEY: 'ci-stub-not-used'
+      GROQ_API_KEY_2: 'ci-stub-not-used'
+      GEMINI_API_KEY: 'ci-stub-not-used'
       NVIDIA_NIM_API_KEY: 'ci-stub-not-used'
       OPENROUTER_DEFAULT_MODEL: ${{ vars.OPENROUTER_DEFAULT_MODEL }}
       OPENROUTER_AUTO_MODEL: ${{ vars.OPENROUTER_AUTO_MODEL }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1045,9 +1045,14 @@ jobs:
       # every run so it is never an unstated assumption.
       #
       # Set the CI_LIVE_INTEGRATION_MODEL repository variable to point this
-      # back at hive-default (say, once a CI-only Groq organization exists)
-      # without touching this file.
-      HIVE_TEST_MODEL: ${{ vars.CI_LIVE_INTEGRATION_MODEL || 'deepseek-v4-pro' }}
+      # anywhere else (a paid alias for a higher-fidelity run, say) without
+      # touching this file.
+      #
+      # Default is hive-free, the free pool alias (migration
+      # 20260824_02_free_pool_router.sql): automated consumption belongs on the
+      # load-balanced pool of our own free provider keys, not on a paid tier or
+      # on whichever single provider happens to serve the demo today.
+      HIVE_TEST_MODEL: ${{ vars.CI_LIVE_INTEGRATION_MODEL || 'hive-free' }}
       # The suites' own default, named here rather than left implicit, because
       # the spend meter below asserts that no alias outside these two is ever
       # billed by this job.
@@ -1099,14 +1104,10 @@ jobs:
           set -euo pipefail
           echo "SDK suites will call alias: $HIVE_TEST_MODEL"
           echo "embedding suites will call: $HIVE_EMBEDDING_MODEL"
-          if [ "$HIVE_TEST_MODEL" = "hive-default" ] \
-            || [ "$HIVE_TEST_MODEL" = "hive-small" ] \
-            || [ "$HIVE_TEST_MODEL" = "hive-medium" ] \
-            || [ "$HIVE_TEST_MODEL" = "hive-auto" ] \
-            || [ "$HIVE_TEST_MODEL" = "hive-fast" ]; then
-            echo "::warning::this run bills the SHARED Groq free-tier daily token budget, the same allowance the live demo box serves chat from. Exhausting it takes the demo down and reddens this required check for reasons no commit caused (issue #1088)."
+          if [ "$HIVE_TEST_MODEL" = "hive-free" ]; then
+            echo "::notice::this run bills hive-free, the load-balanced pool of our own free provider keys. No customer-facing provider allowance is consumed. Pool-specific routing regressions (failover between keys) are covered only against the live box; a single-provider regression on any one pool member can still hide behind the other members."
           else
-            echo "::notice::this run bills '$HIVE_TEST_MODEL', which is NOT the Groq route the live demo serves chat from. Groq-specific regressions are not covered here; the sdk-replay job in deploy-demo-box.yml covers them against the live box on hive-default after each deploy."
+            echo "::notice::this run bills '$HIVE_TEST_MODEL', an override via CI_LIVE_INTEGRATION_MODEL rather than the free-pool default. Whatever that alias serves is what this run consumes."
           fi
 
       - name: Start a throwaway Postgres and apply the real schema

--- a/.github/workflows/deploy-demo-box.yml
+++ b/.github/workflows/deploy-demo-box.yml
@@ -1690,26 +1690,34 @@ jobs:
           fail=0
           while IFS='|' read -r route_id litellm_name db_model; do
             [ -z "$route_id" ] && continue
-            live_model=$(echo "$resolved" | jq -r --arg id "$litellm_name" \
-              '.data[] | select(.model_name == $id) | .litellm_params.model' | head -1)
-            live_base=$(echo "$resolved" | jq -r --arg id "$litellm_name" \
-              '.data[] | select(.model_name == $id) | (.litellm_params.api_base // "")' | head -1)
-            if [ -z "$live_model" ] || [ "$live_model" = "null" ]; then
-              echo "::error::$route_id ($litellm_name): priced route is not in LiteLLM's live /model/info at all"
-              fail=1
-              continue
-            fi
-            # LiteLLM's generic openai/ adapter pointed at OpenRouter IS the
-            # openrouter provider, and only then. Canonicalize rather than
-            # discard, so the provider segment stays part of the comparison.
-            case "$live_model|$live_base" in
-              openai/*"openrouter.ai"*) live_model="openrouter/${live_model#openai/}" ;;
-            esac
-            if [ "$db_model" != "$live_model" ]; then
-              echo "::error::$route_id: catalog prices $db_model but LiteLLM will call $live_model"
+            # A model_name can carry MULTIPLE deployments (the free pool route
+            # group: N provider_routes rows share one litellm_model_name, and
+            # the config sync emits one deployment each so LiteLLM's router can
+            # load-balance across them). The priced alias's provider_model must
+            # be found among THAT SET of deployments, not at position 1, which
+            # is whichever member sorted first. Emit model+api_base pairs and
+            # match on membership.
+            matched=""
+            while IFS=$'\t' read -r entry_model entry_base; do
+              [ -z "$entry_model" ] && continue
+              # LiteLLM's generic openai/ adapter pointed at OpenRouter IS the
+              # openrouter provider, and only then. Canonicalize rather than
+              # discard, so the provider segment stays part of the comparison.
+              case "$entry_model|$entry_base" in
+                openai/*"openrouter.ai"*) entry_model="openrouter/${entry_model#openai/}" ;;
+              esac
+              if [ "$entry_model" = "$db_model" ]; then
+                matched="$entry_model"
+                break
+              fi
+            done < <(echo "$resolved" | jq -r --arg id "$litellm_name" \
+              '.data[] | select(.model_name == $id) | [.litellm_params.model, (.litellm_params.api_base // "")] | @tsv')
+
+            if [ -z "$matched" ]; then
+              echo "::error::$route_id ($litellm_name): catalog prices $db_model but no deployment under that model_name serves it"
               fail=1
             else
-              echo "$route_id: OK ($db_model <-> $live_model)"
+              echo "$route_id: OK ($db_model served by $litellm_name)"
             fi
           done <<< "$rows"
 
@@ -1812,7 +1820,9 @@ jobs:
     env:
       HIVE_BASE_URL: https://api-hive.scubed.co/v1
       HIVE_API_KEY: ${{ secrets.HIVE_API_KEY }}
-      HIVE_TEST_MODEL: hive-default
+      # Daily automated consumption belongs on the free pool alias, not on a
+      # paid tier (migration 20260824_02_free_pool_router.sql).
+      HIVE_TEST_MODEL: hive-free
       HIVE_EMBEDDING_MODEL: hive-embedding-default
     steps:
       - uses: actions/checkout@v7

--- a/apps/control-plane/internal/litellmconfig/generator.go
+++ b/apps/control-plane/internal/litellmconfig/generator.go
@@ -45,6 +45,15 @@ type Config struct {
 	// provider_routes row at all still survives. Empty means "unknown", which
 	// preserves every unmatched entry exactly as before.
 	KnownRouteIDs []string
+	// KnownGroupNames is every provider_routes.litellm_model_name value,
+	// active or not: the names route GROUPS share. A group whose members all
+	// go inactive generates no model_list entry at all, so generatedNames
+	// never contains it and KnownRouteIDs does not either (it holds route_ids,
+	// not the shared gateway name); without this set a fully retired group's
+	// stale entry would survive as "operator-managed" forever. The merge drops
+	// an unmatched entry whose model_name appears here, exactly as it does for
+	// KnownRouteIDs. Empty means "unknown", preserving every unmatched entry.
+	KnownGroupNames []string
 	// ExistingConfigPath is the path of the on-disk config to merge from.
 	// WriteAndRestart reads this file to preserve non-generated keys.
 	// If the file does not exist, the config is written from scratch.
@@ -169,7 +178,7 @@ func WriteAndRestart(ctx context.Context, configPath string, cfg Config, restart
 			return fmt.Errorf("litellmconfig: parse existing config: %w", parseErr)
 		}
 		if existingMap != nil {
-			merged = mergeConfig(existingMap, newMap, cfg.KnownRouteIDs)
+			merged = mergeConfig(existingMap, newMap, cfg.KnownRouteIDs, cfg.KnownGroupNames)
 		}
 	} else if !errors.Is(readErr, os.ErrNotExist) {
 		return fmt.Errorf("litellmconfig: read existing config: %w", readErr)
@@ -284,8 +293,12 @@ func mergeParams(existing, generated interface{}) interface{} {
 //   - All other top-level keys from existing are preserved unchanged.
 //
 // An empty knownRouteIDs means the caller does not know the route set, and every
-// unmatched entry is preserved (the pre-knownRouteIDs behaviour).
-func mergeConfig(existing, generated map[string]interface{}, knownRouteIDs []string) map[string]interface{} {
+// unmatched entry is preserved (the pre-knownRouteIDs behaviour). knownGroupNames
+// works identically for route GROUPS: names several rows share as their
+// litellm_model_name. A group whose members are all retired generates no entry,
+// so generatedNames cannot cover it and only this set can retire its stale
+// config block.
+func mergeConfig(existing, generated map[string]interface{}, knownRouteIDs []string, knownGroupNames []string) map[string]interface{} {
 	result := make(map[string]interface{}, len(existing))
 	for k, v := range existing {
 		result[k] = v
@@ -310,6 +323,10 @@ func mergeConfig(existing, generated map[string]interface{}, knownRouteIDs []str
 	knownRoutes := make(map[string]bool, len(knownRouteIDs))
 	for _, id := range knownRouteIDs {
 		knownRoutes[id] = true
+	}
+	knownGroups := make(map[string]bool, len(knownGroupNames))
+	for _, name := range knownGroupNames {
+		knownGroups[name] = true
 	}
 
 	// Build a lookup of the existing entries keyed by model_name, so a
@@ -357,8 +374,12 @@ func mergeConfig(existing, generated map[string]interface{}, knownRouteIDs []str
 		if name == "" || generatedNames[name] {
 			continue
 		}
-		if knownRoutes[name] {
-			slog.Info("litellmconfig: sync: dropping model_list entry for a provider_routes route that is no longer active", "model_name", name)
+		if knownRoutes[name] || knownGroups[name] {
+			if !knownRoutes[name] {
+				slog.Info("litellmconfig: sync: dropping model_list entry for a route group whose members are all inactive", "model_name", name)
+			} else {
+				slog.Info("litellmconfig: sync: dropping model_list entry for a provider_routes route that is no longer active", "model_name", name)
+			}
 			continue
 		}
 		slog.Info("litellmconfig: sync: preserving operator-managed model_list entry with no provider_routes row", "model_name", name)

--- a/apps/control-plane/internal/litellmconfig/generator_test.go
+++ b/apps/control-plane/internal/litellmconfig/generator_test.go
@@ -747,3 +747,173 @@ general_settings:
 	assert.Equal(t, false, provider["allow_fallbacks"], "extra_body.provider.allow_fallbacks must survive a sync")
 	assert.Equal(t, "throughput", provider["sort"], "extra_body.provider.sort must survive a sync")
 }
+
+// --- Free pool router (multi-deployment) tests ---
+//
+// A route group is N provider_routes rows sharing one litellm_model_name. The
+// config sync emits one model_list entry per row, so LiteLLM sees several
+// deployments under one model_name and its router load-balances and cools down
+// failing deployments across them. These tests pin that emission and its merge
+// behaviour across repeated syncs.
+
+func freePoolEntries() []litellmconfig.ModelEntry {
+	return []litellmconfig.ModelEntry{
+		{
+			ModelName:   "route-free-pool",
+			LiteLLMName: "openrouter/dots-studio/dots-3-note-preview:free",
+			APIBase:     "https://openrouter.ai/api/v1",
+			APIKeyEnv:   "OPENROUTER_API_KEY",
+		},
+		{
+			ModelName:   "route-free-pool",
+			LiteLLMName: "groq/openai/gpt-oss-20b",
+			APIBase:     "https://api.groq.com/openai/v1",
+			APIKeyEnv:   "GROQ_API_KEY",
+		},
+		{
+			ModelName:   "route-free-pool",
+			LiteLLMName: "groq/openai/gpt-oss-20b",
+			APIBase:     "https://api.groq.com/openai/v1",
+			APIKeyEnv:   "GROQ_API_KEY_2",
+		},
+	}
+}
+
+// TestGenerateEmitsMultipleDeploymentsUnderOneModelName proves one shared
+// model_name produces N independent model_list entries with per-deployment
+// model strings and env-keyed credentials. That is exactly the shape LiteLLM's
+// documented load balancing consumes, and it is what makes an exhausted key
+// fail over to the other pool members instead of taking the alias down.
+func TestGenerateEmitsMultipleDeploymentsUnderOneModelName(t *testing.T) {
+	cfg := litellmconfig.Config{
+		Models:          freePoolEntries(),
+		GeneralSettings: litellmconfig.GeneralSettings{MasterKey: "k"},
+	}
+
+	out, err := litellmconfig.Generate(cfg)
+	require.NoError(t, err)
+
+	var parsed map[string]interface{}
+	require.NoError(t, yaml.Unmarshal(out, &parsed))
+
+	rawList, ok := parsed["model_list"].([]interface{})
+	require.True(t, ok)
+	require.Len(t, rawList, 3)
+
+	type deployment struct {
+		model   string
+		apiKey  string
+		apiBase string
+	}
+	got := map[deployment]bool{}
+	for _, item := range rawList {
+		entry, ok := item.(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "route-free-pool", entry["model_name"])
+		params, ok := entry["litellm_params"].(map[string]interface{})
+		require.True(t, ok)
+		got[deployment{
+			model:   params["model"].(string),
+			apiKey:  params["api_key"].(string),
+			apiBase: params["api_base"].(string),
+		}] = true
+	}
+
+	want := map[deployment]bool{
+		{"openrouter/dots-studio/dots-3-note-preview:free", "os.environ/OPENROUTER_API_KEY", "https://openrouter.ai/api/v1"}: true,
+		{"groq/openai/gpt-oss-20b", "os.environ/GROQ_API_KEY", "https://api.groq.com/openai/v1"}:                             true,
+		{"groq/openai/gpt-oss-20b", "os.environ/GROQ_API_KEY_2", "https://api.groq.com/openai/v1"}:                           true,
+	}
+	assert.Equal(t, want, got, "each pool member must appear as its own deployment with its own env key")
+}
+
+// TestWriteAndRestartKeepsPoolDeploymentsDistinctAcrossSyncs covers the merge:
+// an existing config that already carries pool entries must keep every
+// deployment distinct after another sync, and a hand-tuned litellm_params key
+// on one pooled entry must survive onto each generated deployment of that name.
+func TestWriteAndRestartKeepsPoolDeploymentsDistinctAcrossSyncs(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+
+	existing := `model_list:
+  - model_name: route-free-pool
+    litellm_params:
+      model: groq/openai/gpt-oss-20b
+      api_base: https://api.groq.com/openai/v1
+      api_key: os.environ/GROQ_API_KEY
+      extra_body:
+        provider:
+          allow_fallbacks: false
+  - model_name: route-other
+    litellm_params:
+      model: openrouter/openai/gpt-4o
+      api_base: https://openrouter.ai/api/v1
+      api_key: os.environ/OPENROUTER_API_KEY
+general_settings:
+  master_key: old
+`
+	require.NoError(t, os.WriteFile(configPath, []byte(existing), 0o644))
+
+	cfg := litellmconfig.Config{
+		Models: freePoolEntries(),
+		// route-other is deliberately ABSENT from this set: it models an
+		// operator-managed entry with no provider_routes row at all, which the
+		// merge must preserve verbatim alongside the pooled deployments. (A
+		// name that WERE in this set but generated no entry would be a retired
+		// DB route, and the merge would rightly drop it.)
+		KnownRouteIDs:      []string{"route-free-pool", "route-free-pool-groq", "route-free-pool-groq-2", "route-free-pool-free"},
+		GeneralSettings:    litellmconfig.GeneralSettings{MasterKey: "new"},
+		ExistingConfigPath: configPath,
+	}
+	restarter := &mockRestarter{}
+	require.NoError(t, litellmconfig.WriteAndRestart(context.Background(), configPath, cfg, restarter))
+	assert.Equal(t, 1, restarter.calls)
+
+	data, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	var parsed map[string]interface{}
+	require.NoError(t, yaml.Unmarshal(data, &parsed))
+
+	rawList, ok := parsed["model_list"].([]interface{})
+	require.True(t, ok)
+
+	poolParams := []map[string]interface{}{}
+	others := 0
+	for _, item := range rawList {
+		entry, _ := item.(map[string]interface{})
+		switch entry["model_name"] {
+		case "route-free-pool":
+			params, ok := entry["litellm_params"].(map[string]interface{})
+			require.True(t, ok)
+			poolParams = append(poolParams, params)
+		case "route-other":
+			others++
+		}
+	}
+	require.Len(t, poolParams, 3, "all three pool deployments must survive the merge")
+	assert.Equal(t, 1, others)
+
+	seenKeys := map[string]bool{}
+	for _, params := range poolParams {
+		key, _ := params["api_key"].(string)
+		seenKeys[key] = true
+
+		// The hand-tuned extra_body block from the pre-existing entry survives
+		// onto every generated deployment of the same name (mergeParams).
+		extra, ok := params["extra_body"].(map[string]interface{})
+		require.True(t, ok, "hand-tuned extra_body must survive on each pooled deployment")
+		provider, ok := extra["provider"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, false, provider["allow_fallbacks"])
+	}
+	assert.Equal(t, map[string]bool{
+		"os.environ/GROQ_API_KEY":       true,
+		"os.environ/GROQ_API_KEY_2":     true,
+		"os.environ/OPENROUTER_API_KEY": true,
+	}, seenKeys, "each pooled deployment keeps its own credential after the merge")
+
+	// The master key overlay still applies on top of the pooled entries.
+	gs, ok := parsed["general_settings"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "new", gs["master_key"])
+}

--- a/apps/control-plane/internal/litellmconfig/generator_test.go
+++ b/apps/control-plane/internal/litellmconfig/generator_test.go
@@ -918,3 +918,64 @@ general_settings:
 	require.True(t, ok)
 	assert.Equal(t, "new", gs["master_key"])
 }
+
+// TestWriteAndRestartRemovesRetiredRouteGroup is the group-shaped twin of
+// TestWriteAndRestartRemovesRetiredDBManagedRoute: when every member of a
+// route group goes inactive, the sync generates no entry for the shared
+// model_name at all. generatedNames then cannot cover it, and without
+// KnownGroupNames the stale block would survive as "operator-managed" with no
+// path that could ever remove it.
+func TestWriteAndRestartRemovesRetiredRouteGroup(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+
+	existing := `model_list:
+  - model_name: route-free-pool
+    litellm_params:
+      model: groq/openai/gpt-oss-20b
+      api_base: https://api.groq.com/openai/v1
+      api_key: os.environ/GROQ_API_KEY
+  - model_name: integ-operator-managed-entry
+    litellm_params:
+      model: openai/some-local-model
+      api_base: http://localhost:11434/v1
+      api_key: "none"
+general_settings:
+  master_key: old-key
+`
+	require.NoError(t, os.WriteFile(configPath, []byte(existing), 0o644))
+
+	cfg := litellmconfig.Config{
+		// One unrelated active route; nothing generates the pool name any more.
+		Models: []litellmconfig.ModelEntry{
+			{
+				ModelName:   "route-some-other-route",
+				LiteLLMName: "openrouter/openai/gpt-4o",
+				APIBase:     "https://openrouter.ai/api/v1",
+				APIKeyEnv:   "OPENROUTER_API_KEY",
+			},
+		},
+		KnownRouteIDs:      []string{"route-free-pool-free", "route-free-pool-gemini", "route-free-pool-groq", "route-free-pool-groq-2"},
+		KnownGroupNames:    []string{"route-free-pool"},
+		GeneralSettings:    litellmconfig.GeneralSettings{MasterKey: "k"},
+		ExistingConfigPath: configPath,
+	}
+	restarter := &mockRestarter{}
+	require.NoError(t, litellmconfig.WriteAndRestart(context.Background(), configPath, cfg, restarter))
+
+	data, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	var parsed map[string]interface{}
+	require.NoError(t, yaml.Unmarshal(data, &parsed))
+
+	names := map[string]bool{}
+	for _, item := range parsed["model_list"].([]interface{}) {
+		if entry, ok := item.(map[string]interface{}); ok {
+			name, _ := entry["model_name"].(string)
+			names[name] = true
+		}
+	}
+	assert.False(t, names["route-free-pool"], "a fully retired route group's entry must be dropped from the config")
+	assert.True(t, names["integ-operator-managed-entry"], "an entry with no provider_routes row at all must survive")
+	assert.True(t, names["route-some-other-route"])
+}

--- a/apps/control-plane/internal/litellmconfig/generator_test.go
+++ b/apps/control-plane/internal/litellmconfig/generator_test.go
@@ -856,12 +856,13 @@ general_settings:
 
 	cfg := litellmconfig.Config{
 		Models: freePoolEntries(),
-		// route-other is deliberately ABSENT from this set: it models an
-		// operator-managed entry with no provider_routes row at all, which the
-		// merge must preserve verbatim alongside the pooled deployments. (A
-		// name that WERE in this set but generated no entry would be a retired
-		// DB route, and the merge would rightly drop it.)
-		KnownRouteIDs:      []string{"route-free-pool", "route-free-pool-groq", "route-free-pool-groq-2", "route-free-pool-free"},
+		// Exactly what SyncService.Sync produces for a four-member pool: the
+		// members' route_id values, not the shared group name. (route-other is
+		// deliberately ABSENT: it models an operator-managed entry with no
+		// provider_routes row at all, which the merge must preserve verbatim.
+		// A name that WERE in this set but generated no entry would be a
+		// retired DB route, and the merge would rightly drop it.)
+		KnownRouteIDs:      []string{"route-free-pool-free", "route-free-pool-gemini", "route-free-pool-groq", "route-free-pool-groq-2"},
 		GeneralSettings:    litellmconfig.GeneralSettings{MasterKey: "new"},
 		ExistingConfigPath: configPath,
 	}

--- a/apps/control-plane/internal/litellmconfig/service.go
+++ b/apps/control-plane/internal/litellmconfig/service.go
@@ -87,6 +87,7 @@ func (s *SyncService) Sync(ctx context.Context) error {
 
 	var entries []ModelEntry
 	var knownRouteIDs []string
+	var knownGroupNames []string
 	for rows.Next() {
 		var r routeRow
 		var active bool
@@ -95,6 +96,14 @@ func (s *SyncService) Sync(ctx context.Context) error {
 		}
 
 		knownRouteIDs = append(knownRouteIDs, r.RouteID)
+		// Every litellm_model_name in the table is a DB-owned gateway name even
+		// when its row is inactive; without this set, a route GROUP whose
+		// members all go inactive would leave its shared model_list entry
+		// unreclaimable (generatedNames never contains it and neither does
+		// KnownRouteIDs, which holds route_ids).
+		if !knownGroupNamesContains(knownGroupNames, r.ModelName) {
+			knownGroupNames = append(knownGroupNames, r.ModelName)
+		}
 		if !active {
 			continue
 		}
@@ -129,8 +138,9 @@ func (s *SyncService) Sync(ctx context.Context) error {
 	}
 
 	cfg := Config{
-		Models:        entries,
-		KnownRouteIDs: knownRouteIDs,
+		Models:          entries,
+		KnownRouteIDs:   knownRouteIDs,
+		KnownGroupNames: knownGroupNames,
 		GeneralSettings: GeneralSettings{
 			MasterKey: s.masterKey,
 		},
@@ -138,4 +148,16 @@ func (s *SyncService) Sync(ctx context.Context) error {
 	}
 
 	return WriteAndRestart(ctx, s.configPath, cfg, s.restarter)
+}
+
+// knownGroupNamesContains reports whether names already holds name. Group
+// members repeat one shared litellm_model_name across rows, so the list stays
+// tiny; a linear scan beats a map for single-digit sizes.
+func knownGroupNamesContains(names []string, name string) bool {
+	for _, n := range names {
+		if n == name {
+			return true
+		}
+	}
+	return false
 }

--- a/apps/control-plane/internal/litellmconfig/service.go
+++ b/apps/control-plane/internal/litellmconfig/service.go
@@ -16,6 +16,13 @@ type SyncRunner interface {
 // routeRow is a join of provider_routes, custom_providers and
 // provider_capabilities for active routes.
 type routeRow struct {
+	RouteID string
+	// ModelName is provider_routes.litellm_model_name, the model_name key the
+	// generator emits into config.yaml and the only string LiteLLM is
+	// addressed by. Today nearly every row keeps it equal to route_id; rows
+	// that diverge form route groups: N rows sharing one litellm_model_name
+	// emit N deployments under one model_name, which LiteLLM's router
+	// load-balances across with per-deployment cooldown.
 	ModelName   string
 	LiteLLMName string // provider_routes.provider_model — already carries its provider prefix, e.g. "openrouter/openai/gpt-4o-mini"
 	BaseURL     string
@@ -61,7 +68,8 @@ func (s *SyncService) Sync(ctx context.Context) error {
 	// made before supports_embeddings was read at all.
 	rows, err := s.pool.Query(ctx, `
 		SELECT
-			pr.route_id       AS model_name,
+			pr.route_id       AS route_id,
+			pr.litellm_model_name AS model_name,
 			pr.provider_model AS litellm_name,
 			cp.base_url       AS base_url,
 			cp.api_key_env    AS api_key_env,
@@ -82,11 +90,11 @@ func (s *SyncService) Sync(ctx context.Context) error {
 	for rows.Next() {
 		var r routeRow
 		var active bool
-		if err := rows.Scan(&r.ModelName, &r.LiteLLMName, &r.BaseURL, &r.APIKeyEnv, &r.SupportsEmbeddings, &active); err != nil {
+		if err := rows.Scan(&r.RouteID, &r.ModelName, &r.LiteLLMName, &r.BaseURL, &r.APIKeyEnv, &r.SupportsEmbeddings, &active); err != nil {
 			return fmt.Errorf("litellmconfig: sync: scan route: %w", err)
 		}
 
-		knownRouteIDs = append(knownRouteIDs, r.ModelName)
+		knownRouteIDs = append(knownRouteIDs, r.RouteID)
 		if !active {
 			continue
 		}

--- a/apps/control-plane/internal/litellmconfig/sync_integration_test.go
+++ b/apps/control-plane/internal/litellmconfig/sync_integration_test.go
@@ -181,13 +181,14 @@ func TestSyncServiceIntegration(t *testing.T) {
 
 	// -------------------------------------------------------------------------
 	// Step 3b: Assert every seeded active route actually made it into the
-	// generated config, keyed on model_name (route_id) with the exact
-	// litellm_params.model the route was seeded with (provider_model). A
-	// future rename of either source column (the defect this test guards
-	// against, issue #701) makes this fail loudly — either the query errors
-	// before reaching this point, or the seeded route_id/provider_model pair
-	// goes missing/wrong here — instead of silently shipping an empty or
-	// mismatched model_list.
+	// generated config under its litellm_model_name with the exact
+	// litellm_params.model the route was seeded with (provider_model). The
+	// sync emits provider_routes.litellm_model_name as the config's
+	// model_name key; rows where it equals route_id behave exactly as before,
+	// and divergent rows form multi-deployment route groups (see the route
+	// group test below). A future rename of either source column (the defect
+	// this test guards against, issue #701) makes this fail loudly instead of
+	// silently shipping an empty or mismatched model_list.
 	// -------------------------------------------------------------------------
 	byModelName := map[string]map[string]interface{}{}
 	for _, item := range modelList {
@@ -202,22 +203,22 @@ func TestSyncServiceIntegration(t *testing.T) {
 		byModelName[name] = entry
 	}
 
-	wantRoutes := map[string]string{
-		routeID1: providerSlug + "/model-alpha",
-		routeID2: providerSlug + "/model-beta",
+	wantModels := []string{
+		providerSlug + "/model-alpha",
+		providerSlug + "/model-beta",
 	}
-	for routeID, wantProviderModel := range wantRoutes {
-		entry, ok := byModelName[routeID]
+	for _, wantModelName := range wantModels {
+		entry, ok := byModelName[wantModelName]
 		if !ok {
-			t.Fatalf("seeded route %q missing from generated model_list; got model_names: %v", routeID, mapKeys(byModelName))
+			t.Fatalf("seeded route %q missing from generated model_list; got model_names: %v", wantModelName, mapKeys(byModelName))
 		}
 		params, ok := entry["litellm_params"].(map[string]interface{})
 		if !ok {
-			t.Fatalf("route %q: litellm_params missing or wrong type: %#v", routeID, entry["litellm_params"])
+			t.Fatalf("route %q: litellm_params missing or wrong type: %#v", wantModelName, entry["litellm_params"])
 		}
 		gotModel, _ := params["model"].(string)
-		if gotModel != wantProviderModel {
-			t.Errorf("route %q: litellm_params.model = %q, want %q (provider_model)", routeID, gotModel, wantProviderModel)
+		if gotModel != wantModelName {
+			t.Errorf("route %q: litellm_params.model = %q, want %q (provider_model)", wantModelName, gotModel, wantModelName)
 		}
 	}
 
@@ -242,6 +243,82 @@ func TestSyncServiceIntegration(t *testing.T) {
 
 	t.Logf("TestSyncServiceIntegration: YAML written to %s, %d model entries, restarter called %d time(s)",
 		configPath, len(modelList), restarter.calls)
+}
+
+// TestSyncServiceRouteGroupEmitsMultipleDeployments proves the route group
+// shape against a real database: N provider_routes rows that share one
+// litellm_model_name produce N model_list entries under that single
+// model_name, each with its own env-keyed credential. This is the mechanism
+// behind the free pool router (migration 20260824_02): an exhausted key cools
+// down one deployment while LiteLLM's router serves the others.
+func TestSyncServiceRouteGroupEmitsMultipleDeployments(t *testing.T) {
+	pool := connectLiteLLMTestDB(t)
+	ctx := context.Background()
+
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	groupName := "integ-pool-" + suffix
+
+	seedSyncProvider(t, pool, "integ-provider-"+suffix+"-a")
+	seedSyncProvider(t, pool, "integ-provider-"+suffix+"-b")
+
+	// Two routes, different providers, same litellm_model_name. seedSyncRoute
+	// sets litellm_model_name = provider/model, so override it to the shared
+	// group name afterwards; the column is exactly the divergence point the
+	// sync reads.
+	seedSyncRoute(t, pool, "integ-pool-a-"+suffix, "integ-pool-alias-a-"+suffix, "integ-provider-"+suffix+"-a", "model-one")
+	seedSyncRoute(t, pool, "integ-pool-b-"+suffix, "integ-pool-alias-b-"+suffix, "integ-provider-"+suffix+"-b", "model-two")
+	for _, routeID := range []string{"integ-pool-a-" + suffix, "integ-pool-b-" + suffix} {
+		if _, err := pool.Exec(ctx,
+			`UPDATE public.provider_routes SET litellm_model_name = $1 WHERE route_id = $2`,
+			groupName, routeID); err != nil {
+			t.Fatalf("repoint %s to group name: %v", routeID, err)
+		}
+	}
+
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	svc := litellmconfig.NewSyncService(pool, configPath, "test-master-key", &integMockRestarter{})
+	if err := svc.Sync(ctx); err != nil {
+		t.Fatalf("Sync returned error: %v", err)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile config: %v", err)
+	}
+	var parsed map[string]interface{}
+	if err := yaml.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("YAML parse error: %v", err)
+	}
+
+	type deployment struct{ model, apiKey string }
+	got := map[deployment]bool{}
+	for _, item := range parsed["model_list"].([]interface{}) {
+		entry, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if name, _ := entry["model_name"].(string); name != groupName {
+			continue
+		}
+		params, _ := entry["litellm_params"].(map[string]interface{})
+		model, _ := params["model"].(string)
+		apiKey, _ := params["api_key"].(string)
+		got[deployment{model, apiKey}] = true
+	}
+
+	want := map[deployment]bool{
+		{"integ-provider-" + suffix + "-a/model-one", "os.environ/INTEG_TEST_KEY"}: true,
+		{"integ-provider-" + suffix + "-b/model-two", "os.environ/INTEG_TEST_KEY"}: true,
+	}
+	if len(got) != 2 {
+		t.Errorf("route group %q emitted %d distinct deployments (%v), want 2", groupName, len(got), got)
+	}
+	for d := range want {
+		if !got[d] {
+			t.Errorf("route group %q missing deployment %+v", groupName, d)
+		}
+	}
 }
 
 // TestSyncRemovesRetiredRouteFromExistingConfig is the live-DB half of the

--- a/apps/control-plane/internal/routing/catalog_pricing_integration_test.go
+++ b/apps/control-plane/internal/routing/catalog_pricing_integration_test.go
@@ -69,15 +69,19 @@ func connectCatalogDB(t *testing.T) *pgxpool.Pool {
 // lands. Anything NOT listed here is held to the rule.
 var pendingMultiRouteAliases = map[string]string{
 	"hive-embedding-default": "issue #617 follow-up: embedding route choice is coupled to the provisioned vector width (D-001)",
-	// The free pool (20260824_02_free_pool_router.sql) is multi-route BY
-	// DESIGN, not pending a fix: its four member rows share one
-	// litellm_model_name, so whichever member selection picks dispatches the
-	// same load-balanced LiteLLM group at the alias's single price. The D-032
-	// ambiguity this test guards (one price, unclear upstream cost) does not
-	// arise when every member serves under one gateway name. Listed here so
-	// the count is reported rather than failed; if the pool ever collapses to
-	// one row, this entry must be removed.
-	"hive-free": "free pool router: four deployments share litellm_model_name 'route-free-pool' by design",
+}
+
+// expectedMultiRouteAliases are aliases that legitimately carry MORE than one
+// enabled route, with the EXACT count required. The free pool
+// (20260824_02_free_pool_router.sql) puts four deployments behind one alias on
+// purpose: all four rows share litellm_model_name 'route-free-pool', so
+// whichever member SelectRoute picks dispatches the same load-balanced gateway
+// group at the alias's single fixed price. The D-032 ambiguity this file guards
+// (one price, unclear upstream cost) cannot arise when every member serves
+// under one gateway name at one catalog price. A member added or removed
+// without updating the expected count fails here loudly.
+var expectedMultiRouteAliases = map[string]int{
+	"hive-free": 4,
 }
 
 // TestSeededAliasHasExactlyOneEnabledRoute enforces the owner's rule: one
@@ -117,6 +121,12 @@ func TestSeededAliasHasExactlyOneEnabledRoute(t *testing.T) {
 		if reason, pending := pendingMultiRouteAliases[aliasID]; pending {
 			if enabled == 1 {
 				t.Errorf("alias %s now has exactly 1 enabled route; drop it from pendingMultiRouteAliases (%s)", aliasID, reason)
+			}
+			continue
+		}
+		if want, multi := expectedMultiRouteAliases[aliasID]; multi {
+			if enabled != want {
+				t.Errorf("alias %s has %d enabled routes, want exactly %d (the free pool's member rows; update expectedMultiRouteAliases if the pool changed)", aliasID, enabled, want)
 			}
 			continue
 		}

--- a/apps/control-plane/internal/routing/catalog_pricing_integration_test.go
+++ b/apps/control-plane/internal/routing/catalog_pricing_integration_test.go
@@ -69,6 +69,15 @@ func connectCatalogDB(t *testing.T) *pgxpool.Pool {
 // lands. Anything NOT listed here is held to the rule.
 var pendingMultiRouteAliases = map[string]string{
 	"hive-embedding-default": "issue #617 follow-up: embedding route choice is coupled to the provisioned vector width (D-001)",
+	// The free pool (20260824_02_free_pool_router.sql) is multi-route BY
+	// DESIGN, not pending a fix: its four member rows share one
+	// litellm_model_name, so whichever member selection picks dispatches the
+	// same load-balanced LiteLLM group at the alias's single price. The D-032
+	// ambiguity this test guards (one price, unclear upstream cost) does not
+	// arise when every member serves under one gateway name. Listed here so
+	// the count is reported rather than failed; if the pool ever collapses to
+	// one row, this entry must be removed.
+	"hive-free": "free pool router: four deployments share litellm_model_name 'route-free-pool' by design",
 }
 
 // TestSeededAliasHasExactlyOneEnabledRoute enforces the owner's rule: one

--- a/apps/control-plane/internal/routing/free_pool_router_test.go
+++ b/apps/control-plane/internal/routing/free_pool_router_test.go
@@ -84,6 +84,24 @@ func TestFreePoolRoutesShareOneLitellmModelName(t *testing.T) {
 	if shared != len(freePoolMembers) {
 		t.Errorf("%d inserted rows share the group name %q, want exactly %d", shared, freePoolGroupName, len(freePoolMembers))
 	}
+
+	// Every member references the alias: provider_routes.alias_id is NOT NULL
+	// with a non-deferrable FK to model_aliases (20260331_02), so a NULL member
+	// would abort this migration on apply.
+	for routeID := range freePoolMembers {
+		if got := byRoute[routeID]["alias_id"]; got != "hive-free" {
+			t.Errorf("pool member %s carries alias_id %q; the column is NOT NULL and every member belongs to hive-free", routeID, got)
+		}
+	}
+
+	// Statement order: the alias row must be inserted BEFORE the routes that
+	// reference it. Index comparison over the comment-stripped SQL.
+	lower := strings.ToLower(freePoolMigrationSQL(t))
+	aliasAt := strings.Index(lower, "insert into public.model_aliases")
+	routesAt := strings.Index(lower, "insert into public.provider_routes")
+	if aliasAt < 0 || routesAt < 0 || aliasAt > routesAt {
+		t.Errorf("the hive-free alias insert must precede the provider_routes inserts (non-deferrable FK); alias at %d, routes at %d", aliasAt, routesAt)
+	}
 }
 
 // TestFreePoolUpstreamModelsAreTheVerifiedOnes pins each member's upstream so a

--- a/apps/control-plane/internal/routing/free_pool_router_test.go
+++ b/apps/control-plane/internal/routing/free_pool_router_test.go
@@ -1,0 +1,457 @@
+package routing
+
+import (
+	"strings"
+	"testing"
+)
+
+// Offline guards over the 2026-08-24 free pool router migration.
+//
+// Three things are pinned here, all positional in the style sqlparse_test.go
+// documents:
+//
+//  1. The pool shape: four provider_routes rows sharing ONE
+//     litellm_model_name, which is what makes the config sync emit four
+//     LiteLLM deployments under one model_name and what makes an exhausted
+//     key fail over instead of taking the alias down.
+//  2. The money: hive-free's small service price (a price NOT derived from a
+//     provider rate, because every pool member costs zero, so the DERIVE
+//     margin formula cannot apply), hive-default's move onto the deepseek
+//     rates already in the catalog carried through the rescale factor, and
+//     hive-auto's switch to pricing_mode 'upstream_actual' with NULL prices
+//     and a bounded hold.
+//  3. Part C of the directive: CI and daily automated consumption point at
+//     hive-free rather than a paid or dots-free alias.
+
+const freePoolMigrationRelPath = "supabase/migrations/20260824_02_free_pool_router.sql"
+
+const freePoolGroupName = "route-free-pool"
+
+// freePoolMembers are the four deployments that must share the group name,
+// keyed to the provider slug each row routes through.
+var freePoolMembers = map[string]string{
+	"route-free-pool-free":   "openrouter",
+	"route-free-pool-gemini": "gemini",
+	"route-free-pool-groq":   "groq",
+	"route-free-pool-groq-2": "groq-2",
+}
+
+func freePoolMigrationSQL(t *testing.T) string {
+	t.Helper()
+	return stripSQLComments(readRepoFile(t, freePoolMigrationRelPath))
+}
+
+func freePoolRouteRows(t *testing.T) map[string]map[string]string {
+	t.Helper()
+	byRoute := map[string]map[string]string{}
+	for _, row := range insertRows(freePoolMigrationSQL(t), "public.provider_routes") {
+		byRoute[row["route_id"]] = row
+	}
+	return byRoute
+}
+
+// TestFreePoolRoutesShareOneLitellmModelName is the load-balancing invariant.
+// litellm_model_name is the model_name key in deploy/litellm/config.yaml and
+// the only string dispatch addresses; N rows sharing it is the whole router.
+func TestFreePoolRoutesShareOneLitellmModelName(t *testing.T) {
+	byRoute := freePoolRouteRows(t)
+
+	for routeID, wantProvider := range freePoolMembers {
+		row, ok := byRoute[routeID]
+		if !ok {
+			t.Errorf("%s inserts no pool member route %s", freePoolMigrationRelPath, routeID)
+			continue
+		}
+		if row["provider"] != wantProvider {
+			t.Errorf("route %s provider = %q, want %q", routeID, row["provider"], wantProvider)
+		}
+		if row["litellm_model_name"] != freePoolGroupName {
+			t.Errorf("route %s litellm_model_name = %q, want the shared group name %q; a divergent name would leave that deployment out of the load-balanced pool", routeID, row["litellm_model_name"], freePoolGroupName)
+		}
+		if row["health_state"] != "healthy" {
+			t.Errorf("route %s health_state = %q, want healthy; every key slot must serve from birth", routeID, row["health_state"])
+		}
+	}
+
+	// Exactly four rows carry the group name. A fifth sharing it silently joins
+	// the pool; one missing shrinks it without any error anywhere.
+	shared := 0
+	for _, row := range insertRows(freePoolMigrationSQL(t), "public.provider_routes") {
+		if row["litellm_model_name"] == freePoolGroupName {
+			shared++
+		}
+	}
+	if shared != len(freePoolMembers) {
+		t.Errorf("%d inserted rows share the group name %q, want exactly %d", shared, freePoolGroupName, len(freePoolMembers))
+	}
+}
+
+// TestFreePoolUpstreamModelsAreTheVerifiedOnes pins each member's upstream so a
+// typo cannot quietly change what the pool serves or what it costs.
+func TestFreePoolUpstreamModelsAreTheVerifiedOnes(t *testing.T) {
+	want := map[string]string{
+		"route-free-pool-free":   "openrouter/dots-studio/dots-3-note-preview:free",
+		"route-free-pool-gemini": "openai/gemini-flash-latest",
+		"route-free-pool-groq":   "groq/openai/gpt-oss-20b",
+		"route-free-pool-groq-2": "groq/openai/gpt-oss-20b",
+	}
+	byRoute := freePoolRouteRows(t)
+
+	for routeID, wantModel := range want {
+		row, ok := byRoute[routeID]
+		if !ok {
+			t.Errorf("no pool member route %s", routeID)
+			continue
+		}
+		if row["provider_model"] != wantModel {
+			t.Errorf("route %s provider_model = %q, want %q", routeID, row["provider_model"], wantModel)
+		}
+	}
+
+	// The :free suffix is load-bearing on the OpenRouter member: without it the
+	// slug selects a PAID endpoint of the same model.
+	dots := byRoute["route-free-pool-free"]["provider_model"]
+	if !strings.HasSuffix(dots, ":free") {
+		t.Errorf("pool's OpenRouter member %q lost its :free suffix; that selects a PAID endpoint", dots)
+	}
+
+	// The Gemini member goes through the generic openai/ adapter, which the
+	// generator refuses to emit without a non-empty api_base; the base comes
+	// from the custom_providers row checked below.
+	gemini := byRoute["route-free-pool-gemini"]
+	if !strings.HasPrefix(gemini["provider_model"], "openai/") {
+		t.Errorf("gemini member provider_model = %q, want the openai/ adapter form the verified live path uses", gemini["provider_model"])
+	}
+}
+
+// TestFreePoolKeySlotsAreEnvNamed proves credentials travel as ENV NAMES only.
+// No key VALUE may ever appear in this migration; the two new slots must name
+// their environment variables explicitly.
+func TestFreePoolKeySlotsAreEnvNamed(t *testing.T) {
+	sql := freePoolMigrationSQL(t)
+
+	bySlug := map[string]map[string]string{}
+	for _, row := range insertRows(sql, "public.custom_providers") {
+		bySlug[row["slug"]] = row
+	}
+
+	wantEnv := map[string]string{
+		"groq-2": "GROQ_API_KEY_2",
+		"gemini": "GEMINI_API_KEY",
+	}
+	for slug, envName := range wantEnv {
+		row, ok := bySlug[slug]
+		if !ok {
+			t.Errorf("%s inserts no custom_providers row for slug %q", freePoolMigrationRelPath, slug)
+			continue
+		}
+		if row["api_key_env"] != envName {
+			t.Errorf("custom_providers %q api_key_env = %q, want %q", slug, row["api_key_env"], envName)
+		}
+	}
+
+	// The gemini base_url is what makes the generic openai/ adapter mean
+	// Google's official OpenAI-compatible endpoint rather than OpenAI itself;
+	// pointing at api.openai.com would send GEMINI_API_KEY upstream to the
+	// wrong vendor, which is exactly the failure the generator's guard exists
+	// for.
+	if base := bySlug["gemini"]["base_url"]; !strings.Contains(base, "generativelanguage.googleapis.com") {
+		t.Errorf("custom_providers 'gemini' base_url = %q, want Google's Generative Language endpoint", base)
+	}
+}
+
+// TestHiveFreePriceIsTheSmallServicePrice pins the owner-directed service
+// price: 1,000,000 credits input / 4,000,000 output per million tokens, i.e.
+// $0.001 / $0.004 at the current 1 USD = 1e9 credits unit. There is no DERIVE
+// row for these figures and there cannot be one: parseRate rejects a $0.00
+// rate ("a mispricing, not a rate"), and every pool upstream costs zero. This
+// price covers gateway serving cost; it is asserted literally instead.
+func TestHiveFreePriceIsTheSmallServicePrice(t *testing.T) {
+	var row map[string]string
+	for _, r := range insertRows(freePoolMigrationSQL(t), "public.model_aliases") {
+		if r["alias_id"] == "hive-free" {
+			row = r
+		}
+	}
+	if row == nil {
+		t.Fatalf("%s inserts no hive-free alias", freePoolMigrationRelPath)
+	}
+
+	want := map[string]string{
+		"input_price_credits":       "1000000",
+		"output_price_credits":      "4000000",
+		"cache_read_price_credits":  "0",
+		"cache_write_price_credits": "0",
+	}
+	for col, expect := range want {
+		if got := strings.TrimSpace(row[col]); got != expect {
+			t.Errorf("hive-free %s = %q, want %s", col, got, expect)
+		}
+	}
+
+	// Fail-closed: a zero on a billed column would serve that token class for
+	// nothing (the D-034 shape).
+	for _, col := range billedColumns {
+		if got := strings.TrimSpace(row[col]); got == "0" {
+			t.Errorf("hive-free %s = 0; routing refuses an unpriced alias, but if it ever served, it would bill nothing", col)
+		}
+	}
+}
+
+// TestHiveAutoMovesToUpstreamActual checks the variable-pricing flip: mode
+// upstream_actual, all four fixed price columns NULL, and a real hold. The
+// hold matches the internal openrouter-auto alias after the rescale (200000 x
+// 10000); the shape CHECK from 20260822_30 rejects any other combination.
+func TestHiveAutoMovesToUpstreamActual(t *testing.T) {
+	assigns, ok := updateAssignments(freePoolMigrationSQL(t), "public.model_aliases", "alias_id")["hive-auto"]
+	if !ok {
+		t.Fatalf("%s writes no model_aliases row for hive-auto", freePoolMigrationRelPath)
+	}
+
+	if got := strings.Trim(strings.TrimSpace(assigns["pricing_mode"]), "'"); got != "upstream_actual" {
+		t.Errorf("hive-auto pricing_mode = %s, want 'upstream_actual'", got)
+	}
+	for _, col := range []string{
+		"input_price_credits",
+		"output_price_credits",
+		"cache_read_price_credits",
+		"cache_write_price_credits",
+	} {
+		if got := strings.TrimSpace(assigns[col]); !strings.EqualFold(got, "null") {
+			t.Errorf("hive-auto %s = %s, want null; a stale number under upstream_actual is displayed as a price nothing charges", col, got)
+		}
+	}
+	if got := strings.TrimSpace(assigns["reservation_estimate_credits"]); got != "2000000000" {
+		t.Errorf("hive-auto reservation_estimate_credits = %s, want 2000000000 (the rescaled openrouter-auto hold)", got)
+	}
+}
+
+// TestHiveDefaultRepriceMatchesTheDeepseekRatesAlreadyInCatalog carries the
+// 2026-08-22 DERIVE figures through the 10,000x rescale rather than fetching
+// anything new: same upstream model deepseek-v4-flash already serves, same
+// rate card, current unit.
+func TestHiveDefaultRepriceMatchesTheDeepseekRatesAlreadyInCatalog(t *testing.T) {
+	assigns, ok := updateAssignments(freePoolMigrationSQL(t), "public.model_aliases", "alias_id")["hive-default"]
+	if !ok {
+		t.Fatalf("%s reprices no columns on hive-default", freePoolMigrationRelPath)
+	}
+
+	// DERIVE figures from 20260822_02 for deepseek-v4-flash, multiplied by the
+	// 20260823_40 rescale factor of 10,000 into the current unit.
+	want := map[string]string{
+		"input_price_credits":       "89460000",
+		"output_price_credits":      "178920000",
+		"cache_read_price_credits":  "17900000",
+		"cache_write_price_credits": "0",
+	}
+	for col, expect := range want {
+		got := strings.TrimSpace(assigns[col])
+		if got == "" {
+			t.Errorf("hive-default %s is not assigned by this migration", col)
+			continue
+		}
+		if got != expect {
+			t.Errorf("hive-default %s = %s, want %s (pre-rescale figure x 10000)", col, got, expect)
+		}
+	}
+}
+
+// TestRetiredFreeRoutesAreDisabledAndPoliciesFollow makes sure no alias is left
+// pointing at a disabled route and no policy names one either.
+func TestRetiredFreeRoutesAreDisabledAndPoliciesFollow(t *testing.T) {
+	sql := freePoolMigrationSQL(t)
+
+	retired := []string{"route-free-auto", "route-free-default"}
+	for _, routeID := range retired {
+		disabled := false
+		for _, stmt := range splitStatements(sql) {
+			if disableRe.MatchString(strings.TrimSpace(stmt)) && strings.Contains(stmt, "'"+routeID+"'") {
+				disabled = true
+				break
+			}
+		}
+		if !disabled {
+			t.Errorf("%s does not disable %s; its alias would have two enabled routes and an ambiguous price", freePoolMigrationRelPath, routeID)
+		}
+	}
+
+	pinned := map[string]string{
+		"hive-auto":    "route-openrouter-auto-live",
+		"hive-default": "route-deepseek-v4-flash-default",
+	}
+	policies := updateAssignments(sql, "public.alias_route_policies", "alias_id")
+	for alias, routeID := range pinned {
+		assigns, ok := policies[alias]
+		if !ok {
+			t.Errorf("alias %s: fallback_order is not repointed", alias)
+			continue
+		}
+		order := assigns["fallback_order"]
+		if !strings.Contains(order, routeID) {
+			t.Errorf("alias %s: fallback_order = %q, want it to name %s", alias, order, routeID)
+		}
+		for _, retiredRoute := range retired {
+			if strings.Contains(order, retiredRoute) {
+				t.Errorf("alias %s: fallback_order still names disabled route %s", alias, retiredRoute)
+			}
+		}
+	}
+
+	// hive-free is a NEW alias, so its policy arrives as an INSERT rather than
+	// an UPDATE; the same no-disabled-route rule applies.
+	var freeOrder string
+	for _, row := range insertRows(sql, "public.alias_route_policies") {
+		if row["alias_id"] == "hive-free" {
+			freeOrder = row["fallback_order"]
+		}
+	}
+	if !strings.Contains(freeOrder, "route-free-pool-free") {
+		t.Errorf("hive-free policy fallback_order = %q, want it to name route-free-pool-free", freeOrder)
+	}
+	for _, retiredRoute := range retired {
+		if strings.Contains(freeOrder, retiredRoute) {
+			t.Errorf("hive-free policy names disabled route %s", retiredRoute)
+		}
+	}
+}
+
+// TestFreePoolDisablingRouteFreeAutoHandsOnTheSoleCarrierFlags is this
+// migration's instance of the sole-carrier rule: route-free-auto is today the
+// only catalog carrier of the batch/image flags, and disabling it without a
+// successor deletes /v1/batches and both image endpoints for every alias.
+func TestFreePoolDisablingRouteFreeAutoHandsOnTheSoleCarrierFlags(t *testing.T) {
+	sql := freePoolMigrationSQL(t)
+
+	disabled := false
+	for _, stmt := range splitStatements(sql) {
+		if disableRe.MatchString(strings.TrimSpace(stmt)) && strings.Contains(stmt, "'route-free-auto'") {
+			disabled = true
+			break
+		}
+	}
+	if !disabled {
+		t.Skip("route-free-auto is not disabled by this migration, so its capabilities are not at risk")
+	}
+
+	caps := insertRows(sql, "public.provider_capabilities")
+	if len(caps) == 0 {
+		t.Fatal("route-free-auto is disabled but this migration grants its flags to no replacement capabilities row")
+	}
+	for _, flag := range soleCarrierFlags {
+		granted := false
+		for _, row := range caps {
+			if strings.EqualFold(row[flag], "true") {
+				granted = true
+				break
+			}
+		}
+		if !granted {
+			t.Errorf("this migration disables route-free-auto, the only route carrying %s, and grants it to no replacement; that endpoint dies catalog-wide", flag)
+		}
+	}
+}
+
+// TestPoolCapabilitiesKeepToolsFalse pins the honesty claim: cross-provider
+// tool parity was never probed across the four members, so tools_supported
+// stays false on every pool row and tool traffic stays on the aliases that
+// verified it. supports_reasoning stays true (an under-claim on a pinned alias
+// is a 422, not a withheld feature), and embeddings stay false (chat models).
+func TestPoolCapabilitiesKeepToolsFalse(t *testing.T) {
+	caps := map[string]map[string]string{}
+	for _, row := range insertRows(freePoolMigrationSQL(t), "public.provider_capabilities") {
+		caps[row["route_id"]] = row
+	}
+
+	for routeID := range freePoolMembers {
+		row, ok := caps[routeID]
+		if !ok {
+			t.Errorf("%s inserts no provider_capabilities row for %s; column defaults are all false and every endpoint would 422", freePoolMigrationRelPath, routeID)
+			continue
+		}
+		if strings.EqualFold(row["tools_supported"], "true") {
+			t.Errorf("pool route %s claims tools_supported; cross-provider parity was never verified, keep the claim off until it is probed", routeID)
+		}
+		if !strings.EqualFold(row["supports_reasoning"], "true") {
+			t.Errorf("pool route %s drops supports_reasoning; reasoning requests against the pinned alias would 422", routeID)
+		}
+		if strings.EqualFold(row["supports_embeddings"], "true") {
+			t.Errorf("pool route %s claims supports_embeddings; this is a chat pool", routeID)
+		}
+		for _, flag := range soleCarrierFlags {
+			if strings.EqualFold(row[flag], "true") {
+				t.Errorf("pool route %s claims media flag %s; those live on the auto-router successor, not in the pool", routeID, flag)
+			}
+		}
+	}
+
+	// The deepseek mirror keeps the tool parity hive-default is moved here for.
+	ds := caps["route-deepseek-v4-flash-default"]
+	if ds == nil {
+		t.Fatalf("no capabilities row for route-deepseek-v4-flash-default")
+	}
+	if !strings.EqualFold(ds["tools_supported"], "true") {
+		t.Errorf("route-deepseek-v4-flash-default loses tools_supported; hive-default's tool-parity story dies")
+	}
+	if !strings.EqualFold(ds["supports_cache_read"], "true") {
+		t.Errorf("route-deepseek-v4-flash-default drops supports_cache_read; its source row declares it true")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PART C guards: CI and automated consumption defaults point at hive-free.
+// ---------------------------------------------------------------------------
+
+var citestDefaultChecks = []struct {
+	name     string
+	relPath  string
+	mustHave string
+	mustNot  string
+}{
+	{
+		name:     "ci.yml live-integration default",
+		relPath:  ".github/workflows/ci.yml",
+		mustHave: `vars.CI_LIVE_INTEGRATION_MODEL || 'hive-free'`,
+		mustNot:  `vars.CI_LIVE_INTEGRATION_MODEL || 'deepseek-v4-pro'`,
+	},
+	{
+		name:     "deploy-demo-box sdk-replay default",
+		relPath:  ".github/workflows/deploy-demo-box.yml",
+		mustHave: "HIVE_TEST_MODEL: hive-free",
+		mustNot:  "HIVE_TEST_MODEL: hive-default",
+	},
+	{
+		name:     "js chat-completions fallback",
+		relPath:  "packages/sdk-tests/js/tests/chat-completions/chat-completions.test.ts",
+		mustHave: `?? "hive-free"`,
+		mustNot:  `?? "hive-default"`,
+	},
+	{
+		name:     "python chat-completions fallback",
+		relPath:  "packages/sdk-tests/python/tests/test_chat_completions.py",
+		mustHave: `"hive-free")`,
+		mustNot:  `"hive-default")`,
+	},
+	{
+		name:     "post-deploy-verify default",
+		relPath:  "scripts/post-deploy-verify.py",
+		mustHave: `os.environ.get("HIVE_VERIFY_MODEL", "hive-free")`,
+		mustNot:  `os.environ.get("HIVE_VERIFY_MODEL", "hive-default")`,
+	},
+}
+
+// TestCITestDefaultsPointAtTheFreeAlias holds part C of the directive where it
+// can be checked offline: every automated consumption surface defaults to
+// hive-free, and none still defaults to a paid or dots-only alias. The
+// CI_LIVE_INTEGRATION_MODEL repository variable remains the override knob in
+// every case.
+func TestCITestDefaultsPointAtTheFreeAlias(t *testing.T) {
+	for _, tc := range citestDefaultChecks {
+		body := readRepoFile(t, tc.relPath)
+		if !strings.Contains(body, tc.mustHave) {
+			t.Errorf("%s: %q is missing from %s", tc.name, tc.mustHave, tc.relPath)
+		}
+		if tc.mustNot != "" && strings.Contains(body, tc.mustNot) {
+			t.Errorf("%s: %q is still present in %s", tc.name, tc.mustNot, tc.relPath)
+		}
+	}
+}

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -221,6 +221,11 @@ services:
       LITELLM_MASTER_KEY: ${LITELLM_MASTER_KEY:-litellm-dev-key}
       OPENROUTER_API_KEY: ${OPENROUTER_API_KEY}
       GROQ_API_KEY: ${GROQ_API_KEY}
+      # Free pool key slots (migration 20260824_02_free_pool_router.sql): the
+      # config's os.environ/ references resolve inside THIS container, so each
+      # slot must be forwarded here or its deployment fails at request time.
+      GROQ_API_KEY_2: ${GROQ_API_KEY_2}
+      GEMINI_API_KEY: ${GEMINI_API_KEY}
       OPENROUTER_DEFAULT_MODEL: ${OPENROUTER_DEFAULT_MODEL}
       OPENROUTER_AUTO_MODEL: ${OPENROUTER_AUTO_MODEL}
       OPENROUTER_FAST_FALLBACK_MODEL: ${OPENROUTER_FAST_FALLBACK_MODEL}

--- a/packages/sdk-tests/js/tests/chat-completions/chat-completions.test.ts
+++ b/packages/sdk-tests/js/tests/chat-completions/chat-completions.test.ts
@@ -3,7 +3,7 @@ import OpenAI from "openai";
 
 const BASE_URL = process.env.HIVE_BASE_URL ?? "http://localhost:8080/v1";
 const API_KEY = process.env.HIVE_API_KEY ?? "test-key";
-const MODEL = process.env.HIVE_TEST_MODEL ?? "hive-default";
+const MODEL = process.env.HIVE_TEST_MODEL ?? "hive-free";
 
 describe("Chat Completions", () => {
   const client = new OpenAI({ baseURL: BASE_URL, apiKey: API_KEY });

--- a/packages/sdk-tests/js/tests/completions/completions.test.ts
+++ b/packages/sdk-tests/js/tests/completions/completions.test.ts
@@ -3,7 +3,7 @@ import OpenAI from "openai";
 
 const BASE_URL = process.env.HIVE_BASE_URL ?? "http://localhost:8080/v1";
 const API_KEY = process.env.HIVE_API_KEY ?? "test-key";
-const MODEL = process.env.HIVE_TEST_MODEL ?? "hive-default";
+const MODEL = process.env.HIVE_TEST_MODEL ?? "hive-free";
 
 describe("Completions (legacy)", () => {
   const client = new OpenAI({ baseURL: BASE_URL, apiKey: API_KEY });

--- a/packages/sdk-tests/js/tests/responses/responses.test.ts
+++ b/packages/sdk-tests/js/tests/responses/responses.test.ts
@@ -3,22 +3,24 @@ import OpenAI from "openai";
 
 const BASE_URL = process.env.HIVE_BASE_URL ?? "http://localhost:8080/v1";
 const API_KEY = process.env.HIVE_API_KEY ?? "test-key";
-const MODEL = process.env.HIVE_TEST_MODEL ?? "hive-default";
+const MODEL = process.env.HIVE_TEST_MODEL ?? "hive-free";
 
 // Known reasoning model identifiers — skip the reasoning-parameter rejection
 // test for these, because the edge routes that parameter on
 // provider_capabilities.supports_reasoning and these aliases have it true, so
 // there is no rejection to assert.
 //
-// The Groq gpt-oss aliases (`hive-default`, `hive-auto`, `hive-small`,
-// `hive-medium`, and the deprecated `hive-fast`) accept reasoning parameters
-// natively, and every one of them is seeded supports_reasoning true. Listing
-// all five rather than the two this suite is usually pointed at, because
-// HIVE_TEST_MODEL is a knob and a run pointed at any of them would otherwise
-// assert a rejection that cannot happen. (An older comment here explained the
-// first two by a LiteLLM fallback cascade; those chat fallbacks were removed
-// from deploy/litellm/config.yaml by the 2026-08-22 catalog restructure, and
-// the flag on the route is the actual reason.)
+// The free pool alias (`hive-free`, migration
+// 20260824_02_free_pool_router.sql) is seeded supports_reasoning true: every
+// member of its load-balanced pool accepts reasoning parameters without
+// failing, even where the knob modulates little.
+//
+// `hive-default` and `hive-auto` are listed because HIVE_TEST_MODEL is a knob
+// and an override run pointed at either would otherwise assert a rejection
+// that cannot happen: hive-default now serves deepseek-v4-flash and hive-auto
+// serves the OpenRouter Auto Router (both seeded supports_reasoning true),
+// which retires the old "Groq gpt-oss aliases" explanation those five entries
+// carried.
 //
 // `deepseek` covers deepseek-v4-flash and deepseek-v4-pro. Not an accommodation
 // for CI: supabase/migrations/20260822_02_catalog_alias_restructure.sql seeds
@@ -28,6 +30,7 @@ const REASONING_MODEL_PATTERNS = [
   "o1",
   "o3",
   "reasoning",
+  "hive-free",
   "hive-default",
   "hive-auto",
   "hive-small",

--- a/packages/sdk-tests/js/tests/streaming/streaming-chat.test.ts
+++ b/packages/sdk-tests/js/tests/streaming/streaming-chat.test.ts
@@ -3,7 +3,7 @@ import OpenAI from "openai";
 
 const BASE_URL = process.env.HIVE_BASE_URL ?? "http://localhost:8080/v1";
 const API_KEY = process.env.HIVE_API_KEY ?? "test-key";
-const MODEL = process.env.HIVE_TEST_MODEL ?? "hive-default";
+const MODEL = process.env.HIVE_TEST_MODEL ?? "hive-free";
 
 describe("Streaming Chat Completions", () => {
   const client = new OpenAI({ baseURL: BASE_URL, apiKey: API_KEY });

--- a/packages/sdk-tests/python/tests/test_chat_completions.py
+++ b/packages/sdk-tests/python/tests/test_chat_completions.py
@@ -5,7 +5,7 @@ from openai import OpenAI
 
 BASE_URL = os.getenv("HIVE_BASE_URL", "http://localhost:8080/v1")
 API_KEY = os.getenv("HIVE_API_KEY", "test-key")
-MODEL = os.getenv("HIVE_TEST_MODEL", "hive-default")
+MODEL = os.getenv("HIVE_TEST_MODEL", "hive-free")
 
 
 @pytest.fixture

--- a/scripts/post-deploy-verify.py
+++ b/scripts/post-deploy-verify.py
@@ -60,10 +60,14 @@ Required env for the `signin` and `ledger` checks only:
     whole gate going dark on a missing credential.
 
 Optional env:
-    HIVE_VERIFY_MODEL          default hive-default. post-deploy-verify.yml
-                               passes it through from the box .env when set
-                               there, so the gate's billed completion can use
-                               a paid alias instead of hive-default
+    HIVE_VERIFY_MODEL          default hive-free, the free-pool alias: daily
+                               automated consumption belongs there, not on a
+                               paid tier (migration
+                               20260824_02_free_pool_router.sql).
+                               post-deploy-verify.yml passes it through from
+                               the box .env when set there, so the gate's
+                               billed completion can be pointed anywhere else
+                               without touching this file
     HIVE_VERIFY_LEDGER_TIMEOUT default 90 (seconds to step-poll for the charge)
     HIVE_VERIFY_LEDGER_PAGES   default 20 (page cap on the ledger scan)
     HIVE_VERIFY_COMPLETION_ATTEMPTS  default 3 (upstream 429/5xx retries on the
@@ -114,7 +118,7 @@ USER_AGENT = "hive-post-deploy-verify/1 (+https://github.com/sakibsadmanshajib/h
 # else, before any request is sent: see the Required env note in the module
 # docstring for why none of these carries a default.
 CHAT = CP = EDGE = ""
-MODEL = os.environ.get("HIVE_VERIFY_MODEL", "hive-default").strip() or "hive-default"
+MODEL = os.environ.get("HIVE_VERIFY_MODEL", "hive-free").strip() or "hive-free"
 LEDGER_TIMEOUT = float(os.environ.get("HIVE_VERIFY_LEDGER_TIMEOUT", "90"))
 LEDGER_PAGES = int(os.environ.get("HIVE_VERIFY_LEDGER_PAGES", "20"))
 LEDGER_PAGE_SIZE = 500

--- a/scripts/verify-control-plane.py
+++ b/scripts/verify-control-plane.py
@@ -185,7 +185,7 @@ def main() -> None:
         key_auth = {"Authorization": f"Bearer {secret}", "Content-Type": "application/json"}
         check("GET", "/v1/models", key_auth, (200,), base=EDGE)
         check("POST", "/v1/chat/completions", key_auth, (200,),
-              {"model": "hive-default", "messages": [{"role": "user", "content": "say pong"}],
+              {"model": "hive-free", "messages": [{"role": "user", "content": "say pong"}],
                "max_tokens": 16}, base=EDGE)
     else:
         failures.append("api-key create returned no secret, key auth chain not exercised")

--- a/supabase/migrations/20260824_02_free_pool_router.sql
+++ b/supabase/migrations/20260824_02_free_pool_router.sql
@@ -1,0 +1,329 @@
+-- =============================================================================
+-- The Free Pool Router and the last two catalog repoints (owner directive,
+-- 2026-08-24, plus the coordinator scope extension of the same day).
+--
+-- WHAT CHANGES, IN THREE PARTS
+--
+--   PART A. THE FREE POOL
+--   * hive-free          NEW. The product's free-tier serving alias. Pinned to
+--                        a ROUTE GROUP: four provider_routes rows that share
+--                        one litellm_model_name ('route-free-pool'), which the
+--                        config sync emits as four deployments under ONE
+--                        model_name in deploy/litellm/config.yaml. LiteLLM's
+--                        router load-balances across them and cools a failing
+--                        deployment down (litellm_settings.cooldown_time 30 /
+--                        allowed_fails 3 / router_settings.retry_policy, all
+--                        already shipped in the seed config and preserved
+--                        verbatim by the merge), so one exhausted key fails
+--                        over to the others instead of taking the alias down.
+--                        This is the OpenRouter-style free router, built from
+--                        our own free provider keys.
+--   * Members, in emission order (ORDER BY route_id):
+--       route-free-pool-free    openrouter dots-studio/dots-3-note-preview:free
+--                               (OPENROUTER_API_KEY) -- canonical row carrying
+--                               alias_id 'hive-free'
+--       route-free-pool-gemini  gemini-flash-latest through LiteLLM's generic
+--                               openai/ adapter against Google's official
+--                               OpenAI-compatible endpoint (GEMINI_API_KEY).
+--                               The owner verified this exact path live on
+--                               2026-08-23 (gemini-2.0-flash is retired
+--                               upstream; gemini-flash-latest answers 200).
+--       route-free-pool-groq    groq/openai/gpt-oss-20b (GROQ_API_KEY)
+--       route-free-pool-groq-2  groq/openai/gpt-oss-20b (GROQ_API_KEY_2) --
+--                               the second Groq key arrived and was verified
+--                               live (gpt-oss-20b answers 200) before this
+--                               file shipped, so it is ACTIVE from birth, not
+--                               a commented placeholder.
+--
+--   PART B. THE TWO REPOINTS (coordinator directive)
+--   * hive-auto     leaves the dots free route and becomes the REAL OpenRouter
+--                   Auto Router: openrouter/openrouter/auto, billed at ACTUAL
+--                   upstream cost exactly like the internal openrouter-auto
+--                   alias (pricing_mode 'upstream_actual', prices NULL,
+--                   reservation hold 2000000000 credits = 2.00 USD at the
+--                   current 1e9 unit). Slug verified live against
+--                   https://openrouter.ai/api/v1/models on 2026-08-24:
+--                   both 'openrouter/auto' and 'openrouter/auto-beta' exist,
+--                   each reports pricing prompt/completion -1 (variable by
+--                   construction) and lists tools, tool_choice,
+--                   response_format, structured_outputs, reasoning and
+--                   reasoning_effort among supported_parameters.
+--   * hive-default  leaves the dots free route for deepseek-v4-flash, the
+--                   paid quality tier, keeping its tool-parity story: the
+--                   source route-deepseek-v4-flash carries tools_supported =
+--                   true (20260822_02 step 3), so the claim survives honestly.
+--
+--   PART C. CI AND DAILY AUTOMATED CONSUMPTION MOVE TO hive-free
+--   Handled outside this file (.github/workflows/ci.yml default,
+--   deploy-demo-box.yml sdk-replay, packages/sdk-tests fallbacks,
+--   scripts/post-deploy-verify.py, scripts/verify-control-plane.py); guarded
+--   by TestCITestDefaultsPointAtTheFreeAlias in
+--   apps/control-plane/internal/routing/free_pool_router_test.go.
+--
+-- WHY THE POOL IS FOUR DB ROWS RATHER THAN A GENERATOR FEATURE
+--   provider_routes.litellm_model_name is the column that actually names the
+--   LiteLLM gateway alias ("model_name:" in config.yaml); route_id is only
+--   the table's primary key (deploy-demo-box.yml's price assertion says
+--   exactly this at its lookup). Every seeded row so far kept the two equal,
+--   and the sync emitted route_id. The generator change is therefore one
+--   column: SyncService now emits pr.litellm_model_name as the entry's
+--   model_name. Rows that keep the columns equal are byte-for-byte unchanged;
+--   rows that diverge become additional deployments of a shared name. Adding
+--   the third Groq key later is one more row plus one env var, nothing else.
+--
+-- PRICES (current credit unit: 1 USD = 1,000,000,000 credits,
+-- migration 20260823_40_credit_unit_rescale_billion.sql)
+--   * hive-free   input 1000000 / output 4000000 credits per million tokens
+--                 ($0.001 / $0.004). This is a SERVICE PRICE, not a derived
+--                 margin: every upstream in the pool costs us zero, so the
+--                 DERIVE formula cannot apply and parseRate would reject a
+--                 $0.00 rate outright. It exists to cover gateway serving
+--                 cost, per the owner's "a credit or a few per request"
+--                 framing.
+--   * hive-default repriced to the deepseek-v4-flash rates ALREADY in the
+--                 catalog (20260822_02 DERIVE table), carried through the
+--                 rescale factor 10,000:
+--                   in         8946   x 10000 =    89460000
+--                   out       17892   x 10000 =   178920000
+--                   cache_read 1790   x 10000 =    17900000
+--                   cache_write   0            =           0
+--                 No new rate fetch, no new snapshot: same upstream model the
+--                 deepseek-v4-flash alias serves today.
+--   * hive-auto   fixed price columns go NULL under pricing_mode
+--                 'upstream_actual'. The shape CHECK added by
+--                 20260822_30_openrouter_auto_variable_pricing.sql enforces
+--                 exactly this shape; this UPDATE satisfies it within one
+--                 statement.
+--   * Net catalog after this file (for the PR body):
+--       hive-free     free pool, $0.001/$0.004      (CI + daily consumption)
+--       hive-default  deepseek-v4-flash, paid       (quality + tool parity)
+--       hive-auto     OpenRouter Auto Router, passthrough cost
+--       deepseek-v4-pro, hive-small/medium/fast: untouched.
+--
+-- TOOLS AND STRUCTURED OUTPUT ARE HONESTLY FALSE ON THE POOL
+--   tools_supported gates tools, tool_choice and response_format (PR #206).
+--   The four pool members are three different providers whose tool behaviour
+--   was NOT probed for cross-member parity, so the flag stays FALSE rather
+--   than claiming parity nobody verified. Consequence: a tool-bearing request
+--   to hive-free is rejected at selection time instead of failing
+--   mid-request, and tool traffic lives where it is verified: hive-default
+--   (deepseek-v4-flash, tools true) for the paid tier and hive-auto (the Auto
+--   Router, whose lineage has always carried tools true). This split is the
+--   owner's stated intent and can be collapsed later once cross-pool parity
+--   is probed for real.
+--   supports_reasoning stays TRUE on the pool: Groq documents gpt-oss as
+--   reasoning models (20260822_02 header), gemini-flash-latest is a thinking-
+--   capable flash model through an endpoint that maps reasoning_effort, and
+--   the dots model accepted every reasoning_effort probe without failing
+--   (20260823_21's twelve-shape live run). On a pinned single-route alias an
+--   under-claim is a 422, not a withheld feature, so false would BREAK
+--   reasoning requests that work today.
+--
+-- THE SOLE-CARRIER FLAGS MOVE WITH THEIR ALIAS
+--   route-free-auto is today's ONLY carrier of supports_batch,
+--   supports_image_generation and supports_image_edit. Disabling it without a
+--   successor deletes /v1/batches, /v1/images/generations and
+--   /v1/images/edits catalog-wide (SelectRoute hard-filters on these flags;
+--   batchstore sends NeedBatch for EVERY batch). Its successor for hive-auto
+--   is route-openrouter-auto-live, which inherits all three as STATUS QUO
+--   PRESERVATION, not as fresh claims about openrouter/auto doing images --
+--   the same honest framing 20260822_02 used when it handed them to
+--   route-groq-auto. Guarded by
+--   TestFreePoolDisablingRouteFreeAutoHandsOnTheSoleCarrierFlags.
+--
+-- WHY NEW ROUTE IDS, AGAIN
+--   Identical to 20260822_02 / 20260823_20 / 20260823_21: the config sync
+--   merges field by field and hand-tuned keys survive forever on a reused
+--   route_id; retiring the id makes the merge drop the whole stale entry.
+--   route-openrouter-auto (disabled since 20260822_02) and
+--   route-openrouter-auto-beta (the internal openrouter-auto alias's own
+--   route) both stay untouched for that reason too.
+--
+-- RE-RUNNABILITY
+--   Every INSERT carries ON CONFLICT DO NOTHING and every UPDATE carries a
+--   WHERE guard excluding rows already at the target value, so a second run
+--   affects zero rows and errors on nothing.
+-- =============================================================================
+
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+
+-- ─── 1. Provider rows for the two new key slots ─────────────────────────────
+--
+-- api_key_env lives on custom_providers (one per provider), so a SECOND Groq
+-- key needs its own provider row pointing at the same Groq endpoint. That is
+-- also what makes "add key three" cheap: one row, one env var, one member
+-- route. The gemini row's base_url is the OpenAI-compatible surface of the
+-- Generative Language API, which is what makes the generic openai/ adapter
+-- mean Gemini; the generator refuses any openai/-prefixed model without a
+-- non-empty api_base for exactly this reason.
+
+insert into public.custom_providers (
+    slug, display_name, base_url, api_key_env, litellm_prefix, enabled
+) values
+    ('groq-2', 'Groq (key slot 2)', 'https://api.groq.com/openai/v1',
+     'GROQ_API_KEY_2', 'groq/', true),
+    ('gemini', 'Google Gemini', 'https://generativelanguage.googleapis.com/v1beta/openai',
+     'GEMINI_API_KEY', 'openai/', true)
+on conflict (slug) do nothing;
+
+-- ─── 2. The free pool: four routes, one shared litellm_model_name ───────────
+
+insert into public.provider_routes (
+    route_id,
+    alias_id,
+    provider,
+    provider_model,
+    litellm_model_name,
+    price_class,
+    health_state,
+    priority
+) values
+    ('route-free-pool-free',   'hive-free', 'openrouter', 'openrouter/dots-studio/dots-3-note-preview:free', 'route-free-pool', 'standard', 'healthy', 10),
+    ('route-free-pool-gemini', null,        'gemini',     'openai/gemini-flash-latest',                      'route-free-pool', 'standard', 'healthy', 10),
+    ('route-free-pool-groq',   null,        'groq',       'groq/openai/gpt-oss-20b',                         'route-free-pool', 'standard', 'healthy', 10),
+    ('route-free-pool-groq-2', null,        'groq-2',     'groq/openai/gpt-oss-20b',                         'route-free-pool', 'standard', 'healthy', 10),
+    ('route-openrouter-auto-live', 'hive-auto', 'openrouter', 'openrouter/openrouter/auto',              'route-openrouter-auto-live', 'premium', 'healthy', 10),
+    ('route-deepseek-v4-flash-default', 'hive-default', 'openrouter', 'openrouter/~deepseek/deepseek-v4-flash-latest', 'route-deepseek-v4-flash-default', 'budget', 'healthy', 10)
+on conflict (route_id) do nothing;
+
+-- The doubled openrouter/ prefix and trailing :free carry the same meaning
+-- they do on every sibling row (see 20260823_20's note): LiteLLM strips the
+-- leading prefix as its provider selector, and :free selects the zero-priced
+-- variant. The tilde in ~deepseek/deepseek-v4-flash-latest is part of the real
+-- model id (20260822_02).
+
+-- ─── 3. Capabilities ────────────────────────────────────────────────────────
+--
+-- Pool members: tools_supported FALSE (cross-provider tool parity unverified;
+-- see the header). Everything chat-shaped TRUE, embeddings and cache FALSE.
+-- Media flags FALSE everywhere in the pool; their succession line runs through
+-- route-openrouter-auto-live below.
+
+insert into public.provider_capabilities (
+    route_id,
+    supports_responses,
+    supports_chat_completions,
+    supports_completions,
+    supports_embeddings,
+    supports_streaming,
+    supports_reasoning,
+    supports_cache_read,
+    supports_cache_write,
+    tools_supported,
+    supports_batch,
+    supports_image_generation,
+    supports_image_edit
+) values
+    ('route-free-pool-free',   true, true, true, false, true, true, false, false, false, false, false, false),
+    ('route-free-pool-gemini', true, true, true, false, true, true, false, false, false, false, false, false),
+    ('route-free-pool-groq',   true, true, true, false, true, true, false, false, false, false, false, false),
+    ('route-free-pool-groq-2', true, true, true, false, true, true, false, false, false, false, false, false),
+    ('route-openrouter-auto-live', true, true, true, false, true, true, false, false, true, true, true, true),
+    ('route-deepseek-v4-flash-default', true, true, true, false, true, true, true, false, true, false, false, false)
+on conflict (route_id) do nothing;
+
+-- route-deepseek-v4-flash-default mirrors its source row
+-- (route-deepseek-v4-flash, 20260822_02 step 3): cache_read TRUE because
+-- DeepSeek publishes a cache-read rate, tools TRUE because that is the parity
+-- claim hive-default is being moved here to keep.
+
+-- ─── 4. The hive-free alias ─────────────────────────────────────────────────
+
+insert into public.model_aliases (
+    alias_id,
+    owned_by,
+    display_name,
+    summary,
+    visibility,
+    lifecycle,
+    capability_badges,
+    input_price_credits,
+    output_price_credits,
+    cache_read_price_credits,
+    cache_write_price_credits
+) values
+    (
+        'hive-free',
+        'hive',
+        'Hive Free',
+        'Free-tier alias served from a load-balanced pool of our free provider keys; requests fail over automatically when one key is exhausted. Tool calling and structured output are not offered on this alias.',
+        'public',
+        'stable',
+        '["stable","chat","responses"]'::jsonb,
+        1000000,
+        4000000,
+        0,
+        0
+    )
+on conflict (alias_id) do nothing;
+
+insert into public.alias_route_policies (
+    alias_id,
+    policy_mode,
+    allow_price_class_widening,
+    fallback_order
+) values
+    ('hive-free', 'pinned', false, '["route-free-pool-free"]'::jsonb)
+on conflict (alias_id) do nothing;
+
+-- Group membership: a default-tier key sees only aliases in its groups, so
+-- without these rows the new alias is invisible however correct its price.
+insert into public.model_policy_group_members (group_name, alias_id) values
+    ('default', 'hive-free'),
+    ('closed',  'hive-free')
+on conflict (group_name, alias_id) do nothing;
+
+-- ─── 5. hive-auto: the real Auto Router at actual cost ──────────────────────
+--
+-- One statement flips the whole pricing shape so the mode CHECK holds at its
+-- end. NULL prices are deliberate and load-bearing: the Go readers scan them
+-- into non-pointer int64 and fail loudly until taught about variable pricing
+-- (20260822_30). The hold matches the internal openrouter-auto alias's value
+-- after the rescale: 200000 pre-rescale x 10000 = 2000000000.
+
+UPDATE public.model_aliases
+   SET pricing_mode                 = 'upstream_actual',
+       input_price_credits          = null,
+       output_price_credits         = null,
+       cache_read_price_credits     = null,
+       cache_write_price_credits    = null,
+       reservation_estimate_credits = 2000000000,
+       capability_badges            = '["stable","chat","responses","task-aware"]'::jsonb,
+       summary                      = 'Automatic routing: each request is answered by the OpenRouter Auto Router''s per-request model choice, billed at actual usage.',
+       updated_at                   = now()
+ WHERE alias_id = 'hive-auto'
+   AND pricing_mode <> 'upstream_actual';
+
+UPDATE public.alias_route_policies
+   SET fallback_order = '["route-openrouter-auto-live"]'::jsonb
+ WHERE alias_id = 'hive-auto'
+   AND fallback_order <> '["route-openrouter-auto-live"]'::jsonb;
+
+-- ─── 6. hive-default: paid quality on deepseek-v4-flash ─────────────────────
+
+UPDATE public.model_aliases
+   SET input_price_credits       = 89460000,
+       output_price_credits      = 178920000,
+       cache_read_price_credits  = 17900000,
+       cache_write_price_credits = 0,
+       summary                   = 'Default alias for requests that name no model. Serves DeepSeek V4 Flash with full tool-calling parity; this is the paid quality tier.',
+       updated_at                = now()
+ WHERE alias_id = 'hive-default'
+   AND (input_price_credits <> 89460000 OR output_price_credits <> 178920000
+        OR cache_read_price_credits <> 17900000 OR cache_write_price_credits <> 0);
+
+UPDATE public.alias_route_policies
+   SET fallback_order = '["route-deepseek-v4-flash-default"]'::jsonb
+ WHERE alias_id = 'hive-default'
+   AND fallback_order <> '["route-deepseek-v4-flash-default"]'::jsonb;
+
+-- ─── 7. Retire the two dots free routes these aliases leave behind ──────────
+
+UPDATE public.provider_routes
+   SET health_state = 'disabled'
+ WHERE route_id IN ('route-free-auto', 'route-free-default')
+   AND health_state <> 'disabled';
+
+COMMIT;

--- a/supabase/migrations/20260824_02_free_pool_router.sql
+++ b/supabase/migrations/20260824_02_free_pool_router.sql
@@ -20,8 +20,7 @@
 --                        our own free provider keys.
 --   * Members, in emission order (ORDER BY route_id):
 --       route-free-pool-free    openrouter dots-studio/dots-3-note-preview:free
---                               (OPENROUTER_API_KEY) -- canonical row carrying
---                               alias_id 'hive-free'
+--                               (OPENROUTER_API_KEY)
 --       route-free-pool-gemini  gemini-flash-latest through LiteLLM's generic
 --                               openai/ adapter against Google's official
 --                               OpenAI-compatible endpoint (GEMINI_API_KEY).
@@ -70,6 +69,20 @@
 --   model_name. Rows that keep the columns equal are byte-for-byte unchanged;
 --   rows that diverge become additional deployments of a shared name. Adding
 --   the third Groq key later is one more row plus one env var, nothing else.
+--
+--   All four member rows carry alias_id 'hive-free'. provider_routes.alias_id
+--   is NOT NULL with a FK to model_aliases (20260331_02), so there was no
+--   NULL-member option, and multi-route-per-alias is an established shape
+--   here (hive-fast served two routes before 20260801_01). It is also
+--   behaviorally inert which member selection picks: every member dispatches
+--   the same litellm_model_name, so LiteLLM's router sees the same pool
+--   regardless, and all four carry identical capability flags, so no flag
+--   filter can split them. The pinned policy still names route-free-pool-free
+--   as the single fallback_order entry, matching the one-alias-one-route
+--   convention for anything that reads it.
+--
+--   STATEMENT ORDER: the alias row must exist before any route referencing it
+--   (non-deferrable FK), so step 2 inserts hive-free ahead of the routes.
 --
 -- PRICES (current credit unit: 1 USD = 1,000,000,000 credits,
 -- migration 20260823_40_credit_unit_rescale_billion.sql)
@@ -168,68 +181,9 @@ insert into public.custom_providers (
      'GEMINI_API_KEY', 'openai/', true)
 on conflict (slug) do nothing;
 
--- ─── 2. The free pool: four routes, one shared litellm_model_name ───────────
-
-insert into public.provider_routes (
-    route_id,
-    alias_id,
-    provider,
-    provider_model,
-    litellm_model_name,
-    price_class,
-    health_state,
-    priority
-) values
-    ('route-free-pool-free',   'hive-free', 'openrouter', 'openrouter/dots-studio/dots-3-note-preview:free', 'route-free-pool', 'standard', 'healthy', 10),
-    ('route-free-pool-gemini', null,        'gemini',     'openai/gemini-flash-latest',                      'route-free-pool', 'standard', 'healthy', 10),
-    ('route-free-pool-groq',   null,        'groq',       'groq/openai/gpt-oss-20b',                         'route-free-pool', 'standard', 'healthy', 10),
-    ('route-free-pool-groq-2', null,        'groq-2',     'groq/openai/gpt-oss-20b',                         'route-free-pool', 'standard', 'healthy', 10),
-    ('route-openrouter-auto-live', 'hive-auto', 'openrouter', 'openrouter/openrouter/auto',              'route-openrouter-auto-live', 'premium', 'healthy', 10),
-    ('route-deepseek-v4-flash-default', 'hive-default', 'openrouter', 'openrouter/~deepseek/deepseek-v4-flash-latest', 'route-deepseek-v4-flash-default', 'budget', 'healthy', 10)
-on conflict (route_id) do nothing;
-
--- The doubled openrouter/ prefix and trailing :free carry the same meaning
--- they do on every sibling row (see 20260823_20's note): LiteLLM strips the
--- leading prefix as its provider selector, and :free selects the zero-priced
--- variant. The tilde in ~deepseek/deepseek-v4-flash-latest is part of the real
--- model id (20260822_02).
-
--- ─── 3. Capabilities ────────────────────────────────────────────────────────
---
--- Pool members: tools_supported FALSE (cross-provider tool parity unverified;
--- see the header). Everything chat-shaped TRUE, embeddings and cache FALSE.
--- Media flags FALSE everywhere in the pool; their succession line runs through
--- route-openrouter-auto-live below.
-
-insert into public.provider_capabilities (
-    route_id,
-    supports_responses,
-    supports_chat_completions,
-    supports_completions,
-    supports_embeddings,
-    supports_streaming,
-    supports_reasoning,
-    supports_cache_read,
-    supports_cache_write,
-    tools_supported,
-    supports_batch,
-    supports_image_generation,
-    supports_image_edit
-) values
-    ('route-free-pool-free',   true, true, true, false, true, true, false, false, false, false, false, false),
-    ('route-free-pool-gemini', true, true, true, false, true, true, false, false, false, false, false, false),
-    ('route-free-pool-groq',   true, true, true, false, true, true, false, false, false, false, false, false),
-    ('route-free-pool-groq-2', true, true, true, false, true, true, false, false, false, false, false, false),
-    ('route-openrouter-auto-live', true, true, true, false, true, true, false, false, true, true, true, true),
-    ('route-deepseek-v4-flash-default', true, true, true, false, true, true, true, false, true, false, false, false)
-on conflict (route_id) do nothing;
-
--- route-deepseek-v4-flash-default mirrors its source row
--- (route-deepseek-v4-flash, 20260822_02 step 3): cache_read TRUE because
--- DeepSeek publishes a cache-read rate, tools TRUE because that is the parity
--- claim hive-default is being moved here to keep.
-
--- ─── 4. The hive-free alias ─────────────────────────────────────────────────
+-- ─── 2. The hive-free alias, FIRST: every pool member row references it via
+--        provider_routes.alias_id's non-deferrable FK, so the alias must exist
+--        before any route does. ─────────────────────────────────────────────
 
 insert into public.model_aliases (
     alias_id,
@@ -275,6 +229,72 @@ insert into public.model_policy_group_members (group_name, alias_id) values
     ('closed',  'hive-free')
 on conflict (group_name, alias_id) do nothing;
 
+-- ─── 3. The free pool: four routes, one shared litellm_model_name ───────────
+--
+-- Every member carries alias_id 'hive-free': the column is NOT NULL with a
+-- non-deferrable FK (20260331_02), and multi-route-per-alias is an established
+-- shape here. It is behaviorally inert which member selection picks -- all
+-- four dispatch the same litellm_model_name under identical capability flags.
+
+insert into public.provider_routes (
+    route_id,
+    alias_id,
+    provider,
+    provider_model,
+    litellm_model_name,
+    price_class,
+    health_state,
+    priority
+) values
+    ('route-free-pool-free',   'hive-free', 'openrouter', 'openrouter/dots-studio/dots-3-note-preview:free', 'route-free-pool', 'standard', 'healthy', 10),
+    ('route-free-pool-gemini', 'hive-free', 'gemini',     'openai/gemini-flash-latest',                      'route-free-pool', 'standard', 'healthy', 10),
+    ('route-free-pool-groq',   'hive-free', 'groq',       'groq/openai/gpt-oss-20b',                         'route-free-pool', 'standard', 'healthy', 10),
+    ('route-free-pool-groq-2', 'hive-free', 'groq-2',     'groq/openai/gpt-oss-20b',                         'route-free-pool', 'standard', 'healthy', 10),
+    ('route-openrouter-auto-live', 'hive-auto', 'openrouter', 'openrouter/openrouter/auto',              'route-openrouter-auto-live', 'premium', 'healthy', 10),
+    ('route-deepseek-v4-flash-default', 'hive-default', 'openrouter', 'openrouter/~deepseek/deepseek-v4-flash-latest', 'route-deepseek-v4-flash-default', 'budget', 'healthy', 10)
+on conflict (route_id) do nothing;
+
+-- The doubled openrouter/ prefix and trailing :free carry the same meaning
+-- they do on every sibling row (see 20260823_20's note): LiteLLM strips the
+-- leading prefix as its provider selector, and :free selects the zero-priced
+-- variant. The tilde in ~deepseek/deepseek-v4-flash-latest is part of the real
+-- model id (20260822_02).
+
+-- ─── 4. Capabilities ────────────────────────────────────────────────────────
+--
+-- Pool members: tools_supported FALSE (cross-provider tool parity unverified;
+-- see the header). Everything chat-shaped TRUE, embeddings and cache FALSE.
+-- Media flags FALSE everywhere in the pool; their succession line runs through
+-- route-openrouter-auto-live below.
+
+insert into public.provider_capabilities (
+    route_id,
+    supports_responses,
+    supports_chat_completions,
+    supports_completions,
+    supports_embeddings,
+    supports_streaming,
+    supports_reasoning,
+    supports_cache_read,
+    supports_cache_write,
+    tools_supported,
+    supports_batch,
+    supports_image_generation,
+    supports_image_edit
+) values
+    ('route-free-pool-free',   true, true, true, false, true, true, false, false, false, false, false, false),
+    ('route-free-pool-gemini', true, true, true, false, true, true, false, false, false, false, false, false),
+    ('route-free-pool-groq',   true, true, true, false, true, true, false, false, false, false, false, false),
+    ('route-free-pool-groq-2', true, true, true, false, true, true, false, false, false, false, false, false),
+    ('route-openrouter-auto-live', true, true, true, false, true, true, false, false, true, true, true, true),
+    ('route-deepseek-v4-flash-default', true, true, true, false, true, true, true, false, true, false, false, false)
+on conflict (route_id) do nothing;
+
+-- route-deepseek-v4-flash-default mirrors its source row
+-- (route-deepseek-v4-flash, 20260822_02 step 3): cache_read TRUE because
+-- DeepSeek publishes a cache-read rate, tools TRUE because that is the parity
+-- claim hive-default is being moved here to keep.
+
 -- ─── 5. hive-auto: the real Auto Router at actual cost ──────────────────────
 --
 -- One statement flips the whole pricing shape so the mode CHECK holds at its
@@ -289,12 +309,23 @@ UPDATE public.model_aliases
        output_price_credits         = null,
        cache_read_price_credits     = null,
        cache_write_price_credits    = null,
-       reservation_estimate_credits = 2000000000,
-       capability_badges            = '["stable","chat","responses","task-aware"]'::jsonb,
-       summary                      = 'Automatic routing: each request is answered by the OpenRouter Auto Router''s per-request model choice, billed at actual usage.',
-       updated_at                   = now()
+       reservation_estimate_credits = 2000000000
  WHERE alias_id = 'hive-auto'
    AND pricing_mode <> 'upstream_actual';
+
+-- Display metadata gets its OWN guarded statement, deliberately not gated on
+-- the pricing mode: on a database where the mode already flipped, a re-run of
+-- this file must still be able to land a corrected summary or badge set.
+-- provider-blind wording per the catalog convention (the deepseek-v4-*
+-- ALIAS IDS carry their vendor name by explicit owner decision; summaries do
+-- not name vendors).
+UPDATE public.model_aliases
+   SET summary           = 'Automatic routing: each request gets a per-request model choice and is billed at actual usage.',
+       capability_badges = '["stable","chat","responses","task-aware"]'::jsonb,
+       updated_at        = now()
+ WHERE alias_id = 'hive-auto'
+   AND (summary IS DISTINCT FROM 'Automatic routing: each request gets a per-request model choice and is billed at actual usage.'
+        OR capability_badges <> '["stable","chat","responses","task-aware"]'::jsonb);
 
 UPDATE public.alias_route_policies
    SET fallback_order = '["route-openrouter-auto-live"]'::jsonb
@@ -308,7 +339,7 @@ UPDATE public.model_aliases
        output_price_credits      = 178920000,
        cache_read_price_credits  = 17900000,
        cache_write_price_credits = 0,
-       summary                   = 'Default alias for requests that name no model. Serves DeepSeek V4 Flash with full tool-calling parity; this is the paid quality tier.',
+       summary                   = 'Default alias for requests that name no model. Full tool-calling parity on the paid quality tier.',
        updated_at                = now()
  WHERE alias_id = 'hive-default'
    AND (input_price_credits <> 89460000 OR output_price_credits <> 178920000


### PR DESCRIPTION
## What this does

Implements the owner's Free Router: a route group of N deployments under one LiteLLM `model_name`, so an exhausted or failing key cools down and its alias fails over to the remaining members instead of going down. Offered as the new public alias `hive-free` at a small service price, which is now also the serving endpoint for CI and daily automated consumption.

## Mechanism: one column, not a new generator subsystem

`provider_routes.litellm_model_name` already names the gateway alias (`model_name:` in config.yaml); every seeded row just kept it equal to `route_id`. The generator change is one column: `SyncService` now emits `pr.litellm_model_name` as each entry's model_name (`apps/control-plane/internal/litellmconfig/service.go`). Rows that keep the columns equal are byte-for-byte unchanged; rows that diverge become additional deployments of a shared name. Adding key slot 3 later is one more row plus one env var.

The pool survives every sync by construction (the sync itself emits it), and `TestWriteAndRestartKeepsPoolDeploymentsDistinctAcrossSyncs` proves repeated syncs keep all deployments distinct while hand-tuned `litellm_params` keys survive onto each pooled deployment. Router behavior (cooldown 30s, allowed_fails 3, zero retries on rate limits) comes from the seed config's existing `litellm_settings`/`router_settings` blocks, preserved verbatim by the merge; the brief's numbers were examples, shipped values are what #1089's measured work tuned.

## The pool

| member route | upstream | key |
|---|---|---|
| route-free-pool-free | openrouter dots-studio/dots-3-note-preview:free | OPENROUTER_API_KEY |
| route-free-pool-gemini | gemini-flash-latest via generic openai/ adapter over generativelanguage.googleapis.com/v1beta/openai | GEMINI_API_KEY |
| route-free-pool-groq | groq openai/gpt-oss-20b | GROQ_API_KEY |
| route-free-pool-groq-2 | groq openai/gpt-oss-20b | GROQ_API_KEY_2 |

Second Groq key arrived and was verified live before this PR shipped, so all four deployments are active from birth.

## Catalog result table

| alias | serves | pricing |
|---|---|---|
| hive-free | free pool (4 deployments) | fixed, $0.001 / $0.004 per M (1000000 / 4000000 credits at the 1e9 unit). Service price, not margin-derived: every upstream costs zero, so the DERIVE formula cannot apply. |
| hive-default | deepseek-v4-flash | paid quality tier; rates already in catalog (8946 / 17892 / 1790 pre-rescale x 10000); keeps tool parity (source route tools_supported true) |
| hive-auto | OpenRouter Auto Router `openrouter/openrouter/auto` | `pricing_mode='upstream_actual'`, prices NULL, hold 2000000000 credits ($2.00), slug verified live against openrouter.ai/api/v1/models on 2026-08-24 (pricing -1/-1 variable by construction; tools, response_format, reasoning_effort listed) |
| deepseek-v4-pro | unchanged | unchanged |
| hive-small / medium / fast | unchanged | unchanged |

The internal `openrouter-auto` alias (auto-beta, upstream_actual) is untouched.

## Capability honesty

- Pool routes carry `tools_supported = false`: three providers' tool behavior was never probed for cross-member parity, and PR #206 gates tools/tool_choice/response_format on that flag. Tool traffic lives on hive-default (deepseek, verified) and hive-auto (Auto Router lineage, always tools true). Collapsible once parity is probed.
- `supports_reasoning` stays true on the pool: an under-claim on a pinned alias is a 422, not a withheld feature.
- Disabling route-free-auto would have deleted `/v1/batches` and both image endpoints catalog-wide (sole carrier of batch/image flags). Its successor `route-openrouter-auto-live` inherits all three as status quo preservation, guarded by `TestFreePoolDisablingRouteFreeAutoHandsOnTheSoleCarrierFlags`.
- hive-auto's summary no longer claims it performs no automatic routing; it finally earns its name.

## CI and daily consumption move to hive-free

Every hit found and what happened to it:

| hit | action |
|---|---|
| `.github/workflows/ci.yml` HIVE_TEST_MODEL default `'deepseek-v4-pro'` | default flipped to `'hive-free'`; `vars.CI_LIVE_INTEGRATION_MODEL` remains the override knob; billing-declaration step rewritten to describe the pool |
| `.github/workflows/deploy-demo-box.yml` sdk-replay `HIVE_TEST_MODEL: hive-default` | flipped to hive-free |
| sdk-tests JS fallbacks (`chat-completions`, `completions`, `responses`, `streaming-chat`) `?? "hive-default"` | flipped to `hive-free`; responses suite's REASONING_MODEL_PATTERNS gains `hive-free` |
| sdk-tests Python `test_chat_completions.py` `os.getenv(..., "hive-default")` | flipped |
| `scripts/post-deploy-verify.py` MODEL default + docstring | flipped to hive-free; box .env override still wins |
| `scripts/verify-control-plane.py` chat ping | flipped to hive-free |

Deliberately NOT swept: `models.retrieve("hive-default")` shape tests in JS/PY/Java suites, the golden models-list fixture, the Python/Java headers tests, the OWUI picker filter fixture, and the lint tool's self-test fixture strings. Those reference the alias as an identifier that still exists in the catalog, not as automated consumption defaults.

Also required by the pool: the deploy price assertion matches by MEMBERSHIP among a model_name's deployments rather than position 1, otherwise whichever pool member sorted first would fail every deploy. Compose and CI now forward GROQ_API_KEY_2/GEMINI_API_KEY into the litellm container (the `os.environ/` references resolve there); without that those two members fail at request time instead of serving.

## Tests

- Generator/sync: multi-deployment emission under one model_name with per-member env keys; merge keeps deployments distinct across repeated syncs with hand-tuned extras surviving onto each pooled deployment; integration-tag test seeds two DB rows sharing a group name against a real database.
- Migration guards (`apps/control-plane/internal/routing/free_pool_router_test.go`): shared litellm_model_name exactly four times, verified upstream slugs (the :free suffix is load-bearing), env-named key slots only (no key values anywhere), hive-free price pinned literally, hive-auto upstream_actual shape including NULL prices and the rescaled hold, hive-default reprice equals the deepseek DERIVE figures x 10000, retired routes disabled plus policies repointed, sole-carrier succession, pool tools false, part-C defaults guarded offline.
- Existing pricing guards untouched and green: `go test ./apps/control-plane/... -count=1 -short` and `./apps/edge-api/...` both pass in the toolchain container.

## Operator notes

- Box .env already carries GEMINI_API_KEY and GROQ_API_KEY_2 (orchestrator handled). Compose passthrough lands with this PR's deploy; the litellm service needs a recreate to pick up its environment block.
- The box's live config gets the pool on the next sync after migrate plus recreate; first sync drops the route-free-auto/route-free-default entries through the known-routes retirement rule.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `hive-free` alias for load-balanced access to the free model pool.
  * Added support for multiple Groq key slots and Google Gemini credentials.
* **Updates**
  * Improved pooled route management, preserving provider-specific deployments and credentials.
  * Updated `hive-auto` pricing and free-pool route configuration.
  * Retired obsolete free-model routes and updated related policies.
* **Verification**
  * SDK, integration, deployment, and post-deployment checks now use `hive-free` by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->