### PR TITLE
fix: stop dropping metered token counts in the api_key_usage_rollups write

### DIFF
--- a/apps/control-plane/internal/accounting/service.go
+++ b/apps/control-plane/internal/accounting/service.go
@@ -443,7 +443,13 @@ func (s *Service) finalizeLocked(ctx context.Context, input FinalizeReservationI
 		if err := s.apiKeySvc.ApplyReservationDelta(ctx, *attempt.APIKeyID, -heldCredits, actualCredits, at); err != nil {
 			return Reservation{}, fmt.Errorf("accounting: apply reservation delta: %w", err)
 		}
-		if err := s.apiKeySvc.RecordUsageFinalization(ctx, *attempt.APIKeyID, attempt.ModelAlias, 0, 0, 0, 0, actualCredits, at); err != nil {
+		// Cache read/write token counts are not yet threaded into
+		// FinalizeReservationInput from either finalize HTTP path (see
+		// finalizeReservationRequest / internalFinalizeReservationRequest);
+		// they stay zero here until a caller can actually supply them. Input
+		// and output tokens ARE available on input (used two calls above, for
+		// the completed usage event) and must not be dropped the same way.
+		if err := s.apiKeySvc.RecordUsageFinalization(ctx, *attempt.APIKeyID, attempt.ModelAlias, max(input.InputTokens, 0), max(input.OutputTokens, 0), 0, 0, actualCredits, at); err != nil {
 			return Reservation{}, fmt.Errorf("accounting: record usage finalization: %w", err)
 		}
 		if err := s.apiKeySvc.MarkLastUsed(ctx, *attempt.APIKeyID, at); err != nil {

--- a/apps/control-plane/internal/accounting/service_test.go
+++ b/apps/control-plane/internal/accounting/service_test.go
@@ -157,10 +157,14 @@ type apiKeyDeltaCall struct {
 }
 
 type apiKeyUsageCall struct {
-	apiKeyID        uuid.UUID
-	modelAlias      string
-	consumedCredits int64
-	at              time.Time
+	apiKeyID         uuid.UUID
+	modelAlias       string
+	inputTokens      int64
+	outputTokens     int64
+	cacheReadTokens  int64
+	cacheWriteTokens int64
+	consumedCredits  int64
+	at               time.Time
 }
 
 type apiKeyStub struct {
@@ -190,10 +194,14 @@ func (a *apiKeyStub) ApplyReservationDelta(_ context.Context, apiKeyID uuid.UUID
 
 func (a *apiKeyStub) RecordUsageFinalization(_ context.Context, apiKeyID uuid.UUID, modelAlias string, inputTokens, outputTokens, cacheReadTokens, cacheWriteTokens, consumedCredits int64, at time.Time) error {
 	a.finalizationCalls = append(a.finalizationCalls, apiKeyUsageCall{
-		apiKeyID:        apiKeyID,
-		modelAlias:      modelAlias,
-		consumedCredits: consumedCredits,
-		at:              at,
+		apiKeyID:         apiKeyID,
+		modelAlias:       modelAlias,
+		inputTokens:      inputTokens,
+		outputTokens:     outputTokens,
+		cacheReadTokens:  cacheReadTokens,
+		cacheWriteTokens: cacheWriteTokens,
+		consumedCredits:  consumedCredits,
+		at:               at,
 	})
 	return nil
 }
@@ -807,6 +815,65 @@ func TestFinalizeReservationUpdatesBudgetWindowAndUsageRollup(t *testing.T) {
 	}
 	if apiKeySvc.finalizationCalls[0].modelAlias != "hive-fast" || apiKeySvc.finalizationCalls[0].consumedCredits != 70 {
 		t.Fatalf("expected finalization rollup to record model and consumed credits, got %#v", apiKeySvc.finalizationCalls[0])
+	}
+}
+
+// TestFinalizeReservationUsageRollupCarriesMeteredTokens guards the
+// api_key_usage_rollups write against the hardcoded-zero gap found in an
+// audit of accounting/service.go: RecordUsageFinalization was called with
+// literal 0s for input/output tokens even though FinalizeReservationInput
+// carries the real metered counts (used two lines above, in the same
+// function, to build the completed usage event). The rollup table therefore
+// recorded real consumed_credits beside permanently-zero token counts for
+// every finalize, forever, silently, because no test asserted the pass-through
+// (the stub itself discarded the arguments before this test).
+func TestFinalizeReservationUsageRollupCarriesMeteredTokens(t *testing.T) {
+	repo := newRepoStub()
+	ledgerSvc := &ledgerStub{balance: ledger.BalanceSummary{AvailableCredits: 500}}
+	usageSvc := &usageStub{}
+	apiKeyID := uuid.New()
+	apiKeySvc := &apiKeyStub{
+		budgetKindByKey: map[uuid.UUID]string{apiKeyID: "lifetime"},
+	}
+	svc := NewService(repo, ledgerSvc, usageSvc, apiKeySvc)
+
+	accountID := uuid.New()
+	reservation, err := svc.CreateReservation(context.Background(), CreateReservationInput{
+		AccountID:        accountID,
+		RequestID:        "req_rollup_tokens",
+		AttemptNumber:    1,
+		APIKeyID:         &apiKeyID,
+		Endpoint:         "/v1/responses",
+		ModelAlias:       "hive-fast",
+		EstimatedCredits: 100,
+		PolicyMode:       PolicyModeStrict,
+	})
+	if err != nil {
+		t.Fatalf("CreateReservation returned error: %v", err)
+	}
+
+	_, err = svc.FinalizeReservation(context.Background(), FinalizeReservationInput{
+		AccountID:              accountID,
+		ReservationID:          reservation.ID,
+		ActualCredits:          70,
+		TerminalUsageConfirmed: true,
+		Status:                 string(usage.AttemptStatusCompleted),
+		InputTokens:            420,
+		OutputTokens:           133,
+	})
+	if err != nil {
+		t.Fatalf("FinalizeReservation returned error: %v", err)
+	}
+
+	if len(apiKeySvc.finalizationCalls) != 1 {
+		t.Fatalf("expected one usage rollup update, got %#v", apiKeySvc.finalizationCalls)
+	}
+	got := apiKeySvc.finalizationCalls[0]
+	if got.inputTokens != 420 {
+		t.Fatalf("expected the rollup to carry the metered input tokens (420), got %d: the count silently dropped to zero", got.inputTokens)
+	}
+	if got.outputTokens != 133 {
+		t.Fatalf("expected the rollup to carry the metered output tokens (133), got %d: the count silently dropped to zero", got.outputTokens)
 	}
 }
 


### PR DESCRIPTION
## Summary

Scope on this pass was narrowed mid-flight by a priority ruling (demo readiness first, coverage third): finish ledger investigation, then the accounting rollup gap, then stop and open whatever is genuinely done. Filestore, tenants, signup were never started and are explicitly left for the next pass.

- **Ledger**: investigated only, no code changes needed. The 22.8% baseline in the original brief was measured without `HIVE_TEST_DB_URL` set, so every `_live_test.go` in the package (idempotent replay, hold/charge/release lifecycle, bad-amount rejection, over-release corruption reporting) was silently skipping. Against a real bootstrapped Postgres (same `supabase/migrations/` chain CI applies), the package is at **83.4%** and the money invariants already hold: append-only is structural (no `UPDATE` touches `credit_ledger_entries`, only the separate idempotency-key lock row), and every credit field is `int64` (no `float64` anywhere in the package). No redundant tests added.
- **accounting/service.go rollup gap (real bug, fixed)**: `FinalizeReservation` called `apiKeySvc.RecordUsageFinalization` with literal `0` for `input_tokens` and `output_tokens`, even though the real metered counts are sitting on `FinalizeReservationInput` and get used two lines above, in the same function, to build the completed usage event. Every finalized reservation wrote a real `consumed_credits` value into `public.api_key_usage_rollups` beside permanently-zero token counts, for every request, forever. Nothing could have caught it: the test stub for `RecordUsageFinalization` discarded its own arguments before this PR.

  Cache read/write tokens are left at `0` deliberately, not silently: neither finalize HTTP path (`finalizeReservationRequest`, `internalFinalizeReservationRequest`) threads them from edge-api today, so there is nothing real to forward. That is a separate, larger cross-service plumbing gap and is out of scope for this fix; flagging it here rather than filing a new issue since it's a small, precise pointer for whoever picks it up next (`apps/control-plane/internal/accounting/http.go` `internalFinalizeReservationRequest`, plus whatever edge-api settlement call populates it).

This table (`public.api_key_usage_rollups`) has no Go-side reader yet in this repo, so today's blast radius is "a future per-key analytics/billing-breakdown feature reads corrupted zeros," not a live customer-facing wrong number. Still real, still worth closing before that feature exists rather than after.

## What was left undone (explicit map for the next pass)

- **budgets, usage**: not started this pass. Priority ruling said stop at ledger + the rollup gap.
- **tenants, signup**: not started this pass, per the "do not expand scope" instruction (neither had been touched before the scope change landed).
- **filestore**: not started, lowest priority in the original brief and never reached.
- **Cache token plumbing** (accounting → edge-api): real gap, not fixed here, pointer left in the code comment and this PR body.

## Buglog entry

To be appended to `main` separately per this repo's `.wolf/buglog.jsonl` convention (never on a feature branch):

```json
{"date":"2026-08-25","tags":["accounting","billing","rollup","hardcoded-zero"],"error_message":"public.api_key_usage_rollups recorded consumed_credits with permanently-zero input_tokens/output_tokens/cache_read_tokens/cache_write_tokens for every finalized reservation","root_cause":"accounting/service.go FinalizeReservation called apiKeySvc.RecordUsageFinalization with literal 0 for input/output tokens instead of forwarding input.InputTokens/input.OutputTokens, which were already available in scope and used two lines above for the usage_events completed event; the test stub for RecordUsageFinalization discarded its own arguments so no assertion could ever have caught the drop","fix":"forward max(input.InputTokens,0) and max(input.OutputTokens,0) into RecordUsageFinalization; cache_read_tokens/cache_write_tokens remain 0 because neither finalize HTTP path threads them from edge-api yet (separate, larger gap, not fixed here)"}
```

## Test plan

- [x] New test `TestFinalizeReservationUsageRollupCarriesMeteredTokens` written first, confirmed RED against the unfixed code (pasted below), then GREEN after the one-line fix.
- [x] Full `accounting` package suite green, in-process (no DB) and against a real bootstrapped Postgres.
- [x] Full `ledger` package suite green against a real bootstrapped Postgres, 83.4% coverage, confirming the DB-gating finding rather than re-deriving it.
- [x] `go build ./apps/control-plane/...` clean, `go vet` clean on touched package, `gofmt` clean on touched files.

### RED (before the fix)
```
=== RUN   TestFinalizeReservationUsageRollupCarriesMeteredTokens
    service_test.go:873: expected the rollup to carry the metered input tokens (420), got 0: the count silently dropped to zero
--- FAIL: TestFinalizeReservationUsageRollupCarriesMeteredTokens (0.00s)
FAIL
```

### GREEN (after the fix)
```
=== RUN   TestFinalizeReservationUsageRollupCarriesMeteredTokens
--- PASS: TestFinalizeReservationUsageRollupCarriesMeteredTokens (0.00s)
...
ok  	github.com/sakibsadmanshajib/hive/apps/control-plane/internal/accounting	0.025s
```

### Coverage, packages actually touched
| Package | Before (no DB) | Before (real DB) | After (real DB) |
|---|---|---|---|
| accounting | 47.5% | 60.7% | 60.7% (unchanged; fix is one line, new test is a stub-args assertion) |
| ledger | 45.2% | 83.4% | 83.4% (investigated only, no changes) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)