### PR TITLE
fix: sync a Cowork task's tail events before its terminal status

### DIFF
--- a/apps/control-plane/internal/agenttask/eventsync.go
+++ b/apps/control-plane/internal/agenttask/eventsync.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -170,28 +171,7 @@ func (s *EventSyncer) Stop() {
 // the workspace listing. Every failure here logs against this task alone and
 // never reaches RunOnce's return value.
 func (s *EventSyncer) syncTask(ctx context.Context, t Task) {
-	events := []TaskEvent{statusEvent(t)}
-
-	sandboxEvents, err := s.pullSandboxEvents(ctx, t.EngineSessionRef)
-	if err != nil {
-		s.logger.WarnContext(ctx, "agenttask: event sync pull failed",
-			"task_id", t.ID, "error", err)
-	} else {
-		for _, se := range sandboxEvents {
-			if ev, ok := mapSandboxEvent(se); ok {
-				events = append(events, ev)
-			}
-		}
-		files, ferr := s.src.Files(ctx, t.EngineSessionRef)
-		if ferr != nil {
-			s.logger.WarnContext(ctx, "agenttask: workspace listing failed",
-				"task_id", t.ID, "error", ferr)
-		} else {
-			for _, f := range files {
-				events = append(events, fileEvent(f))
-			}
-		}
-	}
+	events := append([]TaskEvent{statusEvent(t)}, s.pullTaskEvents(ctx, t)...)
 
 	if err := s.repo.AppendEvents(ctx, t, events); err != nil {
 		// Retried whole-batch next pass; dedup makes the retry idempotent.
@@ -202,6 +182,51 @@ func (s *EventSyncer) syncTask(ctx context.Context, t Task) {
 	s.remember(t)
 }
 
+// pullTaskEvents pulls t's sandbox events and workspace listing and maps them
+// onto TaskEvent rows, in that order. Both syncTask (t is still active) and
+// finishVanished (t just left the active set, this is its last possible
+// pass) call this: a short task's real activity, tool calls and file writes,
+// often concentrates in the tail of its run, and skipping this pull on the
+// final pass is exactly how issue #1206's run went dead for 58 straight
+// seconds and never recorded the tool_call/tool_result events a genuine
+// terminal command and file write produced. Every failure here logs against
+// t alone; the caller still gets whatever partial slice was built.
+func (s *EventSyncer) pullTaskEvents(ctx context.Context, t Task) []TaskEvent {
+	var events []TaskEvent
+
+	sandboxEvents, err := s.pullSandboxEvents(ctx, t.EngineSessionRef)
+	if err != nil {
+		s.logger.WarnContext(ctx, "agenttask: event sync pull failed",
+			"task_id", t.ID, "error", err)
+		return events
+	}
+	for _, se := range sandboxEvents {
+		if ev, ok := mapSandboxEvent(se); ok {
+			events = append(events, ev)
+		}
+	}
+
+	files, ferr := s.src.Files(ctx, t.EngineSessionRef)
+	if ferr != nil {
+		s.logger.WarnContext(ctx, "agenttask: workspace listing failed",
+			"task_id", t.ID, "error", ferr)
+		return events
+	}
+	for _, f := range files {
+		// A dot-prefixed entry (.git, .cache, ...) is workspace scaffolding,
+		// never something the agent produced for the user; rendering it as a
+		// step is exactly the "bare .git listing reads as progress" defect
+		// #1206 also named. Filtered here, at the same layer as every other
+		// not-an-agent-action exclusion below, rather than left for the
+		// frontend to guess at.
+		if strings.HasPrefix(f.Name, ".") {
+			continue
+		}
+		events = append(events, fileEvent(f))
+	}
+	return events
+}
+
 // remember records t as still-active-seen.
 func (s *EventSyncer) remember(t Task) {
 	if s.seen == nil {
@@ -210,9 +235,10 @@ func (s *EventSyncer) remember(t Task) {
 	s.seen[t.ID] = t
 }
 
-// finishVanished emits the terminal status event for tasks that left the
-// active set since they were last seen, then forgets them. A transient Get
-// failure drops the tracking entry anyway: a missed terminal status event is
+// finishVanished emits the terminal status event, plus one last sandbox
+// events and workspace listing pull, for tasks that left the active set
+// since they were last seen, then forgets them. A transient Get failure
+// drops the tracking entry anyway: a missed terminal status event is
 // degraded-but-safe (acceptance item 5's direction), while keeping the entry
 // would leak memory on a permanently broken read.
 func (s *EventSyncer) finishVanished(ctx context.Context, active map[uuid.UUID]bool) {
@@ -225,7 +251,16 @@ func (s *EventSyncer) finishVanished(ctx context.Context, active map[uuid.UUID]b
 			s.logger.WarnContext(ctx, "agenttask: could not read a finished task's final status for its event",
 				"task_id", id, "error", err)
 		} else if err == nil {
-			_ = s.repo.AppendEvents(ctx, t, []TaskEvent{statusEvent(final)})
+			// This is t's last possible pass: it has already left ListActive,
+			// so no future syncTask call will ever run for it again. Pull the
+			// tail one last time before recording the terminal status, or
+			// whatever tool calls and file writes happened between the last
+			// active pass and completion are lost for good, never a retry.
+			events := append(s.pullTaskEvents(ctx, final), statusEvent(final))
+			if aerr := s.repo.AppendEvents(ctx, t, events); aerr != nil {
+				s.logger.WarnContext(ctx, "agenttask: final event append failed",
+					"task_id", id, "error", aerr)
+			}
 		}
 		delete(s.seen, id)
 	}
@@ -266,14 +301,25 @@ func (s *EventSyncer) pullSandboxEvents(ctx context.Context, sessionRef string) 
 
 // mapSandboxEvent translates one normalized sandbox event into our six-kind
 // vocabulary. The mapping is deliberately isolated here so OpenHands schema
-// drift costs one function, and the fallback NEVER drops silently: any kind
-// this switch does not name lands as kind `status` carrying the raw payload
-// (or a marker when the raw dump was too large to transport), so a new
-// upstream event class surfaces in the transcript instead of vanishing.
+// drift costs one function, and the fallback for a kind this switch does not
+// name NEVER drops silently: it lands as kind `status` carrying the raw
+// payload (or a marker when the raw dump was too large to transport), so a
+// new upstream event class surfaces in the transcript instead of vanishing
+// unexplained.
 //
-// MessageEvent maps for every role, not only assistant: dropping user-role
-// messages would be exactly the silent drop the plan forbids, and the role
-// rides in the payload so consumers can tell them apart.
+// That is a different thing from the false returns below. Those are named,
+// understood kinds this function recognises and deliberately excludes
+// because they are bookkeeping, not agent progress: SystemPromptEvent and
+// ConversationStateUpdateEvent are bootstrap/state-sync noise confirmed
+// against a live run's stored payloads (task a98420c4, issue #1206), where
+// three of five rendered lines were exactly this pair falling through the
+// unmapped branch with neither a `sandbox_kind` nor a `status` key the
+// frontend understood. A user-role MessageEvent is excluded for a narrower,
+// concrete reason: agent-engine's only way to put a user message into this
+// stream is the task's own initiating prompt (InitialMessage at launch,
+// engine.go); there is no running-task follow-up-message surface today, so
+// every user-role MessageEvent that will ever reach this function IS that
+// same prompt echoed back, not a real interjection.
 func mapSandboxEvent(e SandboxEvent) (TaskEvent, bool) {
 	base := TaskEvent{
 		// Empty sandbox ids would be exempt from the dedup index and
@@ -297,6 +343,9 @@ func mapSandboxEvent(e SandboxEvent) (TaskEvent, bool) {
 			"preview":      truncateRunes(e.TextPreview, maxPreviewRunes),
 		})
 	case "MessageEvent":
+		if e.Source == "user" {
+			return TaskEvent{}, false
+		}
 		base.Kind = EventMessage
 		base.Payload = mustJSON(map[string]any{
 			"role":    e.Source,
@@ -307,6 +356,8 @@ func mapSandboxEvent(e SandboxEvent) (TaskEvent, bool) {
 		base.Payload = mustJSON(map[string]any{
 			"preview": truncateRunes(e.TextPreview, maxPreviewRunes),
 		})
+	case "SystemPromptEvent", "ConversationStateUpdateEvent":
+		return TaskEvent{}, false
 	default:
 		base.Kind = EventStatus
 		if raw := capEventPayload(e.Raw); raw != nil {

--- a/apps/control-plane/internal/agenttask/eventsync_test.go
+++ b/apps/control-plane/internal/agenttask/eventsync_test.go
@@ -70,7 +70,7 @@ func TestMapSandboxEvent(t *testing.T) {
 		{"reject", SandboxEvent{ID: "r1", Kind: "UserRejectObservation", TextPreview: "no"}, EventToolResult, "r1"},
 		{"message", SandboxEvent{ID: "m1", Kind: "MessageEvent", Source: "agent", TextPreview: "hi"}, EventMessage, "m1"},
 		{"error", SandboxEvent{ID: "e1", Kind: "AgentErrorEvent", TextPreview: "boom"}, EventError, "e1"},
-		{"unknown falls back to status with raw payload", SandboxEvent{ID: "u1", Kind: "ConversationStateUpdateEvent", Raw: raw}, EventStatus, "u1"},
+		{"unknown falls back to status with raw payload", SandboxEvent{ID: "u1", Kind: "SomeFutureOpenHandsEvent", Raw: raw}, EventStatus, "u1"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -94,10 +94,41 @@ func TestMapSandboxEvent(t *testing.T) {
 		}
 	})
 	t.Run("message role rides in payload", func(t *testing.T) {
-		got, _ := mapSandboxEvent(SandboxEvent{ID: "m2", Kind: "MessageEvent", Source: "user"})
+		got, ok := mapSandboxEvent(SandboxEvent{ID: "m2", Kind: "MessageEvent", Source: "assistant"})
+		if !ok {
+			t.Fatal("assistant-role message must not be filtered")
+		}
 		var p map[string]string
-		if err := json.Unmarshal(got.Payload, &p); err != nil || p["role"] != "user" {
+		if err := json.Unmarshal(got.Payload, &p); err != nil || p["role"] != "assistant" {
 			t.Errorf("role not carried: %s (%v)", got.Payload, err)
+		}
+	})
+
+	// Real payloads captured from public.agent_task_events for task
+	// a98420c4 (issue #1206's live verification run), the concrete shapes
+	// that motivated every filtered case below. Fixtures over invented
+	// shapes: a guessed shape is exactly what let #1202's stub ship the
+	// original defect.
+	t.Run("real captured payloads", func(t *testing.T) {
+		systemPrompt := json.RawMessage(`{"id":"b2fad3c8-653b-4593-aeab-75e633234218","kind":"SystemPromptEvent","tools":[{"kind":"TerminalTool","title":"terminal"}]}`)
+		lastUserMsgID := json.RawMessage(`{"id":"f0fdca9f-10b4-4cf8-9532-028e91bc4cd5","key":"last_user_message_id","kind":"ConversationStateUpdateEvent","value":"60eb8503-ec6b-4e41-a067-2b5ab7a6439d","source":"environment","timestamp":"2026-08-26T01:43:08.336259"}`)
+		execStatus := json.RawMessage(`{"id":"65dac71f-397a-461f-9e69-cbd50af7ea61","key":"execution_status","kind":"ConversationStateUpdateEvent","value":"running","source":"environment","timestamp":"2026-08-26T01:43:08.364442"}`)
+
+		filtered := []struct {
+			name string
+			in   SandboxEvent
+		}{
+			{"SystemPromptEvent", SandboxEvent{ID: "b2fad3c8-653b-4593-aeab-75e633234218", Kind: "SystemPromptEvent", Raw: systemPrompt}},
+			{"ConversationStateUpdateEvent last_user_message_id", SandboxEvent{ID: "f0fdca9f-10b4-4cf8-9532-028e91bc4cd5", Kind: "ConversationStateUpdateEvent", Raw: lastUserMsgID}},
+			{"ConversationStateUpdateEvent execution_status", SandboxEvent{ID: "65dac71f-397a-461f-9e69-cbd50af7ea61", Kind: "ConversationStateUpdateEvent", Raw: execStatus}},
+			{"user prompt echo", SandboxEvent{ID: "u-echo", Kind: "MessageEvent", Source: "user", TextPreview: "Run `ls -la` in the workspace and tell me exactly what files are present."}},
+		}
+		for _, tc := range filtered {
+			t.Run(tc.name, func(t *testing.T) {
+				if _, ok := mapSandboxEvent(tc.in); ok {
+					t.Errorf("%s must be filtered out of the rendered stream, not stored", tc.name)
+				}
+			})
 		}
 	})
 }
@@ -233,6 +264,99 @@ func TestEventSyncerTerminalTracking(t *testing.T) {
 	}
 	if !sawTerminal {
 		t.Error("terminal status event never emitted for the vanished task")
+	}
+}
+
+// TestEventSyncerFinishVanishedSyncsTailEvents is the regression guard for
+// issue #1206's root cause: finishVanished used to emit only a bare terminal
+// status event and never pulled sandbox events or the workspace listing, so
+// any tool_call/tool_result/file activity that happened between a task's
+// last active pass and it going terminal (a short task's real work often
+// concentrates exactly there) was lost, never retried, permanently. This
+// proves the second pass, where the task has already left ListActive, still
+// carries the tail activity through.
+func TestEventSyncerFinishVanishedSyncsTailEvents(t *testing.T) {
+	tenant, user, id := uuid.New(), uuid.New(), uuid.New()
+	task := Task{ID: id, TenantID: tenant, UserID: user, Status: StatusRunning, EngineSessionRef: "sess-3"}
+	repo := &fakeRepoForSync{
+		listActive: []Task{task},
+		get: map[uuid.UUID]Task{
+			id: {ID: id, TenantID: tenant, UserID: user, Status: StatusSucceeded, EngineSessionRef: "sess-3"},
+		},
+	}
+	// Pass 1: nothing has happened in the sandbox yet.
+	src := &fakeEventSource{
+		events: func(context.Context, string) ([]SandboxEvent, error) { return nil, nil },
+		files:  func(context.Context, string) ([]WorkspaceFile, error) { return nil, nil },
+	}
+	s := NewEventSyncer(repo, src, PollerConfig{})
+	mustNil(t, s.RunOnce(context.Background()))
+
+	// Between pass 1 and pass 2 the task ran its real work and went
+	// terminal: it drops out of ListActive, and the sandbox now has the
+	// tool call, its result, and the file it wrote.
+	repo.listActive = nil
+	src.events = func(context.Context, string) ([]SandboxEvent, error) {
+		return []SandboxEvent{
+			{ID: "act-1", Kind: "ActionEvent", ToolName: "terminal", ToolCallID: "c1"},
+			{ID: "obs-1", Kind: "ObservationEvent", ToolName: "terminal", ToolCallID: "c1"},
+		}, nil
+	}
+	src.files = func(context.Context, string) ([]WorkspaceFile, error) {
+		return []WorkspaceFile{{Name: "notes.md", Size: 42, ModTime: time.Now()}}, nil
+	}
+	mustNil(t, s.RunOnce(context.Background()))
+
+	var sawToolCall, sawToolResult, sawFile, sawTerminal bool
+	for _, batch := range repo.appends {
+		for _, ev := range batch {
+			switch {
+			case ev.Kind == EventToolCall:
+				sawToolCall = true
+			case ev.Kind == EventToolResult:
+				sawToolResult = true
+			case ev.Kind == EventFile && strings.Contains(string(ev.Payload), "notes.md"):
+				sawFile = true
+			case ev.Kind == EventStatus && strings.Contains(string(ev.Payload), "succeeded"):
+				sawTerminal = true
+			}
+		}
+	}
+	if !sawToolCall || !sawToolResult || !sawFile {
+		t.Errorf("tail activity lost: tool_call=%v tool_result=%v file=%v", sawToolCall, sawToolResult, sawFile)
+	}
+	if !sawTerminal {
+		t.Error("terminal status event never emitted for the vanished task")
+	}
+}
+
+// TestEventSyncerFiltersHiddenWorkspaceFiles guards the ".git listing reads
+// as a step" half of issue #1206: a dot-prefixed workspace entry is scaffold
+// noise, not agent output, and must never become a rendered file event.
+func TestEventSyncerFiltersHiddenWorkspaceFiles(t *testing.T) {
+	tenant, user := uuid.New(), uuid.New()
+	task := Task{ID: uuid.New(), TenantID: tenant, UserID: user, Status: StatusRunning, EngineSessionRef: "sess-4"}
+	src := &fakeEventSource{
+		events: func(context.Context, string) ([]SandboxEvent, error) { return nil, nil },
+		files: func(context.Context, string) ([]WorkspaceFile, error) {
+			return []WorkspaceFile{
+				{Name: ".git", Size: 4096, ModTime: time.Now()},
+				{Name: "notes.md", Size: 12, ModTime: time.Now()},
+			}, nil
+		},
+	}
+	repo := &fakeRepoForSync{listActive: []Task{task}}
+	s := NewEventSyncer(repo, src, PollerConfig{})
+	mustNil(t, s.RunOnce(context.Background()))
+
+	var names []string
+	for _, ev := range repo.appends[0] {
+		if ev.Kind == EventFile {
+			names = append(names, string(ev.Payload))
+		}
+	}
+	if len(names) != 1 || !strings.Contains(names[0], "notes.md") {
+		t.Errorf("file events = %v, want exactly notes.md (.git filtered out)", names)
 	}
 }
 


### PR DESCRIPTION
## Diagnosis

Issue #1206, verified against the live stored rows for the run's own task,
not inferred from code alone.

```
select task_id, seq, kind, length(payload::text), left(payload::text, 500)
from public.agent_task_events
where task_id = 'a98420c4-95a9-48cd-af03-3bea58e42241'
order by seq;
```

7 rows total, seq 1 through 7. Seq 1 (synthetic "running" status), 2
(SystemPromptEvent), 3 (the initiating user prompt, echoed), 4 and 5
(ConversationStateUpdateEvent), 6 (a bare `.git` workspace listing), 7
(synthetic "succeeded" status). Zero `tool_call`, zero `tool_result`, zero
`file` event for `notes.md`, despite the run genuinely executing `ls -la`
and writing `notes.md`.

This is a **mapping gap layered on an emission-sync gap**, and the sync gap
is the one that actually produced the 58 second dead window:

- `EventSyncer.syncTask` (the per-pass sync for an active task) pulls
  sandbox events and the workspace listing correctly. That produced seq 1
  through 6, all within the first few seconds of the run.
- `EventSyncer.finishVanished`, the path that runs once a task leaves the
  active set (because the status `Poller` already recorded it terminal),
  emitted **only** the bare terminal status event. It never called back into
  the sandbox events or workspace listing pull. Seq 7 is that bare status
  row, and it is the *only* thing recorded between seq 6 (four seconds in)
  and task completion (82 seconds in). Whatever `ActionEvent` /
  `ObservationEvent` pair the terminal command and the file write produced,
  wherever in that window OpenHands actually made them queryable, landed in
  exactly the pass `finishVanished` skips. That is the whole 58 second gap:
  not five slow polls, one structurally incomplete final pass.
- Separately, real payload shapes at seq 2, 4, 5 show `SystemPromptEvent`
  and `ConversationStateUpdateEvent` falling through `mapSandboxEvent`'s
  unmapped-kind fallback. Their raw JSON has neither a `sandbox_kind` nor a
  `status` top-level key (those are wrapper keys this repo's own code
  introduces on the *other* branches), so the frontend's fallback renders
  "An update this version of Hive cannot read." for all three.

## Fix

- `EventSyncer.finishVanished` now shares the same sandbox-events-plus-files
  pull that an active pass uses (extracted to `pullTaskEvents`), so a task's
  tail is synced on its last possible pass instead of silently discarded.
  This is the root-cause fix, in the shared function both callers route
  through, not a rendering patch.
- `mapSandboxEvent` explicitly recognises and filters `SystemPromptEvent`
  and `ConversationStateUpdateEvent`: named, understood bookkeeping kinds,
  excluded on purpose, not an unmapped kind silently vanishing. The existing
  "never drop an unknown kind silently" fallback is untouched for genuinely
  unrecognised kinds.
- A user-role `MessageEvent` is now filtered too: the only way a user
  message enters this stream today is the task's own initiating prompt
  (`InitialMessage` at launch); there is no running-task follow-up-message
  surface, so every one of these is that same prompt echoed back, not a
  real interjection.
- A dot-prefixed workspace entry (`.git`, ...) is filtered from the file
  events: scaffolding, never agent output, and rendering it as a step was
  the other half of #1206's "reads as broken" complaint.

## Tests

Table-driven, over the real payload shapes captured from task `a98420c4`
(not invented shapes: PR #1202's guessed shape is exactly what let the
original defect ship). Plus a dedicated regression test,
`TestEventSyncerFinishVanishedSyncsTailEvents`, that reproduces the failure
pattern directly: an empty first pass, then real `ActionEvent` /
`ObservationEvent` / file activity that only becomes visible on the pass
where the task has already left the active set, asserting all three still
land instead of being dropped.

```
go build ./apps/control-plane/... ./apps/agent-engine/...
go vet ./apps/control-plane/... ./apps/agent-engine/...
go test ./apps/control-plane/internal/agenttask/... -count=1
```

All clean.

## Verification limits

Full live re-verification (launch a real Cowork run against the deployed
box and watch tool steps render during the run) requires this fix to
actually be running there, which only happens on merge to `main`
(`deploy-demo-box.yml`). This PR does not merge itself, so that step is
still pending. What's checked here instead: the fix is proven directly
against the real payload shapes that produced the defect, and against a
regression test that reproduces the exact tail-loss timing, not a fixture
that merely resembles it.

Fixes #1206.