### PR TITLE
fix: capture sandbox events before reap tears down the control socket

### DIFF
--- a/apps/agent-engine/internal/engine/engine.go
+++ b/apps/agent-engine/internal/engine/engine.go
@@ -331,6 +331,19 @@ type session struct {
 	// reaped and terminal are guarded by SandboxEngine.mu.
 	reaped   bool
 	terminal *terminalOutcome
+
+	// finalEvents and finalFiles are the sandbox's last events and workspace
+	// listing, captured by reap() in the brief window before it kills the
+	// sandbox process and removes sessionDir/workingDir. Events/Files below
+	// serve these instead of dialling a control socket or reading a bind
+	// mount that reap has already torn down — issue #1206: pulling a
+	// finished task's tail AFTER it leaves the active set always raced that
+	// teardown and always lost, because the same Status() call that
+	// discovers a terminal execStatus is what triggers reap, synchronously,
+	// before the DB ever records the task as terminal. Guarded by
+	// SandboxEngine.mu, same as reaped and terminal.
+	finalEvents []controlclient.Event
+	finalFiles  []controlclient.WorkspaceFile
 }
 
 // SandboxEngine launches, polls, and cancels agent-engine sandbox sessions.
@@ -677,7 +690,7 @@ func (e *SandboxEngine) finishTerminal(ctx context.Context, sess *session, id uu
 	// apps/control-plane/internal/agenttask's poller only records the status,
 	// it never calls Cancel. Reaping here is what stops completed tasks from
 	// leaking their sandbox process, directories and quota slot.
-	_ = e.reap(sess, &terminalOutcome{status: status, resultSummary: resultSummary, errMessage: errMessage})
+	_ = e.reap(ctx, sess, &terminalOutcome{status: status, resultSummary: resultSummary, errMessage: errMessage})
 	return status, resultSummary, errMessage, nil
 }
 
@@ -828,7 +841,7 @@ func readCapped(root *os.Root, name string, limit int64) ([]byte, error) {
 // calls to replay. Idempotent: only the first call per session does the work.
 // The returned error is the sandbox process kill failure, which Cancel
 // surfaces to its caller and Status has nothing useful to do with.
-func (e *SandboxEngine) reap(sess *session, outcome *terminalOutcome) error {
+func (e *SandboxEngine) reap(ctx context.Context, sess *session, outcome *terminalOutcome) error {
 	e.mu.Lock()
 	if sess.reaped {
 		e.mu.Unlock()
@@ -844,6 +857,27 @@ func (e *SandboxEngine) reap(sess *session, outcome *terminalOutcome) error {
 	// knowledge-work-pack task's JWT would otherwise sit in this process's
 	// memory for the rest of its life.
 	sess.bearerJWT = ""
+	e.mu.Unlock()
+
+	// Capture the sandbox's last events and workspace listing NOW, while its
+	// control socket and /workspace bind mount are both still alive: this is
+	// the last possible moment either exists. sess.proc.Kill() and the
+	// os.RemoveAll calls below are exactly what issue #1206 found a later
+	// /events or /files call racing and losing to, every time. A capture
+	// failure here is logged and left as a nil/empty snapshot rather than
+	// escalated: outcome is already decided by the caller and must never
+	// flip on a diagnostics-only read.
+	events, err := sess.client.SearchEvents(ctx, sess.conversationID)
+	if err != nil {
+		log.Printf("engine: reap: capture final events for %s: %v", sess.conversationID, err)
+	}
+	files, err := listWorkspaceFiles(sess.workingDir)
+	if err != nil {
+		log.Printf("engine: reap: capture final files for %s: %v", sess.conversationID, err)
+	}
+	e.mu.Lock()
+	sess.finalEvents = events
+	sess.finalFiles = files
 	e.mu.Unlock()
 
 	killErr := sess.proc.Kill()
@@ -867,7 +901,7 @@ func (e *SandboxEngine) Cancel(ctx context.Context, sessionRef string) error {
 	// than being deleted: agenttask's poller retries Status whenever its own
 	// Transition call failed, and an unknown-session error there would leave
 	// the task active forever.
-	killErr := e.reap(sess, &terminalOutcome{status: StatusCancelled})
+	killErr := e.reap(ctx, sess, &terminalOutcome{status: StatusCancelled})
 
 	if interruptErr != nil {
 		return fmt.Errorf("engine: interrupt conversation: %w", interruptErr)

--- a/apps/agent-engine/internal/engine/engine_test.go
+++ b/apps/agent-engine/internal/engine/engine_test.go
@@ -56,6 +56,11 @@ type fakeAgentServer struct {
 
 	listener net.Listener
 	srv      *http.Server
+
+	// events backs the /events/search route: one page, no next_page_id.
+	// setEvents lets a test populate it; issue #1206's regression coverage
+	// is the only user today.
+	events []json.RawMessage
 }
 
 func newFakeAgentServer(controlDir string) (*fakeAgentServer, error) {
@@ -98,6 +103,12 @@ func newFakeAgentServer(controlDir string) (*fakeAgentServer, error) {
 		f.executionStatus = controlclient.StatusPaused
 		f.mu.Unlock()
 		_ = json.NewEncoder(w).Encode(map[string]bool{"success": true})
+	})
+	mux.HandleFunc(convoPrefix+"/events/search", func(w http.ResponseWriter, r *http.Request) {
+		f.mu.Lock()
+		items := f.events
+		f.mu.Unlock()
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": items, "next_page_id": ""})
 	})
 	mux.HandleFunc(convoPrefix+"/agent_final_response", func(w http.ResponseWriter, r *http.Request) {
 		// Read the gates and then release f.mu before blocking on them: a
@@ -148,6 +159,21 @@ func (f *fakeAgentServer) setFinalResponse(s string) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.finalResponse = s
+}
+
+// setEvents populates the /events/search fixture from plain kind/field maps,
+// e.g. {"kind": "ActionEvent", "tool_name": "terminal", "tool_call_id": "1"}.
+func (f *fakeAgentServer) setEvents(items ...map[string]any) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.events = make([]json.RawMessage, len(items))
+	for i, item := range items {
+		enc, err := json.Marshal(item)
+		if err != nil {
+			panic(err) // test fixture construction only
+		}
+		f.events[i] = enc
+	}
 }
 
 func (f *fakeAgentServer) wasRun() bool {
@@ -364,6 +390,96 @@ func TestSandboxEngine_Status_TerminalReapsSandboxAndFreesQuota(t *testing.T) {
 	next.UserID = task.UserID
 	if _, err := e.Launch(context.Background(), next); err != nil {
 		t.Fatalf("expected quota slot freed by the reap, got %v", err)
+	}
+}
+
+// Issue #1206: pulling a finished task's tail events and workspace listing
+// AFTER it leaves the active set always raced the sandbox tearing its own
+// control socket and /workspace bind mount down, and always lost — two live
+// runs on the deployed box, 2 for 2. The reason is structural, not timing
+// luck: the same Status() call that discovers a terminal execStatus is what
+// triggers reap(), synchronously, before this or any other caller can ever
+// observe the task as terminal. So Events/Files must serve a snapshot
+// captured before that teardown, never a live pull after it.
+func TestSandboxEngine_Status_CapturesEventsAndFilesBeforeTeardown(t *testing.T) {
+	var fake *fakeAgentServer
+	e := newTestEngine(t, &fake)
+
+	task := testTask()
+	sessionRef, err := e.Launch(context.Background(), task)
+	if err != nil {
+		t.Fatalf("Launch: %v", err)
+	}
+
+	// Written to the sandbox's /workspace bind mount before it goes
+	// terminal, standing in for a real task's tool output.
+	workingDir := filepath.Join(e.cfg.WorkspaceRoot, task.ID.String())
+	if err := os.WriteFile(filepath.Join(workingDir, "notes.md"), []byte("done"), 0o600); err != nil {
+		t.Fatalf("seed workspace file: %v", err)
+	}
+	fake.setEvents(
+		map[string]any{"kind": "ActionEvent", "id": "a1", "tool_name": "terminal", "tool_call_id": "c1"},
+		map[string]any{"kind": "ObservationEvent", "id": "o1", "tool_name": "terminal", "tool_call_id": "c1"},
+	)
+	fake.setFinalResponse("done")
+	fake.setStatus(controlclient.StatusFinished)
+
+	status, _, _, err := e.Status(context.Background(), sessionRef)
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if status != StatusSucceeded {
+		t.Fatalf("expected succeeded, got %s", status)
+	}
+	if !fake.wasKilled() {
+		t.Fatal("expected terminal Status to kill the sandbox process")
+	}
+
+	// The control socket is dead (fake.Kill closed its listener) and
+	// workingDir is removed (reap's os.RemoveAll) by this point. A live pull
+	// would either error or silently see an empty, already-deleted
+	// directory; only the reap-time snapshot can produce this content.
+	events, err := e.Events(context.Background(), sessionRef)
+	if err != nil {
+		t.Fatalf("Events after reap: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("expected 2 captured events surviving reap, got %d: %+v", len(events), events)
+	}
+	if events[0].Kind != "ActionEvent" || events[1].Kind != "ObservationEvent" {
+		t.Fatalf("unexpected event kinds: %+v", events)
+	}
+
+	files, err := e.Files(context.Background(), sessionRef)
+	if err != nil {
+		t.Fatalf("Files after reap: %v", err)
+	}
+	if len(files) != 1 || files[0].Name != "notes.md" {
+		t.Fatalf("expected the seeded workspace file to survive reap, got %+v", files)
+	}
+}
+
+// Same guarantee via Cancel's reap call, the other of reap's two callers.
+func TestSandboxEngine_Cancel_CapturesEventsBeforeTeardown(t *testing.T) {
+	var fake *fakeAgentServer
+	e := newTestEngine(t, &fake)
+
+	sessionRef, err := e.Launch(context.Background(), testTask())
+	if err != nil {
+		t.Fatalf("Launch: %v", err)
+	}
+	fake.setEvents(map[string]any{"kind": "ActionEvent", "id": "a1", "tool_name": "terminal", "tool_call_id": "c1"})
+
+	if err := e.Cancel(context.Background(), sessionRef); err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+
+	events, err := e.Events(context.Background(), sessionRef)
+	if err != nil {
+		t.Fatalf("Events after cancel: %v", err)
+	}
+	if len(events) != 1 || events[0].Kind != "ActionEvent" {
+		t.Fatalf("expected the pre-cancel event to survive reap, got %+v", events)
 	}
 }
 

--- a/apps/agent-engine/internal/engine/events.go
+++ b/apps/agent-engine/internal/engine/events.go
@@ -2,7 +2,10 @@ package engine
 
 // Event/files surface for the launcher daemon: reads the live session's
 // sandbox event store through its control client and lists the workspace
-// bind mount from the host directly.
+// bind mount from the host directly. Once a session is reaped (issue #1206),
+// both instead serve the snapshot reap() captured immediately before it tore
+// the control socket and /workspace bind mount down — the same pattern
+// Status already uses via replayOf/terminal, just for the tail data too.
 
 import (
 	"context"
@@ -13,27 +16,55 @@ import (
 	"github.com/sakibsadmanshajib/hive/apps/agent-engine/internal/controlclient"
 )
 
-// Events returns the session's normalized sandbox events. A reaped session's
-// control socket is gone, so the call errors; the syncer treats that like any
-// other per-task failure and the task's row is terminal by then anyway.
+// Events returns the session's normalized sandbox events: the live pull for
+// an active session, or reap's captured snapshot for one already terminal.
 func (e *SandboxEngine) Events(ctx context.Context, sessionRef string) ([]controlclient.Event, error) {
 	sess, id, err := e.lookup(sessionRef)
 	if err != nil {
 		return nil, err
 	}
+	if cached, reaped := e.finalEventsOf(sess); reaped {
+		return cached, nil
+	}
 	return sess.client.SearchEvents(ctx, id)
 }
 
 // Files lists the session workspace directory (top level, name/size/mtime
-// only), reading the host bind mount directly.
-//
-// ponytail: no recursion; add a walk when a panel needs nested paths.
+// only): the live listing for an active session, or reap's captured snapshot
+// for one already terminal.
 func (e *SandboxEngine) Files(_ context.Context, sessionRef string) ([]controlclient.WorkspaceFile, error) {
 	sess, _, err := e.lookup(sessionRef)
 	if err != nil {
 		return nil, err
 	}
-	entries, err := os.ReadDir(sess.workingDir)
+	if cached, reaped := e.finalFilesOf(sess); reaped {
+		return cached, nil
+	}
+	return listWorkspaceFiles(sess.workingDir)
+}
+
+// finalEventsOf and finalFilesOf return sess's reap-time snapshot plus
+// whether sess has been reaped at all — the caller's signal to use it rather
+// than dial a control socket or read a bind mount that may already be gone.
+// Guarded by e.mu, same as sess.reaped and sess.terminal.
+func (e *SandboxEngine) finalEventsOf(sess *session) ([]controlclient.Event, bool) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return sess.finalEvents, sess.reaped
+}
+
+func (e *SandboxEngine) finalFilesOf(sess *session) ([]controlclient.WorkspaceFile, bool) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return sess.finalFiles, sess.reaped
+}
+
+// listWorkspaceFiles lists dir's top level (name/size/mtime only). Shared by
+// the live-session Files() path and reap's final-snapshot capture.
+//
+// ponytail: no recursion; add a walk when a panel needs nested paths.
+func listWorkspaceFiles(dir string) ([]controlclient.WorkspaceFile, error) {
+	entries, err := os.ReadDir(dir)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			// A reaped session's working dir is already deleted; that is a


### PR DESCRIPTION
## Summary

Fixes #1206 (reopened). PR #1209's `finishVanished` tail pull cannot work as designed: two live runs on the deployed box both hit `dial unix .../agent.sock: connect: no such file or directory` at the exact moment each task completed. The root cause is structural, not timing luck: the same `Status()` call that first observes a terminal execution status is what triggers `reap()` on that session, synchronously, inside `finishTerminal`, before the database or any other caller can ever observe the task as terminal. So a later pull always finds the control socket and `/workspace` bind mount already gone, on 100% of tasks, not just fast ones.

## Fix

`reap()` (`apps/agent-engine/internal/engine/engine.go`) now pulls the session's final sandbox events and workspace listing in the brief window before it kills the sandbox process and removes `sessionDir`/`workingDir`, and caches the result on the session. `Events()`/`Files()` (`apps/agent-engine/internal/engine/events.go`) serve that cache once a session is reaped, the same pattern `Status()` already uses for its own terminal outcome (`sess.terminal`/`replayOf`), instead of dialling a socket or reading a directory that may already be gone.

Both of `reap()`'s callers (`finishTerminal` on natural completion, `Cancel` on user cancellation) now pass `ctx` through so the capture has one to use.

PR #1209's mapping-layer filter is unchanged and kept: bookkeeping events (`SystemPromptEvent`, `ConversationStateUpdateEvent`, the echoed user prompt, dot-prefixed workspace entries) stay excluded, and tool events still render as readable lines rather than the unmapped-kind fallback.

## Live verification (acceptance criterion)

Built this branch's `agent-engine` binary and hot-swapped it into the demo box's `hive-agent-engine` launcher service (backup taken, restored after testing; no merge to `main`, no change to the box's deployed `main` state). Ran two real Cowork tasks through the actual chat UI against the real Apptainer sandbox:

| Task | Duration | Events | Kinds | Socket-teardown error in control-plane log |
|---|---|---|---|---|
| `78eaa59b` | 54s | 8 | `status`, `tool_call`×2, `tool_result`×2, `message`, `file`, `status` | none |
| `591740f7` | 70s | 8 | `status`, `tool_call`×2, `tool_result`×2, `file`, `message`, `status` | none |

Both `tool_call`/`tool_result` pairs share their `tool_call_id`. For comparison, every task run against the *old* binary in this same window (`d4a15732`, `5a5313ff`, `64983c00`) logged the identical `dial unix .../agent.sock: connect: no such file or directory` / `WARN agenttask: event sync pull failed` pair at completion; the two new runs against the fixed binary logged neither line at all, because `Events()`/`Files()` never attempt the dead socket for a reaped session anymore, they serve the cache. `591740f7` (70s) is essentially the same duration class as the previously-failing `64983c00` (74s) and `d4a15732` (61s), and it now succeeds outright rather than depending on an in-flight poll landing first.

Queried directly from `public.agent_task_events` on `hive-supabase-db-1`, not inferred from the UI.

## Test plan

- [x] `go build ./apps/agent-engine/...`
- [x] `go vet ./apps/agent-engine/...`
- [x] `go test ./apps/agent-engine/...` (all packages, including two new regression tests: `TestSandboxEngine_Status_CapturesEventsAndFilesBeforeTeardown`, `TestSandboxEngine_Cancel_CapturesEventsBeforeTeardown`)
- [x] `go build ./apps/control-plane/...` (untouched by this PR, confirmed it still builds)
- [x] Two real live Cowork tasks against the deployed demo box with this branch's binary hot-swapped in, verified via direct DB query (table above)
- [x] Box restored to its original binary after verification; no lingering worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)