### PR TITLE
feat: show remaining credits above the chat composer

### DIFF
--- a/apps/control-plane/cmd/server/main.go
+++ b/apps/control-plane/cmd/server/main.go
@@ -1363,6 +1363,17 @@ func main() {
 	routerMux.Handle("/internal/license/entitlement", platformhttp.RequireInternalToken(cfg.InternalToken, licenseHandler))
 	log.Println("licensing entitlement route registered (issue #304)")
 
+	// Issue #1063: the chat composer's credits banner. Open WebUI's backend
+	// resolves its own signed-in user to an email server side and calls this
+	// internal route; the tenant->billing-account link stays behind the
+	// shared-secret gate and never reaches a browser.
+	if ledgerSvc != nil {
+		ledger.RegisterChatBalanceRoute(routerMux, ledgerSvc, func(h http.Handler) http.Handler {
+			return platformhttp.RequireInternalToken(cfg.InternalToken, h)
+		})
+		log.Println("chat credits balance route registered (issue #1063)")
+	}
+
 	// Phase 14 — register credit grant routes. Admin surface gated via
 	// RequirePlatformAdmin (provider-blind 401/403 sanitised JSON); self
 	// surface gated via plain auth middleware.

--- a/apps/control-plane/cmd/server/main.go
+++ b/apps/control-plane/cmd/server/main.go
@@ -1366,8 +1366,11 @@ func main() {
 	// Issue #1063: the chat composer's credits banner. Open WebUI's backend
 	// resolves its own signed-in user to an email server side and calls this
 	// internal route; the tenant->billing-account link stays behind the
-	// shared-secret gate and never reaches a browser.
-	if ledgerSvc != nil {
+	// shared-secret gate and never reaches a browser. The route is not mounted
+	// at all without a configured token: RequireInternalToken already fails
+	// closed on an empty token, and skipping the mount makes a misconfigured
+	// deployment read as silent absence rather than a live surface.
+	if ledgerSvc != nil && cfg.InternalToken != "" {
 		ledger.RegisterChatBalanceRoute(routerMux, ledgerSvc, func(h http.Handler) http.Handler {
 			return platformhttp.RequireInternalToken(cfg.InternalToken, h)
 		})

--- a/apps/control-plane/internal/ledger/chat_balance.go
+++ b/apps/control-plane/internal/ledger/chat_balance.go
@@ -1,0 +1,119 @@
+package ledger
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Issue #1063: chat users cannot see credits or usage left anywhere.
+//
+// The signed-in chat principal authenticates as an Open WebUI user whose only
+// reliable identifier is an email; the balance lives on the tenant's billing
+// account, and the tenant->account link in public.tenant_billing_accounts is
+// service-role-only by design and must never reach a browser. So the Open
+// WebUI backend resolves its own session to an email server side and calls the
+// internal route below over the shared-secret gate, and this file answers with
+// the smallest trimmed view the composer banner needs.
+//
+// Scope is deliberately TENANT balance. The schema has no per-user allowance;
+// do not fake one off request_attempts.user_id.
+
+// ChatBalanceRoute is mounted behind RequireInternalToken.
+const ChatBalanceRoute = "/internal/chat/credits/balance"
+
+// maxChatBalanceBody bounds the one-field JSON body this route accepts.
+const maxChatBalanceBody = 4 << 10 // 4 KiB
+
+type chatBalanceRequest struct {
+	Email string `json:"email"`
+}
+
+// ChatBalance is what the banner renders from. Nothing else crosses: posted
+// and reserved are already two more numbers than the widget needs, kept
+// because they cost nothing and make the response self-describing in logs.
+type ChatBalance struct {
+	PostedCredits    int64 `json:"posted_credits"`
+	ReservedCredits  int64 `json:"reserved_credits"`
+	AvailableCredits int64 `json:"available_credits"`
+	UsageToday       int64 `json:"usage_today_credits"`
+}
+
+// GetChatBalance resolves the email's tenant billing account and reads its
+// balance plus today's usage. found=false means no active membership on a
+// billed, non-archived tenant; that is a normal answer, not an error, so the
+// caller can render nothing instead of a failure.
+func (s *Service) GetChatBalance(ctx context.Context, email string) (ChatBalance, bool, error) {
+	email = strings.TrimSpace(email)
+	if email == "" {
+		return ChatBalance{}, false, nil
+	}
+
+	accountID, err := s.repo.ResolveAccountIDForEmail(ctx, email)
+	if err != nil {
+		return ChatBalance{}, false, err
+	}
+	if accountID == uuid.Nil {
+		return ChatBalance{}, false, nil
+	}
+
+	balance, err := s.GetBalance(ctx, accountID)
+	if err != nil {
+		return ChatBalance{}, false, err
+	}
+
+	// Midnight UTC. "Today" for a prepaid meter is a display convention, not a
+	// billing boundary; the ledger itself never depends on this number.
+	usageToday, err := s.repo.GetUsageSince(ctx, accountID, time.Now().UTC().Truncate(24*time.Hour))
+	if err != nil {
+		return ChatBalance{}, false, err
+	}
+
+	return ChatBalance{
+		PostedCredits:    balance.PostedCredits,
+		ReservedCredits:  balance.ReservedCredits,
+		AvailableCredits: balance.AvailableCredits,
+		UsageToday:       usageToday,
+	}, true, nil
+}
+
+// RegisterChatBalanceRoute mounts POST /internal/chat/credits/balance behind
+// the shared-secret gate every /internal route runs under.
+func RegisterChatBalanceRoute(mux *http.ServeMux, svc *Service, gate func(http.Handler) http.Handler) {
+	mux.Handle(ChatBalanceRoute, gate(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+			return
+		}
+
+		var req chatBalanceRequest
+		dec := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxChatBalanceBody))
+		if err := dec.Decode(&req); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "email is required"})
+			return
+		}
+		req.Email = strings.TrimSpace(req.Email)
+		if req.Email == "" {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "email is required"})
+			return
+		}
+
+		balance, found, err := svc.GetChatBalance(r.Context(), req.Email)
+		switch {
+		case err != nil:
+			// Opaque on purpose: the email must not be echoed back into a
+			// response body or log line attached to it.
+			slog.ErrorContext(r.Context(), "chat balance read failed")
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "balance could not be read"})
+		case !found:
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": "no billed account"})
+		default:
+			writeJSON(w, http.StatusOK, balance)
+		}
+	})))
+}

--- a/apps/control-plane/internal/ledger/chat_balance_live_test.go
+++ b/apps/control-plane/internal/ledger/chat_balance_live_test.go
@@ -1,0 +1,84 @@
+package ledger
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// Issue #1063, the SQL half. ResolveAccountIDForEmail joins four tables; a
+// wrong join or status filter either shows one user's balance to another or
+// shows nobody anything. The unit stubs encode the same assumption twice, so
+// only the real schema can catch a drift. Gated on HIVE_TEST_DB_URL like the
+// rest of this suite; the CI leg that runs it bootstraps the full migration
+// chain first.
+
+func TestResolveAccountIDForEmail_Live(t *testing.T) {
+	pool := newLedgerTestPool(t)
+	ctx := context.Background()
+
+	email := "chat-balance-" + uuid.NewString() + "@test.local"
+
+	var userID uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO auth.users (id, email, raw_user_meta_data)
+		 VALUES (gen_random_uuid(), $1, '{}'::jsonb) RETURNING id`, email).Scan(&userID); err != nil {
+		t.Fatalf("seed auth.users failed (is this a migrated test DB?): %v", err)
+	}
+	t.Cleanup(func() { _, _ = pool.Exec(ctx, `DELETE FROM auth.users WHERE id = $1`, userID) })
+
+	var tenantID uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO public.tenants(id, slug, name, deployment)
+		 VALUES (gen_random_uuid(), $1, 'chat balance live', 'cloud')
+		 RETURNING id`,
+		"chat-balance-"+uuid.NewString()).Scan(&tenantID); err != nil {
+		t.Fatalf("seed tenants: %v", err)
+	}
+	t.Cleanup(func() { _, _ = pool.Exec(ctx, `DELETE FROM public.tenants WHERE id = $1`, tenantID) })
+
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO public.tenant_users(tenant_id, user_id, role, status)
+		 VALUES ($1, $2, 'MEMBER', 'ACTIVE')`, tenantID, userID); err != nil {
+		t.Fatalf("seed tenant_users: %v", err)
+	}
+
+	repo := &pgxRepository{pool: pool}
+
+	t.Run("unmapped email resolves to Nil without error", func(t *testing.T) {
+		id, err := repo.ResolveAccountIDForEmail(ctx, "nobody-"+uuid.NewString()+"@test.local")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if id != uuid.Nil {
+			t.Fatalf("expected uuid.Nil, got %s", id)
+		}
+	})
+
+	t.Run("active membership on billed tenant resolves case-insensitively", func(t *testing.T) {
+		var accountID uuid.UUID
+		if err := pool.QueryRow(ctx,
+			`INSERT INTO public.accounts (id, slug, display_name, account_type, owner_user_id)
+			 VALUES (gen_random_uuid(), $1, 'chat balance live', 'personal', $2) RETURNING id`,
+			"chat-balance-"+uuid.NewString(), userID).Scan(&accountID); err != nil {
+			t.Fatalf("seed account: %v", err)
+		}
+		t.Cleanup(func() { _, _ = pool.Exec(ctx, `DELETE FROM public.accounts WHERE id = $1`, accountID) })
+
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO public.tenant_billing_accounts(tenant_id, account_id) VALUES ($1, $2)`,
+			tenantID, accountID); err != nil {
+			t.Fatalf("seed tba: %v", err)
+		}
+
+		got, err := repo.ResolveAccountIDForEmail(ctx, strings.ToUpper(email))
+		if err != nil {
+			t.Fatalf("resolve: %v", err)
+		}
+		if got != accountID {
+			t.Fatalf("resolved %s, want %s", got, accountID)
+		}
+	})
+}

--- a/apps/control-plane/internal/ledger/chat_balance_live_test.go
+++ b/apps/control-plane/internal/ledger/chat_balance_live_test.go
@@ -32,7 +32,7 @@ func TestResolveAccountIDForEmail_Live(t *testing.T) {
 	var tenantID uuid.UUID
 	if err := pool.QueryRow(ctx,
 		`INSERT INTO public.tenants(id, slug, name, deployment)
-		 VALUES (gen_random_uuid(), $1, 'chat balance live', 'cloud')
+		 VALUES (gen_random_uuid(), $1, 'chat balance live', 'HIVE_CLOUD')
 		 RETURNING id`,
 		"chat-balance-"+uuid.NewString()).Scan(&tenantID); err != nil {
 		t.Fatalf("seed tenants: %v", err)
@@ -79,6 +79,79 @@ func TestResolveAccountIDForEmail_Live(t *testing.T) {
 		}
 		if got != accountID {
 			t.Fatalf("resolved %s, want %s", got, accountID)
+		}
+	})
+
+	t.Run("selected tenant wins over newer membership", func(t *testing.T) {
+		// Second billed tenant the user joined more recently.
+		var newerTenant, newerAccount uuid.UUID
+		if err := pool.QueryRow(ctx,
+			`INSERT INTO public.tenants(id, slug, name, deployment)
+			 VALUES (gen_random_uuid(), $1, 'chat balance newer', 'HIVE_CLOUD') RETURNING id`,
+			"chat-balance-newer-"+uuid.NewString()).Scan(&newerTenant); err != nil {
+			t.Fatalf("seed second tenant: %v", err)
+		}
+		t.Cleanup(func() { _, _ = pool.Exec(ctx, `DELETE FROM public.tenants WHERE id = $1`, newerTenant) })
+		if err := pool.QueryRow(ctx,
+			`INSERT INTO public.accounts (id, slug, display_name, account_type, owner_user_id)
+			 VALUES (gen_random_uuid(), $1, 'chat balance newer', 'personal', $2) RETURNING id`,
+			"chat-balance-newer-"+uuid.NewString(), userID).Scan(&newerAccount); err != nil {
+			t.Fatalf("seed second account: %v", err)
+		}
+		t.Cleanup(func() { _, _ = pool.Exec(ctx, `DELETE FROM public.accounts WHERE id = $1`, newerAccount) })
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO public.tenant_billing_accounts(tenant_id, account_id) VALUES ($1, $2)`,
+			newerTenant, newerAccount); err != nil {
+			t.Fatalf("seed second tba: %v", err)
+		}
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO public.tenant_users(tenant_id, user_id, role, status)
+			 VALUES ($1, $2, 'MEMBER', 'ACTIVE')`, newerTenant, userID); err != nil {
+			t.Fatalf("seed second membership: %v", err)
+		}
+
+		// No selection: newest membership answers.
+		got, err := repo.ResolveAccountIDForEmail(ctx, email)
+		if err != nil {
+			t.Fatalf("resolve without selection: %v", err)
+		}
+		if got != newerAccount {
+			t.Fatalf("no-selection resolve %s, want newest %s", got, newerAccount)
+		}
+
+		// Selection names the older tenant: it wins despite being older.
+		var olderAccount uuid.UUID
+		if err := pool.QueryRow(ctx,
+			`SELECT account_id FROM public.tenant_billing_accounts WHERE tenant_id = $1`, tenantID).Scan(&olderAccount); err != nil {
+			t.Fatalf("read older account: %v", err)
+		}
+		if _, err := pool.Exec(ctx,
+			`UPDATE auth.users SET raw_user_meta_data = jsonb_set(
+				COALESCE(raw_user_meta_data, '{}'::jsonb),
+				'{selected_tenant_id}', to_jsonb($1::text)) WHERE id = $2`, tenantID.String(), userID); err != nil {
+			t.Fatalf("set selection: %v", err)
+		}
+		got, err = repo.ResolveAccountIDForEmail(ctx, email)
+		if err != nil {
+			t.Fatalf("resolve with selection: %v", err)
+		}
+		if got != olderAccount {
+			t.Fatalf("selection resolve %s, want selected %s", got, olderAccount)
+		}
+
+		// A malformed selection degrades to the fallback order instead of erroring.
+		if _, err := pool.Exec(ctx,
+			`UPDATE auth.users SET raw_user_meta_data = jsonb_set(
+				COALESCE(raw_user_meta_data, '{}'::jsonb),
+				'{selected_tenant_id}', '"not-a-uuid"') WHERE id = $1`, userID); err != nil {
+			t.Fatalf("break selection: %v", err)
+		}
+		got, err = repo.ResolveAccountIDForEmail(ctx, email)
+		if err != nil {
+			t.Fatalf("resolve with malformed selection: %v", err)
+		}
+		if got != newerAccount {
+			t.Fatalf("malformed-selection resolve %s, want fallback %s", got, newerAccount)
 		}
 	})
 }

--- a/apps/control-plane/internal/ledger/chat_balance_test.go
+++ b/apps/control-plane/internal/ledger/chat_balance_test.go
@@ -1,0 +1,159 @@
+package ledger
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// Issue #1063. The chat user's balance is a tenant balance reached through
+// tenant_billing_accounts; the signed-in chat principal only ever identifies
+// itself by the email its Open WebUI session carries, and the browser never
+// learns the tenant->account link.
+
+func TestGetChatBalanceResolvesTenantBillingAccount(t *testing.T) {
+	repo := newStubRepo()
+	email := "member@test.local"
+
+	accountID := uuid.New()
+	repo.emailAccounts[email] = accountID
+	repo.entries[accountID] = []LedgerEntry{
+		{EntryType: EntryTypeGrant, CreditsDelta: 500000},
+		{EntryType: EntryTypeUsageCharge, CreditsDelta: -120000},
+	}
+	repo.usageSince = 42000
+
+	svc := NewService(repo)
+	balance, found, err := svc.GetChatBalance(context.Background(), " Member@Test.Local ")
+	if err != nil {
+		t.Fatalf("GetChatBalance: %v", err)
+	}
+	if !found {
+		t.Fatal("expected membership to resolve")
+	}
+
+	want := ChatBalance{
+		PostedCredits:    380000,
+		AvailableCredits: 380000,
+		UsageToday:       42000,
+	}
+	if balance != want { //nolint:gocritic // comparable struct, field-by-field noise otherwise
+		t.Fatalf("balance mismatch:\n got %+v\nwant %+v", balance, want)
+	}
+}
+
+func TestGetChatBalanceUnknownEmailIsNotFoundNotError(t *testing.T) {
+	repo := newStubRepo()
+	repo.emailAccounts["known@test.local"] = uuid.New()
+
+	svc := NewService(repo)
+	_, found, err := svc.GetChatBalance(context.Background(), "stranger@test.local")
+	if err != nil {
+		t.Fatalf("unknown email must not error: %v", err)
+	}
+	if found {
+		t.Fatal("unmapped email must report not-found")
+	}
+}
+
+func TestChatBalanceHandler(t *testing.T) {
+	repo := newStubRepo()
+	accountID := uuid.New()
+	repo.emailAccounts["member@test.local"] = accountID
+	repo.entries[accountID] = []LedgerEntry{
+		{EntryType: EntryTypeGrant, CreditsDelta: 1000000},
+		{EntryType: EntryTypeUsageCharge, CreditsDelta: -250000},
+	}
+
+	svc := NewService(repo)
+	mux := http.NewServeMux()
+	RegisterChatBalanceRoute(mux, svc, func(h http.Handler) http.Handler { return h })
+
+	do := func(method string, body string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(method, "/internal/chat/credits/balance", strings.NewReader(body))
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+		return rec
+	}
+
+	t.Run("post with known email returns trimmed balance", func(t *testing.T) {
+		rec := do(http.MethodPost, `{"email":"Member@Test.Local"}`)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status %d body %s", rec.Code, rec.Body.String())
+		}
+		var got map[string]any
+		if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		for _, key := range []string{"posted_credits", "reserved_credits", "available_credits", "usage_today_credits"} {
+			if _, ok := got[key]; !ok {
+				t.Fatalf("missing %s in %s", key, rec.Body.String())
+			}
+		}
+		if got["available_credits"].(float64) != 750000 {
+			t.Fatalf("available_credits = %v", got["available_credits"])
+		}
+	})
+
+	t.Run("non-post method rejected", func(t *testing.T) {
+		if rec := do(http.MethodGet, ""); rec.Code != http.StatusMethodNotAllowed {
+			t.Fatalf("status %d", rec.Code)
+		}
+	})
+
+	t.Run("empty email rejected", func(t *testing.T) {
+		for _, body := range []string{`{"email":""}`, `{}`, `not json`} {
+			if rec := do(http.MethodPost, body); rec.Code != http.StatusBadRequest {
+				t.Fatalf("body %q -> status %d, want 400", body, rec.Code)
+			}
+		}
+	})
+
+	t.Run("unknown email is 404 without leaking identity state", func(t *testing.T) {
+		rec := do(http.MethodPost, `{"email":"stranger@test.local"}`)
+		if rec.Code != http.StatusNotFound {
+			t.Fatalf("status %d", rec.Code)
+		}
+		if strings.Contains(strings.ToLower(rec.Body.String()), "stranger") {
+			t.Fatalf("error echoes the email: %s", rec.Body.String())
+		}
+	})
+
+	t.Run("oversized body rejected", func(t *testing.T) {
+		rec := do(http.MethodPost, `{"email":"`+strings.Repeat("a", 4096)+`@test.local"}`)
+		if rec.Code == http.StatusOK {
+			t.Fatalf("oversized body accepted: %d", rec.Code)
+		}
+	})
+}
+
+func TestChatBalanceRouteIsWrappedByGate(t *testing.T) {
+	repo := newStubRepo()
+	accountID := uuid.New()
+	repo.emailAccounts["member@test.local"] = accountID
+
+	wrapped := false
+	mux := http.NewServeMux()
+	RegisterChatBalanceRoute(mux, NewService(repo), func(h http.Handler) http.Handler {
+		wrapped = true
+		return h
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/internal/chat/credits/balance",
+		bytes.NewReader([]byte(`{"email":"member@test.local"}`)))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if !wrapped {
+		t.Fatal("gate middleware never invoked")
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d", rec.Code)
+	}
+}

--- a/apps/control-plane/internal/ledger/repository.go
+++ b/apps/control-plane/internal/ledger/repository.go
@@ -447,19 +447,22 @@ func isUniqueViolation(err error) bool {
 }
 
 // ResolveAccountIDForEmail maps a signed-in chat user's email to the billing
-// account behind that user's tenant (issue #1063). The chat session carries
-// only the Open WebUI identity; the tenant->account link lives in
+// account behind that user's CURRENT tenant (issue #1063). The chat session
+// carries only the Open WebUI identity; the tenant->account link lives in
 // public.tenant_billing_accounts and must never reach the browser, which is
 // why this hop exists server side.
+//
+// "Current" is the tenant the user selected in the product (/v1/tenants/switch
+// writes raw_user_meta_data->>'selected_tenant_id'), not an arbitrary newest
+// membership: showing another tenant's balance than the one this user chats
+// under would be wrong in both directions. When the selection names a tenant
+// this email is actively billed for, it wins outright. Without any selection,
+// the most recently joined membership answers, which matches the signup flow
+// where a fresh personal tenant is both the newest and the only one.
 //
 // Returns uuid.Nil, nil when the email has no active membership on a billed,
 // non-archived tenant. That is an expected state (a pending invite, an
 // unbilled enterprise posture), not an error.
-//
-// ponytail: when one login belongs to several active tenants this picks the
-// most recently joined membership, so the number shown is that tenant's
-// balance. Multi-tenant balance switching is a product decision nobody has
-// made yet; revisit if tenants-per-user stops being rare.
 func (r *pgxRepository) ResolveAccountIDForEmail(ctx context.Context, email string) (uuid.UUID, error) {
 	var accountID uuid.UUID
 	err := r.pool.QueryRow(ctx, `
@@ -469,7 +472,11 @@ func (r *pgxRepository) ResolveAccountIDForEmail(ctx context.Context, email stri
 		JOIN public.tenants t ON t.id = tu.tenant_id AND t.archived_at IS NULL
 		JOIN public.tenant_billing_accounts tba ON tba.tenant_id = t.id
 		WHERE lower(u.email) = lower($1)
-		ORDER BY tu.joined_at DESC
+		ORDER BY
+			-- Text comparison, never a cast: selected_tenant_id is free-form JSON
+			-- and a malformed value must degrade to the fallback order, not 22P02.
+			(t.id::text = COALESCE(u.raw_user_meta_data->>'selected_tenant_id', '')) DESC,
+			tu.joined_at DESC
 		LIMIT 1
 	`, strings.TrimSpace(strings.ToLower(email))).Scan(&accountID)
 	switch {

--- a/apps/control-plane/internal/ledger/repository.go
+++ b/apps/control-plane/internal/ledger/repository.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -20,6 +21,11 @@ type Repository interface {
 	ListEntriesWithCursor(ctx context.Context, filter ListEntriesFilter) ([]LedgerEntry, error)
 	ListInvoices(ctx context.Context, accountID uuid.UUID) ([]InvoiceRow, error)
 	GetInvoice(ctx context.Context, accountID uuid.UUID, invoiceID uuid.UUID) (*InvoiceRow, error)
+
+	// Chat balance surface (#1063): resolve the billing account behind a
+	// signed-in chat user's tenant, and read today's usage for one.
+	ResolveAccountIDForEmail(ctx context.Context, email string) (uuid.UUID, error)
+	GetUsageSince(ctx context.Context, accountID uuid.UUID, since time.Time) (int64, error)
 }
 
 type pgxRepository struct {
@@ -438,4 +444,57 @@ func stampCreditUnit(metadata map[string]any) map[string]any {
 func isUniqueViolation(err error) bool {
 	var pgErr *pgconn.PgError
 	return errors.As(err, &pgErr) && pgErr.Code == "23505"
+}
+
+// ResolveAccountIDForEmail maps a signed-in chat user's email to the billing
+// account behind that user's tenant (issue #1063). The chat session carries
+// only the Open WebUI identity; the tenant->account link lives in
+// public.tenant_billing_accounts and must never reach the browser, which is
+// why this hop exists server side.
+//
+// Returns uuid.Nil, nil when the email has no active membership on a billed,
+// non-archived tenant. That is an expected state (a pending invite, an
+// unbilled enterprise posture), not an error.
+//
+// ponytail: when one login belongs to several active tenants this picks the
+// most recently joined membership, so the number shown is that tenant's
+// balance. Multi-tenant balance switching is a product decision nobody has
+// made yet; revisit if tenants-per-user stops being rare.
+func (r *pgxRepository) ResolveAccountIDForEmail(ctx context.Context, email string) (uuid.UUID, error) {
+	var accountID uuid.UUID
+	err := r.pool.QueryRow(ctx, `
+		SELECT tba.account_id
+		FROM auth.users u
+		JOIN public.tenant_users tu ON tu.user_id = u.id AND tu.status = 'ACTIVE'
+		JOIN public.tenants t ON t.id = tu.tenant_id AND t.archived_at IS NULL
+		JOIN public.tenant_billing_accounts tba ON tba.tenant_id = t.id
+		WHERE lower(u.email) = lower($1)
+		ORDER BY tu.joined_at DESC
+		LIMIT 1
+	`, strings.TrimSpace(strings.ToLower(email))).Scan(&accountID)
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		return uuid.Nil, nil
+	case err != nil:
+		return uuid.Nil, fmt.Errorf("ledger: resolve account for email: %w", err)
+	}
+	return accountID, nil
+}
+
+// GetUsageSince sums usage charges posted since the given instant. It feeds
+// the "used today" figure on the composer banner; a missing sum is zero, not
+// an error, matching how GetBalance treats empty history.
+func (r *pgxRepository) GetUsageSince(ctx context.Context, accountID uuid.UUID, since time.Time) (int64, error) {
+	var used int64
+	err := r.pool.QueryRow(ctx, `
+		SELECT COALESCE(SUM(-credits_delta), 0)
+		FROM public.credit_ledger_entries
+		WHERE account_id = $1
+		  AND entry_type = 'usage_charge'
+		  AND created_at >= $2
+	`, accountID, since).Scan(&used)
+	if err != nil {
+		return 0, fmt.Errorf("ledger: usage since: %w", err)
+	}
+	return used, nil
 }

--- a/apps/control-plane/internal/ledger/service_test.go
+++ b/apps/control-plane/internal/ledger/service_test.go
@@ -3,6 +3,7 @@ package ledger
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -15,6 +16,8 @@ type stubRepo struct {
 	memberships       []accounts.Membership
 	invitations       map[string]*accounts.Invitation
 	entries           map[uuid.UUID][]LedgerEntry
+	emailAccounts     map[string]uuid.UUID
+	usageSince        int64
 	lastListLimit     int
 	lastListRequestID string
 	postErr           error
@@ -24,9 +27,10 @@ type stubRepo struct {
 
 func newStubRepo() *stubRepo {
 	return &stubRepo{
-		accountsMap: make(map[uuid.UUID]*accounts.Account),
-		invitations: make(map[string]*accounts.Invitation),
-		entries:     make(map[uuid.UUID][]LedgerEntry),
+		accountsMap:   make(map[uuid.UUID]*accounts.Account),
+		invitations:   make(map[string]*accounts.Invitation),
+		entries:       make(map[uuid.UUID][]LedgerEntry),
+		emailAccounts: make(map[string]uuid.UUID),
 	}
 }
 
@@ -84,6 +88,18 @@ func (s *stubRepo) GetBalance(_ context.Context, accountID uuid.UUID) (BalanceSu
 		ReservedCredits:  reserved,
 		AvailableCredits: posted - reserved,
 	}, nil
+}
+
+func (s *stubRepo) ResolveAccountIDForEmail(_ context.Context, email string) (uuid.UUID, error) {
+	id, ok := s.emailAccounts[strings.ToLower(email)]
+	if !ok {
+		return uuid.Nil, nil
+	}
+	return id, nil
+}
+
+func (s *stubRepo) GetUsageSince(_ context.Context, _ uuid.UUID, _ time.Time) (int64, error) {
+	return s.usageSince, nil
 }
 
 func (s *stubRepo) ListEntries(_ context.Context, accountID uuid.UUID, limit int) ([]LedgerEntry, error) {

--- a/deploy/docker/Dockerfile.open-webui
+++ b/deploy/docker/Dockerfile.open-webui
@@ -363,6 +363,18 @@ RUN python3 /tmp/apply_agent_proxy_patch.py \
     && grep -q 'hive_agent_router' /app/backend/open_webui/main.py \
     && python3 -c "import ast, pathlib; ast.parse(pathlib.Path('/app/backend/open_webui/utils/hive_agent_proxy.py').read_text())"
 
+# #1063: the composer's credits banner. The chat backend resolves the signed-in
+# user to a balance server side (control-plane internal route behind its shared
+# secret); the browser only ever sees the trimmed numbers under Open WebUI's own
+# session. Deployments that do not carry the control-plane token (Hive
+# Enterprise posture) get a 404 and no banner: silent absence is the posture
+# gate.
+COPY deploy/docker/owui-patches/hive_credits.py /app/backend/open_webui/utils/hive_credits.py
+COPY deploy/docker/owui-patches/apply_credits_patch.py /tmp/apply_credits_patch.py
+RUN python3 /tmp/apply_credits_patch.py \
+    && grep -q 'hive_credits_router' /app/backend/open_webui/main.py \
+    && python3 -c "import ast, pathlib; ast.parse(pathlib.Path('/app/backend/open_webui/utils/hive_credits.py').read_text())"
+
 # #771: drop the Settings > Integrations tab, the chat UI's only entry point to
 # "Manage Tool Servers" and "Open Terminal". Both accept an arbitrary URL and an
 # auth credential. The tool servers added there are direct ones, called by the

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -1081,11 +1081,15 @@ services:
       OPENAI_API_BASE_URL: "http://edge-api:8080/v1"
       # Issue #1063 credits banner: lets the chat backend read the signed-in
       # user's tenant balance from control-plane behind its internal token.
-      # Unset CONTROL_PLANE_INTERNAL_TOKEN (the Hive Enterprise posture) leaves
-      # the endpoint answering 404 and no banner rendering; silent absence is
-      # the intended gate, not a bug.
+      # No committed fallback here on purpose: with the token unset (the Hive
+      # Enterprise posture, or any billing-less deployment) control-plane does
+      # not mount the route and the shim answers 404, so no banner renders.
+      # Silent absence is the intended gate, not a bug. Set
+      # HIVE_CONSOLE_BILLING_URL to point the empty-balance top-up link at the
+      # right deployment's console; unset hides the link but keeps the warning.
       HIVE_CONTROL_PLANE_URL: ${CONTROL_PLANE_URL:-http://control-plane:8081}
-      CONTROL_PLANE_INTERNAL_TOKEN: ${CONTROL_PLANE_INTERNAL_TOKEN:-hive-local-internal-token}
+      CONTROL_PLANE_INTERNAL_TOKEN: ${CONTROL_PLANE_INTERNAL_TOKEN:-}
+      HIVE_CONSOLE_BILLING_URL: ${HIVE_CONSOLE_BILLING_URL:-}
       # OWUI_SHIM_KEY MUST be set when the open-webui profile is active. The
       # edge-api OWUI unwrap middleware only fires when this value matches
       # exactly; an empty/unset value disables the middleware and OWUI

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -1079,6 +1079,13 @@ services:
       ENABLE_VERSION_UPDATE_CHECK: "false"
       DEFAULT_LOCALE: "en"
       OPENAI_API_BASE_URL: "http://edge-api:8080/v1"
+      # Issue #1063 credits banner: lets the chat backend read the signed-in
+      # user's tenant balance from control-plane behind its internal token.
+      # Unset CONTROL_PLANE_INTERNAL_TOKEN (the Hive Enterprise posture) leaves
+      # the endpoint answering 404 and no banner rendering; silent absence is
+      # the intended gate, not a bug.
+      HIVE_CONTROL_PLANE_URL: ${CONTROL_PLANE_URL:-http://control-plane:8081}
+      CONTROL_PLANE_INTERNAL_TOKEN: ${CONTROL_PLANE_INTERNAL_TOKEN:-hive-local-internal-token}
       # OWUI_SHIM_KEY MUST be set when the open-webui profile is active. The
       # edge-api OWUI unwrap middleware only fires when this value matches
       # exactly; an empty/unset value disables the middleware and OWUI

--- a/deploy/docker/owui-patches/apply_credits_patch.py
+++ b/deploy/docker/owui-patches/apply_credits_patch.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Mount hive_credits's router on Open WebUI's FastAPI application.
+
+Same asserted-splice pattern as apply_agent_proxy_patch.py: one anchored
+insertion into main.py that asserts its own assumptions, so a digest bump
+that moves upstream's router block fails the build instead of shipping an
+image whose credits endpoint 404s.
+
+The route lands at /api/v1/hive/credits/balance, next to the agent proxy at
+/api/v1/hive/agent, under the same OWUI session gate.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+import re
+import sys
+
+MAIN = pathlib.Path('/app/backend/open_webui/main.py')
+
+# Anchored on the same utils include_router line the agent-proxy splice uses,
+# because it is one of the last unconditional includes in main.py's block and
+# both insertions can share it without touching each other's output: each
+# inserts immediately after the anchor, so the second one to run finds the
+# anchor intact and lands directly after it too. Order between them does not
+# matter.
+ANCHOR = re.compile(
+    r'^app\.include_router\(\s*utils\.router,\s*prefix=(["\'])/api/v1/utils\1,\s*tags=\[(["\'])utils\2\]\s*\)$',
+    re.MULTILINE,
+)
+
+INSERTION = """
+# hive: the signed-in user's remaining credits for the composer banner
+# (#1063), resolved server side against control-plane behind the internal
+# token. See deploy/docker/owui-patches/hive_credits.py.
+from open_webui.utils.hive_credits import router as hive_credits_router
+
+app.include_router(hive_credits_router, prefix='/api/v1/hive/credits', tags=['hive'])
+"""
+
+MARKER = 'hive_credits_router'
+
+
+def main() -> int:
+    source = MAIN.read_text()
+
+    if MARKER in source:
+        print(f'hive: {MAIN} already mounts the credits router, nothing to do')
+        return 0
+
+    matches = list(ANCHOR.finditer(source))
+    if len(matches) != 1:
+        print(
+            f'hive: expected exactly 1 utils include_router anchor in {MAIN}, found {len(matches)}',
+            file=sys.stderr,
+        )
+        return 1
+
+    end = matches[0].end()
+    patched = source[:end] + '\n' + INSERTION + source[end:]
+
+    if patched.count(MARKER) != 2:
+        print('hive: credits insertion did not land exactly once', file=sys.stderr)
+        return 1
+
+    # Parse before writing, so a broken splice never reaches the image.
+    ast.parse(patched)
+    MAIN.write_text(patched)
+    print('hive: mounted hive_credits router on /api/v1/hive/credits')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/deploy/docker/owui-patches/hive_credits.py
+++ b/deploy/docker/owui-patches/hive_credits.py
@@ -76,7 +76,9 @@ async def balance(user=Depends(get_verified_user)):
             async with session.post(
                 f'{base}/internal/chat/credits/balance',
                 json={'email': email},
-                headers={'Authorization': f'Bearer {token}'},
+                # RequireInternalToken reads X-Internal-Token
+                # (platform/http/internalauth.go), not a bearer header.
+                headers={'X-Internal-Token': token},
             ) as response:
                 if response.status != 200:
                     # One server-side line, no email in it. The browser stays

--- a/deploy/docker/owui-patches/hive_credits.py
+++ b/deploy/docker/owui-patches/hive_credits.py
@@ -34,11 +34,14 @@ under its own session, the ledger stays in the Go service that owns money.
 
 from __future__ import annotations
 
+import logging
 import os
 
 import aiohttp
 from fastapi import APIRouter, Depends, HTTPException
 from open_webui.utils.auth import get_verified_user
+
+log = logging.getLogger('open_webui.utils.hive_credits')
 
 router = APIRouter()
 
@@ -76,14 +79,22 @@ async def balance(user=Depends(get_verified_user)):
                 headers={'Authorization': f'Bearer {token}'},
             ) as response:
                 if response.status != 200:
+                    # One server-side line, no email in it. The browser stays
+                    # quiet; an operator reading container logs still learns
+                    # the surface is down rather than silently absent.
+                    log.warning('hive credits: upstream answered %s', response.status)
                     raise HTTPException(status_code=404, detail='Credits are unavailable.')
                 data = await response.json(content_type=None)
+        # Coerced inside the try on purpose: a malformed payload must land in
+        # the same quiet failure path, not a 500 traceback.
+        balance = {
+            'available_credits': int(data.get('available_credits') or 0),
+            'usage_today_credits': int(data.get('usage_today_credits') or 0),
+        }
     except HTTPException:
         raise
     except Exception:
         # Never echo upstream detail across the customer boundary.
+        log.warning('hive credits: upstream call failed')
         raise HTTPException(status_code=404, detail='Credits are unavailable.')
-    return {
-        'available_credits': int(data.get('available_credits') or 0),
-        'usage_today_credits': int(data.get('usage_today_credits') or 0),
-    }
+    return balance

--- a/deploy/docker/owui-patches/hive_credits.py
+++ b/deploy/docker/owui-patches/hive_credits.py
@@ -90,6 +90,9 @@ async def balance(user=Depends(get_verified_user)):
         balance = {
             'available_credits': int(data.get('available_credits') or 0),
             'usage_today_credits': int(data.get('usage_today_credits') or 0),
+            # Deployment-configured top-up destination, passed through verbatim
+            # or empty. Never derived from the request.
+            'top_up_url': (os.environ.get('HIVE_CONSOLE_BILLING_URL') or '').strip(),
         }
     except HTTPException:
         raise

--- a/deploy/docker/owui-patches/hive_credits.py
+++ b/deploy/docker/owui-patches/hive_credits.py
@@ -1,0 +1,89 @@
+"""hive_credits: the signed-in chat user's remaining credits, server side.
+
+Issue #1063. The composer banner needs one number, and the browser must not
+learn anything it can use to reach billing state directly: the tenant ->
+account link lives in `public.tenant_billing_accounts`, which is
+service-role-only by design, and the browser holds no credential any Hive
+service accepts. So this module is a thin authenticated hop: Open WebUI's own
+session (`get_verified_user`) names the principal, the email rides in a POST
+body (never a URL, so it cannot land in access logs), and control-plane
+resolves the tenant -> account -> balance chain behind its internal token.
+
+What this file is responsible for, all load bearing:
+
+  * The principal is whoever Open WebUI says is signed in. The route depends
+    only on `get_verified_user`; nothing from the request influences which
+    identity is resolved.
+  * The internal token is read per request from the environment and never
+    returned, logged, or echoed in an error.
+  * Every failure is reported as a plain sentence: no URL, no upstream error
+    text, no identity detail. A failure here is also deliberately quiet on
+    the frontend: the banner simply does not render.
+
+Posture gate (#1063 point 5): prepaid credits are a hosted-SaaS concept.
+Enterprise deployments do not set HIVE_CONTROL_PLANE_URL /
+CONTROL_PLANE_INTERNAL_TOKEN on the chat container, the token check below
+fails closed with 404, and no banner renders. Silent absence is the intended
+enterprise posture; loud absence would be console spam in a posture where the
+concept does not apply.
+
+Why a shim at all: D-044 makes Open WebUI a view over control-plane-owned
+state. This endpoint is exactly that shape: OWUI serves the trimmed number
+under its own session, the ledger stays in the Go service that owns money.
+"""
+
+from __future__ import annotations
+
+import os
+
+import aiohttp
+from fastapi import APIRouter, Depends, HTTPException
+from open_webui.utils.auth import get_verified_user
+
+router = APIRouter()
+
+# One small DB read on the far side; 10s is generous. The frontend polls on
+# mount/focus at most every 30-60s, never per message.
+UPSTREAM_TIMEOUT_SECONDS = 10
+
+
+def _control_plane_base() -> str:
+    return (os.environ.get('HIVE_CONTROL_PLANE_URL') or '').strip().rstrip('/')
+
+
+def _internal_token() -> str:
+    return (os.environ.get('CONTROL_PLANE_INTERNAL_TOKEN') or '').strip()
+
+
+@router.get('/balance')
+async def balance(user=Depends(get_verified_user)):
+    """The signed-in user's tenant balance, trimmed to what the banner shows."""
+    base = _control_plane_base()
+    token = _internal_token()
+    email = (getattr(user, 'email', '') or '').strip()
+
+    if not base or not token or not email:
+        # Fail closed as "nothing to show", matching the enterprise posture:
+        # silent absence, not an error surface.
+        raise HTTPException(status_code=404, detail='Credits are unavailable.')
+
+    try:
+        timeout = aiohttp.ClientTimeout(total=UPSTREAM_TIMEOUT_SECONDS)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.post(
+                f'{base}/internal/chat/credits/balance',
+                json={'email': email},
+                headers={'Authorization': f'Bearer {token}'},
+            ) as response:
+                if response.status != 200:
+                    raise HTTPException(status_code=404, detail='Credits are unavailable.')
+                data = await response.json(content_type=None)
+    except HTTPException:
+        raise
+    except Exception:
+        # Never echo upstream detail across the customer boundary.
+        raise HTTPException(status_code=404, detail='Credits are unavailable.')
+    return {
+        'available_credits': int(data.get('available_credits') or 0),
+        'usage_today_credits': int(data.get('usage_today_credits') or 0),
+    }

--- a/docs/proof/usage-at-composer/capture-2026-08-24.md
+++ b/docs/proof/usage-at-composer/capture-2026-08-24.md
@@ -1,0 +1,34 @@
+# Visual proof: credits banner above the chat composer (issue #1063)
+
+Captured 2026-08-24 against a locally running stack built from this branch:
+
+- `hive-open-webui:credits-banner`: builds the frontend from this tree's
+  vendor/open-webui and mounts the owui-patches shim
+- `hive-control-plane:credits-banner`: builds the internal chat-balance route
+  from this tree
+- pgvector/pgvector:pg17 with the full supabase/migrations/ chain applied
+  (test-db-bootstrap.sql first, exactly the CI bootstrap recipe)
+- Seeded tenant + tenant_billing_accounts + ledger entries for the signed-in
+  chat user chatuser@proof.local (Open WebUI signup, session via its own
+  sign-in form)
+
+Endpoint transcript (session-cookie auth, OWUI shim -> control-plane internal
+route behind X-Internal-Token):
+
+```
+GET /api/v1/hive/credits/balance
+  healthy: {"available_credits":1850000,"usage_today_credits":150000,"top_up_url":"https://console-hive.scubed.co/console/billing"}
+  low:     available_credits 30000 (below the $0.50 low threshold)
+  empty:   available_credits 0
+```
+
+States, one screenshot each, all rendered above the composer:
+
+1. credits-01-healthy.png: muted pill, "You've used 150,000 credits today ·
+   1,850,000 remaining"
+2. credits-02-low.png: amber pill at 30,000 remaining
+3. credits-03-empty.png: red pill, "You're out of credits." with the
+   configured Top up link
+
+No credential appears in any URL; the sign-in ran through the form and no
+token was carried in a query string, so there is nothing to redact.

--- a/vendor/open-webui/src/lib/components/chat/Chat.svelte
+++ b/vendor/open-webui/src/lib/components/chat/Chat.svelte
@@ -103,6 +103,9 @@
 
 	import Banner from '../common/Banner.svelte';
 	import MessageInput from '$lib/components/chat/MessageInput.svelte';
+	// hive (#1063): remaining-credits pill above the composer; self-fetching,
+	// renders nothing when the balance is unavailable.
+	import CreditsBanner from '$lib/hive/CreditsBanner.svelte';
 	import Messages from '$lib/components/chat/Messages.svelte';
 	import Navbar from '$lib/components/chat/Navbar.svelte';
 	import ChatControls from './ChatControls.svelte';
@@ -3285,6 +3288,8 @@
 								</div>
 							{:else}
 								<div class=" pb-2 {dragged ? 'z-0' : 'z-10'}">
+									<!-- hive (#1063): credits pill above the composer -->
+									<CreditsBanner />
 									<MessageInput
 										bind:this={messageInput}
 										{history}

--- a/vendor/open-webui/src/lib/components/chat/Chat.svelte
+++ b/vendor/open-webui/src/lib/components/chat/Chat.svelte
@@ -3375,7 +3375,10 @@
 							{/if}
 						{:else}
 							<div class="flex items-center h-full">
-								<Placeholder
+								<div class="w-full">
+									<!-- hive (#1063): credits pill above the landing composer too -->
+									<CreditsBanner />
+									<Placeholder
 									{history}
 									{selectedModels}
 									bind:messageInput
@@ -3410,6 +3413,7 @@
 										}
 									}}
 								/>
+								</div>
 							</div>
 						{/if}
 					</div>

--- a/vendor/open-webui/src/lib/hive/CreditsBanner.svelte
+++ b/vendor/open-webui/src/lib/hive/CreditsBanner.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
+	import { getContext, onMount } from 'svelte';
 
 	import {
 		creditState,
@@ -10,6 +10,8 @@
 		type CreditBalance
 	} from './credits';
 
+	const i18n: any = getContext('i18n');
+
 	/*
 	 * The composer banner (#1063): remaining credits, Claude-style phrasing,
 	 * one line above the composer. Self-fetching so the only edit chat's own
@@ -17,7 +19,10 @@
 	 */
 
 	let balance: CreditBalance | null = null;
-	let creditsDismissedFlag = false;
+	// Initialized from storage, not left false: dismissal must survive SPA
+	// navigation that remounts this component within the same browsing
+	// session, or the dismiss button lies.
+	let creditsDismissedFlag = creditsDismissed();
 
 	$: state = balance === null ? null : creditState(balance.available_credits);
 	$: visible = balance !== null && !creditsDismissedFlag;
@@ -53,19 +58,21 @@
 			role="status"
 		>
 			{#if state === 'empty'}
-				<span>You're out of credits.</span>
+				<span>{$i18n.t("You're out of credits.")}</span>
 				<a
 					href="https://console-hive.scubed.co/console/billing"
 					target="_blank"
 					rel="noreferrer"
 					class="font-medium underline underline-offset-2"
 				>
-					Top up
+					{$i18n.t('Top up')}
 				</a>
 			{:else}
 				<span>
-					You've used {formatCredits(balance?.usage_today_credits ?? 0)} credits today
-					&middot; {formatCredits(balance?.available_credits ?? 0)} remaining
+					{$i18n.t("You've used {{used}} credits today · {{remaining}} remaining", {
+						used: formatCredits(balance?.usage_today_credits ?? 0),
+						remaining: formatCredits(balance?.available_credits ?? 0)
+					})}
 				</span>
 			{/if}
 			<button

--- a/vendor/open-webui/src/lib/hive/CreditsBanner.svelte
+++ b/vendor/open-webui/src/lib/hive/CreditsBanner.svelte
@@ -1,0 +1,90 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+
+	import {
+		creditState,
+		creditsDismissed,
+		dismissCredits,
+		fetchCreditBalance,
+		formatCredits,
+		type CreditBalance
+	} from './credits';
+
+	/*
+	 * The composer banner (#1063): remaining credits, Claude-style phrasing,
+	 * one line above the composer. Self-fetching so the only edit chat's own
+	 * Chat.svelte needs is mounting it; a failed fetch renders nothing.
+	 */
+
+	let balance: CreditBalance | null = null;
+	let creditsDismissedFlag = false;
+
+	$: state = balance === null ? null : creditState(balance.available_credits);
+	$: visible = balance !== null && !creditsDismissedFlag;
+
+	async function load() {
+		balance = await fetchCreditBalance();
+	}
+
+	function onDismiss() {
+		dismissCredits();
+		creditsDismissedFlag = true;
+	}
+
+	function onFocus() {
+		if (document.visibilityState === 'visible') void load();
+	}
+
+	onMount(() => {
+		void load();
+		document.addEventListener('visibilitychange', onFocus);
+		return () => document.removeEventListener('visibilitychange', onFocus);
+	});
+</script>
+
+{#if visible && state}
+	<div class="mb-1.5 flex justify-center px-2">
+		<div
+			class="flex items-center gap-2 rounded-full border px-3 py-1 text-xs {state === 'empty'
+				? 'border-red-200 bg-red-50 text-red-700 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300'
+				: state === 'low'
+					? 'border-amber-200 bg-amber-50 text-amber-800 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-300'
+				: 'border-gray-200/60 bg-gray-50 text-gray-500 dark:border-gray-850 dark:bg-gray-850/40 dark:text-gray-400'}"
+			role="status"
+		>
+			{#if state === 'empty'}
+				<span>You're out of credits.</span>
+				<a
+					href="https://console-hive.scubed.co/console/billing"
+					target="_blank"
+					rel="noreferrer"
+					class="font-medium underline underline-offset-2"
+				>
+					Top up
+				</a>
+			{:else}
+				<span>
+					You've used {formatCredits(balance?.usage_today_credits ?? 0)} credits today
+					&middot; {formatCredits(balance?.available_credits ?? 0)} remaining
+				</span>
+			{/if}
+			<button
+				type="button"
+				class="ms-1 rounded-full p-0.5 text-current opacity-50 transition hover:opacity-100"
+				aria-label="Dismiss"
+				on:click={onDismiss}
+			>
+				<svg
+					xmlns="http://www.w3.org/2000/svg"
+					viewBox="0 0 16 16"
+					fill="currentColor"
+					class="size-3"
+				>
+					<path
+						d="M5.28 4.22a.75.75 0 0 0-1.06 1.06L6.94 8l-2.72 2.72a.75.75 0 1 0 1.06 1.06L8 9.06l2.72 2.72a.75.75 0 1 0 1.06-1.06L9.06 8l2.72-2.72a.75.75 0 0 0-1.06-1.06L8 6.94 5.28 4.22Z"
+					/>
+				</svg>
+			</button>
+		</div>
+	</div>
+{/if}

--- a/vendor/open-webui/src/lib/hive/CreditsBanner.svelte
+++ b/vendor/open-webui/src/lib/hive/CreditsBanner.svelte
@@ -59,14 +59,16 @@
 		>
 			{#if state === 'empty'}
 				<span>{$i18n.t("You're out of credits.")}</span>
-				<a
-					href="https://console-hive.scubed.co/console/billing"
-					target="_blank"
-					rel="noreferrer"
-					class="font-medium underline underline-offset-2"
-				>
-					{$i18n.t('Top up')}
-				</a>
+				{#if balance?.top_up_url}
+					<a
+						href={balance.top_up_url}
+						target="_blank"
+						rel="noreferrer"
+						class="font-medium underline underline-offset-2"
+					>
+						{$i18n.t('Top up')}
+					</a>
+				{/if}
 			{:else}
 				<span>
 					{$i18n.t("You've used {{used}} credits today · {{remaining}} remaining", {

--- a/vendor/open-webui/src/lib/hive/credits.test.ts
+++ b/vendor/open-webui/src/lib/hive/credits.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+	creditState,
+	CREDITS_DISMISS_KEY,
+	creditsDismissed,
+	dismissCredits,
+	fetchCreditBalance
+} from './credits';
+
+describe('creditState', () => {
+	it('empty at zero or below', () => {
+		expect(creditState(0)).toBe('empty');
+		expect(creditState(-5)).toBe('empty');
+	});
+
+	it('low below the threshold, healthy at and above it', () => {
+		expect(creditState(49_999)).toBe('low');
+		expect(creditState(50_000)).toBe('healthy');
+	});
+});
+
+describe('dismissal', () => {
+	it('persists for the session via sessionStorage', () => {
+		const store: Record<string, string> = {};
+		vi.stubGlobal('sessionStorage', {
+			getItem: (k: string) => store[k] ?? null,
+			setItem: (k: string, v: string) => (store[k] = v)
+		});
+		expect(creditsDismissed()).toBe(false);
+		dismissCredits();
+		expect(store[CREDITS_DISMISS_KEY]).toBe('1');
+		expect(creditsDismissed()).toBe(true);
+		vi.unstubAllGlobals();
+	});
+
+	it('degrades silently without storage', () => {
+		vi.stubGlobal('sessionStorage', undefined);
+		expect(creditsDismissed()).toBe(false);
+		expect(() => dismissCredits()).not.toThrow();
+		vi.unstubAllGlobals();
+	});
+});
+
+describe('fetchCreditBalance', () => {
+	it('returns the trimmed balance on 200', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async () =>
+				Response.json({ available_credits: 123456, usage_today_credits: 789 })
+			)
+		);
+		const balance = await fetchCreditBalance('http://x');
+		expect(balance).toEqual({ available_credits: 123456, usage_today_credits: 789 });
+		vi.unstubAllGlobals();
+	});
+
+	it('returns null on any non-200, never throwing', async () => {
+		for (const status of [401, 404, 500]) {
+			vi.stubGlobal(
+				'fetch',
+				vi.fn(async () => new Response(null, { status }))
+			);
+			await expect(fetchCreditBalance('http://x')).resolves.toBeNull();
+			vi.unstubAllGlobals();
+		}
+	});
+
+	it('returns null when the network throws', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async () => {
+				throw new Error('offline');
+			})
+		);
+		await expect(fetchCreditBalance('http://x')).resolves.toBeNull();
+		vi.unstubAllGlobals();
+	});
+});

--- a/vendor/open-webui/src/lib/hive/credits.test.ts
+++ b/vendor/open-webui/src/lib/hive/credits.test.ts
@@ -55,6 +55,33 @@ describe('fetchCreditBalance', () => {
 		vi.unstubAllGlobals();
 	});
 
+	it('passes through a configured top-up URL and drops empty ones', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async () =>
+				Response.json({
+					available_credits: 5,
+					usage_today_credits: 0,
+					top_up_url: 'https://console.example/console/billing'
+				})
+			)
+		);
+		await expect(fetchCreditBalance('http://x')).resolves.toEqual({
+			available_credits: 5,
+			usage_today_credits: 0,
+			top_up_url: 'https://console.example/console/billing'
+		});
+		vi.unstubAllGlobals();
+
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async () => Response.json({ available_credits: 5, usage_today_credits: 0 }))
+		);
+		const without = await fetchCreditBalance('http://x');
+		expect(without?.top_up_url).toBeUndefined();
+		vi.unstubAllGlobals();
+	});
+
 	it('returns null on any non-200, never throwing', async () => {
 		for (const status of [401, 404, 500]) {
 			vi.stubGlobal(

--- a/vendor/open-webui/src/lib/hive/credits.ts
+++ b/vendor/open-webui/src/lib/hive/credits.ts
@@ -1,0 +1,73 @@
+/*
+ * The signed-in chat user's remaining credits, for the composer banner.
+ */
+
+export const DEFAULT_CREDITS_API_BASE_URL = '/api/v1/hive/credits';
+
+export interface CreditBalance {
+	/** Whole credits left on the tenant billing account (100000 credits = $1). */
+	available_credits: number;
+	/** Usage charges posted since midnight UTC today. */
+	usage_today_credits: number;
+}
+
+export type CreditState = 'healthy' | 'low' | 'empty';
+
+/** 50000 credits = $0.50 at CREDITS_PER_USD = 100000. Below this reads as low. */
+export const LOW_CREDITS_THRESHOLD = 50_000;
+
+export function creditState(available: number): CreditState {
+	if (!Number.isFinite(available) || available <= 0) return 'empty';
+	if (available < LOW_CREDITS_THRESHOLD) return 'low';
+	return 'healthy';
+}
+
+export function formatCredits(amount: number): string {
+	if (!Number.isFinite(amount)) return '0';
+	return Math.round(amount).toLocaleString('en-US');
+}
+
+/**
+ * One fetch, silent on every failure: a null return is the "no banner"
+ * answer, never an error surface. The browser holds no credential any Hive
+ * service accepts, so this goes to Open WebUI's own backend, which resolves
+ * the signed-in principal server side (deploy/docker/owui-patches/hive_credits.py).
+ */
+export async function fetchCreditBalance(
+	baseUrl: string = DEFAULT_CREDITS_API_BASE_URL
+): Promise<CreditBalance | null> {
+	try {
+		const response = await fetch(`${baseUrl}/balance`, { credentials: 'same-origin' });
+		if (!response.ok) return null;
+		const data = await response.json();
+		const available = Number(data?.available_credits);
+		if (!Number.isFinite(available)) return null;
+		const usageToday = Number(data?.usage_today_credits);
+		return {
+			available_credits: available,
+			usage_today_credits: Number.isFinite(usageToday) ? usageToday : 0
+		};
+	} catch {
+		// Network failure, offline, session expired: degrade to no banner.
+		return null;
+	}
+}
+
+/** Dismissal lasts for the browsing session only; sessionStorage. */
+export const CREDITS_DISMISS_KEY = 'hive.credits.banner.dismissed';
+
+export function creditsDismissed(): boolean {
+	try {
+		return sessionStorage.getItem(CREDITS_DISMISS_KEY) === '1';
+	} catch {
+		return false;
+	}
+}
+
+export function dismissCredits(): void {
+	try {
+		sessionStorage.setItem(CREDITS_DISMISS_KEY, '1');
+	} catch {
+		/* storage unavailable: banner simply reappears next mount */
+	}
+}

--- a/vendor/open-webui/src/lib/hive/credits.ts
+++ b/vendor/open-webui/src/lib/hive/credits.ts
@@ -9,6 +9,11 @@ export interface CreditBalance {
 	available_credits: number;
 	/** Usage charges posted since midnight UTC today. */
 	usage_today_credits: number;
+	/**
+	 * Deployment-configured top-up destination; empty means the deployment
+	 * named none and the banner shows the warning without a link.
+	 */
+	top_up_url?: string;
 }
 
 export type CreditState = 'healthy' | 'low' | 'empty';
@@ -43,9 +48,11 @@ export async function fetchCreditBalance(
 		const available = Number(data?.available_credits);
 		if (!Number.isFinite(available)) return null;
 		const usageToday = Number(data?.usage_today_credits);
+		const topUpUrl = typeof data?.top_up_url === 'string' ? data.top_up_url : '';
 		return {
 			available_credits: available,
-			usage_today_credits: Number.isFinite(usageToday) ? usageToday : 0
+			usage_today_credits: Number.isFinite(usageToday) ? usageToday : 0,
+			top_up_url: topUpUrl || undefined
 		};
 	} catch {
 		// Network failure, offline, session expired: degrade to no banner.


### PR DESCRIPTION
## What

Closes #1063 (the surface half; the endpoint it asked for is included).

A signed-in chat user had no way to see credits or usage anywhere. This adds a small pill above the chat composer showing credits remaining and today's spend, with Claude-style phrasing, dismissible for the session.

## Data source

The balance is derived, never stored (`credit_ledger_entries` summed by `ledger.Service.GetBalance`, reused untouched). The gap #1063 identified was identity: chat sessions authenticate as Open WebUI users in `tenant_users`, a disjoint id space from `account_memberships`, so `/api/v1/accounts/current/credits/balance` is unusable from chat as-is.

New internal route on control-plane:

```
POST /internal/chat/credits/balance   {"email": "..."}
  -> 200 {posted_credits, reserved_credits, available_credits, usage_today_credits}
  -> 404 no billed account (banner hides)
  -> 400 empty/oversized body
```

Mounted behind `RequireInternalToken`, and only when a nonempty internal token is configured. The OWUI backend shim (owui-patches/hive_credits.py) resolves its own signed-in session to an email server side and calls this route with the `X-Internal-Token` header; the browser only ever sees the trimmed numbers under Open WebUI's own session. `tenant_billing_accounts` never reaches a browser.

Multi-tenant members resolve to the tenant selected in the product (`raw_user_meta_data->>'selected_tenant_id'`, written by /v1/tenants/switch), newest active membership as fallback; malformed selections degrade to the fallback order.

## UI

- `src/lib/hive/CreditsBanner.svelte`: three states.
  - healthy/low (below $0.50 in credits): "You've used N credits today · M remaining", amber at low.
  - empty: "You're out of credits." + Top up link when `HIVE_CONSOLE_BILLING_URL` is configured (deployment configuration served through the shim as `top_up_url`).
- Renders above both composer paths (conversation MessageInput and the landing Placeholder).
- Dismissible for the browsing session (sessionStorage, survives remounts).
- Any fetch failure degrades to no banner, zero console spam.
- MessageInput.svelte submit logic untouched.

## Enterprise posture

Prepaid credits are a hosted-SaaS concept. Deployments that do not carry `CONTROL_PLANE_INTERNAL_TOKEN` on the chat container get 404 and no banner (control-plane does not even mount the route); silent absence is the posture gate, documented in compose comments.

## Tests

- Go unit tests (stub repo): resolution, not-found semantics, handler contract incl. method/body/email edge cases, gate wiring.
- Go live-DB tests (HIVE_TEST_DB_URL-gated, run against the full migrated schema): four-table join, case-insensitive email, selected-tenant-wins, malformed-selection fallback. Verified locally against a migrated throwaway Postgres.
- Frontend vitest suite (81 tests green): state thresholds, dismissal persistence + storage-absence degradation, fetch success/non-200/network-failure silence, top_up_url passthrough.

## Visual proof

Posted below against a stack built from this branch (frontend + control-plane internal route, full migrated schema, signed-in chat user): healthy, low, and empty banner states. Comment: https://github.com/sakibsadmanshajib/hive/pull/1119#issuecomment-5400860095 ; capture log: docs/proof/usage-at-composer/capture-2026-08-24.md

## Review streams

- CodeRabbit GitHub app: ran (5 findings). All addressed or rebutted; every thread resolved.
- Plain adversarial pass: ran. Four findings fixed pre-push (dismissal persistence across remounts, payload coercion inside the failure path, server-side upstream-failure logging, i18n) plus one integration bug caught only by the live proof stack (shim sent the shared secret on `Authorization: Bearer`; RequireInternalToken reads `X-Internal-Token`): fixed and verified end to end.
- CodeRabbit CLI: SKIPPED, twice, WebSocket connection error from this environment. Noted per pipeline fallback rules.

## Buglog entry

Carried in commit 41d070f83 (wrong auth header between shim and RequireInternalToken, found by live-stack verification); to be appended to .wolf/buglog.jsonl on main via a buglog-only PR once this merges, per the issue #873 protocol.