### PR TITLE
fix: add prompt-cache endpoint affinity to the DeepSeek OpenRouter routes

### DIFF
--- a/apps/control-plane/internal/routing/deepseek_cache_affinity_test.go
+++ b/apps/control-plane/internal/routing/deepseek_cache_affinity_test.go
@@ -1,0 +1,101 @@
+package routing
+
+import (
+	"strings"
+	"testing"
+)
+
+// Offline guards over the DeepSeek prompt-cache endpoint-affinity fix
+// (fix/cache-realization, 2026-08-26).
+//
+// Live evidence behind these assertions (OpenRouter direct probes against
+// the demo box key, 2026-08-26, identical ~975-token prompts):
+//
+//   - UNPINNED: three calls to ~deepseek/deepseek-v4-flash-latest landed on
+//     three different providers (Inceptron, Fireworks, OpenInference) with
+//     cached_tokens=0 every time; three calls to deepseek/deepseek-v4-pro-0813
+//     landed on DigitalOcean, SiliconFlow and Together, also all zero. A cold
+//     endpoint cannot serve a cache hit, so with per-call endpoint churn the
+//     advertised supports_cache_read=true on these routes never pays off --
+//     the parity report finding this fix closes (/tmp/reports/parity-inhive.md,
+//     supplement B3).
+//   - PINNED via OpenRouter's soft provider.order preference (fallbacks left
+//     enabled): flash stuck to Incepton at cached_tokens=512 and pro stuck to
+//     DigitalOcean at cached_tokens=768 on every repeat call. Endpoint-level
+//     caching works; per-call endpoint selection was the defect.
+//
+// These tests are positional guards over deploy/litellm/config.yaml in the
+// style of sqlparse_test.go: if someone drops or renames the extra_body block
+// again, the routes go back to silent per-call endpoint churn, the catalog's
+// cache-read pricing becomes dead config, and nothing else in CI would notice.
+
+const litellmConfigRelPath = "deploy/litellm/config.yaml"
+
+func litellmConfigYAML(t *testing.T) string {
+	t.Helper()
+	return readRepoFile(t, litellmConfigRelPath)
+}
+
+// litellmEntryBody returns the YAML text of one model_list entry, from its
+// `- model_name:` line up to (excluding) the next `- model_name:` line.
+func litellmEntryBody(t *testing.T, modelName string) string {
+	t.Helper()
+	lines := strings.Split(litellmConfigYAML(t), "\n")
+	start := -1
+	for i, line := range lines {
+		if strings.TrimSpace(line) == "- model_name: "+modelName {
+			start = i
+			break
+		}
+	}
+	if start == -1 {
+		t.Fatalf("%s has no model_list entry %s", litellmConfigRelPath, modelName)
+	}
+	end := len(lines)
+	for i := start + 1; i < len(lines); i++ {
+		if strings.HasPrefix(strings.TrimSpace(lines[i]), "- model_name: ") {
+			end = i
+			break
+		}
+	}
+	return strings.Join(lines[start:end], "\n")
+}
+
+// TestDeepSeekRoutesCarryCacheEndpointAffinity pins the soft provider.order
+// preference on both paid DeepSeek chat routes. Without it OpenRouter may
+// route consecutive identical prompts to different endpoints, each with a
+// cold prefix cache, and the saving supports_cache_read=true advertises
+// never materializes for any caller.
+func TestDeepSeekRoutesCarryCacheEndpointAffinity(t *testing.T) {
+	cases := []struct {
+		modelName     string
+		pinnedPartner string
+	}{
+		{modelName: "route-deepseek-v4-flash", pinnedPartner: "Inceptron"},
+		{modelName: "route-deepseek-v4-pro", pinnedPartner: "DigitalOcean"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.modelName, func(t *testing.T) {
+			body := litellmEntryBody(t, tc.modelName)
+
+			if !strings.Contains(body, "extra_body:") {
+				t.Fatalf("route %s carries no extra_body block; prompt-cache endpoint affinity is gone and supports_cache_read=true is once again an empty promise (%s)", tc.modelName, litellmConfigRelPath)
+			}
+			if !strings.Contains(body, "provider:") {
+				t.Fatalf("route %s extra_body carries no provider block", tc.modelName)
+			}
+			if !strings.Contains(body, "order:") {
+				t.Fatalf("route %s extra_body.provider carries no order preference; per-call endpoint churn returns", tc.modelName)
+			}
+			if !strings.Contains(body, tc.pinnedPartner) {
+				t.Fatalf("route %s order preference lost its pinned partner %q; update both this test and the config together if the partner changed deliberately", tc.modelName, tc.pinnedPartner)
+			}
+			// Deliberately NOT allow_fallbacks:false: the order entry is a soft
+			// preference, so a dead pinned endpoint falls back instead of taking
+			// the paid alias down. Assert the cliff was not added by mistake.
+			if strings.Contains(body, "allow_fallbacks") {
+				t.Fatalf("route %s must keep fallbacks allowed; hard-pinning a paid flagship route to one endpoint trades availability for cache hits", tc.modelName)
+			}
+		})
+	}
+}

--- a/deploy/litellm/config.yaml
+++ b/deploy/litellm/config.yaml
@@ -240,10 +240,33 @@ model_list:
     litellm_params:
       model: openrouter/~deepseek/deepseek-v4-flash-latest
       api_key: os.environ/OPENROUTER_API_KEY
+      extra_body:
+        # Prompt-cache endpoint affinity, fix/cache-realization (2026-08-26).
+        # Unpinned, OpenRouter bounced three identical prompts across three
+        # endpoints (Inceptron / Fireworks / OpenInference), cached_tokens=0
+        # every time: a cold endpoint cannot serve a cache hit, so the
+        # supports_cache_read=true capability row on this route never paid
+        # off and every repeat prompt billed at full input price. The soft
+        # `order` preference below keeps fallbacks enabled (no availability
+        # cliff): while the preferred endpoint is healthy it serves the
+        # request and DeepSeek prefix caching hits; when it is not, OpenRouter
+        # falls back to another endpoint and callers see a cold cache plus a
+        # different tokenizer's prompt-token count until the preference
+        # resumes. Live-proven pinned: cached_tokens=512 on every repeat.
+        provider:
+          order:
+            - Inceptron
   - model_name: route-deepseek-v4-pro
     litellm_params:
       model: openrouter/deepseek/deepseek-v4-pro-0813
       api_key: os.environ/OPENROUTER_API_KEY
+      extra_body:
+        # Same defect, same fix as route-deepseek-v4-flash above. Unpinned,
+        # pro bounced DigitalOcean / SiliconFlow / Together with zero cache
+        # hits; pinned to DigitalOcean, cached_tokens=768 on every repeat.
+        provider:
+          order:
+            - DigitalOcean
 
   # ── 4. Doc-layout vision (paid, OpenRouter, the last multimodal route) ──────
   # Blueprint Wave 3, Step 3.2 (issue #300): the doc-layout knowledge-work-pack


### PR DESCRIPTION
## Defect

DeepSeek routes advertise `supports_cache_read=true` in `provider_capabilities`, but three identical 817-token prompts through the gateway returned `cached_tokens=0` every time, billed at full input price. The advertised saving never materialized for any caller. Source: `/tmp/reports/parity-inhive.md` supplement B3 (2026-08-26).

## Cause (investigated in the brief's order, each eliminated or proven)

1. **Under minimum cacheable prefix**: eliminated. DeepSeek caches prefixes from the first 64-token block; the probe prompts were ~975 tokens. Pinned probes cached 512/768 tokens immediately.
2. **cache_control flattened/dropped on the chat path**: eliminated. The chat path forwards the raw request body (`litellm_client.go` `rewriteModel` swaps only the model field), and DeepSeek caching needs no `cache_control` anyway. OpenRouter docs: "Prompt caching with DeepSeek is automated and does not require any additional configuration."
3. **Session affinity dropped**: PROVEN ROOT CAUSE, at the OpenRouter endpoint layer rather than inside Hive. Unpinned, three identical calls to `~deepseek/deepseek-v4-flash-latest` landed on THREE different endpoints (Inceptron, Fireworks, OpenInference) with `cached_tokens=0` every time; pro-0813 bounced DigitalOcean / SiliconFlow / Together identically. OpenRouter's automatic sticky routing never engaged because these endpoints report zero cache-write events ("After a request that uses prompt caching, OpenRouter remembers which provider served your request"). No endpoint stability, no cache hit, ever. This also explains the parity report's metering nondeterminism: different endpoints use different tokenizers, so identical prompts metered 975 vs 1054 tokens.
4. **Capability flag wrong**: partially true as a symptom, not the root cause. Endpoint-level caching works once requests stop churning, so the flag is truthful once affinity exists; flipping it to false would have abandoned a real saving.

## Fix

Soft endpoint preference via `extra_body.provider.order` on both routes in `deploy/litellm/config.yaml`: flash to Inceptron, pro to DigitalOcean. Fallbacks remain enabled (deliberately NOT `allow_fallbacks: false`): a dead preferred endpoint degrades to today's churn instead of taking a paid flagship alias down.

The litellmconfig sync preserves operator-tuned `extra_body` across DB-driven regenerations field-by-field (`mergeParams`, guarded by generator_test.go), so this survives deploys.

Pricing consequence: none required. With affinity in place, `supports_cache_read=true` and `cache_read_price_credits` become reachable config instead of dead letters.

## Test evidence

- New `TestDeepSeekRoutesCarryCacheEndpointAffinity` (routing package) fails before the fix ("carries no extra_body block") and passes after; full routing package green, `go vet` clean.
- Live probes against OpenRouter with the demo box key, identical ~975-token prompts, max_tokens=16:
  - Unpinned flash x3: providers Inceptron/Fireworks/OpenInference, `cached_tokens=0` all three, prompt_tokens 975/1054/975 (tokenizer drift across endpoints).
  - Pro unpinned x3: DigitalOcean/SiliconFlow/Together, all zero.
  - Flash soft-ordered to Inceptron x3: same provider all three, `cached_tokens=512` every call.
  - Pro pinned to DigitalOcean x3: same provider, `cached_tokens=768` every call.
- Takes effect on the box after the next deploy-demo-box run recreates LiteLLM with the updated config.

## Buglog entry

```json
{"ts":"2026-08-26T09:00:00Z","error_message":"deepseek-v4-flash cached_tokens=0 on three identical 817-token prompts through the gateway; full-price charges despite supports_cache_read=true","root_cause":"OpenRouter routed each call to a different endpoint serving the slug (no cache-affinity stickiness engaged because these endpoints report no cache writes); cold endpoint per call means zero prefix-cache hits","fix":"soft extra_body.provider.order endpoint preference on route-deepseek-v4-flash and route-deepseek-v4-pro in deploy/litellm/config.yaml plus positional CI guard test; fallbacks kept enabled","tags":["gateway","openrouter","prompt-caching","billing-honesty"]}
```