### PR TITLE
feat: add a model detail page at /console/catalog/[id]

### DIFF
--- a/apps/web-console/app/console/catalog/[id]/page.tsx
+++ b/apps/web-console/app/console/catalog/[id]/page.tsx
@@ -1,0 +1,107 @@
+import type { ReactElement } from "react";
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+
+import {
+  getAccountProfile,
+  getAnalyticsUsage,
+  getCatalogModels,
+  getViewer,
+  type UsageSummaryRow,
+} from "@/lib/control-plane/client";
+import { ConsoleShell } from "@/components/app-shell/console-shell";
+import { ModelDetail } from "@/components/catalog/model-detail";
+import { PageHeader } from "@/components/ui/page-header";
+import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/cn";
+
+interface ModelDetailPageProps {
+  params: Promise<{ id: string }>;
+}
+
+// The analytics window this page reports. 30d is the longest preset the
+// control plane accepts without an explicit from/to pair, and a model page is
+// a "what has this cost me" surface rather than a live one.
+const USAGE_WINDOW = "30d";
+const USAGE_WINDOW_LABEL = "last 30 days";
+
+export default async function ModelDetailPage(
+  props: ModelDetailPageProps,
+): Promise<ReactElement> {
+  const { id } = await props.params;
+  const viewer = await getViewer();
+  if (viewer.user.email_verified === false) {
+    redirect("/console/settings/profile");
+  }
+
+  // There is no single-model endpoint: /api/v1/catalog/models returns the whole
+  // tenant-filtered list and nothing narrower exists. Reading the list and
+  // selecting from it also means an alias this tenant may not see is a 404
+  // here for free, rather than a page that renders a model they cannot call.
+  const [models, profile] = await Promise.all([
+    getCatalogModels(),
+    getAccountProfile().catch(
+      (): { owner_name: string } => ({ owner_name: "" }),
+    ),
+  ]);
+
+  const model = models.find((row) => row.id === id);
+  if (!model) {
+    notFound();
+  }
+
+  // Usage is a separate call and a separate failure: an analytics outage must
+  // not take the pricing table down with it, and it must not render as zero
+  // usage either. `null` row plus `unavailable: false` means genuinely no
+  // requests; `unavailable: true` means we do not know.
+  let usage: UsageSummaryRow | null = null;
+  let usageUnavailable = false;
+  try {
+    const rows = await getAnalyticsUsage({
+      group_by: "model",
+      window: USAGE_WINDOW,
+    });
+    usage = rows.find((row) => row.group_key === model.id) ?? null;
+  } catch {
+    usageUnavailable = true;
+  }
+
+  return (
+    <ConsoleShell
+      workspace={{
+        id: viewer.current_account.id,
+        name: viewer.current_account.display_name,
+        slug: viewer.current_account.slug,
+      }}
+      memberships={viewer.memberships}
+      user={{ email: viewer.user.email, name: profile.owner_name || null }}
+      active="/console/catalog"
+      topbar={
+        <span className="font-medium text-[var(--color-ink-2)]">
+          Model catalog
+        </span>
+      }
+    >
+      <PageHeader
+        eyebrow="Build"
+        title={model.display_name || model.id}
+        description={model.summary || undefined}
+        actions={
+          <Link
+            href="/console/catalog"
+            className={cn(buttonVariants({ variant: "secondary", size: "sm" }))}
+          >
+            Back to catalog
+          </Link>
+        }
+      />
+
+      <ModelDetail
+        model={model}
+        usage={usage}
+        usageUnavailable={usageUnavailable}
+        usageWindowLabel={USAGE_WINDOW_LABEL}
+      />
+    </ConsoleShell>
+  );
+}

--- a/apps/web-console/components/catalog/model-catalog-table.tsx
+++ b/apps/web-console/components/catalog/model-catalog-table.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+
 import type { CatalogModel } from "@/lib/control-plane/client";
 import { Badge } from "@/components/ui/badge";
 import { DataTable, type Column } from "@/components/ui/data-table";
@@ -77,9 +79,12 @@ export function ModelCatalogTable({ models }: ModelCatalogTableProps) {
       header: "Model",
       cell: (row) => (
         <div className="flex flex-col gap-0.5">
-          <span className="text-sm font-medium text-[var(--color-ink)]">
-            {row.display_name}
-          </span>
+          <Link
+            href={`/console/catalog/${encodeURIComponent(row.id)}`}
+            className="text-sm font-medium text-[var(--color-ink)] underline-offset-4 hover:underline"
+          >
+            {row.display_name || row.id}
+          </Link>
           <code className="font-mono text-2xs text-[var(--color-ink-3)]">
             {row.id}
           </code>

--- a/apps/web-console/components/catalog/model-detail.tsx
+++ b/apps/web-console/components/catalog/model-detail.tsx
@@ -1,0 +1,318 @@
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+import type { CatalogModel, UsageSummaryRow } from "@/lib/control-plane/client";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { DataTable, type Column } from "@/components/ui/data-table";
+import { buttonVariants } from "@/components/ui/button";
+import { statusBadge } from "@/components/catalog/model-catalog-table";
+import { formatCredits, formatTokens } from "@/lib/format/credits";
+import { formatInOutPrice, formatModelPrice } from "@/lib/format/model-pricing";
+import { cn } from "@/lib/cn";
+
+export interface ModelDetailProps {
+  model: CatalogModel;
+  /**
+   * This account's own usage of this alias over `usageWindowLabel`, or null
+   * when the account has sent no requests to it in that window. Distinct from
+   * `usageUnavailable`: no rows means zero requests, which is a fact worth
+   * stating; an unavailable analytics call means we do not know.
+   */
+  usage: UsageSummaryRow | null;
+  usageUnavailable: boolean;
+  usageWindowLabel: string;
+}
+
+interface PriceRow {
+  dimension: string;
+  credits: number | null;
+  note: string;
+}
+
+// Every figure on this page is credits per one million metered tokens, the
+// same unit the catalog list prints, so the unit is stated once per section
+// rather than repeated in every cell.
+const CREDITS_PER_MILLION = "Credits per 1M tokens";
+
+/**
+ * A capability Hive's control plane does not publish per model today. Rendered
+ * as a named absence rather than omitted, because an evaluator comparing this
+ * page against OpenRouter's needs to see which columns are missing and why. A
+ * zero or a dash in these slots would read as a measurement.
+ */
+function NotPublished({
+  title,
+  reason,
+}: {
+  title: string;
+  reason: string;
+}): ReactNode {
+  return (
+    <div className="flex flex-col gap-1 rounded-md border border-dashed border-[var(--color-border)] px-4 py-3">
+      <span className="text-xs font-medium text-[var(--color-ink-2)]">
+        {title}
+      </span>
+      <span className="text-2xs leading-relaxed text-[var(--color-ink-3)]">
+        {reason}
+      </span>
+    </div>
+  );
+}
+
+function Tile({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}): ReactNode {
+  return (
+    <div className="flex flex-col gap-1.5 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] px-4 py-3">
+      <span className="text-2xs font-medium uppercase tracking-[0.14em] text-[var(--color-ink-3)]">
+        {label}
+      </span>
+      <div className="text-sm text-[var(--color-ink)]">{children}</div>
+    </div>
+  );
+}
+
+function Stat({
+  label,
+  value,
+}: {
+  label: string;
+  value: string;
+}): ReactNode {
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="text-2xs font-medium uppercase tracking-[0.14em] text-[var(--color-ink-3)]">
+        {label}
+      </span>
+      <span className="text-lg tabular-nums text-[var(--color-ink)]">
+        {value}
+      </span>
+    </div>
+  );
+}
+
+function priceRows(model: CatalogModel): PriceRow[] {
+  return [
+    {
+      dimension: "Input",
+      credits: model.pricing.input_price_credits,
+      note: "Prompt tokens sent to the model.",
+    },
+    {
+      dimension: "Output",
+      credits: model.pricing.output_price_credits,
+      note: "Tokens the model generates.",
+    },
+    {
+      dimension: "Cache read",
+      credits: model.pricing.cache_read_price_credits,
+      note: "Prompt tokens served from an upstream prompt cache.",
+    },
+    {
+      dimension: "Cache write",
+      credits: model.pricing.cache_write_price_credits,
+      note: "Prompt tokens written into an upstream prompt cache.",
+    },
+  ];
+}
+
+export function ModelDetail({
+  model,
+  usage,
+  usageUnavailable,
+  usageWindowLabel,
+}: ModelDetailProps): ReactNode {
+  const status = statusBadge(model.lifecycle);
+  const variablePriced = model.pricing.pricing_mode === "upstream_actual";
+
+  const priceColumns: Column<PriceRow>[] = [
+    {
+      key: "dimension",
+      header: "Dimension",
+      cell: (row) => (
+        <span className="font-medium text-[var(--color-ink)]">
+          {row.dimension}
+        </span>
+      ),
+    },
+    {
+      key: "credits",
+      header: CREDITS_PER_MILLION,
+      numeric: true,
+      align: "right",
+      cell: (row) => formatModelPrice(row.credits, model.pricing.pricing_mode),
+    },
+    {
+      key: "note",
+      header: "What it covers",
+      cell: (row) => (
+        <span className="text-xs text-[var(--color-ink-3)]">{row.note}</span>
+      ),
+    },
+  ];
+
+  return (
+    <div className="flex flex-col gap-8">
+      <section aria-label="Model identity" className="flex flex-col gap-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <code className="rounded bg-[var(--color-surface-inset)] px-2 py-1 font-mono text-xs text-[var(--color-ink-2)]">
+            {model.id}
+          </code>
+          <Badge tone={status.tone}>{status.label}</Badge>
+          {model.capability_badges.map((badge) => (
+            <Badge key={badge} tone="outline">
+              {badge}
+            </Badge>
+          ))}
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          <Tile label="In / out price">
+            <span className="tabular-nums">
+              {formatInOutPrice(model.pricing)}
+            </span>
+            <span className="block text-2xs text-[var(--color-ink-3)]">
+              {CREDITS_PER_MILLION.toLowerCase()}
+            </span>
+          </Tile>
+          <Tile label="Cache read / write">
+            <span className="tabular-nums">
+              {formatModelPrice(
+                model.pricing.cache_read_price_credits,
+                model.pricing.pricing_mode,
+              )}
+              {" / "}
+              {formatModelPrice(
+                model.pricing.cache_write_price_credits,
+                model.pricing.pricing_mode,
+              )}
+            </span>
+            <span className="block text-2xs text-[var(--color-ink-3)]">
+              {CREDITS_PER_MILLION.toLowerCase()}
+            </span>
+          </Tile>
+          <Tile label="Context">
+            <span className="text-[var(--color-ink-3)]">Not published</span>
+            <span className="block text-2xs text-[var(--color-ink-3)]">
+              The catalog carries no context window for this alias.
+            </span>
+          </Tile>
+          <Tile label="Pricing mode">
+            <span>{variablePriced ? "Variable" : "Fixed"}</span>
+            <span className="block text-2xs text-[var(--color-ink-3)]">
+              {variablePriced
+                ? "Charged from the cost the upstream reports per request."
+                : "The published rates above are what you are charged."}
+            </span>
+          </Tile>
+        </div>
+      </section>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Pricing</CardTitle>
+          <CardDescription>
+            {variablePriced
+              ? "This alias is priced from the actual cost of each generation, so it publishes no per-million rate. The charge is derived per request, not from a table."
+              : "Every rate Hive charges for this model, in credits per one million metered tokens. A rate of 0 means that dimension is deliberately not charged. Unknown means the catalog holds no rate, which is not the same as free."}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <DataTable<PriceRow>
+            rows={priceRows(model)}
+            columns={priceColumns}
+            rowKey={(row) => row.dimension}
+          />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Providers and uptime</CardTitle>
+          <CardDescription>
+            Hive routes each request across the providers configured for this
+            alias. Per-provider figures are held in the control plane but are
+            not served to the console today, so they are shown as absent rather
+            than guessed.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-3 sm:grid-cols-2">
+          <NotPublished
+            title="Per-provider pricing"
+            reason="Route-level prices exist in the routing snapshot, which no customer-facing endpoint returns."
+          />
+          <NotPublished
+            title="Latency and throughput"
+            reason="Per-request timings are recorded, but no per-provider percentile is computed or served."
+          />
+          <NotPublished
+            title="Uptime"
+            reason="Route health is tracked for failover decisions only and is not exposed as an availability figure."
+          />
+          <NotPublished
+            title="Benchmarks"
+            reason="Hive publishes no independent benchmark scores for catalog models."
+          />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Your usage</CardTitle>
+          <CardDescription>
+            This workspace&rsquo;s own requests to {model.id} over the{" "}
+            {usageWindowLabel}. Platform-wide usage of a model is not published.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-5">
+          {usageUnavailable ? (
+            <p className="text-sm text-[var(--color-ink-3)]">
+              Usage analytics could not be loaded, so this is unknown rather
+              than zero. Reload to try again.
+            </p>
+          ) : usage === null ? (
+            <p className="text-sm text-[var(--color-ink-3)]">
+              No requests to this model from this workspace in the{" "}
+              {usageWindowLabel}.
+            </p>
+          ) : (
+            <div className="grid gap-5 sm:grid-cols-4">
+              <Stat label="Requests" value={formatTokens(usage.request_count)} />
+              <Stat
+                label="Input tokens"
+                value={formatTokens(usage.total_input_tokens)}
+              />
+              <Stat
+                label="Output tokens"
+                value={formatTokens(usage.total_output_tokens)}
+              />
+              <Stat
+                label="Credits spent"
+                value={formatCredits(usage.total_credits_spent)}
+              />
+            </div>
+          )}
+          <div>
+            <Link
+              href={`/console/logs?model=${encodeURIComponent(model.id)}`}
+              className={cn(buttonVariants({ variant: "secondary", size: "sm" }))}
+            >
+              View requests in the log
+            </Link>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web-console/lib/format/model-pricing.test.ts
+++ b/apps/web-console/lib/format/model-pricing.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import { formatInOutPrice, formatModelPrice } from "./model-pricing";
+
+// This is a billing surface. The whole point of these three branches is that
+// "deliberately free", "variable by design" and "we could not read the price"
+// are different answers, and collapsing any pair of them misleads a customer
+// pricing the gateway. Each case below is one of those collapses.
+describe("formatModelPrice", () => {
+  it("prints a published rate, thousand-separated", () => {
+    expect(formatModelPrice(89_460_000, "fixed")).toBe("89,460,000");
+    expect(formatModelPrice(178_920_000, "fixed")).toBe("178,920,000");
+  });
+
+  it("prints a published zero as zero, never as an absence", () => {
+    // hive-default publishes cache_write_price_credits = 0
+    // (supabase/migrations/20260824_02_free_pool_router.sql). Zero is a
+    // decision: that dimension is not charged. Rendering it as "Unknown" or
+    // "Free" would hide a real published rate behind a word.
+    expect(formatModelPrice(0, "fixed")).toBe("0");
+    expect(formatModelPrice(0, "upstream_actual")).toBe("0");
+  });
+
+  it("calls a missing price on a variable alias Variable", () => {
+    expect(formatModelPrice(null, "upstream_actual")).toBe("Variable");
+  });
+
+  it("calls a missing price on a fixed alias Unknown, not Variable", () => {
+    // A fixed alias with no price means the lookup failed. Saying "Variable"
+    // there would present a broken decode as a pricing model.
+    expect(formatModelPrice(null, "fixed")).toBe("Unknown");
+    expect(formatModelPrice(null, "")).toBe("Unknown");
+  });
+});
+
+describe("formatInOutPrice", () => {
+  it("formats each side independently", () => {
+    expect(
+      formatInOutPrice({
+        input_price_credits: 89_460_000,
+        output_price_credits: 178_920_000,
+        pricing_mode: "fixed",
+      }),
+    ).toBe("89,460,000 / 178,920,000");
+  });
+
+  it("does not let one side borrow the other side's number", () => {
+    expect(
+      formatInOutPrice({
+        input_price_credits: null,
+        output_price_credits: null,
+        pricing_mode: "upstream_actual",
+      }),
+    ).toBe("Variable / Variable");
+
+    expect(
+      formatInOutPrice({
+        input_price_credits: 0,
+        output_price_credits: 178_920_000,
+        pricing_mode: "fixed",
+      }),
+    ).toBe("0 / 178,920,000");
+  });
+});

--- a/apps/web-console/lib/format/model-pricing.ts
+++ b/apps/web-console/lib/format/model-pricing.ts
@@ -1,0 +1,45 @@
+import { formatCredits } from "@/lib/format/credits";
+
+/**
+ * Render one catalog price for display. Three outcomes, deliberately distinct,
+ * because on a pricing surface they mean three different things:
+ *
+ *   - A number, zero included, is a published rate. Zero means the dimension is
+ *     deliberately not charged (hive-default publishes exactly that for cache
+ *     write), so it prints as "0" and never as an absence. A customer reading
+ *     "0" is reading a decision.
+ *   - Null on an `upstream_actual` alias is the design: the price is variable
+ *     per request and there genuinely is no per-million rate to publish.
+ *   - Null on a `fixed` alias means the lookup came back empty. Calling that
+ *     "Variable" would dress a broken decode up as a pricing model on the one
+ *     screen a customer opens to check what a model costs.
+ *
+ * ponytail: components/catalog/model-catalog-table.tsx carries a private twin
+ * of this function. It is left alone on purpose while another branch is editing
+ * that file; fold it into this module once both have landed.
+ */
+export function formatModelPrice(
+  credits: number | null,
+  pricingMode: string,
+): string {
+  if (credits === null) {
+    return pricingMode === "upstream_actual" ? "Variable" : "Unknown";
+  }
+  return formatCredits(credits);
+}
+
+/**
+ * The combined "in / out" figure shown in the model header tile, mirroring the
+ * shape OpenRouter puts in the same position. Both halves go through
+ * formatModelPrice, so a variable-price alias reads "Variable / Variable"
+ * rather than borrowing a number from the other side.
+ */
+export function formatInOutPrice(pricing: {
+  input_price_credits: number | null;
+  output_price_credits: number | null;
+  pricing_mode: string;
+}): string {
+  const input = formatModelPrice(pricing.input_price_credits, pricing.pricing_mode);
+  const output = formatModelPrice(pricing.output_price_credits, pricing.pricing_mode);
+  return `${input} / ${output}`;
+}

--- a/docs/proof/console-model-detail-2026-08-25/README.md
+++ b/docs/proof/console-model-detail-2026-08-25/README.md
@@ -1,0 +1,106 @@
+# Visual proof: model detail page at `/console/catalog/[id]`
+
+Scorecard row 6 ("Model detail page", verdict `missing`) in the vault note
+`session-2026-08-25-openrouter-console-similarity-scorecard`. Captured against a
+running console built from this branch, after the change.
+
+## Where this ran
+
+The console under test is `hive-web-console:modeldetail-proof`, built from this
+worktree with `deploy/docker/Dockerfile.web-console` (which runs `next dev`, so
+the served code is this branch's source, not a cached bundle).
+
+It was attached to an already-running self-hosted stack on this machine
+(compose project `hiveverify`: `supabase-db`, `supabase-auth` (GoTrue),
+`control-plane`, `redis`), so the page's data came from a real control-plane
+over a real Postgres, not from a fixture. Two throwaway containers were added
+for the capture and removed after it:
+
+- `modeldetail-console`: the console itself, on the stack's network.
+- `modeldetail-proxy`: a `caddy:2-alpine` that gives the browser and the server
+  one origin (`http://console.hive.test:13210`), routing `/auth/v1/*` to GoTrue
+  and everything else to the console. It also carries the network alias
+  `caddy-supabase`, because that stack's `control-plane` is configured with
+  `SUPABASE_URL=http://caddy-supabase` and its own Caddy container had exited.
+
+Nothing in the shared checkout, the shared `.env`, or any other agent's
+containers was modified.
+
+## Session
+
+Minted with `apps/web-console/tests/e2e/support/live-auth.mjs`, the audited
+one-time-token flow (`docs/live-test-auth.md`). No password was set, reset or
+rotated. The account is `owner@hive-verify-952.invalid`, a local throwaway
+account that already existed in that stack's database; it is not a shared
+fixture account on any deployed environment.
+
+The signed-in account address is visible in the console's sidebar footer, so it
+is masked in pixels in every screenshot before upload. The linter reads text
+only and cannot inspect a screenshot, so that masking is done at capture time,
+not after.
+
+## Data caveat, stated so no number here is read as production truth
+
+This stack's database predates the 2026-08-24 credit rescale, so its catalog
+rows carry pre-rescale credit values (for example `deepseek-v4-flash` input
+`8,946` here against `89,460,000` in
+`supabase/migrations/20260824_02_free_pool_router.sql`). The page renders
+whatever the control plane returns; these are that database's real values, not
+the deployed ones, and not invented ones.
+
+The account has no `usage_events` rows, so the "Your usage" card renders its
+genuine empty state. No usage figure was fabricated to make the card look
+fuller.
+
+## Captures
+
+| File | URL | HTTP | What it shows |
+| --- | --- | --- | --- |
+| `md-01-catalog-rows-link.png` | `http://console.hive.test:13210/console/catalog` | 200 | The catalog list, with each model name now a link into its detail page. |
+| `md-02-model-detail-deepseek-v4-flash.png` | `http://console.hive.test:13210/console/catalog/deepseek-v4-flash` | 200 | The new page. Header tiles (in/out price, cache read/write, context, pricing mode), the full pricing table including **cache read 1,790** and **cache write 0**, the named absences under Providers and uptime, and the usage card. |
+| `md-03-model-detail-embedding-unknown-cache.png` | `http://console.hive.test:13210/console/catalog/hive-embedding-default` | 200 | The honesty case: this alias holds NULL cache prices on a `fixed` pricing mode, so both cache rows read **Unknown**, visibly different from the **0** on the previous capture. Zero means deliberately not charged; unknown means the catalog holds no rate. |
+| `md-04-model-detail-hive-default.png` | `http://console.hive.test:13210/console/catalog/hive-default` | 200 | A second alias, cache read and cache write both a published `0`. |
+
+## Assertions that a screenshot cannot make
+
+A picture of a table row cannot show that the row navigates, so the capture
+script clicked it:
+
+```
+catalog-row-click-navigates -> href=/console/catalog/deepseek-v4-flash
+                               landed=http://console.hive.test:13210/console/catalog/deepseek-v4-flash
+internal-alias-is-404       -> 404
+```
+
+The second line is `/console/catalog/openrouter-auto`, an alias whose
+visibility is `internal`. The public catalog endpoint omits it, so the page is
+a 404 rather than a detail page for a model this tenant cannot call.
+
+## Browser console transcript
+
+Full transcript for the run, unedited:
+
+```
+[info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[error] Failed to load resource: the server responded with a status of 404 (Not Found)
+```
+
+The single error is the deliberate `openrouter-auto` 404 above. No page error,
+no hydration warning, no failed data fetch.
+
+## Checks run on this branch
+
+```
+docker compose run --rm --build web-console npm run build      -> compiled, route ƒ /console/catalog/[id] present
+docker compose run --rm --build web-console npm run test:unit  -> 679 passed
+docker compose run --rm web-console npx vitest run lib/format/model-pricing.test.ts -> 6 passed
+```
+
+`tests/unit/ci-web-e2e-secret-free.test.ts` fails inside that image on both this
+branch and `main`: it reads `.github/workflows/ci.yml`, which
+`Dockerfile.web-console` does not copy into the image. Pre-existing and
+unrelated to this change.


### PR DESCRIPTION
## What and why

The developer console had no page for a single model. `/console/catalog` listed rows, the rows were not links, no `[id]` route existed, and the cache read and cache write prices that the control plane has carried and metered end to end were rendered nowhere. The OpenRouter similarity scorecard dated 2026-08-25 scores this row `missing` with a credit of 0.00 out of a weight of 6, and calls it one of the two heaviest total absences an evaluator hits first.

This adds `/console/catalog/[id]` and makes each catalog row navigate to it.

## What the page renders

Everything on it comes from what the control plane can answer today. Nothing is computed from a guess.

- Identity: alias id, lifecycle badge, capability badges, summary.
- Header tiles: in and out price, cache read and cache write price, context, pricing mode.
- A pricing table covering all four rate dimensions in credits per one million metered tokens, the same unit the catalog list already prints.
- The account's own usage of that alias over the last thirty days, from `/analytics/usage?group_by=model`, with a link into `/console/logs?model=<alias>`.

## What it refuses to invent

Per provider price, latency, throughput, uptime, benchmarks and the context window are held in the routing snapshot or not held at all, and no customer facing endpoint returns any of them. Each is rendered as a named absence with the reason rather than omitted or filled with a zero. A zero in those slots would read as a measurement.

## The three price outcomes

On a billing surface these mean three different things and the page keeps them apart:

- A published rate, zero included, prints as a number. `hive-default` publishes a cache write rate of exactly 0, and that zero is a decision that the dimension is not charged.
- A missing price on an `upstream_actual` alias prints as `Variable`, which is the design.
- A missing price on a `fixed` alias prints as `Unknown`, because that is a lookup that came back empty, and calling it `Variable` would present a broken decode as a pricing model.

`apps/web-console/lib/format/model-pricing.test.ts` pins each of those three against the other two, so collapsing any pair fails the suite.

No USD figure appears anywhere on the page. Credits are the console's unit on every other surface, and relaxing the existing no-USD presentation is a separate product decision, not something to slip in here.

## Scope discipline

Another branch is editing `components/catalog/model-catalog-table.tsx` to add cache price columns to the list. This PR touches that file in exactly one place: the model name becomes a `Link`. The price formatter it needs was added as a new module (`lib/format/model-pricing.ts`) rather than extracted out of that component, deliberately, so the two diffs do not collide. That leaves a five line twin of `formatPrice` in the table, marked with a `ponytail:` comment; folding the two together is a follow up once both have landed.

## Checks

```
docker compose run --rm --build web-console npm run build      -> compiled, route ƒ /console/catalog/[id] present
docker compose run --rm --build web-console npm run test:unit  -> 679 passed
docker compose run --rm web-console npx vitest run lib/format/model-pricing.test.ts -> 6 passed
```

`tests/unit/ci-web-e2e-secret-free.test.ts` fails inside that image on this branch and on `main` alike: it reads `.github/workflows/ci.yml`, which `Dockerfile.web-console` does not copy into the image. Pre-existing, unrelated.

## Visual proof

Captured against a console built from this branch and attached to a running self-hosted stack with a real control plane over a real Postgres. Full setup, the data caveat, the click assertion that a screenshot cannot make, and the browser console transcript are committed in `docs/proof/console-model-detail-2026-08-25/README.md`. Images are posted as a comment on this PR.

## Not in this PR: the docs surface (scorecard row 7)

Row 7 asked for a hosted docs and API reference generated from an OpenAPI document. That document does exist: `packages/openai-contract/generated/hive-openapi.yaml`, plus a machine readable `packages/openai-contract/matrix/support-matrix.json` with 164 endpoints across four support statuses. It is good material and a docs page over it would be honest and cheap.

It is blocked on one thing outside this PR's scope: `deploy/docker/Dockerfile.web-console` copies `apps/web-console`, `deploy/`, `.env.example` and `supabase/migrations` and nothing else, so neither the spec nor the matrix exists inside the console image. Importing either from `packages/` compiles locally and breaks the Docker build. The fix is one `COPY packages/openai-contract/ /app/packages/openai-contract/` line in that Dockerfile, and then a docs route can import the matrix and serve the YAML. Vendoring a second copy of the matrix into `apps/web-console` was rejected: a duplicated spec is exactly the rot that generating from a spec is supposed to avoid.

## Buglog entry

Nothing to log. This is a missing feature, not a fixed defect.