### PR TITLE
fix: make Next.js SWC binary installs deterministic and loud in console image builds

### DIFF
--- a/deploy/docker/Dockerfile.agent-console
+++ b/deploy/docker/Dockerfile.agent-console
@@ -13,7 +13,21 @@ FROM node:24-slim
 WORKDIR /app/apps/agent-console
 
 COPY apps/agent-console/package.json apps/agent-console/package-lock.json* ./
-RUN npm install
+# Same guard as Dockerfile.web-console.prod: npm treats a failed install of an
+# optional dependency as nonfatal and logs it only at verbose level, so one
+# transient network blip while fetching the @next/swc-linux-x64-gnu tarball
+# silently yields a node_modules without the binary and `next build` falls
+# back to a runtime downloader that crashes without pnpm. Install
+# deterministically from the lockfile with retries and fail loudly if the
+# binary is still missing.
+RUN set -eux; \
+    swc=node_modules/@next/swc-linux-x64-gnu/next-swc.linux-x64-gnu.node; \
+    for attempt in 1 2 3; do \
+        if npm ci --include=optional && test -f "$swc"; then break; fi; \
+        echo "install attempt $attempt produced no Next.js SWC binary, retrying"; \
+        sleep 10; \
+    done; \
+    test -f "$swc"
 
 COPY apps/agent-console/ ./
 

--- a/deploy/docker/Dockerfile.web-console
+++ b/deploy/docker/Dockerfile.web-console
@@ -8,7 +8,23 @@ FROM node:24-slim
 WORKDIR /app/apps/web-console
 
 COPY apps/web-console/package.json apps/web-console/package-lock.json* ./
-RUN npm install
+# npm treats a failure to install an optional dependency as nonfatal and logs
+# it only at verbose level (arborist reify.js), so one transient network blip
+# while fetching the 137 MB @next/swc-linux-x64-gnu tarball silently yields a
+# node_modules without the binary. `next build` and `next dev` then fall back
+# to the runtime swc downloader, which probes `pnpm config get registry` first
+# and dies with an unhandledRejection because pnpm does not exist in this
+# image. Install deterministically from the lockfile, retry on failure, and
+# fail the layer loudly if the binary is still missing instead of deferring
+# the crash to the first compile.
+RUN set -eux; \
+    swc=node_modules/@next/swc-linux-x64-gnu/next-swc.linux-x64-gnu.node; \
+    for attempt in 1 2 3; do \
+        if npm ci --include=optional && test -f "$swc"; then break; fi; \
+        echo "install attempt $attempt produced no Next.js SWC binary, retrying"; \
+        sleep 10; \
+    done; \
+    test -f "$swc"
 
 COPY apps/web-console/ ./
 

--- a/deploy/docker/Dockerfile.web-console.prod
+++ b/deploy/docker/Dockerfile.web-console.prod
@@ -17,7 +17,23 @@ FROM node:24-slim
 WORKDIR /app/apps/web-console
 
 COPY apps/web-console/package.json apps/web-console/package-lock.json* ./
-RUN npm install
+# npm treats a failure to install an optional dependency as nonfatal and logs
+# it only at verbose level (arborist reify.js), so one transient network blip
+# while fetching the 137 MB @next/swc-linux-x64-gnu tarball silently yields a
+# node_modules without the binary. `next build` then falls back to its runtime
+# swc downloader, which probes `pnpm config get registry` first and dies with
+# an unhandledRejection because pnpm does not exist in this image. Install
+# deterministically from the lockfile, retry on failure, and fail the layer
+# loudly if the binary is still missing instead of deferring the crash to
+# `npm run build`.
+RUN set -eux; \
+    swc=node_modules/@next/swc-linux-x64-gnu/next-swc.linux-x64-gnu.node; \
+    for attempt in 1 2 3; do \
+        if npm ci --include=optional && test -f "$swc"; then break; fi; \
+        echo "install attempt $attempt produced no Next.js SWC binary, retrying"; \
+        sleep 10; \
+    done; \
+    test -f "$swc"
 
 COPY apps/web-console/ ./
 


### PR DESCRIPTION
## Summary

Deploy of main is broken at the `web-console-prod` image build. This makes the SWC binary install deterministic and turns any future silent skip into a loud, retryable failure.

Fixes the deploy failure in run 32812392124 (job "Pull + recreate stack on the demo box", step "Rebuild + recreate changed services").

## Root cause

Three stacked facts, each verified:

1. **npm silently drops failed optional dependencies.** `@next/swc-linux-x64-gnu` is an optional dependency of `next`. npm's Arborist treats a failure to reify an optional node as nonfatal and logs it only at verbose level (`arborist/lib/arborist/reify.js`, "failed optional dependency" goes to the trash list). A transient failure fetching that 137 MB tarball therefore leaves no warning in normal output.
2. **The demo box hit exactly that.** The box's build log shows a clean `added 587 packages in 2m` with only allow-scripts and deprecation warnings. An identical fresh `npm install` run locally (same lockfile, same base image digest `sha256:ccd06121...`, same npm 11.17.0) installs **588** packages and includes `node_modules/@next/swc-linux-x64-gnu/next-swc.linux-x64-gnu.node`. The delta is exactly one package: the platform binary. The trigger was almost certainly a transient fetch failure under the parallel multi-service compose build; npm discards the error by design, so it cannot be recovered from the log after the fact.
3. **Next.js fell back to its runtime downloader, which crashed on missing pnpm.** With no binary present, `next build` printed `Downloading swc package @next/swc-linux-x64-gnu...`, probed `pnpm config get registry`, and died with `unhandledRejection [Error: Failed to get registry from "pnpm".]` because pnpm does not exist in `node:24-slim`.

The earlier green builds were luck of the cache: the old `RUN npm install` layer predating PR #811's package.json change was still cached on the box. First cache bust exposed the flakiness that was always there.

Not the cause, checked and ruled out: lockfile is fully in sync with package.json (all 28 declared deps present), the lockfile contains the correct optional entry with os/cpu/libc fields, no `.npmrc` overrides exist, and the box's older `node:24-slim` digest behaves identically when tested directly.

## Fix

All three console Dockerfiles (`Dockerfile.web-console.prod`, dev-mode `Dockerfile.web-console`, `Dockerfile.agent-console`, same landmine in all three) replace bare `RUN npm install` with:

* `npm ci --include=optional`: deterministic install from the committed lockfile.
* A three attempt retry loop whose success condition includes `test -f node_modules/@next/swc-linux-x64-gnu/next-swc.linux-x64-gnu.node`, so a silently skipped binary triggers a reinstall instead of deferring the crash.
* A final `test -f` assert after the loop, failing the layer loudly if three attempts all fail.

pnpm is deliberately not installed anywhere; with the binary guaranteed present, the runtime downloader never runs.

agent-console is included beyond the ticketed file because it ships the identical pattern and builds in the same deploy job; leaving it would re-break the same workflow on its next cache bust.

## Verification

All commands run against this branch, Docker, from `deploy/docker`:

1. `docker compose build web-console-prod`: exit 0, image built, zero retries needed (first attempt clean).
2. `cd deploy/docker && docker compose run --build web-console npm run build`: exit 0, full route table printed (this is the exact CI required-check command for the dev image).
3. `docker compose build agent-console`: exit 0, image built.
4. Guard script validated standalone inside both the current `node:24-slim` digest and the box's exact digest `sha256:ccd0612136f105d59d7266585b0bff88016e3da94c8ebfc8ad1154b529f59e7b`: `npm ci` succeeds, binary asserted, exit 0.

TDD note: a regression test for a Dockerfile install layer is not meaningful here; verification is the successful image build plus the in-layer assertion itself, which now fails loudly instead of crashing later inside `next build` with a misleading pnpm error.

## Buglog entry

```json
{"id":"bug-mt0swc01-9d41e2","timestamp":"2026-08-25T00:00:00.000Z","related_bugs":[],"occurrences":1,"last_seen":"2026-08-25T05:24:24.170Z","title":"Deploy image build silently lost @next/swc-linux-x64-gnu then crashed on missing pnpm","error_message":"/bin/sh: 1: pnpm: not found + unhandledRejection [Error: Failed to get registry from \"pnpm\".] during RUN npm run build in Dockerfile.web-console.prod, deploy-demo-box run 32812392124 job Pull + recreate stack on the demo box","root_cause":"npm treats a failed install of an optional dependency as nonfatal and logs it only at verbose level (arborist reify.js trash-list path), so one transient fetch failure of the 137MB @next/swc-linux-x64-gnu tarball during the box's parallel multi-service compose build yielded a clean looking added-587-packages tree with no binary (healthy install = 588 packages plus swc-linux-x64-gnu). next build then fell back to its runtime swc downloader which probes pnpm config get registry first and crashed with unhandledRejection because pnpm is absent from node:24-slim. Cache luck had hidden this since PR #811 changed package.json.","fix":"Dockerfile.web-console.prod, dev Dockerfile.web-console and Dockerfile.agent-console now run npm ci --include=optional in a three-attempt retry loop whose success condition asserts node_modules/@next/swc-linux-x64-gnu/next-swc.linux-x64-gnu.node exists, with a final loud assert after the loop. Verified: prod target builds green end to end, CI sanity command docker compose run --build web-console npm run build passes, agent-console builds, guard validated on both current and box-exact node:24-slim digests.","tags":["docker","nextjs","swc","npm-optional-deps","silent-failure","deploy-demo-box"]}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved console container builds by using deterministic dependency installation with automatic retries.
  * Added an early check for the required Next.js native compiler binary, helping builds fail clearly instead of during compilation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->