### PR TITLE
test: cover budgets zero-cap, usage rollups, tenants Switch concurrency

### DIFF
--- a/apps/control-plane/internal/budgets/http_test.go
+++ b/apps/control-plane/internal/budgets/http_test.go
@@ -425,3 +425,64 @@ func TestWorkspaceBudgetGET_PlatformAdminOverlayGrantsAccess(t *testing.T) {
 		t.Fatalf("expected 200 for platform admin overlay, got %d: %s", rr.Code, rr.Body.String())
 	}
 }
+
+// -----------------------------------------------------------------------------
+// GET /internal/budgets/{workspace_id}/hard-cap — the edge-api gate's
+// read-through fallback. This is the one place that must distinguish "no
+// budget row exists" (nil, gate stays pass-through) from "a budget row exists
+// with hard_cap = 0" (a legitimate, deliberate spend-everything-blocked
+// config): the JSON body renders null in the first case and the string "0"
+// in the second. edge-api's fetchHardCap (apps/edge-api/internal/limits/
+// budget_gate.go) treats an empty/missing value as pass-through and a parsed
+// "0" as an immediate hard block, so collapsing these two cases here would
+// silently disable every zero-cap workspace's gate.
+// -----------------------------------------------------------------------------
+
+// hardCapRepoStub is a minimal WorkspaceBudgetRepository whose GetBudget
+// answer is set per test, so both branches (nil budget vs. a budget with
+// hard_cap = 0) can be exercised through the same handler.
+type hardCapRepoStub struct {
+	workspaceRepoStub
+	budget *Budget
+}
+
+func (s *hardCapRepoStub) GetBudget(_ context.Context, _ uuid.UUID) (*Budget, error) {
+	return s.budget, nil
+}
+
+// The "no budget renders null" branch is already covered by
+// TestInternalHardCapEndpoint (http_spend_alerts_test.go). The gap that test
+// left open, and this one closes, is the zero-cap branch: a budget row that
+// exists with hard_cap = 0 must still render as "0", not null.
+func TestInternalHardCap_ZeroCapSet_RendersZeroStringNotNull(t *testing.T) {
+	wsID := uuid.New()
+	repo := &hardCapRepoStub{budget: &Budget{
+		WorkspaceID: wsID,
+		SoftCap:     big.NewInt(0),
+		HardCap:     big.NewInt(0),
+		Currency:    "BDT",
+	}}
+	svc := NewServiceWithWorkspace(&httpRepoStub{}, &notifierStub{}, repo, nil, nil)
+	handler := NewHandler(svc, accounts.NewService(newAccountsRepoStub()))
+
+	req := httptest.NewRequest(http.MethodGet, "/internal/budgets/"+wsID.String()+"/hard-cap", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var body struct {
+		HardCap *string `json:"hard_cap_bdt_subunits"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.HardCap == nil {
+		t.Fatal("expected hard_cap_bdt_subunits to be the string \"0\" for a workspace with an explicit zero cap, got JSON null " +
+			"(this is indistinguishable from no-budget-set to edge-api's gate and would disable the block)")
+	}
+	if *body.HardCap != "0" {
+		t.Fatalf("expected hard_cap_bdt_subunits = \"0\", got %q", *body.HardCap)
+	}
+}

--- a/apps/control-plane/internal/budgets/workspace_test.go
+++ b/apps/control-plane/internal/budgets/workspace_test.go
@@ -196,7 +196,7 @@ func (*legacyNoopRepo) GetThreshold(_ context.Context, _ uuid.UUID) (*budgets.Bu
 func (*legacyNoopRepo) UpsertThreshold(_ context.Context, _ uuid.UUID, _ int64) (*budgets.BudgetThreshold, error) {
 	return nil, nil
 }
-func (*legacyNoopRepo) DismissAlert(_ context.Context, _ uuid.UUID) error  { return nil }
+func (*legacyNoopRepo) DismissAlert(_ context.Context, _ uuid.UUID) error { return nil }
 func (*legacyNoopRepo) MarkNotified(_ context.Context, _ uuid.UUID) error { return nil }
 
 type legacyNoopNotifier struct{}
@@ -413,5 +413,49 @@ func TestEvaluateBudgets_RefiresOnNextPeriod(t *testing.T) {
 	}
 	if fired != 1 {
 		t.Fatalf("expected refire in new period, got %d", fired)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// HardCapForWorkspace — nil (no budget) vs *big.Int(0) (explicit zero cap)
+// must stay distinguishable. This is the value edge-api's budget gate reads
+// (apps/edge-api/internal/limits/budget_gate.go: nil hard cap is
+// pass-through, a parsed "0" is an immediate hard block), so collapsing the
+// two here would silently disable every zero-cap workspace's gate.
+// -----------------------------------------------------------------------------
+
+func TestHardCapForWorkspace_ZeroCap_ReturnsNonNilZero(t *testing.T) {
+	wsID := uuid.New()
+	repo := newFakeWorkspaceRepo()
+	svc := newWorkspaceService(repo, &fakeAlertNotifier{})
+	if _, err := svc.SetBudget(context.Background(), budgets.SetBudgetInput{
+		WorkspaceID: wsID,
+		PeriodStart: time.Now().UTC(),
+		SoftCap:     big.NewInt(0),
+		HardCap:     big.NewInt(0),
+	}); err != nil {
+		t.Fatalf("SetBudget with zero caps must be accepted (0 >= 0): %v", err)
+	}
+
+	cap, err := svc.HardCapForWorkspace(context.Background(), wsID)
+	if err != nil {
+		t.Fatalf("HardCapForWorkspace: %v", err)
+	}
+	if cap == nil {
+		t.Fatal("expected a non-nil *big.Int(0) for a workspace with an explicit zero hard cap, got nil " +
+			"(nil means \"no budget configured\" to every caller of this method)")
+	}
+	if cap.Sign() != 0 {
+		t.Fatalf("expected cap value 0, got %s", cap.String())
+	}
+
+	// The other branch: a workspace with genuinely no budget set must still
+	// return nil, or the two cases collapse into one.
+	noCap, err := svc.HardCapForWorkspace(context.Background(), uuid.New())
+	if err != nil {
+		t.Fatalf("HardCapForWorkspace (no budget): %v", err)
+	}
+	if noCap != nil {
+		t.Fatalf("expected nil for a workspace with no budget row, got %s", noCap.String())
 	}
 }

--- a/apps/control-plane/internal/tenants/http.go
+++ b/apps/control-plane/internal/tenants/http.go
@@ -123,25 +123,39 @@ func (h *Handler) Switch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if tag.RowsAffected() == 0 {
-		_ = h.deps.Audit.Log(r.Context(), audit.Event{
+		// Best-effort, not fail-closed: audit.SyncWriter.Write already retries
+		// its own SERIALIZABLE conflicts internally (up to
+		// maxSerializationRetries), and under concurrent Switch calls that
+		// retry budget can still be exhausted (SQLSTATE 40001). A failure
+		// here must never flip a real cross-tenant attempt into a silent
+		// success, so it is logged loudly rather than discarded: the comment
+		// at the top of Switch promises this event is never LOST silently,
+		// and a bare `_ = ...` broke that promise under load.
+		if auditErr := h.deps.Audit.Log(r.Context(), audit.Event{
 			TenantID: user.TenantID,
 			Actor:    audit.Actor{ID: user.ID, Type: audit.ActorUser},
 			Action:   "CROSS_TENANT_ATTEMPT",
 			Severity: audit.SeverityCritical,
 			Before:   map[string]string{"requested_tenant_id": body.TenantID.String()},
-		})
+		}); auditErr != nil {
+			log.Printf("tenants: CROSS_TENANT_ATTEMPT audit write failed for user=%s requested_tenant=%s: %v",
+				user.ID, body.TenantID, auditErr)
+		}
 		writeError(w, http.StatusForbidden, "CROSS_TENANT", "not a member of the requested tenant")
 		return
 	}
 
-	_ = h.deps.Audit.Log(r.Context(), audit.Event{
+	if auditErr := h.deps.Audit.Log(r.Context(), audit.Event{
 		TenantID: body.TenantID,
 		Actor:    audit.Actor{ID: user.ID, Type: audit.ActorUser},
 		Action:   "TENANT_SWITCH",
 		Severity: audit.SeverityInfo,
 		Before:   map[string]string{"from": user.TenantID.String()},
 		After:    map[string]string{"to": body.TenantID.String()},
-	})
+	}); auditErr != nil {
+		log.Printf("tenants: TENANT_SWITCH audit write failed for user=%s tenant=%s: %v",
+			user.ID, body.TenantID, auditErr)
+	}
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)

--- a/apps/control-plane/internal/tenants/http_test.go
+++ b/apps/control-plane/internal/tenants/http_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -191,4 +192,149 @@ func TestSwitch_NilDeps_503(t *testing.T) {
 	rec := httptest.NewRecorder()
 	h.Switch(rec, req)
 	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+}
+
+// -----------------------------------------------------------------------------
+// Concurrency: Switch's single WHERE...EXISTS UPDATE statement is what closed
+// the TOCTOU window a prior SELECT/UPDATE split left open (see the handler
+// comment above Switch). These tests exercise that under real concurrent
+// load against real Postgres: many simultaneous calls must never corrupt
+// selected_tenant_id and must never grant a non-member a switch. Those two
+// invariants are the membership-check's job and hold deterministically.
+//
+// The audit write is a *separate*, best-effort invariant and does not: a
+// burst of N simultaneous Switch calls funnels into audit.SyncWriter.Write,
+// which runs under SERIALIZABLE isolation with its own internal retry (3
+// attempts) around a genuine read/write conflict on public.audit_log's
+// per-month MAX(seq) read. Diagnosed live against this suite's own Postgres
+// (10 fully-simultaneous audit.Write calls, no HTTP layer involved): 6 of 10
+// still failed with SQLSTATE 40001 after exhausting all 3 retries. Before
+// this file, that failure was invisible — apps/control-plane/internal/
+// tenants/http.go discarded the audit.Log() return with a bare `_ = ...` on
+// both call sites, directly contradicting the comment above Switch promising
+// "a misconfiguration cannot silently... lose a CROSS_TENANT_ATTEMPT event."
+// Fixed here to log.Printf on failure instead of discarding it, so the loss
+// is loud rather than silent; the retry-budget/locking fix that would make
+// it not happen at all lives in the audit package, out of this task's scope
+// (a shared writer used well beyond the tenants package). These tests assert
+// the now-honest contract: at least one audit row per outcome, never zero,
+// never more than N — not "always exactly N", which the writer does not
+// actually guarantee under contention.
+// -----------------------------------------------------------------------------
+
+func TestSwitch_ConcurrentCallsFromActiveMember_AllSucceedConsistently(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	pool := newTenantsPool(t, ctx)
+	t.Cleanup(func() { pool.Close() })
+
+	tenantA := mustInsertTenant(t, ctx, pool, "concur-a-"+uuid.NewString(), "HIVE_CLOUD")
+	tenantB := mustInsertTenant(t, ctx, pool, "concur-b-"+uuid.NewString(), "HIVE_CLOUD")
+	userID := mustInsertAuthUser(t, ctx, pool, "concur@y.example")
+	mustInsertMembership(t, ctx, pool, tenantB, userID, "MEMBER")
+
+	logger := audit.NewLogger(audit.LoggerDeps{
+		Sync: audit.NewSyncWriter(pool, audit.WriterConfig{DeploySHA: "s", Env: "test"}),
+		WAL:  noopWAL{},
+	})
+	h := tenants.NewHandler(tenants.Deps{Pool: pool, Audit: logger})
+
+	const n = 10
+	codes := make([]int, n)
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			<-start
+			body, _ := json.Marshal(map[string]string{"tenant_id": tenantB.String()})
+			req := httptest.NewRequest(http.MethodPost, "/v1/tenants/switch", bytes.NewReader(body))
+			req = req.WithContext(tenants.WithUser(req.Context(), tenants.User{ID: userID, TenantID: tenantA}))
+			rec := httptest.NewRecorder()
+			h.Switch(rec, req)
+			codes[idx] = rec.Code
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i, code := range codes {
+		if code != http.StatusOK {
+			t.Fatalf("call %d: expected 200 for an active member switching concurrently, got %d", i, code)
+		}
+	}
+
+	var selected string
+	require.NoError(t, pool.QueryRow(ctx,
+		`SELECT raw_user_meta_data->>'selected_tenant_id' FROM auth.users WHERE id=$1`, userID).Scan(&selected))
+	require.Equal(t, tenantB.String(), selected,
+		"selected_tenant_id must land on the switched-to tenant regardless of how many concurrent calls raced to set it")
+
+	var switchCount int
+	require.NoError(t, pool.QueryRow(ctx,
+		`SELECT count(*) FROM public.audit_log WHERE actor_id=$1 AND action='TENANT_SWITCH'`, userID).Scan(&switchCount))
+	require.GreaterOrEqual(t, switchCount, 1,
+		"expected at least one TENANT_SWITCH audit row to survive; zero means the audit write failure is being silently swallowed again")
+	require.LessOrEqual(t, switchCount, n, "cannot have more audit rows than switch calls")
+}
+
+func TestSwitch_ConcurrentCallsFromNonMember_AllRejectedNoneLeakThrough(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	pool := newTenantsPool(t, ctx)
+	t.Cleanup(func() { pool.Close() })
+
+	tenantA := mustInsertTenant(t, ctx, pool, "concur-nm-a-"+uuid.NewString(), "HIVE_CLOUD")
+	tenantB := mustInsertTenant(t, ctx, pool, "concur-nm-b-"+uuid.NewString(), "HIVE_CLOUD")
+	userID := mustInsertAuthUser(t, ctx, pool, "concur-nm@y.example")
+	mustInsertMembership(t, ctx, pool, tenantA, userID, "MEMBER") // member of A, NOT B
+
+	logger := audit.NewLogger(audit.LoggerDeps{
+		Sync: audit.NewSyncWriter(pool, audit.WriterConfig{DeploySHA: "s", Env: "test"}),
+		WAL:  noopWAL{},
+	})
+	h := tenants.NewHandler(tenants.Deps{Pool: pool, Audit: logger})
+
+	const n = 10
+	codes := make([]int, n)
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			<-start
+			body, _ := json.Marshal(map[string]string{"tenant_id": tenantB.String()})
+			req := httptest.NewRequest(http.MethodPost, "/v1/tenants/switch", bytes.NewReader(body))
+			req = req.WithContext(tenants.WithUser(req.Context(), tenants.User{ID: userID, TenantID: tenantA}))
+			rec := httptest.NewRecorder()
+			h.Switch(rec, req)
+			codes[idx] = rec.Code
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i, code := range codes {
+		if code != http.StatusForbidden {
+			t.Fatalf("call %d: a non-member must never be granted a switch under concurrent load, got %d (want 403)", i, code)
+		}
+	}
+
+	var selected *string
+	require.NoError(t, pool.QueryRow(ctx,
+		`SELECT raw_user_meta_data->>'selected_tenant_id' FROM auth.users WHERE id=$1`, userID).Scan(&selected))
+	if selected != nil {
+		t.Fatalf("expected selected_tenant_id to remain unset for a user with no successful switch, got %q", *selected)
+	}
+
+	var attemptCount int
+	require.NoError(t, pool.QueryRow(ctx,
+		`SELECT count(*) FROM public.audit_log WHERE actor_id=$1 AND action='CROSS_TENANT_ATTEMPT'`, userID).Scan(&attemptCount))
+	require.GreaterOrEqual(t, attemptCount, 1,
+		"expected at least one CROSS_TENANT_ATTEMPT audit row to survive; zero means the audit write failure is being silently swallowed again")
+	require.LessOrEqual(t, attemptCount, n, "cannot have more audit rows than rejected attempts")
 }

--- a/apps/control-plane/internal/usage/repository_live_test.go
+++ b/apps/control-plane/internal/usage/repository_live_test.go
@@ -1,0 +1,452 @@
+package usage
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/sakibsadmanshajib/hive/packages/dbtest"
+)
+
+// Behavioral coverage for the usage repository against the real Postgres
+// schema. Before this file, only CreateAttempt's idempotency was exercised
+// live (repository_test.go); RecordEvent, ListEvents, GetUsageSummary,
+// GetSpendSummary, GetErrorSummary and UpdateAttemptStatus all ran at 0%
+// against real SQL, which is exactly the analytics/rollup surface a mock
+// cannot catch a broken GROUP BY or a dropped column on.
+//
+// Cache-token contract documented here (live context: PR #1173 fixed
+// hardcoded zero input/output tokens in the accounting rollup; issue #1174
+// tracks cache tokens still writing zero because no finalize path carries
+// them). This suite does NOT fix #1174 — that is cross-service plumbing
+// outside this package — but it pins down, against real SQL, exactly which
+// part of usage's own contract already carries cache tokens (the raw
+// RecordEvent/ListEvents round trip) and which part does not
+// (GetUsageSummary's rollup), so a future fix has a guard that goes red the
+// moment either boundary moves.
+
+func newUsageTestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	return dbtest.Pool(t, "HIVE_TEST_DB_URL")
+}
+
+// seedUsageAccount inserts an auth.users row and the public.accounts row it
+// owns, registering cleanup that cascades usage_events/request_attempts.
+func seedUsageAccount(t *testing.T, pool *pgxpool.Pool) uuid.UUID {
+	t.Helper()
+	ctx := context.Background()
+
+	var userID uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO auth.users (id, email, raw_user_meta_data)
+		 VALUES (gen_random_uuid(), $1, '{}'::jsonb) RETURNING id`,
+		"usage-repo-"+uuid.NewString()+"@test.local",
+	).Scan(&userID); err != nil {
+		t.Fatalf("seed auth.users: %v", err)
+	}
+
+	var accountID uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO public.accounts (id, slug, display_name, account_type, owner_user_id)
+		 VALUES (gen_random_uuid(), $1, 'usage repo test', 'personal', $2) RETURNING id`,
+		"usage-repo-"+uuid.NewString(), userID,
+	).Scan(&accountID); err != nil {
+		t.Fatalf("seed account: %v", err)
+	}
+
+	t.Cleanup(func() {
+		c := context.Background()
+		_, _ = pool.Exec(c, `DELETE FROM public.accounts WHERE id = $1`, accountID)
+		_, _ = pool.Exec(c, `DELETE FROM auth.users WHERE id = $1`, userID)
+	})
+	return accountID
+}
+
+func seedUsageAttempt(t *testing.T, ctx context.Context, repo Repository, accountID uuid.UUID) uuid.UUID {
+	t.Helper()
+	attempt, err := repo.CreateAttempt(ctx, StartAttemptInput{
+		AccountID:     accountID,
+		RequestID:     "req-" + uuid.NewString(),
+		AttemptNumber: 1,
+		Endpoint:      "/v1/chat/completions",
+		ModelAlias:    "gpt-test",
+		Status:        AttemptStatusDispatching,
+		CustomerTags:  map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("seed attempt: %v", err)
+	}
+	return attempt.ID
+}
+
+// -----------------------------------------------------------------------------
+// RecordEvent + ListEvents: cache tokens survive the raw event round trip.
+// -----------------------------------------------------------------------------
+
+func TestRecordEventAndListEvents_CacheTokensRoundTrip(t *testing.T) {
+	pool := newUsageTestPool(t)
+	repo := NewPgxRepository(pool)
+	ctx := context.Background()
+	accountID := seedUsageAccount(t, pool)
+	attemptID := seedUsageAttempt(t, ctx, repo, accountID)
+
+	requestID := "req-" + uuid.NewString()
+	written, err := repo.RecordEvent(ctx, RecordEventInput{
+		AccountID:        accountID,
+		RequestAttemptID: attemptID,
+		RequestID:        requestID,
+		EventType:        UsageEventCompleted,
+		Endpoint:         "/v1/chat/completions",
+		ModelAlias:       "gpt-test",
+		Status:           "completed",
+		InputTokens:      100,
+		OutputTokens:     50,
+		CacheReadTokens:  30,
+		CacheWriteTokens: 20,
+		HiveCreditDelta:  -1234,
+		InternalMetadata: map[string]any{},
+		CustomerTags:     map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("RecordEvent: %v", err)
+	}
+	if written.CacheReadTokens != 30 || written.CacheWriteTokens != 20 {
+		t.Fatalf("RecordEvent's own return must carry cache tokens: got read=%d write=%d",
+			written.CacheReadTokens, written.CacheWriteTokens)
+	}
+
+	events, err := repo.ListEvents(ctx, ListEventsFilter{AccountID: accountID, RequestID: requestID, Limit: 10})
+	if err != nil {
+		t.Fatalf("ListEvents: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected exactly 1 event, got %d", len(events))
+	}
+	got := events[0]
+	if got.InputTokens != 100 || got.OutputTokens != 50 {
+		t.Fatalf("expected input/output tokens to round-trip, got input=%d output=%d", got.InputTokens, got.OutputTokens)
+	}
+	if got.CacheReadTokens != 30 || got.CacheWriteTokens != 20 {
+		t.Fatalf("ListEvents must return the cache tokens RecordEvent stored: got read=%d write=%d, want read=30 write=20",
+			got.CacheReadTokens, got.CacheWriteTokens)
+	}
+}
+
+func TestRecordEventAndListEvents_ZeroCacheTokensStayZero(t *testing.T) {
+	// The inverse of the round-trip test: an event that genuinely has no
+	// cache activity must read back as zero, not as some other sentinel and
+	// not as a value borrowed from input/output tokens.
+	pool := newUsageTestPool(t)
+	repo := NewPgxRepository(pool)
+	ctx := context.Background()
+	accountID := seedUsageAccount(t, pool)
+	attemptID := seedUsageAttempt(t, ctx, repo, accountID)
+
+	requestID := "req-" + uuid.NewString()
+	if _, err := repo.RecordEvent(ctx, RecordEventInput{
+		AccountID:        accountID,
+		RequestAttemptID: attemptID,
+		RequestID:        requestID,
+		EventType:        UsageEventCompleted,
+		Endpoint:         "/v1/chat/completions",
+		ModelAlias:       "gpt-test",
+		Status:           "completed",
+		InputTokens:      10,
+		OutputTokens:     5,
+		HiveCreditDelta:  -1,
+		InternalMetadata: map[string]any{},
+		CustomerTags:     map[string]any{},
+	}); err != nil {
+		t.Fatalf("RecordEvent: %v", err)
+	}
+
+	events, err := repo.ListEvents(ctx, ListEventsFilter{AccountID: accountID, RequestID: requestID, Limit: 10})
+	if err != nil {
+		t.Fatalf("ListEvents: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected exactly 1 event, got %d", len(events))
+	}
+	if events[0].CacheReadTokens != 0 || events[0].CacheWriteTokens != 0 {
+		t.Fatalf("expected untouched cache tokens to read back as zero, got read=%d write=%d",
+			events[0].CacheReadTokens, events[0].CacheWriteTokens)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// GetUsageSummary: current rollup contract. Sums input/output tokens and
+// credits correctly. Documents, with a real query, that cache tokens do NOT
+// appear on UsageSummaryRow today (issue #1174) — this must go red the
+// day someone adds cache columns to the rollup without updating the type,
+// or removes them from the type without updating the rollup.
+// -----------------------------------------------------------------------------
+
+func TestGetUsageSummary_SumsInputOutputAndCredits(t *testing.T) {
+	pool := newUsageTestPool(t)
+	repo := NewPgxRepository(pool)
+	ctx := context.Background()
+	accountID := seedUsageAccount(t, pool)
+	attemptID := seedUsageAttempt(t, ctx, repo, accountID)
+
+	from := time.Now().UTC().Add(-1 * time.Hour)
+	for i := 0; i < 2; i++ {
+		if _, err := repo.RecordEvent(ctx, RecordEventInput{
+			AccountID:        accountID,
+			RequestAttemptID: attemptID,
+			RequestID:        "req-" + uuid.NewString(),
+			EventType:        UsageEventCompleted,
+			Endpoint:         "/v1/chat/completions",
+			ModelAlias:       "gpt-summary-test",
+			Status:           "completed",
+			InputTokens:      100,
+			OutputTokens:     50,
+			CacheReadTokens:  30,
+			CacheWriteTokens: 20,
+			HiveCreditDelta:  -1000,
+			InternalMetadata: map[string]any{},
+			CustomerTags:     map[string]any{},
+		}); err != nil {
+			t.Fatalf("seed event %d: %v", i, err)
+		}
+	}
+	to := time.Now().UTC().Add(1 * time.Hour)
+
+	rows, err := repo.GetUsageSummary(ctx, AnalyticsFilter{AccountID: accountID, GroupBy: "model", From: from, To: to})
+	if err != nil {
+		t.Fatalf("GetUsageSummary: %v", err)
+	}
+	var found *UsageSummaryRow
+	for i := range rows {
+		if rows[i].GroupKey == "gpt-summary-test" {
+			found = &rows[i]
+		}
+	}
+	if found == nil {
+		t.Fatalf("expected a summary row for gpt-summary-test, got %#v", rows)
+	}
+	if found.TotalInputTokens != 200 {
+		t.Fatalf("expected summed input tokens 200 (2x100), got %d", found.TotalInputTokens)
+	}
+	if found.TotalOutputTokens != 100 {
+		t.Fatalf("expected summed output tokens 100 (2x50), got %d", found.TotalOutputTokens)
+	}
+	if found.TotalCreditsSpent != 2000 {
+		t.Fatalf("expected summed abs(credit_delta) 2000 (2x1000), got %d", found.TotalCreditsSpent)
+	}
+	if found.RequestCount != 2 {
+		t.Fatalf("expected request_count 2, got %d", found.RequestCount)
+	}
+
+	// Documents the current gap (issue #1174): UsageSummaryRow (types.go) has
+	// no CacheReadTokens/CacheWriteTokens fields, so the 60 cache-read and 40
+	// cache-write tokens across these two events are structurally invisible
+	// to this rollup — there is no column to assert on. A future fix to
+	// #1174 that adds those fields to UsageSummaryRow and the SQL above must
+	// also extend this test with a cache-token sum assertion; until then this
+	// comment is the guard.
+}
+
+func TestGetUsageSummary_ExcludesEventsOutsideWindow(t *testing.T) {
+	pool := newUsageTestPool(t)
+	repo := NewPgxRepository(pool)
+	ctx := context.Background()
+	accountID := seedUsageAccount(t, pool)
+	attemptID := seedUsageAttempt(t, ctx, repo, accountID)
+
+	if _, err := repo.RecordEvent(ctx, RecordEventInput{
+		AccountID:        accountID,
+		RequestAttemptID: attemptID,
+		RequestID:        "req-" + uuid.NewString(),
+		EventType:        UsageEventCompleted,
+		Endpoint:         "/v1/chat/completions",
+		ModelAlias:       "gpt-window-test",
+		Status:           "completed",
+		InputTokens:      999,
+		OutputTokens:     999,
+		HiveCreditDelta:  -1,
+		InternalMetadata: map[string]any{},
+		CustomerTags:     map[string]any{},
+	}); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+
+	// A window that ends before the event was created must exclude it.
+	past := time.Now().UTC().Add(-48 * time.Hour)
+	rows, err := repo.GetUsageSummary(ctx, AnalyticsFilter{
+		AccountID: accountID, GroupBy: "model",
+		From: past.Add(-1 * time.Hour), To: past,
+	})
+	if err != nil {
+		t.Fatalf("GetUsageSummary: %v", err)
+	}
+	for _, row := range rows {
+		if row.GroupKey == "gpt-window-test" {
+			t.Fatalf("expected the out-of-window event to be excluded, got row %#v", row)
+		}
+	}
+}
+
+// -----------------------------------------------------------------------------
+// GetSpendSummary: only negative credit deltas (actual spend) count; a
+// positive delta (e.g. a refund/reconciliation credit) must not appear as
+// spend.
+// -----------------------------------------------------------------------------
+
+func TestGetSpendSummary_OnlyCountsNegativeDeltas(t *testing.T) {
+	pool := newUsageTestPool(t)
+	repo := NewPgxRepository(pool)
+	ctx := context.Background()
+	accountID := seedUsageAccount(t, pool)
+	attemptID := seedUsageAttempt(t, ctx, repo, accountID)
+
+	model := "gpt-spend-test-" + uuid.NewString()[:8]
+	from := time.Now().UTC().Add(-1 * time.Hour)
+
+	// One real spend (-500) and one positive delta (a refund/credit, +200)
+	// that must NOT be counted as spend.
+	for _, delta := range []int64{-500, 200} {
+		if _, err := repo.RecordEvent(ctx, RecordEventInput{
+			AccountID:        accountID,
+			RequestAttemptID: attemptID,
+			RequestID:        "req-" + uuid.NewString(),
+			EventType:        UsageEventCompleted,
+			Endpoint:         "/v1/chat/completions",
+			ModelAlias:       model,
+			Status:           "completed",
+			HiveCreditDelta:  delta,
+			InternalMetadata: map[string]any{},
+			CustomerTags:     map[string]any{},
+		}); err != nil {
+			t.Fatalf("seed event delta=%d: %v", delta, err)
+		}
+	}
+	to := time.Now().UTC().Add(1 * time.Hour)
+
+	rows, err := repo.GetSpendSummary(ctx, AnalyticsFilter{AccountID: accountID, GroupBy: "model", From: from, To: to})
+	if err != nil {
+		t.Fatalf("GetSpendSummary: %v", err)
+	}
+	var found *SpendSummaryRow
+	for i := range rows {
+		if rows[i].GroupKey == model {
+			found = &rows[i]
+		}
+	}
+	if found == nil {
+		t.Fatalf("expected a spend summary row for %s, got %#v", model, rows)
+	}
+	if found.TotalCredits != 500 {
+		t.Fatalf("expected only the -500 delta counted as spend (500 abs), got %d — a positive delta leaked into spend",
+			found.TotalCredits)
+	}
+	if found.EntryCount != 1 {
+		t.Fatalf("expected entry_count 1 (only the negative-delta row), got %d", found.EntryCount)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// GetErrorSummary: error rate is computed over ALL requests in the window,
+// not just the errored ones, and float division must not divide by zero.
+// -----------------------------------------------------------------------------
+
+func TestGetErrorSummary_ComputesRateOverAllRequests(t *testing.T) {
+	pool := newUsageTestPool(t)
+	repo := NewPgxRepository(pool)
+	ctx := context.Background()
+	accountID := seedUsageAccount(t, pool)
+	attemptID := seedUsageAttempt(t, ctx, repo, accountID)
+
+	model := "gpt-error-test-" + uuid.NewString()[:8]
+	from := time.Now().UTC().Add(-1 * time.Hour)
+
+	// 1 error out of 4 total requests on this model => 25% error rate.
+	statuses := []struct {
+		status    string
+		errorCode string
+	}{
+		{"completed", ""},
+		{"completed", ""},
+		{"completed", ""},
+		{"failed", "upstream_5xx"},
+	}
+	for _, s := range statuses {
+		if _, err := repo.RecordEvent(ctx, RecordEventInput{
+			AccountID:        accountID,
+			RequestAttemptID: attemptID,
+			RequestID:        "req-" + uuid.NewString(),
+			EventType:        UsageEventCompleted,
+			Endpoint:         "/v1/chat/completions",
+			ModelAlias:       model,
+			Status:           s.status,
+			ErrorCode:        s.errorCode,
+			InternalMetadata: map[string]any{},
+			CustomerTags:     map[string]any{},
+		}); err != nil {
+			t.Fatalf("seed event status=%s: %v", s.status, err)
+		}
+	}
+	to := time.Now().UTC().Add(1 * time.Hour)
+
+	rows, err := repo.GetErrorSummary(ctx, AnalyticsFilter{AccountID: accountID, GroupBy: "model", From: from, To: to})
+	if err != nil {
+		t.Fatalf("GetErrorSummary: %v", err)
+	}
+	var found *ErrorSummaryRow
+	for i := range rows {
+		if rows[i].GroupKey == model {
+			found = &rows[i]
+		}
+	}
+	if found == nil {
+		t.Fatalf("expected an error summary row for %s, got %#v", model, rows)
+	}
+	if found.TotalRequests != 4 {
+		t.Fatalf("expected total_requests 4, got %d", found.TotalRequests)
+	}
+	if found.ErrorCount != 1 {
+		t.Fatalf("expected error_count 1, got %d", found.ErrorCount)
+	}
+	if found.ErrorRate < 0.249 || found.ErrorRate > 0.251 {
+		t.Fatalf("expected error_rate ~0.25 (1/4), got %v", found.ErrorRate)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// UpdateAttemptStatus against real SQL.
+// -----------------------------------------------------------------------------
+
+func TestUpdateAttemptStatus_PersistsStatusAndCompletedAt(t *testing.T) {
+	pool := newUsageTestPool(t)
+	repo := NewPgxRepository(pool)
+	ctx := context.Background()
+	accountID := seedUsageAccount(t, pool)
+	attemptID := seedUsageAttempt(t, ctx, repo, accountID)
+
+	completedAt := time.Now().UTC()
+	if err := repo.UpdateAttemptStatus(ctx, attemptID, "completed", &completedAt); err != nil {
+		t.Fatalf("UpdateAttemptStatus: %v", err)
+	}
+
+	attempts, err := repo.ListAttempts(ctx, accountID, "", 10)
+	if err != nil {
+		t.Fatalf("ListAttempts: %v", err)
+	}
+	var found *RequestAttempt
+	for i := range attempts {
+		if attempts[i].ID == attemptID {
+			found = &attempts[i]
+		}
+	}
+	if found == nil {
+		t.Fatalf("expected to find the updated attempt, got %#v", attempts)
+	}
+	if found.Status != AttemptStatusCompleted {
+		t.Fatalf("expected status completed, got %q", found.Status)
+	}
+	if found.CompletedAt == nil {
+		t.Fatal("expected completed_at to be persisted, got nil")
+	}
+}

--- a/apps/control-plane/internal/usage/service_test.go
+++ b/apps/control-plane/internal/usage/service_test.go
@@ -21,6 +21,15 @@ type stubRepo struct {
 	lastRecordedEvent RecordEventInput
 	lastAttemptsLimit int
 	lastEventsFilter  ListEventsFilter
+
+	lastAnalyticsFilter    AnalyticsFilter
+	usageSummaryRows       []UsageSummaryRow
+	spendSummaryRows       []SpendSummaryRow
+	errorSummaryRows       []ErrorSummaryRow
+	lastUpdateAttemptID    uuid.UUID
+	lastUpdateStatus       string
+	lastUpdateCompletedAt  *time.Time
+	updateAttemptStatusErr error
 }
 
 func newStubRepo() *stubRepo {
@@ -56,6 +65,12 @@ func (s *stubRepo) CreateAttempt(_ context.Context, input StartAttemptInput) (Re
 }
 
 func (s *stubRepo) UpdateAttemptStatus(_ context.Context, attemptID uuid.UUID, status string, completedAt *time.Time) error {
+	s.lastUpdateAttemptID = attemptID
+	s.lastUpdateStatus = status
+	s.lastUpdateCompletedAt = completedAt
+	if s.updateAttemptStatusErr != nil {
+		return s.updateAttemptStatusErr
+	}
 	for accountID, attempts := range s.attempts {
 		for idx, attempt := range attempts {
 			if attempt.ID == attemptID {
@@ -170,16 +185,19 @@ func (s *stubRepo) ListEvents(_ context.Context, filter ListEventsFilter) ([]Usa
 	return append([]UsageEvent(nil), events...), nil
 }
 
-func (s *stubRepo) GetUsageSummary(_ context.Context, _ AnalyticsFilter) ([]UsageSummaryRow, error) {
-	return nil, nil
+func (s *stubRepo) GetUsageSummary(_ context.Context, filter AnalyticsFilter) ([]UsageSummaryRow, error) {
+	s.lastAnalyticsFilter = filter
+	return s.usageSummaryRows, nil
 }
 
-func (s *stubRepo) GetSpendSummary(_ context.Context, _ AnalyticsFilter) ([]SpendSummaryRow, error) {
-	return nil, nil
+func (s *stubRepo) GetSpendSummary(_ context.Context, filter AnalyticsFilter) ([]SpendSummaryRow, error) {
+	s.lastAnalyticsFilter = filter
+	return s.spendSummaryRows, nil
 }
 
-func (s *stubRepo) GetErrorSummary(_ context.Context, _ AnalyticsFilter) ([]ErrorSummaryRow, error) {
-	return nil, nil
+func (s *stubRepo) GetErrorSummary(_ context.Context, filter AnalyticsFilter) ([]ErrorSummaryRow, error) {
+	s.lastAnalyticsFilter = filter
+	return s.errorSummaryRows, nil
 }
 
 func (s *stubRepo) ListMembershipsByUserID(_ context.Context, userID uuid.UUID) ([]accounts.Membership, error) {
@@ -381,5 +399,188 @@ func TestStartAttemptRejectsBlankRequestID(t *testing.T) {
 	var validationErr *ValidationError
 	if !errors.As(err, &validationErr) {
 		t.Fatalf("expected ValidationError, got %T", err)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Analytics filter validation + pass-through (GetUsageSummary / GetSpendSummary
+// / GetErrorSummary). These three were entirely uncovered: validateAnalyticsFilter
+// gates every one of them but had zero direct tests, so a broken group_by
+// allow-list or a reversed from/to check could ship silently.
+// -----------------------------------------------------------------------------
+
+func TestGetUsageSummary_RejectsInvalidGroupBy(t *testing.T) {
+	repo := newStubRepo()
+	svc := NewService(repo)
+
+	_, err := svc.GetUsageSummary(context.Background(), AnalyticsFilter{
+		AccountID: uuid.New(),
+		GroupBy:   "not_a_real_dimension",
+	})
+	var validationErr *ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("expected ValidationError for bad group_by, got %v", err)
+	}
+	if validationErr.Field != "group_by" {
+		t.Fatalf("expected field=group_by, got %q", validationErr.Field)
+	}
+}
+
+func TestGetUsageSummary_RejectsFromNotBeforeTo(t *testing.T) {
+	repo := newStubRepo()
+	svc := NewService(repo)
+
+	now := time.Now().UTC()
+	_, err := svc.GetUsageSummary(context.Background(), AnalyticsFilter{
+		AccountID: uuid.New(),
+		GroupBy:   "model",
+		From:      now,
+		To:        now.Add(-1 * time.Hour), // to before from
+	})
+	var validationErr *ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("expected ValidationError when from is not before to, got %v", err)
+	}
+}
+
+func TestGetUsageSummary_ValidFilterReachesRepository(t *testing.T) {
+	repo := newStubRepo()
+	want := []UsageSummaryRow{{GroupKey: "gpt-test", TotalInputTokens: 10, TotalOutputTokens: 20, TotalCreditsSpent: 5, RequestCount: 1}}
+	repo.usageSummaryRows = want
+	svc := NewService(repo)
+
+	accountID := uuid.New()
+	got, err := svc.GetUsageSummary(context.Background(), AnalyticsFilter{AccountID: accountID, GroupBy: "endpoint"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 || got[0].GroupKey != "gpt-test" {
+		t.Fatalf("expected the repository's rows to pass through unchanged, got %#v", got)
+	}
+	if repo.lastAnalyticsFilter.AccountID != accountID || repo.lastAnalyticsFilter.GroupBy != "endpoint" {
+		t.Fatalf("expected the validated filter to reach the repository unchanged, got %#v", repo.lastAnalyticsFilter)
+	}
+}
+
+func TestGetSpendSummary_RejectsInvalidGroupBy(t *testing.T) {
+	repo := newStubRepo()
+	svc := NewService(repo)
+	_, err := svc.GetSpendSummary(context.Background(), AnalyticsFilter{AccountID: uuid.New(), GroupBy: "bogus"})
+	var validationErr *ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("expected ValidationError, got %v", err)
+	}
+}
+
+func TestGetSpendSummary_ValidFilterReachesRepository(t *testing.T) {
+	repo := newStubRepo()
+	want := []SpendSummaryRow{{GroupKey: "api-key-1", TotalCredits: 100, EntryCount: 3}}
+	repo.spendSummaryRows = want
+	svc := NewService(repo)
+
+	got, err := svc.GetSpendSummary(context.Background(), AnalyticsFilter{AccountID: uuid.New(), GroupBy: "api_key"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 || got[0].TotalCredits != 100 {
+		t.Fatalf("expected repository rows to pass through, got %#v", got)
+	}
+}
+
+func TestGetErrorSummary_RejectsInvalidGroupBy(t *testing.T) {
+	repo := newStubRepo()
+	svc := NewService(repo)
+	_, err := svc.GetErrorSummary(context.Background(), AnalyticsFilter{AccountID: uuid.New(), GroupBy: "bogus"})
+	var validationErr *ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("expected ValidationError, got %v", err)
+	}
+}
+
+func TestGetErrorSummary_ValidFilterReachesRepository(t *testing.T) {
+	repo := newStubRepo()
+	want := []ErrorSummaryRow{{GroupKey: "model-x", ErrorCount: 2, TotalRequests: 10, ErrorRate: 0.2}}
+	repo.errorSummaryRows = want
+	svc := NewService(repo)
+
+	got, err := svc.GetErrorSummary(context.Background(), AnalyticsFilter{AccountID: uuid.New(), GroupBy: "model"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 || got[0].ErrorRate != 0.2 {
+		t.Fatalf("expected repository rows to pass through, got %#v", got)
+	}
+}
+
+func TestGetUsageSummary_EmptyGroupByIsAllowed(t *testing.T) {
+	// Empty string defaults to "model" at the query level (repository.go's
+	// switch default case); the service validator must let it through rather
+	// than rejecting it as an invalid dimension.
+	repo := newStubRepo()
+	svc := NewService(repo)
+	if _, err := svc.GetUsageSummary(context.Background(), AnalyticsFilter{AccountID: uuid.New(), GroupBy: ""}); err != nil {
+		t.Fatalf("expected empty group_by to be accepted, got %v", err)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// UpdateAttemptStatus validation
+// -----------------------------------------------------------------------------
+
+func TestUpdateAttemptStatus_RejectsNilAttemptID(t *testing.T) {
+	repo := newStubRepo()
+	svc := NewService(repo)
+	err := svc.UpdateAttemptStatus(context.Background(), uuid.Nil, AttemptStatusCompleted, nil)
+	var validationErr *ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("expected ValidationError for nil attempt id, got %v", err)
+	}
+}
+
+func TestUpdateAttemptStatus_RejectsInvalidStatus(t *testing.T) {
+	repo := newStubRepo()
+	svc := NewService(repo)
+	err := svc.UpdateAttemptStatus(context.Background(), uuid.New(), AttemptStatus("not_a_status"), nil)
+	var validationErr *ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("expected ValidationError for invalid status, got %v", err)
+	}
+	if repo.lastUpdateAttemptID != uuid.Nil {
+		t.Fatal("repository must not be called when status validation fails")
+	}
+}
+
+func TestUpdateAttemptStatus_ValidStatusReachesRepository(t *testing.T) {
+	repo := newStubRepo()
+	svc := NewService(repo)
+	accountID := uuid.New()
+	attemptID := uuid.New()
+	repo.attempts[accountID] = []RequestAttempt{{ID: attemptID, AccountID: accountID}}
+	completed := time.Now().UTC()
+
+	for _, status := range []AttemptStatus{
+		AttemptStatusAccepted, AttemptStatusDispatching, AttemptStatusStreaming,
+		AttemptStatusCompleted, AttemptStatusFailed, AttemptStatusCancelled, AttemptStatusInterrupted,
+	} {
+		if err := svc.UpdateAttemptStatus(context.Background(), attemptID, status, &completed); err != nil {
+			t.Fatalf("status %q: unexpected error: %v", status, err)
+		}
+		if repo.lastUpdateStatus != string(status) {
+			t.Fatalf("expected repository to receive status %q, got %q", status, repo.lastUpdateStatus)
+		}
+	}
+}
+
+func TestUpdateAttemptStatus_PropagatesRepositoryError(t *testing.T) {
+	repo := newStubRepo()
+	repo.updateAttemptStatusErr = errors.New("boom")
+	svc := NewService(repo)
+	err := svc.UpdateAttemptStatus(context.Background(), uuid.New(), AttemptStatusCompleted, nil)
+	if err == nil {
+		t.Fatal("expected repository error to propagate")
+	}
+	var validationErr *ValidationError
+	if errors.As(err, &validationErr) {
+		t.Fatal("a repository failure must not be reported as a ValidationError")
 	}
 }


### PR DESCRIPTION
## Summary

Adds test coverage (live-Postgres + unit) for four low-coverage control-plane packages named in the coverage task, plus one real bug fix found while writing the tenants concurrency tests.

- **budgets**: proves `hard_cap = 0` (a deliberate spend-block) stays distinguishable from no-budget-set, both at the service layer (`HardCapForWorkspace`) and the internal HTTP endpoint edge-api's gate reads. Collapsing the two would silently disable every zero-cap workspace's block.
- **usage**: `repository.go`'s `RecordEvent`, `ListEvents`, `GetUsageSummary`, `GetSpendSummary`, `GetErrorSummary`, `UpdateAttemptStatus` ran at 0% against real SQL before this PR (confirmed via `go tool cover -func`; only `CreateAttempt`'s idempotency had ever run live). Adds live-DB coverage for all six, plus unit coverage for the previously-untested analytics-filter validation. Includes an explicit cache-token round-trip guard and a documented note on `GetUsageSummary`'s current cache-token gap (issue #1174 — not fixed here, cross-service plumbing).
- **tenants**: two concurrency tests against real Postgres proving `Switch`'s single `WHERE...EXISTS` UPDATE holds its two deterministic invariants (no corrupted `selected_tenant_id`, no cross-tenant grant) under a 10-way simultaneous race.
- **signup / filestore**: untouched. signup is already well-covered (34+ existing tests); filestore is lowest priority per the task brief and out of this pass's budget.

## Bug fix

`apps/control-plane/internal/tenants/http.go`, `Switch` handler: both `audit.Log()` calls discarded their error with a bare `_ = ...`, contradicting the handler's own comment that a `CROSS_TENANT_ATTEMPT` event is never lost silently. Diagnosed live against this PR's own throwaway Postgres: `audit.SyncWriter.Write` can still hit `SQLSTATE 40001` (serialization failure) after exhausting its own 3-attempt retry budget under real concurrent load (6 of 10 fully-simultaneous calls failed in the reproduction). That failure was previously invisible. Now `log.Printf`'d instead of discarded — turns a silent loss into an observable one without changing the HTTP contract.

The underlying retry-robustness fix (raise the retry budget, or move snapshot acquisition inside the advisory lock) belongs in the shared `audit` package, which is used well beyond `tenants` and is out of this task's scope. Flagging for a follow-up issue rather than fixing it here.

The two new tenants concurrency tests assert the honest post-fix contract: HTTP-level correctness (status codes, final `selected_tenant_id`) holds deterministically under concurrency; the audit side-channel is asserted as "at least 1, at most N" since the writer does not actually guarantee exactly N under contention.

## Coverage, before → after (fresh DB each measurement)

| Package | No-DB before | No-DB after | With-DB before | With-DB after |
|---|---|---|---|---|
| `internal/budgets` | 64.7% | 64.7% | 79.4% | 79.4% |
| `internal/usage` | 30.2% | 34.5% | 32.9% | **57.8%** |
| `internal/tenants` | 31.6% | 30.0% | 92.1% | 92.5% |
| `internal/signup` | 29.7% | 29.7% | 76.4% | 76.4% (untouched) |
| `internal/filestore` | 6.9% | 6.9% | 6.9% | 6.9% (untouched) |

budgets' statement-coverage is unchanged because the new zero-cap tests exercise the same statements existing tests already covered — they differ only in the *value* asserted (0 vs 2000), which line coverage can't see. Proven meaningful via the mutation-kill proof below (test #1) instead.

## Test plan

- [x] `go vet ./apps/control-plane/...` clean
- [x] `gofmt -l` clean on all touched files
- [x] Full target-package suite green without DB (all live tests correctly skip)
- [x] Full target-package suite green with a fresh real Postgres (105/105 migrations applied via `scripts/ci-throwaway-db.sh`)
- [x] Red-then-green proof for 3 tests (mutated production code, watched the test fail for the exact predicted reason, restored, watched it pass — see below)
- [x] Re-verified everything post-rebase onto latest `origin/main`

### Red/green proofs

1. **budgets** — `TestInternalHardCap_ZeroCapSet_RendersZeroStringNotNull`: mutated `handleInternalHardCap` to collapse `cap.Sign() == 0` into the same `null` response as no-budget. RED: `expected ... string "0" ... got JSON null`. Restored → GREEN.
2. **usage** — `TestGetSpendSummary_OnlyCountsNegativeDeltas`: dropped `AND hive_credit_delta < 0` from `GetSpendSummary`'s SQL. RED: `expected only the -500 delta ... got 700 — a positive delta leaked into spend`. Restored → GREEN.
3. **tenants** — `TestSwitch_ConcurrentCallsFromNonMember_AllRejectedNoneLeakThrough`: dropped `AND tenant_id = $1` from `Switch`'s membership predicate. RED: `a non-member must never be granted a switch ... got 200 (want 403)` — a live cross-tenant authorization bypass. Restored → GREEN.

None of the mutations were committed; verified via `git diff` for leftover markers after each restore.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>