### PR TITLE
fix: make the demo-box deploy diagnosable and prove what it deployed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -690,6 +690,16 @@ jobs:
       # because it needs nothing but node and must fire on every PR.
       - if: needs.changes.outputs.run != 'false'
         run: npm run lint:sync-child-process
+      # Issues #1084, #1103. deploy-demo-box.yml is the whole of DEMO.md's
+      # promise that a merge to main reaches the box within minutes, and it
+      # broke in ways the run itself could not explain: the only diagnostic
+      # step sat mid-list so six later steps failed blind, `up -d --build`
+      # reported success without anything asserting what the box now serves,
+      # and the smoke test threw away the status codes that would have told a
+      # 503 apart from a dead host. Guarded here because a required check is
+      # the only place a workflow-only change cannot route around.
+      - if: needs.changes.outputs.run != 'false'
+        run: npm run lint:deploy-diagnosability
       # Drive-by, found while checking the wiring above: this lint existed in
       # package.json but no workflow ran it, so it was coverage on paper only.
       # It passes on main today.

--- a/.github/workflows/deploy-demo-box.yml
+++ b/.github/workflows/deploy-demo-box.yml
@@ -911,8 +911,19 @@ jobs:
           # too, which is the stack-wide restart this is avoiding.
           if [ -n "$drift" ]; then
             echo "::warning::compose left these services on an older image than it had just built:${drift}. That is issue #1103: \`up -d --build\` rebuilt the image, did not recreate the container, and exited 0. Recreating them now."
+            # `--wait` is load bearing, not tidiness. Without it `up -d`
+            # returns as soon as the containers are started, and the steps
+            # after this one talk to those services immediately: dispatch run
+            # 32846121196 recreated open-webui here and the very next step
+            # died with "GET /api/v1/functions/id/hive_jwt_forward could not
+            # reach http://127.0.0.1:8080: <urlopen error [Errno 111]
+            # Connection refused>" because the container was still booting.
+            # The recreate is new behaviour, so the race it opens has to be
+            # closed here rather than left for each later step to rediscover.
+            # --wait-timeout keeps a service that never goes healthy from
+            # sitting here until the job's own 30 minute ceiling.
             # shellcheck disable=SC2086
-            "${COMPOSE[@]}" up -d --force-recreate --no-deps $drift
+            "${COMPOSE[@]}" up -d --force-recreate --no-deps --wait --wait-timeout 300 $drift
             scan
             if [ -n "$drift" ]; then
               echo "::error::these services are STILL running an older image than the one this deploy built after an explicit --force-recreate:${drift}. The box is serving code older than this commit and the deploy could not fix it automatically. Investigate on the box before trusting anything this run reported." >&2

--- a/.github/workflows/deploy-demo-box.yml
+++ b/.github/workflows/deploy-demo-box.yml
@@ -795,6 +795,95 @@ jobs:
           set -euo pipefail
           docker compose $HIVE_COMPOSE_FLAGS up -d --build --remove-orphans
 
+      - name: Assert the running containers are on the images just built
+        # Issue #1103: a compose deploy reports success while serving old
+        # images. The step above prints `Image hive-edge-api:ci Built` followed
+        # by `Container hive-edge-api-1 Running`, and that pair is ambiguous by
+        # construction: it is what a fully cached rebuild of an unchanged
+        # service looks like, and it is also what a service compose declined to
+        # recreate looks like. `up -d` exits 0 either way, so nothing
+        # downstream can tell "nothing changed" from "the change did not
+        # land", and the workflow has never asserted which one happened.
+        #
+        # The check is the one comparison that answers it. A container records
+        # the image ID it was created from (.Image) alongside the reference it
+        # was created from (.Config.Image, e.g. `hive-edge-api:ci`). Resolving
+        # that reference NOW gives the ID the tag points at after the build. If
+        # the two disagree, the tag moved and the container did not: the box is
+        # serving code older than the commit this run deployed, which is
+        # precisely the silent false green. Equal IDs prove the container is on
+        # the image this deploy produced, whether or not it was recreated.
+        #
+        # Deliberately not `--force-recreate` on every deploy instead: that
+        # restarts the whole stack including chat and the gateway on every
+        # merge, which is a real outage traded for a check that costs nothing.
+        # Detect the drift, name the service, and let the operator recreate
+        # just that one.
+        #
+        # The ancestry check is the other half of "merged is not deployed".
+        # The box's clone is advanced by `git pull --ff-only origin main` in
+        # the migrate job, so it lands on main's tip, which may be NEWER than
+        # the commit that triggered this run (the concurrency group serializes
+        # runs, so pushes queue behind each other). Newer is fine and is not
+        # failed here. What is not fine is the box's HEAD not containing this
+        # run's commit at all, because then this run reports success over a
+        # deployment that does not include the change it was triggered by.
+        # Guarded on main: a workflow_dispatch from a branch has a github.sha
+        # main does not contain, and that is expected rather than a fault.
+        working-directory: /home/sakib/hive/deploy/docker
+        run: |
+          set -euo pipefail
+          COMPOSE=(docker compose $HIVE_COMPOSE_FLAGS)
+
+          if [ "$GITHUB_REF" = "refs/heads/main" ]; then
+            head=$(git -C /home/sakib/hive rev-parse HEAD)
+            if git -C /home/sakib/hive merge-base --is-ancestor "$GITHUB_SHA" HEAD; then
+              echo "box HEAD $head contains this run's commit $GITHUB_SHA"
+            else
+              echo "::error::the box's checkout at /home/sakib/hive is on $head, which does not contain this run's commit $GITHUB_SHA. Whatever was just built is not this change, so a green result here would be a lie. Check the migrate job's Pull latest main step." >&2
+              exit 1
+            fi
+          fi
+
+          drift=""
+          checked=0
+          for service in $("${COMPOSE[@]}" ps --services); do
+            cid=$("${COMPOSE[@]}" ps -q "$service" 2>/dev/null | head -1)
+            [ -n "$cid" ] || continue
+            running=$(docker inspect -f '{{.Image}}' "$cid")
+            ref=$(docker inspect -f '{{.Config.Image}}' "$cid")
+            # An image reference that no longer resolves means the tag was
+            # pruned out from under a running container. That is not the drift
+            # this step is looking for and must not be reported as it, but it
+            # is worth saying out loud rather than swallowing.
+            tagged=$(docker image inspect -f '{{.Id}}' "$ref" 2>/dev/null || true)
+            if [ -z "$tagged" ]; then
+              echo "note: $service runs $ref, which no longer resolves locally; cannot compare"
+              continue
+            fi
+            checked=$((checked + 1))
+            if [ "$running" = "$tagged" ]; then
+              short=${running#sha256:}
+              echo "ok   $service is on $ref (${short:0:12})"
+            else
+              echo "DRIFT $service runs an image the tag $ref no longer points at"
+              drift="$drift $service"
+            fi
+          done
+
+          # Zero comparable services means the loop found nothing, which would
+          # make this step green without having checked anything at all.
+          if [ "$checked" -eq 0 ]; then
+            echo "::error::no running service could be compared against its image tag, so this check verified nothing. The compose project resolved by HIVE_COMPOSE_FLAGS is probably empty or wrong." >&2
+            exit 1
+          fi
+
+          if [ -n "$drift" ]; then
+            echo "::error::these services are still running an older image than the one this deploy built:${drift}. The deploy did NOT reach them (issue #1103). Recreate them on the box with: cd /home/sakib/hive/deploy/docker && docker compose \$HIVE_COMPOSE_FLAGS up -d --force-recreate${drift}" >&2
+            exit 1
+          fi
+          echo "$checked running services are on the images this deploy built"
+
       - name: Apply the bind-mounted Caddy configs
         # Every Caddyfile in this stack is bind-mounted into its container, so
         # editing the file's CONTENTS changes nothing about the container
@@ -1370,20 +1459,6 @@ jobs:
           done
           exit "$failed"
 
-      - name: Dump container status + logs on failure
-        if: failure()
-        working-directory: /home/sakib/hive/deploy/docker
-        run: |
-          COMPOSE=(docker compose $HIVE_COMPOSE_FLAGS)
-          echo "::group::docker compose ps"
-          "${COMPOSE[@]}" ps || true
-          echo "::endgroup::"
-          for svc in edge-api control-plane agent-console open-webui litellm redis prometheus grafana alertmanager; do
-            echo "::group::logs ($svc)"
-            "${COMPOSE[@]}" logs --tail=200 --no-color "$svc" 2>&1 || true
-            echo "::endgroup::"
-          done
-
       - name: Prune dangling images
         if: always()
         run: docker image prune -f
@@ -1402,20 +1477,75 @@ jobs:
         # deploy/cloudflare/tunnel-ingress.json is now the source of truth for
         # which hostnames are public, and `npm run cloudflare:check` fails on
         # any -hive.scubed.co record with no ingress rule behind it.
+        #
+        # Every attempt records the HTTP status, and the last one records the
+        # body and the same probe against the box's own loopback port, because
+        # `api=0` on its own is not a diagnosis. Run 32842676794 (2026-08-25)
+        # failed here twelve times with `api=0, control-plane=1, chat=1` and
+        # left no way to tell three very different faults apart:
+        #
+        #   * edge-api answering 503 `{"status":"degraded"}`, which it does
+        #     whenever it cannot reach control-plane to resolve a key (see
+        #     handleHealth in apps/edge-api/cmd/server/main.go). `curl -f`
+        #     turns that into the same exit status as a dead host, and this is
+        #     a runtime dependency state, not a bad deploy.
+        #   * edge-api down or not listening on the host port.
+        #   * the Cloudflare Tunnel ingress for that one hostname being broken
+        #     while the service behind it is fine.
+        #
+        # The loopback probe separates them: public down plus loopback up is
+        # the tunnel, both down is the service, and a 503 body names itself.
+        # The ports come from deploy/cloudflare/tunnel-ingress.json, which is
+        # the source of truth for what each hostname reaches.
         run: |
+          probe() {
+            # Prints "<status> <body-first-line>"; status is 000 when the
+            # request never completed. Never fails the step by itself: the
+            # verdict is the caller's, after all three have been read.
+            local url="$1" body status
+            body=$(curl -sS --max-time 15 -o /dev/stdout -w '\n%{http_code}' "$url" 2>&1 || true)
+            status=$(printf '%s' "$body" | tail -n1)
+            case "$status" in
+              ''|*[!0-9]*) status=000 ;;
+            esac
+            # `sed '$d'` drops the status line -w appended, so the printed
+            # body is the response and nothing else. Command substitution
+            # already stripped the trailing newline, so the status is
+            # unambiguously the last line.
+            printf '%s %s' "$status" "$(printf '%s\n' "$body" | sed '$d' | head -c 200 | tr '\n' ' ')"
+          }
+
+          # 2xx and 3xx, not 200: this replaced `curl -fsS`, which fails only
+          # at 400 and above and follows no redirect, so a hostname that
+          # answers 302 passed before this change and must keep passing.
+          # Tightening the bar here would be an unrelated behaviour change
+          # smuggled into a diagnostics fix.
+          is_ok() { case "$1" in 2??|3??) return 0 ;; *) return 1 ;; esac; }
+
+          api_status=000; cp_status=000; chat_status=000
+          api_last=""; cp_last=""; chat_last=""
           for i in $(seq 1 12); do
-            api_ok=0; cp_ok=0; chat_ok=0
-            curl -fsS https://api-hive.scubed.co/health >/dev/null && api_ok=1 || true
-            curl -fsS https://control-hive.scubed.co/health >/dev/null && cp_ok=1 || true
-            curl -fsS https://chat-hive.scubed.co/ >/dev/null && chat_ok=1 || true
-            if [ "$api_ok" = 1 ] && [ "$cp_ok" = 1 ] && [ "$chat_ok" = 1 ]; then
+            api_last=$(probe https://api-hive.scubed.co/health);      api_status=${api_last%% *}
+            cp_last=$(probe https://control-hive.scubed.co/health);   cp_status=${cp_last%% *}
+            chat_last=$(probe https://chat-hive.scubed.co/);          chat_status=${chat_last%% *}
+            if is_ok "$api_status" && is_ok "$cp_status" && is_ok "$chat_status"; then
               echo "SMOKE OK"
               exit 0
             fi
-            echo "attempt $i failed (api=$api_ok, control-plane=$cp_ok, chat=$chat_ok), retry in 10s"
+            echo "attempt $i failed (api=$api_status, control-plane=$cp_status, chat=$chat_status), retry in 10s"
             sleep 10
           done
-          echo "SMOKE FAIL"
+
+          echo "::group::last response from each hostname"
+          echo "api-hive.scubed.co/health      -> $api_last"
+          echo "control-hive.scubed.co/health  -> $cp_last"
+          echo "chat-hive.scubed.co/           -> $chat_last"
+          echo "::endgroup::"
+          echo "::group::same services over loopback, bypassing the tunnel"
+          echo "localhost:8080/health (edge-api)      -> $(probe http://localhost:8080/health)"
+          echo "localhost:8081/health (control-plane) -> $(probe http://localhost:8081/health)"
+          echo "::endgroup::"
+          echo "::error::SMOKE FAIL after 12 attempts: api=$api_status, control-plane=$cp_status, chat=$chat_status. Read the two groups above before anything else. A hostname that is down publicly but answers over loopback is a Cloudflare Tunnel ingress fault, not a bad deploy; a 503 with a \"degraded\" body is the service reporting a dependency it cannot reach." >&2
           exit 1
 
       - name: Reconcile LiteLLM's config volume with the repo seed
@@ -1835,6 +1965,48 @@ jobs:
         # build is exactly when unused cache layers pile up the fastest.
         if: always()
         run: docker builder prune -f --filter until=24h
+
+      - name: Dump container status + logs on failure
+        # LAST in this job, and that position is the whole point.
+        #
+        # This step used to sit between "Assert the public chat origin refuses
+        # the admin surface" and "Smoke test public hostnames". `if: failure()`
+        # runs a step no matter where it sits, but it can only report on what
+        # has already happened, so a failure in any of the six steps that
+        # followed it produced no `compose ps`, no container logs and no disk
+        # figures at all. That is not hypothetical: run 32842676794
+        # (2026-08-25) failed in "Smoke test public hostnames" with
+        # `api=0, control-plane=1, chat=1` on all twelve attempts and left
+        # nothing behind to say whether edge-api was down, degraded, or simply
+        # unreachable through the tunnel. Moving the dump to the end costs
+        # nothing and makes every step in the job diagnosable.
+        #
+        # `df -h` and `docker system df` are here because disk exhaustion on
+        # this 12 GB-RAM box with a shared 98 GB partition is a recurring cause
+        # of a recreate dying partway (see the build-cache prune step above,
+        # which exists because that cache reached 40.87 GB), and a build that
+        # dies for want of space says so in a way that is easy to miss inside
+        # several thousand lines of BuildKit output.
+        #
+        # `ps -a` rather than `ps`: a container that exited during the recreate
+        # is invisible to plain `ps`, and it is exactly the container whose
+        # logs are wanted.
+        if: failure()
+        working-directory: /home/sakib/hive/deploy/docker
+        run: |
+          COMPOSE=(docker compose $HIVE_COMPOSE_FLAGS)
+          echo "::group::disk"
+          df -h / /var/lib/docker 2>&1 || true
+          docker system df 2>&1 || true
+          echo "::endgroup::"
+          echo "::group::docker compose ps -a"
+          "${COMPOSE[@]}" ps -a || true
+          echo "::endgroup::"
+          for svc in edge-api control-plane agent-console web-console-prod open-webui litellm redis prometheus grafana alertmanager caddy-owui; do
+            echo "::group::logs ($svc)"
+            "${COMPOSE[@]}" logs --tail=200 --no-color "$svc" 2>&1 || true
+            echo "::endgroup::"
+          done
 
   sdk-replay:
     name: SDK replay against the demo box

--- a/.github/workflows/deploy-demo-box.yml
+++ b/.github/workflows/deploy-demo-box.yml
@@ -814,11 +814,21 @@ jobs:
         # precisely the silent false green. Equal IDs prove the container is on
         # the image this deploy produced, whether or not it was recreated.
         #
-        # Deliberately not `--force-recreate` on every deploy instead: that
-        # restarts the whole stack including chat and the gateway on every
-        # merge, which is a real outage traded for a check that costs nothing.
-        # Detect the drift, name the service, and let the operator recreate
-        # just that one.
+        # This is not theoretical. Dispatch run 32845200901 (2026-08-25) built
+        # seven images -- supabase-db, control-plane, edge-api, open-webui,
+        # web-console-prod, agent-console, markitdown -- printed `Running`
+        # rather than `Recreated` for every single container in the project,
+        # and exited 0. All seven were left on the previous images. The step
+        # below is what caught it, and it now repairs it as well as reporting
+        # it, because detection alone would leave this deploy red forever with
+        # nothing in the run able to clear it.
+        #
+        # Deliberately not `--force-recreate` with no arguments on every
+        # deploy instead: that restarts the whole stack including chat and the
+        # gateway on every merge, a real outage traded for a check that costs
+        # nothing. Only the services that actually drifted are recreated, and
+        # the assertion is re-run afterwards so a repair that did not work
+        # still fails the deploy.
         #
         # The ancestry check is the other half of "merged is not deployed".
         # The box's clone is advanced by `git pull --ff-only origin main` in
@@ -845,6 +855,10 @@ jobs:
             fi
           fi
 
+          # Sets `drift` (space-separated service names) and `checked`. Called
+          # once to find the drift and once more to prove the recreate cleared
+          # it, so it is a function rather than a copied loop.
+          scan() {
           drift=""
           checked=0
           for service in $("${COMPOSE[@]}" ps --services); do
@@ -870,6 +884,9 @@ jobs:
               drift="$drift $service"
             fi
           done
+          }
+
+          scan
 
           # Zero comparable services means the loop found nothing, which would
           # make this step green without having checked anything at all.
@@ -878,9 +895,30 @@ jobs:
             exit 1
           fi
 
+          # Detecting the drift and stopping would leave this deploy red
+          # forever, since nothing else in the run recreates anything. So
+          # recreate exactly the services that drifted, and nothing else.
+          #
+          # This is narrower than `--force-recreate` with no arguments, which
+          # restarts the entire stack including chat and the gateway on every
+          # merge. A service only appears here because its image moved and its
+          # container did not, which is the recreate `up -d` was supposed to
+          # have performed a moment ago; a service whose image genuinely did
+          # not change never enters this list and is never touched.
+          #
+          # `--no-deps` because every dependency is already up and healthy by
+          # this point, and without it compose cascades into recreating them
+          # too, which is the stack-wide restart this is avoiding.
           if [ -n "$drift" ]; then
-            echo "::error::these services are still running an older image than the one this deploy built:${drift}. The deploy did NOT reach them (issue #1103). Recreate them on the box with: cd /home/sakib/hive/deploy/docker && docker compose \$HIVE_COMPOSE_FLAGS up -d --force-recreate${drift}" >&2
-            exit 1
+            echo "::warning::compose left these services on an older image than it had just built:${drift}. That is issue #1103: \`up -d --build\` rebuilt the image, did not recreate the container, and exited 0. Recreating them now."
+            # shellcheck disable=SC2086
+            "${COMPOSE[@]}" up -d --force-recreate --no-deps $drift
+            scan
+            if [ -n "$drift" ]; then
+              echo "::error::these services are STILL running an older image than the one this deploy built after an explicit --force-recreate:${drift}. The box is serving code older than this commit and the deploy could not fix it automatically. Investigate on the box before trusting anything this run reported." >&2
+              exit 1
+            fi
+            echo "recreate cleared the drift"
           fi
           echo "$checked running services are on the images this deploy built"
 

--- a/deploy/docker/Dockerfile.open-webui
+++ b/deploy/docker/Dockerfile.open-webui
@@ -28,7 +28,24 @@ WORKDIR /build/vendor/open-webui
 RUN apk add --no-cache git
 
 COPY vendor/open-webui/package.json vendor/open-webui/package-lock.json ./
-RUN npm ci --force
+# CYPRESS_INSTALL_BINARY=0 keeps the deploy off download.cypress.io.
+#
+# cypress@13.17.0 is a devDependency of the vendored tree, and its postinstall
+# fetches a ~120 MB desktop app from download.cypress.io at IMAGE BUILD time.
+# Nothing in this stage runs Cypress: the stage runs `npm run test:frontend`
+# (vitest) and `npm run build`, and the final image ships only build/. So the
+# download buys nothing and costs the whole deploy whenever it fails, which it
+# does on this target more than anywhere else: the demo box builds over home
+# broadband behind a Cloudflare Tunnel. It took the 2026-08-24 21:44 deploy
+# down outright with "The Cypress App could not be downloaded ...
+# URL: https://download.cypress.io/desktop/13.17.0 ... AggregateError", which
+# failed `npm ci --force`, failed the build, and stopped the deploy before a
+# single container was recreated.
+#
+# The variable makes the postinstall a no-op rather than removing the package,
+# so package-lock.json is untouched and the vendored tree stays a clean subtree
+# of upstream.
+RUN CYPRESS_INSTALL_BINARY=0 npm ci --force
 
 # The design tokens live outside the vendored tree on purpose: they are plain
 # CSS custom properties shared with the React applications, and keeping Hive's

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "lint:dead-supabase-secrets": "node tools/lint-no-dead-supabase-secrets.mjs",
     "lint:no-client-cost-fields": "node tools/lint-no-client-cost-fields.mjs",
     "lint:sync-child-process": "node tools/lint-no-sync-child-process-in-tests.mjs",
+    "lint:deploy-diagnosability": "node tools/lint-deploy-diagnosability.mjs",
     "lint:spec-wiring": "node tools/verify-spec-wiring.mjs",
     "lint:spec-wiring:test": "node tools/verify-spec-wiring.test.mjs",
     "lint:go-db-test-wiring": "node tools/lint-go-db-test-wiring.mjs",

--- a/tools/lint-deploy-diagnosability.mjs
+++ b/tools/lint-deploy-diagnosability.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+// Deploy diagnosability guard (issues #1084, #1103).
+//
+// deploy-demo-box.yml is the only thing standing between a merge to main and
+// the live demo box, and DEMO.md's premise is that the two are the same event.
+// Every rule below exists because that premise broke in a way the run itself
+// could not explain.
+//
+//   1. The job's only diagnostic step sat in the middle of the step list. An
+//      `if: failure()` step runs wherever it sits, but it can only report on
+//      what already happened, so the six steps after it failed with no
+//      `compose ps`, no container logs and no disk figures. Run 32842676794
+//      (2026-08-25) failed in the smoke test with `api=0` twelve times and
+//      left nothing behind to say why.
+//
+//   2. `docker compose up -d --build` prints the same shape of output whether
+//      it recreated a service or decided it had nothing to do, and exits 0
+//      either way. Without an explicit comparison of the running container's
+//      image against the image the tag now points at, a deploy that reached
+//      nothing is indistinguishable from one that had nothing to reach. That
+//      is issue #1103 in one sentence.
+//
+//   3. `curl -fsS <url> && ok=1` throws away the status code, so a service
+//      answering 503 "degraded" (which edge-api does whenever it cannot reach
+//      control-plane) reads exactly like a dead host or a broken tunnel. The
+//      smoke test has to record what it saw, and has to probe the same
+//      services over loopback so a public-only failure is identifiable as an
+//      ingress fault rather than a bad deploy.
+//
+//   4. The chat image's `npm ci` pulled a ~120 MB Cypress desktop app from
+//      download.cypress.io at build time, over the box's home broadband. It
+//      took the 2026-08-24 21:44 deploy down outright. Nothing in the image
+//      runs Cypress.
+//
+// Each of these is a one-line edit away from regressing silently, which is why
+// they are asserted here rather than left to a comment.
+
+import { readFileSync } from "node:fs";
+import { parse } from "yaml";
+
+const WORKFLOW = ".github/workflows/deploy-demo-box.yml";
+const DOCKERFILE = "deploy/docker/Dockerfile.open-webui";
+
+const DUMP_STEP = "Dump container status + logs on failure";
+const RECREATE_STEP = "Rebuild + recreate changed services";
+const DRIFT_STEP = "Assert the running containers are on the images just built";
+const SMOKE_STEP = "Smoke test public hostnames";
+
+const errors = [];
+
+const workflow = parse(readFileSync(WORKFLOW, "utf8"));
+const steps = workflow?.jobs?.deploy?.steps;
+if (!Array.isArray(steps) || steps.length === 0) {
+  console.error(`${WORKFLOW} has no jobs.deploy.steps array; cannot lint it.`);
+  process.exit(1);
+}
+
+const names = steps.map((s) => s?.name ?? "(unnamed)");
+const indexOf = (name) => names.indexOf(name);
+const stepBody = (name) => {
+  const step = steps[indexOf(name)];
+  return typeof step?.run === "string" ? step.run : "";
+};
+
+// 1. The dump is last, and fires on failure.
+const dumpAt = indexOf(DUMP_STEP);
+if (dumpAt === -1) {
+  errors.push(
+    `${WORKFLOW}: the deploy job has no step named "${DUMP_STEP}". A deploy that fails with no container status, no logs and no disk figures cannot be diagnosed from the run at all.`,
+  );
+} else {
+  if (dumpAt !== steps.length - 1) {
+    errors.push(
+      `${WORKFLOW}: "${DUMP_STEP}" is step ${dumpAt + 1} of ${steps.length}, not the last one. It can only report on steps that already ran, so every step after it fails blind. Steps that would currently fail blind: ${names.slice(dumpAt + 1).join(", ")}.`,
+    );
+  }
+  if (String(steps[dumpAt]?.if ?? "").replace(/\s/g, "") !== "failure()") {
+    errors.push(
+      `${WORKFLOW}: "${DUMP_STEP}" must carry \`if: failure()\` so it fires for a failure in any earlier step.`,
+    );
+  }
+  const dump = stepBody(DUMP_STEP);
+  for (const needle of ["docker system df", "ps -a", "logs"]) {
+    if (!dump.includes(needle)) {
+      errors.push(
+        `${WORKFLOW}: "${DUMP_STEP}" no longer runs \`${needle}\`. Disk exhaustion, an exited container and container logs are the three things this box's deploy failures have actually needed.`,
+      );
+    }
+  }
+}
+
+// 2. The image-drift assertion exists and runs straight after the recreate.
+const recreateAt = indexOf(RECREATE_STEP);
+const driftAt = indexOf(DRIFT_STEP);
+if (recreateAt === -1) {
+  errors.push(`${WORKFLOW}: the deploy job has no step named "${RECREATE_STEP}".`);
+} else if (driftAt === -1) {
+  errors.push(
+    `${WORKFLOW}: the deploy job has no step named "${DRIFT_STEP}". Without it, \`up -d --build\` reporting success proves nothing about what the box is now serving (issue #1103).`,
+  );
+} else if (driftAt !== recreateAt + 1) {
+  errors.push(
+    `${WORKFLOW}: "${DRIFT_STEP}" must run immediately after "${RECREATE_STEP}"; it is currently ${driftAt - recreateAt} steps later. Anything in between can recreate a container and mask the drift this check exists to find.`,
+  );
+}
+if (driftAt !== -1) {
+  const drift = stepBody(DRIFT_STEP);
+  // The comparison is the check. A version of this step that stopped
+  // resolving the tag would still print reassuring lines and pass.
+  if (!drift.includes("{{.Image}}") || !drift.includes("docker image inspect")) {
+    errors.push(
+      `${WORKFLOW}: "${DRIFT_STEP}" must compare each container's created-from image ID (\`docker inspect -f '{{.Image}}'\`) against the ID its tag resolves to now (\`docker image inspect\`). Anything weaker cannot tell a cached no-op rebuild from a deploy that never landed.`,
+    );
+  }
+}
+
+// 3. The smoke test records what it saw.
+const smokeAt = indexOf(SMOKE_STEP);
+if (smokeAt === -1) {
+  errors.push(`${WORKFLOW}: the deploy job has no step named "${SMOKE_STEP}".`);
+} else {
+  const smoke = stepBody(SMOKE_STEP);
+  if (!smoke.includes("%{http_code}")) {
+    errors.push(
+      `${WORKFLOW}: "${SMOKE_STEP}" must record each probe's HTTP status (\`curl -w '%{http_code}'\`). A bare \`curl -fsS\` verdict cannot tell a 503 "degraded" response from an unreachable host, and both have already happened here.`,
+    );
+  }
+  if (!smoke.includes("localhost:8080") || !smoke.includes("localhost:8081")) {
+    errors.push(
+      `${WORKFLOW}: "${SMOKE_STEP}" must also probe edge-api and control-plane over loopback (localhost:8080, localhost:8081, per deploy/cloudflare/tunnel-ingress.json) when the public probe fails. Public-down plus loopback-up is a Cloudflare Tunnel ingress fault, not a bad deploy, and nothing else in the run distinguishes the two.`,
+    );
+  }
+}
+
+// 4. The chat image does not fetch the Cypress binary at build time.
+const dockerfile = readFileSync(DOCKERFILE, "utf8");
+const npmCi = dockerfile
+  .split("\n")
+  .find((line) => /^RUN\b.*\bnpm ci\b/.test(line));
+if (!npmCi) {
+  errors.push(`${DOCKERFILE}: no \`RUN ... npm ci\` line found; this lint is checking the wrong file.`);
+} else if (!npmCi.includes("CYPRESS_INSTALL_BINARY=0")) {
+  errors.push(
+    `${DOCKERFILE}: \`${npmCi.trim()}\` must set CYPRESS_INSTALL_BINARY=0. cypress is a devDependency of the vendored tree and its postinstall downloads a ~120 MB desktop app from download.cypress.io during the image build; nothing in the image runs Cypress, and that download failed the whole deploy on 2026-08-24.`,
+  );
+}
+
+if (errors.length > 0) {
+  console.error("Deploy diagnosability check FAILED:");
+  for (const e of errors) console.error(`  - ${e}`);
+  process.exit(1);
+}
+
+console.log(
+  `Deploy diagnosability OK: ${steps.length} deploy steps, dump-on-failure last, image drift asserted immediately after the recreate, smoke test records status codes plus a loopback fallback, chat image build fetches no Cypress binary.`,
+);

--- a/tools/lint-deploy-diagnosability.mjs
+++ b/tools/lint-deploy-diagnosability.mjs
@@ -112,6 +112,14 @@ if (driftAt !== -1) {
       `${WORKFLOW}: "${DRIFT_STEP}" must compare each container's created-from image ID (\`docker inspect -f '{{.Image}}'\`) against the ID its tag resolves to now (\`docker image inspect\`). Anything weaker cannot tell a cached no-op rebuild from a deploy that never landed.`,
     );
   }
+  // Detection without repair leaves the deploy permanently red, because
+  // nothing else in the job recreates anything. The repair has to stay
+  // scoped to the drifted services and has to be re-verified.
+  if (!drift.includes("--force-recreate")) {
+    errors.push(
+      `${WORKFLOW}: "${DRIFT_STEP}" must recreate the services it found drifted (\`up -d --force-recreate --no-deps <services>\`) and re-check. Reporting the drift without clearing it leaves every subsequent deploy red with no step able to fix it.`,
+    );
+  }
 }
 
 // 3. The smoke test records what it saw.


### PR DESCRIPTION
Fixes the deploy-demo-box failures tracked in #1084, and fixes (not just detects) the silent-false-green tracked in #1103.

**Headline: the demo box had not received a single deploy since 03:05 UTC today, and the workflow reported that fact nowhere.** Three dispatch runs on this branch took it from red to fully green, and the third one landed main's code on the box for the first time in nine hours.

## What was actually wrong

`deploy-demo-box` has failed on almost every push to main since 2026-08-23. Three distinct causes, plus a fourth defect that hid all of them and a fifth that meant a successful deploy shipped nothing.

**1. The deploy's only diagnostic step could not fire for most of the job.** `Dump container status + logs on failure` was step 11 of 18, ahead of `Smoke test public hostnames`, both LiteLLM reconcile steps, the price assertion and the OAuth scope check. `if: failure()` runs a step wherever it sits, but a step can only report on what has already happened, so a failure in any of the seven steps after it produced no `compose ps`, no container logs and no disk figures at all.

Run [32842676794](https://github.com/sakibsadmanshajib/hive/actions/runs/32842676794) is the clean example. It failed in the smoke test:

```
attempt 1 failed (api=0, control-plane=1, chat=1), retry in 10s
...
attempt 12 failed (api=0, control-plane=1, chat=1), retry in 10s
SMOKE FAIL
```

Twelve identical lines and nothing else. Nothing in that run could say whether edge-api was down, degraded, or unreachable through the tunnel.

**2. A Cypress binary download inside the chat image build.** `Dockerfile.open-webui`'s `RUN npm ci --force` installs `cypress@13.17.0`, whose postinstall pulls a roughly 120 MB desktop app from `download.cypress.io` at image build time, over the demo box's home broadband. From the 2026-08-24 21:44 run:

```
#81 393.9 npm error Installing Cypress (version: 13.17.0)
#81 393.9 npm error The Cypress App could not be downloaded.
#81 393.9 npm error URL: https://download.cypress.io/desktop/13.17.0?platform=linux&arch=x64
#81 393.9 npm error AggregateError
#81 ERROR: process "/bin/sh -c npm ci --force" did not complete successfully: exit code: 1
target open-webui: failed to solve: process "/bin/sh -c npm ci --force" did not complete successfully: exit code: 1
```

Nothing in that image runs Cypress. The stage runs `npm run test:frontend` (vitest) and `npm run build`, and the final image ships only `build/`.

**3. A Next.js SWC binary download in the console image build**, which took down the 05:19 run:

```
#132 1.558    Downloading swc package @next/swc-linux-x64-gnu... to /root/.cache/next-swc
#132 1.568 /bin/sh: 1: pnpm: not found
#132 1.575 unhandledRejection [Error: Failed to get registry from "pnpm".]
#132 ERROR: process "/bin/sh -c npm run build" did not complete successfully: exit code: 1
```

Already fixed on main by #1144. Listed because it is the same failure class as the Cypress one, and the pattern is the point: every deploy rebuilds two Node images that reach out to the public internet for large third-party binaries, on a box behind home broadband and a Cloudflare Tunnel. Any blip is a red deploy.

**4. `docker compose up -d --build` cannot prove what it deployed, and on this box it was in fact deploying nothing.** It prints this pair and exits zero:

```
 Image hive-edge-api:ci Built
 Container hive-edge-api-1 Running
```

which is both what a cached no-op rebuild looks like and what a service compose declined to recreate looks like. That is #1103. It turned out not to be a theoretical ambiguity. Dispatch run [32845200901](https://github.com/sakibsadmanshajib/hive/actions/runs/32845200901) built **seven** images and recreated **zero** containers:

```
 Image hive-supabase-db:pg16-cron Built
 Image hive-control-plane:ci Built
 Image hive-edge-api:ci Built
 Image hive-open-webui:v0.10.2-branded Built
 Image hive-web-console-prod:ci Built
 Image hive-agent-console:ci Built
 Image hive-markitdown:ci Built
 Container hive-control-plane-1 Running
 Container hive-edge-api-1 Running
 Container hive-open-webui-1 Running
 ... every container in the project: Running, none Recreated
```

and the new check caught it:

```
DRIFT agent-console runs an image the tag hive-agent-console:ci no longer points at
DRIFT control-plane runs an image the tag hive-control-plane:ci no longer points at
DRIFT edge-api runs an image the tag hive-edge-api:ci no longer points at
DRIFT markitdown runs an image the tag hive-markitdown:ci no longer points at
DRIFT open-webui runs an image the tag hive-open-webui:v0.10.2-branded no longer points at
DRIFT supabase-db runs an image the tag hive-supabase-db:pg16-cron no longer points at
DRIFT web-console-prod runs an image the tag hive-web-console-prod:ci no longer points at
::error::these services are still running an older image than the one this deploy built: agent-console control-plane edge-api markitdown open-webui supabase-db web-console-prod. The deploy did NOT reach them (issue #1103).
```

The step's `up -d --build` had exited 0 seconds earlier.

## What this changes

**Move the dump to the end of the deploy job**, so it fires for a failure in any step. It also now records `df -h` and `docker system df` and uses `ps -a` so a container that exited during the recreate is visible. It immediately earned its place: it is what produced the box's disk picture (`98G, 77G used, 83%`, build cache `31.11GB`) and the Open WebUI container logs that explained the step-11 failure below.

**New step immediately after the recreate: assert the running containers are on the images just built, and repair them if not.** For every running service it compares the container's created-from image ID (`docker inspect -f '{{.Image}}'`) against the ID its image reference resolves to now (`docker image inspect`). Where they disagree the tag moved and the container did not, so it recreates exactly those services with `--force-recreate --no-deps --wait --wait-timeout 300` and re-runs the same comparison, failing if the drift survives.

Detection alone was not shippable: nothing else in the job recreates anything, so a box in that state fails this step on every run forever. Scoping the repair matters too. `--force-recreate` with no arguments restarts chat and the gateway on every merge; a service only enters this list because its image moved and its container did not, which is the recreate `up -d` was supposed to have just performed.

The same step also fails when the box's checkout does not contain this run's commit, so a green result can no longer stand over a deployment that does not include the change it was triggered by. The box lands on main's tip, which may be newer than this run's commit because the concurrency group queues pushes, so the check is ancestry rather than equality and is gated to `refs/heads/main`.

**Make the smoke test record what it saw.** `curl -fsS <url> && ok=1` throws away the status code. edge-api returns `503 {"status":"degraded","reason":"authorization dependency unavailable"}` whenever it cannot reach control-plane to resolve a key (`handleHealth`, `apps/edge-api/cmd/server/main.go`), and under `-f` that is indistinguishable from a dead host or a broken tunnel. Each probe now records its status; on failure the step prints the last response from each hostname and then probes edge-api and control-plane over loopback per `deploy/cloudflare/tunnel-ingress.json`, which separates an ingress fault from a service fault. The pass bar is 2xx and 3xx, matching `curl -f` exactly, so nothing that passed before fails now.

**`CYPRESS_INSTALL_BINARY=0` on the chat image's `npm ci`.** The postinstall becomes a no-op, `package-lock.json` is untouched, and the vendored tree stays a clean subtree of upstream.

**`tools/lint-deploy-diagnosability.mjs`**, wired into the `repo-policy-lints` required check, asserts all of it: the dump step is last, carries `if: failure()` and still runs `docker system df` / `ps -a` / `logs`; the drift step exists, sits immediately after the recreate, performs the ID comparison, and repairs with `--force-recreate`; the smoke test records `%{http_code}` and probes loopback; the chat image sets `CYPRESS_INSTALL_BINARY=0`.

## Live verification on the demo box

Three `workflow_dispatch` runs from this branch. A dispatch from a branch runs this branch's workflow against the box's own `main` checkout, so no branch code was deployed; only the workflow logic under test differed.

| Run | Result |
| --- | --- |
| [32845200901](https://github.com/sakibsadmanshajib/hive/actions/runs/32845200901) | Recreate green, **drift check caught 7 stale services**, dump step fired last and produced disk plus container logs |
| [32846121196](https://github.com/sakibsadmanshajib/hive/actions/runs/32846121196) | Self-heal recreated all 7 and re-verified clean; got 5 steps further; exposed a boot race the recreate had opened |
| [32847038740](https://github.com/sakibsadmanshajib/hive/actions/runs/32847038740) | **Deploy job green end to end, all 18 steps, `SMOKE OK`.** migrate=success, deploy=success, sdk-replay=success |

The self-heal on the box:

```
DRIFT agent-console / control-plane / edge-api / markitdown / open-webui / supabase-db / web-console-prod
::warning::compose left these services on an older image than it had just built ... Recreating them now.
 Container hive-supabase-db-1 Recreated
 Container hive-control-plane-1 Recreated
 Container hive-edge-api-1 Recreated
 Container hive-web-console-prod-1 Recreated
 Container hive-agent-console-1 Recreated
 Container hive-open-webui-1 Recreated
 Container hive-markitdown-1 Recreated
recreate cleared the drift
20 running services are on the images this deploy built
```

**The `api-hive.scubed.co` failure was the stale image, not the tunnel.** The smoke test had failed twelve times with `api=0` while control-plane and chat answered. Once edge-api was actually recreated onto the image the deploy had built, the identical smoke test printed `SMOKE OK`. That is independent confirmation that the drift check is measuring something real: the repair changed live behaviour, not just an ID comparison.

The boot race run 32846121196 exposed, and the reason `--wait` is in the recreate:

```
hive_jwt_forward install FAILED: GET /api/v1/functions/id/hive_jwt_forward could not reach http://127.0.0.1:8080: <urlopen error [Errno 111] Connection refused>
```

That step, and every step after it, is green in 32847038740.

## Verification off the box

`tools/lint-deploy-diagnosability.mjs` against **the pre-change files** (origin/main copies, run in a scratch tree), proving the gate can go red:

```
Deploy diagnosability check FAILED:
  - "Dump container status + logs on failure" is step 11 of 18, not the last one. It can only report on steps that already ran, so every step after it fails blind. Steps that would currently fail blind: Prune dangling images, Smoke test public hostnames, Reconcile LiteLLM's config volume with the repo seed, Sync LiteLLM model list from the DB catalog (issue, Assert model catalog prices agree with the model LiteLLM will call, Verify the OAuth scopes the chat container asks for are supported, Prune build cache older than 24h.
  - "Dump container status + logs on failure" no longer runs `docker system df`. ...
  - the deploy job has no step named "Assert the running containers are on the images just built". ...
  - "Smoke test public hostnames" must record each probe's HTTP status (`curl -w '%{http_code}'`). ...
  - "Smoke test public hostnames" must also probe edge-api and control-plane over loopback ...
  - deploy/docker/Dockerfile.open-webui: `RUN npm ci --force` must set CYPRESS_INSTALL_BINARY=0. ...
```

and green on this branch.

**The drift check and its repair, exercised against real Docker** with the script lifted straight out of the workflow. A container left on a superseded tag, then repaired:

```
=== DRIFTED (expect warn, recreate, then pass) ===
DRIFT probe runs an image the tag hive-heal-probe:test no longer points at
::warning::compose left these services on an older image than it had just built: probe ... Recreating them now.
 Container hiveheal-probe-1 Recreated
ok   probe is on hive-heal-probe:test (4bfafe1755fe)
recreate cleared the drift
1 running services are on the images this deploy built
exit=0
container image before=sha256:4744e9d01cf0...
container image after =sha256:4bfafe1755fe...
$ docker exec hiveheal-probe-1 cat /marker
v2
```

`v2` is the point: the pass is on the bits actually running in the container, not merely on matching IDs.

And `--wait`, against a service that takes 8 seconds to report healthy:

```
 Container hivewait-probe-1 Waiting
 Container hivewait-probe-1 Healthy
ok   probe is on hive-wait-probe:test (e52968fdba2f)
exit=0 elapsed=22s
health at step exit: healthy
```

**The smoke probe**, against a local server returning each shape the box produces:

```
200      -> 200 {"status": "ok"}
503      -> 503 {"status": "degraded", "reason": "authorization dependency unavailable"}
deadport -> 000 curl: (7) Failed to connect to 127.0.0.1 port 9 after 0 ms: Couldn't connect to server
is_ok(200)=yes  is_ok(302)=yes  is_ok(503)=no  is_ok(000)=no  is_ok(404)=no
```

The 503 line is the diagnosis that did not exist before. `is_ok(302)=yes` is the old `curl -f` behaviour preserved.

**Existing guards, unchanged and still green:**

```
test_selfhost_supabase_seam: ok (25 checks)
Deploy path-filter coverage OK: every COPY/ADD source across 15 Dockerfiles under deploy/docker/ is covered by deploy-demo-box.yml's push.paths.
Merge-gate integrity OK: 27 check names across 10 pull-request workflows, 6 required contexts ...
```

plus all fourteen other `lint:*` scripts in `repo-policy-lints`, and `bash -n` over all 38 `run:` blocks in the workflow.

## Still open, and not fixable in this PR

**`Agent workspace interaction coverage` fails on missing repository secrets.** With the deploy finally green, this job ran for the first time in a long while and failed immediately:

```
##[error]this job mints a live session and needs: SUPABASE_ANON_KEY SUPABASE_SERVICE_ROLE_KEY. The two keys are the self-hosted deployment's own, provisioned as DEMO_SUPABASE_ANON_KEY and DEMO_SUPABASE_SERVICE_ROLE_KEY from the box's .env (issue #1059).
```

That is a correct, deliberate loud failure and the fix is to provision those two repository secrets from the box's `.env`. It is outside this PR (no repo change can supply a secret) and it will keep the overall run red on main until someone with access sets them, even with the deploy job green.

**The tags move on every single deploy.** Between two dispatch runs ten minutes apart with an unchanged tree, all seven built images were rebuilt to new IDs and compose again left every container behind. The self-heal makes that harmless, and the deploy now ships the code either way, but the underlying question of why these builds are not reproducible from cache is worth its own issue: a reproducible build would make the recreate a rare event instead of a per-deploy one.

**Box housekeeping.** The dump step's first run reported `/dev/mapper/ubuntu--vg-ubuntu--lv 98G 77G 17G 83% /` with `Build Cache 31.11GB (13.07GB reclaimable)`. Not urgent, and the existing 24h build-cache prune runs every deploy, but it is now visible on every failure instead of guessed at.

## Buglog entry

To be appended to `.wolf/buglog.jsonl` on main in a separate buglog-only PR after this merges, per `.claude/rules/openwolf.md`.

```json
{"id":"bug-2026-08-25-deploy-dump-step-cannot-fire","date":"2026-08-25","title":"deploy-demo-box's only diagnostic step sat mid-job, so seven later steps failed with no evidence","error_message":"attempt 12 failed (api=0, control-plane=1, chat=1), retry in 10s / SMOKE FAIL","root_cause":"The 'Dump container status + logs on failure' step was step 11 of 18 in the deploy job. `if: failure()` runs a step wherever it sits, but it can only report on what already happened, so a failure in any of the seven steps after it (smoke test, both LiteLLM reconcile steps, the price assertion, the OAuth scope check) produced no compose ps, no container logs and no disk figures.","fix":"Moved the dump to the last position in the deploy job, added df -h and docker system df, and switched compose ps to ps -a so exited containers are visible. tools/lint-deploy-diagnosability.mjs asserts the position in the repo-policy-lints required check.","tags":["ci","deploy","observability","github-actions","demo-box"]}
{"id":"bug-2026-08-25-compose-up-builds-without-recreating","date":"2026-08-25","title":"docker compose up -d --build rebuilt seven images, recreated zero containers, and exited 0","error_message":"Image hive-edge-api:ci Built / Container hive-edge-api-1 Running","root_cause":"On the demo box `up -d --build` rebuilds every service image to a new ID and then leaves every container running on the previous image, reporting success. Confirmed on dispatch run 32845200901: seven images Built, every container Running, none Recreated. The box had therefore received no code since 03:05 UTC despite the recreate step passing, and the log shape of a genuine cached no-op is identical to it (issue #1103).","fix":"Added a step immediately after the recreate that compares every running container's created-from image ID against the ID its image reference resolves to now, recreates exactly the drifted services with --force-recreate --no-deps --wait, and re-runs the comparison, failing if the drift survives. It also fails when the box's checkout does not contain the run's commit.","tags":["ci","deploy","docker-compose","silent-failure","demo-box"]}
{"id":"bug-2026-08-25-smoke-test-discards-status-code","date":"2026-08-25","title":"The deploy smoke test discarded HTTP status codes, so a stale edge-api read exactly like a dead tunnel","error_message":"attempt 1 failed (api=0, control-plane=1, chat=1), retry in 10s","root_cause":"The smoke test decided its verdict with `curl -fsS <url> && ok=1`, which keeps no status code, no body and no curl exit code. edge-api answers 503 {\"status\":\"degraded\"} whenever it cannot reach control-plane, and under -f that is the same signal as an unreachable host or a broken Cloudflare Tunnel ingress. The actual cause on 2026-08-25 was edge-api running a stale image; the same probe returned SMOKE OK once it was recreated.","fix":"Each probe now records status and body via curl -w '%{http_code}'; on failure the step prints the last response from each hostname plus the same probe over loopback (localhost:8080, localhost:8081), which separates a tunnel ingress fault from a service fault. Pass bar kept at 2xx/3xx to preserve curl -f semantics.","tags":["ci","deploy","observability","demo-box","edge-api"]}
{"id":"bug-2026-08-24-cypress-download-fails-demo-deploy","date":"2026-08-25","title":"The chat image build downloaded a 120 MB Cypress binary over the demo box's home broadband and failed the deploy","error_message":"npm error The Cypress App could not be downloaded. URL: https://download.cypress.io/desktop/13.17.0?platform=linux&arch=x64 AggregateError -- target open-webui: failed to solve: process \"/bin/sh -c npm ci --force\" did not complete successfully: exit code: 1","root_cause":"cypress@13.17.0 is a devDependency of vendor/open-webui and its postinstall fetches a ~120 MB desktop app from download.cypress.io at image build time. Nothing in the image runs Cypress: the stage runs vitest and `npm run build`, and the final image ships only build/. The demo box builds over home broadband behind a Cloudflare Tunnel, so the fetch is the least reliable step in the whole deploy.","fix":"CYPRESS_INSTALL_BINARY=0 on the `npm ci --force` line in deploy/docker/Dockerfile.open-webui, which makes the postinstall a no-op without touching package-lock.json. Asserted by tools/lint-deploy-diagnosability.mjs.","tags":["ci","deploy","docker","npm","flaky","demo-box"]}
{"id":"bug-2026-08-25-recreate-opens-boot-race","date":"2026-08-25","title":"Recreating drifted services mid-deploy raced the steps that immediately call them","error_message":"hive_jwt_forward install FAILED: GET /api/v1/functions/id/hive_jwt_forward could not reach http://127.0.0.1:8080: <urlopen error [Errno 111] Connection refused>","root_cause":"`docker compose up -d` returns as soon as containers start, not when they are healthy. The new drift repair recreated open-webui and the very next deploy step called its HTTP API while it was still booting.","fix":"Added --wait --wait-timeout 300 to the repair's compose invocation, so the step returns only once every recreated service reports healthy. Verified against a service that takes 8 seconds to become healthy.","tags":["ci","deploy","docker-compose","race-condition","demo-box"]}
```
