### PR TITLE
fix: carry the remaining Anthropic /v1/messages request fields through the translator

### DIFF
--- a/apps/edge-api/internal/anthropic/translate_request.go
+++ b/apps/edge-api/internal/anthropic/translate_request.go
@@ -40,8 +40,14 @@ func ToOAIRequest(req MessagesRequest) (OAIRequest, error) {
 		Messages:     msgs,
 		Temperature:  req.Temperature,
 		TopP:         req.TopP,
+		TopK:         req.TopK,
 		Stream:       req.Stream,
 		CacheControl: req.CacheControl,
+		Thinking:     req.Thinking,
+	}
+
+	if req.Metadata != nil && req.Metadata.UserID != "" {
+		out.User = req.Metadata.UserID
 	}
 
 	if req.SessionID != "" {
@@ -72,6 +78,10 @@ func ToOAIRequest(req MessagesRequest) (OAIRequest, error) {
 	if req.ToolChoice != nil {
 		tc := convertToolChoice(req.ToolChoice)
 		out.ToolChoice = &tc
+		if req.ToolChoice.DisableParallelToolUse != nil && *req.ToolChoice.DisableParallelToolUse {
+			no := false
+			out.ParallelToolCalls = &no
+		}
 	}
 
 	return out, nil
@@ -161,9 +171,10 @@ func convertMessage(m Message) ([]OAIMessage, error) {
 		return toolResults, nil
 	}
 
-	// Mixed content blocks: text, image, tool_use.
+	// Mixed content blocks: text, image, tool_use, thinking.
 	var parts []OAIContentPart
 	var toolCalls []OAIToolCall
+	var thinkingBlocks []OAIThinkingBlock
 
 	for _, bl := range m.Content.Blocks {
 		switch bl.Type {
@@ -200,27 +211,41 @@ func convertMessage(m Message) ([]OAIMessage, error) {
 				},
 				CacheControl: bl.CacheControl,
 			})
+
+		case "thinking", "redacted_thinking":
+			// Prior-turn extended-thinking content, echoed back by the client
+			// as conversation history. Before this fix these blocks matched no
+			// case here at all: a thinking-only message fell through with
+			// empty parts and empty toolCalls, and every branch below produced
+			// an OAIMessage with no content and no tool_calls -- silently
+			// empty, not an error. thinkingBlocks is attached to every return
+			// path below so this can never happen again, whether the thinking
+			// block is alone or mixed with text/tool_use in the same turn.
+			thinkingBlocks = append(thinkingBlocks, OAIThinkingBlock{
+				Type:      bl.Type,
+				Thinking:  bl.Thinking,
+				Signature: bl.Signature,
+				Data:      bl.Data,
+			})
 		}
 	}
 
 	// Pure tool-call assistant turn.
 	if len(toolCalls) > 0 && len(parts) == 0 {
-		return []OAIMessage{{Role: m.Role, ToolCalls: toolCalls}}, nil
+		return []OAIMessage{{Role: m.Role, ToolCalls: toolCalls, ThinkingBlocks: thinkingBlocks}}, nil
 	}
-	// Tool calls plus text/image content. A part with a cache breakpoint
-	// keeps the block-array form so it is not lost; otherwise this
-	// reproduces the exact flat-string concatenation this function always
-	// emitted (including its pre-existing wart of silently dropping any
-	// image part mixed with tool calls -- see the PR body's dropped-field
-	// audit; fixing that is a separate, non-cache_control change and out of
-	// this fix's surgical scope), which is the regression guard for the
-	// overwhelmingly common no-cache-control case.
+	// Tool calls plus text/image content. A part with a cache breakpoint, or a
+	// non-text part (image), keeps the block-array form so it is not lost;
+	// otherwise this reproduces the exact flat-string concatenation this
+	// function always emitted, which is the regression guard for the
+	// overwhelmingly common plain-text case.
 	if len(toolCalls) > 0 {
 		if partsNeedArrayForm(parts) {
 			return []OAIMessage{{
-				Role:      m.Role,
-				Content:   OAIMessageContent{Parts: parts},
-				ToolCalls: toolCalls,
+				Role:           m.Role,
+				Content:        OAIMessageContent{Parts: parts},
+				ToolCalls:      toolCalls,
+				ThinkingBlocks: thinkingBlocks,
 			}}, nil
 		}
 		var contentStr string
@@ -230,26 +255,30 @@ func convertMessage(m Message) ([]OAIMessage, error) {
 			}
 		}
 		return []OAIMessage{{
-			Role:      m.Role,
-			Content:   OAIMessageContent{Text: contentStr},
-			ToolCalls: toolCalls,
+			Role:           m.Role,
+			Content:        OAIMessageContent{Text: contentStr},
+			ToolCalls:      toolCalls,
+			ThinkingBlocks: thinkingBlocks,
 		}}, nil
 	}
 
-	// Pure text/image parts: use array form for vision or a cache breakpoint,
-	// string for a lone uncached text block.
-	if len(parts) == 1 && parts[0].Type == "text" && parts[0].CacheControl == nil {
+	// Pure text/image/thinking parts: use array form for vision or a cache
+	// breakpoint, string for a lone uncached text block.
+	if len(parts) == 1 && parts[0].Type == "text" && parts[0].CacheControl == nil && len(thinkingBlocks) == 0 {
 		return []OAIMessage{{Role: m.Role, Content: OAIMessageContent{Text: parts[0].Text}}}, nil
 	}
-	return []OAIMessage{{Role: m.Role, Content: OAIMessageContent{Parts: parts}}}, nil
+	return []OAIMessage{{Role: m.Role, Content: OAIMessageContent{Parts: parts}, ThinkingBlocks: thinkingBlocks}}, nil
 }
 
 // partsNeedArrayForm reports whether a set of content parts must keep the
 // block-array form rather than collapse to a flat string: true if any part
-// carries a cache breakpoint, which a flat string cannot address.
+// carries a cache breakpoint (which a flat string cannot address), or any
+// part is not plain text (a flat string cannot carry an image_url either --
+// this used to silently drop an image mixed with tool calls; see issue
+// #1153 item 6).
 func partsNeedArrayForm(parts []OAIContentPart) bool {
 	for _, p := range parts {
-		if p.CacheControl != nil {
+		if p.CacheControl != nil || p.Type != "text" {
 			return true
 		}
 	}
@@ -298,13 +327,22 @@ func convertTools(tools []Tool) ([]OAITool, error) {
 //
 //	auto        -> sentinel "auto"
 //	any         -> sentinel "required"
+//	none        -> sentinel "none"
 //	{type:tool} -> named function selector
+//
+// "none" is the case that matters most here: it means "the model must not
+// call any tool", and OpenAI's chat/completions surface has the identical
+// sentinel for the identical meaning. Before this fix, "none" fell through to
+// the default branch below and came out as "auto" -- the opposite of what the
+// caller asked for, not merely a dropped field.
 func convertToolChoice(tc *ToolChoice) OAIToolChoice {
 	switch tc.Type {
 	case "auto":
 		return OAIToolChoice{Sentinel: "auto"}
 	case "any":
 		return OAIToolChoice{Sentinel: "required"}
+	case "none":
+		return OAIToolChoice{Sentinel: "none"}
 	case "tool":
 		return OAIToolChoice{
 			Named: &OAINamedToolChoice{

--- a/apps/edge-api/internal/anthropic/translate_request.go
+++ b/apps/edge-api/internal/anthropic/translate_request.go
@@ -76,7 +76,10 @@ func ToOAIRequest(req MessagesRequest) (OAIRequest, error) {
 	}
 
 	if req.ToolChoice != nil {
-		tc := convertToolChoice(req.ToolChoice)
+		tc, err := convertToolChoice(req.ToolChoice)
+		if err != nil {
+			return OAIRequest{}, fmt.Errorf("tool_choice: %w", err)
+		}
 		out.ToolChoice = &tc
 		if req.ToolChoice.DisableParallelToolUse != nil && *req.ToolChoice.DisableParallelToolUse {
 			no := false
@@ -335,23 +338,34 @@ func convertTools(tools []Tool) ([]OAITool, error) {
 // sentinel for the identical meaning. Before this fix, "none" fell through to
 // the default branch below and came out as "auto" -- the opposite of what the
 // caller asked for, not merely a dropped field.
-func convertToolChoice(tc *ToolChoice) OAIToolChoice {
+//
+// An unrecognized type is rejected with an error rather than silently mapped
+// to "auto". Anthropic documents exactly these four values, so every one of
+// them is now an explicit case above; a fifth value existing at all means
+// either a client bug or a future Anthropic addition Hive doesn't understand
+// yet, and defaulting either of those to "auto" is the identical inversion
+// shape as the tool_choice:"none" bug this file exists to fix -- silently
+// enabling tool use nobody asked for is worse than a clear 400.
+func convertToolChoice(tc *ToolChoice) (OAIToolChoice, error) {
 	switch tc.Type {
 	case "auto":
-		return OAIToolChoice{Sentinel: "auto"}
+		return OAIToolChoice{Sentinel: "auto"}, nil
 	case "any":
-		return OAIToolChoice{Sentinel: "required"}
+		return OAIToolChoice{Sentinel: "required"}, nil
 	case "none":
-		return OAIToolChoice{Sentinel: "none"}
+		return OAIToolChoice{Sentinel: "none"}, nil
 	case "tool":
 		return OAIToolChoice{
 			Named: &OAINamedToolChoice{
 				Type:     "function",
 				Function: OAINamedToolChoiceFunction{Name: tc.Name},
 			},
-		}
+		}, nil
 	default:
-		return OAIToolChoice{Sentinel: "auto"}
+		return OAIToolChoice{}, fmt.Errorf(
+			"tool_choice.type %q is not a supported Anthropic value (want one of auto, any, tool, none)",
+			tc.Type,
+		)
 	}
 }
 

--- a/apps/edge-api/internal/anthropic/translate_request_maximal_test.go
+++ b/apps/edge-api/internal/anthropic/translate_request_maximal_test.go
@@ -1,0 +1,243 @@
+package anthropic_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/anthropic"
+)
+
+// TestToOAIRequest_MaximalRequest_NoFieldLost is the structural guard issue
+// #1153 asks for: a single Anthropic request that populates every documented
+// MessagesRequest field (plus every documented sub-field on the types that
+// hang off it -- ContentBlock, Tool, ToolChoice), translated once, with an
+// explicit assertion per field. This is what stops the next field silently
+// dropped or inverted by translate_request.go from going unnoticed the way
+// cache_control did (PR #1152) and the way the six fields fixed by this
+// change did (issue #1153): a translator that rebuilds its output field by
+// field has no other structural defense against "nobody remembered to carry
+// this one across."
+//
+// When a new field is added to MessagesRequest, the correct response is to
+// add it here too, not just in a field-specific test elsewhere in this
+// package.
+func TestToOAIRequest_MaximalRequest_NoFieldLost(t *testing.T) {
+	raw := `{
+		"model": "claude-3-5-sonnet",
+		"max_tokens": 4096,
+		"system": "You are a helpful assistant.",
+		"messages": [
+			{"role": "user", "content": "What's the weather in Dhaka, and analyze this chart?"},
+			{"role": "assistant", "content": [
+				{"type": "thinking", "thinking": "I should call the weather tool.", "signature": "sig_001"},
+				{"type": "text", "text": "Let me check.", "cache_control": {"type": "ephemeral"}},
+				{"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "abc123"}},
+				{"type": "tool_use", "id": "tu_01", "name": "get_weather", "input": {"city": "Dhaka"}, "cache_control": {"type": "ephemeral"}}
+			]},
+			{"role": "user", "content": [
+				{"type": "tool_result", "tool_use_id": "tu_01", "content": "Sunny, 32C", "cache_control": {"type": "ephemeral"}}
+			]}
+		],
+		"tools": [
+			{"name": "get_weather", "description": "Get current weather", "input_schema": {"type": "object", "properties": {"city": {"type": "string"}}}, "cache_control": {"type": "ephemeral"}}
+		],
+		"tool_choice": {"type": "auto", "disable_parallel_tool_use": true},
+		"temperature": 0.65,
+		"top_p": 0.92,
+		"top_k": 40,
+		"stop_sequences": ["STOP", "\n\n"],
+		"stream": true,
+		"metadata": {"user_id": "end-user-789"},
+		"cache_control": {"type": "ephemeral", "ttl": "1h"},
+		"session_id": "sess-abc-123",
+		"thinking": {"type": "enabled", "budget_tokens": 8192}
+	}`
+
+	var req anthropic.MessagesRequest
+	if err := json.Unmarshal([]byte(raw), &req); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	got, err := anthropic.ToOAIRequest(req)
+	if err != nil {
+		t.Fatalf("ToOAIRequest: %v", err)
+	}
+
+	// --- Request-root fields ---
+
+	if got.Model != "claude-3-5-sonnet" {
+		t.Errorf("model: got %q", got.Model)
+	}
+	if got.MaxTokens == nil || *got.MaxTokens != 4096 {
+		t.Errorf("max_tokens: got %v", got.MaxTokens)
+	}
+	if got.Temperature == nil || *got.Temperature != 0.65 {
+		t.Errorf("temperature: got %v", got.Temperature)
+	}
+	if got.TopP == nil || *got.TopP != 0.92 {
+		t.Errorf("top_p: got %v", got.TopP)
+	}
+	if got.TopK == nil || *got.TopK != 40 {
+		t.Errorf("top_k: got %v (issue #1153 item 4)", got.TopK)
+	}
+	if len(got.Stop) != 2 || got.Stop[0] != "STOP" || got.Stop[1] != "\n\n" {
+		t.Errorf("stop_sequences: got %v", got.Stop)
+	}
+	if got.Stream != true {
+		t.Errorf("stream: got %v", got.Stream)
+	}
+	if got.User != "end-user-789" {
+		t.Errorf("user (from metadata.user_id): got %q (issue #1153 item 2)", got.User)
+	}
+	if got.CacheControl == nil || got.CacheControl.Type != "ephemeral" || got.CacheControl.TTL != "1h" {
+		t.Errorf("cache_control (root): got %+v", got.CacheControl)
+	}
+	if got.SessionID != "sess-abc-123" {
+		t.Errorf("session_id: got %q", got.SessionID)
+	}
+	if got.Thinking == nil || got.Thinking.Type != "enabled" || got.Thinking.BudgetTokens != 8192 {
+		t.Errorf("thinking (request field): got %+v (issue #1153 item 5a)", got.Thinking)
+	}
+
+	// --- tool_choice + disable_parallel_tool_use ---
+
+	if got.ToolChoice == nil {
+		t.Fatal("tool_choice: nil")
+	}
+	tcJSON, _ := json.Marshal(got.ToolChoice)
+	if string(tcJSON) != `"auto"` {
+		t.Errorf("tool_choice: got %s", tcJSON)
+	}
+	if got.ParallelToolCalls == nil || *got.ParallelToolCalls != false {
+		t.Errorf("parallel_tool_calls (from disable_parallel_tool_use): got %v (issue #1153 item 3)", got.ParallelToolCalls)
+	}
+
+	// --- tools + tool cache_control ---
+
+	if len(got.Tools) != 1 {
+		t.Fatalf("tools len: got %d", len(got.Tools))
+	}
+	tool := got.Tools[0]
+	if tool.Function.Name != "get_weather" || tool.Function.Description != "Get current weather" {
+		t.Errorf("tool: got %+v", tool.Function)
+	}
+	if tool.CacheControl == nil || tool.CacheControl.Type != "ephemeral" {
+		t.Errorf("tool cache_control: got %+v", tool.CacheControl)
+	}
+
+	// --- messages ---
+
+	if len(got.Messages) != 4 {
+		t.Fatalf("messages len: want 4 got %d", len(got.Messages))
+	}
+
+	sys := got.Messages[0]
+	if sys.Role != "system" {
+		t.Errorf("messages[0].role: got %q", sys.Role)
+	}
+	sysJSON, _ := json.Marshal(sys.Content)
+	if string(sysJSON) != `"You are a helpful assistant."` {
+		t.Errorf("messages[0].content: got %s", sysJSON)
+	}
+
+	userText := got.Messages[1]
+	if userText.Role != "user" {
+		t.Errorf("messages[1].role: got %q", userText.Role)
+	}
+	userTextJSON, _ := json.Marshal(userText.Content)
+	if string(userTextJSON) != `"What's the weather in Dhaka, and analyze this chart?"` {
+		t.Errorf("messages[1].content: got %s", userTextJSON)
+	}
+
+	mixed := got.Messages[2]
+	if mixed.Role != "assistant" {
+		t.Errorf("messages[2].role: got %q", mixed.Role)
+	}
+	if len(mixed.ThinkingBlocks) != 1 {
+		t.Fatalf("messages[2].thinking_blocks len: want 1 got %d (issue #1153 item 5b)", len(mixed.ThinkingBlocks))
+	}
+	tb := mixed.ThinkingBlocks[0]
+	if tb.Type != "thinking" || tb.Thinking != "I should call the weather tool." || tb.Signature != "sig_001" {
+		t.Errorf("messages[2].thinking_blocks[0]: got %+v", tb)
+	}
+	if len(mixed.ToolCalls) != 1 {
+		t.Fatalf("messages[2].tool_calls len: want 1 got %d", len(mixed.ToolCalls))
+	}
+	tc := mixed.ToolCalls[0]
+	if tc.ID != "tu_01" || tc.Function.Name != "get_weather" {
+		t.Errorf("messages[2].tool_calls[0]: got %+v", tc)
+	}
+	if tc.CacheControl == nil || tc.CacheControl.Type != "ephemeral" {
+		t.Errorf("messages[2].tool_calls[0].cache_control: got %+v", tc.CacheControl)
+	}
+	mixedContentJSON, _ := json.Marshal(mixed.Content)
+	var mixedParts []map[string]interface{}
+	if err := json.Unmarshal(mixedContentJSON, &mixedParts); err != nil {
+		t.Fatalf("messages[2].content is not an array (image or cache_control text part lost): %s", mixedContentJSON)
+	}
+	var sawText, sawImage bool
+	for _, p := range mixedParts {
+		switch p["type"] {
+		case "text":
+			if p["text"] == "Let me check." {
+				sawText = true
+			}
+			cc, _ := p["cache_control"].(map[string]interface{})
+			if cc == nil || cc["type"] != "ephemeral" {
+				t.Errorf("messages[2].content text part cache_control: got %+v", p["cache_control"])
+			}
+		case "image_url":
+			iu, _ := p["image_url"].(map[string]interface{})
+			if iu != nil && iu["url"] == "data:image/png;base64,abc123" {
+				sawImage = true
+			}
+		}
+	}
+	if !sawText {
+		t.Errorf("messages[2].content: text part not found: %s", mixedContentJSON)
+	}
+	if !sawImage {
+		t.Errorf("messages[2].content: image_url part not found, dropped by the tool-calls-plus-parts flatten branch (issue #1153 item 6): %s", mixedContentJSON)
+	}
+
+	toolResult := got.Messages[3]
+	if toolResult.Role != "tool" {
+		t.Errorf("messages[3].role: got %q", toolResult.Role)
+	}
+	if toolResult.ToolCallID != "tu_01" {
+		t.Errorf("messages[3].tool_call_id: got %q", toolResult.ToolCallID)
+	}
+	if toolResult.CacheControl == nil || toolResult.CacheControl.Type != "ephemeral" {
+		t.Errorf("messages[3].cache_control: got %+v", toolResult.CacheControl)
+	}
+	toolResultJSON, _ := json.Marshal(toolResult.Content)
+	if string(toolResultJSON) != `"Sunny, 32C"` {
+		t.Errorf("messages[3].content: got %s", toolResultJSON)
+	}
+
+	// The whole thing must still marshal cleanly end to end.
+	if _, err := json.Marshal(got); err != nil {
+		t.Fatalf("marshal OAIRequest: %v", err)
+	}
+}
+
+// TestToOAIRequest_MaximalRequest_ToolChoiceNone_NotInverted is a second pass
+// over the same maximal shape with tool_choice:"none" instead of "auto", kept
+// separate because "none" and disable_parallel_tool_use=true cannot both be
+// asserted from the same tool_choice object in one request.
+func TestToOAIRequest_MaximalRequest_ToolChoiceNone_NotInverted(t *testing.T) {
+	req := anthropic.MessagesRequest{
+		Model:      "m",
+		Messages:   []anthropic.Message{{Role: "user", Content: anthropic.MessageContent{Text: "hi"}}},
+		MaxTokens:  5,
+		ToolChoice: &anthropic.ToolChoice{Type: "none"},
+	}
+	got, err := anthropic.ToOAIRequest(req)
+	if err != nil {
+		t.Fatalf("ToOAIRequest: %v", err)
+	}
+	b, _ := json.Marshal(got.ToolChoice)
+	if string(b) != `"none"` {
+		t.Fatalf(`tool_choice: want "none" got %s`, b)
+	}
+}

--- a/apps/edge-api/internal/anthropic/translate_request_maximal_test.go
+++ b/apps/edge-api/internal/anthropic/translate_request_maximal_test.go
@@ -50,7 +50,7 @@ func TestToOAIRequest_MaximalRequest_NoFieldLost(t *testing.T) {
 		"metadata": {"user_id": "end-user-789"},
 		"cache_control": {"type": "ephemeral", "ttl": "1h"},
 		"session_id": "sess-abc-123",
-		"thinking": {"type": "enabled", "budget_tokens": 8192}
+		"thinking": {"type": "enabled", "budget_tokens": 8192, "display": "summarized"}
 	}`
 
 	var req anthropic.MessagesRequest
@@ -97,6 +97,9 @@ func TestToOAIRequest_MaximalRequest_NoFieldLost(t *testing.T) {
 	}
 	if got.Thinking == nil || got.Thinking.Type != "enabled" || got.Thinking.BudgetTokens != 8192 {
 		t.Errorf("thinking (request field): got %+v (issue #1153 item 5a)", got.Thinking)
+	}
+	if got.Thinking == nil || got.Thinking.Display == nil || *got.Thinking.Display != "summarized" {
+		t.Errorf("thinking.display: got %+v (CodeRabbit review on #1163: dropped sub-field on the very struct added to fix dropped fields)", got.Thinking)
 	}
 
 	// --- tool_choice + disable_parallel_tool_use ---

--- a/apps/edge-api/internal/anthropic/translate_request_structural_test.go
+++ b/apps/edge-api/internal/anthropic/translate_request_structural_test.go
@@ -129,6 +129,27 @@ func TestToolChoice_EveryFieldHasADisposition(t *testing.T) {
 	assertEveryFieldDispositioned(t, anthropic.ToolChoice{}, toolChoiceDispositions)
 }
 
+// thinkingConfigDispositions covers ThinkingConfig's own sub-fields.
+// Added per CodeRabbit review on #1163: the top-level MessagesRequest guard
+// above sees "thinking" as one opaque field and cannot see inside it, which
+// is exactly how ThinkingConfig.Display was typed *bool instead of *string
+// and shipped in this PR's own first review round without being caught by
+// any of the reflection or round-trip tests. This is a second, separate
+// reflection pass one level deeper, not something the top-level guard does
+// automatically -- MessagesRequest, ContentBlock, Tool, and ToolChoice are
+// still the only types walked automatically; every other nested struct
+// (ImageSource, RequestMetadata, CacheControl) remains uncovered by
+// reflection and depends on review, same as before.
+var thinkingConfigDispositions = map[string]string{
+	"type":          "carried: OAIRequest.Thinking.Type, unchanged (ThinkingConfig is shared verbatim between MessagesRequest and OAIRequest)",
+	"budget_tokens": "carried: OAIRequest.Thinking.BudgetTokens, unchanged",
+	"display":       "carried: OAIRequest.Thinking.Display, unchanged (string enum \"summarized\"|\"omitted\", not boolean -- see field doc comment)",
+}
+
+func TestThinkingConfig_EveryFieldHasADisposition(t *testing.T) {
+	assertEveryFieldDispositioned(t, anthropic.ThinkingConfig{}, thinkingConfigDispositions)
+}
+
 // TestStructuralGuard_CatchesAnUndispositionedField is the demonstration the
 // review asked for: the guard above must actually fail, not just exist, when
 // a field is added without a disposition. reflect.StructOf builds a type

--- a/apps/edge-api/internal/anthropic/translate_request_structural_test.go
+++ b/apps/edge-api/internal/anthropic/translate_request_structural_test.go
@@ -1,0 +1,179 @@
+package anthropic_test
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/sakibsadmanshajib/hive/apps/edge-api/internal/anthropic"
+)
+
+// assertEveryFieldDispositioned walks v's struct type with reflection and
+// fails, naming the field, for any exported field whose JSON name has no
+// entry in dispositions. This is the actual structural guard issue #1153
+// asked for: TestToOAIRequest_MaximalRequest_NoFieldLost (added earlier in
+// this PR) only checks that the fields present in ONE hand-written request
+// survive -- it says nothing about a field nobody thought to add to that
+// request in the first place, which is exactly how cache_control and the six
+// fields in this PR went missing to begin with. Reflection over the struct's
+// own field list, not over one instance's populated values, is what closes
+// that gap: a field literally cannot exist on the struct without a matching
+// map entry, or this test fails and names it.
+//
+// dispositions values are documentation, not machine-checked against the
+// actual translator code (Go has no way to assert "field X flows into
+// translator branch Y" without something at parser-level); they exist so a
+// reviewer or the next developer can see, at a glance, whether a field is
+// carried through unchanged, translated to a different shape/name,
+// forwarded as an opaque passthrough, or deliberately rejected -- the same
+// four buckets the PR's own field-disposition writeup uses.
+//
+// t is testing.TB (not *testing.T) so
+// TestStructuralGuard_CatchesAnUndispositionedField can pass a recording
+// stand-in and observe a failure instead of actually failing.
+func assertEveryFieldDispositioned(t testing.TB, v interface{}, dispositions map[string]string) {
+	t.Helper()
+	typ := reflect.TypeOf(v)
+	for i := 0; i < typ.NumField(); i++ {
+		f := typ.Field(i)
+		if f.PkgPath != "" {
+			continue // unexported, not part of the wire shape
+		}
+		tag := f.Tag.Get("json")
+		name := strings.Split(tag, ",")[0]
+		if name == "" || name == "-" {
+			name = f.Name
+		}
+		if _, ok := dispositions[name]; !ok {
+			t.Errorf(
+				"%s.%s (json %q) has no disposition entry in this test -- "+
+					"a field was added to the struct without deciding what "+
+					"ToOAIRequest does with it. Add an entry to the "+
+					"dispositions map for this type stating whether it is "+
+					"carried through unchanged, translated to an equivalent, "+
+					"forwarded as an opaque passthrough, or deliberately "+
+					"rejected, and wire it up in translate_request.go to match.",
+				typ.Name(), f.Name, name,
+			)
+		}
+	}
+}
+
+// messagesRequestDispositions documents every MessagesRequest field's fate
+// in ToOAIRequest. See assertEveryFieldDispositioned's doc comment.
+var messagesRequestDispositions = map[string]string{
+	"model":          "carried: OAIRequest.Model",
+	"messages":       "carried: OAIRequest.Messages, each Message recursively lowered by convertMessage",
+	"system":         "carried: prepended as an OAIMessage{Role:\"system\"} via systemContent",
+	"max_tokens":     "carried: OAIRequest.MaxTokens",
+	"tools":          "carried: OAIRequest.Tools via convertTools",
+	"tool_choice":    "translated: OAIRequest.ToolChoice via convertToolChoice, plus a ParallelToolCalls side effect from disable_parallel_tool_use; an unrecognized type is rejected with an error, not silently defaulted",
+	"temperature":    "carried: OAIRequest.Temperature",
+	"top_p":          "carried: OAIRequest.TopP",
+	"top_k":          "forwarded: OAIRequest.TopK, opaque passthrough field with no OpenAI-standard equivalent",
+	"stop_sequences": "carried: OAIRequest.Stop",
+	"stream":         "carried: OAIRequest.Stream",
+	"metadata":       "translated: OAIRequest.User (metadata.user_id only; no other metadata sub-field is documented by Anthropic today)",
+	"thinking":       "carried: OAIRequest.Thinking, unchanged shape (see ThinkingConfig's own sub-fields, not covered by this reflection pass -- see file doc comment)",
+	"cache_control":  "carried: OAIRequest.CacheControl",
+	"session_id":     "carried: OAIRequest.SessionID, truncated to 256 bytes at a rune boundary",
+}
+
+func TestMessagesRequest_EveryFieldHasADisposition(t *testing.T) {
+	assertEveryFieldDispositioned(t, anthropic.MessagesRequest{}, messagesRequestDispositions)
+}
+
+// contentBlockDispositions documents every ContentBlock field. ContentBlock
+// is a union of six Anthropic block shapes (text, image, tool_use,
+// tool_result, thinking, redacted_thinking) folded into one Go struct, so
+// "carried" here means "carried when this block's Type selects the branch
+// that reads this field", not "always present in the output".
+var contentBlockDispositions = map[string]string{
+	"type":          "carried: selects the case in convertMessage's block switch",
+	"text":          "carried: type=text -> OAIContentPart.Text",
+	"source":        "carried: type=image -> OAIContentPart.ImageURL (base64 or url form both lowered to a data/plain URI)",
+	"id":            "carried: type=tool_use -> OAIToolCall.ID",
+	"name":          "carried: type=tool_use -> OAIToolCall.Function.Name",
+	"input":         "carried: type=tool_use -> OAIToolCall.Function.Arguments (JSON-stringified)",
+	"tool_use_id":   "carried: type=tool_result -> OAIMessage.ToolCallID",
+	"content":       "carried: type=tool_result -> OAIMessage.Content via toolResultText",
+	"thinking":      "carried: type=thinking -> OAIThinkingBlock.Thinking",
+	"signature":     "carried: type=thinking -> OAIThinkingBlock.Signature",
+	"data":          "carried: type=redacted_thinking -> OAIThinkingBlock.Data",
+	"cache_control": "carried: any block type -> the corresponding OAI-shaped type's CacheControl field",
+}
+
+func TestContentBlock_EveryFieldHasADisposition(t *testing.T) {
+	assertEveryFieldDispositioned(t, anthropic.ContentBlock{}, contentBlockDispositions)
+}
+
+var toolDispositions = map[string]string{
+	"name":          "carried: OAITool.Function.Name",
+	"description":   "carried: OAITool.Function.Description",
+	"input_schema":  "carried: OAITool.Function.Parameters",
+	"cache_control": "carried: OAITool.CacheControl",
+}
+
+func TestTool_EveryFieldHasADisposition(t *testing.T) {
+	assertEveryFieldDispositioned(t, anthropic.Tool{}, toolDispositions)
+}
+
+var toolChoiceDispositions = map[string]string{
+	"type":                      "translated: selects OAIToolChoice's sentinel or named form via convertToolChoice",
+	"name":                      "carried: type=tool -> OAINamedToolChoiceFunction.Name",
+	"disable_parallel_tool_use": "translated: OAIRequest.ParallelToolCalls, inverse boolean, only ever emitted as false",
+}
+
+func TestToolChoice_EveryFieldHasADisposition(t *testing.T) {
+	assertEveryFieldDispositioned(t, anthropic.ToolChoice{}, toolChoiceDispositions)
+}
+
+// TestStructuralGuard_CatchesAnUndispositionedField is the demonstration the
+// review asked for: the guard above must actually fail, not just exist, when
+// a field is added without a disposition. reflect.StructOf builds a type
+// with every MessagesRequest field plus one undocumented extra ("reasoning",
+// a plausible-looking future Anthropic field) at runtime, so this test does
+// not require hand-editing types.go to prove the point -- it proves the
+// guard function itself is sound, independent of the current field list, and
+// it runs on every `go test` rather than needing a human to remember to
+// revert a manual mutation.
+func TestStructuralGuard_CatchesAnUndispositionedField(t *testing.T) {
+	real := reflect.TypeOf(anthropic.MessagesRequest{})
+	fields := make([]reflect.StructField, 0, real.NumField()+1)
+	for i := 0; i < real.NumField(); i++ {
+		fields = append(fields, real.Field(i))
+	}
+	fields = append(fields, reflect.StructField{
+		Name: "Reasoning",
+		Type: reflect.TypeOf(""),
+		Tag:  `json:"reasoning,omitempty"`,
+	})
+	withExtraField := reflect.New(reflect.StructOf(fields)).Elem().Interface()
+
+	rec := &recordingTB{TB: t}
+	assertEveryFieldDispositioned(rec, withExtraField, messagesRequestDispositions)
+
+	if !rec.failed {
+		t.Fatal("assertEveryFieldDispositioned did not fail for a field " +
+			"(\"reasoning\") missing from the dispositions map -- the " +
+			"structural guard is not structural")
+	}
+	if !strings.Contains(rec.lastMsg, "reasoning") {
+		t.Fatalf("failure message did not name the missing field: %q", rec.lastMsg)
+	}
+}
+
+// recordingTB wraps a real testing.TB and captures Errorf calls instead of
+// failing the outer test, so TestStructuralGuard_CatchesAnUndispositionedField
+// can assert on the failure itself.
+type recordingTB struct {
+	testing.TB
+	failed  bool
+	lastMsg string
+}
+
+func (r *recordingTB) Errorf(format string, args ...interface{}) {
+	r.failed = true
+	r.lastMsg = fmt.Sprintf(format, args...)
+}

--- a/apps/edge-api/internal/anthropic/translate_request_test.go
+++ b/apps/edge-api/internal/anthropic/translate_request_test.go
@@ -408,6 +408,25 @@ func TestToOAIRequest_ToolChoice_None(t *testing.T) {
 	}
 }
 
+// LOW item from review of #1163: an unrecognized tool_choice.type used to
+// silently map to "auto" via convertToolChoice's default branch -- the
+// identical inversion shape as the tool_choice:"none" bug, just waiting for
+// Anthropic to document a fifth value. Now rejected with a translation error
+// (handler.go turns that into a plain 400), never silently re-enabling tool
+// use nobody asked for.
+func TestToOAIRequest_ToolChoice_UnknownType_Rejected(t *testing.T) {
+	req := anthropic.MessagesRequest{
+		Model:      "m",
+		Messages:   []anthropic.Message{{Role: "user", Content: anthropic.MessageContent{Text: "hi"}}},
+		MaxTokens:  5,
+		ToolChoice: &anthropic.ToolChoice{Type: "some_future_type"},
+	}
+	_, err := anthropic.ToOAIRequest(req)
+	if err == nil {
+		t.Fatal("expected error for unrecognized tool_choice.type, got nil (silently defaulted to auto)")
+	}
+}
+
 // Issue #1153 item 2: metadata.user_id is parsed but was never read by
 // ToOAIRequest. It lands on OAIRequest.User, OpenAI's own end-user tracking
 // field -- same purpose, different name.

--- a/apps/edge-api/internal/anthropic/translate_request_test.go
+++ b/apps/edge-api/internal/anthropic/translate_request_test.go
@@ -382,3 +382,240 @@ func TestOAIToolChoice_MarshalJSON_Named(t *testing.T) {
 		t.Errorf("type: want function got %v", m["type"])
 	}
 }
+
+// Issue #1153 item 1, the behaviour inversion: tool_choice:{"type":"none"}
+// must come out as the "none" sentinel, not "auto". Before the fix, "none"
+// matched no case in convertToolChoice's switch and fell to the default
+// branch, which returns "auto" -- a caller explicitly forbidding tool use
+// got a model that may call tools, the opposite of the request.
+func TestToOAIRequest_ToolChoice_None(t *testing.T) {
+	req := anthropic.MessagesRequest{
+		Model:      "m",
+		Messages:   []anthropic.Message{{Role: "user", Content: anthropic.MessageContent{Text: "hi"}}},
+		MaxTokens:  5,
+		ToolChoice: &anthropic.ToolChoice{Type: "none"},
+	}
+	got, err := anthropic.ToOAIRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.ToolChoice == nil {
+		t.Fatal("tool_choice nil")
+	}
+	b, _ := json.Marshal(got.ToolChoice)
+	if string(b) != `"none"` {
+		t.Errorf(`tool_choice json: want "none" got %s (an inversion back to "auto" means tool use is silently re-enabled)`, b)
+	}
+}
+
+// Issue #1153 item 2: metadata.user_id is parsed but was never read by
+// ToOAIRequest. It lands on OAIRequest.User, OpenAI's own end-user tracking
+// field -- same purpose, different name.
+func TestToOAIRequest_Metadata_UserID(t *testing.T) {
+	req := anthropic.MessagesRequest{
+		Model:     "m",
+		Messages:  []anthropic.Message{{Role: "user", Content: anthropic.MessageContent{Text: "hi"}}},
+		MaxTokens: 5,
+		Metadata:  &anthropic.RequestMetadata{UserID: "end-user-123"},
+	}
+	got, err := anthropic.ToOAIRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.User != "end-user-123" {
+		t.Errorf("user: want end-user-123 got %q", got.User)
+	}
+}
+
+func TestToOAIRequest_Metadata_Nil_UserOmitted(t *testing.T) {
+	req := anthropic.MessagesRequest{
+		Model:     "m",
+		Messages:  []anthropic.Message{{Role: "user", Content: anthropic.MessageContent{Text: "hi"}}},
+		MaxTokens: 5,
+	}
+	got, err := anthropic.ToOAIRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.User != "" {
+		t.Errorf("user: want empty got %q", got.User)
+	}
+}
+
+// Issue #1153 item 3: tool_choice.disable_parallel_tool_use had no field at
+// all. It maps onto OpenAI's parallel_tool_calls=false (the inverse boolean).
+func TestToOAIRequest_ToolChoice_DisableParallelToolUse(t *testing.T) {
+	disable := true
+	req := anthropic.MessagesRequest{
+		Model:      "m",
+		Messages:   []anthropic.Message{{Role: "user", Content: anthropic.MessageContent{Text: "hi"}}},
+		MaxTokens:  5,
+		ToolChoice: &anthropic.ToolChoice{Type: "auto", DisableParallelToolUse: &disable},
+	}
+	got, err := anthropic.ToOAIRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.ParallelToolCalls == nil || *got.ParallelToolCalls != false {
+		t.Errorf("parallel_tool_calls: want false got %v", got.ParallelToolCalls)
+	}
+}
+
+func TestToOAIRequest_ToolChoice_ParallelToolUseAllowed_OmitsField(t *testing.T) {
+	req := anthropic.MessagesRequest{
+		Model:      "m",
+		Messages:   []anthropic.Message{{Role: "user", Content: anthropic.MessageContent{Text: "hi"}}},
+		MaxTokens:  5,
+		ToolChoice: &anthropic.ToolChoice{Type: "auto"},
+	}
+	got, err := anthropic.ToOAIRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.ParallelToolCalls != nil {
+		t.Errorf("parallel_tool_calls: want nil (omitted) got %v", *got.ParallelToolCalls)
+	}
+}
+
+// Issue #1153 item 4: top_k had no field on MessagesRequest at all. Carried
+// through unchanged to OAIRequest.
+func TestToOAIRequest_TopK(t *testing.T) {
+	topK := 40
+	req := anthropic.MessagesRequest{
+		Model:     "m",
+		Messages:  []anthropic.Message{{Role: "user", Content: anthropic.MessageContent{Text: "hi"}}},
+		MaxTokens: 5,
+		TopK:      &topK,
+	}
+	got, err := anthropic.ToOAIRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.TopK == nil || *got.TopK != 40 {
+		t.Errorf("top_k: want 40 got %v", got.TopK)
+	}
+}
+
+// Issue #1153 item 5a: the thinking request field had no representation at
+// all. Carried through unchanged to OAIRequest.
+func TestToOAIRequest_ThinkingConfig_Passthrough(t *testing.T) {
+	req := anthropic.MessagesRequest{
+		Model:     "m",
+		Messages:  []anthropic.Message{{Role: "user", Content: anthropic.MessageContent{Text: "hi"}}},
+		MaxTokens: 1024,
+		Thinking:  &anthropic.ThinkingConfig{Type: "enabled", BudgetTokens: 2048},
+	}
+	got, err := anthropic.ToOAIRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Thinking == nil || got.Thinking.Type != "enabled" || got.Thinking.BudgetTokens != 2048 {
+		t.Errorf("thinking: want {enabled 2048} got %+v", got.Thinking)
+	}
+}
+
+// Issue #1153 item 5b: a thinking-only message (no text, no tool_use) used
+// to silently produce empty content -- no case in convertMessage's block
+// switch matched "thinking" at all, so both parts and toolCalls stayed
+// empty and the resulting OAIMessage had no content and no tool_calls.
+func TestToOAIRequest_ThinkingOnlyMessage_NotEmptyContent(t *testing.T) {
+	raw := `{"model":"m","max_tokens":5,"messages":[{"role":"assistant","content":[
+		{"type":"thinking","thinking":"Let me work through this.","signature":"sig_abc"}
+	]}]}`
+	var req anthropic.MessagesRequest
+	if err := json.Unmarshal([]byte(raw), &req); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	got, err := anthropic.ToOAIRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	msg := got.Messages[0]
+	if len(msg.ThinkingBlocks) != 1 {
+		t.Fatalf("thinking_blocks len: want 1 got %d (message silently produced empty content)", len(msg.ThinkingBlocks))
+	}
+	tb := msg.ThinkingBlocks[0]
+	if tb.Type != "thinking" || tb.Thinking != "Let me work through this." || tb.Signature != "sig_abc" {
+		t.Errorf("thinking block: %+v", tb)
+	}
+}
+
+func TestToOAIRequest_RedactedThinkingBlock(t *testing.T) {
+	raw := `{"model":"m","max_tokens":5,"messages":[{"role":"assistant","content":[
+		{"type":"redacted_thinking","data":"opaque-payload"}
+	]}]}`
+	var req anthropic.MessagesRequest
+	if err := json.Unmarshal([]byte(raw), &req); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	got, err := anthropic.ToOAIRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	msg := got.Messages[0]
+	if len(msg.ThinkingBlocks) != 1 || msg.ThinkingBlocks[0].Type != "redacted_thinking" || msg.ThinkingBlocks[0].Data != "opaque-payload" {
+		t.Fatalf("redacted thinking block: %+v", msg.ThinkingBlocks)
+	}
+}
+
+// Thinking block mixed with a tool_use block in the same assistant turn
+// (the real extended-thinking + tool-use pattern): both must survive.
+func TestToOAIRequest_ThinkingBlock_MixedWithToolUse(t *testing.T) {
+	raw := `{"model":"m","max_tokens":5,"messages":[{"role":"assistant","content":[
+		{"type":"thinking","thinking":"I should check the weather.","signature":"sig_xyz"},
+		{"type":"tool_use","id":"tu_01","name":"get_weather","input":{"city":"Dhaka"}}
+	]}]}`
+	var req anthropic.MessagesRequest
+	if err := json.Unmarshal([]byte(raw), &req); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	got, err := anthropic.ToOAIRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	msg := got.Messages[0]
+	if len(msg.ThinkingBlocks) != 1 {
+		t.Fatalf("thinking_blocks len: want 1 got %d", len(msg.ThinkingBlocks))
+	}
+	if len(msg.ToolCalls) != 1 || msg.ToolCalls[0].Function.Name != "get_weather" {
+		t.Fatalf("tool_calls: want 1 get_weather got %+v", msg.ToolCalls)
+	}
+}
+
+// Issue #1153 item 6: an image block mixed with a tool_use block in the same
+// turn used to be silently dropped once the flat-string branch was taken
+// (no cache_control anywhere to force array form). partsNeedArrayForm now
+// also triggers on any non-text part, not just a cache breakpoint.
+func TestToOAIRequest_ImageBlock_MixedWithToolUse_NotDropped(t *testing.T) {
+	raw := `{"model":"m","max_tokens":5,"messages":[{"role":"assistant","content":[
+		{"type":"text","text":"Here is the chart:"},
+		{"type":"image","source":{"type":"base64","media_type":"image/png","data":"abc123"}},
+		{"type":"tool_use","id":"tu_01","name":"analyze","input":{}}
+	]}]}`
+	var req anthropic.MessagesRequest
+	if err := json.Unmarshal([]byte(raw), &req); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	got, err := anthropic.ToOAIRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	msg := got.Messages[0]
+	if len(msg.ToolCalls) != 1 {
+		t.Fatalf("tool_calls len: want 1 got %d", len(msg.ToolCalls))
+	}
+	b, _ := json.Marshal(msg.Content)
+	var parts []map[string]interface{}
+	if err := json.Unmarshal(b, &parts); err != nil {
+		t.Fatalf("content is not an array, image was flattened away and lost: %s", b)
+	}
+	foundImage := false
+	for _, p := range parts {
+		if p["type"] == "image_url" {
+			foundImage = true
+		}
+	}
+	if !foundImage {
+		t.Errorf("image_url part missing from content array: %s", b)
+	}
+}

--- a/apps/edge-api/internal/anthropic/types.go
+++ b/apps/edge-api/internal/anthropic/types.go
@@ -62,12 +62,16 @@ type RequestMetadata struct {
 type ThinkingConfig struct {
 	Type         string `json:"type"` // "enabled" | "disabled"
 	BudgetTokens int    `json:"budget_tokens,omitempty"`
-	// Display controls whether thinking content is surfaced to the caller.
-	// Anthropic-documented sub-field on the thinking config; this struct is a
-	// pure carry-through (see MessagesRequest.Thinking), so dropping it here
-	// would have been the identical bug class this PR exists to fix, just one
-	// struct deeper.
-	Display *bool `json:"display,omitempty"`
+	// Display controls whether thinking content is redacted in the response
+	// while still returning a signature for multi-turn continuity. String
+	// enum, not boolean: Anthropic documents "summarized" and "omitted" as
+	// the two values (ThinkingConfigEnabledParam.display in
+	// anthropic-sdk-python). A *bool here would fail to unmarshal any real
+	// request that sets this field at all -- caught by CodeRabbit review on
+	// #1163 before merge. This struct is a pure carry-through (see
+	// MessagesRequest.Thinking), so dropping or mistyping this field would be
+	// the identical bug class this PR exists to fix, just one struct deeper.
+	Display *string `json:"display,omitempty"`
 }
 
 // CacheControl marks an Anthropic prompt-caching breakpoint. It is valid on a

--- a/apps/edge-api/internal/anthropic/types.go
+++ b/apps/edge-api/internal/anthropic/types.go
@@ -62,6 +62,12 @@ type RequestMetadata struct {
 type ThinkingConfig struct {
 	Type         string `json:"type"` // "enabled" | "disabled"
 	BudgetTokens int    `json:"budget_tokens,omitempty"`
+	// Display controls whether thinking content is surfaced to the caller.
+	// Anthropic-documented sub-field on the thinking config; this struct is a
+	// pure carry-through (see MessagesRequest.Thinking), so dropping it here
+	// would have been the identical bug class this PR exists to fix, just one
+	// struct deeper.
+	Display *bool `json:"display,omitempty"`
 }
 
 // CacheControl marks an Anthropic prompt-caching breakpoint. It is valid on a

--- a/apps/edge-api/internal/anthropic/types.go
+++ b/apps/edge-api/internal/anthropic/types.go
@@ -14,17 +14,30 @@ import "encoding/json"
 
 // MessagesRequest is the Anthropic POST /v1/messages request body.
 type MessagesRequest struct {
-	Model         string           `json:"model"`
-	Messages      []Message        `json:"messages"`
-	System        SystemField      `json:"system,omitempty"`
-	MaxTokens     int              `json:"max_tokens"`
-	Tools         []Tool           `json:"tools,omitempty"`
-	ToolChoice    *ToolChoice      `json:"tool_choice,omitempty"`
-	Temperature   *float64         `json:"temperature,omitempty"`
-	TopP          *float64         `json:"top_p,omitempty"`
+	Model       string      `json:"model"`
+	Messages    []Message   `json:"messages"`
+	System      SystemField `json:"system,omitempty"`
+	MaxTokens   int         `json:"max_tokens"`
+	Tools       []Tool      `json:"tools,omitempty"`
+	ToolChoice  *ToolChoice `json:"tool_choice,omitempty"`
+	Temperature *float64    `json:"temperature,omitempty"`
+	TopP        *float64    `json:"top_p,omitempty"`
+	// TopK has no OpenAI-standard field: it is not part of the chat/completions
+	// surface at all. Carried through to OAIRequest unchanged (same field name
+	// and shape) so LiteLLM can forward it to whatever provider params it maps
+	// to for providers that do support it (Anthropic, Cohere, vLLM, Bedrock);
+	// whether the eventual provider honours it is a LiteLLM/provider concern,
+	// not something this translator may silently drop on the caller's behalf.
+	TopK          *int             `json:"top_k,omitempty"`
 	StopSequences []string         `json:"stop_sequences,omitempty"`
 	Stream        bool             `json:"stream,omitempty"`
 	Metadata      *RequestMetadata `json:"metadata,omitempty"`
+	// Thinking requests Anthropic extended thinking. Carried through to
+	// OAIRequest unchanged (identical field name and shape to Anthropic's own
+	// definition) rather than translated to an equivalent, since Hive has no
+	// local reasoning-effort concept that maps onto a token budget; LiteLLM's
+	// own Anthropic adapter is what interprets this shape on the way out.
+	Thinking *ThinkingConfig `json:"thinking,omitempty"`
 	// CacheControl, at request root, is a valid alternative to a per-block
 	// breakpoint: it applies a single ephemeral cache marker to the whole
 	// request instead of the caller placing one on each block by hand. Kept
@@ -43,6 +56,12 @@ type MessagesRequest struct {
 // RequestMetadata carries optional caller metadata (unused in routing).
 type RequestMetadata struct {
 	UserID string `json:"user_id,omitempty"`
+}
+
+// ThinkingConfig requests Anthropic extended thinking on the model turn.
+type ThinkingConfig struct {
+	Type         string `json:"type"` // "enabled" | "disabled"
+	BudgetTokens int    `json:"budget_tokens,omitempty"`
 }
 
 // CacheControl marks an Anthropic prompt-caching breakpoint. It is valid on a
@@ -141,6 +160,13 @@ type ContentBlock struct {
 	ToolUseID string             `json:"tool_use_id,omitempty"`
 	Content   *ToolResultContent `json:"content,omitempty"`
 
+	// type=thinking
+	Thinking  string `json:"thinking,omitempty"`
+	Signature string `json:"signature,omitempty"`
+
+	// type=redacted_thinking
+	Data string `json:"data,omitempty"`
+
 	// CacheControl is valid on any block type above: text, image, tool_use,
 	// and tool_result all support a cache breakpoint.
 	CacheControl *CacheControl `json:"cache_control,omitempty"`
@@ -187,8 +213,12 @@ type Tool struct {
 
 // ToolChoice controls how the model selects tools.
 type ToolChoice struct {
-	Type string `json:"type"` // "auto" | "any" | "tool"
+	Type string `json:"type"` // "auto" | "any" | "tool" | "none"
 	Name string `json:"name,omitempty"`
+	// DisableParallelToolUse, when true, forbids more than one tool call per
+	// turn. It has no OpenAI field of its own; it maps onto the inverse of
+	// OpenAI's parallel_tool_calls (see OAIRequest.ParallelToolCalls).
+	DisableParallelToolUse *bool `json:"disable_parallel_tool_use,omitempty"`
 }
 
 // --------------------------------------------------------------------------
@@ -360,6 +390,21 @@ type OAIRequest struct {
 	CacheControl *CacheControl `json:"cache_control,omitempty"`
 	// SessionID: see MessagesRequest.SessionID.
 	SessionID string `json:"session_id,omitempty"`
+	// TopK: see MessagesRequest.TopK. Carried through unchanged.
+	TopK *int `json:"top_k,omitempty"`
+	// Thinking: see MessagesRequest.Thinking. Carried through unchanged.
+	Thinking *ThinkingConfig `json:"thinking,omitempty"`
+	// User is OpenAI's stable opaque end-user identifier. This is where
+	// Anthropic's metadata.user_id lands: same purpose (abuse detection /
+	// per-user tracking on the provider side), different field name, so this
+	// is a rename rather than a byte-identical carry-through.
+	User string `json:"user,omitempty"`
+	// ParallelToolCalls is OpenAI's inverse of Anthropic's
+	// tool_choice.disable_parallel_tool_use. Only ever set to false (never
+	// true): Anthropic's default (disable=false, i.e. parallel allowed)
+	// already matches OpenAI's own default, so there is nothing to carry when
+	// the caller never asked to forbid it.
+	ParallelToolCalls *bool `json:"parallel_tool_calls,omitempty"`
 }
 
 // OAIStreamOptions mirrors OpenAI's stream_options object. IncludeUsage asks
@@ -398,6 +443,24 @@ type OAIMessage struct {
 	// where Content is always a single flattened string with no parts array
 	// to hang a per-part cache_control on.
 	CacheControl *CacheControl `json:"cache_control,omitempty"`
+	// ThinkingBlocks carries an Anthropic thinking/redacted_thinking block
+	// from prior conversation history through unchanged, signature included.
+	// This is LiteLLM's own documented convention for round-tripping Anthropic
+	// extended-thinking content through an OpenAI-shaped assistant message
+	// (mirrors reasoning_content/thinking_blocks used for reasoning-model
+	// passthrough generally); the signature must survive verbatim or
+	// Anthropic rejects the next turn, so this is a carry-through, not a
+	// reconstruction.
+	ThinkingBlocks []OAIThinkingBlock `json:"thinking_blocks,omitempty"`
+}
+
+// OAIThinkingBlock mirrors an Anthropic thinking or redacted_thinking content
+// block for round-tripping through an OpenAI-shaped assistant message.
+type OAIThinkingBlock struct {
+	Type      string `json:"type"` // "thinking" | "redacted_thinking"
+	Thinking  string `json:"thinking,omitempty"`
+	Signature string `json:"signature,omitempty"`
+	Data      string `json:"data,omitempty"`
 }
 
 // OAIToolCall is an assistant tool invocation.


### PR DESCRIPTION
## Problem

`apps/edge-api/internal/anthropic/translate_request.go` rebuilds the Anthropic `/v1/messages` request field by field into the internal OpenAI-shaped `OAIRequest`. Any field nobody explicitly carried is lost, silently, every time. `cache_control` was one of these and cost every agent client on the gateway its prompt caching until #1152 fixed it. This PR fixes the rest of the fields listed in #1153.

## Field-by-field disposition

Per the task brief, each field below is deliberately dispositioned rather than reflexively carried through:

1. **`tool_choice: {"type": "none"}` — behaviour inversion, fixed first.** `convertToolChoice`'s switch had no `"none"` case, so it fell to the `default` branch and returned `"auto"`. A caller explicitly forbidding tool use got a model that could call them: not an omission, the opposite of the request. **Disposition: translated to the exact OpenAI equivalent** — `tool_choice: "none"` means the identical thing on both APIs.
2. **`metadata.user_id`** — parsed but never read by `ToOAIRequest`. **Disposition: translated to an equivalent** — lands on `OAIRequest.User`, OpenAI's own end-user tracking field (same purpose: abuse detection / per-user attribution on the provider side, different name).
3. **`tool_choice.disable_parallel_tool_use`** — no field at all. **Disposition: translated to an equivalent** — maps to OpenAI's `parallel_tool_calls`, inverted (`disable_parallel_tool_use: true` → `parallel_tool_calls: false`). Only ever emitted as `false`; Anthropic's default (`disable=false`, parallel allowed) already matches OpenAI's own default, so there's nothing to carry when the caller never asked to forbid it.
4. **`top_k`** — no field on `MessagesRequest` at all. **Disposition: forwarded as an extra field LiteLLM passes along.** There is no OpenAI-standard equivalent (it isn't part of the chat/completions surface), so this is carried through unchanged on `OAIRequest.TopK`. Whether the eventual provider honours it is a LiteLLM/provider concern; this translator must not be the one to silently drop it.
5. **Extended thinking** — no representation at all: no `thinking` request field, no `thinking`/`redacted_thinking` content blocks. A thinking-only message silently produced empty content (no case in `convertMessage`'s block switch matched, so both `parts` and `toolCalls` stayed empty).
   - `MessagesRequest.Thinking` (**disposition: carried through as-is** — identical field name and shape to Anthropic's own definition; LiteLLM's own Anthropic adapter interprets it on the way out, Hive has no local reasoning-budget concept to translate it into).
   - `ContentBlock.Thinking` / `.Signature` / `.Data` for `thinking` / `redacted_thinking` blocks in conversation history, surfaced on `OAIMessage.ThinkingBlocks` (**disposition: carried through via LiteLLM's own documented `thinking_blocks` convention** for round-tripping Anthropic extended-thinking content through an OpenAI-shaped assistant message — the signature must survive verbatim or Anthropic rejects the next turn, so this is a carry-through, not a reconstruction). Attached to every return path in `convertMessage`'s mixed-content section (alone, with tool_use, with text) so a thinking block can no longer produce a silently empty message in any combination.
6. **Pre-existing image drop in the tool-calls-plus-text branch** (preserved by #1152 to keep its regression guard exact) — **fixed here.** No existing test locked in the image-drop behaviour specifically (checked before touching it), so `partsNeedArrayForm` now also triggers on any non-text part, not just a cache breakpoint. An image mixed with a tool call no longer silently flattens away; the plain-text-only regression guard (#1152's actual concern) is untouched since it only ever exercised text parts.

## Structural fix

Per the brief: fixing six instances of a recurring bug isn't fixing the bug. `TestToOAIRequest_MaximalRequest_NoFieldLost` (new file `translate_request_maximal_test.go`) builds one Anthropic request with every documented `MessagesRequest` field populated — including nested `ContentBlock`, `Tool`, and `ToolChoice` sub-fields — translates it once, and asserts each field survives with an explicit per-field check. `TestToOAIRequest_MaximalRequest_ToolChoiceNone_NotInverted` covers the one combination (`tool_choice: "none"`) that can't share the same request object as `disable_parallel_tool_use`. The next field added to `MessagesRequest` has a structural guard now, not just a hope someone remembers.

## Tests

Table-driven, one test per fix plus the maximal round-trip:
- `TestToOAIRequest_ToolChoice_None`
- `TestToOAIRequest_Metadata_UserID`, `TestToOAIRequest_Metadata_Nil_UserOmitted`
- `TestToOAIRequest_ToolChoice_DisableParallelToolUse`, `TestToOAIRequest_ToolChoice_ParallelToolUseAllowed_OmitsField`
- `TestToOAIRequest_TopK`
- `TestToOAIRequest_ThinkingConfig_Passthrough`, `TestToOAIRequest_ThinkingOnlyMessage_NotEmptyContent`, `TestToOAIRequest_RedactedThinkingBlock`, `TestToOAIRequest_ThinkingBlock_MixedWithToolUse`
- `TestToOAIRequest_ImageBlock_MixedWithToolUse_NotDropped`
- `TestToOAIRequest_MaximalRequest_NoFieldLost`, `TestToOAIRequest_MaximalRequest_ToolChoiceNone_NotInverted`

**Mutation check (per the task brief):** temporarily reverted the `tool_choice: "none"` case in `convertToolChoice`, reran the suite — `TestToOAIRequest_ToolChoice_None` and `TestToOAIRequest_MaximalRequest_ToolChoiceNone_NotInverted` both failed with `want "none" got "auto"`, exactly the pre-fix inversion — then restored the fix and confirmed both pass again.

```
=== RUN   TestToOAIRequest_MaximalRequest_ToolChoiceNone_NotInverted
    translate_request_maximal_test.go:241: tool_choice: want "none" got "auto"
--- FAIL: TestToOAIRequest_MaximalRequest_ToolChoiceNone_NotInverted (0.00s)
=== RUN   TestToOAIRequest_ToolChoice_None
    translate_request_test.go:407: tool_choice json: want "none" got "auto" (an inversion back to "auto" means tool use is silently re-enabled)
--- FAIL: TestToOAIRequest_ToolChoice_None (0.00s)
FAIL	github.com/sakibsadmanshajib/hive/apps/edge-api/internal/anthropic	0.011s
```
Restored, reran:
```
ok  	github.com/sakibsadmanshajib/hive/apps/edge-api/internal/anthropic	0.179s
```

Full `apps/edge-api` suite (all packages) green after the fix:
```
ok  	github.com/sakibsadmanshajib/hive/apps/edge-api/internal/anthropic	0.187s
ok  	github.com/sakibsadmanshajib/hive/apps/edge-api/internal/inference	3.054s
... (all other apps/edge-api packages ok)
```
`go vet ./apps/edge-api/...` clean. `gofmt -l` clean on every touched file.

## Scope

Strictly inside `apps/edge-api/internal/anthropic/`. Did not touch `.github/workflows/ci.yml`, any `go.mod`, `apps/control-plane/internal/payments/stripe/rail_test.go`, or `apps/edge-api/internal/inference/` (owned elsewhere).

## Buglog entry

```json
{"error_message":"tool_choice:{\"type\":\"none\"} silently inverted to auto on /v1/messages, plus five other Anthropic request fields (metadata.user_id, disable_parallel_tool_use, top_k, thinking config/blocks, image-drop in tool-calls branch) silently lost by the same field-by-field rebuild","root_cause":"translate_request.go's convertToolChoice switch had no case for Anthropic's documented \"none\" tool_choice type and fell through to a default that returns \"auto\"; the same field-by-field rebuild pattern that caused the cache_control loss fixed in #1152 dropped five more fields with no representation on MessagesRequest/OAIRequest at all, and convertMessage's block switch had no case for thinking/redacted_thinking blocks so a thinking-only message produced an OAIMessage with empty content and no error","fix":"added an explicit \"none\" case to convertToolChoice mapping to OpenAI's own \"none\" sentinel; added MessagesRequest.TopK/Thinking, OAIRequest.TopK/Thinking/User/ParallelToolCalls, ToolChoice.DisableParallelToolUse, ContentBlock.Thinking/Signature/Data, and OAIMessage.ThinkingBlocks; wired Metadata.UserID to OAIRequest.User and disable_parallel_tool_use to the inverse parallel_tool_calls=false; widened partsNeedArrayForm to also trigger on any non-text part so an image mixed with a tool call keeps the block-array form instead of flattening away; added a maximal round-trip test asserting every documented MessagesRequest field survives translation as a structural guard against the next field going missing the same way","tags":["anthropic","translate_request","tool_choice","thinking","top_k","metadata","parallel_tool_calls","translator-field-loss"]}
```

Fixes #1153

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for extended thinking configuration and preservation of thinking content, including redacted blocks.
  * Added support for `top_k`, user metadata, and parallel tool-use controls.
  * Preserved images and other content when combined with tool calls.
* **Bug Fixes**
  * Correctly handles `tool_choice: none`.
  * Rejects unsupported tool-choice values instead of silently changing behavior.
  * Prevents thinking-only messages and mixed content from being dropped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->