### PR TITLE
perf: send signed-out chat visitors to sign-in at parse time

### DIFF
--- a/scripts/test-owui-hive-frontend.sh
+++ b/scripts/test-owui-hive-frontend.sh
@@ -27,6 +27,10 @@ WORK=$(mktemp -d)
 trap 'rm -rf "$WORK"' EXIT
 
 mkdir -p "$WORK/lib/hive"
+# The app template too: early-redirect.test.ts executes the shipped bytes of
+# the inline signed-out fast-exit script by reading src/app.html out of the
+# mirrored tree, so the template must travel with the sources it pins.
+cp "$ROOT/vendor/open-webui/src/app.html" "$WORK"/app.html
 # The whole Hive directory, recursively, rather than a glob per extension. A
 # glob covers only what sits at the top of it today and would silently stop
 # covering a component the day someone put one in a subdirectory, which is the

--- a/vendor/open-webui/src/app.html
+++ b/vendor/open-webui/src/app.html
@@ -53,32 +53,60 @@
 				 both sides when either changes. -->
 		<script>
 			(() => {
+				// Every storage access is individually guarded: a browser that denies
+				// storage must not silence the whole fast exit, only the guard that
+				// needed the value. Reads degrade to "absent"; the attempt-stamp write
+				// is still verified and still fails closed, exactly like
+				// sso-redirect.ts's writeStorage.
+				let readLocalToken = null;
+				try {
+					readLocalToken = window.localStorage.getItem('token');
+				} catch (localError) {}
+				if (readLocalToken) return;
+				let hasTokenCookie = false;
+				try {
+					hasTokenCookie = window.document.cookie
+						.split('; ')
+						.some((cookie) => cookie.startsWith('token='));
+				} catch (cookieError) {}
+				if (hasTokenCookie) return;
+				const readSession = (key) => {
+					try {
+						return window.sessionStorage.getItem(key);
+					} catch (sessionError) {
+						return null;
+					}
+				};
+				const writeSession = (key, value) => {
+					try {
+						window.sessionStorage.setItem(key, value);
+						return window.sessionStorage.getItem(key) === value;
+					} catch (writeError) {
+						return false;
+					}
+				};
 				try {
 					if (window.electronAPI) return;
 					if (location.pathname !== '/') return;
-					if (localStorage.getItem('token')) return;
-					const hasTokenCookie = document.cookie
-						.split('; ')
-						.some((cookie) => cookie.startsWith('token='));
-					if (hasTokenCookie) return;
-					try {
-						if (sessionStorage.getItem('hive:signed-out') === '1') return;
-						const stamp = Number.parseInt(sessionStorage.getItem('hive:sso-attempt-at'), 10);
-						if (
-							Number.isFinite(stamp) &&
-							Date.now() - stamp >= 0 &&
-							Date.now() - stamp < 15000
-						) {
-							return;
-						}
-					} catch (storageError) {}
-					if (/\.scubed\.co$/.test(location.hostname)) {
-						const link = document.createElement('link');
-						link.rel = 'preconnect';
-						link.href = 'https://console-hive.scubed.co';
-						document.head.appendChild(link);
+					if (readSession('hive:signed-out') === '1') return;
+					const stamp = Number.parseInt(readSession('hive:sso-attempt-at'), 10);
+					if (
+						Number.isFinite(stamp) &&
+						Date.now() - stamp >= 0 &&
+						Date.now() - stamp < 15000
+					) {
+						return;
 					}
-					fetch('/api/config', { credentials: 'same-origin' })
+					try {
+						if (/\.scubed\.co$/.test(location.hostname)) {
+							const link = window.document.createElement('link');
+							link.rel = 'preconnect';
+							link.href = 'https://console-hive.scubed.co';
+							window.document.head.appendChild(link);
+						}
+					} catch (preconnectError) {}
+					window
+						.fetch('/api/config', { credentials: 'same-origin' })
 						.then((res) => (res.ok ? res.json() : null))
 						.then((cfg) => {
 							try {
@@ -96,9 +124,7 @@
 									return;
 								}
 								if (cfg.onboarding) return;
-								const now = String(Date.now());
-								sessionStorage.setItem('hive:sso-attempt-at', now);
-								if (sessionStorage.getItem('hive:sso-attempt-at') !== now) return;
+								if (!writeSession('hive:sso-attempt-at', String(Date.now()))) return;
 								location.replace('/oauth/' + providers[0] + '/login');
 							} catch (configError) {}
 						})

--- a/vendor/open-webui/src/app.html
+++ b/vendor/open-webui/src/app.html
@@ -41,6 +41,72 @@
 		-->
 		<link rel="stylesheet" href="/static/custom.css" crossorigin="use-credentials" />
 
+		<!-- Hive: signed-out fast exit (#945, #967). A visitor with no session used
+				 to pay this app's whole boot, about sixty modules plus /api/config plus
+				 socket setup, only for +layout.svelte's SSO decision then bounce them
+				 to the console sign-in. Measured cold, that put the sign-in form about
+				 five seconds behind an already slow HTML response. This runs at parse
+				 time instead and applies the same guards as sso-redirect.ts (the tested
+				 source of truth) with the layout's context. It fails closed: any
+				 surprise, including a failed attempt-stamp write, means do nothing and
+				 let the normal boot own the decision. Keep the guard list identical on
+				 both sides when either changes. -->
+		<script>
+			(() => {
+				try {
+					if (window.electronAPI) return;
+					if (location.pathname !== '/') return;
+					if (localStorage.getItem('token')) return;
+					const hasTokenCookie = document.cookie
+						.split('; ')
+						.some((cookie) => cookie.startsWith('token='));
+					if (hasTokenCookie) return;
+					try {
+						if (sessionStorage.getItem('hive:signed-out') === '1') return;
+						const stamp = Number.parseInt(sessionStorage.getItem('hive:sso-attempt-at'), 10);
+						if (
+							Number.isFinite(stamp) &&
+							Date.now() - stamp >= 0 &&
+							Date.now() - stamp < 15000
+						) {
+							return;
+						}
+					} catch (storageError) {}
+					if (/\.scubed\.co$/.test(location.hostname)) {
+						const link = document.createElement('link');
+						link.rel = 'preconnect';
+						link.href = 'https://console-hive.scubed.co';
+						document.head.appendChild(link);
+					}
+					fetch('/api/config', { credentials: 'same-origin' })
+						.then((res) => (res.ok ? res.json() : null))
+						.then((cfg) => {
+							try {
+								const providers =
+									cfg && cfg.oauth && cfg.oauth.providers ? Object.keys(cfg.oauth.providers) : [];
+								const features = (cfg && cfg.features) || {};
+								if (!cfg || !cfg.oauth || cfg.oauth.auto_redirect !== true) return;
+								if (providers.length !== 1) return;
+								if (
+									features.auth === false ||
+									features.enable_login_form !== false ||
+									features.enable_ldap ||
+									features.auth_trusted_header
+								) {
+									return;
+								}
+								if (cfg.onboarding) return;
+								const now = String(Date.now());
+								sessionStorage.setItem('hive:sso-attempt-at', now);
+								if (sessionStorage.getItem('hive:sso-attempt-at') !== now) return;
+								location.replace('/oauth/' + providers[0] + '/login');
+							} catch (configError) {}
+						})
+						.catch(() => {});
+				} catch (setupError) {}
+			})();
+		</script>
+
 		<script>
 			function resizeIframe(obj) {
 				obj.style.height = obj.contentWindow.document.documentElement.scrollHeight + 'px';

--- a/vendor/open-webui/src/lib/hive/early-redirect.test.ts
+++ b/vendor/open-webui/src/lib/hive/early-redirect.test.ts
@@ -1,0 +1,246 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// The fast exit lives as an inline script in app.html because its entire point
+// is to run before the bundler's output exists. These tests therefore execute
+// the shipped bytes themselves: the script block is pulled out of app.html and
+// run against stubbed browser globals. That keeps the inline copy from drifting
+// away from the behaviour these assertions pin down.
+
+const appHtmlPath = resolve(__dirname, '../../app.html');
+const appHtml = readFileSync(appHtmlPath, 'utf-8');
+
+// Locate the block by its marker comment, then slice out the first <script>
+// body after it. Index arithmetic instead of one clever regex.
+const marker = appHtml.indexOf('signed-out fast exit');
+if (marker === -1) {
+	throw new Error('early SSO comment marker not found in app.html');
+}
+const segment = appHtml.slice(marker);
+const open = segment.indexOf('<script>');
+const close = segment.indexOf('</script>', open);
+if (open === -1 || close === -1) {
+	throw new Error('early SSO script not found in app.html');
+}
+const scriptSource = segment.slice(open + '<script>'.length, close);
+
+type Store = Map<string, string>;
+
+const flush = () => new Promise((resolveDone) => setTimeout(resolveDone, 0));
+
+describe('app.html signed-out fast exit', () => {
+	let location: { pathname: string; hostname: string; replace: ReturnType<typeof vi.fn> };
+	let localStorageStore: Store;
+	let sessionStorageStore: Store;
+	let sessionStorageBroken: boolean;
+	let headChildren: Array<{ rel?: string; href?: string }>;
+	let fetchMock: ReturnType<typeof vi.fn>;
+
+	const config = (overrides: Record<string, unknown> = {}) => ({
+		oauth: {
+			auto_redirect: true,
+			providers: { oidc: {} }
+		},
+		features: {
+			auth: true,
+			enable_login_form: false
+		},
+		onboarding: false,
+		...overrides
+	});
+
+	const runScript = async ({
+		pathname = '/',
+		hostname = 'chat-hive.scubed.co',
+		localStorageToken = null,
+		tokenCookie = null,
+		session = {},
+		cfg = config(),
+		fetchImpl
+	}: {
+		pathname?: string;
+		hostname?: string;
+		localStorageToken?: string | null;
+		tokenCookie?: string | null;
+		session?: Record<string, string>;
+		cfg?: Record<string, unknown> | 'reject' | 'http500';
+		fetchImpl?: ReturnType<typeof vi.fn>;
+	} = {}) => {
+		location = {
+			pathname,
+			hostname,
+			replace: vi.fn()
+		};
+		localStorageStore = new Map();
+		if (localStorageToken) {
+			localStorageStore.set('token', localStorageToken);
+		}
+		sessionStorageStore = new Map(Object.entries(session));
+		sessionStorageBroken = false;
+		headChildren = [];
+		fetchMock = fetchImpl ?? vi.fn().mockResolvedValue({
+			ok: true,
+			json: () => Promise.resolve(cfg)
+		});
+
+		const globals = {
+			window: {} as Record<string, unknown>,
+			location,
+			document: {
+				cookie: tokenCookie ?? '',
+				head: {
+					appendChild: (node: { rel?: string; href?: string }) => {
+						headChildren.push(node);
+					}
+				},
+				createElement: () => ({}) as { rel?: string; href?: string }
+			},
+			fetch: fetchMock,
+			Date,
+			localStorage: {
+				getItem: (key: string) => localStorageStore.get(key) ?? null,
+				setItem: (key: string, value: string) => void localStorageStore.set(key, value),
+				removeItem: (key: string) => void localStorageStore.delete(key)
+			},
+			sessionStorage: {
+				getItem: (key: string) => {
+					if (sessionStorageBroken) throw new Error('storage unavailable');
+					return sessionStorageStore.get(key) ?? null;
+				},
+				setItem: (key: string, value: string) => {
+					if (sessionStorageBroken) throw new Error('storage unavailable');
+					void sessionStorageStore.set(key, value);
+				},
+				removeItem: (key: string) => {
+					if (sessionStorageBroken) throw new Error('storage unavailable');
+					void sessionStorageStore.delete(key);
+				}
+			}
+		};
+		for (const [name, value] of Object.entries(globals)) {
+			(globalThis as Record<string, unknown>)[name] = value;
+		}
+
+		new Function(scriptSource)();
+
+		await flush();
+		await flush();
+	};
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('leaves immediately for the single provider when signed out', async () => {
+		await runScript();
+		expect(location.replace).toHaveBeenCalledWith('/oauth/oidc/login');
+		expect(fetchMock).toHaveBeenCalledWith('/api/config', { credentials: 'same-origin' });
+		expect(sessionStorageStore.has('hive:sso-attempt-at')).toBe(true);
+	});
+
+	it('preconnects to the console host on a scubed.co origin', async () => {
+		await runScript();
+		expect(headChildren).toEqual([{ rel: 'preconnect', href: 'https://console-hive.scubed.co' }]);
+	});
+
+	it('does not preconnect on other origins', async () => {
+		await runScript({ hostname: 'chat.example.com' });
+		expect(headChildren).toEqual([]);
+	});
+
+	it('stays when a localStorage token exists', async () => {
+		await runScript({ localStorageToken: 'abc' });
+		expect(location.replace).not.toHaveBeenCalled();
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it('stays when a token cookie exists', async () => {
+		await runScript({ tokenCookie: 'token=abc; Path=/' });
+		expect(location.replace).not.toHaveBeenCalled();
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it('stays on paths other than /', async () => {
+		await runScript({ pathname: '/new-chat' });
+		expect(location.replace).not.toHaveBeenCalled();
+	});
+
+	it('stays when the signed-out marker is set', async () => {
+		await runScript({ session: { 'hive:signed-out': '1' } });
+		expect(location.replace).not.toHaveBeenCalled();
+	});
+
+	it('stays within the retry window after a recorded attempt', async () => {
+		await runScript({
+			session: { 'hive:sso-attempt-at': String(Date.now() - 3000) },
+			fetchImpl: undefined
+		});
+		expect(location.replace).not.toHaveBeenCalled();
+	});
+
+	it('leaves again once the attempt stamp is older than the retry window', async () => {
+		await runScript({ session: { 'hive:sso-attempt-at': String(Date.now() - 20000) } });
+		expect(location.replace).toHaveBeenCalledWith('/oauth/oidc/login');
+	});
+
+	it('stays when auto redirect is off', async () => {
+		await runScript({
+			cfg: config({ oauth: { auto_redirect: false, providers: { oidc: {} } } })
+		});
+		expect(location.replace).not.toHaveBeenCalled();
+	});
+
+	it('stays when more than one provider is configured', async () => {
+		await runScript({
+			cfg: config({ oauth: { auto_redirect: true, providers: { oidc: {}, saml: {} } } })
+		});
+		expect(location.replace).not.toHaveBeenCalled();
+	});
+
+	it('stays when the login form is enabled', async () => {
+		await runScript({ cfg: config({ features: { auth: true, enable_login_form: true } }) });
+		expect(location.replace).not.toHaveBeenCalled();
+	});
+
+	it('stays when auth is disabled', async () => {
+		await runScript({ cfg: config({ features: { auth: false, enable_login_form: false } }) });
+		expect(location.replace).not.toHaveBeenCalled();
+	});
+
+	it('stays during onboarding', async () => {
+		await runScript({ cfg: config({ onboarding: true }) });
+		expect(location.replace).not.toHaveBeenCalled();
+	});
+
+	it('fails closed when the attempt stamp cannot be stored', async () => {
+		let release!: () => void;
+		const gate = new Promise<void>((resolveGate) => {
+			release = resolveGate;
+		});
+		await runScript({
+			fetchImpl: vi
+				.fn()
+				.mockReturnValue(gate.then(() => ({ ok: true, json: () => Promise.resolve(config()) })))
+		});
+		sessionStorageBroken = true;
+		release();
+		await flush();
+		await flush();
+		expect(location.replace).not.toHaveBeenCalled();
+	});
+
+	it('fails closed when the config fetch rejects', async () => {
+		await runScript({
+			fetchImpl: vi.fn().mockRejectedValue(new Error('network down'))
+		});
+		expect(location.replace).not.toHaveBeenCalled();
+	});
+
+	it('ignores a non-ok config response', async () => {
+		await runScript({
+			fetchImpl: vi.fn().mockResolvedValue({ ok: false, json: () => Promise.resolve({}) })
+		});
+		expect(location.replace).not.toHaveBeenCalled();
+	});
+});

--- a/vendor/open-webui/src/lib/hive/early-redirect.test.ts
+++ b/vendor/open-webui/src/lib/hive/early-redirect.test.ts
@@ -34,6 +34,7 @@ describe('app.html signed-out fast exit', () => {
 	let localStorageStore: Store;
 	let sessionStorageStore: Store;
 	let sessionStorageBroken: boolean;
+	let localStorageBroken: boolean;
 	let headChildren: Array<{ rel?: string; href?: string }>;
 	let fetchMock: ReturnType<typeof vi.fn>;
 
@@ -57,7 +58,9 @@ describe('app.html signed-out fast exit', () => {
 		tokenCookie = null,
 		session = {},
 		cfg = config(),
-		fetchImpl
+		fetchImpl,
+		localStorageThrows = false,
+		sessionStorageThrows = false
 	}: {
 		pathname?: string;
 		hostname?: string;
@@ -66,6 +69,8 @@ describe('app.html signed-out fast exit', () => {
 		session?: Record<string, string>;
 		cfg?: Record<string, unknown> | 'reject' | 'http500';
 		fetchImpl?: ReturnType<typeof vi.fn>;
+		localStorageThrows?: boolean;
+		sessionStorageThrows?: boolean;
 	} = {}) => {
 		location = {
 			pathname,
@@ -77,46 +82,54 @@ describe('app.html signed-out fast exit', () => {
 			localStorageStore.set('token', localStorageToken);
 		}
 		sessionStorageStore = new Map(Object.entries(session));
-		sessionStorageBroken = false;
+		sessionStorageBroken = sessionStorageThrows;
+		localStorageBroken = localStorageThrows;
 		headChildren = [];
 		fetchMock = fetchImpl ?? vi.fn().mockResolvedValue({
 			ok: true,
 			json: () => Promise.resolve(cfg)
 		});
 
-		const globals = {
-			window: {} as Record<string, unknown>,
-			location,
-			document: {
-				cookie: tokenCookie ?? '',
-				head: {
-					appendChild: (node: { rel?: string; href?: string }) => {
-						headChildren.push(node);
-					}
-				},
-				createElement: () => ({}) as { rel?: string; href?: string }
+		const makeStorage = (broken: () => boolean, store: Store) => ({
+			getItem: (key: string) => {
+				if (broken()) throw new Error('storage unavailable');
+				return store.get(key) ?? null;
 			},
+			setItem: (key: string, value: string) => {
+				if (broken()) throw new Error('storage unavailable');
+				void store.set(key, value);
+			},
+			removeItem: (key: string) => {
+				if (broken()) throw new Error('storage unavailable');
+				void store.delete(key);
+			}
+		});
+		const sessionStub = makeStorage(() => sessionStorageBroken, sessionStorageStore);
+		const localStub = makeStorage(() => localStorageBroken, localStorageStore);
+
+		const documentStub = {
+			cookie: tokenCookie ?? '',
+			head: {
+				appendChild: (node: { rel?: string; href?: string }) => {
+					headChildren.push(node);
+				}
+			},
+			createElement: () => ({}) as { rel?: string; href?: string }
+		};
+
+		const globals = {
+			window: {
+				document: documentStub,
+				localStorage: localStub,
+				sessionStorage: sessionStub,
+				fetch: fetchMock
+			} as Record<string, unknown>,
+			location,
+			document: documentStub,
 			fetch: fetchMock,
 			Date,
-			localStorage: {
-				getItem: (key: string) => localStorageStore.get(key) ?? null,
-				setItem: (key: string, value: string) => void localStorageStore.set(key, value),
-				removeItem: (key: string) => void localStorageStore.delete(key)
-			},
-			sessionStorage: {
-				getItem: (key: string) => {
-					if (sessionStorageBroken) throw new Error('storage unavailable');
-					return sessionStorageStore.get(key) ?? null;
-				},
-				setItem: (key: string, value: string) => {
-					if (sessionStorageBroken) throw new Error('storage unavailable');
-					void sessionStorageStore.set(key, value);
-				},
-				removeItem: (key: string) => {
-					if (sessionStorageBroken) throw new Error('storage unavailable');
-					void sessionStorageStore.delete(key);
-				}
-			}
+			localStorage: localStub,
+			sessionStorage: sessionStub
 		};
 		for (const [name, value] of Object.entries(globals)) {
 			(globalThis as Record<string, unknown>)[name] = value;
@@ -241,6 +254,19 @@ describe('app.html signed-out fast exit', () => {
 		await runScript({
 			fetchImpl: vi.fn().mockResolvedValue({ ok: false, json: () => Promise.resolve({}) })
 		});
+		expect(location.replace).not.toHaveBeenCalled();
+	});
+
+	it('keeps going when localStorage denies access', async () => {
+		await runScript({ localStorageThrows: true });
+		expect(fetchMock).toHaveBeenCalled();
+		expect(location.replace).toHaveBeenCalledWith('/oauth/oidc/login');
+	});
+
+	it('fails closed when sessionStorage denies access entirely', async () => {
+		await runScript({ sessionStorageThrows: true });
+		// reads degrade to absent, so the decision path runs, but the
+		// attempt-stamp write cannot be verified, which must block navigation.
 		expect(location.replace).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
## What this changes

Cold load of `https://chat-hive.scubed.co/` while signed out measured **8.3s to 19.9s** until the sign-in form is usable (fresh headless Chromium process and context per run), with one run in five failing outright with a net error. The journey for a signed-out visitor is:

1. chat HTML document: 0.7s to 2.9s through the tunnel
2. about sixty SvelteKit module chunks download and evaluate
3. `GET /api/config` (~0.4s)
4. socket setup, i18n language fetch
5. only then does the root layout's SSO auto-redirect decision fire `/oauth/oidc/login`
6. four more document hops (`oidc/login` → Supabase `authorize` → `/oauth/consent` → `/auth/sign-in`)

Everything up to step 5 is work a signed-out visitor throws away. Measured on the box, none of it was server compute: `docker stats` during a cold load showed open-webui at 0.24% CPU and web-console-prod at 0%. The cost is serial round trips plus a full app boot the visitor never uses.

This PR adds an inline script to `vendor/open-webui/src/app.html` that runs at HTML parse time and makes the same decision the root layout makes later, with the same guards as `sso-redirect.ts` (auto redirect enabled, exactly one provider, no other auth mode enabled, not onboarding) plus the layout's context (no localStorage token, no token cookie, no signed-out marker, no attempt stamp inside the 15s retry window). It fails closed: any surprise, including a failed attempt-stamp write, means do nothing and let the normal boot own the decision. It also preconnects to the console host on scubed.co origins so the next hop's TLS setup starts during this page's lifetime.

The shipped bytes are what the tests execute: `early-redirect.test.ts` extracts the inline script from `app.html` and runs it against stubbed browser globals across 17 cases covering every guard, including fail-closed when storage or config fetch breaks.

## Why not other fixes

- Static asset cache headers are already correct on both hosts (`public, max-age=31536000, immutable`, Cloudflare HIT observed). No Caddyfile change needed.
- Bundle size is not the problem: the final sign-in page transfers 5KB of resources total; the chat boot's chunks land in 1.5 to 2.5s.
- The consent page SSR shell is trivial (client-side panel); its occasional multi-second document latency is tunnel hop variance, not server compute (web-console-prod at 0% CPU while it happened).
- A Caddy-level cookie gate on `/` would be faster still but needs container recreation and is infrastructure auth; the parse-time script keeps the decision in code we review, guarded by the tested decision function's rules.

## Buglog entry

None. No bug fixed here, a performance change; nothing to append.

Refs #945, #967

## Review streams and verdict

**Stream 1, CodeRabbit CLI: RAN.** One MAJOR finding: the console origin is hardcoded in `app.html`; the finding asked for deployment configuration instead. Disposition (full reasoning in the streams comment below): kept, because it is not a secret, the runtime hostname gate makes the link a no-op on any non-scubed.co deployment, and plumbing a public env var through Dockerfile plus compose buys nothing today. The GitHub-side CodeRabbit app check was rate limited ("Review rate limited"), so no inline threads exist on this PR; that half is stated SKIPPED.

**Stream 2, plain adversarial pass: RAN.** What was checked and closed:

- Fail-closed behavior of every guard: attempt-stamp write verified by read-back before navigation; storage reads degrade to absent; config fetch failure, non-ok response, missing oauth block, multi-provider, login form enabled, auth disabled, onboarding all result in no-op.
- Per-access storage guards so one denied getter cannot silence the whole fast exit.
- Redirect-target validation: built only from server-config provider keys, never user input or query parameters; no open-redirect surface.
- Bounce-loop protection identical to the layout's 15s attempt stamp; sessionStorage origin isolation keeps the two sides independent.
- The live simulation surfaced one real gap (a throwing storage getter silently cancelled everything); fixed with per-access guards and pinned by tests. 19 cases execute the shipped bytes of app.html; the fork suite is at 93 passing.

SKIPPED: ecc:code-review and domain specialist streams, outside the dispatched two-stream scope for this diff.

**Verdict: READY.**
