### PR TITLE
feat(chat): chat parity wave 2, Knowledge nav lands in the shell (#1109)

### DIFF
--- a/vendor/open-webui/src/lib/hive/KnowledgeIndex.svelte
+++ b/vendor/open-webui/src/lib/hive/KnowledgeIndex.svelte
@@ -47,9 +47,19 @@
 
 		try {
 			const res = await getKnowledgeBases(localStorage.token);
-			items = res?.items ?? [];
-		} catch (e) {
-			error = typeof e === 'string' ? e : 'Failed to load knowledge bases';
+			// A null return is the client's own failure path (the fetch helper
+			// swallows a rejected request whose error carried no detail), not an
+			// empty account. Mapping it to [] would report a network failure as
+			// a fact about the caller's data.
+			if (!res) {
+				throw new Error('knowledge list unavailable');
+			}
+			items = res.items ?? [];
+		} catch {
+			// The backend's `detail` string is never rendered: error copy at this
+			// boundary is one translated generic message, per the provider-blind
+			// errors rule.
+			error = $i18n.t('Failed to load your knowledge bases.');
 		} finally {
 			loaded = true;
 		}

--- a/vendor/open-webui/src/lib/hive/KnowledgeIndex.svelte
+++ b/vendor/open-webui/src/lib/hive/KnowledgeIndex.svelte
@@ -1,0 +1,90 @@
+<script lang="ts">
+	import { getContext, onMount } from 'svelte';
+	import { goto } from '$app/navigation';
+	import dayjs from 'dayjs';
+	import relativeTime from 'dayjs/plugin/relativeTime';
+
+	dayjs.extend(relativeTime);
+
+	import { user } from '$lib/stores';
+	import { getKnowledgeBases } from '$lib/apis/knowledge';
+
+	const i18n: any = getContext('i18n');
+
+	/*
+	 * A read-only index of the signed-in caller's own knowledge bases.
+	 *
+	 * The sidebar's Knowledge row points at /knowledge rather than at
+	 * /workspace/knowledge because that page sits behind the workspace layout's
+	 * permission guard, which bounces a non-admin without the workspace.knowledge
+	 * permission straight home (#1109). The bounce is what made the row read as
+	 * dead: the click navigates fine, and the guard sends the person back before
+	 * anything renders. This surface lives outside that guard and reads
+	 * GET /api/v1/knowledge/ directly, which needs only a verified user; it lists
+	 * what the caller can actually see, so an account with no bases gets an
+	 * honest empty state rather than a redirect.
+	 *
+	 * An admin or an account holding the workspace.knowledge permission is
+	 * forwarded to /workspace/knowledge, the full management surface (create,
+	 * upload, delete, sharing). Everyone else gets this list.
+	 */
+
+	let loaded = false;
+	let error: string | null = null;
+	type KnowledgeBase = {
+		id: string;
+		name: string;
+		description?: string | null;
+		updated_at: number;
+	};
+	let items: KnowledgeBase[] = [];
+
+	onMount(async () => {
+		if ($user?.role === 'admin' || $user?.permissions?.workspace?.knowledge) {
+			goto('/workspace/knowledge');
+			return;
+		}
+
+		try {
+			const res = await getKnowledgeBases(localStorage.token);
+			items = res?.items ?? [];
+		} catch (e) {
+			error = typeof e === 'string' ? e : 'Failed to load knowledge bases';
+		} finally {
+			loaded = true;
+		}
+	});
+
+	const updated = (ts: number): string => dayjs(ts * 1000).fromNow();
+</script>
+
+<div class="hv-panel-region">
+	<div class="hv-kb" data-hive-knowledge-index>
+		<header>
+			<h1 class="hv-kb-title">{$i18n.t('Knowledge')}</h1>
+			<p class="hv-kb-subtitle">{$i18n.t('The documents your chats can search.')}</p>
+		</header>
+
+		{#if !loaded}
+			<p class="hv-kb-status">{$i18n.t('Loading...')}</p>
+		{:else if error}
+			<p class="hv-kb-status">{error}</p>
+		{:else if items.length === 0}
+			<p class="hv-kb-status">{$i18n.t('No knowledge bases are shared with you yet.')}</p>
+		{:else}
+			<ul class="hv-kb-list">
+				{#each items as kb (kb.id)}
+					<li class="hv-kb-item">
+						<div class="hv-kb-item-main">
+							<p class="hv-kb-name">{kb.name}</p>
+							{#if kb.description}
+								<p class="hv-kb-description">{kb.description}</p>
+							{/if}
+						</div>
+						<time class="hv-kb-updated">{updated(kb.updated_at)}</time>
+					</li>
+				{/each}
+			</ul>
+		{/if}
+	</div>
+</div>

--- a/vendor/open-webui/src/lib/hive/hive.css
+++ b/vendor/open-webui/src/lib/hive/hive.css
@@ -565,3 +565,74 @@ samp,
 	min-height: 0;
 	overflow-y: auto;
 }
+
+/* ------------------------------------------------------------------ *
+ * Knowledge index (#1109)
+ *
+ * The read-only list a non-admin lands on from the sidebar row. Styled
+ * like the 404 card and the agent panel: one bordered column on the
+ * canvas, tokens only.
+ * ------------------------------------------------------------------ */
+.hv-kb {
+	max-width: var(--hv-measure);
+	margin: var(--hv-space-12) auto;
+	padding: 0 var(--hv-space-6);
+}
+
+.hv-kb-title {
+	font-family: var(--hv-font-display);
+	font-size: var(--hv-display-sm);
+	line-height: var(--hv-leading-display-sm);
+	letter-spacing: -0.015em;
+	color: var(--hv-ink);
+}
+
+.hv-kb-subtitle {
+	margin-top: var(--hv-space-2);
+	font-family: var(--hv-font-sans);
+	font-size: var(--hv-text-base);
+	line-height: var(--hv-leading-base);
+	color: var(--hv-ink-secondary);
+}
+
+.hv-kb-status {
+	margin-top: var(--hv-space-8);
+	font-family: var(--hv-font-sans);
+	color: var(--hv-ink-muted);
+}
+
+.hv-kb-list {
+	margin-top: var(--hv-space-6);
+	border-top: 1px solid var(--hv-border);
+}
+
+.hv-kb-item {
+	display: flex;
+	align-items: baseline;
+	justify-content: space-between;
+	gap: var(--hv-space-4);
+	padding: var(--hv-space-4) 0;
+	border-bottom: 1px solid var(--hv-border);
+}
+
+.hv-kb-name {
+	font-family: var(--hv-font-sans);
+	font-weight: var(--hv-weight-label);
+	color: var(--hv-ink);
+}
+
+.hv-kb-description {
+	margin-top: var(--hv-space-1);
+	font-family: var(--hv-font-sans);
+	font-size: var(--hv-text-sm);
+	line-height: var(--hv-leading-sm);
+	color: var(--hv-ink-secondary);
+}
+
+.hv-kb-updated {
+	flex-shrink: 0;
+	font-family: var(--hv-font-mono);
+	font-size: var(--hv-text-xs);
+	line-height: var(--hv-leading-xs);
+	color: var(--hv-ink-muted);
+}

--- a/vendor/open-webui/src/lib/hive/nav.test.ts
+++ b/vendor/open-webui/src/lib/hive/nav.test.ts
@@ -44,6 +44,14 @@ describe('HIVE_NAV', () => {
 		expect(byId('scheduled').href).toBe('/schedules');
 	});
 
+	it('points Knowledge at its own top-level route, outside the workspace permission guard (#1109)', () => {
+		// /workspace/knowledge sits behind the workspace layout's permission
+		// guard and bounced a non-admin straight home, which is what made this
+		// row read as dead on the demo box. The top-level route renders the
+		// read-only index instead.
+		expect(byId('knowledge').href).toBe('/knowledge');
+	});
+
 	it('gives every row a unique id, a label and an in-app href', () => {
 		const ids = HIVE_NAV.map((item) => item.id);
 		expect(new Set(ids).size).toBe(ids.length);
@@ -68,7 +76,7 @@ describe('isNavItemActive', () => {
 
 	it('does not match a route that merely starts with the same characters', () => {
 		expect(isNavItemActive(agents, '/agents-archive')).toBe(false);
-		expect(isNavItemActive(knowledge, '/workspace/knowledgebase')).toBe(false);
+		expect(isNavItemActive(knowledge, '/knowledgebase')).toBe(false);
 	});
 
 	it('treats an empty or missing pathname as no match, since no row links to it', () => {
@@ -81,7 +89,7 @@ describe('isNavItemActive', () => {
 			'/projects',
 			'/projects/abc',
 			'/agents',
-			'/workspace/knowledge',
+			'/knowledge',
 			'/schedules'
 		]) {
 			const active = HIVE_NAV.filter((item) => isNavItemActive(item, route));

--- a/vendor/open-webui/src/lib/hive/nav.ts
+++ b/vendor/open-webui/src/lib/hive/nav.ts
@@ -48,9 +48,15 @@ export const HIVE_NAV: readonly HiveNavItem[] = [
 	{
 		id: 'knowledge',
 		label: 'Knowledge',
-		href: '/workspace/knowledge',
+		// '/knowledge', not '/workspace/knowledge': the workspace layout's
+		// permission guard bounces a non-admin without the workspace.knowledge
+		// permission straight home (#1109), which made this row highlight and do
+		// nothing on the demo box. The /knowledge route sits outside that guard
+		// and renders a read-only index of the caller's own bases; an admin or a
+		// permitted account is forwarded to the full workspace surface.
+		href: '/knowledge',
 		icon: 'knowledge',
-		activePaths: ['/workspace/knowledge']
+		activePaths: ['/knowledge']
 	},
 	{
 		id: 'scheduled',

--- a/vendor/open-webui/src/routes/(app)/knowledge/+page.svelte
+++ b/vendor/open-webui/src/routes/(app)/knowledge/+page.svelte
@@ -1,0 +1,9 @@
+<script>
+	// #1109: the Knowledge nav row pointed at /workspace/knowledge, which sits
+	// behind the workspace layout's permission guard and bounced a non-admin
+	// without the workspace.knowledge permission straight back home. This route
+	// lives outside that guard; see hive/KnowledgeIndex.svelte for the surface.
+	import KnowledgeIndex from '$lib/hive/KnowledgeIndex.svelte';
+</script>
+
+<KnowledgeIndex />


### PR DESCRIPTION
## Summary

Chat parity wave 2. Five of the six dispatched slices were already landed on main by #1161 earlier today; this PR carries the one remaining slice and records where each of the six stands.

1. **Fixed reading measure and hairline turn rules**: shipped in #1161 (slice 3). The transcript, composer column and turn separators share `--hv-measure`, with 1px rules between message rows via `.message-listitem + .message-listitem`.
2. **Four quick-start chips under the composer**: shipped in #1161 (slice 2) as `hive/QuickStartChips.svelte`. Chips seed the composer via `setText` and focus it; nothing auto-sends.
3. **Catalog purpose subtitles in the model picker**: shipped in #1161 (slice 2). `ModelItem.svelte` renders the catalog `description` (the catalog summary carried additively by GET /v1/models) as a subtitle line per alias.
4. **404 and loading states inside the app shell**: 404 shipped in #1161 (slice 1) as the `[...hivePath]` catch-all rendering branded chrome; in-shell slow-load state is the existing sidebar-plus-spinner block in `(app)/+layout.svelte`. The pre-hydration splash image remains an upstream asset, unchanged here.
5. **Theme control at exactly three options**: shipped in #1161 (slice 1). General settings offers System, Light and Dark only; the choice persists to localStorage and System honors `prefers-color-scheme`.
6. **Knowledge nav (#1109), new in this PR**: the row pointed at `/workspace/knowledge`, which sits behind the workspace layout's permission guard. That guard bounces a non-admin without the workspace.knowledge permission straight home, so the click navigated and the person landed back where they started: the row highlighted and did nothing. A new top-level `/knowledge` route outside that guard renders a read-only index of the caller's own bases from `GET /api/v1/knowledge/` (verified-user endpoint); admins and accounts holding the workspace.knowledge permission are forwarded to the full workspace surface. Nav data, tests and hive.css styles updated together.

## Verification

- Full frontend unit suite: `npx vitest run`, 12 files, 119 tests passed.
- Image build from this worktree: `docker build -f deploy/docker/Dockerfile.open-webui -t hive-open-webui:parity2 .` exited 0; final assertion line printed exactly: `hive: shell present, removed surfaces absent`.
- Token audit: every `--hv-*` variable referenced by `hive.css` resolves to a definition in `packages/hive-tokens/tokens.css`; zero unresolved references.
- Class anchors preserved: `.message-listitem`, `chat-assistant`, `data-hive-nav` untouched.

## Test plan

- [x] Frontend unit tests pass
- [x] Image build passes with fail-loud bundle assertions
- [x] Token audit clean
- [ ] Visual proof capture at merge time (orchestrator)

## Known risks

- The read-only index shows only what `GET /api/v1/knowledge/` returns for that caller; a tenant user sees bases shared with them through groups. If product later wants inline document listing from this page, it is a follow-up.
- #1056 (knowledge admin short-circuit across tenants) is being handled separately on the backend router; the frontend surface here consumes the same endpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Knowledge page accessible from the main navigation.
  * Administrators and permitted users can access full knowledge-base management.
  * Other signed-in users can view accessible knowledge bases, including descriptions and relative update times.
  * Added loading, error, and empty states for the knowledge-base list.

* **Bug Fixes**
  * Updated navigation highlighting to correctly recognize Knowledge pages and subpages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->