### PR TITLE
fix: coerce null chat completion content to empty string at the normalization boundary

### DIFF
--- a/apps/edge-api/internal/inference/chat_completions.go
+++ b/apps/edge-api/internal/inference/chat_completions.go
@@ -70,6 +70,21 @@ func normalizeChatCompletion(respBody []byte, aliasID string) ([]byte, *UsageRes
 	resp.Model = aliasID
 	resp.Object = "chat.completion"
 
+	// Every OpenAI SDK generates message.content as a plain string type and
+	// dereferences it unconditionally; content is nullable ONLY when the
+	// message carries a tool call (OpenAI's own contract). A reasoning-heavy
+	// upstream that spends its whole token budget on hidden reasoning and
+	// returns finish_reason=length with content omitted otherwise leaks a
+	// bare `null` straight through to every client. Caught live on the
+	// hive-free pool (deploy run 32879931588, PR #1115/#1155): one of its
+	// four load-balanced members returned null content on a plain, tool-free
+	// "Say hello" prompt. This gateway is provider-blind by design (no pool
+	// member's shape should leak to the client), so the fix belongs at this
+	// normalization boundary, not in any one provider's route config.
+	for i := range resp.Choices {
+		coerceNullContent(&resp.Choices[i].Message)
+	}
+
 	clampZeroCompletionUsage(resp.Usage, chatChoiceTexts(resp.Choices), resp.ID, aliasID, EndpointChatCompletions)
 
 	normalized, err := json.Marshal(resp)
@@ -78,6 +93,29 @@ func normalizeChatCompletion(respBody []byte, aliasID string) ([]byte, *UsageRes
 	}
 
 	return normalized, resp.Usage, nil
+}
+
+// coerceNullContent enforces the OpenAI contract that message.content is a
+// string whenever the message carries no tool call and no legacy function
+// call. content is nullable ONLY alongside tool_calls or function_call; every
+// other shape must be a string, per the SDKs this gateway's clients actually
+// use. Leaves the message untouched otherwise, since a genuine tool-call
+// message with null content is spec-correct and must not be rewritten.
+func coerceNullContent(msg *ChatCompletionMessage) {
+	if msg.Content != nil {
+		return
+	}
+	if rawFieldPresent(msg.ToolCalls) || rawFieldPresent(msg.FunctionCall) {
+		return
+	}
+	empty := ""
+	msg.Content = &empty
+}
+
+// rawFieldPresent reports whether a json.RawMessage field is present and not
+// the JSON literal "null".
+func rawFieldPresent(f json.RawMessage) bool {
+	return len(f) > 0 && string(f) != "null"
 }
 
 // firstToolParam returns the name of the first tool-calling or structured-output

--- a/apps/edge-api/internal/inference/chat_completions_null_content_test.go
+++ b/apps/edge-api/internal/inference/chat_completions_null_content_test.go
@@ -1,0 +1,78 @@
+package inference
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestNormalizeChatCompletion_NullContentCoercedToEmptyString reproduces the
+// live regression from deploy run 32879931588 (packages/sdk-tests/js
+// tests/chat-completions/chat-completions.test.ts:36): a hive-free pool
+// member (PR #1115/#1155) returned a tool-free "Say hello" completion with
+// message.content omitted entirely (null after unmarshal) after burning its
+// token budget on hidden reasoning. Every OpenAI SDK types content as a plain
+// string and dereferences it unconditionally, so a bare `null` broke the
+// client. The normalization boundary must always hand back a string here.
+func TestNormalizeChatCompletion_NullContentCoercedToEmptyString(t *testing.T) {
+	body := []byte(`{"id":"gen-nullcontent","object":"chat.completion","created":0,"model":"route-free-pool-groq","choices":[{"index":0,"message":{"role":"assistant"},"finish_reason":"length"}],"usage":{"prompt_tokens":5,"completion_tokens":256,"total_tokens":261}}`)
+
+	normalized, _, err := normalizeChatCompletion(body, "hive-free")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var resp ChatCompletionResponse
+	if err := json.Unmarshal(normalized, &resp); err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Choices) != 1 {
+		t.Fatalf("expected 1 choice, got %d", len(resp.Choices))
+	}
+	msg := resp.Choices[0].Message
+	if msg.Content == nil {
+		t.Fatal("content is nil, want a non-nil pointer to an empty string")
+	}
+	if *msg.Content != "" {
+		t.Fatalf("content = %q, want empty string", *msg.Content)
+	}
+
+	// The raw bytes sent to the client must contain a JSON string, never the
+	// literal null: an SDK checks the wire shape, not just Go's unmarshal.
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(normalized, &raw); err != nil {
+		t.Fatal(err)
+	}
+	var choices []map[string]json.RawMessage
+	if err := json.Unmarshal(raw["choices"], &choices); err != nil {
+		t.Fatal(err)
+	}
+	var message map[string]json.RawMessage
+	if err := json.Unmarshal(choices[0]["message"], &message); err != nil {
+		t.Fatal(err)
+	}
+	if string(message["content"]) != `""` {
+		t.Fatalf("wire content = %s, want an empty JSON string", message["content"])
+	}
+}
+
+// TestNormalizeChatCompletion_NullContentPreservedWithToolCalls asserts the
+// coercion does NOT touch a genuine tool-call message: OpenAI's own contract
+// keeps content null there, and rewriting it would be a spec violation in
+// the other direction.
+func TestNormalizeChatCompletion_NullContentPreservedWithToolCalls(t *testing.T) {
+	body := []byte(`{"id":"gen-toolcall","object":"chat.completion","created":0,"model":"r","choices":[{"index":0,"message":{"role":"assistant","tool_calls":[{"id":"call_1","type":"function","function":{"name":"get_weather","arguments":"{}"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":5,"completion_tokens":10,"total_tokens":15}}`)
+
+	normalized, _, err := normalizeChatCompletion(body, "hive-free")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var resp ChatCompletionResponse
+	if err := json.Unmarshal(normalized, &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Choices[0].Message.Content != nil {
+		t.Fatalf("content = %q, want nil (tool-call message must stay null per OpenAI contract)",
+			*resp.Choices[0].Message.Content)
+	}
+}


### PR DESCRIPTION
## Summary

The deploy of merge commit 2df3afd29 (PR #1163) failed its SDK replay
against the demo box (run 32879931588):

```
tests/chat-completions/chat-completions.test.ts:36
"Chat Completions > returns a valid chat completion via SDK"
AssertionError: expected 'object' to be 'string'
Expected: "string"
Received: "object"
```

**Correction to the field named in the incident report.** The failing
assertion is `typeof response.choices[0].message.content`, not
`response.model` as first reported. Line 36 of the test is:

```ts
expect(typeof response.choices[0].message.content).toBe("string");
```

`response.model` is asserted separately at line 51 in the very next test
in the same file (`model field shows Hive alias not provider handle`),
which passed. `typeof null === "object"` in JavaScript, so "Received:
object" for a `content` assertion means the wire value was a bare `null`,
not an actual object.

## Root cause

**Not PR #1163.** That PR touches only `apps/edge-api/internal/anthropic/`,
adding request-side fields (`Thinking`, `TopK`, `User`,
`ParallelToolCalls`, `ThinkingBlocks`, `ThinkingConfig`) to that package's
own `OAIRequest`/`OAIMessage` structs. Those structs are private to the
`anthropic` package: `grep -rn "anthropic\." apps/edge-api/internal/inference/*.go`
returns no hits outside a comment. The OpenAI-compatible chat-completions
path (`apps/edge-api/internal/inference`) has its own separate
`ChatCompletionResponse`/`ChatCompletionMessage` types and never touches
the anthropic package's types. No shared struct, no cross-package
marshaling effect.

**The real cause is the free-pool router**, PR #1115 (`hive-free`, four
load-balanced provider members: OpenRouter `dots-3-note-preview:free`,
Google `gemini-flash-latest`, and two Groq `gpt-oss-20b` keys) plus its
retry fix PR #1155 (`dispatchWithRetry`, which lets a request land on any
member on retry). The replay's `HIVE_TEST_MODEL` is `hive-free`
(`deploy-demo-box.yml`), so this plain "Say hello" / `max_tokens: 256`
request could land on any of the four. The failing test ran for 50.8s
versus 1-7s for its four sibling tests in the same run, consistent with a
reasoning-capable member (Groq's `gpt-oss-20b` or Gemini's thinking-capable
flash model) spending its entire token budget on hidden reasoning before
hitting the length limit, returning `finish_reason: "length"` with
`message.content` omitted from the JSON entirely.

Go's `ChatCompletionMessage.Content` is `*string`. Unmarshaling a response
missing that key leaves it `nil`; `normalizeChatCompletion` in
`apps/edge-api/internal/inference/chat_completions.go` re-marshaled that
nil pointer straight back out as JSON `null`, which every OpenAI SDK
(this test uses the real `openai` npm package) treats as an unconditional
string.

This exact class of failure was already documented in
`deploy-demo-box.yml`'s own comments for a different alias
(`deepseek-v4-flash`: "returned message.content as object/null/string
across probes"), which is why `HIVE_TOOLS_MODEL` was pinned away from it.
`hive-free` was never given the same treatment because its tool-free
smoke test uses no `max_tokens` pressure test and had not yet hit a
reasoning-heavy member in CI.

**This gateway is provider-blind by design.** No pool member's response
shape should leak to a client through the OpenAI-compatible surface.
OpenAI's own contract makes `content` nullable *only* alongside
`tool_calls`/`function_call`; every other case must be a string. That is
where this fix lives.

## Fix

`normalizeChatCompletion` (`apps/edge-api/internal/inference/chat_completions.go`)
now coerces a `nil`, tool-free `message.content` to an empty string
before marshaling the response, via a new `coerceNullContent` helper. A
genuine tool-call message with `content: null` is left untouched, since
that shape is spec-correct per OpenAI and is exercised by the existing
"passes tools through" replay test.

## Why no existing test caught this pre-merge

`packages/sdk-tests` only runs against a live deployed box (`sdk-replay`
job, post-merge), never in CI unit/integration tests, because it needs a
real LiteLLM + provider round trip. The Go unit-test suite for
`normalizeChatCompletion` (`usage_clamp_test.go`) had fixtures for
zero-completion-token clamping but none exercising an upstream response
with `content` entirely absent from the JSON. Added two new unit tests in
`chat_completions_null_content_test.go` that assert on the actual
marshaled wire bytes (not just the Go struct), which would have caught
this before any live deploy:

- `TestNormalizeChatCompletion_NullContentCoercedToEmptyString`:
  reproduces the missing-`content` upstream shape and asserts the
  outgoing JSON has `"content":""`, never `null`.
- `TestNormalizeChatCompletion_NullContentPreservedWithToolCalls`: asserts
  a genuine tool-call message's `content: null` is left alone.

## Buglog entry

To be appended to `.wolf/buglog.jsonl` on `main` via a separate
buglog-only PR, per `.claude/rules/openwolf.md`:

```json
{"date":"2026-08-25","error_message":"AssertionError: expected 'object' to be 'string' at tests/chat-completions/chat-completions.test.ts:36 (response.choices[0].message.content)","root_cause":"hive-free free-pool member (PR #1115/#1155) returned message.content omitted (null) after burning its max_tokens budget on hidden reasoning; normalizeChatCompletion re-marshaled the nil *string as JSON null instead of coercing it, leaking a non-OpenAI-contract shape to every SDK client","fix":"apps/edge-api/internal/inference/chat_completions.go: normalizeChatCompletion coerces nil, tool-free message.content to an empty string; tool-call messages with null content are left untouched per the OpenAI contract","tags":["free-pool","chat-completions","normalization","sdk-replay","hive-free"]}
```

## Test plan

- [x] `go build ./apps/edge-api/...`
- [x] `go vet ./apps/edge-api/...`
- [x] New unit tests pass:
      `go test ./apps/edge-api/internal/inference/... -run 'NullContent|NormalizeChatCompletion' -v`
- [x] Full `apps/edge-api` suite green, no regressions:
      `go test ./apps/edge-api/... -count=1 -short`
- [ ] Next deploy's `sdk-replay` job green against the live demo box
      (this PR cannot verify that itself; the orchestrator confirms on
      merge)

Reproduction: static, from the actual failing-run log
(`gh run view --job 97907530300 --log`) plus static code reading. Live
reproduction against the demo box was not attempted directly (no API key
available to this agent; another agent was separately reported to be
investigating an unrelated Cloudflare Tunnel issue on the same box). The
box itself answered a plain reachability probe (`401` on `/v1/models`
with no auth) during this session, so it was not down at the time of
investigation.