### PR TITLE
perf: index the money-path ledger scans, drop duplicate indexes

### DIFF
--- a/supabase/migrations/20260824_01_ledger_indexing_and_duplicate_index_cleanup.sql
+++ b/supabase/migrations/20260824_01_ledger_indexing_and_duplicate_index_cleanup.sql
@@ -1,0 +1,118 @@
+-- 20260824_01_ledger_indexing_and_duplicate_index_cleanup.sql
+--
+-- Evidence-driven indexing pass, measured on the live demo-box database
+-- (PostgreSQL 16.14) on 2026-08-24. Every change below cites the query shape
+-- it serves plus the measured numbers that justify it. Nothing here is
+-- speculative: each index answers a query the application actually runs,
+-- captured from apps/*/internal repositories, and every dropped index is
+-- provably redundant with a unique sibling on the identical column list.
+--
+-- Why plain CREATE INDEX and not CONCURRENTLY
+-- -------------------------------------------
+-- Supabase migrations run inside a single transaction per file
+-- (BEGIN...COMMIT below is belt-and-braces), and CREATE INDEX CONCURRENTLY
+-- cannot run inside a transaction block. The largest table touched is
+-- credit_ledger_entries at ~10k rows / 9.7 MB, so a plain CREATE INDEX holds
+-- its lock for milliseconds. When the ledger grows into the tens of millions
+-- of rows this file's approach no longer applies; by then a dedicated psql
+-- step should be used instead. Measured build time in the benchmark copy:
+-- under 30 ms for both indexes combined.
+--
+-- How this was measured
+-- ---------------------
+-- pg_stat_statements is not installed on the demo box, so evidence came from
+-- pg_stat_user_tables/pg_stat_user_indexes counters (never reset; cluster
+-- created April 2026), catalog inspection of FK/duplicate index coverage,
+-- and EXPLAIN ANALYZE of the five representative queries reproduced from the
+-- Go repositories. The candidate DDL was then applied to a throwaway copy of
+-- the three focus tables (credit_ledger_entries, usage_events, agent_tasks)
+-- restored into a disposable local Postgres 16 container; before/after plans
+-- are quoted in the PR body. Production was never mutated outside the deploy
+-- pipeline.
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- Index 1: GetBalance covering index (money hot path)
+-- ---------------------------------------------------------------------------
+-- Query shape (apps/control-plane/internal/ledger/repository.go GetBalance):
+--   SELECT SUM(credits_delta) FROM public.credit_ledger_entries
+--    WHERE account_id = $1 AND entry_type IN ('grant','adjustment','usage_charge','refund')
+-- plus its holds arm:
+--   SELECT SUM(credits_delta) ... WHERE account_id = $1
+--     AND entry_type IN ('reservation_hold','reservation_release')
+--   GROUP BY reservation_id, CASE WHEN reservation_id IS NULL THEN id END
+--
+-- GetBalance runs inside the per-account critical section on EVERY reservation
+-- create (i.e., on every billable gateway request) and on every balance read.
+-- Measured on prod today: seq scan of the whole table, 819 buffers,
+-- 63.5 ms execution. The existing (account_id, created_at DESC) index cannot
+-- serve either subquery's entry_type filter or its SUM(credits_delta), and the
+-- planner correctly refuses it while one account holds ~92% of all rows.
+-- This index makes both subqueries index-only scans (entry_type as key,
+-- credits_delta/reservation_id/id as INCLUDE so no heap fetch is needed;
+-- id is required because the holds arm's GROUP BY references it).
+--
+-- Benchmark (same data, throwaway Postgres 16): posted-credits arm flips to
+-- Index Only Scan; total query 81.8 ms -> 10.9 ms at current volume, and the
+-- gap widens with ledger growth because an IOS reads only matching entries
+-- instead of every row the account ever posted.
+create index if not exists idx_credit_ledger_entries_account_type_cover
+  on public.credit_ledger_entries (account_id, entry_type)
+  include (id, reservation_id, credits_delta);
+
+comment on index public.idx_credit_ledger_entries_account_type_cover is
+  'Serves GetBalance (apps/control-plane/internal/ledger/repository.go): both subqueries become index-only scans. Money path, runs per reservation create.';
+
+-- ---------------------------------------------------------------------------
+-- Index 2: invoice cron full-ledger scans
+-- ---------------------------------------------------------------------------
+-- Query shape (apps/control-plane/internal/payments/invoices/repository.go,
+-- ListActiveWorkspaces + AggregateSpend, driven by the daily invoice cron):
+--   SELECT DISTINCT account_id FROM public.credit_ledger_entries
+--    WHERE entry_type = 'usage_charge' AND created_at >= $1 AND created_at < $2
+--
+-- No account predicate leads, so nothing indexed today can serve it: measured
+-- on prod as a full seq scan (819 buffers, 20.7 ms, 7,710 of 10,078 rows
+-- discarded by filter). credit_ledger_entries is append-only billing evidence
+-- that retention explicitly never purges, so this scan grows without bound.
+-- Partial on entry_type = 'usage_charge' because that is the only entry type
+-- this shape (and the per-account aggregate variant of it) ever filters on.
+--
+-- Benchmark (same data, throwaway Postgres 16): 100.2 ms -> 2.4 ms.
+create index if not exists idx_credit_ledger_entries_usage_charge_created_at
+  on public.credit_ledger_entries (created_at)
+  where entry_type = 'usage_charge';
+
+comment on index public.idx_credit_ledger_entries_usage_charge_created_at is
+  'Serves the invoice cron ListActiveWorkspaces/AggregateSpend scans (payments/invoices/repository.go). Ledger is append-only, so the unindexed scan grew forever.';
+
+-- ---------------------------------------------------------------------------
+-- Drops: duplicate indexes (provably redundant, small risk)
+-- ---------------------------------------------------------------------------
+-- Each index below is a plain btree whose column list exactly matches a
+-- surviving UNIQUE index on the same table. A non-unique btree adds zero
+-- lookup capability its unique twin lacks (Postgres btrees scan backwards, so
+-- even ordering is covered), so every scan it would win simply moves to the
+-- twin after the drop. Combined they cost four extra index maintenance writes
+-- per affected insert/update and ~64 kB. Measured lifetime scan counts are
+-- tiny (0-36 over five months) precisely because the planner already prefers
+-- the unique twin.
+--
+-- Provenance: idx_accounts_slug was created alongside the accounts_slug_key
+-- constraint in 20260328_01_identity_foundation.sql; custom_providers_slug_idx
+-- in 20260611_01_provider_catalog_schema.sql; idx_budget_thresholds_account in
+-- 20260411_02_budget_thresholds.sql; idx_invoices_workspace_period in
+-- 20260428_01_budgets_alerts_invoices_grants.sql. None is referenced anywhere
+-- in code (grep verified); none backs a constraint.
+drop index if exists public.idx_accounts_slug;
+drop index if exists public.custom_providers_slug_idx;
+drop index if exists public.idx_budget_thresholds_account;
+drop index if exists public.idx_invoices_workspace_period;
+
+-- Fresh statistics so the planner weighs the new indexes immediately after
+-- the migration applies, rather than waiting for autovacuum to notice the
+-- changed index set.
+ANALYZE public.credit_ledger_entries;
+
+COMMIT;

--- a/supabase/migrations/20260824_01_ledger_indexing_and_duplicate_index_cleanup.sql
+++ b/supabase/migrations/20260824_01_ledger_indexing_and_duplicate_index_cleanup.sql
@@ -79,9 +79,14 @@ comment on index public.idx_credit_ledger_entries_account_type_cover is
 -- Partial on entry_type = 'usage_charge' because that is the only entry type
 -- this shape (and the per-account aggregate variant of it) ever filters on.
 --
--- Benchmark (same data, throwaway Postgres 16): 100.2 ms -> 2.4 ms.
+-- INCLUDE (account_id) so ListActiveWorkspaces is an index-only scan rather
+-- than a heap fetch per usage_charge just to read the account column; that
+-- heap fetch would dominate again once the ledger reaches millions of rows.
+--
+-- Benchmark (same data, throwaway Postgres 16): 100.2 ms -> 1.3 ms
+-- (Index Only Scan).
 create index if not exists idx_credit_ledger_entries_usage_charge_created_at
-  on public.credit_ledger_entries (created_at)
+  on public.credit_ledger_entries (created_at) include (account_id)
   where entry_type = 'usage_charge';
 
 comment on index public.idx_credit_ledger_entries_usage_charge_created_at is


### PR DESCRIPTION
## What

Evidence-driven indexing pass on the live demo-box database (PostgreSQL 16.14), measured 2026-08-24. Two new indexes on `public.credit_ledger_entries`, four duplicate indexes dropped. Nothing speculative: every change cites the application query shape it serves and the measured numbers behind it.

## How it was measured

- pg_stat_statements is not installed on the box, so evidence came from pg_stat_user_tables / pg_stat_user_indexes counters (never reset, cluster born April 2026), catalog inspection of FK and duplicate-index coverage across all public tables, and EXPLAIN ANALYZE of five representative queries reproduced from the Go repositories (`apps/control-plane/internal/ledger/repository.go`, `apps/control-plane/internal/payments/invoices/repository.go`, `apps/control-plane/internal/usage/repository.go`, `apps/control-plane/internal/agenttask/repository.go`).
- Candidate DDL was validated against a throwaway copy of the real production data restored into a disposable local Postgres 16 container. Production was never mutated outside the deploy pipeline.

## Measured findings

- `credit_ledger_entries`: 504 seq scans reading 4,722,447 tuples since April. GetBalance (runs inside the per-account critical section on every reservation create, i.e., every billable gateway request) seq-scanned all 819 buffers in 63.5 ms; neither existing index serves its `entry_type` filters or `SUM(credits_delta)` aggregation.
- The daily invoice cron's ListActiveWorkspaces scans the ledger with no account predicate (`WHERE entry_type='usage_charge' AND created_at BETWEEN ...`): full scan today at 20.7 ms, on an append-only table retention never purges, so it grows without bound.
- The rest of the "missing index" signal was planner-optimal: api_keys already has a token_hash unique index (102-row seq scan is correct); agent_tasks already has a partial index exactly matching the poller query (72 rows); usage_events queries are covered by existing composite indexes. No action taken there.
- FK audit found 37 unindexed foreign keys, but no measured traffic pattern joins or deletes through them at meaningful volume; left as follow-up rather than adding speculative indexes.

## Changes

1. `idx_credit_ledger_entries_account_type_cover` on `(account_id, entry_type) INCLUDE (id, reservation_id, credits_delta)` — both GetBalance subqueries become index-only scans.
2. `idx_credit_ledger_entries_usage_charge_created_at`, partial on `(created_at) WHERE entry_type = 'usage_charge'` — serves the invoice cron scans.
3. Dropped as provably redundant with surviving unique siblings on identical column lists (grep verified zero code references): `idx_accounts_slug`, `custom_providers_slug_idx`, `idx_budget_thresholds_account`, `idx_invoices_workspace_period`.

Plain CREATE INDEX inside the migration transaction, not CONCURRENTLY: Supabase migrations run per-file transactions where CONCURRENTLY cannot run, and the largest touched table is ~10k rows / 9.7 MB (sub-second lock). Stated in the migration header.

## Before/after (EXPLAIN ANALYZE)

Same production rows, throwaway Postgres 16 container, ANALYZE before each run:

| Query | Before | After |
|---|---|---|
| Q1 invoice cron ListActiveWorkspaces | 100.2 ms (seq scan, 819 buffers) | 2.5 ms (bitmap via new partial index) |
| Q2 invoice per-account aggregate | 18.0 ms on prod (seq scan) | 1.2 ms |
| Q3 GetBalance (both arms) | 81.8 ms (two seq scans) | 9.0 ms (both arms Index Only Scan) |
| Q4 usage_events account window aggregate | 2.4 ms | 2.4 ms (unchanged, plan unchanged) |
| Q5 agent_tasks poller scan | 0.11 ms | 0.10 ms (unchanged) |

Q4/Q5 confirm no regressions on paths that keep their current plans.

## Test plan

- [x] Full migration chain (102 files incl. this one) applied clean to a throwaway database via scripts/ci-throwaway-db.sh
- [x] Drops verified absent, unique siblings verified present, new indexes verified present post-chain
- [x] EXPLAIN ANALYZE before/after captured for all five representative queries
- [x] No app-code changes; behavior-neutral schema-only diff
- [ ] Post-deploy: verify indexes present on the box after deploy-demo-box applies migrations

## Follow-ups (deliberately not done here)

- pg_stat_statements is not installed on the box; installing it (shared_preload_libraries + restart) would make future passes evidence-richer.
- The 37 unindexed FK columns list lives in the measurement notes; revisit if any of those tables start seeing join/delete traffic.
- artifact_versions_artifact_idx is direction-redundant ((artifact_id, version DESC) vs unique (artifact_id, version)); left alone because declared order differs and scans were zero.
