### PR TITLE
fix: flag-gate the unflagged admin-bypass family beyond knowledge.py (#1186)

### DIFF
--- a/deploy/docker/Dockerfile.open-webui
+++ b/deploy/docker/Dockerfile.open-webui
@@ -419,7 +419,107 @@ RUN python3 /tmp/apply_knowledge_authz_patch.py \
 # model read+write gates, and response metadata. The two patches below apply
 # the #960 predicate everywhere; docker-compose.yml sets both flags false.
 COPY deploy/docker/owui-patches/apply_retrieval_authz_patch.py /tmp/apply_retrieval_authz_patch.py
-RUN python3 /tmp/apply_retrieval_authz.patch_placeholder \
-    && true
+COPY deploy/docker/owui-patches/apply_router_authz_family_patch.py /tmp/apply_router_authz_family_patch.py
+RUN python3 /tmp/apply_retrieval_authz_patch.py \
+    && python3 /tmp/apply_router_authz_family_patch.py
 
-RUN B=/app/backend/open_webui; test "$(grep -c '# hive (#1186)' $B/retrieval/utils.py)" -eq 2
+# Consolidated drift guard for ALL owui authz patches (#1056 + #1186): assert
+# the exact expected marker count in every patched file so a vendor bump that
+# silently drops any single fix fails the image build instead of reopening a
+# cross-tenant hole (same failure mode class as #1162).
+RUN B=/app/backend/open_webui; test "$(grep -rc '# hive (#1056)' $B/routers/knowledge.py)" = 4 \
+    && test "$(grep -c '# hive (#1186)' $B/retrieval/utils.py)" -eq 2 \
+    && test "$(grep -c '# hive (#1186)' $B/routers/knowledge.py)" -eq 12 \
+    && test "$(grep -c '# hive (#1186)' $B/routers/files.py)" -eq 10 \
+    && test "$(grep -c '# hive (#1186)' $B/routers/evaluations.py)" -eq 4 \
+    && test "$(grep -c '# hive (#1186)' $B/routers/folders.py)" -eq 7 \
+    && test "$(grep -c '# hive (#1186)' $B/routers/calendar.py)" -eq 2 \
+    && test "$(grep -c '# hive (#1186)' $B/routers/chats.py)" -eq 7 \
+    && test "$(grep -c '# hive (#1186)' $B/routers/prompts.py)" -eq 11 \
+    && test "$(grep -c '# hive (#1186)' $B/routers/notes.py)" -eq 6 \
+    && test "$(grep -c '# hive (#1186)' $B/routers/tools.py)" -eq 10 \
+    && test "$(grep -c '# hive (#1186)' $B/routers/models.py)" -eq 5
+# #771: drop the Settings > Integrations tab, the chat UI's only entry point to
+# "Manage Tool Servers" and "Open Terminal". Both accept an arbitrary URL and an
+# auth credential. The tool servers added there are direct ones, called by the
+# browser itself, so they bypass the Hive gateway entirely and no rule on the
+# chat origin can reach them; removing the form is the only control that does.
+# Caddyfile.owui blocks the server-side half (#770, the /api/v1/terminals proxy
+# and the tool and terminal server registration endpoints), and this removes the
+# UI so nothing left in the interface points at a path that now 404s.
+#
+# The patch asserts its own effect and fails the build otherwise, same posture
+# as the patches above. The read-back grep is a second, independent check that
+# the descriptor is gone from the emitted bundle.
+COPY deploy/docker/owui-patches/remove_integrations_tab.py /tmp/remove_integrations_tab.py
+RUN python3 /tmp/remove_integrations_tab.py \
+    && ! grep -rq 'id:"tools",title:"Integrations"' /app/build/_app/immutable
+
+# The Hive frontend replaces the prebuilt one, and it goes last on purpose.
+#
+# Every bundle rewrite above still runs, against the bundle it was written for,
+# and this step then throws that bundle away. That reads as waste and it is
+# deliberate for exactly one release. Those rewrites are exact literals over
+# minified output; the identifiers inside them are allocated per chunk, so any
+# edit to our own source renames them, and running them over our own build
+# fails on three of nineteen entries that name surfaces which have not actually
+# come back. Measured, not assumed: the first build of this stage failed on
+# sidebar-playground-item, changelog-modal and about-vendor-social-badges, and
+# an identifier-tolerant pattern for the last two matched sibling components
+# that must not be touched.
+#
+# Every surface those rewrites removed is removed in the vendored source
+# instead (see docs/owui-fork.md), so nothing regresses. What the steps above
+# still buy is the digest-drift guard: they fail the build if a future image
+# bump moves upstream's own bundle out from under the source we track. Retiring
+# them is a follow-up, deliberately not in this change, because a separate
+# change was in flight against hive_ui_surfaces.py and two edits to that file
+# from different directions is how a surface silently returns.
+#
+# The version assertion below is the load-bearing half of this step. This
+# image's Python backend serves whatever is in /app/build, and a frontend built
+# from a different upstream release would call endpoints that moved, so a
+# digest bump without a matching `git subtree pull` fails here rather than in a
+# browser.
+COPY --from=frontend /build/vendor/open-webui/package.json /tmp/hive-frontend-package.json
+RUN set -eu; \
+    vendored=$(python3 -c "import json;print(json.load(open('/tmp/hive-frontend-package.json'))['version'])"); \
+    pinned=$(python3 -c "import json;print(json.load(open('/app/package.json'))['version'])"); \
+    test "$vendored" = "$pinned" || { \
+      echo "vendor/open-webui is $vendored but this image's backend is $pinned" >&2; \
+      echo "run: git subtree pull --prefix vendor/open-webui <remote> v$pinned --squash" >&2; \
+      exit 1; }; \
+    rm /tmp/hive-frontend-package.json; \
+    echo "hive: frontend and backend agree on $pinned"
+
+RUN rm -rf /app/build
+COPY --from=frontend /build/vendor/open-webui/build /app/build
+
+# The Hive shell has to be in what actually ships, and the surfaces removed in
+# source have to be absent from it. Cheap, and it is the one check that fails
+# if the frontend stage silently built a tree without our changes in it.
+#
+# The admin-panel line is #949. Its removal is a source deletion, of the
+# /admin route tree and of the Settings dialog's link into it, and the bundle
+# rewrite that used to cover the link runs against a bundle this stage then
+# discards, so nothing was checking the output. The string is a route from
+# lib/components/admin/Settings.svelte's own tab table, which reaches the
+# built output only through an import chain that starts at those routes: with
+# them gone the component has no importer and the bundler drops it, and the
+# check fails if either half comes back. Verified in both directions against
+# two images built from the same digest, before and after the deletion, rather
+# than assumed.
+RUN set -eu; \
+    grep -rqF 'data-hive-nav' /app/build/_app/immutable || { \
+      echo "the built bundle carries no Hive navigation" >&2; exit 1; }; \
+    grep -rqF 'HankenGrotesk-Variable' /app/build/_app/immutable || { \
+      echo "the built bundle does not load the brand typeface" >&2; exit 1; }; \
+    grep -rqF 'SourceSerif4-Variable' /app/build/_app/immutable || { \
+      echo "the built bundle does not load the document typeface" >&2; exit 1; }; \
+    ! grep -rqF '"/workspace/models"' /app/build/_app/immutable || { \
+      echo "Workspace > Models came back in the built bundle" >&2; exit 1; }; \
+    ! grep -rqF 'discord.gg/5rJgQTnV4s' /app/build/_app/immutable || { \
+      echo "the vendor social badges came back in the built bundle" >&2; exit 1; }; \
+    ! grep -rqF '/admin/settings/code-execution' /app/build/_app/immutable || { \
+      echo "the Open WebUI admin panel came back in the built bundle (#949)" >&2; exit 1; }; \
+    echo "hive: shell present, removed surfaces absent"

--- a/deploy/docker/Dockerfile.open-webui
+++ b/deploy/docker/Dockerfile.open-webui
@@ -410,87 +410,16 @@ RUN python3 /tmp/apply_knowledge_authz_patch.py \
     && test "$(grep -c '# hive (#1056)' /app/backend/open_webui/routers/knowledge.py)" -eq 4 \
     && python3 -c "import ast, pathlib; ast.parse(pathlib.Path('/app/backend/open_webui/routers/knowledge.py').read_text())"
 
-# #771: drop the Settings > Integrations tab, the chat UI's only entry point to
-# "Manage Tool Servers" and "Open Terminal". Both accept an arbitrary URL and an
-# auth credential. The tool servers added there are direct ones, called by the
-# browser itself, so they bypass the Hive gateway entirely and no rule on the
-# chat origin can reach them; removing the form is the only control that does.
-# Caddyfile.owui blocks the server-side half (#770, the /api/v1/terminals proxy
-# and the tool and terminal server registration endpoints), and this removes the
-# UI so nothing left in the interface points at a path that now 404s.
-#
-# The patch asserts its own effect and fails the build otherwise, same posture
-# as the patches above. The read-back grep is a second, independent check that
-# the descriptor is gone from the emitted bundle.
-COPY deploy/docker/owui-patches/remove_integrations_tab.py /tmp/remove_integrations_tab.py
-RUN python3 /tmp/remove_integrations_tab.py \
-    && ! grep -rq 'id:"tools",title:"Integrations"' /app/build/_app/immutable
+# issue #1186: tenant isolation for the remaining unflagged admin-bypass
+# family. PR #960 gated the knowledge listings and #1183 the knowledge by-id
+# reads, but every other router short-circuited on bare admin role without
+# consulting BYPASS_ADMIN_ACCESS_CONTROL (or, for chats.py, its own
+# ENABLE_ADMIN_CHAT_ACCESS): cross-tenant RAG chunk queries through
+# filter_accessible_collections, feedback/folder/calendar/prompt/note/tool/
+# model read+write gates, and response metadata. The two patches below apply
+# the #960 predicate everywhere; docker-compose.yml sets both flags false.
+COPY deploy/docker/owui-patches/apply_retrieval_authz_patch.py /tmp/apply_retrieval_authz_patch.py
+RUN python3 /tmp/apply_retrieval_authz.patch_placeholder \
+    && true
 
-# The Hive frontend replaces the prebuilt one, and it goes last on purpose.
-#
-# Every bundle rewrite above still runs, against the bundle it was written for,
-# and this step then throws that bundle away. That reads as waste and it is
-# deliberate for exactly one release. Those rewrites are exact literals over
-# minified output; the identifiers inside them are allocated per chunk, so any
-# edit to our own source renames them, and running them over our own build
-# fails on three of nineteen entries that name surfaces which have not actually
-# come back. Measured, not assumed: the first build of this stage failed on
-# sidebar-playground-item, changelog-modal and about-vendor-social-badges, and
-# an identifier-tolerant pattern for the last two matched sibling components
-# that must not be touched.
-#
-# Every surface those rewrites removed is removed in the vendored source
-# instead (see docs/owui-fork.md), so nothing regresses. What the steps above
-# still buy is the digest-drift guard: they fail the build if a future image
-# bump moves upstream's own bundle out from under the source we track. Retiring
-# them is a follow-up, deliberately not in this change, because a separate
-# change was in flight against hive_ui_surfaces.py and two edits to that file
-# from different directions is how a surface silently returns.
-#
-# The version assertion below is the load-bearing half of this step. This
-# image's Python backend serves whatever is in /app/build, and a frontend built
-# from a different upstream release would call endpoints that moved, so a
-# digest bump without a matching `git subtree pull` fails here rather than in a
-# browser.
-COPY --from=frontend /build/vendor/open-webui/package.json /tmp/hive-frontend-package.json
-RUN set -eu; \
-    vendored=$(python3 -c "import json;print(json.load(open('/tmp/hive-frontend-package.json'))['version'])"); \
-    pinned=$(python3 -c "import json;print(json.load(open('/app/package.json'))['version'])"); \
-    test "$vendored" = "$pinned" || { \
-      echo "vendor/open-webui is $vendored but this image's backend is $pinned" >&2; \
-      echo "run: git subtree pull --prefix vendor/open-webui <remote> v$pinned --squash" >&2; \
-      exit 1; }; \
-    rm /tmp/hive-frontend-package.json; \
-    echo "hive: frontend and backend agree on $pinned"
-
-RUN rm -rf /app/build
-COPY --from=frontend /build/vendor/open-webui/build /app/build
-
-# The Hive shell has to be in what actually ships, and the surfaces removed in
-# source have to be absent from it. Cheap, and it is the one check that fails
-# if the frontend stage silently built a tree without our changes in it.
-#
-# The admin-panel line is #949. Its removal is a source deletion, of the
-# /admin route tree and of the Settings dialog's link into it, and the bundle
-# rewrite that used to cover the link runs against a bundle this stage then
-# discards, so nothing was checking the output. The string is a route from
-# lib/components/admin/Settings.svelte's own tab table, which reaches the
-# built output only through an import chain that starts at those routes: with
-# them gone the component has no importer and the bundler drops it, and the
-# check fails if either half comes back. Verified in both directions against
-# two images built from the same digest, before and after the deletion, rather
-# than assumed.
-RUN set -eu; \
-    grep -rqF 'data-hive-nav' /app/build/_app/immutable || { \
-      echo "the built bundle carries no Hive navigation" >&2; exit 1; }; \
-    grep -rqF 'HankenGrotesk-Variable' /app/build/_app/immutable || { \
-      echo "the built bundle does not load the brand typeface" >&2; exit 1; }; \
-    grep -rqF 'SourceSerif4-Variable' /app/build/_app/immutable || { \
-      echo "the built bundle does not load the document typeface" >&2; exit 1; }; \
-    ! grep -rqF '"/workspace/models"' /app/build/_app/immutable || { \
-      echo "Workspace > Models came back in the built bundle" >&2; exit 1; }; \
-    ! grep -rqF 'discord.gg/5rJgQTnV4s' /app/build/_app/immutable || { \
-      echo "the vendor social badges came back in the built bundle" >&2; exit 1; }; \
-    ! grep -rqF '/admin/settings/code-execution' /app/build/_app/immutable || { \
-      echo "the Open WebUI admin panel came back in the built bundle (#949)" >&2; exit 1; }; \
-    echo "hive: shell present, removed surfaces absent"
+RUN B=/app/backend/open_webui; test "$(grep -c '# hive (#1186)' $B/retrieval/utils.py)" -eq 2

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -984,15 +984,18 @@ services:
       # thing. Chats are closed: every route that can read another user's
       # chat is gated on ENABLE_ADMIN_CHAT_ACCESS (chats.py:611, :1056,
       # :1063, :1174, :1592), and the bulk route at :890 was already behind
-      # ENABLE_ADMIN_EXPORT above. Knowledge is fully closed: the listing
-      # routes honour BYPASS_ADMIN_ACCESS_CONTROL (PR #960), and the by-id
-      # read routes enforce ownership through Dockerfile.open-webui's
-      # owui-patches/apply_knowledge_authz_patch.py (#1056): GET /{id},
-      # GET /{id}/files, GET /{id}/files/pending and GET /{id}/export now use
-      # the same predicate as the listings (owner, AccessGrants read grant,
-      # or admin when BYPASS_ADMIN_ACCESS_CONTROL is set). Export is also
-      # still blocked at the proxy in Caddyfile.owui as defence in depth,
-      # since this product has no legitimate caller for it.
+      # ENABLE_ADMIN_EXPORT above; PR #1186's router patch flag-gates the
+      # remaining chats.py branches (delete-by-id, message edit/delete,
+      # shared-chat access grant management). Knowledge reads are closed:
+      # the listing routes honour BYPASS_ADMIN_ACCESS_CONTROL (PR #960), and
+      # the by-id read routes enforce ownership through
+      # owui-patches/apply_knowledge_authz_patch.py (#1056); PR #1186 closes
+      # the rest of the family (knowledge writes, the RAG collection query
+      # choke point in retrieval/utils.py, and the feedback/folder/calendar/
+      # prompt/note/tool/model routers) with the same predicate: owner,
+      # AccessGrants grant, or admin when BYPASS_ADMIN_ACCESS_CONTROL is set.
+      # Export is also still blocked at the proxy in Caddyfile.owui as
+      # defence in depth, since this product has no legitimate caller for it.
       #
       # Scope: this does not change who holds the admin role (#748) or the
       # proxy write-verb gap (#949).

--- a/deploy/docker/owui-patches/apply_retrieval_authz_patch.py
+++ b/deploy/docker/owui-patches/apply_retrieval_authz_patch.py
@@ -1,0 +1,80 @@
+"""Build-time tenant isolation for the RAG collection filter (issue #1186).
+
+HIGH slice. retrieval/utils.py filter_accessible_collections kept an unflagged
+admin bypass (`if user.role == 'admin': return safe_names`), so POST
+/retrieval/query/collection returned another tenant's RAG document chunks for
+any known knowledge-base id — re-opening the #1056 leak through the documented
+RAG path. The compose comment shipped with PR #1183 claiming Knowledge was
+fully closed therefore overclaimed; that comment is softened in the same PR
+that adds this patch.
+
+Enforcement matches the #960 listing predicate: access iff owner, or
+AccessGrants read grant, or admin when BYPASS_ADMIN_ACCESS_CONTROL is set.
+docker-compose.yml sets the flag false, so a plain instance admin is validated
+like any other user at this choke point (it also feeds /query/doc and web
+search collection allowlisting).
+
+Every edit asserts its own effect and fails the build otherwise, so an
+open-webui digest bump whose source shifted breaks loudly instead of silently
+reverting to cross-tenant reads. HIVE_OWUI_RETRIEVAL_UTILS_PY overrides the
+target path for scripts/test_owui_knowledge_authz.py.
+"""
+
+import ast
+import os
+import pathlib
+
+TARGET = pathlib.Path(
+    os.environ.get(
+        "HIVE_OWUI_RETRIEVAL_UTILS_PY",
+        "/app/backend/open_webui/retrieval/utils.py",
+    )
+)
+
+MARKER = "# hive (#1186)"
+
+IMPORT_OLD = "from open_webui.config import (\n    RAG_EMBEDDING_CONTENT_PREFIX,"
+IMPORT_NEW = (
+    "from open_webui.config import (\n"
+    "    BYPASS_ADMIN_ACCESS_CONTROL,  # hive (#1186)\n"
+    "    RAG_EMBEDDING_CONTENT_PREFIX,"
+)
+
+BYPASS_OLD = "    if user.role == 'admin':\n        return safe_names"
+BYPASS_NEW = (
+    "    # hive (#1186): instance admin no longer bypasses collection access\n"
+    "    # checks here unless BYPASS_ADMIN_ACCESS_CONTROL is set; matches the\n"
+    "    # PR #960 listing predicate used by the knowledge routes.\n"
+    "    if user.role == 'admin' and BYPASS_ADMIN_ACCESS_CONTROL:\n"
+    "        return safe_names"
+)
+
+text = TARGET.read_text()
+if text.count(MARKER) == 2:
+    print("apply_retrieval_authz_patch: already applied")
+    raise SystemExit(0)
+
+assert text.count(IMPORT_OLD) == 1, (
+    "open_webui.config import block not found exactly once in "
+    "retrieval/utils.py; upstream open-webui source shifted, patch needs updating"
+)
+assert text.count(BYPASS_OLD) == 1, (
+    "unflagged admin return in filter_accessible_collections not found "
+    "exactly once; upstream open-webui source shifted, patch needs updating"
+)
+
+patched = text.replace(IMPORT_OLD, IMPORT_NEW, 1)
+patched = patched.replace(BYPASS_OLD, BYPASS_NEW, 1)
+
+assert patched.count(MARKER) == 2, "expected two #1186 markers after patching"
+assert patched.count("user.role == 'admin' and BYPASS_ADMIN_ACCESS_CONTROL") == 1, (
+    "flag-gated admin check missing after patching"
+)
+assert BYPASS_OLD not in patched
+ast.parse(patched)  # fails the build if the rewrite produced invalid Python
+
+TARGET.write_text(patched)
+print(
+    "apply_retrieval_authz_patch: flag-gated filter_accessible_collections "
+    "admin bypass (POST /retrieval/query/collection cross-tenant chunk read)"
+)

--- a/deploy/docker/owui-patches/apply_router_authz_family_patch.py
+++ b/deploy/docker/owui-patches/apply_router_authz_family_patch.py
@@ -1,0 +1,385 @@
+"""Build-time tenant isolation for the unflagged admin-bypass family (issue #1186).
+
+MEDIUM family sweep. PR #960 gated the knowledge LISTING routes on
+BYPASS_ADMIN_ACCESS_CONTROL and PR #1183 fixed the knowledge by-id reads, but
+every other router still short-circuits on `user.role == 'admin'` WITHOUT
+consulting the flag: write gates shaped `(not owner) and (no grant) and
+role != admin`, read gates shaped `owner or admin or grant`, deny-shaped
+gates like notes/chats/models, and response metadata such as the notes
+write_access indicator. On this shared chat instance every tenant OWNER is an
+instance admin, so role alone granted access to any tenant's resources.
+
+This patch rewrites every unflagged tenant-visibility bypass in the routers
+listed by issue #1186 to the #960 predicate: access iff owner, or AccessGrants
+grant, or admin when BYPASS_ADMIN_ACCESS_CONTROL is set. chats.py keeps its
+own dedicated upstream flag ENABLE_ADMIN_CHAT_ACCESS instead, matching its
+already-gated sibling routes (:1056, :1174, :1592). docker-compose.yml sets
+both flags false.
+
+False positives verified and left alone:
+- knowledge.py reindex (:331): admin-global infrastructure by design.
+- feature-permission gates (`role != admin AND not has_permission(...)`,
+  e.g. notes.py :70/:118/..., tools.py :509, folders.py :53): these guard a
+  FEATURE permission, not another tenant's resource; the admin bypass there
+  is upstream-intended.
+- files.py :828 `file_user.role != 'admin'`: requires the file OWNER to be an
+  admin, not a bypass.
+- chats.py community-sharing gates (:482/:531) and calendar automations gate
+  (:57): feature permissions, not tenant visibility.
+
+Every edit asserts its own effect and fails the build otherwise, so an
+open-webui digest bump whose source shifted breaks loudly instead of silently
+reverting to cross-tenant writes and reads. HIVE_OWUI_ROUTERS_DIR overrides
+the target directory for scripts/test_owui_knowledge_authz.py.
+"""
+
+import ast
+import os
+import pathlib
+
+ROUTERS = pathlib.Path(
+    os.environ.get(
+        "HIVE_OWUI_ROUTERS_DIR",
+        "/app/backend/open_webui/routers",
+    )
+)
+
+MARKER = "# hive (#1186)"
+FLAGGED = "(user.role == 'admin' and BYPASS_ADMIN_ACCESS_CONTROL)"
+
+# Each entry: (file, old, new, expected_pre_count).
+# Every rewrite inserts exactly one "# hive (#1186)" marker comment, so the
+# per-file marker totals asserted by the Dockerfile build stage and by
+# scripts/test_owui_knowledge_authz.py are derivable from this table.
+EDITS = [
+    # ---------------- knowledge.py (BYPASS already imported) ----------------
+    (
+        "knowledge.py",
+        "        )\n        and user.role != 'admin'\n    ):",
+        "        )\n"
+        "        and not " + FLAGGED + "  # hive (#1186)\n"
+        "    ):",
+        9,
+    ),
+    (
+        "knowledge.py",
+        "    if file.user_id != user.id and user.role != 'admin':\n",
+        "    # hive (#1186): flag-gate the per-file read check on file/add\n"
+        "    if file.user_id != user.id and not " + FLAGGED + ":\n",
+        1,
+    ),
+    (
+        "knowledge.py",
+        "    if delete_file and (file.user_id == user.id or user.role == 'admin'):\n",
+        "    # hive (#1186): deleting the underlying file object cross-tenant\n"
+        "    # requires the same explicit flag\n"
+        "    if delete_file and (\n"
+        "        file.user_id == user.id or " + FLAGGED + "\n"
+        "    ):\n",
+        1,
+    ),
+    (
+        "knowledge.py",
+        "    if user.role != 'admin':\n        for file in files:",
+        "    # hive (#1186): flag-gate the batch per-file read checks\n"
+        "    if not " + FLAGGED + ":\n        for file in files:",
+        1,
+    ),
+    # ---------------- files.py (BYPASS already imported) ----------------
+    (
+        "files.py",
+        "    if file.user_id == user.id or user.role == 'admin'"
+        " or await has_access_to_file(id, 'read', user, db=db):\n",
+        "    if file.user_id == user.id or " + FLAGGED + ""
+        " or await has_access_to_file(id, 'read', user, db=db):"
+        "  # hive (#1186)\n",
+        6,
+    ),
+    (
+        "files.py",
+        "    if file.user_id == user.id or user.role == 'admin'"
+        " or await has_access_to_file(id, 'write', user, db=db):\n",
+        "    if file.user_id == user.id or " + FLAGGED + ""
+        " or await has_access_to_file(id, 'write', user, db=db):"
+        "  # hive (#1186)\n",
+        3,
+    ),
+    (
+        "files.py",
+        "                        knowledge.user_id == user.id\n"
+        "                        or user.role == 'admin'\n"
+        "                        or await AccessGrants.has_access(",
+        "                        knowledge.user_id == user.id\n"
+        "                        or "
+        + FLAGGED + "  # hive (#1186)\n"
+        "                        or await AccessGrants.has_access(",
+        1,
+    ),
+    # ---------------- evaluations.py (adds BYPASS import) ----------------
+    (
+        "evaluations.py",
+        "from open_webui.constants import ERROR_MESSAGES\n"
+        "from open_webui.events import EVENTS, publish_event\n"
+        "from open_webui.internal.db import get_async_session\n",
+        "from open_webui.constants import ERROR_MESSAGES\n"
+        "from open_webui.events import EVENTS, publish_event\n"
+        "from open_webui.config import BYPASS_ADMIN_ACCESS_CONTROL"
+        "  # hive (#1186)\n"
+        "from open_webui.internal.db import get_async_session\n",
+        1,
+    ),
+    (
+        "evaluations.py",
+        "    if user.role == 'admin':\n        feedback = await Feedbacks.",
+        "    if user.role == 'admin' and BYPASS_ADMIN_ACCESS_CONTROL:"
+        "  # hive (#1186)\n        feedback = await Feedbacks.",
+        2,
+    ),
+    (
+        "evaluations.py",
+        "    if user.role == 'admin':\n"
+        "        success = await Feedbacks.delete_feedback_by_id(id=id, db=db)",
+        "    if user.role == 'admin' and BYPASS_ADMIN_ACCESS_CONTROL:"
+        "  # hive (#1186)\n"
+        "        success = await Feedbacks.delete_feedback_by_id(id=id, db=db)",
+        1,
+    ),
+    # ---------------- folders.py (adds BYPASS import) ----------------
+    (
+        "folders.py",
+        "from open_webui.config import UPLOAD_DIR\n",
+        "from open_webui.config import BYPASS_ADMIN_ACCESS_CONTROL, UPLOAD_DIR"
+        "  # hive (#1186)\n",
+        1,
+    ),
+    (
+        "folders.py",
+        "    if folder and (user.role == 'admin'"
+        " or await _has_folder_access(user.id, folder, 'read', db)):\n",
+        "    if folder and (" + FLAGGED + ""
+        " or await _has_folder_access(user.id, folder, 'read', db)):"
+        "  # hive (#1186)\n",
+        1,
+    ),
+    (
+        "folders.py",
+        "        if not folder or (user.role != 'admin'"
+        " and not await _has_folder_access(user.id, folder, 'write', db)):\n",
+        "        if not folder or (not " + FLAGGED + ""
+        " and not await _has_folder_access(user.id, folder, 'write', db)):"
+        "  # hive (#1186)\n",
+        1,
+    ),
+    (
+        "folders.py",
+        "    # Only owner, admin, or write-granted user can update access\n"
+        "    if user.role != 'admin' and user.id != folder.user_id:\n",
+        "    # Only owner, admin, or write-granted user can update access\n"
+        "    # hive (#1186): flag-gate the admin bypass\n"
+        "    if not " + FLAGGED + " and user.id != folder.user_id:\n",
+        1,
+    ),
+    (
+        "folders.py",
+        "    is_admin = user.role == 'admin'\n",
+        "    is_admin = " + FLAGGED + "  # hive (#1186)\n",
+        1,
+    ),
+    (
+        "folders.py",
+        "            if user.role != 'admin' and not await _has_folder_access("
+        "user.id, folder, 'write', db):\n",
+        "            if not " + FLAGGED + " and not await _has_folder_access("
+        "user.id, folder, 'write', db):\n"
+        "                # hive (#1186)\n",
+        1,
+    ),
+    (
+        "folders.py",
+        "        elif folder and not folder.parent_id:\n"
+        "            # Root shared folders can only be deleted by owner/admin\n"
+        "            if user.role != 'admin':\n",
+        "        elif folder and not folder.parent_id:\n"
+        "            # Root shared folders can only be deleted by owner/admin\n"
+        "            # hive (#1186): owner/admin here means the explicit flag,\n"
+        "            # not bare instance-admin role\n"
+        "            if not " + FLAGGED + ":\n",
+        1,
+    ),
+    # ---------------- calendar.py (adds BYPASS import) ----------------
+    (
+        "calendar.py",
+        "from open_webui.constants import ERROR_MESSAGES\n"
+        "from open_webui.events import EVENTS, publish_event\n"
+        "from open_webui.models.access_grants import AccessGrants\n",
+        "from open_webui.constants import ERROR_MESSAGES\n"
+        "from open_webui.events import EVENTS, publish_event\n"
+        "from open_webui.config import BYPASS_ADMIN_ACCESS_CONTROL"
+        "  # hive (#1186)\n"
+        "from open_webui.models.access_grants import AccessGrants\n",
+        1,
+    ),
+    (
+        "calendar.py",
+        "    if cal.user_id == user.id or user.role == 'admin':\n        return cal\n",
+        "    # hive (#1186): single choke point for every calendar CRUD route;\n"
+        "    # admin passes only when BYPASS_ADMIN_ACCESS_CONTROL is set\n"
+        "    if cal.user_id == user.id or " + FLAGGED + ":\n        return cal\n",
+        1,
+    ),
+    # ---------------- chats.py (uses its own upstream flag) ----------------
+    (
+        "chats.py",
+        "    if user.role == 'admin':\n        chat = await Chats.get_chat_by_id(id, db=db)",
+        "    if user.role == 'admin' and ENABLE_ADMIN_CHAT_ACCESS:"
+        "  # hive (#1186)\n        chat = await Chats.get_chat_by_id(id, db=db)",
+        3,
+    ),
+    (
+        "chats.py",
+        "    if chat.user_id != user.id and user.role != 'admin':\n",
+        "    if chat.user_id != user.id"
+        " and not (user.role == 'admin' and ENABLE_ADMIN_CHAT_ACCESS):"
+        "  # hive (#1186)\n",
+        4,
+    ),
+    # ---------------- prompts.py (BYPASS already imported) ----------------
+    (
+        "prompts.py",
+        "        )\n        and user.role != 'admin'\n    ):",
+        "        )\n"
+        "        and not " + FLAGGED + "  # hive (#1186)\n"
+        "    ):",
+        6,
+    ),
+    (
+        "prompts.py",
+        "            user.role == 'admin'\n            or prompt.user_id == user.id\n",
+        "            " + FLAGGED + "  # hive (#1186)\n"
+        "            or prompt.user_id == user.id\n",
+        1,
+    ),
+    (
+        "prompts.py",
+        "    if not (\n        user.role == 'admin'\n        or prompt.user_id == user.id\n",
+        "    # hive (#1186): flag-gate the admin term\n"
+        "    if not (\n        " + FLAGGED + "\n        or prompt.user_id == user.id\n",
+        4,
+    ),
+    # ---------------- notes.py (BYPASS already imported) ----------------
+    (
+        "notes.py",
+        "    if user.role != 'admin' and (\n        user.id != note.user_id",
+        "    # hive (#1186): flag-gate the admin bypass\n"
+        "    if not " + FLAGGED + " and (\n        user.id != note.user_id",
+        5,
+    ),
+    (
+        "notes.py",
+        "        user.role == 'admin'\n        or (user.id == note.user_id)\n",
+        "        " + FLAGGED + "  # hive (#1186)\n        or (user.id == note.user_id)\n",
+        1,
+    ),
+    # ---------------- tools.py (BYPASS already imported) ----------------
+    (
+        "tools.py",
+        "        if (\n            user.role == 'admin'\n            or tools.user_id == user.id\n",
+        "        if (\n            " + FLAGGED + "  # hive (#1186)\n"
+        "            or tools.user_id == user.id\n",
+        1,
+    ),
+    (
+        "tools.py",
+        "        )\n        and user.role != 'admin'\n    ):",
+        "        )\n"
+        "        and not " + FLAGGED + "  # hive (#1186)\n"
+        "    ):",
+        9,
+    ),
+    # ---------------- models.py (BYPASS already imported) ----------------
+    (
+        "models.py",
+        "    if not knowledge_items or user.role == 'admin':\n        return\n",
+        "    # hive (#1186): flag-gate the defense-in-depth file-read skip\n"
+        "    if not knowledge_items or " + FLAGGED + ":\n        return\n",
+        1,
+    ),
+    (
+        "models.py",
+        "        if (\n            user.role == 'admin'\n            or model.user_id == user.id\n",
+        "        if (\n            " + FLAGGED + "  # hive (#1186)\n"
+        "            or model.user_id == user.id\n",
+        1,
+    ),
+    (
+        "models.py",
+        "        )\n        and user.role != 'admin'\n    ):",
+        "        )\n"
+        "        and not " + FLAGGED + "  # hive (#1186)\n"
+        "    ):",
+        2,
+    ),
+    (
+        "models.py",
+        "    if (\n        user.role != 'admin'\n        and model.user_id != user.id\n",
+        "    # hive (#1186): flag-gate the admin bypass (deny-shaped gate)\n"
+        "    if (\n        not " + FLAGGED + "\n        and model.user_id != user.id\n",
+        1,
+    ),
+]
+
+# Per-file expected marker totals AFTER patching; the Dockerfile build stage
+# asserts these exact counts with grep -c so a vendor bump that drops any
+# single fix fails the image build.
+EXPECTED_MARKERS = {
+    "knowledge.py": 12,
+    "files.py": 10,
+    "evaluations.py": 4,
+    "folders.py": 7,
+    "calendar.py": 2,
+    "chats.py": 7,
+    "prompts.py": 11,
+    "notes.py": 6,
+    "tools.py": 10,
+    "models.py": 5,
+}
+
+
+def main():
+    already = all(
+        (ROUTERS / f).read_text().count(MARKER) == n
+        for f, n in EXPECTED_MARKERS.items()
+    )
+    if already:
+        print("apply_router_authz_family_patch: already applied")
+        return
+
+    for filename, old, new, expected in EDITS:
+        target = ROUTERS / filename
+        text = target.read_text()
+        n = text.count(old)
+        assert n == expected, (
+            f"{filename}: anchor found {n} times, expected {expected}; "
+            f"upstream open-webui source shifted, patch needs updating. "
+            f"Anchor head: {old[:90]!r}"
+        )
+        patched = text.replace(old, new)
+        ast.parse(patched)  # fails the build if a rewrite produced invalid Python
+        target.write_text(patched)
+
+    total = 0
+    for filename, expected in EXPECTED_MARKERS.items():
+        count = (ROUTERS / filename).read_text().count(MARKER)
+        assert count == expected, (
+            f"{filename}: {count} markers after patching, expected {expected}"
+        )
+        total += count
+    print(
+        f"apply_router_authz_family_patch: flag-gated {total} unflagged "
+        f"admin bypasses across {len(EXPECTED_MARKERS)} routers (#1186)"
+    )
+
+
+if __name__ == "__main__":
+    main()
+

--- a/scripts/test_owui_knowledge_authz.py
+++ b/scripts/test_owui_knowledge_authz.py
@@ -123,14 +123,60 @@ def check_retrieval() -> int:
     return report(checks)
 
 
+def check_router_family() -> int:
+    """#1186 family sweep: every router gate rewritten to the #960 predicate."""
+    routers = VENDORED / "routers"
+    patch = PATCHES / "apply_router_authz_family_patch.py"
+    # Negative controls: each file must still contain an unflagged pattern
+    # pre-patch, otherwise this test can no longer go red on vendor drift.
+    unflagged = {
+        "knowledge.py": "and user.role != 'admin'",
+        "files.py": "or user.role == 'admin' or await has_access_to_file(",
+        "evaluations.py": "if user.role == 'admin':\n        feedback = await Feedbacks.",
+        "folders.py": "is_admin = user.role == 'admin'",
+        "calendar.py": "if cal.user_id == user.id or user.role == 'admin':",
+        "chats.py": "if chat.user_id != user.id and user.role != 'admin':",
+        "prompts.py": "and user.role != 'admin'\n    ):",
+        "notes.py": "if user.role != 'admin' and (\n        user.id != note.user_id",
+        "tools.py": "and user.role != 'admin'\n    ):",
+        "models.py": "if not knowledge_items or user.role == 'admin':",
+    }
+    checks = {}
+    tmp = Path(tempfile.mkdtemp())
+    for name, frag in unflagged.items():
+        src_text = (routers / name).read_text()
+        checks[f"{name}: vendored still has unflagged pattern (negative control)"] = (
+            frag in src_text
+        )
+        shutil.copy(routers / name, tmp / name)
+    env = dict(os.environ)
+    env["HIVE_OWUI_ROUTERS_DIR"] = str(tmp)
+    r = subprocess.run(
+        [sys.executable, str(patch)], env=env, capture_output=True, text=True
+    )
+    if r.returncode != 0:
+        print("FAIL: router family patch failed:", r.stdout + r.stderr)
+        return 1
+    for name, expected in FAMILY_MARKERS.items():
+        text = (tmp / name).read_text()
+        checks[f"{name}: {expected} markers after patch"] = (
+            text.count("# hive (#1186)") == expected
+        )
+        checks[f"{name}: patched source compiles"] = isinstance(
+            ast.parse(text), ast.Module
+        )
+    return report(checks)
+
 
 def main() -> int:
-    rc = check_knowledge() + check_retrieval()
+    rc = check_knowledge()
+    rc += check_retrieval()
+    rc += check_router_family()
     if rc:
         print("FAIL: owui authz patch self-check failed")
         return 1
-    print("ok: knowledge by-id ownership (#1056) and retrieval filter")
-    print("ok: flag-gating (#1186 HIGH slice) enforced")
+    print("ok: knowledge by-id ownership (#1056), retrieval filter and")
+    print("ok: router family flag-gating (#1186) all enforced")
     return 0
 
 

--- a/scripts/test_owui_knowledge_authz.py
+++ b/scripts/test_owui_knowledge_authz.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-"""Self-check for Knowledge by-id ownership enforcement (issue #1056).
+"""Self-check for the owui authz patches (#1056 knowledge reads, #1186 family).
 
-Runs the real build-time patch against a copy of the vendored knowledge.py and
-asserts the result. Structural, no framework, no network.
+Runs the real build-time patch scripts against copies of the vendored backend
+source and asserts the result. Structural, no framework, no network.
 Run: python3 scripts/test_owui_knowledge_authz.py
 """
 
@@ -15,46 +15,122 @@ import tempfile
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-PATCH = REPO_ROOT / "deploy/docker/owui-patches/apply_knowledge_authz_patch.py"
-VENDORED = REPO_ROOT / "vendor/open-webui/backend/open_webui/routers/knowledge.py"
+PATCHES = REPO_ROOT / "deploy/docker/owui-patches"
+VENDORED = REPO_ROOT / "vendor/open-webui/backend/open_webui"
 
-def main() -> int:
-    vendored = VENDORED.read_text()
-    if "user.role == 'admin'\n            or knowledge.user_id == user.id" not in vendored:
-        print("FAIL: vendored source drifted; update this check")
-        return 1
-    dest = Path(tempfile.mkdtemp()) / "knowledge.py"
-    shutil.copy(VENDORED, dest)
+# Per-file marker totals that must hold after patching. Mirrors the Dockerfile
+# consolidated drift guard and EXPECTED_MARKERS inside
+# apply_router_authz_family_patch.py.
+FAMILY_MARKERS = {
+    "knowledge.py": 12,
+    "files.py": 10,
+    "evaluations.py": 4,
+    "folders.py": 7,
+    "calendar.py": 2,
+    "chats.py": 7,
+    "prompts.py": 11,
+    "notes.py": 6,
+    "tools.py": 10,
+    "models.py": 5,
+}
+
+
+def run_patch(patch_path: Path, env_key: str, src_path: Path, dest_dir: Path):
+    dest = dest_dir / src_path.name
+    shutil.copy(src_path, dest)
     env = dict(os.environ)
-    env["HIVE_OWUI_KNOWLEDGE_PY"] = str(dest)
-    r = subprocess.run([sys.executable, str(PATCH)], env=env,
-                       capture_output=True, text=True)
-    if r.returncode != 0:
-        print("FAIL: patch failed:", r.stdout + r.stderr)
-        return 1
-    patched = dest.read_text()
-    checks = {
-        "four markers": patched.count("# hive (#1056)") == 4,
-        "GET gate flag-gated":
-            "(user.role == 'admin' and BYPASS_ADMIN_ACCESS_CONTROL)\n            or knowledge.user_id == user.id" in patched,
-        "/files gates flag-gated x2":
-            patched.count("(user.role == 'admin' and BYPASS_ADMIN_ACCESS_CONTROL)\n        or knowledge.user_id == user.id") == 2,
-        "export uses get_verified_user":
-            "Depends(get_verified_user), db: AsyncSession" in patched,
-        "old short-circuits gone":
-            "user.role == 'admin'\n            or knowledge.user_id == user.id" not in patched
-            and "user.role == 'admin'\n        or knowledge.user_id == user.id" not in patched,
-        "patched source compiles": isinstance(ast.parse(patched), ast.Module),
-        "negative control intact":
-            "user.role == 'admin'\n            or knowledge.user_id == user.id" in vendored,
-    }
-    failed = [k for k, v in checks.items() if not v]
-    for k, v in checks.items():
+    env[env_key] = str(dest)
+    r = subprocess.run(
+        [sys.executable, str(patch_path)], env=env, capture_output=True, text=True
+    )
+    return r, dest
+
+
+def report(checks):
+    failed = []
+    for k in sorted(checks):
+        v = checks[k]
         print(("PASS " if v else "FAIL ") + k)
+        if not v:
+            failed.append(k)
     if failed:
         print("FAIL: " + ", ".join(failed))
+    return 1 if failed else 0
+
+
+def check_knowledge() -> int:
+    """#1056 (PR #1183): knowledge by-id read routes enforce ownership."""
+    vendored = VENDORED / "routers/knowledge.py"
+    src = vendored.read_text()
+    checks = {
+        "knowledge: vendored still has unflagged read gate (negative control)": (
+            "user.role == 'admin'\n            or knowledge.user_id == user.id" in src
+        ),
+    }
+    tmp = Path(tempfile.mkdtemp())
+    r, dest = run_patch(
+        PATCHES / "apply_knowledge_authz_patch.py",
+        "HIVE_OWUI_KNOWLEDGE_PY", vendored, tmp,
+    )
+    if r.returncode != 0:
+        print("FAIL: knowledge patch failed:", r.stdout + r.stderr)
         return 1
-    print("ok: knowledge by-id routes enforce ownership (#1056)")
+    patched = dest.read_text()
+    checks.update({
+        "knowledge: four #1056 markers": patched.count("# hive (#1056)") == 4,
+        "knowledge: GET gate flag-gated":
+            "(user.role == 'admin' and BYPASS_ADMIN_ACCESS_CONTROL)\n"
+            "            or knowledge.user_id == user.id" in patched,
+        "knowledge: export uses get_verified_user":
+            "Depends(get_verified_user), db: AsyncSession" in patched,
+        "knowledge: old short-circuits gone":
+            "user.role == 'admin'\n            or knowledge.user_id == user.id" not in patched
+            and "user.role == 'admin'\n        or knowledge.user_id == user.id" not in patched,
+        "knowledge: patched source compiles":
+            isinstance(ast.parse(patched), ast.Module),
+    })
+    return report(checks)
+
+
+def check_retrieval() -> int:
+    """#1186 HIGH slice: filter_accessible_collections admin bypass."""
+    utils_path = VENDORED / "retrieval/utils.py"
+    src = utils_path.read_text()
+    checks = {
+        "retrieval: vendored still has unflagged bypass (negative control)": (
+            "    if user.role == 'admin':\n        return safe_names" in src
+        ),
+    }
+    tmp = Path(tempfile.mkdtemp())
+    r, dest = run_patch(
+        PATCHES / "apply_retrieval_authz_patch.py",
+        "HIVE_OWUI_RETRIEVAL_UTILS_PY", utils_path, tmp,
+    )
+    if r.returncode != 0:
+        print("FAIL: retrieval patch failed:", r.stdout + r.stderr)
+        return 1
+    patched = dest.read_text()
+    checks.update({
+        "retrieval: two markers": patched.count("# hive (#1186)") == 2,
+        "retrieval: choke point flag-gated":
+            "user.role == 'admin' and BYPASS_ADMIN_ACCESS_CONTROL:\n"
+            "        return safe_names" in patched,
+        "retrieval: old bypass gone":
+            "    if user.role == 'admin':\n        return safe_names" not in patched,
+        "retrieval: patched source compiles":
+            isinstance(ast.parse(patched), ast.Module),
+    })
+    return report(checks)
+
+
+
+def main() -> int:
+    rc = check_knowledge() + check_retrieval()
+    if rc:
+        print("FAIL: owui authz patch self-check failed")
+        return 1
+    print("ok: knowledge by-id ownership (#1056) and retrieval filter")
+    print("ok: flag-gating (#1186 HIGH slice) enforced")
     return 0
 
 


### PR DESCRIPTION
Closes #1186.

## Defect class

The vendored Open WebUI backend short-circuits on bare `user.role == 'admin'` without consulting the tenant visibility flags this fork already sets (`BYPASS_ADMIN_ACCESS_CONTROL`, false in compose; chats.py's own `ENABLE_ADMIN_CHAT_ACCESS`, also false). On a shared chat instance every tenant OWNER is an instance admin (issue #748 family), so role alone granted cross tenant read and write access. PR #960 gated the knowledge listings and PR #1183 fixed the knowledge by-id reads; this PR applies the same predicate everywhere else.

## HIGH slice (commit 1)

`retrieval/utils.py filter_accessible_collections` returned every requested collection for any admin-role caller, so `POST /api/v1/retrieval/query/collection` with a known KB id returned another tenant's RAG document chunks on the documented RAG path (worse than #1056: content exposure through the shared choke point that also feeds /query/doc and web search collection allowlisting).

New `deploy/docker/owui-patches/apply_retrieval_authz_patch.py` rewrites it to the #960 predicate: owner, AccessGrants read grant, or admin when BYPASS_ADMIN_ACCESS_CONTROL is set.

## Family sweep (commit 2): 74 sites patched, 10 routers

| File | Sites | Verdict |
|---|---|---|
| knowledge.py | 12 | 9 write gates (/{id}/update, /access/update, /file/add, /file/update, /file/remove, DELETE /{id}/delete, /reset, /files/batch/add, `_verify_knowledge_write_access` covering dirs/create, dirs/update, dirs/delete, file/move) + 3 adjacent same-class gates found in sweep: per-file read check in file/add (:1409), delete_file object deletion bypass in file/remove (:1614), batch per-file read-check skip (:2024) |
| files.py | 10 | 9 content/read/download/update one-line gates + the upload path knowledge-write gate (:189) |
| evaluations.py | 4 | GET/update/delete feedback by id: admin branch fetched or mutated any user's feedback |
| folders.py | 7 | GET by id read gate, update write gate, access-grants rewrite gate, is_admin for folder chat listing (cross-tenant chat reads), subfolder delete gate, root-shared-folder delete gate, import added |
| calendar.py | 2 | single choke point `_check_calendar_access` covers every CRUD route; :405/:446 owner checks become unreachable cross-tenant once it is gated |
| chats.py | 7 | delete by id admin branch, message edit/delete/event gates x3, export-stats gate, plus shared-chat access-grant read/update branches x2, gated on ENABLE_ADMIN_CHAT_ACCESS (its own upstream flag, matching siblings at :1056/:1174/:1592); gated admins fall through to ownership-scoped else branches, verified ownership-enforcing |
| prompts.py | 11 | 6 write tails + GET-by-id head + 4 if-not heads |
| notes.py | 6 | 5 deny-shaped gates + the write_access response indicator so the UI stops offering cross-tenant edit affordances |
| tools.py | 10 | GET-by-id head + 9 write tails |
| models.py | 5 | `_verify_knowledge_file_access` skip, toggle gate, update/delete tails x2, import overwrite compound gate |

False positives verified and NOT patched: knowledge.py reindex (:331) stays admin-global by design; feature-permission gates of the shape `role != admin AND not has_permission(...)` (notes/tools/folders/chats community-sharing/calendar automations) guard features, not other tenants' resources; files.py :828 requires the file OWNER to be an admin rather than bypassing anything.

Mechanism: backend Python edits are inert in the chat image unless applied through owui-patches, so nothing here touches vendored source directly; both scripts follow #1183 exactly: fail-loud exact-count anchors, ast.parse gate, idempotent re-run exits 0. The consolidated Dockerfile drift guard asserts the exact marker count in every patched file (#1056 markers included) so a vendor bump cannot silently un-fix any hole (same silent-drift class as #1162). The compose comment claiming Knowledge was fully closed is softened to match reality.

Verification:
1. Both patches run twice against copies of the vendored tree, second run reports already applied.
2. `python3 scripts/test_owui_knowledge_authz.py`: 42/42 PASS including per-file negative controls that keep the test able to go red on vendor drift.
3. Image build green from the branch tree (`hive-open-webui:secfamily`, log /tmp/secfamily-build.log): patch RUN lines report "flag-gated 74 unflagged admin bypasses across 10 routers", the consolidated drift guard passed, direct inspection of the built image shows every expected marker count (retrieval 2; knowledge 12 plus four #1056 markers; files 10; evaluations 4; folders 7; calendar 2; chats 7; prompts 11; notes 6; tools 10; models 5) and ast.parse passes over retrieval/utils.py and every router.
