### PR TITLE
feat: show catalog prices in dollars, keeping credits where a bill is reconciled

### DIFF
--- a/apps/web-console/__tests__/console-cache-visibility.test.tsx
+++ b/apps/web-console/__tests__/console-cache-visibility.test.tsx
@@ -170,8 +170,11 @@ describe("model catalog cache pricing columns", () => {
 
     expect(screen.getByText("Cache read / 1M")).toBeDefined();
     expect(screen.getByText("Cache write / 1M")).toBeDefined();
-    expect(screen.getByText("1,200,000")).toBeDefined();
-    expect(screen.getByText("15,000,000")).toBeDefined();
+    // 1,200,000 and 15,000,000 credits per million tokens, rendered as the
+    // dollars-per-million figure the catalog now publishes. Both are well
+    // under a cent and neither may collapse to "$0.00".
+    expect(screen.getByText("$0.0012")).toBeDefined();
+    expect(screen.getByText("$0.015")).toBeDefined();
   });
 
   it("renders a dash, never a zero, when a fixed-price alias publishes no cache rate", () => {

--- a/apps/web-console/app/console/analytics/page.tsx
+++ b/apps/web-console/app/console/analytics/page.tsx
@@ -37,6 +37,7 @@ import {
 import { PageHeader } from "@/components/ui/page-header";
 import { cn } from "@/lib/cn";
 import { formatCredits, formatPercent } from "@/lib/format/credits";
+import { formatUsdFromCredits } from "@/lib/format/model-pricing";
 
 interface AnalyticsPageProps {
   searchParams: Promise<{
@@ -314,16 +315,16 @@ export default async function AnalyticsPage({
                   testId="cache-hit-rate"
                 />
                 <SummaryCard
-                  label="Blended credits / 1M"
+                  label="Blended price / 1M"
                   value={
                     blendedCreditsPerMillion === null
                       ? "—"
-                      : formatCredits(blendedCreditsPerMillion)
+                      : formatUsdFromCredits(blendedCreditsPerMillion)
                   }
                   note={
                     blendedCreditsPerMillion === null
                       ? "No tokens served in this window."
-                      : "Credits spent divided by input plus output tokens, per million. Effective, so cache reads are already priced in."
+                      : `${formatCredits(blendedCreditsPerMillion)} credits. Credits spent divided by input plus output tokens, per million. Effective, so cache reads are already priced in.`
                   }
                   testId="blended-credits-per-million"
                 />

--- a/apps/web-console/components/catalog/model-catalog-table.tsx
+++ b/apps/web-console/components/catalog/model-catalog-table.tsx
@@ -4,39 +4,10 @@ import type { CatalogModel } from "@/lib/control-plane/client";
 import { Badge } from "@/components/ui/badge";
 import { DataTable, type Column } from "@/components/ui/data-table";
 import { EmptyState } from "@/components/ui/empty-state";
-import { formatCredits } from "@/lib/format/credits";
+import { formatCachePrice, formatModelPrice } from "@/lib/format/model-pricing";
 
 interface ModelCatalogTableProps {
   models: CatalogModel[];
-}
-
-// A model priced from actual upstream cost has no per-million rate to show.
-// Rendering 0 there would read as "free", so the absence is shown as what it
-// is. formatCredits still owns every real number.
-//
-// The pricing mode decides which kind of absence this is. A null price on a
-// variable-price alias is the design; a null price on a fixed one means the
-// lookup failed, and calling that "Variable" would present a broken decode as a
-// deliberate pricing model on the very screen an admin uses to check pricing.
-function formatPrice(credits: number | null, pricingMode: string): string {
-  if (credits === null) {
-    return pricingMode === "upstream_actual" ? "Variable" : "Unknown";
-  }
-  return formatCredits(credits);
-}
-
-// Cache prices carry a third kind of absence the input and output columns do
-// not have. A fixed-price alias that publishes no cache rate is neither broken
-// nor variable, it simply has no cache rate to charge, and OpenRouter renders
-// exactly that case as a dash in its own `Cache read /M` column. Rendering 0
-// instead would say the alias caches for free, which is the expensive kind of
-// wrong on a pricing screen. A variable-price alias still reads "Variable",
-// because its cache component is variable for the same reason its input is.
-function formatCachePrice(credits: number | null, pricingMode: string): string {
-  if (credits === null) {
-    return pricingMode === "upstream_actual" ? "Variable" : "—";
-  }
-  return formatCredits(credits);
 }
 
 type ToneName = "neutral" | "accent" | "success" | "warning" | "danger";
@@ -131,14 +102,14 @@ export function ModelCatalogTable({ models }: ModelCatalogTableProps) {
       header: "Input / 1M",
       numeric: true,
       align: "right",
-      cell: (row) => formatPrice(row.pricing.input_price_credits, row.pricing.pricing_mode),
+      cell: (row) => formatModelPrice(row.pricing.input_price_credits, row.pricing.pricing_mode),
     },
     {
       key: "output",
       header: "Output / 1M",
       numeric: true,
       align: "right",
-      cell: (row) => formatPrice(row.pricing.output_price_credits, row.pricing.pricing_mode),
+      cell: (row) => formatModelPrice(row.pricing.output_price_credits, row.pricing.pricing_mode),
     },
     {
       key: "cache_read",

--- a/apps/web-console/components/catalog/model-detail.tsx
+++ b/apps/web-console/components/catalog/model-detail.tsx
@@ -36,10 +36,16 @@ interface PriceRow {
   note: string;
 }
 
-// Every figure on this page is credits per one million metered tokens, the
+// Every figure on this page is a rate per one million metered tokens, the
 // same unit the catalog list prints, so the unit is stated once per section
 // rather than repeated in every cell.
-const CREDITS_PER_MILLION = "Credits per 1M tokens";
+//
+// Both units are shown, and deliberately. Dollars lead because that is the
+// figure a customer comparing gateways reads, and the raw credit integer is
+// kept alongside it because credits are the unit the ledger actually moves:
+// an account reconciling a bill against its usage needs the exact integer,
+// which a dollar figure rounded for legibility cannot give back.
+const PER_MILLION = "Per 1M tokens";
 
 /**
  * A capability Hive's control plane does not publish per model today. Rendered
@@ -147,11 +153,22 @@ export function ModelDetail({
       ),
     },
     {
-      key: "credits",
-      header: CREDITS_PER_MILLION,
+      key: "price",
+      header: "Price / 1M",
       numeric: true,
       align: "right",
       cell: (row) => formatModelPrice(row.credits, model.pricing.pricing_mode),
+    },
+    {
+      key: "credits",
+      header: "Credits / 1M",
+      numeric: true,
+      align: "right",
+      cell: (row) => (
+        <span className="text-xs text-[var(--color-ink-3)]">
+          {formatModelPrice(row.credits, model.pricing.pricing_mode, "credits")}
+        </span>
+      ),
     },
     {
       key: "note",
@@ -183,7 +200,8 @@ export function ModelDetail({
               {formatInOutPrice(model.pricing)}
             </span>
             <span className="block text-2xs text-[var(--color-ink-3)]">
-              {CREDITS_PER_MILLION.toLowerCase()}
+              {formatInOutPrice(model.pricing, "credits")} credits,{" "}
+              {PER_MILLION.toLowerCase()}
             </span>
           </Tile>
           <Tile label="Cache read / write">
@@ -199,7 +217,18 @@ export function ModelDetail({
               )}
             </span>
             <span className="block text-2xs text-[var(--color-ink-3)]">
-              {CREDITS_PER_MILLION.toLowerCase()}
+              {formatModelPrice(
+                model.pricing.cache_read_price_credits,
+                model.pricing.pricing_mode,
+                "credits",
+              )}
+              {" / "}
+              {formatModelPrice(
+                model.pricing.cache_write_price_credits,
+                model.pricing.pricing_mode,
+                "credits",
+              )}{" "}
+              credits, {PER_MILLION.toLowerCase()}
             </span>
           </Tile>
           <Tile label="Context">
@@ -225,7 +254,7 @@ export function ModelDetail({
           <CardDescription>
             {variablePriced
               ? "This alias is priced from the actual cost of each generation, so it publishes no per-million rate. The charge is derived per request, not from a table."
-              : "Every rate Hive charges for this model, in credits per one million metered tokens. A rate of 0 means that dimension is deliberately not charged. Unknown means the catalog holds no rate, which is not the same as free."}
+              : "Every rate Hive charges for this model, per one million metered tokens, in US dollars and in the credits the ledger moves. A rate of 0 means that dimension is deliberately not charged. Unknown means the catalog holds no rate, which is not the same as free."}
           </CardDescription>
         </CardHeader>
         <CardContent>

--- a/apps/web-console/lib/format/model-pricing.test.ts
+++ b/apps/web-console/lib/format/model-pricing.test.ts
@@ -1,15 +1,32 @@
 import { describe, expect, it } from "vitest";
 
-import { formatInOutPrice, formatModelPrice } from "./model-pricing";
+import {
+  CREDITS_PER_USD,
+  formatCachePrice,
+  formatInOutPrice,
+  formatModelPrice,
+  formatUsdFromCredits,
+} from "./model-pricing";
 
-// This is a billing surface. The whole point of these three branches is that
-// "deliberately free", "variable by design" and "we could not read the price"
-// are different answers, and collapsing any pair of them misleads a customer
-// pricing the gateway. Each case below is one of those collapses.
+// This is a billing surface. The whole point of these branches is that
+// "deliberately free", "variable by design", "no such rate" and "we could not
+// read the price" are different answers, and collapsing any pair of them
+// misleads a customer pricing the gateway. Each case below is one of those
+// collapses. Changing the display unit from credits to dollars changes HOW a
+// number is drawn and must never change WHETHER an absence is distinguishable
+// from a zero, so every case is asserted in both units.
 describe("formatModelPrice", () => {
-  it("prints a published rate, thousand-separated", () => {
-    expect(formatModelPrice(89_460_000, "fixed")).toBe("89,460,000");
-    expect(formatModelPrice(178_920_000, "fixed")).toBe("178,920,000");
+  it("prints a published rate as dollars per million tokens", () => {
+    // The live deepseek-v4-flash input and output rates.
+    expect(formatModelPrice(89_460_000, "fixed")).toBe("$0.0895");
+    expect(formatModelPrice(178_920_000, "fixed")).toBe("$0.179");
+  });
+
+  it("still prints the exact credit integer when asked for credits", () => {
+    expect(formatModelPrice(89_460_000, "fixed", "credits")).toBe("89,460,000");
+    expect(formatModelPrice(178_920_000, "fixed", "credits")).toBe(
+      "178,920,000",
+    );
   });
 
   it("prints a published zero as zero, never as an absence", () => {
@@ -17,12 +34,16 @@ describe("formatModelPrice", () => {
     // (supabase/migrations/20260824_02_free_pool_router.sql). Zero is a
     // decision: that dimension is not charged. Rendering it as "Unknown" or
     // "Free" would hide a real published rate behind a word.
-    expect(formatModelPrice(0, "fixed")).toBe("0");
-    expect(formatModelPrice(0, "upstream_actual")).toBe("0");
+    expect(formatModelPrice(0, "fixed")).toBe("$0");
+    expect(formatModelPrice(0, "upstream_actual")).toBe("$0");
+    expect(formatModelPrice(0, "fixed", "credits")).toBe("0");
   });
 
   it("calls a missing price on a variable alias Variable", () => {
     expect(formatModelPrice(null, "upstream_actual")).toBe("Variable");
+    expect(formatModelPrice(null, "upstream_actual", "credits")).toBe(
+      "Variable",
+    );
   });
 
   it("calls a missing price on a fixed alias Unknown, not Variable", () => {
@@ -30,6 +51,73 @@ describe("formatModelPrice", () => {
     // there would present a broken decode as a pricing model.
     expect(formatModelPrice(null, "fixed")).toBe("Unknown");
     expect(formatModelPrice(null, "")).toBe("Unknown");
+    expect(formatModelPrice(null, "fixed", "credits")).toBe("Unknown");
+  });
+});
+
+describe("formatCachePrice", () => {
+  it("distinguishes no-cache-rate from a broken lookup and from free", () => {
+    expect(formatCachePrice(null, "fixed")).toBe("—");
+    expect(formatCachePrice(null, "upstream_actual")).toBe("Variable");
+    expect(formatCachePrice(0, "fixed")).toBe("$0");
+    expect(formatCachePrice(0, "fixed", "credits")).toBe("0");
+  });
+
+  it("renders a real cache rate rather than a dash", () => {
+    // The corrected deepseek-v4-flash cache-read rate, 1/30 of its input rate
+    // (supabase/migrations/20260825_02_deepseek_cache_read_price_correction.sql).
+    expect(formatCachePrice(2_982_000, "fixed")).toBe("$0.00298");
+  });
+});
+
+describe("formatUsdFromCredits", () => {
+  it("matches the plain dollar shape a model page publishes", () => {
+    expect(formatUsdFromCredits(200_000_000)).toBe("$0.20");
+    expect(formatUsdFromCredits(CREDITS_PER_USD)).toBe("$1.00");
+    expect(formatUsdFromCredits(12_500_000_000)).toBe("$12.50");
+  });
+
+  // The failure this guards is specific: rounding a real, tiny, non-zero rate
+  // to two decimals prints "$0.00", which reads as free. That is strictly
+  // worse than the raw credit integer this display replaces, because a raw
+  // integer at least cannot be mistaken for zero.
+  it("never rounds a non-zero rate down to zero", () => {
+    // Every distinct non-zero rate the seeded catalog actually holds, read off
+    // a database with the full migration chain applied:
+    //
+    //   select distinct v from (select input_price_credits v from model_aliases
+    //     union all select output_price_credits from model_aliases
+    //     union all select cache_read_price_credits from model_aliases
+    //     union all select cache_write_price_credits from model_aliases) t
+    //   where v is not null order by v;
+    //
+    // The list is led by one credit, which is not in the catalog: it is the
+    // smallest amount the unit can express at all (1e-9 USD), so it is the
+    // floor this rule has to hold at, not just the floor today's data reaches.
+    const everyRealRate = [
+      1, 10_000, 40_000, 1_000_000, 2_982_000, 4_000_000, 52_360_000,
+      89_460_000, 105_000_000, 178_920_000, 210_000_000, 420_000_000,
+      840_000_000, 1_570_800_000, 4_712_400_000, 30_800_000_000,
+      43_166_670_000,
+    ];
+    for (const credits of everyRealRate) {
+      const rendered = formatUsdFromCredits(credits);
+      expect(rendered, `${credits} credits rendered as free`).not.toBe("$0.00");
+      expect(rendered, `${credits} credits rendered as free`).not.toBe("$0");
+    }
+  });
+
+  it("renders the smallest expressible rate exactly", () => {
+    // One credit is 1e-9 USD, so nine decimals is the exact width of the unit.
+    expect(formatUsdFromCredits(1)).toBe("$0.000000001");
+    // The smallest rate the live catalog actually publishes: the
+    // hive-embedding-default input rate, one hundred-thousandth of a dollar
+    // per million tokens. Two decimals would print this as "$0.00".
+    expect(formatUsdFromCredits(10_000)).toBe("$0.00001");
+  });
+
+  it("prints a true zero as zero", () => {
+    expect(formatUsdFromCredits(0)).toBe("$0");
   });
 });
 
@@ -41,7 +129,7 @@ describe("formatInOutPrice", () => {
         output_price_credits: 178_920_000,
         pricing_mode: "fixed",
       }),
-    ).toBe("89,460,000 / 178,920,000");
+    ).toBe("$0.0895 / $0.179");
   });
 
   it("does not let one side borrow the other side's number", () => {
@@ -59,6 +147,19 @@ describe("formatInOutPrice", () => {
         output_price_credits: 178_920_000,
         pricing_mode: "fixed",
       }),
-    ).toBe("0 / 178,920,000");
+    ).toBe("$0 / $0.179");
+  });
+
+  it("carries the unit through to both halves", () => {
+    expect(
+      formatInOutPrice(
+        {
+          input_price_credits: 89_460_000,
+          output_price_credits: 178_920_000,
+          pricing_mode: "fixed",
+        },
+        "credits",
+      ),
+    ).toBe("89,460,000 / 178,920,000");
   });
 });

--- a/apps/web-console/lib/format/model-pricing.ts
+++ b/apps/web-console/lib/format/model-pricing.ts
@@ -1,45 +1,134 @@
 import { formatCredits } from "@/lib/format/credits";
 
 /**
+ * One US dollar is one billion Hive credits (`.wolf/decisions.md` D-046,
+ * migration `20260823_40_credit_unit_rescale_billion.sql`). Every catalog
+ * price column stores an integer credit rate per one million metered tokens,
+ * so dividing by this constant yields the dollars-per-million figure a
+ * customer recognises.
+ */
+export const CREDITS_PER_USD = 1_000_000_000;
+
+/**
+ * Which unit a price cell renders in. Both units share one absence policy,
+ * because "deliberately free", "variable by design" and "we could not read
+ * the price" mean the same three things whichever unit the number is in.
+ */
+export type PriceUnit = "usd" | "credits";
+
+/**
+ * Render a credit rate as US dollars without ever rounding a real price down
+ * to zero.
+ *
+ * The precision is chosen per value rather than fixed at two decimals. A
+ * two-decimal render prints `$0.00` for a cache-read rate of 2,982,000
+ * credits per million ($0.002982, the corrected DeepSeek flash rate from
+ * `20260825_02_deepseek_cache_read_price_correction.sql`), and a price that
+ * looks free is a worse lie than the raw integer this replaces.
+ *
+ * The rule: keep three significant digits, never fewer than two decimals, and
+ * never more than nine. Nine is not a taste call, it is the exact width of
+ * the unit: one credit is 1e-9 USD, so nine decimals renders ANY integer
+ * credit rate as a non-zero figure. `$0.00` is therefore unreachable for a
+ * non-zero price, which is the invariant the tests pin.
+ *
+ * Locale is pinned to en-US rather than routed through `intlTag`. The unit is
+ * US dollars on every surface, and `bn-BD` renders the same amount as
+ * `US$0.20`, which reads as a second currency next to the `$0.20` the model
+ * pages this mirrors print. Grouping separators only appear above $1,000,
+ * which no per-million token rate in the catalog approaches.
+ */
+export function formatUsdFromCredits(credits: number): string {
+  if (!Number.isFinite(credits) || credits === 0) {
+    return "$0";
+  }
+  const usd = credits / CREDITS_PER_USD;
+  const magnitude = Math.floor(Math.log10(Math.abs(usd)));
+  const maximumFractionDigits = Math.min(9, Math.max(2, 2 - magnitude));
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits,
+  }).format(usd);
+}
+
+function renderPrice(credits: number, unit: PriceUnit): string {
+  return unit === "credits" ? formatCredits(credits) : formatUsdFromCredits(credits);
+}
+
+/**
  * Render one catalog price for display. Three outcomes, deliberately distinct,
  * because on a pricing surface they mean three different things:
  *
  *   - A number, zero included, is a published rate. Zero means the dimension is
  *     deliberately not charged (hive-default publishes exactly that for cache
- *     write), so it prints as "0" and never as an absence. A customer reading
- *     "0" is reading a decision.
+ *     write), so it prints as "$0" and never as an absence. A customer reading
+ *     zero is reading a decision.
  *   - Null on an `upstream_actual` alias is the design: the price is variable
  *     per request and there genuinely is no per-million rate to publish.
  *   - Null on a `fixed` alias means the lookup came back empty. Calling that
  *     "Variable" would dress a broken decode up as a pricing model on the one
  *     screen a customer opens to check what a model costs.
  *
- * ponytail: components/catalog/model-catalog-table.tsx carries a private twin
- * of this function. It is left alone on purpose while another branch is editing
- * that file; fold it into this module once both have landed.
+ * `unit` changes only how a real number is drawn. It cannot turn an absence
+ * into a number or a number into an absence.
  */
 export function formatModelPrice(
   credits: number | null,
   pricingMode: string,
+  unit: PriceUnit = "usd",
 ): string {
   if (credits === null) {
     return pricingMode === "upstream_actual" ? "Variable" : "Unknown";
   }
-  return formatCredits(credits);
+  return renderPrice(credits, unit);
+}
+
+/**
+ * Cache prices carry a fourth outcome the input and output dimensions do not.
+ * A fixed-price alias that publishes no cache rate is neither broken nor
+ * variable, it simply has no cache rate to charge, and the model pages this
+ * mirrors render exactly that case as a dash in their own `Cache read /M`
+ * column. Rendering zero instead would say the alias caches for free, which is
+ * the expensive kind of wrong on a pricing screen. A variable-price alias
+ * still reads "Variable", because its cache component is variable for the same
+ * reason its input is.
+ */
+export function formatCachePrice(
+  credits: number | null,
+  pricingMode: string,
+  unit: PriceUnit = "usd",
+): string {
+  if (credits === null) {
+    return pricingMode === "upstream_actual" ? "Variable" : "—";
+  }
+  return renderPrice(credits, unit);
 }
 
 /**
  * The combined "in / out" figure shown in the model header tile, mirroring the
- * shape OpenRouter puts in the same position. Both halves go through
- * formatModelPrice, so a variable-price alias reads "Variable / Variable"
- * rather than borrowing a number from the other side.
+ * shape the model pages this parity-matches put in the same position. Both
+ * halves go through formatModelPrice, so a variable-price alias reads
+ * "Variable / Variable" rather than borrowing a number from the other side.
  */
-export function formatInOutPrice(pricing: {
-  input_price_credits: number | null;
-  output_price_credits: number | null;
-  pricing_mode: string;
-}): string {
-  const input = formatModelPrice(pricing.input_price_credits, pricing.pricing_mode);
-  const output = formatModelPrice(pricing.output_price_credits, pricing.pricing_mode);
+export function formatInOutPrice(
+  pricing: {
+    input_price_credits: number | null;
+    output_price_credits: number | null;
+    pricing_mode: string;
+  },
+  unit: PriceUnit = "usd",
+): string {
+  const input = formatModelPrice(
+    pricing.input_price_credits,
+    pricing.pricing_mode,
+    unit,
+  );
+  const output = formatModelPrice(
+    pricing.output_price_credits,
+    pricing.pricing_mode,
+    unit,
+  );
   return `${input} / ${output}`;
 }

--- a/docs/proof/console-currency-display-2026-08-25/capture-log.md
+++ b/docs/proof/console-currency-display-2026-08-25/capture-log.md
@@ -1,0 +1,87 @@
+# Console currency display — visual proof capture log
+
+Captured 2026-08-25 for the branch `feat/console-currency-display`.
+
+The screenshots themselves are attached to the pull request through
+`scripts/post-pr-visual-proof.sh`, which uploads them to the permanent
+`visual-proof-assets` release. Only this text log is committed, because
+`npm run lint:proof-tokens` scans `docs/proof/` and nothing else.
+
+## What was running
+
+Not the demo box: the change is not deployed yet, and a before/after pair has
+to render both versions against the same data. The stack was stood up locally
+from this branch's own tree, using the same scripts the `Web E2E (full stack)`
+CI job uses, so the catalog rows are the real seeded catalog rather than
+fixtures invented for the screenshot.
+
+| Component | How it was started |
+| --- | --- |
+| Postgres | `pgvector/pgvector:pg17`, throwaway, published on a free host port |
+| GoTrue + PostgREST + gateway | `scripts/ci-supabase-stack.sh --port 9010` |
+| Schema | the full migration chain, 106 of 106 applied by `scripts/ci-throwaway-db.sh --gotrue` |
+| control-plane | `docker compose --profile local up control-plane`, published on a free host port |
+| Next.js console | `npm run build && npm start` from `apps/web-console`, port 3100 |
+| Account | a run-scoped fixture user created by `tests/e2e/support/e2e-auth-fixtures.mjs` in the throwaway GoTrue, destroyed with the stack. No shared account's password was set, reset or rotated. |
+
+The before frames were captured from the same stack with the working tree
+stashed back to `origin/main`, so the only difference between each pair is
+this branch's diff. The database was untouched between the two runs.
+
+## URLs captured
+
+| Frame | URL |
+| --- | --- |
+| `before-catalog.png`, `after-catalog.png` | `http://localhost:3100/console/catalog` |
+| `before-model-detail.png`, `after-model-detail.png` | `http://localhost:3100/console/catalog/deepseek-v4-flash` |
+| `before-analytics.png`, `after-analytics.png` | `http://localhost:3100/console/analytics?tab=overview&window=24h` |
+
+No URL here carries a credential in its query string or fragment, so there was
+nothing to redact from the address bar. The signed-in account's email address
+is masked in every frame by Playwright's screenshot `mask` option, applied
+before the file is written rather than after.
+
+## Console transcript
+
+Every frame was captured with a `page.on("console")` listener attached. The
+listener recorded no message of any type on any of the six page loads: the
+"--- console messages ---" section of each capture run is empty. No errors, no
+warnings, no React hydration complaints.
+
+## What the frames show
+
+`before-catalog.png` — the four price columns render raw credit integers:
+`89,460,000`, `178,920,000`, `2,982,000`, `1,570,800,000`, `43,166,670,000`.
+
+`after-catalog.png` — the same eleven rows, same data, rendered as dollars per
+million tokens: `$0.0895`, `$0.179`, `$0.00298`, `$1.57`, `$43.17`. The three
+non-numeric states are unchanged and still distinguishable from each other and
+from a real zero:
+
+* `hive-auto` still reads `Variable` in all four columns (an `upstream_actual`
+  alias publishes no per-million rate).
+* `hive-embedding-default` and both voice aliases still show `—` in the two
+  cache columns (a fixed alias with no cache rate is not the same as a free
+  one).
+* `hive-default`'s cache write, `hive-free`'s cache columns and both voice
+  aliases' input still read `$0`, because a published zero is a decision and
+  has to stay visible as one.
+
+The smallest real rates in the catalog are the ones this change could most
+easily have destroyed. `hive-embedding-default` input is 10,000 credits per
+million, one hundred-thousandth of a dollar, and `hive-fast` cache write is
+40,000. Both render as `$0.00001` and `$0.00004` rather than collapsing to
+`$0.00`, which would have read as free.
+
+`before-model-detail.png` / `after-model-detail.png` — the header tiles and the
+Pricing table on `deepseek-v4-flash`. Before: a single `Credits per 1M tokens`
+column. After: `Price / 1M` leads and `Credits / 1M` sits beside it, keeping
+the exact integer an account needs to reconcile a bill against the ledger.
+
+`before-analytics.png` / `after-analytics.png` — the blended effective price
+tile, over six seeded usage rows on the throwaway database (3,438,000 credits
+across 31,200 tokens). Before: `Blended credits / 1M`, `110,192,307`. After:
+`Blended price / 1M`, `$0.11`, with `110,192,307 credits` kept in the tile's
+derivation note. The figures on that page are synthetic rows inserted into the
+throwaway database for this capture; they are not any real account's balance
+or spend.


### PR DESCRIPTION
## What changed

Catalog prices render as US dollars per million tokens instead of raw credit integers. `89,460,000` becomes `$0.0895`. Three surfaces move: the catalog list, the model detail page, and the analytics blended-price tile.

One shared formatter does it. `lib/format/model-pricing.ts` gains `formatUsdFromCredits` and a `unit` parameter on the existing functions, and the private twin of `formatModelPrice` that `components/catalog/model-catalog-table.tsx` was carrying (plus its cache-price sibling) is folded back into that module. The `ponytail:` comment deferring that fold asked for it once both branches then editing the table had landed. Both have.

## The product decision, stated so it is visible and reversible

A previous agent building the model detail page deliberately used credits and no USD, citing decision D-035 and calling a change a separate product decision. That caution was correct at the time. D-035 has since been revoked: the owner ruled on 2026-08-08 that the rule was never an actual regulatory requirement, and the decision record now says currency presentation to BD customers is an unconstrained product decision. The current goal is parity with the model pages this product is measured against, and those show dollars. The orchestrator made the call to display currency; this PR is where it is written down.

## Both units, deliberately

Dollars lead everywhere because that is the figure a customer comparing gateways reads.

Credits stay where a bill gets reconciled. They are the unit the ledger actually moves, and a dollar figure rounded for legibility cannot give the exact integer back. So the model detail page carries both, a `Price / 1M` column and a `Credits / 1M` column beside it, and the analytics tile keeps the credit figure in its derivation note. The catalog list stays currency-only: it is a dense eleven-row comparison table with four price columns, and a second number in every cell works against the one thing that table is for.

## Small denominations

This is the part that could have made the display worse than the integer it replaces. Two fixed decimals would print the corrected DeepSeek cache-read rate ($0.002982 per million) and the embedding alias input rate ($0.00001 per million) as `$0.00`, which reads as free.

Precision is therefore chosen per value: three significant digits, never fewer than two decimals, never more than nine. Nine is not a taste call. One credit is exactly 1e-9 USD, so nine decimals renders any integer credit rate as a non-zero figure, which makes `$0.00` unreachable for a non-zero price. A test asserts exactly that over every distinct non-zero rate the seeded catalog actually holds, read off a database with the full migration chain applied, with one credit prepended as the floor the rule has to hold at rather than the floor today's data happens to reach.

## The honesty invariant is unchanged

Still three distinct outcomes, now asserted in both units:

* a published rate, zero included, renders the number, because a published zero is a decision
* a null on an `upstream_actual` alias renders `Variable`
* a null on a `fixed` alias renders `Unknown`, never `Variable`, because a failed lookup is not a pricing model

The catalog table's separate cache-price rule (a fixed alias with no cache rate renders an em dash) moved across unchanged too. Changing the display unit changes how a number is drawn, never whether an absence is distinguishable from a zero.

## Verification

* `docker compose run --rm --build web-console npm run test:unit`: 720 passed. The one failing file is `tests/unit/ci-web-e2e-secret-free.test.ts`, which reads a workflow file the Dockerfile never copies in and fails the same way on `main`.
* `docker compose run --rm --build web-console npm run build`: green.
* `npm run lint:proof-tokens`: green.

## Visual proof

Before and after frames of all three surfaces, captured against a stack stood up locally from this branch with the real seeded catalog behind it, posted as a comment below. The capture log is committed at `docs/proof/console-currency-display-2026-08-25/capture-log.md` and records how the stack was started, which URLs were captured, and the empty console transcript.

No shared account's password was set, reset or rotated: the stack runs its own throwaway GoTrue and the account is a run-scoped fixture user destroyed with it.
