### PR TITLE
fix: reconcile usage_events.hive_credit_delta with the ledger (#1180)

### DIFF
--- a/apps/control-plane/internal/accounting/usage_ledger_reconciliation_live_test.go
+++ b/apps/control-plane/internal/accounting/usage_ledger_reconciliation_live_test.go
@@ -1,0 +1,139 @@
+package accounting
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/ledger"
+	"github.com/sakibsadmanshajib/hive/apps/control-plane/internal/usage"
+)
+
+// TestUsageEventsAgreeWithLedgerAfterDuplicateCompletedWrite is issue #1180's
+// guard. usage_events.hive_credit_delta and credit_ledger_entries.
+// credits_delta disagreed for the same request: control-plane's own
+// finalizeLocked writes the authoritative 'completed' row (hive_credit_delta
+// = -actualCredits, the same figure charged to the ledger), and edge-api
+// separately POSTs a SECOND 'completed' row for the identical attempt with
+// hive_credit_delta set to a raw token count -- unrelated to money, wrong on
+// every request that hits it. This test reproduces both writes against a
+// real database through the real repositories, the way the live pair (an
+// attempt's two 'completed' rows, one -385, one +151) was measured on the
+// demo box on 2026-08-25.
+//
+// Regressing to a plain INSERT (dropping the ON CONFLICT in
+// usage/repository.go's RecordEvent, or dropping the partial unique index
+// ux_usage_events_completed_attempt) reintroduces the duplicate row and this
+// test fails on the row-count assertion. Regressing the DO UPDATE to also
+// overwrite hive_credit_delta reintroduces the money-figure defect and this
+// test fails on the credit-delta assertion instead.
+func TestUsageEventsAgreeWithLedgerAfterDuplicateCompletedWrite(t *testing.T) {
+	pool := newAccountingTestPool(t)
+	accountID := seedReleaseIdempotencyAccount(t, pool)
+	ctx := context.Background()
+
+	ledgerSvc := ledger.NewService(ledger.NewPgxRepository(pool))
+	usageSvc := usage.NewService(usage.NewPgxRepository(pool))
+	svc := NewService(NewPgxRepository(pool), ledgerSvc, usageSvc)
+
+	if _, err := ledgerSvc.GrantCredits(ctx, accountID, uuid.NewString(), 300000, map[string]any{"reason": "test grant"}); err != nil {
+		t.Fatalf("grant credits: %v", err)
+	}
+
+	const (
+		hold           = int64(10000)
+		actualCredits  = int64(385)
+		measuredInput  = int64(73)
+		measuredOutput = int64(78)
+	)
+
+	reservation, err := svc.CreateReservation(ctx, CreateReservationInput{
+		AccountID:        accountID,
+		RequestID:        uuid.NewString(),
+		AttemptNumber:    1,
+		Endpoint:         "/v1/chat/completions",
+		ModelAlias:       "hive-fast",
+		EstimatedCredits: hold,
+	})
+	if err != nil {
+		t.Fatalf("CreateReservation: %v", err)
+	}
+
+	// Write 1: control-plane's own finalizeLocked, the authoritative write.
+	// Mirrors production exactly: orchestrator.go and stream.go never
+	// populate FinalizeReservationInput.InputTokens/OutputTokens (a separate,
+	// edge-api-side gap, out of this fix's reach), so this row lands with
+	// zero token counts and the correct, ledger-matching credit delta.
+	if _, err := svc.FinalizeReservation(ctx, FinalizeReservationInput{
+		AccountID:              accountID,
+		ReservationID:          reservation.ID,
+		ActualCredits:          actualCredits,
+		TerminalUsageConfirmed: true,
+		Status:                 string(usage.AttemptStatusCompleted),
+	}); err != nil {
+		t.Fatalf("FinalizeReservation: %v", err)
+	}
+
+	// Write 2: edge-api's separate, unconditional POST to
+	// /internal/usage/events (recordCompletedEvent), reproduced directly
+	// against usage.Service.RecordEvent the way usage/http.go's handler
+	// calls it. hive_credit_delta here is TotalTokens, exactly the wrong
+	// value edge-api sends today; input/output tokens are the real measured
+	// counts finalizeLocked never received.
+	wrongDelta := measuredInput + measuredOutput
+	if _, err := usageSvc.RecordEvent(ctx, usage.RecordEventInput{
+		AccountID:        accountID,
+		RequestAttemptID: reservation.RequestAttemptID,
+		RequestID:        reservation.RequestID,
+		EventType:        usage.UsageEventCompleted,
+		Endpoint:         reservation.Endpoint,
+		ModelAlias:       reservation.ModelAlias,
+		Status:           "completed",
+		InputTokens:      measuredInput,
+		OutputTokens:     measuredOutput,
+		HiveCreditDelta:  wrongDelta,
+	}); err != nil {
+		t.Fatalf("second (edge-api-shaped) RecordEvent: %v", err)
+	}
+
+	// Exactly one 'completed' row: the duplicate must fold, not insert.
+	var rowCount int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM public.usage_events WHERE account_id = $1 AND request_attempt_id = $2 AND event_type = 'completed'`,
+		accountID, reservation.RequestAttemptID,
+	).Scan(&rowCount); err != nil {
+		t.Fatalf("count usage_events: %v", err)
+	}
+	if rowCount != 1 {
+		t.Fatalf("got %d 'completed' usage_events rows for one attempt, want 1 (the duplicate-write defect from issue #1180 reintroduced)", rowCount)
+	}
+
+	// The surviving row's hive_credit_delta must still agree with the
+	// ledger, not the second write's wrong value.
+	var usageDelta, ledgerDelta, inputTokens, outputTokens int64
+	if err := pool.QueryRow(ctx,
+		`SELECT hive_credit_delta, input_tokens, output_tokens FROM public.usage_events
+		  WHERE account_id = $1 AND request_attempt_id = $2 AND event_type = 'completed'`,
+		accountID, reservation.RequestAttemptID,
+	).Scan(&usageDelta, &inputTokens, &outputTokens); err != nil {
+		t.Fatalf("read surviving usage_events row: %v", err)
+	}
+	if err := pool.QueryRow(ctx,
+		`SELECT credits_delta FROM public.credit_ledger_entries WHERE account_id = $1 AND attempt_id = $2 AND entry_type = 'usage_charge'`,
+		accountID, reservation.RequestAttemptID,
+	).Scan(&ledgerDelta); err != nil {
+		t.Fatalf("read ledger charge entry: %v", err)
+	}
+	if usageDelta != ledgerDelta {
+		t.Fatalf("usage_events.hive_credit_delta = %d, credit_ledger_entries.credits_delta = %d: the two money surfaces disagree for the same request (issue #1180)", usageDelta, ledgerDelta)
+	}
+	if usageDelta != -actualCredits {
+		t.Fatalf("usage_events.hive_credit_delta = %d, want %d (the second write's wrong value, %d, must never win)", usageDelta, -actualCredits, wrongDelta)
+	}
+
+	// The token counts from the second write must still land: dedup should
+	// not silently drop the only real measurement edge-api sent.
+	if inputTokens != measuredInput || outputTokens != measuredOutput {
+		t.Fatalf("merged token counts = (%d, %d), want (%d, %d): the duplicate write's real measurement was dropped instead of folded in", inputTokens, outputTokens, measuredInput, measuredOutput)
+	}
+}

--- a/apps/control-plane/internal/usage/repository.go
+++ b/apps/control-plane/internal/usage/repository.go
@@ -86,10 +86,36 @@ func (r *pgxRepository) RecordEvent(ctx context.Context, input RecordEventInput)
 		return UsageEvent{}, fmt.Errorf("usage: marshal customer tags: %w", err)
 	}
 
+	// ON CONFLICT targets ux_usage_events_completed_attempt (partial unique
+	// index on (account_id, request_attempt_id) WHERE event_type =
+	// 'completed', supabase/migrations/20260825_03_...sql). Only a
+	// 'completed' insert can ever hit this arbiter; every other event_type
+	// inserts exactly as before.
+	//
+	// Two writers record a 'completed' row for the same attempt today
+	// (issue #1180): control-plane's own accounting.finalizeLocked, which
+	// always runs FIRST and carries the ledger-matching hive_credit_delta,
+	// and edge-api's separate, unconditional POST that always runs SECOND
+	// and carries the real measured token counts but a hive_credit_delta
+	// that is not a credit figure at all (it is edge-api's TotalTokens,
+	// unrelated to this fix's scope). DO UPDATE folds the second write's
+	// token/provider columns onto the first write's row and deliberately
+	// never touches hive_credit_delta, event_type, status, or the account/
+	// request identifiers: the row that lands first is presumed
+	// authoritative on the money question, and every case measured live
+	// (576 of 576 duplicate pairs, 2026-08-25) bears that out.
 	row := r.pool.QueryRow(ctx, `
 		INSERT INTO public.usage_events
 			(account_id, request_attempt_id, api_key_id, request_id, event_type, endpoint, model_alias, status, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, hive_credit_delta, provider_request_id, internal_metadata, customer_tags, error_code, error_type)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15::jsonb, $16::jsonb, $17, $18)
+		ON CONFLICT (account_id, request_attempt_id) WHERE event_type = 'completed'
+		DO UPDATE SET
+			input_tokens = EXCLUDED.input_tokens,
+			output_tokens = EXCLUDED.output_tokens,
+			cache_read_tokens = EXCLUDED.cache_read_tokens,
+			cache_write_tokens = EXCLUDED.cache_write_tokens,
+			provider_request_id = COALESCE(EXCLUDED.provider_request_id, public.usage_events.provider_request_id),
+			internal_metadata = public.usage_events.internal_metadata || EXCLUDED.internal_metadata
 		RETURNING id, account_id, request_attempt_id, api_key_id, request_id, event_type, endpoint, model_alias, status, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, hive_credit_delta, provider_request_id, internal_metadata, customer_tags, error_code, error_type, created_at
 	`, input.AccountID, input.RequestAttemptID, input.APIKeyID, input.RequestID, string(input.EventType), input.Endpoint, input.ModelAlias, input.Status, input.InputTokens, input.OutputTokens, input.CacheReadTokens, input.CacheWriteTokens, input.HiveCreditDelta, nullableString(input.ProviderRequestID), internalMetadata, customerTags, nullableString(input.ErrorCode), nullableString(input.ErrorType))
 

--- a/apps/control-plane/internal/usage/repository_live_test.go
+++ b/apps/control-plane/internal/usage/repository_live_test.go
@@ -189,10 +189,16 @@ func TestGetUsageSummary_SumsInputOutputAndCredits(t *testing.T) {
 	repo := NewPgxRepository(pool)
 	ctx := context.Background()
 	accountID := seedUsageAccount(t, pool)
-	attemptID := seedUsageAttempt(t, ctx, repo, accountID)
 
 	from := time.Now().UTC().Add(-1 * time.Hour)
+	// Two DISTINCT attempts, not one attempt written twice: a single
+	// request_attempt_id carries at most one 'completed' row
+	// (ux_usage_events_completed_attempt, issue #1180's dedup fix), matching
+	// production where one attempt has exactly one terminal outcome. This
+	// test's subject is SUM() across multiple genuine requests, so it needs
+	// multiple genuine attempts to sum over.
 	for i := 0; i < 2; i++ {
+		attemptID := seedUsageAttempt(t, ctx, repo, accountID)
 		if _, err := repo.RecordEvent(ctx, RecordEventInput{
 			AccountID:        accountID,
 			RequestAttemptID: attemptID,
@@ -357,12 +363,15 @@ func TestGetErrorSummary_ComputesRateOverAllRequests(t *testing.T) {
 	repo := NewPgxRepository(pool)
 	ctx := context.Background()
 	accountID := seedUsageAccount(t, pool)
-	attemptID := seedUsageAttempt(t, ctx, repo, accountID)
 
 	model := "gpt-error-test-" + uuid.NewString()[:8]
 	from := time.Now().UTC().Add(-1 * time.Hour)
 
 	// 1 error out of 4 total requests on this model => 25% error rate.
+	// Each entry is its own attempt (issue #1180): a single
+	// request_attempt_id carries at most one 'completed'-event_type row, so
+	// four distinct requests need four distinct attempts, matching how
+	// finalizeLocked and edge-api actually write these rows in production.
 	statuses := []struct {
 		status    string
 		errorCode string
@@ -373,6 +382,7 @@ func TestGetErrorSummary_ComputesRateOverAllRequests(t *testing.T) {
 		{"failed", "upstream_5xx"},
 	}
 	for _, s := range statuses {
+		attemptID := seedUsageAttempt(t, ctx, repo, accountID)
 		if _, err := repo.RecordEvent(ctx, RecordEventInput{
 			AccountID:        accountID,
 			RequestAttemptID: attemptID,

--- a/supabase/migrations/20260825_03_usage_events_completed_dedup_and_rescale_backfill.sql
+++ b/supabase/migrations/20260825_03_usage_events_completed_dedup_and_rescale_backfill.sql
@@ -1,0 +1,170 @@
+-- =============================================================================
+-- usage_events 'completed' dedup + credit-unit rescale backfill (issue #1180).
+--
+-- WHAT WAS FOUND
+--   Every request that goes through a reservation writes TWO usage_events
+--   rows with the same (account_id, request_attempt_id, event_type =
+--   'completed'):
+--     1. Written by control-plane's own accounting.finalizeLocked
+--        (apps/control-plane/internal/accounting/service.go), in-process,
+--        during FinalizeReservation. hive_credit_delta = -actualCredits, the
+--        exact figure charged to credit_ledger_entries in the same call.
+--        This row is authoritative -- it matches the ledger by construction.
+--     2. Written by edge-api's recordCompletedEvent (apps/edge-api/internal/
+--        inference/orchestrator.go and stream.go), a SEPARATE, unconditional
+--        HTTP POST to /internal/usage/events that always follows the
+--        FinalizeReservation call. hive_credit_delta there is set to
+--        usage.TotalTokens -- a raw token COUNT, not a credit amount, not
+--        even negative. It is not a rescale or rounding difference from the
+--        ledger figure, it is a categorically wrong value in that column.
+--   Live measurement on the demo box (2026-08-25, all history): 576 pairs of
+--   duplicate 'completed' rows, zero triples. In every single pair the
+--   earlier-written row's hive_credit_delta is <= 0 (matches the ledger
+--   pattern) and in 575 of 576 the later row's hive_credit_delta equals
+--   input_tokens + output_tokens exactly (the TotalTokens assignment). This
+--   is deterministic, not a race: edge-api only calls recordCompletedEvent
+--   AFTER the synchronous FinalizeReservation HTTP call returns, so the
+--   authoritative row is always inserted first.
+--
+--   A second, narrower defect compounds this: the authoritative row's own
+--   input_tokens/output_tokens are 0, because neither orchestrator.go's nor
+--   stream.go's FinalizeReservation call site populates
+--   FinalizeReservationInput.InputTokens/OutputTokens, even though the wire
+--   contract and control-plane's own plumbing already support it (#856).
+--   That gap is in apps/edge-api, out of this migration's reach; the dedup
+--   below compensates for it by keeping the token counts the second
+--   (edge-api) write actually carries while keeping the credit delta the
+--   first (ledger-backed) write actually carries.
+--
+--   Separately, and NOT the same root cause: usage_events.hive_credit_delta
+--   was missing from the WHAT IS SCALED list in
+--   20260823_40_credit_unit_rescale_billion.sql (D-046, factor 10000, 1 USD
+--   1,000,000 -> 1,000,000,000 credits). credit_ledger_entries.credits_delta
+--   was backfilled by that migration; usage_events.hive_credit_delta was
+--   not. Every authoritative row written before that migration's boundary is
+--   therefore off from its matching ledger entry by exactly 10000x (a stale
+--   unit, not a wrong rate) -- confirmed live: 018658cd.. reads -12 in
+--   usage_events against -120000 in the ledger for the identical attempt,
+--   and -12 * 10000 = -120000 exactly, same pattern on every pre-boundary
+--   row checked.
+--
+-- WHAT THIS FILE DOES (order matters: dedup first, THEN rescale, so the
+-- rescale sees each attempt exactly once)
+--   1. For every (account_id, request_attempt_id) with more than one
+--      event_type = 'completed' row, keep the earliest (the authoritative,
+--      ledger-matching one), fold the token/provider columns from the
+--      later row(s) into it via GREATEST/COALESCE (never destructive: the
+--      authoritative row's own columns are 0 in every case measured), stamp
+--      which duplicate id(s) were merged into internal_metadata for
+--      forensics, and delete the later row(s). hive_credit_delta and
+--      event_type on the keeper are untouched.
+--   2. Backfill the credit-unit rescale that 20260823_40 missed: multiply
+--      hive_credit_delta by 10000 for every usage_events row with a nonzero
+--      delta, created before the rescale marker's applied_at boundary, not
+--      already flagged. Flag key/value ('credit_unit',
+--      'legacy-1usd-100k-credits') is the exact one 20260823_40 already
+--      uses on credit_ledger_entries and credit_reservation_events, so a
+--      row is now identifiable as pre-rescale the same way across all three
+--      tables.
+--   3. Add a partial unique index so a future duplicate 'completed' POST
+--      (edge-api is unchanged by this fix; it will keep sending one) folds
+--      into the existing row instead of inserting a second one. This is the
+--      arbiter the application-side ON CONFLICT in
+--      apps/control-plane/internal/usage/repository.go targets.
+--
+-- WHY PLAIN CREATE INDEX, NOT CONCURRENTLY
+--   Supabase migrations run inside one transaction (BEGIN/COMMIT below),
+--   and CREATE INDEX CONCURRENTLY cannot run inside a transaction block, the
+--   same constraint 20260824_01 already documented for this database.
+--   usage_events is 2,173 rows / 1.4 MB on the demo box (measured
+--   2026-08-25); a plain index build here is milliseconds, not the
+--   ACCESS EXCLUSIVE hazard it would be on a table with real volume.
+--
+-- IDEMPOTENCY
+--   Step 1 is naturally idempotent: after the first run no (account_id,
+--   request_attempt_id) has more than one 'completed' row, so the dedup CTE
+--   selects nothing on replay.
+--   Step 2 guards on the same jsonb flag 20260823_40 already established
+--   (`NOT (internal_metadata ? 'credit_unit')`), so a replay scales nothing
+--   a prior run (or this run) already touched.
+--   Step 3 uses IF NOT EXISTS.
+-- =============================================================================
+
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+
+-- ---------------------------------------------------------------------------
+-- Step 1: fold duplicate 'completed' rows into the earliest (authoritative)
+-- one per attempt.
+-- ---------------------------------------------------------------------------
+CREATE TEMP TABLE _usage_events_completed_ranked ON COMMIT DROP AS
+SELECT id, account_id, request_attempt_id, input_tokens, output_tokens,
+       cache_read_tokens, cache_write_tokens, provider_request_id,
+       row_number() OVER (
+         PARTITION BY account_id, request_attempt_id ORDER BY created_at ASC
+       ) AS rn
+FROM public.usage_events
+WHERE event_type = 'completed';
+
+CREATE TEMP TABLE _usage_events_completed_keepers ON COMMIT DROP AS
+SELECT * FROM _usage_events_completed_ranked WHERE rn = 1;
+
+CREATE TEMP TABLE _usage_events_completed_dupes ON COMMIT DROP AS
+SELECT * FROM _usage_events_completed_ranked WHERE rn > 1;
+
+UPDATE public.usage_events ue
+SET input_tokens        = GREATEST(ue.input_tokens, d.input_tokens),
+    output_tokens        = GREATEST(ue.output_tokens, d.output_tokens),
+    cache_read_tokens    = GREATEST(ue.cache_read_tokens, d.cache_read_tokens),
+    cache_write_tokens   = GREATEST(ue.cache_write_tokens, d.cache_write_tokens),
+    provider_request_id  = COALESCE(ue.provider_request_id, d.provider_request_id),
+    internal_metadata    = ue.internal_metadata || jsonb_build_object(
+        'merged_duplicate_completed_event_ids',
+        (SELECT jsonb_agg(dd.id) FROM _usage_events_completed_dupes dd
+          WHERE dd.account_id = ue.account_id
+            AND dd.request_attempt_id = ue.request_attempt_id)
+    )
+FROM _usage_events_completed_dupes d
+JOIN _usage_events_completed_keepers k
+  ON k.account_id = d.account_id AND k.request_attempt_id = d.request_attempt_id
+WHERE ue.id = k.id;
+
+DELETE FROM public.usage_events ue
+USING _usage_events_completed_dupes d
+WHERE ue.id = d.id;
+
+-- ---------------------------------------------------------------------------
+-- Step 2: rescale backfill 20260823_40 omitted for this table.
+-- ---------------------------------------------------------------------------
+DO $backfill$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM public.credit_unit_rescale) THEN
+        -- Rescale never ran on this database (e.g. a fresh CI throwaway
+        -- seeded straight from HEAD) -- nothing pre-dates a boundary that
+        -- does not exist, so there is nothing to backfill.
+        RETURN;
+    END IF;
+
+    UPDATE public.usage_events
+       SET hive_credit_delta = hive_credit_delta * 10000,
+           internal_metadata = internal_metadata || jsonb_build_object(
+               'credit_unit', 'legacy-1usd-100k-credits')
+     WHERE hive_credit_delta <> 0
+       AND created_at < (SELECT applied_at FROM public.credit_unit_rescale)
+       AND NOT (internal_metadata ? 'credit_unit');
+END
+$backfill$;
+
+-- ---------------------------------------------------------------------------
+-- Step 3: prevent future duplicates. ON CONFLICT target for
+-- apps/control-plane/internal/usage/repository.go's RecordEvent.
+-- ---------------------------------------------------------------------------
+CREATE UNIQUE INDEX IF NOT EXISTS ux_usage_events_completed_attempt
+  ON public.usage_events (account_id, request_attempt_id)
+  WHERE event_type = 'completed';
+
+COMMENT ON INDEX public.ux_usage_events_completed_attempt IS
+  'One completed usage_events row per attempt (issue #1180). Arbiter for RecordEvent''s ON CONFLICT: a second completed write (edge-api''s redundant POST, unchanged by this fix) folds its token counts into the existing row instead of inserting a duplicate with a bogus hive_credit_delta.';
+
+COMMIT;

--- a/supabase/migrations/20260825_03_usage_events_completed_dedup_and_rescale_backfill.sql
+++ b/supabase/migrations/20260825_03_usage_events_completed_dedup_and_rescale_backfill.sql
@@ -1,5 +1,6 @@
 -- =============================================================================
--- usage_events 'completed' dedup + credit-unit rescale backfill (issue #1180).
+-- usage_events 'completed' dedup + ledger-reconciled rescale backfill
+-- (issue #1180, review round 2).
 --
 -- WHAT WAS FOUND
 --   Every request that goes through a reservation writes TWO usage_events
@@ -41,31 +42,70 @@
 --   20260823_40_credit_unit_rescale_billion.sql (D-046, factor 10000, 1 USD
 --   1,000,000 -> 1,000,000,000 credits). credit_ledger_entries.credits_delta
 --   was backfilled by that migration; usage_events.hive_credit_delta was
---   not. Every authoritative row written before that migration's boundary is
---   therefore off from its matching ledger entry by exactly 10000x (a stale
---   unit, not a wrong rate) -- confirmed live: 018658cd.. reads -12 in
---   usage_events against -120000 in the ledger for the identical attempt,
---   and -12 * 10000 = -120000 exactly, same pattern on every pre-boundary
---   row checked.
+--   not. Every authoritative row written in the OLD unit is therefore off
+--   from its matching ledger entry by exactly 10000x (a stale unit, not a
+--   wrong rate) -- confirmed live: 018658cd.. reads -12 in usage_events
+--   against -120000 in the ledger for the identical attempt, and
+--   -12 * 10000 = -120000 exactly, same pattern on every stale-unit row
+--   checked.
 --
--- WHAT THIS FILE DOES (order matters: dedup first, THEN rescale, so the
--- rescale sees each attempt exactly once)
+-- REVIEW ROUND 2: WHY THIS FILE NO LONGER USES created_at < applied_at
+--   The first version of this migration bounded the rescale backfill on
+--   usage_events.created_at < credit_unit_rescale.applied_at, mirroring
+--   20260823_40's own straggler-detection language. That bound
+--   UNDER-APPLIES: 20260823_40 itself documents a deploy-gap race where the
+--   OLD binary keeps writing OLD-unit rows for some seconds-to-minutes
+--   AFTER the migration's COMMIT (between COMMIT and the container
+--   recreate), so a straggler row can carry created_at > applied_at while
+--   still being an old-unit value. A created_at bound skips exactly those
+--   rows, permanently: usage_events carries no positive new-unit stamp of
+--   its own, so nothing could later tell a missed straggler apart from a
+--   genuinely small, correctly-scaled delta.
+--
+--   Fix: stop inferring the unit from a timestamp and reconcile directly
+--   against credit_ledger_entries instead, which 20260823_40 DID correctly
+--   backfill and which this migration's own header already establishes as
+--   the authoritative surface (finalizeLocked charges the ledger with the
+--   same actualCredits value it mirrors onto usage_events). For every
+--   surviving 'completed' row, if its hive_credit_delta disagrees with the
+--   matching credit_ledger_entries.credits_delta (same account_id,
+--   same attempt_id, entry_type = 'usage_charge') by EXACTLY a factor of
+--   10000, it is unambiguously the stale-unit case and gets overwritten
+--   with the ledger's value -- not multiplied, copied, so the result is
+--   the true figure regardless of which direction any rounding went. A
+--   disagreement that is NOT exactly 10000x is left untouched: that would
+--   be a different, unknown mismatch this migration has no evidence about,
+--   and silently "fixing" it would be a guess, not a correction. This
+--   covers every stale-unit row there is or ever was, including the
+--   deploy-gap stragglers a timestamp bound could never see, with no
+--   dependency on created_at or on credit_unit_rescale.applied_at at all.
+--
+-- WHAT THIS FILE DOES (order matters: guard, then dedup, then reconcile, so
+-- reconciliation sees each attempt exactly once)
+--   0. Refuse to run if any (account_id, request_attempt_id) has THREE OR
+--      MORE 'completed' rows. The merge in step 1 is a pairwise
+--      keep-earliest/fold-latest operation; live evidence supports at most
+--      two (576 pairs, 0 triples, 2026-08-25), and a many-to-one UPDATE on
+--      an unexpected triple would let Postgres pick an arbitrary source row
+--      for the folded token columns rather than a deliberate one. A triple
+--      is a different, unexplained shape that a human should look at, not
+--      an assumption this migration should make silently. Raises and rolls
+--      back the whole transaction; changes nothing.
 --   1. For every (account_id, request_attempt_id) with more than one
 --      event_type = 'completed' row, keep the earliest (the authoritative,
 --      ledger-matching one), fold the token/provider columns from the
---      later row(s) into it via GREATEST/COALESCE (never destructive: the
+--      later row into it via GREATEST/COALESCE (never destructive: the
 --      authoritative row's own columns are 0 in every case measured), stamp
---      which duplicate id(s) were merged into internal_metadata for
---      forensics, and delete the later row(s). hive_credit_delta and
---      event_type on the keeper are untouched.
---   2. Backfill the credit-unit rescale that 20260823_40 missed: multiply
---      hive_credit_delta by 10000 for every usage_events row with a nonzero
---      delta, created before the rescale marker's applied_at boundary, not
---      already flagged. Flag key/value ('credit_unit',
---      'legacy-1usd-100k-credits') is the exact one 20260823_40 already
---      uses on credit_ledger_entries and credit_reservation_events, so a
---      row is now identifiable as pre-rescale the same way across all three
---      tables.
+--      which duplicate id was merged into internal_metadata for forensics,
+--      and delete the later row. hive_credit_delta and event_type on the
+--      keeper are untouched.
+--   2. Reconcile stale-unit rows against the ledger (see above): copy
+--      credit_ledger_entries.credits_delta onto any surviving row whose
+--      hive_credit_delta is exactly 1/10000th of it. Flag key/value
+--      ('credit_unit', 'legacy-1usd-100k-credits') is the exact one
+--      20260823_40 already uses on credit_ledger_entries and
+--      credit_reservation_events, so a corrected row is identifiable the
+--      same way across all three tables.
 --   3. Add a partial unique index so a future duplicate 'completed' POST
 --      (edge-api is unchanged by this fix; it will keep sending one) folds
 --      into the existing row instead of inserting a second one. This is the
@@ -81,18 +121,51 @@
 --   ACCESS EXCLUSIVE hazard it would be on a table with real volume.
 --
 -- IDEMPOTENCY
+--   Step 0 only reads; nothing to replay.
 --   Step 1 is naturally idempotent: after the first run no (account_id,
 --   request_attempt_id) has more than one 'completed' row, so the dedup CTE
 --   selects nothing on replay.
---   Step 2 guards on the same jsonb flag 20260823_40 already established
---   (`NOT (internal_metadata ? 'credit_unit')`), so a replay scales nothing
---   a prior run (or this run) already touched.
+--   Step 2 is naturally idempotent too, independent of the credit_unit flag:
+--   once a row is corrected it agrees with the ledger, so the "disagrees by
+--   exactly 10000x" predicate no longer matches it on replay. The flag is
+--   set for forensic identifiability, not for idempotency.
 --   Step 3 uses IF NOT EXISTS.
+--
+-- ROLLBACK ASYMMETRY (documented, not fixed here; see PR body)
+--   This migration has no down-migration. Rolling it back while
+--   control-plane's binary stays on the version that assumes
+--   ux_usage_events_completed_attempt exists (the ON CONFLICT target in
+--   usage/repository.go's RecordEvent) breaks every 'completed' usage_events
+--   write: Postgres rejects an ON CONFLICT clause naming an index that does
+--   not exist. That is a loud error on every completed request, not a silent
+--   money defect, which is why it is acceptable -- but a migration-only
+--   rollback must never be attempted without rolling the binary back first.
 -- =============================================================================
 
 BEGIN;
 
 SET LOCAL lock_timeout = '5s';
+
+-- ---------------------------------------------------------------------------
+-- Step 0: refuse to guess on a shape this migration has no evidence for.
+-- ---------------------------------------------------------------------------
+DO $triple_guard$
+DECLARE
+    triple_count integer;
+BEGIN
+    SELECT count(*) INTO triple_count FROM (
+        SELECT 1
+        FROM public.usage_events
+        WHERE event_type = 'completed'
+        GROUP BY account_id, request_attempt_id
+        HAVING count(*) > 2
+    ) t;
+
+    IF triple_count > 0 THEN
+        RAISE EXCEPTION 'usage_events has % attempt(s) with 3+ completed rows; the pairwise dedup in this migration assumes at most 2 (live shape measured 2026-08-25: 576 pairs, 0 triples). A triple needs a human to pick the right row, not an automatic GREATEST/COALESCE guess across an unplanned third writer. Resolve manually (identify the extra row(s), decide which to keep), then re-run this migration.', triple_count;
+    END IF;
+END
+$triple_guard$;
 
 -- ---------------------------------------------------------------------------
 -- Step 1: fold duplicate 'completed' rows into the earliest (authoritative)
@@ -135,26 +208,23 @@ USING _usage_events_completed_dupes d
 WHERE ue.id = d.id;
 
 -- ---------------------------------------------------------------------------
--- Step 2: rescale backfill 20260823_40 omitted for this table.
+-- Step 2: reconcile stale-unit rows against the ledger (see header for why
+-- this replaced a created_at boundary). No dependency on
+-- credit_unit_rescale.applied_at, so it catches deploy-gap stragglers a
+-- timestamp bound structurally cannot.
 -- ---------------------------------------------------------------------------
-DO $backfill$
-BEGIN
-    IF NOT EXISTS (SELECT 1 FROM public.credit_unit_rescale) THEN
-        -- Rescale never ran on this database (e.g. a fresh CI throwaway
-        -- seeded straight from HEAD) -- nothing pre-dates a boundary that
-        -- does not exist, so there is nothing to backfill.
-        RETURN;
-    END IF;
-
-    UPDATE public.usage_events
-       SET hive_credit_delta = hive_credit_delta * 10000,
-           internal_metadata = internal_metadata || jsonb_build_object(
-               'credit_unit', 'legacy-1usd-100k-credits')
-     WHERE hive_credit_delta <> 0
-       AND created_at < (SELECT applied_at FROM public.credit_unit_rescale)
-       AND NOT (internal_metadata ? 'credit_unit');
-END
-$backfill$;
+UPDATE public.usage_events ue
+   SET hive_credit_delta = cle.credits_delta,
+       internal_metadata = ue.internal_metadata || jsonb_build_object(
+           'credit_unit', 'legacy-1usd-100k-credits',
+           'ledger_reconciled_from', ue.hive_credit_delta)
+  FROM public.credit_ledger_entries cle
+ WHERE cle.entry_type = 'usage_charge'
+   AND cle.account_id = ue.account_id
+   AND cle.attempt_id = ue.request_attempt_id
+   AND ue.hive_credit_delta <> 0
+   AND ue.hive_credit_delta <> cle.credits_delta
+   AND ue.hive_credit_delta * 10000 = cle.credits_delta;
 
 -- ---------------------------------------------------------------------------
 -- Step 3: prevent future duplicates. ON CONFLICT target for

--- a/supabase/migrations/20260825_03_usage_events_completed_dedup_and_rescale_backfill.sql
+++ b/supabase/migrations/20260825_03_usage_events_completed_dedup_and_rescale_backfill.sql
@@ -175,7 +175,7 @@ CREATE TEMP TABLE _usage_events_completed_ranked ON COMMIT DROP AS
 SELECT id, account_id, request_attempt_id, input_tokens, output_tokens,
        cache_read_tokens, cache_write_tokens, provider_request_id,
        row_number() OVER (
-         PARTITION BY account_id, request_attempt_id ORDER BY created_at ASC
+         PARTITION BY account_id, request_attempt_id ORDER BY created_at ASC, id ASC
        ) AS rn
 FROM public.usage_events
 WHERE event_type = 'completed';


### PR DESCRIPTION
## Summary

Fixes #1180. `usage_events.hive_credit_delta` and `credit_ledger_entries.credits_delta` disagreed for the same request. Investigation found two independent, confirmed-live root causes, not one:

**Root cause A (the primary defect, not a rescale/rounding artifact): a genuine duplicate write.** Every reservation-backed request writes TWO `usage_events` rows with `event_type='completed'` for the same attempt:
- Control-plane's own `accounting.finalizeLocked` (`apps/control-plane/internal/accounting/service.go`) writes the authoritative row during `FinalizeReservation`, in-process. `hive_credit_delta = -actualCredits`, the same figure charged to the ledger in the same call.
- edge-api's `recordCompletedEvent` (`apps/edge-api/internal/inference/orchestrator.go`, `stream.go`) then makes a separate, unconditional HTTP POST to `/internal/usage/events` that writes a second row for the identical attempt. Its `hive_credit_delta` is set to `usage.TotalTokens` — a raw token count, not a credit amount, not even negative.

Live measurement on the demo box (2026-08-25, full history, read-only bounded queries): 576 duplicate pairs, zero triples. 576/576 have the earlier row's delta <= 0 (ledger-matching); 575/576 have the later row's delta equal to `input_tokens + output_tokens` exactly. The ordering is deterministic by the code path, not a race: edge-api's POST only fires after the synchronous `FinalizeReservation` call returns.

**Root cause B (a real stale-unit bug, distinct from A): a missed backfill.** `usage_events.hive_credit_delta` was omitted from the column list in `20260823_40_credit_unit_rescale_billion.sql` (D-046, factor 10000). `credit_ledger_entries.credits_delta` was backfilled by that migration; `usage_events.hive_credit_delta` was not. Every authoritative row written before the rescale boundary is off from the ledger by exactly 10000x. Confirmed live (masked attempt id): `-12` in usage_events vs `-120000` in the ledger for the identical attempt, `-12 * 10000 = -120000` exactly.

**Which surface is authoritative:** `credit_ledger_entries`, confirmed from code (it's what actually posts against the account balance) rather than assumed. `usage_events`'s correct row is a mirror of the same `actualCredits` value, not an independent computation.

**Does anything bill from the wrong row:** no live billing/invoicing path reads `usage_events.hive_credit_delta`. `GetSpendSummary` and `GetUsageSummary.total_credits_spent` filter `WHERE hive_credit_delta < 0`, so the always-positive wrong duplicate was silently excluded from those two figures by accident of the sign filter — not corrupted, but `GetUsageSummary.request_count` (unfiltered `COUNT(*)`) was inflated up to 2x, and the raw `ListEvents` listing showed two contradictory rows per request.

## Fix

Chose to make the two surfaces agree (not merely document the estimate), since the authoritative value is cheaply recoverable:

1. `supabase/migrations/20260825_03_usage_events_completed_dedup_and_rescale_backfill.sql`:
   - merges duplicate `'completed'` rows per attempt (keep the earlier/authoritative row, fold the later row's real token counts in, stamp merged ids for forensics)
   - backfills the missed rescale (root cause B) using the exact flag convention `20260823_40` already established (`credit_unit: legacy-1usd-100k-credits`)
   - adds a partial unique index `ux_usage_events_completed_attempt` so a future duplicate POST folds instead of inserting
2. `apps/control-plane/internal/usage/repository.go`: `RecordEvent`'s INSERT gained the matching `ON CONFLICT ... DO UPDATE`, deliberately never touching `hive_credit_delta`/`event_type`/`status`. edge-api is unchanged (out of this fix's scope) — its redundant POST now folds harmlessly.
3. New live guard test `apps/control-plane/internal/accounting/usage_ledger_reconciliation_live_test.go`: reproduces both writes against a real DB and asserts the surviving row's `hive_credit_delta` equals the ledger's `credits_delta`. Verified failing before the fix, passing after.
4. Two existing test fixtures (`repository_live_test.go`) inserted multiple `'completed'` events against one shared attempt id to simulate multiple requests — a shape that never occurs in production and that the new constraint correctly rejects. Fixed to seed one real attempt per event (what the tests were actually meant to exercise).

**Known residual gaps, out of scope (edge-api not in this task's allowlist), noted for the record:**
- edge-api never populates `FinalizeReservationInput.InputTokens/OutputTokens` despite #856 already wiring the field end to end; this fix's merge compensates without needing it fixed, but it's a one-line edge-api bug worth its own ticket.
- The `reservation.ID == ""` fallback path (no reservation ever created) still writes a lone wrong-value row with nothing to reconcile against, since nothing was charged.
- Relation to #1174 (cache tokens never reach `api_key_usage_rollups`): same family of defect, different table/path. The `usage_events` row this fix produces does carry cache tokens correctly; `api_key_usage_rollups` is the surface still missing them.

## Review round 2 (independent review, DO NOT BLOCK, confirmed by reproduction)

Reviewer confirmed the merge logic, backfill idempotency, and index safety by
reproducing rather than reading, and confirmed edge-api's write path only
logs `RecordUsageEvent` errors and never propagates them to the HTTP
response, so the migrate-then-deploy window is not customer-facing. One
finding required a fix before merge.

**Finding: the backfill under-applied.** The first version bounded the
rescale backfill on `usage_events.created_at < credit_unit_rescale.applied_at`.
20260823_40 documents a deploy-gap race of its own: the old binary keeps
writing old-unit rows for a window after that migration's COMMIT (until the
container recreate), so a straggler row can carry `created_at > applied_at`
while still holding a stale-unit value. A timestamp bound skips exactly
those rows, permanently — `usage_events` carries no positive new-unit stamp,
so nothing could ever later tell a missed straggler apart from a
legitimately small delta.

**Fix chosen: option 3, reconcile against the ledger.** `credit_ledger_entries`
was already established as authoritative and was correctly backfilled by
20260823_40. The rescale step now reconciles directly against it instead of
inferring the unit from a timestamp: for every surviving `'completed'` row,
if its `hive_credit_delta` disagrees with the matching
`credit_ledger_entries.credits_delta` (same account, same attempt,
`entry_type = 'usage_charge'`) by **exactly** a factor of 10000, the ledger's
value is copied onto it. A disagreement that is not exactly 10000x is left
untouched — that would be a different, unexplained mismatch this migration
has no evidence about, and "fixing" it would be a guess. This needed no new
column and no timestamp heuristic (option 1/2 both would have), uses truth
already established, and has no dependency on `created_at` or
`credit_unit_rescale.applied_at` at all, so it catches every stale-unit row
including deploy-gap stragglers a timestamp bound structurally cannot see.

Verified by reproduction, not just code-reading: seeded a fabricated
straggler (old-unit `usage_events` row, `created_at` 90s **after** the
rescale marker's `applied_at`, matching ledger entry in new units) on a
throwaway Postgres 17. Before: `hive_credit_delta = -72` vs ledger
`-720000`, a 10000x miss the old bound would never have touched (its
`created_at` is after `applied_at`). After running the revised migration:
`hive_credit_delta = -720000`, `internal_metadata` stamped
`{"credit_unit": "legacy-1usd-100k-credits", "ledger_reconciled_from": -72}`.
Re-ran the file a second time: `UPDATE 0` on the reconciliation step, value
unchanged — idempotent.

**Second finding: triple-row guard (accepted, cheap guard over a fix).** The
dedup merge is a many-to-one join; on an (unobserved, live evidence is 0
triples) 3+-row shape Postgres would pick an arbitrary source row for the
folded token columns. Added a step-0 check that raises and rolls back the
whole transaction if any attempt has 3+ `'completed'` rows, before any
mutation. Verified by reproduction: seeded a genuine triple, ran the
migration, got a loud `ERROR` naming the attempt count and the reason, and
confirmed via a fresh `count(*)` that all three rows were left untouched
(transaction rolled back, no partial state, index also not created).

**Rollback asymmetry (documented in the migration header, not fixed — no
action needed per reviewer):** this migration has no down-migration. Rolling
it back while control-plane's binary stays on the version that assumes
`ux_usage_events_completed_attempt` exists (the `ON CONFLICT` target in
`usage/repository.go`'s `RecordEvent`) breaks every `'completed'`
`usage_events` write — Postgres rejects an `ON CONFLICT` clause naming a
missing index. That fails loudly as errors, not as silent money corruption,
which is why it's acceptable, but a migration-only rollback must never be
attempted without rolling the binary back first.

## Test plan

- [x] `go build ./apps/control-plane/...` and `go vet` on touched packages: clean
- [x] `go test ./apps/control-plane/internal/accounting/... ./apps/control-plane/internal/usage/... ./apps/control-plane/internal/ledger/...` against real Postgres 17 (`scripts/ci-throwaway-db.sh`, 107/107 migrations applied): all green, including the new guard test
- [x] Guard test verified RED before the fix (fails on the unique-violation / wrong-merge), GREEN after
- [x] Migration applies cleanly against the full migration chain from scratch
- [x] Migration idempotency verified by literal replay against fabricated dirty data matching the real live shape (not just code inspection): first run merges + backfills, second run changes 0 rows
- [x] `gofmt -l` clean on every touched file
- [x] Deploy-gap straggler (old-unit row, created_at after the rescale marker) reproduced and confirmed corrected by the ledger reconciliation, not the old timestamp bound
- [x] Fabricated 3-row shape reproduced; migration raises and rolls back with zero rows mutated

🤖 Generated with [Claude Code](https://claude.com/claude-code)