### PR TITLE
fix: regenerate the OpenAPI contract so it stops understating the gateway

### DIFF
--- a/packages/openai-contract/generated/hive-openapi.yaml
+++ b/packages/openai-contract/generated/hive-openapi.yaml
@@ -456,7 +456,7 @@ paths:
               \    text: \"The quick brown fox jumped over the lazy dog.\",\n    voice:\
               \ GeneratedSpeechVoice.Alloy\n);\n\nusing FileStream stream = File.OpenWrite(\"\
               speech.mp3\");\nspeech.ToStream().CopyTo(stream);\n"
-      x-hive-status: planned_for_launch
+      x-hive-status: supported_now
       x-hive-phase: 6
       x-hive-notes: Text-to-speech
   /audio/transcriptions:
@@ -777,7 +777,7 @@ paths:
             \      ],\n      \"temperature\": 0.0,\n      \"avg_logprob\": -0.2860786020755768,\n\
             \      \"compression_ratio\": 1.2363636493682861,\n      \"no_speech_prob\"\
             : 0.00985979475080967\n    },\n    ...\n  ]\n}\n"
-      x-hive-status: planned_for_launch
+      x-hive-status: supported_now
       x-hive-phase: 6
       x-hive-notes: Speech-to-text
   /audio/translations:
@@ -825,7 +825,7 @@ paths:
               \nConsole.WriteLine($\"{transcription.Text}\");\n"
           response: "{\n  \"text\": \"Hello, my name is Wolfgang and I come from Germany.\
             \ Where are you heading today?\"\n}\n"
-      x-hive-status: planned_for_launch
+      x-hive-status: supported_now
       x-hive-phase: 6
       x-hive-notes: Audio translation to English
   /batches:
@@ -916,7 +916,7 @@ paths:
             : 0,\n    \"failed\": 0\n  },\n  \"metadata\": {\n    \"customer_id\"\
             : \"user_123456789\",\n    \"batch_description\": \"Nightly eval job\"\
             ,\n  }\n}\n"
-      x-hive-status: planned_for_launch
+      x-hive-status: supported_now
       x-hive-phase: 7
       x-hive-notes: Create batch
     get:
@@ -988,7 +988,7 @@ paths:
             ,\n        \"batch_description\": \"Nightly job\",\n      }\n    },\n\
             \    { ... },\n  ],\n  \"first_id\": \"batch_abc123\",\n  \"last_id\"\
             : \"batch_abc456\",\n  \"has_more\": true\n}\n"
-      x-hive-status: planned_for_launch
+      x-hive-status: supported_now
       x-hive-phase: 7
       x-hive-notes: List batches
   /batches/{batch_id}:
@@ -1042,7 +1042,7 @@ paths:
             : {\n    \"total\": 100,\n    \"completed\": 95,\n    \"failed\": 5\n\
             \  },\n  \"metadata\": {\n    \"customer_id\": \"user_123456789\",\n \
             \   \"batch_description\": \"Nightly eval job\",\n  }\n}\n"
-      x-hive-status: planned_for_launch
+      x-hive-status: supported_now
       x-hive-phase: 7
       x-hive-notes: Retrieve batch
   /batches/{batch_id}/cancel:
@@ -1099,7 +1099,7 @@ paths:
             \  \"total\": 100,\n    \"completed\": 23,\n    \"failed\": 1\n  },\n\
             \  \"metadata\": {\n    \"customer_id\": \"user_123456789\",\n    \"batch_description\"\
             : \"Nightly eval job\",\n  }\n}\n"
-      x-hive-status: planned_for_launch
+      x-hive-status: supported_now
       x-hive-phase: 7
       x-hive-notes: Cancel batch
   /chat/completions:
@@ -1560,9 +1560,13 @@ paths:
             \      \"reasoning_tokens\": 0,\n      \"accepted_prediction_tokens\"\
             : 0,\n      \"rejected_prediction_tokens\": 0\n    }\n  },\n  \"system_fingerprint\"\
             : null\n}\n"
-      x-hive-status: planned_for_launch
+      x-hive-status: supported_now
       x-hive-phase: 6
-      x-hive-notes: Chat completion inference
+      x-hive-notes: 'Chat completion inference. tools, tool_choice, response_format,
+        parallel_tool_calls, functions, function_call are conditionally supported
+        (Phase 20): passed through when the alias has at least one route with provider_capabilities.tools_supported=true;
+        returns 400 unsupported_parameter (with param field) when no capable route
+        exists for the alias.'
   /chat/completions/{completion_id}:
     get:
       operationId: getChatCompletion
@@ -1921,7 +1925,7 @@ paths:
             \    {\n      \"text\": \"This\",\n      \"index\": 0,\n      \"logprobs\"\
             : null,\n      \"finish_reason\": null\n    }\n  ],\n  \"model\": \"gpt-3.5-turbo-instruct\"\
             \n  \"system_fingerprint\": \"fp_44709d6fcb\",\n}\n"
-      x-hive-status: planned_for_launch
+      x-hive-status: supported_now
       x-hive-phase: 6
       x-hive-notes: Legacy completion inference
   /embeddings:
@@ -1974,7 +1978,7 @@ paths:
             \     -0.0028842222,\n      ],\n      \"index\": 0\n    }\n  ],\n  \"\
             model\": \"text-embedding-ada-002\",\n  \"usage\": {\n    \"prompt_tokens\"\
             : 8,\n    \"total_tokens\": 8\n  }\n}\n"
-      x-hive-status: planned_for_launch
+      x-hive-status: supported_now
       x-hive-phase: 6
       x-hive-notes: Text embeddings
   /evals:
@@ -3175,7 +3179,7 @@ paths:
             \   \"object\": \"file\",\n      \"bytes\": 140,\n      \"created_at\"\
             : 1613779121,\n      \"filename\": \"puppy.jsonl\",\n      \"purpose\"\
             : \"fine-tune\",\n    }\n  ],\n  \"object\": \"list\"\n}\n"
-      x-hive-status: planned_for_launch
+      x-hive-status: supported_now
       x-hive-phase: 5
       x-hive-notes: List files
     post:
@@ -3235,7 +3239,7 @@ paths:
           response: "{\n  \"id\": \"file-abc123\",\n  \"object\": \"file\",\n  \"\
             bytes\": 120000,\n  \"created_at\": 1677610602,\n  \"filename\": \"mydata.jsonl\"\
             ,\n  \"purpose\": \"fine-tune\",\n}\n"
-      x-hive-status: planned_for_launch
+      x-hive-status: supported_now
       x-hive-phase: 5
       x-hive-notes: Upload a file
   /files/{file_id}:
@@ -3279,7 +3283,7 @@ paths:
               file-abc123\");\n\n  console.log(file);\n}\n\nmain();"
           response: "{\n  \"id\": \"file-abc123\",\n  \"object\": \"file\",\n  \"\
             deleted\": true\n}\n"
-      x-hive-status: planned_for_launch
+      x-hive-status: supported_now
       x-hive-phase: 5
       x-hive-notes: Delete a file
     get:
@@ -3324,7 +3328,7 @@ paths:
           response: "{\n  \"id\": \"file-abc123\",\n  \"object\": \"file\",\n  \"\
             bytes\": 120000,\n  \"created_at\": 1677610602,\n  \"filename\": \"mydata.jsonl\"\
             ,\n  \"purpose\": \"fine-tune\",\n}\n"
-      x-hive-status: planned_for_launch
+      x-hive-status: supported_now
       x-hive-phase: 5
       x-hive-notes: Retrieve file metadata
   /files/{file_id}/content:
@@ -3366,7 +3370,7 @@ paths:
             node.js: "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\
               \nasync function main() {\n  const file = await openai.files.content(\"\
               file-abc123\");\n\n  console.log(file);\n}\n\nmain();\n"
-      x-hive-status: planned_for_launch
+      x-hive-status: supported_now
       x-hive-phase: 5
       x-hive-notes: Download file content
   /fine_tuning/checkpoints/{fine_tuned_model_checkpoint}/permissions:
@@ -4083,7 +4087,7 @@ paths:
             : 100,\n    \"input_tokens\": 50,\n    \"output_tokens\": 50,\n    \"\
             input_tokens_details\": {\n      \"text_tokens\": 10,\n      \"image_tokens\"\
             : 40\n    }\n  }\n}\n"
-      x-hive-status: planned_for_launch
+      x-hive-status: supported_now
       x-hive-phase: 6
       x-hive-notes: Image editing
   /images/generations:
@@ -4133,7 +4137,7 @@ paths:
             : 100,\n    \"input_tokens\": 50,\n    \"output_tokens\": 50,\n    \"\
             input_tokens_details\": {\n      \"text_tokens\": 10,\n      \"image_tokens\"\
             : 40\n    }\n  }\n}\n"
-      x-hive-status: planned_for_launch
+      x-hive-status: supported_now
       x-hive-phase: 6
       x-hive-notes: Image generation
   /images/variations:
@@ -5052,7 +5056,7 @@ paths:
             cached_tokens\": 0\n    },\n    \"output_tokens\": 1035,\n    \"output_tokens_details\"\
             : {\n      \"reasoning_tokens\": 832\n    },\n    \"total_tokens\": 1116\n\
             \  },\n  \"user\": null,\n  \"metadata\": {}\n}\n"
-      x-hive-status: planned_for_launch
+      x-hive-status: supported_now
       x-hive-phase: 6
       x-hive-notes: Responses API inference
   /responses/{response_id}:
@@ -7164,7 +7168,7 @@ paths:
             \  \"bytes\": 2147483648,\n  \"created_at\": 1719184911,\n  \"filename\"\
             : \"training_examples.jsonl\",\n  \"purpose\": \"fine-tune\",\n  \"status\"\
             : \"pending\",\n  \"expires_at\": 1719127296\n}\n"
-      x-hive-status: planned_for_launch
+      x-hive-status: supported_now
       x-hive-phase: 5
       x-hive-notes: Create upload
   /uploads/{upload_id}/cancel:
@@ -7206,7 +7210,7 @@ paths:
             \  \"bytes\": 2147483648,\n  \"created_at\": 1719184911,\n  \"filename\"\
             : \"training_examples.jsonl\",\n  \"purpose\": \"fine-tune\",\n  \"status\"\
             : \"cancelled\",\n  \"expires_at\": 1719127296\n}\n"
-      x-hive-status: planned_for_launch
+      x-hive-status: supported_now
       x-hive-phase: 5
       x-hive-notes: Cancel upload
   /uploads/{upload_id}/complete:
@@ -7261,7 +7265,7 @@ paths:
             id\": \"file-xyz321\",\n    \"object\": \"file\",\n    \"bytes\": 2147483648,\n\
             \    \"created_at\": 1719186911,\n    \"filename\": \"training_examples.jsonl\"\
             ,\n    \"purpose\": \"fine-tune\",\n  }\n}\n"
-      x-hive-status: planned_for_launch
+      x-hive-status: supported_now
       x-hive-phase: 5
       x-hive-notes: Complete upload
   /uploads/{upload_id}/parts:
@@ -7309,7 +7313,7 @@ paths:
           response: "{\n  \"id\": \"part_def456\",\n  \"object\": \"upload.part\"\
             ,\n  \"created_at\": 1719185911,\n  \"upload_id\": \"upload_abc123\"\n\
             }\n"
-      x-hive-status: planned_for_launch
+      x-hive-status: supported_now
       x-hive-phase: 5
       x-hive-notes: Add upload part
   /vector_stores:


### PR DESCRIPTION
Closes #1192 (part one). Parts two and three below are decisions and findings, deliberately not implemented here.

## What this changes

One file: `packages/openai-contract/generated/hive-openapi.yaml`, regenerated by its own generator. No hand edits.

The generated spec had been produced from an older support matrix and never regenerated, so it annotated 22 live endpoints `planned_for_launch`. Since #1187 that file is served publicly and unauthenticated at `/api/openapi.yaml` for code generators to consume, which means every integrator who pointed tooling at it was told that `POST /v1/chat/completions`, the gateway's primary endpoint, is merely planned. The same applied to `/v1/embeddings`, `/v1/responses`, and all of `/v1/files/*`, `/v1/batches/*`, `/v1/audio/*`, `/v1/images/*` and `/v1/uploads/*`.

Regenerated with `sh packages/openai-contract/scripts/generate-matrix.sh`, which runs `packages/openai-contract/scripts/sync_hive_contract.py` against the committed matrix and the pinned upstream document (`upstream/SPEC_VERSION` records the 2026-03-28 download, so the transform is deterministic and reproducible from the repo alone).

The diff is 27 insertions and 23 deletions: the 22 `x-hive-status` flips, plus the `/chat/completions` `x-hive-notes` picking up the Phase 20 conditional tool-support text the matrix already carried. There is no formatting churn, which confirms the local PyYAML matches the version that produced the committed file. Running the generator a second time produces byte-identical output, so it is idempotent.

## Verification

Re-running the exact comparison the console performs (`diffSpecAgainstMatrix` in `apps/web-console/lib/api-contract.ts`):

| | before | after |
|---|---|---|
| total disagreements | 89 | 67 |
| `status_mismatch` | 22 | **0** |
| `missing_from_spec` | 67 | 67 |
| `missing_from_matrix` | 0 | 0 |

The 67 remaining are the benign ones the issue predicted and are unchanged: 51 are `out_of_scope` and dropped from the spec on purpose by the generator, and 16 are Hive-native endpoints that were never in the upstream OpenAI document (part two below).

**The direction guard passes.** `tests/unit/console-docs-contract.test.ts` is green, all 12 tests, both with and without a populated env file. The spec operation count still matches the `x-hive-status` annotation count exactly (97 = 97), so the line scan that reads the spec did not stop matching after regeneration.

**The served artifact was verified, not assumed.** `hive-web-console-prod:ci` was built from this branch and run, and `GET /api/openapi.yaml` returned HTTP 200 with `content-type: application/yaml`. The served body hashes to `a1aa0cda...`, byte-identical to the regenerated file in the tree. Parsing the served payload confirms `POST /v1/chat/completions`, `/v1/embeddings`, `/v1/responses`, `/v1/files`, `/v1/batches`, `/v1/audio/speech`, `/v1/images/generations` and `/v1/uploads` all now report `supported_now`. The production image was checked specifically because fixing only the dev image would have shipped a page that 500s in production while every local check stayed green.

Container unit-test failures unrelated to this change: `tests/unit/ci-web-e2e-secret-free.test.ts` fails in-container by design (it reads a workflow file the Dockerfile never copies in). A further set of render tests fail in the container and drop from 15 files to 8 once an env file is supplied, so they are environment artifacts rather than code. Only three files in the app read the contract at all (`app/api/openapi.yaml/route.ts`, `app/console/docs/page.tsx`, `tests/unit/console-docs-contract.test.ts`) and none of them are in the failing set.

## Part two, a decision for the owner, not implemented here

Sixteen endpoints classified `supported_now` in the matrix have no machine-readable schema anywhere: `/v1/rag/*` (6 operations), `/v1/agent/tasks*` (4), `/v1/artifacts*` (3), `/v1/featuregate`, and the Anthropic-compatible `/v1/messages` and `/v1/messages/count_tokens`. The generator is built purely from OpenAI's upstream document, so nothing Hive added itself can appear in its output by construction. A developer cannot generate a client for any of them.

Three ways forward, in ascending cost:

1. **Leave it.** The spec stays a pure OpenAI-compatibility document and Hive's own surface stays undocumented in machine-readable form. Zero work, and the docs page keeps reporting the 16 as a visible disagreement rather than hiding them.
2. **Author them by hand and merge them in the generator.** This is cheaper than it looks, because the pattern already exists in this package and is currently orphaned: `packages/openai-contract/spec/paths/` already contains four hand-authored Hive OpenAPI documents (`spend-alerts.yaml`, `invoices.yaml`, `grants.yaml`, `budgets.yaml`) covering the `/api/v1/*` control-plane surface. Nothing reads them. `sync_hive_contract.py` consumes only `upstream/openapi.yaml` and the matrix, so those four files are authored, committed, reviewed, and consumed by nothing. Option 2 is roughly: write 16 operations in that same style, then teach the generator to merge `spec/paths/*.yaml` into its output. The ongoing cost is keeping hand-written schema in step with Go handlers by review discipline alone.
3. **Generate from the handlers.** Highest fidelity and lowest long-term rot, but the services route with plain `net/http.ServeMux` and carry no schema annotations, so this means adding an annotation layer or adopting a framework. Much the largest change.

This is the difference between "an OpenAI-compatible gateway" and "a gateway with its own documented API", so it is a product call rather than an engineering one.

While mapping this I also found that **`packages/openai-contract/overlays/hive-support-status.yaml` is a third orphaned artefact**. It is a 148-action OpenAPI Overlay document that sets `x-hive-status` per operation, it is not read by the generator (which takes status straight from the matrix), and it is itself stale in exactly the way the generated spec was: it still declares `/chat/completions` `planned_for_launch`. `.wolf/buglog.jsonl` already records it as "consumed by nothing" as of 2026-07-17. Worth deleting or wiring up, so nobody edits it believing it has an effect.

## Part three, the matrix is itself stale against the code

Asked for because the console prints the matrix's own `generated` date. Two problems.

**The printed date is wrong.** The matrix declares `generated: 2026-03-28`, but the file was last edited 2026-07-28 (#573), and before that 2026-07-22 (#416) and 2026-07-17 (#352). The field is hand-maintained and was not updated by those edits, so the console currently prints a date roughly four months earlier than the file's real content.

**Five route families exist in the code and are absent from the matrix entirely**, four of which shipped after the stated generation date:

| route family | service | shipped | PR |
|---|---|---|---|
| `/v1/agent/schedules`, `/v1/agent/schedules/{id}` | edge-api | 2026-08-23 | #1081 |
| `/v1/audio/voices` | edge-api | 2026-08-24 | #1079 |
| `/v1/tenants/switch` | control-plane | 2026-05-17 | #140 |
| `/v1/admin/credit-grants`, `/v1/admin/credit-grants/{id}` | control-plane | 2026-05-08 | #136 |
| `/v1/credit-grants/me` | control-plane | 2026-05-08 | #136 |

Per the brief I have not fixed this here, because adding matrix rows changes runtime behaviour (see below), would need its own integration-test additions, and would change this PR's diff again.

### The part that needs a decision quickly

The matrix is not documentation. `apps/edge-api/cmd/server/main.go:581` wraps the entire mux in `middleware.UnsupportedEndpointMiddleware(m)`, and `matrix.Lookup` (`apps/edge-api/internal/matrix/types.go:44`) returns `StatusUnknown` for any method and path it cannot match exactly or by template. The middleware answers `StatusUnknown` with a 404, `Unknown endpoint`.

Replaying that exact lookup algorithm against the committed matrix, all six operations of the two newest edge-api route families resolve to `StatusUnknown`, and therefore to a 404:

```
GET    /v1/audio/voices                 -> UNKNOWN -> 404
GET    /v1/agent/schedules              -> UNKNOWN -> 404
POST   /v1/agent/schedules              -> UNKNOWN -> 404
GET    /v1/agent/schedules/{id}         -> UNKNOWN -> 404
PUT    /v1/agent/schedules/{id}         -> UNKNOWN -> 404
DELETE /v1/agent/schedules/{id}         -> UNKNOWN -> 404
(control:  POST /v1/chat/completions    -> supported_now)
(control:  POST /v1/agent/tasks         -> supported_now)
```

This is the same failure recorded in `.wolf/buglog.jsonl` as `matrix-missing-proprietary-endpoints` on 2026-07-17, which was a demo blocker. The guard built in response, `apps/edge-api/internal/middleware/unsupported_integration_test.go`, drives the real middleware against the real committed matrix, but it enumerates only the Waves 2-4 routes. It covers neither `/v1/agent/schedules*` nor `/v1/audio/voices`, so the same class of regression landed again without turning anything red.

I have verified this by reading the middleware and `Lookup` and by replaying the algorithm, not against a live stack, so please confirm against a running edge-api before acting. If it holds, scheduled agent tasks (#1081) and the Open WebUI voice roster (#1079) are both dead in any deployment, and the fix is matrix rows plus adding those paths to the integration test's table.

## Why this rotted, and the cheapest guard

Nothing regenerates the spec in CI. The only reference to this package in `.github/workflows/ci.yml` is an unrelated lint script, so a matrix edit has never been forced to bring the generated spec with it.

The repo already has the right pattern a few lines above, for a different artefact:

```yaml
      - name: Codegen drift — permissions.generated.ts
        run: |
          make gen-permissions
          git diff --exit-code apps/web-console/lib/control-plane/permissions.generated.ts
```

The same shape would have caught this on the day the matrix changed:

```yaml
      - name: Codegen drift — hive-openapi.yaml
        run: |
          sh packages/openai-contract/scripts/generate-matrix.sh
          git diff --exit-code packages/openai-contract/generated/hive-openapi.yaml
```

Not added here because `.github/workflows/ci.yml` was explicitly out of scope for this task and other lanes are live in it. Recommended as a small follow-up.

## Two smaller findings

**The direction guard is now vacuously true, and its allowance is stale.** `console-docs-contract.test.ts` pins the direction of status mismatches rather than their count, which was the right call while a known-stale direction existed. After this PR there are zero status mismatches, so the loop body never executes. The guard is not dead (any *new* mismatch still enters the loop and fails, including the overstating direction it was written to catch), but the allowed direction it whitelists is exactly the bug this PR just fixed, so that specific regression could return silently. The test's comment also now describes a live defect that no longer exists.

Per the brief I have not edited the test, since changing a guard in the same PR that changes what it guards deserves a separate decision. The one-line tightening, if wanted:

```ts
expect(disagreements.filter((entry) => entry.kind === "status_mismatch")).toEqual([]);
```

That is strictly louder than what is there now, and because the generator stamps `x-hive-status` directly from the matrix, a mismatch is structurally impossible unless somebody edited the matrix without regenerating. In other words, that assertion is the drift guard, in a place CI already runs.

**The generator writes a file the repo deleted.** `sync_hive_contract.py` still renders `docs/support-matrix.md`, but that file was removed from the repo by #315 when planning docs moved to the Obsidian vault, and it is not in `.gitignore`. Every run therefore drops a 21 KB untracked file into the tree, which a later `git add -A` would sweep back in and silently restore a deliberately deleted document. I removed it from my tree rather than committing it. Either drop `render_markdown` from the generator or ignore its output, but somebody should pick one.

## Buglog entry

To be appended to `.wolf/buglog.jsonl` on `main` in a separate buglog-only PR after this merges, per `.claude/rules/openwolf.md`.

```json
{"id":"openapi-spec-stale-understates-gateway","priority":"P1","date":"2026-08-25","error_message":"Publicly served /api/openapi.yaml annotated 22 live endpoints planned_for_launch, including POST /v1/chat/completions, telling every integrator the gateway's primary endpoint was not shipped","root_cause":"packages/openai-contract/generated/hive-openapi.yaml is generated from matrix/support-matrix.json by scripts/sync_hive_contract.py, but nothing in CI regenerates it or fails on drift. The matrix was edited three times (#352, #416, #573) without the generated spec being regenerated, so the spec kept the statuses of a much older matrix. Invisible until #1187 started serving the file publicly and rendering a spec-vs-matrix diff on /console/docs, which surfaced 89 disagreements.","fix":"Ran packages/openai-contract/scripts/generate-matrix.sh to regenerate the spec from the committed matrix and the pinned upstream document, no hand edits. Status mismatches went 22 to 0 and total disagreements 89 to 67 (the remaining 67 are out_of_scope drops and Hive-native endpoints absent from upstream, both by design). Verified the regenerated bytes reach the served artefact by building hive-web-console-prod:ci and hashing the GET /api/openapi.yaml response body. Follow-up recommended: a CI codegen-drift step mirroring the existing permissions.generated.ts one.","tags":["contract","openapi","codegen-drift","docs","ci-gap"]}
```
