### PR TITLE
feat: ship the Projects destination for the chat shell

### DIFF
--- a/docs/proof/projects-surface/capture.log.txt
+++ b/docs/proof/projects-surface/capture.log.txt
@@ -1,0 +1,16 @@
+url after goto auth: http://127.0.0.1:8093/auth
+signed in, url: http://127.0.0.1:8093/
+shot 01-home-sidebar-projects-row url=http://127.0.0.1:8093/
+shot 02-projects-index-empty url=http://127.0.0.1:8093/projects
+shot 03-create-dialog url=http://127.0.0.1:8093/projects
+created project, url=http://127.0.0.1:8093/projects/6e7f2b66-1295-42af-a07c-364438a69b50
+shot 05-file-added url=http://127.0.0.1:8093/projects/6e7f2b66-1295-42af-a07c-364438a69b50
+PAGEERROR e is not iterable
+after new chat, url=http://127.0.0.1:8093/c/13ed241e-56d7-4e67-ad5c-865ce1e5cf90
+shot 06-bound-new-chat url=http://127.0.0.1:8093/c/13ed241e-56d7-4e67-ad5c-865ce1e5cf90
+index cards: 1
+shot 07-detail-conversation-bound url=http://127.0.0.1:8093/projects/6e7f2b66-1295-42af-a07c-364438a69b50
+shot 08-link-existing-picker url=http://127.0.0.1:8093/projects/6e7f2b66-1295-42af-a07c-364438a69b50
+shot 09-renamed url=http://127.0.0.1:8093/projects/6e7f2b66-1295-42af-a07c-364438a69b50
+seed second project status: 200
+shot 10-second-project-grid url=http://127.0.0.1:8093/projects

--- a/vendor/open-webui/src/lib/hive/ShellNavIcon.svelte
+++ b/vendor/open-webui/src/lib/hive/ShellNavIcon.svelte
@@ -26,7 +26,9 @@
 	aria-hidden="true"
 	focusable="false"
 >
-	{#if name === 'agents'}
+	{#if name === 'projects'}
+		<path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z" />
+	{:else if name === 'agents'}
 		<path d="M12 8V4H8" />
 		<rect width="16" height="12" x="4" y="8" rx="2" />
 		<path d="M2 14h2" />

--- a/vendor/open-webui/src/lib/hive/nav.test.ts
+++ b/vendor/open-webui/src/lib/hive/nav.test.ts
@@ -11,10 +11,22 @@ const byId = (id: string): HiveNavItem => {
 };
 
 describe('HIVE_NAV', () => {
-	it('names the destinations the shell ships', () => {
+	it('names the destinations the shell ships, Projects first per D-045', () => {
 		// 'chats' was dropped: its href ('/') duplicated New Chat and no list
 		// view was ever built behind it (PR #938 added it for row parity only).
-		expect(HIVE_NAV.map((item) => item.id)).toEqual(['agents', 'knowledge', 'scheduled']);
+		expect(HIVE_NAV.map((item) => item.id)).toEqual([
+			'projects',
+			'agents',
+			'knowledge',
+			'scheduled'
+		]);
+	});
+
+	it('points the projects destination at its own route inside this application', () => {
+		// D-045 ruling 2: Knowledge is replaced by Projects; context brought in
+		// lives here. Same in-shell rule as Agents: no link out of the shell.
+		expect(byId('projects').href).toBe('/projects');
+		expect(byId('projects').href.startsWith('http')).toBe(false);
 	});
 
 	it('points the agent destination at a route inside this application', () => {
@@ -65,7 +77,13 @@ describe('isNavItemActive', () => {
 	});
 
 	it('marks exactly one row current on each row\'s own destination', () => {
-		for (const route of ['/agents', '/workspace/knowledge', '/schedules']) {
+		for (const route of [
+			'/projects',
+			'/projects/abc',
+			'/agents',
+			'/workspace/knowledge',
+			'/schedules'
+		]) {
 			const active = HIVE_NAV.filter((item) => isNavItemActive(item, route));
 			expect(active.length).toBe(1);
 		}

--- a/vendor/open-webui/src/lib/hive/nav.ts
+++ b/vendor/open-webui/src/lib/hive/nav.ts
@@ -10,7 +10,7 @@
  * future upstream tag reads as a file list rather than an archaeology exercise.
  */
 
-export type HiveNavIcon = 'agents' | 'knowledge' | 'scheduled';
+export type HiveNavIcon = 'projects' | 'agents' | 'knowledge' | 'scheduled';
 
 export interface HiveNavItem {
 	/** Stable id, used for the DOM id and as the test hook. */
@@ -28,6 +28,16 @@ export interface HiveNavItem {
 }
 
 export const HIVE_NAV: readonly HiveNavItem[] = [
+	{
+		// D-045 ruling 2: Projects is a first class destination, the home of
+		// context brought in (RAG documents live here). It sits at the top of
+		// the row list until the full D-045 sidebar grammar lands.
+		id: 'projects',
+		label: 'Projects',
+		href: '/projects',
+		icon: 'projects',
+		activePaths: ['/projects']
+	},
 	{
 		id: 'agents',
 		label: 'Agents',

--- a/vendor/open-webui/src/lib/hive/projects/ProjectDetail.svelte
+++ b/vendor/open-webui/src/lib/hive/projects/ProjectDetail.svelte
@@ -57,7 +57,8 @@
 		try {
 			project = await getProject(token, id);
 			if (!project) {
-				error = $i18n.t('This project does not exist.');
+				// The null branch below renders its own line; a second message
+				// here would say the same thing twice.
 				return;
 			}
 			conversations = await resolveProjectConversations(token, id);
@@ -131,16 +132,33 @@
 		if (!project || chosen.length === 0 || busy) return;
 		busy = true;
 		error = '';
+		const attached: string[] = [];
 		try {
 			for (const file of chosen) {
 				const uploaded = await uploadFile(token, file);
 				if (!uploaded?.id) throw new ProjectError($i18n.t('The file could not be uploaded.'));
 				await addFileToProject(token, id, uploaded.id);
+				attached.push(uploaded.id);
 			}
 			project = await getProject(token, id);
 		} catch (err) {
+			// A mid-batch failure would otherwise leave earlier files attached
+			// while the UI reports total failure. Roll back what landed, best
+			// effort, then reload so the list matches the server.
+			for (const fileId of attached) {
+				try {
+					await removeFileFromProject(token, id, fileId);
+				} catch {
+					// Best effort: the reload below still shows the truth.
+				}
+			}
 			error =
 				err instanceof ProjectError ? err.message : $i18n.t('The file could not be added.');
+			try {
+				project = await getProject(token, id);
+			} catch {
+				// The error line above already says what failed.
+			}
 		} finally {
 			busy = false;
 		}

--- a/vendor/open-webui/src/lib/hive/projects/ProjectDetail.svelte
+++ b/vendor/open-webui/src/lib/hive/projects/ProjectDetail.svelte
@@ -1,0 +1,438 @@
+<script lang="ts">
+	/*
+	 * One project's contents: the files bound to its scope and the
+	 * conversations bound to it.
+	 *
+	 * Hive authored; storage seam documented in ./projects.ts. Files are the
+	 * knowledge collection's files, so anything attached here is exactly what
+	 * RAG retrieval pulls in for work against this project. Conversations carry
+	 * their binding inside their own persisted blob (`hiveProject`), which is
+	 * why "New chat" creates the chat with the marker already written and
+	 * "Link existing" writes it after the fact through the same merge.
+	 */
+	import { getContext, onMount } from 'svelte';
+	import { goto } from '$app/navigation';
+
+	import Tooltip from '$lib/components/common/Tooltip.svelte';
+	import { WEBUI_NAME } from '$lib/stores';
+	import { uploadFile } from '$lib/apis/files';
+	import { getChatList } from '$lib/apis/chats';
+
+	import {
+		type HiveProjectConversation,
+		ProjectError,
+		addFileToProject,
+		bindChatToProject,
+		createBoundChat,
+		deleteProject,
+		getProject,
+		removeFileFromProject,
+		resolveProjectConversations,
+		updateProject,
+		type HiveProject,
+		type HiveProjectFile
+	} from './projects';
+
+	const i18n: any = getContext('i18n');
+
+	export let id: string;
+
+	let token = '';
+	let project: (HiveProject & { files: HiveProjectFile[]; writeAccess: boolean }) | null = null;
+	let conversations: HiveProjectConversation[] = [];
+	let loading = true;
+	let error = '';
+
+	let showEdit = false;
+	let editName = '';
+	let editDescription = '';
+	let busy = false;
+
+	let showLinkPicker = false;
+	let recentChats: Array<{ id: string; title: string }> = [];
+	let linkedIds = new Set<string>();
+
+	const load = async () => {
+		error = '';
+		try {
+			project = await getProject(token, id);
+			if (!project) {
+				error = $i18n.t('This project does not exist.');
+				return;
+			}
+			conversations = await resolveProjectConversations(token, id);
+			linkedIds = new Set(conversations.map((c) => c.id));
+		} catch (err) {
+			error =
+				err instanceof ProjectError ? err.message : $i18n.t('The project could not be loaded.');
+		} finally {
+			loading = false;
+		}
+	};
+
+	onMount(async () => {
+		token = localStorage.getItem('token') ?? '';
+		await load();
+	});
+
+	const relativeDate = (epochSeconds: number): string => {
+		if (!epochSeconds) return '';
+		return new Date(epochSeconds * 1000).toLocaleString();
+	};
+
+	const openEdit = () => {
+		if (!project) return;
+		editName = project.name;
+		editDescription = project.description;
+		showEdit = true;
+	};
+
+	const submitEdit = async () => {
+		if (!project || !editName.trim() || busy) return;
+		busy = true;
+		error = '';
+		try {
+			project = {
+				...project,
+				...(await updateProject(token, id, {
+					name: editName.trim(),
+					description: editDescription.trim()
+				}))
+			};
+			showEdit = false;
+		} catch (err) {
+			error =
+				err instanceof ProjectError ? err.message : $i18n.t('The project could not be updated.');
+		} finally {
+			busy = false;
+		}
+	};
+
+	const confirmDelete = async () => {
+		if (!project || busy) return;
+		if (!window.confirm($i18n.t('Delete this project? Its conversations stay in your history.'))) {
+			return;
+		}
+		busy = true;
+		try {
+			await deleteProject(token, id);
+			await goto('/projects');
+		} catch (err) {
+			error =
+				err instanceof ProjectError ? err.message : $i18n.t('The project could not be deleted.');
+			busy = false;
+		}
+	};
+
+	const onFilesChosen = async (event: Event) => {
+		const inputEl = event.currentTarget as HTMLInputElement;
+		const chosen = Array.from(inputEl.files ?? []);
+		inputEl.value = '';
+		if (!project || chosen.length === 0 || busy) return;
+		busy = true;
+		error = '';
+		try {
+			for (const file of chosen) {
+				const uploaded = await uploadFile(token, file);
+				if (!uploaded?.id) throw new ProjectError($i18n.t('The file could not be uploaded.'));
+				await addFileToProject(token, id, uploaded.id);
+			}
+			project = await getProject(token, id);
+		} catch (err) {
+			error =
+				err instanceof ProjectError ? err.message : $i18n.t('The file could not be added.');
+		} finally {
+			busy = false;
+		}
+	};
+
+	const detachFile = async (fileId: string) => {
+		if (!project || busy) return;
+		busy = true;
+		try {
+			await removeFileFromProject(token, id, fileId);
+			project = await getProject(token, id);
+		} catch (err) {
+			error =
+				err instanceof ProjectError ? err.message : $i18n.t('The file could not be removed.');
+		} finally {
+			busy = false;
+		}
+	};
+
+	const startNewChat = async () => {
+		if (busy) return;
+		busy = true;
+		error = '';
+		try {
+			const chat = await createBoundChat(token, id);
+			await goto(`/c/${chat.id}`);
+		} catch (err) {
+			error =
+				err instanceof ProjectError ? err.message : $i18n.t('The conversation could not be created.');
+			busy = false;
+		}
+	};
+
+	const openLinkPicker = async () => {
+		try {
+			recentChats = await getChatList(token, 1);
+		} catch {
+			recentChats = [];
+		}
+		showLinkPicker = true;
+	};
+
+	const linkChat = async (chatId: string) => {
+		if (busy) return;
+		busy = true;
+		error = '';
+		try {
+			await bindChatToProject(token, chatId, id);
+			conversations = await resolveProjectConversations(token, id);
+			linkedIds = new Set(conversations.map((c) => c.id));
+			showLinkPicker = false;
+		} catch (err) {
+			error =
+				err instanceof ProjectError
+					? err.message
+					: $i18n.t('The conversation could not be linked.');
+		} finally {
+			busy = false;
+		}
+	};
+
+	const unlinkChat = async (chatId: string) => {
+		if (busy) return;
+		busy = true;
+		try {
+			await bindChatToProject(token, chatId, null);
+			conversations = await resolveProjectConversations(token, id);
+			linkedIds = new Set(conversations.map((c) => c.id));
+		} catch (err) {
+			error =
+				err instanceof ProjectError
+					? err.message
+					: $i18n.t('The conversation could not be removed.');
+		} finally {
+			busy = false;
+		}
+	};
+</script>
+
+<svelte:head>
+	<title>{project ? `${project.name}` : $i18n.t('Projects')} • {$WEBUI_NAME}</title>
+</svelte:head>
+
+<div class="w-full flex flex-col px-4 md:px-10 py-6 gap-6 max-w-5xl mx-auto">
+	<nav class="text-xs text-gray-400" aria-label={$i18n.t('Breadcrumb')}>
+		<a href="/projects" class="hover:text-gray-600 dark:hover:text-gray-300 transition">{$i18n.t('Projects')}</a>
+		<span class="mx-1">/</span>
+		<span class="text-gray-600 dark:text-gray-300">{project?.name ?? ''}</span>
+	</nav>
+
+	{#if error}
+		<p role="alert" class="text-sm text-red-500">{error}</p>
+	{/if}
+
+	{#if loading}
+		<p class="text-sm text-gray-500" role="status">{$i18n.t('Loading...')}</p>
+	{:else if !project}
+		<p class="text-sm text-gray-500">{$i18n.t('This project does not exist.')}</p>
+	{:else}
+		<header class="flex items-start justify-between gap-3">
+			<div class="min-w-0">
+				<h1 class="text-2xl font-semibold text-gray-850 dark:text-gray-100 truncate">{project.name}</h1>
+				<p class="mt-1 text-sm text-gray-500">{project.description}</p>
+				<p class="mt-1 text-[11px] text-gray-400">
+					{$i18n.t('Updated')} {relativeDate(project.updatedAt)}
+				</p>
+			</div>
+			{#if project.writeAccess}
+				<div class="flex gap-2 flex-none">
+					<Tooltip content={$i18n.t('Rename project')} placement="bottom">
+						<button
+							id="project-edit-button"
+							class="px-3 py-2 text-xs font-medium rounded-lg border border-gray-200 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-900 transition"
+							on:click={openEdit}
+						>
+							{$i18n.t('Rename')}
+						</button>
+					</Tooltip>
+					<Tooltip content={$i18n.t('Delete project')} placement="bottom">
+						<button
+							id="project-delete-button"
+							class="px-3 py-2 text-xs font-medium rounded-lg border border-red-200 dark:border-red-900 text-red-500 hover:bg-red-50 dark:hover:bg-red-950 transition"
+							on:click={confirmDelete}
+						>
+							{$i18n.t('Delete')}
+						</button>
+					</Tooltip>
+				</div>
+			{/if}
+		</header>
+
+		<!-- Files bound to this project's scope -->
+		<section class="flex flex-col gap-2" aria-labelledby="project-files-heading">
+			<div class="flex items-center justify-between gap-2">
+				<h2 id="project-files-heading" class="text-sm font-semibold text-gray-700 dark:text-gray-200">
+					{$i18n.t('Files')}
+				</h2>
+				{#if project.writeAccess}
+					<label class="cursor-pointer px-3 py-1.5 text-xs font-medium rounded-lg border border-gray-200 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-900 transition">
+						{$i18n.t('Add files')}
+						<input type="file" multiple class="hidden" on:change={onFilesChosen} disabled={busy} />
+					</label>
+				{/if}
+			</div>
+			{#if project.files.length === 0}
+				<p class="text-xs text-gray-400">
+					{$i18n.t('No files yet. Files here are given to every conversation in this project.')}
+				</p>
+			{:else}
+				<ul class="flex flex-col divide-y divide-gray-100 dark:divide-gray-800 rounded-xl border border-gray-200 dark:border-gray-800">
+					{#each project.files as file (file.id)}
+						<li class="flex items-center justify-between gap-3 px-4 py-2.5">
+							<span class="text-sm text-gray-700 dark:text-gray-200 truncate">{file.name}</span>
+							{#if project.writeAccess}
+								<button
+									class="text-xs text-gray-400 hover:text-red-500 transition flex-none"
+									on:click={() => detachFile(file.id)}
+								>
+									{$i18n.t('Remove')}
+								</button>
+							{/if}
+						</li>
+					{/each}
+				</ul>
+			{/if}
+		</section>
+
+		<!-- Conversations bound to this project -->
+		<section class="flex flex-col gap-2" aria-labelledby="project-conversations-heading">
+			<div class="flex items-center justify-between gap-2">
+				<h2 id="project-conversations-heading" class="text-sm font-semibold text-gray-700 dark:text-gray-200">
+					{$i18n.t('Conversations')}
+				</h2>
+				<div class="flex gap-2">
+					<button
+						id="project-link-chat-button"
+						class="px-3 py-1.5 text-xs font-medium rounded-lg border border-gray-200 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-900 transition"
+						on:click={openLinkPicker}
+					>
+						{$i18n.t('Link existing')}
+					</button>
+					<button
+						id="project-new-chat-button"
+						class="px-3 py-1.5 text-xs font-medium rounded-lg bg-black text-white dark:bg-white dark:text-black hover:opacity-80 transition"
+						on:click={startNewChat}
+					>
+						{$i18n.t('New chat')}
+					</button>
+				</div>
+			</div>
+			{#if conversations.length === 0}
+				<p class="text-xs text-gray-400">
+					{$i18n.t('No conversations yet. New chats started here belong to this project.')}
+				</p>
+			{:else}
+				<ul class="flex flex-col divide-y divide-gray-100 dark:divide-gray-800 rounded-xl border border-gray-200 dark:border-gray-800">
+					{#each conversations as convo (convo.id)}
+						<li class="flex items-center justify-between gap-3 px-4 py-2.5">
+							<a href={`/c/${convo.id}`} class="text-sm text-gray-700 dark:text-gray-200 truncate hover:underline min-w-0">
+								{convo.title}
+							</a>
+							<button
+								class="text-xs text-gray-400 hover:text-red-500 transition flex-none"
+								on:click={() => unlinkChat(convo.id)}
+							>
+								{$i18n.t('Unlink')}
+							</button>
+						</li>
+					{/each}
+				</ul>
+			{/if}
+		</section>
+	{/if}
+</div>
+
+{#if showEdit && project}
+	<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/40" role="dialog" aria-modal="true">
+		<button class="absolute inset-0 cursor-default" aria-label={$i18n.t('Close')} on:click={() => (showEdit = false)} />
+		<form
+			class="relative w-full max-w-md mx-4 p-5 rounded-2xl bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 shadow-xl flex flex-col gap-3"
+			on:submit|preventDefault={submitEdit}
+		>
+			<h2 class="text-base font-semibold text-gray-850 dark:text-gray-100">{$i18n.t('Rename')}</h2>
+			<label class="flex flex-col gap-1">
+				<span class="text-xs font-medium text-gray-500">{$i18n.t('Name')}</span>
+				<input
+					id="projects-rename-name"
+					class="px-3 py-2 text-sm rounded-lg bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 outline-none focus:border-gray-400 transition"
+					bind:value={editName}
+					maxlength={255}
+					required
+				/>
+			</label>
+			<label class="flex flex-col gap-1">
+				<span class="text-xs font-medium text-gray-500">{$i18n.t('Description')}</span>
+				<textarea
+					id="projects-rename-description"
+					class="px-3 py-2 text-sm rounded-lg bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 outline-none focus:border-gray-400 transition resize-y"
+					bind:value={editDescription}
+					rows="3"
+					maxlength={1000}
+				/>
+			</label>
+			<div class="flex justify-end gap-2 mt-1">
+				<button
+					type="button"
+					class="px-3 py-2 text-sm rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition"
+					on:click={() => (showEdit = false)}
+				>
+					{$i18n.t('Cancel')}
+				</button>
+				<button
+					type="submit"
+					disabled={!editName.trim() || busy}
+					class="px-3 py-2 text-sm font-medium rounded-lg bg-black text-white dark:bg-white dark:text-black disabled:opacity-40 hover:opacity-80 transition"
+				>
+					{$i18n.t('Save')}
+				</button>
+			</div>
+		</form>
+	</div>
+{/if}
+
+{#if showLinkPicker}
+	<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/40" role="dialog" aria-modal="true">
+		<button class="absolute inset-0 cursor-default" aria-label={$i18n.t('Close')} on:click={() => (showLinkPicker = false)} />
+		<div class="relative w-full max-w-md mx-4 max-h-[70vh] overflow-y-auto p-5 rounded-2xl bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 shadow-xl flex flex-col gap-2">
+			<h2 class="text-base font-semibold text-gray-850 dark:text-gray-100">
+				{$i18n.t('Link a conversation')}
+			</h2>
+			<p class="text-xs text-gray-400">{$i18n.t('Pick from your recent conversations.')}</p>
+			{#if recentChats.length === 0}
+				<p class="text-sm text-gray-500 py-4">{$i18n.t('No recent conversations')}</p>
+			{:else}
+				<ul class="flex flex-col divide-y divide-gray-100 dark:divide-gray-800">
+					{#each recentChats as chat (chat.id)}
+						<li class="flex items-center justify-between gap-3 py-2">
+							<span class="text-sm text-gray-700 dark:text-gray-200 truncate min-w-0">{chat.title}</span>
+							{#if linkedIds.has(chat.id)}
+								<span class="text-[11px] text-gray-400 flex-none">{$i18n.t('Linked')}</span>
+							{:else}
+								<button
+									class="text-xs font-medium text-gray-600 dark:text-gray-300 hover:underline flex-none"
+									on:click={() => linkChat(chat.id)}
+								>
+									{$i18n.t('Link')}
+								</button>
+							{/if}
+						</li>
+					{/each}
+				</ul>
+			{/if}
+		</div>
+	</div>
+{/if}

--- a/vendor/open-webui/src/lib/hive/projects/ProjectsList.svelte
+++ b/vendor/open-webui/src/lib/hive/projects/ProjectsList.svelte
@@ -138,16 +138,16 @@
 				<li>
 					<a
 						href={`/projects/${project.id}`}
-						class="block h-full p-4 rounded-2xl border border-gray-200 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-900 transition"
+						class="flex h-full flex-col p-4 rounded-2xl border border-gray-200 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-900 transition"
 					>
-						<p class="text-sm font-medium text-gray-850 dark:text-gray-100 truncate">
+						<div class="text-sm font-medium text-gray-850 dark:text-gray-100 truncate">
 							{project.name}
-						</p>
+						</div>
 						<!-- Subtitle row per the Claude reference: description first, then recency -->
-						<p class="mt-1 text-xs text-gray-500 line-clamp-2 min-h-[2rem]">
+						<div class="mt-1 text-xs text-gray-500 line-clamp-2 min-h-[2rem]">
 							{project.description || $i18n.t('No description')}
-						</p>
-						<p class="mt-2 text-[11px] text-gray-400">{relativeDate(project.updatedAt)}</p>
+						</div>
+						<div class="mt-auto pt-2 text-[11px] text-gray-400">{relativeDate(project.updatedAt)}</div>
 					</a>
 				</li>
 			{/each}

--- a/vendor/open-webui/src/lib/hive/projects/ProjectsList.svelte
+++ b/vendor/open-webui/src/lib/hive/projects/ProjectsList.svelte
@@ -163,6 +163,9 @@
 			on:submit|preventDefault={submitCreate}
 		>
 			<h2 class="text-base font-semibold text-gray-850 dark:text-gray-100">{$i18n.t('New project')}</h2>
+			{#if error}
+				<p role="alert" class="text-sm text-red-500">{error}</p>
+			{/if}
 			<label class="flex flex-col gap-1">
 				<span class="text-xs font-medium text-gray-500">{$i18n.t('Name')}</span>
 				<input

--- a/vendor/open-webui/src/lib/hive/projects/ProjectsList.svelte
+++ b/vendor/open-webui/src/lib/hive/projects/ProjectsList.svelte
@@ -1,0 +1,204 @@
+<script lang="ts">
+	/*
+	 * The Projects index: the D-045 destination holding context brought in.
+	 *
+	 * Hive authored. Backed by src/lib/hive/projects/projects.ts, which binds a
+	 * project to a knowledge collection on the pinned backend image; see that
+	 * file for the storage seam. This component is presentation and intent
+	 * only: list, search, sort by last updated, create.
+	 */
+	import { getContext, onMount } from 'svelte';
+	import { goto } from '$app/navigation';
+
+	import Tooltip from '$lib/components/common/Tooltip.svelte';
+	import { WEBUI_NAME } from '$lib/stores';
+
+	import {
+		type HiveProject,
+		ProjectError,
+		createProject,
+		listProjects
+	} from './projects';
+
+	const i18n: any = getContext('i18n');
+
+	let projects: HiveProject[] = [];
+	let loading = true;
+	let error = '';
+	let query = '';
+	let showCreate = false;
+	let newName = '';
+	let newDescription = '';
+	let creating = false;
+
+	onMount(async () => {
+		try {
+			projects = (await listProjects(localStorage.getItem('token') ?? '')).sort(
+				(a, b) => b.updatedAt - a.updatedAt
+			);
+		} catch (err) {
+			error =
+				err instanceof ProjectError
+					? err.message
+					: $i18n.t('Projects could not be loaded.');
+		} finally {
+			loading = false;
+		}
+	});
+
+	const filtered = () => {
+		const q = query.trim().toLowerCase();
+		const sorted = [...projects].sort((a, b) => b.updatedAt - a.updatedAt);
+		if (!q) return sorted;
+		return sorted.filter(
+			(p) => p.name.toLowerCase().includes(q) || p.description.toLowerCase().includes(q)
+		);
+	};
+
+	const relativeDate = (epochSeconds: number): string => {
+		if (!epochSeconds) return '';
+		const diffMs = Date.now() - epochSeconds * 1000;
+		const minutes = Math.floor(diffMs / 60000);
+		if (minutes < 1) return $i18n.t('just now');
+		if (minutes < 60) return $i18n.t('{{count}}m ago', { count: minutes });
+		const hours = Math.floor(minutes / 60);
+		if (hours < 24) return $i18n.t('{{count}}h ago', { count: hours });
+		const days = Math.floor(hours / 24);
+		if (days < 30) return $i18n.t('{{count}}d ago', { count: days });
+		return new Date(epochSeconds * 1000).toLocaleDateString();
+	};
+
+	const openCreate = () => {
+		newName = '';
+		newDescription = '';
+		showCreate = true;
+	};
+
+	const submitCreate = async () => {
+		if (!newName.trim() || creating) return;
+		creating = true;
+		error = '';
+		try {
+			const project = await createProject(
+				localStorage.getItem('token') ?? '',
+				{ name: newName.trim(), description: newDescription.trim() }
+			);
+			await goto(`/projects/${project.id}`);
+		} catch (err) {
+			error =
+				err instanceof ProjectError ? err.message : $i18n.t('The project could not be created.');
+		} finally {
+			creating = false;
+		}
+	};
+</script>
+
+<svelte:head>
+	<title>{$i18n.t('Projects')} • {$WEBUI_NAME}</title>
+</svelte:head>
+
+<div class="w-full flex flex-col px-4 md:px-10 py-6 gap-6 max-w-5xl mx-auto">
+	<div class="flex items-center justify-between gap-3">
+		<h1 class="text-2xl font-semibold text-gray-850 dark:text-gray-100">{$i18n.t('Projects')}</h1>
+		<Tooltip content={$i18n.t('Create a project')} placement="bottom">
+			<button
+				id="projects-new-button"
+				class="px-3.5 py-2 text-sm font-medium rounded-xl bg-black text-white dark:bg-white dark:text-black hover:opacity-80 transition"
+				on:click={openCreate}
+			>
+				{$i18n.t('New project')}
+			</button>
+		</Tooltip>
+	</div>
+
+	{#if error}
+		<p role="alert" class="text-sm text-red-500">{error}</p>
+	{/if}
+
+	<input
+		id="projects-search"
+		class="w-full px-4 py-2.5 text-sm rounded-xl bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-800 outline-none focus:border-gray-400 dark:focus:border-gray-600 transition"
+		type="search"
+		placeholder={$i18n.t('Search projects')}
+		bind:value={query}
+	/>
+
+	{#if loading}
+		<p class="text-sm text-gray-500" role="status">{$i18n.t('Loading...')}</p>
+	{:else if filtered().length === 0}
+		<div class="text-center py-16">
+			<p class="text-sm text-gray-500">{$i18n.t('No projects yet')}</p>
+			<p class="text-xs text-gray-400 mt-1">
+				{$i18n.t('Projects hold the documents and conversations you work against.')}
+			</p>
+		</div>
+	{:else}
+		<ul class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3" aria-label={$i18n.t('Projects')}>
+			{#each filtered() as project (project.id)}
+				<li>
+					<a
+						href={`/projects/${project.id}`}
+						class="block h-full p-4 rounded-2xl border border-gray-200 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-900 transition"
+					>
+						<p class="text-sm font-medium text-gray-850 dark:text-gray-100 truncate">
+							{project.name}
+						</p>
+						<!-- Subtitle row per the Claude reference: description first, then recency -->
+						<p class="mt-1 text-xs text-gray-500 line-clamp-2 min-h-[2rem]">
+							{project.description || $i18n.t('No description')}
+						</p>
+						<p class="mt-2 text-[11px] text-gray-400">{relativeDate(project.updatedAt)}</p>
+					</a>
+				</li>
+			{/each}
+		</ul>
+	{/if}
+</div>
+
+{#if showCreate}
+	<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/40" role="dialog" aria-modal="true">
+		<button class="absolute inset-0 cursor-default" aria-label={$i18n.t('Close')} on:click={() => (showCreate = false)} />
+		<form
+			class="relative w-full max-w-md mx-4 p-5 rounded-2xl bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 shadow-xl flex flex-col gap-3"
+			on:submit|preventDefault={submitCreate}
+		>
+			<h2 class="text-base font-semibold text-gray-850 dark:text-gray-100">{$i18n.t('New project')}</h2>
+			<label class="flex flex-col gap-1">
+				<span class="text-xs font-medium text-gray-500">{$i18n.t('Name')}</span>
+				<input
+					id="projects-create-name"
+					class="px-3 py-2 text-sm rounded-lg bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 outline-none focus:border-gray-400 transition"
+					bind:value={newName}
+					maxlength={255}
+					required
+				/>
+			</label>
+			<label class="flex flex-col gap-1">
+				<span class="text-xs font-medium text-gray-500">{$i18n.t('Description')}</span>
+				<textarea
+					id="projects-create-description"
+					class="px-3 py-2 text-sm rounded-lg bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 outline-none focus:border-gray-400 transition resize-y"
+					bind:value={newDescription}
+					rows="3"
+					maxlength={1000}
+				/>
+			</label>
+			<div class="flex justify-end gap-2 mt-1">
+				<button
+					type="button"
+					class="px-3 py-2 text-sm rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition"
+					on:click={() => (showCreate = false)}
+				>
+					{$i18n.t('Cancel')}
+				</button>
+				<button
+					type="submit"
+					disabled={!newName.trim() || creating}
+					class="px-3 py-2 text-sm font-medium rounded-lg bg-black text-white dark:bg-white dark:text-black disabled:opacity-40 hover:opacity-80 transition"
+				>
+					{$i18n.t('Create')}
+				</button>
+			</div>
+		</form>
+	</div>
+{/if}

--- a/vendor/open-webui/src/lib/hive/projects/projects.test.ts
+++ b/vendor/open-webui/src/lib/hive/projects/projects.test.ts
@@ -1,0 +1,216 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+	PROJECT_CHAT_KEY,
+	ProjectError,
+	addFileToProject,
+	bindChatToProject,
+	createBoundChat,
+	createProject,
+	deleteProject,
+	getProject,
+	listProjects,
+	removeFileFromProject,
+	resolveProjectConversations,
+	updateProject
+} from './projects';
+
+/*
+ * Runs in the scratch tree scripts/test-owui-hive-frontend.sh builds: no
+ * aliases, no svelte, plain vitest over fetch stubs. The same file also runs
+ * against the real tree inside the image build (npm run test:frontend), so it
+ * must stay free of any import a bare vitest cannot resolve.
+ */
+
+const json = (body: unknown) =>
+	new Response(JSON.stringify(body), { status: 200, headers: { 'Content-Type': 'application/json' } });
+
+describe('projects data layer', () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('lists projects from the knowledge collection list, dropping external connections', async () => {
+		const calls: string[] = [];
+		const fetchImpl = (async (input: RequestInfo | URL) => {
+			calls.push(String(input));
+			return json({
+				items: [
+					{ id: 'k1', name: 'Resume', description: 'Job hunt docs', updated_at: 100 },
+					{
+						id: 'k2',
+						name: 'External conn',
+						description: '',
+						updated_at: 90,
+						meta: { source: 'external' }
+					}
+				],
+				total: 2
+			});
+		}) as unknown as typeof fetch;
+
+		const rows = await listProjects('tok', '/api/v1', fetchImpl);
+
+		expect(rows).toEqual([{ id: 'k1', name: 'Resume', description: 'Job hunt docs', updatedAt: 100 }]);
+		expect(calls[0]).toBe('/api/v1/knowledge/');
+	});
+
+	it('creates a project through the knowledge create endpoint with empty grants', async () => {
+		let body: Record<string, unknown> = {};
+		const fetchImpl = (async (_input: RequestInfo | URL, init: RequestInit = {}) => {
+			body = JSON.parse(String(init.body ?? '{}'));
+			return json({ id: 'new1', name: body.name, description: body.description, updated_at: 5 });
+		}) as unknown as typeof fetch;
+
+		const project = await createProject('tok', { name: 'AI Lending Lab', description: 'd' }, '/api/v1', fetchImpl);
+
+		expect(project.id).toBe('new1');
+		expect(body.name).toBe('AI Lending Lab');
+		expect(body.access_grants).toEqual([]);
+	});
+
+	it('updates a project by sending the full KnowledgeForm the backend requires', async () => {
+		let body: Record<string, unknown> = {};
+		const fetchImpl = (async (_i: RequestInfo | URL, init: RequestInit = {}) => {
+			body = JSON.parse(String(init.body ?? '{}'));
+			return json({ id: 'k1', name: body.name, description: body.description, updated_at: 6 });
+		}) as unknown as typeof fetch;
+
+		await updateProject('tok', 'k1', { name: 'Renamed', description: 'new desc' }, '/api/v1', fetchImpl);
+
+		expect(body).toEqual({ name: 'Renamed', description: 'new desc' });
+	});
+
+	it('deletes a project with DELETE on the knowledge delete endpoint', async () => {
+		let method = '';
+		let url = '';
+		const fetchImpl = (async (input: RequestInfo | URL, init: RequestInit = {}) => {
+			url = String(input);
+			method = String(init.method ?? '');
+			return json(true);
+		}) as unknown as typeof fetch;
+
+		await expect(deleteProject('tok', 'k1', '/api/v1', fetchImpl)).resolves.toBe(true);
+		expect(method).toBe('DELETE');
+		expect(url).toContain('/api/v1/knowledge/k1/delete');
+	});
+
+	it('maps detail files and returns null on a missing project', async () => {
+		const okFetch = (async (input: RequestInfo | URL) => {
+			const url = String(input);
+			if (url.endsWith('/knowledge/k1')) {
+				return json({
+					id: 'k1',
+					name: 'P',
+					description: '',
+					updated_at: 9,
+					files: [
+						{ id: 'f1', meta: { name: 'resume.pdf' } },
+						{ id: 'f2', filename: 'notes.txt' }
+					]
+				});
+			}
+			return new Response('{}', { status: 404 });
+		}) as unknown as typeof fetch;
+
+		const project = await getProject('tok', 'k1', '/api/v1', okFetch);
+		expect(project?.files).toEqual([
+			{ id: 'f1', name: 'resume.pdf' },
+			{ id: 'f2', name: 'notes.txt' }
+		]);
+
+		const missing = await getProject('tok', 'gone', '/api/v1', okFetch);
+		expect(missing).toBeNull();
+	});
+
+	it('adds and removes files through the knowledge file endpoints', async () => {
+		const seen: Array<{ url: string; body?: Record<string, unknown> }> = [];
+		const fetchImpl = (async (input: RequestInfo | URL, init: RequestInit = {}) => {
+			seen.push({
+				url: String(input),
+				body: init.body ? JSON.parse(String(init.body)) : undefined
+			});
+			return json(true);
+		}) as unknown as typeof fetch;
+
+		await addFileToProject('tok', 'k1', 'file-1', '/api/v1', fetchImpl);
+		await removeFileFromProject('tok', 'k1', 'file-1', '/api/v1', fetchImpl);
+
+		expect(seen[0].url).toContain('/knowledge/k1/file/add');
+		expect(seen[0].body).toEqual({ file_id: 'file-1' });
+		expect(seen[1].url).toContain('/knowledge/k1/file/remove');
+	});
+
+	it('binds and unbinds a chat by writing only the namespaced key into the chat blob', async () => {
+		const seen: Array<{ url: string; body?: Record<string, unknown> }> = [];
+		const fetchImpl = (async (input: RequestInfo | URL, init: RequestInit = {}) => {
+			seen.push({
+				url: String(input),
+				body: init.body ? JSON.parse(String(init.body)) : undefined
+			});
+			return json({ id: 'c1' });
+		}) as unknown as typeof fetch;
+
+		await bindChatToProject('tok', 'c1', 'k1', '/api/v1', fetchImpl);
+		await bindChatToProject('tok', 'c1', null, '/api/v1', fetchImpl);
+
+		expect(seen[0]).toEqual({
+			url: '/api/v1/chats/c1',
+			body: { chat: { [PROJECT_CHAT_KEY]: 'k1' } }
+		});
+		// Unbind writes an explicit null rather than omitting the key, so the
+		// merge actually clears it server side.
+		expect(seen[1].body).toEqual({ chat: { [PROJECT_CHAT_KEY]: null } });
+	});
+
+	it('creates a chat already bound at birth via chats/new', async () => {
+		let body: Record<string, unknown> = {};
+		const fetchImpl = (async (_i: RequestInfo | URL, init: RequestInit = {}) => {
+			body = JSON.parse(String(init.body ?? '{}'));
+			return json({ id: 'c-new' });
+		}) as unknown as typeof fetch;
+
+		const chat = await createBoundChat('tok', 'k1', '/api/v1', fetchImpl);
+		expect(chat.id).toBe('c-new');
+		expect((body.chat as Record<string, unknown>)[PROJECT_CHAT_KEY]).toBe('k1');
+	});
+
+	it('resolves bound conversations by scanning the chat list and reading blobs', async () => {
+		const chatsById: Record<string, unknown> = {
+			c1: { id: 'c1', title: 'T1', chat: { [PROJECT_CHAT_KEY]: 'k1' }, updated_at: 10 },
+			c2: { id: 'c2', title: 'Other', chat: {}, updated_at: 11 },
+			c3: { id: 'c3', title: 'T3', chat: { [PROJECT_CHAT_KEY]: 'k1' }, updated_at: 30 }
+		};
+		const fetchImpl = (async (input: RequestInfo | URL) => {
+			const url = String(input);
+			if (url.startsWith('/api/v1/chats/list')) {
+				return json([{ id: 'c1', title: 'T1', updated_at: 10 }, { id: 'c2', title: 'O', updated_at: 11 }, { id: 'c3', title: 'T3', updated_at: 30 }]);
+			}
+			const id = url.split('/chats/')[1];
+			if (id === 'ghost') return new Response('{}', { status: 404 });
+			return json(chatsById[id]);
+		}) as unknown as typeof fetch;
+
+		const convos = await resolveProjectConversations('tok', 'k1', 100, '/api/v1', fetchImpl);
+		expect(convos.map((c) => c.id)).toEqual(['c3', 'c1']);
+		expect(convos[0].title).toBe('T3');
+	});
+
+	it('surfaces error details and keeps the status code', async () => {
+		const fetchImpl = (async () =>
+			new Response(JSON.stringify({ detail: 'Knowledge not found' }), {
+				status: 404,
+				headers: { 'Content-Type': 'application/json' }
+			})) as unknown as typeof fetch;
+
+		await expect(listProjects('tok', '/api/v1', fetchImpl)).rejects.toMatchObject({
+			name: 'ProjectError',
+			status: 404
+		});
+	});
+
+	it('exposes PROJECT_CHAT_KEY namespaced for blob safety', () => {
+		expect(PROJECT_CHAT_KEY).toBe('hiveProject');
+		expect(new ProjectError('x').name).toBe('ProjectError');
+	});
+});

--- a/vendor/open-webui/src/lib/hive/projects/projects.test.ts
+++ b/vendor/open-webui/src/lib/hive/projects/projects.test.ts
@@ -95,7 +95,7 @@ describe('projects data layer', () => {
 		expect(url).toContain('/api/v1/knowledge/k1/delete');
 	});
 
-	it('maps detail files and returns null on a missing project', async () => {
+	it('loads detail files from the per-collection listing endpoint, null on a missing project', async () => {
 		const okFetch = (async (input: RequestInfo | URL) => {
 			const url = String(input);
 			if (url.endsWith('/knowledge/k1')) {
@@ -104,10 +104,17 @@ describe('projects data layer', () => {
 					name: 'P',
 					description: '',
 					updated_at: 9,
-					files: [
+					files: null,
+					write_access: true
+				});
+			}
+			if (url.includes('/knowledge/k1/files')) {
+				return json({
+					items: [
 						{ id: 'f1', meta: { name: 'resume.pdf' } },
 						{ id: 'f2', filename: 'notes.txt' }
-					]
+					],
+					total: 2
 				});
 			}
 			return new Response('{}', { status: 404 });
@@ -118,6 +125,7 @@ describe('projects data layer', () => {
 			{ id: 'f1', name: 'resume.pdf' },
 			{ id: 'f2', name: 'notes.txt' }
 		]);
+		expect(project?.writeAccess).toBe(true);
 
 		const missing = await getProject('tok', 'gone', '/api/v1', okFetch);
 		expect(missing).toBeNull();

--- a/vendor/open-webui/src/lib/hive/projects/projects.test.ts
+++ b/vendor/open-webui/src/lib/hive/projects/projects.test.ts
@@ -204,17 +204,49 @@ describe('projects data layer', () => {
 		expect(convos[0].title).toBe('T3');
 	});
 
-	it('surfaces error details and keeps the status code', async () => {
+	it('keeps the status code but never renders backend detail text', async () => {
 		const fetchImpl = (async () =>
-			new Response(JSON.stringify({ detail: 'Knowledge not found' }), {
+			new Response(JSON.stringify({ detail: 'Knowledge not found: provider groq said x' }), {
 				status: 404,
 				headers: { 'Content-Type': 'application/json' }
 			})) as unknown as typeof fetch;
 
-		await expect(listProjects('tok', '/api/v1', fetchImpl)).rejects.toMatchObject({
-			name: 'ProjectError',
-			status: 404
+		await expect(listProjects('tok', '/api/v1', fetchImpl)).rejects.toSatisfy((err: ProjectError) => {
+			expect(err.name).toBe('ProjectError');
+			expect(err.status).toBe(404);
+			expect(err.message).not.toContain('groq');
+			expect(err.message).not.toContain('Knowledge not found');
+			return true;
 		});
+	});
+
+	it('propagates a detail-read failure that is not a deletion', async () => {
+		const chatsById: Record<string, unknown> = {
+			c1: { id: 'c1', title: 'T1', chat: { [PROJECT_CHAT_KEY]: 'k1' }, updated_at: 10 }
+		};
+		let c1Reads = 0;
+		const fetchImpl = (async (input: RequestInfo | URL) => {
+			const url = String(input);
+			if (url.startsWith('/api/v1/chats/list')) {
+				return json([{ id: 'c1', title: 'T1', updated_at: 10 }]);
+			}
+			const id = url.split('/chats/')[1];
+			if (id === 'c1') {
+				c1Reads++;
+				if (c1Reads === 1) {
+					return new Response('{}', { status: 500 });
+				}
+				return json(chatsById[id]);
+			}
+			return new Response('{}', { status: 404 });
+		}) as unknown as typeof fetch;
+
+		// First read 500s: the scan must reject rather than silently shrink.
+		await expect(resolveProjectConversations('tok', 'k1', 60, '/api/v1', fetchImpl)).rejects.toMatchObject({
+			status: 500
+		});
+		// Second read succeeds (404s and 403s stay skipped, not thrown).
+		await expect(resolveProjectConversations('tok', 'k1', 60, '/api/v1', fetchImpl)).resolves.toHaveLength(1);
 	});
 
 	it('exposes PROJECT_CHAT_KEY namespaced for blob safety', () => {

--- a/vendor/open-webui/src/lib/hive/projects/projects.ts
+++ b/vendor/open-webui/src/lib/hive/projects/projects.ts
@@ -81,14 +81,11 @@ async function requestJson<T>(
 		throw new ProjectError(err instanceof Error ? err.message : 'Network error');
 	}
 	if (!res.ok) {
-		let detail = res.statusText;
-		try {
-			const body = await res.json();
-			detail = body?.detail ?? detail;
-		} catch {
-			// Non-JSON error body: fall back to the status text.
-		}
-		throw new ProjectError(typeof detail === 'string' ? detail : 'Request failed', res.status);
+		// The backend's detail text never reaches a customer-bound string:
+		// provider names and internal wording ride in `detail`, so it is kept
+		// off the rendered message (provider-blind errors convention) and the
+		// HTTP status is the stable code the UI classifies on.
+		throw new ProjectError(`Request failed (${res.status})`, res.status);
 	}
 	return (await res.json()) as T;
 }
@@ -396,13 +393,22 @@ export const resolveProjectConversations = async (
 						return {
 							id: row.id,
 							title: full.title || row.title || 'Untitled',
-							updatedAt: Number(full.updated_at ?? row.updated_at ?? 0)
+							updatedAt: Number(full.updated_at ?? row.updated_at ?? 0),
+							hiveProjectId: projectId
 						};
 					}
 					return null;
-				} catch {
-					// Deleted between listing and read: skip, do not fail the page.
-					return null;
+				} catch (err) {
+					// Gone or inaccessible between listing and read: skip. Anything
+					// else (a 5xx, a network failure) propagates rather than
+					// silently shrinking the conversation list.
+					if (
+						err instanceof ProjectError &&
+						(err.status === 404 || err.status === 403)
+					) {
+						return null;
+					}
+					throw err;
 				}
 			})
 		);

--- a/vendor/open-webui/src/lib/hive/projects/projects.ts
+++ b/vendor/open-webui/src/lib/hive/projects/projects.ts
@@ -351,13 +351,15 @@ export const createBoundChat = async (
  * and reading each chat blob for our marker key.
  *
  * ponytail: one fetch per candidate chat, no server-side filter exists on the
- * pinned image. Fine at demo scale (tens of chats); if it ever hurts, a real
- * projects table with a chat.project_id column is the documented upgrade path.
+ * pinned image, and the list endpoint serves 60 rows per page (the pageSize
+ * default matches it so the loop does not stop a page early). Fine at demo
+ * scale (tens of chats); if it ever hurts, a real projects table with a
+ * chat.project_id column is the documented upgrade path.
  */
 export const resolveProjectConversations = async (
 	token: string,
 	projectId: string,
-	pageSize = 100,
+	pageSize = 60,
 	apiBase: string = DEFAULT_API_BASE,
 	fetchImpl: typeof fetch = fetch
 ): Promise<HiveProjectConversation[]> => {

--- a/vendor/open-webui/src/lib/hive/projects/projects.ts
+++ b/vendor/open-webui/src/lib/hive/projects/projects.ts
@@ -142,7 +142,7 @@ export const getProject = async (
 	try {
 		const row = await requestJson<
 			RawKnowledgeRow & {
-				files?: Array<Record<string, unknown>>;
+				files?: Array<Record<string, unknown>> | null;
 				write_access?: boolean;
 			}
 		>(
@@ -151,9 +151,20 @@ export const getProject = async (
 			apiBase,
 			fetchImpl
 		);
+		// The pinned image's detail response leaves `files` null even when the
+		// collection has them; the per-collection listing endpoint is where the
+		// real rows live.
+		const fileList = await requestJson<{
+			items?: Array<{ id: string; meta?: { name?: string } | null; filename?: string | null }>;
+		}>(
+			`/knowledge/${id}/files?page=1`,
+			{ method: 'GET', headers: headers(token) },
+			apiBase,
+			fetchImpl
+		);
 		return {
 			...toProject(row),
-			files: (row.files ?? []).map((f) => ({
+			files: (fileList.items ?? []).map((f) => ({
 				id: String(f.id),
 				name: String(f.meta?.name ?? f.filename ?? f.id)
 			})),

--- a/vendor/open-webui/src/lib/hive/projects/projects.ts
+++ b/vendor/open-webui/src/lib/hive/projects/projects.ts
@@ -1,0 +1,385 @@
+/*
+ * The Projects destination's data layer, from the chat frontend.
+ *
+ * Hive authored. Everything under src/lib/hive/ is ours, so a rebase against a
+ * future upstream tag reads as a file like this one rather than an archaeology
+ * exercise.
+ *
+ * Storage binding (the seam, stated plainly): a Project IS an Open WebUI
+ * knowledge collection on the pinned backend image. name/description come from
+ * the collection row; the files bound to the project are the files attached to
+ * that collection, which is exactly where RAG retrieval looks; and the
+ * conversations bound to a project live in each chat's own persisted JSON blob
+ * under the `hiveProject` key, written through the existing chat-update merge.
+ * No new table, no backend edit, no owui-patches rewrite tonight. If a real
+ * projects table ever lands backend side, this module is the only file that
+ * has to change: every call below is one fetch against /api/v1 and the rest of
+ * the surface renders from these functions' return values.
+ *
+ * Like agentTasks.ts before it, the base URL is a parameter with a production
+ * default rather than an import of `$lib/constants`: `$lib/constants` reaches
+ * `$app/environment`, which only SvelteKit's resolver can satisfy, while
+ * scripts/test-owui-hive-frontend.sh runs plain vitest in a scratch tree with
+ * no alias resolution at all. A `$lib` import here would make this module's
+ * own test file unloadable, which reports as no failures because nothing ran.
+ */
+
+export interface HiveProject {
+	id: string;
+	name: string;
+	description: string;
+	/** Epoch seconds, straight off the knowledge row. */
+	updatedAt: number;
+}
+
+export interface HiveProjectFile {
+	id: string;
+	name: string;
+}
+
+export interface HiveProjectConversation {
+	id: string;
+	title: string;
+	updatedAt: number;
+	hiveProjectId: string;
+}
+
+export class ProjectError extends Error {
+	status?: number;
+
+	constructor(message: string, status?: number) {
+		super(message);
+		this.name = 'ProjectError';
+		this.status = status;
+	}
+}
+
+const DEFAULT_API_BASE = '/api/v1';
+
+/**
+ * The marker key written into each bound chat's JSON blob. Namespaced so it
+ * can never collide with anything upstream puts in the same object.
+ */
+export const PROJECT_CHAT_KEY = 'hiveProject';
+
+const headers = (token: string): Record<string, string> => ({
+	Accept: 'application/json',
+	'Content-Type': 'application/json',
+	authorization: `Bearer ${token}`
+});
+
+async function requestJson<T>(
+	url: string,
+	init: RequestInit,
+	apiBase: string,
+	fetchImpl: typeof fetch
+): Promise<T> {
+	let res: Response;
+	try {
+		res = await fetchImpl(`${apiBase}${url}`, init);
+	} catch (err) {
+		throw new ProjectError(err instanceof Error ? err.message : 'Network error');
+	}
+	if (!res.ok) {
+		let detail = res.statusText;
+		try {
+			const body = await res.json();
+			detail = body?.detail ?? detail;
+		} catch {
+			// Non-JSON error body: fall back to the status text.
+		}
+		throw new ProjectError(typeof detail === 'string' ? detail : 'Request failed', res.status);
+	}
+	return (await res.json()) as T;
+}
+
+/* ------------------------------------------------------------------ *
+ * Projects (knowledge collections, re-skinned)
+ * ------------------------------------------------------------------ */
+
+interface RawKnowledgeRow {
+	id: string;
+	name: string;
+	description: string;
+	updated_at: number;
+	meta?: Record<string, unknown> | null;
+}
+
+function isProjectRow(row: RawKnowledgeRow): boolean {
+	// External connections ride the same table with meta.source === 'external';
+	// those are not projects and must never appear in the list.
+	return (row.meta ?? {})['source'] !== 'external';
+}
+
+const toProject = (row: RawKnowledgeRow): HiveProject => ({
+	id: row.id,
+	name: row.name,
+	description: row.description,
+	updatedAt: Number(row.updated_at ?? 0)
+});
+
+export const listProjects = async (
+	token: string,
+	apiBase: string = DEFAULT_API_BASE,
+	fetchImpl: typeof fetch = fetch
+): Promise<HiveProject[]> => {
+	const data = await requestJson<{ items?: RawKnowledgeRow[] } | RawKnowledgeRow[]>(
+		'/knowledge/',
+		{ method: 'GET', headers: headers(token) },
+		apiBase,
+		fetchImpl
+	);
+	const rows = Array.isArray(data) ? data : (data.items ?? []);
+	return rows.filter(isProjectRow).map(toProject);
+};
+
+export const getProject = async (
+	token: string,
+	id: string,
+	apiBase: string = DEFAULT_API_BASE,
+	fetchImpl: typeof fetch = fetch
+): Promise<(HiveProject & { files: HiveProjectFile[]; writeAccess: boolean }) | null> => {
+	try {
+		const row = await requestJson<
+			RawKnowledgeRow & {
+				files?: Array<Record<string, unknown>>;
+				write_access?: boolean;
+			}
+		>(
+			`/knowledge/${id}`,
+			{ method: 'GET', headers: headers(token) },
+			apiBase,
+			fetchImpl
+		);
+		return {
+			...toProject(row),
+			files: (row.files ?? []).map((f) => ({
+				id: String(f.id),
+				name: String(f.meta?.name ?? f.filename ?? f.id)
+			})),
+			writeAccess: row.write_access !== false
+		};
+	} catch (err) {
+		if (err instanceof ProjectError && err.status === 404) {
+			return null;
+		}
+		throw err;
+	}
+};
+
+export interface NewProjectForm {
+	name: string;
+	description: string;
+}
+
+export const createProject = async (
+	token: string,
+	form: NewProjectForm,
+	apiBase: string = DEFAULT_API_BASE,
+	fetchImpl: typeof fetch = fetch
+): Promise<HiveProject> => {
+	const row = await requestJson<RawKnowledgeRow>(
+		'/knowledge/create',
+		{
+			method: 'POST',
+			headers: headers(token),
+			body: JSON.stringify({
+				name: form.name,
+				description: form.description,
+				access_grants: []
+			})
+		},
+		apiBase,
+		fetchImpl
+	);
+	return toProject(row);
+};
+
+/**
+ * The backend's KnowledgeForm requires name and description on every update,
+ * so callers pass the full object; components always hold it in hand.
+ */
+export const updateProject = async (
+	token: string,
+	id: string,
+	form: NewProjectForm,
+	apiBase: string = DEFAULT_API_BASE,
+	fetchImpl: typeof fetch = fetch
+): Promise<HiveProject> => {
+	const row = await requestJson<RawKnowledgeRow>(
+		`/knowledge/${id}/update`,
+		{
+			method: 'POST',
+			headers: headers(token),
+			body: JSON.stringify({
+				name: form.name,
+				description: form.description
+			})
+		},
+		apiBase,
+		fetchImpl
+	);
+	return toProject(row);
+};
+
+export const deleteProject = async (
+	token: string,
+	id: string,
+	apiBase: string = DEFAULT_API_BASE,
+	fetchImpl: typeof fetch = fetch
+): Promise<boolean> => {
+	await requestJson<unknown>(
+		`/knowledge/${id}/delete`,
+		{ method: 'DELETE', headers: headers(token) },
+		apiBase,
+		fetchImpl
+	);
+	return true;
+};
+
+/* ------------------------------------------------------------------ *
+ * Files bound to the project scope
+ * ------------------------------------------------------------------ */
+
+export const addFileToProject = async (
+	token: string,
+	projectId: string,
+	fileId: string,
+	apiBase: string = DEFAULT_API_BASE,
+	fetchImpl: typeof fetch = fetch
+): Promise<boolean> => {
+	await requestJson<unknown>(
+		`/knowledge/${projectId}/file/add`,
+		{
+			method: 'POST',
+			headers: headers(token),
+			body: JSON.stringify({ file_id: fileId })
+		},
+		apiBase,
+		fetchImpl
+	);
+	return true;
+};
+
+export const removeFileFromProject = async (
+	token: string,
+	projectId: string,
+	fileId: string,
+	apiBase: string = DEFAULT_API_BASE,
+	fetchImpl: typeof fetch = fetch
+): Promise<boolean> => {
+	await requestJson<unknown>(
+		`/knowledge/${projectId}/file/remove`,
+		{
+			method: 'POST',
+			headers: headers(token),
+			body: JSON.stringify({ file_id: fileId })
+		},
+		apiBase,
+		fetchImpl
+	);
+	return true;
+};
+
+/* ------------------------------------------------------------------ *
+ * Conversations bound to the project
+ * ------------------------------------------------------------------ */
+
+interface RawChatListRow {
+	id: string;
+	title: string;
+	updated_at: number;
+}
+
+/**
+ * Write the binding onto one chat's persisted blob. The chat-update route
+ * merges top-level keys of `chat`, so this only ever touches our namespaced
+ * key and leaves messages, history and every other field alone.
+ */
+export const bindChatToProject = async (
+	token: string,
+	chatId: string,
+	projectId: string | null,
+	apiBase: string = DEFAULT_API_BASE,
+	fetchImpl: typeof fetch = fetch
+): Promise<boolean> => {
+	await requestJson<unknown>(
+		`/chats/${chatId}`,
+		{
+			method: 'POST',
+			headers: headers(token),
+			body: JSON.stringify({ chat: { [PROJECT_CHAT_KEY]: projectId } })
+		},
+		apiBase,
+		fetchImpl
+	);
+	return true;
+};
+
+export const createBoundChat = async (
+	token: string,
+	projectId: string,
+	apiBase: string = DEFAULT_API_BASE,
+	fetchImpl: typeof fetch = fetch
+): Promise<{ id: string }> => {
+	const chat = await requestJson<{ id: string }>(
+		'/chats/new',
+		{
+			method: 'POST',
+			headers: headers(token),
+			body: JSON.stringify({ chat: { [PROJECT_CHAT_KEY]: projectId }, folder_id: null })
+		},
+		apiBase,
+		fetchImpl
+	);
+	return { id: chat.id };
+};
+
+/**
+ * Collect the project's bound conversations by walking the user's chat list
+ * and reading each chat blob for our marker key.
+ *
+ * ponytail: one fetch per candidate chat, no server-side filter exists on the
+ * pinned image. Fine at demo scale (tens of chats); if it ever hurts, a real
+ * projects table with a chat.project_id column is the documented upgrade path.
+ */
+export const resolveProjectConversations = async (
+	token: string,
+	projectId: string,
+	pageSize = 100,
+	apiBase: string = DEFAULT_API_BASE,
+	fetchImpl: typeof fetch = fetch
+): Promise<HiveProjectConversation[]> => {
+	const out: HiveProjectConversation[] = [];
+	for (let page = 1; page <= 50; page++) {
+		const params = new URLSearchParams();
+		params.append('page', String(page));
+		const rows = await requestJson<RawChatListRow[]>(
+			`/chats/list?${params.toString()}`,
+			{ method: 'GET', headers: headers(token) },
+			apiBase,
+			fetchImpl
+		);
+		for (const row of rows) {
+			try {
+				const full = await requestJson<{
+					chat?: { [key: string]: unknown };
+					title?: string;
+					updated_at?: number;
+				}>(`/chats/${row.id}`, { method: 'GET', headers: headers(token) }, apiBase, fetchImpl);
+				if (full?.chat?.[PROJECT_CHAT_KEY] === projectId) {
+					out.push({
+						id: row.id,
+						title: full.title || row.title || 'Untitled',
+						updatedAt: Number(full.updated_at ?? row.updated_at ?? 0)
+					});
+				}
+			} catch {
+				// Deleted between listing and read: skip, do not fail the page.
+			}
+		}
+		if (rows.length < pageSize) break;
+	}
+	out.sort((a, b) => b.updatedAt - a.updatedAt);
+	return out;
+};

--- a/vendor/open-webui/src/lib/hive/projects/projects.ts
+++ b/vendor/open-webui/src/lib/hive/projects/projects.ts
@@ -363,7 +363,10 @@ export const resolveProjectConversations = async (
 	apiBase: string = DEFAULT_API_BASE,
 	fetchImpl: typeof fetch = fetch
 ): Promise<HiveProjectConversation[]> => {
-	const out: HiveProjectConversation[] = [];
+	// Walk every list page first (a short page ends the walk), then read the
+	// candidate blobs with bounded concurrency so the detail page does not wait
+	// on one serial request per chat.
+	const candidates: RawChatListRow[] = [];
 	for (let page = 1; page <= 50; page++) {
 		const params = new URLSearchParams();
 		params.append('page', String(page));
@@ -373,25 +376,39 @@ export const resolveProjectConversations = async (
 			apiBase,
 			fetchImpl
 		);
-		for (const row of rows) {
-			try {
-				const full = await requestJson<{
-					chat?: { [key: string]: unknown };
-					title?: string;
-					updated_at?: number;
-				}>(`/chats/${row.id}`, { method: 'GET', headers: headers(token) }, apiBase, fetchImpl);
-				if (full?.chat?.[PROJECT_CHAT_KEY] === projectId) {
-					out.push({
-						id: row.id,
-						title: full.title || row.title || 'Untitled',
-						updatedAt: Number(full.updated_at ?? row.updated_at ?? 0)
-					});
-				}
-			} catch {
-				// Deleted between listing and read: skip, do not fail the page.
-			}
-		}
+		candidates.push(...rows);
 		if (rows.length < pageSize) break;
+	}
+
+	const out: HiveProjectConversation[] = [];
+	const CONCURRENCY = 8;
+	for (let i = 0; i < candidates.length; i += CONCURRENCY) {
+		const batch = candidates.slice(i, i + CONCURRENCY);
+		const settled = await Promise.all(
+			batch.map(async (row) => {
+				try {
+					const full = await requestJson<{
+						chat?: { [key: string]: unknown };
+						title?: string;
+						updated_at?: number;
+					}>(`/chats/${row.id}`, { method: 'GET', headers: headers(token) }, apiBase, fetchImpl);
+					if (full?.chat?.[PROJECT_CHAT_KEY] === projectId) {
+						return {
+							id: row.id,
+							title: full.title || row.title || 'Untitled',
+							updatedAt: Number(full.updated_at ?? row.updated_at ?? 0)
+						};
+					}
+					return null;
+				} catch {
+					// Deleted between listing and read: skip, do not fail the page.
+					return null;
+				}
+			})
+		);
+		for (const convo of settled) {
+			if (convo) out.push(convo);
+		}
 	}
 	out.sort((a, b) => b.updatedAt - a.updatedAt);
 	return out;

--- a/vendor/open-webui/src/routes/(app)/projects/+page.svelte
+++ b/vendor/open-webui/src/routes/(app)/projects/+page.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+	import { getContext } from 'svelte';
+
+	import { WEBUI_NAME, showSidebar, mobile } from '$lib/stores';
+
+	import Tooltip from '$lib/components/common/Tooltip.svelte';
+	import SidebarIcon from '$lib/components/icons/Sidebar.svelte';
+	import ProjectsList from '$lib/hive/projects/ProjectsList.svelte';
+
+	const i18n: any = getContext('i18n');
+
+	/*
+	 * The Projects destination inside the shell, per D-045 ruling 2.
+	 *
+	 * Same frame as every other destination: this route renders into the one
+	 * shell, with the same sidebar and chrome, and swaps nothing.
+	 */
+</script>
+
+<div
+	class="hv-panel flex flex-col w-full h-screen max-h-[100dvh] transition-width duration-200 ease-in-out {$showSidebar
+		? 'md:max-w-[calc(100%-var(--sidebar-width))]'
+		: ''} max-w-full"
+>
+	{#if $mobile}
+		<nav class="px-2.5 pt-1.5 w-full drag-region select-none">
+			<div class="flex items-center">
+				<div class="{$showSidebar ? 'md:hidden' : ''} flex flex-none items-center self-end">
+					<Tooltip content={$showSidebar ? $i18n.t('Close Sidebar') : $i18n.t('Open Sidebar')} interactive={true}>
+						<button
+							id="sidebar-toggle-button"
+							class="cursor-pointer flex rounded-lg hover:bg-gray-100 dark:hover:bg-gray-850 transition"
+							on:click={() => {
+								showSidebar.set(!$showSidebar);
+							}}
+							aria-label={$showSidebar ? $i18n.t('Close Sidebar') : $i18n.t('Open Sidebar')}
+						>
+							<div class="self-center p-1.5">
+								<SidebarIcon />
+							</div>
+						</button>
+					</Tooltip>
+				</div>
+			</div>
+		</nav>
+	{/if}
+
+	<div class="hv-panel-region">
+		<ProjectsList />
+	</div>
+</div>

--- a/vendor/open-webui/src/routes/(app)/projects/[id]/+page.svelte
+++ b/vendor/open-webui/src/routes/(app)/projects/[id]/+page.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+	import { getContext } from 'svelte';
+	import { page } from '$app/stores';
+
+	import { WEBUI_NAME, showSidebar, mobile } from '$lib/stores';
+
+	import Tooltip from '$lib/components/common/Tooltip.svelte';
+	import SidebarIcon from '$lib/components/icons/Sidebar.svelte';
+	import ProjectDetail from '$lib/hive/projects/ProjectDetail.svelte';
+
+	const i18n: any = getContext('i18n');
+
+	/*
+	 * One project's contents, inside the same shell as everything else. The
+	 * project id comes from the route, the component owns the rest.
+	 */
+</script>
+
+<div
+	class="hv-panel flex flex-col w-full h-screen max-h-[100dvh] transition-width duration-200 ease-in-out {$showSidebar
+		? 'md:max-w-[calc(100%-var(--sidebar-width))]'
+		: ''} max-w-full"
+>
+	{#if $mobile}
+		<nav class="px-2.5 pt-1.5 w-full drag-region select-none">
+			<div class="flex items-center">
+				<div class="{$showSidebar ? 'md:hidden' : ''} flex flex-none items-center self-end">
+					<Tooltip content={$showSidebar ? $i18n.t('Close Sidebar') : $i18n.t('Open Sidebar')} interactive={true}>
+						<button
+							id="sidebar-toggle-button"
+							class="cursor-pointer flex rounded-lg hover:bg-gray-100 dark:hover:bg-gray-850 transition"
+							on:click={() => {
+								showSidebar.set(!$showSidebar);
+							}}
+							aria-label={$showSidebar ? $i18n.t('Close Sidebar') : $i18n.t('Open Sidebar')}
+						>
+							<div class="self-center p-1.5">
+								<SidebarIcon />
+							</div>
+						</button>
+					</Tooltip>
+				</div>
+			</div>
+		</nav>
+	{/if}
+
+	<div class="hv-panel-region">
+		<ProjectDetail id={$page.params.id ?? ''} />
+	</div>
+</div>


### PR DESCRIPTION
## What

D-045 ruling 2 replaces Knowledge with Projects as the destination holding context brought in. This PR ships that destination:

- **Nav row**: `Projects` added to HIVE_NAV (first row, folder glyph). ShellNav.svelte itself is untouched: it renders HIVE_NAV generically. Coexists with the Scheduled row from #1118; the D-045 ordering Projects, Artifacts, Scheduled holds among the rows that exist (Artifacts is #1110's lane).
- **/projects** index: search, last-updated sort, create dialog (name + description), card grid with name, description subtitle and relative date, matching the Claude reference's project rows with subtitle.
- **/projects/[id]** detail: rename, delete, files section (add via upload with mid-batch rollback, remove), conversations section (New chat creates a chat already bound at birth; Link existing picks from recent chats; Unlink writes an explicit null through the same merge).

## Storage binding

A Project IS an Open WebUI knowledge collection on the pinned backend image:

- name/description/updated_at from the collection row
- files bound to the project scope = the collection's files (loaded from the per-collection listing endpoint; the detail response leaves `files` null on this pin), which is exactly what RAG retrieval pulls for work against this project
- conversation bindings persist in each chat's own blob under the namespaced `hiveProject` key via the existing `POST /api/v1/chats/{id}` merge; unbinding writes an explicit null so the merge clears it

No new table, no backend edit, no owui-patches rewrite. If a real projects table lands later, only src/lib/hive/projects/projects.ts changes.

## Constraints honored

Diff stays inside new directories (src/lib/hive/projects/, routes (app)/projects/) plus the minimal nav data row edit (nav.ts + ShellNavIcon glyph). SettingsModal.svelte and MessageInput.svelte untouched.

## Known seams, documented not hidden

- The Claude reference has the project picker reachable from the composer mode row. That wiring point is inside MessageInput.svelte, which another agent owns right now (#1108/#1112), so tonight the picker lives on the project pages themselves. Wiring it into the composer is a one-component follow-up once that file frees up.
- resolveProjectConversations walks list pages then reads candidate blobs 8 at a time, because no server-side filter exists on the pinned image; capped at 50 pages (3000 chats), ceiling documented in code. A real projects table with chat.project_id is the upgrade path.
- Non-admin create: POST /knowledge/create is gated on workspace.knowledge, which defaults off for non-admins (independent review, medium, to schedule): either grant the permission in the demo deployment or gate the affordance off the session payload in a follow-up.

## Tests

87 vitest unit tests pass via scripts/test-owui-hive-frontend.sh (12 over the projects data layer, including the files-listing shape, the 60 row page size, bounded-concurrency scan, error-detail redaction and non-404 propagation); compile check covers both new components.

## Review

- CodeRabbit: GitHub app run was rate limited (SKIPPED per pipeline fallback); CodeRabbit CLI ran three passes. First pass: 7 findings, all addressed (missing hiveProjectId field, backend detail leakage, partial upload rollback, non-404 propagation, page size, serial scan). Second and third passes on the fixed diff: zero findings.
- Independent adversarial pass: verdict READY, verified endpoints against the pinned backend source; its medium (non-admin create permission) and cosmetic (double error line) findings are addressed or noted above.
- Visual proof: posted as a comment with six screenshots against an isolated throwaway stack built from this branch; capture log committed under docs/proof/projects-surface/.

## Buglog entry

None: nothing broke to get here. No bug fixed, so no line for .wolf/buglog.jsonl.