### PR TITLE
docs: correct DEMO.md against live verification of the deployed box

### DIFF
--- a/DEMO.md
+++ b/DEMO.md
@@ -30,6 +30,8 @@ Two repoints shipped alongside the pool (PR #1115): `hive-auto` is now the real 
 
 Stated honestly: `hive-free` rejects tool bearing requests at selection time (tools_supported is false until cross member parity is probed). Tools and structured output belong to `hive-default` and `hive-auto`. Reasoning works on the pool.
 
+Backend hardening merged 2026-08-25, not a demo beat (nothing user visible changes): cache-aware billing (PR #1157, prices cache-read and cache-write tokens at their own catalog rate instead of the flat input rate) and Anthropic `cache_control` request passthrough (PR #1152). Confirmed live: the model catalog has no Anthropic model today, so `cache_control` has nothing to act on yet, and a direct query of `usage_events` right after deploy showed zero cache-bearing requests so far on any provider. The code and its tests are real and shipped; there is simply no live traffic exercising it yet.
+
 ## The 30 minute script
 
 | Min | Beat | Notes |
@@ -37,9 +39,9 @@ Stated honestly: `hive-free` rejects tool bearing requests at selection time (to
 | 0 to 3 | Sign in via OIDC, land on one shell | The OAuth consent round trip works end to end |
 | 3 to 8 | Chat: strong model, Bengali plus English, voice dictation | Streaming works; dictation is metered like every other call; picker labels are still opaque aliases (#941) |
 | 8 to 14 | Retrieval: grounded question over your own document | The chat Knowledge surface is dead today (#1109), so demonstrate `/v1/rag/chat` with curl against api-hive instead |
-| 14 to 20 | Artifacts: generated content opened on its hosted link | The chat artifacts index spins forever (#1110), so fall back to an API published static artifact |
+| 14 to 20 | Artifacts: generated content opened on its hosted link | The chat artifacts index is real now (#1110 fixed by PR #1141, confirmed live 2026-08-25: `/artifacts` renders an actual empty-state index, not a spinner), so ask the model for a web page or chart and open it there. No sidebar entry exists yet, only the direct `/artifacts` URL or a link the model returns, so type or bookmark the URL beforehand |
 | 20 to 26 | Developer story: mint an API key in the console, call api-hive with an OpenAI SDK, show usage in analytics | A freshly minted key can 403 on first use outside the fixture account (#798); rehearse with the demo fixture key |
-| 26 to 30 | Money story: prepaid credits, ledger, spend caps | Look only: credits and caps are viewable, live checkout stays off stage while #917 and #928 are open, pre made slide as fallback |
+| 26 to 30 | Money story: prepaid credits, ledger, spend caps | Credits are now visible live in chat too (#1063 fixed by PR #1119, confirmed live 2026-08-25: a "You've used N credits today, N remaining" strip sits above the composer, matching the console Billing balance exactly), on top of the console ledger. Live checkout itself stays off stage while #917 and #928 are open; pre made slide as fallback for that part only |
 
 Cowork: the agent service gate now defaults on for every workspace (#1107 closed by PR #1111) and code interpreter genuinely executes inside chat. If a live sandbox launch misbehaves on the day, show the code interpreter beat and move on.
 
@@ -50,21 +52,21 @@ Cowork: the agent service gate now defaults on for every workspace (#1107 closed
 - Code interpreter inside chat: sandboxed execution rendered as inline tool cards
 - Uploads with visible size caps and honest inline errors (#1108 and #1113 fixed)
 - Full console: keys, catalog, logs, analytics, members invites, feature gates, MCP marketplace. Credits are viewable in billing (balance plus ledger); the live top up flow is shown only if #917 and #928 close by demo day, otherwise a pre made slide stands in
-- Free pool with automatic cross provider failover
+- Credits are also visible directly in chat, above the composer (#1063 fixed by PR #1119)
+- Artifacts has a real index at `/artifacts` in chat (#1110 fixed by PR #1141); reach it by URL or via a link the model returns, there is no sidebar entry yet
+- Free pool with automatic cross provider failover, now hardened to actually fail over when a member is retired rather than only when it is failing (#1155, merged 2026-08-25)
 - RAG over the API (`/v1/rag/chat`) with admin selectable embedding model and dimension
 
 ## Known rough edges (open issues)
 
-- Knowledge nav item dead on chat (#1109)
-- Artifacts index renders an eternal loading shell (#1110)
+- Knowledge nav item dead on chat (#1109, confirmed live 2026-08-25): clicking it just highlights itself in the sidebar and leaves the home composer showing, no navigation happens. Typing the URL directly now at least answers an honest 404 ("Nothing is served at /knowledge") instead of silently bouncing home, but there is still no working Knowledge surface to demo; keep using `/v1/rag/chat` with curl for the retrieval beat
 - Model picker offers opaque aliases with no purpose subtitles (#941)
-- Sidebar still carries Agents, Knowledge and Folders pending the D-045 rebuild (#944); Scheduled just landed behind its own surface (PR #1118)
-- No credits or usage visibility anywhere in chat (#1063)
+- Sidebar still carries Agents, Knowledge and Folders pending the D-045 rebuild (#944); Scheduled just landed behind its own surface (PR #1118); Artifacts shipped a real index (#1110) but also has no sidebar entry yet
 - Freshly console minted keys can 403 on first real use (#798)
 - Streamed turn settlement edge cases make live checkout undemoable (#917, #928)
 - Verification tooling can leave admin grants on the demo account (#752) and conversations accumulate on it (#916)
 
-Not demoable: multi user isolation claims (#947, #948, #949 family), Enterprise sovereignty claims, live checkout.
+Not demoable: Enterprise sovereignty claims, live checkout. Multi user isolation is better than this doc previously said but still not clean: the three original cross-tenant admin bugs this doc used to cite (#947 shared-instance document/conversation exposure, #948 OAuth-secret and gateway-key leak on the public chat origin, #949 reachable Admin Settings) were fixed 2026-08-23 by PRs #960, #1067, #1091 and #1096. One narrower residual is still open, #1056: two Knowledge by-id/files routes still short-circuit on `role == admin` with no ownership check, so a tenant OWNER (every tenant OWNER holds Open WebUI's admin role today, #748) who has a collection id can still read another tenant's Knowledge collection. Do not demonstrate cross-tenant Knowledge access, and do not claim multi-user isolation is fully solved.
 
 ## T-1 day checklist
 
@@ -73,3 +75,4 @@ Not demoable: multi user isolation claims (#947, #948, #949 family), Enterprise 
 3. Run `scripts/post-deploy-verify.py` against the box and confirm backend specific health for all four hosts (for chat that means `/api/config` reporting status true with the OIDC provider configured). A bare root HTTP 200 from chat-hive, console-hive, api-hive or control-hive .scubed.co is not readiness evidence.
 4. Clean the demo account: no leftover admin grants (#752), conversations pruned (#916), credits topped up, and the account's Enter key behavior verified with `node apps/web-console/scripts/demo-chat-settings.mjs <demo account email>` (add `--repair` if it drifts).
 5. Confirm last night's backup set verified. Never demo the day backups are red.
+6. If the surfaces look down from Bangladesh right before or during the demo, check `.github/workflows/external-uptime-probe.yml` (runs on `ubuntu-latest`, outside the local network path, every 15 minutes) before touching anything. Green there while the room sees timeouts means a regional Cloudflare edge problem, not a real outage; do not restart `cloudflared` and do not redeploy. This happened for real on 2026-08-25 (roughly 70 minutes of Dhaka/Singapore/Hong Kong colo maintenance read as a total loss of every public surface while the box served the rest of the world normally); the probe exists specifically so the next occurrence gets read correctly.

--- a/docs/proof/demo-readiness-verify-2026-08-25/log.md
+++ b/docs/proof/demo-readiness-verify-2026-08-25/log.md
@@ -1,0 +1,75 @@
+# Demo readiness live verification, 2026-08-25
+
+Live verification of DEMO.md's claims against the deployed demo box, run
+against https://chat-hive.scubed.co, https://console-hive.scubed.co and
+https://api-hive.scubed.co after the 2026-08-25 Cloudflare regional-edge
+false alarm had cleared. Session obtained via the standard admin
+one-time-token mint (`apps/web-console/tests/e2e/support/live-auth.mjs`,
+read-only against `demo@hive-demo.invalid`, no password touched), run inside
+the box's own `hive_default` docker network so the internal Kong-equivalent
+auth proxy (`http://caddy-supabase`) could serve `/auth/v1/admin/generate_link`,
+then a follow-up cookie-encoding pass using the same public
+`NEXT_PUBLIC_SUPABASE_URL`/`NEXT_PUBLIC_SUPABASE_ANON_KEY` pair the deployed
+web-console frontend actually uses, so the minted cookie name matches what
+the browser bundle reads. Chat's own session was obtained by letting the real
+OIDC auto-redirect run once a valid console-hive session existed, not by
+forging a chat-side cookie (chat does not proxy `/auth/v1` at all).
+
+## Surface reachability (curl, this session)
+
+```
+chat-hive.scubed.co/api/config   -> 200 {"status":true,"name":"Hive",...,"oauth":{"providers":{"oidc":"Hive"}}}
+console-hive.scubed.co/          -> 307 (redirect to sign-in, expected)
+api-hive.scubed.co/health        -> 200 {"status":"ok"}
+control-hive.scubed.co/          -> 404 (API only, no root route, expected)
+```
+
+All four live and healthy at verification time.
+
+## Capability matrix
+
+| Capability | DEMO.md claim | Verdict | Evidence |
+|---|---|---|---|
+| Artifacts (#1110 / PR #1141) | stale: "spins forever" | WORKS | `/artifacts` renders a real empty-state index ("No artifacts yet..."), not a spinner. Screenshot 04. |
+| Credits in chat (#1063 / PR #1119) | stale: "no visibility" | WORKS | Composer shows "You've used 24,696 credits today, 99,997,301,021 remaining"; matches console Billing overview exactly (99,997,301,021 available). Screenshots 01, 02. |
+| Knowledge nav (#1109) | broken, open | STILL BROKEN | Clicking "Knowledge" in the sidebar highlights the row but leaves the home composer showing (URL unchanged). Screenshot 03. Direct `/knowledge` now answers an honest 404 ("Nothing is served at /knowledge") instead of the originally-reported silent bounce to home; symptom shifted slightly, underlying bug (no working surface) unchanged. Screenshot 07. |
+| Cache-aware billing (PR #1157) | not previously in DEMO.md | SHIPPED, UNEXERCISED | `usage_events` query for the 6 hours before/after deploy: 143 requests, 0 with `cache_read_tokens>0` or `cache_write_tokens>0`. Code and tests are real; no live cache-bearing request has hit it yet. |
+| `cache_control` passthrough (PR #1152) | not previously in DEMO.md | SHIPPED, NOTHING TO ACT ON | Live model catalog (console Model catalog page, screenshot 08) has no Anthropic/Claude model at all: Deepseek V4 Flash/Pro, hive-auto, hive-default, hive-embedding-default, hive-fast, hive-free, hive-medium, hive-small, hive-stt, hive-tts. `cache_control` is an Anthropic-native request field; there is no live route it can affect today. |
+| Free pool failover (PR #1155) | already in DEMO.md as working | STILL WORKS, NO REGRESSION | `hive-free` served 52 completed + 26 in-flight requests in the trailing 24h with zero error-status `usage_events` rows. No member has actually failed during the observation window, so the specific failover trigger was not caught in the act, but nothing broke either. |
+| Null-content coercion (PR #1169) | not previously in DEMO.md | SHIPPED, NO REGRESSION OBSERVED | Zero `error`/`upstream_error`/`finalize_failed` rows anywhere in `usage_events` in the trailing 24h (356 total rows, all `completed`/`dispatching`/`streaming`). The specific reasoning-model-exhausts-max-tokens scenario that originally triggered this fix has not recurred live to re-test directly. |
+| External uptime probe (PR #1166) | not previously in DEMO.md | WORKS, RUNNING ON SCHEDULE | `gh run list --workflow=external-uptime-probe.yml`: three runs, all `success`, most recent scheduled run 2026-08-25T19:43:46Z (9s). Cron confirmed `*/15 * * * *` in the workflow file. |
+| OIDC sign-in round trip | "works end to end" | CONFIRMED LIVE | Console session -> chat-hive auto-redirect landed signed in on chat with no manual click needed (`auto_redirect: true`). |
+| Multi-user isolation (#947/#948/#949 family) | "not demoable" | PARTIALLY FIXED, NOT FULLY | `gh issue view`: #947, #948 and #949 are all CLOSED, fixed 2026-08-23 by PRs #960, #1067, #1091, #1096. One residual is still OPEN: #1056, an acknowledged partial fix of #947 covering two Knowledge by-id/files routes that still short-circuit on `role == admin` with no ownership check. |
+
+## Screenshots (uploaded to the visual-proof GitHub release, linked from the PR)
+
+1. `01-console-landing.png` - console dashboard, Available credits 99,997,301,021
+2. `02-chat-landing.png` - chat composer, credits strip above composer, sidebar with Knowledge/Agents/no-Artifacts-entry visible
+3. `03-chat-after-knowledge-click.png` - Knowledge row highlighted, content unchanged (dead nav)
+4. `04-chat-artifacts.png` - `/artifacts` real empty-state index
+5. `06-console-providers.png` - Providers page correctly gated behind platform-admin ("Managed by your administrator") for this tenant-OWNER account
+6. `07-chat-knowledge-direct.png` - `/knowledge` honest 404
+7. `08-console-model-catalog-real.png` - full live model catalog, no Anthropic/Claude model present
+
+No credential, token or account address beyond the already-public fixture
+address `demo@hive-demo.invalid` (documented in `docs/live-test-auth.md`)
+appears in any of these captures. No screenshot shows a browser URL bar
+(full-page DOM captures only), so no query-string token exposure is
+possible from this capture method.
+
+## What this pass did not attempt
+
+No real chat message was sent, no API key was minted, no agent task was
+submitted, and no checkout flow was exercised, per
+`docs/live-test-auth.md`'s "never point a write-capable suite at the demo
+account" rule: everything above is a sign-in plus page loads, all read-only.
+Streaming chat itself, voice dictation, read-aloud, code interpreter
+execution and file uploads were not re-exercised this pass (would require
+real spend and write actions); no evidence either way beyond what DEMO.md
+already stated.
+
+## New issues filed
+
+None. Every genuinely broken thing found (dead Knowledge nav, residual
+cross-tenant Knowledge-by-id read, missing Artifacts sidebar entry) already
+has an open tracking issue (#1109, #1056, #943 item 4 respectively).


### PR DESCRIPTION
## Summary

Live verification of every capability DEMO.md claims, against the actually deployed box (chat-hive, console-hive, api-hive, control-hive), run today after the 2026-08-25 Cloudflare regional-edge false alarm cleared. Full capability matrix and methodology in `docs/proof/demo-readiness-verify-2026-08-25/log.md`.

**Confirmed fixed, DEMO.md corrected (was stale):**
- Artifacts (#1110, fixed by PR #1141): `/artifacts` renders a real empty-state index today, not the "spins forever" DEMO.md described. No sidebar entry yet (tracked by #943 item 4, not new).
- In-chat credits (#1063, fixed by PR #1119): a "You've used N credits today, N remaining" strip sits above the composer, matching the console Billing balance exactly.

**Confirmed still broken, unchanged:**
- Knowledge nav (#1109): clicking it still does nothing (URL unchanged). Direct `/knowledge` now answers an honest 404 instead of the originally-reported silent bounce home, a minor symptom shift, not a fix.

**Verified today's merges, all landed after this session started:**
- Cache-aware billing (#1157) and Anthropic `cache_control` passthrough (#1152): shipped and tested, but unexercised live. The catalog has no Anthropic model today, and a direct `usage_events` query shows zero cache-bearing requests since deploy.
- Free pool failover (#1155) and the null-content coercion fix (#1169): no regressions in the trailing 24h of live traffic (zero error-status `usage_events` rows across 356 requests), though neither fix's specific trigger recurred live to re-test directly.
- External uptime probe (#1166): confirmed running on its 15-minute schedule, all green. Added a T-1 checklist note pointing at it, since today's regional Cloudflare maintenance window is exactly the scenario it exists to catch.

**Corrected a claim broader than the two named stale items:** the "not demoable: multi user isolation (#947, #948, #949 family)" line was itself stale. All three were fixed 2026-08-23 (PRs #960, #1067, #1091, #1096). One residual, #1056 (two Knowledge by-id/files routes still short-circuit on `role == admin`), is still open, so the line now says that precisely instead of citing three closed issues.

## New issues filed

None. Every genuinely broken thing found already has an open tracking issue (#1109, #1056, #943).

## Verification

- `node tools/lint-no-token-in-proof-captures.mjs` passes against the new proof log.
- Live session obtained via the standard admin one-time-token mint (`docs/live-test-auth.md`), read-only against the demo fixture account, no password touched, no message sent, no key minted, no task submitted.
- Screenshots posted separately to the PR via `scripts/post-pr-visual-proof.sh` (permanent GitHub Release, per `.wolf/decisions.md` D-042).

## Test plan

- [x] `node tools/lint-no-token-in-proof-captures.mjs`
- [x] Manual read of the rendered DEMO.md for internal consistency