### PR TITLE
fix: acquire audit writer advisory lock before SERIALIZABLE snapshot forms

### DIFF
--- a/apps/control-plane/internal/audit/monthlockkey_test.go
+++ b/apps/control-plane/internal/audit/monthlockkey_test.go
@@ -1,0 +1,70 @@
+package audit_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/audit"
+)
+
+// TestMonthLockKey_PinnedValues pins audit.MonthLockKey against known
+// timestamps, including a UTC month boundary and two non-UTC-zoned
+// timestamps that land on the opposite side of a month boundary from
+// their own local calendar date. This is what stops a future change
+// from reintroducing a dependency on the caller's (or Postgres's
+// session) timezone: MonthLockKey must bucket purely on the instant's
+// UTC month, not on whatever Location happens to be attached to the
+// time.Time it's given (#1188 review thread).
+func TestMonthLockKey_PinnedValues(t *testing.T) {
+	newYork, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Fatalf("load America/New_York: %v", err)
+	}
+	tokyo, err := time.LoadLocation("Asia/Tokyo")
+	if err != nil {
+		t.Fatalf("load Asia/Tokyo: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		ts   time.Time
+		want time.Time // UTC month-start the key must correspond to
+	}{
+		{
+			name: "UTC mid-month",
+			ts:   time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC),
+			want: time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name: "UTC exact month boundary",
+			ts:   time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+			want: time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			// 2026-01-31 23:30 America/New_York (EST, UTC-5) is
+			// 2026-02-01 04:30 UTC: the local calendar date is still
+			// January, but the UTC instant is already February.
+			name: "non-UTC zone: local date lags the UTC month",
+			ts:   time.Date(2026, 1, 31, 23, 30, 0, 0, newYork),
+			want: time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			// 2026-06-01 03:00 Asia/Tokyo (JST, UTC+9) is
+			// 2026-05-31 18:00 UTC: the local calendar date is
+			// already June, but the UTC instant is still May.
+			name: "non-UTC zone: local date leads the UTC month",
+			ts:   time.Date(2026, 6, 1, 3, 0, 0, 0, tokyo),
+			want: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := audit.MonthLockKey(tc.ts)
+			want := tc.want.Unix()
+			if got != want {
+				t.Errorf("MonthLockKey(%v) = %d, want %d (%v)", tc.ts, got, want, tc.want)
+			}
+		})
+	}
+}

--- a/apps/control-plane/internal/audit/sync.go
+++ b/apps/control-plane/internal/audit/sync.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgerrcode"
@@ -31,6 +32,54 @@ type SyncWriter struct {
 
 func NewSyncWriter(pool *pgxpool.Pool, cfg WriterConfig) *SyncWriter {
 	return &SyncWriter{pool: pool, cfg: cfg}
+}
+
+// MonthLockKey derives the audit-writer advisory lock key for ts's
+// absolute instant, bucketed by UTC calendar month. Exported so #1182's
+// regression test can pin known values without reaching into the
+// package, and so the derivation is a pure, directly-testable function
+// rather than inline arithmetic duplicated across the lock and unlock
+// call sites.
+//
+// ts is forced to UTC here regardless of the Location it arrives with.
+// writeOnce's ts is already UTC (canonical.TruncateTS calls .UTC()),
+// but this function does not trust that: it is the single source of
+// truth for "which month does this instant belong to", and it must
+// give the same answer for the same instant no matter what Location
+// happened to be attached to the caller's time.Time. That is also why
+// it is pure Go arithmetic rather than a `SELECT date_trunc('month',
+// $1::timestamptz)` round trip: a SQL date_trunc on a timestamptz
+// buckets by the session's TimeZone GUC, not by UTC, so the old
+// pg_advisory_xact_lock version of this file computed a DIFFERENT key
+// for the same event on any session whose TimeZone wasn't UTC. See
+// assertUTCSession below for the other half of closing that gap:
+// making today's "Supabase defaults to UTC" assumption true by
+// construction instead of true by luck (#1188 review thread).
+func MonthLockKey(ts time.Time) int64 {
+	ts = ts.UTC()
+	monthStart := time.Date(ts.Year(), ts.Month(), 1, 0, 0, 0, 0, time.UTC)
+	return monthStart.Unix()
+}
+
+// assertUTCSession fails loudly, instead of silently computing a
+// mismatched lock key, if this connection's session TimeZone GUC is
+// ever not UTC. Nothing in apps/control-plane/internal/platform/db/
+// pool.go sets TimeZone explicitly today, so it is UTC only because
+// Supabase's default happens to be UTC — unasserted, true by luck. Run
+// on every write (not cached past the first check): the risk this
+// guards is a config drift making the assumption false at some point
+// in this process's lifetime, not only at startup, and the added round
+// trip is one cheap query on a connection already checked out for the
+// advisory lock.
+func assertUTCSession(ctx context.Context, conn *pgxpool.Conn) error {
+	var tz string
+	if err := conn.QueryRow(ctx, `SHOW TimeZone`).Scan(&tz); err != nil {
+		return fmt.Errorf("audit: check session timezone: %w", err)
+	}
+	if !strings.EqualFold(tz, "UTC") && !strings.EqualFold(tz, "Etc/UTC") {
+		return fmt.Errorf("audit: session TimeZone is %q, not UTC; refusing to write because MonthLockKey is computed in UTC and would silently diverge from a SQL date_trunc-based reading of the same month under any other session timezone (#1188)", tz)
+	}
+	return nil
 }
 
 // Write inserts a single audit row and chains it off the last row in
@@ -96,16 +145,17 @@ func (w *SyncWriter) writeOnce(ctx context.Context, e Event, before, after []byt
 	ts := canonical.TruncateTS(time.Now())
 	monthStart := time.Date(ts.Year(), ts.Month(), 1, 0, 0, 0, 0, time.UTC)
 	monthEnd := monthStart.AddDate(0, 1, 0)
-	// Lock key is the month's epoch as bigint (not ::int, which is
-	// 32-bit and would silently overflow in January 2038), computed
-	// once here in Go and reused for both lock and unlock below.
-	lockKey := monthStart.Unix()
+	lockKey := MonthLockKey(ts)
 
 	conn, err := w.pool.Acquire(ctx)
 	if err != nil {
 		return fmt.Errorf("audit: acquire conn: %w", err)
 	}
 	defer conn.Release()
+
+	if err := assertUTCSession(ctx, conn); err != nil {
+		return err
+	}
 
 	// Session-scoped advisory lock, acquired BEFORE the SERIALIZABLE
 	// transaction opens, held until the explicit unlock below.

--- a/apps/control-plane/internal/audit/sync.go
+++ b/apps/control-plane/internal/audit/sync.go
@@ -54,7 +54,12 @@ func NewSyncWriter(pool *pgxpool.Pool, cfg WriterConfig) *SyncWriter {
 // with serialisation_failure (40001). We retry the entire transaction
 // up to maxSerializationRetries because each attempt is short and
 // retrying with a fresh `ts` keeps the row attributable to its true
-// commit time, not its first attempt.
+// commit time, not its first attempt. As of #1182 the advisory lock
+// is held from before BeginTx through the explicit unlock (see
+// writeOnce), so two SyncWriter.Write calls racing each other no
+// longer produce 40001 at all — the retry loop is defense-in-depth
+// against a conflict from something else entirely serializable on
+// public.audit_log, not the writer's own concurrency.
 func (w *SyncWriter) Write(ctx context.Context, e Event) error {
 	if e.Action == "" {
 		return errors.New("audit: action required")
@@ -84,32 +89,65 @@ func (w *SyncWriter) Write(ctx context.Context, e Event) error {
 }
 
 func (w *SyncWriter) writeOnce(ctx context.Context, e Event, before, after []byte) error {
-	tx, err := w.pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.Serializable})
-	if err != nil {
-		return fmt.Errorf("audit: begin tx: %w", err)
-	}
-	defer func() { _ = tx.Rollback(ctx) }()
-
 	// Truncate to microseconds so the canonical hash, the canonical
 	// timestamp string, and the value Postgres stores are identical.
 	// Re-captured per attempt so a retried row carries its actual
 	// commit time, not the first attempt's stale time.
 	ts := canonical.TruncateTS(time.Now())
-
-	// Advisory lock keyed on the month's epoch as bigint. ::int was
-	// 32-bit and would silently overflow in January 2038; ::bigint is
-	// 64-bit and matches pg_advisory_xact_lock(bigint) so the lock
-	// namespace is unambiguous.
-	if _, err := tx.Exec(
-		ctx,
-		`SELECT pg_advisory_xact_lock(extract(epoch from date_trunc('month', $1::timestamptz))::bigint)`,
-		ts,
-	); err != nil {
-		return fmt.Errorf("audit: advisory lock: %w", err)
-	}
-
 	monthStart := time.Date(ts.Year(), ts.Month(), 1, 0, 0, 0, 0, time.UTC)
 	monthEnd := monthStart.AddDate(0, 1, 0)
+	// Lock key is the month's epoch as bigint (not ::int, which is
+	// 32-bit and would silently overflow in January 2038), computed
+	// once here in Go and reused for both lock and unlock below.
+	lockKey := monthStart.Unix()
+
+	conn, err := w.pool.Acquire(ctx)
+	if err != nil {
+		return fmt.Errorf("audit: acquire conn: %w", err)
+	}
+	defer conn.Release()
+
+	// Session-scoped advisory lock, acquired BEFORE the SERIALIZABLE
+	// transaction opens, held until the explicit unlock below.
+	//
+	// Postgres takes a SERIALIZABLE transaction's snapshot at the
+	// first statement inside it, not at BEGIN. The previous version of
+	// this writer took the lock with pg_advisory_xact_lock as that
+	// first statement: every concurrent writer's snapshot was formed
+	// the instant it started waiting on the lock, not the instant it
+	// actually got its turn, so each one committed against a MAX(seq)
+	// read that was already stale by the time it ran — the textbook
+	// SSI write-skew shape, and exactly why 6 of 10 fully-simultaneous
+	// writers failed with SQLSTATE 40001 (#1182). Acquiring the lock
+	// on the plain session first, before BEGIN, means the transaction
+	// below can only take its snapshot once this writer already has
+	// exclusive possession of the month, so nothing downstream of
+	// BEGIN can observe a stale one.
+	//
+	// Session- not transaction-scoped deliberately: it must survive
+	// past BeginTx to Commit. If the connection drops mid-hold,
+	// Postgres releases the session lock when the backend terminates,
+	// so the failure mode is one orphaned physical connection (which
+	// the pool detects and evicts on the next health check), never a
+	// permanently stuck lock. Same acquire/exec/defer-release shape as
+	// accounting.PgxAccountLocker (internal/accounting/pglock.go); no
+	// in-process gate is needed here the way that locker needs one,
+	// because this critical section never asks the pool for a second
+	// connection while holding the first.
+	if _, err := conn.Exec(ctx, `SELECT pg_advisory_lock($1)`, lockKey); err != nil {
+		return fmt.Errorf("audit: advisory lock: %w", err)
+	}
+	defer func() {
+		// Background context: unlock must run even if ctx was cancelled.
+		_, _ = conn.Exec(context.Background(), `SELECT pg_advisory_unlock($1)`, lockKey)
+	}()
+
+	tx, err := conn.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.Serializable})
+	if err != nil {
+		return fmt.Errorf("audit: begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
 	tenantArg := nullableUUID(e.TenantID)
 
 	var maxSeq int64

--- a/apps/control-plane/internal/audit/sync_concurrency_test.go
+++ b/apps/control-plane/internal/audit/sync_concurrency_test.go
@@ -16,7 +16,9 @@ import (
 
 // TestSyncWriter_ConcurrentWrites_ExactlyNRows drives N fully simultaneous
 // SyncWriter.Write calls straight at the writer, with no HTTP layer and no
-// caller-level retry, and asserts EXACTLY N rows land — not "at least one".
+// caller-level retry, and asserts EXACTLY N rows land — not "at least one" —
+// AND that the writer's advisory lock is fully released afterward, not just
+// that N writes were fast enough to look serialized.
 //
 // Before #1182's fix, this reproduces the diagnosed failure directly: the
 // SERIALIZABLE snapshot inside writeOnce was taken at the first statement
@@ -26,6 +28,12 @@ import (
 // COMMIT with 40001 once it detects the resulting write skew on the shared
 // MAX(seq) read, and the writer's own 3-attempt retry is not enough to cover
 // 10-way full concurrency.
+//
+// The row-count assertion alone proves throughput, not release: ten
+// sequential-ish writes through a leaked-but-somehow-reacquired lock could
+// still land ten rows. The pg_locks assertion at the end is what actually
+// tests the risk this PR carries (a held session-scoped lock never being
+// unlocked) rather than a proxy for it (#1188 review thread).
 func TestSyncWriter_ConcurrentWrites_ExactlyNRows(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -38,6 +46,10 @@ func TestSyncWriter_ConcurrentWrites_ExactlyNRows(t *testing.T) {
 	tenantID := uuid.New()
 	actorID := uuid.New()
 	const n = 10
+	// Captured once, before any write, so every write in this run is
+	// expected to land in the same UTC month bucket and the pg_locks
+	// check below queries the exact key writeOnce used.
+	lockKey := audit.MonthLockKey(time.Now())
 
 	errs := make([]error, n)
 	var wg sync.WaitGroup
@@ -73,6 +85,42 @@ func TestSyncWriter_ConcurrentWrites_ExactlyNRows(t *testing.T) {
 		`SELECT count(*) FROM public.audit_log WHERE tenant_id=$1 AND actor_id=$2 AND action='CROSS_TENANT_ATTEMPT'`,
 		tenantID, actorID).Scan(&rowCount))
 	require.Equal(t, n, rowCount, "N fully-simultaneous writes must produce exactly N audit rows, not merely at-least-one")
+
+	// By the time wg.Wait() returned above, every goroutine's w.Write()
+	// call had already returned — which only happens after writeOnce's
+	// deferred pg_advisory_unlock and conn.Release() have both run. So
+	// THIS test's own writes cannot be the source of a lock still held
+	// below. What CAN legitimately still be held for a few more
+	// milliseconds: the lock key is coarse-grained (per UTC calendar
+	// month, not per test, not per package), and `go test ./a/... ./b/...`
+	// runs different packages' test binaries concurrently by default.
+	// internal/tenants' own Switch concurrency tests also drive real
+	// audit.SyncWriter writes against this same live Postgres, land in
+	// the same month's key, and can genuinely be mid-write at the exact
+	// instant this check runs — that's the lock doing its job for a
+	// DIFFERENT writer, not this one leaking. A real leak never clears;
+	// a neighboring package's in-flight write clears within one write's
+	// duration (tens of milliseconds per the timings above), so poll
+	// briefly instead of checking once. pg_locks splits a single-bigint
+	// advisory lock into its high/low 32 bits as classid/objid with
+	// objsubid=1 (see PostgreSQL docs, System Catalogs > pg_locks).
+	highBits := lockKey >> 32
+	lowBits := lockKey & 0xFFFFFFFF
+	var heldLocks int
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		require.NoError(t, pool.QueryRow(ctx,
+			`SELECT count(*) FROM pg_locks
+			  WHERE locktype = 'advisory' AND objsubid = 1
+			    AND classid::bigint = $1 AND objid::bigint = $2`,
+			highBits, lowBits).Scan(&heldLocks))
+		if heldLocks == 0 || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	require.Zero(t, heldLocks,
+		"advisory lock %d must be fully released within 2s of every write returning; a nonzero count means SyncWriter leaked the session-scoped lock (#1188 review thread)", lockKey)
 }
 
 func newSyncConcurrencyPool(t *testing.T, ctx context.Context) *pgxpool.Pool {

--- a/apps/control-plane/internal/audit/sync_concurrency_test.go
+++ b/apps/control-plane/internal/audit/sync_concurrency_test.go
@@ -1,0 +1,87 @@
+package audit_test
+
+import (
+	"context"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/audit"
+)
+
+// TestSyncWriter_ConcurrentWrites_ExactlyNRows drives N fully simultaneous
+// SyncWriter.Write calls straight at the writer, with no HTTP layer and no
+// caller-level retry, and asserts EXACTLY N rows land — not "at least one".
+//
+// Before #1182's fix, this reproduces the diagnosed failure directly: the
+// SERIALIZABLE snapshot inside writeOnce was taken at the first statement
+// after BeginTx (the old pg_advisory_xact_lock call), which is BEFORE that
+// lock is actually granted, so concurrent writers blocked on the lock each
+// already held a snapshot that predates their turn. Postgres SSI aborts the
+// COMMIT with 40001 once it detects the resulting write skew on the shared
+// MAX(seq) read, and the writer's own 3-attempt retry is not enough to cover
+// 10-way full concurrency.
+func TestSyncWriter_ConcurrentWrites_ExactlyNRows(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	pool := newSyncConcurrencyPool(t, ctx)
+	t.Cleanup(func() { pool.Close() })
+
+	w := audit.NewSyncWriter(pool, audit.WriterConfig{DeploySHA: "concurrency-test", Env: "test"})
+
+	tenantID := uuid.New()
+	actorID := uuid.New()
+	const n = 10
+
+	errs := make([]error, n)
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			<-start
+			errs[idx] = w.Write(ctx, audit.Event{
+				TenantID:  tenantID,
+				Actor:     audit.Actor{ID: actorID, Type: audit.ActorUser},
+				Action:    audit.ActionCrossTenantAttempt,
+				Severity:  audit.SeverityCritical,
+				RequestID: uuid.New(),
+			})
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	failed := 0
+	for i, err := range errs {
+		if err != nil {
+			failed++
+			t.Logf("write %d failed: %v", i, err)
+		}
+	}
+	require.Zero(t, failed, "%d of %d fully-simultaneous audit.SyncWriter.Write calls failed; N simultaneous writes must produce N rows (#1182)", failed, n)
+
+	var rowCount int
+	require.NoError(t, pool.QueryRow(ctx,
+		`SELECT count(*) FROM public.audit_log WHERE tenant_id=$1 AND actor_id=$2 AND action='CROSS_TENANT_ATTEMPT'`,
+		tenantID, actorID).Scan(&rowCount))
+	require.Equal(t, n, rowCount, "N fully-simultaneous writes must produce exactly N audit rows, not merely at-least-one")
+}
+
+func newSyncConcurrencyPool(t *testing.T, ctx context.Context) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("HIVE_TEST_DB_URL")
+	if dsn == "" {
+		t.Skip("HIVE_TEST_DB_URL not set")
+	}
+	pool, err := pgxpool.New(ctx, dsn)
+	require.NoError(t, err)
+	return pool
+}

--- a/apps/control-plane/internal/tenants/http_test.go
+++ b/apps/control-plane/internal/tenants/http_test.go
@@ -202,24 +202,26 @@ func TestSwitch_NilDeps_503(t *testing.T) {
 // selected_tenant_id and must never grant a non-member a switch. Those two
 // invariants are the membership-check's job and hold deterministically.
 //
-// The audit write is a *separate*, best-effort invariant and does not: a
-// burst of N simultaneous Switch calls funnels into audit.SyncWriter.Write,
-// which runs under SERIALIZABLE isolation with its own internal retry (3
-// attempts) around a genuine read/write conflict on public.audit_log's
-// per-month MAX(seq) read. Diagnosed live against this suite's own Postgres
-// (10 fully-simultaneous audit.Write calls, no HTTP layer involved): 6 of 10
-// still failed with SQLSTATE 40001 after exhausting all 3 retries. Before
-// this file, that failure was invisible — apps/control-plane/internal/
-// tenants/http.go discarded the audit.Log() return with a bare `_ = ...` on
-// both call sites, directly contradicting the comment above Switch promising
-// "a misconfiguration cannot silently... lose a CROSS_TENANT_ATTEMPT event."
-// Fixed here to log.Printf on failure instead of discarding it, so the loss
-// is loud rather than silent; the retry-budget/locking fix that would make
-// it not happen at all lives in the audit package, out of this task's scope
-// (a shared writer used well beyond the tenants package). These tests assert
-// the now-honest contract: at least one audit row per outcome, never zero,
-// never more than N — not "always exactly N", which the writer does not
-// actually guarantee under contention.
+// The audit write used to be a *separate*, best-effort invariant: a burst of
+// N simultaneous Switch calls funnels into audit.SyncWriter.Write, which runs
+// under SERIALIZABLE isolation with its own internal retry (3 attempts)
+// around a genuine read/write conflict on public.audit_log's per-month
+// MAX(seq) read. Diagnosed live against this suite's own Postgres (10
+// fully-simultaneous audit.Write calls, no HTTP layer involved): 6 of 10
+// still failed with SQLSTATE 40001 after exhausting all 3 retries, because
+// the SERIALIZABLE snapshot was taken at the first statement inside the
+// transaction (the old pg_advisory_xact_lock call) — BEFORE that lock was
+// actually granted — so a blocked writer's snapshot predated its own turn.
+// apps/control-plane/internal/tenants/http.go discarded the audit.Log()
+// return with a bare `_ = ...` on both call sites, directly contradicting the
+// comment above Switch promising "a misconfiguration cannot silently... lose
+// a CROSS_TENANT_ATTEMPT event"; that was fixed to log.Printf on failure
+// instead of discarding it. #1182 then fixed the root cause in the audit
+// package itself: the advisory lock is now session-scoped and acquired
+// BEFORE BeginTx, so the transaction's snapshot can only form once this
+// writer already has exclusive possession of the month. These tests now
+// assert the contract the writer actually holds: exactly N audit rows for N
+// fully-simultaneous calls, not merely "at least one".
 // -----------------------------------------------------------------------------
 
 func TestSwitch_ConcurrentCallsFromActiveMember_AllSucceedConsistently(t *testing.T) {
@@ -275,9 +277,8 @@ func TestSwitch_ConcurrentCallsFromActiveMember_AllSucceedConsistently(t *testin
 	var switchCount int
 	require.NoError(t, pool.QueryRow(ctx,
 		`SELECT count(*) FROM public.audit_log WHERE actor_id=$1 AND action='TENANT_SWITCH'`, userID).Scan(&switchCount))
-	require.GreaterOrEqual(t, switchCount, 1,
-		"expected at least one TENANT_SWITCH audit row to survive; zero means the audit write failure is being silently swallowed again")
-	require.LessOrEqual(t, switchCount, n, "cannot have more audit rows than switch calls")
+	require.Equal(t, n, switchCount,
+		"expected exactly N TENANT_SWITCH audit rows for N fully-simultaneous switch calls (#1182); fewer means the audit writer is still losing rows under concurrency")
 }
 
 func TestSwitch_ConcurrentCallsFromNonMember_AllRejectedNoneLeakThrough(t *testing.T) {
@@ -334,7 +335,6 @@ func TestSwitch_ConcurrentCallsFromNonMember_AllRejectedNoneLeakThrough(t *testi
 	var attemptCount int
 	require.NoError(t, pool.QueryRow(ctx,
 		`SELECT count(*) FROM public.audit_log WHERE actor_id=$1 AND action='CROSS_TENANT_ATTEMPT'`, userID).Scan(&attemptCount))
-	require.GreaterOrEqual(t, attemptCount, 1,
-		"expected at least one CROSS_TENANT_ATTEMPT audit row to survive; zero means the audit write failure is being silently swallowed again")
-	require.LessOrEqual(t, attemptCount, n, "cannot have more audit rows than rejected attempts")
+	require.Equal(t, n, attemptCount,
+		"expected exactly N CROSS_TENANT_ATTEMPT audit rows for N fully-simultaneous rejected attempts (#1182); fewer means the audit writer is still losing rows under concurrency")
 }


### PR DESCRIPTION
## Summary

Fixes #1182. Related: #1148, #1181.

`audit.SyncWriter.Write` took its `pg_advisory_xact_lock` as the first statement inside a SERIALIZABLE transaction. Postgres takes a SERIALIZABLE transaction's snapshot at the first statement inside it, not at BEGIN, so every writer blocked waiting on that lock had already formed its snapshot before it actually got its turn. Each one then committed against a `MAX(seq)` read that was already stale by the time it ran, and Postgres SSI aborted the COMMIT with `serialization_failure` (40001). Diagnosed live on a throwaway database: 10 fully-simultaneous `Write` calls produced 5-6 failures even after the writer's own 3-attempt retry. Audit rows lost this way include CRITICAL severity events such as `CROSS_TENANT_ATTEMPT`.

## Option chosen and why

Of the four options weighed in #1182, option 1: take the advisory lock before `BeginTx`. This is the smallest correct fix and it directly targets the diagnosed mechanism (snapshot timing vs lock timing), rather than working around the symptom.

- Option 2 (drop to READ COMMITTED) was rejected: establishing what invariant SERIALIZABLE actually buys here versus the lock is a separate investigation this issue didn't require, and downgrading isolation without that analysis is exactly the kind of thing the issue warned against.
- Option 3 (outbox) is the right end state per #1148 and removes the global lock from the mutation's critical path entirely, but it's a caller-visible contract change (`Logger.Log` would need a caller-supplied transaction, or a new drain path) touching every security-tier call site. Out of scope for this issue; #1148 stays open to track it.
- Option 4 (more retries) was explicitly rejected per the issue: it lowers the failure rate without changing the shape and makes the residual failures rarer and harder to notice.

## The fix

`writeOnce` now acquires a dedicated connection (`pool.Acquire`), takes a **session-scoped** `pg_advisory_lock` on that connection *before* `BeginTx`, then opens the SERIALIZABLE transaction, does the read/insert/commit, and releases the lock with an explicit `pg_advisory_unlock` in a deferred call (background context, so it still runs if the caller's context was cancelled). The transaction's own first statement (the `MAX(seq)` read) can then only execute once this writer already has exclusive possession of the month, so nothing downstream of `BEGIN` can observe a stale snapshot.

Session- not transaction-scoped deliberately: it has to survive from before `BeginTx` through `Commit`. If the connection drops mid-hold, Postgres releases the session lock when the backend terminates, so the failure mode is one orphaned physical connection (which the pool detects and evicts), never a permanently stuck lock.

Same acquire/exec/defer-release shape as the existing `accounting.PgxAccountLocker` (`apps/control-plane/internal/accounting/pglock.go`), reused rather than reinvented. Unlike that locker, no in-process gate is needed here: the audit critical section never asks the pool for a second connection while holding the first, so there's no risk of a waiter starving the holder's own further pool use.

The retry loop (`maxSerializationRetries`) is left in place as defense-in-depth against a conflict from something else entirely on `public.audit_log`, not the writer's own concurrency, which this fix closes.

## Blast radius

`SyncWriter.pool` is a concrete `*pgxpool.Pool`, not an interface, so no caller or test mocks it. Every caller goes through `audit.Logger.Log(ctx, e)`, whose signature and error semantics are unchanged: `cmd/server/main.go` (construction), `internal/tenants/http.go`, `internal/identity/finalize.go`, `internal/signup/{personal_tenant,reconcile,webhook}.go`, `internal/byok/service.go`. None of them change.

**Latency**: net one extra round trip per write (the explicit `pg_advisory_unlock`, since the old lock released implicitly at `COMMIT`). Measured effect is noise: 10-way full concurrency completed in 130-200ms both before and after across the runs below; the difference is that after the fix all 10 succeed instead of roughly half of them burning their retry budget and still failing.

## Acceptance test: N-of-N, red then green

New test `TestSyncWriter_ConcurrentWrites_ExactlyNRows` (`apps/control-plane/internal/audit/sync_concurrency_test.go`) drives 10 fully-simultaneous `SyncWriter.Write` calls directly at the writer (no HTTP layer, no caller-level retry) and asserts **zero failures and exactly N rows**, not "at least one."

Run against a throwaway `pgvector/pgvector:pg17` Postgres, schema bootstrapped via `scripts/ci-throwaway-db.sh` with all 106 migrations applied.

**RED**, fix stashed out, unfixed `writeOnce`:
```
=== RUN   TestSyncWriter_ConcurrentWrites_ExactlyNRows
    sync_concurrency_test.go:66: write 1 failed: audit: insert: ERROR: could not serialize access due to read/write dependencies among transactions (SQLSTATE 40001)
    sync_concurrency_test.go:66: write 3 failed: audit: insert: ERROR: could not serialize access due to read/write dependencies among transactions (SQLSTATE 40001)
    sync_concurrency_test.go:66: write 4 failed: audit: insert: ERROR: could not serialize access due to read/write dependencies among transactions (SQLSTATE 40001)
    sync_concurrency_test.go:66: write 6 failed: audit: insert: ERROR: could not serialize access due to read/write dependencies among transactions (SQLSTATE 40001)
    sync_concurrency_test.go:66: write 8 failed: audit: insert: ERROR: could not serialize access due to read/write dependencies among transactions (SQLSTATE 40001)
    sync_concurrency_test.go:69: Error: Should be zero, but was 5
--- FAIL: TestSyncWriter_ConcurrentWrites_ExactlyNRows (0.18s)
FAIL
```

**GREEN**, fix restored, fresh throwaway database:
```
=== RUN   TestSyncWriter_ConcurrentWrites_ExactlyNRows
--- PASS: TestSyncWriter_ConcurrentWrites_ExactlyNRows (0.20s)
PASS
```
Reran 5x back to back (`-count=5`) against the same fixed writer: 5/5 clean passes.

The two existing tenants concurrency tests from #1181 (`TestSwitch_ConcurrentCallsFromActiveMember_AllSucceedConsistently`, `TestSwitch_ConcurrentCallsFromNonMember_AllRejectedNoneLeakThrough`) are tightened here from `GreaterOrEqual(count, 1)` / `LessOrEqual(count, n)` to `Equal(n, count)`, per the issue's own acceptance criterion, and both pass with the fix in place. Full `internal/audit` and `internal/tenants` suites pass (`go test ./... -v -count=1`), `go vet` and `gofmt -l` clean.

## Buglog entry

```json
{"date":"2026-08-25","tags":["audit","postgres","serializable","concurrency","compliance"],"error_message":"audit.SyncWriter.Write: SQLSTATE 40001 could not serialize access due to read/write dependencies among transactions","root_cause":"pg_advisory_xact_lock was the first statement inside a SERIALIZABLE transaction; Postgres takes the SERIALIZABLE snapshot at the first statement, not at BEGIN, so a writer blocked on that lock had already formed a stale snapshot before its turn, and SSI aborted the commit once the writer ahead of it committed a conflicting MAX(seq) read","fix":"acquire the lock as a session-scoped pg_advisory_lock on a dedicated connection BEFORE BeginTx, released with an explicit pg_advisory_unlock after commit, so the transaction cannot take its snapshot until this writer already holds exclusive possession of the lock key"}
```

## Test plan

- [x] `go build ./apps/control-plane/...`
- [x] `go vet ./apps/control-plane/internal/audit/... ./apps/control-plane/internal/tenants/...`
- [x] `gofmt -l` clean on touched files
- [x] New concurrency test: RED against unfixed writer (5/10 fail, SQLSTATE 40001), GREEN against fixed writer (10/10 pass, x5)
- [x] Tightened tenants concurrency tests pass with `Equal(n, count)`
- [x] Full `internal/audit` and `internal/tenants` suites pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)