### PR TITLE
fix: correct DeepSeek cache_read rate from a wrong 0.2x to the vendor's real 1/30

### DIFF
--- a/apps/edge-api/internal/inference/pricing.go
+++ b/apps/edge-api/internal/inference/pricing.go
@@ -75,7 +75,17 @@ func CanPriceTokens(route SelectRouteResult) bool {
 // cache_write_price_credits, because the true multiplier varies by provider
 // and model (Anthropic and GPT-5-class: 0.1x read / 1.25x write; OpenAI o3:
 // 0.25x / free; gpt-4o and o1: 0.5x / free; Groq: 0.5x / free; DeepSeek:
-// 0.1x / 1.0x -- vault spec-2026-08-25-cache-aware-billing.md). Falling back
+// ~0.033x (1/30) read / 1.0x write, per DeepSeek's own Models & Pricing page
+// (https://api-docs.deepseek.com/quick_start/pricing, cache-hit vs
+// cache-miss input columns, fetched 2026-08-25). deepseek-v4-pro's published
+// rate is an exact $0.022 / $0.66 = 1/30; deepseek-v4-flash's $0.007 / $0.22
+// rounds to the same 1/30 at the page's 3-decimal display precision. This
+// comment corrects two earlier, mutually-inconsistent figures: it previously
+// said 0.1x here (a copy of the Anthropic/GPT-5-class row above it, not
+// actually sourced from DeepSeek), and vault
+// spec-2026-08-25-cache-aware-billing.md separately said ~0.2x. Both were
+// wrong. See supabase/migrations/20260825_02_deepseek_cache_read_price_correction.sql
+// for the full reconciliation and issue #1176 for the investigation. Falling back
 // to the flat input rate instead (treating cache read as ordinary input) is
 // exactly the bug this feature fixes, and falling back to zero is revenue
 // loss D-034 forbids, so this fallback is the third option, not either of

--- a/supabase/migrations/20260825_02_deepseek_cache_read_price_correction.sql
+++ b/supabase/migrations/20260825_02_deepseek_cache_read_price_correction.sql
@@ -1,0 +1,98 @@
+-- =============================================================================
+-- Correct the DeepSeek cache_read_price_credits multiplier (issue #1176).
+--
+-- GROUND TRUTH, established from DeepSeek's own current pricing page, not
+-- from memory and not from OpenRouter's aggregator table (independently
+-- observed to lag vendor pricing): https://api-docs.deepseek.com/quick_start/
+-- pricing, "Models & Pricing", fetched 2026-08-25. The page publishes a
+-- CACHE HIT and a CACHE MISS price per model rather than a bare multiplier,
+-- so the multiplier is derived here from those two published dollar figures:
+--
+--   deepseek-v4-pro  : $0.022 (cache hit) / $0.66 (cache miss)  = 1/30 exactly
+--   deepseek-v4-flash: $0.007 (cache hit) / $0.22 (cache miss)  = 0.03182,
+--                       which is $0.22 / 30 = $0.0073(3), rounding down to
+--                       the page's 3-decimal display precision.
+--
+-- Both figures resolve to the SAME underlying multiplier, 1/30 (~0.0333x),
+-- once the flash row's display rounding is accounted for. That is the real,
+-- current DeepSeek cache-read rate for both models: not the 0.1x this
+-- codebase's pricing.go comment claimed (a copy-paste of the unrelated
+-- Anthropic/GPT-5-class row above it, corrected in the same PR as this
+-- migration), and not the ~0.2x vault spec-2026-08-25-cache-aware-billing.md
+-- described as "sourced, already in the catalog" (it was in the catalog, but
+-- it was never actually sourced from DeepSeek; see below).
+--
+-- WHAT WAS ACTUALLY WRONG, AND WHAT WAS NOT
+--   20260822_02_catalog_alias_restructure.sql's DERIVE block seeded BOTH
+--   DeepSeek aliases' cache_read_price_credits from an OpenRouter-quoted
+--   per-model USD figure, then rescaled x10000 by
+--   20260823_40_credit_unit_rescale_billion.sql. The rescale is a pure unit
+--   change (it multiplies numerator and denominator alike), so it cannot be
+--   the source of a ratio error, and it is not: recomputing the ratio from
+--   today's live (post-rescale) column values reproduces exactly the same
+--   two ratios the original USD figures did. This is a RATE error from the
+--   original derivation, not a stale unit-factor error.
+--
+--   deepseek-v4-pro:   cache_read 52360000 / input 1570800000 = 1/30 exactly.
+--                       This already matches DeepSeek's real rate above.
+--                       NOT TOUCHED by this migration.
+--   deepseek-v4-flash: cache_read 17900000 / input 89460000   = 0.2 exactly.
+--                       Six times the real 1/30 rate. This is the bug: every
+--                       cache-hit token billed against deepseek-v4-flash (or
+--                       any alias repriced to match it, see below) has been
+--                       overcharged 6x, not the 2x the issue that opened this
+--                       investigation suspected before the vendor page was
+--                       actually checked.
+--
+-- SCOPE, deliberately narrow. Two rows carry the bad 17900000 figure today:
+--
+--   1. deepseek-v4-flash itself.
+--   2. hive-default. 20260824_02_free_pool_router.sql repriced hive-default
+--      to "the deepseek-v4-flash rates ALREADY in the catalog" by copying
+--      the same literal cache_read_price_credits = 17900000 into a second
+--      row rather than referencing deepseek-v4-flash's own price, so the
+--      root-cause fix has to reach both rows or hive-default (the alias
+--      served to any request that names no model) keeps the 6x overcharge
+--      after this migration. hive-default's cache_write_price_credits stays
+--      an explicit 0, untouched here: this migration corrects cache_read
+--      only, and an explicit stored zero is a considered price, never
+--      overwritten by this kind of fix.
+--
+--   deepseek-v4-pro is not touched: its seeded value already matches the
+--   real vendor rate, see above. The Groq gpt-oss aliases' explicit 0/0 is
+--   not touched either, for the reason already on record in
+--   20260825_01_deepseek_cache_write_price.sql's header.
+--
+-- DERIVATION, self-referential rather than a literal, matching the pattern
+-- 20260825_01_deepseek_cache_write_price.sql and
+-- 20260823_40_credit_unit_rescale_billion.sql already use: each row's new
+-- cache_read_price_credits is computed from that SAME row's own current
+-- input_price_credits at UPDATE time (CEIL(input_price_credits / 30), never
+-- rounding a money figure down), so this migration stays correct if a future
+-- migration reprices either alias's input rate before this one runs, and
+-- reruns as a no-op once applied.
+--
+--   deepseek-v4-flash: CEIL(89460000 / 30) = 2982000 (exact, no remainder).
+--   hive-default:      CEIL(89460000 / 30) = 2982000 (same input price,
+--                       same underlying deepseek-v4-flash upstream model).
+--
+-- IDEMPOTENT: each UPDATE's WHERE clause only matches a row that still
+-- carries the specific known-wrong value (17900000), so re-running this
+-- file, or running it after some future repricing migration has already
+-- moved either alias's cache_read_price_credits to a new, deliberate value,
+-- is a no-op rather than a second write or a clobber of that later decision.
+--
+-- CUSTOMER IMPACT: see this migration's pull request body. This file cannot
+-- determine it (read-only against any live database, per this task's
+-- constraints); it states what is knowable from the code and migration
+-- history alone.
+-- =============================================================================
+
+BEGIN;
+
+UPDATE public.model_aliases
+   SET cache_read_price_credits = CEIL(input_price_credits::numeric / 30)::bigint
+ WHERE alias_id IN ('deepseek-v4-flash', 'hive-default')
+   AND cache_read_price_credits = 17900000;
+
+COMMIT;


### PR DESCRIPTION
Closes #1176.

## Ground truth (vendor page, not memory, not OpenRouter)

Source: https://api-docs.deepseek.com/quick_start/pricing ("Models & Pricing", DeepSeek API Docs), fetched live 2026-08-25. The page's model versions (`DeepSeek-V4-Flash-0731`, `DeepSeek-V4-Pro-0813`) match exactly the OpenRouter slugs Hive's catalog pins to, confirming this is the right vendor page for the right models.

The page publishes cache-hit and cache-miss dollar prices per model, not a bare multiplier:

| Model | Cache hit (off-peak) | Cache miss (off-peak) | Ratio |
|---|---|---|---|
| deepseek-v4-pro | $0.022 | $0.66 | 0.022/0.66 = **1/30 exactly** |
| deepseek-v4-flash | $0.007 | $0.22 | 0.22/30 = $0.007333, rounds down to $0.007 at the page's 3-decimal display precision |

Both resolve to the same real multiplier: **1/30, ~0.0333x**. No separate cache-write price is published; cache writes ride the ordinary input rate, which `20260825_01_deepseek_cache_write_price.sql` already encodes (1.0x) and this PR does not touch.

## Reconciling the disagreeing sources

- **Database (before this fix)**: `deepseek-v4-pro` cache_read/input = 52,360,000 / 1,570,800,000 = exactly 1/30, already correct. `deepseek-v4-flash` cache_read/input = 17,900,000 / 89,460,000 = exactly 0.2, a **6x overcharge**, not the 2x the issue's opening hypothesis guessed before the vendor page was checked.
- **`DERIVE` comment block** in `20260822_02_catalog_alias_restructure.sql`: same two ratios, computed pre-rescale. The later 10000x unit rescale (`20260823_40_credit_unit_rescale_billion.sql`) scales numerator and denominator alike, so it cannot explain a ratio error and does not: recomputing from today's live column values reproduces the identical 0.2 and 1/30. This is a rate-derivation error on the flash row specifically, not a stale-unit problem.
- **`pricing.go`'s comment** said "DeepSeek: 0.1x read / 1.0x write". That figure is a verbatim copy of the unrelated Anthropic/GPT-5-class row directly above it in the same comment block, never actually sourced from DeepSeek. Corrected in this PR to cite the vendor page, the date, and the derivation.
- **Vault `spec-2026-08-25-cache-aware-billing.md`** (out of this PR's touch scope) says "~0.2x read [sourced, already in the catalog]", taking the flash row's wrong number at face value while pro's row in the same migration already carried the correct 1/30. Flagging for the vault owner, not edited here.

## Scope: two rows, not one

`20260824_02_free_pool_router.sql` repriced `hive-default` (served to any request naming no model) "to the deepseek-v4-flash rates ALREADY in the catalog" by copying the literal `cache_read_price_credits = 17900000` into a second row instead of referencing deepseek-v4-flash's price. Fixing only `deepseek-v4-flash` would leave `hive-default`, almost certainly the higher-traffic alias, still 6x overcharging. This migration corrects both rows. `deepseek-v4-pro` is untouched; it was already right.

`deploy/litellm/config.yaml` in git still shows `hive-default` on the old free route (comment dated 2026-08-23, predates the 2026-08-24 migration); the file's own header documents it as a first-boot seed only, superseded at runtime by the DB-driven sync. No later migration reverts `hive-default` off the paid deepseek-v4-flash route, so per migration history it is live on the buggy rate today.

## The fix

New migration `supabase/migrations/20260825_02_deepseek_cache_read_price_correction.sql`:

```sql
UPDATE public.model_aliases
   SET cache_read_price_credits = CEIL(input_price_credits::numeric / 30)::bigint
 WHERE alias_id IN ('deepseek-v4-flash', 'hive-default')
   AND cache_read_price_credits = 17900000;
```

Self-referential (matches the `20260825_01` / `20260823_40` pattern) so it survives a future reprice, and idempotent, guarded on the specific known-wrong value so a rerun or a run after a deliberate future reprice is a no-op. Result: 17,900,000 to 2,982,000 (exact, `89,460,000 / 30`) for both aliases. Not applied by this PR; ships for the deploy pipeline's migrate-before-deploy step.

## Customer impact (quantified, read-only live query, 2026-08-25)

SSH access to the demo box became available after this PR was opened. Ran bounded, read-only queries against `public.usage_events` and `public.credit_ledger_entries` (2018-row table, full scan trivial, `statement_timeout` capped, no writes, no migration applied by hand).

- **`deepseek-v4-flash`**: 65 `completed` events across its whole history, **0 with `cache_read_tokens > 0`**. The wrong rate was never exercised on this alias. Zero impact here, confirmed, not assumed.
- **`hive-default`**: 106 `completed` events since the `20260824_02` cutover (2026-08-24) that put it on this rate. **11 of them, all from one account, carried `cache_read_tokens > 0`**, totaling **92,672 cache-read tokens**. Every other account had zero.
- Real money moved for those 11 requests, read from `credit_ledger_entries` (`entry_type = 'usage_charge'`, the actual balance-affecting row, not `usage_events.hive_credit_delta`, which we found does not match the ledger and is a separate, unrelated observability discrepancy worth someone's attention but out of this PR's scope): **8,748,124 credits charged in total (≈$0.00875 at 1 USD = 1,000,000,000 credits, D-046)**.
- Upper bound for the slice of that attributable to the cache-read rate bug specifically: `92,672 cache-read tokens × (17.9 − 2.982 credits/token) = 1,382,481 credits (≈$0.00138, ~15.8% of the real total charged to those 11 requests)`. This is a ceiling, not a confirmed figure: reconstructing the exact per-component formula from `usage_events`' token columns did not cleanly reproduce the real ledger amounts under either an inclusive- or exclusive-of-cache `input_tokens` reading, so the true cache-attributable slice could be smaller than this bound. It cannot be larger, since it is bounded by the real total charged.
- One account, single-digit dollars-of-a-cent at most. Not manufacturing precision this data cannot support past that bound; not rounding down to zero either, since real cache-read tokens were metered and real money was charged on the affected requests.

## Buglog entry

```json
{"ts":"2026-08-25","error_message":"DeepSeek cache_read_price_credits seeded at 0.2x input rate for deepseek-v4-flash (and copied into hive-default), 6x DeepSeek's real published cache-hit/cache-miss ratio","root_cause":"20260822_02_catalog_alias_restructure.sql's DERIVE block computed deepseek-v4-flash's cache_read multiplier from a wrong basis versus deepseek-v4-pro's row in the same migration (0.2x vs the correct ~1/30); 20260824_02_free_pool_router.sql then copied the same wrong literal into hive-default; the later 10000x unit rescale (20260823_40) preserved the ratio unchanged, confirming a rate error rather than a unit error","fix":"20260825_02_deepseek_cache_read_price_correction.sql re-derives cache_read_price_credits as CEIL(input_price_credits/30) for deepseek-v4-flash and hive-default only (deepseek-v4-pro already matched the correct rate); pricing.go's stale 0.1x comment corrected to cite DeepSeek's own pricing page (fetched 2026-08-25, ratio 1/30 exact on deepseek-v4-pro)","tags":["billing","pricing","deepseek","cache","migration","issue-1176"]}
```

## Test plan

- [ ] CI green (SQL is idempotent 2-row UPDATE, no Go logic changed beyond a comment)
- [ ] Deploy pipeline applies the migration before recreating containers (`deploy-demo-box.yml` ordering)
- [ ] Post-deploy spot check: `SELECT alias_id, input_price_credits, cache_read_price_credits FROM public.model_aliases WHERE alias_id IN ('deepseek-v4-flash','deepseek-v4-pro','hive-default');` expect flash and hive-default at 2,982,000, pro unchanged at 52,360,000
