### PR TITLE
fix: point the alias-echo replay test at a bounded model and raise free-lane timeouts

### DIFF
--- a/packages/sdk-tests/js/tests/chat-completions/chat-completions.test.ts
+++ b/packages/sdk-tests/js/tests/chat-completions/chat-completions.test.ts
@@ -23,7 +23,13 @@ const TOOL_CAPABLE_MODEL =
 describe("Chat Completions", () => {
   const client = new OpenAI({ baseURL: BASE_URL, apiKey: API_KEY });
 
-  it("returns a valid chat completion via SDK", async () => {
+  // The only test still on the free MODEL. Free-lane worst case (retry on
+  // empty content, reasoning-member budgets) can exceed vitest's default
+  // 60s; fail here on assertion, never on the runner's timeout.
+  it(
+    "returns a valid chat completion via SDK",
+    { timeout: 120000 },
+    async () => {
     const response = await client.chat.completions.create({
       model: MODEL,
       messages: [{ role: "user", content: "Say hello" }],
@@ -38,11 +44,17 @@ describe("Chat Completions", () => {
     expect(response.usage).toBeDefined();
     expect(response.usage!.prompt_tokens).toBeGreaterThan(0);
     expect(response.usage!.completion_tokens).toBeGreaterThan(0);
-  });
+    },
+  );
 
   it("model field shows Hive alias not provider handle", async () => {
+    // Alias-echo check, not a free-lane exercise: since #1225 the free pool
+    // retries once on empty content and reasoning members inflate budgets,
+    // so worst-case free-lane latency exceeds vitest's 60s default. This
+    // test only needs any live alias to echo itself back, so it runs on the
+    // same fast bounded model as the tools/response_format tests.
     const response = await client.chat.completions.create({
-      model: MODEL,
+      model: TOOL_CAPABLE_MODEL,
       messages: [{ role: "user", content: "Say hello" }],
       max_tokens: 256,
     });


### PR DESCRIPTION
## What

The deploy SDK replay test `model field shows Hive alias not provider handle` timed out at 60s on the free lane. Since #1225 the free pool retries once on empty content and reasoning members inflate token budgets, so worst-case free-lane latency now exceeds vitest's default 60s per-test timeout (the sibling free-lane test passed at 26.5s).

## Change

- The alias-echo test's purpose is the alias echo, not a free-lane exercise, so it now runs on `HIVE_TOOLS_MODEL` (default `deepseek-v4-flash`), mirroring the tools and response_format tests in the same file.
- The one remaining test that intentionally uses the free `MODEL` gets an explicit `{ timeout: 120000 }` so future latency growth fails on assertion, not on the runner default.
- Assertions are identical; no behavior change to what is verified.

## Test plan

- [x] `tsc --noEmit -p tsconfig.json` on `packages/sdk-tests/js`: no new errors (the single pre-existing TS2339 on main reproduces identically, shifted lines only)
- [ ] Live replay run against the deployed gateway (requires live stack; suite is deploy-gated)

## Buglog entry

None: no bug fixed in shipped code, this is test-infrastructure retargeting.