### PR TITLE
fix: enforce ownership on Knowledge by-id read routes (#1056, SECURITY)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ test-scripts:
 	python3 scripts/test_owui_ui_surfaces.py
 	python3 scripts/test_owui_display_name.py
 	python3 scripts/test_owui_tenant_role.py
+	python3 scripts/test_owui_knowledge_authz.py
 	python3 scripts/owui-promote-instance-admin.py --self-check
 	python3 scripts/test_caddy_owui_blocklist.py
 	python3 scripts/test_owui_model_picker_filter.py

--- a/deploy/docker/Caddyfile.owui
+++ b/deploy/docker/Caddyfile.owui
@@ -144,10 +144,10 @@
   # and ENABLE_ADMIN_EXPORT is already false for the routes that honour it.
   #
   # Deliberately NOT blocking `GET /api/v1/knowledge/<id>` or its `/files`
-  # child, which have the same admin short-circuit but ARE the routes an owner
-  # uses to open their own collection. Those need a real ownership check in
-  # Python through owui-patches, tracked separately; blocking them here would
-  # be an outage, not a fix.
+  # children, which an owner uses to open their own collection: those now
+  # enforce ownership in the backend itself through owui-patches'
+  # apply_knowledge_authz_patch.py (#1056). This block stays scoped to the
+  # export route, which has no legitimate caller in this product at all.
   @blocked {
     path_regexp blocked (?i)^/+(?:admin|signup|signin|signup\.html|register|create-account|users/new|invite|auth/signup|auth/signin|auth/register|auths/signup|auths/signin|openai/config|api(?:/v[0-9]+)?/(?:admin|signup|register|invite|notes|terminals|users/admin|users/new|auths/(?:signup|admin)|configs/(?:export|import|namespace|terminal_servers|tool_servers)|knowledge/[^/]+/export))/?(?:/.*)?$
   }

--- a/deploy/docker/Dockerfile.open-webui
+++ b/deploy/docker/Dockerfile.open-webui
@@ -397,6 +397,19 @@ RUN python3 /tmp/apply_credits_patch.py \
     && grep -q 'hive_credits_router' /app/backend/open_webui/main.py \
     && python3 -c "import ast, pathlib; ast.parse(pathlib.Path('/app/backend/open_webui/utils/hive_credits.py').read_text())"
 
+# issue #1056: ownership enforcement on the Knowledge by-id read routes. The
+# listing routes honour BYPASS_ADMIN_ACCESS_CONTROL (PR #960), but GET /{id},
+# GET /{id}/files (which takes include_content), GET /{id}/files/pending and
+# GET /{id}/export short-circuited on user.role == 'admin', so an instance
+# admin -- which every tenant OWNER is on this shared instance -- could read
+# another tenant's collection given only its id. The patch applies the same
+# predicate as the listings: owner, AccessGrants read grant, or admin when
+# BYPASS_ADMIN_ACCESS_CONTROL is set. docker-compose.yml sets it false.
+COPY deploy/docker/owui-patches/apply_knowledge_authz_patch.py /tmp/apply_knowledge_authz_patch.py
+RUN python3 /tmp/apply_knowledge_authz_patch.py \
+    && test "$(grep -c '# hive (#1056)' /app/backend/open_webui/routers/knowledge.py)" -eq 4 \
+    && python3 -c "import ast, pathlib; ast.parse(pathlib.Path('/app/backend/open_webui/routers/knowledge.py').read_text())"
+
 # #771: drop the Settings > Integrations tab, the chat UI's only entry point to
 # "Manage Tool Servers" and "Open Terminal". Both accept an arbitrary URL and an
 # auth credential. The tool servers added there are direct ones, called by the

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -984,18 +984,15 @@ services:
       # thing. Chats are closed: every route that can read another user's
       # chat is gated on ENABLE_ADMIN_CHAT_ACCESS (chats.py:611, :1056,
       # :1063, :1174, :1592), and the bulk route at :890 was already behind
-      # ENABLE_ADMIN_EXPORT above. Knowledge is closed for DISCOVERY only:
-      # the listing routes honour BYPASS_ADMIN_ACCESS_CONTROL, so an admin no
-      # longer sees another tenant's collections, but three by-id routes
-      # short-circuit on `user.role == 'admin'` without consulting either
-      # flag -- knowledge.py:1039 (GET /{id}), :1289 (GET /{id}/files, which
-      # takes include_content) and :2096 (GET /{id}/export, which checks not
-      # even ENABLE_ADMIN_EXPORT). The export route is blocked at the proxy
-      # instead, in Caddyfile.owui, since a backend edit here would be inert:
-      # Dockerfile.open-webui builds only the frontend from vendor/. The
-      # other two need a real ownership check through owui-patches and are
-      # tracked separately; they are reachable only by someone who already
-      # knows a collection id.
+      # ENABLE_ADMIN_EXPORT above. Knowledge is fully closed: the listing
+      # routes honour BYPASS_ADMIN_ACCESS_CONTROL (PR #960), and the by-id
+      # read routes enforce ownership through Dockerfile.open-webui's
+      # owui-patches/apply_knowledge_authz_patch.py (#1056): GET /{id},
+      # GET /{id}/files, GET /{id}/files/pending and GET /{id}/export now use
+      # the same predicate as the listings (owner, AccessGrants read grant,
+      # or admin when BYPASS_ADMIN_ACCESS_CONTROL is set). Export is also
+      # still blocked at the proxy in Caddyfile.owui as defence in depth,
+      # since this product has no legitimate caller for it.
       #
       # Scope: this does not change who holds the admin role (#748) or the
       # proxy write-verb gap (#949).

--- a/deploy/docker/owui-patches/apply_knowledge_authz_patch.py
+++ b/deploy/docker/owui-patches/apply_knowledge_authz_patch.py
@@ -1,0 +1,81 @@
+"""Build-time ownership enforcement for the Knowledge by-id read routes.
+
+Issue #1056, residual half of #947. PR #960 gated the knowledge listing
+routes on BYPASS_ADMIN_ACCESS_CONTROL, but the by-id read routes still
+short-circuit on user.role == 'admin': GET /{id}, GET /{id}/files (which
+takes include_content and can return document text), GET /{id}/files/pending
+(identical guard text to /files, patched in the same edit), and GET
+/{id}/export (bare get_admin_user, no ownership check at all). On this shared
+chat instance every tenant OWNER is an instance admin, so a collection id,
+which is not secret, was enough to read another tenant's knowledge.
+
+Enforcement matches the listing routes exactly (PR #960): access iff owner,
+or AccessGrants read grant, or admin when BYPASS_ADMIN_ACCESS_CONTROL is set.
+docker-compose.yml sets that flag false, so admins stop reading across
+tenants; flipping it restores upstream behaviour.
+
+Every edit asserts its own effect and fails the build otherwise, so an
+open-webui digest bump whose source shifted breaks loudly instead of silently
+reverting to cross-tenant reads. HIVE_OWUI_KNOWLEDGE_PY overrides the target
+path for scripts/test_owui_knowledge_authz.py.
+"""
+
+import ast
+import os
+import pathlib
+
+TARGET = pathlib.Path(
+    os.environ.get(
+        "HIVE_OWUI_KNOWLEDGE_PY",
+        "/app/backend/open_webui/routers/knowledge.py",
+    )
+)
+
+MARKER = "# hive (#1056)"
+
+SITE_GET_OLD = "        if (\n            user.role == 'admin'\n            or knowledge.user_id == user.id\n"
+
+SITE_FILES_OLD = "    if not (\n        user.role == 'admin'\n        or knowledge.user_id == user.id\n"
+
+EXPORT_OLD = 'async def export_knowledge_by_id(id: str, user=Depends(get_admin_user), db: AsyncSession = Depends(get_async_session)):\n    """\n    Export a knowledge base as a zip file containing .txt files.\n    Admin only.\n    """\n\n    knowledge = await Knowledges.get_knowledge_by_id(id=id, db=db)\n    if not knowledge:\n        raise HTTPException(\n            status_code=status.HTTP_404_NOT_FOUND,\n            detail=ERROR_MESSAGES.NOT_FOUND,\n        )\n    if is_external_knowledge(knowledge):\n        external_knowledge_error()\n'
+SITE_GET_NEW = "        # hive (#1056): instance admin no longer bypasses the read check here;\n        # same predicate as the listing routes (PR #960): owner, AccessGrants\n        # read grant, or admin when BYPASS_ADMIN_ACCESS_CONTROL is set.\n        if (\n            (user.role == 'admin' and BYPASS_ADMIN_ACCESS_CONTROL)\n            or knowledge.user_id == user.id\n"
+
+SITE_FILES_NEW = "    # hive (#1056): instance admin no longer bypasses the read check here;\n    # same predicate as the listing routes (PR #960): owner, AccessGrants\n    # read grant, or admin when BYPASS_ADMIN_ACCESS_CONTROL is set.\n    if not (\n        (user.role == 'admin' and BYPASS_ADMIN_ACCESS_CONTROL)\n        or knowledge.user_id == user.id\n"
+
+EXPORT_NEW = 'async def export_knowledge_by_id(id: str, user=Depends(get_verified_user), db: AsyncSession = Depends(get_async_session)):\n    """\n    Export a knowledge base as a zip file containing .txt files.\n\n    hive (#1056): owner, an AccessGrants read grant, or an admin when\n    BYPASS_ADMIN_ACCESS_CONTROL is explicitly set; previously the bare\n    get_admin_user dependency let any instance admin download any tenant\'s\n    collection as a zip given only its id.\n    """\n\n    knowledge = await Knowledges.get_knowledge_by_id(id=id, db=db)\n    if not knowledge:\n        raise HTTPException(\n            status_code=status.HTTP_404_NOT_FOUND,\n            detail=ERROR_MESSAGES.NOT_FOUND,\n        )\n    if is_external_knowledge(knowledge):\n        external_knowledge_error()\n\n    # hive (#1056): ownership gate replacing the bare get_admin_user\n    # dependency. Same predicate as the listing routes (PR #960).\n    if not (\n        knowledge.user_id == user.id\n        or await AccessGrants.has_access(\n            user_id=user.id,\n            resource_type=\'knowledge\',\n            resource_id=knowledge.id,\n            permission=\'read\',\n            db=db,\n        )\n        or (user.role == \'admin\' and BYPASS_ADMIN_ACCESS_CONTROL)\n    ):\n        raise HTTPException(\n            status_code=status.HTTP_401_UNAUTHORIZED,\n            detail=ERROR_MESSAGES.ACCESS_PROHIBITED,\n        )\n'
+
+text = TARGET.read_text()
+n = text.count(MARKER)
+if n == 4:
+    print("apply_knowledge_authz_patch: already applied")
+    raise SystemExit(0)
+
+assert text.count(SITE_GET_OLD) == 1, (
+    "GET /{id} admin short-circuit not found exactly once; upstream "
+    "open-webui source shifted, patch needs updating"
+)
+assert text.count(SITE_FILES_OLD) == 2, (
+    "shared /files admin short-circuit not found exactly twice (GET "
+    "/{id}/files and GET /{id}/files/pending); upstream open-webui source "
+    "shifted, patch needs updating"
+)
+assert text.count(EXPORT_OLD) == 1, (
+    "export route head not found exactly once; upstream open-webui source "
+    "shifted, patch needs updating"
+)
+
+patched = text.replace(SITE_GET_OLD, SITE_GET_NEW, 1)
+patched = patched.replace(SITE_FILES_OLD, SITE_FILES_NEW)
+patched = patched.replace(EXPORT_OLD, EXPORT_NEW, 1)
+
+assert patched.count(MARKER) == 4, "expected four #1056 markers after patching"
+assert SITE_GET_OLD not in patched
+assert SITE_FILES_OLD not in patched
+assert EXPORT_OLD not in patched
+ast.parse(patched)  # fails the build if the rewrite produced invalid Python
+
+TARGET.write_text(patched)
+print(
+    "apply_knowledge_authz_patch: enforced ownership on GET /{id}, "
+    "GET /{id}/files, GET /{id}/files/pending and GET /{id}/export"
+)

--- a/scripts/test_owui_knowledge_authz.py
+++ b/scripts/test_owui_knowledge_authz.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Self-check for Knowledge by-id ownership enforcement (issue #1056).
+
+Runs the real build-time patch against a copy of the vendored knowledge.py and
+asserts the result. Structural, no framework, no network.
+Run: python3 scripts/test_owui_knowledge_authz.py
+"""
+
+import ast
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PATCH = REPO_ROOT / "deploy/docker/owui-patches/apply_knowledge_authz_patch.py"
+VENDORED = REPO_ROOT / "vendor/open-webui/backend/open_webui/routers/knowledge.py"
+
+def main() -> int:
+    vendored = VENDORED.read_text()
+    if "user.role == 'admin'\n            or knowledge.user_id == user.id" not in vendored:
+        print("FAIL: vendored source drifted; update this check")
+        return 1
+    dest = Path(tempfile.mkdtemp()) / "knowledge.py"
+    shutil.copy(VENDORED, dest)
+    env = dict(os.environ)
+    env["HIVE_OWUI_KNOWLEDGE_PY"] = str(dest)
+    r = subprocess.run([sys.executable, str(PATCH)], env=env,
+                       capture_output=True, text=True)
+    if r.returncode != 0:
+        print("FAIL: patch failed:", r.stdout + r.stderr)
+        return 1
+    patched = dest.read_text()
+    checks = {
+        "four markers": patched.count("# hive (#1056)") == 4,
+        "GET gate flag-gated":
+            "(user.role == 'admin' and BYPASS_ADMIN_ACCESS_CONTROL)\n            or knowledge.user_id == user.id" in patched,
+        "/files gates flag-gated x2":
+            patched.count("(user.role == 'admin' and BYPASS_ADMIN_ACCESS_CONTROL)\n        or knowledge.user_id == user.id") == 2,
+        "export uses get_verified_user":
+            "Depends(get_verified_user), db: AsyncSession" in patched,
+        "old short-circuits gone":
+            "user.role == 'admin'\n            or knowledge.user_id == user.id" not in patched
+            and "user.role == 'admin'\n        or knowledge.user_id == user.id" not in patched,
+        "patched source compiles": isinstance(ast.parse(patched), ast.Module),
+        "negative control intact":
+            "user.role == 'admin'\n            or knowledge.user_id == user.id" in vendored,
+    }
+    failed = [k for k, v in checks.items() if not v]
+    for k, v in checks.items():
+        print(("PASS " if v else "FAIL ") + k)
+    if failed:
+        print("FAIL: " + ", ".join(failed))
+        return 1
+    print("ok: knowledge by-id routes enforce ownership (#1056)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## SECURITY fix: Knowledge by-id routes read across tenants (residual half of #947)

Closes #1056.

**Do not merge before the other parity-sec fixes; reviewers please prioritize.**

### Defect

PR #960 gated the knowledge LISTING routes (`GET /`, `GET /search`) on `BYPASS_ADMIN_ACCESS_CONTROL`, which docker-compose.yml sets to `false`. Three by-id read routes in the chat backend never consulted it and short-circuited on `user.role == 'admin'`:

| Route | Old behaviour |
|---|---|
| `GET /api/v1/knowledge/{id}` | admin read any collection |
| `GET /api/v1/knowledge/{id}/files` | admin list files; `include_content=true` returned extracted document text |
| `GET /api/v1/knowledge/{id}/export` | bare `get_admin_user`, no ownership check at all: full zip of any tenant's collection given only its id |

A fourth route, `GET /{id}/files/pending`, carries the identical guard text and got the same fix in the same edit.

On this shared chat instance every tenant OWNER is an Open WebUI instance admin (issue #748 family), so a collection id, which is not secret (shared links, support tickets, logs), was enough to read another tenant's knowledge.

### Mechanism

The chat image builds only the frontend from `vendor/open-webui`; the backend comes from the pinned upstream image, so an edit to vendored backend Python is inert at runtime unless applied through `owui-patches`. This PR follows the established pattern (`apply_tenant_role_patch.py` and siblings): new `deploy/docker/owui-patches/apply_knowledge_authz_patch.py` rewrites all four gates at image build time with exact-count anchors plus an `ast.parse` check, failing the build loudly if upstream source shifts.

### Enforcement semantics

All four routes now use exactly the listing routes' predicate: access iff owner, or `AccessGrants.has_access(..., permission='read')`, or admin when `BYPASS_ADMIN_ACCESS_CONTROL` is set. With the compose value `false`, instance admins stop reading across tenants; flipping the flag restores upstream behaviour for deployments that want it.

### Verification

1. Patch run against the vendored source: four markers, idempotent re-run exits 0.
2. Image build green: patch step logged "enforced ownership", the RUN line's independent assertions passed (`grep -c '# hive (#1056)' -eq 4`, `ast.parse`).
3. Built image inspected directly: 4 markers present in `/app/backend/open_webui/routers/knowledge.py`, export route now `Depends(get_verified_user)`.
4. New CI self-check `scripts/test_owui_knowledge_authz.py` (wired into `make test-scripts`) passes locally, including its negative control that keeps the test able to go red.
