### PR TITLE
fix: restore go.work.sum before the deploy pull, not only after the installer

### DIFF
--- a/.github/workflows/deploy-demo-box.yml
+++ b/.github/workflows/deploy-demo-box.yml
@@ -340,6 +340,15 @@ jobs:
           set -euo pipefail
           cd /home/sakib/hive
 
+          # go.work.sum is machine-generated checksum state, so restoring it
+          # is always safe. The previous deploy's installer step (the only
+          # invocation here that can modify it) already restores it after it
+          # runs, but a run that died before reaching that restore leaves the
+          # file dirty, and this step's own pull below trips its dirty-tree
+          # guard over exactly that leftover (#1224, run 32954258787 first
+          # attempt). Restore before the pull too.
+          git -C /home/sakib/hive checkout -- go.work.sum || true
+
           # A leftover .git/index.lock from a prior run killed mid checkout
           # (the timeout-minutes below, a manual cancel, or a box reboot
           # this file's own header says the runner does not survive) would


### PR DESCRIPTION
Follow-up to #1227 on #1224.

#1227 restores `go.work.sum` immediately after the installer step, the only invocation in the deploy workflow that can modify it. That covers the steady state, but a run that dies between dirtying the file and reaching that restore leaves it dirty on the box, and the next deploy's `Pull latest main` step trips its own dirty-tree guard over exactly that leftover before any restore runs (live: run 32954258787 first attempt).

This adds the same tolerant restore, `git checkout -- go.work.sum || true`, at the top of `Pull latest main`, before the pull. The file is machine-generated checksum state, so restoring is always safe. #1227's later restore is kept as a second layer.

## Test plan
- [x] YAML validated (`yaml.safe_load` passes)
- [x] Change is workflow-only; no runtime code touched
- [ ] Next demo-box deploy run passes its first pull attempt with a previously dirtied tree

Fixes the remaining half of #1224's failure mode.