### PR TITLE
feat(chat): show a Cowork run's real steps while it is still running

### DIFF
--- a/docs/proof/cowork-run-progress-2026-08-26/capture-log.md
+++ b/docs/proof/cowork-run-progress-2026-08-26/capture-log.md
@@ -1,0 +1,166 @@
+# Cowork run progress: capture log
+
+Branch: feat/cowork-run-progress
+Date: 2026-08-26
+Pull request: #1202 (follow-up to #1193)
+
+## Substrate, stated plainly
+
+The frontend under test is THIS BRANCH, built the way the deploy builds it:
+`docker build -f deploy/docker/Dockerfile.open-webui -t hive-owui:runprogress .`
+from the worktree, so the bundle in the running container is the production
+`npm run build` output of the changed sources, not a dev server. That image's
+own build stage ran the Hive frontend unit tests before building: `Test Files
+14 passed (14) / Tests 176 passed (176)`.
+
+What is NOT live, and why:
+
+  * The demo box could not carry this change. `deploy-demo-box.yml` for
+    4ece687a (#1193, this PR's parent) FAILED, so the deployed box does not
+    even have the composer Cowork mode yet, let alone this follow-up.
+  * A real agent run cannot be produced on this development box at all. The
+    sandbox image is linux/amd64 Apptainer (deploy/apptainer/agent-engine.def)
+    and the box is WSL2 with no `/dev/fuse` and no launcher socket, so
+    `buildAgentEngine` resolves to `NotConfiguredEngine` and every submitted
+    task fails at launch without ever producing an event.
+  * A live session against the deployed environment could not be minted
+    either: the cloud Supabase project in the checkout's `.env` no longer
+    resolves (NXDOMAIN) since the self-hosted migration, and no service-role
+    key for the self-hosted stack is available here. No password was set,
+    reset or rotated on any account at any point; the standalone mint helper
+    was attempted first and failed at DNS.
+
+So the agent sandbox and the control-plane event syncer are stood in for by a
+local process (`agent_stub.py`, capture-only, never committed and never
+shipped) that serves the six `/api/v1/hive/agent/*` routes and proxies every
+other path untouched to the real Open WebUI container. Its wire shapes are not
+invented: each one is transcribed from the shipped Go.
+
+  * task shape: apps/edge-api/internal/agenttask/types.go (`Task`)
+  * event shape: same file (`Event`: seq, source_event_id, kind, payload,
+    created_at), served as `{"events": [...]}` by handler.go
+  * per-kind payloads: apps/control-plane/internal/agenttask/eventsync.go
+    (`mapSandboxEvent`, `statusEvent`, `fileEvent`)
+  * truncation marker: apps/control-plane/internal/agenttask/events.go
+    (`capEventPayload` writes `{"truncated": true, "size": N}`)
+  * preview cap: same file, `maxPreviewRunes = 2000`, with no marker left
+    behind, which is why a preview sitting exactly on the cap is the only
+    evidence there is that anything was cut
+  * cursor semantics: repository.go `ListEvents` (`seq > $2 ORDER BY seq ASC
+    LIMIT $4`), and the proxy's own integer-only validation of `after_seq`
+    and `limit` in deploy/docker/owui-patches/hive_agent_proxy.py
+
+Everything from that wire response to the pixels is the shipped read path:
+`getTaskEvents` -> `foldRunSteps` -> the turn's `statusHistory` ->
+StatusHistory.svelte -> StatusItem.svelte, none of which is stubbed.
+
+## Stack
+
+    docker run -d --name runprogress-owui \
+      --add-host=host.docker.internal:host-gateway \
+      -p 127.0.0.1:18082:8080 \
+      -e ENABLE_OPENAI_API=true \
+      -e OPENAI_API_BASE_URL=http://host.docker.internal:8080/v1 \
+      hive-owui:runprogress
+
+A throwaway local Open WebUI account was created through the ordinary signup
+route on an ephemeral container whose database is discarded with it. No shared
+account and no deployed environment was touched.
+
+## What the run showed (screenshots on the pull request)
+
+  * 04-in-flight-t28s: 28 seconds in. One muted line above the turn,
+    `Using execute_bash: grep -rn "retry" ./src | head -40`, shimmering
+    because that tool call has not returned yet, over `Working on it.`
+    Before this change the same moment rendered `Working on it.` and nothing
+    else, for the whole run.
+  * 06-in-flight-expanded-t58s: 58 seconds in, step list expanded. Seven
+    lines, including `Used str_replace_editor: File created.` (a tool call
+    joined to its result on tool_call_id), `Workspace file: notes.md`, and
+    `An update too large to show here (82134 bytes).` for the payload the
+    backend replaced with its truncation marker.
+  * 07-reloaded-mid-run-t65s: the page reloaded while the run was still
+    going. Every line survived, the turn is still in flight, and the follower
+    resumed from the stored cursor rather than re-reading from zero (see the
+    request log below).
+  * 08-settled-t93s: the run settled. Eight lines, none shimmering, and the
+    run's own summary as the turn's content.
+
+## The cursor, from the browser's own request log
+
+Every request the page made to the agent surface, in order. Note that
+`/agent/tasks` (the whole-list read this change removed from the follower)
+appears exactly once, as the POST that creates the run.
+
+```
+2026-08-26T00:43:52.766Z POST /api/v1/hive/agent/tasks
+2026-08-26T00:43:55.942Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b
+2026-08-26T00:43:55.948Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b/events?after_seq=0&limit=200
+2026-08-26T00:43:59.140Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b
+2026-08-26T00:43:59.147Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b/events?after_seq=0&limit=200
+2026-08-26T00:44:02.369Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b
+2026-08-26T00:44:02.374Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b/events?after_seq=2&limit=200
+2026-08-26T00:44:03.411Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b
+2026-08-26T00:44:03.416Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b/events?after_seq=2&limit=200
+2026-08-26T00:44:06.674Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b
+2026-08-26T00:44:06.694Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b/events?after_seq=3&limit=200
+2026-08-26T00:44:09.875Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b
+2026-08-26T00:44:09.881Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b/events?after_seq=3&limit=200
+2026-08-26T00:44:13.072Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b
+2026-08-26T00:44:13.079Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b/events?after_seq=4&limit=200
+2026-08-26T00:44:16.262Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b
+2026-08-26T00:44:16.266Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b/events?after_seq=5&limit=200
+2026-08-26T00:44:19.580Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b
+2026-08-26T00:44:19.581Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b/events?after_seq=5&limit=200
+2026-08-26T00:44:22.763Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b
+2026-08-26T00:44:22.770Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b/events?after_seq=5&limit=200
+2026-08-26T00:44:25.944Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b
+2026-08-26T00:44:25.949Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b/events?after_seq=6&limit=200
+2026-08-26T00:44:29.132Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b
+2026-08-26T00:44:29.137Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b/events?after_seq=7&limit=200
+2026-08-26T00:44:30.127Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b
+2026-08-26T00:44:30.132Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b/events?after_seq=8&limit=200
+2026-08-26T00:44:33.338Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b
+2026-08-26T00:44:33.343Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b/events?after_seq=8&limit=200
+2026-08-26T00:44:36.531Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b
+2026-08-26T00:44:36.537Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b/events?after_seq=8&limit=200
+2026-08-26T00:44:39.789Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b
+2026-08-26T00:44:39.797Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b/events?after_seq=8&limit=200
+2026-08-26T00:44:42.980Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b
+2026-08-26T00:44:43.015Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b/events?after_seq=9&limit=200
+2026-08-26T00:44:46.186Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b
+2026-08-26T00:44:46.191Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b/events?after_seq=10&limit=200
+2026-08-26T00:44:49.476Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b
+2026-08-26T00:44:49.482Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b/events?after_seq=10&limit=200
+2026-08-26T00:44:54.204Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b
+2026-08-26T00:44:54.239Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b/events?after_seq=10&limit=200
+2026-08-26T00:44:57.427Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b
+2026-08-26T00:44:57.433Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b/events?after_seq=10&limit=200
+2026-08-26T00:44:58.558Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b
+2026-08-26T00:44:58.563Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b/events?after_seq=10&limit=200
+2026-08-26T00:45:01.729Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b
+```
+
+... 6 further polls, omitted here, cursor continuing to advance ...
+
+The page was reloaded mid-run at 00:44:54, and the request either side of it
+is the evidence for the resume: the cursor did NOT restart at 0. It continued
+from 10, read off the lines already stored on the turn by `latestStepSeq`.
+
+```
+2026-08-26T00:45:14.478Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b
+2026-08-26T00:45:14.484Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b/events?after_seq=11&limit=200
+2026-08-26T00:45:17.662Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b
+2026-08-26T00:45:17.666Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b/events?after_seq=12&limit=200
+2026-08-26T00:45:20.849Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b
+2026-08-26T00:45:20.855Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b/events?after_seq=12&limit=200```
+
+Polling stops there, at the first terminal reading, rather than continuing
+against a settled task.
+
+## Counts
+
+    $ grep -c 'agent/tasks$' network.log        # whole-list reads: the create POST only
+    1
+    $ wc -l < network.log                       # every agent request the page made
+    58

--- a/docs/proof/cowork-run-progress-2026-08-26/capture-log.md
+++ b/docs/proof/cowork-run-progress-2026-08-26/capture-log.md
@@ -54,6 +54,11 @@ Everything from that wire response to the pixels is the shipped read path:
 `getTaskEvents` -> `foldRunSteps` -> the turn's `statusHistory` ->
 StatusHistory.svelte -> StatusItem.svelte, none of which is stubbed.
 
+The capture was taken on the final build of this branch, after the cursor
+commit (96c17d45d). An earlier capture of the same run, posted first on the
+pull request, was taken on the build before it; the rendering is identical
+between the two, and the commit changed only which seq a poll acknowledges.
+
 ## Stack
 
     docker run -d --name runprogress-owui \
@@ -79,11 +84,11 @@ account and no deployed environment was touched.
     joined to its result on tool_call_id), `Workspace file: notes.md`, and
     `An update too large to show here (82134 bytes).` for the payload the
     backend replaced with its truncation marker.
-  * 07-reloaded-mid-run-t65s: the page reloaded while the run was still
+  * 07-reloaded-mid-run-t70s: the page reloaded while the run was still
     going. Every line survived, the turn is still in flight, and the follower
     resumed from the stored cursor rather than re-reading from zero (see the
     request log below).
-  * 08-settled-t93s: the run settled. Eight lines, none shimmering, and the
+  * 08-settled-t99s: the run settled. Eight lines, none shimmering, and the
     run's own summary as the turn's content.
 
 ## The cursor, from the browser's own request log
@@ -93,67 +98,68 @@ Every request the page made to the agent surface, in order. Note that
 appears exactly once, as the POST that creates the run.
 
 ```
-2026-08-26T00:43:52.766Z POST /api/v1/hive/agent/tasks
-2026-08-26T00:43:55.942Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b
-2026-08-26T00:43:55.948Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b/events?after_seq=0&limit=200
-2026-08-26T00:43:59.140Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b
-2026-08-26T00:43:59.147Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b/events?after_seq=0&limit=200
-2026-08-26T00:44:02.369Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b
-2026-08-26T00:44:02.374Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b/events?after_seq=2&limit=200
-2026-08-26T00:44:03.411Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b
-2026-08-26T00:44:03.416Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b/events?after_seq=2&limit=200
-2026-08-26T00:44:06.674Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b
-2026-08-26T00:44:06.694Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b/events?after_seq=3&limit=200
-2026-08-26T00:44:09.875Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b
-2026-08-26T00:44:09.881Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b/events?after_seq=3&limit=200
-2026-08-26T00:44:13.072Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b
-2026-08-26T00:44:13.079Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b/events?after_seq=4&limit=200
-2026-08-26T00:44:16.262Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b
-2026-08-26T00:44:16.266Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b/events?after_seq=5&limit=200
-2026-08-26T00:44:19.580Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b
-2026-08-26T00:44:19.581Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b/events?after_seq=5&limit=200
-2026-08-26T00:44:22.763Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b
-2026-08-26T00:44:22.770Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b/events?after_seq=5&limit=200
-2026-08-26T00:44:25.944Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b
-2026-08-26T00:44:25.949Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b/events?after_seq=6&limit=200
-2026-08-26T00:44:29.132Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b
-2026-08-26T00:44:29.137Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b/events?after_seq=7&limit=200
-2026-08-26T00:44:30.127Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b
-2026-08-26T00:44:30.132Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b/events?after_seq=8&limit=200
-2026-08-26T00:44:33.338Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b
-2026-08-26T00:44:33.343Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b/events?after_seq=8&limit=200
-2026-08-26T00:44:36.531Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b
-2026-08-26T00:44:36.537Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b/events?after_seq=8&limit=200
-2026-08-26T00:44:39.789Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b
-2026-08-26T00:44:39.797Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b/events?after_seq=8&limit=200
-2026-08-26T00:44:42.980Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b
-2026-08-26T00:44:43.015Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b/events?after_seq=9&limit=200
-2026-08-26T00:44:46.186Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b
-2026-08-26T00:44:46.191Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b/events?after_seq=10&limit=200
-2026-08-26T00:44:49.476Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b
-2026-08-26T00:44:49.482Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b/events?after_seq=10&limit=200
-2026-08-26T00:44:54.204Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b
-2026-08-26T00:44:54.239Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b/events?after_seq=10&limit=200
-2026-08-26T00:44:57.427Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b
-2026-08-26T00:44:57.433Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b/events?after_seq=10&limit=200
-2026-08-26T00:44:58.558Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b
-2026-08-26T00:44:58.563Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b/events?after_seq=10&limit=200
-2026-08-26T00:45:01.729Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b
+2026-08-26T01:00:07.763Z POST /api/v1/hive/agent/tasks
+2026-08-26T01:00:10.945Z GET /api/v1/hive/agent/tasks/0ce3e5cc-c8e3-435b-b881-cd06c4c2be24
+2026-08-26T01:00:10.951Z GET /api/v1/hive/agent/tasks/0ce3e5cc-c8e3-435b-b881-cd06c4c2be24/events?after_seq=0&limit=200
+2026-08-26T01:00:14.145Z GET /api/v1/hive/agent/tasks/0ce3e5cc-c8e3-435b-b881-cd06c4c2be24
+2026-08-26T01:00:14.150Z GET /api/v1/hive/agent/tasks/0ce3e5cc-c8e3-435b-b881-cd06c4c2be24/events?after_seq=0&limit=200
+2026-08-26T01:00:17.351Z GET /api/v1/hive/agent/tasks/0ce3e5cc-c8e3-435b-b881-cd06c4c2be24
+2026-08-26T01:00:17.365Z GET /api/v1/hive/agent/tasks/0ce3e5cc-c8e3-435b-b881-cd06c4c2be24/events?after_seq=2&limit=200
+2026-08-26T01:00:18.449Z GET /api/v1/hive/agent/tasks/0ce3e5cc-c8e3-435b-b881-cd06c4c2be24
+2026-08-26T01:00:18.454Z GET /api/v1/hive/agent/tasks/0ce3e5cc-c8e3-435b-b881-cd06c4c2be24/events?after_seq=2&limit=200
+2026-08-26T01:00:21.639Z GET /api/v1/hive/agent/tasks/0ce3e5cc-c8e3-435b-b881-cd06c4c2be24
+2026-08-26T01:00:21.644Z GET /api/v1/hive/agent/tasks/0ce3e5cc-c8e3-435b-b881-cd06c4c2be24/events?after_seq=3&limit=200
+2026-08-26T01:00:24.819Z GET /api/v1/hive/agent/tasks/0ce3e5cc-c8e3-435b-b881-cd06c4c2be24
+2026-08-26T01:00:24.833Z GET /api/v1/hive/agent/tasks/0ce3e5cc-c8e3-435b-b881-cd06c4c2be24/events?after_seq=3&limit=200
+2026-08-26T01:00:28.040Z GET /api/v1/hive/agent/tasks/0ce3e5cc-c8e3-435b-b881-cd06c4c2be24
+2026-08-26T01:00:28.046Z GET /api/v1/hive/agent/tasks/0ce3e5cc-c8e3-435b-b881-cd06c4c2be24/events?after_seq=4&limit=200
+2026-08-26T01:00:31.230Z GET /api/v1/hive/agent/tasks/0ce3e5cc-c8e3-435b-b881-cd06c4c2be24
+2026-08-26T01:00:31.234Z GET /api/v1/hive/agent/tasks/0ce3e5cc-c8e3-435b-b881-cd06c4c2be24/events?after_seq=5&limit=200
+2026-08-26T01:00:34.401Z GET /api/v1/hive/agent/tasks/0ce3e5cc-c8e3-435b-b881-cd06c4c2be24
+2026-08-26T01:00:34.405Z GET /api/v1/hive/agent/tasks/0ce3e5cc-c8e3-435b-b881-cd06c4c2be24/events?after_seq=5&limit=200
+2026-08-26T01:00:37.671Z GET /api/v1/hive/agent/tasks/0ce3e5cc-c8e3-435b-b881-cd06c4c2be24
+2026-08-26T01:00:37.680Z GET /api/v1/hive/agent/tasks/0ce3e5cc-c8e3-435b-b881-cd06c4c2be24/events?after_seq=5&limit=200
+2026-08-26T01:00:40.891Z GET /api/v1/hive/agent/tasks/0ce3e5cc-c8e3-435b-b881-cd06c4c2be24
+2026-08-26T01:00:40.898Z GET /api/v1/hive/agent/tasks/0ce3e5cc-c8e3-435b-b881-cd06c4c2be24/events?after_seq=6&limit=200
+2026-08-26T01:00:44.089Z GET /api/v1/hive/agent/tasks/0ce3e5cc-c8e3-435b-b881-cd06c4c2be24
+2026-08-26T01:00:44.094Z GET /api/v1/hive/agent/tasks/0ce3e5cc-c8e3-435b-b881-cd06c4c2be24/events?after_seq=7&limit=200
+2026-08-26T01:00:45.153Z GET /api/v1/hive/agent/tasks/0ce3e5cc-c8e3-435b-b881-cd06c4c2be24
+2026-08-26T01:00:45.159Z GET /api/v1/hive/agent/tasks/0ce3e5cc-c8e3-435b-b881-cd06c4c2be24/events?after_seq=8&limit=200
+2026-08-26T01:00:48.338Z GET /api/v1/hive/agent/tasks/0ce3e5cc-c8e3-435b-b881-cd06c4c2be24
+2026-08-26T01:00:48.343Z GET /api/v1/hive/agent/tasks/0ce3e5cc-c8e3-435b-b881-cd06c4c2be24/events?after_seq=8&limit=200
+2026-08-26T01:00:51.513Z GET /api/v1/hive/agent/tasks/0ce3e5cc-c8e3-435b-b881-cd06c4c2be24
+2026-08-26T01:00:51.519Z GET /api/v1/hive/agent/tasks/0ce3e5cc-c8e3-435b-b881-cd06c4c2be24/events?after_seq=8&limit=200
+2026-08-26T01:00:54.730Z GET /api/v1/hive/agent/tasks/0ce3e5cc-c8e3-435b-b881-cd06c4c2be24
+2026-08-26T01:00:54.747Z GET /api/v1/hive/agent/tasks/0ce3e5cc-c8e3-435b-b881-cd06c4c2be24/events?after_seq=8&limit=200
+2026-08-26T01:00:57.939Z GET /api/v1/hive/agent/tasks/0ce3e5cc-c8e3-435b-b881-cd06c4c2be24
+2026-08-26T01:00:57.943Z GET /api/v1/hive/agent/tasks/0ce3e5cc-c8e3-435b-b881-cd06c4c2be24/events?after_seq=9&limit=200
+2026-08-26T01:01:01.124Z GET /api/v1/hive/agent/tasks/0ce3e5cc-c8e3-435b-b881-cd06c4c2be24
+2026-08-26T01:01:01.129Z GET /api/v1/hive/agent/tasks/0ce3e5cc-c8e3-435b-b881-cd06c4c2be24/events?after_seq=10&limit=200
+2026-08-26T01:01:04.313Z GET /api/v1/hive/agent/tasks/0ce3e5cc-c8e3-435b-b881-cd06c4c2be24
+2026-08-26T01:01:04.320Z GET /api/v1/hive/agent/tasks/0ce3e5cc-c8e3-435b-b881-cd06c4c2be24/events?after_seq=10&limit=200
+2026-08-26T01:01:12.143Z GET /api/v1/hive/agent/tasks/0ce3e5cc-c8e3-435b-b881-cd06c4c2be24
+2026-08-26T01:01:12.279Z GET /api/v1/hive/agent/tasks/0ce3e5cc-c8e3-435b-b881-cd06c4c2be24/events?after_seq=10&limit=200
+2026-08-26T01:01:15.429Z GET /api/v1/hive/agent/tasks/0ce3e5cc-c8e3-435b-b881-cd06c4c2be24
+2026-08-26T01:01:15.439Z GET /api/v1/hive/agent/tasks/0ce3e5cc-c8e3-435b-b881-cd06c4c2be24/events?after_seq=10&limit=200
+2026-08-26T01:01:18.708Z GET /api/v1/hive/agent/tasks/0ce3e5cc-c8e3-435b-b881-cd06c4c2be24
 ```
 
-... 6 further polls, omitted here, cursor continuing to advance ...
+... 5 further polls, omitted here, cursor continuing to advance ...
 
-The page was reloaded mid-run at 00:44:54, and the request either side of it
-is the evidence for the resume: the cursor did NOT restart at 0. It continued
-from 10, read off the lines already stored on the turn by `latestStepSeq`.
+The page was reloaded mid-run: that is the 7.8 second gap in the log, the one
+break in an otherwise 3-second cadence, ending at 01:01:12. The request on the
+far side of it is the evidence for the resume. The cursor did NOT restart at 0.
+It came back as `after_seq=10`, read off the lines already stored on the turn
+by `latestStepSeq`.
 
 ```
-2026-08-26T00:45:14.478Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b
-2026-08-26T00:45:14.484Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b/events?after_seq=11&limit=200
-2026-08-26T00:45:17.662Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b
-2026-08-26T00:45:17.666Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b/events?after_seq=12&limit=200
-2026-08-26T00:45:20.849Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b
-2026-08-26T00:45:20.855Z GET /api/v1/hive/agent/tasks/ea9fce9a-648f-4265-8fa3-d33dbac10d6b/events?after_seq=12&limit=200```
+2026-08-26T01:01:28.782Z GET /api/v1/hive/agent/tasks/0ce3e5cc-c8e3-435b-b881-cd06c4c2be24
+2026-08-26T01:01:28.789Z GET /api/v1/hive/agent/tasks/0ce3e5cc-c8e3-435b-b881-cd06c4c2be24/events?after_seq=11&limit=200
+2026-08-26T01:01:32.018Z GET /api/v1/hive/agent/tasks/0ce3e5cc-c8e3-435b-b881-cd06c4c2be24
+2026-08-26T01:01:32.030Z GET /api/v1/hive/agent/tasks/0ce3e5cc-c8e3-435b-b881-cd06c4c2be24/events?after_seq=12&limit=200
+2026-08-26T01:01:35.239Z GET /api/v1/hive/agent/tasks/0ce3e5cc-c8e3-435b-b881-cd06c4c2be24
+2026-08-26T01:01:35.245Z GET /api/v1/hive/agent/tasks/0ce3e5cc-c8e3-435b-b881-cd06c4c2be24/events?after_seq=12&limit=200
+```
 
 Polling stops there, at the first terminal reading, rather than continuing
 against a settled task.
@@ -163,4 +169,4 @@ against a settled task.
     $ grep -c 'agent/tasks$' network.log        # whole-list reads: the create POST only
     1
     $ wc -l < network.log                       # every agent request the page made
-    58
+    55

--- a/vendor/open-webui/src/lib/components/chat/Chat.svelte
+++ b/vendor/open-webui/src/lib/components/chat/Chat.svelte
@@ -107,12 +107,23 @@
 	// hive (#1063): remaining-credits pill above the composer; self-fetching,
 	// renders nothing when the balance is unavailable.
 	import CreditsBanner from '$lib/hive/CreditsBanner.svelte';
-	import { createTask, describeRefusal, listTasks, TERMINAL_STATUSES } from '$lib/hive/agentTasks';
 	import {
+		createTask,
+		describeRefusal,
+		EVENT_PAGE_SIZE,
+		getTask,
+		getTaskEvents,
+		TERMINAL_STATUSES
+	} from '$lib/hive/agentTasks';
+	import {
+		foldRunSteps,
+		latestStepSeq,
 		packForMode,
 		renderRun,
 		runTurnIsDone,
-		selectPendingCoworkTurns
+		selectPendingCoworkTurns,
+		settleRunSteps,
+		type RunStep
 	} from '$lib/hive/coworkMode';
 	import Messages from '$lib/components/chat/Messages.svelte';
 	import Navbar from '$lib/components/chat/Navbar.svelte';
@@ -2152,14 +2163,24 @@
 	 * ------------------------------------------------------------------ */
 
 	// How often the run is re-read, and how long this tab keeps following one.
-	// ponytail: a poll, not a stream, because edge-api exposes no event feed
-	// for a task; when one lands, this loop becomes a subscription and nothing
-	// else in this file moves. The ceiling exists so a task wedged in `running`
-	// cannot leave a browser tab polling until it is closed.
+	// ponytail: a poll, not a stream. The event feed added in #1073 is a cursor
+	// read, not a subscription, so there is nothing to subscribe to yet; when a
+	// stream exists this loop becomes one and nothing else in this file moves.
+	// The ceiling exists so a task wedged in `running` cannot leave a browser
+	// tab polling until it is closed.
 	const COWORK_POLL_INTERVAL_MS = 3000;
 	const COWORK_FOLLOW_CEILING_MS = 30 * 60 * 1000;
 
+	// How many event pages one reading will drain before leaving the rest for
+	// the next poll. Only a conversation reopened after a long run ever sees a
+	// full page, and this bounds the catch-up so a large backlog cannot hold
+	// the loop for an unbounded number of round trips.
+	const COWORK_EVENT_PAGES_PER_READ = 5;
+
 	const coworkTurn = (messageId: string) => history.messages[messageId] ?? null;
+
+	const coworkSteps = (messageId: string): RunStep[] =>
+		(coworkTurn(messageId)?.statusHistory ?? []) as RunStep[];
 
 	/**
 	 * Writes one reading of the run onto its transcript turn.
@@ -2168,8 +2189,12 @@
 	 * conversation, which is the caller's signal to stop: `history` is replaced
 	 * wholesale on navigation, so a late write would land on a different chat's
 	 * transcript.
+	 *
+	 * `steps` is the run's progress lines, and omitting it leaves whatever the
+	 * turn already shows: a caller reporting a transport failure has no new
+	 * progress to report and must not erase the real progress on screen.
 	 */
-	const applyCoworkRun = async (_chatId, messageId: string, task) => {
+	const applyCoworkRun = async (_chatId, messageId: string, task, steps?: RunStep[]) => {
 		if ($chatId !== _chatId) {
 			return false;
 		}
@@ -2180,11 +2205,63 @@
 
 		turn.content = renderRun(task);
 		turn.done = runTurnIsDone(task);
+		if (steps) {
+			// A step still open under a run that has settled would shimmer forever
+			// beneath a turn saying the task finished.
+			turn.statusHistory = turn.done ? settleRunSteps(steps) : steps;
+		} else if (turn.done && turn.statusHistory) {
+			turn.statusHistory = settleRunSteps(turn.statusHistory as RunStep[]);
+		}
 		history.messages[messageId] = turn;
 		history = history;
 
 		await saveChatHandler(_chatId, history);
 		return true;
+	};
+
+	/**
+	 * One reading of a run: its status, plus every event it has produced since
+	 * this turn last saw one.
+	 *
+	 * The cursor is what makes this cheap. `latestStepSeq` reads the highest
+	 * seq already on the turn, the read asks for events strictly after it, and
+	 * a full page means there is more behind it and the loop asks again. A
+	 * follower that re-read the whole event list every poll would be the same
+	 * mistake as the whole-task-list read this replaced.
+	 *
+	 * The status read is the authority and its failure propagates; the event
+	 * read is best effort, because progress lines that stop arriving are a
+	 * worse-looking run, while a status that stops arriving is a wrong one.
+	 */
+	const readCoworkRun = async (_chatId, messageId: string, taskId: string) => {
+		const task = await getTask(localStorage.token, taskId);
+
+		let steps = coworkSteps(messageId);
+		let cursor = latestStepSeq(steps);
+		try {
+			for (let page = 0; page < COWORK_EVENT_PAGES_PER_READ; page++) {
+				const events = await getTaskEvents(
+					localStorage.token,
+					taskId,
+					cursor,
+					EVENT_PAGE_SIZE
+				);
+				if (events.length === 0) {
+					break;
+				}
+				steps = foldRunSteps(steps, events);
+				cursor = latestStepSeq(steps);
+				if (events.length < EVENT_PAGE_SIZE) {
+					break;
+				}
+			}
+		} catch (error) {
+			// Keep the lines already on screen and this reading's status. Nothing
+			// is invented to fill the gap.
+		}
+
+		const applied = await applyCoworkRun(_chatId, messageId, task, steps);
+		return { task, applied };
 	};
 
 	const followCoworkRun = async (_chatId, messageId: string, taskId: string) => {
@@ -2200,12 +2277,9 @@
 				return;
 			}
 
-			let task;
+			let reading;
 			try {
-				// ponytail: edge-api has no GET /v1/agent/tasks/{id}, so the list
-				// is read and filtered. Fine at demo volume, wrong at scale; swap
-				// the two lines below the day a by-id read exists.
-				task = (await listTasks(localStorage.token)).find((row) => row.id === taskId);
+				reading = await readCoworkRun(_chatId, messageId, taskId);
 			} catch (error) {
 				// A blip is worth another attempt; a refusal is not, and asking a
 				// settled question every three seconds forever is how a surface
@@ -2220,14 +2294,10 @@
 				continue;
 			}
 
-			if (!task) {
-				continue;
-			}
-
-			if (!(await applyCoworkRun(_chatId, messageId, task))) {
+			if (!reading.applied) {
 				return;
 			}
-			if (TERMINAL_STATUSES.has(task.status) || task.status === 'unknown') {
+			if (TERMINAL_STATUSES.has(reading.task.status) || reading.task.status === 'unknown') {
 				return;
 			}
 		}
@@ -2256,25 +2326,26 @@
 			return;
 		}
 
-		let tasks;
-		try {
-			tasks = await listTasks(localStorage.token);
-		} catch (error) {
-			// Leave every stored turn exactly as it was rather than overwriting a
-			// real result with a transport failure.
-			return;
-		}
-
 		for (const pending of pendingTurns) {
 			const taskId = pending.hive_agent_task_id;
-			const task = tasks.find((row) => row.id === taskId);
-			if (!task) {
+
+			let reading;
+			try {
+				// Read by id, one request per turn. A failure here leaves this
+				// turn exactly as it was stored rather than overwriting a real
+				// result with a transport failure, and the remaining turns are
+				// still read: one unreadable run must not strand the others.
+				reading = await readCoworkRun(_chatId, pending.id, taskId);
+			} catch (error) {
 				continue;
 			}
-			if (!(await applyCoworkRun(_chatId, pending.id, task))) {
+			if (!reading.applied) {
 				return;
 			}
-			if (!TERMINAL_STATUSES.has(task.status) && task.status !== 'unknown') {
+			if (
+				!TERMINAL_STATUSES.has(reading.task.status) &&
+				reading.task.status !== 'unknown'
+			) {
 				void followCoworkRun(_chatId, pending.id, taskId);
 			}
 		}

--- a/vendor/open-webui/src/lib/components/chat/Chat.svelte
+++ b/vendor/open-webui/src/lib/components/chat/Chat.svelte
@@ -2250,7 +2250,11 @@
 					break;
 				}
 				steps = foldRunSteps(steps, events);
-				cursor = latestStepSeq(steps);
+				// Advanced from the PAGE, not from the folded lines. An event
+				// that renders no line (a status row repeating the task's own
+				// state, which is most of them) would otherwise leave the cursor
+				// behind it and be re-read on every poll for the rest of the run.
+				cursor = Math.max(cursor, ...events.map((event) => event.seq));
 				if (events.length < EVENT_PAGE_SIZE) {
 					break;
 				}

--- a/vendor/open-webui/src/lib/hive/agentTasks.test.ts
+++ b/vendor/open-webui/src/lib/hive/agentTasks.test.ts
@@ -8,7 +8,11 @@ import {
 	describeTask,
 	canStartTask,
 	describeRefusal,
+	decodeEvent,
 	ENGINE_UNAVAILABLE_MESSAGE,
+	EVENT_PAGE_SIZE,
+	getTask,
+	getTaskEvents,
 	listTasks
 } from './agentTasks';
 
@@ -199,5 +203,106 @@ describe('canStartTask', () => {
 	it('still refuses an empty brief and a submission already in flight', () => {
 		expect(canStartTask({ ...base, instructions: '   ' })).toBe(false);
 		expect(canStartTask({ ...base, submitting: true })).toBe(false);
+	});
+});
+
+const eventRow = (over: Record<string, unknown> = {}) => ({
+	seq: 7,
+	source_event_id: 'evt-7',
+	kind: 'tool_call',
+	payload: { tool_name: 'bash', tool_call_id: 'call-1', preview: 'ls -la' },
+	created_at: '2026-08-25T10:00:03Z',
+	...over
+});
+
+describe('decodeEvent', () => {
+	it('keeps a kind this build does not recognise', () => {
+		// The backend deliberately refuses to drop an unmapped upstream event
+		// class (it lands as `status` carrying the raw payload). Dropping it here
+		// would undo that at the last hop.
+		expect(decodeEvent(eventRow({ kind: 'reticulating' }))?.kind).toBe('unknown');
+	});
+
+	it('drops a row with no usable cursor position', () => {
+		// seq is the cursor. A row that cannot be acknowledged would be re-read
+		// on every poll forever.
+		expect(decodeEvent(eventRow({ seq: undefined }))).toBeNull();
+		expect(decodeEvent(eventRow({ seq: '7' }))).toBeNull();
+		expect(decodeEvent(eventRow({ seq: -1 }))).toBeNull();
+		expect(decodeEvent('not an object')).toBeNull();
+	});
+
+	it('keeps the event when the payload is not an object', () => {
+		const decoded = decodeEvent(eventRow({ payload: 'raw text' }));
+		expect(decoded?.payload).toEqual({});
+		expect(decoded?.kind).toBe('tool_call');
+	});
+});
+
+describe('the by-id reads', () => {
+	let fetchMock: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		fetchMock = vi.fn();
+		vi.stubGlobal('fetch', fetchMock);
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('reads one task by id instead of filtering the whole list', async () => {
+		fetchMock.mockResolvedValue(jsonResponse(row()));
+
+		const task = await getTask('owui-session-token', 'a0f0d4d2-0000-4000-8000-000000000001');
+
+		expect(task.id).toBe('a0f0d4d2-0000-4000-8000-000000000001');
+		expect(fetchMock.mock.calls[0][0]).toBe(
+			'/api/v1/hive/agent/tasks/a0f0d4d2-0000-4000-8000-000000000001'
+		);
+	});
+
+	it('reports a refused task read rather than returning nothing', async () => {
+		fetchMock.mockResolvedValue(jsonResponse({ error: { message: 'task not found' } }, 404));
+
+		await expect(getTask('t', 'a0f0d4d2-0000-4000-8000-000000000001')).rejects.toBeInstanceOf(
+			AgentTaskError
+		);
+	});
+
+	it('sends the cursor, so a follower asks only for what it has not seen', async () => {
+		fetchMock.mockResolvedValue(jsonResponse({ events: [eventRow()] }));
+
+		const events = await getTaskEvents('t', 'a0f0d4d2-0000-4000-8000-000000000001', 12);
+
+		expect(events).toHaveLength(1);
+		expect(fetchMock.mock.calls[0][0]).toBe(
+			`/api/v1/hive/agent/tasks/a0f0d4d2-0000-4000-8000-000000000001/events?after_seq=12&limit=${EVENT_PAGE_SIZE}`
+		);
+	});
+
+	it('floors the cursor to what the proxy accepts, which is a plain integer', async () => {
+		// hive_agent_proxy.py answers anything else with a 400 before it reaches
+		// a URL, so sending it costs a round trip and returns no events.
+		fetchMock.mockResolvedValue(jsonResponse({ events: [] }));
+
+		await getTaskEvents('t', 'a0f0d4d2-0000-4000-8000-000000000001', -5, 3.7);
+
+		expect(fetchMock.mock.calls[0][0]).toContain('after_seq=0&limit=3');
+	});
+
+	it('reads an empty feed as no progress yet, and an unreadable one as a failure', async () => {
+		fetchMock.mockResolvedValue(jsonResponse({ events: [] }));
+		await expect(getTaskEvents('t', 'a0f0d4d2-0000-4000-8000-000000000001')).resolves.toEqual([]);
+
+		fetchMock.mockResolvedValue(jsonResponse({ events: null }));
+		await expect(getTaskEvents('t', 'a0f0d4d2-0000-4000-8000-000000000001')).resolves.toEqual([]);
+
+		// No `events` key at all is a payload we could not read. Returning [] here
+		// would report "nothing has happened" for a broken response.
+		fetchMock.mockResolvedValue(jsonResponse({ tasks: [] }));
+		await expect(getTaskEvents('t', 'a0f0d4d2-0000-4000-8000-000000000001')).rejects.toThrow(
+			'Failed to parse task events response'
+		);
 	});
 });

--- a/vendor/open-webui/src/lib/hive/agentTasks.ts
+++ b/vendor/open-webui/src/lib/hive/agentTasks.ts
@@ -322,6 +322,177 @@ export const cancelTask = async (
 	return decoded;
 };
 
+/**
+ * One task, read by id.
+ *
+ * The list read this replaced returned every task the user owns in order to
+ * find one of them, which is the wrong request at any volume and was only ever
+ * written because this endpoint did not exist yet. It does: control-plane
+ * serves it, edge-api exposes it as GET /v1/agent/tasks/{id}, and the proxy
+ * routes it (deploy/docker/owui-patches/hive_agent_proxy.py, `get_task`).
+ *
+ * A task that is not this user's is a 404 here, not a filtered-out row, so a
+ * caller gets an AgentTaskError rather than a silent "not found in the list".
+ */
+export const getTask = async (
+	token: string,
+	id: string,
+	apiBase: string = DEFAULT_AGENT_API_BASE_URL
+): Promise<AgentTask> => {
+	const response = await fetch(`${apiBase}/tasks/${encodeURIComponent(id)}`, {
+		method: 'GET',
+		headers: headers(token)
+	});
+	if (!response.ok) {
+		await raise(response, 'Failed to load task');
+	}
+	const decoded = decodeTask(await readBody(response));
+	if (!decoded) {
+		throw new Error('Failed to parse task response');
+	}
+	return decoded;
+};
+
+/*
+ * The per-step event feed.
+ *
+ * The six kinds are the CHECK constraint on public.agent_task_events, mirrored
+ * in apps/control-plane/internal/agenttask/events.go. `unknown` is the same
+ * local seventh that TaskStatus carries and for the same reason: a kind this
+ * build cannot name still reaches the caller, which can say so, rather than
+ * being dropped on the floor. The backend itself already refuses to drop an
+ * unmapped OpenHands class (it lands as `status` carrying the raw payload), so
+ * discarding it here would undo that deliberately.
+ */
+export type TaskEventKind =
+	| 'status'
+	| 'tool_call'
+	| 'tool_result'
+	| 'message'
+	| 'error'
+	| 'file'
+	| 'unknown';
+
+const EVENT_KINDS: ReadonlySet<string> = new Set([
+	'status',
+	'tool_call',
+	'tool_result',
+	'message',
+	'error',
+	'file'
+]);
+
+export interface TaskEvent {
+	seq: number;
+	kind: TaskEventKind;
+	/**
+	 * Whatever JSONB the syncer stored. Every layer between here and the
+	 * database passes it through without parsing it, so this is the first place
+	 * that reads inside it, and it reads defensively: see runSteps() in
+	 * coworkMode.ts for the per-kind shapes and what happens to a payload that
+	 * does not match one.
+	 */
+	payload: Record<string, unknown>;
+	created_at: string;
+}
+
+/**
+ * Decodes one event row, or null when it carries no cursor position.
+ *
+ * `seq` is the only truly load-bearing field: it is the cursor, and a row
+ * without a usable one cannot be acknowledged, so accepting it would mean
+ * re-reading it forever. A non-object payload (nothing this backend writes
+ * today, but the column is raw JSONB) degrades to an empty object rather than
+ * discarding the event, because the kind alone is still worth something.
+ */
+export const decodeEvent = (value: unknown): TaskEvent | null => {
+	if (!isRecord(value)) {
+		return null;
+	}
+	const seq = value['seq'];
+	if (typeof seq !== 'number' || !Number.isFinite(seq) || seq < 0) {
+		return null;
+	}
+	const kind = readString(value, 'kind');
+	const payload = value['payload'];
+	return {
+		seq,
+		kind: kind !== null && EVENT_KINDS.has(kind) ? (kind as TaskEventKind) : 'unknown',
+		payload: isRecord(payload) ? payload : {},
+		created_at: readString(value, 'created_at') ?? ''
+	};
+};
+
+/*
+ * The page size this front end asks for.
+ *
+ * edge-api clamps `limit` to 500 (maxEventsLimit in
+ * apps/edge-api/internal/agenttask/handler.go) and defaults it to 100. 200 is
+ * a follower's page, not a backlog dump: a live run produces a handful of
+ * events between polls, and the only time a full page comes back is the first
+ * read of a conversation reopened after a long run, which pages.
+ */
+export const EVENT_PAGE_SIZE = 200;
+
+/**
+ * Events strictly newer than `afterSeq`, oldest first.
+ *
+ * The cursor is the whole point. A follower that re-read the full event list
+ * every few seconds would repeat the mistake this call was added to fix, one
+ * layer down: control-plane's read is `seq > $2 ORDER BY seq ASC LIMIT $4`
+ * (repository.go), so passing the highest seq already seen costs one small
+ * page per poll no matter how long the run has been going.
+ *
+ * A returned page of exactly `limit` rows means there may be more behind it.
+ * The caller advances the cursor and asks again rather than assuming the run
+ * has produced nothing since.
+ */
+export const getTaskEvents = async (
+	token: string,
+	id: string,
+	afterSeq: number = 0,
+	limit: number = EVENT_PAGE_SIZE,
+	apiBase: string = DEFAULT_AGENT_API_BASE_URL
+): Promise<TaskEvent[]> => {
+	// The proxy validates both as plain non-negative integers before they reach
+	// a URL and answers anything else with a 400, so they are floored to that
+	// shape here rather than sent as-is and refused a round trip later.
+	const cursor = Math.max(0, Math.floor(afterSeq));
+	const page = Math.max(1, Math.floor(limit));
+	const response = await fetch(
+		`${apiBase}/tasks/${encodeURIComponent(id)}/events?after_seq=${cursor}&limit=${page}`,
+		{
+			method: 'GET',
+			headers: headers(token)
+		}
+	);
+	if (!response.ok) {
+		await raise(response, 'Failed to load task events');
+	}
+	const body = await readBody(response);
+	if (!isRecord(body) || !('events' in body)) {
+		// Same distinction listTasks draws: a missing key is a payload we could
+		// not read, and reporting it as "no progress yet" would be the exact
+		// silent failure this surface exists to stop.
+		throw new Error('Failed to parse task events response');
+	}
+	const rows = body['events'];
+	if (rows === null) {
+		return [];
+	}
+	if (!Array.isArray(rows)) {
+		throw new Error('Failed to parse task events response');
+	}
+	const events: TaskEvent[] = [];
+	for (const row of rows) {
+		const decoded = decodeEvent(row);
+		if (decoded) {
+			events.push(decoded);
+		}
+	}
+	return events;
+};
+
 // Polling and the cancel button both stop once a task reaches one of these
 // (matches apps/control-plane/internal/agenttask/SYNC_CONTRACT.md's state
 // machine). `unknown` is deliberately absent: a state we cannot name is not a

--- a/vendor/open-webui/src/lib/hive/coworkMode.test.ts
+++ b/vendor/open-webui/src/lib/hive/coworkMode.test.ts
@@ -6,13 +6,19 @@ import { describe, expect, it } from 'vitest';
 
 import {
 	COMPOSER_MODES,
+	describeEvent,
+	foldRunSteps,
 	isComposerMode,
+	latestStepSeq,
 	nextMode,
 	packForMode,
 	renderRun,
 	runTurnIsDone,
-	selectPendingCoworkTurns
+	selectPendingCoworkTurns,
+	settleRunSteps,
+	type RunStep
 } from './coworkMode';
+import type { TaskEvent } from './agentTasks';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const readComponent = (relative: string): string =>
@@ -205,5 +211,196 @@ describe('sending in cowork mode starts a run instead of a completion', () => {
 
 	it('bounds the poll loop, so a wedged run cannot poll forever', () => {
 		expect(chat).toContain('COWORK_FOLLOW_CEILING_MS');
+	});
+});
+
+const event = (over: Partial<TaskEvent> = {}): TaskEvent => ({
+	seq: 1,
+	kind: 'tool_call',
+	payload: {},
+	created_at: '2026-08-25T10:00:00Z',
+	...over
+});
+
+describe('describeEvent', () => {
+	it('names the tool on a call and on its result', () => {
+		expect(
+			describeEvent(event({ kind: 'tool_call', payload: { tool_name: 'bash', preview: 'ls -la' } }))
+		).toBe('Using bash: ls -la');
+		expect(
+			describeEvent(
+				event({ kind: 'tool_result', payload: { tool_name: 'bash', preview: 'README.md' } })
+			)
+		).toBe('Used bash: README.md');
+	});
+
+	it('still says something when the tool has no name and the preview is empty', () => {
+		expect(describeEvent(event({ kind: 'tool_call', payload: {} }))).toBe('Using a tool');
+	});
+
+	it('says a preview was shortened rather than showing it as complete', () => {
+		// The wire cut every preview to 2000 runes and left no marker, so a
+		// preview sitting exactly on the boundary is the only evidence.
+		const long = 'x'.repeat(2000);
+		expect(describeEvent(event({ kind: 'message', payload: { preview: long } }))).toBe(
+			`${long} (shortened)`
+		);
+		const short = 'x'.repeat(1999);
+		expect(describeEvent(event({ kind: 'message', payload: { preview: short } }))).toBe(short);
+	});
+
+	it('counts runes, not UTF-16 units, the way the backend cap does', () => {
+		// 1500 astral characters is 3000 UTF-16 units and 1500 runes: under the
+		// cap, so nothing was removed and nothing may claim otherwise.
+		const astral = '𝄞'.repeat(1500);
+		expect(describeEvent(event({ kind: 'message', payload: { preview: astral } }))).toBe(astral);
+	});
+
+	it('reports a payload the backend replaced with its truncation marker', () => {
+		expect(describeEvent(event({ kind: 'tool_result', payload: { truncated: true, size: 82000 } }))).toBe(
+			'An update too large to show here (82000 bytes).'
+		);
+	});
+
+	it('skips a status row that only repeats the task state the turn already shows', () => {
+		expect(describeEvent(event({ kind: 'status', payload: { status: 'running' } }))).toBeNull();
+	});
+
+	it('surfaces an upstream event class this build has never met', () => {
+		// The syncer's fallback stores an unmapped class as `status` with its raw
+		// payload precisely so it cannot vanish. It must not vanish here either.
+		expect(
+			describeEvent(event({ kind: 'status', payload: { sandbox_kind: 'CondenserEvent' } }))
+		).toBe('Sandbox event: CondenserEvent');
+		expect(describeEvent(event({ kind: 'unknown', payload: {} }))).toBe(
+			'An update this version of Hive cannot read.'
+		);
+	});
+
+	it('names a workspace file', () => {
+		expect(describeEvent(event({ kind: 'file', payload: { name: 'report.md', size: 12 } }))).toBe(
+			'Workspace file: report.md'
+		);
+	});
+});
+
+describe('foldRunSteps', () => {
+	it('closes a tool call with its own result rather than adding a second line', () => {
+		const called = foldRunSteps([], [
+			event({ seq: 1, kind: 'tool_call', payload: { tool_name: 'bash', tool_call_id: 'c1' } })
+		]);
+		expect(called).toHaveLength(1);
+		expect(called[0].done).toBe(false);
+
+		const answered = foldRunSteps(called, [
+			event({
+				seq: 2,
+				kind: 'tool_result',
+				payload: { tool_name: 'bash', tool_call_id: 'c1', preview: 'ok' }
+			})
+		]);
+		expect(answered).toHaveLength(1);
+		expect(answered[0].done).toBe(true);
+		expect(answered[0].description).toBe('Used bash: ok');
+		expect(answered[0].seq).toBe(2);
+	});
+
+	it('gives an orphan result its own line instead of dropping it', () => {
+		// A conversation reopened mid-run has its earlier events behind the
+		// cursor, so the call this result belongs to is not on the turn.
+		const steps = foldRunSteps([], [
+			event({ seq: 9, kind: 'tool_result', payload: { tool_name: 'bash', tool_call_id: 'gone' } })
+		]);
+		expect(steps).toHaveLength(1);
+		expect(steps[0].done).toBe(true);
+	});
+
+	it('pairs a result with the newest matching open call, not an already-closed one', () => {
+		const steps = foldRunSteps([], [
+			event({ seq: 1, kind: 'tool_call', payload: { tool_name: 'bash', tool_call_id: 'c1' } }),
+			event({ seq: 2, kind: 'tool_result', payload: { tool_name: 'bash', tool_call_id: 'c1' } }),
+			event({ seq: 3, kind: 'tool_call', payload: { tool_name: 'bash', tool_call_id: 'c1' } }),
+			event({ seq: 4, kind: 'tool_result', payload: { tool_name: 'bash', tool_call_id: 'c1' } })
+		]);
+		expect(steps).toHaveLength(2);
+		expect(steps.every((step) => step.done)).toBe(true);
+	});
+
+	it('never mutates the lines already on the turn', () => {
+		const before: RunStep[] = [
+			{ action: 'hive_agent_step', description: 'Using bash', done: false, seq: 1, tool_call_id: 'c1' }
+		];
+		const after = foldRunSteps(before, [
+			event({ seq: 2, kind: 'tool_result', payload: { tool_name: 'bash', tool_call_id: 'c1' } })
+		]);
+		expect(before[0].done).toBe(false);
+		expect(after[0].done).toBe(true);
+		expect(after).not.toBe(before);
+	});
+
+	it('renders nothing the backend did not send', () => {
+		expect(foldRunSteps([], [])).toEqual([]);
+		// A status row repeating the task state contributes no line, and adds no
+		// placeholder in its stead.
+		expect(foldRunSteps([], [event({ kind: 'status', payload: { status: 'running' } })])).toEqual(
+			[]
+		);
+	});
+});
+
+describe('the follower cursor', () => {
+	it('resumes from the highest seq the turn already carries', () => {
+		const steps = foldRunSteps([], [
+			event({ seq: 4, kind: 'message', payload: { preview: 'starting' } }),
+			event({ seq: 11, kind: 'message', payload: { preview: 'still going' } })
+		]);
+		expect(latestStepSeq(steps)).toBe(11);
+	});
+
+	it('starts at zero for a turn with no lines, and for one stored before seq existed', () => {
+		expect(latestStepSeq([])).toBe(0);
+		expect(latestStepSeq(undefined)).toBe(0);
+		expect(latestStepSeq([{ action: 'hive_agent_step', description: 'x', done: true } as RunStep])).toBe(
+			0
+		);
+	});
+});
+
+describe('settleRunSteps', () => {
+	it('stops a step shimmering under a run that has finished', () => {
+		const settled = settleRunSteps([
+			{ action: 'hive_agent_step', description: 'Using bash', done: false, seq: 1 }
+		]);
+		expect(settled[0].done).toBe(true);
+		// The text is not rewritten: what is known is that it stopped, not that
+		// it succeeded.
+		expect(settled[0].description).toBe('Using bash');
+	});
+});
+
+describe('the run turn follows the detail endpoint, not the task list', () => {
+	const chat = readComponent('../components/chat/Chat.svelte');
+
+	it('reads one task by id rather than filtering every task the user owns', () => {
+		expect(chat).toContain('getTask(localStorage.token, taskId)');
+		expect(chat).not.toContain('listTasks');
+	});
+
+	it('uses the events cursor, so a poll asks only for what it has not seen', () => {
+		expect(chat).toContain('getTaskEvents(');
+		expect(chat).toContain('latestStepSeq(steps)');
+	});
+
+	it('renders progress from the events themselves', () => {
+		expect(chat).toContain('foldRunSteps(steps, events)');
+		expect(chat).toContain('turn.statusHistory');
+	});
+
+	it('keeps the three behaviours #1193 review fixed', () => {
+		// The navigation guard, resuming every pending run rather than the first,
+		// and the clean refusal when files are attached in Cowork mode.
+		expect(chat).toContain('if ($chatId !== _chatId) {');
+		expect(chat).toContain('for (const pending of pendingTurns)');
+		expect(chat).toContain('Attachments are not supported in Cowork mode yet');
 	});
 });

--- a/vendor/open-webui/src/lib/hive/coworkMode.test.ts
+++ b/vendor/open-webui/src/lib/hive/coworkMode.test.ts
@@ -243,10 +243,20 @@ describe('describeEvent', () => {
 		// preview sitting exactly on the boundary is the only evidence.
 		const long = 'x'.repeat(2000);
 		expect(describeEvent(event({ kind: 'message', payload: { preview: long } }))).toBe(
-			`${long} (shortened)`
+			`(shortened) ${long}`
 		);
 		const short = 'x'.repeat(1999);
 		expect(describeEvent(event({ kind: 'message', payload: { preview: short } }))).toBe(short);
+	});
+
+	it('puts the marker in front, where a one-line clamp cannot eat it', () => {
+		// Appended, it is the first thing the clamp drops, and the line then
+		// reads as a complete tool result. Seen in the first capture of this
+		// surface, which is why this test exists.
+		const line = describeEvent(
+			event({ kind: 'tool_result', payload: { tool_name: 'execute_bash', preview: 'y'.repeat(2000) } })
+		);
+		expect(line?.startsWith('Used execute_bash (shortened): ')).toBe(true);
 	});
 
 	it('counts runes, not UTF-16 units, the way the backend cap does', () => {

--- a/vendor/open-webui/src/lib/hive/coworkMode.ts
+++ b/vendor/open-webui/src/lib/hive/coworkMode.ts
@@ -221,20 +221,34 @@ const asString = (payload: Record<string, unknown>, key: string): string => {
 	return typeof raw === 'string' ? raw : '';
 };
 
-/** A preview, with the fact of its truncation attached when it hit the cap. */
-const preview = (payload: Record<string, unknown>): string => {
+/**
+ * A preview, and whether the wire had already cut it.
+ *
+ * Array.from, not .length: the cap counts runes, and a surrogate pair is one
+ * rune and two UTF-16 units.
+ */
+const preview = (payload: Record<string, unknown>): { text: string; shortened: boolean } => {
 	const raw = asString(payload, 'preview').trim();
 	if (raw === '') {
-		return '';
+		return { text: '', shortened: false };
 	}
-	// Array.from, not .length: the cap counts runes, and a surrogate pair is
-	// one rune and two UTF-16 units.
-	return Array.from(raw).length >= PREVIEW_RUNE_CAP ? `${raw} (shortened)` : raw;
+	return { text: raw, shortened: Array.from(raw).length >= PREVIEW_RUNE_CAP };
 };
 
+/*
+ * The truncation marker goes in FRONT of the text it is about, never after it.
+ *
+ * A step renders as a single clamped line, so a marker appended to a 2000-rune
+ * preview is the first thing the clamp throws away and the line reads as a
+ * complete tool result. That is the exact failure this marker exists to
+ * prevent, and it was visible in the first capture of this surface.
+ */
+const SHORTENED = '(shortened)';
+
 const withPreview = (label: string, payload: Record<string, unknown>): string => {
-	const text = preview(payload);
-	return text === '' ? label : `${label}: ${text}`;
+	const { text, shortened } = preview(payload);
+	const head = shortened ? `${label} ${SHORTENED}` : label;
+	return text === '' ? head : `${head}: ${text}`;
 };
 
 const toolLabel = (payload: Record<string, unknown>, verb: string): string => {
@@ -270,8 +284,11 @@ export const describeEvent = (event: TaskEvent): string | null => {
 		case 'tool_result':
 			return withPreview(toolLabel(payload, 'Used'), payload);
 		case 'message': {
-			const text = preview(payload);
-			return text === '' ? null : text;
+			const { text, shortened } = preview(payload);
+			if (text === '') {
+				return null;
+			}
+			return shortened ? `${SHORTENED} ${text}` : text;
 		}
 		case 'error':
 			return withPreview('Error', payload);

--- a/vendor/open-webui/src/lib/hive/coworkMode.ts
+++ b/vendor/open-webui/src/lib/hive/coworkMode.ts
@@ -21,6 +21,8 @@
  * transcript component as a chat.
  */
 
+import type { TaskEvent } from './agentTasks';
+
 export type ComposerMode = 'chat' | 'cowork';
 
 export const COMPOSER_MODES: readonly ComposerMode[] = ['chat', 'cowork'];
@@ -72,13 +74,13 @@ export const nextMode = (current: ComposerMode, key: string): ComposerMode | nul
  * state while it is queued or running and its own result once it settles, so
  * one transcript component renders both kinds of turn with no branch in it.
  *
- * ponytail: the ceiling here is the wire, not the renderer. edge-api exposes
- * a task's status and its final `result_summary_ref` and nothing in between:
- * there is no per-step feed, so the intermediate tool lines D-045 describes
- * ("Used Claude in Chrome (2 actions)") and the Progress / Working folder /
- * Context panel cannot be populated by any frontend. When a per-task detail or
- * event endpoint lands, the extra lines go here and the panel reads the same
- * source; nothing else in the composer path has to move.
+ * The turn's content is the run's own words: its state while it is queued or
+ * running, its summary once it settles. The intermediate tool lines D-045
+ * describes ("Used Claude in Chrome (2 actions)") are NOT content: they are
+ * built by runSteps() below from the per-step event feed and ride on the same
+ * `statusHistory` field the chat path already uses for "Searching the web",
+ * which is why they render as muted lines with no new component and no branch
+ * in the transcript.
  */
 export interface RunLike {
 	status: string;
@@ -161,3 +163,224 @@ export const selectPendingCoworkTurns = (
 				typeof (message as { id?: unknown }).id === 'string'
 		)
 		.map((message) => ({ id: message.id, hive_agent_task_id: message.hive_agent_task_id }));
+
+/* ---------------------------------------------------------------------- *
+ * Per-step progress (#1193 follow-up)
+ *
+ * The run turn used to show nothing at all between submit and completion,
+ * which reads as a hang, and the reason given for it was that the wire had no
+ * per-step feed. It has had one since #1073: agent-engine emits real
+ * tool_call / tool_result / message / error / status / file events, the
+ * control-plane stores and serves them behind a cursor, edge-api exposes them
+ * and the chat proxy already routes them. The only missing piece was here.
+ *
+ * WHAT IS AND IS NOT INVENTED HERE
+ * --------------------------------
+ * Every line below comes from an event the backend actually sent. There is no
+ * optimistic step, no "thinking" placeholder and no synthesised progress: a
+ * fabricated step is worse than a spinner, because a person will believe it.
+ * The one thing this file adds that no single event carries is the PAIRING of
+ * a tool_result back onto its tool_call, which is not invention: both events
+ * carry the same tool_call_id precisely so they can be joined.
+ * ---------------------------------------------------------------------- */
+
+/**
+ * One muted line in the transcript, in the shape `statusHistory` already
+ * takes (see ResponseMessage.svelte's MessageType and StatusItem.svelte).
+ *
+ * `action` is deliberately a name no StatusItem branch matches, so the line
+ * falls to that component's default branch and renders as plain muted text.
+ * `done: false` is what makes the newest line shimmer while the step is still
+ * running, which is the same treatment a web search gets in an ordinary chat
+ * turn and the one piece of this surface the parity review found already
+ * matched the reference product.
+ */
+export interface RunStep {
+	action: 'hive_agent_step';
+	description: string;
+	done: boolean;
+	/** Cursor position of the event that produced this line. */
+	seq: number;
+	/** Present on a tool step, so its result can find it. */
+	tool_call_id?: string;
+}
+
+/*
+ * maxPreviewRunes in apps/control-plane/internal/agenttask/events.go. Every
+ * preview on the wire was cut to this many RUNES, with no marker left behind,
+ * so a preview sitting exactly on the boundary is the only evidence that
+ * anything was removed. Treating it as truncated over-reports by one preview
+ * in a very large number; the alternative under-reports, and showing a
+ * shortened tool result as though it were complete is the failure this whole
+ * change is against.
+ */
+const PREVIEW_RUNE_CAP = 2000;
+
+const asString = (payload: Record<string, unknown>, key: string): string => {
+	const raw = payload[key];
+	return typeof raw === 'string' ? raw : '';
+};
+
+/** A preview, with the fact of its truncation attached when it hit the cap. */
+const preview = (payload: Record<string, unknown>): string => {
+	const raw = asString(payload, 'preview').trim();
+	if (raw === '') {
+		return '';
+	}
+	// Array.from, not .length: the cap counts runes, and a surrogate pair is
+	// one rune and two UTF-16 units.
+	return Array.from(raw).length >= PREVIEW_RUNE_CAP ? `${raw} (shortened)` : raw;
+};
+
+const withPreview = (label: string, payload: Record<string, unknown>): string => {
+	const text = preview(payload);
+	return text === '' ? label : `${label}: ${text}`;
+};
+
+const toolLabel = (payload: Record<string, unknown>, verb: string): string => {
+	const name = asString(payload, 'tool_name').trim();
+	return name === '' ? `${verb} a tool` : `${verb} ${name}`;
+};
+
+/**
+ * The sentence one event becomes, or null when it says nothing a person can
+ * read that the turn is not already saying.
+ *
+ * Only two kinds return null, and neither is a dropped event: a `status` row
+ * carrying the task's own status duplicates the turn's state, which is
+ * rendered from the task itself and would otherwise appear twice, and a
+ * `message` with an empty preview has no text to show. Everything else,
+ * including a kind this build has never heard of, produces a line.
+ */
+export const describeEvent = (event: TaskEvent): string | null => {
+	const payload = event.payload;
+
+	// capEventPayload replaces an oversized payload wholesale with this marker,
+	// so it is checked before the kind: there is no preview left to read.
+	if (payload['truncated'] === true) {
+		const size = payload['size'];
+		return typeof size === 'number'
+			? `An update too large to show here (${size} bytes).`
+			: 'An update too large to show here.';
+	}
+
+	switch (event.kind) {
+		case 'tool_call':
+			return withPreview(toolLabel(payload, 'Using'), payload);
+		case 'tool_result':
+			return withPreview(toolLabel(payload, 'Used'), payload);
+		case 'message': {
+			const text = preview(payload);
+			return text === '' ? null : text;
+		}
+		case 'error':
+			return withPreview('Error', payload);
+		case 'file': {
+			const name = asString(payload, 'name').trim();
+			return name === '' ? 'Wrote a file in the workspace.' : `Workspace file: ${name}`;
+		}
+		case 'status': {
+			const sandboxKind = asString(payload, 'sandbox_kind').trim();
+			if (sandboxKind !== '') {
+				return `Sandbox event: ${sandboxKind}`;
+			}
+			if (asString(payload, 'status') !== '') {
+				return null;
+			}
+			return 'An update this version of Hive cannot read.';
+		}
+		default:
+			return 'An update this version of Hive cannot read.';
+	}
+};
+
+/**
+ * Folds a page of new events onto the lines a turn already shows.
+ *
+ * Incremental rather than a recompute, because the read is incremental: the
+ * follower asks for events after the highest seq it has, so the pages it gets
+ * never contain a step that is already on screen and there is nothing to
+ * rebuild. New array, new objects: the caller assigns the result onto the
+ * message, and mutating the stored one in place would leave Svelte with no
+ * change to notice.
+ *
+ * A tool_result closes the newest still-open step with its tool_call_id. When
+ * there is none, which happens on a conversation reopened mid-run whose
+ * earlier events are already behind the cursor, it becomes its own line
+ * instead of being dropped.
+ */
+export const foldRunSteps = (previous: readonly RunStep[], events: readonly TaskEvent[]): RunStep[] => {
+	const steps = previous.map((step) => ({ ...step }));
+
+	for (const event of events) {
+		if (event.kind === 'tool_result') {
+			const callId = asString(event.payload, 'tool_call_id').trim();
+			if (callId !== '') {
+				const open = steps.map((s, i) => ({ s, i })).filter(({ s }) => s.tool_call_id === callId && !s.done);
+				if (open.length > 0) {
+					const { s, i } = open[open.length - 1];
+					steps[i] = {
+						...s,
+						done: true,
+						description: describeEvent(event) ?? s.description,
+						seq: event.seq
+					};
+					continue;
+				}
+			}
+		}
+
+		const description = describeEvent(event);
+		if (description === null) {
+			continue;
+		}
+		const step: RunStep = {
+			action: 'hive_agent_step',
+			description,
+			// A tool call is the only step that stays open, because it is the
+			// only one with a second event coming that closes it.
+			done: event.kind !== 'tool_call',
+			seq: event.seq
+		};
+		if (event.kind === 'tool_call') {
+			const callId = asString(event.payload, 'tool_call_id').trim();
+			if (callId !== '') {
+				step.tool_call_id = callId;
+			}
+		}
+		steps.push(step);
+	}
+
+	return steps;
+};
+
+/**
+ * The cursor a turn resumes from: the highest seq any of its lines carries.
+ *
+ * Read off the stored lines rather than kept in a variable, so a conversation
+ * reopened in a new tab asks for the events it has not seen instead of
+ * re-reading the whole run from zero and re-rendering lines it already shows.
+ * A step written before this field existed contributes 0, which re-reads and
+ * is merely wasteful, never wrong.
+ */
+export const latestStepSeq = (steps: readonly RunStep[] | null | undefined): number => {
+	let highest = 0;
+	for (const step of steps ?? []) {
+		if (typeof step?.seq === 'number' && Number.isFinite(step.seq) && step.seq > highest) {
+			highest = step.seq;
+		}
+	}
+	return highest;
+};
+
+/**
+ * Closes any step still shimmering once the run itself has settled.
+ *
+ * A tool call whose result never arrived (a cancelled run, a sandbox that
+ * died) would otherwise shimmer forever under a turn that says the task
+ * finished, which claims work is still happening after the run is over. The
+ * text is left exactly as it was: what is known is that the step stopped, not
+ * that it succeeded.
+ */
+export const settleRunSteps = (steps: readonly RunStep[]): RunStep[] =>
+	steps.map((step) => (step.done ? { ...step } : { ...step, done: true }));


### PR DESCRIPTION
Follow-up to #1193, which made Cowork a mode of the composer and rendered a run as a conversation turn. Between submit and completion that turn showed nothing, which reads as a hang.

## The gap was frontend only

The comment left in `coworkMode.ts` said the wire had no per-step feed. It has had one since #1073 merged:

- agent-engine emits real per-step events, mapped from OpenHands `ActionEvent`, `ObservationEvent`, `MessageEvent` and `AgentErrorEvent`, with an unmapped class deliberately landing as a `status` event carrying the raw payload rather than being dropped.
- control-plane stores them and serves `GET /internal/agent-tasks/{id}` and `/events` behind an `after_seq` cursor.
- edge-api exposes `GET /v1/agent/tasks/{id}` and `/events`, FeatureCowork gated.
- The chat proxy already routed `get_task` and `list_task_events`, with UUID and cursor validation.

`vendor/open-webui/src/lib/hive/agentTasks.ts` had `listTasks`, `createTask` and `cancelTask` and nothing else, so the run turn polled the whole task list and rendered no steps.

## What this changes

**`agentTasks.ts`**: `getTask` and `getTaskEvents`, matching the proxy's contract. The cursor and limit are floored to plain non-negative integers, which is exactly what `hive_agent_proxy.py` accepts and the only shape that avoids a 400. `decodeEvent` keeps an event whose kind this build does not recognise, the way `decodeTask` already keeps an unrecognised status, because the backend goes out of its way not to drop an unmapped upstream class and dropping it at the last hop would undo that.

**The follower**: reads one task by id instead of listing every task the user owns and filtering it, which was the ponytail note in the code. Each poll then asks for events strictly after the highest seq the turn already carries. That seq is read off the stored lines, so a conversation reopened in another tab resumes where it left off instead of re-reading the run from zero. A full page means more is behind it and the loop asks again, bounded at five pages per read.

**The rendering**: events fold into muted lines on the same `statusHistory` field the chat path already uses for "Searching the web" and "Retrieved 3 sources". No new component, no branch in the transcript, and the treatment is the one the parity review found already matched the reference product. A tool call and its result join on `tool_call_id` into one line, which shimmers while the call is open.

## Honesty properties, each with a test

- Nothing renders that the backend did not send. No optimistic step, no synthesised progress. A `status` row that only repeats the task's own state contributes no line rather than a placeholder.
- A payload the backend replaced with its truncation marker says so, and says the size. A preview sitting exactly on the 2000-rune cap is reported as shortened rather than shown as though complete: the cap leaves no marker behind, so the boundary is the only evidence there is.
- A terminal run settles every line still open, so nothing shimmers under a turn that says the task finished. The text is not rewritten, because what is known is that the step stopped, not that it succeeded.
- An event kind this build has never met still produces a line.
- The events read is best effort and the status read is the authority: a failed event fetch keeps the lines already on screen and never erases real progress with a transport failure.

## Not regressed, and pinned by tests

The three behaviours #1193's review fixed: the `_chatId` navigation guard, resuming every pending run rather than the oldest (`selectPendingCoworkTurns`), and the clean refusal when files are attached in Cowork mode.

## Tests

`scripts/test-owui-hive-frontend.sh`: 175 passing, up from 147. Svelte compile pass green for all 13 Hive components; `Chat.svelte` compiled separately with the image build's pinned svelte 5.56.0 after TypeScript preprocessing.

Visual proof follows in a comment.