### PR TITLE
fix: keep catalog cache price states consistent across console surfaces

### DIFF
--- a/apps/web-console/__tests__/model-detail-price-states.test.tsx
+++ b/apps/web-console/__tests__/model-detail-price-states.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * The 2026-08-25 console parity rescore flagged the model detail page as
+ * rendering the three catalog price states on the model detail page
+ * inconsistently with the catalog list. The lib
+ * (lib/format/model-pricing.ts) pins the invariant: on a cache dimension a
+ * null rate on a fixed alias means "no such rate" (a dash, matching the
+ * upstream model pages this surface mirrors), while on input/output a null
+ * rate on a fixed alias is a broken lookup ("Unknown"). The detail page was
+ * routing its cache tile and cache table rows through formatModelPrice, so
+ * the same alias showed a dash in the catalog list and "Unknown" on its own
+ * detail page.
+ *
+ * These tests render the real ModelDetail component and pin all three price
+ * states on both of its surfaces (the header tiles and the pricing table),
+ * so neither screen can drift from the other again.
+ */
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { ModelDetail } from "@/components/catalog/model-detail";
+import type { CatalogModel } from "@/lib/control-plane/client";
+
+function fixture(overrides: Partial<CatalogModel["pricing"]> = {}): CatalogModel {
+  return {
+    id: "hive-deepseek-v4-flash",
+    display_name: "DeepSeek V4 Flash",
+    summary: "",
+    capability_badges: ["chat"],
+    lifecycle: "stable",
+    pricing: {
+      input_price_credits: 89_460_000,
+      output_price_credits: 178_920_000,
+      cache_read_price_credits: 2_982_000,
+      cache_write_price_credits: 0,
+      pricing_mode: "fixed",
+      ...overrides,
+    },
+  };
+}
+
+function renderDetail(model: CatalogModel) {
+  return render(
+    <ModelDetail
+      model={model}
+      usage={null}
+      usageUnavailable={false}
+      usageWindowLabel="last 24 hours"
+    />,
+  );
+}
+
+describe("ModelDetail price states", () => {
+  it("shows a real cache rate in dollars and credits", () => {
+    renderDetail(fixture());
+    expect(screen.getAllByText("$0.00298").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("2,982,000").length).toBeGreaterThan(0);
+  });
+
+  it("renders a published zero as $0, never Unknown", () => {
+    // hive-default publishes cache_write_price_credits = 0; zero is a
+    // decision, not an absence.
+    renderDetail(fixture({ cache_write_price_credits: 0 }));
+    expect(screen.queryAllByText("Unknown")).toHaveLength(0);
+    expect(screen.getAllByText("$0").length).toBeGreaterThan(0);
+  });
+
+  it("never shows Unknown for a missing cache rate on a fixed alias", () => {
+    // The catalog list renders this exact fixture's cache cells as a dash
+    // (formatCachePrice); the detail page must agree with it.
+    renderDetail(fixture({ cache_read_price_credits: null, cache_write_price_credits: null }));
+    expect(screen.queryAllByText("Unknown")).toHaveLength(0);
+    expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("still calls a broken lookup Unknown on input/output dimensions", () => {
+    // The dash rule is cache-only. A fixed alias whose INPUT rate failed to
+    // decode must keep saying Unknown, not borrow the cache dash.
+    renderDetail(fixture({ input_price_credits: null }));
+    expect(screen.getAllByText("Unknown").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("calls every missing rate Variable on an upstream_actual alias", () => {
+    renderDetail(
+      fixture({
+        input_price_credits: null,
+        output_price_credits: null,
+        cache_read_price_credits: null,
+        cache_write_price_credits: null,
+        pricing_mode: "upstream_actual",
+      }),
+    );
+    expect(screen.queryAllByText("Unknown")).toHaveLength(0);
+    expect(screen.getAllByText("Variable").length).toBeGreaterThanOrEqual(4);
+  });
+});

--- a/apps/web-console/app/console/analytics/page.tsx
+++ b/apps/web-console/app/console/analytics/page.tsx
@@ -36,7 +36,11 @@ import {
 } from "@/components/ui/card";
 import { PageHeader } from "@/components/ui/page-header";
 import { cn } from "@/lib/cn";
-import { formatCredits, formatPercent } from "@/lib/format/credits";
+import {
+  formatCredits,
+  formatNumber,
+  formatPercent,
+} from "@/lib/format/credits";
 import { formatUsdFromCredits } from "@/lib/format/model-pricing";
 
 interface AnalyticsPageProps {
@@ -324,7 +328,7 @@ export default async function AnalyticsPage({
                   note={
                     blendedCreditsPerMillion === null
                       ? "No tokens served in this window."
-                      : `${formatCredits(blendedCreditsPerMillion)} credits. Credits spent divided by input plus output tokens, per million. Effective, so cache reads are already priced in.`
+                      : `${formatNumber(blendedCreditsPerMillion)} credits. Credits spent divided by input plus output tokens, per million. Effective, so cache reads are already priced in.`
                   }
                   testId="blended-credits-per-million"
                 />

--- a/apps/web-console/components/catalog/model-detail.tsx
+++ b/apps/web-console/components/catalog/model-detail.tsx
@@ -14,7 +14,11 @@ import { DataTable, type Column } from "@/components/ui/data-table";
 import { buttonVariants } from "@/components/ui/button";
 import { statusBadge } from "@/components/catalog/model-catalog-table";
 import { formatCredits, formatTokens } from "@/lib/format/credits";
-import { formatInOutPrice, formatModelPrice } from "@/lib/format/model-pricing";
+import {
+  formatCachePrice,
+  formatInOutPrice,
+  formatModelPrice,
+} from "@/lib/format/model-pricing";
 import { cn } from "@/lib/cn";
 
 export interface ModelDetailProps {
@@ -34,6 +38,12 @@ interface PriceRow {
   dimension: string;
   credits: number | null;
   note: string;
+  /**
+   * Cache dimensions follow the cache absence policy: a missing rate on a
+   * fixed alias is "no such rate" (a dash), not a broken lookup. Input and
+   * output keep the plain price policy, where the same null reads "Unknown".
+   */
+  cache?: boolean;
 }
 
 // Every figure on this page is a rate per one million metered tokens, the
@@ -124,11 +134,13 @@ function priceRows(model: CatalogModel): PriceRow[] {
       dimension: "Cache read",
       credits: model.pricing.cache_read_price_credits,
       note: "Prompt tokens served from an upstream prompt cache.",
+      cache: true,
     },
     {
       dimension: "Cache write",
       credits: model.pricing.cache_write_price_credits,
       note: "Prompt tokens written into an upstream prompt cache.",
+      cache: true,
     },
   ];
 }
@@ -157,7 +169,10 @@ export function ModelDetail({
       header: "Price / 1M",
       numeric: true,
       align: "right",
-      cell: (row) => formatModelPrice(row.credits, model.pricing.pricing_mode),
+      cell: (row) =>
+        row.cache
+          ? formatCachePrice(row.credits, model.pricing.pricing_mode)
+          : formatModelPrice(row.credits, model.pricing.pricing_mode),
     },
     {
       key: "credits",
@@ -166,7 +181,9 @@ export function ModelDetail({
       align: "right",
       cell: (row) => (
         <span className="text-xs text-[var(--color-ink-3)]">
-          {formatModelPrice(row.credits, model.pricing.pricing_mode, "credits")}
+          {row.cache
+            ? formatCachePrice(row.credits, model.pricing.pricing_mode, "credits")
+            : formatModelPrice(row.credits, model.pricing.pricing_mode, "credits")}
         </span>
       ),
     },
@@ -206,24 +223,24 @@ export function ModelDetail({
           </Tile>
           <Tile label="Cache read / write">
             <span className="tabular-nums">
-              {formatModelPrice(
+              {formatCachePrice(
                 model.pricing.cache_read_price_credits,
                 model.pricing.pricing_mode,
               )}
               {" / "}
-              {formatModelPrice(
+              {formatCachePrice(
                 model.pricing.cache_write_price_credits,
                 model.pricing.pricing_mode,
               )}
             </span>
             <span className="block text-2xs text-[var(--color-ink-3)]">
-              {formatModelPrice(
+              {formatCachePrice(
                 model.pricing.cache_read_price_credits,
                 model.pricing.pricing_mode,
                 "credits",
               )}
               {" / "}
-              {formatModelPrice(
+              {formatCachePrice(
                 model.pricing.cache_write_price_credits,
                 model.pricing.pricing_mode,
                 "credits",
@@ -254,7 +271,7 @@ export function ModelDetail({
           <CardDescription>
             {variablePriced
               ? "This alias is priced from the actual cost of each generation, so it publishes no per-million rate. The charge is derived per request, not from a table."
-              : "Every rate Hive charges for this model, per one million metered tokens, in US dollars and in the credits the ledger moves. A rate of 0 means that dimension is deliberately not charged. Unknown means the catalog holds no rate, which is not the same as free."}
+              : "Every rate Hive charges for this model, per one million metered tokens, in US dollars and in the credits the ledger moves. A rate of 0 means that dimension is deliberately not charged. Unknown means the catalog holds no rate, which is not the same as free. A dash on a cache row means this alias publishes no cache rate."}
           </CardDescription>
         </CardHeader>
         <CardContent>


### PR DESCRIPTION
## Summary

The 2026-08-25 evening rescore flagged two remaining currency-formatting gaps in apps/web-console on top of #1195:

1. **Cache price states inconsistent between surfaces.** The model detail page routed its cache tile and its pricing-table cache rows through `formatModelPrice`, so a fixed alias with no published cache rate rendered as "Unknown" there while the catalog list rendered the same data as a dash (`formatCachePrice`). The lib's documented invariant (and the upstream model pages this surface mirrors) is that a missing rate on a *fixed* alias's cache dimension means *no such rate*, drawn as a dash, while the same null on input/output means a broken lookup and keeps "Unknown". All cache surfaces now go through `formatCachePrice` and the pricing card copy explains the dash.
2. **Blended price note truncated fractional credits.** The analytics "Blended price / 1M" note used `formatCredits`, which truncates, so a blended figure of 89.46 credits read as "89". It now uses `formatNumber`, which keeps fraction digits. The USD tile value already went through `formatUsdFromCredits`.

The precision guarantee itself (three significant digits, minimum two decimals, maximum nine, so a non-zero rate can never print as $0.00, e.g. the DeepSeek cache-read 2,982,000 credit rate rendering $0.00298) was already landed by #1195 and its tests are unchanged and green here; this PR closes the surfaces that had not adopted it.

## Test plan

- [x] New component test `__tests__/model-detail-price-states.test.tsx` pins all three states on the detail page: published zero renders $0 and never Unknown, missing cache rate renders the dash and never Unknown, broken input lookup still renders Unknown, every missing rate on an upstream_actual alias renders Variable. Red before the fix (4 stray Unknown strings), green after.
- [x] Full unit suite: `npm run test:unit` 65 files, 728 tests passed.
- [x] `npm run build` green.
- [ ] Post-merge deploy screenshot per visual-proof policy (orchestrator step).

## Buglog entry

```json
{"ts":"2026-08-26T06:45:00Z","source":"console-currency-format-pr","error_message":"model detail page rendered missing cache rates on fixed aliases as Unknown while the catalog list rendered the same data as a dash, and the analytics blended price note truncated fractional credits (89.46 shown as 89)","root_cause":"detail page cache tile and cache table rows called formatModelPrice instead of formatCachePrice, bypassing the documented cache absence policy; blended note used truncating formatCredits for a fractional credits-per-million figure","fix":"route all detail-page cache surfaces through formatCachePrice with a cache flag on price rows, explain the dash in card copy, switch blended note to formatNumber","tags":["web-console","pricing","formatting","parity"]}
```

Co-authored-by: Claude Fable 5 <noreply@anthropic.com>