### PR TITLE
feat: render the cache pricing and cache tokens the gateway already meters

### DIFF
--- a/apps/web-console/__tests__/console-cache-visibility.test.tsx
+++ b/apps/web-console/__tests__/console-cache-visibility.test.tsx
@@ -117,6 +117,26 @@ describe("deriveCacheHitRate", () => {
     expect(result.rate).toBe(0.5);
   });
 
+  it("does not let an artifact cache_write_tokens value flip a genuinely inclusive row to the exclusive shape", () => {
+    // A pre-#1157 row can carry a garbage cache_write_tokens value large
+    // enough on its own to exceed input_tokens, even though cache_read_tokens
+    // (400) sits well inside input_tokens (1000) and the row is really the
+    // ordinary inclusive shape: 400 of 1000 prompt tokens came from cache.
+    // Letting the artifact drive shape detection used to add it to the
+    // denominator too, diluting a true 40% hit rate down to under 1%.
+    const result = deriveCacheHitRate([
+      event({
+        input_tokens: 1000,
+        cache_read_tokens: 400,
+        cache_write_tokens: 50_000,
+      }),
+    ]);
+
+    expect(result.promptTokens).toBe(1000);
+    expect(result.cachedTokens).toBe(400);
+    expect(result.rate).toBe(0.4);
+  });
+
   it("excludes cache writes from the numerator", () => {
     // D-056: a pre-#1157 cache_write_tokens value is a bug artifact, not a
     // measured quantity, so it must not move the hit rate.

--- a/apps/web-console/__tests__/console-cache-visibility.test.tsx
+++ b/apps/web-console/__tests__/console-cache-visibility.test.tsx
@@ -1,0 +1,396 @@
+/**
+ * Cache visibility across the console: the two catalog price columns, the two
+ * request-log token columns, the CSV export, and the derivations behind the
+ * analytics cache tiles.
+ *
+ * Every assertion here exists to catch one specific way this feature could
+ * lie: a null price rendered as free, an unmeasured token count rendered as a
+ * verified zero, an unknown price winning a cheapest-first sort, or a cache
+ * hit rate computed against the wrong denominator.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import type { CatalogModel, UsageEventRow } from "@/lib/control-plane/client";
+import {
+  deriveBlendedCreditsPerMillion,
+  deriveCacheHitRate,
+} from "@/lib/analytics/cache-metrics";
+import { ModelCatalogBrowser } from "@/components/catalog/model-catalog-browser";
+import { ModelCatalogTable } from "@/components/catalog/model-catalog-table";
+import { UsageLogsCsv } from "@/components/logs/usage-logs-csv";
+import { UsageLogsTable } from "@/components/logs/usage-logs-table";
+import { formatPercent } from "@/lib/format/credits";
+
+function model(overrides: Partial<CatalogModel> = {}): CatalogModel {
+  return {
+    id: "hive-default",
+    display_name: "Hive Default",
+    summary: "Balanced default chat model.",
+    capability_badges: ["chat"],
+    pricing: {
+      input_price_credits: 12_000_000,
+      output_price_credits: 36_000_000,
+      cache_read_price_credits: 1_200_000,
+      cache_write_price_credits: 15_000_000,
+      pricing_mode: "fixed",
+    },
+    lifecycle: "stable",
+    ...overrides,
+  };
+}
+
+function event(overrides: Partial<UsageEventRow> = {}): UsageEventRow {
+  return {
+    id: "e1",
+    request_id: "r1",
+    request_attempt_id: "a1",
+    event_type: "completed",
+    endpoint: "/v1/chat/completions",
+    model_alias: "hive-default",
+    status: "completed",
+    input_tokens: 1000,
+    output_tokens: 100,
+    hive_credit_delta: -500,
+    customer_tags: {},
+    created_at: "2026-08-25T10:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("deriveCacheHitRate", () => {
+  it("divides cache reads by total prompt tokens on the inclusive shape", () => {
+    // input_tokens already counts the cached subset, which is the convention
+    // every dispatch path in the product reaches today. 800 of 1000 prompt
+    // tokens came from cache.
+    const result = deriveCacheHitRate([
+      event({ input_tokens: 1000, cache_read_tokens: 800 }),
+    ]);
+
+    expect(result.promptTokens).toBe(1000);
+    expect(result.cachedTokens).toBe(800);
+    expect(result.rate).toBe(0.8);
+  });
+
+  it("adds the cache components back when the row came from the exclusive shape", () => {
+    // Anthropic's native convention reports prompt_tokens with both cache
+    // components already removed, so cache read alone exceeds input_tokens.
+    // Treating input_tokens as the denominator there would report 400%.
+    const result = deriveCacheHitRate([
+      event({
+        input_tokens: 200,
+        cache_read_tokens: 800,
+        cache_write_tokens: 0,
+      }),
+    ]);
+
+    expect(result.promptTokens).toBe(1000);
+    expect(result.rate).toBe(0.8);
+  });
+
+  it("never reports a rate above 100 percent", () => {
+    const result = deriveCacheHitRate([
+      event({ input_tokens: 1, cache_read_tokens: 5_000 }),
+      event({ input_tokens: 10, cache_read_tokens: 9 }),
+    ]);
+
+    expect(result.rate).not.toBeNull();
+    expect(result.rate!).toBeLessThanOrEqual(1);
+  });
+
+  it("returns a null rate rather than zero on an empty sample", () => {
+    // A zero here would claim a measured zero-percent hit rate over a window
+    // in which nothing was measured at all.
+    const result = deriveCacheHitRate([]);
+
+    expect(result.rate).toBeNull();
+    expect(result.sampleSize).toBe(0);
+    expect(formatPercent(result.rate)).toBe("—");
+  });
+
+  it("counts a row with no cache fields as fully uncached", () => {
+    const result = deriveCacheHitRate([
+      event({ input_tokens: 500 }),
+      event({ input_tokens: 500, cache_read_tokens: 500 }),
+    ]);
+
+    expect(result.rate).toBe(0.5);
+  });
+
+  it("excludes cache writes from the numerator", () => {
+    // D-056: a pre-#1157 cache_write_tokens value is a bug artifact, not a
+    // measured quantity, so it must not move the hit rate.
+    const withWrite = deriveCacheHitRate([
+      event({
+        input_tokens: 1000,
+        cache_read_tokens: 400,
+        cache_write_tokens: 300,
+      }),
+    ]);
+
+    expect(withWrite.cachedTokens).toBe(400);
+    expect(withWrite.rate).toBe(0.4);
+  });
+});
+
+describe("deriveBlendedCreditsPerMillion", () => {
+  it("restates credits per token as credits per million tokens", () => {
+    expect(deriveBlendedCreditsPerMillion(2_000, 1_000)).toBe(2_000_000);
+  });
+
+  it("returns null on a zero-token window instead of zero or Infinity", () => {
+    expect(deriveBlendedCreditsPerMillion(0, 0)).toBeNull();
+    expect(deriveBlendedCreditsPerMillion(500, 0)).toBeNull();
+  });
+});
+
+describe("model catalog cache pricing columns", () => {
+  it("renders both cache prices when the alias publishes them", () => {
+    render(<ModelCatalogTable models={[model()]} />);
+
+    expect(screen.getByText("Cache read / 1M")).toBeDefined();
+    expect(screen.getByText("Cache write / 1M")).toBeDefined();
+    expect(screen.getByText("1,200,000")).toBeDefined();
+    expect(screen.getByText("15,000,000")).toBeDefined();
+  });
+
+  it("renders a dash, never a zero, when a fixed-price alias publishes no cache rate", () => {
+    const { container } = render(
+      <ModelCatalogTable
+        models={[
+          model({
+            pricing: {
+              input_price_credits: 12_000_000,
+              output_price_credits: 36_000_000,
+              cache_read_price_credits: null,
+              cache_write_price_credits: null,
+              pricing_mode: "fixed",
+            },
+          }),
+        ]}
+      />,
+    );
+
+    const cells = Array.from(container.querySelectorAll("td")).map(
+      (cell) => cell.textContent,
+    );
+    expect(cells).toContain("—");
+    expect(cells).not.toContain("0");
+  });
+
+  it("says Variable for a cache price on an upstream-priced alias", () => {
+    render(
+      <ModelCatalogTable
+        models={[
+          model({
+            pricing: {
+              input_price_credits: null,
+              output_price_credits: null,
+              cache_read_price_credits: null,
+              cache_write_price_credits: null,
+              pricing_mode: "upstream_actual",
+            },
+          }),
+        ]}
+      />,
+    );
+
+    expect(screen.getAllByText("Variable").length).toBe(4);
+  });
+});
+
+describe("model catalog search, filter and sort", () => {
+  const models = [
+    model({
+      id: "alpha-chat",
+      display_name: "Alpha Chat",
+      capability_badges: ["chat"],
+      pricing: {
+        input_price_credits: 9_000_000,
+        output_price_credits: 1_000_000,
+        cache_read_price_credits: 900_000,
+        cache_write_price_credits: null,
+        pricing_mode: "fixed",
+      },
+    }),
+    model({
+      id: "beta-embed",
+      display_name: "Beta Embed",
+      capability_badges: ["embeddings"],
+      pricing: {
+        input_price_credits: 1_000_000,
+        output_price_credits: 2_000_000,
+        cache_read_price_credits: null,
+        cache_write_price_credits: null,
+        pricing_mode: "fixed",
+      },
+    }),
+    model({
+      id: "gamma-variable",
+      display_name: "Gamma Variable",
+      capability_badges: ["chat"],
+      pricing: {
+        input_price_credits: null,
+        output_price_credits: null,
+        cache_read_price_credits: null,
+        cache_write_price_credits: null,
+        pricing_mode: "upstream_actual",
+      },
+    }),
+  ];
+
+  function visibleAliases(container: HTMLElement): string[] {
+    return Array.from(container.querySelectorAll("tbody code")).map(
+      (node) => node.textContent ?? "",
+    );
+  }
+
+  it("filters rows by a search term over alias, name and summary", () => {
+    const { container } = render(<ModelCatalogBrowser models={models} />);
+
+    fireEvent.change(screen.getByLabelText("Search models"), {
+      target: { value: "beta" },
+    });
+
+    expect(visibleAliases(container)).toEqual(["beta-embed"]);
+    expect(screen.getByTestId("catalog-result-count").textContent).toBe(
+      "1 of 3 models",
+    );
+  });
+
+  it("filters rows by capability", () => {
+    const { container } = render(<ModelCatalogBrowser models={models} />);
+
+    fireEvent.change(screen.getByLabelText("Capability"), {
+      target: { value: "embeddings" },
+    });
+
+    expect(visibleAliases(container)).toEqual(["beta-embed"]);
+  });
+
+  it("sorts an unpriced alias last in a cheapest-first sort, never first", () => {
+    const { container } = render(<ModelCatalogBrowser models={models} />);
+
+    fireEvent.change(screen.getByLabelText("Sort"), {
+      target: { value: "input_asc" },
+    });
+
+    expect(visibleAliases(container)).toEqual([
+      "beta-embed",
+      "alpha-chat",
+      "gamma-variable",
+    ]);
+  });
+
+  it("keeps the unpriced alias last in the descending sort too", () => {
+    const { container } = render(<ModelCatalogBrowser models={models} />);
+
+    fireEvent.change(screen.getByLabelText("Sort"), {
+      target: { value: "input_desc" },
+    });
+
+    expect(visibleAliases(container).at(-1)).toBe("gamma-variable");
+  });
+
+  it("distinguishes an empty filter result from an empty catalog", () => {
+    render(<ModelCatalogBrowser models={models} />);
+
+    fireEvent.change(screen.getByLabelText("Search models"), {
+      target: { value: "nothing-matches-this" },
+    });
+
+    expect(screen.getByText("No models match these filters")).toBeDefined();
+    expect(screen.queryByText("No models available")).toBeNull();
+  });
+});
+
+describe("request log cache token columns", () => {
+  it("renders cache read and cache write counts when present", () => {
+    render(
+      <UsageLogsTable
+        rows={[
+          event({ cache_read_tokens: 12_345, cache_write_tokens: 678 }),
+        ]}
+        keyNames={{}}
+      />,
+    );
+
+    expect(screen.getByText("Cached in")).toBeDefined();
+    expect(screen.getByText("Cache write")).toBeDefined();
+    expect(screen.getByText("12,345")).toBeDefined();
+    expect(screen.getByText("678")).toBeDefined();
+  });
+
+  it("renders an em-dash, not a zero, when the field is absent", () => {
+    // The control-plane omits both fields when zero, so the console cannot
+    // tell an unmeasured value from a measured zero.
+    const { container } = render(
+      <UsageLogsTable rows={[event()]} keyNames={{}} />,
+    );
+
+    const cells = Array.from(container.querySelectorAll("tbody td")).map(
+      (cell) => cell.textContent,
+    );
+    expect(cells.filter((text) => text === "—").length).toBeGreaterThanOrEqual(
+      2,
+    );
+    expect(cells).not.toContain("0");
+  });
+});
+
+describe("usage CSV export", () => {
+  async function exportedCsv(rows: UsageEventRow[]): Promise<string> {
+    let captured = "";
+    const createObjectURL = vi
+      .spyOn(URL, "createObjectURL")
+      .mockImplementation((blob: Blob | MediaSource) => {
+        void (blob as Blob)
+          .text()
+          .then((text) => {
+            captured = text;
+          })
+          .catch(() => {});
+        return "blob:mock";
+      });
+    vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+
+    render(<UsageLogsCsv rows={rows} keyNames={{}} />);
+    fireEvent.click(screen.getByText("Export CSV"));
+
+    // Blob.text() resolves on a microtask; flush before asserting.
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(createObjectURL).toHaveBeenCalled();
+    return captured;
+  }
+
+  it("carries both cache token columns in the header", async () => {
+    const csv = await exportedCsv([event({ cache_read_tokens: 900 })]);
+
+    const [header] = csv.split("\n");
+    expect(header.split(",")).toEqual([
+      "created_at",
+      "request_id",
+      "model_alias",
+      "status",
+      "input_tokens",
+      "output_tokens",
+      "cache_read_tokens",
+      "cache_write_tokens",
+      "hive_credit_delta",
+      "error_code",
+      "api_key",
+    ]);
+  });
+
+  it("exports an absent cache count as an empty cell rather than a zero", async () => {
+    const csv = await exportedCsv([event({ cache_read_tokens: 900 })]);
+
+    const [, row] = csv.split("\n");
+    const cells = row.split(",");
+    expect(cells[6]).toBe("900");
+    expect(cells[7]).toBe("");
+  });
+});

--- a/apps/web-console/app/console/analytics/page.tsx
+++ b/apps/web-console/app/console/analytics/page.tsx
@@ -7,13 +7,19 @@ import {
   getAnalyticsErrors,
   getAnalyticsSpend,
   getAnalyticsUsage,
+  getUsageEvents,
   getViewer,
 } from "@/lib/control-plane/client";
 import type {
   ErrorSummaryRow,
   SpendSummaryRow,
+  UsageEventRow,
   UsageSummaryRow,
 } from "@/lib/control-plane/client";
+import {
+  deriveBlendedCreditsPerMillion,
+  deriveCacheHitRate,
+} from "@/lib/analytics/cache-metrics";
 import { AnalyticsControls } from "@/components/analytics/analytics-controls";
 import { ObservabilityTiles } from "@/components/analytics/observability-tiles";
 import { AnalyticsTable } from "@/components/analytics/analytics-table";
@@ -30,7 +36,7 @@ import {
 } from "@/components/ui/card";
 import { PageHeader } from "@/components/ui/page-header";
 import { cn } from "@/lib/cn";
-import { formatCredits } from "@/lib/format/credits";
+import { formatCredits, formatPercent } from "@/lib/format/credits";
 
 interface AnalyticsPageProps {
   searchParams: Promise<{
@@ -66,9 +72,14 @@ const TABS: ReadonlyArray<{ id: TabName; label: string }> = [
 interface SummaryCardProps {
   label: string;
   value: string;
+  // Says what the number above actually covers. Required on any tile whose
+  // value is derived rather than read straight off the server aggregate, so
+  // the sample or the formula is never left implicit.
+  note?: string;
+  testId?: string;
 }
 
-function SummaryCard({ label, value }: SummaryCardProps) {
+function SummaryCard({ label, value, note, testId }: SummaryCardProps) {
   return (
     <Card>
       <CardContent className="flex flex-col gap-1 px-5 py-5">
@@ -78,13 +89,35 @@ function SummaryCard({ label, value }: SummaryCardProps) {
         <p
           className="metric text-2xl text-[var(--color-ink)]"
           data-numeric
+          data-testid={testId}
         >
           {value}
         </p>
+        {note ? (
+          <p className="text-2xs leading-tight text-[var(--color-ink-3)]">
+            {note}
+          </p>
+        ) : null}
       </CardContent>
     </Card>
   );
 }
+
+// Windows the usage-events endpoint accepts as a preset. The analytics
+// controls also offer 90d and a custom range, which parseListEventsFilter
+// (apps/control-plane/internal/usage/http.go) rejects with a 400. Rather than
+// fire a request that is known to fail, or quietly substitute a different
+// window and label the answer as though it covered the one on screen, the
+// cache tile says it has no sample for those windows.
+//
+// ponytail: preset windows only. Widening it means teaching getUsageEvents to
+// pass explicit from/to bounds, which the endpoint already accepts.
+const EVENT_SAMPLE_WINDOWS: ReadonlyArray<string> = ["1h", "24h", "7d", "30d"];
+
+// The usage-events endpoint caps a page at 100 rows (maxEventsPageLimit), so
+// the cache sample is the most recent 100 requests in the window and every
+// tile built from it says so.
+const CACHE_SAMPLE_LIMIT = 100;
 
 export default async function AnalyticsPage({
   searchParams,
@@ -146,6 +179,52 @@ export default async function AnalyticsPage({
     (sum, r) => sum + r.total_credits_spent,
     0,
   );
+
+  // Cache hit rate has no server-side aggregate to read (GetUsageSummary sums
+  // input, output, credits and count only), so it is derived here from real
+  // usage_events rows. The sample is bounded by the endpoint's page cap, and
+  // the tile prints the sample size rather than implying it covered the whole
+  // window.
+  let cacheSample: UsageEventRow[] | null = null;
+  let cacheSampleTruncated = false;
+  if (activeTab === "overview" && EVENT_SAMPLE_WINDOWS.includes(timeWindow)) {
+    try {
+      const page = await getUsageEvents({
+        limit: CACHE_SAMPLE_LIMIT,
+        window: timeWindow,
+      });
+      cacheSample = page.events;
+      cacheSampleTruncated = page.next_cursor !== null;
+    } catch {
+      // Leave cacheSample null: the tile renders as unavailable rather than
+      // as a zero-percent hit rate nobody measured.
+      cacheSample = null;
+    }
+  }
+
+  const cacheHitRate = cacheSample ? deriveCacheHitRate(cacheSample) : null;
+  const blendedCreditsPerMillion = deriveBlendedCreditsPerMillion(
+    totalCreditsSpent,
+    totalInputTokens + totalOutputTokens,
+  );
+
+  function cacheHitNote(): string {
+    if (!EVENT_SAMPLE_WINDOWS.includes(timeWindow)) {
+      return "No sample for this window. Pick 24h, 7d or 30d.";
+    }
+    if (!cacheHitRate) {
+      return "Request sample unavailable.";
+    }
+    if (cacheHitRate.sampleSize === 0) {
+      return "No requests in this window.";
+    }
+    if (cacheHitRate.promptTokens === 0) {
+      return `No prompt tokens across the last ${cacheHitRate.sampleSize} requests.`;
+    }
+    return cacheSampleTruncated
+      ? `Cached prompt tokens over the last ${cacheHitRate.sampleSize} requests, the most this window returns in one page.`
+      : `Cached prompt tokens over all ${cacheHitRate.sampleSize} requests in this window.`;
+  }
 
   return (
     <ConsoleShell
@@ -211,7 +290,7 @@ export default async function AnalyticsPage({
         <>
           {activeTab === "overview" ? (
             <div className="flex flex-col gap-6">
-              <section className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+              <section className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
                 <SummaryCard
                   label="Total requests"
                   value={formatCredits(totalRequests)}
@@ -227,6 +306,26 @@ export default async function AnalyticsPage({
                 <SummaryCard
                   label="Credits spent"
                   value={formatCredits(totalCreditsSpent)}
+                />
+                <SummaryCard
+                  label="Cache hit rate"
+                  value={formatPercent(cacheHitRate?.rate ?? null)}
+                  note={cacheHitNote()}
+                  testId="cache-hit-rate"
+                />
+                <SummaryCard
+                  label="Blended credits / 1M"
+                  value={
+                    blendedCreditsPerMillion === null
+                      ? "—"
+                      : formatCredits(blendedCreditsPerMillion)
+                  }
+                  note={
+                    blendedCreditsPerMillion === null
+                      ? "No tokens served in this window."
+                      : "Credits spent divided by input plus output tokens, per million. Effective, so cache reads are already priced in."
+                  }
+                  testId="blended-credits-per-million"
                 />
               </section>
               <ChartCard title="Usage" description="Requests and tokens.">

--- a/apps/web-console/app/console/analytics/page.tsx
+++ b/apps/web-console/app/console/analytics/page.tsx
@@ -210,7 +210,7 @@ export default async function AnalyticsPage({
 
   function cacheHitNote(): string {
     if (!EVENT_SAMPLE_WINDOWS.includes(timeWindow)) {
-      return "No sample for this window. Pick 24h, 7d or 30d.";
+      return "No sample for this window. Pick 1h, 24h, 7d or 30d.";
     }
     if (!cacheHitRate) {
       return "Request sample unavailable.";

--- a/apps/web-console/app/console/catalog/page.tsx
+++ b/apps/web-console/app/console/catalog/page.tsx
@@ -6,7 +6,7 @@ import {
   getViewer,
 } from "@/lib/control-plane/client";
 import { ConsoleShell } from "@/components/app-shell/console-shell";
-import { ModelCatalogTable } from "@/components/catalog/model-catalog-table";
+import { ModelCatalogBrowser } from "@/components/catalog/model-catalog-browser";
 import { PageHeader } from "@/components/ui/page-header";
 
 export default async function CatalogPage() {
@@ -41,10 +41,10 @@ export default async function CatalogPage() {
       <PageHeader
         eyebrow="Build"
         title="Model catalog"
-        description="Available models and per-million-token pricing across providers. Capabilities are surfaced as tags."
+        description="Available models with per-million-token input, output and prompt-cache pricing. Search, filter by capability, or sort by price."
       />
 
-      <ModelCatalogTable models={models} />
+      <ModelCatalogBrowser models={models} />
     </ConsoleShell>
   );
 }

--- a/apps/web-console/components/catalog/model-catalog-browser.tsx
+++ b/apps/web-console/components/catalog/model-catalog-browser.tsx
@@ -1,0 +1,223 @@
+"use client";
+
+import * as React from "react";
+import { Search } from "lucide-react";
+
+import type { CatalogModel } from "@/lib/control-plane/client";
+import { ModelCatalogTable } from "@/components/catalog/model-catalog-table";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/cn";
+
+interface ModelCatalogBrowserProps {
+  models: CatalogModel[];
+}
+
+type SortKey =
+  | "name"
+  | "input_asc"
+  | "input_desc"
+  | "output_asc"
+  | "output_desc"
+  | "cache_read_asc";
+
+const SORT_OPTIONS: ReadonlyArray<{ value: SortKey; label: string }> = [
+  { value: "name", label: "Name (A to Z)" },
+  { value: "input_asc", label: "Input price, low to high" },
+  { value: "input_desc", label: "Input price, high to low" },
+  { value: "output_asc", label: "Output price, low to high" },
+  { value: "output_desc", label: "Output price, high to low" },
+  { value: "cache_read_asc", label: "Cache read price, low to high" },
+];
+
+// A model with no per-million rate sorts to the end of every price ordering,
+// in BOTH directions. It is not the cheapest model and it is not the most
+// expensive one, it is a model whose price this screen does not know, and
+// letting an unknown win either end of a price sort is how an evaluator picks
+// a model on a number that was never there.
+//
+// This is a partition rather than a sentinel value: a sentinel such as
+// Infinity survives the ascending comparator and then loses the descending
+// one, because negating the comparison flips the sentinel to the front. The
+// unit test for the descending sort exists because that is exactly what the
+// first version of this function did.
+function comparePrice(
+  a: number | null,
+  b: number | null,
+  descending: boolean,
+): number {
+  if (a === null && b === null) return 0;
+  if (a === null) return 1;
+  if (b === null) return -1;
+  return descending ? b - a : a - b;
+}
+
+function compareModels(a: CatalogModel, b: CatalogModel, sort: SortKey): number {
+  switch (sort) {
+    case "input_asc":
+      return comparePrice(
+        a.pricing.input_price_credits,
+        b.pricing.input_price_credits,
+        false,
+      );
+    case "input_desc":
+      return comparePrice(
+        a.pricing.input_price_credits,
+        b.pricing.input_price_credits,
+        true,
+      );
+    case "output_asc":
+      return comparePrice(
+        a.pricing.output_price_credits,
+        b.pricing.output_price_credits,
+        false,
+      );
+    case "output_desc":
+      return comparePrice(
+        a.pricing.output_price_credits,
+        b.pricing.output_price_credits,
+        true,
+      );
+    case "cache_read_asc":
+      return comparePrice(
+        a.pricing.cache_read_price_credits,
+        b.pricing.cache_read_price_credits,
+        false,
+      );
+    default:
+      return (a.display_name || a.id).localeCompare(b.display_name || b.id);
+  }
+}
+
+function matchesSearch(model: CatalogModel, needle: string): boolean {
+  if (!needle) return true;
+  const haystack = [model.id, model.display_name, model.summary]
+    .join(" ")
+    .toLowerCase();
+  return haystack.includes(needle);
+}
+
+/**
+ * Search, capability filter and sort over the catalog.
+ *
+ * The whole catalog is already fetched by the server component above, so this
+ * filters the array in memory rather than issuing a request per keystroke.
+ * That holds while the catalog is tens of aliases; a catalog in the hundreds
+ * wants a server-side query and pagination instead.
+ *
+ * ponytail: in-memory filter, move to a server-side query if the catalog ever
+ * outgrows a single page fetch.
+ */
+export function ModelCatalogBrowser({ models }: ModelCatalogBrowserProps) {
+  const [query, setQuery] = React.useState("");
+  const [capability, setCapability] = React.useState("");
+  const [sort, setSort] = React.useState<SortKey>("name");
+
+  // Offer only the capabilities this catalog actually carries. A hardcoded
+  // list would show filters that match nothing.
+  const capabilities = React.useMemo(() => {
+    const seen = new Set<string>();
+    for (const model of models) {
+      for (const badge of model.capability_badges) {
+        seen.add(badge);
+      }
+    }
+    return Array.from(seen).sort((a, b) => a.localeCompare(b));
+  }, [models]);
+
+  const visible = React.useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    return [...models]
+      .filter(
+        (model) =>
+          matchesSearch(model, needle) &&
+          (capability === "" || model.capability_badges.includes(capability)),
+      )
+      .sort((a, b) => compareModels(a, b, sort));
+  }, [models, query, capability, sort]);
+
+  const selectClass = cn(
+    "h-9 rounded-md border border-[var(--color-border)]",
+    "bg-[var(--color-surface)] px-2 text-sm text-[var(--color-ink)]",
+  );
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="relative min-w-[16rem] flex-1">
+          <Search
+            size={14}
+            aria-hidden="true"
+            className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-[var(--color-ink-4)]"
+          />
+          <label className="sr-only" htmlFor="catalog-search">
+            Search models
+          </label>
+          <Input
+            id="catalog-search"
+            type="search"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search models…"
+            className="pl-8"
+          />
+        </div>
+
+        <label className="sr-only" htmlFor="catalog-capability">
+          Capability
+        </label>
+        <select
+          id="catalog-capability"
+          value={capability}
+          onChange={(event) => setCapability(event.target.value)}
+          className={selectClass}
+        >
+          <option value="">All capabilities</option>
+          {capabilities.map((badge) => (
+            <option key={badge} value={badge}>
+              {badge}
+            </option>
+          ))}
+        </select>
+
+        <label className="sr-only" htmlFor="catalog-sort">
+          Sort
+        </label>
+        <select
+          id="catalog-sort"
+          value={sort}
+          onChange={(event) => setSort(event.target.value as SortKey)}
+          className={selectClass}
+        >
+          {SORT_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <p
+        className="text-xs text-[var(--color-ink-3)]"
+        data-testid="catalog-result-count"
+        aria-live="polite"
+      >
+        {visible.length === models.length
+          ? `${models.length} models`
+          : `${visible.length} of ${models.length} models`}
+      </p>
+
+      {/* ModelCatalogTable's own empty state says the catalog is empty for
+          this workspace, which is a different and alarming claim when the
+          catalog is fine and the filter simply matched nothing. */}
+      {visible.length === 0 && models.length > 0 ? (
+        <EmptyState
+          title="No models match these filters"
+          description="Clear the search or widen the capability filter to see the rest of the catalog."
+        />
+      ) : (
+        <ModelCatalogTable models={visible} />
+      )}
+    </div>
+  );
+}

--- a/apps/web-console/components/catalog/model-catalog-table.tsx
+++ b/apps/web-console/components/catalog/model-catalog-table.tsx
@@ -23,6 +23,20 @@ function formatPrice(credits: number | null, pricingMode: string): string {
   return formatCredits(credits);
 }
 
+// Cache prices carry a third kind of absence the input and output columns do
+// not have. A fixed-price alias that publishes no cache rate is neither broken
+// nor variable, it simply has no cache rate to charge, and OpenRouter renders
+// exactly that case as a dash in its own `Cache read /M` column. Rendering 0
+// instead would say the alias caches for free, which is the expensive kind of
+// wrong on a pricing screen. A variable-price alias still reads "Variable",
+// because its cache component is variable for the same reason its input is.
+function formatCachePrice(credits: number | null, pricingMode: string): string {
+  if (credits === null) {
+    return pricingMode === "upstream_actual" ? "Variable" : "—";
+  }
+  return formatCredits(credits);
+}
+
 type ToneName = "neutral" | "accent" | "success" | "warning" | "danger";
 
 function capabilityTone(badge: string): ToneName {
@@ -120,6 +134,28 @@ export function ModelCatalogTable({ models }: ModelCatalogTableProps) {
       numeric: true,
       align: "right",
       cell: (row) => formatPrice(row.pricing.output_price_credits, row.pricing.pricing_mode),
+    },
+    {
+      key: "cache_read",
+      header: "Cache read / 1M",
+      numeric: true,
+      align: "right",
+      cell: (row) =>
+        formatCachePrice(
+          row.pricing.cache_read_price_credits,
+          row.pricing.pricing_mode,
+        ),
+    },
+    {
+      key: "cache_write",
+      header: "Cache write / 1M",
+      numeric: true,
+      align: "right",
+      cell: (row) =>
+        formatCachePrice(
+          row.pricing.cache_write_price_credits,
+          row.pricing.pricing_mode,
+        ),
     },
     {
       key: "status",

--- a/apps/web-console/components/logs/usage-logs-csv.tsx
+++ b/apps/web-console/components/logs/usage-logs-csv.tsx
@@ -12,8 +12,15 @@ interface UsageLogsCsvProps {
 
 export function UsageLogsCsv({ rows, keyNames }: UsageLogsCsvProps) {
   function handleExport() {
+    // cache_read_tokens and cache_write_tokens sit next to the token columns
+    // they belong with. An absent value exports as an EMPTY cell rather than
+    // 0, for the same reason the table renders an em-dash: the control-plane
+    // omits both fields when they are zero, so the console cannot tell a
+    // measured zero from an unmeasured one, and a spreadsheet full of zeroes
+    // is exactly the shape a customer would reconcile a bill against.
     const header =
-      "created_at,request_id,model_alias,status,input_tokens,output_tokens,hive_credit_delta,error_code,api_key\n";
+      "created_at,request_id,model_alias,status,input_tokens,output_tokens," +
+      "cache_read_tokens,cache_write_tokens,hive_credit_delta,error_code,api_key\n";
     const lines = rows.map((row) => {
       const key = row.api_key_id
         ? (keyNames[row.api_key_id] ?? `…${row.api_key_id.slice(-6)}`)
@@ -26,6 +33,12 @@ export function UsageLogsCsv({ rows, keyNames }: UsageLogsCsvProps) {
         row.status,
         String(row.input_tokens),
         String(row.output_tokens),
+        row.cache_read_tokens === undefined
+          ? ""
+          : String(row.cache_read_tokens),
+        row.cache_write_tokens === undefined
+          ? ""
+          : String(row.cache_write_tokens),
         String(row.hive_credit_delta),
         row.error_code ?? "",
         key,

--- a/apps/web-console/components/logs/usage-logs-table.tsx
+++ b/apps/web-console/components/logs/usage-logs-table.tsx
@@ -35,6 +35,22 @@ function lifecycleLabel(entryType: string): string {
   }
 }
 
+// Cache token counts are rendered as an em-dash when the field is absent,
+// never as 0.
+//
+// The control-plane omits cache_read_tokens and cache_write_tokens from the
+// event payload whenever they are zero (handleListEvents in
+// apps/control-plane/internal/usage/http.go), so a missing field and a real
+// measured zero arrive here as the identical `undefined`. On top of that,
+// decision D-056 records that every cache_write_tokens value written before
+// PR #1157 deployed is a bug artifact rather than a measured zero, and a
+// stored row carries no marker saying which side of that deploy it fell on.
+// Printing "0" would assert a verified zero this column cannot verify, so it
+// prints the absence instead.
+function formatCacheTokens(value: number | undefined): string {
+  return value === undefined ? "—" : formatTokens(value);
+}
+
 interface LifecycleState {
   loading: boolean;
   entries: LedgerEntry[] | null;
@@ -129,6 +145,20 @@ export function UsageLogsTable({ rows, keyNames }: UsageLogsTableProps) {
       numeric: true,
       align: "right",
       cell: (row) => formatTokens(row.output_tokens),
+    },
+    {
+      key: "cache_read",
+      header: "Cached in",
+      numeric: true,
+      align: "right",
+      cell: (row) => formatCacheTokens(row.cache_read_tokens),
+    },
+    {
+      key: "cache_write",
+      header: "Cache write",
+      numeric: true,
+      align: "right",
+      cell: (row) => formatCacheTokens(row.cache_write_tokens),
     },
     {
       key: "credits",

--- a/apps/web-console/lib/analytics/cache-metrics.ts
+++ b/apps/web-console/lib/analytics/cache-metrics.ts
@@ -45,15 +45,23 @@ export interface CacheHitRate {
  * The EXCLUSIVE convention reports `prompt_tokens` with both cache components
  * already removed, and nothing in a stored row marks which shape produced it.
  * So this guards on the arithmetic rather than on a flag that does not exist:
- * under INCLUSIVE, cache read plus cache write can never exceed `input_tokens`,
- * because the fresh remainder is clamped non-negative upstream. A row where
- * they do exceed it can only have come from the exclusive shape, and its true
- * prompt total is the sum of all three components.
+ * under INCLUSIVE, cache read alone can never exceed `input_tokens`, because
+ * it is a subset of it. A row where cache read does exceed input can only
+ * have come from the exclusive shape.
  *
- * Only cache READ feeds the numerator. Cache WRITE is deliberately excluded:
- * per decision D-056 every `cache_write_tokens` value stored before PR #1157
- * deployed is a bug artifact rather than a measured zero, and a stored row
- * carries no marker saying which side of that deploy it fell on.
+ * That check deliberately reads `cache_read_tokens` alone, never
+ * `cache_write_tokens`. Per decision D-056 every `cache_write_tokens` value
+ * stored before PR #1157 deployed is a bug artifact rather than a measured
+ * quantity, and a stored row carries no marker saying which side of that
+ * deploy it fell on, so it can never be trusted, in either direction: not as
+ * the signal that decides which shape a row is, and not as an addend in the
+ * prompt-token total once a shape is picked. An artifact large enough on its
+ * own to push `cache_read_tokens + cache_write_tokens` past `input_tokens`
+ * used to flip a genuinely inclusive row to the exclusive branch and inflate
+ * the denominator with garbage, silently lowering the displayed hit rate.
+ * Cache WRITE is excluded from both the shape check and the prompt-token sum
+ * for exactly that reason; only cache READ, which carries no such artifact
+ * history, ever moves this arithmetic.
  */
 export function deriveCacheHitRate(
   rows: ReadonlyArray<CacheTokenRow>,
@@ -63,11 +71,10 @@ export function deriveCacheHitRate(
 
   for (const row of rows) {
     const cacheRead = row.cache_read_tokens ?? 0;
-    const cacheWrite = row.cache_write_tokens ?? 0;
     const input = row.input_tokens;
-    const exclusiveShape = cacheRead + cacheWrite > input;
+    const exclusiveShape = cacheRead > input;
 
-    promptTokens += exclusiveShape ? input + cacheRead + cacheWrite : input;
+    promptTokens += exclusiveShape ? input + cacheRead : input;
     cachedTokens += cacheRead;
   }
 

--- a/apps/web-console/lib/analytics/cache-metrics.ts
+++ b/apps/web-console/lib/analytics/cache-metrics.ts
@@ -1,0 +1,105 @@
+/**
+ * Cache metrics the console derives from rows it already fetches.
+ *
+ * The control-plane analytics aggregate (`GetUsageSummary` in
+ * apps/control-plane/internal/usage/repository.go) sums input tokens, output
+ * tokens, credits and request count only. It has no `SUM(cache_read_tokens)`,
+ * so there is no server-side cache hit rate to read. Rather than invent one,
+ * these functions derive it from the same `usage_events` rows the request log
+ * renders, and every caller is required to state which sample the number
+ * covers. A cache hit rate whose sample is unstated is worse than no tile.
+ */
+
+/** The subset of a usage event these derivations read. */
+export interface CacheTokenRow {
+  input_tokens: number;
+  cache_read_tokens?: number;
+  cache_write_tokens?: number;
+}
+
+export interface CacheHitRate {
+  /** Cache-read tokens observed across the sample. */
+  cachedTokens: number;
+  /** Total prompt tokens across the sample, cached subset included. */
+  promptTokens: number;
+  /** cachedTokens / promptTokens, or null when the sample carries no prompt tokens. */
+  rate: number | null;
+  /** How many rows the sample actually covered. */
+  sampleSize: number;
+}
+
+/**
+ * Cache hit rate as cached prompt tokens over total prompt tokens, which is
+ * the definition OpenRouter's own tile uses.
+ *
+ * The arithmetic rests on one fact about what is stored.
+ * `usage_events.input_tokens` holds the RAW upstream `prompt_tokens` figure,
+ * not the fresh count that billing prices: see the `UsageAccumulator.InputTokens`
+ * comment in apps/edge-api/internal/inference/stream.go and the assignment in
+ * orchestrator.go's `recordCompletedEvent`. Under the INCLUSIVE convention,
+ * which is the only one any dispatch path in the product reaches today because
+ * LiteLLM normalizes even an Anthropic response to it (see `NormalizeCacheUsage`
+ * in cache_usage.go), `prompt_tokens` already counts the cached subset. So
+ * `input_tokens` is the denominator and `cache_read_tokens` is the numerator.
+ *
+ * The EXCLUSIVE convention reports `prompt_tokens` with both cache components
+ * already removed, and nothing in a stored row marks which shape produced it.
+ * So this guards on the arithmetic rather than on a flag that does not exist:
+ * under INCLUSIVE, cache read plus cache write can never exceed `input_tokens`,
+ * because the fresh remainder is clamped non-negative upstream. A row where
+ * they do exceed it can only have come from the exclusive shape, and its true
+ * prompt total is the sum of all three components.
+ *
+ * Only cache READ feeds the numerator. Cache WRITE is deliberately excluded:
+ * per decision D-056 every `cache_write_tokens` value stored before PR #1157
+ * deployed is a bug artifact rather than a measured zero, and a stored row
+ * carries no marker saying which side of that deploy it fell on.
+ */
+export function deriveCacheHitRate(
+  rows: ReadonlyArray<CacheTokenRow>,
+): CacheHitRate {
+  let cachedTokens = 0;
+  let promptTokens = 0;
+
+  for (const row of rows) {
+    const cacheRead = row.cache_read_tokens ?? 0;
+    const cacheWrite = row.cache_write_tokens ?? 0;
+    const input = row.input_tokens;
+    const exclusiveShape = cacheRead + cacheWrite > input;
+
+    promptTokens += exclusiveShape ? input + cacheRead + cacheWrite : input;
+    cachedTokens += cacheRead;
+  }
+
+  return {
+    cachedTokens,
+    promptTokens,
+    rate: promptTokens > 0 ? cachedTokens / promptTokens : null,
+    sampleSize: rows.length,
+  };
+}
+
+/**
+ * Blended effective price: the credits actually charged across a window
+ * divided by the tokens that window moved, restated per million tokens so it
+ * sits in the same unit as the catalog's `Input / 1M` and `Output / 1M`
+ * columns.
+ *
+ * "Effective" is the whole point of the number. It is what the account paid
+ * after cache reads were priced at the cache rate, so it lands below the
+ * listed input rate exactly when caching is working. Both inputs come from
+ * the server-side aggregate, so this covers the full window rather than a
+ * sample.
+ *
+ * Returns null on a zero-token window: dividing by it would print Infinity,
+ * and printing 0 would claim the account was served for free.
+ */
+export function deriveBlendedCreditsPerMillion(
+  totalCreditsSpent: number,
+  totalTokens: number,
+): number | null {
+  if (totalTokens <= 0) {
+    return null;
+  }
+  return (totalCreditsSpent / totalTokens) * 1_000_000;
+}

--- a/apps/web-console/lib/format/credits.ts
+++ b/apps/web-console/lib/format/credits.ts
@@ -76,3 +76,25 @@ export function formatShortDate(
     timeZone: DISPLAY_TIME_ZONE,
   }).format(date);
 }
+
+/**
+ * Format a 0..1 ratio as a percentage with one decimal place ("96.0%").
+ *
+ * Takes `number | null` because the rates this renders are genuinely absent
+ * on an empty sample, and a null that silently became "0.0%" would assert a
+ * measured zero-percent cache hit rate where nothing was measured at all.
+ * Callers render the em-dash as the visible absence.
+ */
+export function formatPercent(
+  value: number | null,
+  locale: AppLocale = DEFAULT_LOCALE,
+): string {
+  if (value === null || !Number.isFinite(value)) {
+    return "—";
+  }
+  return new Intl.NumberFormat(intlTag(locale, "number"), {
+    style: "percent",
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1,
+  }).format(value);
+}

--- a/docs/proof/console-cache-visibility-2026-08-25/README.md
+++ b/docs/proof/console-cache-visibility-2026-08-25/README.md
@@ -1,0 +1,122 @@
+# Visual proof: console cache visibility (PR #1172)
+
+Captured 2026-08-25 against a running stack, after the change, per the
+visual-proof rule in `.claude/rules/orchestrator.md`.
+
+The screenshots themselves are attached to PR #1172 as GitHub Release assets
+via `scripts/post-pr-visual-proof.sh`. They are deliberately not committed
+here: a `raw.githubusercontent.com` URL pinned to this PR's branch 404s the
+moment the branch is deleted, which is what squash-and-delete does on merge
+(D-042). This directory carries the text half, because
+`npm run lint:proof-tokens` scans this directory and nothing else.
+
+## What was running
+
+Real stack, not a mock. Both passes read the same database rows and the same
+control-plane; the only thing swapped between them is the console image.
+
+| Component | What it was |
+| --- | --- |
+| Postgres | `hiveverify-supabase-db-1`, self-hosted Supabase Postgres 16 with the full migration chain |
+| Auth | `hiveverify-supabase-auth-1`, GoTrue v2.189.0, reached through a Caddy gateway on the `caddy-supabase` network alias |
+| control-plane | Go binary built from this branch (`deploy/docker/Dockerfile.control-plane`), container `cachevis-cp` |
+| Console under test (after) | `hive-web-console:cachevis-proof`, built from this branch |
+| Console for the before shots | `hive-web-console:cachevis-before`, built from `origin/main` at 78c4b61a4 |
+| Reached at | `http://127.0.0.1:13310`, a Caddy proxy sharing the console's network namespace |
+
+The session was minted through the admin one-time-token flow in
+`apps/web-console/tests/e2e/support/live-auth.mjs`. No password was set, read
+or rotated, per `docs/live-test-auth.md`.
+
+Two notes on the stack, neither caused by this change:
+
+- The `caddy-supabase` gateway that control-plane validates bearer tokens
+  against had exited two days earlier, so every token was being rejected with
+  "invalid or expired token". A replacement gateway was started on the same
+  network alias. This is stack repair, not a code change.
+- The control-plane image already running in that project predated the
+  `id` and `request_attempt_id` fields on the usage-events payload, so the
+  request log could not decode a single row. A control-plane built from this
+  branch was used instead. Nothing in this PR touches Go.
+
+## Redaction
+
+The signed-in account address is masked in the page DOM immediately before
+each screenshot, in text nodes only. No number, column, control or layout is
+altered. No URL in any capture carries a token, and no key or credential
+appears in any frame.
+
+## Fixture rows behind the numbers
+
+`public.usage_events` was empty, so six rows were seeded for account
+`bdf639ea…` (workspace "Verify 952") and removed again after the capture.
+They are listed here in full so a reviewer can check every rendered number by
+hand rather than taking the screenshot's word for it.
+
+| Model | input_tokens | output_tokens | cache_read | cache_write | credits |
+| --- | --- | --- | --- | --- | --- |
+| deepseek-v4-pro | 52,000 | 1,900 | 47,000 | 0 | -1,927 |
+| deepseek-v4-flash | 24,000 | 800 | 21,000 | 0 | -79 |
+| deepseek-v4-flash | 18,500 | 640 | 15,200 | 0 | -68 |
+| hive-fast | 3,200 | 410 | 0 | 2,800 | -21 |
+| hive-default | 1,450 | 220 | 0 | 0 | -24 |
+| hive-embedding-default | 900 | 0 | 0 | 0 | -1 |
+
+Each credit figure was derived from that alias's own seeded per-million rates
+in `public.model_aliases`, pricing the fresh input remainder, the cache-read
+subset and the output at their separate rates, so the blended tile below is
+checkable rather than decorative.
+
+### The two tiles, checked by hand
+
+```
+cache hit rate = cache_read / prompt_tokens
+               = (47,000 + 21,000 + 15,200) / (52,000 + 24,000 + 18,500 + 3,200 + 1,450 + 900)
+               = 83,200 / 100,050
+               = 0.83158  ->  83.2%          rendered: 83.2%
+
+blended        = credits / (input + output) * 1,000,000
+               = 2,120 / (100,050 + 3,970) * 1,000,000
+               = 2,120 / 104,020 * 1,000,000
+               = 20,380.7  ->  20,380        rendered: 20,380
+```
+
+Cache writes are excluded from the hit-rate numerator on purpose (D-056), so
+the hive-fast row's 2,800 cache-write tokens move the log table and the CSV
+but not the rate.
+
+## Catalog pricing, all three absence cases from real seeded rows
+
+The catalog capture is not a constructed case. The seeded `model_aliases`
+already carry all three:
+
+| Alias | cache_read_price_credits | pricing_mode | Renders |
+| --- | --- | --- | --- |
+| deepseek-v4-flash | 1790 | fixed | `1,790` |
+| deepseek-v4-pro | 5236 | fixed | `5,236` |
+| hive-default | 0 | fixed | `0` (a real stored zero, not an absence) |
+| hive-embedding-default | NULL | fixed | `—` |
+| hive-stt | NULL | fixed | `—` |
+| hive-tts | NULL | fixed | `—` |
+
+The `Variable` case (`pricing_mode = upstream_actual`, alias
+`openrouter-auto`) is not visible in the capture because that alias is not
+public to this tenant. It is covered by a unit test instead.
+
+## Captures
+
+Before is `origin/main`. After is this branch. Same data, same backend.
+
+| File | Surface | URL |
+| --- | --- | --- |
+| `before-catalog.png` | Model catalog, five columns, no search, filter or sort | `/console/catalog` |
+| `after-catalog.png` | Model catalog with Cache read / 1M and Cache write / 1M, plus search, capability filter, sort and a result count | `/console/catalog` |
+| `before-logs.png` | Request logs, seven columns, no cache tokens | `/console/logs?window=24h` |
+| `after-logs.png` | Request logs with Cached in and Cache write columns | `/console/logs?window=24h` |
+| `before-analytics.png` | Overview, four tiles | `/console/analytics?tab=overview&window=24h` |
+| `after-analytics.png` | Overview, six tiles including Cache hit rate and Blended credits / 1M, each with its derivation note | `/console/analytics?tab=overview&window=24h` |
+| `after-catalog-search.png` | Search "deepseek" narrowing the table to 2 of 10 models | `/console/catalog` |
+| `after-catalog-sort-desc.png` | Sort "Input price, high to low", with unpriced aliases still last | `/console/catalog` |
+
+Browser console errors during both passes: none. The per-surface run log is in
+`capture.run.log`.

--- a/docs/proof/console-cache-visibility-2026-08-25/capture.run.log
+++ b/docs/proof/console-cache-visibility-2026-08-25/capture.run.log
@@ -1,0 +1,12 @@
+[after] session minted for owner@hive-verify-952.invalid via admin one-time token (no password used)
+[after] catalog  http://127.0.0.1:13310/console/catalog  ->  /tmp/claude-1001/-home-sakib-hive/ee163698-f9fe-4d9a-8fda-4bc3b84e922c/scratchpad/proof/after-catalog.png
+[after] logs  http://127.0.0.1:13310/console/logs?window=24h  ->  /tmp/claude-1001/-home-sakib-hive/ee163698-f9fe-4d9a-8fda-4bc3b84e922c/scratchpad/proof/after-logs.png
+[after] analytics  http://127.0.0.1:13310/console/analytics?tab=overview&window=24h  ->  /tmp/claude-1001/-home-sakib-hive/ee163698-f9fe-4d9a-8fda-4bc3b84e922c/scratchpad/proof/after-analytics.png
+[after] catalog-search  http://127.0.0.1:13310/console/catalog  search="deepseek"  ->  /tmp/claude-1001/-home-sakib-hive/ee163698-f9fe-4d9a-8fda-4bc3b84e922c/scratchpad/proof/after-catalog-search.png
+[after] catalog-sort-desc  http://127.0.0.1:13310/console/catalog  sort="input_desc"  ->  /tmp/claude-1001/-home-sakib-hive/ee163698-f9fe-4d9a-8fda-4bc3b84e922c/scratchpad/proof/after-catalog-sort-desc.png
+[after] browser console errors: none
+[before] session minted for owner@hive-verify-952.invalid via admin one-time token (no password used)
+[before] catalog  http://127.0.0.1:13310/console/catalog  ->  /tmp/claude-1001/-home-sakib-hive/ee163698-f9fe-4d9a-8fda-4bc3b84e922c/scratchpad/proof/before-catalog.png
+[before] logs  http://127.0.0.1:13310/console/logs?window=24h  ->  /tmp/claude-1001/-home-sakib-hive/ee163698-f9fe-4d9a-8fda-4bc3b84e922c/scratchpad/proof/before-logs.png
+[before] analytics  http://127.0.0.1:13310/console/analytics?tab=overview&window=24h  ->  /tmp/claude-1001/-home-sakib-hive/ee163698-f9fe-4d9a-8fda-4bc3b84e922c/scratchpad/proof/before-analytics.png
+[before] browser console errors: none


### PR DESCRIPTION
## What this does

Hive has metered prompt-cache reads and writes end to end since PR #1157, and `apps/web-console/lib/control-plane/client.ts` has decoded all four fields since then (`:1409-1410` on `CatalogModel.pricing`, `:2389-2390` on `UsageEventRow`). Nothing on any screen rendered them. This PR is the rendering half. It is presentation only. No backend file is touched and no API contract changes.

Scope comes from the P1 list in `session-2026-08-25-openrouter-console-similarity-scorecard.md`, which scored the console at roughly 35 percent against OpenRouter.

### 1. Cache pricing in the model catalog

`Cache read / 1M` and `Cache write / 1M` columns beside the existing input and output prices, matching the `Cache read /M` column on OpenRouter's own Providers table.

Absence is rendered as absence:

| Case | Renders |
| --- | --- |
| Fixed-price alias with a published cache rate | the number |
| Fixed-price alias with no cache rate | `—` |
| Upstream-priced alias (`pricing_mode: upstream_actual`) | `Variable` |

Zero means deliberately free. Absent means unknown. A cache rate rendered as `0` would tell a customer this alias caches for free, which is the most expensive kind of wrong on a pricing screen. OpenRouter renders the same case as `--` (see `or-11-model-detail-llama-33-70b-providers-cache-read.jpg`, where DeepInfra and Cloudflare show `--` while AkashML shows `$0.10`).

### 2. Catalog search, filter and sort

The catalog had five columns and no discovery controls at all. It now has a search box over alias, display name and summary; a capability filter built from the badges the catalog actually carries; and six sort orders across input, output and cache-read price.

An alias with no published rate sorts **last in both directions**. It is not the cheapest model and it is not the most expensive one, it is a model whose price this screen does not know. The first implementation used `Infinity` as a sort key, which survives the ascending comparator and then loses the descending one, putting unknown-price models first under "high to low". The unit test caught it and the sort is now an explicit partition rather than a sentinel.

The filtered-empty state is distinct from the catalog-empty state. `ModelCatalogTable`'s own empty state says the catalog is empty for this workspace, which is a false and alarming claim when the catalog is fine and a search simply matched nothing.

### 3. Cache tokens in the request log and the CSV

`Cached in` and `Cache write` columns on `/console/logs`, and both fields in the CSV export, positioned next to the token columns they belong with:

```
created_at,request_id,model_alias,status,input_tokens,output_tokens,
cache_read_tokens,cache_write_tokens,hive_credit_delta,error_code,api_key
```

An absent count renders as `—` and exports as an empty cell, never as `0`. Two reasons, both load bearing:

- `handleListEvents` (`apps/control-plane/internal/usage/http.go:121-126`) omits both fields from the payload whenever they are zero, so a measured zero and an unmeasured one reach the console as the identical `undefined`.
- Decision **D-056** records that every `cache_write_tokens` value stored before PR #1157 deployed is a bug artifact rather than a measured zero, with no marker in the row saying which side of that deploy it fell on.

A spreadsheet full of zeroes is exactly the shape a customer would reconcile a bill against, so this column declines to assert a zero it cannot verify.

### 4. Analytics tiles

Two new tiles on `/console/analytics` (Overview), matching the `Cache hit rate` and `Blended $/1M` tiles on OpenRouter's Activity page.

**Blended credits / 1M** is exact and covers the whole window. Both inputs come from the server-side aggregate:

```
blended = (sum(total_credits_spent) / (sum(total_input_tokens) + sum(total_output_tokens))) * 1_000_000
```

It is stated in credits per million tokens, the same unit as the catalog's `Input / 1M` and `Output / 1M` columns and the unit the ledger actually stores (D-046: 1 USD equals 1,000,000,000 credits). Effective by construction, so it lands below the listed input rate exactly when caching is working. A zero-token window returns null and the tile renders `—`, never `0` and never `Infinity`.

**Cache hit rate is derived client side, and here is exactly how**, because `GetUsageSummary` (`apps/control-plane/internal/usage/repository.go:226-264`) sums input tokens, output tokens, credits and request count only. There is no `SUM(cache_read_tokens)` to read, and adding one is backend work this PR does not do.

The derivation lives in `apps/web-console/lib/analytics/cache-metrics.ts`:

```
rate = sum(cache_read_tokens) / sum(prompt_tokens)
```

Three decisions in that arithmetic that a reviewer should check:

1. **The denominator.** `usage_events.input_tokens` stores the raw upstream `prompt_tokens`, not the fresh count billing prices. See the `UsageAccumulator.InputTokens` comment at `apps/edge-api/internal/inference/stream.go:23-27` ("the total prompt tokens delivered, cache subset included, for the ledger and for display") and the assignment in `recordCompletedEvent`. Under the INCLUSIVE convention, which is the only one any dispatch path reaches today because LiteLLM normalizes even an Anthropic response to it (`NormalizeCacheUsage`, `cache_usage.go:41-52`), `prompt_tokens` already counts the cached subset, so `input_tokens` is the correct denominator.

2. **The exclusive-shape guard.** The EXCLUSIVE convention reports `prompt_tokens` with both cache components already removed, and nothing in a stored row marks which shape produced it. So the guard is on the arithmetic, not on a flag that does not exist: under INCLUSIVE, cache read plus cache write can never exceed `input_tokens`, because the fresh remainder is clamped non-negative upstream. A row where they do exceed it can only have come from the exclusive shape, and its prompt total is the sum of all three. Without this guard such a row reports 400 percent. There is a test for it.

3. **Cache writes are excluded from the numerator**, per D-056 above.

**The sample is bounded and the tile says so.** `maxEventsPageLimit` is 100 (`http.go:147`), so the tile reads the most recent 100 requests in the window and prints, beneath the number, either "over all N requests in this window" or "over the last N requests, the most this window returns in one page". A cache hit rate whose sample is unstated is worse than no tile. Where nothing can be sampled the tile renders `—` with the reason, never `0.0%`:

| Situation | Value | Note |
| --- | --- | --- |
| Window is 90d or custom | `—` | usage-events rejects those presets; "No sample for this window" |
| Events fetch failed | `—` | "Request sample unavailable" |
| No requests in window | `—` | "No requests in this window" |

## Not in this PR

- **Model detail page** (`/console/catalog/[id]`) and **hosted API docs**, the two heaviest absences in the scorecard at weights 6 and 5. Both are separate, larger work. Out of scope by instruction.
- **Context length column.** Deliberately omitted, not forgotten. No table stores it: `model_aliases` has no such column (`apps/control-plane/internal/catalog/repository.go:52-70`) and a repo-wide search for `context_window`, `context_length` and `max_context` finds only a comment and an error code. Rendering a context column would have meant inventing the numbers. This needs a schema column, a catalog repository change and a response field before it can be a column, which is backend work.
- **Try this model deep link.** Blocked on deploy config, not on code. The console has no chat URL available to it: `HIVE_CHAT_URL` exists in `.env.example` but is never passed to the web-console image, and `NEXT_PUBLIC_*` values are baked in at `next build` time (`deploy/docker/docker-compose.yml:680-687`). Adding the build arg is a one-line compose change outside this PR's permitted scope. Shipping a link that can never render, and therefore can never be visually proved, would have been worse than not shipping it.

## Tests

`apps/web-console/__tests__/console-cache-visibility.test.tsx`, 19 tests. Each one exists to catch a specific way this feature could lie rather than to raise a coverage number:

- a null cache price rendered as free, in both the fixed and upstream-priced cases
- an unmeasured token count rendered as a verified zero, in both the table and the CSV
- an unknown price winning a cheapest-first sort, and the same in the descending direction (this one found a real bug before merge)
- a cache hit rate computed against the wrong denominator, including the exclusive-shape row that would otherwise report over 100 percent
- an empty sample reported as a measured zero percent
- a zero-token window reported as zero or Infinity blended cost
- a filtered-empty catalog claiming the workspace has no models

Full suite: **693 passed, 693 total**, and `npm run build` is green.

One suite fails inside the test container and is unrelated to this change: `tests/unit/ci-web-e2e-secret-free.test.ts` reads `.github/workflows/ci.yml`, which `deploy/docker/Dockerfile.web-console` never copies into the image. It passes in CI, where the full checkout exists.

## Buglog entry

```json
{"id":"console-null-price-sort-sentinel","date":"2026-08-25","area":"web-console","error_message":"Catalog sort by input price high to low placed models with no published price first, ahead of every priced model","root_cause":"Unknown prices were mapped to a sentinel of Number.POSITIVE_INFINITY and then compared numerically. The sentinel survives the ascending comparator, which puts it last, but the descending comparator is the ascending one negated, which flips the sentinel to the front. A model whose price the console does not know was therefore presented as the most expensive model available.","fix":"Replaced the sentinel with an explicit partition in comparePrice (apps/web-console/components/catalog/model-catalog-browser.tsx): a null price returns 1 and a null on the other side returns -1 before any numeric comparison runs, so unpriced aliases sort last in both directions. Regression test 'keeps the unpriced alias last in the descending sort too'.","tags":["web-console","catalog","sorting","null-handling","pricing-display"]}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cache hit-rate and blended-credit metrics to analytics, with clear unavailable and sample-limited states.
  * Added catalog search, capability filters, pricing-based sorting, and cache pricing columns.
  * Added cache read/write token columns to usage logs and CSV exports.
* **Bug Fixes**
  * Improved handling of missing, unknown, zero, and variable pricing and cache values.
  * Ensured cache writes do not inflate reported hit rates.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->