### PR TITLE
fix: flag-gate shared-chat grant skip and global knowledge reindex (#1191)

### DIFF
--- a/deploy/docker/Dockerfile.open-webui
+++ b/deploy/docker/Dockerfile.open-webui
@@ -423,7 +423,19 @@ COPY deploy/docker/owui-patches/apply_router_authz_family_patch.py /tmp/apply_ro
 RUN python3 /tmp/apply_retrieval_authz_patch.py \
     && python3 /tmp/apply_router_authz_family_patch.py
 
-# Consolidated drift guard for ALL owui authz patches (#1056 + #1186): assert
+# issue #1191: two residuals from the #1190-family review that the #1186 sweep
+# had classified as false positives. chats.py clone_shared_chat_by_id let a
+# bare instance admin skip the shared-chat AccessGrants check and read (clone)
+# any tenant's ALREADY-SHARED chat; knowledge.py /reindex let a bare instance
+# admin trigger a global wipe+rebuild of every tenant's vector collections.
+# Both are flag-gated here: ENABLE_ADMIN_CHAT_ACCESS for chats (the router's
+# own predicate) and BYPASS_ADMIN_ACCESS_CONTROL for reindex (already imported,
+# same escape hatch as the rest of the knowledge family); compose sets both
+# false. Same fail-loud posture as the patches above.
+COPY deploy/docker/owui-patches/apply_authz_residuals_1191_patch.py /tmp/apply_authz_residuals_1191_patch.py
+RUN python3 /tmp/apply_authz_residuals_1191_patch.py
+
+# Consolidated drift guard for ALL owui authz patches (#1056 + #1186 + #1191):
 # the exact expected marker count in every patched file so a vendor bump that
 # silently drops any single fix fails the image build instead of reopening a
 # cross-tenant hole (same failure mode class as #1162).
@@ -438,7 +450,9 @@ RUN B=/app/backend/open_webui; test "$(grep -rc '# hive (#1056)' $B/routers/know
     && test "$(grep -c '# hive (#1186)' $B/routers/prompts.py)" -eq 11 \
     && test "$(grep -c '# hive (#1186)' $B/routers/notes.py)" -eq 6 \
     && test "$(grep -c '# hive (#1186)' $B/routers/tools.py)" -eq 10 \
-    && test "$(grep -c '# hive (#1186)' $B/routers/models.py)" -eq 5
+    && test "$(grep -c '# hive (#1186)' $B/routers/models.py)" -eq 5 \
+    && test "$(grep -c '# hive (#1191)' $B/routers/chats.py)" -eq 1 \
+    && test "$(grep -c '# hive (#1191)' $B/routers/knowledge.py)" -eq 1
 # #771: drop the Settings > Integrations tab, the chat UI's only entry point to
 # "Manage Tool Servers" and "Open Terminal". Both accept an arbitrary URL and an
 # auth credential. The tool servers added there are direct ones, called by the

--- a/deploy/docker/owui-patches/apply_authz_residuals_1191_patch.py
+++ b/deploy/docker/owui-patches/apply_authz_residuals_1191_patch.py
@@ -1,0 +1,118 @@
+"""Build-time authz residuals for the #1190-family review (issue #1191).
+
+Two sites the #1186 family sweep had left as verified false positives (see
+apply_router_authz_family_patch.py) that review reclassified as residuals:
+
+1. chats.py clone_shared_chat_by_id (:1603): the shared-chat grant check
+   `if shared and user.role != 'admin' ...` let a bare instance admin skip
+   AccessGrants enforcement entirely, so an admin could read (clone) any
+   tenant's ALREADY-SHARED chat without ENABLE_ADMIN_CHAT_ACCESS or a grant.
+   Rewritten to this router's own predicate: admin bypasses only when
+   ENABLE_ADMIN_CHAT_ACCESS is set; otherwise owner-or-grant like everyone
+   else. docker-compose.yml sets that flag false.
+2. knowledge.py /reindex (:331): the bare role check let an instance admin
+   trigger a global wipe+rebuild of every tenant's vector collections.
+   Flag-gated on BYPASS_ADMIN_ACCESS_CONTROL (already imported in this
+   router; the same flag the #960/#1056/#1186 knowledge family reads), so
+   with compose defaults nobody can trigger a global reindex over the API;
+   flipping the flag restores operator use.
+
+Fail-loud posture, identical to the sibling authz patches: exact-literal
+anchors with expected occurrence counts, ast.parse after every rewrite,
+marker totals asserted at the end and again by the Dockerfile drift guard,
+idempotent early-exit once applied. HIVE_OWUI_ROUTERS_DIR overrides the
+target directory for scripts/test_owui_knowledge_authz.py.
+"""
+
+import ast
+import os
+import pathlib
+
+ROUTERS = pathlib.Path(
+    os.environ.get(
+        "HIVE_OWUI_ROUTERS_DIR",
+        "/app/backend/open_webui/routers",
+    )
+)
+
+MARKER = "# hive (#1191)"
+
+# Each entry: (file, old, new, expected_pre_count). Each rewrite inserts
+# exactly one MARKER comment, so per-file totals are chats.py 1 and
+# knowledge.py 1. Anchors were verified unique against the vendored source.
+EDITS = [
+    (
+        "chats.py",
+        "    if shared and user.role != 'admin' and shared.user_id != user.id:\n",
+        "    # hive (#1191): bare admin no longer skips the shared-chat grant\n"
+        "    # check; same predicate as this router's other admin fallbacks\n"
+        "    if (\n"
+        "        shared\n"
+        "        and not (user.role == 'admin' and ENABLE_ADMIN_CHAT_ACCESS)\n"
+        "        and shared.user_id != user.id\n"
+        "    ):\n",
+        1,
+    ),
+    (
+        "knowledge.py",
+        "    if user.role != 'admin':\n"
+        "        raise HTTPException(\n"
+        "            status_code=status.HTTP_401_UNAUTHORIZED,\n"
+        "            detail=ERROR_MESSAGES.UNAUTHORIZED,\n"
+        "        )\n",
+        "    # hive (#1191): reindex wipes and rebuilds EVERY tenant's vector\n"
+        "    # collections, so bare instance-admin role is not enough; the\n"
+        "    # explicit BYPASS_ADMIN_ACCESS_CONTROL flag is required, matching\n"
+        "    # the knowledge family's cross-tenant escape hatch.\n"
+        "    if not (user.role == 'admin' and BYPASS_ADMIN_ACCESS_CONTROL):\n"
+        "        raise HTTPException(\n"
+        "            status_code=status.HTTP_401_UNAUTHORIZED,\n"
+        "            detail=ERROR_MESSAGES.UNAUTHORIZED,\n"
+        "        )\n",
+        1,
+    ),
+]
+
+EXPECTED_MARKERS = {
+    "chats.py": 1,
+    "knowledge.py": 1,
+}
+
+
+def main():
+    already = all(
+        (ROUTERS / f).read_text().count(MARKER) == n
+        for f, n in EXPECTED_MARKERS.items()
+    )
+    if already:
+        print("apply_authz_residuals_1191_patch: already applied")
+        return
+
+    for filename, old, new, expected in EDITS:
+        target = ROUTERS / filename
+        text = target.read_text()
+        n = text.count(old)
+        assert n == expected, (
+            f"{filename}: anchor found {n} times, expected {expected}; "
+            f"upstream open-webui source shifted, patch needs updating. "
+            f"Anchor head: {old[:90]!r}"
+        )
+        patched = text.replace(old, new)
+        ast.parse(patched)  # fails the build if a rewrite produced invalid Python
+        target.write_text(patched)
+
+    total = 0
+    for filename, expected in EXPECTED_MARKERS.items():
+        count = (ROUTERS / filename).read_text().count(MARKER)
+        assert count == expected, (
+            f"{filename}: {count} markers after patching, expected {expected}"
+        )
+        total += count
+    print(
+        f"apply_authz_residuals_1191_patch: flag-gated reindex and "
+        f"shared-chat grant skip across 2 routers (#1191)"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_owui_knowledge_authz.py
+++ b/scripts/test_owui_knowledge_authz.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-"""Self-check for the owui authz patches (#1056 knowledge reads, #1186 family).
+"""Self-check for the owui authz patches (#1056 knowledge reads, #1186 family,
+#1191 residuals).
 
 Runs the real build-time patch scripts against copies of the vendored backend
 source and asserts the result. Structural, no framework, no network.
@@ -167,16 +168,66 @@ def check_router_family() -> int:
         )
     return report(checks)
 
+def check_authz_residuals() -> int:
+    """#1191: shared-chat grant-skip and global reindex are flag-gated."""
+    routers = VENDORED / "routers"
+    patch = PATCHES / "apply_authz_residuals_1191_patch.py"
+    CHATS_OLD = (
+        "    if shared and user.role != 'admin' and shared.user_id != user.id:\n"
+    )
+    KNOW_OLD = (
+        "    if user.role != 'admin':\n"
+        "        raise HTTPException(\n"
+        "            status_code=status.HTTP_401_UNAUTHORIZED,\n"
+        "            detail=ERROR_MESSAGES.UNAUTHORIZED,\n"
+        "        )\n"
+    )
+    checks = {
+        "chats: vendored still has unflagged grant skip (negative control)":
+            CHATS_OLD in (routers / "chats.py").read_text(),
+        "knowledge: vendored still has bare reindex guard (negative control)":
+            KNOW_OLD in (routers / "knowledge.py").read_text(),
+    }
+    tmp = Path(tempfile.mkdtemp())
+    shutil.copy(routers / "chats.py", tmp / "chats.py")
+    shutil.copy(routers / "knowledge.py", tmp / "knowledge.py")
+    env = dict(os.environ)
+    env["HIVE_OWUI_ROUTERS_DIR"] = str(tmp)
+    r = subprocess.run(
+        [sys.executable, str(patch)], env=env, capture_output=True, text=True
+    )
+    if r.returncode != 0:
+        print("FAIL: authz residuals patch failed:", r.stdout + r.stderr)
+        return 1
+    for name in ("chats.py", "knowledge.py"):
+        text = (tmp / name).read_text()
+        checks[f"{name}: one #1191 marker after patch"] = (
+            text.count("# hive (#1191)") == 1
+        )
+        checks[f"{name}: patched source compiles"] = isinstance(
+            ast.parse(text), ast.Module
+        )
+    checks["chats: old grant skip gone"] = CHATS_OLD not in (tmp / "chats.py").read_text()
+    checks["chats: flag-or-grant predicate present"] = (
+        "and not (user.role == 'admin' and ENABLE_ADMIN_CHAT_ACCESS)" in (tmp / "chats.py").read_text()
+    )
+    checks["knowledge: bare reindex guard gone"] = KNOW_OLD not in (tmp / "knowledge.py").read_text()
+    checks["knowledge: BYPASS predicate present"] = (
+        "if not (user.role == 'admin' and BYPASS_ADMIN_ACCESS_CONTROL):" in (tmp / "knowledge.py").read_text()
+    )
+    return report(checks)
+
 
 def main() -> int:
     rc = check_knowledge()
     rc += check_retrieval()
     rc += check_router_family()
+    rc += check_authz_residuals()
     if rc:
         print("FAIL: owui authz patch self-check failed")
         return 1
     print("ok: knowledge by-id ownership (#1056), retrieval filter and")
-    print("ok: router family flag-gating (#1186) all enforced")
+    print("ok: router family flag-gating (#1186) and residuals (#1191) all enforced")
     return 0
 
 


### PR DESCRIPTION
Closes #1191.

Two authorization residuals from the #1190-family review that the #1186 sweep had classified as verified false positives. Both are fixed with build-time patches following the established fail-loud posture (exact-literal anchors with expected occurrence counts, ast.parse after every rewrite, idempotent early-exit, marker totals asserted again by the consolidated Dockerfile drift guard).

## Fix 1: shared-chat grant check skip (MEDIUM)

`chats.py` `clone_shared_chat_by_id` enforced AccessGrants only for non-admins:

```python
if shared and user.role != 'admin' and shared.user_id != user.id:
```

On this shared instance every tenant OWNER is an instance admin, so a bare admin could clone any tenant's ALREADY-SHARED chat without `ENABLE_ADMIN_CHAT_ACCESS` or a grant. The skip is now gated on `ENABLE_ADMIN_CHAT_ACCESS`, chosen because it is this router's own existing predicate for admin fallbacks (:1056, :1174, :1592) and docker-compose.yml already sets it false.

## Fix 2: global knowledge reindex (MEDIUM-LOW)

`knowledge.py` `/reindex` accepted any bare instance admin and wiped plus rebuilt every tenant's vector collections in one call. It is now gated on `BYPASS_ADMIN_ACCESS_CONTROL`. Chosen over a new dedicated env because it is already imported in this router and is the knowledge family's established cross-tenant escape hatch; compose sets it false, so a global reindex becomes an explicit operator action rather than something an instance admin can trigger by role alone. No new config plumbing required.

## Assertion coverage

- New patch script: `deploy/docker/owui-patches/apply_authz_residuals_1191_patch.py`.
- Dockerfile drift guard extended with exact marker counts (`# hive (#1191)` = 1 in chats.py, = 1 in knowledge.py), so a vendor bump that drops either fix fails the image build.
- `scripts/test_owui_knowledge_authz.py` gains `check_authz_residuals()`: both anchors asserted still-unflagged pre-patch (negative controls that let the test go red on vendor drift), then marker counts, old-pattern absence, new predicate presence, and clean ast parse post-patch. All 51 checks pass.
- All four authz patch scripts run twice against fresh copies of the vendored source; second pass reports already applied with identical checksums.

## Verification

- `python3 scripts/test_owui_knowledge_authz.py`: exit 0, all checks PASS including negative controls.
- Image built from this branch: `docker build -f deploy/docker/Dockerfile.open-webui -t hive-open-webui:sec1191 .` succeeds; patch stage logs its success line; consolidated drift guard passes; markers confirmed inside the built image at /app/backend/open_webui/routers/{chats,knowledge}.py with the new predicates in place.