### PR TITLE
fix: carry cache read/write tokens through finalize into api_key_usage_rollups

### DIFF
--- a/apps/control-plane/internal/accounting/http.go
+++ b/apps/control-plane/internal/accounting/http.go
@@ -236,6 +236,11 @@ type internalFinalizeReservationRequest struct {
 	Status                 string `json:"status"`
 	InputTokens            int64  `json:"input_tokens"`
 	OutputTokens           int64  `json:"output_tokens"`
+	// CacheReadTokens and CacheWriteTokens carry the prompt's cache components
+	// into the rollup write (#1174). Optional: an older edge-api that omits
+	// them settles exactly as before, with zeroes in the rollup.
+	CacheReadTokens  int64 `json:"cache_read_tokens,omitempty"`
+	CacheWriteTokens int64 `json:"cache_write_tokens,omitempty"`
 }
 
 type internalReleaseReservationRequest struct {
@@ -309,6 +314,8 @@ func (h *Handler) handleInternalFinalizeReservation(w http.ResponseWriter, r *ht
 		Status:                 req.Status,
 		InputTokens:            req.InputTokens,
 		OutputTokens:           req.OutputTokens,
+		CacheReadTokens:        req.CacheReadTokens,
+		CacheWriteTokens:       req.CacheWriteTokens,
 	})
 	if err != nil {
 		writeAccountingError(w, err)

--- a/apps/control-plane/internal/accounting/service.go
+++ b/apps/control-plane/internal/accounting/service.go
@@ -443,13 +443,15 @@ func (s *Service) finalizeLocked(ctx context.Context, input FinalizeReservationI
 		if err := s.apiKeySvc.ApplyReservationDelta(ctx, *attempt.APIKeyID, -heldCredits, actualCredits, at); err != nil {
 			return Reservation{}, fmt.Errorf("accounting: apply reservation delta: %w", err)
 		}
-		// Cache read/write token counts are not yet threaded into
-		// FinalizeReservationInput from either finalize HTTP path (see
-		// finalizeReservationRequest / internalFinalizeReservationRequest);
-		// they stay zero here until a caller can actually supply them. Input
-		// and output tokens ARE available on input (used two calls above, for
-		// the completed usage event) and must not be dropped the same way.
-		if err := s.apiKeySvc.RecordUsageFinalization(ctx, *attempt.APIKeyID, attempt.ModelAlias, max(input.InputTokens, 0), max(input.OutputTokens, 0), 0, 0, actualCredits, at); err != nil {
+		// The cache components ride in on FinalizeReservationInput like their
+		// input/output siblings (#1174): edge-api threads them from the same
+		// metered usage block that priced ActualCredits, so
+		// public.api_key_usage_rollups carries real cache_read/write counts
+		// instead of the permanent zeroes #1173 left behind. Clamped like every
+		// other token count entering the ledger surfaces. The customer-facing
+		// finalize request still carries no token fields at all; widening it is
+		// a separate decision with no caller today.
+		if err := s.apiKeySvc.RecordUsageFinalization(ctx, *attempt.APIKeyID, attempt.ModelAlias, max(input.InputTokens, 0), max(input.OutputTokens, 0), max(input.CacheReadTokens, 0), max(input.CacheWriteTokens, 0), actualCredits, at); err != nil {
 			return Reservation{}, fmt.Errorf("accounting: record usage finalization: %w", err)
 		}
 		if err := s.apiKeySvc.MarkLastUsed(ctx, *attempt.APIKeyID, at); err != nil {

--- a/apps/control-plane/internal/accounting/service.go
+++ b/apps/control-plane/internal/accounting/service.go
@@ -421,10 +421,12 @@ func (s *Service) finalizeLocked(ctx context.Context, input FinalizeReservationI
 		// into usage_events and the console's analytics beside a non-negative
 		// credit delta, and a SUM over that column would silently understate
 		// consumption.
-		InputTokens:     max(input.InputTokens, 0),
-		OutputTokens:    max(input.OutputTokens, 0),
-		HiveCreditDelta: -actualCredits,
-		CustomerTags:    reservation.CustomerTags,
+		InputTokens:      max(input.InputTokens, 0),
+		OutputTokens:     max(input.OutputTokens, 0),
+		CacheReadTokens:  max(input.CacheReadTokens, 0),
+		CacheWriteTokens: max(input.CacheWriteTokens, 0),
+		HiveCreditDelta:  -actualCredits,
+		CustomerTags:     reservation.CustomerTags,
 		InternalMetadata: map[string]any{
 			"reservation_id": reservation.ID.String(),
 			// The unused part of the hold, matching the reservation row's

--- a/apps/control-plane/internal/accounting/service_test.go
+++ b/apps/control-plane/internal/accounting/service_test.go
@@ -877,6 +877,95 @@ func TestFinalizeReservationUsageRollupCarriesMeteredTokens(t *testing.T) {
 	}
 }
 
+// TestFinalizeReservationUsageRollupCarriesCacheTokens extends the guard above
+// (#1173) to the cache halves of the rollup write (#1174):
+// RecordUsageFinalization must forward the metered cache read/write counts
+// from FinalizeReservationInput into public.api_key_usage_rollups instead of
+// the literal zeroes it used to write, and it must stay backward compatible:
+// a caller that omits the fields settles exactly as before.
+func TestFinalizeReservationUsageRollupCarriesCacheTokens(t *testing.T) {
+	repo := newRepoStub()
+	ledgerSvc := &ledgerStub{balance: ledger.BalanceSummary{AvailableCredits: 500}}
+	usageSvc := &usageStub{}
+	apiKeyID := uuid.New()
+	apiKeySvc := &apiKeyStub{
+		budgetKindByKey: map[uuid.UUID]string{apiKeyID: "lifetime"},
+	}
+	svc := NewService(repo, ledgerSvc, usageSvc, apiKeySvc)
+
+	accountID := uuid.New()
+	reservation, err := svc.CreateReservation(context.Background(), CreateReservationInput{
+		AccountID:        accountID,
+		RequestID:        "req_rollup_cache_tokens",
+		AttemptNumber:    1,
+		APIKeyID:         &apiKeyID,
+		Endpoint:         "/v1/chat/completions",
+		ModelAlias:       "hive-fast",
+		EstimatedCredits: 100,
+		PolicyMode:       PolicyModeStrict,
+	})
+	if err != nil {
+		t.Fatalf("CreateReservation returned error: %v", err)
+	}
+
+	_, err = svc.FinalizeReservation(context.Background(), FinalizeReservationInput{
+		AccountID:              accountID,
+		ReservationID:          reservation.ID,
+		ActualCredits:          35,
+		TerminalUsageConfirmed: true,
+		Status:                 string(usage.AttemptStatusCompleted),
+		InputTokens:            205_000,
+		OutputTokens:           2_000,
+		CacheReadTokens:        200_000,
+		CacheWriteTokens:       4_000,
+	})
+	if err != nil {
+		t.Fatalf("FinalizeReservation returned error: %v", err)
+	}
+
+	if len(apiKeySvc.finalizationCalls) != 1 {
+		t.Fatalf("expected one usage rollup update, got %#v", apiKeySvc.finalizationCalls)
+	}
+	got := apiKeySvc.finalizationCalls[0]
+	if got.cacheReadTokens != 200_000 {
+		t.Fatalf("expected the rollup to carry the metered cache-read tokens (200000), got %d: the count silently dropped to zero", got.cacheReadTokens)
+	}
+	if got.cacheWriteTokens != 4_000 {
+		t.Fatalf("expected the rollup to carry the metered cache-write tokens (4000), got %d: the count silently dropped to zero", got.cacheWriteTokens)
+	}
+
+	// A caller that does not know about the cache fields settles exactly as
+	// before: omitted means zero, never a fabricated count or an error.
+	reservation2, err := svc.CreateReservation(context.Background(), CreateReservationInput{
+		AccountID:        accountID,
+		RequestID:        "req_rollup_cache_tokens_omitted",
+		AttemptNumber:    1,
+		APIKeyID:         &apiKeyID,
+		Endpoint:         "/v1/chat/completions",
+		ModelAlias:       "hive-fast",
+		EstimatedCredits: 100,
+		PolicyMode:       PolicyModeStrict,
+	})
+	if err != nil {
+		t.Fatalf("CreateReservation returned error: %v", err)
+	}
+	if _, err := svc.FinalizeReservation(context.Background(), FinalizeReservationInput{
+		AccountID:     accountID,
+		ReservationID: reservation2.ID,
+		ActualCredits: 10,
+		Status:        string(usage.AttemptStatusCompleted),
+	}); err != nil {
+		t.Fatalf("FinalizeReservation (no cache fields) returned error: %v", err)
+	}
+	if len(apiKeySvc.finalizationCalls) != 2 {
+		t.Fatalf("expected two usage rollup updates, got %#v", apiKeySvc.finalizationCalls)
+	}
+	omitted := apiKeySvc.finalizationCalls[1]
+	if omitted.cacheReadTokens != 0 || omitted.cacheWriteTokens != 0 {
+		t.Fatalf("expected omitted cache fields to settle as zeroes, got read=%d write=%d", omitted.cacheReadTokens, omitted.cacheWriteTokens)
+	}
+}
+
 func TestBudgetProjectionCountsOpenReservations(t *testing.T) {
 	repo := newRepoStub()
 	ledgerSvc := &ledgerStub{balance: ledger.BalanceSummary{AvailableCredits: 500}}

--- a/apps/control-plane/internal/accounting/service_test.go
+++ b/apps/control-plane/internal/accounting/service_test.go
@@ -934,6 +934,29 @@ func TestFinalizeReservationUsageRollupCarriesCacheTokens(t *testing.T) {
 		t.Fatalf("expected the rollup to carry the metered cache-write tokens (4000), got %d: the count silently dropped to zero", got.cacheWriteTokens)
 	}
 
+	// The completed usage_event written by the same finalizeLocked pass must
+	// carry the same counts: two accounting surfaces diverging on exactly the
+	// token classes that dominate agent traffic is the bug shape #1174 guards
+	// against.
+	var completed *usage.RecordEventInput
+	for i := range usageSvc.eventCalls {
+		if usageSvc.eventCalls[i].EventType == "completed" {
+			completed = &usageSvc.eventCalls[i]
+			break
+		}
+	}
+	if completed == nil {
+		t.Fatalf("expected a completed usage event, got %#v", usageSvc.eventCalls)
+	}
+	if completed.CacheReadTokens != 200_000 || completed.CacheWriteTokens != 4_000 {
+		t.Fatalf("expected the completed usage event to carry cache read=200000 write=4000, got read=%d write=%d: the surfaces diverge",
+			completed.CacheReadTokens, completed.CacheWriteTokens)
+	}
+	if completed.InputTokens != 205_000 || completed.OutputTokens != 2_000 {
+		t.Fatalf("expected the completed usage event to carry input=205000 output=2000, got input=%d output=%d",
+			completed.InputTokens, completed.OutputTokens)
+	}
+
 	// A caller that does not know about the cache fields settles exactly as
 	// before: omitted means zero, never a fabricated count or an error.
 	reservation2, err := svc.CreateReservation(context.Background(), CreateReservationInput{

--- a/apps/control-plane/internal/accounting/types.go
+++ b/apps/control-plane/internal/accounting/types.go
@@ -75,6 +75,14 @@ type FinalizeReservationInput struct {
 	// settles exactly as before, with zeroes.
 	InputTokens  int64
 	OutputTokens int64
+	// CacheReadTokens and CacheWriteTokens are the cache components of the
+	// prompt behind ActualCredits (#1174). The gateway meters and prices them
+	// (#1157); without these fields the finalize path dropped both counts on
+	// the floor and public.api_key_usage_rollups accumulated zeroes in exactly
+	// the token classes that dominate agent traffic. Optional like their
+	// siblings: omitted means zero, never an error.
+	CacheReadTokens  int64
+	CacheWriteTokens int64
 }
 
 type ReleaseReservationInput struct {

--- a/apps/edge-api/internal/chat/billing.go
+++ b/apps/edge-api/internal/chat/billing.go
@@ -209,8 +209,8 @@ func (h *Handler) startSettlement(
 // Every settlement call runs on its own fresh background context, never the
 // request context: a client disconnect is exactly what cancels that one, and
 // settling on it converts a delivered response into a free one.
-func (s *settlement) finalize(credits int64, confirmed bool, inTokens, outTokens int64) bool {
-	err := s.finalizeOnce(credits, confirmed, inTokens, outTokens)
+func (s *settlement) finalize(credits int64, confirmed bool, inTokens, outTokens, cacheReadTokens, cacheWriteTokens int64) bool {
+	err := s.finalizeOnce(credits, confirmed, inTokens, outTokens, cacheReadTokens, cacheWriteTokens)
 	if err == nil {
 		return true
 	}
@@ -226,7 +226,7 @@ func (s *settlement) finalize(credits int64, confirmed bool, inTokens, outTokens
 	// It cannot produce a second charge.
 	slog.Warn("session chat finalize failed, retrying once before release",
 		"err", err, "request_id", s.requestID, "reservation_id", s.reservationID)
-	if retryErr := s.finalizeOnce(credits, confirmed, inTokens, outTokens); retryErr != nil {
+	if retryErr := s.finalizeOnce(credits, confirmed, inTokens, outTokens, cacheReadTokens, cacheWriteTokens); retryErr != nil {
 		slog.Error("session chat finalize failed twice, releasing hold instead",
 			"err", retryErr, "request_id", s.requestID, "reservation_id", s.reservationID)
 		return false
@@ -235,8 +235,9 @@ func (s *settlement) finalize(credits int64, confirmed bool, inTokens, outTokens
 }
 
 // finalizeOnce is one attempt, on its own fresh context so a retry is never
-// handed the timed-out context of the attempt it is retrying.
-func (s *settlement) finalizeOnce(credits int64, confirmed bool, inTokens, outTokens int64) error {
+// handed the timed-out context of the attempt it is retrying. The cache
+// components ride along with the input/output counts they split (#1174).
+func (s *settlement) finalizeOnce(credits int64, confirmed bool, inTokens, outTokens, cacheReadTokens, cacheWriteTokens int64) error {
 	ctx, cancel := context.WithTimeout(context.Background(), settlementTimeout)
 	defer cancel()
 	return s.accounting.FinalizeReservation(ctx, inference.FinalizeReservationInput{
@@ -249,6 +250,8 @@ func (s *settlement) finalizeOnce(credits int64, confirmed bool, inTokens, outTo
 		TerminalUsageConfirmed: confirmed,
 		InputTokens:            inTokens,
 		OutputTokens:           outTokens,
+		CacheReadTokens:        cacheReadTokens,
+		CacheWriteTokens:       cacheWriteTokens,
 		Status:                 "completed",
 	})
 }

--- a/apps/edge-api/internal/chat/dispatch.go
+++ b/apps/edge-api/internal/chat/dispatch.go
@@ -401,7 +401,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			releaseReason = "client_disconnect"
 		}
 		costCredits = 0
-	case settle.finalize(costCredits, confirmed, inTokens, outTokens):
+	case settle.finalize(costCredits, confirmed, inTokens, outTokens, cacheUsage.CacheReadTokens, cacheUsage.CacheWriteTokens):
 		settled = true
 	default:
 		// The charge did not land. Leaving settled false hands the reservation

--- a/apps/edge-api/internal/inference/accounting_client.go
+++ b/apps/edge-api/internal/inference/accounting_client.go
@@ -109,6 +109,13 @@ type FinalizeReservationInput struct {
 	// Optional: a caller that omits them settles exactly as before.
 	InputTokens  int64 `json:"input_tokens,omitempty"`
 	OutputTokens int64 `json:"output_tokens,omitempty"`
+	// CacheReadTokens and CacheWriteTokens are the prompt's cache components
+	// behind ActualCredits (#1174). Control-plane forwards them into the
+	// api_key_usage_rollups write, so the rollup stops accumulating zeroes in
+	// exactly the token classes that dominate agent traffic. Optional like
+	// their siblings: a caller that omits them settles exactly as before.
+	CacheReadTokens  int64 `json:"cache_read_tokens,omitempty"`
+	CacheWriteTokens int64 `json:"cache_write_tokens,omitempty"`
 }
 
 // ReleaseReservationInput is the request body for releasing a reservation.

--- a/apps/edge-api/internal/inference/orchestrator.go
+++ b/apps/edge-api/internal/inference/orchestrator.go
@@ -365,6 +365,16 @@ func (o *Orchestrator) executeSync(
 				// carrying real token counts earns it.
 				TerminalUsageConfirmed: confirmed,
 				Status:                 "completed",
+				// Forward every metered count the settlement priced from
+				// (#856, #1174): control-plane writes them onto the completed
+				// usage event and the api_key_usage_rollups row, so both
+				// surfaces carry real figures instead of zeroes. The sync path
+				// never sent even input/output before, so the rollup stayed
+				// zero across all four token columns on this route.
+				InputTokens:      inputTokens,
+				OutputTokens:     outputTokens,
+				CacheReadTokens:  cache.CacheReadTokens,
+				CacheWriteTokens: cache.CacheWriteTokens,
 			})
 			endFinalize()
 			cancel()

--- a/apps/edge-api/internal/inference/settle_from_catalog_test.go
+++ b/apps/edge-api/internal/inference/settle_from_catalog_test.go
@@ -349,6 +349,11 @@ func TestExecuteStreaming_SettlesCacheAwarePrice(t *testing.T) {
 	if confirmed, _ := body["terminal_usage_confirmed"].(bool); !confirmed {
 		t.Error("terminal_usage_confirmed must stay true: the upstream reported a real usage block")
 	}
+	// #1174: the finalize call itself must carry the metered cache counts, so
+	// control-plane's api_key_usage_rollups write stops recording zeroes.
+	if got, _ := body["cache_read_tokens"].(float64); int64(got) != 200_000 {
+		t.Errorf("finalize cache_read_tokens = %v, want 200000: the count was dropped from the settlement call", body["cache_read_tokens"])
+	}
 }
 
 // TestExecuteSync_SettlesCacheAwarePrice is the same scenario through the
@@ -375,6 +380,10 @@ func TestExecuteSync_SettlesCacheAwarePrice(t *testing.T) {
 	}
 	if int64(actual) == 645_000 {
 		t.Error("actual_credits = 645000: still the flat-rate price, cache pricing was not applied on the sync path")
+	}
+	// #1174: same bound as the streaming sibling, on the non-streaming path.
+	if got, _ := body["cache_read_tokens"].(float64); int64(got) != 200_000 {
+		t.Errorf("finalize cache_read_tokens = %v, want 200000: the count was dropped from the settlement call", body["cache_read_tokens"])
 	}
 }
 
@@ -404,6 +413,10 @@ func TestExecuteSync_SettlesCacheWritePrice(t *testing.T) {
 	}
 	if int64(actual) == 630_000 {
 		t.Error("actual_credits = 630000: the pre-fix flat-rate undercharge for cache-write tokens")
+	}
+	// #1174: the write side of the same bound.
+	if got, _ := body["cache_write_tokens"].(float64); int64(got) != 200_000 {
+		t.Errorf("finalize cache_write_tokens = %v, want 200000: the count was dropped from the settlement call", body["cache_write_tokens"])
 	}
 }
 

--- a/apps/edge-api/internal/inference/stream.go
+++ b/apps/edge-api/internal/inference/stream.go
@@ -586,6 +586,15 @@ func (o *Orchestrator) settleStream(reqCtx context.Context, snapshot authz.AuthS
 		ActualCredits:          credits,
 		TerminalUsageConfirmed: confirmed,
 		Status:                 "completed",
+		// Forward every metered count the settlement priced from (#856,
+		// #1174), same as the sync path in orchestrator.go: control-plane
+		// writes them onto the completed usage event and the
+		// api_key_usage_rollups row. This route never sent any token counts
+		// on finalize before, so all four rollup columns stayed zero here.
+		InputTokens:      acc.InputTokens,
+		OutputTokens:     acc.OutputTokens,
+		CacheReadTokens:  acc.CachedTokens,
+		CacheWriteTokens: acc.CacheWriteTokens,
 	})
 	// Cancelled the moment finalize returns, never before: the call has
 	// already completed, so this can only release the timer, never abort a


### PR DESCRIPTION
Closes #1174. Sibling of #1173, which fixed the same class of drop for input/output tokens on control-plane's side.

## Summary

The gateway has metered and priced prompt-cache tokens correctly since #1157, and usage_events carries their real counts. But `public.api_key_usage_rollups` accumulated zeroes in `cache_read_tokens` and `cache_write_tokens` for every finalized reservation (#1174): the finalize path had no way to carry them.

Root cause was a two-sided gap:

- **control-plane**: `internalFinalizeReservationRequest` decoded no cache fields, and `accounting/service.go` called `RecordUsageFinalization` with literal `0, 0` for the two cache arguments, exactly where #1173 had left a pointer comment naming this follow-up.
- **edge-api**: none of its three settlement call sites could have supplied cache counts anyway. `executeSync`, `settleStream`, and session chat all finalized without any token fields beyond chat's input/output, so even #1173's fixed control-plane path still received zeroes from these routes.

### Changes

**control-plane** (`apps/control-plane/internal/accounting/`)
- `FinalizeReservationInput` grows optional `CacheReadTokens`/`CacheWriteTokens`.
- The internal finalize request decodes optional `cache_read_tokens`/`cache_write_tokens` and wires them into the input struct.
- `RecordUsageFinalization` now forwards `max(clamped)` cache counts into the rollup upsert. The customer-facing finalize request is untouched: it carries no token fields today and has no caller that would populate them; widening it is a separate decision.

**edge-api**
- `inference.FinalizeReservationInput` grows optional `cache_read_tokens`/`cache_write_tokens` (omitempty).
- `executeSync` now forwards input/output tokens plus the cache components it already normalized for pricing; `settleStream` forwards all four counts from the accumulator; chat settlement threads `cacheUsage` through `finalize`/`finalizeOnce`. Audio and images carry no cache quantities by nature and are untouched.
- Adjacent same-class gap closed at the touched sites: neither inference route had ever sent even input/output tokens on finalize, so all four rollup token columns stayed zero on those routes. Both now send them.

No migration: the rollup columns have existed since `supabase/migrations/20260331_04_api_key_usage_and_limits.sql`.

Backward compatible throughout: omitted fields settle as zeroes exactly as before, so older binaries on either side keep working during rolling deploys.

## Buglog entry

To be appended to `main` separately per the `.wolf/buglog.jsonl` convention (never on a feature branch):

```json
{"date":"2026-08-25","tags":["accounting","billing","rollup","cache-tokens"],"error_message":"public.api_key_usage_rollups accumulated zeroes in cache_read_tokens and cache_write_tokens for every finalized reservation while usage_events carried real counts","root_cause":"the internal finalize HTTP request decoded no cache fields and accounting/service.go passed literal 0 for both cache arguments to RecordUsageFinalization; edge-api's three settlement call sites (sync, streaming, session chat) sent no cache counts either, and neither inference route sent even input/output tokens, so nothing upstream of the rollup write could have supplied real figures","fix":"added optional CacheReadTokens/CacheWriteTokens to FinalizeReservationInput on both services and threaded the metered counts from every settlement call site (sync via cache.CacheReadTokens/CacheWriteTokens, stream via acc.CachedTokens/CacheWriteTokens, chat via cacheUsage); control-plane forwards max-clamped cache counts into RecordUsageFinalization; input/output tokens now also sent on both inference paths"}
```

## Test plan

- [x] New test written first, confirmed RED against the unfixed code: `TestFinalizeReservationUsageRollupCarriesCacheTokens` failed with `expected the rollup to carry the metered cache-read tokens (200000), got 0: the count silently dropped to zero`; GREEN after the fix. Also pins backward compatibility (omitted fields settle zero).
- [x] Three existing cache-aware settlement tests extended with finalize-body assertions, confirmed RED first (`finalize cache_read_tokens = <nil>, want 200000: the count was dropped from the settlement call`, plus the write-side sibling), GREEN after.
- [x] Full `./apps/control-plane/...` suite green (`go test -count=1 -short`, docker toolchain).
- [x] Full `./apps/edge-api/...` suite green (same pattern, exit 0).
- [x] Touched packages re-verified individually: accounting, apikeys, inference, chat all ok.
- [x] `go vet` clean on all four touched packages. gofmt clean on every touched file except pre-existing alignment drift in types.go that predates this branch (PolicyMode const block, untouched).
- [x] Rebased onto current main (feebbaf44) before push.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Usage settlement now records cache-read and cache-write token counts alongside input and output tokens.
  - Cache token metrics are preserved for both streaming and synchronous inference requests.
  - Existing requests that omit cache metrics continue to settle successfully with zero values.

- **Bug Fixes**
  - Corrected usage records and API-key rollups so they include applicable cache token usage.

- **Tests**
  - Added coverage verifying cache token propagation across settlement flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->