### PR TITLE
fix: point capability SDK tests at a tools-capable alias (+ CI free-pool key forwarding)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -997,14 +997,6 @@ jobs:
       LITELLM_MASTER_KEY: ${{ secrets.LITELLM_MASTER_KEY }}
       OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
       GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
-      # Free pool key slots (#1115): compose forwards these into the litellm
-      # container, whose config resolves them via os.environ/ at request time.
-      # Unset here, every hive-free deployment fails and the alias reads as
-      # invalid to LiteLLM ("Invalid model name passed in model=hive-free"),
-      # which is the same knob-set-but-never-forwarded defect class as
-      # issue #1088. Both exist as repository secrets.
-      GROQ_API_KEY_2: ${{ secrets.GROQ_API_KEY_2 }}
-      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
       # Free pool key slots; hive-free (the default HIVE_TEST_MODEL) fails over
       # across all four deployments, so each slot must reach the litellm
       # container.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1002,6 +1002,13 @@ jobs:
       # container.
       GROQ_API_KEY_2: ${{ secrets.GROQ_API_KEY_2 }}
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+      # The internal token control-plane requires on POST /internal/litellm/sync,
+      # which the step below calls to derive LiteLLM's serving config from the
+      # migration-seeded catalog exactly the way a deploy does. This job sets no
+      # other value and compose defaults the variable to this same literal, so
+      # pinning it here keeps the sync call and the container in agreement
+      # without introducing a new secret.
+      CONTROL_PLANE_INTERNAL_TOKEN: hive-local-internal-token
       NVIDIA_NIM_API_KEY: ${{ secrets.NVIDIA_NIM_API_KEY }}
       # Which alias the token-consuming SDK suites call, and therefore which
       # provider account this job bills. Issue #1088.
@@ -1340,6 +1347,77 @@ jobs:
           echo "/v1/models lists hive-default"
           jq -r '.data[0:3] | .[] | .id' /tmp/models.json
 
+      - name: Sync LiteLLM model list from the DB catalog
+        # The seam this job was missing: a deploy derives LiteLLM's serving
+        # config from the database via POST /internal/litellm/sync
+        # (deploy-demo-box.yml), but this job never called it, so LiteLLM kept
+        # serving the static seed file deploy/litellm/config.yaml. The seed
+        # predates the free pool: it has no route-free-pool group, so every
+        # alias resolving into the pool (hive-free, this job's default
+        # HIVE_TEST_MODEL) failed with Invalid model name while /v1/models,
+        # which reads the DB catalog, listed it happily. Calling the same
+        # endpoint production calls makes the migration chain the single source
+        # of truth for what CI's gateway serves, exactly as on the box. The
+        # assertion at the bottom is the regression guard: if anyone breaks
+        # this wiring again, the gateway itself reports no pool and the job
+        # fails before the suites run.
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Same call shape as deploy-demo-box.yml's sync step: internal-token
+          # auth, 35s max-time (the endpoint's own work includes a bounded
+          # Docker restart), retried past cold-start blips, never swallowed.
+          status=""
+          response_file=$(mktemp)
+          trap 'rm -f "$response_file"' EXIT
+          for i in 1 2 3; do
+            status=$(curl -sS -o "$response_file" -w '%{http_code}' \
+              --connect-timeout 2 --max-time 35 \
+              -X POST -H "X-Internal-Token: $CONTROL_PLANE_INTERNAL_TOKEN" \
+              http://localhost:8081/internal/litellm/sync) || status="000"
+            if [ "$status" = "200" ]; then
+              break
+            fi
+            echo "attempt $i: sync returned $status, retry in 5s"
+            sleep 5
+          done
+          if [ "$status" != "200" ]; then
+            echo "::error::litellm config sync failed after 3 attempts, last status $status"
+            cat "$response_file" 2>/dev/null || true
+            exit 1
+          fi
+          echo "LiteLLM config synced from provider_routes"
+
+          # Sync restarts the litellm container as its last act, so the gateway
+          # is briefly down here. Wait for it to answer again rather than let
+          # the suites race the boot.
+          master_key="${LITELLM_MASTER_KEY:-litellm-dev-key}"
+          deadline=$(( $(date +%s) + 90 ))
+          : > /tmp/litellm-models.json
+          while :; do
+            if body=$(curl -sS --max-time 5 \
+                 -H "Authorization: Bearer $master_key" \
+                 http://localhost:4000/v1/models 2>/dev/null); then
+              printf '%s' "$body" > /tmp/litellm-models.json
+              break
+            fi
+            if [ "$(date +%s)" -gt "$deadline" ]; then
+              echo "::error::litellm did not come back up within 90s of the config sync"
+              exit 1
+            fi
+            sleep 3
+          done
+
+          # The regression assertion: LiteLLM must now serve the route-free-pool
+          # group that migration 20260824_02_free_pool_router.sql seeds, or
+          # every plain-chat suite call would 400 with an Invalid model error.
+          if ! jq -e '.data | map(.id) | index("route-free-pool") != null' /tmp/litellm-models.json >/dev/null; then
+            echo "::error::litellm does not serve route-free-pool after syncing from the DB catalog, so HIVE_TEST_MODEL=hive-free cannot resolve. Gateway models: $(jq -r '[.data[].id] | join(", ")' /tmp/litellm-models.json)"
+            exit 1
+          fi
+          echo "gateway serves route-free-pool; models: $(jq -r '[.data[].id] | join(", ")' /tmp/litellm-models.json)"
+
       - name: Run SDK suites in parallel (JS + Python + Java)
         # id, because the spend meter below runs on always() and needs to tell
         # "the suites failed, so the database may not exist" from "the suites
@@ -1452,7 +1530,7 @@ jobs:
               ;;
           esac
 
-          echo "::notice::live-integration metered ${total} tokens on alias '${HIVE_TEST_MODEL}' (ceiling ${RUN_TOKEN_CEILING})"
+          echo "::notice::live-integration metered ${total} tokens across the configured aliases (ceiling ${RUN_TOKEN_CEILING}); see the per-alias breakdown above"
 
           if [ "$total" -gt "$RUN_TOKEN_CEILING" ]; then
             echo "::error::this run metered ${total} tokens, over the ${RUN_TOKEN_CEILING} ceiling. Something is generating far more than the suites should. Find it before raising the ceiling: a provider allowance is shared with the live demo."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -997,6 +997,14 @@ jobs:
       LITELLM_MASTER_KEY: ${{ secrets.LITELLM_MASTER_KEY }}
       OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
       GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+      # Free pool key slots (#1115): compose forwards these into the litellm
+      # container, whose config resolves them via os.environ/ at request time.
+      # Unset here, every hive-free deployment fails and the alias reads as
+      # invalid to LiteLLM ("Invalid model name passed in model=hive-free"),
+      # which is the same knob-set-but-never-forwarded defect class as
+      # issue #1088. Both exist as repository secrets.
+      GROQ_API_KEY_2: ${{ secrets.GROQ_API_KEY_2 }}
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
       # Free pool key slots; hive-free (the default HIVE_TEST_MODEL) fails over
       # across all four deployments, so each slot must reach the litellm
       # container.
@@ -1231,7 +1239,8 @@ jobs:
           # SUPABASE_DB_URL stays, because the throwaway-database step writes it
           # to $GITHUB_ENV and a silent failure there is exactly this step's job.
           for v in SUPABASE_DB_URL \
-                   OPENROUTER_API_KEY HIVE_API_KEY S3_ENDPOINT S3_ACCESS_KEY S3_SECRET_KEY; do
+                   OPENROUTER_API_KEY GROQ_API_KEY_2 GEMINI_API_KEY HIVE_API_KEY \
+                   S3_ENDPOINT S3_ACCESS_KEY S3_SECRET_KEY; do
             val="${!v:-}"
             if [ -z "$val" ]; then
               echo "::error::$v is empty in workflow env"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1061,9 +1061,12 @@ jobs:
       # Capability-specific tests (tools, response_format) in the JS
       # chat-completions suite cannot run on hive-free: its pool members are
       # seeded tools_supported=false until cross-member parity is probed
-      # (#1115), so they point at a tools-capable alias instead (run
-      # 32736430913). Same override pattern as above.
-      HIVE_TOOLS_MODEL: ${{ vars.CI_LIVE_INTEGRATION_TOOLS_MODEL || 'deepseek-v4-flash' }}
+      # (#1115), so the edge correctly 400s those parameters there (run
+      # 32736430913). deepseek-v4-pro is the alias whose route is tools-
+      # capable AND contract-stable; see the deepseek note below for why the
+      # flash variant was rejected on evidence. Same override pattern as
+      # HIVE_TEST_MODEL above.
+      HIVE_TOOLS_MODEL: ${{ vars.CI_LIVE_INTEGRATION_TOOLS_MODEL || 'deepseek-v4-pro' }}
       # The suites' own default, named here rather than left implicit, because
       # the spend meter below asserts that no alias outside these is ever
       # billed by this job.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1058,8 +1058,14 @@ jobs:
       # load-balanced pool of our own free provider keys, not on a paid tier or
       # on whichever single provider happens to serve the demo today.
       HIVE_TEST_MODEL: ${{ vars.CI_LIVE_INTEGRATION_MODEL || 'hive-free' }}
+      # Capability-specific tests (tools, response_format) in the JS
+      # chat-completions suite cannot run on hive-free: its pool members are
+      # seeded tools_supported=false until cross-member parity is probed
+      # (#1115), so they point at a tools-capable alias instead (run
+      # 32736430913). Same override pattern as above.
+      HIVE_TOOLS_MODEL: ${{ vars.CI_LIVE_INTEGRATION_TOOLS_MODEL || 'deepseek-v4-flash' }}
       # The suites' own default, named here rather than left implicit, because
-      # the spend meter below asserts that no alias outside these two is ever
+      # the spend meter below asserts that no alias outside these is ever
       # billed by this job.
       HIVE_EMBEDDING_MODEL: hive-embedding-default
       # Nothing reads this. It is passed only because docker-compose.yml
@@ -1109,6 +1115,7 @@ jobs:
           set -euo pipefail
           echo "SDK suites will call alias: $HIVE_TEST_MODEL"
           echo "embedding suites will call: $HIVE_EMBEDDING_MODEL"
+          echo "capability tests will call: $HIVE_TOOLS_MODEL"
           if [ "$HIVE_TEST_MODEL" = "hive-free" ]; then
             echo "::notice::this run bills hive-free, the load-balanced pool of our own free provider keys. No customer-facing provider allowance is consumed. Pool-specific routing regressions (failover between keys) are covered only against the live box; a single-provider regression on any one pool member can still hide behind the other members."
           else
@@ -1448,10 +1455,12 @@ jobs:
             exit 1
           fi
 
-          # The alias assertion. Only two aliases can legitimately appear: the
-          # chat/completions/responses suites use HIVE_TEST_MODEL and the
-          # embedding suites use HIVE_EMBEDDING_MODEL. Anything else means the
-          # value this workflow sets is not the value being billed.
+          # The alias assertion. Only three aliases can legitimately appear:
+          # chat/completions/responses suites use HIVE_TEST_MODEL, capability
+          # tests use HIVE_TOOLS_MODEL (a tools-capable alias, since hive-free
+          # correctly refuses tools/response_format), and the embedding suites
+          # use HIVE_EMBEDDING_MODEL. Anything else means the value this
+          # workflow sets is not the value being billed.
           #
           # The query's own failure is checked, not just its result: a psql
           # error returns an EMPTY string here, which reads exactly like "no
@@ -1460,12 +1469,12 @@ jobs:
           if ! unexpected=$(q "select string_agg(distinct model_alias, ', ')
                                  from public.usage_events
                                 where event_type = 'completed'
-                                  and model_alias not in ('${HIVE_TEST_MODEL}', '${HIVE_EMBEDDING_MODEL}')"); then
+                                  and model_alias not in ('${HIVE_TEST_MODEL}', '${HIVE_TOOLS_MODEL}', '${HIVE_EMBEDDING_MODEL}')"); then
             echo "::error::the alias assertion query failed, so this run's billed alias is unverified"
             exit 1
           fi
           if [ -n "$unexpected" ]; then
-            echo "::error::this run billed alias(es) '${unexpected}', which is not what HIVE_TEST_MODEL ('${HIVE_TEST_MODEL}') or HIVE_EMBEDDING_MODEL ('${HIVE_EMBEDDING_MODEL}') selects. The model knob is not reaching the suites (issue #1088), so this job is spending an allowance it did not choose."
+            echo "::error::this run billed alias(es) '${unexpected}', which is not what HIVE_TEST_MODEL ('${HIVE_TEST_MODEL}'), HIVE_TOOLS_MODEL ('${HIVE_TOOLS_MODEL}') or HIVE_EMBEDDING_MODEL ('${HIVE_EMBEDDING_MODEL}') selects. The model knob is not reaching the suites (issue #1088), so this job is spending an allowance it did not choose."
             exit 1
           fi
 

--- a/.github/workflows/deploy-demo-box.yml
+++ b/.github/workflows/deploy-demo-box.yml
@@ -1840,8 +1840,10 @@ jobs:
       # Capability tests (tools/response_format) cannot run on hive-free: its
       # pool members are seeded tools_supported=false until cross-member parity
       # is probed (#1115), and the edge correctly 400s those parameters there
-      # (run 32736430913). deepseek-v4-flash has verified tool support.
-      HIVE_TOOLS_MODEL: deepseek-v4-flash
+      # (run 32736430913). deepseek-v4-pro is tools-capable with a pinned,
+      # contract-stable route; the flash variant returned message.content as
+      # object/null/string across probes (run 32665985618).
+      HIVE_TOOLS_MODEL: deepseek-v4-pro
       HIVE_EMBEDDING_MODEL: hive-embedding-default
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/deploy-demo-box.yml
+++ b/.github/workflows/deploy-demo-box.yml
@@ -1875,7 +1875,11 @@ jobs:
           body="$(curl -fsS --retry 5 --retry-all-errors --retry-delay 5 --max-time 15 \
             -H "Authorization: Bearer $HIVE_API_KEY" "$HIVE_BASE_URL/models")"
           echo "$body" | jq -e '.data | length >= 4' >/dev/null
-          for alias in hive-auto hive-default hive-embedding-default hive-fast; do
+          # HIVE_TEST_MODEL and HIVE_TOOLS_MODEL join the fixed list: this job's
+          # env sets both, and a deployment whose catalog lost either alias must
+          # fail here in preflight rather than mid-suite (CodeRabbit finding).
+          for alias in hive-auto hive-default hive-embedding-default hive-fast \
+                       "$HIVE_TEST_MODEL" "$HIVE_TOOLS_MODEL"; do
             echo "$body" | jq -e --arg id "$alias" '.data | map(.id) | index($id) != null' >/dev/null \
               || { echo "missing alias: $alias"; exit 1; }
           done

--- a/.github/workflows/deploy-demo-box.yml
+++ b/.github/workflows/deploy-demo-box.yml
@@ -1837,6 +1837,11 @@ jobs:
       # Daily automated consumption belongs on the free pool alias, not on a
       # paid tier (migration 20260824_02_free_pool_router.sql).
       HIVE_TEST_MODEL: hive-free
+      # Capability tests (tools/response_format) cannot run on hive-free: its
+      # pool members are seeded tools_supported=false until cross-member parity
+      # is probed (#1115), and the edge correctly 400s those parameters there
+      # (run 32736430913). deepseek-v4-flash has verified tool support.
+      HIVE_TOOLS_MODEL: deepseek-v4-flash
       HIVE_EMBEDDING_MODEL: hive-embedding-default
     steps:
       - uses: actions/checkout@v7

--- a/apps/control-plane/internal/routing/catalog_pricing_integration_test.go
+++ b/apps/control-plane/internal/routing/catalog_pricing_integration_test.go
@@ -274,3 +274,102 @@ func TestEveryAliasHasACostBasis(t *testing.T) {
 		t.Fatalf("iterate: %v", err)
 	}
 }
+
+// TestHiveFreeResolvesInASeededDatabase is the regression guard for the CI
+// live-integration outage of 2026-08-24 (PR #1121): the throwaway database
+// carried the free pool rows, yet every plain-chat suite call failed with
+// Invalid model name, because nothing had derived LiteLLM's serving config
+// from this catalog. The data half is guarded here: the alias the suites call
+// by default must resolve to ACTIVE pool members under the exact activity rule
+// litellmconfig.SyncService uses (health_state not disabled/eol on an enabled
+// provider), so a migration that seeds the rows but leaves them unselectable,
+// or a repoint that strands the pinned policy on a dead member, fails in the
+// go-tests job instead of only in a live-keyed run. The wiring half (LiteLLM
+// actually being told about the group) is asserted in ci.yml's live-integration
+// job right after its config sync.
+func TestHiveFreeResolvesInASeededDatabase(t *testing.T) {
+	pool := connectCatalogDB(t)
+
+	// The alias itself must exist and be publicly selectable.
+	var visibility, lifecycle string
+	err := pool.QueryRow(context.Background(), `
+		SELECT visibility, lifecycle
+		FROM public.model_aliases
+		WHERE alias_id = 'hive-free'
+	`).Scan(&visibility, &lifecycle)
+	if err != nil {
+		t.Fatalf("hive-free missing from the seeded catalog: %v", err)
+	}
+	if visibility != "public" || lifecycle != "stable" {
+		t.Errorf("hive-free visibility=%q lifecycle=%q, want public/stable", visibility, lifecycle)
+	}
+
+	// Active members under SyncService's own filter, which is stricter than
+	// SelectRoute's: it also excludes 'eol' and requires the provider enabled.
+	rows, err := pool.Query(context.Background(), `
+		SELECT pr.route_id, pr.litellm_model_name
+		FROM public.provider_routes pr
+		JOIN public.custom_providers cp ON cp.slug = pr.provider
+		WHERE pr.alias_id = 'hive-free'
+		  AND pr.health_state NOT IN ('disabled', 'eol')
+		  AND cp.enabled
+		ORDER BY pr.route_id
+	`)
+	if err != nil {
+		t.Fatalf("query active hive-free routes: %v", err)
+	}
+	defer rows.Close()
+
+	const wantGroup = "route-free-pool"
+	var members []string
+	for rows.Next() {
+		var routeID, modelName string
+		if err := rows.Scan(&routeID, &modelName); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		members = append(members, routeID)
+		if modelName != wantGroup {
+			t.Errorf("pool member %s serves group %q, want %q", routeID, modelName, wantGroup)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate: %v", err)
+	}
+	if len(members) == 0 {
+		t.Fatal("hive-free has no active route: the sync would emit no deployment for it and every plain-chat request would fail with Invalid model name")
+	}
+
+	// The pinned fallback must point at one of those active members.
+	var pinned string
+	err = pool.QueryRow(context.Background(), `
+	 SELECT fallback_order->>0
+	 FROM public.alias_route_policies
+	 WHERE alias_id = 'hive-free'
+	`).Scan(&pinned)
+	if err != nil {
+		t.Fatalf("read hive-free pinned policy: %v", err)
+	}
+	pinnedActive := false
+	for _, m := range members {
+		if m == pinned {
+			pinnedActive = true
+			break
+		}
+	}
+	if !pinnedActive {
+		t.Errorf("hive-free pins fallback_order[0]=%q, which is not among the active members %v; selection would strand on a dead route", pinned, members)
+	}
+
+	// Group membership rows gate tenant visibility: a default-tier key sees
+	// only aliases in its groups. Missing membership makes the alias invisible
+	// however correct everything else is.
+	var groupCount int
+	if err := pool.QueryRow(context.Background(), `
+	 SELECT count(*) FROM public.model_policy_group_members WHERE alias_id = 'hive-free'
+	`).Scan(&groupCount); err != nil {
+		t.Fatalf("query hive-free group membership: %v", err)
+	}
+	if groupCount == 0 {
+		t.Error("hive-free belongs to no model_policy_group, so no default-tier tenant can see it")
+	}
+}

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -325,9 +325,12 @@ services:
       HIVE_TEST_MODEL: ${HIVE_TEST_MODEL:-hive-default}
       HIVE_EMBEDDING_MODEL: ${HIVE_EMBEDDING_MODEL:-hive-embedding-default}
       # Capability tests in chat-completions.test.ts read this one (run
-      # 32736430913): tools/response_format need a tools_supported alias, not
-      # the plain-chat alias above.
-      HIVE_TOOLS_MODEL: ${HIVE_TOOLS_MODEL:-deepseek-v4-flash}
+      # 32736430913): tools/response_format need an alias whose route is
+      # tools_supported AND whose provider honors the response contract, not
+      # the plain-chat alias above. deepseek-v4-flash is tools-capable but its
+      # unpinned `-latest` router returned message.content as object/null/
+      # string across probes (run 32665985618), so the pinned deepseek-v4-pro.
+      HIVE_TOOLS_MODEL: ${HIVE_TOOLS_MODEL:-deepseek-v4-pro}
 
   sdk-tests-py:
     image: hive-sdk-tests-py:ci

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -324,6 +324,10 @@ services:
       # value is visible here rather than only in the test file.
       HIVE_TEST_MODEL: ${HIVE_TEST_MODEL:-hive-default}
       HIVE_EMBEDDING_MODEL: ${HIVE_EMBEDDING_MODEL:-hive-embedding-default}
+      # Capability tests in chat-completions.test.ts read this one (run
+      # 32736430913): tools/response_format need a tools_supported alias, not
+      # the plain-chat alias above.
+      HIVE_TOOLS_MODEL: ${HIVE_TOOLS_MODEL:-deepseek-v4-flash}
 
   sdk-tests-py:
     image: hive-sdk-tests-py:ci

--- a/packages/sdk-tests/js/tests/chat-completions/chat-completions.test.ts
+++ b/packages/sdk-tests/js/tests/chat-completions/chat-completions.test.ts
@@ -5,15 +5,20 @@ const BASE_URL = process.env.HIVE_BASE_URL ?? "http://localhost:8080/v1";
 const API_KEY = process.env.HIVE_API_KEY ?? "test-key";
 const MODEL = process.env.HIVE_TEST_MODEL ?? "hive-free";
 // Capability-specific tests (tools, response_format) need an alias whose
-// routes are seeded tools_supported=true. hive-free is the free pool of our
-// own keys with tools_supported=false on every member until cross-member
-// parity is probed (#1115), so the edge correctly 400s those parameters there
-// instead of silently dropping them (run 32736430913). deepseek-v4-flash's
-// source route has verified tool support, so capability coverage points there.
-// HIVE_TOOLS_MODEL exists so a deployment can repoint the tests without
-// editing them; the compose service forwards it like HIVE_TEST_MODEL.
+// route is seeded tools_supported=true AND whose provider honors the OpenAI
+// response contract. hive-free fails the first bar (free pool members are
+// seeded tools_supported=false until cross-member parity is probed, #1115),
+// and the edge correctly 400s tools/response_format there (run 32736430913).
+// deepseek-v4-flash passes the first bar but not the second: its unpinned
+// `-latest` router slug returned message.content as a parsed JSON object
+// (run 32665985618), as null, and as string on different probes, which no
+// strict assertion can survive. deepseek-v4-pro is date-pinned (-0813),
+// returns content as a string every time, and answers forced tool_choice
+// with a real tool_calls shape (probed live through the box's LiteLLM,
+// recorded in ci.yml). HIVE_TOOLS_MODEL lets a deployment repoint these
+// tests without editing them; compose forwards it like HIVE_TEST_MODEL.
 const TOOL_CAPABLE_MODEL =
-  process.env.HIVE_TOOLS_MODEL ?? "deepseek-v4-flash";
+  process.env.HIVE_TOOLS_MODEL ?? "deepseek-v4-pro";
 
 describe("Chat Completions", () => {
   const client = new OpenAI({ baseURL: BASE_URL, apiKey: API_KEY });
@@ -108,8 +113,10 @@ describe("Chat Completions", () => {
     // The edge must NOT 400 on response_format for a capable alias. The
     // assertions below are the OpenAI contract and stay strict: content is
     // typed as string on the wire, so an alias whose provider returns it as a
-    // raw object fails here by design (do not loosen this to fit one route).
-    // If the default TOOL_CAPABLE_MODEL regresses, repoint HIVE_TOOLS_MODEL.
+    // raw object or null fails here by design. That is exactly what the
+    // unpinned deepseek-v4-flash router did (run 32665985618), which is why
+    // the default is the pinned deepseek-v4-pro instead. Do not loosen this
+    // to fit one route; repoint HIVE_TOOLS_MODEL if the default regresses.
     const response = await client.chat.completions.create({
       model: TOOL_CAPABLE_MODEL,
       messages: [

--- a/packages/sdk-tests/js/tests/chat-completions/chat-completions.test.ts
+++ b/packages/sdk-tests/js/tests/chat-completions/chat-completions.test.ts
@@ -4,6 +4,16 @@ import OpenAI from "openai";
 const BASE_URL = process.env.HIVE_BASE_URL ?? "http://localhost:8080/v1";
 const API_KEY = process.env.HIVE_API_KEY ?? "test-key";
 const MODEL = process.env.HIVE_TEST_MODEL ?? "hive-free";
+// Capability-specific tests (tools, response_format) need an alias whose
+// routes are seeded tools_supported=true. hive-free is the free pool of our
+// own keys with tools_supported=false on every member until cross-member
+// parity is probed (#1115), so the edge correctly 400s those parameters there
+// instead of silently dropping them (run 32736430913). deepseek-v4-flash's
+// source route has verified tool support, so capability coverage points there.
+// HIVE_TOOLS_MODEL exists so a deployment can repoint the tests without
+// editing them; the compose service forwards it like HIVE_TEST_MODEL.
+const TOOL_CAPABLE_MODEL =
+  process.env.HIVE_TOOLS_MODEL ?? "deepseek-v4-flash";
 
 describe("Chat Completions", () => {
   const client = new OpenAI({ baseURL: BASE_URL, apiKey: API_KEY });
@@ -49,11 +59,11 @@ describe("Chat Completions", () => {
   });
 
   it("passes tools through and returns a tool_calls completion", async () => {
-    // Phase 20 (#118): capability-based passthrough ships. Capable routes
-    // (openrouter, groq) have tools_supported=true seeded, so tool calls are
-    // forwarded rather than rejected. The edge must NOT 400 on tools.
+    // Phase 20 (#118): capability-based passthrough ships. Routes with
+    // tools_supported=true seeded have tool calls forwarded rather than
+    // rejected; the edge must NOT 400 on tools for a capable alias.
     const response = await client.chat.completions.create({
-      model: MODEL,
+      model: TOOL_CAPABLE_MODEL,
       messages: [
         { role: "user", content: "What is the weather like in London?" },
       ],
@@ -95,9 +105,13 @@ describe("Chat Completions", () => {
 
   it("passes response_format through and returns valid JSON", async () => {
     // Phase 20 (#118): response_format forwarded to capable routes.
-    // The edge must NOT 400 on response_format; content must be parseable JSON.
+    // The edge must NOT 400 on response_format for a capable alias. The
+    // assertions below are the OpenAI contract and stay strict: content is
+    // typed as string on the wire, so an alias whose provider returns it as a
+    // raw object fails here by design (do not loosen this to fit one route).
+    // If the default TOOL_CAPABLE_MODEL regresses, repoint HIVE_TOOLS_MODEL.
     const response = await client.chat.completions.create({
-      model: MODEL,
+      model: TOOL_CAPABLE_MODEL,
       messages: [
         {
           role: "user",


### PR DESCRIPTION
## Verification state (final)

- [x] `npm run lint:sdk-test-env` passes locally.
- [x] Duplicate-key-aware YAML validation over both workflow files passes.
- [x] Labeled live-integration runs 32756113070 and 32775828952: both capability tests PASS on deepseek-v4-pro (tools 2420 ms; response_format 4474 ms with the strict string assertion).
- [x] CodeRabbit CLI major finding resolved (flash rejected on evidence, corrected alias documented in-file).
- [x] Workflow rejection fixed: commit 4 removed the duplicated free-pool env keys; run 32775828952 materializes 13 jobs and all nine required checks are GREEN.
- [x] sdk-replay path verified by inspection against the failing replay (run 32736430913): its two failures are exactly the two tests this PR repoints at deepseek-v4-pro.
- [ ] Known residual, NOT introduced here: live-integration's plain-chat suites fail on hive-free because control-plane drops route-free-pool in the CI throwaway DB ("members are all inactive"), a #1115 gap that reddens main's own push runs today. Tracked for a separate fix.

## Commit map

1. 682f39039: split the suite; HIVE_TOOLS_MODEL knob + compose/ci/deploy-demo-box wiring.
2. d9da95a53: default corrected flash -> pinned deepseek-v4-pro per CodeRabbit finding and ci.yml probe record.
3. e0f6924ab + ed1037f77/75fe19fd9: pre-verify additions, then dedup fix after the duplicate-key rejection; ed1037f77 integrates main.
