### PR TITLE
fix: stop the migration job from dirtying go.work.sum for the next deploy

### DIFF
--- a/.github/workflows/deploy-demo-box.yml
+++ b/.github/workflows/deploy-demo-box.yml
@@ -704,6 +704,21 @@ jobs:
           fi
           bash scripts/install-agent-engine-host.sh
 
+          # The installer just ran `go build` against THIS checkout as a Docker
+          # bind mount (scripts/install-agent-engine-host.sh). In workspace
+          # mode, a build that resolves modules whose sums go.work.sum lacks
+          # appends them to that tracked file. Dependabot bumps land exactly
+          # that shape: it updates each module's go.sum but not the workspace
+          # sum, so the first build on the box after such a merge rewrites
+          # /home/sakib/hive/go.work.sum. Left behind, the NEXT deploy's
+          # "Pull latest main" step trips its dirty-tree guard over that one
+          # modified file and the deploy dies until someone runs
+          # git reset --hard by hand (#1224): success, re-dirty, fail, repeat.
+          # Restore the file here, immediately after the only invocation in
+          # this workflow that can modify it, and tolerate nothing-to-restore
+          # so a tree that was never dirtied is not an error.
+          git -C /home/sakib/hive checkout -- go.work.sum || true
+
       - name: Point control-plane at the launch daemon's socket
         # Shell environment beats --env-file in compose interpolation, so
         # exporting here is what actually reaches the container (the same


### PR DESCRIPTION
Fixes #1224.

## Root cause

The go commands do not run in the migrate job; they run in the deploy job's first step, "Install and restart the agent-engine launch daemon". That step calls scripts/install-agent-engine-host.sh, which builds the engine binary with:

docker run -v "$REPO_DIR":/workspace ... golang:1.26-alpine go build ./apps/agent-engine/cmd/agent-engine

with REPO_DIR defaulting to /home/sakib/hive. In Go workspace mode this build appends any missing module sums to the tracked go.work.sum in the mounted checkout. Dependabot merges produce exactly that shape: it updates each module's own go.sum but not the workspace sum, so the first box-side build after such a merge rewrites /home/sakib/hive/go.work.sum. The next deploy's "Pull latest main" step then fails its dirty-tree guard over that single modified file (run 32951717783 shows M go.work.sum), and the deploy stays red until someone runs git reset --hard by hand. Success, re-dirty, fail: the self-sustaining loop described in #1224.

## Change

One tolerant restore immediately after the installer call in that step:

git -C /home/sakib/hive checkout -- go.work.sum || true

This is the only place in this workflow that runs go inside the box checkout; all other jobs run on ubuntu-latest and never touch the box tree. GOFLAGS=-mod=readonly was considered instead but cannot be injected into the nested docker run from the workflow file alone (the script hardcodes its -e list), so the restore-after-writer approach is the one taken.

Discarding the appended sums after a successful build is safe: they are only recorded verification checksums for modules already downloaded into the shared hive_gomodcache volume, so the built binary is unaffected and a later build simply re-adds them if ever needed.

## Validation

- YAML parses (python3 yaml.safe_load); all five jobs intact.
- Confirmed against live evidence: failed run 32951717783's log shows the dirty-tree guard failing with exactly M go.work.sum.