### PR TITLE
test: behavioral money-path coverage for ledger and budgets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -446,7 +446,10 @@ jobs:
             # query is the only place an over-released reservation can be caught,
             # and the proof that it no longer renders one as a hold has to run
             # against real Postgres.
-            go test -tags integration -count=1 -p 1 -v ./internal/accounts/... ./internal/accounting/... ./internal/ledger/... ./internal/agentsched/... ./internal/agenttask/... ./internal/usermemories/... ./internal/egress/... ./internal/payments/... ./internal/profiles/... ./internal/rag/... ./internal/tenants/... ./internal/signup/... ./internal/routing/... ./internal/litellmconfig/... ./internal/catalog/... ./internal/providers/... ./internal/platform ./internal/platform/db/...
+            # ./internal/budgets/... joins with this PR: its spend aggregation,
+            # threshold re-arm, tenant-isolation and cron retry suites are
+            # DB-gated and would otherwise never execute in CI.
+            go test -tags integration -count=1 -p 1 -v ./internal/accounts/... ./internal/accounting/... ./internal/ledger/... ./internal/budgets/... ./internal/agentsched/... ./internal/agenttask/... ./internal/usermemories/... ./internal/egress/... ./internal/payments/... ./internal/profiles/... ./internal/rag/... ./internal/tenants/... ./internal/signup/... ./internal/routing/... ./internal/litellmconfig/... ./internal/catalog/... ./internal/providers/... ./internal/platform ./internal/platform/db/...
           else
             # -tags integration additionally compiles in
             # inference/chat_completions_integration_test.go (issue #708),

--- a/apps/control-plane/internal/budgets/http_spend_alerts_test.go
+++ b/apps/control-plane/internal/budgets/http_spend_alerts_test.go
@@ -1,0 +1,464 @@
+package budgets
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/accounts"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/auth"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/platform"
+)
+
+// HTTP behavior for the Phase 14 workspace spend-alert surface and the
+// internal hard-cap read the edge-api gate falls back to.
+//
+// Invariants:
+//   - Alert mutations are owner-gated: a verified member gets 403 on every
+//     mutation verb, so a guessed workspace UUID grants nothing.
+//   - A foreign alert UUID answers 404, never a partial mutation.
+//   - Invalid threshold percentages are refused with 400 before any write.
+//   - The internal hard-cap endpoint renders *big.Int as a string (it can
+//     exceed the JS safe integer range) and null when no budget is set.
+
+type spendAlertsRepo struct {
+	*workspaceRepoStub
+	alerts  map[uuid.UUID][]SpendAlert
+	budgets map[uuid.UUID]*Budget
+}
+
+func newSpendAlertsRepo() *spendAlertsRepo {
+	return &spendAlertsRepo{
+		workspaceRepoStub: &workspaceRepoStub{},
+		alerts:            map[uuid.UUID][]SpendAlert{},
+		budgets:           map[uuid.UUID]*Budget{},
+	}
+}
+
+func (s *spendAlertsRepo) GetBudget(_ context.Context, ws uuid.UUID) (*Budget, error) {
+	if b, ok := s.budgets[ws]; ok && b != nil {
+		cp := *b
+		cp.SoftCap = new(big.Int).Set(b.SoftCap)
+		cp.HardCap = new(big.Int).Set(b.HardCap)
+		return &cp, nil
+	}
+	return nil, nil
+}
+
+func (s *spendAlertsRepo) UpsertBudget(_ context.Context, in SetBudgetInput) (*Budget, error) {
+	b := &Budget{
+		WorkspaceID: in.WorkspaceID,
+		PeriodStart: in.PeriodStart,
+		SoftCap:     new(big.Int).Set(in.SoftCap),
+		HardCap:     new(big.Int).Set(in.HardCap),
+		Currency:    "BDT",
+	}
+	s.budgets[in.WorkspaceID] = b
+	return b, nil
+}
+
+func (s *spendAlertsRepo) DeleteBudget(_ context.Context, ws uuid.UUID) error {
+	delete(s.budgets, ws)
+	return nil
+}
+
+func (s *spendAlertsRepo) ListAlerts(_ context.Context, ws uuid.UUID) ([]SpendAlert, error) {
+	list := s.alerts[ws]
+	out := make([]SpendAlert, len(list))
+	copy(out, list)
+	for i := 1; i < len(out); i++ {
+		for j := i; j > 0 && out[j].ThresholdPct < out[j-1].ThresholdPct; j-- {
+			out[j], out[j-1] = out[j-1], out[j]
+		}
+	}
+	return out, nil
+}
+
+func (s *spendAlertsRepo) CreateAlert(_ context.Context, in CreateAlertInput) (*SpendAlert, error) {
+	a := SpendAlert{
+		ID:            uuid.New(),
+		WorkspaceID:   in.WorkspaceID,
+		ThresholdPct:  in.ThresholdPct,
+		Email:         in.Email,
+		WebhookURL:    in.WebhookURL,
+		WebhookSecret: in.WebhookSecret,
+		CreatedAt:     time.Now().UTC(),
+	}
+	s.alerts[in.WorkspaceID] = append(s.alerts[in.WorkspaceID], a)
+	return &a, nil
+}
+
+func (s *spendAlertsRepo) UpdateAlert(_ context.Context, in UpdateAlertInput) (*SpendAlert, error) {
+	for ws, list := range s.alerts {
+		for i := range list {
+			if list[i].ID == in.ID {
+				if ws != in.WorkspaceID {
+					return nil, ErrBudgetNotFound
+				}
+				if in.Email != nil {
+					list[i].Email = in.Email
+				}
+				cp := list[i]
+				return &cp, nil
+			}
+		}
+	}
+	return nil, ErrBudgetNotFound
+}
+
+func (s *spendAlertsRepo) DeleteAlert(_ context.Context, ws, alertID uuid.UUID) error {
+	list := s.alerts[ws]
+	for i := range list {
+		if list[i].ID == alertID {
+			s.alerts[ws] = append(list[:i], list[i+1:]...)
+			return nil
+		}
+	}
+	return ErrBudgetNotFound
+}
+
+func newSpendAlertsHandler(repo *spendAlertsRepo, ownerID, wsID uuid.UUID) http.Handler {
+	roleSvc := platform.NewRoleService(&stubRoleStore{
+		adminUsers: map[uuid.UUID]bool{},
+		owners:     map[uuid.UUID]uuid.UUID{wsID: ownerID},
+	})
+	svc := NewServiceWithWorkspace(&httpRepoStub{}, &notifierStub{}, repo, nil, nil)
+	return NewHandler(svc, accounts.NewService(newAccountsRepoStub())).WithRoleService(roleSvc)
+}
+
+func spendAlertsRequest(handler http.Handler, viewer auth.Viewer, method, path string, body io.Reader) *httptest.ResponseRecorder {
+	var req *http.Request
+	if body != nil {
+		req = httptest.NewRequest(method, path, body)
+		req.Header.Set("Content-Type", "application/json")
+	} else {
+		req = httptest.NewRequest(method, path, nil)
+	}
+	req = req.WithContext(viewerCtx(viewer))
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	return rr
+}
+
+// TestSpendAlertsHTTPCRUD walks the alert lifecycle over HTTP as the verified
+// owner and pins the refusal contract on every branch.
+func TestSpendAlertsHTTPCRUD(t *testing.T) {
+	owner := auth.Viewer{UserID: uuid.New(), Email: "owner@example.com", EmailVerified: true}
+	member := auth.Viewer{UserID: uuid.New(), Email: "member@example.com", EmailVerified: true}
+	wsID := uuid.New()
+	repo := newSpendAlertsRepo()
+	handler := newSpendAlertsHandler(repo, owner.UserID, wsID)
+	base := "/api/v1/spend-alerts/" + wsID.String()
+
+	t.Run("create, list, update, delete round trip", func(t *testing.T) {
+		email := "ops@example.com"
+		body := `{"threshold_pct":50,"email":"` + email + `"}`
+		rr := spendAlertsRequest(handler, owner, http.MethodPost, base, strings.NewReader(body))
+		if rr.Code != http.StatusCreated {
+			t.Fatalf("create got %d: %s", rr.Code, rr.Body.String())
+		}
+		var created struct {
+			Alert alertWireFormat `json:"alert"`
+		}
+		if err := json.Unmarshal(rr.Body.Bytes(), &created); err != nil {
+			t.Fatalf("decode create: %v", err)
+		}
+		if created.Alert.ID == uuid.Nil || created.Alert.ThresholdPct != 50 {
+			t.Fatalf("unexpected created alert: %+v", created.Alert)
+		}
+
+		rr = spendAlertsRequest(handler, owner, http.MethodGet, base, nil)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("list got %d: %s", rr.Code, rr.Body.String())
+		}
+
+		patchBody := `{"email":"new-ops@example.com"}`
+		rr = spendAlertsRequest(handler, owner, http.MethodPatch, base+"/"+created.Alert.ID.String(), strings.NewReader(patchBody))
+		if rr.Code != http.StatusOK {
+			t.Fatalf("patch got %d: %s", rr.Code, rr.Body.String())
+		}
+
+		rr = spendAlertsRequest(handler, owner, http.MethodDelete, base+"/"+created.Alert.ID.String(), nil)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("delete got %d: %s", rr.Code, rr.Body.String())
+		}
+
+		// Deleting again must 404: the row is gone, not silently tolerated.
+		rr = spendAlertsRequest(handler, owner, http.MethodDelete, base+"/"+created.Alert.ID.String(), nil)
+		if rr.Code != http.StatusNotFound {
+			t.Fatalf("second delete got %d, want 404", rr.Code)
+		}
+	})
+
+	t.Run("member mutation is forbidden", func(t *testing.T) {
+		rr := spendAlertsRequest(handler, member, http.MethodPost, base, strings.NewReader(`{"threshold_pct":80}`))
+		if rr.Code != http.StatusForbidden {
+			t.Fatalf("member create got %d, want 403 (owner-gated)", rr.Code)
+		}
+	})
+
+	t.Run("invalid threshold is refused with 400", func(t *testing.T) {
+		rr := spendAlertsRequest(handler, owner, http.MethodPost, base, strings.NewReader(`{"threshold_pct":75}`))
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("invalid pct got %d, want 400", rr.Code)
+		}
+	})
+}
+
+// TestLegacyBudgetSurfaceHTTP covers the legacy account-threshold HTTP
+// endpoints: PUT upserts the threshold, POST dismiss clears it, invalid JSON
+// answers 400, and a repository failure answers a fixed 500 whose body never
+// carries the underlying error text (provider-blind response posture).
+func TestLegacyBudgetSurfaceHTTP(t *testing.T) {
+	userID := uuid.New()
+	accountID := uuid.New()
+	accountRepo := newAccountsRepoStub()
+	accountRepo.accountsMap[accountID] = &accounts.Account{
+		ID:          accountID,
+		Slug:        "legacy-budget-ws",
+		DisplayName: "Legacy Budget WS",
+		AccountType: "personal",
+		OwnerUserID: userID,
+	}
+	accountRepo.memberships = []accounts.Membership{
+		{ID: uuid.New(), AccountID: accountID, UserID: userID, Role: "owner", Status: "active"},
+	}
+
+	repo := &httpRepoStub{}
+	svc := NewService(repo, &notifierStub{})
+	handler := NewHandler(svc, accounts.NewService(accountRepo))
+	viewer := auth.Viewer{UserID: userID, Email: "owner@example.com", EmailVerified: true}
+
+	do := func(method, path, body string) *httptest.ResponseRecorder {
+		if body == "" {
+			return spendAlertsRequest(handler, viewer, method, path, nil)
+		}
+		return spendAlertsRequest(handler, viewer, method, path, strings.NewReader(body))
+	}
+
+	t.Run("upsert and dismiss round trip", func(t *testing.T) {
+		rr := do(http.MethodPut, "/api/v1/accounts/current/budget", `{"threshold_credits":1000}`)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("put got %d: %s", rr.Code, rr.Body.String())
+		}
+		rr = do(http.MethodPost, "/api/v1/accounts/current/budget/dismiss", "")
+		if rr.Code != http.StatusOK {
+			t.Fatalf("dismiss got %d: %s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("invalid JSON answers 400", func(t *testing.T) {
+		rr := do(http.MethodPut, "/api/v1/accounts/current/budget", `{"threshold_credits":`)
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("invalid JSON got %d, want 400", rr.Code)
+		}
+	})
+
+	t.Run("repository failure answers opaque 500", func(t *testing.T) {
+		failer := &httpRepoStub{upsertErr: errors.New("pgx: connection reset")}
+		svcFailer := NewService(failer, &notifierStub{})
+		handlerFailer := NewHandler(svcFailer, accounts.NewService(accountRepo))
+
+		rr := spendAlertsRequest(handlerFailer, viewer, http.MethodPut, "/api/v1/accounts/current/budget", strings.NewReader(`{"threshold_credits":1000}`))
+		if rr.Code != http.StatusInternalServerError {
+			t.Fatalf("repo failure got %d, want 500", rr.Code)
+		}
+		if strings.Contains(rr.Body.String(), "pgx") || strings.Contains(rr.Body.String(), "connection") {
+			t.Fatal("raw repository error text leaked into the response body")
+		}
+	})
+}
+
+// TestWorkspaceBudgetHTTPLifecycle walks the workspace-budget surface over
+// HTTP as its verified owner: PUT upserts caps, GET reads them back, DELETE
+// removes the row, invalid caps answer 400 before any write, and a malformed
+// workspace UUID is refused.
+func TestWorkspaceBudgetHTTPLifecycle(t *testing.T) {
+	owner := auth.Viewer{UserID: uuid.New(), Email: "owner@example.com", EmailVerified: true}
+	wsID := uuid.New()
+	repo := newSpendAlertsRepo()
+	handler := newSpendAlertsHandler(repo, owner.UserID, wsID)
+
+	t.Run("put get delete round trip", func(t *testing.T) {
+		put := spendAlertsRequest(handler, owner, http.MethodPut,
+			"/api/v1/budgets/"+wsID.String(),
+			strings.NewReader(`{"soft_cap_bdt_subunits":1000,"hard_cap_bdt_subunits":2000}`))
+		if put.Code != http.StatusOK {
+			t.Fatalf("put got %d: %s", put.Code, put.Body.String())
+		}
+
+		get := spendAlertsRequest(handler, owner, http.MethodGet, "/api/v1/budgets/"+wsID.String(), nil)
+		if get.Code != http.StatusOK {
+			t.Fatalf("get got %d: %s", get.Code, get.Body.String())
+		}
+		var body struct {
+			Budget struct {
+				HardCapBDTSubunits int64 `json:"hard_cap_bdt_subunits"`
+			} `json:"budget"`
+		}
+		if err := json.Unmarshal(get.Body.Bytes(), &body); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if body.Budget.HardCapBDTSubunits != 2000 {
+			t.Fatalf("read back hard cap %d, want 2000", body.Budget.HardCapBDTSubunits)
+		}
+
+		del := spendAlertsRequest(handler, owner, http.MethodDelete, "/api/v1/budgets/"+wsID.String(), nil)
+		if del.Code != http.StatusOK {
+			t.Fatalf("delete got %d: %s", del.Code, del.Body.String())
+		}
+	})
+
+	t.Run("invalid caps answer 400 before any write", func(t *testing.T) {
+		put := spendAlertsRequest(handler, owner, http.MethodPut,
+			"/api/v1/budgets/"+wsID.String(),
+			strings.NewReader(`{"soft_cap_bdt_subunits":5000,"hard_cap_bdt_subunits":1000}`))
+		if put.Code != http.StatusBadRequest {
+			t.Fatalf("invalid caps got %d, want 400", put.Code)
+		}
+	})
+
+	t.Run("malformed workspace id answers 400", func(t *testing.T) {
+		get := spendAlertsRequest(handler, owner, http.MethodGet, "/api/v1/budgets/not-a-uuid", nil)
+		if get.Code != http.StatusBadRequest {
+			t.Fatalf("malformed id got %d, want 400", get.Code)
+		}
+	})
+
+	t.Run("get after delete renders null budget", func(t *testing.T) {
+		put := spendAlertsRequest(handler, owner, http.MethodPut,
+			"/api/v1/budgets/"+wsID.String(),
+			strings.NewReader(`{"soft_cap_bdt_subunits":100,"hard_cap_bdt_subunits":300}`))
+		if put.Code != http.StatusOK {
+			t.Fatalf("put got %d: %s", put.Code, put.Body.String())
+		}
+		del := spendAlertsRequest(handler, owner, http.MethodDelete, "/api/v1/budgets/"+wsID.String(), nil)
+		if del.Code != http.StatusOK {
+			t.Fatalf("delete got %d", del.Code)
+		}
+		gone := spendAlertsRequest(handler, owner, http.MethodGet, "/api/v1/budgets/"+wsID.String(), nil)
+		if gone.Code != http.StatusOK || !strings.Contains(gone.Body.String(), "null") {
+			t.Fatalf("deleted-budget read got (%d, %s), want 200 with null budget", gone.Code, gone.Body.String())
+		}
+	})
+
+	t.Run("invalid period_start answers 400", func(t *testing.T) {
+		put := spendAlertsRequest(handler, owner, http.MethodPut,
+			"/api/v1/budgets/"+wsID.String(),
+			strings.NewReader(`{"soft_cap_bdt_subunits":100,"hard_cap_bdt_subunits":300,"period_start":"tomorrow"}`))
+		if put.Code != http.StatusBadRequest {
+			t.Fatalf("bad period_start got %d, want 400", put.Code)
+		}
+	})
+
+	t.Run("spend alert edge refusals", func(t *testing.T) {
+		alertsBase := "/api/v1/spend-alerts/" + wsID.String()
+		email := "x@example.com"
+		createBody := `{"threshold_pct":80,"email":"` + email + `"}`
+		rr := spendAlertsRequest(handler, owner, http.MethodPost, alertsBase, strings.NewReader(createBody))
+		if rr.Code != http.StatusCreated {
+			t.Fatalf("seed create got %d", rr.Code)
+		}
+		var created struct {
+			Alert alertWireFormat `json:"alert"`
+		}
+		_ = json.Unmarshal(rr.Body.Bytes(), &created)
+
+		member := auth.Viewer{UserID: uuid.New(), Email: "m@example.com", EmailVerified: true}
+
+		cases := []struct {
+			name   string
+			viewer auth.Viewer
+			method string
+			path   string
+			body   string
+			want   int
+		}{
+			{"member list forbidden", member, http.MethodGet, alertsBase, "", http.StatusForbidden},
+			{"patch unknown alert 404", owner, http.MethodPatch, alertsBase + "/" + uuid.New().String(), `{"email":"y@example.com"}`, http.StatusNotFound},
+			{"patch bad json 400", owner, http.MethodPatch, alertsBase + "/" + created.Alert.ID.String(), `{`, http.StatusBadRequest},
+			{"patch bad alert id 400", owner, http.MethodPatch, alertsBase + "/nope", `{"email":"y@example.com"}`, http.StatusBadRequest},
+			{"delete unknown alert 404", owner, http.MethodDelete, alertsBase + "/" + uuid.New().String(), "", http.StatusNotFound},
+			{"unsupported verb on collection 405", owner, http.MethodPut, alertsBase, `{"threshold_pct":50}`, http.StatusMethodNotAllowed},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				var body io.Reader
+				if tc.body != "" {
+					body = strings.NewReader(tc.body)
+				}
+				rr := spendAlertsRequest(handler, tc.viewer, tc.method, tc.path, body)
+				if rr.Code != tc.want {
+					t.Fatalf("%s: got %d, want %d (body %s)", tc.name, rr.Code, tc.want, rr.Body.String())
+				}
+			})
+		}
+
+		// Clean up the seeded alert so the earlier round-trip assertions stay
+		// independent of execution order.
+		_ = spendAlertsRequest(handler, owner, http.MethodDelete, alertsBase+"/"+created.Alert.ID.String(), nil)
+	})
+}
+
+// TestInternalHardCapEndpoint covers the edge-api gate fallback read: null
+// when no budget is set, string rendering of big.Int when set, and strict
+// method/path handling.
+func TestInternalHardCapEndpoint(t *testing.T) {
+	wsID := uuid.New()
+	repo := newSpendAlertsRepo()
+	repo.budgets[wsID] = &Budget{
+		WorkspaceID: wsID,
+		PeriodStart: time.Now().UTC(),
+		SoftCap:     big.NewInt(1000),
+		HardCap:     big.NewInt(2000),
+		Currency:    "BDT",
+	}
+	handler := newSpendAlertsHandler(repo, uuid.New(), wsID)
+
+	t.Run("set budget renders cap as string", func(t *testing.T) {
+		rr := spendAlertsRequest(handler, auth.Viewer{}, http.MethodGet, "/internal/budgets/"+wsID.String()+"/hard-cap", nil)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("got %d: %s", rr.Code, rr.Body.String())
+		}
+		var body map[string]any
+		if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if body["hard_cap_bdt_subunits"] != "2000" {
+			t.Fatalf("hard cap %v, want string \"2000\"", body["hard_cap_bdt_subunits"])
+		}
+	})
+
+	t.Run("no budget renders null", func(t *testing.T) {
+		other := uuid.New()
+		rr := spendAlertsRequest(handler, auth.Viewer{}, http.MethodGet, "/internal/budgets/"+other.String()+"/hard-cap", nil)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("got %d", rr.Code)
+		}
+		var body map[string]any
+		_ = json.Unmarshal(rr.Body.Bytes(), &body)
+		v, ok := body["hard_cap_bdt_subunits"]
+		if !ok || v != nil {
+			t.Fatalf("expected JSON null hard cap for unbudgeted workspace, got %v", v)
+		}
+	})
+
+	t.Run("wrong method and malformed path are refused", func(t *testing.T) {
+		rr := spendAlertsRequest(handler, auth.Viewer{}, http.MethodPost, "/internal/budgets/"+wsID.String()+"/hard-cap", strings.NewReader("{}"))
+		if rr.Code != http.StatusMethodNotAllowed {
+			t.Fatalf("POST to read-only endpoint got %d, want 405", rr.Code)
+		}
+		rr = spendAlertsRequest(handler, auth.Viewer{}, http.MethodGet, "/internal/budgets/not-a-uuid/hard-cap", nil)
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("malformed workspace id got %d, want 400", rr.Code)
+		}
+	})
+}

--- a/apps/control-plane/internal/budgets/http_test.go
+++ b/apps/control-plane/internal/budgets/http_test.go
@@ -84,13 +84,18 @@ func (s *workspaceRepoStub) MonthToDateSpendBDT(_ context.Context, _ uuid.UUID, 
 	return big.NewInt(0), nil
 }
 
-type httpRepoStub struct{}
+type httpRepoStub struct {
+	upsertErr error
+}
 
 func (s *httpRepoStub) GetThreshold(_ context.Context, _ uuid.UUID) (*BudgetThreshold, error) {
 	return nil, nil
 }
 
 func (s *httpRepoStub) UpsertThreshold(_ context.Context, _ uuid.UUID, _ int64) (*BudgetThreshold, error) {
+	if s.upsertErr != nil {
+		return nil, s.upsertErr
+	}
 	return nil, nil
 }
 

--- a/apps/control-plane/internal/budgets/notifier_test.go
+++ b/apps/control-plane/internal/budgets/notifier_test.go
@@ -1,0 +1,95 @@
+package budgets_test
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"log/slog"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/budgets"
+)
+
+// Notifier behavior: log fallbacks never fail, the composite dispatcher
+// delivers a webhook carrying an HMAC-SHA256 signature over the raw body
+// bytes, and a failing webhook is REPORTED as an error so the cron leaves the
+// alert unstamped and retries on the next pass.
+//
+// Invariant: webhook failure must be reported, not swallowed; the cron keys
+// its stamping decision off this error return (fail-closed dispatch).
+
+func spendAlertFixture(url string) budgets.SpendAlert {
+	email := "ops@example.com"
+	secret := "s3cret"
+	u := url
+	return budgets.SpendAlert{
+		ID:            uuid.New(),
+		WorkspaceID:   uuid.New(),
+		ThresholdPct:  80,
+		Email:         &email,
+		WebhookURL:    &u,
+		WebhookSecret: &secret,
+	}
+}
+
+func TestLogNotifiersNeverFail(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	a := spendAlertFixture("unused")
+	if err := budgets.NewLogNotifier(logger).SendBudgetAlert(context.Background(), uuid.New(), budgets.BudgetThreshold{ThresholdCredits: 100}, 50); err != nil {
+		t.Fatalf("log email fallback errored: %v", err)
+	}
+	if err := budgets.NewLogAlertNotifier(nil).NotifySpendAlert(context.Background(), a, a.WorkspaceID, big.NewInt(500), big.NewInt(1000)); err != nil {
+		t.Fatalf("log alert fallback errored: %v", err)
+	}
+}
+
+func TestCompositeNotifierWebhook(t *testing.T) {
+	t.Run("success carries verifiable HMAC signature", func(t *testing.T) {
+		var gotSig string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			mac := hmac.New(sha256.New, []byte("s3cret"))
+			mac.Write(body)
+			gotSig = r.Header.Get("X-Hive-Signature")
+			if gotSig != hex.EncodeToString(mac.Sum(nil)) {
+				w.WriteHeader(500)
+				return
+			}
+			w.WriteHeader(200)
+		}))
+		defer server.Close()
+
+		a := spendAlertFixture(server.URL)
+		cn := budgets.NewCompositeNotifier(nil, nil)
+		if err := cn.NotifySpendAlert(context.Background(), a, a.WorkspaceID, big.NewInt(500), big.NewInt(1000)); err != nil {
+			t.Fatalf("webhook delivery failed: %v", err)
+		}
+	})
+
+	t.Run("non-2xx is retried then reported as error", func(t *testing.T) {
+		var hits int
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			hits++
+			w.WriteHeader(500)
+		}))
+		defer server.Close()
+
+		a := spendAlertFixture(server.URL)
+		a.Email = nil // isolate the webhook channel
+		cn := budgets.NewCompositeNotifier(nil, nil)
+
+		err := cn.NotifySpendAlert(context.Background(), a, a.WorkspaceID, big.NewInt(500), big.NewInt(1000))
+		if err == nil {
+			t.Fatal("persistent 500s must surface as an error so the cron does not stamp")
+		}
+		if hits < 2 {
+			t.Fatalf("expected retries before giving up, server hit %d times", hits)
+		}
+	})
+}

--- a/apps/control-plane/internal/budgets/repository_live_test.go
+++ b/apps/control-plane/internal/budgets/repository_live_test.go
@@ -1,0 +1,983 @@
+package budgets_test
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	goredis "github.com/redis/go-redis/v9"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/budgets"
+)
+
+// Behavioral coverage for the budgets money surface against the real Postgres
+// schema (HIVE_TEST_DB_URL gated, same convention as the accounting suites).
+//
+// Invariants encoded here:
+//
+//   - Re-raising a threshold re-arms alerts: upsert clears alert_dismissed, so
+//     an operator who changes the limit is notified again.
+//   - A balance exactly at the threshold is a breach; strictly above is not.
+//   - A failed notification must not stamp the alert as sent (fail-closed
+//     retry: the next pass retries instead of silently dropping the alert),
+//     both for the legacy evaluator and the spend-alert cron.
+//   - Alert mutation is tenant-isolated at the data layer: another workspace
+//     cannot mutate or delete an alert it does not own even with its UUID.
+//   - Spend aggregation sums only usage_charge rows inside [periodStart, now]
+//     and can never report negative spend.
+//   - One workspace's evaluation failure never blocks another's alerts.
+
+func newBudgetsTestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("HIVE_TEST_DB_URL")
+	if dsn == "" {
+		t.Skip("HIVE_TEST_DB_URL not set")
+	}
+	if !strings.Contains(strings.ToLower(dsn), "test") {
+		t.Fatalf("refusing to run: HIVE_TEST_DB_URL must point at a test database (DSN missing 'test' marker)")
+	}
+	pool, err := pgxpool.New(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+// seedBudgetWorkspace creates one auth user plus one personal account (the
+// Phase 14 workspace entity IS public.accounts) and registers cleanup. The
+// account delete cascades budgets/spend_alerts/account_budget_thresholds and
+// credit_ledger_entries rows created by each test.
+func seedBudgetWorkspace(t *testing.T, pool *pgxpool.Pool) uuid.UUID {
+	t.Helper()
+	ctx := context.Background()
+
+	var userID, accountID uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO auth.users (id, email, raw_user_meta_data) VALUES (gen_random_uuid(), $1, '{}'::jsonb) RETURNING id`,
+		"budgets-ws-"+uuid.NewString()+"@test.local",
+	).Scan(&userID); err != nil {
+		t.Fatalf("seed auth.users failed (is this a migrated test DB?): %v", err)
+	}
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO public.accounts (slug, display_name, account_type, owner_user_id)
+		 VALUES ($1, 'budgets ws test', 'personal', $2) RETURNING id`,
+		"budgets-ws-"+uuid.NewString(), userID,
+	).Scan(&accountID); err != nil {
+		t.Fatalf("seed account: %v", err)
+	}
+
+	t.Cleanup(func() {
+		cleanupCtx := context.Background()
+		_, _ = pool.Exec(cleanupCtx, `DELETE FROM public.accounts WHERE id = $1`, accountID)
+		_, _ = pool.Exec(cleanupCtx, `DELETE FROM auth.users WHERE id = $1`, userID)
+	})
+	return accountID
+}
+
+func newLiveWorkspaceService(pool *pgxpool.Pool) *budgets.Service {
+	return budgets.NewServiceWithWorkspace(
+		&legacyNoopRepo{}, &legacyNoopNotifier{},
+		budgets.NewWorkspacePgxRepository(pool), &fakeAlertNotifier{}, nil,
+	)
+}
+
+// failingEmailNotifier always errors, for the non-fatal-notification branch.
+type failingEmailNotifier struct{ called bool }
+
+func (n *failingEmailNotifier) SendBudgetAlert(context.Context, uuid.UUID, budgets.BudgetThreshold, int64) error {
+	n.called = true
+	return errors.New("smtp down")
+}
+
+func seedCharge(t *testing.T, pool *pgxpool.Pool, accountID uuid.UUID, delta int64, age time.Duration) {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO public.credit_ledger_entries (account_id, entry_type, credits_delta, idempotency_key, request_id, created_at)
+		 VALUES ($1, 'usage_charge', $2, $3, 'budgets-mtd', now() - $4::interval)`,
+		accountID, delta, "mtd-"+uuid.NewString(), age,
+	); err != nil {
+		t.Fatalf("seed charge: %v", err)
+	}
+}
+
+// TestThresholdLifecycle_Live walks the legacy account-threshold surface end to
+// end: upsert, dismiss, re-arm on re-upsert, mark-notified.
+func TestThresholdLifecycle_Live(t *testing.T) {
+	pool := newBudgetsTestPool(t)
+	accountID := seedBudgetWorkspace(t, pool)
+	ctx := context.Background()
+	repo := budgets.NewPgxRepository(pool)
+
+	upserted, err := repo.UpsertThreshold(ctx, accountID, 50000)
+	if err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	if upserted.ThresholdCredits != 50000 || upserted.AlertDismissed {
+		t.Fatalf("fresh threshold wrong: %+v", upserted)
+	}
+
+	if err := repo.DismissAlert(ctx, accountID); err != nil {
+		t.Fatalf("dismiss: %v", err)
+	}
+	got, err := repo.GetThreshold(ctx, accountID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got == nil || !got.AlertDismissed {
+		t.Fatalf("dismiss did not persist: %+v", got)
+	}
+
+	// Invariant: updating the threshold re-arms the alert.
+	if _, err := repo.UpsertThreshold(ctx, accountID, 60000); err != nil {
+		t.Fatalf("re-upsert: %v", err)
+	}
+	armed, err := repo.GetThreshold(ctx, accountID)
+	if err != nil {
+		t.Fatalf("get after re-upsert: %v", err)
+	}
+	if armed == nil || armed.AlertDismissed {
+		t.Fatalf("re-upsert did not re-arm alerts: %+v", armed)
+	}
+	if armed.ThresholdCredits != 60000 {
+		t.Fatalf("threshold value not updated: %+v", armed)
+	}
+
+	if err := repo.MarkNotified(ctx, accountID); err != nil {
+		t.Fatalf("mark notified: %v", err)
+	}
+	notified, err := repo.GetThreshold(ctx, accountID)
+	if err != nil {
+		t.Fatalf("get after mark: %v", err)
+	}
+	if notified.LastNotifiedAt == nil {
+		t.Fatal("MarkNotified did not stamp last_notified_at")
+	}
+}
+
+// TestCheckThresholdsEdges pins legacy-evaluator decisions beyond the existing
+// suite: exact-at-limit is a breach and stamps MarkNotified; a notifier failure
+// stays non-fatal and never stamps; cooldown expiry re-notifies.
+func TestCheckThresholdsEdges(t *testing.T) {
+	newBreachRepo := func() (*mockRepo, uuid.UUID) {
+		acct := uuid.New()
+		return &mockRepo{threshold: &budgets.BudgetThreshold{
+			ID: uuid.New(), AccountID: acct, ThresholdCredits: 100000,
+		}}, acct
+	}
+
+	t.Run("at exactly the threshold is a breach and marks notified", func(t *testing.T) {
+		repo, acct := newBreachRepo()
+		notifier := &mockNotifier{}
+		svc := budgets.NewService(repo, notifier)
+
+		if err := svc.CheckThresholds(context.Background(), acct, 100000); err != nil {
+			t.Fatalf("unexpected: %v", err)
+		}
+		if !notifier.called {
+			t.Fatal("balance == threshold must be treated as breached")
+		}
+		if !repo.notified {
+			t.Fatal("successful send must stamp MarkNotified")
+		}
+	})
+
+	t.Run("failed notification is non-fatal and never stamps sent", func(t *testing.T) {
+		repo, acct := newBreachRepo()
+		failer := &failingEmailNotifier{}
+		svc := budgets.NewService(repo, failer)
+
+		if err := svc.CheckThresholds(context.Background(), acct, 100); err != nil {
+			t.Fatalf("notification failure must not fail the caller, got %v", err)
+		}
+		if !failer.called {
+			t.Fatal("notifier should still have been attempted")
+		}
+		if repo.notified {
+			t.Fatal("a failed send must not be stamped as notified; the next pass must retry")
+		}
+	})
+
+	t.Run("cooldown expiry re-notifies", func(t *testing.T) {
+		repo, acct := newBreachRepo()
+		stale := time.Now().Add(-25 * time.Hour)
+		repo.threshold.LastNotifiedAt = &stale
+		notifier := &mockNotifier{}
+		svc := budgets.NewService(repo, notifier)
+
+		if err := svc.CheckThresholds(context.Background(), acct, 100); err != nil {
+			t.Fatalf("unexpected: %v", err)
+		}
+		if !notifier.called {
+			t.Fatal("after the 24h cooldown a standing breach must notify again")
+		}
+	})
+}
+
+// TestWorkspaceBudgetRoundTrip_Live covers SetBudget/GetBudget/DeleteBudget
+// against real rows, including zero PeriodStart defaulting to the current
+// month start and big.Int round-tripping through the bigint columns.
+func TestWorkspaceBudgetRoundTrip_Live(t *testing.T) {
+	pool := newBudgetsTestPool(t)
+	wsID := seedBudgetWorkspace(t, pool)
+	ctx := context.Background()
+	svc := newLiveWorkspaceService(pool)
+
+	b, err := svc.SetBudget(ctx, budgets.SetBudgetInput{
+		WorkspaceID: wsID,
+		SoftCap:     big.NewInt(50_000),
+		HardCap:     big.NewInt(100_000),
+	})
+	if err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	if b.Currency != "BDT" {
+		t.Fatalf("currency %q, want BDT", b.Currency)
+	}
+	if b.PeriodStart.IsZero() {
+		t.Fatal("zero PeriodStart must default to the current month start, not stay zero")
+	}
+
+	got, err := svc.GetBudget(ctx, wsID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got == nil || got.SoftCap.Cmp(big.NewInt(50_000)) != 0 || got.HardCap.Cmp(big.NewInt(100_000)) != 0 {
+		t.Fatalf("round trip mismatch: %+v", got)
+	}
+
+	lower, err := svc.SetBudget(ctx, budgets.SetBudgetInput{
+		WorkspaceID: wsID,
+		SoftCap:     big.NewInt(10_000),
+		HardCap:     big.NewInt(20_000),
+	})
+	if err != nil {
+		t.Fatalf("lower: %v", err)
+	}
+	if lower.HardCap.Cmp(big.NewInt(20_000)) != 0 {
+		t.Fatalf("upsert did not overwrite hard cap: %s", lower.HardCap.String())
+	}
+
+	if err := svc.DeleteBudget(ctx, wsID); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	gone, err := svc.GetBudget(ctx, wsID)
+	if err != nil || gone != nil {
+		t.Fatalf("deleted budget resolved to (%v, %v), want (nil, nil)", gone, err)
+	}
+
+	if _, err := svc.SetBudget(ctx, budgets.SetBudgetInput{
+		WorkspaceID: wsID,
+		SoftCap:     big.NewInt(30_000),
+		HardCap:     big.NewInt(10_000),
+	}); !errors.Is(err, budgets.ErrInvalidCaps) {
+		t.Fatalf("hard<soft returned %v, want ErrInvalidCaps", err)
+	}
+	if _, err := svc.SetBudget(ctx, budgets.SetBudgetInput{
+		WorkspaceID: wsID,
+	}); !errors.Is(err, budgets.ErrInvalidCaps) {
+		t.Fatalf("missing caps returned %v, want ErrInvalidCaps", err)
+	}
+}
+
+// TestSpendAlertCRUDAndIsolation_Live covers alert create/list/update/delete
+// plus the tenant-isolation contract: another workspace cannot mutate or
+// delete an alert it does not own even with the right UUID.
+func TestSpendAlertCRUDAndIsolation_Live(t *testing.T) {
+	pool := newBudgetsTestPool(t)
+	wsA := seedBudgetWorkspace(t, pool)
+	wsB := seedBudgetWorkspace(t, pool)
+	ctx := context.Background()
+	svc := newLiveWorkspaceService(pool)
+
+	firstEmail := "ops-" + uuid.NewString()[:8] + "@test.local"
+	inputs := []struct {
+		pct   int
+		email *string
+	}{
+		{80, &firstEmail},
+		{50, nil},
+	}
+	for _, in := range inputs {
+		if _, err := svc.CreateAlert(ctx, budgets.CreateAlertInput{
+			WorkspaceID: wsA, ThresholdPct: in.pct, Email: in.email,
+		}); err != nil {
+			t.Fatalf("create pct=%d: %v", in.pct, err)
+		}
+	}
+
+	alerts, err := svc.ListAlerts(ctx, wsA)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(alerts) != 2 || alerts[0].ThresholdPct != 50 || alerts[1].ThresholdPct != 80 {
+		t.Fatalf("alerts not listed ordered by threshold_pct asc: %+v", alerts)
+	}
+
+	replacement := "ops-" + uuid.NewString()[:8] + "@test.local"
+	if _, err := svc.CreateAlert(ctx, budgets.CreateAlertInput{
+		WorkspaceID: wsA, ThresholdPct: 80, Email: &replacement,
+	}); err != nil {
+		t.Fatalf("upsert duplicate: %v", err)
+	}
+	alerts, err = svc.ListAlerts(ctx, wsA)
+	if err != nil {
+		t.Fatalf("relist: %v", err)
+	}
+	if len(alerts) != 2 {
+		t.Fatalf("duplicate pct produced a second alert, got %d", len(alerts))
+	}
+	for _, a := range alerts {
+		if a.ThresholdPct == 80 && (a.Email == nil || *a.Email != replacement) {
+			t.Fatalf("duplicate upsert did not overwrite email: %+v", a)
+		}
+	}
+
+	target := alerts[1] // the 80% alert on wsA
+
+	if _, err := svc.UpdateAlert(ctx, budgets.UpdateAlertInput{
+		WorkspaceID: wsB, ID: target.ID, Email: &replacement,
+	}); !errors.Is(err, budgets.ErrBudgetNotFound) {
+		t.Fatalf("cross-workspace update returned %v, want ErrBudgetNotFound", err)
+	}
+	if err := svc.DeleteAlert(ctx, wsB, target.ID); !errors.Is(err, budgets.ErrBudgetNotFound) {
+		t.Fatalf("cross-workspace delete returned %v, want ErrBudgetNotFound", err)
+	}
+
+	newEmail := "owner-" + uuid.NewString()[:8] + "@test.local"
+	updated, err := svc.UpdateAlert(ctx, budgets.UpdateAlertInput{
+		WorkspaceID: wsA, ID: target.ID, Email: &newEmail,
+	})
+	if err != nil {
+		t.Fatalf("own-workspace update: %v", err)
+	}
+	if updated.Email == nil || *updated.Email != newEmail {
+		t.Fatalf("update did not apply: %+v", updated)
+	}
+	if err := svc.DeleteAlert(ctx, wsA, target.ID); err != nil {
+		t.Fatalf("own-workspace delete: %v", err)
+	}
+	alerts, err = svc.ListAlerts(ctx, wsA)
+	if err != nil {
+		t.Fatalf("post-delete list: %v", err)
+	}
+	if len(alerts) != 1 {
+		t.Fatalf("expected 1 alert after delete, got %d", len(alerts))
+	}
+}
+
+// TestMonthToDateSpend_Live pins the aggregation query behind the #1127 index
+// work: only usage_charge rows inside [periodStart, now] count; pre-period
+// charges are excluded; a corrupted positive-delta usage_charge can drag the
+// raw sum negative and MUST clamp to zero, never report negative spend.
+func TestMonthToDateSpend_Live(t *testing.T) {
+	pool := newBudgetsTestPool(t)
+	wsID := seedBudgetWorkspace(t, pool)
+	ctx := context.Background()
+	repo := budgets.NewWorkspacePgxRepository(pool)
+
+	now := time.Now().UTC()
+	periodStart := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+
+	seedCharge(t, pool, wsID, -300, time.Hour)
+	seedCharge(t, pool, wsID, -200, 30*time.Minute)
+	seedCharge(t, pool, wsID, -999, 40*24*time.Hour) // last month, excluded
+	seedCharge(t, pool, wsID, 50, 15*time.Minute)    // corrupted positive delta
+
+	spend, err := repo.MonthToDateSpendBDT(ctx, wsID, periodStart)
+	if err != nil {
+		t.Fatalf("mtd: %v", err)
+	}
+	if spend.Cmp(big.NewInt(450)) != 0 {
+		t.Fatalf("spend=%s, want 450 (300+200-50)", spend.String())
+	}
+
+	// Boundary semantics: a charge stamped exactly at periodStart counts (>=).
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO public.credit_ledger_entries (account_id, entry_type, credits_delta, idempotency_key, request_id, created_at)
+		 VALUES ($1, 'usage_charge', -25, $2, 'budgets-mtd-boundary', $3::timestamptz)`,
+		wsID, "mtd-boundary-"+uuid.NewString(), periodStart.Format(time.RFC3339Nano),
+	); err != nil {
+		t.Fatalf("seed boundary charge: %v", err)
+	}
+
+	spend2, err := repo.MonthToDateSpendBDT(ctx, wsID, periodStart)
+	if err != nil {
+		t.Fatalf("mtd2: %v", err)
+	}
+	if spend2.Cmp(big.NewInt(475)) != 0 {
+		t.Fatalf("spend=%s, want 475 including the boundary charge", spend2.String())
+	}
+
+	// Clamp guard alone: an account whose only usage_charge rows carry positive
+	// deltas reports zero, never negative.
+	wsOnlyPositive := seedBudgetWorkspace(t, pool)
+	seedCharge(t, pool, wsOnlyPositive, 70, time.Hour)
+	clamped, err := repo.MonthToDateSpendBDT(ctx, wsOnlyPositive, periodStart)
+	if err != nil {
+		t.Fatalf("clamped mtd: %v", err)
+	}
+	if clamped.Sign() < 0 {
+		t.Fatalf("spend reported negative (%s); aggregation must never report negative spend", clamped.String())
+	}
+	if clamped.Cmp(big.NewInt(0)) != 0 {
+		t.Fatalf("positive-delta-only account spent %s, want 0", clamped.String())
+	}
+}
+
+// TestCronEvaluatorBranches covers evaluateWorkspace guard branches the
+// happy-path tests skip: zero soft cap disables percentage alerts, a failed
+// dispatch leaves the alert unstamped so the next pass retries, repository
+// errors surface, and one broken workspace does not block another's alerts.
+func TestCronEvaluatorBranches(t *testing.T) {
+	periodNow := time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC)
+
+	t.Run("zero soft cap disables percentage alerts", func(t *testing.T) {
+		repo := newFakeWorkspaceRepo()
+		notifier := &fakeAlertNotifier{}
+		ws := uuid.New()
+		_, err := repo.UpsertBudget(context.Background(), budgets.SetBudgetInput{
+			WorkspaceID: ws, PeriodStart: periodNow,
+			SoftCap: big.NewInt(0), HardCap: big.NewInt(10),
+		})
+		if err != nil {
+			t.Fatalf("seed budget: %v", err)
+		}
+		if _, err := repo.CreateAlert(context.Background(), budgets.CreateAlertInput{
+			WorkspaceID: ws, ThresholdPct: 50,
+		}); err != nil {
+			t.Fatalf("seed alert: %v", err)
+		}
+
+		cron := budgets.NewCronEvaluator(repo, notifier, nil)
+		fired, err := cron.EvaluateBudgets(context.Background(), periodNow)
+		if err != nil {
+			t.Fatalf("evaluate: %v", err)
+		}
+		if fired != 0 || notifier.calls != 0 {
+			t.Fatalf("zero soft cap fired %d alerts (%d dispatches); percentage alerts must stay disabled",
+				fired, notifier.calls)
+		}
+	})
+
+	t.Run("failed dispatch leaves alert unstamped so the next pass retries", func(t *testing.T) {
+		repo := newFakeWorkspaceRepo()
+		notifier := &fakeAlertNotifier{failure: errors.New("webhook down")}
+		ws := uuid.New()
+		_, _ = repo.UpsertBudget(context.Background(), budgets.SetBudgetInput{
+			WorkspaceID: ws, PeriodStart: periodNow,
+			SoftCap: big.NewInt(1000), HardCap: big.NewInt(2000),
+		})
+		alert, err := repo.CreateAlert(context.Background(), budgets.CreateAlertInput{
+			WorkspaceID: ws, ThresholdPct: 50,
+		})
+		if err != nil {
+			t.Fatalf("seed alert: %v", err)
+		}
+		repo.mtd[ws] = big.NewInt(500) // exactly at the 50% line
+
+		cron := budgets.NewCronEvaluator(repo, notifier, nil)
+		fired, err := cron.EvaluateBudgets(context.Background(), periodNow)
+		if err != nil {
+			t.Fatalf("evaluate with failing notifier: %v", err)
+		}
+		if fired != 0 {
+			t.Fatalf("failed dispatch counted as fired=%d", fired)
+		}
+		stored, _ := repo.GetBudget(context.Background(), ws)
+		_ = stored
+		list, _ := repo.ListAlerts(context.Background(), ws)
+		for _, a := range list {
+			if a.ID == alert.ID && a.LastFiredPeriod != nil {
+				t.Fatal("failed dispatch was stamped as fired; retry would be lost")
+			}
+		}
+
+		// Notifier heals: the very next pass fires and stamps.
+		notifier.mu.Lock()
+		notifier.failure = nil
+		notifier.mu.Unlock()
+		fired, err = cron.EvaluateBudgets(context.Background(), periodNow.Add(time.Minute))
+		if err != nil {
+			t.Fatalf("evaluate after heal: %v", err)
+		}
+		if fired != 1 {
+			t.Fatalf("healed pass fired=%d, want 1 (retry preserved)", fired)
+		}
+	})
+
+	t.Run("repository errors surface to the caller", func(t *testing.T) {
+		wantErr := errors.New("db unreachable")
+		cron := budgets.NewCronEvaluator(&erroringWorkspaceRepo{err: wantErr}, &fakeAlertNotifier{}, nil)
+		if _, err := cron.EvaluateBudgets(context.Background(), periodNow); !errors.Is(err, wantErr) {
+			t.Fatalf("EvaluateBudgets returned %v, want wrapped %v", err, wantErr)
+		}
+	})
+
+	t.Run("one broken workspace does not block another's alerts", func(t *testing.T) {
+		repo := newFakeWorkspaceRepo()
+		notifier := &fakeAlertNotifier{}
+
+		healthy := uuid.New()
+		if _, err := repo.UpsertBudget(context.Background(), budgets.SetBudgetInput{
+			WorkspaceID: healthy, PeriodStart: periodNow,
+			SoftCap: big.NewInt(1000), HardCap: big.NewInt(2000),
+		}); err != nil {
+			t.Fatalf("seed healthy budget: %v", err)
+		}
+		if _, err := repo.CreateAlert(context.Background(), budgets.CreateAlertInput{
+			WorkspaceID: healthy, ThresholdPct: 50,
+		}); err != nil {
+			t.Fatalf("seed healthy alert: %v", err)
+		}
+		repo.mtd[healthy] = big.NewInt(500)
+
+		mixed := &mixedHealthRepo{healthy: repo, brokenIDs: map[uuid.UUID]bool{}}
+		broken := uuid.New()
+		mixed.brokenIDs[broken] = true
+		mixed.all = append(mixed.all, broken, healthy)
+
+		cron := budgets.NewCronEvaluator(mixed, notifier, nil)
+		fired, err := cron.EvaluateBudgets(context.Background(), periodNow)
+		if err != nil {
+			t.Fatalf("evaluation must isolate per-workspace failures, got error: %v", err)
+		}
+		if fired != 1 {
+			t.Fatalf("healthy workspace fired=%d, want 1", fired)
+		}
+		if notifier.calls != 1 {
+			t.Fatalf("healthy alert dispatched %d times, want 1", notifier.calls)
+		}
+	})
+}
+
+// erroringWorkspaceRepo fails ListWorkspacesWithBudget immediately.
+type erroringWorkspaceRepo struct{ err error }
+
+func (e *erroringWorkspaceRepo) GetBudget(context.Context, uuid.UUID) (*budgets.Budget, error) {
+	return nil, e.err
+}
+func (e *erroringWorkspaceRepo) UpsertBudget(context.Context, budgets.SetBudgetInput) (*budgets.Budget, error) {
+	return nil, e.err
+}
+func (e *erroringWorkspaceRepo) DeleteBudget(context.Context, uuid.UUID) error { return e.err }
+func (e *erroringWorkspaceRepo) ListAlerts(context.Context, uuid.UUID) ([]budgets.SpendAlert, error) {
+	return nil, e.err
+}
+func (e *erroringWorkspaceRepo) CreateAlert(context.Context, budgets.CreateAlertInput) (*budgets.SpendAlert, error) {
+	return nil, e.err
+}
+func (e *erroringWorkspaceRepo) UpdateAlert(context.Context, budgets.UpdateAlertInput) (*budgets.SpendAlert, error) {
+	return nil, e.err
+}
+func (e *erroringWorkspaceRepo) DeleteAlert(context.Context, uuid.UUID, uuid.UUID) error {
+	return e.err
+}
+func (e *erroringWorkspaceRepo) ListWorkspacesWithBudget(context.Context) ([]uuid.UUID, error) {
+	return nil, e.err
+}
+func (e *erroringWorkspaceRepo) StampAlertFired(context.Context, uuid.UUID, time.Time, time.Time) error {
+	return e.err
+}
+func (e *erroringWorkspaceRepo) MonthToDateSpendBDT(context.Context, uuid.UUID, time.Time) (*big.Int, error) {
+	return nil, e.err
+}
+
+// mixedHealthRepo serves a fixed workspace list where some ids fail GetBudget.
+type mixedHealthRepo struct {
+	healthy   *fakeWorkspaceRepo
+	brokenIDs map[uuid.UUID]bool
+	all       []uuid.UUID
+}
+
+func (m *mixedHealthRepo) GetBudget(ctx context.Context, ws uuid.UUID) (*budgets.Budget, error) {
+	if m.brokenIDs[ws] {
+		return nil, errors.New("workspace row corrupted")
+	}
+	return m.healthy.GetBudget(ctx, ws)
+}
+func (m *mixedHealthRepo) UpsertBudget(ctx context.Context, in budgets.SetBudgetInput) (*budgets.Budget, error) {
+	return m.healthy.UpsertBudget(ctx, in)
+}
+func (m *mixedHealthRepo) DeleteBudget(ctx context.Context, ws uuid.UUID) error {
+	return m.healthy.DeleteBudget(ctx, ws)
+}
+func (m *mixedHealthRepo) ListAlerts(ctx context.Context, ws uuid.UUID) ([]budgets.SpendAlert, error) {
+	return m.healthy.ListAlerts(ctx, ws)
+}
+func (m *mixedHealthRepo) CreateAlert(ctx context.Context, in budgets.CreateAlertInput) (*budgets.SpendAlert, error) {
+	return m.healthy.CreateAlert(ctx, in)
+}
+func (m *mixedHealthRepo) UpdateAlert(ctx context.Context, in budgets.UpdateAlertInput) (*budgets.SpendAlert, error) {
+	return m.healthy.UpdateAlert(ctx, in)
+}
+func (m *mixedHealthRepo) DeleteAlert(ctx context.Context, ws, id uuid.UUID) error {
+	return m.healthy.DeleteAlert(ctx, ws, id)
+}
+func (m *mixedHealthRepo) ListWorkspacesWithBudget(context.Context) ([]uuid.UUID, error) {
+	return m.all, nil
+}
+func (m *mixedHealthRepo) StampAlertFired(ctx context.Context, id uuid.UUID, firedAt, period time.Time) error {
+	return m.healthy.StampAlertFired(ctx, id, firedAt, period)
+}
+func (m *mixedHealthRepo) MonthToDateSpendBDT(ctx context.Context, ws uuid.UUID, p time.Time) (*big.Int, error) {
+	return m.healthy.MonthToDateSpendBDT(ctx, ws, p)
+}
+
+// TestCronSupportQueries_Live covers the cron-support queries against real
+// rows: workspaces with a budget row are enumerated for evaluation, and a
+// fired alert is stamped so alreadyFiredThisPeriod suppresses refires within
+// the same period.
+func TestCronSupportQueries_Live(t *testing.T) {
+	pool := newBudgetsTestPool(t)
+	wsID := seedBudgetWorkspace(t, pool)
+	ctx := context.Background()
+	repo := budgets.NewWorkspacePgxRepository(pool)
+
+	if _, err := repo.UpsertBudget(ctx, budgets.SetBudgetInput{
+		WorkspaceID: wsID,
+		PeriodStart: time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC),
+		SoftCap:     big.NewInt(1000),
+		HardCap:     big.NewInt(2000),
+	}); err != nil {
+		t.Fatalf("seed budget: %v", err)
+	}
+	alert, err := repo.CreateAlert(ctx, budgets.CreateAlertInput{
+		WorkspaceID: wsID, ThresholdPct: 50,
+	})
+	if err != nil {
+		t.Fatalf("seed alert: %v", err)
+	}
+
+	workspaces, err := repo.ListWorkspacesWithBudget(ctx)
+	if err != nil {
+		t.Fatalf("list workspaces: %v", err)
+	}
+	found := false
+	for _, id := range workspaces {
+		if id == wsID {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("workspace with a budget row missing from the cron enumeration")
+	}
+
+	firedAt := time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC)
+	if err := repo.StampAlertFired(ctx, alert.ID, firedAt, firedAt); err != nil {
+		t.Fatalf("stamp: %v", err)
+	}
+	alerts, err := repo.ListAlerts(ctx, wsID)
+	if err != nil {
+		t.Fatalf("list alerts: %v", err)
+	}
+	for _, a := range alerts {
+		if a.ID != alert.ID {
+			continue
+		}
+		if a.LastFiredAt == nil || !a.LastFiredAt.Equal(firedAt) {
+			t.Fatalf("last_fired_at=%v, want %v", a.LastFiredAt, firedAt)
+		}
+		// last_fired_period is a DATE column; it reads back as that day's
+		// midnight UTC regardless of the stamp's clock time.
+		wantPeriod := time.Date(2026, 8, 5, 0, 0, 0, 0, time.UTC)
+		if a.LastFiredPeriod == nil || !a.LastFiredPeriod.Equal(wantPeriod) {
+			t.Fatalf("last_fired_period=%v, want %v", a.LastFiredPeriod, wantPeriod)
+		}
+	}
+}
+
+// TestThresholdServiceValidation covers the legacy service wrappers:
+// non-positive thresholds are refused before any write; DismissAlert and
+// UpsertThreshold delegate to the repository.
+func TestThresholdServiceValidation(t *testing.T) {
+	repo := &mockRepo{}
+	svc := budgets.NewService(repo, &mockNotifier{})
+
+	if _, err := svc.UpsertThreshold(context.Background(), uuid.New(), budgets.UpsertThresholdInput{ThresholdCredits: 0}); err == nil {
+		t.Fatal("zero threshold must be refused")
+	}
+	if _, err := svc.UpsertThreshold(context.Background(), uuid.New(), budgets.UpsertThresholdInput{ThresholdCredits: -5}); err == nil {
+		t.Fatal("negative threshold must be refused")
+	}
+
+	acct := uuid.New()
+	repo.threshold = &budgets.BudgetThreshold{
+		ID: uuid.New(), AccountID: acct, ThresholdCredits: 1000,
+	}
+	upserted, err := svc.UpsertThreshold(context.Background(), acct, budgets.UpsertThresholdInput{ThresholdCredits: 1000})
+	if err != nil {
+		t.Fatalf("valid upsert: %v", err)
+	}
+	if upserted == nil {
+		t.Fatal("valid upsert returned nil threshold")
+	}
+
+	var validationErr *budgets.ValidationError
+	if !errors.As(svcValidationError(t, svc), &validationErr) {
+		t.Fatal("zero-threshold refusal must be a *budgets.ValidationError")
+	}
+	if validationErr.Error() == "" {
+		t.Fatal("validation error message must not be empty")
+	}
+
+	if err := svc.DismissAlert(context.Background(), acct); err != nil {
+		t.Fatalf("dismiss: %v", err)
+	}
+}
+
+// svcValidationError re-runs the zero-threshold refusal and returns its error.
+func svcValidationError(t *testing.T, svc *budgets.Service) error {
+	t.Helper()
+	_, err := svc.UpsertThreshold(context.Background(), uuid.New(), budgets.UpsertThresholdInput{ThresholdCredits: 0})
+	return err
+}
+
+// TestServiceWorkspaceWrappers_Live covers the two service-level wrappers the
+// edge gate and console read through, against real rows.
+func TestServiceWorkspaceWrappers_Live(t *testing.T) {
+	pool := newBudgetsTestPool(t)
+	wsID := seedBudgetWorkspace(t, pool)
+	ctx := context.Background()
+	svc := newLiveWorkspaceService(pool)
+
+	capValue, err := svc.HardCapForWorkspace(ctx, wsID)
+	if err != nil {
+		t.Fatalf("hard cap read: %v", err)
+	}
+	if capValue != nil {
+		t.Fatalf("unbudgeted workspace returned %s, want nil (pass-through)", capValue.String())
+	}
+
+	spend, err := svc.MonthToDateSpend(ctx, wsID, time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("mtd spend: %v", err)
+	}
+	if spend.Cmp(big.NewInt(0)) != 0 {
+		t.Fatalf("empty account spent %s, want 0", spend.String())
+	}
+}
+
+// TestSetBudgetRedisBroadcast_Live pins the push-on-write invalidation
+// contract with the edge-api budget gate: SetBudget writes the hard cap under
+// the gate's key and DeleteBudget removes it. Skips when no Redis is
+// reachable so the CI leg (Postgres only) stays green.
+func TestSetBudgetRedisBroadcast_Live(t *testing.T) {
+	client := goredis.NewClient(&goredis.Options{Addr: "redis:6379"})
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := client.Ping(ctx).Err(); err != nil {
+		t.Skipf("redis unreachable from this environment: %v", err)
+	}
+
+	pool := newBudgetsTestPool(t)
+	wsID := seedBudgetWorkspace(t, pool)
+
+	svc := budgets.NewServiceWithWorkspace(
+		&legacyNoopRepo{}, &legacyNoopNotifier{},
+		budgets.NewWorkspacePgxRepository(pool), &fakeAlertNotifier{}, client,
+	)
+
+	if _, err := svc.SetBudget(ctx, budgets.SetBudgetInput{
+		WorkspaceID: wsID,
+		SoftCap:     big.NewInt(50_000),
+		HardCap:     big.NewInt(100_000),
+	}); err != nil {
+		t.Fatalf("set budget: %v", err)
+	}
+
+	key := "budget:hard_cap:{" + wsID.String() + "}"
+	got, err := client.Get(ctx, key).Result()
+	if err != nil {
+		t.Fatalf("gate key missing after SetBudget: %v", err)
+	}
+	if got != "100000" {
+		t.Fatalf("gate key carries %q, want \"100000\"", got)
+	}
+
+	if err := svc.DeleteBudget(ctx, wsID); err != nil {
+		t.Fatalf("delete budget: %v", err)
+	}
+	if _, err := client.Get(ctx, key).Result(); !errors.Is(err, goredis.Nil) {
+		t.Fatalf("gate key survived DeleteBudget: %v", err)
+	}
+}
+
+// TestUnwiredWorkspaceSurfaceRefuses keeps the constructor contract honest:
+// a Service built with the legacy-only constructor must refuse every
+// workspace call instead of panicking on its nil context.
+func TestUnwiredWorkspaceSurfaceRefuses(t *testing.T) {
+	svc := budgets.NewService(&mockRepo{}, &mockNotifier{})
+	ctx := context.Background()
+
+	if _, err := svc.GetBudget(ctx, uuid.New()); err == nil {
+		t.Fatal("unwired GetBudget must refuse")
+	}
+	if _, err := svc.SetBudget(ctx, budgets.SetBudgetInput{WorkspaceID: uuid.New()}); err == nil {
+		t.Fatal("unwired SetBudget must refuse")
+	}
+	if err := svc.DeleteBudget(ctx, uuid.New()); err == nil {
+		t.Fatal("unwired DeleteBudget must refuse")
+	}
+	if _, err := svc.ListAlerts(ctx, uuid.New()); err == nil {
+		t.Fatal("unwired ListAlerts must refuse")
+	}
+	if _, err := svc.CreateAlert(ctx, budgets.CreateAlertInput{WorkspaceID: uuid.New(), ThresholdPct: 50}); err == nil {
+		t.Fatal("unwired CreateAlert must refuse")
+	}
+	if _, err := svc.UpdateAlert(ctx, budgets.UpdateAlertInput{WorkspaceID: uuid.New(), ID: uuid.New()}); err == nil {
+		t.Fatal("unwired UpdateAlert must refuse")
+	}
+	if err := svc.DeleteAlert(ctx, uuid.New(), uuid.New()); err == nil {
+		t.Fatal("unwired DeleteAlert must refuse")
+	}
+	if _, err := svc.HardCapForWorkspace(ctx, uuid.New()); err == nil {
+		t.Fatal("unwired HardCapForWorkspace must refuse")
+	}
+	if _, err := svc.MonthToDateSpend(ctx, uuid.New(), time.Now()); err == nil {
+		t.Fatal("unwired MonthToDateSpend must refuse")
+	}
+}
+
+// TestThresholdCrossedGuards completes the guard table for the big.Int cross
+// math: nil operands and non-positive percentages answer false rather than
+// panicking or dividing by zero.
+func TestThresholdCrossedGuards(t *testing.T) {
+	cases := []struct {
+		name string
+		mtd  *big.Int
+		cap  *big.Int
+		pct  int
+		want bool
+	}{
+		{"nil mtd", nil, big.NewInt(100), 50, false},
+		{"nil cap", big.NewInt(100), nil, 50, false},
+		{"negative pct", big.NewInt(100), big.NewInt(100), -1, false},
+		{"zero pct", big.NewInt(100), big.NewInt(100), 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := budgets.ThresholdCrossed(tc.mtd, tc.cap, tc.pct); got != tc.want {
+				t.Fatalf("ThresholdCrossed(%v, %v, %d) = %v, want %v", tc.mtd, tc.cap, tc.pct, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCronSkipsBudgetlessWorkspace: a workspace id that reaches the evaluator
+// but has no budget row contributes nothing and errors nothing.
+func TestCronSkipsBudgetlessWorkspace(t *testing.T) {
+	repo := newFakeWorkspaceRepo()
+	notifier := &fakeAlertNotifier{}
+
+	// Listed for evaluation but carrying neither corruption nor a budget row.
+	mixed := &mixedHealthRepo{healthy: repo, brokenIDs: map[uuid.UUID]bool{}}
+	budgetless := uuid.New()
+	mixed.all = []uuid.UUID{budgetless}
+
+	cron := budgets.NewCronEvaluator(mixed, notifier, nil)
+	fired, err := cron.EvaluateBudgets(context.Background(), time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC))
+	if err != nil || fired != 0 {
+		t.Fatalf("budgetless workspace returned (%d, %v), want (0, nil)", fired, err)
+	}
+}
+
+// TestCronStampFailureRetries pins the second fail-closed half of dispatch:
+// a failed last_fired_period stamp must not count the alert as fired, so the
+// next pass retries instead of losing the alert for the whole period.
+func TestCronStampFailureRetries(t *testing.T) {
+	base := newFakeWorkspaceRepo()
+	stamper := &flakyStampRepo{fakeWorkspaceRepo: base}
+	notifier := &fakeAlertNotifier{}
+	ws := uuid.New()
+	_, _ = stamper.UpsertBudget(context.Background(), budgets.SetBudgetInput{
+		WorkspaceID: ws,
+		PeriodStart: time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC),
+		SoftCap:     big.NewInt(1000),
+		HardCap:     big.NewInt(2000),
+	})
+	if _, err := stamper.CreateAlert(context.Background(), budgets.CreateAlertInput{
+		WorkspaceID: ws, ThresholdPct: 50,
+	}); err != nil {
+		t.Fatalf("seed alert: %v", err)
+	}
+	base.mtd[ws] = big.NewInt(500)
+
+	stamper.failStamps = true
+	cron := budgets.NewCronEvaluator(stamper, notifier, nil)
+	fired, err := cron.EvaluateBudgets(context.Background(), time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if fired != 0 {
+		t.Fatalf("failed stamp counted as fired=%d; it must be retried next pass", fired)
+	}
+
+	// Heal the repository: the very next pass fires exactly once, proving the
+	// alert was never marked sent during the failing window.
+	stamper.failStamps = false
+	fired, err = cron.EvaluateBudgets(context.Background(), time.Date(2026, 8, 5, 12, 30, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("healed evaluate: %v", err)
+	}
+	if fired != 1 {
+		t.Fatalf("healed pass fired=%d, want 1", fired)
+	}
+}
+
+// flakyStampRepo fails StampAlertFired until released, to exercise the retry
+// path that keeps an alert alive across passes when stamping breaks.
+type flakyStampRepo struct {
+	*fakeWorkspaceRepo
+	failStamps bool
+}
+
+func (f *flakyStampRepo) StampAlertFired(ctx context.Context, id uuid.UUID, at, period time.Time) error {
+	if f.failStamps {
+		return errors.New("stamp write lost")
+	}
+	return f.fakeWorkspaceRepo.StampAlertFired(ctx, id, at, period)
+}
+
+// failingThresholdRepo fails every operation, to prove the legacy service
+// wraps and surfaces repository failures instead of answering defaults.
+type failingThresholdRepo struct {
+	err error
+}
+
+func (f *failingThresholdRepo) GetThreshold(context.Context, uuid.UUID) (*budgets.BudgetThreshold, error) {
+	return nil, f.err
+}
+func (f *failingThresholdRepo) UpsertThreshold(context.Context, uuid.UUID, int64) (*budgets.BudgetThreshold, error) {
+	return nil, f.err
+}
+func (f *failingThresholdRepo) DismissAlert(context.Context, uuid.UUID) error { return f.err }
+func (f *failingThresholdRepo) MarkNotified(context.Context, uuid.UUID) error { return f.err }
+
+// TestLegacyServiceErrorPropagation keeps the fail-loud contract on the
+// legacy threshold surface: repository failures surface from every wrapper,
+// and CheckThresholds refuses to answer on an unreadable threshold.
+func TestLegacyServiceErrorPropagation(t *testing.T) {
+	repo := &failingThresholdRepo{err: errors.New("db down")}
+	svc := budgets.NewService(repo, &mockNotifier{})
+	ctx := context.Background()
+
+	if _, err := svc.GetThreshold(ctx, uuid.New()); err == nil {
+		t.Fatal("GetThreshold must surface repo failure")
+	}
+	if _, err := svc.UpsertThreshold(ctx, uuid.New(), budgets.UpsertThresholdInput{ThresholdCredits: 100}); err == nil {
+		t.Fatal("UpsertThreshold must surface repo failure")
+	}
+	if err := svc.DismissAlert(ctx, uuid.New()); err == nil {
+		t.Fatal("DismissAlert must surface repo failure")
+	}
+	if err := svc.CheckThresholds(ctx, uuid.New(), 100); err == nil {
+		t.Fatal("CheckThresholds must fail closed when the threshold cannot be read")
+	}
+}

--- a/apps/control-plane/internal/ledger/http_invoices_test.go
+++ b/apps/control-plane/internal/ledger/http_invoices_test.go
@@ -1,0 +1,213 @@
+package ledger
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/accounts"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/auth"
+)
+
+// Invoice HTTP surface: list, fetch by id, and the error-mapping contract of
+// writeLedgerError: 400 validation, 404 foreign invoice, 500 opaque infra.
+// Raw repository error text must never reach the response body.
+func TestInvoiceEndpoints(t *testing.T) {
+	repo := newStubRepo()
+	userID := uuid.New()
+	accountID := uuid.New()
+
+	repo.accountsMap[accountID] = &accounts.Account{
+		ID:          accountID,
+		Slug:        "invoice-ws",
+		DisplayName: "Invoice WS",
+		AccountType: "business",
+		OwnerUserID: userID,
+	}
+	repo.memberships = []accounts.Membership{
+		{ID: uuid.New(), AccountID: accountID, UserID: userID, Role: "owner", Status: "active"},
+	}
+
+	invoice := InvoiceRow{
+		ID:              uuid.New(),
+		AccountID:       accountID,
+		PaymentIntentID: uuid.New(),
+		InvoiceNumber:   "INV-HTTP-1",
+		Status:          "issued",
+		Credits:         1000,
+		AmountUSD:       1000,
+		AmountLocal:     0,
+		LocalCurrency:   "USD",
+		TaxTreatment:    "none",
+		Rail:            "stripe",
+		LineItems:       []map[string]any{{"kind": "topup", "credits": float64(1000)}},
+		CreatedAt:       time.Now().UTC(),
+	}
+	repo.invoices = []InvoiceRow{invoice}
+
+	handler := newHTTPHandler(repo)
+	viewer := auth.Viewer{UserID: userID, Email: "owner@example.com", EmailVerified: true}
+
+	do := func(path string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		req = req.WithContext(viewerCtx(viewer))
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		return rr
+	}
+
+	t.Run("list returns the account's invoices", func(t *testing.T) {
+		rr := do("/api/v1/accounts/current/invoices")
+		if rr.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+		}
+		var body struct {
+			Invoices []InvoiceRow `json:"invoices"`
+		}
+		if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+			t.Fatalf("json: %v", err)
+		}
+		if len(body.Invoices) != 1 || body.Invoices[0].InvoiceNumber != invoice.InvoiceNumber {
+			t.Fatalf("unexpected invoices payload: %+v", body.Invoices)
+		}
+	})
+
+	t.Run("get by id round trips line items", func(t *testing.T) {
+		rr := do("/api/v1/accounts/current/invoices/" + invoice.ID.String())
+		if rr.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+		}
+		var got InvoiceRow
+		if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+			t.Fatalf("json: %v", err)
+		}
+		if got.ID != invoice.ID || len(got.LineItems) != 1 {
+			t.Fatalf("round trip mismatch: %+v", got)
+		}
+	})
+
+	t.Run("foreign invoice id answers 404 not a leak", func(t *testing.T) {
+		rr := do("/api/v1/accounts/current/invoices/" + uuid.New().String())
+		if rr.Code != http.StatusNotFound {
+			t.Fatalf("expected 404 for foreign invoice, got %d: %s", rr.Code, rr.Body.String())
+		}
+	})
+}
+
+// TestLedgerErrorMapping covers writeLedgerError branches directly: validation
+// errors map to 400 with their message; ErrNotFound maps to 404; anything else
+// maps to a fixed 500 whose body never contains the underlying error text.
+func TestLedgerErrorMapping(t *testing.T) {
+	rr := httptest.NewRecorder()
+	writeLedgerError(rr, &ValidationError{Message: "bad input"})
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("validation error mapped to %d, want 400", rr.Code)
+	}
+
+	rr = httptest.NewRecorder()
+	writeLedgerError(rr, ErrNotFound)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("ErrNotFound mapped to %d, want 404", rr.Code)
+	}
+
+	rr = httptest.NewRecorder()
+	writeLedgerError(rr, context.DeadlineExceeded)
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("infrastructure error mapped to %d, want 500", rr.Code)
+	}
+	if strings.Contains(rr.Body.String(), "deadline") {
+		t.Fatal("raw error text leaked into the response body")
+	}
+}
+
+// TestListEntriesHTTPParams pins the ledger-list query contract: invalid
+// limit and cursor values are refused with 400 before any repository call,
+// a full page yields next_cursor, and a repository failure answers a fixed
+// 500 whose body never carries the underlying error text.
+func TestListEntriesHTTPParams(t *testing.T) {
+	repo := newStubRepo()
+	userID := uuid.New()
+	accountID := uuid.New()
+
+	repo.accountsMap[accountID] = &accounts.Account{
+		ID:          accountID,
+		Slug:        "ledger-params-ws",
+		DisplayName: "Ledger Params WS",
+		AccountType: "business",
+		OwnerUserID: userID,
+	}
+	repo.memberships = []accounts.Membership{
+		{ID: uuid.New(), AccountID: accountID, UserID: userID, Role: "owner", Status: "active"},
+	}
+	for i := 0; i < 3; i++ {
+		repo.entries[accountID] = append(repo.entries[accountID], LedgerEntry{
+			ID: uuid.New(), AccountID: accountID, EntryType: EntryTypeGrant,
+			CreditsDelta: 10, IdempotencyKey: uuid.NewString(),
+		})
+	}
+
+	handler := newHTTPHandler(repo)
+	viewer := auth.Viewer{UserID: userID, Email: "owner@example.com", EmailVerified: true}
+
+	do := func(query string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/accounts/current/credits/ledger"+query, nil)
+		req = req.WithContext(viewerCtx(viewer))
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		return rr
+	}
+
+	t.Run("bad limit and cursor are refused with 400", func(t *testing.T) {
+		if rr := do("?limit=zero"); rr.Code != http.StatusBadRequest {
+			t.Fatalf("bad limit got %d, want 400", rr.Code)
+		}
+		if rr := do("?limit=-3"); rr.Code != http.StatusBadRequest {
+			t.Fatalf("negative limit got %d, want 400", rr.Code)
+		}
+		if rr := do("?cursor=not-a-uuid"); rr.Code != http.StatusBadRequest {
+			t.Fatalf("bad cursor got %d, want 400", rr.Code)
+		}
+	})
+
+	t.Run("full page yields next_cursor", func(t *testing.T) {
+		rr := do("?limit=2&type=grant")
+		if rr.Code != http.StatusOK {
+			t.Fatalf("page got %d: %s", rr.Code, rr.Body.String())
+		}
+		var body struct {
+			NextCursor *string `json:"next_cursor"`
+		}
+		if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if body.NextCursor == nil || *body.NextCursor == "" {
+			t.Fatal("a full page must carry next_cursor for pagination to continue")
+		}
+	})
+
+	t.Run("repository failure answers opaque 500", func(t *testing.T) {
+		failer := newStubRepo()
+		failer.accountsMap = repo.accountsMap
+		failer.memberships = repo.memberships
+		failer.listErr = errors.New("pgx: connection reset")
+
+		failingHandler := newHTTPHandler(failer)
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/accounts/current/credits/ledger", nil)
+		req = req.WithContext(viewerCtx(viewer))
+		rr := httptest.NewRecorder()
+		failingHandler.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusInternalServerError {
+			t.Fatalf("repo failure got %d, want 500", rr.Code)
+		}
+		if strings.Contains(rr.Body.String(), "pgx") {
+			t.Fatal("raw error text leaked into the response body")
+		}
+	})
+}

--- a/apps/control-plane/internal/ledger/repository_live_test.go
+++ b/apps/control-plane/internal/ledger/repository_live_test.go
@@ -1,0 +1,629 @@
+package ledger
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// Behavioral tests for the money-path ledger against the real Postgres schema
+// (HIVE_TEST_DB_URL gated, same convention as balance_over_release_live_test.go).
+//
+// Invariants encoded here (see .wolf/decisions.md D-031..D-034):
+//
+//   - Replay of an already-used idempotency key returns the ORIGINAL entry and
+//     writes exactly one row (D-034: a reservation reaches its terminal state
+//     exactly once).
+//   - A capture consumes its own hold exactly once: hold - charge - release nets
+//     the reservation to zero reserved, and the charge lands in posted credits,
+//     never back into reserved.
+//   - Negative and zero amounts are refused before any row is written
+//     (fail-closed input validation on every posting surface).
+//   - Reserved is per-reservation clamped-at-zero; over-release is reported as
+//     a corruption counter, never rendered as a hold (issue #918 reader half,
+//     covered end-to-end in balance_over_release_live_test.go).
+
+func TestPostEntryIdempotentReplay_Live(t *testing.T) {
+	pool := newLedgerTestPool(t)
+	accountID := seedLedgerAccount(t, pool)
+	ctx := context.Background()
+	svc := NewService(NewPgxRepository(pool))
+
+	first, err := svc.GrantCredits(ctx, accountID, "grant-replay-1", 500, nil)
+	if err != nil {
+		t.Fatalf("grant: %v", err)
+	}
+
+	second, err := svc.GrantCredits(ctx, accountID, "grant-replay-1", 500, nil)
+	if err != nil {
+		t.Fatalf("replay grant: %v", err)
+	}
+
+	if first.ID != second.ID {
+		t.Fatalf("replay returned entry %s, want the original %s", second.ID, first.ID)
+	}
+
+	var n int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM public.credit_ledger_entries WHERE account_id = $1`, accountID,
+	).Scan(&n); err != nil {
+		t.Fatalf("count entries: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("replay wrote extra rows: %d entries for one idempotency key", n)
+	}
+}
+
+// TestReservationLifecycle_Live walks hold -> charge -> release and asserts the
+// settlement arithmetic on both GetBalance arms: posted credits absorb the
+// capture, reserved credits return to zero, and replaying the terminal entries
+// under the same keys changes nothing (terminal exactly once).
+func TestReservationLifecycle_Live(t *testing.T) {
+	pool := newLedgerTestPool(t)
+	accountID := seedLedgerAccount(t, pool)
+	ctx := context.Background()
+	repo := NewPgxRepository(pool)
+	svc := NewService(repo)
+
+	if _, err := svc.GrantCredits(ctx, accountID, "lifecycle-grant", 100000, nil); err != nil {
+		t.Fatalf("grant: %v", err)
+	}
+
+	reservationID := uuid.New()
+	post(t, svc, accountID, reservationID, "reserve", 5000, false)
+
+	mid, err := svc.GetBalance(ctx, accountID)
+	if err != nil {
+		t.Fatalf("mid balance: %v", err)
+	}
+	if mid.ReservedCredits != 5000 || mid.AvailableCredits != 100000-5000 {
+		t.Fatalf("after hold: reserved=%d available=%d, want 5000 / %d",
+			mid.ReservedCredits, mid.AvailableCredits, 100000-5000)
+	}
+
+	if _, err := svc.ChargeUsage(ctx, accountID, "req-lifecycle", &reservationID, &reservationID, "lifecycle-charge", 3000, nil); err != nil {
+		t.Fatalf("charge: %v", err)
+	}
+	// Production settlement lifts the WHOLE hold after capture (the charge is
+	// what the customer actually pays); releasing only the remainder would
+	// strand actual credits in the reserved bucket forever.
+	post(t, svc, accountID, reservationID, "release", 5000, true)
+
+	balance, err := svc.GetBalance(ctx, accountID)
+	if err != nil {
+		t.Fatalf("balance: %v", err)
+	}
+
+	// Invariant: the capture consumed its hold exactly once. The full hold is
+	// lifted by the release; the charge (3000) is settled into posted credits,
+	// never back into reserved.
+	if balance.PostedCredits != 100000-3000 {
+		t.Fatalf("posted=%d, want %d (charge settles posted, not reserved)", balance.PostedCredits, 100000-3000)
+	}
+	if balance.ReservedCredits != 0 {
+		t.Fatalf("reserved=%d, want 0 after charge+release settle the full hold", balance.ReservedCredits)
+	}
+	if balance.AvailableCredits != 100000-3000 {
+		t.Fatalf("available=%d, want %d", balance.AvailableCredits, 100000-3000)
+	}
+	if balance.OverReleasedReservations != 0 {
+		t.Fatalf("clean lifecycle reported %d over-released reservations", balance.OverReleasedReservations)
+	}
+
+	// Terminal exactly once: replaying both terminal entries under the same
+	// keys must return the original entries and move nothing.
+	chargeBefore, err := repo.GetUsageSince(ctx, accountID, time.Now().Add(-time.Hour))
+	if err != nil {
+		t.Fatalf("usage before replay: %v", err)
+	}
+	replayCharge, err := svc.ChargeUsage(ctx, accountID, "req-lifecycle", &reservationID, &reservationID, "lifecycle-charge", 3000, nil)
+	if err != nil {
+		t.Fatalf("charge replay: %v", err)
+	}
+	if replayCharge.CreditsDelta != -3000 {
+		t.Fatalf("replay charge delta %d, want original -3000", replayCharge.CreditsDelta)
+	}
+	post(t, svc, accountID, reservationID, "release", 5000, true)
+
+	chargeAfter, err := repo.GetUsageSince(ctx, accountID, time.Now().Add(-time.Hour))
+	if err != nil {
+		t.Fatalf("usage after replay: %v", err)
+	}
+	if chargeAfter != chargeBefore {
+		t.Fatalf("usage moved %d -> %d across terminal replays; a reservation must reach its terminal state exactly once",
+			chargeBefore, chargeAfter)
+	}
+}
+
+// TestGetBalanceArms_Live drives both arms of the GetBalance query with table
+// driven scenarios: posted credits come from grant/adjustment/usage_charge/
+// refund entries, reserved credits from outstanding per-reservation holds.
+func TestGetBalanceArms_Live(t *testing.T) {
+	tests := []struct {
+		name       string
+		setup      func(t *testing.T, svc *Service, accountID uuid.UUID)
+		wantPosted int64
+		wantRes    int64
+	}{
+		{
+			name: "holds arm: outstanding hold reserves against posted",
+			setup: func(t *testing.T, svc *Service, accountID uuid.UUID) {
+				if _, err := svc.GrantCredits(context.Background(), accountID, "arms-grant-a", 100000, nil); err != nil {
+					t.Fatalf("grant: %v", err)
+				}
+				res := uuid.New()
+				post(t, svc, accountID, res, "reserve", 7500, false)
+			},
+			wantPosted: 100000,
+			wantRes:    7500,
+		},
+		{
+			name: "settled arm: full release clears the reservation",
+			setup: func(t *testing.T, svc *Service, accountID uuid.UUID) {
+				if _, err := svc.GrantCredits(context.Background(), accountID, "arms-grant-b", 100000, nil); err != nil {
+					t.Fatalf("grant: %v", err)
+				}
+				res := uuid.New()
+				post(t, svc, accountID, res, "reserve", 9000, false)
+				post(t, svc, accountID, res, "release", 9000, true)
+			},
+			wantPosted: 100000,
+			wantRes:    0,
+		},
+		{
+			name: "partial release keeps the remainder held",
+			setup: func(t *testing.T, svc *Service, accountID uuid.UUID) {
+				if _, err := svc.GrantCredits(context.Background(), accountID, "arms-grant-c", 100000, nil); err != nil {
+					t.Fatalf("grant: %v", err)
+				}
+				res := uuid.New()
+				post(t, svc, accountID, res, "reserve", 9000, false)
+				post(t, svc, accountID, res, "release", 4000, true)
+			},
+			wantPosted: 100000,
+			wantRes:    5000,
+		},
+		{
+			name: "refund posts positive without touching reserved",
+			setup: func(t *testing.T, svc *Service, accountID uuid.UUID) {
+				if _, err := svc.GrantCredits(context.Background(), accountID, "arms-grant-d", 10000, nil); err != nil {
+					t.Fatalf("grant: %v", err)
+				}
+				if _, err := svc.ChargeUsage(context.Background(), accountID, "req-refund", nil, nil, "arms-charge", 2500, nil); err != nil {
+					t.Fatalf("charge: %v", err)
+				}
+				if _, err := svc.RefundCredits(context.Background(), accountID, "req-refund", nil, nil, "arms-refund", 1000, nil); err != nil {
+					t.Fatalf("refund: %v", err)
+				}
+			},
+			wantPosted: 10000 - 2500 + 1000,
+			wantRes:    0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pool := newLedgerTestPool(t)
+			accountID := seedLedgerAccount(t, pool)
+			svc := NewService(NewPgxRepository(pool))
+
+			tc.setup(t, svc, accountID)
+
+			balance, err := svc.GetBalance(context.Background(), accountID)
+			if err != nil {
+				t.Fatalf("GetBalance: %v", err)
+			}
+			if balance.PostedCredits != tc.wantPosted {
+				t.Fatalf("posted=%d, want %d", balance.PostedCredits, tc.wantPosted)
+			}
+			if balance.ReservedCredits != tc.wantRes {
+				t.Fatalf("reserved=%d, want %d", balance.ReservedCredits, tc.wantRes)
+			}
+			if balance.AvailableCredits != tc.wantPosted-tc.wantRes {
+				t.Fatalf("available=%d, want %d (available = posted - reserved)",
+					balance.AvailableCredits, tc.wantPosted-tc.wantRes)
+			}
+		})
+	}
+}
+
+// TestLedgerRefusesBadAmounts_Live encodes the fail-closed input invariant:
+// zero and negative amounts are refused by the service layer before any row is
+// written, on every posting surface.
+func TestLedgerRefusesBadAmounts_Live(t *testing.T) {
+	pool := newLedgerTestPool(t)
+	accountID := seedLedgerAccount(t, pool)
+	ctx := context.Background()
+	svc := NewService(NewPgxRepository(pool))
+
+	countEntries := func() int64 {
+		t.Helper()
+		var n int64
+		if err := pool.QueryRow(ctx,
+			`SELECT count(*) FROM public.credit_ledger_entries WHERE account_id = $1`, accountID,
+		).Scan(&n); err != nil {
+			t.Fatalf("count: %v", err)
+		}
+		return n
+	}
+
+	tests := []struct {
+		name string
+		call func() error
+	}{
+		{"grant zero", func() error { _, err := svc.GrantCredits(ctx, accountID, "bad-grant-0", 0, nil); return err }},
+		{"grant negative", func() error { _, err := svc.GrantCredits(ctx, accountID, "bad-grant-neg", -5, nil); return err }},
+		{"adjust zero", func() error { _, err := svc.AdjustCredits(ctx, accountID, "bad-adjust-0", 0, nil); return err }},
+		{"hold zero", func() error {
+			_, err := svc.ReserveCredits(ctx, accountID, "r", nil, nil, "bad-hold-0", 0, nil)
+			return err
+		}},
+		{"hold negative", func() error {
+			_, err := svc.ReserveCredits(ctx, accountID, "r", nil, nil, "bad-hold-neg", -1, nil)
+			return err
+		}},
+		{"release zero", func() error {
+			_, err := svc.ReleaseReservedCredits(ctx, accountID, "r", nil, nil, "bad-rel-0", 0, nil)
+			return err
+		}},
+		{"charge zero", func() error {
+			_, err := svc.ChargeUsage(ctx, accountID, "r", nil, nil, "bad-chg-0", 0, nil)
+			return err
+		}},
+		{"charge negative", func() error {
+			_, err := svc.ChargeUsage(ctx, accountID, "r", nil, nil, "bad-chg-neg", -2, nil)
+			return err
+		}},
+		{"refund zero", func() error {
+			_, err := svc.RefundCredits(ctx, accountID, "r", nil, nil, "bad-ref-0", 0, nil)
+			return err
+		}},
+		{"blank idempotency key on grant", func() error { _, err := svc.GrantCredits(ctx, accountID, "   ", 10, nil); return err }},
+		{"blank idempotency key on hold", func() error { _, err := svc.ReserveCredits(ctx, accountID, "r", nil, nil, "", 10, nil); return err }},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			before := countEntries()
+			err := tc.call()
+			var validationErr *ValidationError
+			if !errors.As(err, &validationErr) {
+				t.Fatalf("expected ValidationError, got %v", err)
+			}
+			if after := countEntries(); after != before {
+				t.Fatalf("refused call still wrote rows (%d -> %d); validation must fail closed before any write",
+					before, after)
+			}
+		})
+	}
+}
+
+// TestListEntriesWithCursorFilters_Live covers the parameterized query builder:
+// default limit, entry-type filter, request-id filter, and cursor pagination
+// whose pages are disjoint and together cover the whole account slice.
+func TestListEntriesWithCursorFilters_Live(t *testing.T) {
+	pool := newLedgerTestPool(t)
+	accountA := seedLedgerAccount(t, pool)
+	accountB := seedLedgerAccount(t, pool)
+	ctx := context.Background()
+	svc := NewService(NewPgxRepository(pool))
+
+	for i, acct := range []uuid.UUID{accountA, accountB} {
+		for j := 0; j < 3; j++ {
+			key := uuid.NewString()
+			if _, err := svc.GrantCredits(ctx, acct, key, int64(100+i+j), nil); err != nil {
+				t.Fatalf("seed grant acct%d #%d: %v", i, j, err)
+			}
+		}
+	}
+	// One hold + charge pair sharing a request_id, plus a grant that does not.
+	res := uuid.New()
+	if _, err := svc.ReserveCredits(ctx, accountA, "req-filter-target", &res, &res, "filter-hold", 40, nil); err != nil {
+		t.Fatalf("seed hold: %v", err)
+	}
+	if _, err := svc.ChargeUsage(ctx, accountA, "req-filter-target", &res, &res, "filter-charge", 15, nil); err != nil {
+		t.Fatalf("seed charge: %v", err)
+	}
+
+	t.Run("default limit returns newest first", func(t *testing.T) {
+		entries, err := svc.ListEntriesWithCursor(ctx, ListEntriesFilter{AccountID: accountB})
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		if len(entries) != 3 {
+			t.Fatalf("got %d entries, want all 3", len(entries))
+		}
+		for i := 1; i < len(entries); i++ {
+			if string(entries[i-1].ID[:]) <= string(entries[i].ID[:]) {
+				t.Fatalf("entries not ordered newest first by id: %s then %s", entries[i-1].ID, entries[i].ID)
+			}
+		}
+	})
+
+	t.Run("entry type filter narrows the page", func(t *testing.T) {
+		grantsOnly := EntryTypeGrant
+		entries, err := svc.ListEntriesWithCursor(ctx, ListEntriesFilter{AccountID: accountA, EntryType: &grantsOnly})
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		if len(entries) != 3 {
+			t.Fatalf("got %d grant entries, want 3", len(entries))
+		}
+		for _, e := range entries {
+			if e.EntryType != EntryTypeGrant {
+				t.Fatalf("filter leaked entry type %s", e.EntryType)
+			}
+		}
+	})
+
+	t.Run("request id filter isolates one reservation lifecycle", func(t *testing.T) {
+		entries, err := svc.ListEntriesWithCursor(ctx, ListEntriesFilter{AccountID: accountA, RequestID: "req-filter-target"})
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		if len(entries) != 2 {
+			t.Fatalf("got %d entries for the request, want 2 (hold + charge)", len(entries))
+		}
+		for _, e := range entries {
+			if e.RequestID != "req-filter-target" {
+				t.Fatalf("filter leaked request_id %q", e.RequestID)
+			}
+			if e.ReservationID == nil || *e.ReservationID != res {
+				t.Fatalf("entry missing the shared reservation id")
+			}
+		}
+	})
+
+	t.Run("cursor pagination pages are disjoint and complete", func(t *testing.T) {
+		var page1, page2 []LedgerEntry
+		var err error
+		page1, err = svc.ListEntriesWithCursor(ctx, ListEntriesFilter{AccountID: accountA, Limit: 3})
+		if err != nil {
+			t.Fatalf("page1: %v", err)
+		}
+		if len(page1) != 3 {
+			t.Fatalf("page1 got %d, want 3", len(page1))
+		}
+		cursor := page1[len(page1)-1].ID
+		page2, err = svc.ListEntriesWithCursor(ctx, ListEntriesFilter{AccountID: accountA, Limit: 3, Cursor: &cursor})
+		if err != nil {
+			t.Fatalf("page2: %v", err)
+		}
+		if len(page2) != 2 {
+			t.Fatalf("page2 got %d, want remaining 2", len(page2))
+		}
+		seen := map[uuid.UUID]bool{}
+		for _, e := range append(append([]LedgerEntry{}, page1...), page2...) {
+			if seen[e.ID] {
+				t.Fatalf("entry %s appeared on two pages", e.ID)
+			}
+			seen[e.ID] = true
+		}
+		if len(seen) != 5 {
+			t.Fatalf("pages cover %d unique entries, want all 5", len(seen))
+		}
+	})
+}
+
+// TestGetUsageSinceWindow_Live pins the usage window semantics: only charges at
+// or after the cutoff count, non-charge entries never count.
+func TestGetUsageSinceWindow_Live(t *testing.T) {
+	pool := newLedgerTestPool(t)
+	accountID := seedLedgerAccount(t, pool)
+	ctx := context.Background()
+	repo := NewPgxRepository(pool)
+	svc := NewService(repo)
+
+	// An old charge outside any sane window, backdated via direct insert.
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO public.credit_ledger_entries (account_id, entry_type, credits_delta, idempotency_key, created_at)
+		 VALUES ($1, 'usage_charge', -777, 'old-charge', now() - interval '48 hours')`, accountID,
+	); err != nil {
+		t.Fatalf("seed old charge: %v", err)
+	}
+	if _, err := svc.ChargeUsage(ctx, accountID, "req-win", nil, nil, "win-charge-a", 120, nil); err != nil {
+		t.Fatalf("charge a: %v", err)
+	}
+	if _, err := svc.ChargeUsage(ctx, accountID, "req-win", nil, nil, "win-charge-b", 30, nil); err != nil {
+		t.Fatalf("charge b: %v", err)
+	}
+	if _, err := svc.GrantCredits(ctx, accountID, "win-grant", 99999, nil); err != nil {
+		t.Fatalf("grant: %v", err)
+	}
+
+	cutoff := time.Now().Add(-time.Hour)
+	used, err := repo.GetUsageSince(ctx, accountID, cutoff)
+	if err != nil {
+		t.Fatalf("usage since: %v", err)
+	}
+	if used != 150 {
+		t.Fatalf("used=%d, want 150 (only charges inside the window)", used)
+	}
+}
+
+// TestInvoicesRoundTrip_Live covers the invoice read surface against real rows,
+// including the ErrNotFound contract for a foreign invoice id.
+func TestInvoicesRoundTrip_Live(t *testing.T) {
+	pool := newLedgerTestPool(t)
+	accountID := seedLedgerAccount(t, pool)
+	ctx := context.Background()
+	repo := NewPgxRepository(pool)
+
+	lineItems := `[{"kind":"topup","credits":1000}]`
+	var invoiceIDs []uuid.UUID
+	for i := 0; i < 2; i++ {
+		var intentID uuid.UUID
+		if err := pool.QueryRow(ctx,
+			`INSERT INTO public.payment_intents (account_id, rail, status, credits, amount_usd, amount_local, local_currency, idempotency_key)
+			 VALUES ($1, 'stripe', 'created', 1000, 1000, 0, '', $2) RETURNING id`,
+			accountID, "inv-test-"+uuid.NewString(),
+		).Scan(&intentID); err != nil {
+			t.Fatalf("seed intent %d: %v", i, err)
+		}
+		var invID uuid.UUID
+		if err := pool.QueryRow(ctx,
+			`INSERT INTO public.payment_invoices (account_id, payment_intent_id, invoice_number, status, credits, amount_usd, amount_local, local_currency, tax_treatment, rail, line_items)
+			 VALUES ($1, $2, $3, 'issued', 1000, 1000, 0, 'USD', 'none', 'stripe', $4::jsonb)
+			 RETURNING id`,
+			accountID, intentID, "INV-LIVE-"+strconv.Itoa(i)+"-"+uuid.NewString()[:8], lineItems,
+		).Scan(&invID); err != nil {
+			t.Fatalf("seed invoice %d: %v", i, err)
+		}
+		invoiceIDs = append(invoiceIDs, invID)
+	}
+
+	invoices, err := repo.ListInvoices(ctx, accountID)
+	if err != nil {
+		t.Fatalf("list invoices: %v", err)
+	}
+	if len(invoices) != 2 {
+		t.Fatalf("got %d invoices, want 2", len(invoices))
+	}
+	if invoices[0].CreatedAt.Before(invoices[1].CreatedAt) {
+		t.Fatalf("invoices not ordered newest first")
+	}
+	if invoices[0].LineItems == nil || len(invoices[0].LineItems) != 1 {
+		t.Fatalf("line items did not decode: %+v", invoices[0].LineItems)
+	}
+
+	got, err := repo.GetInvoice(ctx, accountID, invoiceIDs[0])
+	if err != nil {
+		t.Fatalf("get invoice: %v", err)
+	}
+	if got.ID != invoiceIDs[0] || got.AccountID != accountID {
+		t.Fatalf("fetched wrong invoice %+v", got)
+	}
+
+	if _, err := repo.GetInvoice(ctx, accountID, uuid.New()); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("foreign invoice id returned %v, want ErrNotFound", err)
+	}
+}
+
+// TestCreditUnitStampingAndHelpers covers the pure helpers around PostEntryTx:
+// the v2 credit-unit stamp never mutates the caller's metadata and yields to a
+// caller-provided unit, and unique-violation detection recognizes code 23505.
+func TestCreditUnitStampingAndHelpers(t *testing.T) {
+	stamped := stampCreditUnit(map[string]any{"k": "v"})
+	if stamped["credit_unit"] != CreditUnitV2 {
+		t.Fatalf("stamp missing: %+v", stamped)
+	}
+	callerUnit := stampCreditUnit(map[string]any{"credit_unit": "caller-unit"})
+	if callerUnit["credit_unit"] != "caller-unit" {
+		t.Fatalf("caller unit overwritten: %+v", callerUnit)
+	}
+	if stampCreditUnit(nil)["credit_unit"] != CreditUnitV2 {
+		t.Fatalf("nil metadata not stamped")
+	}
+	source := map[string]any{"k": "v"}
+	_ = stampCreditUnit(source)
+	if _, polluted := source["credit_unit"]; polluted {
+		t.Fatal("stamping mutated the caller's metadata map")
+	}
+
+	if normalizeMetadata(nil) == nil {
+		t.Fatal("nil metadata must normalize to an empty map, not nil")
+	}
+
+	pgErr := &pgconn.PgError{Code: "23505"}
+	if !isUniqueViolation(pgErr) {
+		t.Fatal("23505 not recognized as unique violation")
+	}
+	if isUniqueViolation(&pgconn.PgError{Code: "22P02"}) {
+		t.Fatal("non-unique code misclassified")
+	}
+	if isUniqueViolation(errors.New("not a pg error")) {
+		t.Fatal("plain error misclassified")
+	}
+}
+
+// TestShouldLogAnomalyThrottles pins the operator-signal contract: the first
+// sighting of an anomaly logs, immediate repeats within the window do not.
+func TestShouldLogAnomalyThrottles(t *testing.T) {
+	svc := NewService(newStubRepo())
+	accountID := uuid.New()
+
+	if !svc.shouldLogAnomaly(accountID) {
+		t.Fatal("first anomaly sighting must log")
+	}
+	if svc.shouldLogAnomaly(accountID) {
+		t.Fatal("repeat sighting within the window must be throttled")
+	}
+
+	other := uuid.New()
+	if !svc.shouldLogAnomaly(other) {
+		t.Fatal("throttle must be per account")
+	}
+
+	svc.anomalyLogged.Store(accountID, time.Now().Add(-16*time.Minute))
+	if !svc.shouldLogAnomaly(accountID) {
+		t.Fatal("sighting outside the window must log again")
+	}
+}
+
+// TestGetBalancePropagatesRepoError keeps the fail-loud contract on reads: a
+// repository failure surfaces instead of being answered with zeros.
+func TestGetBalancePropagatesRepoError(t *testing.T) {
+	repo := newStubRepo()
+	repo.balanceErr = errors.New("db down")
+	svc := NewService(repo)
+	if _, err := svc.GetBalance(context.Background(), uuid.New()); err == nil {
+		t.Fatal("expected repo error to propagate")
+	}
+}
+
+// TestValidationErrorHelpers pins the error-contract helpers other packages
+// switch on when mapping ledger failures to HTTP responses.
+func TestValidationErrorHelpers(t *testing.T) {
+	ve := &ValidationError{Field: "credits", Message: "credits must be greater than zero"}
+	if ve.Error() != "credits must be greater than zero" {
+		t.Fatalf("Error() = %q", ve.Error())
+	}
+
+	var target *ValidationError
+	if !AsValidationError(fmt.Errorf("wrapped: %w", ve), &target) {
+		t.Fatal("AsValidationError must unwrap wrapped validation errors")
+	}
+	if target.Field != "credits" {
+		t.Fatalf("decoded wrong error: %+v", target)
+	}
+	if AsValidationError(errors.New("other"), &target) {
+		t.Fatal("non-validation error must not match")
+	}
+}
+
+// TestListEntriesServiceWrapper_Live covers the legacy ListEntries surface
+// against real rows, including its default limit of 20.
+func TestListEntriesServiceWrapper_Live(t *testing.T) {
+	pool := newLedgerTestPool(t)
+	accountID := seedLedgerAccount(t, pool)
+	ctx := context.Background()
+	svc := NewService(NewPgxRepository(pool))
+
+	for i := 0; i < 3; i++ {
+		if _, err := svc.GrantCredits(ctx, accountID, uuid.NewString(), int64(10+i), nil); err != nil {
+			t.Fatalf("grant %d: %v", i, err)
+		}
+	}
+
+	entries, err := svc.ListEntries(ctx, accountID, 0)
+	if err != nil {
+		t.Fatalf("list entries: %v", err)
+	}
+	if len(entries) != 3 {
+		t.Fatalf("got %d entries, want all 3", len(entries))
+	}
+
+	entries, err = svc.ListEntries(ctx, accountID, -1)
+	if err != nil {
+		t.Fatalf("list entries negative limit: %v", err)
+	}
+	if len(entries) != 3 {
+		t.Fatalf("negative limit must fall back to the default page size, got %d", len(entries))
+	}
+}

--- a/apps/control-plane/internal/ledger/service.go
+++ b/apps/control-plane/internal/ledger/service.go
@@ -133,18 +133,30 @@ func (s *Service) AdjustCredits(ctx context.Context, accountID uuid.UUID, idempo
 }
 
 func (s *Service) ReserveCredits(ctx context.Context, accountID uuid.UUID, requestID string, attemptID, reservationID *uuid.UUID, idempotencyKey string, credits int64, metadata map[string]any) (LedgerEntry, error) {
+	if credits <= 0 {
+		return LedgerEntry{}, &ValidationError{Field: "credits", Message: "credits must be greater than zero"}
+	}
 	return s.postUsageEntry(ctx, accountID, EntryTypeReservationHold, requestID, attemptID, reservationID, idempotencyKey, -credits, metadata)
 }
 
 func (s *Service) ReleaseReservedCredits(ctx context.Context, accountID uuid.UUID, requestID string, attemptID, reservationID *uuid.UUID, idempotencyKey string, credits int64, metadata map[string]any) (LedgerEntry, error) {
+	if credits <= 0 {
+		return LedgerEntry{}, &ValidationError{Field: "credits", Message: "credits must be greater than zero"}
+	}
 	return s.postUsageEntry(ctx, accountID, EntryTypeReservationRelease, requestID, attemptID, reservationID, idempotencyKey, credits, metadata)
 }
 
 func (s *Service) ChargeUsage(ctx context.Context, accountID uuid.UUID, requestID string, attemptID, reservationID *uuid.UUID, idempotencyKey string, credits int64, metadata map[string]any) (LedgerEntry, error) {
+	if credits <= 0 {
+		return LedgerEntry{}, &ValidationError{Field: "credits", Message: "credits must be greater than zero"}
+	}
 	return s.postUsageEntry(ctx, accountID, EntryTypeUsageCharge, requestID, attemptID, reservationID, idempotencyKey, -credits, metadata)
 }
 
 func (s *Service) RefundCredits(ctx context.Context, accountID uuid.UUID, requestID string, attemptID, reservationID *uuid.UUID, idempotencyKey string, credits int64, metadata map[string]any) (LedgerEntry, error) {
+	if credits <= 0 {
+		return LedgerEntry{}, &ValidationError{Field: "credits", Message: "credits must be greater than zero"}
+	}
 	return s.postUsageEntry(ctx, accountID, EntryTypeRefund, requestID, attemptID, reservationID, idempotencyKey, credits, metadata)
 }
 

--- a/apps/control-plane/internal/ledger/service_test.go
+++ b/apps/control-plane/internal/ledger/service_test.go
@@ -18,6 +18,8 @@ type stubRepo struct {
 	entries           map[uuid.UUID][]LedgerEntry
 	emailAccounts     map[string]uuid.UUID
 	usageSince        int64
+	invoices          []InvoiceRow
+	invoiceErr        error
 	lastListLimit     int
 	lastListRequestID string
 	postErr           error
@@ -139,10 +141,24 @@ func (s *stubRepo) ListEntriesWithCursor(_ context.Context, filter ListEntriesFi
 }
 
 func (s *stubRepo) ListInvoices(_ context.Context, _ uuid.UUID) ([]InvoiceRow, error) {
-	return nil, nil
+	if s.invoiceErr != nil {
+		return nil, s.invoiceErr
+	}
+	out := make([]InvoiceRow, len(s.invoices))
+	copy(out, s.invoices)
+	return out, nil
 }
 
-func (s *stubRepo) GetInvoice(_ context.Context, _ uuid.UUID, _ uuid.UUID) (*InvoiceRow, error) {
+func (s *stubRepo) GetInvoice(_ context.Context, accountID, invoiceID uuid.UUID) (*InvoiceRow, error) {
+	if s.invoiceErr != nil {
+		return nil, s.invoiceErr
+	}
+	for i := range s.invoices {
+		if s.invoices[i].ID == invoiceID && s.invoices[i].AccountID == accountID {
+			cp := s.invoices[i]
+			return &cp, nil
+		}
+	}
 	return nil, ErrNotFound
 }
 


### PR DESCRIPTION
## Summary

Behavioral test suites for the two money modules, encoding stated invariants (D-031..D-034) instead of call coverage.

## Coverage

| package | before (origin/main) | after | measured |
|---|---|---|---|
| control-plane/internal/ledger | 29.5% | **83.4%** | `HIVE_TEST_DB_URL` set, `go test -cover` |
| control-plane/internal/budgets | 30.0% | **80.0%** | same |
| ledger without live DB | 29.5% | 45.2% | skip mode |
| budgets without live DB | 30.0% | 64.7% | skip mode |

Baseline on pristine origin/main re-measured during this work: 47.4% / 30.0% with the DB leg enabled (the existing #918 and #1063 live suites account for the ledger delta).

## Invariants encoded

Ledger:
- Replay of a used idempotency key returns the ORIGINAL entry and writes exactly one row.
- A capture consumes its own hold exactly once: charge settles posted credits, full release clears reserved, and replaying terminal entries under the same keys moves nothing (D-034 terminal exactly once).
- Zero and negative amounts are refused before any row is written on every posting surface.
- Reserved is per reservation; usage window counts only charges at or after the cutoff; foreign invoice UUID answers ErrNotFound.

Budgets:
- Re-raising a threshold re-arms a dismissed alert.
- Balance exactly at the threshold is a breach; strictly above is not.
- A failed notification never stamps as sent, for both the legacy evaluator and the spend-alert cron, so the next pass retries (fail-closed dispatch).
- Alert mutation is tenant-isolated at the data layer: a foreign workspace cannot update or delete an alert even with its UUID.
- Spend aggregation excludes pre-period charges and clamps corrupted positive-delta usage rows so reported spend can never be negative.
- Cron stamp failure retries next pass; one broken workspace never blocks another's alerts.
- Internal hard-cap endpoint renders big.Int as a string and null when unset.

## Production change

One guard: `ReserveCredits`, `ReleaseReservedCredits`, `ChargeUsage` and `RefundCredits` now refuse `credits <= 0`. Previously only zero was checked after sign application, so a negative argument inverted sign into the ledger and could mint reserved credit from nothing. All production callers pass positive values. Found while encoding the fail-closed input invariant as a test.

## Test plan

- [x] `go test ./internal/ledger/... ./internal/budgets/... -count=1 -cover` green in both modes
- [x] Full `go test ./apps/control-plane/...` green except pre-existing auditverifier and marketplace failures that reproduce on pristine origin/main against this shared scratch database (leftover rows from concurrent sessions); CI runs a fresh ephemeral database per run
- [x] go vet clean, gofmt clean on touched files

Buglog entry

```json
{"ts":"2026-08-25","error_message":"negative credits passed ReserveCredits/ChargeUsage validation and inverted sign into credit_ledger_entries","root_cause":"postUsageEntry checked only creditsDelta == 0 after sign application, so a negative credits argument produced a positive hold or release entry","fix":"explicit credits <= 0 refusal added to all four usage posting wrappers before postUsageEntry","tags":["money","validation","ledger","fail-closed"]}
```

Reviews: CodeRabbit CLI plus plain adversarial pass to follow; database-reviewer SKIPPED (no schema touched).