### PR TITLE
fix: stop the browser CI jobs from reading secrets a Dependabot run never gets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1802,7 +1802,12 @@ jobs:
       CONTROL_PLANE_PORT: '8081'
       CONTROL_PLANE_BASE_URL: http://localhost:8081
       EDGE_CONTROL_PLANE_BASE_URL: http://control-plane:8081
-      LITELLM_MASTER_KEY: ${{ secrets.LITELLM_MASTER_KEY }}
+      # LITELLM_MASTER_KEY is deliberately absent, and its absence is not a
+      # gap. docker-compose.yml defaults it to litellm-dev-key for the litellm
+      # container and for both Go services, so all three agree on a throwaway
+      # value and this job never handles the production one. Naming the secret
+      # is also half of what made a Dependabot-triggered run behave differently
+      # from every other run: see the S3 block below.
       # Live provider keys are NOT supplied to web-e2e. The Playwright
       # specs run here (unauth, auth-shell, profile-completion) exercise
       # only the UI layer and Supabase auth flows; they make no LLM
@@ -1821,13 +1826,38 @@ jobs:
       GROQ_FAST_MODEL: ${{ vars.GROQ_FAST_MODEL }}
       GROQ_REASONING_MODEL: ${{ vars.GROQ_REASONING_MODEL }}
       NVIDIA_NIM_EMBEDDING_MODEL: ${{ vars.NVIDIA_NIM_EMBEDDING_MODEL }}
-      S3_ENDPOINT: ${{ secrets.S3_ENDPOINT }}
-      S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}
-      S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}
-      S3_REGION: ${{ secrets.S3_REGION }}
-      S3_USE_SSL: 'true'
-      S3_BUCKET_FILES: ${{ secrets.S3_BUCKET_FILES }}
-      S3_BUCKET_IMAGES: ${{ secrets.S3_BUCKET_IMAGES }}
+      # The object store is stubbed here, not supplied, for the same reason
+      # the provider keys above are: no spec in the chromium project uploads
+      # or downloads an object. control-plane and edge-api only require these
+      # names to be non-empty at boot (loadStorageConfigFromEnv in
+      # apps/control-plane/cmd/server/main.go, NewS3Client in
+      # packages/storage/s3.go), and neither dials anything at startup, so a
+      # stub boots the stack. Port 9 is discard: a spec that starts touching
+      # storage gets connection refused and fails loudly, instead of quietly
+      # reading and writing the live Supabase bucket the way this job did
+      # while these were secrets.
+      #
+      # THIS IS WHAT WEDGED THE DEPENDENCY QUEUE. A workflow run triggered by
+      # Dependabot is handed the Dependabot secret store, not the Actions one,
+      # so every `secrets.S3_*` above resolved to the empty string, and
+      # control-plane exited at boot with `storage unavailable: missing
+      # S3_ENDPOINT, S3_ACCESS_KEY, S3_SECRET_KEY, S3_REGION`. The stack never
+      # came up, this required check failed on ten open dependency pull
+      # requests at once (#1013, #1015, #1016, #1018, #1036, #1037, #1039,
+      # #1132, #1134, #1140), and not one of them could have caused it. The
+      # fix is not to copy the secrets into the Dependabot store: this job
+      # boots its own Postgres, GoTrue, PostgREST, Redis and LiteLLM, and a
+      # job that stands up everything it needs should need no credential at
+      # all. It now needs none, and the unit test
+      # `apps/web-console/tests/unit/ci-web-e2e-secret-free.test.ts` fails the
+      # next pull request that puts one back. See issues #820 and #821.
+      S3_ENDPOINT: 'http://127.0.0.1:9'
+      S3_ACCESS_KEY: 'ci-stub-not-used'
+      S3_SECRET_KEY: 'ci-stub-not-used'
+      S3_REGION: 'us-east-1'
+      S3_USE_SSL: 'false'
+      S3_BUCKET_FILES: 'ci-stub-files'
+      S3_BUCKET_IMAGES: 'ci-stub-images'
       NEXT_PUBLIC_APP_URL: http://localhost:3000
       # HIVE_API_KEY is gone with the shared project. It only ever fed
       # openai-sdk.spec.ts, which skips on `!HIVE_API_KEY || !EDGE_BASE_URL`
@@ -2051,21 +2081,41 @@ jobs:
           done
           echo "::error::Next.js did not start"; cat /tmp/nextjs.log; exit 1
 
-      - name: Generate the fixture invitation token
-        # Random per job, and masked, because the seeder stores its sha256 as a
-        # live pending invitation. A value anybody can derive from the public
-        # run page is a published credential for as long as the run lasts.
+      - name: Generate the fixture credentials
+        # Random per job, and masked, because the seeder stores the token's
+        # sha256 as a live pending invitation. A value anybody can derive from
+        # the public run page is a published credential for as long as the run
+        # lasts.
         #
         # 24 bytes gives 48 hex characters. The floor it has to clear is
         # minTokenLength in tests/e2e/support/e2e-auth-defaults.json, which
         # requiredSecretEnv enforces at 16, so do not shorten this below that
         # without moving both: the failure would otherwise surface far from
         # here, naming a variable this step does not mention.
+        #
+        # The two fixture passwords are generated the same way, and used to be
+        # repository secrets. Generating them is strictly stronger than reading
+        # them: the accounts they belong to are created by this run's own
+        # seeder, in a throwaway GoTrue that is destroyed with the job, at
+        # addresses already namespaced by run id and attempt, so a value shared
+        # across runs bought nothing. It cost something, though. A run
+        # triggered by Dependabot never receives an Actions secret, so both
+        # passwords arrived empty and requiredSecretEnv threw by name; that was
+        # the second wall behind the S3 one documented in this job's env block.
+        # This does not weaken the rule these secrets were introduced to
+        # enforce, which is that no credential has a committed default: nothing
+        # is committed here either, and a caller that neither sets nor
+        # generates one still fails by name.
         run: |
           set -euo pipefail
           token="$(openssl rand -hex 24)"
           echo "::add-mask::$token"
           echo "E2E_INVITATION_TOKEN=$token" >> "$GITHUB_ENV"
+          for var in E2E_VERIFIED_PASSWORD E2E_UNVERIFIED_PASSWORD; do
+            secret="$(openssl rand -hex 24)"
+            echo "::add-mask::$secret"
+            echo "$var=$secret" >> "$GITHUB_ENV"
+          done
 
       - name: Run UI Playwright suite (unauth + credentialed)
         working-directory: apps/web-console
@@ -2098,19 +2148,22 @@ jobs:
           # reassign rows out from under this job's own reads mid-test.
           # github.run_attempt makes a manual re-run of a flake get a fresh
           # identity too, not the one the previous attempt already consumed.
-          # The passwords come from secrets and have no fallback. They used to
-          # fall back to plaintext values committed in
+          # The passwords are generated per run by the step above and have no
+          # fallback. They used to fall back to plaintext values committed in
           # e2e-auth-defaults.json, in a public repository, for live accounts
           # holding a tenant OWNER role; the seeder then wrote those values
-          # back onto the accounts. The fallback is gone and an unset secret
-          # now fails this job by name. They need not be unique per run:
-          # nothing looks a user up by password, and the addresses above are
-          # already run-scoped.
+          # back onto the accounts. That fallback is gone and is not coming
+          # back. They were then repository secrets, which failed by name when
+          # unset, and which a Dependabot-triggered run never receives at all.
+          # Generating them removes the last reason this job needs a secret,
+          # and costs nothing: nothing looks a user up by password, the
+          # addresses above are already run-scoped, and the GoTrue holding
+          # these accounts is torn down with the job.
           E2E_RUN_KEY: ${{ github.run_id }}-${{ github.run_attempt }}
           E2E_VERIFIED_EMAIL: e2e-verified+${{ github.run_id }}-${{ github.run_attempt }}@scubed.com.bd
-          E2E_VERIFIED_PASSWORD: ${{ secrets.E2E_VERIFIED_PASSWORD }}
+          E2E_VERIFIED_PASSWORD: ${{ env.E2E_VERIFIED_PASSWORD }}
           E2E_UNVERIFIED_EMAIL: e2e-unverified+${{ github.run_id }}-${{ github.run_attempt }}@scubed.com.bd
-          E2E_UNVERIFIED_PASSWORD: ${{ secrets.E2E_UNVERIFIED_PASSWORD }}
+          E2E_UNVERIFIED_PASSWORD: ${{ env.E2E_UNVERIFIED_PASSWORD }}
           # Generated in the step above, not derived here. It used to be a
           # committed literal concatenated with the run id and attempt, both
           # of which are public on the run page, and e2e-fixture-seed.mjs
@@ -2134,7 +2187,7 @@ jobs:
           # fail: a silent hole inside a green check. Pointing it at the
           # fixture user means the spec now always runs.
           E2E_WORKSPACE_OWNER_EMAIL: e2e-verified+${{ github.run_id }}-${{ github.run_attempt }}@scubed.com.bd
-          E2E_WORKSPACE_OWNER_PASSWORD: ${{ secrets.E2E_VERIFIED_PASSWORD }}
+          E2E_WORKSPACE_OWNER_PASSWORD: ${{ env.E2E_VERIFIED_PASSWORD }}
         # Selects by PROJECT, never by file path (issue #813). The
         # `chromium` project's testDir is apps/web-console/tests/e2e, so a
         # spec added to that directory runs here the day it lands with no
@@ -2312,7 +2365,10 @@ jobs:
       CONTROL_PLANE_PORT: '8081'
       CONTROL_PLANE_BASE_URL: http://localhost:8081
       EDGE_CONTROL_PLANE_BASE_URL: http://control-plane:8081
-      LITELLM_MASTER_KEY: ${{ secrets.LITELLM_MASTER_KEY }}
+      # LITELLM_MASTER_KEY is deliberately absent, for the reason Web E2E
+      # states at its own env block: compose defaults it to litellm-dev-key for
+      # every service that reads it, and naming the secret made a
+      # Dependabot-triggered run differ from every other run.
       # The gate drives the UI only. It never asks for a completion, so
       # stub provider keys satisfy LiteLLM startup without exposing paid
       # credentials to a job that has no use for them.
@@ -2327,13 +2383,20 @@ jobs:
       GROQ_FAST_MODEL: ${{ vars.GROQ_FAST_MODEL }}
       GROQ_REASONING_MODEL: ${{ vars.GROQ_REASONING_MODEL }}
       NVIDIA_NIM_EMBEDDING_MODEL: ${{ vars.NVIDIA_NIM_EMBEDDING_MODEL }}
-      S3_ENDPOINT: ${{ secrets.S3_ENDPOINT }}
-      S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}
-      S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}
-      S3_REGION: ${{ secrets.S3_REGION }}
-      S3_USE_SSL: 'true'
-      S3_BUCKET_FILES: ${{ secrets.S3_BUCKET_FILES }}
-      S3_BUCKET_IMAGES: ${{ secrets.S3_BUCKET_IMAGES }}
+      # Stubbed, not supplied, for the reason Web E2E documents in full at its
+      # own env block: the gate touches no object, the two Go services only
+      # require these names to be non-empty at boot, and a Dependabot-triggered
+      # run receives no Actions secret, so as secrets these resolved empty and
+      # control-plane exited at boot with `storage unavailable`. Port 9 is
+      # discard, so a spec that starts touching storage fails loudly rather
+      # than reaching the live bucket.
+      S3_ENDPOINT: 'http://127.0.0.1:9'
+      S3_ACCESS_KEY: 'ci-stub-not-used'
+      S3_SECRET_KEY: 'ci-stub-not-used'
+      S3_REGION: 'us-east-1'
+      S3_USE_SSL: 'false'
+      S3_BUCKET_FILES: 'ci-stub-files'
+      S3_BUCKET_IMAGES: 'ci-stub-images'
       NEXT_PUBLIC_APP_URL: http://localhost:3000
     steps:
       - uses: actions/checkout@v7
@@ -2548,6 +2611,16 @@ jobs:
           token="$(openssl rand -hex 24)"
           echo "::add-mask::$token"
           echo "E2E_INVITATION_TOKEN=$token" >> "$GITHUB_ENV"
+          # The two fixture passwords are generated here for the reason Web
+          # E2E states at its own generation step: the accounts are created by
+          # this run's seeder in a throwaway GoTrue at run-scoped addresses, so
+          # a value shared across runs bought nothing, and as a repository
+          # secret it arrived empty on every Dependabot-triggered run.
+          for var in E2E_VERIFIED_PASSWORD E2E_UNVERIFIED_PASSWORD; do
+            secret="$(openssl rand -hex 24)"
+            echo "::add-mask::$secret"
+            echo "$var=$secret" >> "$GITHUB_ENV"
+          done
 
       - name: Seed the fixture identity the gate signs in as
         working-directory: apps/web-console
@@ -2559,9 +2632,9 @@ jobs:
           # exactly that failure in run 32266955684.
           E2E_RUN_KEY: ${{ env.INTERACTION_RUN_KEY }}
           E2E_VERIFIED_EMAIL: ${{ env.INTERACTION_FIXTURE_EMAIL }}
-          E2E_VERIFIED_PASSWORD: ${{ secrets.E2E_VERIFIED_PASSWORD }}
+          E2E_VERIFIED_PASSWORD: ${{ env.E2E_VERIFIED_PASSWORD }}
           E2E_UNVERIFIED_EMAIL: ${{ env.INTERACTION_FIXTURE_EMAIL_UNVERIFIED }}
-          E2E_UNVERIFIED_PASSWORD: ${{ secrets.E2E_UNVERIFIED_PASSWORD }}
+          E2E_UNVERIFIED_PASSWORD: ${{ env.E2E_UNVERIFIED_PASSWORD }}
           E2E_INVITATION_TOKEN: ${{ env.E2E_INVITATION_TOKEN }}
           # Prints the summary of what it actually seeded, which the next line
           # checks. Without it the seeder is silent on success, and a run that

--- a/apps/web-console/tests/unit/ci-web-e2e-secret-free.test.ts
+++ b/apps/web-console/tests/unit/ci-web-e2e-secret-free.test.ts
@@ -1,0 +1,129 @@
+/**
+ * ci-web-e2e-secret-free.test.ts
+ *
+ * The two browser jobs in ci.yml that stand up their own full stack must
+ * reference no repository secret at all.
+ *
+ * The bug this guards: a workflow run triggered by Dependabot is handed the
+ * Dependabot secret store, never the Actions one, so every `secrets.*`
+ * expression in it resolves to the empty string with no warning anywhere. On
+ * 2026-08-25 `Web E2E (full stack)`, a required context on main, was failing
+ * on ten open dependency pull requests at once for exactly that reason:
+ * `S3_ENDPOINT` and its four siblings arrived empty, control-plane exited at
+ * boot with `storage unavailable: missing S3_ENDPOINT, S3_ACCESS_KEY,
+ * S3_SECRET_KEY, S3_REGION`, the compose stack never came up, and the whole
+ * dependency-update queue sat blocked behind a check none of those pull
+ * requests could have broken. Behind it stood a second wall: the two fixture
+ * passwords were secrets too, and would have thrown by name a few steps later.
+ *
+ * Both jobs boot their own Postgres, GoTrue, PostgREST, Redis and LiteLLM, so
+ * neither has any business holding a credential. Reading a secret into either
+ * one is what makes a Dependabot run behave differently from every other run,
+ * and the difference shows up as a stack that will not start rather than as
+ * anything naming the actual cause. Asserting the absence is cheap, runs in
+ * the required unit check with no network, and fails at review time on the
+ * pull request that adds the secret.
+ *
+ * A job that genuinely needs live credentials (`live-integration`, the
+ * deploy jobs) is not covered here and should not be: those already skip
+ * themselves rather than run degraded.
+ *
+ * See issues #820 and #821.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(HERE, "../../../..");
+const WORKFLOW = resolve(REPO_ROOT, ".github/workflows/ci.yml");
+
+// The display names, not the YAML keys: the display name is what branch
+// protection lists as a required context, so it is the stable handle.
+const SECRET_FREE_JOBS = [
+  "Web E2E (full stack)",
+  "Interaction coverage (console controls)",
+];
+
+/**
+ * Slices ci.yml into top-level job blocks without a YAML parser, which keeps
+ * this test free of a dependency and, more usefully, keeps it reading the same
+ * bytes a reviewer reads. A job starts at a two-space-indented key and runs
+ * until the next one.
+ */
+function jobBlocks(source: string): Map<string, string[]> {
+  const lines = source.split("\n");
+  const blocks = new Map<string, string[]>();
+  let current: string[] | null = null;
+  let inJobs = false;
+
+  for (const line of lines) {
+    if (/^jobs:\s*$/.test(line)) {
+      inJobs = true;
+      continue;
+    }
+    if (!inJobs) continue;
+    // A key back at column zero ends the jobs mapping.
+    if (/^\S/.test(line)) break;
+
+    const jobKey = /^ {2}([A-Za-z0-9_-]+):\s*$/.exec(line);
+    if (jobKey) {
+      current = [];
+      blocks.set(jobKey[1], current);
+      continue;
+    }
+    current?.push(line);
+  }
+  return blocks;
+}
+
+function blockForDisplayName(
+  blocks: Map<string, string[]>,
+  displayName: string
+): { key: string; lines: string[] } {
+  for (const [key, lines] of blocks) {
+    if (lines.some((l) => l.trim() === `name: ${displayName}`)) {
+      return { key, lines };
+    }
+  }
+  throw new Error(
+    `no job in .github/workflows/ci.yml declares \`name: ${displayName}\`. ` +
+      "If the job was renamed, rename it here too; if it was deleted, it was " +
+      "a required context and its deletion needs saying out loud."
+  );
+}
+
+describe("ci.yml browser jobs are secret-free", () => {
+  const source = readFileSync(WORKFLOW, "utf8");
+  const blocks = jobBlocks(source);
+
+  it("finds the jobs it is asserting about", () => {
+    expect(blocks.size).toBeGreaterThan(5);
+  });
+
+  for (const displayName of SECRET_FREE_JOBS) {
+    it(`${displayName} reads no repository secret`, () => {
+      const { key, lines } = blockForDisplayName(blocks, displayName);
+      const offenders = lines
+        .map((line, index) => ({ line, index }))
+        .filter(({ line }) => /\bsecrets\./.test(line) && !isComment(line))
+        .map(({ line }) => line.trim());
+
+      expect(
+        offenders,
+        `job \`${key}\` (${displayName}) reads ${offenders.length} ` +
+          "repository secret(s). A Dependabot-triggered run receives none of " +
+          "them and gets the empty string instead, which boots a broken " +
+          "stack rather than failing by name. This job stands up everything " +
+          "it needs; stub the value or generate it in a step, the way the " +
+          "S3 block and the fixture passwords already are."
+      ).toEqual([]);
+    });
+  }
+});
+
+function isComment(line: string): boolean {
+  return line.trim().startsWith("#");
+}


### PR DESCRIPTION
## What was actually wrong

`Web E2E (full stack)` is a required context on `main`. It was failing on ten open dependency pull requests at once (#1013, #1015, #1016, #1018, #1036, #1037, #1039, #1132, #1134, #1140) while passing on `main` and on every human-authored branch. None of those pull requests could have caused it, and none of them is flaky.

Every one of the ten fails at the same step, `Start core stack (no rebuild — images already loaded)`, with the same two lines:

```
 Container hive-control-plane-1  Error
dependency failed to start: container hive-control-plane-1 is unhealthy
##[error]Process completed with exit code 1.
```

The uploaded compose log says why, and it says the same thing in all of them:

```
control-plane-1 | 2026/08/25 02:16:33 storage unavailable: missing S3_ENDPOINT, S3_ACCESS_KEY, S3_SECRET_KEY, S3_REGION
control-plane-1 | 2026/08/25 02:16:33 Process Exit with Code: 1
```

A workflow run triggered by Dependabot is handed the Dependabot secret store, never the Actions one, so every `secrets.*` expression in the job resolves to the empty string with no warning anywhere. The job's own log prints it plainly on a Dependabot run:

```
  S3_ENDPOINT:
  S3_ACCESS_KEY:
  S3_REGION:
```

and on a human-authored run, same job, same lines:

```
  S3_ENDPOINT: ***
  S3_REGION: ***
```

`loadStorageConfigFromEnv` in `apps/control-plane/cmd/server/main.go` requires five of these names to be non-empty at boot, so control-plane exits before it ever opens a port and compose fails the whole stack. Behind that stood a second wall nobody had reached yet: `E2E_VERIFIED_PASSWORD` and `E2E_UNVERIFIED_PASSWORD` were secrets too, so `requiredSecretEnv` would have thrown by name a few steps later.

## Per-pull-request classification

| PR | `Web E2E` state | Category |
|----|-----------------|----------|
| #1013 | fail | (iv) infrastructure — secrets unavailable to a Dependabot run |
| #1015 | fail | (iv) infrastructure |
| #1016 | fail | (iv) infrastructure |
| #1018 | fail | (iv) infrastructure |
| #1036 | fail | (iv) infrastructure |
| #1037 | fail | (iv) infrastructure |
| #1039 | fail | (iv) infrastructure |
| #1132 | fail | (iv) infrastructure |
| #1134 | fail | (iv) infrastructure |
| #1140 | fail | (iv) infrastructure |
| #409 | **skipping** | not affected — its Web E2E never ran, every check on it passes or skips, and it is blocked by being a draft |

Nothing here is (i) flaky, (ii) a stale base, or (iii) a regression caused by a bump. The failure happens before a single browser starts, and it is deterministic: the stack cannot boot on a Dependabot-triggered run, and it always boots on any other run.

## The fix

Both browser jobs already stand up their own Postgres, GoTrue, PostgREST, Redis and LiteLLM. A job that boots everything it needs should hold no credential at all, and now neither does. `web-e2e` and `interaction-coverage` both change, because both carry the identical env block and the second would have hit the identical wall the moment it started running on these pull requests.

- **The object store is stubbed rather than supplied.** No spec in either project uploads or downloads an object, and neither Go service dials anything at startup, so a stub is enough to boot. The endpoint is the discard port, so a spec that starts touching storage gets connection refused and fails loudly, instead of quietly reading and writing the live Supabase bucket, which is what these jobs did on every run where the secrets did resolve.
- **The two fixture passwords are generated per run**, in the step that already generates the invitation token exactly this way. That is stronger than reading them, not weaker: the accounts are created by this run's own seeder, in a throwaway GoTrue that is destroyed with the job, at addresses already namespaced by run id and attempt, so a value shared across runs bought nothing. No committed default comes back, and a caller that neither sets nor generates one still fails by name. Nothing sets, resets or rotates any shared account's password.
- **`LITELLM_MASTER_KEY` is dropped.** `docker-compose.yml` defaults it to `litellm-dev-key` for every service that reads it, which is what a Dependabot run has been using all along and it started LiteLLM fine, and a throwaway LiteLLM has no use for the production key.

Copying the secrets into the Dependabot secret store would also have made these runs go green. It was rejected: it doubles a secret surface for jobs that need no secret, it leaves the live storage bucket wired into pull-request CI, and it fixes nothing for the next contributor whose fork PR arrives with the same empty values.

## Regression guard

`apps/web-console/tests/unit/ci-web-e2e-secret-free.test.ts` reads `ci.yml`, slices out these two jobs by their display names (the names branch protection lists as required contexts), and fails on any `secrets.` reference in either. It runs in the required unit check, with no network and no credentials.

Verified in both directions, not just the green one:

```
 ✓ apps/web-console/tests/unit/ci-web-e2e-secret-free.test.ts (3 tests) 32ms
 Test Files  1 passed (1)
```

and against a copy of this same file with one S3 line reverted to `${{ secrets.S3_REGION }}`:

```
 × Web E2E (full stack) reads no repository secret
 × Interaction coverage (console controls) reads no repository secret
AssertionError: job `web-e2e` (Web E2E (full stack)) reads 1 repository secret(s). ...
 Tests  2 failed | 1 passed (3)
```

`npx tsc --noEmit` is clean.

## What was deliberately not done

No spec was skipped, quarantined, narrowed or retried. No retry count was raised. `Web E2E (full stack)` stays a required context, and the path gate that decides when it runs is untouched. A quiet absence would have been worse than the loud failure.

## Unblocking the ten

Merging this does not by itself re-run anything. Each Dependabot pull request needs a fresh run against a head that includes this change, so once this is on `main`:

```
gh pr comment <n> --body "@dependabot rebase"
```

for #1013, #1015, #1016, #1018, #1036, #1037, #1039, #1132, #1134 and #1140. Rebasing them before this merges would only reproduce the same failure, which is why none of them was touched here. Serially, not all at once: these jobs each boot a full stack.

Refs #820, #821.

## Buglog entry

```json
{"id":"BUG-2026-08-25-web-e2e-dependabot-secrets","date":"2026-08-25","title":"Required Web E2E check failed on every Dependabot PR because Actions secrets are not available to Dependabot-triggered runs","error_message":"storage unavailable: missing S3_ENDPOINT, S3_ACCESS_KEY, S3_SECRET_KEY, S3_REGION / dependency failed to start: container hive-control-plane-1 is unhealthy","root_cause":"The web-e2e and interaction-coverage jobs read S3_*, LITELLM_MASTER_KEY and the two E2E fixture passwords from repository Actions secrets. A workflow run triggered by Dependabot receives the Dependabot secret store instead, so every one of those expressions resolved to the empty string. control-plane's loadStorageConfigFromEnv requires five S3 names to be non-empty at boot and exited immediately, so compose never brought the stack up and the required check failed on ten dependency PRs at once, none of which could have caused it.","fix":"Both jobs now hold no repository secret at all. The object store is stubbed at the discard port (no spec touches an object, and neither Go service dials at startup), the two fixture passwords are generated per run beside the invitation token that already worked that way, and LITELLM_MASTER_KEY is dropped in favour of the compose default both services already share. Guarded by apps/web-console/tests/unit/ci-web-e2e-secret-free.test.ts, which fails on any secrets. reference in either job.","tags":["ci","github-actions","dependabot","secrets","web-e2e","required-checks","docker-compose","control-plane"]}
```
