### PR TITLE
fix: make the free pool actually fail over when one member is retired

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1440,6 +1440,43 @@ jobs:
           fi
           echo "gateway serves route-free-pool; models: $(jq -r '[.data[].id] | join(", ")' /tmp/litellm-models.json)"
 
+      # Name the dead pool member, if there is one, BEFORE the suites run.
+      #
+      # Serving route-free-pool (asserted above) only proves the group exists,
+      # not that its four members answer. Free model ids churn constantly on
+      # every provider in the pool, and a retired one answers 404 -- which is
+      # exactly the error LiteLLM refuses to fail over (issue #1064). Without
+      # this step that shows up as a generic "hive-free is not available." with
+      # nothing anywhere naming which of the four models went away.
+      #
+      # `/health?model=` is LiteLLM's own per-group probe: it runs one tiny
+      # request against each deployment in that group and reports them
+      # individually, so this costs four small completions on free keys and
+      # nothing on any paid alias.
+      #
+      # Deliberately NOT a hard gate on a single dead member. Surviving one is
+      # the pool's entire purpose, so failing the job on it would make the
+      # resilience worthless; the suites below are the real gate, and they now
+      # pass through a degraded pool. It IS a hard failure when every member is
+      # down, because then hive-free genuinely serves nothing.
+      - name: Probe each free pool member and name any that is gone
+        shell: bash
+        run: |
+          set -uo pipefail
+          code=$(curl -sS -o /tmp/pool-health.json -w '%{http_code}' --max-time 120 \
+            -H "Authorization: Bearer ${LITELLM_MASTER_KEY}" \
+            "http://localhost:4000/health?model=route-free-pool") || code="000"
+
+          if [ "$code" != "200" ]; then
+            echo "::warning::could not probe the free pool (HTTP ${code}), so this run cannot say whether all four members are alive"
+            exit 0
+          fi
+
+          # python3 rather than jq purely so the reporting and the credential
+          # redaction are the same language and the same process; the redactor
+          # is already a python module this repo ships.
+          python3 scripts/report-free-pool-health.py /tmp/pool-health.json
+
       - name: Run SDK suites in parallel (JS + Python + Java)
         # id, because the spend meter below runs on always() and needs to tell
         # "the suites failed, so the database may not exist" from "the suites
@@ -1629,12 +1666,16 @@ jobs:
             class="the provider rate limited us (429). Check whether the window is per minute (transient, so a rerun may pass) or per day (an allowance that is spent)."
           elif grep -qiE 'insufficient.?credit|402 Payment Required' /tmp/upstream.log; then
             class="the provider account is out of credit (402). No retry fixes this; it needs funding."
+          elif grep -qiE 'No fallback model group found' /tmp/upstream.log; then
+            # Last, on purpose: the three refusals above are more specific about
+            # spend and should win when both signatures are present.
+            class="a POOL MEMBER IS DEAD, not the whole provider. LiteLLM answered 'No fallback model group found', which is what it says when one deployment in a load-balanced group returns 404 and the group has no fallback group configured. A 404 is what a RETIRED free model returns, and LiteLLM will not fail over on it (litellm/router.py::should_retry_this_error re-raises NotFoundError, and RetryPolicy has no NotFoundErrorRetries knob). The edge now retries this so the pool routes around the dead member; seeing it here means the retry ladder was also exhausted, so more than one member is down. The 'Probe each free pool member' step earlier in this job names them."
           fi
 
           if [ -n "$class" ]; then
             echo "::error::UPSTREAM REFUSAL, not a performance regression: $class"
             echo "matching lines (redacted, first 5):"
-            grep -iE 'tokens per day|rate.?limit|RateLimitError|rate_limit_exceeded|insufficient.?credit|402 Payment Required' \
+            grep -iE 'tokens per day|rate.?limit|RateLimitError|rate_limit_exceeded|insufficient.?credit|402 Payment Required|No fallback model group found' \
               /tmp/upstream.log | head -5
             echo "UPSTREAM_FAILURE_CLASS=$class" >> "$GITHUB_ENV"
           else

--- a/apps/edge-api/internal/inference/retry.go
+++ b/apps/edge-api/internal/inference/retry.go
@@ -1,10 +1,12 @@
 package inference
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"math/rand"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -15,6 +17,70 @@ var retryableStatuses = map[int]bool{
 	http.StatusBadGateway:          true, // 502
 	http.StatusServiceUnavailable:  true, // 503
 	http.StatusGatewayTimeout:      true, // 504
+}
+
+// litellmRouterExhaustionMarker is LiteLLM's own wording when its router gives
+// up on a model group WITHOUT trying that group's remaining healthy
+// deployments. It is the reason a load-balanced pool does not actually fail
+// over, and it is why this file retries a status that is otherwise terminal.
+//
+// The mechanism, read out of the pinned image's source (v1.98.0) rather than
+// inferred:
+//
+//   - litellm/router.py::should_retry_this_error re-raises immediately for
+//     NotFoundError, and again for any status where litellm._should_retry() is
+//     false. 404 is both. It is called from async_function_with_retries AND
+//     from async_function_with_fallbacks, so neither the in-group retry nor the
+//     cross-group fallback ever runs.
+//   - litellm/types/router.py::RetryPolicy has no NotFoundErrorRetries field,
+//     so no configuration lifts this. The only per-class knob this repo sets,
+//     RateLimitErrorRetries, cannot reach it.
+//   - The request therefore dies on the FIRST deployment that answers 404,
+//     with the other members of the group untouched and healthy. That is what
+//     took the hive-free alias down in CI run 32830060362 while three of its
+//     four pool members were fine.
+//
+// What makes retrying here correct rather than hopeful: before raising, LiteLLM
+// has already put the offending deployment into cooldown.
+// router_utils/cooldown_handlers.py::_should_cooldown_deployment returns true
+// on the first failure when litellm._should_retry(status) is false, so a 404
+// member is excluded from selection immediately, not after allowed_fails. The
+// next attempt therefore picks a DIFFERENT member. The whole retry ladder below
+// finishes inside 2.9s, well inside the 5s DEFAULT_COOLDOWN_TIME_SECONDS the
+// router actually applies, so the dead member cannot be re-picked mid-ladder.
+//
+// Scope: this matches on the message, not on a bare 404, so a genuine "that
+// model does not exist" stays an immediate 404 and costs no retries.
+const litellmRouterExhaustionMarker = "no fallback model group found"
+
+// maxRetryPeekBytes bounds how much of a 404 body is read to classify it.
+// Upstream error envelopes are small; anything past this is not a marker this
+// function would recognise anyway.
+const maxRetryPeekBytes = 8 << 10
+
+// isRouterExhaustion404 reports whether resp is LiteLLM's router-exhaustion
+// answer rather than a genuine "no such model".
+//
+// The body is always spliced back together before returning, so the caller sees
+// a complete, unread response either way. That matters: this runs on the path
+// that hands the upstream error to the customer, and a half-consumed body would
+// silently truncate the error they see.
+func isRouterExhaustion404(resp *http.Response) bool {
+	if resp == nil || resp.StatusCode != http.StatusNotFound || resp.Body == nil {
+		return false
+	}
+
+	orig := resp.Body
+	head, err := io.ReadAll(io.LimitReader(orig, maxRetryPeekBytes))
+	resp.Body = struct {
+		io.Reader
+		io.Closer
+	}{Reader: io.MultiReader(bytes.NewReader(head), orig), Closer: orig}
+	if err != nil {
+		return false
+	}
+
+	return strings.Contains(strings.ToLower(string(head)), litellmRouterExhaustionMarker)
 }
 
 // retryDelays is the progressive backoff between attempts.
@@ -78,7 +144,13 @@ func dispatchWithRetry(ctx context.Context, litellmModel string, body []byte, di
 		}
 
 		// Success or non-retryable status → return immediately.
-		if !retryableStatuses[resp.StatusCode] {
+		//
+		// isRouterExhaustion404 is only consulted for statuses the table does
+		// not already cover, so the common 429/5xx path never pays to read a
+		// body. See its doc comment for why a 404 is worth another attempt at
+		// all: for a pooled alias it means "this one member is dead", and the
+		// member is already in cooldown, so the next attempt gets a live one.
+		if !retryableStatuses[resp.StatusCode] && !isRouterExhaustion404(resp) {
 			return resp, nil
 		}
 

--- a/apps/edge-api/internal/inference/retry_test.go
+++ b/apps/edge-api/internal/inference/retry_test.go
@@ -145,3 +145,137 @@ func TestDispatchWithRetry_ContextCancelStopsRetries(t *testing.T) {
 		t.Fatalf("calls = %d, want 1 (cancel before retry)", got)
 	}
 }
+
+// routerExhaustionBody is the verbatim upstream envelope the edge received from
+// LiteLLM on CI run 32830060362, when one member of the four-deployment
+// route-free-pool group answered 404 and the router abandoned the request
+// instead of trying the other three. Copied from the run's compose-logs
+// artifact rather than paraphrased, because the whole fix keys off this text:
+// if LiteLLM rewords it in a future image bump, these tests are what notices.
+const routerExhaustionBody = `{"error":{"message":"litellm.NotFoundError: NotFoundError: OpenAIException - Error code: 404No fallback model group found for original model_group=route-free-pool. Fallbacks=[{'route-openrouter-embedding': ['route-openrouter-embedding-fallback']}]. Received Model Group=route-free-pool\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"404"}}`
+
+// TestDispatchWithRetry_FailsOverWhenOnePoolMemberIsGone is the regression
+// guard for issue #1064.
+//
+// The free pool's entire product claim is that one exhausted or retired key
+// fails over to the others. LiteLLM does not deliver that for a 404: it aborts
+// on the first member that answers one. The pool's existing coverage
+// (free_pool_router_test.go) asserts the four rows share a litellm_model_name,
+// which stayed true the whole time this was broken -- the shape was right and
+// the behaviour was wrong. This asserts the behaviour instead.
+func TestDispatchWithRetry_FailsOverWhenOnePoolMemberIsGone(t *testing.T) {
+	origDelays := retryDelays
+	retryDelays = []time.Duration{0, 1 * time.Millisecond, 1 * time.Millisecond, 1 * time.Millisecond}
+	t.Cleanup(func() { retryDelays = origDelays })
+
+	var calls int32
+	fn := func(ctx context.Context, model string, body []byte) (*http.Response, error) {
+		// Attempt 1 lands on the dead member. LiteLLM cools it down before
+		// answering, so attempt 2 reaches a live one.
+		if atomic.AddInt32(&calls, 1) == 1 {
+			return mkResp(404, routerExhaustionBody), nil
+		}
+		return mkResp(200, `{"object":"chat.completion"}`), nil
+	}
+
+	resp, err := dispatchWithRetry(context.Background(), "route-free-pool", []byte("{}"), fn)
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d, want 200: a pooled alias must survive one dead member", resp.StatusCode)
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Fatalf("calls = %d, want 2", got)
+	}
+}
+
+// TestDispatchWithRetry_GenuineModelNotFoundIsNotRetried keeps the blast radius
+// of the fix above at exactly the router-exhaustion case. A customer naming a
+// model that does not exist must still get a fast 404, not four attempts and
+// three seconds of backoff.
+func TestDispatchWithRetry_GenuineModelNotFoundIsNotRetried(t *testing.T) {
+	origDelays := retryDelays
+	retryDelays = []time.Duration{0, 1 * time.Millisecond, 1 * time.Millisecond, 1 * time.Millisecond}
+	t.Cleanup(func() { retryDelays = origDelays })
+
+	const body = `{"error":{"message":"The model 'nonexistent-model-12345' does not exist","code":"404"}}`
+	var calls int32
+	fn := func(ctx context.Context, model string, body2 []byte) (*http.Response, error) {
+		atomic.AddInt32(&calls, 1)
+		return mkResp(404, body), nil
+	}
+
+	resp, err := dispatchWithRetry(context.Background(), "m", []byte("{}"), fn)
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if resp.StatusCode != 404 {
+		t.Fatalf("status = %d, want 404", resp.StatusCode)
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("calls = %d, want 1: a real model-not-found must not be retried", got)
+	}
+	got, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("reading body: %v", err)
+	}
+	if string(got) != body {
+		t.Fatalf("body = %q, want it returned intact", got)
+	}
+}
+
+// TestDispatchWithRetry_DeadPoolReturnsTheUpstream404Intact covers the case the
+// retry cannot rescue: every member is gone. The client must still receive the
+// real upstream status and a COMPLETE body, because classifying that body is
+// how the edge decides what to tell the customer
+// (errors.sanitizeProviderBlindMessage) and how CI names the failure. A body
+// left half-consumed by the peek above would truncate both.
+func TestDispatchWithRetry_DeadPoolReturnsTheUpstream404Intact(t *testing.T) {
+	origDelays := retryDelays
+	retryDelays = []time.Duration{0, 1 * time.Millisecond, 1 * time.Millisecond, 1 * time.Millisecond}
+	t.Cleanup(func() { retryDelays = origDelays })
+
+	var calls int32
+	fn := func(ctx context.Context, model string, body []byte) (*http.Response, error) {
+		atomic.AddInt32(&calls, 1)
+		return mkResp(404, routerExhaustionBody), nil
+	}
+
+	resp, err := dispatchWithRetry(context.Background(), "route-free-pool", []byte("{}"), fn)
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if resp.StatusCode != 404 {
+		t.Fatalf("status = %d, want the real upstream 404", resp.StatusCode)
+	}
+	if got := atomic.LoadInt32(&calls); got != int32(len(retryDelays)) {
+		t.Fatalf("calls = %d, want %d", got, len(retryDelays))
+	}
+	got, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("reading body: %v", err)
+	}
+	if string(got) != routerExhaustionBody {
+		t.Fatalf("body = %q, want the upstream envelope returned whole", got)
+	}
+}
+
+// TestIsRouterExhaustion404LeavesTheBodyReadable pins the splice itself for
+// bodies larger than the peek window, which is the case where a naive
+// implementation silently drops everything past maxRetryPeekBytes.
+func TestIsRouterExhaustion404LeavesTheBodyReadable(t *testing.T) {
+	big := strings.Repeat("x", maxRetryPeekBytes*2)
+	resp := mkResp(404, big)
+
+	if isRouterExhaustion404(resp) {
+		t.Fatal("a body with no marker must not be classified as router exhaustion")
+	}
+	got, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("reading body: %v", err)
+	}
+	if len(got) != len(big) {
+		t.Fatalf("body length = %d, want %d: the peek truncated the response", len(got), len(big))
+	}
+}

--- a/deploy/litellm/config.yaml
+++ b/deploy/litellm/config.yaml
@@ -439,6 +439,28 @@ litellm_settings:
   # above names.
   num_retries: 3
   request_timeout: 45
+  # DO NOT "TIDY" allowed_fails / cooldown_time INTO router_settings.
+  #
+  # They look misplaced, and in the narrow sense they are: both are Router
+  # constructor params (litellm/types/router.py::UpdateRouterConfig lists them),
+  # so sitting under litellm_settings they never reach the Router. The effective
+  # cooldown is therefore DEFAULT_COOLDOWN_TIME_SECONDS (5), not the 30 written
+  # here -- confirmed at runtime, not inferred: CI run 32830060362's litellm log
+  # prints `'cooldown_time': 5` in its Cooldown Deployments line.
+  #
+  # Moving allowed_fails would BREAK the free pool. With it unset on the Router,
+  # router_utils/cooldown_handlers.py::_should_cooldown_deployment takes its
+  # BASE CASE branch, whose last test is `litellm._should_retry(status) is False
+  # -> return True`: a 404 member is cooled down on its FIRST failure. Set
+  # allowed_fails on the Router and that branch is skipped for
+  # should_cooldown_based_on_allowed_fails_policy, which needs `fails >
+  # allowed_fails` -- four failures before a dead member is taken out of
+  # rotation. The edge's failover retry (apps/edge-api/internal/inference/
+  # retry.go) depends on the immediate cooldown to land its next attempt on a
+  # different member, so that change would quietly restore issue #1064.
+  #
+  # Left as-is deliberately, with the reason written down, rather than "fixed"
+  # into a regression. Revisit only alongside that retry ladder.
   allowed_fails: 3
   cooldown_time: 30
   drop_params: true

--- a/scripts/report-free-pool-health.py
+++ b/scripts/report-free-pool-health.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Turn LiteLLM's `/health?model=route-free-pool` answer into a named verdict.
+
+Why this exists (issue #1064). The live-integration job already asserts that
+the gateway SERVES the route-free-pool group, but serving a group only proves
+the group exists, not that its four members answer. Free model ids churn
+constantly on every provider in the pool, and a retired one answers 404 --
+which is precisely the error LiteLLM refuses to fail over on
+(litellm/router.py::should_retry_this_error re-raises NotFoundError, and
+RetryPolicy carries no NotFoundErrorRetries knob to lift it). Before this
+script, that surfaced as a generic "hive-free is not available." with nothing
+anywhere naming which of the four models had gone away.
+
+Exit codes, and the reasoning behind them:
+
+  0  every member healthy, or SOME members down. Surviving a dead member is
+     the pool's entire purpose, so failing the job on one would make the
+     resilience worthless. The dead one is named as a ::warning:: and the SDK
+     suites remain the real gate.
+  1  every member down. hive-free then serves nothing, which is a free-tier
+     outage rather than a degraded pool, and it should stop the run loudly.
+  0  a malformed or unreadable payload, reported as a ::warning::. A probe that
+     cannot parse its input has not discovered an outage, and turning "I could
+     not tell" into a red run is how a check starts crying wolf.
+
+Self-check: python3 scripts/report-free-pool-health.py --selfcheck
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+def _load_redactor():
+    """Import redact-log-credentials.py, whose filename is not a Python name.
+
+    That module is the published-log redactor this repo already uses for every
+    container dump. LiteLLM strips api_key from health output itself
+    (ILLEGAL_DISPLAY_PARAMS in litellm/proxy/health_check.py), but `error` is
+    free-form provider text and this job's log is world-readable on a public
+    repository, so it goes through the same filter as everything else.
+    """
+    import importlib.util
+
+    path = pathlib.Path(__file__).resolve().parent / "redact-log-credentials.py"
+    spec = importlib.util.spec_from_file_location("redact_log_credentials", path)
+    if spec is None or spec.loader is None:
+        return lambda line: line
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    for name in ("redact_line", "redact", "scrub_line", "scrub"):
+        fn = getattr(module, name, None)
+        if callable(fn):
+            return fn
+    return lambda line: line
+
+
+ERROR_EXCERPT_CHARS = 300
+
+
+def report(payload: dict, redact) -> int:
+    endpoints_healthy = payload.get("healthy_endpoints") or []
+    endpoints_unhealthy = payload.get("unhealthy_endpoints") or []
+    # Prefer the explicit counts, fall back to the lists. A payload that
+    # carries one but not the other must not read as "zero unhealthy".
+    healthy = payload.get("healthy_count")
+    unhealthy = payload.get("unhealthy_count")
+    if not isinstance(healthy, int):
+        healthy = len(endpoints_healthy)
+    if not isinstance(unhealthy, int):
+        unhealthy = len(endpoints_unhealthy)
+
+    print(f"free pool members: {healthy} healthy, {unhealthy} unhealthy")
+
+    for endpoint in endpoints_unhealthy:
+        if not isinstance(endpoint, dict):
+            endpoint = {}
+        # `model` is the upstream model id, which is the thing that gets retired
+        # and therefore the thing worth printing by name.
+        model = endpoint.get("model") or "unknown"
+        detail = str(endpoint.get("error") or "no error text")[:ERROR_EXCERPT_CHARS]
+        print(redact(f"  DEAD MEMBER: {model} -- {detail}"))
+        print(
+            redact(
+                f"::warning::free pool member '{model}' is not answering. If its "
+                "provider no longer lists that model, it is RETIRED: replace the "
+                "member row in supabase/migrations/ rather than waiting for it to "
+                "come back. The pool routes around it for now."
+            )
+        )
+
+    if healthy == 0:
+        print(
+            "::error::every free pool member is down, so hive-free can serve "
+            "nothing. This is an outage of the free tier, not a degraded pool."
+        )
+        return 1
+    return 0
+
+
+def _selfcheck() -> int:
+    plain = lambda line: line  # noqa: E731
+
+    one_dead = {
+        "healthy_count": 3,
+        "unhealthy_count": 1,
+        "healthy_endpoints": [{"model": "groq/openai/gpt-oss-20b"}],
+        "unhealthy_endpoints": [
+            {"model": "openai/gemini-flash-latest", "error": "Error code: 404"}
+        ],
+    }
+    assert report(one_dead, plain) == 0, "one dead member must not fail the job"
+
+    all_dead = {
+        "healthy_count": 0,
+        "unhealthy_count": 4,
+        "healthy_endpoints": [],
+        "unhealthy_endpoints": [{"model": f"m{i}"} for i in range(4)],
+    }
+    assert report(all_dead, plain) == 1, "a fully dead pool must fail the job"
+
+    all_healthy = {"healthy_count": 4, "unhealthy_count": 0}
+    assert report(all_healthy, plain) == 0
+
+    # Counts missing entirely: fall back to the lists rather than reading as
+    # "0 healthy" and failing a perfectly good pool.
+    no_counts = {"healthy_endpoints": [{"model": "a"}], "unhealthy_endpoints": []}
+    assert report(no_counts, plain) == 0, "missing counts must fall back to the lists"
+
+    # A non-dict endpoint must not crash the reporter.
+    junk = {"healthy_count": 1, "unhealthy_count": 1, "unhealthy_endpoints": ["nope"]}
+    assert report(junk, plain) == 0
+
+    print("ok: report-free-pool-health verdicts and fallbacks")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    if "--selfcheck" in argv:
+        return _selfcheck()
+    if len(argv) < 2:
+        print("::warning::report-free-pool-health.py needs a path to the health JSON")
+        return 0
+
+    try:
+        payload = json.loads(pathlib.Path(argv[1]).read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        print(f"::warning::could not read the free pool health payload: {exc}")
+        return 0
+    if not isinstance(payload, dict):
+        print("::warning::the free pool health payload was not a JSON object")
+        return 0
+
+    return report(payload, _load_redactor())
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
## Summary

`hive-free` is served by a load-balanced LiteLLM group of four free provider keys, and its whole product claim is that one exhausted or retired key fails over to the others. It does not. One member answering 404 takes the entire alias down for that request. That is what has been failing `Live integration (SDK tests + smoke)` on main.

Fixes #1064.

## Which of the four candidate causes it was

**Routing.** Not credentials, not pricing, not metering.

All four members' credentials and models were verified live while diagnosing this:

| Member | Upstream | Verified |
| --- | --- | --- |
| `route-free-pool-free` | `dots-studio/dots-3-note-preview:free` | listed in OpenRouter's public catalog right now |
| `route-free-pool-groq` | `openai/gpt-oss-20b` | listed in Groq's `/v1/models` right now |
| `route-free-pool-groq-2` | `openai/gpt-oss-20b`, second key slot | same model, secret present |
| `route-free-pool-gemini` | `openai/gemini-flash-latest` | not probeable from the dev box, no key there |

All four repository secrets exist. The gateway serves the group: the run's own assertion printed `gateway serves route-free-pool`.

## Request failed, or metering silently dropped it?

**Request failed.** This matters because the repo has been burned by the second shape before (2026-07-31, the gateway billed nothing for three days and every failure was silent), so it was checked first rather than assumed.

The failing run's own spend report:

```
      model_alias       |     event_type      | events | input_tokens | output_tokens
------------------------+---------------------+--------+--------------+---------------
 hive-free              | completed           |     14 |          318 |           278
 hive-free              | error               |      1 |            0 |             0
 hive-free              | reconciled          |      2 |            0 |             0
 hive-free              | released            |      2 |            0 |             0
 hive-free              | reservation_created |     10 |            0 |             0
```

Fourteen metered completions on `hive-free`, plus one metered `error`. Metering is healthy and is recording both outcomes. The "zero metered completions" framing does not hold for this run: the `served == 0` assertion is gated on `SUITES_OUTCOME = success` and never executed, because the suites had already failed.

## The actual failure

Three JS tests failed, all of them the *second* `hive-free` call in their file. The first call in each file passed. Python's suite passed 14/14 because pytest runs sequentially while vitest runs test files in parallel, so only the JS run had concurrent `hive-free` traffic.

```
 ❯ tests/completions/completions.test.ts (2 tests | 1 failed)
   ✓ Completions (legacy) > returns a valid text completion via SDK  2451ms
   × Completions (legacy) > model field shows Hive alias not provider handle 128ms
     → 404 hive-free is not available.
 ❯ tests/chat-completions/chat-completions.test.ts (5 tests | 1 failed)
   × Chat Completions > model field shows Hive alias not provider handle 60004ms
     → Test timed out in 60000ms.
```

The customer-facing `hive-free is not available.` is our provider-blind collapse of this, from the run's `compose-logs` artifact:

```
litellm.NotFoundError: NotFoundError: OpenAIException - Error code: 404
No fallback model group found for original model_group=route-free-pool.
Fallbacks=[{'route-openrouter-embedding': ['route-openrouter-embedding-fallback']}].
Received Model Group=route-free-pool
Available Model Group Fallbacks=None
Cooldown Deployments=[('e644bb2c...', {'exception_received': 'litellm.NotFoundError: ...',
                       'status_code': '404', 'timestamp': ..., 'cooldown_time': 5})]
```

One deployment returned 404. Three were fine. The request died anyway.

## Root cause

Read out of the pinned image's source (`v1.98.0`), not inferred:

1. `litellm/router.py::should_retry_this_error` re-raises immediately for `NotFoundError`, and again for any status where `litellm._should_retry()` is false. 404 is both:
   ```python
   status_code = getattr(error, "status_code", None)
   if status_code is not None and not litellm._should_retry(status_code):
       if status_code not in (401, 403):
           raise error
   if isinstance(error, litellm.NotFoundError):
       raise error
   ```
2. It is called from **both** `async_function_with_retries` and `async_function_with_fallbacks`, so neither the in-group retry across the other three members nor the cross-group fallback ever runs.
3. `litellm/types/router.py::RetryPolicy` has fields for BadRequest, Authentication, Timeout, RateLimit, ContentPolicyViolation and InternalServer errors, and **none for NotFound**. There is no configuration that lifts this.

A retired free model is exactly what returns 404, and free model ids churn constantly on every provider in this pool. So the pool's failover premise is false against the single most likely way a free member dies.

## The fix

**Make the pool answer.** `apps/edge-api/internal/inference/retry.go` is the one shared dispatch seam that every chat, completions, responses and streaming path already flows through, so the fix lands once for every pooled alias rather than for `hive-free` alone. It now retries a LiteLLM router-exhaustion 404.

This is sound rather than hopeful because LiteLLM cools the offending deployment down *before* raising: `router_utils/cooldown_handlers.py::_should_cooldown_deployment` ends its base case with `litellm._should_retry(status) is False -> return True`, so a 404 member is out of rotation on its **first** failure, not after `allowed_fails`. The next attempt therefore picks a different member, and the existing 300/800/1800 ms ladder finishes inside 2.9 s, comfortably inside the 5 s cooldown, so the dead member cannot be re-picked mid-ladder.

Scope is deliberately narrow: the retry matches on LiteLLM's message, not on a bare 404, so a customer naming a model that does not exist still gets a fast 404 and pays no retries. `isRouterExhaustion404` splices the body back together after peeking, so the caller always receives a complete response; a half-consumed body would truncate the error the customer sees and the text CI classifies on.

**Make the failure legible.** Two additions, neither of which weakens a check:

* A new step probes each member individually through LiteLLM's own `/health?model=route-free-pool` and **names the model that is gone**. One dead member is a `::warning::`, because surviving one is the pool's entire purpose and failing the job on it would make that resilience worthless; the SDK suites remain the real gate. Every member dead is a hard failure, because the free tier then genuinely serves nothing. Output goes through `scripts/redact-log-credentials.py` like every other published dump in this job.
* The upstream-refusal classifier gained a branch for the `No fallback model group found` signature, so this reads as "a pool member is dead" instead of falling through to "this failure is something else".

**No paid fallback was added.** Pointing `hive-free` at a paid model would silently spend real budget and break the one-alias-one-price rule; if a paid fallback is the right product answer, that is an owner decision, not one to smuggle into a CI fix.

## A trap this leaves behind, documented rather than fixed

`allowed_fails` and `cooldown_time` sit under `litellm_settings` in `deploy/litellm/config.yaml`. They look misplaced and in the narrow sense they are: both are Router constructor params, so they never reach the Router, and the effective cooldown is the default 5 s, not the 30 written there. That is observed, not deduced: the failing run's log prints `'cooldown_time': 5`.

**Moving `allowed_fails` onto the Router would quietly restore this bug.** With it unset, `_should_cooldown_deployment` takes the base case that cools a 404 member down on the first failure. Set it, and that branch is skipped for `should_cooldown_based_on_allowed_fails_policy`, which needs `fails > allowed_fails`: four failures before a dead member leaves rotation, which the retry ladder above cannot outlast. The config now says so in place, so the next tidy-up does not walk into it.

## What kind of check actually closes this gap

The pool already had unit coverage, `apps/control-plane/internal/routing/free_pool_router_test.go`, and it passed the entire time this was broken. It parses the migration text and asserts the four rows share one `litellm_model_name`. That assertion was **true**; the shape was right and the behaviour was wrong. A test that can only see the config can never catch a failure that lives in the router's exception handling.

What closes it is a test that exercises the real function against the real upstream envelope, so this PR adds behavioural coverage over `dispatchWithRetry` using the verbatim 404 body from run 32830060362:

* `TestDispatchWithRetry_FailsOverWhenOnePoolMemberIsGone` — dead member on attempt 1, 200 on attempt 2. Fails on `main`.
* `TestDispatchWithRetry_GenuineModelNotFoundIsNotRetried` — bounds the blast radius; a real model-not-found stays one attempt.
* `TestDispatchWithRetry_DeadPoolReturnsTheUpstream404Intact` — when retries cannot rescue it, the client still gets the real status and a complete body.
* `TestIsRouterExhaustion404LeavesTheBodyReadable` — the body splice survives a payload larger than the peek window.

Plus `scripts/report-free-pool-health.py --selfcheck`, covering the one-dead / all-dead / missing-counts / malformed-endpoint verdicts.

The live half is closed by the new probe step, which is the only thing in CI that can name a retired model, and by the classifier branch that stops this failure shape reading as unexplained.

## Test evidence

```
=== RUN   TestDispatchWithRetry_FailsOverWhenOnePoolMemberIsGone
--- PASS: TestDispatchWithRetry_FailsOverWhenOnePoolMemberIsGone (0.00s)
=== RUN   TestDispatchWithRetry_GenuineModelNotFoundIsNotRetried
--- PASS: TestDispatchWithRetry_GenuineModelNotFoundIsNotRetried (0.00s)
=== RUN   TestDispatchWithRetry_DeadPoolReturnsTheUpstream404Intact
--- PASS: TestDispatchWithRetry_DeadPoolReturnsTheUpstream404Intact (0.00s)
=== RUN   TestIsRouterExhaustion404LeavesTheBodyReadable
--- PASS: TestIsRouterExhaustion404LeavesTheBodyReadable (0.00s)
PASS
ok  	github.com/sakibsadmanshajib/hive/apps/edge-api/internal/inference	0.028s
```

Full module, plus build and vet:

```
BUILD_OK
VET_OK
ok  github.com/sakibsadmanshajib/hive/apps/edge-api/internal/inference  3.161s
ok  github.com/sakibsadmanshajib/hive/apps/edge-api/internal/errors     0.065s
... (25 packages, all ok)
ok  github.com/sakibsadmanshajib/hive/apps/control-plane/internal/routing       0.185s
ok  github.com/sakibsadmanshajib/hive/apps/control-plane/internal/litellmconfig 0.181s
```

```
$ python3 scripts/report-free-pool-health.py --selfcheck
ok: report-free-pool-health verdicts and fallbacks

$ node tools/lint-litellm-config-fallbacks.mjs
lint-litellm-config-fallbacks: PASS
```

Redaction verified end to end on a synthetic error carrying a key-shaped value:

```
  DEAD MEMBER: openai/gemini-flash-latest -- Error code: 404 - models/gemini-flash-latest is not found. api_key=<redacted>
```

`gofmt -l` output is byte-identical before and after this change, so no formatting regression was introduced.

## Buglog entry

```json
{"id":"free-pool-404-no-failover","date":"2026-08-25","title":"LiteLLM aborts a load-balanced group on one member's 404 instead of failing over, taking hive-free down","error_message":"litellm.NotFoundError: NotFoundError: OpenAIException - Error code: 404No fallback model group found for original model_group=route-free-pool. Available Model Group Fallbacks=None -- surfaced to the customer as 'hive-free is not available.'","root_cause":"litellm/router.py::should_retry_this_error re-raises immediately for NotFoundError and for any status where litellm._should_retry() is false; 404 is both. It is called from async_function_with_retries and async_function_with_fallbacks, so one pool member answering 404 (what a retired free model returns) killed the request while the group's other three members were healthy. litellm/types/router.py::RetryPolicy has no NotFoundErrorRetries field, so no config lifts it. The pool's existing unit test asserts the four rows share a litellm_model_name, which stayed true throughout, so the shape was right and the behaviour was wrong.","fix":"Retry a LiteLLM router-exhaustion 404 in the shared dispatch seam (apps/edge-api/internal/inference/retry.go), matched on LiteLLM's message rather than on a bare 404 so a genuine model-not-found stays fast. Sound because LiteLLM cools the 404 deployment down on its first failure, so the next attempt picks a different member inside the 5s window. Added behavioural tests over dispatchWithRetry, a CI step that names a dead member via /health?model=, and a classifier branch for the signature.","tags":["litellm","routing","free-pool","failover","ci","edge-api","hive-free","404"]}
```

```json
{"id":"litellm-router-knobs-in-wrong-config-block","date":"2026-08-25","title":"allowed_fails and cooldown_time under litellm_settings never reach the LiteLLM Router, and moving allowed_fails would break free pool failover","error_message":"config declares cooldown_time: 30 but the runtime log prints 'cooldown_time': 5 in its Cooldown Deployments line","root_cause":"allowed_fails and cooldown_time are Router constructor params (litellm/types/router.py::UpdateRouterConfig), not litellm_settings keys, so the values are silently ignored and DEFAULT_COOLDOWN_TIME_SECONDS (5) applies. The apparent misplacement is load-bearing: with allowed_fails unset on the Router, _should_cooldown_deployment takes its base case and cools a 404 member down on the first failure, which is what lets the edge retry land on a different member.","fix":"Left both settings in place deliberately and documented the trap in deploy/litellm/config.yaml, including that moving allowed_fails into router_settings would require four failures before a dead member leaves rotation and would quietly restore the free pool 404 bug.","tags":["litellm","config","cooldown","free-pool","footgun"]}
```
