### PR TITLE
fix: default the tools capability lane to deepseek-v4-flash instead of pro

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1127,11 +1127,16 @@ jobs:
       # chat-completions suite cannot run on hive-free: its pool members are
       # seeded tools_supported=false until cross-member parity is probed
       # (#1115), so the edge correctly 400s those parameters there (run
-      # 32736430913). deepseek-v4-pro is the alias whose route is tools-
-      # capable AND contract-stable; see the deepseek note below for why the
-      # flash variant was rejected on evidence. Same override pattern as
-      # HIVE_TEST_MODEL above.
-      HIVE_TOOLS_MODEL: ${{ vars.CI_LIVE_INTEGRATION_TOOLS_MODEL || 'deepseek-v4-pro' }}
+      # 32736430913). deepseek-v4-flash is the tools default (owner decision
+      # 2026-08-25): its route is seeded tools_supported=true and it was
+      # verified healthy in provider_capabilities on the live box. It costs a
+      # fraction of deepseek-v4-pro, which served as the tools default until
+      # CI burned 150 calls / 30.2M credits on it in one day. The flash
+      # router's earlier response-contract instability (run 32665985618, see
+      # the deepseek note above) is the known risk: if the strict
+      # response_format assertion starts failing, repoint this override var,
+      # do not silently re-pin pro. Same override pattern as HIVE_TEST_MODEL.
+      HIVE_TOOLS_MODEL: ${{ vars.CI_LIVE_INTEGRATION_TOOLS_MODEL || 'deepseek-v4-flash' }}
       # The suites' own default, named here rather than left implicit, because
       # the spend meter below asserts that no alias outside these is ever
       # billed by this job.
@@ -1184,6 +1189,10 @@ jobs:
           echo "SDK suites will call alias: $HIVE_TEST_MODEL"
           echo "embedding suites will call: $HIVE_EMBEDDING_MODEL"
           echo "capability tests will call: $HIVE_TOOLS_MODEL"
+          if [ "$HIVE_TOOLS_MODEL" = "deepseek-v4-pro" ]; then
+            echo "::error::HIVE_TOOLS_MODEL resolved to deepseek-v4-pro, the expensive paid route that burned 150 calls and 30.2M credits in one day of CI (2026-08-25). The tools lane must stay on deepseek-v4-flash (or a cheaper override); see PR fix/tools-model-cheap-default."
+            exit 1
+          fi
           if [ "$HIVE_TEST_MODEL" = "hive-free" ]; then
             echo "::notice::this run bills hive-free, the load-balanced pool of our own free provider keys. No customer-facing provider allowance is consumed. Pool-specific routing regressions (failover between keys) are covered only against the live box; a single-provider regression on any one pool member can still hide behind the other members."
           else

--- a/.github/workflows/deploy-demo-box.yml
+++ b/.github/workflows/deploy-demo-box.yml
@@ -2073,10 +2073,12 @@ jobs:
       # Capability tests (tools/response_format) cannot run on hive-free: its
       # pool members are seeded tools_supported=false until cross-member parity
       # is probed (#1115), and the edge correctly 400s those parameters there
-      # (run 32736430913). deepseek-v4-pro is tools-capable with a pinned,
-      # contract-stable route; the flash variant returned message.content as
-      # object/null/string across probes (run 32665985618).
-      HIVE_TOOLS_MODEL: deepseek-v4-pro
+      # (run 32736430913). deepseek-v4-flash is the tools default (owner
+      # decision 2026-08-25, tools_supported=true verified live): pro burned
+      # 150 calls / 30.2M credits in one day of CI. Flash's `-latest` router
+      # showed message.content instability (run 32665985618); if it recurs the
+      # suite fails loudly and HIVE_TOOLS_MODEL gets repointed.
+      HIVE_TOOLS_MODEL: deepseek-v4-flash
       HIVE_EMBEDDING_MODEL: hive-embedding-default
     steps:
       - uses: actions/checkout@v7

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -327,10 +327,13 @@ services:
       # Capability tests in chat-completions.test.ts read this one (run
       # 32736430913): tools/response_format need an alias whose route is
       # tools_supported AND whose provider honors the response contract, not
-      # the plain-chat alias above. deepseek-v4-flash is tools-capable but its
-      # unpinned `-latest` router returned message.content as object/null/
-      # string across probes (run 32665985618), so the pinned deepseek-v4-pro.
-      HIVE_TOOLS_MODEL: ${HIVE_TOOLS_MODEL:-deepseek-v4-pro}
+      # the plain-chat alias above. deepseek-v4-flash is the tools default
+      # (owner decision 2026-08-25, tools_supported=true verified live);
+      # deepseek-v4-pro burned 150 calls / 30.2M credits as the old default.
+      # Flash's `-latest` router showed message.content instability (run
+      # 32665985618); if it recurs the suite fails loudly and this var gets
+      # repointed.
+      HIVE_TOOLS_MODEL: ${HIVE_TOOLS_MODEL:-deepseek-v4-flash}
 
   sdk-tests-py:
     image: hive-sdk-tests-py:ci

--- a/packages/sdk-tests/js/tests/chat-completions/chat-completions.test.ts
+++ b/packages/sdk-tests/js/tests/chat-completions/chat-completions.test.ts
@@ -9,16 +9,16 @@ const MODEL = process.env.HIVE_TEST_MODEL ?? "hive-free";
 // response contract. hive-free fails the first bar (free pool members are
 // seeded tools_supported=false until cross-member parity is probed, #1115),
 // and the edge correctly 400s tools/response_format there (run 32736430913).
-// deepseek-v4-flash passes the first bar but not the second: its unpinned
-// `-latest` router slug returned message.content as a parsed JSON object
-// (run 32665985618), as null, and as string on different probes, which no
-// strict assertion can survive. deepseek-v4-pro is date-pinned (-0813),
-// returns content as a string every time, and answers forced tool_choice
-// with a real tool_calls shape (probed live through the box's LiteLLM,
-// recorded in ci.yml). HIVE_TOOLS_MODEL lets a deployment repoint these
-// tests without editing them; compose forwards it like HIVE_TEST_MODEL.
+// The default is deepseek-v4-flash (owner decision 2026-08-25): tools-
+// capable and verified healthy on the live box, at a fraction of the cost
+// of deepseek-v4-pro, which as the previous default burned 150 calls /
+// 30.2M credits in one day of CI. Known risk, kept visible rather than
+// buried: that flash router's `-latest` slug returned message.content as a
+// parsed JSON object (run 32665985618), as null, and as string across
+// probes on 2026-08-23. If that instability recurs, this suite fails loudly
+// by design; repoint HIVE_TOOLS_MODEL instead of loosening the assertions.
 const TOOL_CAPABLE_MODEL =
-  process.env.HIVE_TOOLS_MODEL ?? "deepseek-v4-pro";
+  process.env.HIVE_TOOLS_MODEL ?? "deepseek-v4-flash";
 
 describe("Chat Completions", () => {
   const client = new OpenAI({ baseURL: BASE_URL, apiKey: API_KEY });
@@ -114,8 +114,8 @@ describe("Chat Completions", () => {
     // assertions below are the OpenAI contract and stay strict: content is
     // typed as string on the wire, so an alias whose provider returns it as a
     // raw object or null fails here by design. That is exactly what the
-    // unpinned deepseek-v4-flash router did (run 32665985618), which is why
-    // the default is the pinned deepseek-v4-pro instead. Do not loosen this
+    // unpinned deepseek-v4-flash router did on 2026-08-23 (run 32665985618),
+    // the standing risk of the flash default. Do not loosen this
     // to fit one route; repoint HIVE_TOOLS_MODEL if the default regresses.
     const response = await client.chat.completions.create({
       model: TOOL_CAPABLE_MODEL,


### PR DESCRIPTION
CI burned 150 calls and 30.2M credits in one day (2026-08-25) on the uat-test-hive-s-workspace account because the tools capability lane kept defaulting to deepseek-v4-pro, the expensive paid route, while the chat lane had already moved to the free pool. This repoints every tools-lane default to deepseek-v4-flash (tools_supported=true, verified healthy in provider_capabilities on the live box) and adds a guard so the regression cannot come back silently.

Changed:
- .github/workflows/ci.yml: HIVE_TOOLS_MODEL fallback deepseek-v4-pro to deepseek-v4-flash; the CI_LIVE_INTEGRATION_TOOLS_MODEL override is preserved.
- .github/workflows/deploy-demo-box.yml sdk-replay job: HIVE_TOOLS_MODEL deepseek-v4-pro to deepseek-v4-flash.
- deploy/docker/docker-compose.yml: compose default for the js sdk-tests service follows suit.
- packages/sdk-tests/js/tests/chat-completions/chat-completions.test.ts: in-code fallback follows suit, comments updated.

Guard: the "Declare which provider account this run bills" step in ci.yml now fails immediately if the resolved HIVE_TOOLS_MODEL is deepseek-v4-pro, before any spend.

Known risk, stated rather than buried: probes on 2026-08-23 (run 32665985618) caught the unpinned flash `-latest` router returning message.content as object/null/string under response_format json_object. The strict response_format assertion stays strict on purpose; if that instability recurs the suite fails loudly and CI_LIVE_INTEGRATION_TOOLS_MODEL repoints the lane.

Buglog entry (to be appended via a buglog-only PR after merge):
{"ts":"2026-08-25","error_message":"CI tools capability lane billed deepseek-v4-pro: 150 calls, 30.2M credits burned in one day on uat-test-hive-s-workspace","root_cause":"HIVE_TOOLS_MODEL still defaulted to the paid deepseek-v4-pro alias across ci.yml, deploy-demo-box sdk-replay, docker-compose and the js suite while the chat lane had already moved to free-pool hive-free","fix":"all four defaults repointed to deepseek-v4-flash plus a ci.yml guard failing any run whose resolved HIVE_TOOLS_MODEL is deepseek-v4-pro","tags":["ci-cost","billing","model-defaults"]}
