### PR TITLE
test: close two unguarded regressions in PR #1222's identity-leak fixes

### DIFF
--- a/apps/edge-api/internal/inference/stream_fallback_sanitize_test.go
+++ b/apps/edge-api/internal/inference/stream_fallback_sanitize_test.go
@@ -1,0 +1,91 @@
+package inference
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// --- PR #1222 security review round 2, blocking finding 1 ---
+//
+// executeStreaming's typed decode fails on some upstream frames (the
+// DeepSeek-family surprise-frame class covered by unparseableFrameSSEServer
+// in stream_usage_missing_test.go). Before the round-2 fix, that fallback
+// branched on route.Pricing.IsUpstreamActual(): a variable-price route ran
+// the frame through SanitizeVariablePriceFrame, but a FIXED-price route
+// (the D-032 norm for most aliases) wrote the raw upstream line verbatim,
+// id/system_fingerprint and all, with no sanitization and no log line. The
+// fix collapsed both branches onto the one sanitizer, unconditionally.
+//
+// This test exercises the real executeStreaming call site end to end (not a
+// hand-simulated reimplementation) against a fixed-price route, so a revert
+// of the collapse back to the old two-branch shape fails it.
+
+// decodeFailureFixedPriceSSEServer streams one frame that fails typed
+// decode into ChatCompletionChunk (model typed as a number where a string
+// is declared) and carries an upstream id + system_fingerprint in the exact
+// shape the live leak had (OpenRouter gen-* id, PR #1222 evidence), then
+// [DONE].
+func decodeFailureFixedPriceSSEServer() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher := w.(http.Flusher)
+		fmt.Fprintln(w, `data: {"id":"gen-1787734329-THDkSN71nG5F8uAbPdnB","object":"chat.completion.chunk","created":1700000000,"model":42,"system_fingerprint":"fp_deadbeef1234","choices":[{"index":0,"delta":{"content":"hi"},"finish_reason":null}]}`)
+		flusher.Flush()
+		fmt.Fprintln(w, "data: [DONE]")
+		flusher.Flush()
+	}))
+}
+
+// TestExecuteStreaming_FixedPriceDecodeFailureFallback_SanitizesUpstreamIdentity
+// is the regression guard for blocking finding 1: a decode-failure frame on
+// a FIXED-price route (catalogHiveFast, via newRoutingMock -- the branch
+// that shipped raw before the round-2 fix) must never leak the upstream id
+// or system_fingerprint to the client, and must carry a gateway-minted id
+// instead.
+func TestExecuteStreaming_FixedPriceDecodeFailureFallback_SanitizesUpstreamIdentity(t *testing.T) {
+	rec := &accountingRecorder{}
+	acctSrv := newAccountingMock(rec)
+	defer acctSrv.Close()
+
+	litellmSrv := decodeFailureFixedPriceSSEServer()
+	defer litellmSrv.Close()
+
+	// catalogHiveFast (settle_from_catalog_test.go) is FixedPricing:
+	// IsUpstreamActual() must be false here, exactly the branch that used
+	// to skip sanitization entirely.
+	routingSrv := newRoutingMock(litellmSrv.URL)
+	defer routingSrv.Close()
+
+	orch := newAuthorizedOrchestrator(acctSrv.URL, routingSrv.URL, litellmSrv.URL)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{}`))
+	req.Header.Set("Authorization", "Bearer test-token")
+	w := newHeaderCommitRecorder()
+	doneCh := make(chan struct{})
+	go func() {
+		defer close(doneCh)
+		_ = orch.executeStreaming(context.Background(), w, req, EndpointChatCompletions, []byte(`{}`), "gpt-4o", "gpt-4o",
+			NeedFlags{NeedChatCompletions: true, NeedStreaming: true}, 10000, false, nil, orch.litellm.ChatCompletion)
+	}()
+	waitDone(t, doneCh)
+
+	body := w.Body.String()
+
+	if strings.Contains(body, "gen-1787734329-THDkSN71nG5F8uAbPdnB") {
+		t.Errorf("fixed-price decode-failure fallback leaked the raw upstream id verbatim:\n%s", body)
+	}
+	if strings.Contains(body, "system_fingerprint") {
+		t.Errorf("fixed-price decode-failure fallback leaked the system_fingerprint key:\n%s", body)
+	}
+	if strings.Contains(body, "fp_deadbeef1234") {
+		t.Errorf("fixed-price decode-failure fallback leaked the system_fingerprint value:\n%s", body)
+	}
+	if !strings.Contains(body, `"id":"chatcmpl-`) {
+		t.Fatalf("expected a gateway-minted chatcmpl- id in the sanitized fallback output, got:\n%s", body)
+	}
+}

--- a/apps/edge-api/internal/rag/chat_handler_test.go
+++ b/apps/edge-api/internal/rag/chat_handler_test.go
@@ -246,7 +246,12 @@ func TestHandleChat_ChatNotConfigured_Returns503(t *testing.T) {
 // cannedSSEResponse includes an event: line carrying a provider name so the
 // test proves non-data upstream lines are dropped (never relayed): if the
 // relay forwarded it, assertNoLeak would catch "groq" in the response body.
-const cannedSSEResponse = `data: {"id":"up-1","object":"chat.completion.chunk","model":"route-groq-fast","choices":[{"index":0,"delta":{"content":"The answer"}}]}
+// The first chunk also carries a system_fingerprint (the PR #1222 third-leak
+// shape: Groq's own fingerprint value), so a regression that drops the
+// `delete(chunk, "system_fingerprint")` line in streamGroundedChat fails the
+// assertions below instead of passing silently -- the fixture had never
+// carried this field before, so nothing could catch its removal.
+const cannedSSEResponse = `data: {"id":"up-1","object":"chat.completion.chunk","model":"route-groq-fast","system_fingerprint":"fp_44709d6fcb","choices":[{"index":0,"delta":{"content":"The answer"}}]}
 
 event: groq.internal.rate_notice
 
@@ -322,6 +327,18 @@ func TestHandleChat_StreamingRelaysCitationsAndChunks(t *testing.T) {
 	if strings.Contains(body, "up-1") {
 		t.Errorf("upstream chunk id leaked into the stream:\n%s", body)
 	}
+
+	// system_fingerprint (both the key and the upstream's fingerprint
+	// value, per cannedSSEResponse's first chunk) must never reach the
+	// client: same provider-identity leak class as the id, third leak found
+	// during the PR #1222 security review.
+	if strings.Contains(body, "system_fingerprint") {
+		t.Errorf("system_fingerprint key leaked into the stream:\n%s", body)
+	}
+	if strings.Contains(body, "fp_44709d6fcb") {
+		t.Errorf("system_fingerprint value leaked into the stream:\n%s", body)
+	}
+
 	idPrefix := `"id":"`
 	start := strings.Index(body, idPrefix)
 	if start == -1 || !strings.HasPrefix(body[start+len(idPrefix):], "ragchat-") {


### PR DESCRIPTION
## Summary

An independent security review of PR #1222 (merged, commit 483ba7983) verified its identity-leak fixes were correct, but found two of the three had no test at the actual call site: reverting either fix left the suite green. This PR adds exactly those two regression guards. No source files changed, tests and fixtures only.

## Gap 1: `stream.go`'s decode-failure fallback (fixed-price route)

Before PR #1222's security-review round 2, `executeStreaming`'s SSE relay branched on `route.Pricing.IsUpstreamActual()` when a chunk failed typed decode: a variable-price route ran the frame through `SanitizeVariablePriceFrame`, but a **fixed-price route** (the D-032 norm for most aliases) wrote the raw upstream line verbatim, id and `system_fingerprint` included, with no log line. The fix collapsed both branches onto the one sanitizer, unconditionally. Nothing exercised that call site end to end, so a revert of the collapse stayed green.

New test `TestExecuteStreaming_FixedPriceDecodeFailureFallback_SanitizesUpstreamIdentity` (`apps/edge-api/internal/inference/stream_fallback_sanitize_test.go`) drives the real `executeStreaming` function end to end against a fixed-price route (`catalogHiveFast`, the existing `FixedPricing` fixture) with a frame that fails typed decode and carries an upstream id + `system_fingerprint` in the exact shape the live leak had. Asserts absence of the raw id, absence of the `system_fingerprint` key, absence of its value, and presence of a gateway-minted `chatcmpl-` id.

## Gap 2: RAG `streamGroundedChat`'s `system_fingerprint` strip

`apps/edge-api/internal/rag/chat_handler.go`'s `streamGroundedChat` strips `system_fingerprint` via `delete(chunk, "system_fingerprint")`, but the existing test fixture (`cannedSSEResponse`) never carried that field, so deleting the strip line left `TestHandleChat_StreamingRelaysCitationsAndChunks` green.

Extended `cannedSSEResponse`'s first chunk to carry `"system_fingerprint":"fp_44709d6fcb"` and added assertions that neither the key nor its value reach the client.

## Verification (red-then-green, both gaps)

For each test: wrote it, confirmed pass against current `main`; reverted the corresponding source fix in place (kept the new test), confirmed the test **failed**; restored the fix, confirmed pass again.

**Gap 1** (temporarily reverted `stream.go`'s unified fallback back to the pre-round-2 two-branch shape):
```
--- FAIL: TestExecuteStreaming_FixedPriceDecodeFailureFallback_SanitizesUpstreamIdentity (0.04s)
    stream_fallback_sanitize_test.go:80: fixed-price decode-failure fallback leaked the raw upstream id verbatim
    stream_fallback_sanitize_test.go:83: fixed-price decode-failure fallback leaked the system_fingerprint key
    stream_fallback_sanitize_test.go:86: fixed-price decode-failure fallback leaked the system_fingerprint value
    stream_fallback_sanitize_test.go:89: expected a gateway-minted chatcmpl- id in the sanitized fallback output
```
Restored the fix: `--- PASS`.

**Gap 2** (temporarily reverted `chat_handler.go`'s `delete(chunk, "system_fingerprint")` line):
```
--- FAIL: TestHandleChat_StreamingRelaysCitationsAndChunks (0.00s)
    chat_handler_test.go:339: system_fingerprint value leaked into the stream:
        ...,"system_fingerprint":"fp_44709d6fcb"}
```
Restored the fix: `--- PASS`.

Full suite: `go test ./apps/edge-api/... -count=1 -short` all green, run from this worktree's own toolchain container (not the shared checkout).

## Buglog entry

Not applicable: no bug was fixed here, only missing regression coverage was added to a fix that already merged correctly.

## Constraints honored

No behaviour changes: tests and fixtures only, both source fixes restored byte-identical to `origin/main` (`git diff` on both source files is empty). Did not touch settlement arithmetic, `HasForwardedChunk`, `Accumulate`, or `ClampUsage`. Did not touch `apps/web-console` or `vendor/open-webui`.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming fallback handling to remove upstream identity details from relayed responses.
  * Streaming responses now use a gateway-generated completion ID when required.
  * Removed upstream `system_fingerprint` data from streaming chat output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->