### PR TITLE
test: cover money-path console components with behavioral UI suites

### DIFF
--- a/apps/web-console/components/api-keys/api-key-create-form.test.tsx
+++ b/apps/web-console/components/api-keys/api-key-create-form.test.tsx
@@ -1,0 +1,182 @@
+/**
+ * Behavioral tests for ApiKeyCreateForm: nickname validation, the create
+ * POST, the one-time secret panel with copy to clipboard, and reset.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+const refresh = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh }),
+}));
+
+import { ApiKeyCreateForm } from "./api-key-create-form";
+
+const CREATE_URL = "/api/v1/accounts/current/api-keys";
+
+function createdKeyBody(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "key-1",
+    nickname: "prod",
+    status: "active",
+    redacted_suffix: "abcd",
+    created_at: "2026-08-20T00:00:00Z",
+    updated_at: "2026-08-20T00:00:00Z",
+    expires_at: null,
+    last_used_at: null,
+    expiration_summary: { kind: "never", label: "Never expires" },
+    budget_summary: { kind: "unlimited", label: "No budget" },
+    allowlist_summary: { mode: "all", group_names: [], label: "All groups" },
+    secret: "sk-hive-once-only-secret",
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  Reflect.deleteProperty(navigator, "clipboard");
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  refresh.mockClear();
+});
+
+function nicknameInput(): HTMLInputElement {
+  const el = screen.getByLabelText(/nickname/i);
+  if (!(el instanceof HTMLInputElement)) {
+    throw new Error("nickname input not found");
+  }
+  return el;
+}
+
+function submitButton(): HTMLElement {
+  return screen.getByRole("button", { name: /create key|creating/i });
+}
+
+describe("ApiKeyCreateForm validation and creation", () => {
+  it("blank nickname is refused client side without a request", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<ApiKeyCreateForm />);
+    const form = nicknameInput().closest("form");
+    if (!form) {
+      throw new Error("create form not found");
+    }
+    fireEvent.submit(form);
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toContain("Nickname is required.");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("create fires once with the trimmed nickname and no expiry field when unset", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(createdKeyBody()), { status: 201 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<ApiKeyCreateForm />);
+    fireEvent.change(nicknameInput(), { target: { value: "  prod-server  " } });
+    fireEvent.click(submitButton());
+
+    await screen.findByTestId("created-api-key-secret");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toBe(CREATE_URL);
+    expect(init?.method).toBe("POST");
+    expect(JSON.parse(String(init?.body))).toEqual({ nickname: "prod-server" });
+    expect(screen.getByTestId("created-api-key-secret").textContent).toBe(
+      "sk-hive-once-only-secret",
+    );
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("an expiry date is sent as an ISO timestamp", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(createdKeyBody()), { status: 201 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<ApiKeyCreateForm />);
+    fireEvent.change(nicknameInput(), { target: { value: "rotating" } });
+    fireEvent.change(screen.getByLabelText(/expires/i), {
+      target: { value: "2027-01-15" },
+    });
+    fireEvent.click(submitButton());
+
+    await screen.findByTestId("created-api-key-secret");
+    const body = JSON.parse(String(fetchMock.mock.calls[0][1]?.body));
+    expect(body.nickname).toBe("rotating");
+    expect(body.expires_at).toBe(new Date("2027-01-15").toISOString());
+  });
+
+  it("server rejection surfaces the retry error instead of the secret panel", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response("denied", { status: 403 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<ApiKeyCreateForm />);
+    fireEvent.change(nicknameInput(), { target: { value: "prod" } });
+    fireEvent.click(submitButton());
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toContain("Failed to create key");
+    expect(screen.queryByTestId("created-api-key-secret")).toBeNull();
+  });
+
+  it("copy button writes the one-time secret to the clipboard exactly once per click", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(createdKeyBody()), { status: 201 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+      writable: true,
+    });
+
+    render(<ApiKeyCreateForm />);
+    fireEvent.change(nicknameInput(), { target: { value: "prod" } });
+    fireEvent.click(submitButton());
+    await screen.findByTestId("created-api-key-secret");
+
+    fireEvent.click(screen.getByRole("button", { name: /copy/i }));
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith("sk-hive-once-only-secret");
+    });
+    expect(screen.getByRole("button", { name: /copied/i })).toBeTruthy();
+
+    // Create another returns to a clean form for a second key.
+    fireEvent.click(screen.getByRole("button", { name: /create another/i }));
+    expect(nicknameInput().value).toBe("");
+    expect(screen.queryByTestId("created-api-key-secret")).toBeNull();
+  });
+
+  it("clipboard refusal degrades silently instead of throwing", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(createdKeyBody()), { status: 201 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const writeText = vi.fn().mockRejectedValue(new DOMException("denied"));
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+      writable: true,
+    });
+
+    render(<ApiKeyCreateForm />);
+    fireEvent.change(nicknameInput(), { target: { value: "prod" } });
+    fireEvent.click(submitButton());
+    await screen.findByTestId("created-api-key-secret");
+
+    fireEvent.click(screen.getByRole("button", { name: /copy/i }));
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalled();
+    });
+    // No crash, still on the secret panel, Copy label unchanged.
+    expect(screen.getByRole("button", { name: /^Copy$/i })).toBeTruthy();
+  });
+});

--- a/apps/web-console/components/api-keys/revoke-confirm-panel.test.tsx
+++ b/apps/web-console/components/api-keys/revoke-confirm-panel.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * Behavioral tests for RevokeConfirmPanel: the two step confirm before an
+ * API key is permanently revoked. Revocation is irreversible, so the suite
+ * pins both the cancel path (no request) and the confirm path (exactly one
+ * revoke POST for the right key id).
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+const refresh = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh }),
+}));
+
+import { RevokeConfirmPanel } from "./revoke-confirm-panel";
+
+function revokeUrl(keyId: string): string {
+  return `/api/v1/accounts/current/api-keys/${keyId}/revoke`;
+}
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  refresh.mockClear();
+});
+
+describe("RevokeConfirmPanel", () => {
+  it("starts as a Revoke button with no confirmation surface", () => {
+    render(
+      <RevokeConfirmPanel keyId="key-42" keyNickname="prod-server" />,
+    );
+    expect(screen.getByRole("button", { name: "Revoke" })).toBeTruthy();
+    expect(screen.queryByText(/revoke this key/i)).toBeNull();
+  });
+
+  it("clicking Revoke shows the confirm panel naming the key", () => {
+    render(
+      <RevokeConfirmPanel keyId="key-42" keyNickname="prod-server" />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Revoke" }));
+    expect(screen.getByText(/revoke this key\?/i)).toBeTruthy();
+    expect(screen.getByText(/prod-server/)).toBeTruthy();
+    expect(screen.getByRole("button", { name: /keep key/i })).toBeTruthy();
+  });
+
+  it("Keep key cancels without any network call", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const onCancel = vi.fn();
+
+    render(
+      <RevokeConfirmPanel
+        keyId="key-42"
+        keyNickname="prod-server"
+        onCancel={onCancel}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Revoke" }));
+    fireEvent.click(screen.getByRole("button", { name: /keep key/i }));
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(fetchMock).not.toHaveBeenCalled();
+    // Back to the idle trigger.
+    expect(screen.getByRole("button", { name: "Revoke" })).toBeTruthy();
+  });
+
+  it("confirming fires exactly one revoke POST for the right key id and completes", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("{}", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const onComplete = vi.fn();
+
+    render(
+      <RevokeConfirmPanel
+        keyId="key-42"
+        keyNickname="prod-server"
+        onComplete={onComplete}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Revoke" }));
+    fireEvent.click(screen.getByRole("button", { name: /revoke key/i }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toBe(revokeUrl("key-42"));
+    expect(init?.method).toBe("POST");
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    // Panel collapses back to the idle trigger after success.
+    expect(screen.getByRole("button", { name: "Revoke" })).toBeTruthy();
+  });
+
+  it("failed revoke surfaces an error and keeps the panel open", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("locked", { status: 409 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <RevokeConfirmPanel keyId="key-42" keyNickname="prod-server" />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Revoke" }));
+    fireEvent.click(screen.getByRole("button", { name: /revoke key/i }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toContain("Failed to revoke key");
+    expect(screen.queryByRole("button", { name: /revoke key/i })).toBeTruthy();
+  });
+
+  it("network failure during revoke also keeps the panel open", async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new TypeError("offline"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <RevokeConfirmPanel keyId="key-42" keyNickname="prod-server" />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Revoke" }));
+    fireEvent.click(screen.getByRole("button", { name: /revoke key/i }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toContain("offline");
+    expect(screen.queryByRole("button", { name: /revoke key/i })).toBeTruthy();
+  });
+});

--- a/apps/web-console/components/billing/budget-form-ui.test.tsx
+++ b/apps/web-console/components/billing/budget-form-ui.test.tsx
@@ -1,0 +1,158 @@
+/**
+ * Behavioral UI tests for BudgetForm: the workspace budget cap editor.
+ * The sibling budget-form.test.tsx locks the taka/subunit conversion math;
+ * this suite proves what a user's submit actually sends and what invalid
+ * input refuses to send.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import { BudgetForm } from "./budget-form";
+import type { BudgetSettings } from "@/lib/control-plane/client";
+
+const BUDGET_URL = (ws: string) => `/api/budget/${ws}`;
+
+function settingsFixture(overrides: Partial<BudgetSettings> = {}): BudgetSettings {
+  return {
+    workspace_id: "ws-1",
+    period_start: "2026-08-01",
+    soft_cap_bdt_subunits: 100_000,
+    hard_cap_bdt_subunits: 200_000,
+    currency: "BDT",
+    created_at: "2026-08-01T00:00:00Z",
+    updated_at: "2026-08-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function inputById(id: string): HTMLInputElement {
+  const el = screen.getByLabelText(new RegExp(id.replace("budget-", ""), "i"));
+  if (!(el instanceof HTMLInputElement)) {
+    throw new Error(`input ${id} not found`);
+  }
+  return el;
+}
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("BudgetForm behavior", () => {
+  it("prefills both caps from existing settings as editable taka strings", () => {
+    render(<BudgetForm workspaceId="ws-1" budget={settingsFixture()} readOnly={false} />);
+    const soft = inputById("soft");
+    const hard = inputById("hard");
+    expect(soft.value).toBe("1000.00");
+    expect(hard.value).toBe("2000.00");
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("submit fires once with parsed subunit values", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(settingsFixture()), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<BudgetForm workspaceId="ws-1" budget={null} readOnly={false} />);
+    fireEvent.change(inputById("soft"), { target: { value: "10.50" } });
+    fireEvent.change(inputById("hard"), { target: { value: "20" } });
+    fireEvent.click(screen.getByRole("button", { name: /save budget/i }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toBe(BUDGET_URL("ws-1"));
+    expect(init?.method).toBe("PUT");
+    expect(JSON.parse(String(init?.body))).toEqual({
+      soft_cap_bdt_subunits: 1050,
+      hard_cap_bdt_subunits: 2000,
+    });
+    expect(await screen.findByRole("status")).toBeTruthy();
+  });
+
+  it("malformed caps are refused client side without any network call", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<BudgetForm workspaceId="ws-1" budget={null} readOnly={false} />);
+    fireEvent.change(inputById("soft"), { target: { value: "abc" } });
+    fireEvent.change(inputById("hard"), { target: { value: "-5" } });
+    fireEvent.click(screen.getByRole("button", { name: /save budget/i }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toContain("non-negative numbers");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("a soft cap above the hard cap never reaches the server", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<BudgetForm workspaceId="ws-1" budget={null} readOnly={false} />);
+    fireEvent.change(inputById("soft"), { target: { value: "50" } });
+    fireEvent.change(inputById("hard"), { target: { value: "40" } });
+    fireEvent.click(screen.getByRole("button", { name: /save budget/i }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toContain("less than or equal to hard cap");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("read-only mode disables the form and blocks submission", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <BudgetForm
+        workspaceId="ws-1"
+        budget={settingsFixture()}
+        readOnly
+      />,
+    );
+    expect(inputById("soft").disabled).toBe(true);
+    expect(inputById("hard").disabled).toBe(true);
+    const save = screen.getByRole("button", { name: /save budget/i });
+    expect(save instanceof HTMLButtonElement && save.disabled).toBe(true);
+
+    // Even a forced submit event is refused.
+    const form = save.closest("form");
+    if (!form) {
+      throw new Error("budget form not found");
+    }
+    fireEvent.submit(form);
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toContain("Only the workspace owner");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("server rejection surfaces the backend error message", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: "hard cap exceeds account limit" }), { status: 422 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<BudgetForm workspaceId="ws-1" budget={null} readOnly={false} />);
+    fireEvent.change(inputById("soft"), { target: { value: "10" } });
+    fireEvent.change(inputById("hard"), { target: { value: "20" } });
+    fireEvent.click(screen.getByRole("button", { name: /save budget/i }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toContain("hard cap exceeds account limit");
+  });
+
+  it("network failure falls back to a retryable message", async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new TypeError("connection lost"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<BudgetForm workspaceId="ws-1" budget={null} readOnly={false} />);
+    fireEvent.change(inputById("soft"), { target: { value: "1" } });
+    fireEvent.change(inputById("hard"), { target: { value: "2" } });
+    fireEvent.click(screen.getByRole("button", { name: /save budget/i }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toContain("connection lost");
+  });
+});

--- a/apps/web-console/components/billing/checkout-modal-ui.test.tsx
+++ b/apps/web-console/components/billing/checkout-modal-ui.test.tsx
@@ -1,0 +1,237 @@
+/**
+ * Behavioral UI tests for CheckoutModal (the money entry surface).
+ *
+ * The sibling checkout-modal.test.tsx locks the pricing math; this suite
+ * drives the rendered component through jsdom: rails loading, amount
+ * stepping against min/max, cancel paths that must NOT fire a checkout
+ * intent, and the initiate POST payload.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import { CheckoutModal } from "./checkout-modal";
+import type { CheckoutOptions } from "@/lib/control-plane/client";
+
+const RAILS_URL = "/api/v1/accounts/current/checkout/rails";
+const INITIATE_URL = "/api/v1/accounts/current/checkout/initiate";
+
+function optionsFixture(overrides: Partial<CheckoutOptions> = {}): CheckoutOptions {
+  return {
+    rails: [
+      {
+        rail: "bkash",
+        currency: "BDT",
+        label: "bKash",
+        enabled: true,
+      },
+    ],
+    credit_increment: 500,
+    min_credits: 1000,
+    max_credits: 3000,
+    price_per_block_minor: 11550,
+    credit_block_size: 1_000_000_000,
+    currency: "BDT",
+    ...overrides,
+  };
+}
+
+// One fetch mock for both calls the modal makes: GET rails on mount and
+// POST initiate on Continue to payment. Dispatch by URL so each test only
+// declares the initiate outcome it cares about.
+function stubFetch(opts: {
+  rails?: CheckoutOptions;
+  railsOk?: boolean;
+  initiate?: () => Response;
+}) {
+  const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url === RAILS_URL) {
+      if (opts.railsOk === false) {
+        return new Response("nope", { status: 500 });
+      }
+      return new Response(JSON.stringify(opts.rails ?? optionsFixture()), {
+        status: 200,
+      });
+    }
+    if (url === INITIATE_URL) {
+      return opts.initiate ? opts.initiate() : new Response("{}", { status: 200 });
+    }
+    throw new Error(`Unexpected fetch: ${url}`);
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+function buttonDisabled(button: HTMLElement): boolean {
+  return button instanceof HTMLButtonElement && button.disabled;
+}
+
+function amountInput(): HTMLInputElement {
+  // The numeric credit field renders as a spinbutton. Its wrapper div
+  // shares the label wiring, so role-based lookup is the reliable handle.
+  const el = screen.getByRole("spinbutton");
+  if (!(el instanceof HTMLInputElement)) {
+    throw new Error("credit amount spinbutton not found");
+  }
+  return el;
+}
+
+async function renderLoadedModal(props: {
+  accountCountryCode?: string;
+  onClose?: () => void;
+} = {}) {
+  const onClose = props.onClose ?? vi.fn();
+  render(
+    <CheckoutModal accountCountryCode={props.accountCountryCode ?? "US"} onClose={onClose} />,
+  );
+  // Wait past the mount-time rails fetch.
+  await screen.findByText("Payment method");
+  return { onClose };
+}
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("CheckoutModal behavior", () => {
+  it("pay button is gated until a rail is selectable (no enabled rails renders it disabled)", async () => {
+    stubFetch({ rails: optionsFixture({ rails: [{ rail: "bkash", currency: "BDT", label: "bKash", enabled: false }] }) });
+    render(<CheckoutModal accountCountryCode="US" onClose={vi.fn()} />);
+    await screen.findByText("Payment method");
+    const pay = screen.getByRole("button", { name: /continue to payment/i });
+    expect(buttonDisabled(pay)).toBe(true);
+  });
+
+  it("increase and decrease step by credit_increment and clamp to min/max", async () => {
+    stubFetch({});
+    await renderLoadedModal();
+    const increase = screen.getByRole("button", { name: "Increase" });
+    const decrease = screen.getByRole("button", { name: "Decrease" });
+
+    // Starts at min_credits; decrease is pinned at the floor.
+    expect(amountInput().value).toBe("1000");
+    expect(buttonDisabled(decrease)).toBe(true);
+
+    fireEvent.click(increase);
+    expect(amountInput().value).toBe("1500");
+    fireEvent.click(increase);
+    expect(amountInput().value).toBe("2000");
+
+    fireEvent.click(decrease);
+    expect(amountInput().value).toBe("1500");
+    expect(buttonDisabled(decrease)).toBe(false);
+
+    // Walk back down to the floor; decrease disables again.
+    fireEvent.click(decrease);
+    fireEvent.click(decrease);
+    expect(amountInput().value).toBe("1000");
+    expect(buttonDisabled(decrease)).toBe(true);
+
+    // Typing past the ceiling clamps instead of storing an invalid amount.
+    fireEvent.change(amountInput(), { target: { value: "99999" } });
+    expect(amountInput().value).toBe("3000");
+
+    // At the ceiling the increase button pins too.
+    expect(buttonDisabled(increase)).toBe(true);
+  });
+
+  it("cancel (Keep balance) closes without firing a checkout intent", async () => {
+    const fetchMock = stubFetch({});
+    const { onClose } = await renderLoadedModal();
+
+    fireEvent.click(screen.getByRole("button", { name: /keep balance/i }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1); // rails GET only
+    expect(fetchMock.mock.calls.every(([u]) => String(u) === RAILS_URL)).toBe(true);
+  });
+
+  it("overlay click equals cancel: backdrop closes, content inside does not", async () => {
+    stubFetch({});
+    const { onClose } = await renderLoadedModal();
+    const dialog = screen.getByRole("dialog");
+
+    // Click on inner content bubbles but target != currentTarget: no close.
+    fireEvent.click(screen.getByText("Buy credits"));
+    expect(onClose).not.toHaveBeenCalled();
+
+    fireEvent.click(dialog); // target IS currentTarget here
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("close (X) button closes the modal without any network call", async () => {
+    const fetchMock = stubFetch({});
+    const { onClose } = await renderLoadedModal();
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1); // rails GET only
+  });
+
+  it("continue to payment fires the initiate intent exactly once with the selected rail and stepped credits", async () => {
+    const fetchMock = stubFetch({
+      initiate: () =>
+        new Response(JSON.stringify({ redirect_url: "https://pay.example.test/redirect" }), {
+          status: 200,
+        }),
+    });
+    await renderLoadedModal();
+
+    fireEvent.click(screen.getByRole("button", { name: /increase/i }));
+    fireEvent.click(screen.getByRole("button", { name: /continue to payment/i }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+    const [url, init] = fetchMock.mock.calls[1];
+    expect(String(url)).toBe(INITIATE_URL);
+    expect(init?.method).toBe("POST");
+    const body = JSON.parse(String(init?.body));
+    expect(body).toEqual({
+      rail: "bkash",
+      credits: 1500,
+      idempotency_key: expect.stringMatching(/^checkout-\d+-[a-z0-9]+$/),
+    });
+  });
+
+  it("failed initiate surfaces an error and hands control back to the user", async () => {
+    stubFetch({ initiate: () => new Response("declined", { status: 402 }) });
+    await renderLoadedModal();
+
+    fireEvent.click(screen.getByRole("button", { name: /continue to payment/i }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toContain("Unable to start checkout");
+    const pay = screen.getByRole("button", { name: /continue to payment/i });
+    expect(buttonDisabled(pay)).toBe(false);
+  });
+
+  it("rails load failure shows the refresh error instead of the form", async () => {
+    stubFetch({ railsOk: false });
+    render(<CheckoutModal accountCountryCode="US" onClose={vi.fn()} />);
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toContain("Unable to load payment options");
+    expect(screen.queryByText(/continue to payment/i)).toBeNull();
+  });
+
+  it("non-BD accounts see the computed local total; BD accounts never do", async () => {
+    stubFetch({});
+    const { unmount } = render(
+      <CheckoutModal accountCountryCode="US" onClose={vi.fn()} />,
+    );
+    await screen.findByText("Payment method");
+    expect(screen.getByText("Total")).toBeTruthy();
+    expect(document.querySelector("[data-numeric]")).toBeTruthy();
+    unmount();
+    cleanup();
+
+    stubFetch({});
+    render(<CheckoutModal accountCountryCode="BD" onClose={vi.fn()} />);
+    await screen.findByText("Payment method");
+    expect(screen.getByText("Final amount")).toBeTruthy();
+    // Regulatory invariant: no numeric FX-style total on the BD surface.
+    expect(document.querySelector("[data-numeric]")).toBeNull();
+    expect(screen.getByText(/shown on the bKash payment page/i)).toBeTruthy();
+  });
+});

--- a/apps/web-console/components/billing/checkout-modal-ui.test.tsx
+++ b/apps/web-console/components/billing/checkout-modal-ui.test.tsx
@@ -43,21 +43,23 @@ function stubFetch(opts: {
   railsOk?: boolean;
   initiate?: () => Response;
 }) {
-  const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
-    const url = String(input);
-    if (url === RAILS_URL) {
-      if (opts.railsOk === false) {
-        return new Response("nope", { status: 500 });
+  const fetchMock = vi.fn(
+    async (input: RequestInfo | URL, _init?: RequestInit) => {
+      const url = String(input);
+      if (url === RAILS_URL) {
+        if (opts.railsOk === false) {
+          return new Response("nope", { status: 500 });
+        }
+        return new Response(JSON.stringify(opts.rails ?? optionsFixture()), {
+          status: 200,
+        });
       }
-      return new Response(JSON.stringify(opts.rails ?? optionsFixture()), {
-        status: 200,
-      });
-    }
-    if (url === INITIATE_URL) {
-      return opts.initiate ? opts.initiate() : new Response("{}", { status: 200 });
-    }
-    throw new Error(`Unexpected fetch: ${url}`);
-  });
+      if (url === INITIATE_URL) {
+        return opts.initiate ? opts.initiate() : new Response("{}", { status: 200 });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    },
+  );
   vi.stubGlobal("fetch", fetchMock);
   return fetchMock;
 }

--- a/apps/web-console/components/billing/invoice-download-button.test.tsx
+++ b/apps/web-console/components/billing/invoice-download-button.test.tsx
@@ -1,0 +1,201 @@
+/**
+ * Behavioral tests for the client-side invoice PDF download button.
+ * The @react-pdf/renderer dependency is mocked at the module boundary. The
+ * suite proves the user-visible contract: clicking Download PDF produces a
+ * blob download named invoice-{id}.pdf, guards against double clicks while
+ * generation runs, and degrades to an alert on failure.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+const pdfHarness = vi.hoisted(() => {
+  const harness = {
+    resolvers: new Array<(blob: Blob) => void>(),
+    failNext: false,
+    defer: false,
+  };
+  return harness;
+});
+
+vi.mock("@react-pdf/renderer", () => {
+  function StubNode() {
+    return null;
+  }
+  return {
+    Document: StubNode,
+    Page: StubNode,
+    View: StubNode,
+    Text: StubNode,
+    StyleSheet: { create: (styles: unknown) => styles },
+    pdf: () => ({
+      toBlob: () =>
+        new Promise<Blob>((resolve, reject) => {
+          if (pdfHarness.failNext) {
+            reject(new Error("render exploded"));
+            return;
+          }
+          if (pdfHarness.defer) {
+            pdfHarness.resolvers.push(resolve);
+            return;
+          }
+          resolve(new Blob(["%PDF-fake"], { type: "application/pdf" }));
+        }),
+    }),
+  };
+});
+
+import { InvoiceDownloadButton } from "./invoice-download-button";
+import type { Invoice } from "@/lib/control-plane/client";
+
+function invoiceFixture(overrides: Partial<Invoice> = {}): Invoice {
+  return {
+    id: "inv-9",
+    invoice_number: "INV-009",
+    status: "paid",
+    credits: 1_000_000_000,
+    amount_local: 11_500,
+    local_currency: "BDT",
+    tax_treatment: "VAT registered",
+    rail: "bkash",
+    line_items: [],
+    created_at: "2026-08-20T10:00:00Z",
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  Reflect.deleteProperty(URL, "createObjectURL");
+  Reflect.deleteProperty(URL, "revokeObjectURL");
+  Reflect.deleteProperty(window, "alert");
+  pdfHarness.resolvers.length = 0;
+  pdfHarness.failNext = false;
+  pdfHarness.defer = false;
+  vi.restoreAllMocks();
+});
+
+function installDownloadCapture(): Array<{ download: string | null }> {
+  const anchors: Array<{ download: string | null }> = [];
+  vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(function mockClick(
+    this: HTMLAnchorElement,
+  ) {
+    anchors.push({ download: this.getAttribute("download") });
+  });
+  Object.defineProperty(URL, "createObjectURL", {
+    value: () => "blob:invoice-mock",
+    configurable: true,
+    writable: true,
+  });
+  Object.defineProperty(URL, "revokeObjectURL", {
+    value: () => {},
+    configurable: true,
+    writable: true,
+  });
+  return anchors;
+}
+
+describe("InvoiceDownloadButton", () => {
+  it("download completes and returns the button to its idle label", async () => {
+    installDownloadCapture();
+    const blobs: Blob[] = [];
+    Object.defineProperty(URL, "createObjectURL", {
+      value: (blob: Blob) => {
+        blobs.push(blob);
+        return "blob:invoice-mock";
+      },
+      configurable: true,
+      writable: true,
+    });
+
+    render(<InvoiceDownloadButton invoice={invoiceFixture()} />);
+    fireEvent.click(screen.getByRole("button", { name: /download pdf/i }));
+
+    await waitFor(() => {
+      expect(blobs.length).toBeGreaterThan(0);
+    });
+    expect(blobs[0].type).toBe("application/pdf");
+    const button = screen.getByRole("button", { name: /download pdf/i });
+    expect(button.textContent).toContain("Download PDF");
+  });
+
+  it("uses the invoice id in the download filename", async () => {
+    const anchors = installDownloadCapture();
+    render(<InvoiceDownloadButton invoice={invoiceFixture({ id: "inv-77" })} />);
+    fireEvent.click(screen.getByRole("button", { name: /download pdf/i }));
+
+    await waitFor(() => {
+      expect(anchors).toHaveLength(1);
+    });
+    expect(anchors[0].download).toBe("invoice-inv-77.pdf");
+  });
+
+  it("ignores a second click while generation is still running", async () => {
+    const anchors = installDownloadCapture();
+    pdfHarness.defer = true;
+
+    render(<InvoiceDownloadButton invoice={invoiceFixture()} />);
+    const button = () => screen.getByRole("button", { name: /download pdf|generating/i });
+
+    const settled = act(async () => {
+      fireEvent.click(button());
+      // Generation is parked on the deferred resolver; the label flips.
+      await waitFor(() => {
+        expect(screen.getByText(/Generating/)).toBeTruthy();
+      });
+      fireEvent.click(button()); // busy guard + disabled state
+      for (const resolve of pdfHarness.resolvers.splice(0)) {
+        resolve(new Blob(["%PDF-fake"], { type: "application/pdf" }));
+      }
+    });
+    await settled;
+
+    expect(anchors).toHaveLength(1);
+    expect(screen.getByRole("button", { name: /download pdf/i }).textContent).toContain(
+      "Download PDF",
+    );
+  });
+
+  it("generation failure alerts instead of downloading", async () => {
+    const alertSpy = vi.fn();
+    Object.defineProperty(window, "alert", {
+      value: alertSpy,
+      configurable: true,
+      writable: true,
+    });
+    installDownloadCapture();
+    pdfHarness.failNext = true;
+
+    render(<InvoiceDownloadButton invoice={invoiceFixture()} />);
+    fireEvent.click(screen.getByRole("button", { name: /download pdf/i }));
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledTimes(1);
+    });
+    expect(String(alertSpy.mock.calls[0][0])).toContain("render exploded");
+    expect(
+      screen.getByRole("button", { name: /download pdf/i }).textContent,
+    ).toContain("Download PDF");
+  });
+
+  it("missing local_currency refuses to render and alerts", async () => {
+    const alertSpy = vi.fn();
+    Object.defineProperty(window, "alert", {
+      value: alertSpy,
+      configurable: true,
+      writable: true,
+    });
+    installDownloadCapture();
+
+    render(
+      <InvoiceDownloadButton
+        invoice={invoiceFixture({ local_currency: "" })}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /download pdf/i }));
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledTimes(1);
+    });
+    expect(String(alertSpy.mock.calls[0][0])).toContain("local_currency");
+  });
+});

--- a/apps/web-console/components/billing/invoice-row.test.tsx
+++ b/apps/web-console/components/billing/invoice-row.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * InvoiceRow renders the server-side invoice table row. Its money-relevant
+ * contract is the download link: it must point at the per-invoice PDF proxy
+ * for exactly the right invoice id.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("next/link", () => ({
+  default: ({ href, children }: { href: string; children?: React.ReactNode }) => (
+    <a href={href} data-testid="invoice-pdf-link">
+      {children}
+    </a>
+  ),
+}));
+
+import { InvoiceRow } from "./invoice-row";
+import type { InvoiceRecord } from "@/lib/control-plane/client";
+
+function recordFixture(overrides: Partial<InvoiceRecord> = {}): InvoiceRecord {
+  return {
+    id: "inv-4021",
+    workspace_id: "ws-1",
+    period_start: "2026-07-01",
+    period_end: "2026-07-31",
+    total_bdt_subunits: "11500",
+    line_items: [],
+    generated_at: "2026-08-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("InvoiceRow", () => {
+  it("download link targets the pdf proxy endpoint for this invoice id", () => {
+    render(
+      <table>
+        <tbody>
+          <InvoiceRow invoice={recordFixture()} />
+        </tbody>
+      </table>,
+    );
+    const link = screen.getByTestId("invoice-pdf-link");
+    expect(link.getAttribute("href")).toBe("/api/invoices/inv-4021/pdf");
+  });
+
+  it("renders the period range and model count", () => {
+    render(
+      <table>
+        <tbody>
+          <InvoiceRow invoice={recordFixture()} />
+        </tbody>
+      </table>,
+    );
+    expect(screen.getByText(/2026-07-01/)).toBeTruthy();
+    const modelsCell = screen.getByText(/models/i).closest("td");
+    expect(modelsCell?.textContent?.replace(/\s+/g, " ").trim()).toBe("0 models");
+  });
+});

--- a/apps/web-console/components/billing/ledger-csv-export.test.tsx
+++ b/apps/web-console/components/billing/ledger-csv-export.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * Behavioral tests for LedgerCsvExport: the export button must produce a
+ * real CSV blob download named ledger-export.csv and stay inert when there
+ * is nothing to export.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import { LedgerCsvExport } from "./ledger-csv-export";
+import type { LedgerEntry } from "@/lib/control-plane/client";
+
+function entryFixture(overrides: Partial<LedgerEntry> = {}): LedgerEntry {
+  return {
+    id: "le-1",
+    entry_type: "usage",
+    credits_delta: -1_250,
+    idempotency_key: "idem-abc-123",
+    request_id: "req-1",
+    metadata: {},
+    created_at: "2026-08-20T10:00:00Z",
+    ...overrides,
+  };
+}
+
+interface CapturedAnchor {
+  download: string | null;
+  href: string;
+}
+
+// jsdom Blob predates the .text() convenience; read through FileReader.
+function readBlobText(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result));
+    reader.onerror = () => reject(reader.error);
+    reader.readAsText(blob);
+  });
+}
+
+afterEach(() => {
+  cleanup();
+  // Remove the static URL method stubs installed by Object.defineProperty.
+  Reflect.deleteProperty(URL, "createObjectURL");
+  Reflect.deleteProperty(URL, "revokeObjectURL");
+  vi.restoreAllMocks();
+});
+
+function installDownloadCapture(): {
+  anchors: CapturedAnchor[];
+  blobs: Blob[];
+} {
+  const anchors: CapturedAnchor[] = [];
+  const blobs: Blob[] = [];
+  const clickSpy = vi
+    .spyOn(HTMLAnchorElement.prototype, "click")
+    .mockImplementation(function mockClick(this: HTMLAnchorElement) {
+      anchors.push({
+        download: this.getAttribute("download"),
+        href: this.href,
+      });
+    });
+  void clickSpy;
+  let urlCounter = 0;
+  Object.defineProperty(URL, "createObjectURL", {
+    value: (blob: Blob) => {
+      blobs.push(blob);
+      urlCounter += 1;
+      return `blob:mock-${urlCounter}`;
+    },
+    configurable: true,
+    writable: true,
+  });
+  Object.defineProperty(URL, "revokeObjectURL", {
+    value: () => {},
+    configurable: true,
+    writable: true,
+  });
+  return { anchors, blobs };
+}
+
+describe("LedgerCsvExport", () => {
+  it("is disabled when there is nothing to export", () => {
+    render(<LedgerCsvExport entries={[]} />);
+    const button = screen.getByRole("button", { name: /export csv/i });
+    expect(button instanceof HTMLButtonElement && button.disabled).toBe(true);
+  });
+
+  it("export triggers a ledger-export.csv download whose content is the rendered rows", async () => {
+    const { anchors, blobs } = installDownloadCapture();
+    render(
+      <LedgerCsvExport
+        entries={[
+          entryFixture(),
+          entryFixture({
+            id: "le-2",
+            entry_type: "topup",
+            credits_delta: 50_000_000,
+            idempotency_key: "idem,x-with-commas",
+            created_at: "2026-08-21T09:30:00Z",
+          }),
+        ]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /export csv/i }));
+
+    expect(anchors).toHaveLength(1);
+    expect(anchors[0].download).toBe("ledger-export.csv");
+    expect(blobs).toHaveLength(1);
+    expect(blobs[0].type).toBe("text/csv");
+    const csv = await readBlobText(blobs[0]);
+    expect(csv.split("\n")).toEqual([
+      "date,type,credits_delta,idempotency_key",
+      "2026-08-20T10:00:00Z,usage,-1250,idem-abc-123",
+      "2026-08-21T09:30:00Z,topup,50000000,idemx-with-commas",
+    ]);
+  });
+
+  it("revokes the object URL after triggering the click", async () => {
+    const revokeSpy = vi.fn();
+    Object.defineProperty(URL, "createObjectURL", {
+      value: () => "blob:mock-revoke",
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(URL, "revokeObjectURL", {
+      value: revokeSpy,
+      configurable: true,
+      writable: true,
+    });
+    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+
+    render(<LedgerCsvExport entries={[entryFixture()]} />);
+    fireEvent.click(screen.getByRole("button", { name: /export csv/i }));
+
+    expect(revokeSpy).toHaveBeenCalledWith("blob:mock-revoke");
+  });
+});

--- a/apps/web-console/components/billing/spend-alert-form-ui.test.tsx
+++ b/apps/web-console/components/billing/spend-alert-form-ui.test.tsx
@@ -1,0 +1,250 @@
+/**
+ * Behavioral UI tests for the spend-alert creation surface: SpendAlertForm
+ * submit validation and the BudgetAlertBanner dismiss (the alert delete
+ * path a user can actually trigger; the per-alert DELETE proxy has no
+ * console control yet).
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import { SpendAlertForm } from "./spend-alert-form";
+import { BudgetAlertBanner } from "./budget-alert-banner";
+import type { BudgetThreshold } from "@/lib/control-plane/client";
+
+const ALERTS_URL = (ws: string) => `/api/spend-alerts/${ws}`;
+const BUDGET_URL = "/api/budget";
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+function thresholdInput(): HTMLSelectElement {
+  const el = screen.getByLabelText(/threshold/i);
+  if (!(el instanceof HTMLSelectElement)) {
+    throw new Error("threshold select not found");
+  }
+  return el;
+}
+
+function emailInput(): HTMLInputElement {
+  const el = screen.getByLabelText(/notify email/i);
+  if (!(el instanceof HTMLInputElement)) {
+    throw new Error("email input not found");
+  }
+  return el;
+}
+
+function webhookInput(): HTMLInputElement {
+  const el = screen.getByLabelText(/webhook url/i);
+  if (!(el instanceof HTMLInputElement)) {
+    throw new Error("webhook input not found");
+  }
+  return el;
+}
+
+describe("SpendAlertForm behavior", () => {
+  it("submit fires once with the selected threshold and only the filled channel", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ id: "al-1" }), { status: 201 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <SpendAlertForm workspaceId="ws-1" readOnly={false} existingThresholds={[80]} />,
+    );
+    fireEvent.change(thresholdInput(), { target: { value: "50" } });
+    fireEvent.change(emailInput(), { target: { value: "alerts@example.test" } });
+    fireEvent.click(screen.getByRole("button", { name: /create alert/i }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toBe(ALERTS_URL("ws-1"));
+    expect(init?.method).toBe("POST");
+    expect(JSON.parse(String(init?.body))).toEqual({
+      threshold_pct: 50,
+      email: "alerts@example.test",
+      webhook_url: null,
+    });
+    expect(await screen.findByRole("status")).toBeTruthy();
+  });
+
+  it("webhook-only alerts post a null email and the chosen threshold", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ id: "al-2" }), { status: 201 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <SpendAlertForm workspaceId="ws-1" readOnly={false} existingThresholds={[]} />,
+    );
+    fireEvent.change(thresholdInput(), { target: { value: "100" } });
+    fireEvent.change(webhookInput(), {
+      target: { value: "https://hooks.example.test/spend" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /create alert/i }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+    const body = JSON.parse(String(fetchMock.mock.calls[0][1]?.body));
+    expect(body).toEqual({
+      threshold_pct: 100,
+      email: null,
+      webhook_url: "https://hooks.example.test/spend",
+    });
+  });
+
+  it("an already-configured threshold is refused client side without a request", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <SpendAlertForm workspaceId="ws-1" readOnly={false} existingThresholds={[50]} />,
+    );
+    fireEvent.change(emailInput(), { target: { value: "alerts@example.test" } });
+    fireEvent.click(screen.getByRole("button", { name: /create alert/i }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toContain("already exists");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("no delivery channel at all is refused without a request", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <SpendAlertForm workspaceId="ws-1" readOnly={false} existingThresholds={[]} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /create alert/i }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toContain("at least one delivery channel");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("read-only mode disables every control and blocks submission", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <SpendAlertForm workspaceId="ws-1" readOnly existingThresholds={[]} />,
+    );
+    expect(thresholdInput().disabled).toBe(true);
+    expect(emailInput().disabled).toBe(true);
+    expect(webhookInput().disabled).toBe(true);
+    const create = screen.getByRole("button", { name: /create alert/i });
+    expect(create instanceof HTMLButtonElement && create.disabled).toBe(true);
+
+    const form = create.closest("form");
+    if (!form) {
+      throw new Error("spend alert form not found");
+    }
+    fireEvent.submit(form);
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toContain("Only the workspace owner");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("server rejection surfaces the backend message and keeps the form editable", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: "email looks invalid" }), { status: 400 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <SpendAlertForm workspaceId="ws-1" readOnly={false} existingThresholds={[]} />,
+    );
+    fireEvent.change(emailInput(), { target: { value: "alerts@example.test" } });
+    fireEvent.click(screen.getByRole("button", { name: /create alert/i }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toContain("email looks invalid");
+  });
+
+  it("success clears both channels so a second submit cannot silently duplicate", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ id: "al-3" }), { status: 201 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <SpendAlertForm workspaceId="ws-1" readOnly={false} existingThresholds={[]} />,
+    );
+    fireEvent.change(emailInput(), { target: { value: "alerts@example.test" } });
+    fireEvent.click(screen.getByRole("button", { name: /create alert/i }));
+    await screen.findByRole("status");
+
+    expect(emailInput().value).toBe("");
+    expect(webhookInput().value).toBe("");
+
+    // The immediate resubmit now hits the no-channel guard, not the API.
+    fireEvent.click(screen.getByRole("button", { name: /create alert/i }));
+    await screen.findByRole("alert");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("BudgetAlertBanner dismiss (alert delete path)", () => {
+  function thresholdFixture(): BudgetThreshold {
+    return {
+      id: "th-1",
+      threshold_credits: 500,
+      alert_dismissed: false,
+      last_notified_at: null,
+      created_at: "2026-08-01T00:00:00Z",
+      updated_at: "2026-08-01T00:00:00Z",
+    };
+  }
+
+  it("renders nothing while the balance is comfortably above the threshold", () => {
+    const { container } = render(
+      <BudgetAlertBanner threshold={thresholdFixture()} currentBalance={10_000} />,
+    );
+    expect(container.childElementCount).toBe(0);
+  });
+
+  it("dismiss fires the budget DELETE once and hides the banner", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("{}", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <BudgetAlertBanner
+        threshold={thresholdFixture()}
+        currentBalance={300}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /dismiss/i }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toBe(BUDGET_URL);
+    expect(init?.method).toBe("DELETE");
+    await waitFor(() => {
+      expect(screen.queryByRole("status")).toBeNull();
+    });
+  });
+
+  it("dismiss hides the banner even when the network call fails", async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new TypeError("offline"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <BudgetAlertBanner
+        threshold={thresholdFixture()}
+        currentBalance={300}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /dismiss/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("status")).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes the audit gap: the money-path console surfaces had no UI-level (Testing Library) behavioral tests. The pre-existing suites only locked pure math helpers and source-string guards; nothing drove the rendered components.

Adds eight co-located vitest suites, all mocking fetch at the boundary (no network):

- **CheckoutModal** (components/billing/checkout-modal-ui.test.tsx): pay button gated until a rail is selectable, increase/decrease stepping clamped to min/max including typed over-max input, cancel via Keep balance / X / overlay click closes without firing a checkout intent, initiate POST fired exactly once with the right rail and credits plus an idempotency key, failed initiate resurfaces an actionable error and re-enables the button, rails load failure shows the refresh error, and the BD account surface never renders a numeric FX-style total.
- **BudgetForm** (budget-form-ui.test.tsx): submit fires once with parsed subunit values, malformed caps refused client side without a request, soft-above-hard refused without a request, read-only mode disables and blocks even a forced submit, server rejection surfaces the backend message, network failure falls back to the retryable message.
- **SpendAlertForm + BudgetAlertBanner** (spend-alert-form-ui.test.tsx): posts once with the chosen threshold and only the filled channel (null for empty), webhook-only variant, duplicate threshold refused without a request, no-channel refusal, read-only block, success clears inputs so an immediate resubmit hits the guard instead of duplicating, server error passthrough; banner dismiss fires DELETE /api/budget exactly once and hides the banner even when the request fails.
- **InvoiceDownloadButton + InvoiceRow** (invoice-download-button.test.tsx, invoice-row.test.tsx): download produces an application/pdf blob named invoice-{id}.pdf, second click ignored while generation runs, generation failure alerts instead of downloading, missing local_currency refuses to render; row link targets /api/invoices/{id}/pdf for exactly the rendered invoice id.
- **LedgerCsvExport** (ledger-csv-export.test.tsx): disabled when there is nothing to export, export triggers a ledger-export.csv download whose blob content matches the rendered rows exactly (comma stripping included), object URL revoked after the click.
- **ApiKeyCreateForm** (api-key-create-form.test.tsx): blank nickname refused without a request, create POST carries the trimmed nickname and ISO expiry only when set, one-time secret panel renders, copy writes the secret to the clipboard and flips to Copied, clipboard refusal degrades silently, Create another resets to a clean form.
- **RevokeConfirmPanel** (revoke-confirm-panel.test.tsx): idle trigger exposes no confirm surface, Revoke reveals the panel naming the key, Keep key cancels with zero requests, confirm fires exactly one revoke POST for the right key id then completes, failed or network-broken revoke keeps the panel open with an alert.

## Test plan

- [x] cd deploy/docker && docker compose run --build web-console npm run test:unit
- [x] All eight new suites green: 48/48 new tests pass
- [x] Full docker run: 599 passed of 601; the 2 remaining failures are pre-existing on clean main inside this image only (control-plane-host reads /app/.env.example and chat-coverage-lib reads docs/proof/chat-interaction-coverage-2026-08-10/coverage.run.json, neither of which Dockerfile.web-console COPYs into the image). CI runs vitest directly on the checkout where both pass today on main.
- [ ] Reviewer confirms the two baseline failures are out of scope for this diff

## Notes

- No production code changed; this PR is test-only.
- The per-alert DELETE proxy route exists but no console control renders it yet, so the alert-delete behavior covered here is the BudgetAlertBanner dismiss path (the only user-triggerable alert delete in the product today).