### PR TITLE
test: fail loudly in CI when DB-gated suites would silently skip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -475,7 +475,14 @@ jobs:
             # helper this wiring turns on). Removed from KNOWN_DARK in the
             # same change, since the lint fails if a package both runs and
             # stays listed as debt.
-            go test -tags integration -count=1 -p 1 -v ./internal/accounts/... ./internal/accounting/... ./internal/budgets/... ./internal/byok/... ./internal/ledger/... ./internal/agentsched/... ./internal/agenttask/... ./internal/usermemories/... ./internal/egress/... ./internal/payments/... ./internal/profiles/... ./internal/rag/... ./internal/tenants/... ./internal/signup/... ./internal/routing/... ./internal/litellmconfig/... ./internal/catalog/... ./internal/providers/... ./internal/platform ./internal/platform/db/... ./internal/marketplace/... ./internal/usage/... ./internal/tenant/...
+            # 2026-08-26 un-skip pass (owner-directed coverage audit): audit,
+            # auditarchive, auditverifier, auditworker, licensing and
+            # tests/compliance join this step's package list. Their DSN gates
+            # now fail loudly in CI instead of skipping silently, and their
+            # suites run against real Postgres for the first time; a suite
+            # that has never run is not known to pass, which is exactly what
+            # this step proves.
+            go test -tags integration -count=1 -p 1 -v ./internal/accounts/... ./internal/accounting/... ./internal/audit/... ./internal/auditarchive/... ./internal/auditverifier/... ./internal/auditworker/... ./internal/licensing/... ./tests/compliance/... ./internal/budgets/... ./internal/byok/... ./internal/ledger/... ./internal/agentsched/... ./internal/agenttask/... ./internal/usermemories/... ./internal/egress/... ./internal/payments/... ./internal/profiles/... ./internal/rag/... ./internal/tenants/... ./internal/signup/... ./internal/routing/... ./internal/litellmconfig/... ./internal/catalog/... ./internal/providers/... ./internal/platform ./internal/platform/db/... ./internal/marketplace/... ./internal/usage/... ./internal/tenant/...
           else
             # -tags integration additionally compiles in
             # inference/chat_completions_integration_test.go (issue #708),

--- a/apps/control-plane/internal/accounting/release_idempotency_test.go
+++ b/apps/control-plane/internal/accounting/release_idempotency_test.go
@@ -68,7 +68,10 @@ func seedReleaseIdempotencyAccount(t *testing.T, pool *pgxpool.Pool) uuid.UUID {
 		 VALUES (gen_random_uuid(), $1, '{}'::jsonb) RETURNING id`,
 		"release-idempotency-"+uuid.NewString()+"@test.local",
 	).Scan(&userID); err != nil {
-		t.Skipf("seed auth.users failed (is this a migrated test DB?): %v", err)
+		// Fatal, not Skip, matching balance_over_release_live_test.go: the CI
+		// live leg bootstraps the full migration chain, so a seed failure here
+		// is a schema regression that skipping would report green.
+		t.Fatalf("seed auth.users failed (is this a migrated test DB?): %v", err)
 	}
 
 	var accountID uuid.UUID

--- a/apps/control-plane/internal/agentsched/repository_test.go
+++ b/apps/control-plane/internal/agentsched/repository_test.go
@@ -21,6 +21,14 @@ func newRLSTestPool(t *testing.T) *pgxpool.Pool {
 	t.Helper()
 	dsn := os.Getenv("HIVE_TEST_DB_URL")
 	if dsn == "" {
+		// CI wires HIVE_TEST_DB_URL for the live-Postgres step and passes
+		// -short for the step that has none, so a missing DSN there is a wiring
+		// defect (the silent-green never-runs shape of issues #701/#708/#797),
+		// not a laptop without Postgres. Fail loudly in CI live leg; local runs
+		// without a test database still skip.
+		if os.Getenv("CI") != "" && !testing.Short() {
+			t.Fatal("HIVE_TEST_DB_URL not set in CI: this suite guards a real-SQL proof and must not silently skip")
+		}
 		t.Skip("HIVE_TEST_DB_URL not set")
 	}
 	if !strings.Contains(strings.ToLower(dsn), "test") {
@@ -40,6 +48,11 @@ func newRLSTestPool(t *testing.T) *pgxpool.Pool {
 	}
 	if _, err := pool.Exec(ctx, "SET ROLE hive_app"); err != nil {
 		pool.Close()
+		// Same loudness contract as the DSN gate: role provisioning failure in
+		// CI is a schema regression, never a normal day.
+		if os.Getenv("CI") != "" && !testing.Short() {
+			t.Fatalf("SET ROLE hive_app failed: %v", err)
+		}
 		t.Skipf("SET ROLE hive_app failed: %v", err)
 	}
 	t.Cleanup(pool.Close)

--- a/apps/control-plane/internal/agenttask/repository_test.go
+++ b/apps/control-plane/internal/agenttask/repository_test.go
@@ -22,6 +22,14 @@ func newRLSTestPool(t *testing.T) *pgxpool.Pool {
 	t.Helper()
 	dsn := os.Getenv("HIVE_TEST_DB_URL")
 	if dsn == "" {
+		// CI wires HIVE_TEST_DB_URL for the live-Postgres step and passes
+		// -short for the step that has none, so a missing DSN there is a wiring
+		// defect (the silent-green never-runs shape of issues #701/#708/#797),
+		// not a laptop without Postgres. Fail loudly in CI live leg; local runs
+		// without a test database still skip.
+		if os.Getenv("CI") != "" && !testing.Short() {
+			t.Fatal("HIVE_TEST_DB_URL not set in CI: this suite guards a real-SQL proof and must not silently skip")
+		}
 		t.Skip("HIVE_TEST_DB_URL not set")
 	}
 	if !strings.Contains(strings.ToLower(dsn), "test") {
@@ -41,6 +49,11 @@ func newRLSTestPool(t *testing.T) *pgxpool.Pool {
 	}
 	if _, err := pool.Exec(ctx, "SET ROLE hive_app"); err != nil {
 		pool.Close()
+		// Same loudness contract as the DSN gate: role provisioning failure in
+		// CI is a schema regression, never a normal day.
+		if os.Getenv("CI") != "" && !testing.Short() {
+			t.Fatalf("SET ROLE hive_app failed (is hive_app provisioned + migrations applied on this test DB?): %v", err)
+		}
 		t.Skipf("SET ROLE hive_app failed (is hive_app provisioned + migrations applied on this test DB?): %v", err)
 	}
 	t.Cleanup(pool.Close)

--- a/apps/control-plane/internal/audit/log_test.go
+++ b/apps/control-plane/internal/audit/log_test.go
@@ -94,6 +94,14 @@ func newPool(t *testing.T, ctx context.Context) *pgxpool.Pool {
 	t.Helper()
 	dsn := os.Getenv("HIVE_TEST_DB_URL")
 	if dsn == "" {
+		// CI wires HIVE_TEST_DB_URL for the live-Postgres step and passes
+		// -short for the step that has none, so a missing DSN there is a wiring
+		// defect (the silent-green never-runs shape of issues #701/#708/#797),
+		// not a laptop without Postgres. Fail loudly in CI live leg; local runs
+		// without a test database still skip.
+		if os.Getenv("CI") != "" && !testing.Short() {
+			t.Fatal("HIVE_TEST_DB_URL not set in CI: this suite guards a real-SQL proof and must not silently skip")
+		}
 		t.Skip("HIVE_TEST_DB_URL not set")
 	}
 	pool, err := pgxpool.New(ctx, dsn)

--- a/apps/control-plane/internal/audit/sync_concurrency_test.go
+++ b/apps/control-plane/internal/audit/sync_concurrency_test.go
@@ -127,6 +127,14 @@ func newSyncConcurrencyPool(t *testing.T, ctx context.Context) *pgxpool.Pool {
 	t.Helper()
 	dsn := os.Getenv("HIVE_TEST_DB_URL")
 	if dsn == "" {
+		// CI wires HIVE_TEST_DB_URL for the live-Postgres step and passes
+		// -short for the step that has none, so a missing DSN there is a wiring
+		// defect (the silent-green never-runs shape of issues #701/#708/#797),
+		// not a laptop without Postgres. Fail loudly in CI live leg; local runs
+		// without a test database still skip.
+		if os.Getenv("CI") != "" && !testing.Short() {
+			t.Fatal("HIVE_TEST_DB_URL not set in CI: this suite guards a real-SQL proof and must not silently skip")
+		}
 		t.Skip("HIVE_TEST_DB_URL not set")
 	}
 	pool, err := pgxpool.New(ctx, dsn)

--- a/apps/control-plane/internal/audit/wal_test.go
+++ b/apps/control-plane/internal/audit/wal_test.go
@@ -56,6 +56,14 @@ func newWALPool(t *testing.T, ctx context.Context) *pgxpool.Pool {
 	t.Helper()
 	dsn := os.Getenv("HIVE_TEST_DB_URL")
 	if dsn == "" {
+		// CI wires HIVE_TEST_DB_URL for the live-Postgres step and passes
+		// -short for the step that has none, so a missing DSN there is a wiring
+		// defect (the silent-green never-runs shape of issues #701/#708/#797),
+		// not a laptop without Postgres. Fail loudly in CI live leg; local runs
+		// without a test database still skip.
+		if os.Getenv("CI") != "" && !testing.Short() {
+			t.Fatal("HIVE_TEST_DB_URL not set in CI: this suite guards a real-SQL proof and must not silently skip")
+		}
 		t.Skip("HIVE_TEST_DB_URL not set")
 	}
 	pool, err := pgxpool.New(ctx, dsn)

--- a/apps/control-plane/internal/auditarchive/repository_rls_test.go
+++ b/apps/control-plane/internal/auditarchive/repository_rls_test.go
@@ -32,6 +32,14 @@ func newRLSTestPool(t *testing.T, role string) *pgxpool.Pool {
 	t.Helper()
 	dsn := os.Getenv("HIVE_TEST_DB_URL")
 	if dsn == "" {
+		// CI wires HIVE_TEST_DB_URL for the live-Postgres step and passes
+		// -short for the step that has none, so a missing DSN there is a wiring
+		// defect (the silent-green never-runs shape of issues #701/#708/#797),
+		// not a laptop without Postgres. Fail loudly in CI live leg; local runs
+		// without a test database still skip.
+		if os.Getenv("CI") != "" && !testing.Short() {
+			t.Fatal("HIVE_TEST_DB_URL not set in CI: this suite guards a real-SQL proof and must not silently skip")
+		}
 		t.Skip("HIVE_TEST_DB_URL not set")
 	}
 	if !strings.Contains(strings.ToLower(dsn), "test") {
@@ -51,6 +59,11 @@ func newRLSTestPool(t *testing.T, role string) *pgxpool.Pool {
 	}
 	if _, err := pool.Exec(ctx, "SET ROLE "+role); err != nil {
 		pool.Close()
+		// Same loudness contract as the DSN gate: role provisioning failure in
+		// CI is a schema regression, never a normal day.
+		if os.Getenv("CI") != "" && !testing.Short() {
+			t.Fatalf("SET ROLE %s failed (is %s provisioned + migrations applied on this test DB?): %v", role, role, err)
+		}
 		t.Skipf("SET ROLE %s failed (is %s provisioned + migrations applied on this test DB?): %v", role, role, err)
 	}
 	t.Cleanup(pool.Close)
@@ -72,6 +85,14 @@ func seedTenant(t *testing.T, id uuid.UUID) {
 	// the skip, an empty DSN falls back to a local unix socket and the seed
 	// fails in CI (which is TCP-only) instead of skipping like the pool helper.
 	if dsn == "" {
+		// CI wires HIVE_TEST_DB_URL for the live-Postgres step and passes
+		// -short for the step that has none, so a missing DSN there is a wiring
+		// defect (the silent-green never-runs shape of issues #701/#708/#797),
+		// not a laptop without Postgres. Fail loudly in CI live leg; local runs
+		// without a test database still skip.
+		if os.Getenv("CI") != "" && !testing.Short() {
+			t.Fatal("HIVE_TEST_DB_URL not set in CI: this suite guards a real-SQL proof and must not silently skip")
+		}
 		t.Skip("HIVE_TEST_DB_URL not set")
 	}
 	if !strings.Contains(strings.ToLower(dsn), "test") {

--- a/apps/control-plane/internal/auditverifier/verifier_test.go
+++ b/apps/control-plane/internal/auditverifier/verifier_test.go
@@ -60,6 +60,11 @@ func TestVerifierTamperedRowDetected(t *testing.T) {
 		 WHERE id = (SELECT id FROM first)
 		   AND ts = (SELECT ts FROM first)`)
 	if err != nil {
+		// Same loudness contract as the DSN gate: a tamper UPDATE failing in CI
+		// means privilege or policy wiring regressed; never a normal day.
+		if os.Getenv("CI") != "" && !testing.Short() {
+			t.Fatal("tamper UPDATE failed in CI: owner privilege or audit_log policy regressed")
+		}
 		t.Skip("tamper requires owner privilege on test DB")
 	}
 
@@ -73,6 +78,14 @@ func newVerifierPool(t *testing.T, ctx context.Context) *pgxpool.Pool {
 	t.Helper()
 	dsn := os.Getenv("HIVE_TEST_DB_URL")
 	if dsn == "" {
+		// CI wires HIVE_TEST_DB_URL for the live-Postgres step and passes
+		// -short for the step that has none, so a missing DSN there is a wiring
+		// defect (the silent-green never-runs shape of issues #701/#708/#797),
+		// not a laptop without Postgres. Fail loudly in CI live leg; local runs
+		// without a test database still skip.
+		if os.Getenv("CI") != "" && !testing.Short() {
+			t.Fatal("HIVE_TEST_DB_URL not set in CI: this suite guards a real-SQL proof and must not silently skip")
+		}
 		t.Skip("HIVE_TEST_DB_URL not set")
 	}
 	pool, err := pgxpool.New(ctx, dsn)

--- a/apps/control-plane/internal/auditverifier/verifier_test.go
+++ b/apps/control-plane/internal/auditverifier/verifier_test.go
@@ -18,6 +18,7 @@ func TestVerifierChainOKReturnsNoMismatch(t *testing.T) {
 
 	pool := newVerifierPool(t, ctx)
 	t.Cleanup(func() { pool.Close() })
+	resetAuditLog(t, ctx, pool)
 
 	writer := audit.NewSyncWriter(pool, audit.WriterConfig{DeploySHA: "s", Env: "test"})
 	for i := 0; i < 3; i++ {
@@ -40,6 +41,7 @@ func TestVerifierTamperedRowDetected(t *testing.T) {
 
 	pool := newVerifierPool(t, ctx)
 	t.Cleanup(func() { pool.Close() })
+	resetAuditLog(t, ctx, pool)
 
 	writer := audit.NewSyncWriter(pool, audit.WriterConfig{DeploySHA: "s", Env: "test"})
 	require.NoError(t, writer.Write(ctx, audit.Event{
@@ -72,6 +74,23 @@ func TestVerifierTamperedRowDetected(t *testing.T) {
 	mismatches, err := v.VerifyPartition(ctx, time.Now())
 	require.NoError(t, err)
 	require.GreaterOrEqual(t, mismatches, 1)
+}
+
+// resetAuditLog makes the live tests hermetic on a shared sequential-run
+// database: the CI live leg runs every package against ONE Postgres with
+// -p 1, so this suite's whole-partition "zero mismatches" assertion and the
+// first-row-by-seq tamper UPDATE both see rows other suites left behind. The
+// tamper test corrupted another tenant's chain and broke this suite the first
+// time it ever actually ran (found by the 2026-08-26 un-skip pass); it had
+// been silently skipping everywhere before that.
+func resetAuditLog(t *testing.T, ctx context.Context, pool *pgxpool.Pool) {
+	t.Helper()
+	if _, err := pool.Exec(ctx, "DELETE FROM public.audit_log"); err != nil {
+		t.Fatalf("reset audit_log: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), "DELETE FROM public.audit_log")
+	})
 }
 
 func newVerifierPool(t *testing.T, ctx context.Context) *pgxpool.Pool {

--- a/apps/control-plane/internal/auditworker/worker_test.go
+++ b/apps/control-plane/internal/auditworker/worker_test.go
@@ -116,6 +116,14 @@ func newWorkerPool(t *testing.T, ctx context.Context) *pgxpool.Pool {
 	t.Helper()
 	dsn := os.Getenv("HIVE_TEST_DB_URL")
 	if dsn == "" {
+		// CI wires HIVE_TEST_DB_URL for the live-Postgres step and passes
+		// -short for the step that has none, so a missing DSN there is a wiring
+		// defect (the silent-green never-runs shape of issues #701/#708/#797),
+		// not a laptop without Postgres. Fail loudly in CI live leg; local runs
+		// without a test database still skip.
+		if os.Getenv("CI") != "" && !testing.Short() {
+			t.Fatal("HIVE_TEST_DB_URL not set in CI: this suite guards a real-SQL proof and must not silently skip")
+		}
 		t.Skip("HIVE_TEST_DB_URL not set")
 	}
 	pool, err := pgxpool.New(ctx, dsn)

--- a/apps/control-plane/internal/budgets/repository_live_test.go
+++ b/apps/control-plane/internal/budgets/repository_live_test.go
@@ -36,6 +36,14 @@ func newBudgetsTestPool(t *testing.T) *pgxpool.Pool {
 	t.Helper()
 	dsn := os.Getenv("HIVE_TEST_DB_URL")
 	if dsn == "" {
+		// CI wires HIVE_TEST_DB_URL for the live-Postgres step and passes
+		// -short for the step that has none, so a missing DSN there is a wiring
+		// defect (the silent-green never-runs shape of issues #701/#708/#797),
+		// not a laptop without Postgres. Fail loudly in CI live leg; local runs
+		// without a test database still skip.
+		if os.Getenv("CI") != "" && !testing.Short() {
+			t.Fatal("HIVE_TEST_DB_URL not set in CI: this suite guards a real-SQL proof and must not silently skip")
+		}
 		t.Skip("HIVE_TEST_DB_URL not set")
 	}
 	if !strings.Contains(strings.ToLower(dsn), "test") {

--- a/apps/control-plane/internal/byok/repository_test.go
+++ b/apps/control-plane/internal/byok/repository_test.go
@@ -24,6 +24,14 @@ func requireRepoTestDSN(t *testing.T) string {
 	t.Helper()
 	dsn := os.Getenv("HIVE_TEST_DB_URL")
 	if dsn == "" {
+		// CI wires HIVE_TEST_DB_URL for the live-Postgres step and passes
+		// -short for the step that has none, so a missing DSN there is a wiring
+		// defect (the silent-green never-runs shape of issues #701/#708/#797),
+		// not a laptop without Postgres. Fail loudly in CI live leg; local runs
+		// without a test database still skip.
+		if os.Getenv("CI") != "" && !testing.Short() {
+			t.Fatal("HIVE_TEST_DB_URL not set in CI: this suite guards a real-SQL proof and must not silently skip")
+		}
 		t.Skip("HIVE_TEST_DB_URL not set")
 	}
 	return dsn
@@ -72,6 +80,11 @@ func TestRepositoryIsolationAgainstRealSQL(t *testing.T) {
 
 	pool, err := pgxpool.New(ctx, dsn)
 	if err != nil {
+		// Same loudness contract as the DSN gate: role provisioning failure in
+		// CI is a schema regression, never a normal day.
+		if os.Getenv("CI") != "" && !testing.Short() {
+			t.Fatalf("test database unreachable in CI: %v", err)
+		}
 		t.Skipf("test database unreachable: %v", err)
 	}
 	defer pool.Close()
@@ -143,6 +156,11 @@ func TestRepositoryUniqueConstraintsAgainstRealSQL(t *testing.T) {
 
 	pool, err := pgxpool.New(ctx, dsn)
 	if err != nil {
+		// Same loudness contract as the DSN gate: role provisioning failure in
+		// CI is a schema regression, never a normal day.
+		if os.Getenv("CI") != "" && !testing.Short() {
+			t.Fatalf("test database unreachable in CI: %v", err)
+		}
 		t.Skipf("test database unreachable: %v", err)
 	}
 	defer pool.Close()

--- a/apps/control-plane/internal/egress/repository_test.go
+++ b/apps/control-plane/internal/egress/repository_test.go
@@ -23,6 +23,14 @@ func newRLSTestPool(t *testing.T) *pgxpool.Pool {
 	t.Helper()
 	dsn := os.Getenv("HIVE_TEST_DB_URL")
 	if dsn == "" {
+		// CI wires HIVE_TEST_DB_URL for the live-Postgres step and passes
+		// -short for the step that has none, so a missing DSN there is a wiring
+		// defect (the silent-green never-runs shape of issues #701/#708/#797),
+		// not a laptop without Postgres. Fail loudly in CI live leg; local runs
+		// without a test database still skip.
+		if os.Getenv("CI") != "" && !testing.Short() {
+			t.Fatal("HIVE_TEST_DB_URL not set in CI: this suite guards a real-SQL proof and must not silently skip")
+		}
 		t.Skip("HIVE_TEST_DB_URL not set")
 	}
 	if !strings.Contains(strings.ToLower(dsn), "test") {
@@ -42,6 +50,11 @@ func newRLSTestPool(t *testing.T) *pgxpool.Pool {
 	}
 	if _, err := pool.Exec(ctx, "SET ROLE hive_app"); err != nil {
 		pool.Close()
+		// Same loudness contract as the DSN gate: role provisioning failure in
+		// CI is a schema regression, never a normal day.
+		if os.Getenv("CI") != "" && !testing.Short() {
+			t.Fatalf("SET ROLE hive_app failed (is hive_app provisioned + migrations applied on this test DB?): %v", err)
+		}
 		t.Skipf("SET ROLE hive_app failed (is hive_app provisioned + migrations applied on this test DB?): %v", err)
 	}
 	t.Cleanup(pool.Close)

--- a/apps/control-plane/internal/licensing/repository_test.go
+++ b/apps/control-plane/internal/licensing/repository_test.go
@@ -19,6 +19,14 @@ func newTestPool(t *testing.T, ctx context.Context) (*pgxpool.Pool, func()) {
 	t.Helper()
 	dsn := os.Getenv("HIVE_TEST_DB_URL")
 	if dsn == "" {
+		// CI wires HIVE_TEST_DB_URL for the live-Postgres step and passes
+		// -short for the step that has none, so a missing DSN there is a wiring
+		// defect (the silent-green never-runs shape of issues #701/#708/#797),
+		// not a laptop without Postgres. Fail loudly in CI live leg; local runs
+		// without a test database still skip.
+		if os.Getenv("CI") != "" && !testing.Short() {
+			t.Fatal("HIVE_TEST_DB_URL not set in CI: this suite guards a real-SQL proof and must not silently skip")
+		}
 		t.Skip("HIVE_TEST_DB_URL not set")
 	}
 	if !strings.Contains(strings.ToLower(dsn), "test") {

--- a/apps/control-plane/internal/payments/settlement_live_db_test.go
+++ b/apps/control-plane/internal/payments/settlement_live_db_test.go
@@ -41,7 +41,10 @@ func seedPaymentsAccount(t *testing.T, pool *pgxpool.Pool) uuid.UUID {
 		 VALUES (gen_random_uuid(), $1, '{}'::jsonb) RETURNING id`,
 		"payment-settlement-"+uuid.NewString()+"@test.local",
 	).Scan(&userID); err != nil {
-		t.Skipf("seed auth.users failed (is this a migrated test DB?): %v", err)
+		// Fatal, not Skip, matching balance_over_release_live_test.go: the CI
+		// live leg bootstraps the full migration chain, so a seed failure here
+		// is a schema regression that skipping would report green.
+		t.Fatalf("seed auth.users failed (is this a migrated test DB?): %v", err)
 	}
 
 	var accountID uuid.UUID

--- a/apps/control-plane/internal/platform/db/pool_test.go
+++ b/apps/control-plane/internal/platform/db/pool_test.go
@@ -332,6 +332,14 @@ func TestOpen_ErrorWrapping(t *testing.T) {
 func TestSessionPoolReleasesIdleConnections(t *testing.T) {
 	base := os.Getenv("HIVE_TEST_DB_URL")
 	if base == "" {
+		// CI wires HIVE_TEST_DB_URL for the live-Postgres step and passes
+		// -short for the step that has none, so a missing DSN there is a wiring
+		// defect (the silent-green never-runs shape of issues #701/#708/#797),
+		// not a laptop without Postgres. Fail loudly in CI live leg; local runs
+		// without a test database still skip.
+		if os.Getenv("CI") != "" && !testing.Short() {
+			t.Fatal("HIVE_TEST_DB_URL not set in CI: this suite guards a real-SQL proof and must not silently skip")
+		}
 		t.Skip("HIVE_TEST_DB_URL not set; this test needs a live Postgres")
 	}
 

--- a/apps/control-plane/internal/platform/membership_role_rls_test.go
+++ b/apps/control-plane/internal/platform/membership_role_rls_test.go
@@ -48,6 +48,14 @@ func requireAccountRoleTestDSN(t *testing.T) string {
 	t.Helper()
 	dsn := os.Getenv("HIVE_TEST_DB_URL")
 	if dsn == "" {
+		// CI wires HIVE_TEST_DB_URL for the live-Postgres step and passes
+		// -short for the step that has none, so a missing DSN there is a wiring
+		// defect (the silent-green never-runs shape of issues #701/#708/#797),
+		// not a laptop without Postgres. Fail loudly in CI live leg; local runs
+		// without a test database still skip.
+		if os.Getenv("CI") != "" && !testing.Short() {
+			t.Fatal(skipNoTestDSN + " in CI: this membership RLS suite must not silently skip")
+		}
 		t.Skip(skipNoTestDSN)
 	}
 	cfg, err := pgxpool.ParseConfig(dsn)

--- a/apps/control-plane/internal/profiles/repository_billing_join_test.go
+++ b/apps/control-plane/internal/profiles/repository_billing_join_test.go
@@ -19,6 +19,14 @@ func newBillingJoinTestPool(t *testing.T) *pgxpool.Pool {
 	t.Helper()
 	dsn := os.Getenv("HIVE_TEST_DB_URL")
 	if dsn == "" {
+		// CI wires HIVE_TEST_DB_URL for the live-Postgres step and passes
+		// -short for the step that has none, so a missing DSN there is a wiring
+		// defect (the silent-green never-runs shape of issues #701/#708/#797),
+		// not a laptop without Postgres. Fail loudly in CI live leg; local runs
+		// without a test database still skip.
+		if os.Getenv("CI") != "" && !testing.Short() {
+			t.Fatal("HIVE_TEST_DB_URL not set in CI: this suite guards a real-SQL proof and must not silently skip")
+		}
 		t.Skip("HIVE_TEST_DB_URL not set")
 	}
 	if !strings.Contains(strings.ToLower(dsn), "test") {

--- a/apps/control-plane/internal/rag/provision_test.go
+++ b/apps/control-plane/internal/rag/provision_test.go
@@ -20,6 +20,14 @@ func newProvisionTestPool(t *testing.T) *pgxpool.Pool {
 	t.Helper()
 	dsn := os.Getenv("HIVE_TEST_DB_URL")
 	if dsn == "" {
+		// CI wires HIVE_TEST_DB_URL for the live-Postgres step and passes
+		// -short for the step that has none, so a missing DSN there is a wiring
+		// defect (the silent-green never-runs shape of issues #701/#708/#797),
+		// not a laptop without Postgres. Fail loudly in CI live leg; local runs
+		// without a test database still skip.
+		if os.Getenv("CI") != "" && !testing.Short() {
+			t.Fatal("HIVE_TEST_DB_URL not set in CI: this suite guards a real-SQL proof and must not silently skip")
+		}
 		t.Skip("HIVE_TEST_DB_URL not set")
 	}
 	if !strings.Contains(strings.ToLower(dsn), "test") {

--- a/apps/control-plane/internal/rag/repository_rls_test.go
+++ b/apps/control-plane/internal/rag/repository_rls_test.go
@@ -22,6 +22,14 @@ func newRLSTestPool(t *testing.T) *pgxpool.Pool {
 	t.Helper()
 	dsn := os.Getenv("HIVE_TEST_DB_URL")
 	if dsn == "" {
+		// CI wires HIVE_TEST_DB_URL for the live-Postgres step and passes
+		// -short for the step that has none, so a missing DSN there is a wiring
+		// defect (the silent-green never-runs shape of issues #701/#708/#797),
+		// not a laptop without Postgres. Fail loudly in CI live leg; local runs
+		// without a test database still skip.
+		if os.Getenv("CI") != "" && !testing.Short() {
+			t.Fatal("HIVE_TEST_DB_URL not set in CI: this suite guards a real-SQL proof and must not silently skip")
+		}
 		t.Skip("HIVE_TEST_DB_URL not set")
 	}
 	if !strings.Contains(strings.ToLower(dsn), "test") {
@@ -41,6 +49,11 @@ func newRLSTestPool(t *testing.T) *pgxpool.Pool {
 	}
 	if _, err := pool.Exec(ctx, "SET ROLE hive_app"); err != nil {
 		pool.Close()
+		// Same loudness contract as the DSN gate: role provisioning failure in
+		// CI is a schema regression, never a normal day.
+		if os.Getenv("CI") != "" && !testing.Short() {
+			t.Fatalf("SET ROLE hive_app failed (is hive_app provisioned + migrations applied on this test DB?): %v", err)
+		}
 		t.Skipf("SET ROLE hive_app failed (is hive_app provisioned + migrations applied on this test DB?): %v", err)
 	}
 	t.Cleanup(pool.Close)

--- a/apps/control-plane/internal/signup/webhook_test.go
+++ b/apps/control-plane/internal/signup/webhook_test.go
@@ -269,6 +269,14 @@ func newPool(t *testing.T, ctx context.Context) *pgxpool.Pool {
 	t.Helper()
 	dsn := os.Getenv("HIVE_TEST_DB_URL")
 	if dsn == "" {
+		// CI wires HIVE_TEST_DB_URL for the live-Postgres step and passes
+		// -short for the step that has none, so a missing DSN there is a wiring
+		// defect (the silent-green never-runs shape of issues #701/#708/#797),
+		// not a laptop without Postgres. Fail loudly in CI live leg; local runs
+		// without a test database still skip.
+		if os.Getenv("CI") != "" && !testing.Short() {
+			t.Fatal("HIVE_TEST_DB_URL not set in CI: this suite guards a real-SQL proof and must not silently skip")
+		}
 		t.Skip("HIVE_TEST_DB_URL not set")
 	}
 	pool, err := pgxpool.New(ctx, dsn)

--- a/apps/control-plane/internal/tenants/http_test.go
+++ b/apps/control-plane/internal/tenants/http_test.go
@@ -31,6 +31,14 @@ func newTenantsPool(t *testing.T, ctx context.Context) *pgxpool.Pool {
 	t.Helper()
 	dsn := os.Getenv("HIVE_TEST_DB_URL")
 	if dsn == "" {
+		// CI wires HIVE_TEST_DB_URL for the live-Postgres step and passes
+		// -short for the step that has none, so a missing DSN there is a wiring
+		// defect (the silent-green never-runs shape of issues #701/#708/#797),
+		// not a laptop without Postgres. Fail loudly in CI live leg; local runs
+		// without a test database still skip.
+		if os.Getenv("CI") != "" && !testing.Short() {
+			t.Fatal("HIVE_TEST_DB_URL not set in CI: this suite guards a real-SQL proof and must not silently skip")
+		}
 		t.Skip("HIVE_TEST_DB_URL not set")
 	}
 	pool, err := pgxpool.New(ctx, dsn)

--- a/apps/control-plane/internal/usage/repository_test.go
+++ b/apps/control-plane/internal/usage/repository_test.go
@@ -32,7 +32,10 @@ func seedAttemptAccount(t *testing.T, pool *pgxpool.Pool) uuid.UUID {
 		 VALUES (gen_random_uuid(), $1, '{}'::jsonb) RETURNING id`,
 		"attempt-idem-"+uuid.NewString()+"@test.local",
 	).Scan(&userID); err != nil {
-		t.Skipf("seed auth.users failed (is this a migrated test DB?): %v", err)
+		// Fatal, not Skip, matching balance_over_release_live_test.go: the CI
+		// live leg bootstraps the full migration chain, so a seed failure here
+		// is a schema regression that skipping would report green.
+		t.Fatalf("seed auth.users failed (is this a migrated test DB?): %v", err)
 	}
 
 	var accountID uuid.UUID

--- a/apps/control-plane/internal/usermemories/repository_test.go
+++ b/apps/control-plane/internal/usermemories/repository_test.go
@@ -20,6 +20,14 @@ func newRLSTestPool(t *testing.T) *pgxpool.Pool {
 	t.Helper()
 	dsn := os.Getenv("HIVE_TEST_DB_URL")
 	if dsn == "" {
+		// CI wires HIVE_TEST_DB_URL for the live-Postgres step and passes
+		// -short for the step that has none, so a missing DSN there is a wiring
+		// defect (the silent-green never-runs shape of issues #701/#708/#797),
+		// not a laptop without Postgres. Fail loudly in CI live leg; local runs
+		// without a test database still skip.
+		if os.Getenv("CI") != "" && !testing.Short() {
+			t.Fatal("HIVE_TEST_DB_URL not set in CI: this suite guards a real-SQL proof and must not silently skip")
+		}
 		t.Skip("HIVE_TEST_DB_URL not set")
 	}
 	if !strings.Contains(strings.ToLower(dsn), "test") {
@@ -37,6 +45,11 @@ func newRLSTestPool(t *testing.T) *pgxpool.Pool {
 	}
 	if _, err := pool.Exec(ctx, "SET ROLE hive_app"); err != nil {
 		pool.Close()
+		// Same loudness contract as the DSN gate: role provisioning failure in
+		// CI is a schema regression, never a normal day.
+		if os.Getenv("CI") != "" && !testing.Short() {
+			t.Fatalf("SET ROLE hive_app failed: %v", err)
+		}
 		t.Skipf("SET ROLE hive_app failed: %v", err)
 	}
 	t.Cleanup(pool.Close)

--- a/apps/control-plane/tests/compliance/audit_chain_integrity_test.go
+++ b/apps/control-plane/tests/compliance/audit_chain_integrity_test.go
@@ -49,6 +49,14 @@ func newPool(t *testing.T, ctx context.Context) *pgxpool.Pool {
 	t.Helper()
 	dsn := os.Getenv("HIVE_TEST_DB_URL")
 	if dsn == "" {
+		// CI wires HIVE_TEST_DB_URL for the live-Postgres step and passes
+		// -short for the step that has none, so a missing DSN there is a wiring
+		// defect (the silent-green never-runs shape of issues #701/#708/#797),
+		// not a laptop without Postgres. Fail loudly in CI live leg; local runs
+		// without a test database still skip.
+		if os.Getenv("CI") != "" && !testing.Short() {
+			t.Fatal("HIVE_TEST_DB_URL not set in CI: this suite guards a real-SQL proof and must not silently skip")
+		}
 		t.Skip("HIVE_TEST_DB_URL not set")
 	}
 	pool, err := pgxpool.New(ctx, dsn)

--- a/apps/control-plane/tests/compliance/audit_coverage_test.go
+++ b/apps/control-plane/tests/compliance/audit_coverage_test.go
@@ -16,6 +16,14 @@ import (
 // failure once those phases land.
 func TestAuditCoverage_AllControlsHaveEvents(t *testing.T) {
 	if os.Getenv("HIVE_TEST_DB_URL") == "" {
+		// CI wires HIVE_TEST_DB_URL for the live-Postgres step and passes
+		// -short for the step that has none, so a missing DSN there is a wiring
+		// defect (the silent-green never-runs shape of issues #701/#708/#797),
+		// not a laptop without Postgres. Fail loudly in CI live leg; local runs
+		// without a test database still skip.
+		if os.Getenv("CI") != "" && !testing.Short() {
+			t.Fatal("HIVE_TEST_DB_URL not set in CI: the SOC2 coverage check must not silently skip")
+		}
 		t.Skip("HIVE_TEST_DB_URL not set")
 	}
 

--- a/apps/edge-api/internal/artifacts/repository_rls_test.go
+++ b/apps/edge-api/internal/artifacts/repository_rls_test.go
@@ -18,6 +18,14 @@ func newRLSTestPool(t *testing.T) *pgxpool.Pool {
 	t.Helper()
 	dsn := os.Getenv("HIVE_TEST_DB_URL")
 	if dsn == "" {
+		// CI wires HIVE_TEST_DB_URL for the live-Postgres step and passes
+		// -short for the step that has none, so a missing DSN there is a wiring
+		// defect (the silent-green never-runs shape of issues #701/#708/#797),
+		// not a laptop without Postgres. Fail loudly in CI live leg; local runs
+		// without a test database still skip.
+		if os.Getenv("CI") != "" && !testing.Short() {
+			t.Fatal("HIVE_TEST_DB_URL not set in CI: this suite guards a real-SQL proof and must not silently skip")
+		}
 		t.Skip("HIVE_TEST_DB_URL not set")
 	}
 	if !strings.Contains(strings.ToLower(dsn), "test") {
@@ -37,6 +45,11 @@ func newRLSTestPool(t *testing.T) *pgxpool.Pool {
 	}
 	if _, err := pool.Exec(ctx, "SET ROLE hive_app"); err != nil {
 		pool.Close()
+		// Same loudness contract as the DSN gate: role provisioning failure in
+		// CI is a schema regression, never a normal day.
+		if os.Getenv("CI") != "" && !testing.Short() {
+			t.Fatalf("SET ROLE hive_app failed (is hive_app provisioned + migrations applied on this test DB?): %v", err)
+		}
 		t.Skipf("SET ROLE hive_app failed (is hive_app provisioned + migrations applied on this test DB?): %v", err)
 	}
 	t.Cleanup(pool.Close)

--- a/apps/edge-api/internal/rag/repository_rls_test.go
+++ b/apps/edge-api/internal/rag/repository_rls_test.go
@@ -22,6 +22,14 @@ func newRLSTestPool(t *testing.T) *pgxpool.Pool {
 	t.Helper()
 	dsn := os.Getenv("HIVE_TEST_DB_URL")
 	if dsn == "" {
+		// CI wires HIVE_TEST_DB_URL for the live-Postgres step and passes
+		// -short for the step that has none, so a missing DSN there is a wiring
+		// defect (the silent-green never-runs shape of issues #701/#708/#797),
+		// not a laptop without Postgres. Fail loudly in CI live leg; local runs
+		// without a test database still skip.
+		if os.Getenv("CI") != "" && !testing.Short() {
+			t.Fatal("HIVE_TEST_DB_URL not set in CI: this suite guards a real-SQL proof and must not silently skip")
+		}
 		t.Skip("HIVE_TEST_DB_URL not set")
 	}
 	if !strings.Contains(strings.ToLower(dsn), "test") {
@@ -41,6 +49,11 @@ func newRLSTestPool(t *testing.T) *pgxpool.Pool {
 	}
 	if _, err := pool.Exec(ctx, "SET ROLE hive_app"); err != nil {
 		pool.Close()
+		// Same loudness contract as the DSN gate: role provisioning failure in
+		// CI is a schema regression, never a normal day.
+		if os.Getenv("CI") != "" && !testing.Short() {
+			t.Fatalf("SET ROLE hive_app failed (is hive_app provisioned + migrations applied on this test DB?): %v", err)
+		}
 		t.Skipf("SET ROLE hive_app failed (is hive_app provisioned + migrations applied on this test DB?): %v", err)
 	}
 	t.Cleanup(pool.Close)

--- a/tools/lint-go-db-test-wiring.mjs
+++ b/tools/lint-go-db-test-wiring.mjs
@@ -41,12 +41,10 @@ const SKIP_DIRS = new Set(["node_modules", "vendor", ".git", "target", "dist", "
 // leaves the workflow's list, and it fails again if a package is exempted here
 // after it starts running.
 const KNOWN_DARK = new Map([
-  ["apps/control-plane/./internal/audit", "#797 backlog, never executed"],
-  ["apps/control-plane/./internal/auditarchive", "#797 backlog, never executed"],
-  ["apps/control-plane/./internal/auditverifier", "#797 backlog, never executed"],
-  ["apps/control-plane/./internal/auditworker", "#797 backlog, never executed"],
-  ["apps/control-plane/./internal/licensing", "#797 backlog, never executed"],
-  ["apps/control-plane/./tests/compliance", "#797 backlog, outside ./internal, never executed"],
+  // audit, auditarchive, auditverifier, auditworker, licensing and
+  // tests/compliance were wired into the go-tests job's live-Postgres step by
+  // the 2026-08-26 un-skip pass: removed here because the lint fails if a
+  // package both runs and is still declared as debt.
   // marketplace, tenant/settings and usage wired into the go-tests job's
   // live-Postgres step by issue #708: removed here because the lint fails
   // if a package both runs and is still declared as debt.


### PR DESCRIPTION
## Problem

The 2026-08-26 owner-directed coverage audit found DB-gated test suites that call t.Skip unconditionally when their DSN env var is unset. A skip and a pass are indistinguishable inside a green check, so suites guarding RLS tenant isolation and money-path idempotency reported green without executing.

packages/dbtest.RequireURL has had the loud contract since issue #708 (skip locally, fail in CI), but 27 files predate or miss it.

## Real count vs the audit's 13

The audit said 13 critical sites: ten killing RLS proofs, three killing money-path idempotency proofs. Enumeration found a larger surface; this PR converts all of it:

| Family | Sites | Files |
|---|---|---|
| Env gates (t.Skip("HIVE_TEST_DB_URL not set")) | 23 | 21 control-plane + 2 edge-api helper sites |
| SET ROLE provisioning skips | 9 | 8 RLS suite helpers |
| Money seed-failure skips (Skipf to Fatalf) | 3 | accounting release idempotency, payments settlement, usage attribution |
| byok unreachable-DB skips | 2 | byok repository isolation proof |
| auditverifier tamper-privilege skip | 1 | auditverifier |
| Total | 38 sites / 27 files | |

The three seed-failure conversions are exactly the money-path idempotency trio (release-key dedup #652, settlement magnitude #616, usage attribution). The ten RLS gate sites sit inside the 23 env-gate conversions (auditarchive x2, rag x2, role_rls, membership_role_rls, usermemories, egress, agentsched, agenttask, plus edge-api artifacts/rag).

## What changes

- Every converted site keeps its local skip (a laptop without Postgres is normal) but fails the test in CI (CI set, not -short) with a message naming what the suite guards.
- Seed failures in money-path suites become fatal, matching balance_over_release_live_test.go's precedent.
- Six never-executed packages join the live-Postgres CI step: audit, auditarchive, auditverifier, auditworker, licensing, tests/compliance. Removed from KNOWN_DARK; wiring lint reports 25 wired pairs, 0 dark debt.
- auditverifier live tests made hermetic (below).

## First real runs found two things

auditverifier test-isolation flaw (fixed here): the tamper test's first-row-by-seq UPDATE corrupted another tenant's chain left by an earlier package on the shared sequential-run database, then the zero-mismatch assertion counted that damage. Both live tests now DELETE FROM public.audit_log around themselves. Not a product bug; writer and verifier agree.

tests/compliance needs node: TestAuditCoverage_AllControlsHaveEvents shells out to node. Ubuntu runners have it preinstalled, so the CI step works as listed; the local throwaway-Postgres proof run needed node added to the toolchain container.

## Proof

Throwaway pgvector/pgvector:pg17 Postgres, full 108-file migration chain applied via the ci.yml recipe:
- control-plane: 33 packages ok against live Postgres, including the six newly-wired ones (audit, auditarchive, auditverifier after the hermeticity fix, auditworker, licensing, tests/compliance).
- edge-api: artifacts + rag RLS suites ok.
- Loud-skip behavior: no env shows visible --- SKIP lines naming the missing DSN; CI=true without env fails with "must not silently skip".

## Buglog entry

```json
{"ts":"2026-08-26","error_message":"auditverifier tamper test corrupted another tenant's hash chain on the shared sequential-run test DB, breaking TestVerifierChainOKReturnsNoMismatch the first time the suite ever ran","root_cause":"tamper UPDATE targets the globally-first row by seq instead of a row the test owns; suite asserted whole-partition invariants on a shared database without isolating its data","fix":"resetAuditLog helper DELETEs audit_log around each live test so both hold regardless of run order; suite previously never ran anywhere because of a silent HIVE_TEST_DB_URL skip","tags":["test-isolation","audit-chain","silent-skip","never-ran"]}
```
